### PR TITLE
Use PCI_BUS_ID as CUDA_DEVICE_ORDER in GPUResourceConsumer

### DIFF
--- a/nvflare/app_common/resource_consumers/gpu_resource_consumer.py
+++ b/nvflare/app_common/resource_consumers/gpu_resource_consumer.py
@@ -21,6 +21,7 @@ class GPUResourceConsumer(ResourceConsumerSpec):
     def __init__(self, gpu_resource_key="gpu"):
         super().__init__()
         self.gpu_resource_key = gpu_resource_key
+        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 
     def consume(self, resources: dict):
         gpu_numbers = []


### PR DESCRIPTION
- Use PCI_BUS_ID as CUDA_DEVICE_ORDER in GPUResourceConsumer