### PR TITLE
Fix deploy commands missing target in README of examples

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -74,6 +74,10 @@ the FL process. Log in by entering ``admin`` for both the username and password.
 
 Example Apps for NVIDIA FLARE
 =============================
+NVIDIA FLARE has several examples to help you get started with federated learning and to explore certain features in
+`the examples directory <https://github.com/NVIDIA/NVFlare/tree/main/examples>`_.
+
+The following quickstart guides walk you through some of these examples:
 
 .. toctree::
    :maxdepth: 1

--- a/examples/hello-monai/README.md
+++ b/examples/hello-monai/README.md
@@ -25,7 +25,7 @@ Then, use these Admin commands to run the experiment:
 ```
 set_run_number 1
 upload_app hello-monai
-deploy_app hello-monai
+deploy_app hello-monai all
 start_app all
 ```
 

--- a/examples/hello-numpy-cross-val/README.md
+++ b/examples/hello-numpy-cross-val/README.md
@@ -20,7 +20,7 @@ Then, use these Admin commands to run the experiment:
 ```
 set_run_number 1
 upload_app hello-numpy-cross-val
-deploy_app hello-numpy-cross-val
+deploy_app hello-numpy-cross-val all
 start_app all
 ```
 

--- a/examples/hello-pt/README.md
+++ b/examples/hello-pt/README.md
@@ -25,7 +25,7 @@ Then, use these Admin commands to run the experiment:
 ```
 set_run_number 1
 upload_app hello-pt
-deploy_app hello-pt
+deploy_app hello-pt all
 start_app all
 ```
 

--- a/examples/hello-tf2/README.md
+++ b/examples/hello-tf2/README.md
@@ -25,7 +25,7 @@ Then, use these Admin commands to run the experiment:
 ```
 set_run_number 1
 upload_app hello-tf2
-deploy_app hello-tf2
+deploy_app hello-tf2 all
 start_app all
 ```
 


### PR DESCRIPTION
This PR fixes the commands in some README pages of examples where deploy_app is missing the target. Also, this slightly refines the page in the docs introducing the examples and provides a link.

This will close #110.