### PR TITLE
Modify existing premerge CI to runs-on temp-ci label

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, temp-ci]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8
@@ -21,7 +21,7 @@ jobs:
       - run: PYTHONPATH=$(pwd) ./runtest.sh
 
   example-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, temp-ci]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8
@@ -35,7 +35,7 @@ jobs:
           ./run_example_tests.sh
 
   app-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, temp-ci]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8
@@ -49,7 +49,7 @@ jobs:
           ./run_app_tests.sh
 
   wheel-build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, temp-ci]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Currently we are setting up blossom self-hosted runner. 
If no specific label, the CI may randomly pick unexpected runner to run CI.

This PR is trying to modify `runs-on` for existing workflow first. 