### PR TITLE
Add AnalyticsSender and enhance streaming widgets

### DIFF
--- a/nvflare/apis/analytix.py
+++ b/nvflare/apis/analytix.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
+from typing import Optional
 
 from nvflare.apis.dxo import DXO, DataKind
 
@@ -20,25 +21,31 @@ DATA_TYPE_KEY = "analytics_data_type"
 KWARGS_KEY = "analytics_kwargs"
 
 
-class DataType(Enum):
+class AnalyticsDataType(Enum):
     SCALARS = "SCALARS"
     SCALAR = "SCALAR"
     IMAGE = "IMAGE"
     TEXT = "TEXT"
 
 
-class Data:
-    """This class defines Data format.
-    It is a wrapper to provide from / to DXO conversion.
-    """
+class AnalyticsData:
+    def __init__(self, tag: str, value, data_type: AnalyticsDataType, kwargs: Optional[dict]):
+        """This class defines AnalyticsData format.
 
-    def __init__(self, tag, value, data_type, kwargs):
+            It is a wrapper to provide from / to DXO conversion.
+        Args:
+            tag (str): tag name
+            value: value
+            data_type (AnalyticDataType): type of the analytic data.
+            kwargs (optional, dict): additional arguments to be passed.
+        """
         self.tag = tag
         self.value = value
         self.data_type = data_type
         self.kwargs = kwargs
 
     def to_dxo(self):
+        """Converts the AnalyticsData to DXO object."""
         dxo = DXO(data_kind=DataKind.ANALYTIC, data={self.tag: self.value})
         dxo.set_meta_prop(DATA_TYPE_KEY, self.data_type)
         dxo.set_meta_prop(KWARGS_KEY, self.kwargs)
@@ -46,6 +53,11 @@ class Data:
 
     @classmethod
     def from_dxo(cls, dxo: DXO):
+        """Generates the AnalyticsData from DXO object.
+
+        Args:
+            dxo (DXO): The DXO object to convert.
+        """
         if not isinstance(dxo, DXO):
             raise TypeError(f"dxo is not of type DXO, instead it has type {type(dxo)}.")
 
@@ -56,7 +68,7 @@ class Data:
 
         data_type = dxo.get_meta_prop(DATA_TYPE_KEY)
         kwargs = dxo.get_meta_prop(KWARGS_KEY)
-        if not isinstance(data_type, DataType):
-            raise ValueError("data_type is not supported.")
+        if not isinstance(data_type, AnalyticsDataType):
+            raise ValueError(f"data_type {data_type} is not supported.")
 
         return cls(tag, value, data_type, kwargs)

--- a/nvflare/apis/fl_component.py
+++ b/nvflare/apis/fl_component.py
@@ -17,8 +17,7 @@ import traceback
 
 from nvflare.apis.utils.fl_context_utils import generate_log_message
 
-from .analytix import Data as AnalytixData
-from .analytix import DataType
+from .analytix import AnalyticsData, AnalyticsDataType
 from .event_type import EventType
 from .fl_constant import EventScope, FedEventHeader, FLContextKey, LogMessageTag
 from .fl_context import FLContext
@@ -157,7 +156,7 @@ class FLComponent(object):
         #     )
 
     def _fire_log_event(self, event_type: str, log_tag: str, log_msg: str, fl_ctx: FLContext):
-        event_data = AnalytixData(tag=log_tag, value=log_msg, data_type=DataType.TEXT, kwargs=None)
+        event_data = AnalyticsData(tag=log_tag, value=log_msg, data_type=AnalyticsDataType.TEXT, kwargs=None)
         dxo = event_data.to_dxo()
         fl_ctx.set_prop(key=FLContextKey.EVENT_DATA, value=dxo.to_shareable(), private=True, sticky=False)
         self.fire_event(event_type=event_type, fl_ctx=fl_ctx)

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -168,3 +168,4 @@ class LogMessageTag(object):
     EXCEPTION = "log/exception"
     INFO = "log/info"
     WARNING = "log/warning"
+    CRITICAL = "log/critical"

--- a/nvflare/app_common/widgets/streaming.py
+++ b/nvflare/app_common/widgets/streaming.py
@@ -13,29 +13,36 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from threading import Lock
 from typing import List, Optional
 
-from nvflare.apis.analytix import Data as AnalyticsData
-from nvflare.apis.analytix import DataType as AnalyticsDataType
+from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
 from nvflare.apis.dxo import DXO
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import FedEventHeader, FLContextKey, ReservedKey
+from nvflare.apis.fl_constant import EventScope, FLContextKey, LogMessageTag, ReservedKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.widgets.widget import Widget
 
