### PR TITLE
Increase fed event firing frequency

### DIFF
--- a/nvflare/apis/event_type.py
+++ b/nvflare/apis/event_type.py
@@ -20,6 +20,7 @@ class EventType(object):
 
     ABOUT_TO_START_RUN = "_about_to_start_run"
     START_RUN = "_start_run"
+    ABOUT_TO_END_RUN = "_about_to_end_run"
     END_RUN = "_end_run"
     START_WORKFLOW = "_start_workflow"
     END_WORKFLOW = "_end_workflow"

--- a/nvflare/private/fed/client/client_aux_runner.py
+++ b/nvflare/private/fed/client/client_aux_runner.py
@@ -49,6 +49,7 @@ class ClientAuxRunner(AuxRunner):
             self.sender.start()
         elif event_type == EventType.END_RUN:
             self.asked_to_stop = True
+            self.log_debug(fl_ctx, "Received END_RUN")
             if self.sender and self.sender.is_alive():
                 self.sender.join()
 
@@ -79,7 +80,7 @@ class ClientAuxRunner(AuxRunner):
             # this is fire-and-forget request
             with self.fnf_lock:
                 self.fnf_requests.append(req_to_send)
-                return make_reply(ReturnCode.OK)
+            return make_reply(ReturnCode.OK)
 
         # send regular request
         engine = fl_ctx.get_engine()
@@ -104,23 +105,27 @@ class ClientAuxRunner(AuxRunner):
         sleep_time = 0.5
         while True:
             time.sleep(sleep_time)
-            if self.asked_to_stop or self.abort_signal.triggered:
+            if self.abort_signal.triggered:
                 break
 
-            with self.fnf_lock:
-                if len(self.fnf_requests) <= 0:
+            if len(self.fnf_requests) <= 0:
+                if self.asked_to_stop:
+                    break
+                else:
                     sleep_time = 1.0
                     continue
 
-                with self.engine.new_context() as fl_ctx:
-                    bulk = Shareable()
-                    bulk.set_header(ReservedHeaderKey.TOPIC, topic)
-                    bulk.set_peer_props(fl_ctx.get_all_public_props())
+            with self.engine.new_context() as fl_ctx:
+                self.log_debug(fl_ctx, "preparing bulk send")
+                bulk = Shareable()
+                bulk.set_header(ReservedHeaderKey.TOPIC, topic)
+                bulk.set_peer_props(fl_ctx.get_all_public_props())
+                with self.fnf_lock:
                     bulk[self.DATA_KEY_BULK] = self.fnf_requests
                     reply = self.engine.aux_send(topic=topic, request=bulk, timeout=1.0, fl_ctx=fl_ctx)
-
                     rc = reply.get_return_code()
                     if rc != ReturnCode.COMMUNICATION_ERROR:
+                        self.log_debug(fl_ctx, "aux bulk send returns no ERROR")
                         # if communication error we'll retry
                         self.fnf_requests = []
             sleep_time = 0.5

--- a/nvflare/private/fed/client/client_aux_runner.py
+++ b/nvflare/private/fed/client/client_aux_runner.py
@@ -49,7 +49,6 @@ class ClientAuxRunner(AuxRunner):
             self.sender.start()
         elif event_type == EventType.END_RUN:
             self.asked_to_stop = True
-            self.log_debug(fl_ctx, "Received END_RUN")
             if self.sender and self.sender.is_alive():
                 self.sender.join()
 
@@ -116,7 +115,6 @@ class ClientAuxRunner(AuxRunner):
                     continue
 
             with self.engine.new_context() as fl_ctx:
-                self.log_debug(fl_ctx, "preparing bulk send")
                 bulk = Shareable()
                 bulk.set_header(ReservedHeaderKey.TOPIC, topic)
                 bulk.set_peer_props(fl_ctx.get_all_public_props())
@@ -125,7 +123,6 @@ class ClientAuxRunner(AuxRunner):
                     reply = self.engine.aux_send(topic=topic, request=bulk, timeout=1.0, fl_ctx=fl_ctx)
                     rc = reply.get_return_code()
                     if rc != ReturnCode.COMMUNICATION_ERROR:
