### PR TITLE
Save job workspace

### DIFF
--- a/nvflare/apis/job_def.py
+++ b/nvflare/apis/job_def.py
@@ -34,7 +34,15 @@ class RunStatus(str, Enum):
     FAILED_TO_RUN = "FAILED_TO_RUN"
 
 
+class JobDataKey(str, Enum):
+    DATA = "data"
+    META = "meta"
+    JOB_DATA = "job_data_"
+    WORKSPACE_DATA = "workspace_data_"
+
+
 class JobMetaKey(str, Enum):
+    VERSION = "job_version"
     JOB_ID = "job_id"
     JOB_NAME = "name"
     JOB_FOLDER_NAME = "job_folder_name"

--- a/nvflare/apis/job_def_manager_spec.py
+++ b/nvflare/apis/job_def_manager_spec.py
@@ -95,6 +95,23 @@ class JobDefManagerSpec(FLComponent, ABC):
         pass
 
     @abstractmethod
+    def get_job_data(self, jid: str, fl_ctx: FLContext) -> dict:
+        """Gets the entire uploaded content and workspace for a job.
+
+        Args:
+            jid (str): Job ID
+            fl_ctx (FLContext): FLContext information
+
+        Returns:
+            a dict to hold the job data and workspace.
+            Format: {
+                        JobDataKey.JOB_DATA.value: stored_data,
+                        JobDataKey.WORKSPACE_DATA: workspace_data
+                    }
+        """
+        pass
+
+    @abstractmethod
     def update_meta(self, jid: str, meta, fl_ctx: FLContext):
         """Update the meta of an existing Job.
 
@@ -180,6 +197,18 @@ class JobDefManagerSpec(FLComponent, ABC):
 
         Args:
             jid (str): Job ID
+            fl_ctx (FLContext): FLContext information
+
+        """
+        pass
+
+    @abstractmethod
+    def save_workspace(self, jid: str, data: bytes, fl_ctx: FLContext):
+        """Save the job workspace to the job storage.
+
+        Args:
+            jid (str): Job ID
+            data: Job workspace data
             fl_ctx (FLContext): FLContext information
 
         """

--- a/tests/unit_test/apis/impl/job_def_manager_test.py
+++ b/tests/unit_test/apis/impl/job_def_manager_test.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import mock
+
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.impl.job_def_manager import SimpleJobDefManager
+from nvflare.apis.job_def import JobDataKey, JobMetaKey
+from nvflare.app_common.storages.filesystem_storage import FilesystemStorage
+from nvflare.fuel.hci.zip_utils import zip_directory_to_bytes
+from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
+
+
+class TestJobManager(unittest.TestCase):
+    def setUp(self) -> None:
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        self.uri_root = tempfile.mkdtemp()
+        self.data_folder = os.path.join(dir_path, "../../data/jobs")
+        self.job_manager = SimpleJobDefManager(uri_root=self.uri_root)
+        self.fl_ctx = FLContext()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.uri_root)
+
+    def test_create_job(self):
+        with mock.patch('nvflare.apis.impl.job_def_manager.SimpleJobDefManager._get_job_store') as mock_store:
+            mock_store.return_value = FilesystemStorage()
+
+            data, meta = self._create_job()
+            content = self.job_manager.get_content(meta.get(JobMetaKey.JOB_ID), self.fl_ctx)
+            assert content == data
+
+    def _create_job(self):
+        data = zip_directory_to_bytes(self.data_folder, "valid_job")
+        folder_name = "valid_job"
+        job_validator = JobMetaValidator()
+        valid, error, meta = job_validator.validate(folder_name, data)
+        meta = self.job_manager.create(meta, data, self.fl_ctx)
+        return data, meta
+
+    def test_save_workspace(self):
+        with mock.patch('nvflare.apis.impl.job_def_manager.SimpleJobDefManager._get_job_store') as mock_store:
+            mock_store.return_value = FilesystemStorage()
+
+            data, meta = self._create_job()
+            job_id = meta.get(JobMetaKey.JOB_ID)
+            self.job_manager.save_workspace(job_id, data, self.fl_ctx)
+            result = self.job_manager.get_job_data(job_id, self.fl_ctx)
+            assert result.get(JobDataKey.WORKSPACE_DATA) == data
+


### PR DESCRIPTION
- Save the workspace to the job permanent storage after the job run complete.
- Delete the server workspace once workspace persisted.
- The download_job include the job run workspace.
- backward compatible with the existing jobs.