### PR TITLE
Improve docstrings and coding style for fuel

### DIFF
--- a/nvflare/fuel/hci/base64_utils.py
+++ b/nvflare/fuel/hci/base64_utils.py
@@ -28,8 +28,7 @@ def b64str_to_bytes(b64str: str) -> bytes:
 
 
 def binary_file_to_b64str(file_name) -> str:
-    """
-    Encode content of a binary file to a Base64-encoded ASCII string.
+    """Encode content of a binary file to a Base64-encoded ASCII string.
 
     Args:
         file_name: the binary file to be processed
@@ -42,8 +41,7 @@ def binary_file_to_b64str(file_name) -> str:
 
 
 def b64str_to_binary_file(b64str: str, file_name):
-    """
-    Decode a base64-encoded string and write it into a binary file.
+    """Decode a base64-encoded string and write it into a binary file.
 
     Args:
         b64str: the base64-encoded ASCII string
@@ -59,8 +57,7 @@ def b64str_to_binary_file(b64str: str, file_name):
 
 
 def text_file_to_b64str(file_name) -> str:
-    """
-    Encode content of a text file to a Base64-encoded ASCII string.
+    """Encode content of a text file to a Base64-encoded ASCII string.
 
     Args:
         file_name: name of the text file
@@ -74,8 +71,7 @@ def text_file_to_b64str(file_name) -> str:
 
 
 def b64str_to_text_file(b64str: str, file_name):
-    """
-    Decode a base64-encoded string and write result into a text file.
+    """Decode a base64-encoded string and write result into a text file.
 
     Args:
         b64str: base64-encoded string

--- a/nvflare/fuel/hci/client/api_status.py
+++ b/nvflare/fuel/hci/client/api_status.py
@@ -16,9 +16,7 @@ from enum import Enum
 
 
 class APIStatus(str, Enum):
-    """
-    Constants for the valid status options for the status of FLAdminAPIResponse.
-    """
+    """Constants for the valid status options for the status of FLAdminAPIResponse."""
 
     SUCCESS = "SUCCESS"  # command issues successfully
     ERROR_PROTOCOL = (

--- a/nvflare/fuel/hci/client/fl_admin_api_constants.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_constants.py
@@ -16,9 +16,7 @@ from enum import Enum
 
 
 class FLDetailKey(str, Enum):
-    """
-    Constants for FL details that can be returned in the FLAdminAPI.
-    """
+    """Constants for FL details that can be returned in the FLAdminAPI."""
 
     RUN_NUMBER = "run_number"
     APP_NAME = "app_name"

--- a/nvflare/fuel/hci/client/fl_admin_api_runner.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_runner.py
@@ -60,8 +60,9 @@ class FLAdminAPIRunner:
         poc=False,
         debug=False,
     ):
-        """Initializes and logs into an FLAdminAPI instance. The default locations for certs, keys, and directories
-        are used.
+        """Initializes and logs into an FLAdminAPI instance.
+
+        The default locations for certs, keys, and directories are used.
 
         Args:
             host: string for
