### PR TITLE
Add information about enable_byoc and allow_byoc

### DIFF
--- a/build_doc.sh
+++ b/build_doc.sh
@@ -51,7 +51,7 @@ function clean_docs() {
 function build_html_docs() {
     # pip install -e ./
     pip install -r requirements-doc.txt
-    sphinx-apidoc -f -o docs/apidocs/ nvflare "*poc" "*private"
+    sphinx-apidoc --module-first -f -o docs/apidocs/ nvflare "*poc" "*private"
     sphinx-build -b html docs docs/_build
 }
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -191,6 +191,14 @@ Operational
     The :ref:`Admin client <admin_commands>` is used to orchestrate the FL study, including starting and stopping server
     and clients, deploying applications, and managing FL experiments.
 
+#. Why am I getting an error about my custom files not being found?
+
+    Make sure that BYOC is enabled. BYOC is always enabled in POC mode, but disabled by default in secure mode when
+    provisioning.  Either through the UI tool or though yml, make sure the ``enable_byoc`` flag is set for each participant.
+    If the ``enable_byoc`` flag is disabled, even if you have custom code in your application folder, it will not be loaded.
+    There is also a setting for ``allow_byoc`` through the authorization rule groups. This controls whether or not apps
+    containing BYOC code will be allowed to be uploaded and deployed.
+
 ********
 Security
 ********

--- a/docs/user_guide/provisioning_tool.rst
+++ b/docs/user_guide/provisioning_tool.rst
@@ -387,6 +387,18 @@ The following is an example of the default project.yml file.
 .. literalinclude:: ../../nvflare/lighter/project.yml
   :language: yaml
 
+.. note::
+
+   For each participant, the ``enable_byoc`` flag can be set to enable loading of code in the custom folder of applications.
+   If the ``enable_byoc`` flag is disabled, even if you have custom code in your application folder, it will not be loaded.
+
+   There is also a setting for ``allow_byoc`` in the rules for authorization groups (in AuthPolicyBuilder). This controls
+   whether or not applications containing custom code will be allowed to be uploaded and deployed to the participants
+   of the orgs of that rule group.
+
+   Here, ``byoc`` is referring to the custom code in the custom folder in an FL application. Code already in the python path
+   through other means is not considered ``byoc`` for these purposes.
+
 *****************************
 Provision commandline options
 *****************************


### PR DESCRIPTION
Update documentation to add information about enable_byoc and allow_byoc and what they do in the provisioning process, and have the apidocs pages display better with module-first.