### PR TITLE
runtests scripts refactoring

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ black==22.3.0
 click==8.1.2
 pytest-xdist==2.5.0
 pytest-cov==3.0.0
+# wait for approval
+# pylint!=2.13  # https://github.com/PyCQA/pylint/issues/5969

--- a/runtest.sh
+++ b/runtest.sh
@@ -63,6 +63,7 @@ function clean {
 }
 
 function torch_validate {
+    echo "validate torch installation"
     python3 -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
 }
 
@@ -87,6 +88,7 @@ function report_status() {
 }
 
 function is_pip_installed() {
+  echo "check target installed by pip"
 	return $(python3 -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader(sys.argv[1]) else 1)" $1)
 }
 
@@ -189,7 +191,6 @@ function fix_style_import() {
   isort_fix "${fix_target}"
 }
 
-
 ################################################################################
 export PYTHONPATH=${WORK_DIR}:$PYTHONPATH && echo "PYTHONPATH is ${PYTHONPATH}"
 
@@ -215,7 +216,8 @@ function help() {
     echo "    -u | --unit-tests             : unit tests"
     echo "    -r | --test-report            : used with -u command, turn on unit test report flag. It has no effect without -u "
     echo "    -c | --coverage               : used with -u command, turn on coverage flag,  It has no effect without -u "
-    echo "    -d | --clean                  : clean py and other artifacts generated, clean flag to allow re-install dependencies"
+    echo "    -d | --dry-run                : dry run, print out command"
+    echo "         --clean                  : clean py and other artifacts generated, clean flag to allow re-install dependencies"
 #   echo "    -i | --integration-tests      : integration tests"
     exit 1
 }
@@ -269,7 +271,7 @@ do
         ;;
 
       -u |--unit*)
-        cmd_prefix="python3 -m pytest --numprocesses=auto "
+        cmd_prefix="torch_validate; python3 -m pytest --numprocesses=auto "
 
         echo "coverage_report=" ${coverage_report}
         if [ "${coverage_report}" == true ]; then
@@ -282,7 +284,7 @@ do
         cmd="$cmd_prefix"
         ;;
 
-      -d |--clean)
+       --clean)
          clean
          exit
          ;;

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash 
+set -e
 
 # output formatting
 separator=""
@@ -16,65 +17,278 @@ then
     noColor="$(tput sgr0)"
 fi
 
-function print_style_fail_msg() { 
-    echo "${red}Check failed!${noColor}" 
-    echo "Please run ${green}./runtest.sh${noColor} to check errors and fix them." 
-} 
+WORK_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NUM_PARALLEL=1
 
-set +e
-folders_to_check_license="nvflare tests"
+target="${@: -1}"
+echo "target=$target"
+if [[ "${target}" == -* ]] ;then
+    target=""
+fi
 