-EVENT = "log_analytics"
+_ANALYTIC_EVENT_TYPE = "analytix_log_stats"
+
+_LOG_DEBUG_EVENT_TYPE = "analytix_log_debug"
+_LOG_INFO_EVENT_TYPE = "analytix_log_info"
+_LOG_WARNING_EVENT_TYPE = "analytix_log_warning"
+_LOG_ERROR_EVENT_TYPE = "analytix_log_error"
+_LOG_EXCEPTION_EVENT_TYPE = "analytix_log_exception"
+_LOG_CRITICAL_EVENT_TYPE = "analytix_log_critical"
 
 
-def send_analytic_dxo(comp: FLComponent, dxo: DXO, fl_ctx: FLContext):
-    """
-    Sends analytic dxo.
+def send_analytic_dxo(comp: FLComponent, dxo: DXO, fl_ctx: FLContext, event_type: str = _ANALYTIC_EVENT_TYPE):
+    """Sends analytic dxo.
 
     Args:
-        comp (FLComponent):
+        comp (FLComponent): An FLComponent.
         dxo (DXO): analytic data in dxo.
         fl_ctx (FLContext): fl context info.
+        event_type (str): Event type.
     """
     if not isinstance(comp, FLComponent):
         raise TypeError("expect comp to be FLComponent, but got {}".format(type(fl_ctx)))
@@ -45,12 +52,11 @@ def send_analytic_dxo(comp: FLComponent, dxo: DXO, fl_ctx: FLContext):
         raise TypeError("expect fl_ctx to be FLContext, but got {}".format(type(fl_ctx)))
 
     fl_ctx.set_prop(key=FLContextKey.EVENT_DATA, value=dxo.to_shareable(), private=True, sticky=False)
-    comp.fire_event(event_type=EVENT, fl_ctx=fl_ctx)
+    comp.fire_event(event_type=event_type, fl_ctx=fl_ctx)
 
 
-def write(tag: str, value, data_type: AnalyticsDataType, kwargs=None) -> DXO:
-    """
-    Writes the analytic data.
+def _write(tag: str, value, data_type: AnalyticsDataType, kwargs: Optional[dict] = None) -> DXO:
+    """Writes the analytic data.
 
     Args:
         tag (str): the tag associated with this value.
@@ -67,66 +73,160 @@ def write(tag: str, value, data_type: AnalyticsDataType, kwargs=None) -> DXO:
 
 
 def write_scalar(tag: str, scalar: float, **kwargs) -> DXO:
-    """
-    Writes a scalar.
+    """Writes a scalar.
 
     Args:
         tag (str): the tag associated with this value.
         scalar (float): a scalar to write.
     """
-    return write(tag, scalar, data_type=AnalyticsDataType.SCALAR, kwargs=kwargs)
+    return _write(tag, scalar, data_type=AnalyticsDataType.SCALAR, kwargs=kwargs)
 
 
 def write_scalars(tag: str, tag_scalar_dict: dict, **kwargs) -> DXO:
-    """
-    Writes scalars.
+    """Writes scalars.
 
     Args:
         tag (str): the tag associated with this dict.
         tag_scalar_dict (dict): A dictionary that contains tag and scalars to write.
     """
-    return write(tag, tag_scalar_dict, data_type=AnalyticsDataType.SCALARS, kwargs=kwargs)
+    return _write(tag, tag_scalar_dict, data_type=AnalyticsDataType.SCALARS, kwargs=kwargs)
 
 
 def write_image(tag: str, image, **kwargs) -> DXO:
-    """
-    Writes an image.
+    """Writes an image.
 
     Args:
         tag (str): the tag associated with this value.
         image: the image to write.
     """
-    return write(tag, image, data_type=AnalyticsDataType.IMAGE, kwargs=kwargs)
+    return _write(tag, image, data_type=AnalyticsDataType.IMAGE, kwargs=kwargs)
 
 
 def write_text(tag: str, text: str, **kwargs) -> DXO:
