### PR TITLE
get client IP more robustly

### DIFF
--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -107,13 +107,33 @@ class Communicator:
 
         return state_message
 
+    def get_client_ip(self):
+        """Return localhost IP.
+
+        More robust than ``socket.gethostbyname(socket.gethostname())``. See
+        https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib/28950776#28950776
+        for more details.
+
+        :return: The host IP.
+        """
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(('10.255.255.255', 1))  # doesn't even have to be reachable
+            ip = s.getsockname()[0]
+        except Exception:
+            ip = '127.0.0.1'
+        finally:
+            s.close()
+        return ip
+
     def client_registration(self, client_name, servers, project_name):
         """
         Client's meta data used to authenticate and communicate.
 
         :return: a ClientLogin message.
         """
-        local_ip = socket.gethostbyname(socket.gethostname())
+        local_ip = self.get_client_ip()
+
         login_message = fed_msg.ClientLogin(client_name=client_name, client_ip=local_ip)
         # login_message = fed_msg.ClientLogin(
         #     client_id=None, token=None, client_ip=local_ip)


### PR DESCRIPTION
When running the NVflare client inside a `runc` container the client IP cannot be resolved because `socket.gethostbyname(socket.gethostname())` raises with `socket.gaierror: [Errno -3] Temporary failure in name resolution`. 

As explained in this [SO](https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib/28950776#28950776), the method proposed here is more robust and solved the issue.

Thanks @ehlertjd