### PR TITLE
Replace run_number with job_id in most occurrences

### DIFF
--- a/docs/programming_guide/event_system.rst
+++ b/docs/programming_guide/event_system.rst
@@ -90,8 +90,8 @@ NVIDIA FLARE's system-defined event types are specified in :class:`nvflare.apis.
 .. csv-table::
    :header: Event, Description, Data Key, Data Type, Server, Client
 
-    START_RUN,A new RUN is about to start,fl_ctx.get_run_number(),int,X,X
-    END_RUN,The current RUN is about to end,fl_ctx.get_run_number(),int,X,X
+    START_RUN,A new RUN is about to start,fl_ctx.get_job_id(),int,X,X
+    END_RUN,The current RUN is about to end,fl_ctx.get_job_id(),int,X,X
     START_WORKFLOW,Workflow is about start,FLContextKey.WORKFLOW,int,X,
     END_WORKFLOW,Workflow is about to end,FLContextKey.WORKFLOW,int,X,
     BEFORE_PROCESS_SUBMISSION,Task result submission is about to be processed,FLContextKey.TASK_NAME,str,X,

--- a/docs/programming_guide/fl_context.rst
+++ b/docs/programming_guide/fl_context.rst
@@ -78,7 +78,7 @@ Engine (fl_ctx.get_engine())
 The engine represents the underlying services that can be used by the application. See ServerEngineSpec and/or
 ClientEngineSpec for services they provide.
 
-Run Number (fl_ctx.get_run_number())
+Job ID (fl_ctx.get_job_id())
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 FL application is always running within a RUN, which has a unique ID number. From NVIDIA FLARE version 2.1.0, job ID is
 used as the run number, and it no longer has to be an integer.
@@ -204,7 +204,7 @@ The following diagram shows the lifecycle of the FL context for each iteration.
     :height: 600px
 
 In the Peer Context, following props from the Server are available (job ID is used as the run number in version 2.1.0+):
-    - Run Number: peer_ctx.get_run_number())
+    - Run Number: peer_ctx.get_job_id())
 
 Server Side FL Context
 ----------------------
@@ -218,7 +218,7 @@ fired during the task request processing.
 Note that this context contains the "peer context" of the client.
 
 In the Peer Context, following props from the Client are available:
-    - Run Number: peer_ctx.get_run_number()
+    - Job ID: peer_ctx.get_job_id()
     - Client Name: peer_ctx.get_identity_name()
     - May have additional public props
 
@@ -231,7 +231,7 @@ task result processing.
 Note that this context contains the "peer context" of the client.
 
 In the Peer Context, following props from the Client are available:
-    - Run Number: peer_ctx.get_run_number()
+    - Job ID: peer_ctx.get_job_id()
     - Client Name: peer_ctx.get_identity_name()
     - Task ID: peer_ctx.get_prop(FLContextKey.TASK_ID)
     - Task Name: peer_ctx.get_prop(FLContextKey.TASK_NAME)
@@ -274,9 +274,7 @@ between communicating peers! This is done through what is called "peer context":
 What is in the peer context? It depends on what public props are in the FLContext before being sent to the peer. But in
 general, the following props are always available:
 
-    - Run Number (fl_ctx.get_run_number()). This is the ID number of the RUN on the peer site. Job ID is internally used
-      run number. Note that the peer's RUN number may be different from the host site's RUN number in case the two sites
-      get out of sync.
+    - Job ID (fl_ctx.get_job_id()). This is the ID number of the RUN on the peer site.
     - Identity Name (fl_ctx.get_identity_name()). This is the unique name of the peer site (client name or server name).
 
 Additional props are available from the peer context, depending on the communication scenarios.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -225,7 +225,7 @@ Once you are ready to start the FL system, you can run the following commands to
   
   as described in the :ref:`installation <installation>` section.
 
-  If running containerized, you can use a terminal multiplexer like screen or tmux if availble.  Another option is creating multiple interactive shells by running ``docker exec`` into the running container.
+  If running containerized, you can use a terminal multiplexer like screen or tmux if available.  Another option is creating multiple interactive shells by running ``docker exec`` into the running container.
 
 The first step is starting the FL server:
 
@@ -281,9 +281,9 @@ As an example, we can check the status of the server:
 
   > check_status server
   Engine status: stopped
-  -------------------------
-  | RUN_NUMBER | APP NAME |
-  -------------------------
+  ---------------------
+  | JOB_ID | APP NAME |
+  ---------------------
   -------------------------
   Registered clients: 2 
   ----------------------------------------------------------------------------
@@ -306,7 +306,7 @@ Now you can verify that the job has been submitted and clients started with
 
   > check_status client
   -------------------------------------------------------------------------
-  | CLIENT | APP_NAME    | RUN_NUMBER                           | STATUS  |
+  | CLIENT | APP_NAME    | JOB_ID                               | STATUS  |
   -------------------------------------------------------------------------
   | site-1 | hello-pt-tb | aefdb0a3-6fbb-4c53-a677-b6951d6845a6 | started |
   | site-2 | hello-pt-tb | aefdb0a3-6fbb-4c53-a677-b6951d6845a6 | started |

--- a/docs/user_guide/job.rst
+++ b/docs/user_guide/job.rst
@@ -204,8 +204,8 @@ requirements for the clients, the job runner will dispatch the FL application fo
 corresponding destination. Then the job runner will start the FL server application and client applications to run
 the job.
 
-The job runner keeps track of the running jobs and the corresponding run numbers. Once a job finishes running, or the
-job execution got aborted, the job runner will remove the run number from the running_jobs table.
+The job runner keeps track of the running jobs and the corresponding job ids. Once a job finishes running, or the
+job execution got aborted, the job runner will remove the job id from the running_jobs table.
 
 One-Shot Execution
 ------------------

--- a/docs/user_guide/operation.rst
+++ b/docs/user_guide/operation.rst
@@ -25,7 +25,7 @@ commands shown as examples of how they may be run with a description.
     help,``help``,Get command help information
     lpwd,``lpwd``,Print local workspace root directory of the admin client
     info,``info``,Show folder setup info (upload and download sources and destinations)
-    check_status,``check_status server``,"The FL run number, FL server status, and the registered clients with their names and tokens are displayed. If training is running, the round information is also displayed."
+    check_status,``check_status server``,"The FL job id, FL server status, and the registered clients with their names and tokens are displayed. If training is running, the round information is also displayed."
     ,``check_status client``,"The name, token, and status of each connected client are displayed."
     ,``check_status client clientname``,"The name, token, and status of the specified client with *clientname* are displayed."
     submit_job,``submit_job job_folder_name``,Submits the job to the server.

--- a/docs/user_guide/workspace.rst
+++ b/docs/user_guide/workspace.rst
@@ -2,8 +2,8 @@
 NVIDIA FLARE Workspace
 ######################
 
-NVIDIA FLARE maintains a workspace for keeping the FL apps and execution results of different ``run_number``
-experiments. The following is the workspace folder structure when running NVIDIA FLARE for the server and clients.
+NVIDIA FLARE maintains a workspace for keeping the FL apps and execution results for different jobs under folders with
+the name of the ``job_id``.  The following is the workspace folder structure when running NVIDIA FLARE for the server and clients.
 
 ******
 Server
@@ -11,12 +11,12 @@ Server
 ::
 
     server/
-        run_1/
+        aefdb0a3-6fbb-4c53-a677-b6951d6845a6/
             app_server/
                 ...
                 config_fed_server.json
             fl_app.txt
-        run_2/
+        baaf8789-e83f-4863-b085-3ca95303e6bc/
             app_server/
                 ...
                 config/
@@ -35,12 +35,12 @@ Client
 ::
 
     clientA/
-        run_1/
+        aefdb0a3-6fbb-4c53-a677-b6951d6845a6/
             app_clientA/
                 ...
                 config_fed_client.json
             fl_app.txt
-        run_2/
+        baaf8789-e83f-4863-b085-3ca95303e6bc/
             app_clientA/
                 ...
                 config/
@@ -52,16 +52,10 @@ Client
             start.sh
             sub_start.sh
 
-The FL application and run data from different ``run_number`` are kept in the separate ``run_N`` folders for each run
-number ``N``. Under the ``run_N`` folder, the ``app_server`` folder holds the FL application content of the server. The
+The FL application and run data from different ``job_ids`` are kept in the separate folders for each job. Under the job
+folder, the ``app_server`` folder holds the FL application content of the server. The
 ``app_clientName`` folder holds the FL application content of the client. The config_fed_server.json and
 config_fed_client.json may be in the root folder of the FL App, or in a sub-folder (for example: config) of the FL App.
-
-The fl_app.txt indicates which FL App current ``run_number`` is using. The ``deploy_app`` command will deploy the
-corresponding FL app into the current ``run_number``. If the ``app_server`` or ``app_clientName`` folder
-already exists, all the contents within that folder will be wiped out and deployed a new FL application. If you would
-like to keep some execution results within the same ``run_number``, you can keep them in the root directory of the
-``run_N`` folder.
 
 The ``startup`` folder contains the config and the scripts to start the FL server and client program.
 

--- a/nvflare/apis/fl_context.py
+++ b/nvflare/apis/fl_context.py
@@ -127,7 +127,7 @@ class FLContext(object):
     def get_engine(self):
         return self.get_prop(key=ReservedKey.ENGINE, default=None)
 
-    def get_run_number(self):
+    def get_job_id(self):
         return self.get_prop(key=ReservedKey.RUN_NUM, default=None)
 
     def get_identity_name(self):
@@ -182,19 +182,19 @@ class FLContextManager(object):
 
     """
 
-    def __init__(self, engine, identity_name: str, run_num: str, public_stickers, private_stickers):
+    def __init__(self, engine, identity_name: str, job_id: str, public_stickers, private_stickers):
         """Init the FLContextManager.
 
         Args:
             engine: the engine that created this FLContextManager object
             identity_name (str): identity name
-            run_num: the run number
+            job_id: the job id
             public_stickers: public sticky properties that are copied into or copied from
             private_stickers: private sticky properties that are copied into or copied from
         """
         self.engine = engine
         self.identity_name = identity_name
-        self.run_num = run_num
+        self.job_id = job_id
         self._update_lock = threading.Lock()
 
         self.public_stickers = {}
@@ -219,7 +219,7 @@ class FLContextManager(object):
 
         # set permanent props
         ctx.set_prop(key=ReservedKey.ENGINE, value=self.engine, private=True)
-        ctx.set_prop(key=ReservedKey.RUN_NUM, value=self.run_num, private=False)
+        ctx.set_prop(key=ReservedKey.RUN_NUM, value=self.job_id, private=False)
 
         if self.identity_name:
             ctx.set_prop(key=ReservedKey.IDENTITY_NAME, value=self.identity_name, private=False)

--- a/nvflare/apis/fl_snapshot.py
+++ b/nvflare/apis/fl_snapshot.py
@@ -20,11 +20,11 @@ class RunSnapshot:
             { component_id: component_state_dict }
     """
 
-    def __init__(self, run_number: str):
+    def __init__(self, job_id: str):
         super().__init__()
         self.component_states = {}
         self.completed = False
-        self.run_number = run_number
+        self.job_id = job_id
 
     def get_component_snapshot(self, component_id: str) -> dict:
         """Get a state snapshot of a particular FL component.
@@ -54,44 +54,44 @@ class FLSnapshot:
     """FLSnapshot keeps a snapshot of all the current running FL application RunSnapshots.
 
     The format is:
