### PR TITLE
Add FedSM example using prostate experiment setting

### DIFF
--- a/examples/FedSM/configs/prostate_fedsm/config/config_fed_client.json
+++ b/examples/FedSM/configs/prostate_fedsm/config/config_fed_client.json
@@ -1,0 +1,35 @@
+{
+  "format_version": 2,
+
+  "executors": [
+    {
+      "tasks": [
+        "train", "submit_model", "validate"
+      ],
+      "executor": {
+        "id": "Executor",
+        "name": "LearnerExecutor",
+        "args": {
+          "learner_id": "prostate-learner"
+        }
+      }
+    }
+  ],
+
+  "task_result_filters": [
+  ],
+  "task_data_filters": [
+  ],
+
+  "components": [
+    {
+      "id": "prostate-learner",
+      "path": "pt.learners.prostate_fedsm_learner.ProstateFedSMLearner",
+      "args": {
+        "train_config_filename": "config_train.json",
+        "select_num_classes": 2,
+        "aggregation_epochs": 10
+      }
+    }
+  ]
+}

--- a/examples/FedSM/configs/prostate_fedsm/config/config_fed_server.json
+++ b/examples/FedSM/configs/prostate_fedsm/config/config_fed_server.json
@@ -1,0 +1,136 @@
+{
+  "format_version": 2,
+  "min_clients": 2,
+  "num_rounds": 100,
+  "server": {
+    "heart_beat_timeout": 600
+  },
+  "task_data_filters": [],
+  "task_result_filters": [],
+  "components": [
+    {
+      "id": "persistor_global",
+      "path": "pt.persistors.pt_file_model_persistor.PTFileModelPersistor",
+      "args": {
+        "id": "global",
+        "model_file_name": "FL_global_models.pt",
+        "best_model_file_name": "best_FL_global_models.pt",
+        "model": {
+          "path": "monai.networks.nets.unet.UNet",
+          "args": {
+            "dimensions": 3,
+            "in_channels": 1,
+            "out_channels": 1,
+            "channels": [
+              16,
+              32,
+              64,
+              128,
+              256
+            ],
+            "strides": [
+              2,
+              2,
+              2,
+              2
+            ],
+            "num_res_units": 2
+          }
+        }
+      }
+    },
+    {
+      "id": "persistor_select",
+      "path": "pt.persistors.pt_file_model_persistor_ext.PTFileModelPersistorExt",
+      "args": {
+        "id": "select",
+        "model_file_name": "FL_select_models.pt",
+        "best_model_file_name": "best_FL_select_models.pt",
+        "model": {
+          "path": "pt.networks.vgg.vgg11",
+          "args": {
+            "num_classes": 2
+          }
+        }
+      }
+    },
+    {
+      "id": "persistor_person",
+      "path": "pt.persistors.pt_file_model_persistor_personalized.PTFileModelPersistorPersonalized",
+      "args": {
+        "client_ids": [
+          "client_I2CVB",
+          "client_MSD"
+        ],
+        "model": {
+          "path": "monai.networks.nets.unet.UNet",
+          "args": {
+            "dimensions": 3,
+            "in_channels": 1,
+            "out_channels": 1,
+            "channels": [
+              16,
+              32,
+              64,
+              128,
+              256
+            ],
+            "strides": [
+              2,
+              2,
+              2,
+              2
+            ],
+            "num_res_units": 2
+          }
+        }
+      }
+    },
+    {
+      "id": "shareable_generator",
+      "path": "pt.shareablegenerators.full_model_shareable_generator_fedsm.FullModelShareableGeneratorFedSM",
+      "args": {}
+    },
+    {
+      "id": "aggregator",
+      "path": "pt.aggregators.accumulate_model_aggregator_personalized_softpull.AccumulateWeightedAggregatorPersonalizedSoftPull",
+      "args": {
+        "soft_pull_lambda": 0.8,
+        "aggregation_weights": {
+          "client_MSD": 1.0,
+          "client_I2CVB": 1.0
+        }
+      }
+    },
+    {
+      "id": "model_selector",
+      "path": "pt.handlers.intime_model_selection_fedsm_handler.IntimeModelSelectionFedSMHandler",
+      "args": {}
+    },
+    {
+      "id": "json_generator",
+      "name": "ValidationJsonGenerator",
+      "args": {}
+    }
+  ],
+  "workflows": [
+    {
+      "id": "scatter_and_gather_fedsm",
+      "path": "pt.workflows.scatter_and_gather_fedsm.ScatterAndGatherFedSM",
+      "args": {
+        "client_id_label_mapping": {"client_I2CVB": 0, "client_MSD": 1},
+        "min_clients": "{min_clients}",
+        "num_rounds": "{num_rounds}",
+        "start_round": 0,
+        "wait_time_after_min_received": 10,
+        "aggregator_id": "aggregator",
+        "persistor_id_select": "persistor_select",
+        "persistor_id_global": "persistor_global",
+        "persistor_id_person": "persistor_person",
+        "shareable_generator_id": "shareable_generator",
+        "train_task_name": "train",
+        "train_timeout": 0
+      }
+    }
+  ]
+}

--- a/examples/FedSM/configs/prostate_fedsm/config/config_train.json
+++ b/examples/FedSM/configs/prostate_fedsm/config/config_train.json
@@ -1,0 +1,8 @@
+{
+  "learning_rate": 1e-2,
+  "learning_rate_select": 1e-4,
+  "select_num_classes": 2,
+  "cache_dataset": 1.0,
+  "dataset_base_dir": "/media/ziyuexu/Research/Experiment/NVFlare/Github_Run/prostate/data_preparation/dataset",
+  "datalist_json_path": "/media/ziyuexu/Research/Experiment/NVFlare/Github_Run/prostate/data_preparation/datalists/client_All.json"
+}

--- a/examples/FedSM/pt/aggregators/accumulate_model_aggregator_personalized_softpull.py
+++ b/examples/FedSM/pt/aggregators/accumulate_model_aggregator_personalized_softpull.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import numpy as np
+
+from nvflare.apis.dxo import DXO, DataKind, MetaKey, from_shareable
+from nvflare.apis.fl_constant import ReservedKey, ReturnCode
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+from nvflare.app_common.abstract.aggregator import Aggregator
+from nvflare.app_common.app_constant import AppConstants
+
+
+class _AccuItem(object):
+    def __init__(self, client, data, steps):
+        self.client = client
+        self.data = data
+        self.steps = steps
+
+
+class AccumulateWeightedAggregatorPersonalizedSoftPull(Aggregator):
+    def __init__(self, soft_pull_lambda=0.3, exclude_vars_global=None, exclude_vars_person=None, exclude_vars_select=None, aggregation_weights=None):
+        """FedSM aggregator.
+
+        This aggregator performs two types of aggregation among received shareables from clients:
+        weighted arithmetic average for model_global and model_select
+        SoftPull aggregation for model_person
+
+        Args:
+            soft_pull_lambda: the control weight for generating person models via soft pull mechanism. Defaults to 0.3.
+            exclude_vars (list, optional) for three models (_global/person/select): if not specified (None), all layers are included;
+                    if list of variable/layer names, only specified variables are excluded;
+                    if string containing regular expression (e.g. "conv"), only matched variables are being excluded.
+                    Defaults to None.
+            aggregation_weights (dict, optional): a mapping from client names to weights. Defaults to None.
+
+        Raises:
+            ValueError: if data_kind is neither WEIGHT_DIFF nor WEIGHTS
+        """
+        super().__init__()
+        self.soft_pull_lambda = soft_pull_lambda
+        self.exclude_vars_global = re.compile(exclude_vars_global) if exclude_vars_global else None
+        self.exclude_vars_person = re.compile(exclude_vars_person) if exclude_vars_person else None
+        self.exclude_vars_select = re.compile(exclude_vars_select) if exclude_vars_select else None
+        self.aggregation_weights = aggregation_weights or {}
+        self.logger.debug(f"aggregation weights control: {aggregation_weights}")
+        # FedSM aggregator expects "COLLECTION" DXO containing all three models.
+        self.expected_data_kind = DataKind.COLLECTION
+        self.accumulator = []
+        self.warning_count = dict()
+        self.warning_limit = 10
+
+    def accept(self, shareable: Shareable, fl_ctx: FLContext) -> bool:
+        try:
+            dxo = from_shareable(shareable)
+        except:
+            self.log_exception(fl_ctx, "shareable data is not a valid DXO")
+            return False
+
+        if dxo.data_kind != self.expected_data_kind:
+            self.log_error(fl_ctx, "FedSM aggregator expect {} but got {}".format(self.expected_data_kind, dxo.data_kind))
+            return False
+
+        processed_algorithm = dxo.get_meta_prop(MetaKey.PROCESSED_ALGORITHM)
+        if processed_algorithm is not None:
+            self.log_error(fl_ctx, f"unable to accept shareable processed by {processed_algorithm}")
+            return False
+
+        current_round = fl_ctx.get_prop(AppConstants.CURRENT_ROUND)
+        self.log_debug(fl_ctx, f"current_round: {current_round}")
+        client_name = shareable.get_peer_prop(key=ReservedKey.IDENTITY_NAME, default="?")
+        contribution_round = shareable.get_header(AppConstants.CONTRIBUTION_ROUND)
+
+        rc = shareable.get_return_code()
+        if rc and rc != ReturnCode.OK:
+            self.log_info(fl_ctx, f"Client {client_name} returned rc: {rc}. Disregarding contribution.")
+            return False
+
+        data = dxo.data
+        if data is None:
+            self.log_error(fl_ctx, "no data to aggregate")
+            return False
+        n_iter = dxo.get_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND)
+
+        if contribution_round == current_round:
+            if not self._client_in_accumulator(client_name):
+                self.accumulator.append(_AccuItem(client_name, data, n_iter))
+                accepted = True
+            else:
+                self.log_info(
+                    fl_ctx,
+                    f"Discarded: Current round: {current_round} contributions already include client: {client_name}",
+                )
+                accepted = False
+        else:
+            self.log_info(
+                fl_ctx,
+                "Discarded the contribution from {} for round: {}. Current round is: {}".format(
+                    client_name, contribution_round, current_round
+                ),
+            )
+            accepted = False
+        return accepted
+
+    def _client_in_accumulator(self, client_name):
+        return any(client_name == item.client for item in self.accumulator)
+
+    def aggregate(self, fl_ctx: FLContext) -> Shareable:
+        """Aggregate model variables.
+
+        This function is not thread-safe.
+
+
+        Args:
+            fl_ctx (FLContext): System-wide FL Context
+
+        Returns:
+            Shareable: Return True to indicates the current model is the best model so far.
+        """
+        current_round = fl_ctx.get_prop(AppConstants.CURRENT_ROUND)
+        self.log_info(fl_ctx, "aggregating {} updates at round {}".format(len(self.accumulator), current_round))
+
+        # regular weighted average aggregation for global and selector models
+        model_ids = ["_model_weights_", "select_weights"]
+        aggregated_model_dict = {}
+        for model_id in model_ids:
+            acc_vars = [set(acc.data[model_id].data.keys()) for acc in self.accumulator]
+            acc_vars = set.union(*acc_vars) if acc_vars else acc_vars
+
+            # update vars that are not in exclude pattern
+            if model_id == "_model_weights_":
+                exclude_vars = self.exclude_vars_global
+            elif model_id == "select_weights":
+                exclude_vars = self.exclude_vars_select
+            vars_to_aggregate = (
+                [g_var for g_var in acc_vars if not exclude_vars.search(g_var)] if exclude_vars else acc_vars
+            )
+
+            clients_with_messages = []
+            aggregated_model = {}
+            for v_name in vars_to_aggregate:
+                n_local_iters, np_vars = [], []
+                for item in self.accumulator:
+                    client_name = item.client
+                    data = item.data[model_id].data
+
+                    n_iter = item.steps
+                    if n_iter is None:
+                        if self.warning_count.get(client_name, 0) <= self.warning_limit:
+                            self.log_warning(
+                                fl_ctx,
+                                f"NUM_STEPS_CURRENT_ROUND missing in meta of shareable"
+                                f" from {client_name} and set to default value, 1.0. "
+                                f" This kind of message will show {self.warning_limit} times at most.",
+                            )
+                            if client_name in self.warning_count:
+                                self.warning_count[client_name] = self.warning_count[client_name] + 1
+                            else:
+                                self.warning_count[client_name] = 0
+                        n_iter = 1.0
+                    if v_name not in data.keys():
+                        continue  # this acc doesn't have the variable from client
+                    float_n_iter = float(n_iter)
+                    n_local_iters.append(float_n_iter)
+                    aggregation_weight = self.aggregation_weights.get(client_name)
+                    if aggregation_weight is None:
+                        if self.warning_count.get(client_name, 0) <= self.warning_limit:
+                            self.log_warning(
+                                fl_ctx,
+                                f"Aggregation_weight missing for {client_name} and set to default value, 1.0"
+                                f" This kind of message will show {self.warning_limit} times at most.",
+                            )
+                            if client_name in self.warning_count:
+                                self.warning_count[client_name] = self.warning_count[client_name] + 1
+                            else:
+                                self.warning_count[client_name] = 0
+                        aggregation_weight = 1.0
+
+                    weighted_value = data[v_name] * float_n_iter * aggregation_weight
+                    if client_name not in clients_with_messages:
+                        if client_name in self.aggregation_weights.keys():
+                            self.log_debug(fl_ctx, f"Client {client_name} use weight {aggregation_weight} for aggregation.")
+                        else:
+                            self.log_debug(
+                                fl_ctx,
+                                f"Client {client_name} not defined in the aggregation weight list. Use default value 1.0",
+                            )
+                        clients_with_messages.append(client_name)
+                    np_vars.append(weighted_value)
+                if not n_local_iters:
+                    continue  # all acc didn't receive the variable from clients
+                new_val = np.sum(np_vars, axis=0) / np.sum(n_local_iters)
+                aggregated_model[v_name] = new_val
+            # make aggregated weights a DXO and add to dict
+            dxo_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=aggregated_model)
+            aggregated_model_dict[model_id] = dxo_weights
+
+        # SoftPull for personalized models
+        # initialize the personalized model set dict
+        aggregated_model = {}
+        model_id = "person_weights"
+        for item in self.accumulator:
+            client_name = item.client
+            aggregated_model[client_name] = {}
+        # exclude specified vars
+        acc_vars = [set(acc.data[model_id].data.keys()) for acc in self.accumulator]
+        acc_vars = set.union(*acc_vars) if acc_vars else acc_vars
+        exclude_vars = self.exclude_vars_select
+        vars_to_aggregate = (
+            [g_var for g_var in acc_vars if not exclude_vars.search(g_var)] if exclude_vars else acc_vars
+        )
+        # SoftPull aggregation, weighted without step size
+        clients_with_messages = []
+        for v_name in vars_to_aggregate:
+            # np_vars for personalized model set is a dict for each client
+            # initialize
+            np_vars = {}
+            for item in self.accumulator:
+                client_name = item.client
+                np_vars[client_name] = []
+
+            # go over the accumulator for aggregation
+            for item in self.accumulator:
+                client_name = item.client
+                data = item.data[model_id].data
+
+                if v_name not in data.keys():
+                    continue  # this acc doesn't have the variable from client
+
+                aggregation_weight = self.aggregation_weights.get(client_name)
+                if aggregation_weight is None:
+                    if self.warning_count.get(client_name, 0) <= self.warning_limit:
+                        self.log_warning(
+                            fl_ctx,
+                            f"Aggregation_weight missing for {client_name} and set to default value, 1.0"
+                            f" This kind of message will show {self.warning_limit} times at most.",
+                        )
+                        if client_name in self.warning_count:
+                            self.warning_count[client_name] = self.warning_count[client_name] + 1
+                        else:
+                            self.warning_count[client_name] = 0
+                    aggregation_weight = 1.0
+
+                if client_name not in clients_with_messages:
+                    if client_name in self.aggregation_weights.keys():
+                        self.log_debug(fl_ctx, f"Client {client_name} use weight {aggregation_weight} for aggregation.")
+                    else:
+                        self.log_debug(
+                            fl_ctx,
+                            f"Client {client_name} not defined in the aggregation weight list. Use default value 1.0",
+                        )
+                    clients_with_messages.append(client_name)
+
+                #
+                # print(acc.client)
+                # print(acc.steps)
+                # print(acc.data.keys())
+                # print(acc.data[model_id].data.keys())
+                # print(self.soft_pull_lambda)
+                # print(len(self.accumulator) - 1)
+                for aggr_item in self.accumulator:
+                    aggr_client_name = aggr_item.client
+                    if aggr_client_name == client_name:
+                        weighted_value = data[v_name] * aggregation_weight * self.soft_pull_lambda
+                    else:
+                        weighted_value = data[v_name] * aggregation_weight * (1 - self.soft_pull_lambda) / (len(self.accumulator) - 1)
+                    np_vars[aggr_client_name].append(weighted_value)
+
+            for item in self.accumulator:
+                client_name = item.client
+                new_val = np.sum(np_vars[client_name], axis=0)
+                aggregated_model[client_name][v_name] = new_val
+        # make aggregated weights a DXO and add to dict
+        dxo_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=aggregated_model)
+        aggregated_model_dict["person_weights"] = dxo_weights
+
+        self.accumulator.clear()
+        self.log_debug(fl_ctx, f"Model after aggregation: {aggregated_model_dict}")
+        dxo = DXO(data_kind=self.expected_data_kind, data=aggregated_model_dict)
+        return dxo.to_shareable()

