### PR TITLE
Fix resource manager clean up thread calling

### DIFF
--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -112,3 +112,6 @@ class SSLConstants:
     CERT = "ssl_cert"
     PRIVATE_KEY = "ssl_private_key"
     ROOT_CERT = "ssl_root_cert"
+
+
+ERROR_MSG_PREFIX = "NVFLARE_ERROR"

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -71,7 +71,7 @@ class ClientEngine(ClientEngineInternalSpec):
             raise ValueError("workers must >= 1")
         self.executor = ThreadPoolExecutor(max_workers=workers)
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.fl_components = [x for x in self.client.components if isinstance(x, FLComponent)]
+        self.fl_components = [x for x in self.client.components.values() if isinstance(x, FLComponent)]
 
     def fire_event(self, event_type: str, fl_ctx: FLContext):
         fire_event(event=event_type, handlers=self.fl_components, ctx=fl_ctx)
@@ -160,7 +160,7 @@ class ClientEngine(ClientEngineInternalSpec):
             resource_manager,
         )
 
-        return "Start the client app..."
+        return ""
 
     def get_client_name(self):
         return self.client.client_name
@@ -201,7 +201,7 @@ class ClientEngine(ClientEngineInternalSpec):
 
         self.client_executor.abort_train(self.client, run_number)
 
-        return "Abort signal has been sent to the client App."
+        return ""
 
     def abort_task(self, run_number: str) -> str:
         status = self.client_executor.get_status(run_number)
@@ -213,7 +213,7 @@ class ClientEngine(ClientEngineInternalSpec):
 
         self.client_executor.abort_task(self.client, run_number)
 
-        return "Abort signal has been sent to the current task. "
+        return ""
 
     def shutdown(self) -> str:
         self.logger.info("Client shutdown...")
@@ -222,7 +222,7 @@ class ClientEngine(ClientEngineInternalSpec):
         self.fire_event(EventType.SYSTEM_END, self.new_context())
         _ = self.executor.submit(lambda p: _shutdown_client(*p), [self.client, self.admin_agent, touch_file])
 
-        return "Shutdown the client..."
+        return ""
 
     def restart(self) -> str:
         self.logger.info("Client shutdown...")
@@ -231,7 +231,7 @@ class ClientEngine(ClientEngineInternalSpec):
         self.fire_event(EventType.SYSTEM_END, self.new_context())
         _ = self.executor.submit(lambda p: _shutdown_client(*p), [self.client, self.admin_agent, touch_file])
 
-        return "Restart the client..."
+        return ""
 
     def deploy_app(self, app_name: str, run_num: int, client_name: str, app_data) -> str:
         workspace = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(run_num))
@@ -245,7 +245,7 @@ class ClientEngine(ClientEngineInternalSpec):
         run_number_folder = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(run_num))
         if os.path.exists(run_number_folder):
             shutil.rmtree(run_number_folder)
-        return "Delete run folder: {}".format(run_number_folder)
+        return ""
 
     def get_current_run_info(self, run_number) -> ClientRunInfo:
         return self.client_executor.get_run_info(run_number)

--- a/nvflare/private/fed/client/client_engine_internal_spec.py
+++ b/nvflare/private/fed/client/client_engine_internal_spec.py
@@ -50,7 +50,7 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
 
     @abstractmethod
     def deploy_app(self, app_name: str, run_num: int, client_name: str, app_data) -> str:
-        """Deploy the app to specified run.
+        """Deploys the app to specified run.
 
         Args:
             app_name: FL_app name
@@ -58,8 +58,8 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
             client_name: name of the client
             app_data: zip data of the app
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 
@@ -72,7 +72,7 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         resource_consumer=None,
         resource_manager=None,
     ) -> str:
-        """Start the app for the specified run.
+        """Starts the app for the specified run.
 
         Args:
             run_number: run_number
@@ -81,17 +81,17 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
             resource_consumer: resource consumer
             resource_manager: resource manager
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 
     @abstractmethod
     def abort_app(self, run_number: int) -> str:
