### PR TITLE
Wait for admin login

### DIFF
--- a/nvflare/fuel/hci/client/fl_admin_api_runner.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_runner.py
@@ -122,6 +122,14 @@ class FLAdminAPIRunner:
             debug=debug,
         )
 
+        # wait for admin to login
+        _t_warning_start = time.time()
+        while self.api.login_result != "OK":
+            time.sleep(0.5)
+            if time.time() - _t_warning_start > 10:
+                print("Admin login is taking very long...")
+                _t_warning_start = time.time()
+
     def run(
         self,
         job_folder_name,


### PR DESCRIPTION
admin API commands would cause an error because the API hasn't logged in yet.
This PR adds a check until successful login.