### PR TITLE
fix shutdown_system command

### DIFF
--- a/nvflare/ha/ha_admin_cmds.py
+++ b/nvflare/ha/ha_admin_cmds.py
@@ -90,8 +90,8 @@ class HACommandModule(CommandModule):
 
     def shutdown_system(self, args, api):
         try:
-            status = api.check_status("server").get("details").get("server_engine_status")
-            if status != "stopped":
+            status = api.do_command("check_status server").get("data")
+            if status[0].get("data") != "Engine status: stopped":
                 return {
                     "status": APIStatus.ERROR_RUNTIME,
                     "details": "Error: There are still jobs running. Please let them finish or abort_job before attempting shutdown.",
@@ -99,7 +99,9 @@ class HACommandModule(CommandModule):
         except Exception as e:
             return {
                 "status": APIStatus.ERROR_RUNTIME,
-                "details": "Error getting server status: {}".format(e),
+                "details": "Error getting server status to make sure all jobs are stopped before shutting down system: {}".format(
+                    e
+                ),
             }
         print("Shutting down the system...")
         resp = api.overseer_agent.set_state("shutdown")


### PR DESCRIPTION
api here is not FLAdminAPI but AdminAPI so check_status is not available and do_command needs to be used instead.

Fixes this, and improves exception message to be more clear of what the error is for.