-        """Abort the app execution in current run.
+        """Aborts the app execution for the specified run.
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 
@@ -99,38 +99,38 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
     def abort_task(self, run_number: int) -> str:
         """Abort the client current executing task.
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 
     @abstractmethod
     def delete_run(self, run_num: int) -> str:
-        """Delete the specified run.
+        """Deletes the specified run.
 
         Args:
             run_num: run_number
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 
     @abstractmethod
     def shutdown(self) -> str:
-        """Shutdown the FL client.
+        """Shuts down the FL client.
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 
     @abstractmethod
     def restart(self) -> str:
-        """Restart the FL client.
+        """Restarts the FL client.
 
-        Returns: error if any
-
+        Returns:
+            A string message.
         """
         pass
 

--- a/nvflare/private/fed/client/scheduler_cmds.py
+++ b/nvflare/private/fed/client/scheduler_cmds.py
@@ -19,7 +19,7 @@ from nvflare.apis.fl_constant import ReturnCode, SystemComponents
 from nvflare.apis.resource_manager_spec import ResourceConsumerSpec, ResourceManagerSpec
 from nvflare.apis.shareable import Shareable
 from nvflare.private.admin_defs import Message
-from nvflare.private.defs import RequestHeader, TrainingTopic
+from nvflare.private.defs import ERROR_MSG_PREFIX, RequestHeader, TrainingTopic
 from nvflare.private.fed.client.admin import RequestProcessor
 from nvflare.private.fed.client.client_engine_internal_spec import ClientEngineInternalSpec
 from nvflare.private.scheduler_constants import ShareableHeader
@@ -51,8 +51,6 @@ class CheckResourceProcessor(RequestProcessor):
             except Exception:
                 result.set_return_code(ReturnCode.EXECUTION_EXCEPTION)
 
-        if not result:
-            result = "OK"
         return Message(topic="reply_" + req.topic, body=pickle.dumps(result))
 
 
@@ -92,7 +90,7 @@ class StartJobProcessor(RequestProcessor):
                 resource_manager=resource_manager,
             )
         except Exception as e:
-            result = f"Execution exception: {e}."
+            result = f"{ERROR_MSG_PREFIX}: Execution exception: {e}."
 
         if not result:
             result = "OK"
@@ -123,6 +121,4 @@ class CancelResourceProcessor(RequestProcessor):
             except Exception:
                 result.set_return_code(ReturnCode.EXECUTION_EXCEPTION)
 
