### PR TITLE
Fixes #301 by lowering max admin connections to 16.

### DIFF
--- a/nvflare/fuel/hci/server/hci.py
+++ b/nvflare/fuel/hci/server/hci.py
@@ -23,7 +23,7 @@ from nvflare.fuel.hci.security import get_certificate_common_name
 
 from .reg import ServerCommandRegister
 
-MAX_ADMIN_CONNECTIONS = 128
+MAX_ADMIN_CONNECTIONS = 16
 
 
 class _MsgHandler(socketserver.BaseRequestHandler):


### PR DESCRIPTION
Lowered admin connections to 16 so max memory usage is limited to 8GB.