-grep -r --include "*.py" --exclude-dir "*protos*" -L "\(# Copyright (c) \(2021\|2021-2022\|2022\), NVIDIA CORPORATION.  All rights reserved.\)\|\(This file is released into the public domain.\)" ${folders_to_check_license} > no_license.lst
-if [ -s no_license.lst ]; then
-    # The file is not-empty.
-    cat no_license.lst
-    echo "License text not found on the above files."
-    echo "Please fix them."
-    rm -f no_license.lst
+
+function install_deps {
+    echo "pip installing development dependencies"
+    python3 -m pip install -r requirements-dev.txt
+}
+
+function clean_py {
+    echo "remove coverage history"
+    python3 -m coverage erase
+
+    echo "uninstalling nvflare development files..."
+    python3 setup.py develop --user --uninstall
+
+    echo "removing temporary files in ${WORK_DIR}"
+
+    find ${WORK_DIR}/nvflare -type d -name "__pycache__" -exec rm -r "{}" \;
+    find ${WORK_DIR}/nvflare -type f -name "*.py[co]" -exec rm -r "{}" \;
+
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name ".eggs" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name "nvflare.egg-info" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name "build" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name "dist" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name ".mypy_cache" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name ".pytype" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name ".coverage" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type f -name ".coverage.*" -exec rm -r "{}" \;
+    find ${WORK_DIR} -depth -maxdepth 1 -type d -name "__pycache__" -exec rm -r "{}" \;
+}
+
+function torch_validate {
+    python3 -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
+}
+
+function print_error_msg() {
+    echo "${red}Error: $1.${noColor}"
+    echo ""
+}
+
+function print_style_fail_msg() {
+    echo "${red}Check failed!${noColor}"
+    echo "Please run auto style fixes: ${green}./runtests.sh -f {noColor}"
+}
+function report_status() {
+    status="$1"
+    if [ ${status} -ne 0 ]
+    then
+       print_style_fail_msg
+       exit ${status}
+    else
+       echo "${green}passed!${noColor}"
+    fi
+}
+
+function is_pip_installed() {
+	return $(python3 -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader(sys.argv[1]) else 1)" $1)
+}
+
+function dry_run() {
+    echo "${separator}${blue}dryrun${noColor}"
+    echo "    " "$1"
+}
+
+function check_license() {
+  folders_to_check_license="nvflare tests"
+  grep -r --include "*.py" --exclude-dir "*protos*" -L "\(# Copyright (c) \(2021\|2021-2022\|2022\), NVIDIA CORPORATION.  All rights reserved.\)\|\(This file is released into the public domain.\)" ${folders_to_check_license} > no_license.lst
+  if [ -s no_license.lst ]; then
+      # The file is not-empty.
+      cat no_license.lst
+      echo "License text not found on the above files."
+      echo "Please fix them."
+      rm -f no_license.lst
+      exit 1
+  else
+      echo "All Python files in folder (${folders_to_check_license}) have license header"
+      rm -f no_license.lst
+  fi
+}
+function flake8_check() {
+    #python3 -m flake8 nvflare
+    echo "${separator}${blue}flake8${noColor}"
+    python3 -m flake8 --version
+    python3 -m flake8 "$1" --count --statistics
+    report_status "$?"
+}
+function black_check() {
+  echo "${separator}${blue}black-check${noColor}"
+  python3 -m black --check "$1"
+  report_status "$?"
+  echo "Done with black code style checks"
+}
+
+function black_fix() {
+  echo "${separator}${blue}black-fix${noColor}"
+  python3 -m black "$1"
+}
+
+function isort_check() {
+  echo "${separator}${blue}isort-check${noColor}"
+  python3 -m isort --check "$1"
+  report_status "$?"
+}
+
+function isort_fix() {
+  echo "${separator}${blue}isort-fix${noColor}"
+  python3 -m isort "$1"
+}
+
+# wait for approval
+#function pylint_check() {
+#        echo "${separator}${blue}pylint${noColor}"
+#        python3 -m pylint --version
+#        ignore_codes="E1101,E1102,E0601,E1130,E1123,E0102,E1120,E1137,E1136"
+#        python3 -m pylint "$1" -E --disable=$ignore_codes -j $NUM_PARALLEL
+#        report_status "$?"
+#}
+
+function pytype_check() {
+    echo "${separator}${blue}pytype${noColor}"
+    pytype_ver=$(python3 -m pytype --version)
+    if [[ "$OSTYPE" == "darwin"* && "$pytype_ver" == "2021."* ]]; then
+        echo "${red}pytype not working on macOS 2021 (https://github.com/google/pytype/issues/661). Please upgrade to 2022*.${noColor}"
+        exit 1
+    else
+        python3 -m pytype --version
+        python3 -m pytype -j ${NUM_PARALLEL} --python-version="$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")" "$1"
+        report_status "$?"
+    fi
+}
+
+function `mypy_check`() {
+    echo "${separator}${blue}mypy${noColor}"
+    python3 -m mypy --version
+    python3 -m mypy "$1"
+    report_status "$?"
+}
+
+function check_style_type_import() {
+  check_target="$1"
+  # remove pylint for now
+  # pylint_check  $check_target
+  black_check   $check_target
+  isort_check   $check_target
+  flake8_check  $check_target
+  # pytype causing check fails, comment for now
+  # pytype_check  $check_target
+
+  # gives a lot false alarm, comment out for now
+  # mypy_check    $check_target
+}
+
+function fix_style_import() {
+  fix_target="$1"
+  black_fix "${fix_target}"
+  isort_fix "${fix_target}"
+}
+
+
+################################################################################
+export PYTHONPATH=${WORK_DIR}:$PYTHONPATH && echo "PYTHONPATH is ${PYTHONPATH}"
+
+function help() {
+    echo "Add description of the script functions here."
+    echo
+    echo "Syntax: runtests.sh  [-h|--help]
+                               [-l|--check-license]
+                               [-s|--check-format]
+                               [-f|--fix-format]
+                               [-u|--unit-tests]
+                               [-r|--test-report]
+                               [-c|--coverage]
+                               <target> "
+    echo "<target> : target directories or files used for unit tests, or license check or format checks etc. "
+    echo " "
+    echo "options:"
+    echo ""
+    echo "    -h | --help                   : display usage help"
+    echo "    -l | --check-license          : check copy license"
+    echo "    -s | --check-format           : check code styles, formatting, typing, import"
+    echo "    -f | --fix-format             : auto fix style formats, import"
+    echo "    -u | --unit-tests             : unit tests"
+    echo "    -r | --test-report            : used with -u command, turn on unit test report flag. It has no effect without -u "
+    echo "    -c | --coverage               : used with -u command, turn on coverage flag,  It has no effect without -u "
+#   echo "    -i | --integration-tests      : integration tests"
     exit 1
+}
+
+coverage_report=false
+unit_test_report=false
+
+# parse arguments
+cmd=""
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+        -h|--help)
+          help
+          exit
+        ;;
+
+       -l|--check-license)
+          cmd="check_license"
+        ;;
+
+       -s |--check-format) # check format and styles
+          cmd="check_style_type_import"
+          if [[ -z $target ]]; then
+            target="nvflare tests"
+          fi
+        ;;
+
+      -f |--fix-format)
+          if [ ! -z "${target}" ]; then
+            cmd="fix_style_import ${target}"
+          else
+            cmd="fix_style_import nvflare && fix_style_import tests"
+          fi
+        ;;
+      -c|--coverage)
+          coverage_report=true
+        ;;
+
+      -r|--test-report)
+          echo "set unit test flag"
+          unit_test_report=true
+        ;;
+
+      -u |--unit*)
+        cmd_prefix="python3 -m pytest --numprocesses=auto "
+
+        echo "coverage_report=" ${coverage_report}
+        if [ "${coverage_report}" == true ]; then
+          cmd_prefix="${cmd_prefix} --cov=${target} --cov-report html:cov_html"
+        fi
+
+        if [ "${unit_test_report}" == true ]; then
+          cmd_prefix="${cmd_prefix} --junitxml=unit_test.xml "
+        fi
+        cmd="$cmd_prefix"
+        ;;
+
+       -*)
+          help
+          exit
+        ;;
+
+    esac
+    shift
+done
+
+if [[ -z $cmd ]]; then
+   cmd="check_license -l;
+        check_style_type_import nvflare tests;
+        fix_style_import nvflare;
+        fix_style_import tests ;
+        python3 -m pytest --numprocesses=auto --cov=nvflare --cov-report html:cov_html --junitxml=unit_test.xml tests/unit_test ;
+       "
 else