--- a/examples/FedSM/pt/handlers/intime_model_selection_fedsm_handler.py
+++ b/examples/FedSM/pt/handlers/intime_model_selection_fedsm_handler.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from nvflare.apis.dxo import DataKind, MetaKey, from_shareable
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_component import FLComponent
+from nvflare.apis.fl_constant import FLContextKey, ReservedKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.app_event_type import AppEventType
+
+
+class IntimeModelSelectionFedSMHandler(FLComponent):
+    def __init__(self, weigh_by_local_iter=False, aggregation_weights=None):
+        """Handler to determine if the model is globally best.
+        Note that only model_global and model_select participate in this selection process, while personalized models do not
+        Args:
+            weigh_by_local_iter (bool, optional): whether the metrics should be weighted by trainer's iteration number. Defaults to False.
+            aggregation_weights (dict, optional): a mapping of client name to float for aggregation. Defaults to None.
+        """
+        super().__init__()
+
+        self.val_metric_global = self.best_val_metric_global = -np.inf
+        self.val_metric_select = self.best_val_metric_select = -np.inf
+        self.weigh_by_local_iter = weigh_by_local_iter
+        self.validation_metric_name = MetaKey.INITIAL_METRICS
+        self.aggregation_weights = aggregation_weights or {}
+
+        self.logger.debug(f"model selection weights control: {aggregation_weights}")
+        self._reset_stats()
+
+    def handle_event(self, event_type: str, fl_ctx: FLContext):
+        """Perform the handler process based on the event_type.
+
+        Args:
+            event_type (str): event type delivered from workflow
+            fl_ctx (FLContext): FL context, including peer context and other information
+        """
+        if event_type == EventType.START_RUN:
+            self._startup(fl_ctx)
+        elif event_type == EventType.BEFORE_PROCESS_SUBMISSION:
+            self._before_accept(fl_ctx)
+        elif event_type == AppEventType.BEFORE_AGGREGATION:
+            self._before_aggregate(fl_ctx)
+
+    def _startup(self, fl_ctx):
+        self._reset_stats()
+
+    def _reset_stats(self):
+        self.validation_mertic_global_weighted_sum = 0
+        self.validation_metric_global_sum_of_weights = 0
+        self.validation_mertic_select_weighted_sum = 0
+        self.validation_metric_select_sum_of_weights = 0
+
+    def _before_accept(self, fl_ctx: FLContext):
+        peer_ctx = fl_ctx.get_peer_context()
+        shareable: Shareable = peer_ctx.get_prop(FLContextKey.SHAREABLE)
+        try:
+            dxo = from_shareable(shareable)
+        except:
+            self.log_exception(fl_ctx, "shareable data is not a valid DXO")
+            return False
+
+        # check data_kind
+        if dxo.data_kind not in (DataKind.WEIGHT_DIFF, DataKind.WEIGHTS, DataKind.COLLECTION):
+            self.log_debug(fl_ctx, "I cannot handle {}".format(dxo.data_kind))
+            return False
+
+        if dxo.data is None:
+            self.log_debug(fl_ctx, "no data to filter")
+            return False
+
+        # DXO for FedSM is in "collection" format, containing three dxo objects (_model_weights_, person_weights, select_weights)
+        # together with the meta information
+        contribution_round = shareable.get_header(AppConstants.CONTRIBUTION_ROUND)
+        client_name = shareable.get_peer_prop(ReservedKey.IDENTITY_NAME, default="?")
+
+        current_round = fl_ctx.get_prop(AppConstants.CURRENT_ROUND)
+
+        if current_round == 0:
+            self.log_debug(fl_ctx, "skipping round 0")
+            return False  # There is no aggregated model at round 0
+
+        if contribution_round != current_round:
+            self.log_debug(
+                fl_ctx,
+                f"discarding shareable from {client_name} for round: {contribution_round}. Current round is: {current_round}",
+            )
+            return False
+
+        # validation metric is a list of three numbers, corresponding to the three models
+        # [model_global, model_person, model_select]
+        validation_metric = dxo.get_meta_prop(self.validation_metric_name)
+        if validation_metric is None:
+            self.log_debug(fl_ctx, f"validation metric not existing in {client_name}")
+            return False
+        else:
+            self.log_info(fl_ctx, f"validation metric {validation_metric} from client {client_name}")
+
+        if self.weigh_by_local_iter:
+            n_iter = dxo.get_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1.0)
+        else:
+            n_iter = 1.0
+
+        aggregation_weights = self.aggregation_weights.get(client_name, 1.0)
+        self.log_debug(fl_ctx, f"aggregation weight: {aggregation_weights}")
+
+        self.validation_mertic_global_weighted_sum += validation_metric[0] * n_iter * aggregation_weights
+        self.validation_metric_global_sum_of_weights += n_iter
+        self.validation_mertic_select_weighted_sum += validation_metric[2] * n_iter * aggregation_weights
+        self.validation_metric_select_sum_of_weights += n_iter
+        return True
+
+    def _before_aggregate(self, fl_ctx):
+        self.validation_mertic_global_weighted_sum = 0
+        self.validation_metric_global_sum_of_weights = 0
+        self.validation_mertic_select_weighted_sum = 0
+        self.validation_metric_select_sum_of_weights = 0
+
+        if self.validation_metric_global_sum_of_weights == 0:
+            self.log_debug(fl_ctx, "nothing accumulated for model_global")
+            return False
+        if self.validation_mertic_select_weighted_sum == 0:
+            self.log_debug(fl_ctx, "nothing accumulated for model_selector")
+            return False
+
+        self.val_metric_global = self.validation_mertic_global_weighted_sum / self.validation_metric_global_sum_of_weights
+        self.val_metric_select = self.validation_mertic_select_weighted_sum / self.validation_metric_select_sum_of_weights
+
+        self.logger.debug(f"weighted validation metric {self.val_metric}")
+        if self.val_metric_global > self.best_val_metric_global:
+            self.best_val_metric_global = self.val_metric_global
+            current_round = fl_ctx.get_prop(AppConstants.CURRENT_ROUND)
+            self.log_info(fl_ctx, f"new best validation metric for model_global at round {current_round}: {self.best_val_metric_global}")
+            # Fire event to notify that the current global model is a new best
+            self.fire_event(AppEventType.GLOBAL_BEST_MODEL_AVAILABLE, fl_ctx)
+
+        self._reset_stats()
+        return True

--- a/examples/FedSM/pt/learners/prostate_fedsm_learner.py
+++ b/examples/FedSM/pt/learners/prostate_fedsm_learner.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.optim as optim
+from monai.losses import DiceLoss
+from monai.networks.nets.unet import UNet
+
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.pt.pt_fedproxloss import PTFedProxLoss
+from nvflare.apis.signal import Signal
+
+from pt.learners.supervised_fedsm_learner import SupervisedFedSMLearner
+from pt.learners.supervised_prostate_learner import SupervisedProstateLearner
+from pt.networks.vgg import vgg11
+
+import numpy as np
+
+
+def Accuracy(output, target, topk=(1,)):
+    """Computes the accuracy over the k top predictions for the specified values of k"""
+    with torch.no_grad():
+        maxk = max(topk)
+        batch_size = target.size(0)
+
+        _, pred = output.topk(maxk, 1, True, True)
+        pred = pred.t()
+        correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+        res = []
+        for k in topk:
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
+            res.append(correct_k.mul_(100.0 / batch_size))
+        return res
+
+
+class ProstateFedSMLearner(SupervisedFedSMLearner, SupervisedProstateLearner):
+    def __init__(
+        self,
+        train_config_filename,
+        select_num_classes,
+        aggregation_epochs: int = 1,
+        train_task_name: str = AppConstants.TASK_TRAIN,
+        submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
+    ):
+        """Trainer for prostate segmentation task. It inherits from MONAI trainer.
+
+        Args:
+            train_config_filename: directory of config file.
+            train_task_name: name of the task to train the model.
+            aggregation_epochs: the number of training epochs of global model for a round. Defaults to 1.
+            select_num_classes: the number of classes for selector model. Defaults to 1.
+            submit_model_task_name: name of the task to submit the best local model.
+
+        Returns:
+            a Shareable with the updated local model after running `execute()`
+            or the best local model depending on the specified task.
+        """
+        super().__init__(
+            train_config_filename=train_config_filename,
+            aggregation_epochs=aggregation_epochs,
+            train_task_name=train_task_name,
+            submit_model_task_name=submit_model_task_name,
+        )
+        self.select_num_classes = select_num_classes
+
+    def _extra_train_config(self, fl_ctx: FLContext, config_info: str):
+        # Get the config_info
+        super()._extra_train_config(fl_ctx, config_info)
+        # FedSM and prostate specific
+        self.lr_select = config_info["learning_rate_select"]
+        self.bs_slice_select = 12
+
+        # Additional personalized and select model/criterion/optimizer
+        self.model_person = UNet(
+            dimensions=3,
+            in_channels=1,
+            out_channels=1,
+            channels=(16, 32, 64, 128, 256),
+            strides=(2, 2, 2, 2),
+            num_res_units=2,
+        ).to(self.device)
+        self.criterion_person = DiceLoss(sigmoid=True)
+        self.optimizer_person = optim.SGD(self.model_person.parameters(), lr=self.lr, momentum=0.9)
+
+        self.model_select = vgg11(
+            num_classes=self.select_num_classes,
+        ).to(self.device)
+        self.criterion_select = torch.nn.CrossEntropyLoss()
+        self.optimizer_select = optim.SGD(self.model_select.parameters(), lr=self.lr_select, momentum=0.9)
+
+    def local_train(
+        self,
+        fl_ctx,
+        train_loader,
+        abort_signal: Signal,
+        select_label,
+    ):
+        """
+        three model trainings
+        """
+        for epoch in range(self.aggregation_epochs):
+            if abort_signal.triggered:
+                return
+            self.model.train()
+            self.model_person.train()
+            self.model_select.train()
+
+            epoch_len = len(train_loader)
+            self.epoch_global = self.epoch_of_start_time + epoch
+            self.log_info(
+                fl_ctx,
+                f"Local epoch {self.client_id}: {epoch + 1}/{self.aggregation_epochs} (lr_main={self.lr}, lr_select={self.lr_select})",
+            )
+
+            for i, batch_data in enumerate(train_loader):
+                if abort_signal.triggered:
+                    return
+                # input and expected output
+                images = batch_data["image"].to(self.device)
+                labels = batch_data["label"].to(self.device)
+                # pick select_bs of 2D slices at random location as input to 2D selector model
+                slice_ct = images.size()[-1]
+                rand_idx = np.random.randint(slice_ct, size=self.bs_slice_select)
+                rand_idx = torch.tensor(rand_idx).to(self.device)
+                images_select = torch.index_select(images, -1, rand_idx)
+                # re-organize: move last axis (slices) to first, and merge with original batch
+                images_select = torch.moveaxis(images_select, -1, 0)
+                images_select = images_select.flatten(0, 1)
+                # generate label vector: image batch_size * slice batch_size, same label
+                labels_select = np.ones(images.size()[0]*self.bs_slice_select) * select_label
+                labels_select = torch.tensor(labels_select, dtype=torch.int64).to(self.device)
+
+                # zero the parameter gradients
+                self.optimizer.zero_grad()
+                self.optimizer_person.zero_grad()
+                self.optimizer_select.zero_grad()
+
+                # forward + backward + optimize
+                outputs = self.model(images)
+                outputs_person = self.model_person(images)
+                outputs_select = self.model_select(images_select)
+
+                loss = self.criterion(outputs, labels)
+                loss_person = self.criterion_person(outputs_person, labels)
+                loss_select = self.criterion_select(outputs_select, labels_select)
+
+                loss.backward()
+                loss_person.backward()
+                loss_select.backward()
+
+                self.optimizer.step()
+                self.optimizer_person.step()
+                self.optimizer_select.step()
+
+                current_step = epoch_len * self.epoch_global + i
+                self.writer.add_scalar("train_loss_global", loss.item(), current_step)
+                self.writer.add_scalar("train_loss_personalized", loss_person.item(), current_step)
+                self.writer.add_scalar("train_loss_selector", loss_select.item(), current_step)
+                
+    def local_valid(self, valid_loader, abort_signal: Signal, select_label=None, tb_id=None):
+        self.model.eval()
+        self.model_person.eval()
+        if select_label is not None:
+            self.model_select.eval()
+        with torch.no_grad():
+            metric_score_global = 0
+            metric_score_person = 0
+            metric_score_select = 0
+            for i, batch_data in enumerate(valid_loader):
+                if abort_signal.triggered:
+                    return self._abort_execution()
+                # input and expected output
+                images = batch_data["image"].to(self.device)
+                labels = batch_data["label"].to(self.device)
+                # inference
+                outputs_global = self.inferer(images, self.model)
+                outputs_global = self.transform_post(outputs_global)
+                outputs_person = self.inferer(images, self.model_person)
+                outputs_person = self.transform_post(outputs_person)
+                # compute metric
+                metric = self.valid_metric(y_pred=outputs_global, y=labels)
+                metric_score_global += metric.item()
+                metric = self.valid_metric(y_pred=outputs_person, y=labels)
+                metric_score_person += metric.item()
+
+                # validate the selector model
+                if select_label is not None:
+                    # pick select_bs of 2D slices at random location as input to 2D selector model
+                    slice_ct = images.size()[-1]
+                    rand_idx = np.random.randint(slice_ct, size=self.bs_slice_select)
+                    rand_idx = torch.tensor(rand_idx).to(self.device)
+                    images_select = torch.index_select(images, -1, rand_idx)
+                    # re-organize: move last axis (slices) to first, and merge with original batch
+                    images_select = torch.moveaxis(images_select, -1, 0)
+                    images_select = images_select.flatten(0, 1)
+
+                    # generate label vector: image batch_size * slice batch_size, same label
+                    select = np.ones(images.size()[0]*self.bs_slice_select) * select_label
+                    select = torch.tensor(select).to(self.device)
+
+                    # inference
+                    outputs_select = self.model_select(images_select)
+
+                    # compute metric
+                    metric = Accuracy(outputs_select, select, topk=(1, ))
+                    metric_score_select += metric[0].item()
+                else:
+                    metric_score_select = 0
+
+            # compute mean dice/acc over whole validation set
+            metric_score_global /= len(valid_loader)
+            metric_score_person /= len(valid_loader)
+            metric_score_select /= len(valid_loader)
+
+            if tb_id:
+                self.writer.add_scalar(tb_id + "_global", metric_score_global, self.epoch_of_start_time)
+                self.writer.add_scalar(tb_id + "_personalized", metric_score_person, self.epoch_of_start_time)
+                self.writer.add_scalar(tb_id + "_selector", metric_score_select, self.epoch_of_start_time)
+        return metric_score_global, metric_score_person, metric_score_select

