### PR TITLE
Add default FL app validator

### DIFF
--- a/nvflare/apis/app_validation.py
+++ b/nvflare/apis/app_validation.py
@@ -25,8 +25,7 @@ class AppValidationKey(object):
 class AppValidator(ABC):
     @abstractmethod
     def validate(self, app_folder: str) -> Tuple[str, Dict]:
-        """
-        Validate and/or clean the content of specified application folder.
+        """Validate and/or clean the content of specified application folder.
 
         Args:
             app_folder: path to the app folder to be validated
@@ -37,7 +36,6 @@ class AppValidator(ABC):
             error_msg contains error message if failed to pass; otherwise an empty string.
             authorization_context is the context needed by authorization.
 
-            For example: the result result could be ("", {"byoc": True, "custom_datalist": True})
-
+            For example: the result could be ("", {"byoc": True, "custom_datalist": True})
         """
         pass

--- a/nvflare/apis/workspace.py
+++ b/nvflare/apis/workspace.py
@@ -12,29 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Workspace folder structure:
-
-WSROOT
-    startup (optional)
-        provisioned content
-    runs
-        1
-            config (required)
-                config_fed_client.json
-                config_fed_server.json
-                ...
-            custom (optional)
-                custom python code
-            whatever (app defined)
-
-"""
 
 import os
 
 
-class Workspace(object):
+class Workspace:
     def __init__(self, root_dir: str, name: str, config_folder: str):
+        """Define a workspace.
+
+        NOTE::
+
+            Workspace folder structure:
+
+                Workspace ROOT
+                    startup (optional)
+                        provisioned content
+                    runs
+                        1
+                            config (required)
+                                configurations
+                            custom (optional)
+                                custom python code
+                            other_folder (app defined)
+
+        Args:
+            root_dir: root directory.
+            name: name of the workspace.
+            config_folder: where to find required config inside an app.
+        """
         self.root_dir = root_dir
         self.name = name
         self.config_folder = config_folder

--- a/nvflare/private/fed/app/default_app_validator.py
+++ b/nvflare/private/fed/app/default_app_validator.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Dict, Tuple
+
+from nvflare.apis.app_validation import AppValidationKey, AppValidator
+
+
+class DefaultAppValidator(AppValidator):
+    def validate(self, app_folder: str) -> Tuple[str, Dict]:
+        result = dict()
+        app_root = os.path.abspath(app_folder)
+        if not os.path.exists(os.path.join(app_root, "config")):
+            return "Missing config folder inside app folder.", {}
+        if not os.path.exists(os.path.join(app_root, "config", "config_fed_server.json")):
+            return "Missing config_fed_server.json inside app/config folder.", {}
+        if not os.path.exists(os.path.join(app_root, "config", "config_fed_client.json")):
+            return "Missing config_fed_client.json inside app/config folder.", {}
+        if os.path.exists(os.path.join(app_root, "custom")):
+            result[AppValidationKey.BYOC] = True
+        return "", result

--- a/nvflare/private/fed/app/fl_app_validator.py
+++ b/nvflare/private/fed/app/fl_app_validator.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional, Tuple
+
+from nvflare.apis.app_validation import AppValidator
+
+from .default_app_validator import DefaultAppValidator
+
+
+class FLAppValidator(AppValidator):
+    def __init__(self, custom_validators: Optional[List[AppValidator]] = None):
+        super().__init__()
+        self.validators = [DefaultAppValidator()]
+        if custom_validators:
+            if not isinstance(custom_validators, list):
+                raise TypeError("custom_validators must be list, but got {}".format(type(custom_validators)))
+            for validator in custom_validators:
+                if not isinstance(validator, AppValidator):
+                    raise TypeError("validator must be AppValidator, but got {}".format(type(validator)))
+                self.validators.append(validator)
+
+    def validate(self, app_folder: str) -> Tuple[str, Dict]:
+        final_result = {}
+        for v in self.validators:
+            err, result = v.validate(app_folder)
+            if err:
+                return err, result
+            if result:
+                final_result.update(result)
+        return "", final_result

--- a/nvflare/private/fed/app/fl_conf.py
+++ b/nvflare/private/fed/app/fl_conf.py
@@ -24,6 +24,7 @@ from nvflare.fuel.utils.wfconf import ConfigContext
 from nvflare.private.fed.client.base_client_deployer import BaseClientDeployer
 from nvflare.private.json_configer import JsonConfigurator
 
+from .fl_app_validator import FLAppValidator
 from .trainers.server_deployer import ServerDeployer
 
 FL_PACKAGES = ["nvflare"]
@@ -77,6 +78,7 @@ class FLServerStarterConfiger(JsonConfigurator):
         self.app_root = app_root
         self.server_config_file_name = server_config_file_name
 
+        self.deployer = None
         self.app_validator = None
         self.enable_byoc = False
 
@@ -134,6 +136,9 @@ class FLServerStarterConfiger(JsonConfigurator):
             secure_train = self.cmd_vars["secure_train"]
         if not secure_train:
             self.enable_byoc = True
+
+        custom_validators = [self.app_validator] if self.app_validator else []
+        self.app_validator = FLAppValidator(custom_validators=custom_validators)
 
         build_ctx = {
             "secure_train": secure_train,
@@ -195,6 +200,7 @@ class FLClientStarterConfiger(JsonConfigurator):
         self.app_root = app_root
         self.client_config_file_name = client_config_file_name
         self.enable_byoc = False
+        self.base_deployer = None
 
     def process_config_element(self, config_ctx: ConfigContext, node: Node):
         """Process config element.
@@ -202,7 +208,6 @@ class FLClientStarterConfiger(JsonConfigurator):
         Args:
             config_ctx: config context
             node: element node
-
         """
         # JsonConfigurator.process_config_element(self, config_ctx, node)
 
@@ -218,7 +223,6 @@ class FLClientStarterConfiger(JsonConfigurator):
 
         Args:
             config_ctx: config context
-
         """
         super().start_config(config_ctx)
 
@@ -238,7 +242,6 @@ class FLClientStarterConfiger(JsonConfigurator):
 
         Args:
             config_ctx: config context
-
         """
         secure_train = False
         if self.cmd_vars.get("secure_train"):
@@ -257,14 +260,3 @@ class FLClientStarterConfiger(JsonConfigurator):
 
         self.base_deployer = BaseClientDeployer()
         self.base_deployer.build(build_ctx)
-        # self.trainer = trainer
-        # self.client_trainer = trainer
-
-    # def build_nested(self, config_dict, app_root):
-    #     if get_config_classname(config_dict) == "ClaraEvaluator":
-    #         config_dict["args"]["app_root"] = app_root
-    #     for k in config_dict["args"]:
-    #         element = config_dict["args"][k]
-    #         if isinstance(element, dict) and element.get("args") is not None:
-    #             config_dict["args"][k] = self.build_nested(config_dict["args"][k], app_root)
-    #     return self.build_component(config_dict)


### PR DESCRIPTION
Add a default FL AppValidator to ensure the application's structure is valid.

- DefaultAppValidator: Validates an application has config folder and config_fed_server.json and config_fed_client.json inside it.
- FLAppValidator: The built-in FL app validator, by default it contains the DefaultAppValidator