-    """
-    Writes text.
+    """Writes text.
 
     Args:
         tag (str): the tag associated with this value.
         text (str): the text to write.
     """
-    return write(tag, text, data_type=AnalyticsDataType.TEXT, kwargs=kwargs)
+    return _write(tag, text, data_type=AnalyticsDataType.TEXT, kwargs=kwargs)
+
+
+class AnalyticsSender(Widget):
+    def __init__(self):
+        """Sends analytics data.
+
+        This class implements some common methods follows signatures from PyTorch SummaryWriter and Python logger.
+        It provides a convenient way for LearnerService to use.
+        """
+        super().__init__()
+        self.engine = None
+
+    def handle_event(self, event_type: str, fl_ctx: FLContext):
+        if event_type == EventType.START_RUN:
+            self.engine = fl_ctx.get_engine()
+
+    def _add(self, tag: str, value, data_type: AnalyticsDataType, kwargs: Optional[dict] = None):
+        dxo = _write(tag=tag, value=value, data_type=data_type, kwargs=kwargs)
+        with self.engine.new_context() as fl_ctx:
+            send_analytic_dxo(self, dxo=dxo, fl_ctx=fl_ctx)
+
+    def add_scalar(self, tag: str, scalar: float, **kwargs):
+        """Sends a scalar.
+
+        Args:
+            tag (str): Data identifier.
+            scalar (float): Value to send.
+            **kwargs: Additional arguments to pass to the receiver side.
+        """
+        self._add(tag=tag, value=scalar, data_type=AnalyticsDataType.SCALAR, kwargs=kwargs)
+
+    def add_scalars(self, tag: str, scalars: dict, **kwargs):
+        """Sends scalars.
+
+        Args:
+            tag (str): The parent name for the tags.
+            scalars (dict): Key-value pair storing the tag and corresponding values.
+            **kwargs: Additional arguments to pass to the receiver side.
+        """
+        self._add(tag=tag, value=scalars, data_type=AnalyticsDataType.SCALARS, kwargs=kwargs)
+
+    def add_text(self, tag: str, text: str, **kwargs):
+        """Sends a text.
+
+        Args:
+            tag (str): Data identifier.
+            text (str): String to send.
+            **kwargs: Additional arguments to pass to the receiver side.
+        """
+        self._add(tag=tag, value=text, data_type=AnalyticsDataType.TEXT, kwargs=kwargs)
+
+    def add_image(self, tag: str, image, **kwargs):
+        """Sends an image.
+
+        Args:
+            tag (str): Data identifier.
+            image: Image to send.
+            **kwargs: Additional arguments to pass to the receiver side.
+        """
+        self._add(tag=tag, value=image, data_type=AnalyticsDataType.IMAGE, kwargs=kwargs)
+
+    def _log(self, tag: LogMessageTag, msg: str, event_type: str, *args, **kwargs):
+        """Logs a message.
+
+        Args:
+            tag (LogMessageTag): A tag that contains the level of the log message.
+            msg (str): Message to log.
+            event_type (str): Event type that associated with this message.
+            *args: From python logger api, args is used to format strings.
+            **kwargs: Additional arguments to be passed into the log function.
+        """
+        msg = msg.format(*args, **kwargs)
+        dxo = _write(tag=str(tag), value=msg, data_type=AnalyticsDataType.TEXT, kwargs=kwargs)
+        with self.engine.new_context() as fl_ctx:
+            send_analytic_dxo(self, dxo=dxo, fl_ctx=fl_ctx, event_type=event_type)
+
+    def info(self, msg: str, *args, **kwargs):
+        """Logs a message with tag LogMessageTag.INFO."""
+        self._log(tag=LogMessageTag.INFO, msg=msg, event_type=_LOG_INFO_EVENT_TYPE, args=args, kwargs=kwargs)
+
+    def warning(self, msg: str, *args, **kwargs):
+        """Logs a message with tag LogMessageTag.WARNING."""
+        self._log(tag=LogMessageTag.WARNING, msg=msg, event_type=_LOG_WARNING_EVENT_TYPE, args=args, kwargs=kwargs)
+
+    def error(self, msg: str, *args, **kwargs):
+        """Logs a message with tag LogMessageTag.ERROR."""
+        self._log(tag=LogMessageTag.ERROR, msg=msg, event_type=_LOG_ERROR_EVENT_TYPE, args=args, kwargs=kwargs)
+
+    def debug(self, msg: str, *args, **kwargs):
+        """Logs a message with tag LogMessageTag.DEBUG."""
+        self._log(tag=LogMessageTag.DEBUG, msg=msg, event_type=_LOG_DEBUG_EVENT_TYPE, args=args, kwargs=kwargs)
+
+    def exception(self, msg: str, *args, **kwargs):
+        """Logs a message with tag LogMessageTag.EXCEPTION."""
+        self._log(tag=LogMessageTag.EXCEPTION, msg=msg, event_type=_LOG_EXCEPTION_EVENT_TYPE, args=args, kwargs=kwargs)
+
+    def critical(self, msg: str, *args, **kwargs):
+        """Logs a message with tag LogMessageTag.CRITICAL."""
+        self._log(tag=LogMessageTag.CRITICAL, msg=msg, event_type=_LOG_CRITICAL_EVENT_TYPE, args=args, kwargs=kwargs)
 
 
 class AnalyticsReceiver(Widget, ABC):
     def __init__(self, events: Optional[List[str]] = None):
-        """
-        Receives analytic data.
+        """Receives analytic data.
 
         Args:
-            events (optional, List[str]): A list of event that this receiver will handled.
+            events (optional, List[str]): A list of event that this receiver will handle.
         """
