### PR TITLE
disable byoc in provisioning

### DIFF
--- a/examples/cifar10/workspaces/secure_project.yml
+++ b/examples/cifar10/workspaces/secure_project.yml
@@ -9,6 +9,7 @@ participants:
     org: nvidia
     fed_learn_port: 8002
     admin_port: 8003
+    # enable_byoc: true would allow loading python codes in app.  Default is false. Needs to be enabled for each site if desired.
   - name: site-1
     type: client
     org: nvidia
@@ -62,8 +63,8 @@ builders:
         relaxed: 
           desc: org group with relaxed policies
           rules: 
-            allow_byoc: true
-            allow_custom_datalist: true
+            allow_byoc: false
+            allow_custom_datalist: false
       disabled: false
   - path: nvflare.lighter.impl.cert.CertBuilder
   - path: nvflare.lighter.impl.he.HEBuilder

--- a/examples/cifar10/workspaces/secure_project.yml
+++ b/examples/cifar10/workspaces/secure_project.yml
@@ -9,7 +9,8 @@ participants:
     org: nvidia
     fed_learn_port: 8002
     admin_port: 8003
-    # enable_byoc: true would allow loading python codes in app.  Default is false. Needs to be enabled for each site if desired.
+    # `enable_byoc: true` would allow loading python codes in app.  Default is false.
+    # Needs to be enabled for each site if desired. Also enable `allow_byoc` for your admin group below.
   - name: site-1
     type: client
     org: nvidia


### PR DESCRIPTION
Closes https://github.com/NVIDIA/NVFlare/issues/321

Decided to disable byoc by default as CIFAR10 example uses PYTHONPATH rather than custom code inside the app folders. Added comment showing how to enable it.