@@ -71,7 +72,6 @@ class FLAdminAPIRunner:
             poc: whether to run in poc mode without SSL certs
             debug: whether to turn on debug mode
         """
-
         assert isinstance(host, str), "host must be str"
         assert isinstance(port, int), "port must be int"
         assert isinstance(username, str), "username must be str"
@@ -127,8 +127,10 @@ class FLAdminAPIRunner:
         shutdown_on_error=False,
         shutdown_at_end=False,
     ):
-        """An example script to upload, deploy, and start a specified app(app folder must be in upload_dir already).
-        Prints the command to be executed first so it is easy to follow along as the commands run.
+        """An example script to upload, deploy, and start a specified app.
+
+        Note that the app folder must be in upload_dir already. Prints the command to be executed first so it is easy
+        to follow along as the commands run.
 
         Args:
             run_number: run number to use

--- a/nvflare/fuel/hci/client/fl_admin_api_spec.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_spec.py
@@ -20,19 +20,24 @@ from nvflare.fuel.hci.client.api_status import APIStatus
 
 
 class FLAdminAPIResponse(dict):
-    """
-    Structure containing the response of calls to the api as key value pairs. The status key is the primary indicator of
-    the success of a call and can contain APIStatus.SUCCESS or another APIStatus. Most calls will return additional
-    information in the details key, which is also a dictionary of key value pairs. The raw key can optionally have
-    the underlying response from AdminAPI when relevant, particularly when data is received from the server and the
-    status of a call is APIStatus.ERROR_RUNTIME to provide additional information.
-
-    Note that the status in this response primarily indicates that the command submitted successfully. Depending on the
-    command and especially for calls to multiple clients, the contents of details or the raw response should be examined
-    to determine if the execution of the command was successful for each specific client.
-    """
-
     def __init__(self, status: APIStatus, details: dict = None, raw: dict = None):
+        """Structure containing the response of calls to the api as key value pairs.
+
+        The status key is the primary indicator of the success of a call and can contain APIStatus.SUCCESS or another
+        APIStatus. Most calls will return additional information in the details key, which is also a dictionary of key
+        value pairs. The raw key can optionally have the underlying response from AdminAPI when relevant, particularly
+        when data is received from the server and the status of a call is APIStatus.ERROR_RUNTIME to provide additional
+        information.
+
+        Note that the status in this response primarily indicates that the command submitted successfully. Depending on
+        the command and especially for calls to multiple clients, the contents of details or the raw response should be
+        examined to determine if the execution of the command was successful for each specific client.
+
+        Args:
+            status: APIStatus for primary indicator of the success of a call
+            details: response details
+            raw: raw response from server
+        """
         super().__init__()
         self["status"] = status
         if details:
@@ -54,8 +59,9 @@ class TargetType(str, Enum):
 class FLAdminAPISpec(ABC):
     @abstractmethod
     def check_status(self, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
-        """
-        Checks and returns the FL status. If target_type is server, the call does not wait for the server to retrieve
+        """Checks and returns the FL status.
+
+        If target_type is server, the call does not wait for the server to retrieve
         information on the clients but returns the last information the server had at the time this call is made.
 
         If target_type is client, specific clients can be specified in targets, and this call generally takes longer
@@ -72,8 +78,7 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def set_run_number(self, run_number: int) -> FLAdminAPIResponse:
-        """
-        Sets a current run number.
+        """Sets a current run number.
 
         Args:
             run_number: run number in order to set for the current experiment, must be integer greater than 0
@@ -85,8 +90,9 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def delete_run_number(self, run_number: int) -> FLAdminAPIResponse:
-        """
-        Deletes a specified run number. This deletes the run folder corresponding to the run number on the server and
+        """Deletes a specified run number.
+
+        This deletes the run folder corresponding to the run number on the server and
         all connected clients. This is not reversible.
 
         Args:
@@ -99,9 +105,9 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def upload_app(self, app: str) -> FLAdminAPIResponse:
-        """
-        Uploads specified app to the upload directory of FL server. Currently assumes app is in the upload_dir set in
-        API init.
+        """Uploads specified app to the upload directory of FL server.
+
+        Currently assumes app is in the upload_dir set in API init.
 
         Args:
             app: name of the folder in upload_dir to upload
@@ -113,9 +119,9 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def deploy_app(self, app: str, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
-        """
-        Issues a command to deploy the specified app to the specified target for the current run number. The app must
-        be already uploaded and available on the server.
+        """Issues a command to deploy the specified app to the specified target for the current run number.
+
+        The app must be already uploaded and available on the server.
 
         Args:
             app: name of app to deploy
@@ -129,8 +135,7 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def start_app(self, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
-        """
-        Issue a command to start the deployed app for the current run number at the specified target.
+        """Issue a command to start the deployed app for the current run number at the specified target.
 
         Args:
             target_type: server | client | all
@@ -156,8 +161,9 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def restart(self, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
-        """Issue a command to restart the specified target. If the target is server, all FL clients will be restarted
-        as well.
+        """Issue a command to restart the specified target.
+
+        If the target is server, all FL clients will be restarted as well.
 
         Args:
             target_type: server | client
@@ -170,8 +176,9 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def shutdown(self, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
-        """Issue a command to stop FL entirely for a specific FL client or specific FL clients. Note that the targets
-        will not be able to start with an API command after shutting down.
+        """Issue a command to stop FL entirely for a specific FL client or specific FL clients.
+
+        Note that the targets will not be able to start with an API command after shutting down.
 
         Args:
             target_type: server | client
@@ -184,8 +191,9 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def remove_client(self, targets: List[str]) -> FLAdminAPIResponse:
-        """Issue a command to remove a specific FL client or FL clients. Note that the targets
-        will not be able to start with an API command after shutting down.
+        """Issue a command to remove a specific FL client or FL clients.
+
+        Note that the targets will not be able to start with an API command after shutting down.
 
         Args:
             targets: a list of client names
@@ -197,8 +205,7 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def set_timeout(self, timeout: float) -> FLAdminAPIResponse:
-        """
-        Sets the timeout for admin commands on the server.
+        """Sets the timeout for admin commands on the server.
 
         Args:
             timeout: timeout of admin commands to set on the server
@@ -214,7 +221,8 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def ls_target(self, target: str, options: str = None, path: str = None) -> FLAdminAPIResponse:
-        """
+        """Issue ls command.
+
         Sends the shell command to get the directory listing of the target allowing for options that the ls command
         of admin client allows.
 
@@ -230,7 +238,8 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def cat_target(self, target: str, options: str = None, file: str = None) -> FLAdminAPIResponse:
-        """
+        """Issue cat command.
+
         Sends the shell command to get the contents of the target's specified file allowing for options that the cat
         command of admin client allows.
 
@@ -286,7 +295,8 @@ class FLAdminAPISpec(ABC):
     def grep_target(
         self, target: str, options: str = None, pattern: str = None, file: str = None
     ) -> FLAdminAPIResponse:
-        """
+        """Issue grep command.
+
         Sends the shell command to grep the contents of the target's specified file allowing for options that the grep
         command of admin client allows.
 
@@ -327,9 +337,11 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def get_connected_client_list(self) -> FLAdminAPIResponse:
-        """A convenience function to get a list of the clients currently connected to the FL server through the check
-        status server call. Note that this returns the client list based on the last known statuses on the server, so it
-        can be possible for a client to be disconnected and not yet removed from the list of connected clients.
+        """A convenience function to get a list of the clients currently connected to the FL server.
+
+        Operates through the check status server call. Note that this returns the client list based on the last known
+        statuses on the server, so it can be possible for a client to be disconnected and not yet removed from the list
+        of connected clients.
 
         Returns: FLAdminAPIResponse
 
@@ -344,8 +356,10 @@ class FLAdminAPISpec(ABC):
         callback: Callable[[FLAdminAPIResponse], bool] = None,
         fail_attempts: int = 3,
     ) -> FLAdminAPIResponse:
-        """Wait until provided callback returns True, with the option to specify a timeout and interval to
-        check the server status. If no callback function is provided, the default callback returns True when the server
+        """Wait until provided callback returns True.
+
+        There is the option to specify a timeout and interval to check the server status. If no callback function is
+        provided, the default callback returns True when the server
         status is "training stopped". A custom callback can be provided to add logic to handle checking for other
         conditions. A timeout should be set in case there are any error conditions that result in the system being stuck
         in a state where the callback never returns True.

--- a/nvflare/fuel/hci/cmd_arg_utils.py
+++ b/nvflare/fuel/hci/cmd_arg_utils.py
@@ -43,11 +43,12 @@ def join_args(segs: List[str]) -> str:
 
 
 class ArgValidator(argparse.ArgumentParser):
-    """
-    Validator for admin shell commands that uses argparse to check arguments and get usage through print_help.
-    """
-
     def __init__(self, name):
+        """Validator for admin shell commands that uses argparse to check arguments and get usage through print_help.
+
+        Args:
+            name: name of the program to pass to ArgumentParser
+        """
         argparse.ArgumentParser.__init__(self, prog=name, add_help=False)
         self.err = ""
 

--- a/nvflare/fuel/hci/conn.py
+++ b/nvflare/fuel/hci/conn.py
@@ -67,9 +67,7 @@ def _split_data(data: str):
 
 
 def _process_one_line(line: str, process_json_func):
-    """
-    Validate and process one line, which should be a str containing a JSON document.
-    """
+    """Validate and process one line, which should be a str containing a JSON document."""
     json_data = validate_proto(line)
     process_json_func(json_data)
 
@@ -101,11 +99,13 @@ def receive_and_process(sock, process_json_func):
 
 
 class Connection(BaseContext):
-    """
-    Object containing connection information and buffer to build and send a line with socket passed in at init.
-    """
-
     def __init__(self, sock, server):
+        """Object containing connection information and buffer to build and send a line with socket passed in at init.
+
+        Args:
+            sock: sock for the connection
+            server: server for the connection
+        """
         BaseContext.__init__(self)
         self.sock = sock
         self.server = server
@@ -117,9 +117,7 @@ class Connection(BaseContext):
         self.buffer = Buffer()
 
     def _send_line(self, line: str, all_end=False):
-        """
-        If not self.ended, send line with sock.
-        """
+        """If not ``self.ended``, send line with sock."""
         if self.ended:
             return
 

--- a/nvflare/fuel/hci/file_transfer_defs.py
+++ b/nvflare/fuel/hci/file_transfer_defs.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Constants for file transfer command module.
-"""
+"""Constants for file transfer command module."""
 
 SERVER_MODULE_NAME = "file_transfer"
 SERVER_CMD_UPLOAD_TEXT = "_upload_text_file"

