### PR TITLE
Fix missing endrun streaming

### DIFF
--- a/nvflare/apis/event_type.py
+++ b/nvflare/apis/event_type.py
@@ -22,6 +22,7 @@ class EventType(object):
     START_RUN = "_start_run"
     ABOUT_TO_END_RUN = "_about_to_end_run"
     END_RUN = "_end_run"
+    RUN_WRAP_UP = "_run_wrap_up"
     START_WORKFLOW = "_start_workflow"
     END_WORKFLOW = "_end_workflow"
     ABORT_TASK = "_abort_task"

--- a/nvflare/app_common/widgets/log_streaming.py
+++ b/nvflare/app_common/widgets/log_streaming.py
@@ -57,7 +57,7 @@ class LogAnalyticsSender(Widget, logging.StreamHandler):
         if event_type == EventType.ABOUT_TO_START_RUN:
             self.engine = fl_ctx.get_engine()
             logging.root.addHandler(self)
-        elif event_type == EventType.END_RUN:
+        elif event_type == EventType.RUN_WRAP_UP:
             logging.root.removeHandler(self)
 
     def emit(self, record: LogRecord):
@@ -113,6 +113,7 @@ class LogAnalyticsReceiver(AnalyticsReceiver):
 
                 record: LogRecord = dxo.data.get(LogMessageTag.LOG_RECORD)
                 handler.emit(record)
+                handler.flush()
         except ValueError:
             self.logger.error(f"Failed to save the log received: {record_origin}")
 

--- a/nvflare/app_common/widgets/streaming.py
+++ b/nvflare/app_common/widgets/streaming.py
@@ -200,9 +200,9 @@ class AnalyticsReceiver(Widget, ABC):
         if event_type == EventType.START_RUN:
             self.initialize(fl_ctx)
         elif event_type in self.events:
-            if self._end:
-                self.log_debug(fl_ctx, f"Already received end run event, drop event {event_type}.", fire_event=False)
-                return
+            # if self._end:
+            #     self.log_debug(fl_ctx, f"Already received end run event, drop event {event_type}.", fire_event=False)
+            #     return
             data = fl_ctx.get_prop(FLContextKey.EVENT_DATA, None)
             if data is None:
                 self.log_error(fl_ctx, "Missing event data.", fire_event=False)

--- a/nvflare/app_common/widgets/streaming.py
+++ b/nvflare/app_common/widgets/streaming.py
@@ -200,9 +200,6 @@ class AnalyticsReceiver(Widget, ABC):
         if event_type == EventType.START_RUN:
             self.initialize(fl_ctx)
         elif event_type in self.events:
-            # if self._end:
-            #     self.log_debug(fl_ctx, f"Already received end run event, drop event {event_type}.", fire_event=False)
-            #     return
             data = fl_ctx.get_prop(FLContextKey.EVENT_DATA, None)
             if data is None:
                 self.log_error(fl_ctx, "Missing event data.", fire_event=False)

--- a/nvflare/private/fed/client/client_aux_runner.py
+++ b/nvflare/private/fed/client/client_aux_runner.py
@@ -47,7 +47,7 @@ class ClientAuxRunner(AuxRunner):
             self.abort_signal = fl_ctx.get_run_abort_signal()
             self.sender = threading.Thread(target=self._send_fnf_requests, args=())
             self.sender.start()
-        elif event_type == EventType.END_RUN:
+        elif event_type == EventType.RUN_WRAP_UP:
             self.asked_to_stop = True
             if self.sender and self.sender.is_alive():
                 self.sender.join()
@@ -104,8 +104,6 @@ class ClientAuxRunner(AuxRunner):
         sleep_time = 0.5
         while True:
             time.sleep(sleep_time)
-            if self.abort_signal.triggered:
-                break
 
             if len(self.fnf_requests) <= 0:
                 if self.asked_to_stop:
@@ -126,3 +124,7 @@ class ClientAuxRunner(AuxRunner):
                         # if communication error we'll retry
                         self.fnf_requests = []
             sleep_time = 0.5
+
+            if self.abort_signal.triggered:
+                break
+

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -386,6 +386,7 @@ class ClientRunner(FLComponent):
     def _handle_end_run(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:
         self.log_info(fl_ctx, "received aux request from Server to end current RUN")
         self._abort_current_task()
+        self.asked_to_stop = True
         self.end_run_events_sequence("AUX END_RUN ")
 
         return make_reply(ReturnCode.OK)

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -345,6 +345,7 @@ class ClientRunner(FLComponent):
                     self.fire_event(EventType.END_RUN, fl_ctx)
                     self.log_info(fl_ctx, "END_RUN fired")
                     self.end_run_fired = True
+                    self.fire_event(EventType.RUN_WRAP_UP, fl_ctx)
 
     def abort(self):
         """
@@ -384,7 +385,9 @@ class ClientRunner(FLComponent):
 
     def _handle_end_run(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:
         self.log_info(fl_ctx, "received aux request from Server to end current RUN")
-        self.abort()
+        self._abort_current_task()
+        self.end_run_events_sequence("AUX END_RUN ")
+
         return make_reply(ReturnCode.OK)
 
     def _handle_abort_task(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:


### PR DESCRIPTION
The solution is to add a wrap up time for the client to send the "last patch" of logging data to the server when the END_RUN event has been fired.