### PR TITLE
add tests for running through FLAdminAPI commands

### DIFF
--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -334,7 +334,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         if not isinstance(run_number, str):
             raise APISyntaxError("run_number must be str but got {}.".format(type(run_number)))
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(
-            AdminCommandNames.DELETE_RUN + str(run_number)
+            AdminCommandNames.DELETE_RUN + " " + str(run_number)
         )
         if reply_data_full_response:
             if "can not be deleted" in reply_data_full_response:
@@ -671,7 +671,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         if options:
             options = self._validate_options_string(options)
             command = command + " " + options
-        command = command + " " + pattern + " " + file
+        command = command + ' "' + pattern + '" ' + file
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(command)
         if reply_data_full_response:
             return FLAdminAPIResponse(APIStatus.SUCCESS, {"message": reply_data_full_response})

--- a/tests/integration_test/admin_controller.py
+++ b/tests/integration_test/admin_controller.py
@@ -25,6 +25,7 @@ from nvflare.fuel.hci.client.fl_admin_api_constants import FLDetailKey
 from nvflare.fuel.hci.client.fl_admin_api_spec import TargetType
 from nvflare.ha.dummy_overseer_agent import DummyOverseerAgent
 from nvflare.ha.overseer_agent import HttpOverseerAgent
+from tests.integration_test.test_fladminapi import run_admin_api_tests
 
 
 def process_logs(logs, run_state):
@@ -456,68 +457,7 @@ class AdminController:
 
             elif command == "test":
                 if args[0] == "admin_commands":
-                    print(("\n" + "*" * 120) * 20)
-                    print("\n" + "=" * 40)
-                    print("\nRunning through tests of admin commands:")
-                    print("\n" + "=" * 40)
-                    print("\nCommand: set_timeout")
-                    print(self.admin_api.set_timeout(11).get("details").get("message"))
-                    print("\nActive SP:")
-                    print(self.admin_api.get_active_sp().get("details"))
-                    print("\nList SP:")
-                    print(self.admin_api.list_sp().get("details"))
-                    print("\nCommand: get_available_apps_to_upload")
-                    print(self.admin_api.get_available_apps_to_upload())
-                    print("\nList Jobs:")
-                    list_jobs_return_message = self.admin_api.list_jobs().get("details").get("message")
-                    print(list_jobs_return_message)
-                    first_job = list_jobs_return_message.split()[14]
-                    print("\nCommand: ls server -a .")
-                    ls_return_message = self.admin_api.ls_target("server", "-a", ".").get("details").get("message")
-                    print(ls_return_message)
-                    print("\nJob {} is in the server root dir:".format(first_job))
-                    print(first_job in ls_return_message)
-                    print("\nAborting Job {}:".format(first_job))
-                    print("\n" + "=" * 50)
-                    print(self.admin_api.abort_job(first_job).get("details").get("message"))
-                    print("\n" + "=" * 50)
-                    # print("\nCloning Job {}:".format(first_job))
-                    # clone_job_return = self.admin_api.clone_job(first_job)
-                    # print(clone_job_return.get("details").get("message"))
-                    # second_job = clone_job_return.get("details").get("job_id")
-                    # print("\nSecond job_id is: {}".format(second_job))
-                    print("\nCommand: env server")
-                    print(self.admin_api.env_target("server").get("details"))
-                    print("\nCommand: pwd")
-                    print(self.admin_api.get_working_directory("server").get("details").get("message"))
-                    print("\nCommand: env site-1")
-                    print(self.admin_api.env_target("site-1").get("details"))
-                    print("\nCommand: tail_target_log server")
-                    tail_return_message = self.admin_api.tail_target_log("server").get("details").get("message")
-                    print(tail_return_message)
-                    print("\nFirst job matches end of tail:".format(first_job))
-                    print(tail_return_message[-36:] == first_job)
-                    print("\nCommand: grep_target server -n 'deployed to the server for run' log.txt")
-                    grep_return_message = (
-                        self.admin_api.grep_target("server", "-n", "Stop the job run", "log.txt")
-                        .get("details")
-                        .get("message")
-                    )
-                    print(grep_return_message)
-                    print("\nFirst job matches job_id in grep:".format(first_job))
-                    print(grep_return_message[-36:] == first_job)
-                    print("\nDeleting run for the first job {}:".format(first_job))
-                    print(self.admin_api.delete_run(first_job))
-                    print("\nCommand: ls server -a .")
-                    ls_return_message = self.admin_api.ls_target("server", "-a", ".").get("details").get("message")
-                    print(ls_return_message)
-                    print("\nJob {} is no longer in the server root dir:".format(first_job))
-                    print(first_job not in ls_return_message)
-                    # print("\nAborting Job {}:".format(second_job))
-                    print("\n" + "=" * 50)
-                    # print(self.admin_api.abort_job(second_job).get("details").get("message"))
-                    print("Finished with admin commands testing through FLAdminAPI.")
-                    print(("\n" + "*" * 120) * 20)
+                    run_admin_api_tests(self.admin_api)
             else:
                 raise RuntimeError(f"Command {command} is not supported.")
 