--- a/nvflare/fuel/hci/proto.py
+++ b/nvflare/fuel/hci/proto.py
@@ -20,11 +20,8 @@ from .table import Table
 
 
 class Buffer(object):
-    """
-    Buffer to append to for :class:`nvflare.fuel.hci.conn.Connection`.
-    """
-
     def __init__(self):
+        """Buffer to append to for :class:`nvflare.fuel.hci.conn.Connection`."""
         self.output = {"time": "{}".format(datetime.now()), "data": []}
 
     def append_table(self, headers: List[str]) -> Table:
@@ -70,8 +67,7 @@ def make_error(data: str):
 
 
 def validate_proto(line: str):
-    """
-    Validate that the line being received is of the expected format.
+    """Validate that the line being received is of the expected format.
 
     Args:
         line: str containing a JSON document

--- a/nvflare/fuel/hci/reg.py
+++ b/nvflare/fuel/hci/reg.py
@@ -16,9 +16,15 @@ from typing import List
 
 
 class CommandSpec(object):
-    """Specification of a command within a CommandModuleSpec to register into CommandRegister as a CommandEntry.
 
-    Args:
+    valid_confirms = ["none", "yesno", "auth"]
+
+    def __init__(
+        self, name: str, description: str, usage: str, handler_func, authz_func=None, visible=True, confirm=None
+    ):
+        """Specification of a command within a CommandModuleSpec to register into CommandRegister as a CommandEntry.
+
+        Args:
             name: command name
             description: command description text
             usage: string to show usage of the command
@@ -26,13 +32,7 @@ class CommandSpec(object):
             authz_func: authorization function to run to get a tuple of (valid, authz_ctx) in AuthzFilter
             visible: whether the command is visible or not
             confirm: whether the command needs confirmation to execute
-    """
-
-    valid_confirms = ["none", "yesno", "auth"]
-
-    def __init__(
-        self, name: str, description: str, usage: str, handler_func, authz_func=None, visible=True, confirm=None
-    ):
+        """
         self.name = name
         self.description = description
         self.usage = usage
@@ -47,30 +47,21 @@ class CommandSpec(object):
 
 
 class CommandModuleSpec(object):
-    """
-    Specification for a command module containing a list of commands in the form of CommandSpec.
+    def __init__(self, name: str, cmd_specs: List[CommandSpec]):
+        """Specification for a command module containing a list of commands in the form of CommandSpec.
 
-    Args:
+        Args:
             name: becomes the scope name of the commands in cmd_specs when registered in CommandRegister
             cmd_specs: list of CommandSpec objects with
-    """
-
-    def __init__(self, name: str, cmd_specs: List[CommandSpec]):
+        """
         self.name = name
         self.cmd_specs = cmd_specs
 
 
 class CommandModule(object):
-    """
-    Base class containing CommandModuleSpec.
-    """
+    """Base class containing CommandModuleSpec."""
 
     def get_spec(self) -> CommandModuleSpec:
-        """
-
-        Returns: CommandModuleSpec
-
-        """
         pass
 
     def close(self):
@@ -78,10 +69,10 @@ class CommandModule(object):
 
 
 class CommandEntry(object):
-    """
-    Contains information about a command. This is registered in Scope within CommandRegister
+    def __init__(self, scope, name, desc, usage, handler, authz_func, visible, confirm):
+        """Contains information about a command. This is registered in Scope within CommandRegister.
 
-    Args:
+        Args:
             scope: scope for this command
             name: command name
             desc: command description text
@@ -90,9 +81,7 @@ class CommandEntry(object):
             authz_func: authorization function to run to get a tuple of (valid, authz_ctx) in AuthzFilter
             visible: whether the command is visible or not
             confirm: whether the command needs confirmation to execute
-    """
-
-    def __init__(self, scope, name, desc, usage, handler, authz_func, visible, confirm):
+        """
         self.scope = scope
         self.name = name
         self.desc = desc
@@ -104,11 +93,12 @@ class CommandEntry(object):
 
 
 class _Scope(object):
-    """
-    A container grouping CommandEntry objects inside CommandRegister.
-    """
-
     def __init__(self, name: str):
