### PR TITLE
Fix enum error

### DIFF
--- a/nvflare/widgets/widget.py
+++ b/nvflare/widgets/widget.py
@@ -36,7 +36,7 @@ class Widget(FLComponent):
         FLComponent.__init__(self)
 
 
-class WidgetID(Enum, str):
+class WidgetID(str, Enum):
 
     INFO_COLLECTOR = "info_collector"
     COMPONENT_CALLER = "component_caller"


### PR DESCRIPTION
Unit tests are failing due to "New enum creations must be created as ..". This fixes that.