### PR TITLE
logout from admin api after submitting job

### DIFF
--- a/examples/cifar10/submit_job.py
+++ b/examples/cifar10/submit_job.py
@@ -83,6 +83,7 @@ def main():
     api_command_wrapper(runner.api.submit_job(args.job))
 
     # finish
+    runner.api.logout()
     runner.api.overseer_agent.end()
 
 

--- a/examples/prostate/prostate_2D/submit_job.py
+++ b/examples/prostate/prostate_2D/submit_job.py
@@ -39,6 +39,7 @@ def main():
     api_command_wrapper(runner.api.submit_job(args.job))
 
     # finish
+    runner.api.logout()
     runner.api.overseer_agent.end()
 
 

--- a/examples/prostate/prostate_3D/submit_job.py
+++ b/examples/prostate/prostate_3D/submit_job.py
@@ -39,6 +39,7 @@ def main():
     api_command_wrapper(runner.api.submit_job(args.job))
 
     # finish
+    runner.api.logout()
     runner.api.overseer_agent.end()
 
 


### PR DESCRIPTION
following best practices, it is better to explicitly log out of the admin client after submitting a job.