+        """A container grouping CommandEntry objects inside CommandRegister.
+
+        Args:
+            name: name of scope grouping commands
+        """
         self.name = name
         self.entries = {}
 
@@ -121,13 +111,15 @@ class _Scope(object):
 
 
 class CommandRegister(object):
-    """
-    Object containing the commands in scopes once they have been registered. ServerCommandRegister is derived from this
-    class and calls the handler of the command through process_command and _do_command. This is also used to register
-    commands for the admin client.
-    """
-
     def __init__(self, app_ctx):
+        """Object containing the commands in scopes once they have been registered.
+
+        ServerCommandRegister is derived from this class and calls the handler of the command through
+        ``process_command`` and ``_do_command``. This is also used to register commands for the admin client.
+
+        Args:
+            app_ctx: app context
+        """
         self.app_ctx = app_ctx
         self.scopes = {}
         self.cmd_map = {}

--- a/nvflare/fuel/hci/security.py
+++ b/nvflare/fuel/hci/security.py
@@ -65,7 +65,7 @@ def make_session_token():
 
 
 def get_certificate_common_name(cert):
-    """ "Gets the common name of the provided certificate.
+    """Gets the common name of the provided certificate.
 
     Args:
         cert: certificate

--- a/nvflare/fuel/hci/server/audit.py
+++ b/nvflare/fuel/hci/server/audit.py
@@ -21,16 +21,17 @@ from .reg import CommandFilter
 
 
 class CommandAudit(CommandFilter):
-    """
-    Command filter for auditing by adding events.
-
-    This filter needs to be registered after the login filter because it needs the user name established
-    by the login filter.
-    """
-
     def __init__(self, auditor: Auditor):
+        """Command filter for auditing by adding events.
+
+        This filter needs to be registered after the login filter because it needs the username established
+        by the login filter.
+
+        Args:
+            auditor: instance of Auditor
+        """
         CommandFilter.__init__(self)
-        assert isinstance(auditor, Auditor), "auditor must be Auditor"
+        assert isinstance(auditor, Auditor), "auditor must be Auditor but got {}".format(type(auditor))
         self.auditor = auditor
 
     def pre_command(self, conn: Connection, args: List[str]):

--- a/nvflare/fuel/hci/server/authz.py
+++ b/nvflare/fuel/hci/server/authz.py
@@ -87,11 +87,12 @@ class AuthorizationService(object):
 
 
 class AuthzFilter(CommandFilter):
-    """
-    Filter for authorization of admin commands.
-    """
-
     def __init__(self, authorizer: Authorizer):
+        """Filter for authorization of admin commands.
+
+        Args:
+            authorizer: instance of Authorizer
+        """
         CommandFilter.__init__(self)
         assert isinstance(authorizer, Authorizer), "authorizer must be Authorizer but got {}".format(type(authorizer))
         self.authorizer = authorizer
@@ -142,6 +143,11 @@ class AuthzFilter(CommandFilter):
 
 class AuthzCommandModule(CommandModule):
     def __init__(self, authorizer: Authorizer):
+        """Authorization command module.
+
+        Args:
+            authorizer: instance of Authorizer
+        """
         assert isinstance(authorizer, Authorizer), "authorizer must be Authorizer but got {}".format(type(authorizer))
         self.authorizer = authorizer
 

--- a/nvflare/fuel/hci/server/builtin.py
+++ b/nvflare/fuel/hci/server/builtin.py
@@ -20,11 +20,12 @@ from .reg import ServerCommandRegister
 
 
 class BuiltInCmdModule(CommandModule):
-    """
-    Built in CommandModule with the ability to list commands.
-    """
-
     def __init__(self, reg: ServerCommandRegister):
+        """Built in CommandModule with the ability to list commands.
+
+        Args:
+            reg: ServerCommandRegister
+        """
         self.reg = reg
 
     def get_spec(self):

--- a/nvflare/fuel/hci/server/constants.py
+++ b/nvflare/fuel/hci/server/constants.py
@@ -14,9 +14,7 @@
 
 
 class ConnProps(object):
-    """
-    Constants for connection properties.
-    """
+    """Constants for connection properties."""
 
     EVENT_ID = "_eventId"
     USER_NAME = "_userName"

--- a/nvflare/fuel/hci/server/file_transfer.py
+++ b/nvflare/fuel/hci/server/file_transfer.py
@@ -38,11 +38,14 @@ def upload_folder_authz_func_signature(folder_path: str) -> (str, AuthzContext):
 
 
 class FileTransferModule(CommandModule):
-    """
-    Command module for file transfers.
-    """
-
     def __init__(self, upload_dir: str, download_dir: str, upload_folder_authz_func=None):
+        """Command module for file transfers.
+
+        Args:
+            upload_dir:
+            download_dir:
+            upload_folder_authz_func:
+        """
         assert os.path.isdir(upload_dir), "upload_dir {} is not a valid dir".format(upload_dir)
 
         assert os.path.isdir(download_dir), "download_dir {} is not a valid dir".format(download_dir)

--- a/nvflare/fuel/hci/server/hci.py
+++ b/nvflare/fuel/hci/server/hci.py
@@ -26,8 +26,9 @@ from .reg import ServerCommandRegister
 
 
 class _MsgHandler(socketserver.BaseRequestHandler):
-    """
-    Message handler used by the AdminServer to receive admin commands, validate, then process and do command through the
+    """Message handler.
+
+    Used by the AdminServer to receive admin commands, validate, then process and do command through the
     ServerCommandRegister.
     """
 
@@ -76,10 +77,6 @@ def initialize_hci():
 
 
 class AdminServer(socketserver.ThreadingTCPServer):
-    """
-    Base class of FedAdminServer to create a server that can receive commands.
-    """
-
     # faster re-binding
     allow_reuse_address = True
 
@@ -99,13 +96,25 @@ class AdminServer(socketserver.ThreadingTCPServer):
         server_key=None,
         accepted_client_cns=None,
     ):
+        """Base class of FedAdminServer to create a server that can receive commands.
 