-    echo "All Python files in folder (${folders_to_check_license}) have license header"
-    rm -f no_license.lst
+   cmd="$cmd $target"
 fi
 
-set -e
-export PYTHONPATH=$(pwd):$PYTHONPATH && echo "PYTHONPATH is ${PYTHONPATH}"
-
-python3 -m flake8 nvflare
-
-echo "${separator}${blue}isort-fix${noColor}"
-python3 -m isort --check $PWD/nvflare
-isort_status=$?
-if [ ${isort_status} -ne 0 ]
-then
-    print_style_fail_msg
-else
-    echo "${green}passed!${noColor}"
-fi
-
-echo "${separator}${blue}black-fix${noColor}"
-python3 -m black --check $PWD/nvflare 
-black_status=$?
-if [ ${black_status} -ne 0 ]
-then
-    print_style_fail_msg
-else
-    echo "${green}passed!${noColor}"
-fi
-echo "Done with isort/black code style checks"
-
-set +e
-echo "${separator}${blue}pydocstyle-fix${noColor}"
-python3 -m pydocstyle $PWD/nvflare 
-black_status=$?
-if [ ${black_status} -ne 0 ]
-then
-    echo "docstring check failed"
-else
-    echo "${green}passed!${noColor}"
-fi
-echo "Done with pydocstyle docstring style checks"
-
-echo "Running unit tests"
-python -m pytest --cov=nvflare --cov-report html:cov_html --cov-report xml:cov.xml --junitxml=unit_test.xml --numprocesses=auto tests/unit_test/
-echo "Done with unit tests"
+echo "cmd='$cmd'"
+install_deps
+eval $cmd
+echo "Done"