-            { run_number: RunSnapshot }
+            { job_id: RunSnapshot }
     """
 
     def __init__(self):
         super().__init__()
         self.run_snapshots = {}
 
-    def add_snapshot(self, run_number: str, snapshot: RunSnapshot):
-        """Add the RunSnapshot for run_number to the FLSnapshot.
+    def add_snapshot(self, job_id: str, snapshot: RunSnapshot):
+        """Add the RunSnapshot for job_id to the FLSnapshot.
 
         Args:
-            run_number: the run_number
+            job_id: the job_id
             snapshot: snapshot of the Run
 
         Returns:
 
         """
-        self.run_snapshots[run_number] = snapshot
+        self.run_snapshots[job_id] = snapshot
 
-    def get_snapshot(self, run_number: str) -> RunSnapshot:
-        """Get the RunSnapshot for run_number to the FLSnapshot.
+    def get_snapshot(self, job_id: str) -> RunSnapshot:
+        """Get the RunSnapshot for job_id to the FLSnapshot.
 
         Args:
-            run_number: the run_number
+            job_id: the job_id
 
         Returns: Snapshot of the Run
 
         """
-        return self.run_snapshots.get(run_number)
+        return self.run_snapshots.get(job_id)
 
-    def remove_snapshot(self, run_number: str):
-        """Remove the RunSnapshot of run_number from the FLSnapshot.
+    def remove_snapshot(self, job_id: str):
+        """Remove the RunSnapshot of job_id from the FLSnapshot.
 
         Args:
-            run_number: the run_number
+            job_id: the job_id
 
         Returns:
 
         """
-        if run_number in self.run_snapshots.keys():
-            self.run_snapshots.pop(run_number)
+        if job_id in self.run_snapshots.keys():
+            self.run_snapshots.pop(job_id)

--- a/nvflare/apis/job_def.py
+++ b/nvflare/apis/job_def.py
@@ -87,7 +87,7 @@ class Job:
 
         self.submit_time = None
 
-        self.run_record = None  # run number, dispatched time/UUID, finished time, completion code (normal, aborted)
+        self.run_record = None  # job id, dispatched time/UUID, finished time, completion code (normal, aborted)
 
     def get_deployment(self) -> Dict[str, List[str]]:
         """Returns the deployment configuration.

--- a/nvflare/apis/responder.py
+++ b/nvflare/apis/responder.py
@@ -67,7 +67,7 @@ class Responder(FLComponent, ABC):
         """Called when a new RUN is about to start.
 
         Args:
-            fl_ctx: FL context. It must contain 'run_number' that is to be initialized
+            fl_ctx: FL context. It must contain 'job_id' that is to be initialized
 
         """
         pass

--- a/nvflare/apis/server_engine_spec.py
+++ b/nvflare/apis/server_engine_spec.py
@@ -146,12 +146,12 @@ class ServerEngineSpec(ABC):
         pass
 
     @abstractmethod
-    def start_client_job(self, run_number, client_sites):
+    def start_client_job(self, job_id, client_sites):
         """To send the start client run commands to the clients
 
         Args:
             client_sites: client sites
-            run_number: run_number
+            job_id: job_id
 
         Returns:
 

--- a/nvflare/apis/state_persistor.py
+++ b/nvflare/apis/state_persistor.py
@@ -40,14 +40,14 @@ class StatePersistor(ABC):
         pass
 
     @abstractmethod
-    def retrieve_run(self, run_number: str) -> RunSnapshot:
-        """Loads the persisted RunSnapshot of a run_number from the persisted location.
+    def retrieve_run(self, job_id: str) -> RunSnapshot:
+        """Loads the persisted RunSnapshot of a job_id from the persisted location.
 
         Args:
-            run_number: run_number
+            job_id: job_id
 
         Returns:
-            A RunSnapshot of the run_number
+            A RunSnapshot of the job_id
         """
         pass
 
@@ -57,6 +57,6 @@ class StatePersistor(ABC):
         pass
 
     @abstractmethod
-    def delete_run(self, run_number: str):
-        """Deletes the RunSnapshot of a run_number"""
+    def delete_run(self, job_id: str):
+        """Deletes the RunSnapshot of a job_id"""
         pass

--- a/nvflare/apis/utils/fl_context_utils.py
+++ b/nvflare/apis/utils/fl_context_utils.py
@@ -43,7 +43,7 @@ def generate_log_message(fl_ctx: FLContext, msg: str):
     _wf = "wf"
 
     all_kvs = {}
-    my_run = fl_ctx.get_run_number()
+    my_run = fl_ctx.get_job_id()
     if not my_run:
         my_run = "?"
     all_kvs[_my_run] = my_run
@@ -65,7 +65,7 @@ def generate_log_message(fl_ctx: FLContext, msg: str):
     if peer_ctx:
         if not isinstance(peer_ctx, FLContext):
             raise TypeError("peer_ctx must be an instance of FLContext, but got {}".format(type(peer_ctx)))
-        peer_run = peer_ctx.get_run_number()
+        peer_run = peer_ctx.get_job_id()
         if not peer_run:
             peer_run = "?"
         all_kvs[_peer_run] = peer_run

--- a/nvflare/apis/workspace.py
+++ b/nvflare/apis/workspace.py
@@ -50,14 +50,14 @@ class Workspace:
     def get_root_dir(self) -> str:
         return self.root_dir
 
-    def get_run_dir(self, run_num: str) -> str:
-        return os.path.join(self.root_dir, WorkspaceConstants.WORKSPACE_PREFIX + str(run_num))
+    def get_run_dir(self, job_id: str) -> str:
+        return os.path.join(self.root_dir, WorkspaceConstants.WORKSPACE_PREFIX + str(job_id))
 
-    def get_app_dir(self, run_num: str) -> str:
-        return os.path.join(self.get_run_dir(run_num), WorkspaceConstants.APP_PREFIX + self.name)
+    def get_app_dir(self, job_id: str) -> str:
+        return os.path.join(self.get_run_dir(job_id), WorkspaceConstants.APP_PREFIX + self.name)
 
-    def get_app_config_dir(self, run_num: str) -> str:
-        return os.path.join(self.get_app_dir(run_num), self.config_folder)
+    def get_app_config_dir(self, job_id: str) -> str:
+        return os.path.join(self.get_app_dir(job_id), self.config_folder)
 
-    def get_app_custom_dir(self, run_num: str) -> str:
-        return os.path.join(self.get_app_dir(run_num), "custom")
+    def get_app_custom_dir(self, job_id: str) -> str:
+        return os.path.join(self.get_app_dir(job_id), "custom")

--- a/nvflare/app_common/np/np_model_locator.py
+++ b/nvflare/app_common/np/np_model_locator.py
@@ -58,8 +58,8 @@ class NPModelLocator(ModelLocator):
 
         if model_name == NPModelLocator.SERVER_MODEL_NAME:
             try:
-                run_number = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
-                run_dir = engine.get_workspace().get_run_dir(run_number)
+                job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
+                run_dir = engine.get_workspace().get_run_dir(job_id)
                 model_path = os.path.join(run_dir, self.model_dir)
 
                 model_load_path = os.path.join(model_path, self.model_file_name)

--- a/nvflare/app_common/np/np_model_persistor.py
+++ b/nvflare/app_common/np/np_model_persistor.py
@@ -28,10 +28,10 @@ def _get_run_dir(fl_ctx: FLContext):
     engine = fl_ctx.get_engine()
     if engine is None:
         raise RuntimeError("engine is missing in fl_ctx.")
-    run_number = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
-    if run_number is None:
-        raise RuntimeError("run_number is missing in fl_ctx.")
-    run_dir = engine.get_workspace().get_run_dir(run_number)
+    job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
+    if job_id is None:
+        raise RuntimeError("job_id is missing in fl_ctx.")
+    run_dir = engine.get_workspace().get_run_dir(job_id)
     return run_dir
 
 

--- a/nvflare/app_common/np/np_trainer.py
+++ b/nvflare/app_common/np/np_trainer.py
@@ -179,8 +179,8 @@ class NPTrainer(Executor):
 
     def _load_local_model(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
-        run_number = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
-        run_dir = engine.get_workspace().get_run_dir(run_number)
+        job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
+        run_dir = engine.get_workspace().get_run_dir(job_id)
         model_path = os.path.join(run_dir, self._model_dir)
 
         model_load_path = os.path.join(model_path, self._model_name)
@@ -198,8 +198,8 @@ class NPTrainer(Executor):
     def _save_local_model(self, fl_ctx: FLContext, model: dict):
         # Save local model
         engine = fl_ctx.get_engine()
-        run_number = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
-        run_dir = engine.get_workspace().get_run_dir(run_number)
+        job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
+        run_dir = engine.get_workspace().get_run_dir(job_id)
         model_path = os.path.join(run_dir, self._model_dir)
         if not os.path.exists(model_path):
             os.makedirs(model_path)

--- a/nvflare/app_common/pt/tb_receiver.py
+++ b/nvflare/app_common/pt/tb_receiver.py
@@ -60,7 +60,7 @@ class TBAnalyticsReceiver(AnalyticsReceiver):
 
     def initialize(self, fl_ctx: FLContext):
         workspace = fl_ctx.get_engine().get_workspace()
-        run_dir = workspace.get_run_dir(fl_ctx.get_run_number())
+        run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
         root_log_dir = os.path.join(run_dir, self.tb_folder)
         os.makedirs(root_log_dir, exist_ok=True)
         self.root_log_dir = root_log_dir

--- a/nvflare/app_common/state_persistors/storage_state_persistor.py
+++ b/nvflare/app_common/state_persistors/storage_state_persistor.py
@@ -41,7 +41,7 @@ class StorageStatePersistor(StatePersistor):
         Returns:
             storage location
         """
-        path = os.path.join(self.uri_root, snapshot.run_number)
+        path = os.path.join(self.uri_root, snapshot.job_id)
         if snapshot.completed:
             full_uri = self.storage.delete_object(path)
         else:
@@ -61,20 +61,20 @@ class StorageStatePersistor(StatePersistor):
         fl_snapshot = FLSnapshot()
         for item in all_items:
             snapshot = pickle.loads(self.storage.get_data(item))
-            fl_snapshot.add_snapshot(snapshot.run_number, snapshot)
+            fl_snapshot.add_snapshot(snapshot.job_id, snapshot)
         return fl_snapshot
 
-    def retrieve_run(self, run_number: str) -> RunSnapshot:
-        """Call to load the persisted RunSnapshot of a run_number from the persisted location.
+    def retrieve_run(self, job_id: str) -> RunSnapshot:
+        """Call to load the persisted RunSnapshot of a job from the persisted location.
 
         Args:
-            run_number: run_number
+            job_id: job_id
 
         Returns:
-            RunSnapshot of the run_number
+            RunSnapshot of the job_id
 
         """
-        path = os.path.join(self.uri_root, run_number)
+        path = os.path.join(self.uri_root, job_id)
         snapshot = pickle.loads(self.storage.get_data(uri=path))
         return snapshot
 
@@ -85,11 +85,11 @@ class StorageStatePersistor(StatePersistor):
         for item in all_items:
             self.storage.delete_object(item)
 
-    def delete_run(self, run_number: str):
-        """Deletes the RunSnapshot of a run_number.
+    def delete_run(self, job_id: str):
+        """Deletes the RunSnapshot of a job.
 
         Args:
-            run_number: run_number
+            job_id: job_id
         """
-        path = os.path.join(self.uri_root, run_number)
+        path = os.path.join(self.uri_root, job_id)
         self.storage.delete_object(path)

--- a/nvflare/app_common/widgets/event_recorder.py
+++ b/nvflare/app_common/widgets/event_recorder.py
@@ -200,7 +200,7 @@ class EventRecorder(Widget):
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if not self._log_handler_added:
             workspace = fl_ctx.get_engine().get_workspace()
