### PR TITLE
cifar-10: Use unique dir for datasplits

### DIFF
--- a/examples/cifar10/submit_job.py
+++ b/examples/cifar10/submit_job.py
@@ -68,10 +68,10 @@ def main():
         meta_config = read_json(meta_config_filename)
         print(f"Set alpha to {args.alpha}")
         token = str(uuid.uuid4())
-        job_name = f"{job_name}_alpha{args.alpha}_{token}"
+        job_name = f"{job_name}_alpha{args.alpha}"
         server_config["alpha"] = args.alpha
         meta_config["name"] = job_name
-        split_dir = os.path.join(args.train_split_root, job_name)
+        split_dir = os.path.join(args.train_split_root, f"{job_name}_{token}")
         print(f"Set train split root to {split_dir}")
         server_config["TRAIN_SPLIT_ROOT"] = split_dir
         client_config["TRAIN_SPLIT_ROOT"] = split_dir

--- a/examples/cifar10/submit_job.py
+++ b/examples/cifar10/submit_job.py
@@ -15,6 +15,7 @@
 import argparse
 import json
 import os
+import uuid
 
 from nvflare.fuel.hci.client.fl_admin_api_runner import FLAdminAPIRunner, api_command_wrapper
 
@@ -66,7 +67,8 @@ def main():
         server_config = read_json(server_config_filename)
         meta_config = read_json(meta_config_filename)
         print(f"Set alpha to {args.alpha}")
-        job_name = f"{job_name}_alpha{args.alpha}"
+        token = str(uuid.uuid4())
+        job_name = f"{job_name}_alpha{args.alpha}_{token}"
         server_config["alpha"] = args.alpha
         meta_config["name"] = job_name
         split_dir = os.path.join(args.train_split_root, job_name)


### PR DESCRIPTION
Change to unique job name for cifar-10 examples to avoid race condition (writing to the same location) if multiple jobs running in the client machine