### PR TITLE
Add information about cross site validation to documentation

### DIFF
--- a/docs/programming_guide/controllers/cross_site_model_evaluation.rst
+++ b/docs/programming_guide/controllers/cross_site_model_evaluation.rst
@@ -2,7 +2,8 @@
 
 Cross Site Model Evaluation / Federated Evaluation
 --------------------------------------------------
-The cross site model evaluation workflow uses the data from clients to run evaluation with the models of other clients.
+The :class:`cross site model evaluation workflow<nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval>`
+uses the data from clients to run evaluation with the models of other clients.
 Data is not shared, rather the collection of models is distributed to each client site to run local validation.  The
 results of local validation are collected by the server to construct an all-to-all matrix of model performance vs.
 client dataset.
@@ -10,6 +11,14 @@ client dataset.
 The server’s global model is also distributed to each client for evaluation on the client’s local dataset for global
 model evaluation.
 
-See the code for details:
+The `hello-numpy-cross-val example <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-pt-tb>`_ is a simple
+example that implements the :class:`cross site model evaluation workflow<nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval>`.
 
-:class:`nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval`
+.. note::
+
+   Previously in NVFlare before version 2.0, cross-site validation was built into the framework itself, and there was an
+   admin command to retrieve cross-site validation results. In NVFlare 2.0, with the ability to have customized
+   workflows, cross-site validation is no longer in the NVFlare framework but is instead handled by the workflow. The
+   the `cifar10 example <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_ is configured to run cross-site
+   model evaluation and ``config_fed_server.json`` is configured with ``pt.validation_json_generator.ValidationJsonGenerator``
+   to write the results to a JSON file on the server.

--- a/docs/user_guide/admin_commands.rst
+++ b/docs/user_guide/admin_commands.rst
@@ -53,8 +53,6 @@ commands shown as examples of how they may be run with a description.
     ,``ls clientname -SR``,List files in workspace root directory (-S: sort by file size; -R: list subdirectories recursively)
     pwd,``pwd server``,Print the name of workspace root directory
     ,``pwd clientname``,Print the name of workspace root directory
-    validate,``validate src_client dsc_client``, Gets the performance metrics for cross-site validation of a model
-    ,``validate all``, Gets the performance metrics for cross-site validation of all models
 
 
 .. tip::


### PR DESCRIPTION
Add information in the documentation about how cross site validation has changed from before 2.0 and link to example with configuration for writing cross site model evaluation results to JSON.