-            app_dir = workspace.get_app_dir(fl_ctx.get_run_number())
+            app_dir = workspace.get_app_dir(fl_ctx.get_job_id())
             output_file_handler = logging.FileHandler(os.path.join(app_dir, self.log_file_name))
             formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
             output_file_handler.setFormatter(formatter)

--- a/nvflare/app_common/widgets/validation_json_generator.py
+++ b/nvflare/app_common/widgets/validation_json_generator.py
@@ -73,7 +73,7 @@ class ValidationJsonGenerator(Widget):
             else:
                 self.log_error(fl_ctx, "Validation result not found.", fire_event=False)
         elif event_type == EventType.END_RUN:
-            run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_run_number())
+            run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
             cross_val_res_dir = os.path.join(run_dir, self._results_dir)
             if not os.path.exists(cross_val_res_dir):
                 os.makedirs(cross_val_res_dir)

--- a/nvflare/app_common/workflows/cross_site_model_eval.py
+++ b/nvflare/app_common/workflows/cross_site_model_eval.py
@@ -133,7 +133,7 @@ class CrossSiteModelEval(Controller):
 
         # Create shareable dirs for models and results
         workspace: Workspace = engine.get_workspace()
-        run_dir = workspace.get_run_dir(fl_ctx.get_run_number())
+        run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
         cross_val_path = os.path.join(run_dir, self._cross_val_dir)
         self._cross_val_models_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_MODEL_DIR_NAME)
         self._cross_val_results_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_RESULTS_DIR_NAME)

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -330,11 +330,11 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         )
 
     @wrap_with_return_exception_responses
-    def delete_run(self, run_number: str) -> FLAdminAPIResponse:
-        if not isinstance(run_number, str):
-            raise APISyntaxError("run_number must be str but got {}.".format(type(run_number)))
+    def delete_run(self, job_id: str) -> FLAdminAPIResponse:
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(
-            AdminCommandNames.DELETE_RUN + " " + str(run_number)
+            AdminCommandNames.DELETE_RUN + " " + str(job_id)
         )
         if reply_data_full_response:
             if "can not be deleted" in reply_data_full_response:
@@ -414,23 +414,21 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         )
 
     @wrap_with_return_exception_responses