+        Args:
+            cmd_reg: CommandRegister
+            host: the IP address of the admin server
+            port: port number of admin server
+            ca_cert: the root CA's cert file name
+            server_cert: server's cert, signed by the CA
+            server_key: server's private key file
+            accepted_client_cns: list of accepted Common Names from client, if specified
+        """
         socketserver.TCPServer.__init__(self, (host, port), _MsgHandler, False)
 
         self.use_ssl = False
         if ca_cert and server_cert:
             if accepted_client_cns:
-                assert isinstance(accepted_client_cns, list), "accepted_client_cns must be list"
+                assert isinstance(accepted_client_cns, list), "accepted_client_cns must be list but got {}.".format(
+                    accepted_client_cns
+                )
 
             ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             ctx.verify_mode = ssl.CERT_REQUIRED

--- a/nvflare/fuel/hci/server/login.py
+++ b/nvflare/fuel/hci/server/login.py
@@ -27,13 +27,10 @@ CERT_LOGIN_CMD_NAME = "_cert_login"
 
 
 class Authenticator(object):
-    """
-    Base class for authenticating credentials.
-    """
+    """Base class for authenticating credentials."""
 
     def authenticate(self, user_name: str, credential: str, credential_type: str) -> bool:
-        """
-        Authenticate a specified user with the provided credential.
+        """Authenticate a specified user with the provided credential.
 
         Args:
             user_name: user login name
@@ -47,11 +44,12 @@ class Authenticator(object):
 
 
 class SimpleAuthenticator(Authenticator):
-    """
-    Authenticator to use in the LoginModule for authenticating admin clients for login.
-    """
-
     def __init__(self, users):
+        """Authenticator to use in the LoginModule for authenticating admin clients for login.
+
+        Args:
+            users: user information
+        """
         self.users = users
 
     def authenticate_password(self, user_name: str, pwd: str):
@@ -74,16 +72,24 @@ class SimpleAuthenticator(Authenticator):
 
 
 class LoginModule(CommandModule, CommandFilter):
-    """
-    CommandModule containing the login commands to handle login and logout of admin clients, as well as the
-    CommandFilter pre_command to check that a client is logged in with a valid session.
-    """
-
     def __init__(self, authenticator: Authenticator, sess_mgr: SessionManager):
-        if authenticator:
-            assert isinstance(authenticator, Authenticator), "authenticator must be Authenticator"
+        """Login module.
 
-        assert isinstance(sess_mgr, SessionManager), "sess_mgr must be SessionManager"
+        CommandModule containing the login commands to handle login and logout of admin clients, as well as the
+        CommandFilter pre_command to check that a client is logged in with a valid session.
+
+        Args:
+            authenticator: Authenticator
+            sess_mgr: SessionManager
+        """
+        if authenticator:
+            assert isinstance(authenticator, Authenticator), "authenticator must be Authenticator but got {}.".format(
+                type(authenticator)
+            )
+
+        assert isinstance(sess_mgr, SessionManager), "sess_mgr must be SessionManager but got {}.".format(
+            type(sess_mgr)
+        )
 
         self.authenticator = authenticator
         self.session_mgr = sess_mgr

--- a/nvflare/fuel/hci/server/reg.py
+++ b/nvflare/fuel/hci/server/reg.py
@@ -23,9 +23,7 @@ from .constants import ConnProps
 
 
 class CommandFilter(object):
-    """
-    Base class for filters to run before or after commands.
-    """
+    """Base class for filters to run before or after commands."""
 
     def pre_command(self, conn: Connection, args: List[str]) -> bool:
         """Code to execute before executing a command.
@@ -43,20 +41,27 @@ class CommandFilter(object):
 
 
 class ServerCommandRegister(CommandRegister):
-    """Runs filters and executes commands by calling their handler function. This is the main command register used by
-    AdminServer."""
-
     def __init__(self, app_ctx):
+        """Runs filters and executes commands by calling their handler function.
+
+        This is the main command register used by AdminServer.
+
+        Args:
+            app_ctx: app context
+        """
         CommandRegister.__init__(self, app_ctx)
         self.filters = []
         self.closed = False
 
     def add_filter(self, cmd_filter: CommandFilter):
-        assert isinstance(cmd_filter, CommandFilter), "cmd_filter must be CommandFilter"
+        assert isinstance(cmd_filter, CommandFilter), "cmd_filter must be CommandFilter but got {}.".format(
+            type(cmd_filter)
+        )
         self.filters.append(cmd_filter)
 
     def _do_command(self, conn: Connection, command: str):
-        """
+        """Executes command.
+
         Getting the command from the command registry, invoke filters and call the handler function, passing along conn
         and the args split from the command.
         """

--- a/nvflare/fuel/hci/server/sess.py
+++ b/nvflare/fuel/hci/server/sess.py
@@ -23,11 +23,8 @@ from nvflare.fuel.utils.time_utils import time_to_string
 
 
 class Session(object):
-    """
-    Object keeping track of an admin client session with token and time data.
-    """
-
     def __init__(self):
+        """Object keeping track of an admin client session with token and time data."""
         self.user_name = None
         self.start_time = None
         self.last_active_time = None
@@ -38,11 +35,13 @@ class Session(object):
 
 
 class SessionManager(CommandModule):
-    """
-    CommandModule handling session management.
-    """
-
     def __init__(self, idle_timeout=3600, monitor_interval=5):
+        """Session manager.
+
+        Args:
+            idle_timeout: session idle timeout
+            monitor_interval: interval for obtaining updates when monitoring
+        """
         if monitor_interval <= 0:
             monitor_interval = 5
 
@@ -83,8 +82,7 @@ class SessionManager(CommandModule):
         self.monitor.join(timeout=10)
 
     def create_session(self, user_name):
-        """
-        Creates new session with a new session token.
+        """Creates new session with a new session token.
 
         Args:
             user_name: user name for session
@@ -132,9 +130,9 @@ class SessionManager(CommandModule):
         )
 
     def handle_list_sessions(self, conn: Connection, args: List[str]):
-        """
-        Lists sessions and the details in a table. Not registered by default but can be registered in FedAdminServer
-        with cmd_reg.register_module(sess_mgr).
+        """Lists sessions and the details in a table.
+
+        Not registered by default but can be registered in FedAdminServer with ``cmd_reg.register_module(sess_mgr)``.
         """
         sess_list = list(self.sessions.values())
         sess_list.sort(key=lambda x: x.user_name, reverse=False)