-        if not result:
-            result = "OK"
         return Message(topic="reply_" + req.topic, body=pickle.dumps(result))

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -440,6 +440,8 @@ class FederatedServer(BaseServer, fed_service.FederatedTrainingServicer, admin_s
                 return task
 
     def _process_task_request(self, client, fl_ctx, shared_fl_ctx):
+        task_name = SpecialTaskName.END_RUN
+        task_id = ""
         shareable = None
         try:
             with self.engine.lock:
@@ -463,11 +465,8 @@ class FederatedServer(BaseServer, fed_service.FederatedTrainingServicer, admin_s
                     child_fl_ctx = return_data.get(ServerCommandKey.FL_CONTEXT)
 
                     fl_ctx.props.update(child_fl_ctx)
-        except BaseException:
-            self.logger.info("Could not connect to server runner process - asked client to end the run")
-            task_name = SpecialTaskName.END_RUN
-            task_id = ""
-            shareable = None
+        except BaseException as e:
+            self.logger.info(f"Could not connect to server runner process: {e} - asked client to end the run")
         return shareable, task_id, task_name
 
     def SubmitUpdate(self, request, context):

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -36,8 +36,8 @@ def _check_client_replies(replies, client_sites: List[str], command: str):
 
     error_msg = ""
     for r, client_name in zip(replies, client_sites):
-        if r.reply != "OK":
-            error_msg += f"{client_name}: {r}\n"
+        if r.reply.body != "OK":
+            error_msg += f"{client_name}: {r.reply.body}\n"
     if error_msg != "":
         raise RuntimeError(f"Failed to {command} to the following clients: \n{error_msg}")
     return True

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -217,11 +217,14 @@ class JobRunner(FLComponent):
         message.set_header(RequestHeader.RUN_NUM, str(run_number))
         self.log_debug(fl_ctx, f"Send delete_run command to the site for run:{run_number}")
         replies = _send_to_clients(admin_server, client_sites, engine, message)
-        _check_client_replies(replies=replies, client_sites=client_sites, command="send delete_run command")
+        try:
+            _check_client_replies(replies=replies, client_sites=client_sites, command="send delete_run command")
+        except RuntimeError as e:
+            self.log_error(fl_ctx, f"Failed to execute delete run ({run_number}) on the clients: {e}")
 
         err = engine.delete_run_number(run_number)
         if err:
-            self.log_error(fl_ctx, f"Failed to delete_run the server for run_.{run_number}")
+            self.log_error(fl_ctx, f"Failed to delete_run the server for run: {run_number}")
 
     def _job_complete_process(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -55,6 +55,7 @@ from nvflare.fuel.hci.zip_utils import zip_directory_to_bytes
 from nvflare.private.admin_defs import Message
 from nvflare.private.defs import RequestHeader, TrainingTopic
 from nvflare.private.fed.server.server_json_config import ServerJsonConfigurator
+from nvflare.private.fed.utils.fed_utils import check_client_replies
 from nvflare.private.scheduler_constants import ShareableHeader
 from nvflare.widgets.info_collector import InfoCollector
 from nvflare.widgets.widget import Widget, WidgetID
@@ -748,20 +749,14 @@ class ServerEngine(ServerEngineInternalSpec):
             request = Message(topic=TrainingTopic.START_JOB, body=pickle.dumps(resource_requirement))
             request.set_header(RequestHeader.RUN_NUM, run_number)
             request.set_header(ShareableHeader.RESOURCE_RESERVE_TOKEN, token)
-            # request.set_header(ShareableHeader.RESOURCE_SPEC, resource_requirements)
             client = self.get_client_from_name(site)
             if client:
                 requests.update({client.token: request})
         replies = []
         if requests:
             replies = self._send_admin_requests(requests)
+        check_client_replies(replies=replies, client_sites=client_sites, command=f"start job ({run_number})")
         return replies
-
-        # admin_server = engine.server.admin_server
-        # message = Message(topic=TrainingTopic.START_JOB, body="")
-        # message.set_header(RequestHeader.RUN_NUM, run_number)
-        # replies = self._send_to_clients(admin_server, client_sites, engine, message)
-        # return replies
 
     def stop_all_jobs(self):
         fl_ctx = self.new_context()

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -22,6 +22,7 @@ from typing import List
 from nvflare.apis.fl_constant import WorkspaceConstants
 from nvflare.apis.fl_context import FLContext
 from nvflare.fuel.hci.zip_utils import unzip_all_from_bytes
+from nvflare.private.defs import ERROR_MSG_PREFIX
 from nvflare.private.fed.protos.federated_pb2 import ModelData
 from nvflare.private.fed.utils.numproto import bytes_to_proto
 
@@ -105,7 +106,7 @@ def check_client_replies(replies, client_sites: List[str], command: str):
 
     error_msg = ""
     for r, client_name in zip(replies, client_sites):
-        if r.reply.body != "OK":
+        if ERROR_MSG_PREFIX in r.reply.body:
             error_msg += f"{client_name}: {r.reply.body}\n"
     if error_msg != "":
         raise RuntimeError(f"Failed to {command} to the following clients: \n{error_msg}")

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -17,6 +17,7 @@ import pickle
 import shutil
 from logging.handlers import RotatingFileHandler
 from multiprocessing.connection import Listener
+from typing import List
 
 from nvflare.apis.fl_constant import WorkspaceConstants
 from nvflare.apis.fl_context import FLContext
@@ -93,3 +94,18 @@ def listen_command(listen_port, engine, execute_func, logger):
             conn.close()
         if listener:
             listener.close()
+
+
+def check_client_replies(replies, client_sites: List[str], command: str):
+    display_sites = ",".join(client_sites)
+    if not replies:
+        raise RuntimeError(f"Failed to {command} to the clients {display_sites}: no replies.")
+    if len(replies) != len(client_sites):
+        raise RuntimeError(f"Failed to {command} to the clients {display_sites}: not enough replies.")
+
+    error_msg = ""
+    for r, client_name in zip(replies, client_sites):
+        if r.reply.body != "OK":
+            error_msg += f"{client_name}: {r.reply.body}\n"
+    if error_msg != "":
+        raise RuntimeError(f"Failed to {command} to the following clients: \n{error_msg}")


### PR DESCRIPTION
- Fix event firing
- Fix a situation where `task_id` might be referenced before assignment in `_process_task_request` in `nvflare/private/fed/server/fed_server.py`
- Fix client replies error handling in `nvflare/private/fed/server/job_runner.py`
- Fix return responses in `ClientEngine`