-    def abort(
-        self, run_number: str, target_type: TargetType, targets: Optional[List[str]] = None
-    ) -> FLAdminAPIResponse:
-        if not run_number:
-            raise APISyntaxError("run_number is required but not specified.")
-        if not isinstance(run_number, str):
-            raise APISyntaxError("run_number must be str but got {}.".format(type(run_number)))
+    def abort(self, job_id: str, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
+        if not job_id:
+            raise APISyntaxError("job_id is required but not specified.")
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
         if target_type == TargetType.ALL:
-            command = AdminCommandNames.ABORT + " " + run_number + " all"
+            command = AdminCommandNames.ABORT + " " + job_id + " all"
         elif target_type == TargetType.SERVER:
-            command = AdminCommandNames.ABORT + " " + run_number + " server"
+            command = AdminCommandNames.ABORT + " " + job_id + " server"
         elif target_type == TargetType.CLIENT:
             if targets:
                 processed_targets_str = self._process_targets_into_str(targets)
-                command = AdminCommandNames.ABORT + " " + run_number + " client " + processed_targets_str
+                command = AdminCommandNames.ABORT + " " + job_id + " client " + processed_targets_str
             else:
-                command = AdminCommandNames.ABORT + " " + run_number + " client"
+                command = AdminCommandNames.ABORT + " " + job_id + " client"
         else:
             raise APISyntaxError("target_type must be server, client, or all.")
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(command)
@@ -681,20 +679,20 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
 
     @wrap_with_return_exception_responses
     def show_stats(
-        self, run_number: str, target_type: TargetType, targets: Optional[List[str]] = None
+        self, job_id: str, target_type: TargetType, targets: Optional[List[str]] = None
     ) -> FLAdminAPIResponse:
-        if not run_number:
-            raise APISyntaxError("run_number is required but not specified.")
-        if not isinstance(run_number, str):
-            raise APISyntaxError("run_number must be str but got {}.".format(type(run_number)))
+        if not job_id:
+            raise APISyntaxError("job_id is required but not specified.")
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
         if target_type == TargetType.SERVER:
-            command = AdminCommandNames.SHOW_STATS + " " + run_number + " server"
+            command = AdminCommandNames.SHOW_STATS + " " + job_id + " server"
         elif target_type == TargetType.CLIENT:
             if targets:
                 processed_targets_str = self._process_targets_into_str(targets)
-                command = AdminCommandNames.SHOW_STATS + " " + run_number + " client " + processed_targets_str
+                command = AdminCommandNames.SHOW_STATS + " " + job_id + " client " + processed_targets_str
             else:
-                command = AdminCommandNames.SHOW_STATS + " " + run_number + " client"
+                command = AdminCommandNames.SHOW_STATS + " " + job_id + " client"
         else:
             raise APISyntaxError("target_type must be server or client.")
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(command)
@@ -712,20 +710,20 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
 
     @wrap_with_return_exception_responses
     def show_errors(
-        self, run_number: str, target_type: TargetType, targets: Optional[List[str]] = None
+        self, job_id: str, target_type: TargetType, targets: Optional[List[str]] = None
     ) -> FLAdminAPIResponse:
-        if not run_number:
-            raise APISyntaxError("run_number is required but not specified.")
-        if not isinstance(run_number, str):
-            raise APISyntaxError("run_number must be str but got {}.".format(type(run_number)))
+        if not job_id:
+            raise APISyntaxError("job_id is required but not specified.")
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
         if target_type == TargetType.SERVER:
-            command = AdminCommandNames.SHOW_ERRORS + " " + run_number + " server"
+            command = AdminCommandNames.SHOW_ERRORS + " " + job_id + " server"
         elif target_type == TargetType.CLIENT:
             if targets:
                 processed_targets_str = self._process_targets_into_str(targets)
-                command = AdminCommandNames.SHOW_ERRORS + " " + run_number + " client " + processed_targets_str
+                command = AdminCommandNames.SHOW_ERRORS + " " + job_id + " client " + processed_targets_str
             else:
-                command = AdminCommandNames.SHOW_ERRORS + " " + run_number + " client"
+                command = AdminCommandNames.SHOW_ERRORS + " " + job_id + " client"
         else:
             raise APISyntaxError("target_type must be server or client.")
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(command)
@@ -740,13 +738,13 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         return FLAdminAPIResponse(APIStatus.SUCCESS, {"message": "No errors."}, reply)
 
     @wrap_with_return_exception_responses
-    def reset_errors(self, run_number: str) -> FLAdminAPIResponse:
-        if not run_number:
-            raise APISyntaxError("run_number is required but not specified.")
-        if not isinstance(run_number, str):
-            raise APISyntaxError("run_number must be str but got {}.".format(type(run_number)))
+    def reset_errors(self, job_id: str) -> FLAdminAPIResponse:
+        if not job_id:
+            raise APISyntaxError("job_id is required but not specified.")
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
         success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(
-            AdminCommandNames.RESET_ERRORS + " " + run_number
+            AdminCommandNames.RESET_ERRORS + " " + job_id
         )
         if reply_data_full_response:
             if "App is not running" in reply_data_full_response:

--- a/nvflare/fuel/hci/client/fl_admin_api_spec.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_spec.py
@@ -77,14 +77,14 @@ class FLAdminAPISpec(ABC):
         pass
 
     @abstractmethod
-    def delete_run(self, run_number: str) -> FLAdminAPIResponse:
+    def delete_run(self, job_id: str) -> FLAdminAPIResponse:
         """Deletes a specified run.
 
-        This deletes the run folder corresponding to the run number on the server and
+        This deletes the run folder corresponding to the job id on the server and
         all connected clients. This is not reversible.
 
         Args:
-            run_number (str): run number to delete
+            job_id (str): job id to delete
 
         Returns: FLAdminAPIResponse
 
@@ -142,13 +142,11 @@ class FLAdminAPISpec(ABC):
         pass
 
     @abstractmethod
-    def abort(
-        self, run_number: str, target_type: TargetType, targets: Optional[List[str]] = None
-    ) -> FLAdminAPIResponse:
+    def abort(self, job_id: str, target_type: TargetType, targets: Optional[List[str]] = None) -> FLAdminAPIResponse:
         """Issue a command to abort training.
 
         Args:
-            run_number (str): run number
+            job_id (str): job id
             target_type: server | client
             targets: if target_type is client, targets can optionally be a list of client names
 
@@ -358,12 +356,12 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def show_stats(
-        self, run_number: str, target_type: TargetType, targets: Optional[List[str]] = None
+        self, job_id: str, target_type: TargetType, targets: Optional[List[str]] = None
     ) -> FLAdminAPIResponse:
         """Gets and shows stats from the Info Collector.
 
         Args:
-            run_number (str): run number
+            job_id (str): job id
             target_type: server | client
             targets: if target_type is client, targets can optionally be a list of client names
 
@@ -373,12 +371,12 @@ class FLAdminAPISpec(ABC):
 
     @abstractmethod
     def show_errors(
-        self, run_number: str, target_type: TargetType, targets: Optional[List[str]] = None
+        self, job_id: str, target_type: TargetType, targets: Optional[List[str]] = None
     ) -> FLAdminAPIResponse:
         """Gets and shows errors from the Info Collector.
 
         Args:
-            run_number (str): run number
+            job_id (str): job id
             target_type: server | client
             targets: if target_type is client, targets can optionally be a list of client names
 
@@ -387,11 +385,11 @@ class FLAdminAPISpec(ABC):
         """
 
     @abstractmethod
-    def reset_errors(self, run_number: str) -> FLAdminAPIResponse:
+    def reset_errors(self, job_id: str) -> FLAdminAPIResponse:
         """Resets the collector errors.
 
         Args:
-            run_number (str): run number
+            job_id (str): job id
 
         Returns: FLAdminAPIResponse
 

--- a/nvflare/private/aux_runner.py
+++ b/nvflare/private/aux_runner.py
@@ -30,7 +30,7 @@ class AuxRunner(FLComponent):
     def __init__(self):
         """To init the AuxRunner."""
         FLComponent.__init__(self)
-        self.run_num = None
+        self.job_id = None
         self.topic_table = {
             self.TOPIC_BULK: self._process_bulk_requests,
         }  # topic => handler
@@ -38,7 +38,7 @@ class AuxRunner(FLComponent):
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if event_type == EventType.START_RUN:
-            self.run_num = fl_ctx.get_run_number()
+            self.job_id = fl_ctx.get_job_id()
 
     def register_aux_message_handler(self, topic: str, message_handle_func):
         """Register aux message handling function with specified topics.
@@ -111,9 +111,9 @@ class AuxRunner(FLComponent):
             )
             return make_reply(ReturnCode.BAD_PEER_CONTEXT)
 
-        peer_run_num = peer_props.get(ReservedKey.RUN_NUM)
-        if peer_run_num != self.run_num:
-            self.log_error(fl_ctx, "invalid aux msg: not for the same run_number")
+        peer_job_id = peer_props.get(ReservedKey.RUN_NUM)
+        if peer_job_id != self.job_id:
+            self.log_error(fl_ctx, "invalid aux msg: not for the same job_id")
             return make_reply(ReturnCode.RUN_MISMATCH)
 
         try:

--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -53,7 +53,7 @@ class TrainingTopic(object):
     SHUTDOWN = "train.shutdown"
     RESTART = "train.restart"
     CHECK_STATUS = "train.check_status"
-    SET_RUN_NUMBER = "train.set_run_number"
+    SET_JOB_ID = "train.set_job_id"
     CHECK_RESOURCE = "scheduler.check_resource"
     ALLOCATE_RESOURCE = "scheduler.allocate_resource"
     CANCEL_RESOURCE = "scheduler.cancel_resource"
@@ -62,7 +62,7 @@ class TrainingTopic(object):
 
 class RequestHeader(object):
 
-    RUN_NUM = "run_number"
+    JOB_ID = "job_id"
     APP_NAME = "app_name"
     CONTROL_COMMAND = "control_command"
     CALL_NAME = "call_name"
@@ -88,7 +88,7 @@ class ControlCommandName(object):
 
 class ClientStatusKey(object):
 
-    RUN_NUM = "run_number"
+    JOB_ID = "job_id"
     CURRENT_TASK = "current_task"
     STATUS = "status"
     APP_NAME = "app_name"

--- a/nvflare/private/fed/app/client/sub_worker_process.py
+++ b/nvflare/private/fed/app/client/sub_worker_process.py
@@ -134,11 +134,11 @@ def main():
     data = exe_conn.recv()
 
     client_name = data[CommunicationMetaData.FL_CTX].get_prop(FLContextKey.CLIENT_NAME)
-    run_number = data[CommunicationMetaData.FL_CTX].get_prop(FLContextKey.CURRENT_RUN)
+    job_id = data[CommunicationMetaData.FL_CTX].get_prop(FLContextKey.CURRENT_RUN)
     workspace = data[CommunicationMetaData.FL_CTX].get_prop(FLContextKey.WORKSPACE_OBJECT)
     run_manager = ClientRunManager(
         client_name=client_name,
-        run_num=run_number,
+        job_id=job_id,
         workspace=workspace,
         client=None,
         components=data[CommunicationMetaData.COMPONENTS],
@@ -149,7 +149,7 @@ def main():
     log_config_file_path = os.path.join(startup, "log.config")
     logging.config.fileConfig(fname=log_config_file_path, disable_existing_loggers=False)
 
-    log_file = os.path.join(args.workspace, run_number, "log.txt")
+    log_file = os.path.join(args.workspace, job_id, "log.txt")
     add_logfile_handler(log_file)
 
     relayer = EventRelayer(event_conn, local_rank)

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -55,7 +55,7 @@ def main():
     parser.add_argument("--startup", "-w", type=str, help="startup folder", required=True)
     parser.add_argument("--token", "-t", type=str, help="token", required=True)
     parser.add_argument("--ssid", "-d", type=str, help="ssid", required=True)
-    parser.add_argument("--run_number", "-n", type=str, help="run_number", required=True)
+    parser.add_argument("--job_id", "-n", type=str, help="job_id", required=True)
     parser.add_argument("--client_name", "-c", type=str, help="client name", required=True)
     parser.add_argument("--listen_port", "-p", type=str, help="listen port", required=True)
     parser.add_argument("--sp_target", "-g", type=str, help="Sp target", required=True)
@@ -108,13 +108,13 @@ def main():
     startup = args.startup
     app_root = os.path.join(
         args.workspace,
-        WorkspaceConstants.WORKSPACE_PREFIX + str(args.run_number),
+        WorkspaceConstants.WORKSPACE_PREFIX + str(args.job_id),
         WorkspaceConstants.APP_PREFIX + args.client_name,
     )
 
     logging_setup(app_root, args, config_folder, startup)
 
-    log_file = os.path.join(args.workspace, args.run_number, "log.txt")
+    log_file = os.path.join(args.workspace, args.job_id, "log.txt")
     add_logfile_handler(log_file)
     logger = logging.getLogger("worker_process")
     logger.info("Worker_process started.")
@@ -153,7 +153,7 @@ def main():
         workspace = Workspace(args.workspace, args.client_name, config_folder)
         run_manager = ClientRunManager(
             client_name=args.client_name,
-            run_num=args.run_number,
+            job_id=args.job_id,
             workspace=workspace,
             client=federated_client,
             components=conf.runner_config.components,
@@ -171,7 +171,7 @@ def main():
             fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, private=True)
             fl_ctx.set_prop(FLContextKey.SECURE_MODE, secure_train, private=True, sticky=True)
 
-            client_runner = ClientRunner(config=conf.runner_config, run_num=args.run_number, engine=run_manager)
+            client_runner = ClientRunner(config=conf.runner_config, job_id=args.job_id, engine=run_manager)
             run_manager.add_handler(client_runner)
             fl_ctx.set_prop(FLContextKey.RUNNER, client_runner, private=True)
 

--- a/nvflare/private/fed/app/deployer/server_deployer.py
+++ b/nvflare/private/fed/app/deployer/server_deployer.py
@@ -111,7 +111,7 @@ class ServerDeployer:
         run_manager = RunManager(
             server_name=services.project_name,
             engine=services.engine,
-            run_num="",
+            job_id="",
             workspace=workspace,
             components=self.components,
             handlers=self.handlers,

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -39,7 +39,7 @@ def main():
         "--fed_server", "-s", type=str, help="an aggregation server specification json file", required=True
     )
     parser.add_argument("--app_root", "-r", type=str, help="App Root", required=True)
-    parser.add_argument("--run_number", "-n", type=str, help="run number", required=True)
+    parser.add_argument("--job_id", "-n", type=str, help="job id", required=True)
     parser.add_argument("--port", "-p", type=str, help="listen port", required=True)
     parser.add_argument("--conn", "-c", type=str, help="connection port", required=True)
 
@@ -64,7 +64,7 @@ def main():
     startup = os.path.join(args.workspace, "startup")
     logging_setup(startup)
 
-    log_file = os.path.join(args.workspace, args.run_number, "log.txt")
+    log_file = os.path.join(args.workspace, args.job_id, "log.txt")
     add_logfile_handler(log_file)
     logger = logging.getLogger("runner_process")
     logger.info("Runner_process started.")
@@ -105,9 +105,9 @@ def main():
 
             snapshot = None
             if args.snapshot:
-                snapshot = server.snapshot_persistor.retrieve_run(args.run_number)
+                snapshot = server.snapshot_persistor.retrieve_run(args.job_id)
 
-            start_server_app(server, args, args.app_root, args.run_number, snapshot, logger)
+            start_server_app(server, args, args.app_root, args.job_id, snapshot, logger)
         finally:
             if command_agent:
                 command_agent.shutdown()
@@ -124,7 +124,7 @@ def logging_setup(startup):
     logging.config.fileConfig(fname=log_config_file_path, disable_existing_loggers=False)
 
 
-def start_server_app(server, args, app_root, run_number, snapshot, logger):
+def start_server_app(server, args, app_root, job_id, snapshot, logger):
 
     try:
         server_config_file_name = os.path.join(app_root, args.server_config)
@@ -141,7 +141,7 @@ def start_server_app(server, args, app_root, run_number, snapshot, logger):
         server.engine.create_parent_connection(int(args.conn))
         server.engine.sync_clients_from_main_process()
 
-        server.start_run(run_number, app_root, conf, args, snapshot)
+        server.start_run(job_id, app_root, conf, args, snapshot)
     except BaseException as e:
         logger.exception(f"FL server execution exception: {e}", exc_info=True)
         raise e

--- a/nvflare/private/fed/client/client_aux_runner.py
+++ b/nvflare/private/fed/client/client_aux_runner.py
@@ -98,7 +98,7 @@ class ClientAuxRunner(AuxRunner):
         rc = reply.get_return_code()
         if rc == ReturnCode.RUN_MISMATCH:
             self.log_info(fl_ctx, "got RUN_MISMATCH - asked engine to abort app")
-            engine.abort_app(run_number=self.run_num, fl_ctx=fl_ctx)
+            engine.abort_app(job_id=self.run_num, fl_ctx=fl_ctx)
 
         return reply
 

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -62,7 +62,7 @@ class ClientEngine(ClientEngineInternalSpec):
         self.client_executor = ProcessExecutor(client.client_name, os.path.join(args.workspace, "startup"))
 
         self.fl_ctx_mgr = FLContextManager(
-            engine=self, identity_name=client_name, run_num="", public_stickers={}, private_stickers={}
+            engine=self, identity_name=client_name, job_id="", public_stickers={}, private_stickers={}
         )
 
         self.status = MachineStatus.STOPPED
@@ -93,16 +93,16 @@ class ClientEngine(ClientEngineInternalSpec):
 
     def get_engine_status(self):
         running_jobs = []
-        for run_number in self.get_all_run_numbers():
-            run_folder = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(run_number))
+        for job_id in self.get_all_job_ids():
+            run_folder = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(job_id))
             app_file = os.path.join(run_folder, "fl_app.txt")
             if os.path.exists(app_file):
                 with open(app_file, "r") as f:
                     app_name = f.readline().strip()
             job = {
                 ClientStatusKey.APP_NAME: app_name,
-                ClientStatusKey.RUN_NUM: run_number,
-                ClientStatusKey.STATUS: self.client_executor.check_status(self.client, run_number),
+                ClientStatusKey.JOB_ID: job_id,
+                ClientStatusKey.STATUS: self.client_executor.check_status(self.client, job_id),
             }
             running_jobs.append(job)
 
@@ -114,19 +114,19 @@ class ClientEngine(ClientEngineInternalSpec):
 
     def start_app(
         self,
-        run_number: str,
+        job_id: str,
         allocated_resource: dict = None,
         token: str = None,
         resource_consumer=None,
         resource_manager=None,
     ) -> str:
-        status = self.client_executor.get_status(run_number)
+        status = self.client_executor.get_status(job_id)
         if status == ClientStatus.STARTED:
             return "Client app already started."
 
         app_root = os.path.join(
             self.args.workspace,
-            WorkspaceConstants.WORKSPACE_PREFIX + str(run_number),
+            WorkspaceConstants.WORKSPACE_PREFIX + str(job_id),
             WorkspaceConstants.APP_PREFIX + self.client.client_name,
         )
         if not os.path.exists(app_root):
@@ -148,7 +148,7 @@ class ClientEngine(ClientEngineInternalSpec):
 
         self.client_executor.start_train(
             self.client,
-            run_number,
+            job_id,
             self.args,
             app_root,
             app_custom_folder,
@@ -165,7 +165,7 @@ class ClientEngine(ClientEngineInternalSpec):
     def get_client_name(self):
         return self.client.client_name
 
-    def _write_token_file(self, run_number, open_port):
+    def _write_token_file(self, job_id, open_port):
         token_file = os.path.join(self.args.workspace, EngineConstant.CLIENT_TOKEN_FILE)
         if os.path.exists(token_file):
             os.remove(token_file)
@@ -175,7 +175,7 @@ class ClientEngine(ClientEngineInternalSpec):
                 % (
                     self.client.token,
                     self.client.ssid,
-                    run_number,
+                    job_id,
                     self.client.client_name,
                     open_port,
                     list(self.client.servers.values())[0]["target"],
@@ -188,8 +188,8 @@ class ClientEngine(ClientEngineInternalSpec):
         for path in custom_paths:
             sys.path.remove(path)
 
-    def abort_app(self, run_number: str) -> str:
-        status = self.client_executor.get_status(run_number)
+    def abort_app(self, job_id: str) -> str:
+        status = self.client_executor.get_status(job_id)
         if status == ClientStatus.STOPPED:
             return "Client app already stopped."
 
@@ -199,19 +199,19 @@ class ClientEngine(ClientEngineInternalSpec):
         if status == ClientStatus.STARTING:
             return "Client app is starting, please wait for client to have started before abort."
 
-        self.client_executor.abort_train(self.client, run_number)
+        self.client_executor.abort_train(self.client, job_id)
 
         return "Abort signal has been sent to the client App."
 
-    def abort_task(self, run_number: str) -> str:
-        status = self.client_executor.get_status(run_number)
+    def abort_task(self, job_id: str) -> str:
+        status = self.client_executor.get_status(job_id)
         if status == ClientStatus.NOT_STARTED:
             return "Client app has not started."
 
         if status == ClientStatus.STARTING:
             return "Client app is starting, please wait for started before abort_task."
 
-        self.client_executor.abort_task(self.client, run_number)
+        self.client_executor.abort_task(self.client, job_id)
 
         return "Abort signal has been sent to the current task."
 
@@ -235,33 +235,33 @@ class ClientEngine(ClientEngineInternalSpec):
         self.executor.shutdown()
         return "Restart the client..."
 
-    def deploy_app(self, app_name: str, run_num: str, client_name: str, app_data) -> str:
-        workspace = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(run_num))
+    def deploy_app(self, app_name: str, job_id: str, client_name: str, app_data) -> str:
+        workspace = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(job_id))
 
         if deploy_app(app_name, client_name, workspace, app_data):
             return f"Deployed app {app_name} to {client_name}"
         else:
             return f"{ERROR_MSG_PREFIX}: Failed to deploy_app"
 
-    def delete_run(self, run_num: str) -> str:
-        run_number_folder = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(run_num))
-        if os.path.exists(run_number_folder):
-            shutil.rmtree(run_number_folder)
-        return f"Delete run folder: {run_number_folder}."
+    def delete_run(self, job_id: str) -> str:
+        job_id_folder = os.path.join(self.args.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(job_id))
+        if os.path.exists(job_id_folder):
+            shutil.rmtree(job_id_folder)
+        return f"Delete run folder: {job_id_folder}."
 
-    def get_current_run_info(self, run_number) -> ClientRunInfo:
-        return self.client_executor.get_run_info(run_number)
+    def get_current_run_info(self, job_id) -> ClientRunInfo:
+        return self.client_executor.get_run_info(job_id)
 
-    def get_errors(self, run_number):
-        return self.client_executor.get_errors(run_number)
+    def get_errors(self, job_id):
+        return self.client_executor.get_errors(job_id)
 
-    def reset_errors(self, run_number):
-        self.client_executor.reset_errors(run_number)
+    def reset_errors(self, job_id):
+        self.client_executor.reset_errors(job_id)
 
-    def send_aux_command(self, shareable: Shareable, run_number):
-        return self.client_executor.send_aux_command(shareable, run_number)
+    def send_aux_command(self, shareable: Shareable, job_id):
+        return self.client_executor.send_aux_command(shareable, job_id)
 
-    def get_all_run_numbers(self):
+    def get_all_job_ids(self):
         return self.client_executor.run_processes.keys()
 
 

--- a/nvflare/private/fed/client/client_engine_executor_spec.py
+++ b/nvflare/private/fed/client/client_engine_executor_spec.py
@@ -98,11 +98,11 @@ class ClientEngineExecutorSpec(ClientEngineSpec, ABC):
         """
 
     @abstractmethod
-    def abort_app(self, run_number: str, fl_ctx: FLContext):
+    def abort_app(self, job_id: str, fl_ctx: FLContext):
         """Abort the running FL App on the client.
 
         Args:
-            run_number: current_run_number
+            job_id: current_job_id
             fl_ctx: FLContext
 
         """

--- a/nvflare/private/fed/client/client_engine_internal_spec.py
+++ b/nvflare/private/fed/client/client_engine_internal_spec.py
@@ -49,12 +49,12 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def deploy_app(self, app_name: str, run_num: str, client_name: str, app_data) -> str:
+    def deploy_app(self, app_name: str, job_id: str, client_name: str, app_data) -> str:
         """Deploys the app to specified run.
 
         Args:
             app_name: FL_app name
-            run_num: run that the app is to be deployed to
+            job_id: job that the app is to be deployed to
             client_name: name of the client
             app_data: zip data of the app
 
@@ -66,7 +66,7 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
     @abstractmethod
     def start_app(
         self,
-        run_number: str,
+        job_id: str,
         allocated_resource: dict = None,
         token: str = None,
         resource_consumer=None,
@@ -75,7 +75,7 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         """Starts the app for the specified run.
 
         Args:
-            run_number: run_number
+            job_id: job_id
             allocated_resource: allocated resource
             token: token
             resource_consumer: resource consumer
@@ -87,7 +87,7 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def abort_app(self, run_number: str) -> str:
+    def abort_app(self, job_id: str) -> str:
         """Aborts the app execution for the specified run.
 
         Returns:
@@ -96,7 +96,7 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def abort_task(self, run_number: str) -> str:
+    def abort_task(self, job_id: str) -> str:
         """Abort the client current executing task.
 
         Returns:
@@ -105,11 +105,11 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def delete_run(self, run_num: str) -> str:
+    def delete_run(self, job_id: str) -> str:
         """Deletes the specified run.
 
         Args:
-            run_num: run_number
+            job_id: job_id
 
         Returns:
             A string message.
@@ -135,10 +135,10 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def get_all_run_numbers(self) -> []:
-        """Get all the client run_number.
+    def get_all_job_ids(self) -> []:
+        """Get all the client job_id.
 
-        Returns: list of all the run_number
+        Returns: list of all the job_id
 
         """
         pass

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -33,13 +33,13 @@ from .fed_client import FederatedClient
 
 
 class ClientRunInfo(object):
-    def __init__(self, run_number):
+    def __init__(self, job_id):
         """To init the ClientRunInfo.
 
         Args:
-            run_number: run number
+            job_id: job id
         """
-        self.run_number = run_number
+        self.job_id = job_id
         self.current_task_name = ""
         self.start_time = None
         # self.status = MachineStatus.STOPPED
@@ -51,7 +51,7 @@ class ClientRunManager(ClientEngineExecutorSpec):
     def __init__(
         self,
         client_name: str,
-        run_num: str,
+        job_id: str,
         workspace: Workspace,
         client: FederatedClient,
         components: Dict[str, FLComponent],
@@ -62,7 +62,7 @@ class ClientRunManager(ClientEngineExecutorSpec):
 
         Args:
             client_name: client name
-            run_num: run number
+            job_id: job id
             workspace: workspacee
             client: FL client object
             components: available FL components
@@ -80,10 +80,10 @@ class ClientRunManager(ClientEngineExecutorSpec):
         self.conf = conf
 
         self.fl_ctx_mgr = FLContextManager(
-            engine=self, identity_name=client_name, run_num=run_num, public_stickers={}, private_stickers={}
+            engine=self, identity_name=client_name, job_id=job_id, public_stickers={}, private_stickers={}
         )
 
-        self.run_info = ClientRunInfo(run_number=run_num)
+        self.run_info = ClientRunInfo(job_id=job_id)
 
         self.widgets = {WidgetID.INFO_COLLECTOR: InfoCollector(), WidgetID.FED_EVENT_RUNNER: ClientFedEventRunner()}
         for _, widget in self.widgets.items():
@@ -160,7 +160,7 @@ class ClientRunManager(ClientEngineExecutorSpec):
     def fire_and_forget_aux_request(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:
         return self.send_aux_request(topic, request, 0.0, fl_ctx)
 
-    def abort_app(self, run_number: str, fl_ctx: FLContext):
+    def abort_app(self, job_id: str, fl_ctx: FLContext):
         runner = fl_ctx.get_prop(key=FLContextKey.RUNNER, default=None)
         if isinstance(runner, ClientRunner):
             runner.abort()

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -55,7 +55,7 @@ class ClientRunner(FLComponent):
     def __init__(
         self,
         config: ClientRunnerConfig,
-        run_num,
+        job_id,
         engine: ClientEngineSpec,
         task_fetch_interval: int = 5,  # fetch task every 5 secs
     ):
@@ -63,7 +63,7 @@ class ClientRunner(FLComponent):
 
         Args:
             config: ClientRunnerConfig
-            run_num: run number
+            job_id: job id
             engine: ClientEngine object
             task_fetch_interval:  fetch task interval
         """
@@ -72,7 +72,7 @@ class ClientRunner(FLComponent):
         self.task_data_filters = config.task_data_filters
         self.task_result_filters = config.task_result_filters
 
-        self.run_num = run_num
+        self.job_id = job_id
         self.engine = engine
         self.task_fetch_interval = task_fetch_interval
         self.run_abort_signal = Signal()
@@ -115,9 +115,9 @@ class ClientRunner(FLComponent):
             return make_reply(ReturnCode.BAD_PEER_CONTEXT)
 
         task.data.set_peer_props(peer_ctx.get_all_public_props())
-        peer_run_num = peer_ctx.get_run_number()
-        if peer_run_num != self.run_num:
-            self.log_error(fl_ctx, "bad task assignment: not for the same run_number")
+        peer_job_id = peer_ctx.get_job_id()
+        if peer_job_id != self.job_id:
+            self.log_error(fl_ctx, "bad task assignment: not for the same job_id")
             return make_reply(ReturnCode.RUN_MISMATCH)
 
         executor = self.task_table.get(task.name)
@@ -395,7 +395,7 @@ class ClientRunner(FLComponent):
                     current_task_name = "None"
                 collector.set_info(
                     group_name="ClientRunner",
-                    info={"run_number": self.run_num, "current_task_name": current_task_name, "status": "started"},
+                    info={"job_id": self.job_id, "current_task_name": current_task_name, "status": "started"},
                 )
         elif event_type == EventType.FATAL_TASK_ERROR:
             reason = fl_ctx.get_prop(key=FLContextKey.EVENT_DATA, default="")

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -44,7 +44,7 @@ def _get_client_state(project_name, token, ssid, fl_ctx: FLContext):
     """
     state_message = fed_msg.ClientState(token=token, ssid=ssid)
     state_message.meta.project.name = project_name
-    # state_message.meta.run_number = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
+    # state_message.meta.job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
 
     context_data = make_context_data(fl_ctx)
     state_message.context["fl_context"].CopyFrom(context_data)
@@ -406,9 +406,9 @@ class Communicator:
                     while retry > 0:
                         try:
                             self.logger.debug(f"Send {task_name} heartbeat {token}")
-                            run_numbers = engine.get_all_run_numbers()
+                            job_ids = engine.get_all_job_ids()
                             del message.jobs[:]
-                            message.jobs.extend(run_numbers)
+                            message.jobs.extend(job_ids)
                             response = stub.Heartbeat(message)
                             self._clean_up_runs(engine, response)
                             break

--- a/nvflare/private/fed/client/comp_caller_cmd.py
+++ b/nvflare/private/fed/client/comp_caller_cmd.py
@@ -34,7 +34,7 @@ class ComponentCallerProcessor(RequestProcessor):
             raise TypeError("caller must be ComponentCaller, but got {}".format(type(caller)))
 
         run_info = engine.get_current_run_info()
-        if not run_info or run_info.run_number < 0:
+        if not run_info or run_info.job_id < 0:
             result = {"error": "app not running"}
         else:
             comp_target = req.get_header(RequestHeader.COMPONENT_TARGET)

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -145,8 +145,8 @@ class FederatedClientBase:
 
     def _switch_ssid(self):
         if self.engine:
-            for run_number in self.engine.get_all_run_numbers():
-                self.engine.abort_task(run_number)
+            for job_id in self.engine.get_all_job_ids():
+                self.engine.abort_task(job_id)
         # self.register()
         self.logger.info(f"Primary SP switched to new SSID: {self.ssid}")
 

--- a/nvflare/private/fed/client/info_coll_cmd.py
+++ b/nvflare/private/fed/client/info_coll_cmd.py
@@ -33,23 +33,19 @@ class ClientInfoProcessor(RequestProcessor):
         if not isinstance(engine, ClientEngineInternalSpec):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
 
-        run_number = req.get_header(RequestHeader.RUN_NUM)
+        job_id = req.get_header(RequestHeader.JOB_ID)
         if req.topic == InfoCollectorTopic.SHOW_STATS:
-            result = engine.get_current_run_info(run_number)
+            result = engine.get_current_run_info(job_id)
         elif req.topic == InfoCollectorTopic.SHOW_ERRORS:
-            result = engine.get_errors(run_number)
+            result = engine.get_errors(job_id)
         elif req.topic == InfoCollectorTopic.RESET_ERRORS:
-            engine.reset_errors(run_number)
+            engine.reset_errors(job_id)
             result = {"status": "OK"}
         else:
             result = {"error": "invalid topic {}".format(req.topic)}
 
         if not isinstance(result, dict):
             result = {}
-
-        # # add current run number
-        # if run_num >= 0:
-        #     result['run_num'] = run_num
 
         result = json.dumps(result)
         return Message(topic="reply_" + req.topic, body=result)

--- a/nvflare/private/fed/client/process_aux_cmd.py
+++ b/nvflare/private/fed/client/process_aux_cmd.py
@@ -30,8 +30,8 @@ class AuxRequestProcessor(RequestProcessor):
 
         shareable = pickle.loads(req.body)
 
-        run_number = req.get_header(RequestHeader.RUN_NUM)
-        result = engine.send_aux_command(shareable, run_number)
+        job_id = req.get_header(RequestHeader.JOB_ID)
+        result = engine.send_aux_command(shareable, job_id)
         if not result:
             result = make_reply(ReturnCode.EXECUTION_EXCEPTION)
 

--- a/nvflare/private/fed/client/scheduler_cmds.py
+++ b/nvflare/private/fed/client/scheduler_cmds.py
@@ -77,13 +77,13 @@ class StartJobProcessor(RequestProcessor):
         try:
             with engine.new_context() as fl_ctx:
                 resource_spec = pickle.loads(req.body)
-                run_number = req.get_header(RequestHeader.RUN_NUM)
+                job_id = req.get_header(RequestHeader.JOB_ID)
                 token = req.get_header(ShareableHeader.RESOURCE_RESERVE_TOKEN)
                 allocated_resources = resource_manager.allocate_resources(
                     resource_requirement=resource_spec, token=token, fl_ctx=fl_ctx
                 )
             result = engine.start_app(
-                run_number,
+                job_id,
                 allocated_resource=allocated_resources,
                 token=token,
                 resource_consumer=resource_consumer,

--- a/nvflare/private/fed/client/training_cmds.py
+++ b/nvflare/private/fed/client/training_cmds.py
@@ -30,8 +30,8 @@ class StartAppProcessor(RequestProcessor):
         if not isinstance(engine, ClientEngineInternalSpec):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
 
-        run_number = req.get_header(RequestHeader.RUN_NUM)
-        result = engine.start_app(run_number)
+        job_id = req.get_header(RequestHeader.JOB_ID)
+        result = engine.start_app(job_id)
         if not result:
             result = "OK"
         return Message(topic="reply_" + req.topic, body=result)
@@ -45,8 +45,8 @@ class AbortAppProcessor(RequestProcessor):
         engine = app_ctx
         if not isinstance(engine, ClientEngineInternalSpec):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
-        run_number = req.get_header(RequestHeader.RUN_NUM)
-        result = engine.abort_app(run_number)
+        job_id = req.get_header(RequestHeader.JOB_ID)
+        result = engine.abort_app(job_id)
         if not result:
             result = "OK"
         return Message(topic="reply_" + req.topic, body=result)
@@ -60,8 +60,8 @@ class AbortTaskProcessor(RequestProcessor):
         engine = app_ctx
         if not isinstance(engine, ClientEngineInternalSpec):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
-        run_number = req.get_header(RequestHeader.RUN_NUM)
-        result = engine.abort_task(run_number)
+        job_id = req.get_header(RequestHeader.JOB_ID)
+        result = engine.abort_task(job_id)
         if not result:
             result = "OK"
         return Message(topic="reply_" + req.topic, body=result)
@@ -103,10 +103,10 @@ class DeployProcessor(RequestProcessor):
         engine = app_ctx
         if not isinstance(engine, ClientEngineInternalSpec):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
-        run_number = req.get_header(RequestHeader.RUN_NUM)
+        job_id = req.get_header(RequestHeader.JOB_ID)
         app_name = req.get_header(RequestHeader.APP_NAME)
         client_name = engine.get_client_name()
-        result = engine.deploy_app(app_name=app_name, run_num=run_number, client_name=client_name, app_data=req.body)
+        result = engine.deploy_app(app_name=app_name, job_id=job_id, client_name=client_name, app_data=req.body)
         if not result:
             result = "OK"
         return Message(topic="reply_" + req.topic, body=result)
@@ -120,8 +120,8 @@ class DeleteRunNumberProcessor(RequestProcessor):
         engine = app_ctx
         if not isinstance(engine, ClientEngineInternalSpec):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
-        run_number = req.get_header(RequestHeader.RUN_NUM)
-        result = engine.delete_run(run_number)
+        job_id = req.get_header(RequestHeader.JOB_ID)
+        result = engine.delete_run(job_id)
         if not result:
             result = "OK"
         message = Message(topic="reply_" + req.topic, body=result)
@@ -138,14 +138,14 @@ class ClientStatusProcessor(RequestProcessor):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
         result = engine.get_engine_status()
         # run_info = engine.get_current_run_info()
-        # if not run_info or run_info.run_number < 0:
+        # if not run_info or run_info.job_id < 0:
         #     result = {
         #         ClientStatusKey.RUN_NUM: 'none',
         #         ClientStatusKey.CURRENT_TASK: 'none'
         #     }
         # else:
         #     result = {
-        #         ClientStatusKey.RUN_NUM: str(run_info.run_number),
+        #         ClientStatusKey.RUN_NUM: str(run_info.job_id),
         #         ClientStatusKey.CURRENT_TASK: run_info.current_task_name
         #     }
         result = json.dumps(result)

--- a/nvflare/private/fed/server/cmd_utils.py
+++ b/nvflare/private/fed/server/cmd_utils.py
@@ -34,7 +34,7 @@ class CommandUtil(object):
 
     SITE_SERVER = "server"
     ALL_SITES = "@ALL"
-    RUN_NUMBER = "run_number"
+    JOB_ID = "job_id"
 
     def validate_command_targets(self, conn: Connection, args: List[str]) -> str:
         """Validate specified args and determine and set target type and target names in the Connection.
@@ -136,15 +136,13 @@ class CommandUtil(object):
 
     def authorize_train(self, conn: Connection, args: List[str]):
         if len(args) != 3:
-            conn.append_error("syntax error: missing run_number and target")
+            conn.append_error("syntax error: missing job_id and target")
             return False, None
 
-        run_number = args[1].lower()
-        if not run_number.startswith(WorkspaceConstants.WORKSPACE_PREFIX):
-            conn.append_error("syntax error: run_number must be run_XXX")
-            return False, None
-        destination = run_number[len(WorkspaceConstants.WORKSPACE_PREFIX) :]
-        conn.set_prop(self.RUN_NUMBER, destination)
+        job_id = args[1].lower()
+
+        destination = job_id[len(WorkspaceConstants.WORKSPACE_PREFIX) :]
+        conn.set_prop(self.JOB_ID, destination)
 
         return self._authorize_actions(conn, args[2:], [Action.TRAIN])
 

--- a/nvflare/private/fed/server/comp_caller_cmd.py
+++ b/nvflare/private/fed/server/comp_caller_cmd.py
@@ -61,7 +61,7 @@ class ComponentCallerCommandModule(CommandModule, CommandUtil):
         conn.set_prop(self._CONN_KEY_CALLER, caller)
 
         run_info = engine.get_app_run_info()
-        if not run_info or run_info.run_number < 0:
+        if not run_info or run_info.job_id < 0:
             conn.append_string("App is not running")
             return False, None
 

--- a/nvflare/private/fed/server/info_coll_cmd.py
+++ b/nvflare/private/fed/server/info_coll_cmd.py
@@ -76,8 +76,8 @@ class InfoCollectorCommandModule(CommandModule, CommandUtil):
         if not run_destination.startswith(WorkspaceConstants.WORKSPACE_PREFIX):
             conn.append_error("syntax error: run_destination must be run_XXX")
             return False, None
-        run_number = run_destination[len(WorkspaceConstants.WORKSPACE_PREFIX) :]
-        conn.set_prop(self.RUN_NUMBER, run_number)
+        job_id = run_destination[len(WorkspaceConstants.WORKSPACE_PREFIX) :]
+        conn.set_prop(self.JOB_ID, job_id)
 
         engine = conn.app_ctx
         if not isinstance(engine, ServerEngineInternalSpec):
@@ -94,11 +94,11 @@ class InfoCollectorCommandModule(CommandModule, CommandUtil):
 
         conn.set_prop(self.CONN_KEY_COLLECTOR, collector)
 
-        run_info = engine.get_app_run_info(run_number)
+        run_info = engine.get_app_run_info(job_id)
         if not run_info:
             conn.append_string(
                 "Cannot find job: {}. Please make sure the first arg following the command is a valid job_id.".format(
-                    run_number
+                    job_id
                 )
             )
             return False, None
@@ -115,14 +115,14 @@ class InfoCollectorCommandModule(CommandModule, CommandUtil):
         if not isinstance(engine, ServerEngineInternalSpec):
             raise TypeError("engine must be ServerEngineInternalSpec but got {}".format(type(engine)))
 
-        run_number = conn.get_prop(self.RUN_NUMBER)
+        job_id = conn.get_prop(self.JOB_ID)
         target_type = args[2]
         if target_type == self.TARGET_TYPE_SERVER:
-            result = engine.show_stats(run_number)
+            result = engine.show_stats(job_id)
             conn.append_any(result)
         elif target_type == self.TARGET_TYPE_CLIENT:
             message = new_message(conn, topic=InfoCollectorTopic.SHOW_STATS, body="")
-            message.set_header(RequestHeader.RUN_NUM, run_number)
+            message.set_header(RequestHeader.JOB_ID, job_id)
             replies = self.send_request_to_clients(conn, message)
             self._process_stats_replies(conn, replies)
 
@@ -135,10 +135,10 @@ class InfoCollectorCommandModule(CommandModule, CommandUtil):
         if not isinstance(engine, ServerEngineInternalSpec):
             raise TypeError("engine must be ServerEngineInternalSpec but got {}".format(type(engine)))
 
-        run_number = conn.get_prop(self.RUN_NUMBER)
+        job_id = conn.get_prop(self.JOB_ID)
         target_type = args[2]
         if target_type == self.TARGET_TYPE_SERVER:
-            result = engine.get_errors(run_number)
+            result = engine.get_errors(job_id)
             conn.append_any(result)
         elif target_type == self.TARGET_TYPE_CLIENT:
             message = new_message(conn, topic=InfoCollectorTopic.SHOW_ERRORS, body="")
@@ -146,7 +146,7 @@ class InfoCollectorCommandModule(CommandModule, CommandUtil):
             self._process_stats_replies(conn, replies)
 
     def reset_errors(self, conn: Connection, args: List[str]):
-        run_number = conn.get_prop(self.RUN_NUMBER)
+        job_id = conn.get_prop(self.JOB_ID)
         collector = conn.get_prop(self.CONN_KEY_COLLECTOR)
         collector.reset_errors()
         conn.append_string("errors reset")

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -78,7 +78,7 @@ class JobCommandModule(TrainingCommandModule, CommandUtil):
             return False, None
 
         job_id = args[1].lower()
-        conn.set_prop(self.RUN_NUMBER, job_id)
+        conn.set_prop(self.JOB_ID, job_id)
         engine = conn.app_ctx
         job_def_manager = engine.job_def_manager
 
@@ -141,7 +141,7 @@ class JobCommandModule(TrainingCommandModule, CommandUtil):
         conn.append_success("")
 
     def delete_job(self, conn: Connection, args: List[str]):
-        job_id = conn.get_prop(self.RUN_NUMBER)
+        job_id = conn.get_prop(self.JOB_ID)
         engine = conn.app_ctx
         try:
             if not isinstance(engine, ServerEngine):
@@ -164,8 +164,8 @@ class JobCommandModule(TrainingCommandModule, CommandUtil):
         job_runner = engine.job_runner
 
         try:
-            run_number = conn.get_prop(self.RUN_NUMBER)
-            job_runner.stop_run(run_number, engine.new_context())
+            job_id = conn.get_prop(self.JOB_ID)
+            job_runner.stop_run(job_id, engine.new_context())
             conn.append_string("Abort signal has been sent to the server app.")
             conn.append_success("")
         except Exception as e:
@@ -173,7 +173,7 @@ class JobCommandModule(TrainingCommandModule, CommandUtil):
             return
 
     def clone_job(self, conn: Connection, args: List[str]):
-        job_id = conn.get_prop(self.RUN_NUMBER)
+        job_id = conn.get_prop(self.JOB_ID)
         engine = conn.app_ctx
         try:
             if not isinstance(engine, ServerEngine):

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -53,19 +53,19 @@ class JobRunner(FLComponent):
             engine = fl_ctx.get_engine()
             self.scheduler = engine.get_component(SystemComponents.JOB_SCHEDULER)
 
-    def _deploy_clients(self, app_data, app_name, run_number, client_sites: List[str], fl_ctx):
+    def _deploy_clients(self, app_data, app_name, job_id, client_sites: List[str], fl_ctx):
         engine = fl_ctx.get_engine()
         # deploy app to all the client sites
         admin_server = engine.server.admin_server
         message = Message(topic=TrainingTopic.DEPLOY, body=app_data)
-        message.set_header(RequestHeader.RUN_NUM, run_number)
+        message.set_header(RequestHeader.JOB_ID, job_id)
         message.set_header(RequestHeader.APP_NAME, app_name)
-        self.log_debug(fl_ctx, f"Send deploy command to the clients for run: {run_number}")
+        self.log_debug(fl_ctx, f"Send deploy command to the clients for run: {job_id}")
         replies = _send_to_clients(admin_server, client_sites, engine, message)
         return replies
 
     def _deploy_job(self, job: Job, sites: dict, fl_ctx: FLContext) -> str:
-        """deploy the application to the list of participants
+        """Deploy the application to the list of participants
 
         Args:
             job: job to be deployed
@@ -73,7 +73,7 @@ class JobRunner(FLComponent):
             fl_ctx: FLContext
 
         Returns:
-            run_number
+            job_id
         """
         fl_ctx.remove_prop(FLContextKey.JOB_RUN_NUMBER)
         engine = fl_ctx.get_engine()
@@ -98,7 +98,7 @@ class JobRunner(FLComponent):
                 if p == "server":
                     success = deploy_app(app_name=app_name, site_name="server", workspace=workspace, app_data=app_data)
                     self.log_info(
-                        fl_ctx, f"Application {app_name} deployed to the server for run: {run_number}", fire_event=False
+                        fl_ctx, f"Application {app_name} deployed to the server for job: {run_number}", fire_event=False
                     )
                     if not success:
                         raise RuntimeError(f"Failed to deploy the App: {app_name} to the server")
@@ -119,69 +119,69 @@ class JobRunner(FLComponent):
         self.fire_event(EventType.JOB_DEPLOYED, fl_ctx)
         return run_number
 
-    def _start_run(self, run_number: str, job: Job, client_sites: dict, fl_ctx: FLContext):
+    def _start_run(self, job_id: str, job: Job, client_sites: dict, fl_ctx: FLContext):
         """Start the application
 
         Args:
-            run_number: run_number
+            job_id: job_id
             client_sites: participating sites
             fl_ctx: FLContext
         """
         engine = fl_ctx.get_engine()
         job_clients = engine.get_job_clients(client_sites)
-        err = engine.start_app_on_server(run_number, job_id=job.job_id, job_clients=job_clients)
+        err = engine.start_app_on_server(job_id, job_id=job.job_id, job_clients=job_clients)
         if err:
-            raise RuntimeError(f"Could not start the server App for Run: {run_number}.")
+            raise RuntimeError(f"Could not start the server App for job: {job_id}.")
 
-        replies = engine.start_client_job(run_number, client_sites)
+        replies = engine.start_client_job(job_id, client_sites)
         client_sites_names = list(client_sites.keys())
-        check_client_replies(replies=replies, client_sites=client_sites_names, command=f"start job ({run_number})")
+        check_client_replies(replies=replies, client_sites=client_sites_names, command=f"start job ({job_id})")
         display_sites = ",".join(client_sites_names)
 
-        self.log_info(fl_ctx, f"Started run: {run_number} for clients: {display_sites}")
+        self.log_info(fl_ctx, f"Started run: {job_id} for clients: {display_sites}")
         self.fire_event(EventType.JOB_STARTED, fl_ctx)
 
-    def _stop_run(self, run_number, fl_ctx: FLContext):
+    def _stop_run(self, job_id, fl_ctx: FLContext):
         """Stop the application
 
         Args:
-            run_number: run_number to be stopped
+            job_id: job_id to be stopped
             fl_ctx: FLContext
         """
         engine = fl_ctx.get_engine()
-        run_process = engine.run_processes.get(run_number)
+        run_process = engine.run_processes.get(job_id)
         if run_process:
             client_sites = run_process.get(RunProcessKey.PARTICIPANTS)
-            self.abort_client_run(run_number, client_sites, fl_ctx)
+            self.abort_client_run(job_id, client_sites, fl_ctx)
 
-            err = engine.abort_app_on_server(run_number)
+            err = engine.abort_app_on_server(job_id)
             if err:
-                self.log_error(fl_ctx, f"Failed to abort the server for run: {run_number}")
+                self.log_error(fl_ctx, f"Failed to abort the server for run: {job_id}")
 
-    def abort_client_run(self, run_number, client_sites: List[str], fl_ctx):
+    def abort_client_run(self, job_id, client_sites: List[str], fl_ctx):
         """Send the abort run command to the clients
 
         Args:
-            run_number: run_number
+            job_id: job_id
             client_sites: Clients to be aborted
             fl_ctx: FLContext
         """
         engine = fl_ctx.get_engine()
         admin_server = engine.server.admin_server
         message = Message(topic=TrainingTopic.ABORT, body="")
-        message.set_header(RequestHeader.RUN_NUM, str(run_number))
-        self.log_debug(fl_ctx, f"Send abort command to the clients for run: {run_number}")
+        message.set_header(RequestHeader.JOB_ID, str(job_id))
+        self.log_debug(fl_ctx, f"Send abort command to the clients for run: {job_id}")
         try:
             replies = _send_to_clients(admin_server, client_sites, engine, message)
             check_client_replies(replies=replies, client_sites=client_sites, command="abort the run")
         except RuntimeError as e:
-            self.log_error(fl_ctx, f"Failed to abort run ({run_number}) on the clients: {e}")
+            self.log_error(fl_ctx, f"Failed to abort run ({job_id}) on the clients: {e}")
 
-    def _delete_run(self, run_number, client_sites: List[str], fl_ctx: FLContext):
+    def _delete_run(self, job_id, client_sites: List[str], fl_ctx: FLContext):
         """Deletes the run workspace
 
         Args:
-            run_number: run_number
+            job_id: job_id
             client_sites: participating sites
             fl_ctx: FLContext
         """
@@ -189,39 +189,39 @@ class JobRunner(FLComponent):
 
         admin_server = engine.server.admin_server
         message = Message(topic=TrainingTopic.DELETE_RUN, body="")
-        message.set_header(RequestHeader.RUN_NUM, str(run_number))
-        self.log_debug(fl_ctx, f"Send delete_run command to the clients for run: {run_number}")
+        message.set_header(RequestHeader.JOB_ID, str(job_id))
+        self.log_debug(fl_ctx, f"Send delete_run command to the clients for run: {job_id}")
         try:
             replies = _send_to_clients(admin_server, client_sites, engine, message)
             check_client_replies(replies=replies, client_sites=client_sites, command="send delete_run command")
         except RuntimeError as e:
-            self.log_error(fl_ctx, f"Failed to execute delete run ({run_number}) on the clients: {e}")
+            self.log_error(fl_ctx, f"Failed to execute delete run ({job_id}) on the clients: {e}")
 
-        err = engine.delete_run_number(run_number)
+        err = engine.delete_job_id(job_id)
         if err:
-            self.log_error(fl_ctx, f"Failed to delete_run the server for run: {run_number}")
+            self.log_error(fl_ctx, f"Failed to delete_run the server for run: {job_id}")
 
     def _job_complete_process(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
         while not self.ask_to_stop:
-            for run_number in list(self.running_jobs.keys()):
-                if run_number not in engine.run_processes.keys():
+            for job_id in list(self.running_jobs.keys()):
+                if job_id not in engine.run_processes.keys():
                     with self.lock:
-                        job = self.running_jobs.get(run_number)
+                        job = self.running_jobs.get(job_id)
                         if job:
-                            if run_number in engine.execution_exception_run_processes:
-                                self.log_info(fl_ctx, f"Try to abort run ({run_number}) on clients.")
-                                run_process = engine.execution_exception_run_processes[run_number]
+                            if job_id in engine.execution_exception_run_processes:
+                                self.log_info(fl_ctx, f"Try to abort run ({job_id}) on clients.")
+                                run_process = engine.execution_exception_run_processes[job_id]
 
                                 # stop client run
                                 client_sites = run_process.get(RunProcessKey.PARTICIPANTS)
-                                self.abort_client_run(run_number, client_sites, fl_ctx)
+                                self.abort_client_run(job_id, client_sites, fl_ctx)
 
                                 job_manager.set_status(job.job_id, RunStatus.FINISHED_EXECUTION_EXCEPTION, fl_ctx)
                             else:
                                 job_manager.set_status(job.job_id, RunStatus.FINISHED_COMPLETED, fl_ctx)
-                            del self.running_jobs[run_number]
+                            del self.running_jobs[job_id]
                             fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, job.job_id)
                             self.fire_event(EventType.JOB_COMPLETED, fl_ctx)
                             self.log_debug(fl_ctx, f"Finished running job:{job.job_id}")
@@ -242,25 +242,25 @@ class JobRunner(FLComponent):
                     if ready_job:
                         with self.lock:
                             client_sites = {k: v for k, v in sites.items() if k != "server"}
-                            run_number = None
+                            job_id = None
                             try:
                                 self.log_info(fl_ctx, f"Got the job:{ready_job.job_id} from the scheduler to run")
                                 fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, ready_job.job_id)
-                                run_number = self._deploy_job(ready_job, sites, fl_ctx)
+                                job_id = self._deploy_job(ready_job, sites, fl_ctx)
                                 job_manager.set_status(ready_job.job_id, RunStatus.DISPATCHED, fl_ctx)
                                 self._start_run(
-                                    run_number=run_number,
+                                    job_id=job_id,
                                     job=ready_job,
                                     client_sites=client_sites,
                                     fl_ctx=fl_ctx,
                                 )
-                                self.running_jobs[run_number] = ready_job
+                                self.running_jobs[job_id] = ready_job
                                 job_manager.set_status(ready_job.job_id, RunStatus.RUNNING, fl_ctx)
                             except Exception as e:
-                                if run_number:
-                                    if run_number in self.running_jobs:
-                                        del self.running_jobs[run_number]
-                                    self._stop_run(run_number, fl_ctx)
+                                if job_id:
+                                    if job_id in self.running_jobs:
+                                        del self.running_jobs[job_id]
+                                    self._stop_run(job_id, fl_ctx)
                                 job_manager.set_status(ready_job.job_id, RunStatus.FAILED_TO_RUN, fl_ctx)
                                 self.fire_event(EventType.JOB_ABORTED, fl_ctx)
                                 self.log_error(fl_ctx, f"Failed to run the Job ({ready_job.job_id}): {e}")
@@ -277,29 +277,29 @@ class JobRunner(FLComponent):
             job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
             job = job_manager.get_job(jid=job_id, fl_ctx=fl_ctx)
             with self.lock:
-                self.running_jobs[run_number] = job
+                self.running_jobs[job_id] = job
         except Exception as e:
             self.log_error(fl_ctx, f"Failed to restore the job: {job_id} to the running job table: {e}.")
 
-    def stop_run(self, run_number: str, fl_ctx: FLContext):
+    def stop_run(self, job_id: str, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
         with self.lock:
-            self._stop_run(run_number, fl_ctx)
-            job = self.running_jobs.get(run_number)
+            self._stop_run(job_id, fl_ctx)
+            job = self.running_jobs.get(job_id)
             if job:
-                self.log_info(fl_ctx, f"Stop the job run: {run_number}")
+                self.log_info(fl_ctx, f"Stop the job run: {job_id}")
                 fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, job.job_id)
                 job_manager.set_status(job.job_id, RunStatus.FINISHED_ABORTED, fl_ctx)
-                del self.running_jobs[run_number]
+                del self.running_jobs[job_id]
                 self.fire_event(EventType.JOB_ABORTED, fl_ctx)
             else:
-                raise RuntimeError(f"Job run: {run_number} does not exist.")
+                raise RuntimeError(f"Job run: {job_id} does not exist.")
 
     def stop_all_runs(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
-        for run_number in engine.run_processes.keys():
-            self.stop_run(run_number, fl_ctx)
+        for job_id in engine.run_processes.keys():
+            self.stop_run(job_id, fl_ctx)
 
         self.log_info(fl_ctx, "Stop all the running jobs.")
         self.ask_to_stop = True

--- a/nvflare/private/fed/server/run_manager.py
+++ b/nvflare/private/fed/server/run_manager.py
@@ -27,9 +27,9 @@ from .server_aux_runner import ServerAuxRunner
 
 
 class RunInfo(object):
-    def __init__(self, run_num, app_path):
+    def __init__(self, job_id, app_path):
         """Information for a run."""
-        self.run_number = run_num
+        self.job_id = job_id
         self.start_time = time.time()
         self.app_path = app_path
         self.status = MachineStatus.STOPPED
@@ -40,7 +40,7 @@ class RunManager:
         self,
         server_name,
         engine: ServerEngineSpec,
-        run_num,
+        job_id,
         workspace: Workspace,
         components: {str: FLComponent},
         client_manager: Optional[ClientManager] = None,
@@ -51,7 +51,7 @@ class RunManager:
         Args:
             server_name: server name
             engine (ServerEngineSpec): server engine
-            run_num: run number
+            job_id: job id
             workspace (Workspace): workspace
             components (dict): A dict of extra python objects {id: object}
             client_manager (ClientManager, optional): client manager
@@ -66,11 +66,11 @@ class RunManager:
         self.add_handler(self.aux_runner)
 
         self.fl_ctx_mgr = FLContextManager(
-            engine=engine, identity_name=server_name, run_num=run_num, public_stickers={}, private_stickers={}
+            engine=engine, identity_name=server_name, job_id=job_id, public_stickers={}, private_stickers={}
         )
 
         self.workspace = workspace
-        self.run_info = RunInfo(run_num=run_num, app_path=self.workspace.get_app_dir(run_num))
+        self.run_info = RunInfo(job_id=job_id, app_path=self.workspace.get_app_dir(job_id))
 
         self.components = components
 

--- a/nvflare/private/fed/server/server_engine_internal_spec.py
+++ b/nvflare/private/fed/server/server_engine_internal_spec.py
@@ -57,13 +57,13 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def deploy_app_to_server(self, run_number: str, app_name: str, app_staging_path: str) -> str:
+    def deploy_app_to_server(self, job_id: str, app_name: str, app_staging_path: str) -> str:
         """Deploy the specified app to the server.
 
         Copy the app folder tree from staging area to the server's RUN area
 
         Args:
-            run_number: run number of the app to be deployed
+            job_id: job id of the app to be deployed
             app_name: name of the app to be deployed
             app_staging_path: the full path to the app folder in staging area
 
@@ -85,7 +85,7 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def get_app_run_info(self, run_number) -> RunInfo:
+    def get_app_run_info(self, job_id) -> RunInfo:
         """Get the app RunInfo from the child process.
 
         Returns:
@@ -95,12 +95,12 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def delete_run_number(self, run_num: str) -> str:
+    def delete_job_id(self, job_id: str) -> str:
         """Delete specified RUN.
 
         The Engine must do status check before the run can be deleted.
         Args:
-            run_num: run number
+            job_id: job id
 
         Returns:
             An error message. An empty string if successful.
@@ -108,7 +108,7 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def start_app_on_server(self, run_number: str, job_id: str = None, job_clients=None, snapshot=None) -> str:
+    def start_app_on_server(self, job_idber: str, job_id: str = None, job_clients=None, snapshot=None) -> str:
         """Start the FL app on Server.
 
         Returns:
@@ -117,7 +117,7 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def check_app_start_readiness(self, run_number: str) -> str:
+    def check_app_start_readiness(self, job_id: str) -> str:
         """Check whether the app is ready to start.
 
         Returns:
@@ -131,7 +131,7 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def abort_app_on_server(self, run_number: str):
+    def abort_app_on_server(self, job_id: str):
         """Abort the application on the server."""
         pass
 
@@ -274,11 +274,11 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def show_stats(self, run_number):
+    def show_stats(self, job_id):
         """Show_stats of the server.
 
         Args:
-            run_number: current run_number
+            job_id: current job_id
 
         Returns:
             Component stats of the server
@@ -287,11 +287,11 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
         pass
 
     @abstractmethod
-    def get_errors(self, run_number):
+    def get_errors(self, job_id):
         """Get the errors of the server components.
 
         Args:
-            run_number: current run_number
+            job_id: current job_id
 
         Returns:
             Server components errors.

--- a/nvflare/widgets/info_collector.py
+++ b/nvflare/widgets/info_collector.py
@@ -243,6 +243,6 @@ class InfoCollector(Widget):
         """Gets the error category information."""
         return self.get_category(self.CATEGORY_ERROR)
 
-    def reset_errors(self, run_number):
+    def reset_errors(self, job_id):
         """Resets the error category information."""
         self.reset_category(self.CATEGORY_ERROR)

--- a/tests/integration_test/admin_controller.py
+++ b/tests/integration_test/admin_controller.py
@@ -97,13 +97,13 @@ def _update_run_state(stats: dict, run_state: dict, job_run_status: str):
     #               'CrossSiteModelEval':
     #                   {'tasks': {}},
     #               'ServerRunner': {
-    #                   'run_number': XXX,
+    #                   'job_id': XXX,
     #                   'status': 'started',
     #                   'workflow': 'scatter_and_gather'
     #                }
     #            }
     #       },
-    # 'raw': {'time': '2022-04-04 15:13:09.367350', 'data': [{'type': 'dict', 'data': {'ScatterAndGather': {'tasks': {'train': []}, 'phase': 'train', 'current_round': 0, 'num_rounds': 2}, 'CrossSiteModelEval': {'tasks': {}}, 'ServerRunner': {'run_number': XXX, 'status': 'started', 'workflow': 'scatter_and_gather'}}}], 'status': <APIStatus.SUCCESS: 'SUCCESS'>}}
+    # 'raw': {'time': '2022-04-04 15:13:09.367350', 'data': [{'type': 'dict', 'data': {'ScatterAndGather': {'tasks': {'train': []}, 'phase': 'train', 'current_round': 0, 'num_rounds': 2}, 'CrossSiteModelEval': {'tasks': {}}, 'ServerRunner': {'job_id': XXX, 'status': 'started', 'workflow': 'scatter_and_gather'}}}], 'status': <APIStatus.SUCCESS: 'SUCCESS'>}}
     prev_run_state = run_state.copy()
 
     # parse stats

--- a/tests/integration_test/data/apps/pt/custom/pt_model_locator.py
+++ b/tests/integration_test/data/apps/pt/custom/pt_model_locator.py
@@ -39,7 +39,7 @@ class PTModelLocator(ModelLocator):
     def locate_model(self, model_name, fl_ctx: FLContext) -> Union[DXO, None]:
         if model_name == PTConstants.PTServerName:
             try:
-                server_run_dir = fl_ctx.get_engine().get_workspace().get_app_dir(fl_ctx.get_run_number())
+                server_run_dir = fl_ctx.get_engine().get_workspace().get_app_dir(fl_ctx.get_job_id())
                 model_path = os.path.join(server_run_dir, PTConstants.PTFileModelName)
                 if not os.path.exists(model_path):
                     return None

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -80,7 +80,7 @@ class MockEngine:
         self.fl_ctx_mgr = FLContextManager(
             engine=self,
             identity_name="__mock_engine",
-            run_num=run_name,
+            job_id=run_name,
             public_stickers={},
             private_stickers={},
         )

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -71,7 +71,7 @@ class MockServerEngine(ServerEngineSpec):
         self.fl_ctx_mgr = FLContextManager(
             engine=self,
             identity_name="__mock_engine",
-            run_num=run_name,
+            job_id=run_name,
             public_stickers={},
             private_stickers={},
         )
@@ -113,7 +113,7 @@ class MockServerEngine(ServerEngineSpec):
     def restore_components(self, snapshot, fl_ctx: FLContext):
         pass
 
-    def start_client_job(self, run_number, client_sites):
+    def start_client_job(self, job_id, client_sites):
         pass
 
     def check_client_resources(self, resource_reqs: Dict[str, dict]) -> Dict[str, Tuple[bool, Optional[str]]]:

--- a/tests/unit_test/app_common/resource_managers/list_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/list_resource_manager_test.py
@@ -26,7 +26,7 @@ class MockEngine:
         self.fl_ctx_mgr = FLContextManager(
             engine=self,
             identity_name="__mock_engine",
-            run_num=run_name,
+            job_id=run_name,
             public_stickers={},
             private_stickers={},
         )

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -24,11 +24,11 @@ from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 
 
 class MockSimpleEngine:
-    def __init__(self, run_num="unit_test"):
+    def __init__(self, job_id="unit_test"):
         self.fl_ctx_mgr = FLContextManager(
             engine=self,
             identity_name="__mock_simple_engine",
-            run_num=run_num,
+            job_id=job_id,
             public_stickers={},
             private_stickers={},
         )


### PR DESCRIPTION
Replaces run_number and strings with job_id. Areas that may still need attention:

nvflare/private/fed/server/job_runner.py:
- uses FLContextKey.JOB_RUN_NUMBER, appends with logic of run_number = job.job_id + ":" + str(count)

nvflare/private/fed/server/server_engine.py: these methods have both run_number and job_id
- start_app_on_server
- _start_runner_process

    
nvflare/private/fed/server/fed_server.py:
- _turn_to_hot
    
nvflare/apis/fl_constant.py:
- ReservedKey.RUN_NUM
    
nvflare/app_common/widgets/event_recorder.py:
- has "__run_num__"
    
nvflare/private/fed/protos/federated_pb2.py