--- a/nvflare/fuel/hci/shell_cmd_val.py
+++ b/nvflare/fuel/hci/shell_cmd_val.py
@@ -18,11 +18,12 @@ from nvflare.fuel.hci.cmd_arg_utils import ArgValidator
 
 
 class ShellCommandValidator(object):
-    """
-    Base class for validators to be called by command executors for shell commands.
-    """
-
     def __init__(self, arg_validator: ArgValidator):
+        """Base class for validators to be called by command executors for shell commands.
+
+        Args:
+            arg_validator: instance of ArgValidator
+        """
         self.arg_validator = arg_validator
 
     def validate(self, args: List[str]):
@@ -34,11 +35,8 @@ class ShellCommandValidator(object):
 
 
 class TailValidator(ShellCommandValidator):
-    """
-    Validator for the tail command.
-    """
-
     def __init__(self):
+        """Validator for the tail command."""
         val = ArgValidator("tail")
         val.add_argument("-c", type=int, help="output the last C bytes")
         val.add_argument("-n", type=int, help="output the last N lines")
@@ -47,11 +45,8 @@ class TailValidator(ShellCommandValidator):
 
 
 class HeadValidator(ShellCommandValidator):
-    """
-    Validator for the head command.
-    """
-
     def __init__(self):
+        """Validator for the head command."""
         val = ArgValidator("head")
         val.add_argument("-c", type=int, help="print the first C bytes of each file")
         val.add_argument("-n", type=int, help="print the first N lines instead of the first 10")
@@ -60,11 +55,8 @@ class HeadValidator(ShellCommandValidator):
 
 
 class GrepValidator(ShellCommandValidator):
-    """
-    Validator for the grep command.
-    """
-
     def __init__(self):
+        """Validator for the grep command."""
         val = ArgValidator("grep")
         val.add_argument("-n", action="store_true", help="print line number with output lines")
         val.add_argument("-i", action="store_true", help="ignore case distinctions")
@@ -75,11 +67,8 @@ class GrepValidator(ShellCommandValidator):
 
 
 class CatValidator(ShellCommandValidator):
-    """
-    Validator for the cat command.
-    """
-
     def __init__(self):
+        """Validator for the cat command."""
         val = ArgValidator("cat")
         val.add_argument("-n", action="store_true", help="number all output lines")
         val.add_argument("-b", action="store_true", help="number nonempty output lines, overrides -n")
@@ -90,11 +79,8 @@ class CatValidator(ShellCommandValidator):
 
 
 class LsValidator(ShellCommandValidator):
-    """
-    Validator for the ls command.
-    """
-
     def __init__(self):
+        """Validator for the ls command."""
         val = ArgValidator("ls")
         val.add_argument("-a", action="store_true")
         val.add_argument("-l", action="store_true", help="use a long listing format")

--- a/nvflare/fuel/hci/tools/authz_preview.py
+++ b/nvflare/fuel/hci/tools/authz_preview.py
@@ -22,20 +22,19 @@ from nvflare.fuel.sec.authz import Policy, validate_policy_config
 
 
 class Commander(cmd.Cmd):
-    """
-    Command line prompt helper tool for getting information for authorization configurations.
-    Args:
-            policy: authorization policy object
-    """
-
     def __init__(self, policy: Policy):
+        """Command line prompt helper tool for getting information for authorization configurations.
+
+        Args:
+            policy: authorization policy object
+        """
         cmd.Cmd.__init__(self)
         self.policy = policy
         self.intro = "Type help or ? to list commands.\n"
         self.prompt = ">"
 
     def do_bye(self, arg):
-        """exit from the client"""
+        """Exits from the client."""
         return True
 
     def emptyline(self):
@@ -187,9 +186,7 @@ class Commander(cmd.Cmd):
 
 
 def main():
-    """
-    Tool to help preview and see the details of an authorization policy with command line commands.
-    """
+    """Tool to help preview and see the details of an authorization policy with command line commands."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--policy", "-p", type=str, help="authz policy file", required=False, default="")
     parser.add_argument("--defs", "-d", type=str, help="authz definition file", required=False, default="")

--- a/nvflare/fuel/hci/zip_utils.py
+++ b/nvflare/fuel/hci/zip_utils.py
@@ -18,8 +18,8 @@ from zipfile import ZipFile
 
 
 def get_all_file_paths(directory):
-    """
-    Get all file paths in the directory.
+    """Get all file paths in the directory.
+
     Args:
         directory: directory to get all paths for
 
@@ -38,12 +38,12 @@ def get_all_file_paths(directory):
 
 
 def _zip_directory(root_dir: str, folder_name: str, writer):
-    """
-    Create a zip archive file for the specified directory.
+    """Create a zip archive file for the specified directory.
 
     Args:
         root_dir: root path that contains the folder to be zipped
         folder_name: path to the folder to be zipped, relative to root_dir
+        writer: file to write to
     """
     dir_name = os.path.join(root_dir, folder_name)
     assert os.path.exists(dir_name), 'directory "{}" does not exist'.format(dir_name)
@@ -60,8 +60,7 @@ def _zip_directory(root_dir: str, folder_name: str, writer):
 
 
 def zip_directory_to_file(root_dir: str, folder_name: str, output_file_name: str):
-    """
-    Create a zip archive file for the specified directory.
+    """Create a zip archive file for the specified directory.
 
     Args:
         root_dir: root path that contains the folder to be zipped
