### PR TITLE
Fix handling of config exception during job running

### DIFF
--- a/nvflare/apis/fl_context.py
+++ b/nvflare/apis/fl_context.py
@@ -142,9 +142,6 @@ class FLContext(object):
     def get_peer_context(self):
         return self.get_prop(key=ReservedKey.PEER_CTX, default=None)
 
-    def set_run_number(self, run_number):
-        return self.set_prop(key=ReservedKey.RUN_NUM, value=int(run_number), private=False)
-
     def set_public_props(self, metadata: dict):
         # remove all public props
         self.props = {k: v for k, v in self.props.items() if self._is_private(v["mask"] or self._is_sticky(v["mask"]))}

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -72,12 +72,11 @@ def main():
 
     print("starting the client .....")
 
-    deployer = None
-    command_agent = None
-
     startup = os.path.join(args.workspace, "startup")
     SecurityContentService.initialize(content_folder=startup)
 
+    deployer = None
+    command_agent = None
     federated_client = None
     try:
         token_file = os.path.join(args.workspace, EngineConstant.CLIENT_TOKEN_FILE)
@@ -160,10 +159,6 @@ def main():
             run_manager.add_handler(client_runner)
             fl_ctx.set_prop(FLContextKey.RUNNER, client_runner, private=True)
 
-            # # Start the thread for responding the inquire
-            # federated_client.stop_listen = False
-            # thread = threading.Thread(target=listen_command, args=[federated_client, int(listen_port), client_runner])
-            # thread.start()
             # Start the command agent
             command_agent = CommandAgent(federated_client, int(listen_port), client_runner)
             command_agent.start(fl_ctx)
@@ -173,19 +168,15 @@ def main():
 
     except BaseException as e:
         traceback.print_exc()
-        print("FL client execution exception: " + str(e))
+        print(f"FL client execution exception: {e}")
+        raise e
     finally:
-        # if federated_client:
-        #     federated_client.stop_listen = True
-        #     thread.join()
         if command_agent:
             command_agent.shutdown()
         if deployer:
             deployer.close()
-        federated_client.close()
-        # address = ('localhost', 6000)
-        # conn_client = Client(address, authkey='client process secret password'.encode())
-        # conn_client.send('bye')
+        if federated_client:
+            federated_client.close()
 
 
 def remove_restart_file(args):

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -55,7 +55,7 @@ class ClientRunner(FLComponent):
     def __init__(
         self,
         config: ClientRunnerConfig,
-        run_num: int,
+        run_num,
         engine: ClientEngineSpec,
         task_fetch_interval: int = 5,  # fetch task every 5 secs
     ):

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -94,7 +94,7 @@ class ServerEngine(ServerEngineInternalSpec):
         self.server = server
         self.args = args
         self.run_processes = {}
-        self.execution_exception_run_number = []
+        self.execution_exception_run_processes = {}
         self.run_manager = None
         self.conf = None
         # TODO:: does this class need client manager?
@@ -259,7 +259,7 @@ class ServerEngine(ServerEngineInternalSpec):
                     return_code = run_process_info[RunProcessKey.CHILD_PROCESS].poll()
                     # if process exit but with Execution exception
                     if return_code and return_code != 0:
-                        self.execution_exception_run_number.append(run_number)
+                        self.execution_exception_run_processes[run_number] = run_process_info
                 self.engine_info.status = MachineStatus.STOPPED
                 break
 


### PR DESCRIPTION
Fix handling of the following exception scenario:

- server has started the app, but the app code requires library that server did not install so execution exception happens
  => set job run status to `FINISHED: EXECUTION_EXCEPTION`
- client has started the app, but the app code requires library that client did not install so execution exception happens
  => job would stay RUNNING status since server side success
        since client side has started but execution exception happens, so the resource is freed.

