### PR TITLE
fix issue with FLAdminAPI stalling

### DIFF
--- a/nvflare/fuel/hci/client/fl_admin_api_runner.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_runner.py
@@ -123,10 +123,11 @@ class FLAdminAPIRunner:
 
         # wait for admin to login
         _t_warning_start = time.time()
-        while self.api.login_result != "OK":
+        while not self.api.server_sess_active:
             time.sleep(0.5)
             if time.time() - _t_warning_start > 10:
-                print("Admin login is taking very long...")
+                print("Admin is taking a long time to log in to the server...")
+                print("Make sure the server is up and available, and all configurations are correct.")
                 _t_warning_start = time.time()
 
     def run(


### PR DESCRIPTION
There was an issue where occasionally, the FLAdminAPIRunner will finish init and submit_job can be called before api.server_sess_active = True, causing an error of 'Exception: API session is inactive'

This is due to timing, because FLAdminAPI automatically sends another call to the server to register the commands after a successful login before setting self.server_sess_active = True.

To fix, FLAdminAPIRunner's init will now wait for self.server_sess_active = True.