@@ -78,8 +77,7 @@ def zip_directory_to_bytes(root_dir: str, folder_name: str):
 
 
 def _unzip_all(reader, output_dir_name: str):
-    """
-    Decompress a zip archive file and extract all files to the specified output directory.
+    """Decompress a zip archive file and extract all files to the specified output directory.
 
     Args:
         reader: the input zip reader
@@ -94,8 +92,7 @@ def _unzip_all(reader, output_dir_name: str):
 
 
 def unzip_all_from_file(zip_file_name: str, output_dir_name: str):
-    """
-    Decompress a zip archive file and extract all files to the specified output directory.
+    """Decompress a zip archive file and extract all files to the specified output directory.
 
     Args:
         zip_file_name: the input zip archive file

--- a/nvflare/fuel/utils/argument_utils.py
+++ b/nvflare/fuel/utils/argument_utils.py
@@ -16,7 +16,9 @@ from distutils.util import strtobool
 
 
 def parse_var(s):
-    """Returns (key, value) tuple from string with equals sign with the portion before the first equals sign as the key
+    """Parse string variable into key-value tuple.
+
+    Returns (key, value) tuple from string with equals sign with the portion before the first equals sign as the key
     and the rest as the value.
 
     Args:

--- a/nvflare/fuel/utils/class_utils.py
+++ b/nvflare/fuel/utils/class_utils.py
@@ -35,8 +35,7 @@ def get_class(class_path):
 
 
 def instantiate_class(class_path, init_params):
-    """
-    Method for creating an instance for the class.
+    """Method for creating an instance for the class.
 
     Args:
         class_path: full path of the class
@@ -44,7 +43,6 @@ def instantiate_class(class_path, init_params):
         arguments. The transform name will be appended to `medical.common.transforms` to make a
         full name of the transform to be built.
     """
-
     c = get_class(class_path)
     try:
         if init_params:
@@ -77,6 +75,13 @@ def get_config_classname(config_dict: dict):
 
 class ModuleScanner:
     def __init__(self, base_pkgs: List[str], module_names: List[str], exclude_libs=True):
+        """Scanner to look for and load specified module names.
+
+        Args:
+            base_pkgs: base packages to look for modules in
+            module_names: module names to load
+            exclude_libs: excludes modules containing .libs if True. Defaults to True.
+        """
         self.base_pkgs = base_pkgs
         self.module_names = module_names
         self.exclude_libs = exclude_libs

--- a/nvflare/fuel/utils/comm.py
+++ b/nvflare/fuel/utils/comm.py
@@ -17,6 +17,11 @@ import threading
 
 class Queue(object):
     def __init__(self, name):
+        """Queue object with basic functions.
+
+        Args:
+            name: name of queue
+        """
         self.name = name
         self.items = []
         self._update_lock = threading.Lock()
@@ -63,6 +68,12 @@ class Queue(object):
 
 class Channel(object):
     def __init__(self, src, dest):
+        """Channel object.
+
+        Args:
+            src: source
+            dest: destination
+        """
         self.src = src
         self.dest = dest
         self.req = Queue("req")

--- a/nvflare/fuel/utils/component_builder.py
+++ b/nvflare/fuel/utils/component_builder.py
@@ -21,8 +21,8 @@ from nvflare.fuel.utils.class_utils import instantiate_class
 class ComponentBuilder:
     @abstractmethod
     def get_module_scanner(self):
-        """
-        Provide the package module scanner.
+        """Provide the package module scanner.
+
         Returns: module_scanner
 
         """
@@ -33,7 +33,7 @@ class ComponentBuilder:
             return None
 
         if not isinstance(config_dict, dict):
-            raise ConfigError("component config must be dict")
+            raise ConfigError("component config must be dict but got {}.".format(type(config_dict)))
 
         if config_dict.get("disabled") is True:
             return None
@@ -60,7 +60,7 @@ class ComponentBuilder:
         if "path" in config_dict.keys():
             path_spec = config_dict["path"]
             if not isinstance(path_spec, str):
-                raise ConfigError("path spec must be str")
+                raise ConfigError("path spec must be str but got {}.".format(type(path_spec)))
 
             if len(path_spec) <= 0:
                 raise ConfigError("path spec must not be empty")
@@ -76,7 +76,7 @@ class ComponentBuilder:
             class_name = config_dict["name"]
 
             if not isinstance(class_name, str):
-                raise ConfigError("class name must be str")
+                raise ConfigError("class name must be str but got {}.".format(type(class_name)))
 
             if len(class_name) <= 0:
                 raise ConfigError("class name must not be empty")

--- a/nvflare/fuel/utils/json_scanner.py
+++ b/nvflare/fuel/utils/json_scanner.py
@@ -18,11 +18,12 @@ from nvflare.fuel.common.excepts import ConfigError
 
 
 class Node(object):
-    """
-    A JSON element with additional data.
-    """
-
     def __init__(self, element):
+        """A JSON element with additional data.
+
+        Args:
+            element: element to create Node object for
+        """
         self.parent = None
         self.element = element
         self.level = 0
@@ -63,30 +64,25 @@ def _child_node(node: Node, key, pos, element) -> Node:
 
 
 class JsonObjectProcessor(object):
-    """
-    JsonObjectProcessor is used to process JSON elements by the scan_json() function.
-
-    """
+    """JsonObjectProcessor is used to process JSON elements by the scan_json() function."""
 
     def process_element(self, node: Node):
-        """
-        This method is called by the scan() function for each JSON element scanned.
+        """This method is called by the scan() function for each JSON element scanned.
 
         Args:
             node: the node representing the JSON element
