### PR TITLE
fix links, add information to docs raised from QA

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -368,5 +368,5 @@ Known issues
 #. After calling ``shutdown client`` for a client running multi GPUs, a process (sub_worker_process) may remain. The
    work around for this is to run ``abort client`` before the ``shutdown`` command.
 #. If a snapshot is in a corrupted state, the server may try to restore the job and get stuck. To resolve this, delete
-   the snapshot from the location configured in project.yml for the snapshot_persistor storage, and ``abort_job`` should
-   be able to stop the job on the server.
+   the snapshot from the location configured in project.yml for the snapshot_persistor storage (by default
+   ``/tmp/nvflare/jobs-storage``), and ``abort_job`` should be able to stop the job on the server.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -181,17 +181,17 @@ Operational
 
 #. What is the difference between the Admin client and the FL client?
 
-    The :ref:`Admin client <admin_commands>` is used to control the state of the server's controller workflow and only interacts with the
+    The :ref:`Admin client <operating_nvflare>` is used to control the state of the server's controller workflow and only interacts with the
     server.  FL clients poll the server and perform tasks based on the state of the server.  The Admin client does not
     interact directly with FL client.
 
 #. Where does the Admin client run?
 
-    The :ref:`Admin client <admin_commands>` runs as a standalone process, typically on a researcher's workstation or laptop.
+    The :ref:`Admin client <operating_nvflare>` runs as a standalone process, typically on a researcher's workstation or laptop.
 
 #. What can you do with the Admin client?
 
-    The :ref:`Admin client <admin_commands>` is used to orchestrate the FL study, including starting and stopping server
+    The :ref:`Admin client <operating_nvflare>` is used to orchestrate the FL study, including starting and stopping server
     and clients, deploying applications, and managing FL experiments.
 
 #. Why am I getting an error about my custom files not being found?
@@ -363,13 +363,10 @@ Overall training flow related questions
 Known issues
 ************
 
-#. If server dies and then is restarted, intentionally or unintentionally, all clients will have to be restarted.
 #. Running out of memory can happen at any time, especially if the server and clients are running on same machine.
    This can cause the server to die unexpectedly.
-#. Putting applications in the transfer folders without using the upload_app command or forgetting to delete the models
-   folder inside, a mysterious error may occur when running the deploy_app command because the application folder is too
-   large to be uploaded and that causes timeout.
-#. Please don't start a new training run or start a new app before the previous application is fully stopped. Users
-   can do ``abort client`` and ``abort server`` before ``start_app`` for the new run.
 #. After calling ``shutdown client`` for a client running multi GPUs, a process (sub_worker_process) may remain. The
    work around for this is to run ``abort client`` before the ``shutdown`` command.
+#. If a snapshot is in a corrupted state, the server may try to restore the job and get stuck. To resolve this, delete
+   the snapshot from the location configured in project.yml for the snapshot_persistor storage, and ``abort_job`` should
+   be able to stop the job on the server.

--- a/docs/programming_guide/system_architecture.rst
+++ b/docs/programming_guide/system_architecture.rst
@@ -97,6 +97,12 @@ This component is specified as one item in the components.server section.
 
 This configuration is included in the fed_server.json of the Server’s Startup Kit.
 
+.. note::
+
+   The default storage is `FilesystemStorage<nvflare.app_common.storages.filesystem_storage.FilesystemStorage>` and is
+   configured to use paths available in the file system to persist data. Other implementations can be used instead that
+   may need to take other arguments or configurations.
+
 Job Scheduler
 -------------
 The Job scheduler is responsible for determining the next job to run. Job scheduler config specifies the Job scheduler Python object.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ Quickstart
 ##########
 
 This section provides a starting point for new users to start NVIDIA FLARE.
