### PR TITLE
relax python requirement to 3.8.7+

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Installation
 Python Version
 --------------
 
-NVIDIA FLARE requires `Python 3.8.10 <https://www.python.org/downloads/release/python-3810/>`_.
+NVIDIA FLARE requires `Python 3.8.7 <https://www.python.org/downloads/release/python-387/>`_ and above in the 3.8 line.
 
 Install NVIDIA FLARE in virtual environments
 --------------------------------------------


### PR DESCRIPTION
As far as I am being told and was able to test, NVflare is compatible with 3.8.7+ in the the 3.8 line.