### PR TITLE
cherrypick the monitor parent process exit to dev-2.1.

### DIFF
--- a/nvflare/private/fed/app/client/sub_worker_process.py
+++ b/nvflare/private/fed/app/client/sub_worker_process.py
@@ -138,7 +138,7 @@ def main():
     workspace = data[CommunicationMetaData.FL_CTX].get_prop(FLContextKey.WORKSPACE_OBJECT)
     run_manager = ClientRunManager(
         client_name=client_name,
-        run_num=int(run_number),
+        run_num=run_number,
         workspace=workspace,
         client=None,
         components=data[CommunicationMetaData.COMPONENTS],


### PR DESCRIPTION
1. Cherry-pick the monitor parent process exit, then terminate the child process into dev-2.1 branch.
2. Fixed a run_number issue for multi-gpu training.