-        FLComponent.__init__(self)
+        super().__init__()
         if events is None:
-            events = [EVENT, f"fed.{EVENT}"]
+            events = [_ANALYTIC_EVENT_TYPE, f"fed.{_ANALYTIC_EVENT_TYPE}"]
         self.events = events
+        self._save_lock = Lock()
 
     @abstractmethod
     def initialize(self, fl_ctx: FLContext):
-        """
-        Initializes the receiver.
+        """Initializes the receiver.
 
         Args:
             fl_ctx (FLContext): fl context.
@@ -135,8 +235,7 @@ class AnalyticsReceiver(Widget, ABC):
 
     @abstractmethod
     def save(self, fl_ctx: FLContext, shareable: Shareable, record_origin: str):
-        """
-        Saves the received data.
+        """Saves the received data.
 
         Args:
             fl_ctx (FLContext): fl context.
@@ -147,8 +246,7 @@ class AnalyticsReceiver(Widget, ABC):
 
     @abstractmethod
     def finalize(self, fl_ctx: FLContext):
-        """
-        Finalizes the receiver.
+        """Finalizes the receiver.
 
         Args:
             fl_ctx (FLContext): fl context.
@@ -170,13 +268,14 @@ class AnalyticsReceiver(Widget, ABC):
             record_origin = fl_ctx.get_identity_name()
 
             # if fed event use peer name to save
-            if data.get_header(FedEventHeader.ORIGIN) is not None:
+            if fl_ctx.get_prop(FLContextKey.EVENT_SCOPE) == EventScope.FEDERATION:
                 peer_name = data.get_peer_prop(ReservedKey.IDENTITY_NAME, None)
                 record_origin = peer_name
 
             if record_origin is None:
                 self.log_error(fl_ctx, "record_origin can't be None.")
                 return
-            self.save(shareable=data, fl_ctx=fl_ctx, record_origin=record_origin)
+            with self._save_lock:
+                self.save(shareable=data, fl_ctx=fl_ctx, record_origin=record_origin)
         elif event_type == EventType.END_RUN:
             self.finalize(fl_ctx)

--- a/nvflare/widgets/info_collector.py
+++ b/nvflare/widgets/info_collector.py
@@ -14,7 +14,7 @@
 
 import datetime
 
-from nvflare.apis.analytix import Data as AnalytixData
+from nvflare.apis.analytix import AnalyticsData
 from nvflare.apis.dxo import from_shareable
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey
@@ -101,7 +101,7 @@ class InfoCollector(Widget):
                 )
                 return
 
-            analytic_data = AnalytixData.from_dxo(dxo)
+            analytic_data = AnalyticsData.from_dxo(dxo)
 
             if event_type == EventType.ERROR_LOG_AVAILABLE:
                 key = "error"

--- a/test/app_testing/test_apps/tb_streaming/config/config_fed_client.json
+++ b/test/app_testing/test_apps/tb_streaming/config/config_fed_client.json
@@ -24,12 +24,12 @@
     {
       "id": "tb_analytics_receive",
       "path": "nvflare.app_common.pt.tb_receiver.TBAnalyticsReceiver",
-      "args": {"events": ["log_analytics"]}
+      "args": {"events": ["analytix_log_stats"]}
     },
     {
       "id": "event_to_fed",
       "path": "nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent",
-      "args": {"events_to_convert": ["log_analytics"], "fed_event_prefix": "fed."}
+      "args": {"events_to_convert": ["analytix_log_stats"], "fed_event_prefix": "fed."}
     }
   ]
 }

--- a/test/app_testing/test_apps/tb_streaming/config/config_fed_server.json
+++ b/test/app_testing/test_apps/tb_streaming/config/config_fed_server.json
@@ -25,7 +25,7 @@
     {
       "id": "tb_analytics_receive",
       "path": "nvflare.app_common.pt.tb_receiver.TBAnalyticsReceiver",
-      "args": {"events": ["fed.log_analytics"]}
+      "args": {"events": ["fed.analytix_log_stats"]}
     }
   ],
   "workflows": [


### PR DESCRIPTION
- Rename DataType, Data to AnalyticsDataType and AnalyticsData in nvflare/apis/analytix.py
- Add AnalyticsSender which implements the following functions:

    - info, debug, error, exception, warning, critical following the method signature of Python logger
    - add_scalar, add_scalars, add_text, add_image following the method signature of PyTorch SummaryWriter
- Add a lock for save action in AnalyticsReceiver to ensure thread safety
- Update docstrings 