--- a/tests/integration_test/admin_controller.py
+++ b/tests/integration_test/admin_controller.py
@@ -391,7 +391,10 @@ class AdminController:
                                     if row[3] != "stopped":
                                         continue
                                 # check if job is completed
-                                if job_run_statuses[self.job_id] == RunStatus.FINISHED_COMPLETED.value:
+                                if job_run_statuses[self.job_id] in (
+                                    RunStatus.FINISHED_COMPLETED.value,
+                                    RunStatus.FINISHED_ABORTED.value,
+                                ):
                                     training_done = True
             time.sleep(self.poll_period)
 
@@ -450,6 +453,71 @@ class AdminController:
                         client_ids = list(site_launcher.client_properties.keys())
                     for cid in client_ids:
                         site_launcher.start_client(cid)
+
+            elif command == "test":
+                if args[0] == "admin_commands":
+                    print(("\n" + "*" * 120) * 20)
+                    print("\n" + "=" * 40)
+                    print("\nRunning through tests of admin commands:")
+                    print("\n" + "=" * 40)
+                    print("\nCommand: set_timeout")
+                    print(self.admin_api.set_timeout(11).get("details").get("message"))
+                    print("\nActive SP:")
+                    print(self.admin_api.get_active_sp().get("details"))
+                    print("\nList SP:")
+                    print(self.admin_api.list_sp().get("details"))
+                    print("\nCommand: get_available_apps_to_upload")
+                    print(self.admin_api.get_available_apps_to_upload())
+                    print("\nList Jobs:")
+                    list_jobs_return_message = self.admin_api.list_jobs().get("details").get("message")
+                    print(list_jobs_return_message)
+                    first_job = list_jobs_return_message.split()[14]
+                    print("\nCommand: ls server -a .")
+                    ls_return_message = self.admin_api.ls_target("server", "-a", ".").get("details").get("message")
+                    print(ls_return_message)
+                    print("\nJob {} is in the server root dir:".format(first_job))
+                    print(first_job in ls_return_message)
+                    print("\nAborting Job {}:".format(first_job))
+                    print("\n" + "=" * 50)
+                    print(self.admin_api.abort_job(first_job).get("details").get("message"))
+                    print("\n" + "=" * 50)
+                    # print("\nCloning Job {}:".format(first_job))
+                    # clone_job_return = self.admin_api.clone_job(first_job)
+                    # print(clone_job_return.get("details").get("message"))
+                    # second_job = clone_job_return.get("details").get("job_id")
+                    # print("\nSecond job_id is: {}".format(second_job))
+                    print("\nCommand: env server")
+                    print(self.admin_api.env_target("server").get("details"))
+                    print("\nCommand: pwd")
+                    print(self.admin_api.get_working_directory("server").get("details").get("message"))
+                    print("\nCommand: env site-1")
+                    print(self.admin_api.env_target("site-1").get("details"))
+                    print("\nCommand: tail_target_log server")
+                    tail_return_message = self.admin_api.tail_target_log("server").get("details").get("message")
+                    print(tail_return_message)
+                    print("\nFirst job matches end of tail:".format(first_job))
+                    print(tail_return_message[-36:] == first_job)
+                    print("\nCommand: grep_target server -n 'deployed to the server for run' log.txt")
+                    grep_return_message = (
+                        self.admin_api.grep_target("server", "-n", "Stop the job run", "log.txt")
+                        .get("details")
+                        .get("message")
+                    )
+                    print(grep_return_message)
+                    print("\nFirst job matches job_id in grep:".format(first_job))
+                    print(grep_return_message[-36:] == first_job)
+                    print("\nDeleting run for the first job {}:".format(first_job))
+                    print(self.admin_api.delete_run(first_job))
+                    print("\nCommand: ls server -a .")
+                    ls_return_message = self.admin_api.ls_target("server", "-a", ".").get("details").get("message")
+                    print(ls_return_message)
+                    print("\nJob {} is no longer in the server root dir:".format(first_job))
+                    print(first_job not in ls_return_message)
+                    # print("\nAborting Job {}:".format(second_job))
+                    print("\n" + "=" * 50)
+                    # print(self.admin_api.abort_job(second_job).get("details").get("message"))
+                    print("Finished with admin commands testing through FLAdminAPI.")
+                    print(("\n" + "*" * 120) * 20)
             else:
                 raise RuntimeError(f"Command {command} is not supported.")
 

--- a/tests/integration_test/data/fladminapi/execute_fladminapi_commands.yml
+++ b/tests/integration_test/data/fladminapi/execute_fladminapi_commands.yml
@@ -1,0 +1,15 @@
+description: "upload a job, execute a chain of admin commands through FLAdminAPI to test for expected functionality"
+events: [
+    {
+        "trigger": "sent task assignment to client",
+        "actions": ["test admin_commands"],
+        "result_state": {
+        "workflows": {
+          "ScatterAndGather": {
+            "phase": "train",
+            "current_round": 0
+          }
+        }
+      },
+    },
+]

