### PR TITLE
Remove minio server in test scripts and fix format issues

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,3 @@ black==22.3.0
 click==8.1.2
 pytest-xdist==2.5.0
 pytest-cov==3.0.0
-minio==7.1.6
-mock==4.0.3

--- a/runtest.sh
+++ b/runtest.sh
@@ -76,16 +76,5 @@ fi
 echo "Done with pydocstyle docstring style checks"
 
 echo "Running unit tests"
-wget "https://dl.min.io/server/minio/release/linux-amd64/minio"
-chmod +x ./minio
-export MINIO_STORE_PATH=nvflare_unittest_minio_server
-export MINIO_ROOT_USER=admin
-export MINIO_ROOT_PASSWORD=password
-export MINIO_SERVER_PORT=9001
-./minio server $MINIO_STORE_PATH --console-address :$MINIO_SERVER_PORT &
-echo $! > ./minio_pid
-minio_pid=`cat ./minio_pid`
 python -m pytest --cov=nvflare --cov-report html:cov_html --cov-report xml:cov.xml --junitxml=unit_test.xml --numprocesses=auto tests/unit_test/
-kill -9 $minio_pid
-rm -rf ./$MINIO_STORE_PATH ./minio_pid ./minio
 echo "Done with unit tests"

--- a/tests/unit_test/app_common/storages/storage_test.py
+++ b/tests/unit_test/app_common/storages/storage_test.py
@@ -49,7 +49,8 @@ def random_meta():
 ROOT_DIR = os.path.abspath(os.sep)
 
 
-@pytest.fixture(name="storage", params=["FilesystemStorage", "S3Storage"])
+# TODO:: Add S3Storage test
+@pytest.fixture(name="storage", params=["FilesystemStorage"])
 def setup_and_teardown(request):
     print(f"setup {request.param}")
     if request.param == "FilesystemStorage":

--- a/tests/unit_test/lighter/project_test.py
+++ b/tests/unit_test/lighter/project_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from nvflare.lighter.spec import Project, Participant
+from nvflare.lighter.spec import Participant, Project
 
 
 def create_participants(type, number, org, name):

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+
+from unittest.mock import MagicMock, Mock, patch
 
 import nvflare.private.fed.protos.federated_pb2 as fed_msg
-from mock import MagicMock
 from nvflare.private.fed.server.fed_server import FederatedServer
 
 
 class TestFederatedServer:
-
     def test_heart_beat_abort_jobs(self):
-        with mock.patch("nvflare.private.fed.server.fed_server.ServerEngine") as mock_engine:
+        with patch("nvflare.private.fed.server.fed_server.ServerEngine") as mock_engine:
             server = FederatedServer(
                 project_name="project_name",
                 min_num_clients=1,
@@ -37,7 +36,7 @@ class TestFederatedServer:
                 overseer_agent=MagicMock(),
             )
 
-            request = mock.Mock(token="token", jobs=["extra_job"])
+            request = Mock(token="token", jobs=["extra_job"])
             context = MagicMock()
             expected = fed_msg.FederatedSummary(abort_jobs=["extra_job"])
             assert server.Heartbeat(request, context) == expected

--- a/tests/unit_test/private/fed/server/job_validator_test.py
+++ b/tests/unit_test/private/fed/server/job_validator_test.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, List, Optional, Tuple
 
 from nvflare.apis.client import Client
-from nvflare.apis.fl_context import FLContextManager, FLContext
+from nvflare.apis.fl_context import FLContext, FLContextManager
 from nvflare.apis.fl_snapshot import RunSnapshot
 from nvflare.apis.server_engine_spec import ServerEngineSpec
 from nvflare.apis.shareable import Shareable
@@ -26,14 +26,9 @@ from nvflare.widgets.widget import Widget
 
 
 class MockServerEngine(ServerEngineSpec):
-
     def __init__(self):
         self.fl_ctx_mgr = FLContextManager(
-            engine=self,
-            identity_name="__mock_engine",
-            run_num="unit-test-run",
-            public_stickers={},
-            private_stickers={}
+            engine=self, identity_name="__mock_engine", run_num="unit-test-run", public_stickers={}, private_stickers={}
         )
 
     def fire_event(self, event_type: str, fl_ctx: FLContext):
@@ -78,8 +73,9 @@ class MockServerEngine(ServerEngineSpec):
     def check_client_resources(self, resource_reqs: Dict[str, dict]) -> Dict[str, Tuple[bool, Optional[str]]]:
         pass
 
-    def cancel_client_resources(self, resource_check_results: Dict[str, Tuple[bool, str]],
-                                resource_reqs: Dict[str, dict]):
+    def cancel_client_resources(
+        self, resource_check_results: Dict[str, Tuple[bool, str]], resource_reqs: Dict[str, dict]
+    ):
         pass
 
     def get_client_name_from_token(self, token: str) -> str:
@@ -87,7 +83,6 @@ class MockServerEngine(ServerEngineSpec):
 
 
 class TestJobValidator:
-
     @classmethod
     def setup_class(cls):
         cls.engine = MockServerEngine()


### PR DESCRIPTION
- Remove minio server setup/teardown in runtest.sh
- Remove S3Storage unit tests
- Change "mock" to use default python system package "unittest.mock"
- Fix format issues