--- a/examples/FedSM/pt/learners/supervised_fedsm_learner.py
+++ b/examples/FedSM/pt/learners/supervised_fedsm_learner.py
@@ -1,0 +1,505 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+import os
+
+import numpy as np
+import torch
+from torch.utils.tensorboard import SummaryWriter
+
+from nvflare.apis.dxo import DXO, DataKind, MetaKey, from_shareable
+from nvflare.apis.fl_constant import FLContextKey, ReturnCode
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import ReservedHeaderKey, Shareable, make_reply
+from nvflare.apis.signal import Signal
+from nvflare.app_common.app_constant import AppConstants, ModelName, ValidateType
+
+from pt.learners.supervised_learner import SupervisedLearner
+
+
+class SupervisedFedSMLearner(SupervisedLearner):
+    def __init__(
+        self,
+        train_config_filename,
+        aggregation_epochs: int = 1,
+        train_task_name: str = AppConstants.TASK_TRAIN,
+        submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
+    ):
+        """ Supervised Trainer for FedSM algorithm.
+
+        Args:
+            train_config_filename: path of config file, containing basic configs for fedsm training
+
+            aggregation_epochs: the number of training epochs for a round for all three models. Defaults to 1.
+                Potentially, the main and selector models can have different epochs, we used the same in this study
+            train_task_name: name of the task to train the model.
+            submit_model_task_name: name of the task to submit the best local model.
+
+        Returns:
+            a Shareable with the updated local model after running `execute()`
+            or the best local model depending on the specified task.
+        """
+        super().__init__(
+            train_config_filename=train_config_filename,
+            aggregation_epochs=aggregation_epochs,
+            train_task_name=train_task_name,
+            submit_model_task_name=submit_model_task_name,
+        )
+        # trainer init happens at the very beginning, only the basic info regarding the trainer is set here
+        # the actual run has not started at this point
+        self.best_acc_global = 0.0
+        self.best_acc_person = 0.0
+        self.best_acc_select = 0.0
+
+        # FedSM parameters
+        self.lr_select = None
+
+    def initialize(self, parts: dict, fl_ctx: FLContext):
+        super().initialize(parts=parts, fl_ctx=fl_ctx)
+        self.local_model_file_person = os.path.join(self.app_dir, "local_model_person.pt")
+        self.local_model_file_select = os.path.join(self.app_dir, "local_model_select.pt")
+        self.best_local_model_file_person = os.path.join(self.app_dir, "best_local_model_person.pt")
+        self.best_local_model_file_select = os.path.join(self.app_dir, "best_local_model_select.pt")
+
+    def save_model(self, model_id, is_best=False):
+        # save model
+        if model_id == "global":
+            model_weights = self.model.state_dict()
+            save_dict = {"model_weights": model_weights, "epoch": self.epoch_global}
+            if is_best:
+                save_dict.update({"best_acc": self.best_acc_global})
+                torch.save(save_dict, self.best_local_model_file)
+            else:
+                torch.save(save_dict, self.local_model_file)
+        elif model_id == "person":
+            model_weights = self.model_person.state_dict()
+            save_dict = {"model_weights": model_weights, "epoch": self.epoch_global}
+            if is_best:
+                save_dict.update({"best_acc": self.best_acc_person})
+                torch.save(save_dict, self.best_local_model_file_person)
+            else:
+                torch.save(save_dict, self.local_model_file_person)
+        elif model_id == "select":
+            model_weights = self.model_select.state_dict()
+            save_dict = {"model_weights": model_weights, "epoch": self.epoch_global}
+            if is_best:
+                save_dict.update({"best_acc": self.best_acc_select})
+                torch.save(save_dict, self.best_local_model_file_select)
+            else:
+                torch.save(save_dict, self.local_model_file_select)
+
+    def local_train(
+        self,
+        fl_ctx,
+        train_loader,
+        abort_signal: Signal,
+        select_label,
+    ):
+        """
+        three model trainings
+        """
+        for epoch in range(self.aggregation_epochs):
+            if abort_signal.triggered:
+                return
+            self.model.train()
+            self.model_person.train()
+            self.model_select.train()
+
+            epoch_len = len(train_loader)
+            self.epoch_global = self.epoch_of_start_time + epoch
+            self.log_info(
+                fl_ctx,
+                f"Local epoch {self.client_id}: {epoch + 1}/{self.aggregation_epochs} (lr_main={self.lr_main}, lr_select={self.lr_select})",
+            )
+
+            for i, batch_data in enumerate(train_loader):
+                if abort_signal.triggered:
+                    return
+                inputs = batch_data["image"].to(self.device)
+                labels = batch_data["label"].to(self.device)
+                # construct vector of selector label
+                labels_select = np.ones(inputs.size()[0]) * select_label
+                labels_select = torch.tensor(labels_select).to(self.device)
+
+                # zero the parameter gradients
+                self.optimizer.zero_grad()
+                self.optimizer_person.zero_grad()
+                self.optimizer_select.zero_grad()
+
+                # forward + backward + optimize
+                outputs = self.model(inputs)
+                outputs_person = self.model_person(inputs)
+                outputs_select = self.model_person(outputs_select)
+
+                loss = self.criterion(outputs, labels)
+                loss_person = self.criterion_person(outputs_person, labels)
+                loss_select = self.criterion(outputs_select, labels_select)
+
+                loss.backward()
+                loss_person.backward()
+                loss_select.backward()
+
+                self.optimizer.step()
+                self.optimizer_person.step()
+                self.optimizer_select.step()
+
+                current_step = epoch_len * self.epoch_global + i
+                self.writer.add_scalar("train_loss_global", loss.item(), current_step)
+                self.writer.add_scalar("train_loss_personalized", loss_person.item(), current_step)
+                self.writer.add_scalar("train_loss_selector", loss_select.item(), current_step)
+
+    def local_valid(self, valid_loader, abort_signal: Signal, select_label=None, tb_id=None):
+        self.model.eval()
+        self.model_person.eval()
+        self.model_select.eval()
+        with torch.no_grad():
+            total = 0
+            correct_global = 0
+            correct_person = 0
+            correct_select = 0
+            for i, (inputs, labels) in enumerate(valid_loader):
+                if abort_signal.triggered:
+                    return None
+                inputs, labels = inputs.to(self.device), labels.to(self.device)
+
+                outputs_global = self.model(inputs)
+                _, pred_label_global = torch.max(outputs_global.data, 1)
+
+                outputs_person = self.model_person(inputs)
+                _, pred_label_person = torch.max(outputs_person.data, 1)
+
+                outputs_select = self.model_select(inputs)
+                pred_label_select = outputs_select.data
+
+                total += inputs.data.size()[0]
+                correct_global += (pred_label_global == labels.data).sum().item()
+                correct_person += (pred_label_person == labels.data).sum().item()
+                correct_select += (pred_label_select == select_label).sum().item()
+
+            metric_global = correct_global / float(total)
+            metric_person = correct_person / float(total)
+            metric_select = correct_select / float(total)
+            if tb_id:
+                self.writer.add_scalar(tb_id + "global", metric_global, self.epoch_global)
+                self.writer.add_scalar(tb_id + "personalized", metric_person, self.epoch_global)
+                self.writer.add_scalar(tb_id + "selector", metric_select, self.epoch_global)
+
+        return metric_global, metric_person, metric_select
+
+    def train(
+        self,
+        shareable: Shareable,
+        fl_ctx: FLContext,
+        abort_signal: Signal,
+    ) -> Shareable:
+        # Check abort signal
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+
+        # get round information
+        current_round = shareable.get_header(AppConstants.CURRENT_ROUND)
+        total_rounds = shareable.get_header(AppConstants.NUM_ROUNDS)
+        self.log_info(fl_ctx, f"Current/Total Round: {current_round + 1}/{total_rounds}")
+        self.log_info(fl_ctx, f"Client identity: {fl_ctx.get_identity_name()}")
+
+        # update local model weights with received weights
+        dxo = from_shareable(shareable)
+        global_weights = dxo.data["_model_weights_"].data
+        person_weights = dxo.data["person_weights"].data
+        person_weights = person_weights["weights"]
+        select_weights = dxo.data["select_weights"].data
+        select_weights = select_weights["weights"]
+        select_label = dxo.data["select_label"]
+
+        # tensors might need to be reshaped to support HE for secure aggregation.
+        # Loading global model weights
+        local_var_dict = self.model.state_dict()
+        model_keys = global_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(global_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No global weights loaded for validation! Received weight dict is {global_weights}")
+        # Loading personalized model weights
+        local_var_dict = self.model_person.state_dict()
+        model_keys = person_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(person_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model_person.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No personalized weights loaded for validation! Received weight dict is {person_weights}")
+        # Loading selector model weights
+        local_var_dict = self.model_select.state_dict()
+        model_keys = select_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(select_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model_select.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No personalized weights loaded for validation! Received weight dict is {select_weights}")
+
+        # local steps
+        epoch_len = len(self.train_loader)
+        self.log_info(fl_ctx, f"Local steps per epoch: {epoch_len}")
+
+        # local train
+        self.local_train(
+            fl_ctx=fl_ctx,
+            train_loader=self.train_loader,
+            abort_signal=abort_signal,
+            select_label=select_label
+        )
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+        self.epoch_of_start_time += self.aggregation_epochs
+
+        # perform valid after local train
+        acc_global, acc_person, acc_select = self.local_valid(self.valid_loader, abort_signal,
+                                                              select_label=select_label, tb_id="val_acc_after_train")
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+        self.log_info(fl_ctx, f"val_acc_after_train: global {acc_global:.4f}, personalized {acc_person:.4f}, selector {acc_select:.4f}")
+
+        # save model
+        self.save_model(model_id="global", is_best=False)
+        self.save_model(model_id="person", is_best=False)
+        self.save_model(model_id="select", is_best=False)
+        if acc_global > self.best_acc_global:
+            self.best_acc_global = acc_global
+            self.save_model(model_id="global", is_best=True)
+        if acc_person > self.best_acc_person:
+            self.best_acc_person = acc_person
+            self.save_model(model_id="person", is_best=True)
+        if acc_select >= self.best_acc_select:
+            self.best_acc_select = acc_select
+            self.save_model(model_id="select", is_best=True)
+
+        # compute delta models, initial models has the primary key set
+        local_weights = self.model.state_dict()
+        model_diff_global = {}
+        for name in global_weights:
+            if name not in local_weights:
+                continue
+            model_diff_global[name] = local_weights[name].cpu().numpy() - global_weights[name]
+            if np.any(np.isnan(model_diff_global[name])):
+                self.system_panic(f"{name} weights became NaN...", fl_ctx)
+                return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+        local_weights = self.model_person.state_dict()
+        model_diff_person = {}
+        for name in person_weights:
+            if name not in local_weights:
+                continue
+            model_diff_person[name] = local_weights[name].cpu().numpy() - person_weights[name]
+            if np.any(np.isnan(model_diff_person[name])):
+                self.system_panic(f"{name} weights became NaN...", fl_ctx)
+                return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+        local_weights = self.model_select.state_dict()
+        model_diff_select = {}
+        for name in select_weights:
+            if name not in local_weights:
+                continue
+            model_diff_select[name] = local_weights[name].cpu().numpy() - select_weights[name]
+            if np.any(np.isnan(model_diff_select[name])):
+                self.system_panic(f"{name} weights became NaN...", fl_ctx)
+                return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+        # build the shareable
+        dxo_global_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=model_diff_global)
+        dxo_person_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=model_diff_person)
+        dxo_select_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=model_diff_select)
+
+        dxo_dict = {
+            AppConstants.MODEL_WEIGHTS: dxo_global_weights,
+            "person_weights": dxo_person_weights,
+            "select_weights": dxo_select_weights
+        }
+        dxo_collection = DXO(data_kind=DataKind.COLLECTION, data=dxo_dict)
+        dxo_collection.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, epoch_len)
+
+        self.log_info(fl_ctx, "Local epochs finished. Returning shareable")
+        return dxo_collection.to_shareable()
+
+    def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
+        # Retrieve the best local model saved during training.
+        if model_name == ModelName.BEST_MODEL:
+            model_data = None
+            try:
+                # load model to cpu as server might or might not have a GPU
+                model_data = torch.load(self.best_local_model_file, map_location="cpu")
+            except Exception as e:
+                self.log_error(fl_ctx, f"Unable to load best model_global: {e}")
+            model_data_person = None
+            try:
+                # load model to cpu as server might or might not have a GPU
+                model_data_person = torch.load(self.best_local_model_file_person, map_location="cpu")
+            except Exception as e:
+                self.log_error(fl_ctx, f"Unable to load best model_person: {e}")
+            model_data_select = None
+            try:
+                # load model to cpu as server might or might not have a GPU
+                model_data_select = torch.load(self.best_local_model_file_select, map_location="cpu")
+            except Exception as e:
+                self.log_error(fl_ctx, f"Unable to load best model_select: {e}")
+
+            # Create DXO and shareable from model data.
+            if model_data and model_data_person and model_data_select:
+                dxo_global_weights = DXO(data_kind=DataKind.WEIGHTS, data=model_data["model_weights"])
+                dxo_select_weights = DXO(data_kind=DataKind.WEIGHTS, data=model_data_person["model_weights"])
+                dxo_person_weights = DXO(data_kind=DataKind.WEIGHTS, data=model_data_select["model_weights"])
+
+                dxo_dict = {
+                    AppConstants.MODEL_WEIGHTS: dxo_global_weights,
+                    "select_weights": dxo_select_weights,
+                    "person_weights": dxo_person_weights,
+                }
+                dxo_collection = DXO(data_kind=DataKind.COLLECTION, data=dxo_dict)
+                return dxo_collection.to_shareable()
+            else:
+                # Set return code.
+                self.log_error(fl_ctx, f"best local model not found at {self.best_local_model_file}.")
+                return make_reply(ReturnCode.EXECUTION_RESULT_ERROR)
+        else:
+            raise ValueError(f"Unknown model_type: {model_name}")  # Raised errors are caught in LearnerExecutor class.
+
+    def validate(self, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> Shareable:
+        # Check abort signal
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+
+        # get validation information
+        self.log_info(fl_ctx, f"Client identity: {fl_ctx.get_identity_name()}")
+        model_owner = shareable.get(ReservedHeaderKey.HEADERS).get(AppConstants.MODEL_OWNER)
+        if model_owner:
+            self.log_info(fl_ctx, f"Evaluating model from {model_owner} on {fl_ctx.get_identity_name()}")
+        else:
+            model_owner = "model_from_server"
+
+        # update local model weights with received weights
+        # three models
+        dxo = from_shareable(shareable)
+        global_weights = dxo.data["_model_weights_"].data
+        select_weights = dxo.data["select_weights"].data
+        select_weights = select_weights["weights"]
+        person_weights = dxo.data["person_weights"].data
+        person_weights = person_weights["weights"]
+        select_label = dxo.data["select_label"]
+
+        # tensors might need to be reshaped to support HE for secure aggregation.
+        # Loading global model weights
+        local_var_dict = self.model.state_dict()
+        model_keys = global_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(global_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No global weights loaded for validation! Received weight dict is {global_weights}")
+        # Loading personalized model weights
+        local_var_dict = self.model_person.state_dict()
+        model_keys = person_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(person_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model_person.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No personalized weights loaded for validation! Received weight dict is {person_weights}")
+        # Loading selector model weights
+        local_var_dict = self.model_select.state_dict()
+        model_keys = select_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(select_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model_select.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No personalized weights loaded for validation! Received weight dict is {select_weights}")
+
+        validate_type = shareable.get_header(AppConstants.VALIDATE_TYPE)
+        if validate_type == ValidateType.BEFORE_TRAIN_VALIDATE:
+            # perform valid before local train
+            acc_global, acc_person, acc_select = self.local_valid(self.valid_loader, abort_signal, select_label=select_label, tb_id="val_acc_before_train")
+            if abort_signal.triggered:
+                return make_reply(ReturnCode.TASK_ABORTED)
+            self.log_info(fl_ctx, f"val_acc_before_train ({model_owner}): global {acc_global:.4f}, personalized {acc_person:.4f}, selector {acc_select:.4f}")
+
+            return DXO(data_kind=DataKind.METRICS, data={MetaKey.INITIAL_METRICS: [acc_global, acc_person, acc_select]}, meta={}).to_shareable()
+
+        elif validate_type == ValidateType.MODEL_VALIDATE:
+            # perform valid
+            train_acc_global, train_acc_person, _ = self.local_valid(self.train_for_valid_loader, abort_signal)
+            if abort_signal.triggered:
+                return make_reply(ReturnCode.TASK_ABORTED)
+            self.log_info(fl_ctx, f"training acc ({model_owner}): global {train_acc_global:.4f}, personalized {train_acc_person:.4f}")
+
+            val_acc_global, val_acc_person, _ = self.local_valid(self.valid_loader, abort_signal)
+            if abort_signal.triggered:
+                return make_reply(ReturnCode.TASK_ABORTED)
+            self.log_info(fl_ctx, f"validation acc ({model_owner}): global {val_acc_global:.4f}, personalized {val_acc_person:.4f}")
+
+            self.log_info(fl_ctx, "Evaluation finished. Returning shareable")
+
+            val_results = {"train_accuracy": [train_acc_global, train_acc_person], "val_accuracy": [val_acc_global, val_acc_person]}
+
+            metric_dxo = DXO(data_kind=DataKind.METRICS, data=val_results)
+            return metric_dxo.to_shareable()
+
+        else:
+            return make_reply(ReturnCode.VALIDATE_TYPE_UNKNOWN)

--- a/examples/FedSM/pt/learners/supervised_learner.py
+++ b/examples/FedSM/pt/learners/supervised_learner.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+import os
+
+import numpy as np
+import torch
+from torch.utils.tensorboard import SummaryWriter
+
+from nvflare.apis.dxo import DXO, DataKind, MetaKey, from_shareable
+from nvflare.apis.fl_constant import FLContextKey, ReturnCode
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import ReservedHeaderKey, Shareable, make_reply
+from nvflare.apis.signal import Signal
+from nvflare.app_common.abstract.learner_spec import Learner
+from nvflare.app_common.app_constant import AppConstants, ModelName, ValidateType
+
+
+class SupervisedLearner(Learner):
+    def __init__(
+        self,
+        train_config_filename,
+        aggregation_epochs: int = 1,
+        train_task_name: str = AppConstants.TASK_TRAIN,
+        submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
+    ):
+        """Simple Supervised Trainer.
+
+        Args:
+            train_config_filename: directory of config file.
+            aggregation_epochs: the number of training epochs for a round. Defaults to 1.
+            train_task_name: name of the task to train the model.
+            submit_model_task_name: name of the task to submit the best local model.
+
+        Returns:
+            a Shareable with the updated local model after running `execute()`
+            or the best local model depending on the specified task.
+        """
+        super().__init__()
+        # trainer init happens at the very beginning, only the basic info regarding the trainer is set here
+        # the actual run has not started at this point
+        self.train_config_filename = train_config_filename
+        self.aggregation_epochs = aggregation_epochs
+        self.train_task_name = train_task_name
+        self.submit_model_task_name = submit_model_task_name
+        self.best_acc = 0.0
+        self.initialized = False
+        self.app_dir = None
+
+        # Epoch counter
+        self.epoch_of_start_time = 0
+        self.epoch_global = 0
+
+        # FedProx related
+        self.fedproxloss_mu = 0.0
+        self.criterion_prox = None
+
+    def initialize(self, parts: dict, fl_ctx: FLContext):
+        # when the run starts, this is where the actual settings get initialized for trainer
+
+        # Set the paths according to fl_ctx
+        engine = fl_ctx.get_engine()
+        ws = engine.get_workspace()
+        app_config_dir = ws.get_app_config_dir(fl_ctx.get_run_number())
+        self.app_dir = ws.get_app_dir(fl_ctx.get_run_number())
+
+        self.local_model_file = os.path.join(self.app_dir, "local_model.pt")
+        self.best_local_model_file = os.path.join(self.app_dir, "best_local_model.pt")
+        train_config_file_path = os.path.join(app_config_dir, self.train_config_filename)
+
+        # get and print the args
+        fl_args = fl_ctx.get_prop(FLContextKey.ARGS)
+        self.client_id = fl_ctx.get_identity_name()
+        self.log_info(
+            fl_ctx,
+            f"Client {self.client_id} initialized with args: \n {fl_args}",
+        )
+
+        # Set local tensorboard writer - to be replaced by event
+        self.writer = SummaryWriter(self.app_dir)
+        # Set the training-related contexts
+        self.train_config(fl_ctx, train_config_file_path=train_config_file_path)
+
+    def _extra_train_config(self, fl_ctx: FLContext, config_info: dict):
+        """Additional monai traning configuration customized to individual tasks
+        Need the following implementations for further training and validation:
+        self.model
+        self.device
+        self.optimizer
+        self.criterion
+        self.transform_post
+        self.train_loader
+        self.train_for_valid_loader
+        self.valid_loader
+        self.inferer
+        self.valid_metric
+        """
+        pass
+
+    def train_config(self, fl_ctx: FLContext, train_config_file_path: str):
+        """Common monai traning configuration
+        Individual training tasks can be customized by implementing `_extra_train_config`
+        """
+
+        # Load training configurations
+        if not os.path.isfile(train_config_file_path):
+            self.log_error(
+                fl_ctx,
+                f"Training configuration file does not exist at {train_config_file_path}",
+            )
+        with open(train_config_file_path) as file:
+            config_info = json.load(file)
+
+        self._extra_train_config(fl_ctx, config_info)
+
+    def finalize(self, fl_ctx: FLContext):
+        # collect threads, close files here
+        pass
+
+    def local_train(
+        self,
+        fl_ctx,
+        train_loader,
+        model_global,
+        abort_signal: Signal,
+        val_freq: int = 0,
+    ):
+        """
+        val_freq: the validation interval for local training
+        """
+        for epoch in range(self.aggregation_epochs):
+            if abort_signal.triggered:
+                return
+            self.model.train()
+            epoch_len = len(train_loader)
+            self.epoch_global = self.epoch_of_start_time + epoch
+            self.log_info(
+                fl_ctx,
+                f"Local epoch {self.client_id}: {epoch + 1}/{self.aggregation_epochs} (lr={self.lr})",
+            )
+            for i, batch_data in enumerate(train_loader):
+                if abort_signal.triggered:
+                    return
+                inputs = batch_data["image"].to(self.device)
+                labels = batch_data["label"].to(self.device)
+
+                # zero the parameter gradients
+                self.optimizer.zero_grad()
+                # forward + backward + optimize
+                outputs = self.model(inputs)
+                loss = self.criterion(outputs, labels)
+
+                # FedProx loss term
+                if self.fedproxloss_mu > 0:
+                    fed_prox_loss = self.criterion_prox(self.model, model_global)
+                    loss += fed_prox_loss
+
+                loss.backward()
+                self.optimizer.step()
+                current_step = epoch_len * self.epoch_global + i
+                self.writer.add_scalar("train_loss", loss.item(), current_step)
+            if val_freq > 0 and epoch % val_freq == 0:
+                acc = self.local_valid(self.valid_loader, abort_signal, tb_id="val_acc_local_model")
+                if acc > self.best_acc:
+                    self.save_model(is_best=True)
+
+    def local_valid(self, valid_loader, abort_signal: Signal, tb_id=None):
+        self.model.eval()
+        with torch.no_grad():
+            correct, total = 0, 0
+            for i, (inputs, labels) in enumerate(valid_loader):
+                if abort_signal.triggered:
+                    return None
+                inputs, labels = inputs.to(self.device), labels.to(self.device)
+                outputs = self.model(inputs)
+                _, pred_label = torch.max(outputs.data, 1)
+
+                total += inputs.data.size()[0]
+                correct += (pred_label == labels.data).sum().item()
+            metric = correct / float(total)
+            if tb_id:
+                self.writer.add_scalar(tb_id, metric, self.epoch_global)
+        return metric
+
+    def save_model(self, is_best=False):
+        # save model
+        model_weights = self.model.state_dict()
+        save_dict = {"model_weights": model_weights, "epoch": self.epoch_global}
+        if is_best:
+            save_dict.update({"best_acc": self.best_acc})
+            torch.save(save_dict, self.best_local_model_file)
+        else:
+            torch.save(save_dict, self.local_model_file)
+
+    def train(
+        self,
+        shareable: Shareable,
+        fl_ctx: FLContext,
+        abort_signal: Signal,
+    ) -> Shareable:
+        # Check abort signal
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+
+        # get round information
+        current_round = shareable.get_header(AppConstants.CURRENT_ROUND)
+        total_rounds = shareable.get_header(AppConstants.NUM_ROUNDS)
+        self.log_info(fl_ctx, f"Current/Total Round: {current_round + 1}/{total_rounds}")
+        self.log_info(fl_ctx, f"Client identity: {fl_ctx.get_identity_name()}")
+
+        # update local model weights with received weights
+        dxo = from_shareable(shareable)
+        global_weights = dxo.data
+
+        # Before loading weights, tensors might need to be reshaped to support HE for secure aggregation.
+        local_var_dict = self.model.state_dict()
+        model_keys = global_weights.keys()
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = global_weights[var_name]
+                try:
+                    # reshape global weights to compute difference later on
+                    global_weights[var_name] = np.reshape(weights, local_var_dict[var_name].shape)
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(global_weights[var_name])
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model.load_state_dict(local_var_dict)
+
+        # local steps
+        epoch_len = len(self.train_loader)
+        self.log_info(fl_ctx, f"Local steps per epoch: {epoch_len}")
+
+        # make a copy of model_global as reference for potential FedProx loss
+        if self.fedproxloss_mu > 0:
+            model_global = copy.deepcopy(self.model)
+            for param in model_global.parameters():
+                param.requires_grad = False
+        else:
+            model_global = None
+
+        # local train
+        self.local_train(
+            fl_ctx=fl_ctx,
+            train_loader=self.train_loader,
+            model_global=model_global,
+            abort_signal=abort_signal,
+            val_freq=0,
+        )
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+        self.epoch_of_start_time += self.aggregation_epochs
+
+        # perform valid after local train
+        acc = self.local_valid(self.valid_loader, abort_signal, tb_id="val_acc_local_model")
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+        self.log_info(fl_ctx, f"val_acc_local_model: {acc:.4f}")
+
+        # save model
+        self.save_model(is_best=False)
+        if acc > self.best_acc:
+            self.save_model(is_best=True)
+
+        # compute delta model, global model has the primary key set
+        local_weights = self.model.state_dict()
+        model_diff = {}
+        for name in global_weights:
+            if name not in local_weights:
+                continue
+            model_diff[name] = local_weights[name].cpu().numpy() - global_weights[name]
+            if np.any(np.isnan(model_diff[name])):
+                self.system_panic(f"{name} weights became NaN...", fl_ctx)
+                return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+
+        # build the shareable
+        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=model_diff)
+        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, epoch_len)
+
+        self.log_info(fl_ctx, "Local epochs finished. Returning shareable")
+        return dxo.to_shareable()
+
+    def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
+        # Retrieve the best local model saved during training.
+        if model_name == ModelName.BEST_MODEL:
+            model_data = None
+            try:
+                # load model to cpu as server might or might not have a GPU
+                model_data = torch.load(self.best_local_model_file, map_location="cpu")
+            except Exception as e:
+                self.log_error(fl_ctx, f"Unable to load best model: {e}")
+
+            # Create DXO and shareable from model data.
+            if model_data:
+                dxo = DXO(data_kind=DataKind.WEIGHTS, data=model_data["model_weights"])
+                return dxo.to_shareable()
+            else:
+                # Set return code.
+                self.log_error(fl_ctx, f"best local model not found at {self.best_local_model_file}.")
+                return make_reply(ReturnCode.EXECUTION_RESULT_ERROR)
+        else:
+            raise ValueError(f"Unknown model_type: {model_name}")  # Raised errors are caught in LearnerExecutor class.
+
+    def validate(self, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> Shareable:
+        # Check abort signal
+        if abort_signal.triggered:
+            return make_reply(ReturnCode.TASK_ABORTED)
+
+        # get validation information
+        self.log_info(fl_ctx, f"Client identity: {fl_ctx.get_identity_name()}")
+        model_owner = shareable.get(ReservedHeaderKey.HEADERS).get(AppConstants.MODEL_OWNER)
+        if model_owner:
+            self.log_info(fl_ctx, f"Evaluating model from {model_owner} on {fl_ctx.get_identity_name()}")
+        else:
+            model_owner = "global_model"
+
+        # update local model weights with received weights
+        dxo = from_shareable(shareable)
+        global_weights = dxo.data
+
+        # Before loading weights, tensors might need to be reshaped to support HE for secure aggregation.
+        local_var_dict = self.model.state_dict()
+        model_keys = global_weights.keys()
+        n_loaded = 0
+        for var_name in local_var_dict:
+            if var_name in model_keys:
+                weights = torch.as_tensor(global_weights[var_name], device=self.device)
+                try:
+                    # update the local dict
+                    local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
+                    n_loaded += 1
+                except Exception as e:
+                    raise ValueError("Convert weight from {} failed with error: {}".format(var_name, str(e)))
+        self.model.load_state_dict(local_var_dict)
+        if n_loaded == 0:
+            raise ValueError(f"No weights loaded for validation! Received weight dict is {global_weights}")
+
+        validate_type = shareable.get_header(AppConstants.VALIDATE_TYPE)
+        if validate_type == ValidateType.BEFORE_TRAIN_VALIDATE:
+            # perform valid before local train
+            global_acc = self.local_valid(self.valid_loader, abort_signal, tb_id="val_acc_global_model")
+            if abort_signal.triggered:
+                return make_reply(ReturnCode.TASK_ABORTED)
+            self.log_info(fl_ctx, f"val_acc_global_model ({model_owner}): {global_acc:.4f}")
+
+            return DXO(data_kind=DataKind.METRICS, data={MetaKey.INITIAL_METRICS: global_acc}, meta={}).to_shareable()
+
+        elif validate_type == ValidateType.MODEL_VALIDATE:
+            # perform valid
+            train_acc = self.local_valid(self.train_for_valid_loader, abort_signal)
+            if abort_signal.triggered:
+                return make_reply(ReturnCode.TASK_ABORTED)
+            self.log_info(fl_ctx, f"training acc ({model_owner}): {train_acc:.4f}")
+
+            val_acc = self.local_valid(self.valid_loader, abort_signal)
+            if abort_signal.triggered:
+                return make_reply(ReturnCode.TASK_ABORTED)
+            self.log_info(fl_ctx, f"validation acc ({model_owner}): {val_acc:.4f}")
+
+            self.log_info(fl_ctx, "Evaluation finished. Returning shareable")
+
+            val_results = {"train_accuracy": train_acc, "val_accuracy": val_acc}
+
+            metric_dxo = DXO(data_kind=DataKind.METRICS, data=val_results)
+            return metric_dxo.to_shareable()
+
+        else:
+            return make_reply(ReturnCode.VALIDATE_TYPE_UNKNOWN)

--- a/examples/FedSM/pt/learners/supervised_prostate_learner.py
+++ b/examples/FedSM/pt/learners/supervised_prostate_learner.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+import torch.optim as optim
+from monai.data import CacheDataset, DataLoader, Dataset, load_decathlon_datalist
+from monai.inferers import SlidingWindowInferer
+from monai.losses import DiceLoss
+from monai.metrics import DiceMetric
+from monai.networks.nets.unet import UNet
+from monai.transforms import (
+    Activations,
+    AsDiscrete,
+    Compose,
+    DivisiblePadd,
+    EnsureChannelFirstd,
+    EnsureType,
+    EnsureTyped,
+    LoadImaged,
+    NormalizeIntensityd,
+    Orientationd,
+    RandCropByPosNegLabeld,
+    RandFlipd,
+    RandScaleIntensityd,
+    RandShiftIntensityd,
+    Spacingd,
+)
+from pt.utils.custom_client_datalist_json_path import custom_client_datalist_json_path
+
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.signal import Signal
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.pt.pt_fedproxloss import PTFedProxLoss
+
+from pt.learners.supervised_learner import SupervisedLearner
+
+
+class SupervisedProstateLearner(SupervisedLearner):
+    def __init__(
+        self,
+        train_config_filename,
+        aggregation_epochs: int = 1,
+        train_task_name: str = AppConstants.TASK_TRAIN,
+        submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
+    ):
+        """Trainer for prostate segmentation task. It inherits from MONAI trainer.
+
+        Args:
+            train_config_filename: directory of config file.
+            aggregation_epochs: the number of training epochs for a round.
+            train_task_name: name of the task to train the model.
+            submit_model_task_name: name of the task to submit the best local model.
+
+        Returns:
+            a Shareable with the updated local model after running `execute()`
+            or the best local model depending on the specified task.
+        """
+        super().__init__(
+            train_config_filename=train_config_filename,
+            aggregation_epochs=aggregation_epochs,
+            train_task_name=train_task_name,
+            submit_model_task_name=submit_model_task_name,
+        )
+
+    def _extra_train_config(self, fl_ctx: FLContext, config_info: str):
+        # Get the config_info
+        self.lr = config_info["learning_rate"]
+        if "fedproxloss_mu" in config_info:
+            self.fedproxloss_mu = config_info["fedproxloss_mu"]
+        else:
+            self.fedproxloss_mu = 0
+
+        self.roi_size = config_info.get("roi_size", (224, 224, 32))
+        self.infer_roi_size = config_info.get("infer_roi_size", (224, 224, 32))
+        cache_rate = config_info["cache_dataset"]
+        dataset_base_dir = config_info["dataset_base_dir"]
+        datalist_json_path = config_info["datalist_json_path"]
+
+        # Get datalist json
+        datalist_json_path = custom_client_datalist_json_path(datalist_json_path, self.client_id)
+
+        # Set datalist
+        train_list = load_decathlon_datalist(
+            data_list_file_path=datalist_json_path,
+            is_segmentation=True,
+            data_list_key="training",
+            base_dir=dataset_base_dir,
+        )
+        valid_list = load_decathlon_datalist(
+            data_list_file_path=datalist_json_path,
+            is_segmentation=True,
+            data_list_key="validation",
+            base_dir=dataset_base_dir,
+        )
+        self.log_info(
+            fl_ctx,
+            f"Training Size: {len(train_list)}, Validation Size: {len(valid_list)}",
+        )
+
+        # Set the training-related context
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        self.model = UNet(
+            dimensions=3,
+            in_channels=1,
+            out_channels=1,
+            channels=(16, 32, 64, 128, 256),
+            strides=(2, 2, 2, 2),
+            num_res_units=2,
+        ).to(self.device)
+        self.optimizer = optim.SGD(self.model.parameters(), lr=self.lr, momentum=0.9)
+        self.criterion = DiceLoss(sigmoid=True)
+        if self.fedproxloss_mu > 0:
+            self.log_info(fl_ctx, f"using FedProx loss with mu {self.fedproxloss_mu}")
+            self.criterion_prox = PTFedProxLoss(mu=self.fedproxloss_mu)
+
+        self.transform_train = Compose(
+            [
+                LoadImaged(keys=["image", "label"]),
+                EnsureChannelFirstd(keys=["image", "label"]),
+                Spacingd(
+                    keys=["image", "label"],
+                    pixdim=(0.3, 0.3, 1.0),
+                    mode=("bilinear", "nearest"),
+                ),
+                DivisiblePadd(keys=["image", "label"], k=32),
+                Orientationd(keys=["image", "label"], axcodes="RAS"),
+                RandCropByPosNegLabeld(
+                    keys=["image", "label"],
+                    label_key="label",
+                    spatial_size=self.roi_size,
+                    pos=1,
+                    neg=1,
+                    num_samples=4,
+                ),
+                RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=0),
+                RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=1),
+                RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=2),
+                NormalizeIntensityd(keys="image", nonzero=True, channel_wise=True),
+                RandScaleIntensityd(keys="image", factors=0.1, prob=1.0),
+                RandShiftIntensityd(keys="image", offsets=0.1, prob=1.0),
+                EnsureTyped(keys=["image", "label"]),
+            ]
+        )
+        self.transform_valid = Compose(
+            [
+                LoadImaged(keys=["image", "label"]),
+                EnsureChannelFirstd(keys=["image", "label"]),
+                Spacingd(
+                    keys=["image", "label"],
+                    pixdim=(0.3, 0.3, 1.0),
+                    mode=("bilinear", "nearest"),
+                ),
+                DivisiblePadd(keys=["image", "label"], k=32),
+                Orientationd(keys=["image", "label"], axcodes="RAS"),
+                NormalizeIntensityd(keys="image", nonzero=True, channel_wise=True),
+                EnsureTyped(keys=["image", "label"]),
+            ]
+        )
+        self.transform_post = Compose([EnsureType(), Activations(sigmoid=True), AsDiscrete(threshold=0.5)])
+
+        # Set dataset
+        if cache_rate > 0.0:
+            self.train_dataset = CacheDataset(
+                data=train_list,
+                transform=self.transform_train,
+                cache_rate=cache_rate,
+                num_workers=4,
+            )
+        else:
+            self.train_dataset = Dataset(
+                data=train_list,
+                transform=self.transform_train,
+            )
+        self.train_dataset_for_valid = Dataset(
+            data=train_list,
+            transform=self.transform_valid,
+        )
+        self.valid_dataset = Dataset(
+            data=valid_list,
+            transform=self.transform_valid,
+        )
+
+        self.train_loader = DataLoader(
+            self.train_dataset,
+            batch_size=1,
+            shuffle=True,
+            num_workers=2,
+        )
+        self.train_for_valid_loader = DataLoader(
+            self.train_dataset_for_valid,
+            batch_size=1,
+            shuffle=False,
+            num_workers=2,
+        )
+        self.valid_loader = DataLoader(
+            self.valid_dataset,
+            batch_size=1,
+            shuffle=False,
+            num_workers=2,
+        )
+
+        # Set inferer and evaluation metric
+        self.inferer = SlidingWindowInferer(roi_size=self.infer_roi_size, sw_batch_size=4, overlap=0.25)
+        self.valid_metric = DiceMetric(include_background=True, reduction="mean", get_not_nans=False)
+
+    def local_valid(self, valid_loader, abort_signal: Signal, tb_id=None):
+        self.model.eval()
+        with torch.no_grad():
+            metric_score = 0
+            for i, batch_data in enumerate(valid_loader):
+                if abort_signal.triggered:
+                    return self._abort_execution()
+                val_images = batch_data["image"].to(self.device)
+                val_labels = batch_data["label"].to(self.device)
+                # Inference
+                val_outputs = self.inferer(val_images, self.model)
+                val_outputs = self.transform_post(val_outputs)
+                # Compute metric
+                metric = self.valid_metric(y_pred=val_outputs, y=val_labels)
+                metric_score += metric.item()
+            # compute mean dice over whole validation set
+            metric_score /= len(valid_loader)
+            if tb_id:
+                self.writer.add_scalar(tb_id, metric_score, self.epoch_of_start_time)
+        return metric_score