--- a/tests/integration_test/data/single_app_as_job/test_fladminapi.yml
+++ b/tests/integration_test/data/single_app_as_job/test_fladminapi.yml
@@ -1,0 +1,10 @@
+system_setup: ./data/system/ha_1_server_2_clients.yml
+apps_root_dir: ./data/apps
+single_app_as_job: True
+cleanup: True
+
+
+tests:
+  - app_name: np_sag
+    validators:
+    event_sequence_yaml: ./data/fladminapi/execute_fladminapi_commands.yml

--- a/tests/integration_test/test_cases.yml
+++ b/tests/integration_test/test_cases.yml
@@ -2,3 +2,4 @@ test_configs:
   - ./data/single_app_as_job/test_example_apps.yml
   - ./data/single_app_as_job/test_internal_apps.yml
   - ./data/single_app_as_job/test_ha.yml
+  - ./data/single_app_as_job/test_fladminapi.yml

--- a/tests/integration_test/test_fladminapi.py
+++ b/tests/integration_test/test_fladminapi.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from nvflare.fuel.hci.client.fl_admin_api import FLAdminAPI
+
+
+def run_admin_api_tests(admin_api: FLAdminAPI):
+    print(("\n" + "*" * 120) * 20)
+    print("\n" + "=" * 40)
+    print("\nRunning through tests of admin commands:")
+    print("\n" + "=" * 40)
+    print("\nCommand: set_timeout")
+    print(admin_api.set_timeout(11).get("details").get("message"))
+    print("\nActive SP:")
+    print(admin_api.get_active_sp().get("details"))
+    print("\nList SP:")
+    print(admin_api.list_sp().get("details"))
+    print("\nCommand: get_available_apps_to_upload")
+    print(admin_api.get_available_apps_to_upload())
+    print("\nList Jobs:")
+    list_jobs_return_message = admin_api.list_jobs().get("details").get("message")
+    print(list_jobs_return_message)
+    first_job = list_jobs_return_message.split()[14]
+    print("\nCommand: ls server -a .")
+    ls_return_message = admin_api.ls_target("server", "-a", ".").get("details").get("message")
+    print(ls_return_message)
+    print("\nAssert Job {} is in the server root dir...".format(first_job))
+    assert(first_job in ls_return_message)
+
+    print("\nAborting Job {}:".format(first_job))
+    print("\n" + "=" * 50)
+    print(admin_api.abort_job(first_job).get("details").get("message"))
+    print("\n" + "=" * 50)
+    # print("\nCloning Job {}:".format(first_job))
+    # clone_job_return = admin_api.clone_job(first_job)
+    # print(clone_job_return.get("details").get("message"))
+    # second_job = clone_job_return.get("details").get("job_id")
+    # print("\nSecond job_id is: {}".format(second_job))
+    print("\nCommand: env server")
+    print(admin_api.env_target("server").get("details"))
+    print("\nCommand: pwd")
+    print(admin_api.get_working_directory("server").get("details").get("message"))
+    print("\nCommand: env site-1")
+    print(admin_api.env_target("site-1").get("details"))
+    print("\nCommand: tail_target_log server")
+    tail_return_message = admin_api.tail_target_log("server").get("details").get("message")
+    print(tail_return_message)
+    print("\nAssert first job matches end of tail...".format(first_job))
+    assert(tail_return_message[-36:] == first_job)
+    print("\nCommand: grep_target server -n 'deployed to the server for run' log.txt")
+    grep_return_message = (
+        admin_api.grep_target("server", "-n", "Stop the job run", "log.txt")
+        .get("details")
+        .get("message")
+    )
+    print(grep_return_message)
+    print("\nAssert first job matches job_id in grep...".format(first_job))
+    assert(grep_return_message[-36:] == first_job)
+    print("\nDeleting run for the first job {}:".format(first_job))
+    print(admin_api.delete_run(first_job))
+    print("\nCommand: ls server -a .")
+    ls_return_message = admin_api.ls_target("server", "-a", ".").get("details").get("message")
+    print(ls_return_message)
+    print("\nAssert Job {} is no longer in the server root dir...".format(first_job))
+    assert(first_job not in ls_return_message)
+
+    # print("\nAborting Job {}:".format(second_job))
+    print("\n" + "=" * 50)
+    # print(admin_api.abort_job(second_job).get("details").get("message"))
+    print("Finished with admin commands testing through FLAdminAPI.")
+    print(("\n" + "*" * 120) * 20)


### PR DESCRIPTION
Adds a test to execute a chain of FLAdminAPI commands. This adds 30s to the tests and covers most of the FLAdminAPI commands.

Fixes some issues with commands in FLAdminAPI.

Testing clone_job is a bit tricky because the cloned job will be picked up to run and the abort right now does not stop it properly if it is in the SUBMITTED state even with some modifications to job_cmds.py (simply setting the status to FINISHED:ABORTED does not work because it still gets picked up and then the status becomes RUNNING again, but this is another issue from these tests).