### PR TITLE
Requires implementation of fire_event method for ServerEngineSpec

### DIFF
--- a/nvflare/apis/server_engine_spec.py
+++ b/nvflare/apis/server_engine_spec.py
@@ -25,6 +25,7 @@ from .workspace import Workspace
 
 
 class ServerEngineSpec(ABC):
+    @abstractmethod
     def fire_event(self, event_type: str, fl_ctx: FLContext):
         pass
 


### PR DESCRIPTION
The implementation should write the "fire_event" method.