--- a/runtest.sh
+++ b/runtest.sh
@@ -164,7 +164,7 @@ function pytype_check() {
     fi
 }
 
-function `mypy_check`() {
+function mypy_check() {
     echo "${separator}${blue}mypy${noColor}"
     python3 -m mypy --version
     python3 -m mypy "$1"
@@ -216,7 +216,7 @@ function help() {
     echo "    -u | --unit-tests             : unit tests"
     echo "    -r | --test-report            : used with -u command, turn on unit test report flag. It has no effect without -u "
     echo "    -c | --coverage               : used with -u command, turn on coverage flag,  It has no effect without -u "
-    echo "    -d | --dry-run                : dry run, print out command"
+    echo "    -d | --dry-run                : set dry run flag, print out command"
     echo "         --clean                  : clean py and other artifacts generated, clean flag to allow re-install dependencies"
 #   echo "    -i | --integration-tests      : integration tests"
     exit 1
@@ -224,7 +224,7 @@ function help() {
 
 coverage_report=false
 unit_test_report=false
-
+dry_run_flag=false
 flare_deps_installed=false
 if [[ -f /tmp/.flare_deps_installed ]]; then
   flare_deps_installed=true
@@ -282,12 +282,20 @@ do
           cmd_prefix="${cmd_prefix} --junitxml=unit_test.xml "
         fi
         cmd="$cmd_prefix"
+
+        if [[ -z $target ]]; then
+            target="tests/unit_test"
+        fi
+
         ;;
 
        --clean)
-         clean
-         exit
+         cmd="clean"
          ;;
+       -d|--dry-run)
+        dry_run_flag=true
+        ;;
+
        -*)
           help
           exit
@@ -302,12 +310,20 @@ if [[ -z $cmd ]]; then
         check_style_type_import nvflare tests;
         fix_style_import nvflare;
         fix_style_import tests ;
-        python3 -m pytest --numprocesses=auto --cov=nvflare --cov-report html:cov_html --junitxml=unit_test.xml tests/unit_test ;
+        python3 -m pytest --numprocesses=auto --cov=nvflare --cov-report html:cov_html --junitxml=unit_test.xml tests/unit_test;
        "
 else
    cmd="$cmd $target"
 fi
 
-install_deps
-eval $cmd
+echo "running command: "
+echo "                  install_deps "
+echo "                 " "$cmd"
+echo "                 "
+if [[ $dry_run_flag = "true" ]]; then
+    dry_run "$cmd"
+else
+    install_deps
+    eval "$cmd"
+fi
 echo "Done"

--- a/tests/integration_test/oa_laucher.py
+++ b/tests/integration_test/oa_laucher.py
@@ -15,8 +15,8 @@
 import os
 import subprocess
 import sys
-from threading import Thread
 import time
+from threading import Thread
 
 from nvflare.ha.overseer_agent import HttpOverseerAgent
 


### PR DESCRIPTION
1) refactoring runtests.sh to stream line different functions
   check license
   check imports, style, format, etc.
   fix import format, style
   run unit tests with option to turn on coverage test and unit test reports

2) give option to only run sub directories of styles, unit tests.

This make it possible to combine all tests (unit tests and integration tests) under the same command, We might re-name the command from runtests to something more general.

Our code base did not pass pylint and pytype checks, I have to disable both of them for now.
pylint usage may need legal approval due to GPL v2 license. I commented out the dependency and related codes.