-Users can go through the :ref:`example_apps` and get familiar with how NVIDIA FLARE is designed,
+Users can go through the :ref:`example_applications` and get familiar with how NVIDIA FLARE is designed,
 operates and works.
 
 Each example introduces concepts about NVIDIA FLARE, while showcasing how some popular libraries and frameworks can

--- a/docs/user_guide/job.rst
+++ b/docs/user_guide/job.rst
@@ -110,6 +110,11 @@ folder with meta.json.
 There is only one server, and only one app can be deployed to it for the Job, so "server" can appear only once in
 the ``deploy_map``.
 
+The ``deploy_map`` cannot be empty, and "@all" when specified as a site name carries a special meaning of all
+sites to deploy to. If "@all" is used, there should be no other apps being deployed to the sites. If an empty list of
+sites is specified for an app in the ``deploy_map``, then that app is to be deployed to no sites, and no validation is
+done other than checking that the folder exists.
+
 Resource-less Jobs
 ==================
 Similarly, for simple FL jobs or in POC mode, resources are not a concern. In this case, the resource spec can be

--- a/docs/user_guide/job.rst
+++ b/docs/user_guide/job.rst
@@ -110,10 +110,24 @@ folder with meta.json.
 There is only one server, and only one app can be deployed to it for the Job, so "server" can appear only once in
 the ``deploy_map``.
 
-The ``deploy_map`` cannot be empty, and "@all" when specified as a site name carries a special meaning of all
-sites to deploy to. If "@all" is used, there should be no other apps being deployed to the sites. If an empty list of
-sites is specified for an app in the ``deploy_map``, then that app is to be deployed to no sites, and no validation is
-done other than checking that the folder exists.
+The ``deploy_map`` cannot be empty, so the following is not allowed::
+
+    "deploy_map": {}
+
+When specified as a site name, "@ALL" carries a special meaning of all sites to deploy to. If "@ALL" is used, there
+should be no other apps being deployed to the sites. This means the following example of ``deploy_map`` is not allowed::
+
+    "deploy_map": {
+        "app1": ["@ALL"], "app2": ["site-1"]
+    }
+
+If an empty list of sites is specified for an app in the ``deploy_map``, then that app is to be deployed to no sites,
+and no validation is done other than checking that the folder exists. This is the case for "app2" in the following valid
+example of ``deploy_map`` for a job containing app1 and app2::
+
+    "deploy_map": {
+        "app1": ["@ALL"], "app2": []
+    }
 
 Resource-less Jobs
 ==================

--- a/docs/user_guide/operation.rst
+++ b/docs/user_guide/operation.rst
@@ -61,6 +61,13 @@ commands shown as examples of how they may be run with a description.
     shutdown_system,``shutdown_system``,Shut down entire system by setting the system state to shutdown through the overseer
 
 
+.. note::
+
+   The commands ``promote_sp`` and ``shutdown_system`` both go to the Overseer and have a different mechanism of
+   authorization than the other commands sent to the FL server. The Overseer keeps track of a list of privileged users,
+   configured to be admin users with the role of "super". Only users owning certificates whose cn is in the privileged
+   user list can call these commands.
+
 .. tip::
 
    Outputs of any command can be redirected into a file by using the greater-than symbol ">", however there must be no

--- a/docs/user_guide/overview.rst
+++ b/docs/user_guide/overview.rst
@@ -215,7 +215,7 @@ started successfully as described in the preceding section, `Federated learning 
 admin commands can be used to operate a federated learning project. The FLAdminAPI provides a way to programmatically
 issue commands to operate the system so it can be run with a script.
 
-For a complete list of admin commands, see :ref:`admin_commands`.
+For a complete list of admin commands, see :ref:`operating_nvflare`.
 
 For examples of using the commands to operate a FL system, see the examples in the :ref:`quickstart` section.
 


### PR DESCRIPTION
- Fix links after some renaming in docs restructure
- add information on new changes to the deploy_map
- add to FAQ item from QA about aborting server after corrupted snapshot
- add information about permissions for super user for Overseer commands