-                        self.log_debug(fl_ctx, "aux bulk send returns no ERROR")
                         # if communication error we'll retry
                         self.fnf_requests = []
             sleep_time = 0.5

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -345,8 +345,13 @@ class ClientRunner(FLComponent):
         Returns:
 
         """
-        self._abort_current_task()
         with self.engine.new_context() as fl_ctx:
+            self.log_info(fl_ctx, "ABORT (RUN) command received")
+        self._abort_current_task()
+        self.run_abort_signal.trigger("ABORT (RUN) triggered")
+        self.asked_to_stop = True
+        with self.engine.new_context() as fl_ctx:
+            self.log_info(fl_ctx, "ABORT (RUN) request sequence done")
             with self.end_run_lock:
                 if not self.end_run_fired:
                     self.fire_event(EventType.ABOUT_TO_END_RUN, fl_ctx)

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -154,7 +154,6 @@ class FederatedClientBase:
                 self.servers, project_name, self.token, fl_ctx, self.client_name, shareable, topic, timeout
             )
 
-            self.logger.info("Done with sending aux message.")
             return message
         except FLCommunicationError as e:
             self.local_logger.info(e)

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -154,6 +154,7 @@ class FederatedClientBase:
                 self.servers, project_name, self.token, fl_ctx, self.client_name, shareable, topic, timeout
             )
 
+            self.logger.info("Done with sending aux message.")
             return message
         except FLCommunicationError as e:
             self.local_logger.info(e)

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -128,8 +128,10 @@ class ServerRunner(FLComponent):
         self.status = "done"
         with self.wf_lock:
             with self.engine.new_context() as fl_ctx:
-                self.log_debug(fl_ctx, "firing event EventType.END_RUN")
+                self.fire_event(EventType.ABOUT_TO_END_RUN, fl_ctx)
+                self.log_info(fl_ctx, "ABOUT_TO_END_RUN fired")
                 self.fire_event(EventType.END_RUN, fl_ctx)
+                self.log_info(fl_ctx, "END_RUN fired")
 
         # ask all clients to end run!
         self.engine.send_aux_request(

--- a/nvflare/widgets/fed_event.py
+++ b/nvflare/widgets/fed_event.py
@@ -106,7 +106,6 @@ class FedEventRunner(Widget):
             self.log_error(fl_ctx, "missing event_type in incoming fed event")
             return make_reply(ReturnCode.BAD_REQUEST_DATA)
 
-        self.log_debug(fl_ctx, f"Current in_events size {len(self.in_events)}")
         with self.in_lock:
             last_timestamp = self.last_timestamps.get(peer_name, None)
             if last_timestamp is None or timestamp > last_timestamp:
@@ -161,7 +160,6 @@ class FedEventRunner(Widget):
             with self.engine.new_context() as fl_ctx:
                 assert isinstance(fl_ctx, FLContext)
 
-                self.log_debug(fl_ctx, "firing fed event")
                 if self.asked_to_stop:
                     self.log_warning(fl_ctx, f"{n} items remained in in_events.  Will stop when it reaches 0.")
                 fl_ctx.set_prop(key=FLContextKey.EVENT_DATA, value=event_to_post, private=True, sticky=False)

--- a/nvflare/widgets/fed_event.py
+++ b/nvflare/widgets/fed_event.py
@@ -36,6 +36,10 @@ class FedEventRunner(Widget):
         self.topic = topic
         self.abort_signal = None
         self.asked_to_stop = False
+        self.asked_to_flush = False
+        self.regular_interval = 0.001
+        self.grace_period = 2
+        self.flush_wait = 2
         self.engine = None
         self.last_timestamps = {}  # client name => last_timestamp
         self.in_events = []
@@ -48,7 +52,14 @@ class FedEventRunner(Widget):
             self.engine.register_aux_message_handler(topic=self.topic, message_handle_func=self._receive)
             self.abort_signal = fl_ctx.get_run_abort_signal()
             self.asked_to_stop = False
+            self.asked_to_flush = False
             self.poster.start()
+        elif event_type == EventType.ABOUT_TO_END_RUN:
+            self.asked_to_flush = True
+            # delay self.flush_wait seconds so
+            # _post can empty the queue before
+            # END_RUN is fired
+            time.sleep(self.flush_wait)
         elif event_type == EventType.END_RUN:
             self.asked_to_stop = True
             if self.poster.is_alive():
@@ -95,6 +106,7 @@ class FedEventRunner(Widget):
             self.log_error(fl_ctx, "missing event_type in incoming fed event")
             return make_reply(ReturnCode.BAD_REQUEST_DATA)
 
+        self.log_debug(fl_ctx, f"Current in_events size {len(self.in_events)}")
         with self.in_lock:
             last_timestamp = self.last_timestamps.get(peer_name, None)
             if last_timestamp is None or timestamp > last_timestamp:
@@ -109,29 +121,60 @@ class FedEventRunner(Widget):
         return make_reply(ReturnCode.OK)
 
     def _post(self):
-        sleep_time = 0.1
+        """
+        During ABOUT_TO_END_RUN, sleep_time is 0 and system will flush
+         in_events by firing events without delay.
+        During END_RUN, system will wait for self.grace_period, even the queue is empty,
+        so any new item can be processed.
+        However, since the system does not guarantee the receiving side of _post is still
+        alive, we catch the exception and show warning messages to users if events can not
+        be handled by receiving side.
+        """
+        sleep_time = self.regular_interval
+        countdown = self.grace_period
         while True:
             time.sleep(sleep_time)
-            if self.asked_to_stop or self.abort_signal.triggered:
+            if self.abort_signal.triggered:
                 break
-
-            with self.in_lock:
-                if len(self.in_events) <= 0:
+            n = len(self.in_events)
+            if n > 0:
+                if self.asked_to_flush:
+                    sleep_time = 0
+                else:
+                    sleep_time = self.regular_interval
+                with self.in_lock:
+                    event_to_post = self.in_events.pop(0)
+            elif self.asked_to_stop:
+                # the queue is empty and we are asked to stop.  Give
+                # it self.grace_period seconds to wait, then
+                # exit.
+                if countdown < 0:
+                    break
+                else:
+                    countdown = countdown - 1
+                    time.sleep(1)
                     continue
-                event_to_post = self.in_events.pop(0)
-                assert isinstance(event_to_post, Shareable)
-
-            if self.asked_to_stop or self.abort_signal.triggered:
-                break
+            else:
+                sleep_time = min(sleep_time * 2, 1)
+                continue
 
             with self.engine.new_context() as fl_ctx:
                 assert isinstance(fl_ctx, FLContext)
 
+                self.log_debug(fl_ctx, "firing fed event")
+                if self.asked_to_stop:
+                    self.log_warning(fl_ctx, f"{n} items remained in in_events.  Will stop when it reaches 0.")
                 fl_ctx.set_prop(key=FLContextKey.EVENT_DATA, value=event_to_post, private=True, sticky=False)
                 fl_ctx.set_prop(key=FLContextKey.EVENT_SCOPE, value=EventScope.FEDERATION, private=True, sticky=False)
 
                 event_type = event_to_post.get_header(FedEventHeader.EVENT_TYPE)
-                self.engine.fire_event(event_type=event_type, fl_ctx=fl_ctx)
+                try:
+                    self.engine.fire_event(event_type=event_type, fl_ctx=fl_ctx)
+                except BaseException as e:
+                    if self.asked_to_stop:
+                        self.log_warning(fl_ctx, f"event {event_to_post} fired unsuccessfully during END_RUN")
+                    else:
+                        raise e
 
 
 class ServerFedEventRunner(FedEventRunner):


### PR DESCRIPTION
Add ABOUT_TO_END_RUN to flush queue
Allow thread to exit only when queue is empty during END_RUN

Signed-off-by: Isaac Yang <isaacy@nvidia.com>