--- a/examples/FedSM/pt/networks/vgg.py
+++ b/examples/FedSM/pt/networks/vgg.py
@@ -1,0 +1,197 @@
+import torch
+import torch.nn as nn
+from torch.hub import load_state_dict_from_url
+from typing import Union, List, Dict, Any, cast
+
+
+__all__ = [
+    'VGG', 'vgg11', 'vgg11_bn', 'vgg13', 'vgg13_bn', 'vgg16', 'vgg16_bn',
+    'vgg19_bn', 'vgg19',
+]
+
+
+model_urls = {
+    'vgg11': 'https://download.pytorch.org/models/vgg11-8a719046.pth',
+    'vgg13': 'https://download.pytorch.org/models/vgg13-19584684.pth',
+    'vgg16': 'https://download.pytorch.org/models/vgg16-397923af.pth',
+    'vgg19': 'https://download.pytorch.org/models/vgg19-dcbb9e9d.pth',
+    'vgg11_bn': 'https://download.pytorch.org/models/vgg11_bn-6002323d.pth',
+    'vgg13_bn': 'https://download.pytorch.org/models/vgg13_bn-abd245e5.pth',
+    'vgg16_bn': 'https://download.pytorch.org/models/vgg16_bn-6c64b313.pth',
+    'vgg19_bn': 'https://download.pytorch.org/models/vgg19_bn-c79401a0.pth',
+}
+
+
+class VGG(nn.Module):
+
+    def __init__(
+        self,
+        features: nn.Module,
+        num_classes: int = 1000,
+        init_weights: bool = True
+    ) -> None:
+        super(VGG, self).__init__()
+        self.features = features
+        self.avgpool = nn.AdaptiveAvgPool2d((7, 7))
+        self.classifier = nn.Sequential(
+            nn.Linear(512 * 7 * 7, 4096),
+            nn.ReLU(True),
+            nn.Dropout(),
+            nn.Linear(4096, 4096),
+            nn.ReLU(True),
+            nn.Dropout(),
+            nn.Linear(4096, num_classes),
+        )
+        if init_weights:
+            self._initialize_weights()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = self.avgpool(x)
+        feature = torch.flatten(x, 1)
+        x = self.classifier(feature)
+        return x
+
+    def _initialize_weights(self) -> None:
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                nn.init.constant_(m.bias, 0)
+
+
+def make_layers(cfg: List[Union[str, int]], batch_norm: bool = False) -> nn.Sequential:
+    layers: List[nn.Module] = []
+    in_channels = 1
+    for v in cfg:
+        if v == 'M':
+            layers += [nn.MaxPool2d(kernel_size=2, stride=2)]
+        else:
+            v = cast(int, v)
+            conv2d = nn.Conv2d(in_channels, v, kernel_size=3, padding=1)
+            if batch_norm:
+                layers += [conv2d, nn.BatchNorm2d(v), nn.ReLU(inplace=True)]
+            else:
+                layers += [conv2d, nn.ReLU(inplace=True)]
+            in_channels = v
+    return nn.Sequential(*layers)
+
+
+cfgs: Dict[str, List[Union[str, int]]] = {
+    'A': [64, 'M', 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M'],
+    'B': [64, 64, 'M', 128, 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M'],
+    'D': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 'M', 512, 512, 512, 'M', 512, 512, 512, 'M'],
+    'E': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 256, 'M', 512, 512, 512, 512, 'M', 512, 512, 512, 512, 'M'],
+}
+
+
+def _vgg(arch: str, cfg: str, batch_norm: bool, pretrained: bool, progress: bool, **kwargs: Any) -> VGG:
+    if pretrained:
+        kwargs['init_weights'] = False
+    model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), **kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def vgg11(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 11-layer model (configuration "A") from
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg11', 'A', False, pretrained, progress, **kwargs)
+
+
+
+def vgg11_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 11-layer model (configuration "A") with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg11_bn', 'A', True, pretrained, progress, **kwargs)
+
+
+
+def vgg13(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 13-layer model (configuration "B")
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg13', 'B', False, pretrained, progress, **kwargs)
+
+
+
+def vgg13_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 13-layer model (configuration "B") with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg13_bn', 'B', True, pretrained, progress, **kwargs)
+
+
+
+def vgg16(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 16-layer model (configuration "D")
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg16', 'D', False, pretrained, progress, **kwargs)
+
+
+
+def vgg16_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 16-layer model (configuration "D") with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg16_bn', 'D', True, pretrained, progress, **kwargs)
+
+
+
+def vgg19(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 19-layer model (configuration "E")
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg19', 'E', False, pretrained, progress, **kwargs)
+
+
+
+def vgg19_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
+    r"""VGG 19-layer model (configuration 'E') with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg('vgg19_bn', 'E', True, pretrained, progress, **kwargs)

--- a/examples/FedSM/pt/persistors/pt_fed_utils.py
+++ b/examples/FedSM/pt/persistors/pt_fed_utils.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections import OrderedDict
+
+import torch
+import torch.nn as nn
+
+from nvflare.apis.dxo import MetaKey
+from nvflare.app_common.abstract.model import (
+    ModelLearnable,
+    ModelLearnableKey,
+    make_model_learnable,
+    validate_model_learnable,
+)
+from nvflare.app_common.app_constant import ModelFormat
+
+
+class PTModelPersistenceFormatManagerPersonalized(object):
+
+    PERSISTENCE_KEY_PER_MODELS = "personalized_models"
+    PERSISTENCE_KEY_TRAIN_CONF = "train_conf"
+    PERSISTENCE_KEY_META_PROPS = "meta_props"
+
+    def __init__(self, data: dict, default_train_conf=None):
+        """Manage the format for model persistence.
+
+        Args:
+            data (dict): a dict of dict.
+            default_train_conf (dict, optional): configuration for train. Defaults to None.
+
+        Raises:
+            TypeError: when data is not a dictionary
+        """
+        if not isinstance(data, dict):
+            raise TypeError("data must be a dict but got {}".format(type(data)))
+
+        self.var_dict = None
+        self.model_dict = None
+        self.meta = None
+        self.train_conf = None
+        self.other_props = {}  # other props from the original data that need to be kept
+
+        # dict of dicts
+        self.model_dict = data[self.PERSISTENCE_KEY_PER_MODELS]
+        self.meta = data.get(self.PERSISTENCE_KEY_META_PROPS, None)
+        self.train_conf = data.get(self.PERSISTENCE_KEY_TRAIN_CONF, None)
+
+        # we need to keep other props, if any, so they can be kept when persisted
+        for k, v in data.items():
+            if k not in [
+                self.PERSISTENCE_KEY_PER_MODELS,
+                self.PERSISTENCE_KEY_META_PROPS,
+                self.PERSISTENCE_KEY_TRAIN_CONF,
+            ]:
+                self.other_props[k] = v
+
+        if not self.train_conf:
+            self.train_conf = default_train_conf
+
+    def _get_processed_vars(self) -> dict:
+        if self.meta:
+            return self.meta.get(MetaKey.PROCESSED_KEYS, {})
+        else:
+            return {}
+
+    def to_model_learnable(self, exclude_vars) -> dict:
+        processed_vars = self._get_processed_vars()
+        models = {}
+        for client_id in self.model_dict.keys():
+            weights = OrderedDict()
+            var_dict = self.model_dict[client_id]
+            for k, v in var_dict.items():
+                if exclude_vars and exclude_vars.search(k):
+                    continue
+
+                is_processed = processed_vars.get(k, False)
+                if is_processed:
+                    weights[k] = v
+                else:
+                    weights[k] = v.cpu().numpy()
+            models[client_id] = make_model_learnable(weights, self.meta)
+        return models
+
+    def to_persistence_dict(self) -> dict:
+        processed_vars = self._get_processed_vars()
+        models = {}
+        for client_id in self.model_dict.keys():
+            weights_dict = OrderedDict()
+            var_dict = self.model_dict[client_id]
+            for k, v in var_dict.items():
+                is_processed = processed_vars.get(k, False)
+                if is_processed:
+                    weights_dict[k] = v
+                else:
+                    weights_dict[k] = torch.as_tensor(v)
+            models[client_id] = weights_dict
+
+        # always use complex format for saving
+        persistence_dict = OrderedDict()
+        persistence_dict[self.PERSISTENCE_KEY_PER_MODELS] = models
+        if self.meta:
+            persistence_dict[self.PERSISTENCE_KEY_META_PROPS] = self.meta
+        if self.train_conf:
+            persistence_dict[self.PERSISTENCE_KEY_TRAIN_CONF] = self.train_conf
+        if self.other_props:
+            for k, v in self.other_props.items():
+                persistence_dict[k] = v
+        return persistence_dict
+
+    def update(self, ml_dict: dict):
+        """Update the persistence data with the learned values.
+
+        Args:
+            ml_dict (Dict of ModelLearnable): updated information to be merged into existing Dict of ModelLearnable
+        """
+        for client_id in ml_dict.keys():
+            if client_id != "meta":
+                ml = ml_dict[client_id]
+                # update with value of the model learnable
+                # note that the original weights that are not learned are still kept!
+                learned_weights = ml[ModelLearnableKey.WEIGHTS]
+                for k, v in learned_weights.items():
+                    self.model_dict[client_id][k] = v
+
+    def get_persist_model_format(self):
+        return ModelFormat.PT_CHECKPOINT

--- a/examples/FedSM/pt/persistors/pt_file_model_persistor.py
+++ b/examples/FedSM/pt/persistors/pt_file_model_persistor.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import re
+from collections import OrderedDict
+
+import torch
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.abstract.model import ModelLearnable
+from nvflare.app_common.abstract.model_persistor import ModelPersistor
+from nvflare.app_common.app_constant import AppConstants, DefaultCheckpointFileName, EnvironmentKey
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.model_desc import ModelDescriptor
+from nvflare.app_common.pt.pt_fed_utils import PTModelPersistenceFormatManager
+
+
+class PTFileModelPersistor(ModelPersistor):
+    def __init__(
+        self,
+        exclude_vars=None,
+        model=None,
+        id=None,
+        model_file_name="FL_models.pt",
+        best_model_file_name="best_FL_models.pt",
+        source_ckpt_file_full_name=None,
+    ):
+        """Persist pytorch-based model to/from file system.
+
+        This Model Persistor tries to load PT model data in following three ways:
+
+        1. Load from a specified source checkpoint file
+        2. Load from a location from the app folder
+        3. Load from a torch model object
+
+        The Persistor tries method 1 first if the source_ckpt_file_full_name is specified;
+        If source_ckpt_file_full_name is not specified, it tries the method 2;
+        If no checkpoint location is specified in the app folder, it tries method 3.
+
+        Method 2 - Load from a location from the app folder
+        It is assumed that the app folder must contain the environments.json file. Among other things, this
+        JSON file must specify where to find the checkpoint file. It does so with two JSON elements:
+
+            APP_CKPT_DIR - this element specifies the folder (within the app) where the checkpoint file resides.
+            APP_CKPT - this element specified the base file name of the checkpoint
+
+        Here is an example of the environments.json content:
+
+            {
+                "APP_CKPT_DIR": "model",
+                "APP_CKPT": "pretrained_model.pt"
+            }
+
+        In this example, the checkpoint file is located in the "model" folder within the app and is named
+        pretrained_model.pt.
+
+        Method 3 - Load from a torch model object. In this case, the 'model' arg must be a valid torch
+        model, or the component ID of a valid torch model included in the "components" section of
+        your config_fed_server.json.
+
+        If all 3 methods fail, system_panic() is called.
+
+        If checkpoint folder name is specified, then global model and best global model will be saved to it;
+        Otherwise they will be saved directly in the app folder.
+        Args:
+            exclude_vars (str, optional): regex expression specifying weight vars to be excluded from training. Defaults to None.
+            model (str, optional): torch model object or component id of the model object. Defaults to None.
+            model_file_name (str, optional): file name for saving global model. Defaults to DefaultCheckpointFileName.GLOBAL_MODEL.
+            best_model_file_name (str, optional): file name for saving best global model. Defaults to DefaultCheckpointFileName.BEST_GLOBAL_MODEL.
+            source_ckpt_file_full_name (str, optional): full file name for source model checkpoint file. Defaults to None.
+
+        Raises:
+            ValueError: when source_ckpt_file_full_name does not exist
+        """
+        super().__init__()
+        self.exclude_vars = re.compile(exclude_vars) if exclude_vars else None
+        self.model = model
+        self.id = id
+        self.log_dir = None
+        self.ckpt_preload_path = None
+        self.persistence_manager = None
+        self.ckpt_dir_env_key = EnvironmentKey.CHECKPOINT_DIR
+        self.ckpt_file_name_env_key = EnvironmentKey.CHECKPOINT_FILE_NAME
+        self.model_file_name = model_file_name
+        self.best_model_file_name = best_model_file_name
+        self.source_ckpt_file_full_name = source_ckpt_file_full_name
+
+        self.default_train_conf = None
+
+        if source_ckpt_file_full_name and not os.path.exists(source_ckpt_file_full_name):
+            raise ValueError("specified source checkpoint model file {} does not exist")
+
+    def _initialize(self, fl_ctx: FLContext):
+        self.log_info(fl_ctx, self.id + " persistor initialized")
+        app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+        env = None
+        run_args = fl_ctx.get_prop(FLContextKey.ARGS)
+        if run_args:
+            env_config_file_name = os.path.join(app_root, run_args.env)
+            if os.path.exists(env_config_file_name):
+                try:
+                    with open(env_config_file_name) as file:
+                        env = json.load(file)
+                except:
+                    self.system_panic(
+                        reason="error opening env config file {}".format(env_config_file_name), fl_ctx=fl_ctx
+                    )
+                    return
+
+        if env is not None:
+            if env.get(self.ckpt_dir_env_key, None):
+                fl_ctx.set_prop(AppConstants.LOG_DIR, env[self.ckpt_dir_env_key], private=True, sticky=True)
+            if env.get(self.ckpt_file_name_env_key) is not None:
+                fl_ctx.set_prop(
+                    AppConstants.CKPT_PRELOAD_PATH, env[self.ckpt_file_name_env_key], private=True, sticky=True
+                )
+
+        log_dir = fl_ctx.get_prop(AppConstants.LOG_DIR)
+        if log_dir:
+            self.log_dir = os.path.join(app_root, log_dir)
+        else:
+            self.log_dir = app_root
+
+        self._ckpt_save_path = os.path.join(self.log_dir, self.model_file_name)
+        self._best_ckpt_save_path = os.path.join(self.log_dir, self.best_model_file_name)
+
+        ckpt_preload_path = fl_ctx.get_prop(AppConstants.CKPT_PRELOAD_PATH)
+        if ckpt_preload_path:
+            self.ckpt_preload_path = os.path.join(app_root, ckpt_preload_path)
+
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+
+        if isinstance(self.model, str):
+            # treat it as model component ID
+            model_component_id = self.model
+            engine = fl_ctx.get_engine()
+            self.model = engine.get_component(model_component_id)
+            if not self.model:
+                self.system_panic(reason="cannot find model component '{}'".format(model_component_id), fl_ctx=fl_ctx)
+                return
+            if not isinstance(self.model, torch.nn.Module):
+                self.system_panic(
+                    reason="expect model component '{}' to be torch.nn.Module but got {}".format(
+                        model_component_id, type(self.model)
+                    ),
+                    fl_ctx=fl_ctx,
+                )
+                return
+        elif self.model and not isinstance(self.model, torch.nn.Module):
+            self.system_panic(
+                reason="expect model to be torch.nn.Module but got {}".format(type(self.model)), fl_ctx=fl_ctx
+            )
+            return
+
+        fl_ctx.sync_sticky()
+
+    def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
+        """Convert initialised model into Learnable/Model format.
+
+        Args:
+            fl_ctx (FLContext): FL Context delivered by workflow
+
+        Returns:
+            Model: a Learnable/Model object
+        """
+        src_file_name = None
+        if self.source_ckpt_file_full_name:
+            src_file_name = self.source_ckpt_file_full_name
+        elif self.ckpt_preload_path:
+            src_file_name = self.ckpt_preload_path
+
+        if src_file_name:
+            try:
+                device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+                data = torch.load(src_file_name, map_location=device)
+                # "checkpoint may contain 'model', 'optimizer', 'lr_scheduler', etc. or only contain model dict directly."
+            except:
+                self.log_exception(fl_ctx, "error loading checkpoint from {}".format(src_file_name))
+                self.system_panic(reason="cannot load model checkpoint", fl_ctx=fl_ctx)
+                return None
+        else:
+            # if no pretrained model provided, use the generated network weights from APP config
+            # note that, if set "determinism" in the config, the init model weights will always be the same
+            try:
+                data = self.model.state_dict() if self.model is not None else OrderedDict()
+            except:
+                self.log_exception(fl_ctx, "error getting state_dict from model object")
+                self.system_panic(reason="cannot create state_dict from model object", fl_ctx=fl_ctx)
+                return None
+
+        if self.model:
+            self.default_train_conf = {"train": {"model": type(self.model).__name__}}
+
+        self.persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
+        return self.persistence_manager.to_model_learnable(self.exclude_vars)
+
+    def handle_event(self, event: str, fl_ctx: FLContext):
+        if event == EventType.START_RUN:
+            self._initialize(fl_ctx)
+        elif event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE:
+            # save the current model as the best model!
+            self.save_model_file(self._best_ckpt_save_path)
+
+    def save_model_file(self, save_path: str):
+        save_dict = self.persistence_manager.to_persistence_dict()
+        torch.save(save_dict, save_path)
+
+    def save_model(self, ml: ModelLearnable, fl_ctx: FLContext):
+        self.persistence_manager.update(ml)
+        self.save_model_file(self._ckpt_save_path)
+
+    def get_model(self, model_file, fl_ctx: FLContext) -> ModelLearnable:
+        try:
+            # device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+            # Use the "cpu" to load the global model weights, avoid GPU out of memory
+            device = "cpu"
+            location = os.path.join(self.log_dir, model_file)
+            data = torch.load(location, map_location=device)
+            persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
+            return persistence_manager.to_model_learnable(self.exclude_vars)
+        except BaseException as e:
+            self.log_exception(fl_ctx, "error loading checkpoint from {}".format(model_file))
+            return {}
+
+    def get_model_inventory(self, fl_ctx: FLContext) -> {str: ModelDescriptor}:
+        model_inventory = {}
+        location = os.path.join(self.log_dir, self.model_file_name)
+        if os.path.exists(location):
+            model_inventory[self.model_file_name] = ModelDescriptor(
+                name=self.model_file_name,
+                location=location,
+                model_format=self.persistence_manager.get_persist_model_format(),
+                props={},
+            )
+
+        location = os.path.join(self.log_dir, self.best_model_file_name)
+        if os.path.exists(location):
+            model_inventory[self.best_model_file_name] = ModelDescriptor(
+                name=self.best_model_file_name,
+                location=location,
+                model_format=self.persistence_manager.get_persist_model_format(),
+                props={},
+            )
+
+        return model_inventory

--- a/examples/FedSM/pt/persistors/pt_file_model_persistor_ext.py
+++ b/examples/FedSM/pt/persistors/pt_file_model_persistor_ext.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import re
+from collections import OrderedDict
+
+import torch
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.abstract.model import ModelLearnable
+from nvflare.app_common.abstract.model_persistor import ModelPersistor
+from nvflare.app_common.app_constant import AppConstants, DefaultCheckpointFileName, EnvironmentKey
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.model_desc import ModelDescriptor
+from nvflare.app_common.pt.pt_fed_utils import PTModelPersistenceFormatManager
+
+
+class PTFileModelPersistorExt(ModelPersistor):
+    def __init__(
+        self,
+        exclude_vars=None,
+        model=None,
+        id=None,
+        model_file_name="FL_models.pt",
+        best_model_file_name="best_FL_models.pt",
+        source_ckpt_file_full_name=None,
+    ):
+        """Persist pytorch-based model to/from file system.
+
+        This Model Persistor tries to load PT model data in following three ways:
+
+        1. Load from a specified source checkpoint file
+        2. Load from a location from the app folder
+        3. Load from a torch model object
+
+        The Persistor tries method 1 first if the source_ckpt_file_full_name is specified;
+        If source_ckpt_file_full_name is not specified, it tries the method 2;
+        If no checkpoint location is specified in the app folder, it tries method 3.
+
+        Method 2 - Load from a location from the app folder
+        It is assumed that the app folder must contain the environments.json file. Among other things, this
+        JSON file must specify where to find the checkpoint file. It does so with two JSON elements:
+
+            APP_CKPT_DIR - this element specifies the folder (within the app) where the checkpoint file resides.
+            APP_CKPT - this element specified the base file name of the checkpoint
+
+        Here is an example of the environments.json content:
+
+            {
+                "APP_CKPT_DIR": "model",
+                "APP_CKPT": "pretrained_model.pt"
+            }
+
+        In this example, the checkpoint file is located in the "model" folder within the app and is named
+        pretrained_model.pt.
+
+        Method 3 - Load from a torch model object. In this case, the 'model' arg must be a valid torch
+        model, or the component ID of a valid torch model included in the "components" section of
+        your config_fed_server.json.
+
+        If all 3 methods fail, system_panic() is called.
+
+        If checkpoint folder name is specified, then global model and best global model will be saved to it;
+        Otherwise they will be saved directly in the app folder.
+        Args:
+            exclude_vars (str, optional): regex expression specifying weight vars to be excluded from training. Defaults to None.
+            model (str, optional): torch model object or component id of the model object. Defaults to None.
+            model_file_name (str, optional): file name for saving global model. Defaults to DefaultCheckpointFileName.GLOBAL_MODEL.
+            best_model_file_name (str, optional): file name for saving best global model. Defaults to DefaultCheckpointFileName.BEST_GLOBAL_MODEL.
+            source_ckpt_file_full_name (str, optional): full file name for source model checkpoint file. Defaults to None.
+
+        Raises:
+            ValueError: when source_ckpt_file_full_name does not exist
+        """
+        super().__init__()
+        self.exclude_vars = re.compile(exclude_vars) if exclude_vars else None
+        self.model = model
+        self.id = id
+        self.log_dir = None
+        self.ckpt_preload_path = None
+        self.persistence_manager = None
+        self.ckpt_dir_env_key = EnvironmentKey.CHECKPOINT_DIR
+        self.ckpt_file_name_env_key = EnvironmentKey.CHECKPOINT_FILE_NAME
+        self.model_file_name = model_file_name
+        self.best_model_file_name = best_model_file_name
+        self.source_ckpt_file_full_name = source_ckpt_file_full_name
+
+        self.default_train_conf = None
+
+        if source_ckpt_file_full_name and not os.path.exists(source_ckpt_file_full_name):
+            raise ValueError("specified source checkpoint model file {} does not exist")
+
+    def _initialize(self, fl_ctx: FLContext):
+        self.log_info(fl_ctx, self.id + " persistor initialized")
+        app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+        env = None
+        run_args = fl_ctx.get_prop(FLContextKey.ARGS)
+        if run_args:
+            env_config_file_name = os.path.join(app_root, run_args.env)
+            if os.path.exists(env_config_file_name):
+                try:
+                    with open(env_config_file_name) as file:
+                        env = json.load(file)
+                except:
+                    self.system_panic(
+                        reason="error opening env config file {}".format(env_config_file_name), fl_ctx=fl_ctx
+                    )
+                    return
+
+        if env is not None:
+            if env.get(self.ckpt_dir_env_key, None):
+                fl_ctx.set_prop(AppConstants.LOG_DIR, env[self.ckpt_dir_env_key], private=True, sticky=True)
+            if env.get(self.ckpt_file_name_env_key) is not None:
+                fl_ctx.set_prop(
+                    AppConstants.CKPT_PRELOAD_PATH, env[self.ckpt_file_name_env_key], private=True, sticky=True
+                )
+
+        log_dir = fl_ctx.get_prop(AppConstants.LOG_DIR)
+        if log_dir:
+            self.log_dir = os.path.join(app_root, log_dir)
+        else:
+            self.log_dir = app_root
+
+        self._ckpt_save_path = os.path.join(self.log_dir, self.model_file_name)
+        self._best_ckpt_save_path = os.path.join(self.log_dir, self.best_model_file_name)
+
+        ckpt_preload_path = fl_ctx.get_prop(AppConstants.CKPT_PRELOAD_PATH)
+        if ckpt_preload_path:
+            self.ckpt_preload_path = os.path.join(app_root, ckpt_preload_path)
+
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+
+        if isinstance(self.model, str):
+            # treat it as model component ID
+            model_component_id = self.model
+            engine = fl_ctx.get_engine()
+            self.model = engine.get_component(model_component_id)
+            if not self.model:
+                self.system_panic(reason="cannot find model component '{}'".format(model_component_id), fl_ctx=fl_ctx)
+                return
+            if not isinstance(self.model, torch.nn.Module):
+                self.system_panic(
+                    reason="expect model component '{}' to be torch.nn.Module but got {}".format(
+                        model_component_id, type(self.model)
+                    ),
+                    fl_ctx=fl_ctx,
+                )
+                return
+        elif self.model and not isinstance(self.model, torch.nn.Module):
+            self.system_panic(
+                reason="expect model to be torch.nn.Module but got {}".format(type(self.model)), fl_ctx=fl_ctx
+            )
+            return
+
+        fl_ctx.sync_sticky()
+
+    def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
+        """Convert initialised model into Learnable/Model format.
+
+        Args:
+            fl_ctx (FLContext): FL Context delivered by workflow
+
+        Returns:
+            Model: a Learnable/Model object
+        """
+        src_file_name = None
+        if self.source_ckpt_file_full_name:
+            src_file_name = self.source_ckpt_file_full_name
+        elif self.ckpt_preload_path:
+            src_file_name = self.ckpt_preload_path
+
+        if src_file_name:
+            try:
+                device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+                data = torch.load(src_file_name, map_location=device)
+                # "checkpoint may contain 'model', 'optimizer', 'lr_scheduler', etc. or only contain model dict directly."
+            except:
+                self.log_exception(fl_ctx, "error loading checkpoint from {}".format(src_file_name))
+                self.system_panic(reason="cannot load model checkpoint", fl_ctx=fl_ctx)
+                return None
+        else:
+            # if no pretrained model provided, use the generated network weights from APP config
+            # note that, if set "determinism" in the config, the init model weights will always be the same
+            try:
+                data = self.model.state_dict() if self.model is not None else OrderedDict()
+            except:
+                self.log_exception(fl_ctx, "error getting state_dict from model object")
+                self.system_panic(reason="cannot create state_dict from model object", fl_ctx=fl_ctx)
+                return None
+
+        if self.model:
+            self.default_train_conf = {"train": {"model": type(self.model).__name__}}
+
+        self.persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
+        return self.persistence_manager.to_model_learnable(self.exclude_vars)
+
+    def handle_event(self, event: str, fl_ctx: FLContext):
+        if event == EventType.START_RUN:
+            self._initialize(fl_ctx)
+        elif event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE:
+            # save the current model as the best model!
+            self.save_model_file(self._best_ckpt_save_path)
+
+    def save_model_file(self, save_path: str):
+        save_dict = self.persistence_manager.to_persistence_dict()
+        torch.save(save_dict, save_path)
+
+    def save_model(self, ml: ModelLearnable, fl_ctx: FLContext):
+        self.persistence_manager.update(ml)
+        self.save_model_file(self._ckpt_save_path)
+
+    def get_model(self, model_file, fl_ctx: FLContext) -> ModelLearnable:
+        try:
+            # device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+            # Use the "cpu" to load the global model weights, avoid GPU out of memory
+            device = "cpu"
+            location = os.path.join(self.log_dir, model_file)
+            data = torch.load(location, map_location=device)
+            persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
+            return persistence_manager.to_model_learnable(self.exclude_vars)
+        except BaseException as e:
+            self.log_exception(fl_ctx, "error loading checkpoint from {}".format(model_file))
+            return {}
+
+    def get_model_inventory(self, fl_ctx: FLContext) -> {str: ModelDescriptor}:
+        model_inventory = {}
+        location = os.path.join(self.log_dir, self.model_file_name)
+        if os.path.exists(location):
+            model_inventory[self.model_file_name] = ModelDescriptor(
+                name=self.model_file_name,
+                location=location,
+                model_format=self.persistence_manager.get_persist_model_format(),
+                props={},
+            )
+
+        location = os.path.join(self.log_dir, self.best_model_file_name)
+        if os.path.exists(location):
+            model_inventory[self.best_model_file_name] = ModelDescriptor(
+                name=self.best_model_file_name,
+                location=location,
+                model_format=self.persistence_manager.get_persist_model_format(),
+                props={},
+            )
+
+        return model_inventory

--- a/examples/FedSM/pt/persistors/pt_file_model_persistor_personalized.py
+++ b/examples/FedSM/pt/persistors/pt_file_model_persistor_personalized.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import re
+from collections import OrderedDict
+
+import copy
+
+import torch
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.abstract.model import ModelLearnable
+from nvflare.app_common.pt.pt_file_model_persistor import PTFileModelPersistor
+from nvflare.app_common.app_constant import AppConstants, DefaultCheckpointFileName, EnvironmentKey
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.model_desc import ModelDescriptor
+
+from pt.persistors.pt_fed_utils import PTModelPersistenceFormatManagerPersonalized
+
+
+class PTFileModelPersistorPersonalized(PTFileModelPersistor):
+    def __init__(
+        self,
+        client_ids,
+        exclude_vars=None,
+        model=None,
+        model_file_name="FL_person_models.pt",
+        best_model_file_name="best_FL_person_models.pt",
+        source_ckpt_file_full_name=None,
+    ):
+        """Persist a dict of personalized pytorch-based models to/from file system.
+
+        Single model behavior is the same as PTFileModelPersistor,
+        Instead of a single model, it creates a set of models with the same structure corresponding to each client
+
+        Args:
+            client_ids (list): the list of client ids
+            exclude_vars (str, optional): regex expression specifying weight vars to be excluded from training. Defaults to None.
+            model (str, optional): torch model object or component id of the model object. Defaults to None.
+            global_model_file_name (str, optional): file name for saving global model. Defaults to DefaultCheckpointFileName.GLOBAL_MODEL.
+            best_global_model_file_name (str, optional): file name for saving best global model. Defaults to DefaultCheckpointFileName.BEST_GLOBAL_MODEL.
+            source_ckpt_file_full_name (str, optional): full file name for source model checkpoint file. Defaults to None.
+
+        Raises:
+            ValueError: when source_ckpt_file_full_name does not exist
+        """
+        super().__init__(
+            exclude_vars=exclude_vars,
+            model=model,
+            global_model_file_name=model_file_name,
+            best_global_model_file_name=best_model_file_name,
+            source_ckpt_file_full_name=source_ckpt_file_full_name,
+        )
+        self.client_ids = client_ids
+
+    def _initialize(self, fl_ctx: FLContext):
+        self.log_info(fl_ctx, "personalized persistor initialized")
+        super()._initialize(fl_ctx=fl_ctx)
+        # self.model is only for getting the model structure from config
+        # all operations will be performed on self.personal_models
+        # which is a dict of models with same structure as self.model
+        self.personal_models = {}
+        for id in self.client_ids:
+            self.personal_models[id] = copy.deepcopy(self.model)
+
+    def load_model(self, fl_ctx: FLContext) -> dict:
+        """Convert initialised models into a dict of Learnable/Model format.
+
+        Args:
+            fl_ctx (FLContext): FL Context delivered by workflow
+
+        Returns:
+            Dict of models: a Dict of Learnable/Model object
+        """
+        src_file_name = None
+        if self.source_ckpt_file_full_name:
+            src_file_name = self.source_ckpt_file_full_name
+        elif self.ckpt_preload_path:
+            src_file_name = self.ckpt_preload_path
+        # data is a dict of personalized models with other training-related items,
+        # personalized models under a dict "personalized_models"
+        data = {"personalized_models":{}}
+        if src_file_name:
+            try:
+                device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+                data = torch.load(src_file_name, map_location=device)
+                # "checkpoint may contain a dict "personalized_models" of models indexed with client ids, 'optimizer', 'lr_scheduler', etc."
+            except:
+                self.log_exception(fl_ctx, "error loading checkpoint from {}".format(src_file_name))
+                self.system_panic(reason="cannot load model checkpoint", fl_ctx=fl_ctx)
+                return None
+        else:
+            # if no pretrained model provided, use the generated network weights from APP config
+            # note that, if set "determinism" in the config, the init model weights will always be the same
+            try:
+                for id in self.client_ids:
+                    data["personalized_models"][id] = self.personal_models[id].state_dict() if self.personal_models[id] is not None else OrderedDict()
+            except:
+                self.log_exception(fl_ctx, "error getting state_dict from model object")
+                self.system_panic(reason="cannot create state_dict from model object", fl_ctx=fl_ctx)
+                return None
+
+        if self.model:
+            self.default_train_conf = {"train": {"model": type(self.model).__name__}}
+
+        self.persistence_manager = PTModelPersistenceFormatManagerPersonalized(data, default_train_conf=self.default_train_conf)
+        return self.persistence_manager.to_model_learnable(self.exclude_vars)
+
+    def handle_event(self, event: str, fl_ctx: FLContext):
+        if event == EventType.START_RUN:
+            self._initialize(fl_ctx)
+        elif event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE:
+            # save the current models as the best model
+            self.save_model_file(self._best_ckpt_save_path)
+
+    def save_model_file(self, save_path: str):
+        save_dict = self.persistence_manager.to_persistence_dict()
+        torch.save(save_dict, save_path)
+
+    def save_model(self, ml_dict: dict, fl_ctx: FLContext):
+        self.persistence_manager.update(ml_dict)
+        self.save_model_file(self._ckpt_save_path)
+
+    def get_model(self, model_file, fl_ctx: FLContext) -> ModelLearnable:
+        try:
+            # device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+            # Use the "cpu" to load the global model weights, avoid GPU out of memory
+            device = "cpu"
+            location = os.path.join(self.log_dir, model_file)
+            data = torch.load(location, map_location=device)
+            persistence_manager = PTModelPersistenceFormatManagerPersonalized(data, default_train_conf=self.default_train_conf)
+            return persistence_manager.to_model_learnable(self.exclude_vars)
+        except BaseException as e:
+            self.log_exception(fl_ctx, "error loading checkpoint from {}".format(model_file))
+            return {}
+
+    def get_model_inventory(self, fl_ctx: FLContext) -> {str: ModelDescriptor}:
+        model_inventory = {}
+        location = os.path.join(self.log_dir, self.global_model_file_name)
+        if os.path.exists(location):
+            model_inventory[self.global_model_file_name] = ModelDescriptor(
+                name=self.global_model_file_name,
+                location=location,
+                model_format=self.persistence_manager.get_persist_model_format(),
+                props={},
+            )
+
+        location = os.path.join(self.log_dir, self.best_global_model_file_name)
+        if os.path.exists(location):
+            model_inventory[self.best_global_model_file_name] = ModelDescriptor(
+                name=self.best_global_model_file_name,
+                location=location,
+                model_format=self.persistence_manager.get_persist_model_format(),
+                props={},
+            )
+
+        return model_inventory

--- a/examples/FedSM/pt/shareablegenerators/full_model_shareable_generator_fedsm.py
+++ b/examples/FedSM/pt/shareablegenerators/full_model_shareable_generator_fedsm.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvflare.apis.dxo import DataKind, from_shareable
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+from nvflare.app_common.abstract.model import ModelLearnable, ModelLearnableKey, model_learnable_to_dxo
+from nvflare.app_common.abstract.shareable_generator import ShareableGenerator
+from nvflare.app_common.app_constant import AppConstants
+
+
+class FullModelShareableGeneratorFedSM(ShareableGenerator):
+    def learnable_to_shareable(self, model_learnable: ModelLearnable, fl_ctx: FLContext) -> Shareable:
+        """Convert ModelLearnable to Shareable.
+
+        Args:
+            model_learnable (ModelLearnable): model to be converted
+            fl_ctx (FLContext): FL context
+
+        Returns:
+            Shareable: a shareable containing a DXO object.
+        """
+        dxo = model_learnable_to_dxo(model_learnable)
+        return dxo.to_shareable()
+
+    def shareable_to_learnable(self, shareable: Shareable, model_id: str, mode: str, fl_ctx: FLContext, client_id: list = None) -> ModelLearnable:
+        """Convert Shareable to ModelLearnable.
+
+        Supporting TYPE == TYPE_WEIGHT_DIFF or TYPE_WEIGHTS
+
+        Args:
+            shareable (Shareable): Shareable that contains a DXO object
+            model_id: model id for getting the base model from fl_ctx
+            fl_ctx (FLContext): FL context
+
+        Returns:
+            A ModelLearnable object
+
+        Raises:
+            TypeError: if shareable is not of type shareable
+            ValueError: if data_kind is not `DataKind.WEIGHTS` and is not `DataKind.WEIGHT_DIFF`
+        """
+        if not isinstance(shareable, Shareable):
+            raise TypeError("shareable must be Shareable, but got {}.".format(type(shareable)))
+
+        base_model = fl_ctx.get_prop(model_id)
+        if not base_model:
+            self.system_panic(reason="No base model for {}!".format(model_id), fl_ctx=fl_ctx)
+            return base_model
+
+        if mode == "single":
+            weights = base_model[ModelLearnableKey.WEIGHTS]
+            dxo = from_shareable(shareable)
+
+            if dxo.data_kind == DataKind.WEIGHT_DIFF:
+                if dxo.data is not None:
+                    model_diff = dxo.data
+                    for v_name, v_value in model_diff.items():
+                        weights[v_name] = weights[v_name] + v_value
+            elif dxo.data_kind == DataKind.WEIGHTS:
+                weights = dxo.data
+                if not weights:
+                    self.log_info(fl_ctx, "No model weights found. Model will not be updated.")
+                else:
+                    base_model[ModelLearnableKey.WEIGHTS] = weights
+            else:
+                raise ValueError(
+                    "data_kind should be either DataKind.WEIGHTS or DataKind.WEIGHT_DIFF, but got {}".format(dxo.data_kind)
+                )
+        elif mode == "set":
+            if client_id is None:
+                raise ValueError(
+                    "client_id list not available for model set!"
+                )
+
+            for model_id in client_id:
+                base_model_single = base_model[model_id]
+                weights = base_model_single[ModelLearnableKey.WEIGHTS]
+                dxo = from_shareable(shareable)
+                if dxo.data_kind == DataKind.WEIGHT_DIFF:
+                    if dxo.data is not None:
+                        model_diff = dxo.data[model_id]
+                        # add corresponding weight_diff from aggregator record
+                        for v_name in model_diff.keys():
+                            weights[v_name] = weights[v_name] + model_diff[v_name]
+                elif dxo.data_kind == DataKind.WEIGHTS:
+                    weights = dxo.data.items()[model_id]
+                    if not weights:
+                        self.log_info(fl_ctx, "No model weights found. Model will not be updated.")
+                    else:
+                        base_model_single[ModelLearnableKey.WEIGHTS] = weights
+                else:
+                    raise ValueError(
+                        "data_kind should be either DataKind.WEIGHTS or DataKind.WEIGHT_DIFF, but got {}".format(
+                            dxo.data_kind)
+                    )
+        else:
+            raise ValueError(
+                "mode should be either single or set, but got {}".format(mode)
+            )
+
+        base_model[ModelLearnableKey.META] = dxo.get_meta_props()
+        return base_model

--- a/examples/FedSM/pt/utils/custom_client_datalist_json_path.py
+++ b/examples/FedSM/pt/utils/custom_client_datalist_json_path.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+
+def custom_client_datalist_json_path(datalist_json_path: str, client_id: str) -> str:
+    """
+    Customize datalist_json_path for each client
+    Args:
+         datalist_json_path: default datalist_json_path
+         client_id: e.g., site-2
+    """
+    # Customize datalist_json_path for each client
+    # - client_id: e.g. site-5
+    head, tail = os.path.split(datalist_json_path)
+    datalist_json_path = os.path.join(
+        head,
+        client_id + ".json",
+    )
+    return datalist_json_path

--- a/examples/FedSM/pt/workflows/scatter_and_gather_fedsm.py
+++ b/examples/FedSM/pt/workflows/scatter_and_gather_fedsm.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import traceback
+
+import numpy as np
+
+from nvflare.apis.dxo import DXO, DataKind, from_shareable
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.impl.controller import Task
+from nvflare.apis.signal import Signal
+from nvflare.app_common.abstract.model import model_learnable_to_dxo
+from nvflare.app_common.app_constant import AlgorithmConstants, AppConstants
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
+
+from nvflare.app_common.abstract.aggregator import Aggregator
+from nvflare.app_common.abstract.learnable_persistor import LearnablePersistor
+
+from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
+
+class ScatterAndGatherFedSM(ScatterAndGather):
+    def __init__(
+        self,
+        client_id_label_mapping,
+        min_clients: int = 1,
+        num_rounds: int = 5,
+        start_round: int = 0,
+        wait_time_after_min_received: int = 10,
+        aggregator_id=AppConstants.DEFAULT_AGGREGATOR_ID,
+        persistor_id_global="persistor_global",
+        persistor_id_select="persistor_select",
+        persistor_id_person="persistor_person",
+        shareable_generator_id=AppConstants.DEFAULT_SHAREABLE_GENERATOR_ID,
+        train_task_name=AppConstants.TASK_TRAIN,
+        train_timeout: int = 0,
+        ignore_result_error: bool = True,
+    ):
+        """FedSM Workflow. The ScatterAndGatherFedSM workflow defines federated training on all clients.
+        FedSM involves training, aggregating, and persisting three types of models:
+        - global model: FL the same as regular FedAvg
+        - selector model: FL the same as regular FedAvg
+        - personalized models: one for each candidate site, FL aggregation with SoftPull
+        client_id_label_mapping is needed for training selector model
+        Three model persistors are used to load/save the initial models sent to clients according to the client IDs.
+        - persistor_global and persistor_select are standard persistors
+        - persistor_person is customized for persisting personalized models (a dict of models) for all clients
+        Each client sends it's updated three weights after local training, to be aggregated accordingly by aggregator,
+        we use one customized aggregator to handle all three models, global and selector models following standard weighted average,
+        and personalized models following SoftPull
+        The shareable generator is used to convert the aggregated weights to shareable, and shareable back to weights.
+
+        Args:
+            client_id_label_mapping: needed for training selector model, no Default.
+            min_clients (int, optional): Min number of clients in training. Defaults to 1.
+            num_rounds (int, optional): The total number of training rounds. Defaults to 5.
+            start_round (int, optional): Start round for training. Defaults to 0.
+            wait_time_after_min_received (int, optional): Time to wait before beginning aggregation after contributions received. Defaults to 10.
+            train_timeout (int, optional): Time to wait for clients to do local training.
+            aggregator_id (str, optional): ID of the aggregator component for FedSM models. Defaults to "aggregator".
+            persistor_id_global (str, optional): ID of the persistor component for global model. Defaults to "persistor_global".
+            persistor_id_select (str, optional): ID of the persistor component for selector model. Defaults to "persistor_select".
+            persistor_id_person (str, optional): ID of the persistor component for personalized models. Defaults to "persistor_person".
+            shareable_generator_id (str, optional): ID of the shareable generator. Defaults to "shareable_generator".
+            train_task_name (str, optional): Name of the train task. Defaults to "train".
+
+        """
+
+        super().__init__(
+            min_clients=min_clients,
+            num_rounds=num_rounds,
+            start_round=start_round,
+            wait_time_after_min_received=wait_time_after_min_received,
+            aggregator_id=aggregator_id,
+            persistor_id=persistor_id_global,
+            shareable_generator_id=shareable_generator_id,
+            train_task_name=train_task_name,
+            train_timeout=train_timeout,
+            ignore_result_error=ignore_result_error,
+        )
+
+        # extras for FedSM
+        # client_id to label mapping
+        self.client_id_label_mapping = client_id_label_mapping
+
+        # global model covered by super class
+        # add select and person models
+        # SoftPull aggregation requires one parameter
+        self.persistor_id_select = persistor_id_select
+        self.persistor_id_person = persistor_id_person
+
+        self._select_weights = None
+        self._person_weights = None
+
+
+    def start_controller(self, fl_ctx: FLContext) -> None:
+        super().start_controller(fl_ctx=fl_ctx)
+        self.log_info(fl_ctx, "Initializing FedSM-specific workflow components.")
+        self.log_info(fl_ctx, "Client_ID to selector label mapping: {}".format(self.client_id_label_mapping))
+        # get engine
+        engine = fl_ctx.get_engine()
+        if not engine:
+            self.system_panic("Engine not found. ScatterAndGather exiting.", fl_ctx)
+            return
+
+        # Get all clients
+        clients = engine.get_clients()
+        self.participating_clients = [c.name for c in clients]
+        self.log_info(fl_ctx, "Participating clients: {}".format(self.participating_clients))
+
+        # Validate client info
+        for client_id in self.participating_clients:
+            if client_id not in self.client_id_label_mapping.keys():
+                self.system_panic("Client {} not found in the id_label mapping. Please double check. ScatterAndGatherFedSM exiting.".format(client_id), fl_ctx)
+                return
+
+        # Add persistors for both selector and personalized models
+        self.log_info(fl_ctx, "Preparing selector model persistor")
+        self.persistor_select = engine.get_component(self.persistor_id_select)
+        if not isinstance(self.persistor_select, LearnablePersistor):
+            self.system_panic(
+                f"Model Persistor {self.persistor_id_select} must be a LearnablePersistor type object but got {type(self.persistor_select)}",
+                fl_ctx,
+            )
+            return
+        self.log_info(fl_ctx, "Preparing personalized models persistor")
+        self.persistor_person = engine.get_component(self.persistor_id_person)
+        if not isinstance(self.persistor_person, LearnablePersistor):
+            self.system_panic(
+                f"Model Persistor {self.persistor_id_person} must be a LearnablePersistor type object but got {type(self.persistor_person)}",
+                fl_ctx,
+            )
+            return
+
+        # initialize select and person models
+        self._select_weights = self.persistor_select.load(fl_ctx)
+        self._person_weights = self.persistor_person.load(fl_ctx)
+
+        # add models to fl_ctx, because all models combined will be the "super model" for FedSM
+        fl_ctx.set_prop("select_model", self._select_weights, private=True, sticky=True)
+        fl_ctx.set_prop("person_model", self._person_weights, private=True, sticky=True)
+
+
+    def control_flow(self, abort_signal: Signal, fl_ctx: FLContext) -> None:
+        try:
+            
+            self.log_info(fl_ctx, "Beginning ScatterAndGatherFedSM training phase.")
+            self._phase = AppConstants.PHASE_TRAIN
+
+            fl_ctx.set_prop(AppConstants.PHASE, self._phase, private=True, sticky=False)
+            fl_ctx.set_prop(AppConstants.NUM_ROUNDS, self._num_rounds, private=True, sticky=False)
+            self.fire_event(AppEventType.TRAINING_STARTED, fl_ctx)
+
+            for self._current_round in range(self._start_round, self._start_round + self._num_rounds):
+                if self._check_abort_signal(fl_ctx, abort_signal):
+                    return
+
+                self.log_info(fl_ctx, f"Round {self._current_round} started.")
+                fl_ctx.set_prop(AppConstants.GLOBAL_MODEL, self._global_weights, private=True, sticky=True)
+                fl_ctx.set_prop("select_model", self._select_weights, private=True, sticky=True)
+                fl_ctx.set_prop("person_model", self._person_weights, private=True, sticky=True)
+                fl_ctx.set_prop(AppConstants.CURRENT_ROUND, self._current_round, private=True, sticky=False)
+                self.fire_event(AppEventType.ROUND_STARTED, fl_ctx)
+
+                # Create train_task for each participating clients
+                for client_id in self.participating_clients:
+                    client_weight = self._person_weights[client_id]
+                    client_label = self.client_id_label_mapping[client_id]
+
+                    # get DXO with global model weights
+                    dxo_global_weights = model_learnable_to_dxo(self._global_weights)
+                    # add select and person model using a DXO collection
+                    dxo_person_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=client_weight)
+                    dxo_select_weights = DXO(data_kind=DataKind.WEIGHT_DIFF, data=self._select_weights)
+
+                    dxo_dict = {
+                        AppConstants.MODEL_WEIGHTS: dxo_global_weights,
+                        "person_weights": dxo_person_weights,
+                        "select_weights": dxo_select_weights,
+                        # add target id info for checking at client end
+                        "target_id": client_id,
+                        # add target label for client end selector training
+                        "select_label": client_label
+                    }
+                    dxo_collection = DXO(data_kind=DataKind.COLLECTION, data=dxo_dict)
+                    data_shareable = dxo_collection.to_shareable()
+
+                    # add meta information
+                    data_shareable.set_header(AppConstants.CURRENT_ROUND, self._current_round)
+                    data_shareable.set_header(AppConstants.NUM_ROUNDS, self._num_rounds)
+                    data_shareable.add_cookie(AppConstants.CONTRIBUTION_ROUND, self._current_round)
+
+                    # create task
+                    train_task = Task(
+                        name=self.train_task_name,
+                        data=data_shareable,
+                        props={},
+                        timeout=self._train_timeout,
+                        before_task_sent_cb=self._prepare_train_task_data,
+                        result_received_cb=self._process_train_result,
+                    )
+
+                    # send only to the target client
+                    self.send_and_wait(
+                        task=train_task,
+                        targets=[client_id],
+                        fl_ctx=fl_ctx,
+                        abort_signal=abort_signal,
+                    )
+
+                    if self._check_abort_signal(fl_ctx, abort_signal):
+                        return
+
+                # aggregate the returned results in shareable
+                self.fire_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
+                aggr_result = self.aggregator.aggregate(fl_ctx)
+
+                # extract and check aggregated weights
+                collection_dxo = from_shareable(aggr_result)
+                dxo_aggr_result_global = collection_dxo.data.get(AppConstants.MODEL_WEIGHTS)
+                if not dxo_aggr_result_global:
+                    self.log_error(fl_ctx, "Aggregated global model weights are missing!")
+                    return
+                dxo_aggr_result_select = collection_dxo.data.get("select_weights")
+                if not dxo_aggr_result_select:
+                    self.log_error(fl_ctx, "Aggregated selector model weights are missing!")
+                    return
+                dxo_aggr_result_person = collection_dxo.data.get("person_weights")
+                if not dxo_aggr_result_person:
+                    self.log_error(fl_ctx, "Aggregated personalized models weights are missing!")
+                    return
+
+                fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, aggr_result, private=True, sticky=False)
+                self.fire_event(AppEventType.AFTER_AGGREGATION, fl_ctx)
+
+                if self._check_abort_signal(fl_ctx, abort_signal):
+                    return
+
+                # update all models using shareable generator
+                self.fire_event(AppEventType.BEFORE_SHAREABLE_TO_LEARNABLE, fl_ctx)
+                self._global_weights = self.shareable_gen.shareable_to_learnable(dxo_aggr_result_global.to_shareable(), model_id=AppConstants.GLOBAL_MODEL, mode="single", fl_ctx=fl_ctx)
+                self._person_weights = self.shareable_gen.shareable_to_learnable(dxo_aggr_result_person.to_shareable(), model_id="person_model", mode="set", client_id=self.participating_clients,fl_ctx=fl_ctx)
+                self._select_weights = self.shareable_gen.shareable_to_learnable(dxo_aggr_result_select.to_shareable(), model_id="select_model", mode="single", fl_ctx=fl_ctx)
+
+                # update models
+                fl_ctx.set_prop(AppConstants.GLOBAL_MODEL, self._global_weights, private=True, sticky=True)
+                fl_ctx.set_prop("person_model", self._person_weights, private=True, sticky=True)
+                fl_ctx.set_prop("select_model", self._select_weights, private=True, sticky=True)
+                fl_ctx.sync_sticky()
+                self.fire_event(AppEventType.AFTER_SHAREABLE_TO_LEARNABLE, fl_ctx)
+
+                if self._check_abort_signal(fl_ctx, abort_signal):
+                    return
+
+                self.fire_event(AppEventType.BEFORE_LEARNABLE_PERSIST, fl_ctx)
+                self.persistor.save(self._global_weights, fl_ctx)
+                self.persistor_person.save(self._person_weights, fl_ctx)
+                self.persistor_select.save(self._select_weights, fl_ctx)
+                self.fire_event(AppEventType.AFTER_LEARNABLE_PERSIST, fl_ctx)
+
+                self.fire_event(AppEventType.ROUND_DONE, fl_ctx)
+                self.log_info(fl_ctx, f"Round {self._current_round} finished.")
+
+            self._phase = AppConstants.PHASE_FINISHED
+            self.log_info(fl_ctx, "Finished ScatterAndGatherFedSM Training.")
+        except BaseException as e:
+            traceback.print_exc()
+            error_msg = f"Exception in ScatterAndGatherFedSM control_flow: {e}"
+            self.log_exception(fl_ctx, error_msg)
+            self.system_panic(str(e), fl_ctx)


### PR DESCRIPTION
Functional first version of FedSM with prostate experiment, but need significant polish.
Two major issues at this time:

1. Workflow using send_and_wait, making it inefficient, needs a new "broadcast_and_wait" with client customization capability to replace the current implementation.

2. Issue with persistor: fedsm needs three persistors, but if referencing the same persistor python code (global model and selector model can use the same script), only the first one will be initialized (that's why there are three custom persistors under pt/persistors and two of them are identical) - needs further investigation.