-
-        Returns:
-
         """
         pass
 
 
 class JsonScanner(object):
-    """
-    Scanner for processing JSON data.
-    """
-
     def __init__(self, json_data: dict, location=None):
+        """Scanner for processing JSON data.
+
+        Args:
+            json_data: dictionary containing json data to scan
+            location: location to provide in error messages
+        """
         assert isinstance(json_data, dict), "json_data must be dict"
         self.location = location
         self.data = json_data

--- a/nvflare/fuel/utils/pipe/file_pipe.py
+++ b/nvflare/fuel/utils/pipe/file_pipe.py
@@ -20,11 +20,13 @@ from .pipe import Pipe
 
 
 class FilePipe(Pipe):
-    """
-    Implementation of communication through the file system.
-    """
-
     def __init__(self, root_path: str, name: str):
+        """Implementation of communication through the file system.
+
+        Args:
+            root_path: root path
+            name: name of pipe
+        """
         assert os.path.exists(root_path), 'root path "{}" does not exist'.format(root_path)
         pipe_path = os.path.join(root_path, name)
 

--- a/nvflare/fuel/utils/pipe/pipe.py
+++ b/nvflare/fuel/utils/pipe/pipe.py
@@ -14,11 +14,13 @@
 
 
 class EndPoint(object):
-    """
-    Object with put and get functions.
-    """
-
     def __init__(self, get_func, put_func):
+        """Object with put and get functions.
+
+        Args:
+            get_func: get function
+            put_func: put function
+        """
         self.get_func = get_func
         self.put_func = put_func
 
@@ -30,11 +32,12 @@ class EndPoint(object):
 
 
 class Pipe(object):
-    """
-    Base class for communication.
-    """
-
     def __init__(self, name):
+        """Base class for communication.
+
+        Args:
+            name: name of pipe
+        """
         self.name = name
         self.x = EndPoint(self.x_get, self.x_put)
         self.y = EndPoint(self.y_get, self.y_put)

--- a/nvflare/fuel/utils/wfconf.py
+++ b/nvflare/fuel/utils/wfconf.py
@@ -26,11 +26,8 @@ from .json_scanner import JsonObjectProcessor, JsonScanner, Node
 
 
 class ConfigContext(object):
-    """
-    Object containing configuration context.
-    """
-
     def __init__(self):
+        """Object containing configuration context."""
         self.app_root = ""
         self.vars = None
         self.config_json = None
@@ -42,7 +39,7 @@ class _EnvUpdater(JsonObjectProcessor):
         JsonObjectProcessor.__init__(self)
         self.vars = vs
         if element_filter is not None and not callable(element_filter):
-            raise ValueError("element_filter must be a callable function")
+            raise ValueError("element_filter must be a callable function but got {}.".format(type(element_filter)))
         self.element_filter = element_filter
 
     def process_element(self, node: Node):
@@ -69,10 +66,6 @@ class _EnvUpdater(JsonObjectProcessor):
 
 
 class Configurator(JsonObjectProcessor):
-    """
-    Base class of Configurator to parse JSON configuration.
-    """
-
     def __init__(
         self,
         app_root: str,
@@ -87,27 +80,44 @@ class Configurator(JsonObjectProcessor):
         element_filter=None,
         var_processor=None,
     ):
+        """Base class of Configurator to parse JSON configuration.
+
+        Args:
+            app_root: app root
+            cmd_vars: command vars
+            env_config: environment configuration
+            wf_config_file_name: config file name
+            base_pkgs: base packages
+            module_names: module names
+            exclude_libs: whether to exclude libs
+            default_vars: default vars
+            num_passes: number of passes
+            element_filter: element filter
+            var_processor: variable processor
+        """
         JsonObjectProcessor.__init__(self)
 
-        assert isinstance(app_root, str), "app_root must be str"
+        assert isinstance(app_root, str), "app_root must be str but got {}.".format(type(app_root))
 
-        assert isinstance(num_passes, int), "num_passes must be int"
+        assert isinstance(num_passes, int), "num_passes must be int but got {}.".format(type(num_passes))
         assert num_passes > 0, "num_passes must > 0"
 
         if cmd_vars:
-            assert isinstance(cmd_vars, dict), "cmd_vars must be dict"
+            assert isinstance(cmd_vars, dict), "cmd_vars must be dict but got {}.".format(type(cmd_vars))
 
         if env_config:
-            assert isinstance(env_config, dict), "env_config must be dict"
+            assert isinstance(env_config, dict), "env_config must be dict but got {}.".format(type(env_config))
 
-        assert isinstance(wf_config_file_name, str), "wf_config_file_name must be str"
+        assert isinstance(wf_config_file_name, str), "wf_config_file_name must be str but got {}.".format(
+            type(wf_config_file_name)
+        )
         assert os.path.isfile(wf_config_file_name), "wf_config_file_name {} is not a valid file".format(
             wf_config_file_name
         )
         assert os.path.exists(wf_config_file_name), "wf_config_file_name {} does not exist".format(wf_config_file_name)
 
         if default_vars is not None:
-            assert isinstance(default_vars, dict), "default_vars must be dict"
+            assert isinstance(default_vars, dict), "default_vars must be dict but got {}.".format(type(default_vars))
         else:
             default_vars = {}
 
@@ -206,7 +216,7 @@ class Configurator(JsonObjectProcessor):
             return None
 
         if not isinstance(config_dict, dict):
-            raise ConfigError("component config must be dict")
+            raise ConfigError("component config must be dict but got {}.".format(type(config_dict)))
 
         if config_dict.get("disabled") is True:
             return None
@@ -227,7 +237,7 @@ class Configurator(JsonObjectProcessor):
         if "path" in config_dict.keys():
             path_spec = config_dict["path"]
             if not isinstance(path_spec, str):
-                raise ConfigError("path spec must be str")
+                raise ConfigError("path spec must be str but got {}.".format(type(path_spec)))
 
             if len(path_spec) <= 0:
                 raise ConfigError("path spec must not be empty")


### PR DESCRIPTION
Similar to #171, this addresses the pydocstyle issues through the rest of the fuel sub-directory while excluding some files that are in other PRs. Also standardizes error messages in the files modified as part of the code cleanup.

Sorry @IsaacYangSLA and @SYangster I did not realize the directories under fuel were split out until afterwards, so hopefully there is not too much wasted effort for that.