### PR TITLE
Add a white space to log info when deploying an application

### DIFF
--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -68,7 +68,7 @@ class JobRunner(FLComponent):
                 if p == "server":
                     success = deploy_app(app_name=app_name, site_name="server", workspace=workspace, app_data=app_data)
                     self.log_info(
-                        fl_ctx, f"Application{app_name} deployed to the server for run:{run_number}", fire_event=False
+                        fl_ctx, f"Application {app_name} deployed to the server for run:{run_number}", fire_event=False
                     )
                     if not success:
                         raise RuntimeError("Failed to deploy the App to the server")
@@ -80,7 +80,7 @@ class JobRunner(FLComponent):
             display_sites = ",".join(client_sites)
             self.log_info(
                 fl_ctx,
-                f"Application{app_name} deployed to the clients: {display_sites} for run:{run_number}",
+                f"Application {app_name} deployed to the clients: {display_sites} for run:{run_number}",
                 fire_event=False,
             )
 


### PR DESCRIPTION
log was missing a white space after Application

2022-04-28 12:39:50,087 - JobRunner - INFO - [run=?]: Applicationcifar10_scaffold deployed to the server for run:2812e375-6054-497c-ae45-b924cafc99ee
2022-04-28 12:39:50,588 - JobRunner - INFO - [run=?]: Applicationcifar10_scaffold deployed to the clients: site-1,site-2,site-3,site-4,site-5,site-6,site-7,site-8 for run:2812e375-6054-497c-ae45-b924cafc99ee