### PR TITLE
make commands consistent with updates for FLAdminAPI and docs

### DIFF
--- a/docs/user_guide/operation.rst
+++ b/docs/user_guide/operation.rst
@@ -35,7 +35,8 @@ commands shown as examples of how they may be run with a description.
     abort,``abort job_id client``,Aborts the job for the specified job_id for all clients. Individual client jobs can be aborted by specifying *clientname*.
     ,``abort job_id server``,Aborts the server job for the specified job_id.
     abort_task,``abort_task job_id clientname``,Aborts the running task for the specified job ID and client.
-    download_folder,``download_folder foldername``,Download folder from the server's file_download_dir (set to transfer by default)
+    download_job,``download_job job_id``,Download folder from the job store containing the job and workspace if the job is finished
+    delete_job,``delete_job job_id``,Delete the job from the job store
     cat,``cat server startup/fed_server.json -ns``,Show content of a file (-n: number all output lines; -s: suppress repeated empty output lines)
     ,``cat clientname startup/docker.sh -bT``,Show content of a file (-b: number nonempty output lines; -T: display TAB characters as ^I)
     env,``env server``,Show environment variables

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -330,22 +330,6 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         )
 
     @wrap_with_return_exception_responses
-    def delete_run(self, job_id: str) -> FLAdminAPIResponse:
-        if not isinstance(job_id, str):
-            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
-        success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(
-            AdminCommandNames.DELETE_RUN + " " + str(job_id)
-        )
-        if reply_data_full_response:
-            if "can not be deleted" in reply_data_full_response:
-                return FLAdminAPIResponse(APIStatus.ERROR_RUNTIME, {"message": reply_data_full_response})
-        if success:
-            return FLAdminAPIResponse(APIStatus.SUCCESS, {"message": reply_data_full_response}, reply)
-        return FLAdminAPIResponse(
-            APIStatus.ERROR_RUNTIME, {"message": "Runtime error: could not handle server reply."}, reply
-        )
-
-    @wrap_with_return_exception_responses
     def submit_job(self, job_folder: str) -> FLAdminAPIResponse:
         if not job_folder:
             raise APISyntaxError("job_folder is required but not specified.")
@@ -365,12 +349,12 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         )
 
     @wrap_with_return_exception_responses
-    def clone_job(self, job_folder: str) -> FLAdminAPIResponse:
-        if not job_folder:
+    def clone_job(self, job_id: str) -> FLAdminAPIResponse:
+        if not job_id:
             raise APISyntaxError("job_folder is required but not specified.")
-        if not isinstance(job_folder, str):
-            raise APISyntaxError("job_folder must be str but got {}.".format(type(job_folder)))
-        success, reply_data_full_response, reply = self._get_processed_cmd_reply_data("clone_job " + job_folder)
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_folder must be str but got {}.".format(type(job_id)))
+        success, reply_data_full_response, reply = self._get_processed_cmd_reply_data("clone_job " + job_id)
         if reply_data_full_response:
             if "Cloned job" in reply_data_full_response:
                 return FLAdminAPIResponse(
@@ -396,6 +380,23 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         )
 
     @wrap_with_return_exception_responses
+    def download_job(self, job_id: str) -> FLAdminAPIResponse:
+        if not job_id:
+            raise APISyntaxError("job_id is required but not specified.")
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
+        success, reply_data_full_response, reply = self._get_processed_cmd_reply_data("download_job " + job_id)
+        if success:
+            return FLAdminAPIResponse(
+                APIStatus.SUCCESS,
+                {"message": reply.get("details")},
+                reply,
+            )
+        return FLAdminAPIResponse(
+            APIStatus.ERROR_RUNTIME, {"message": "Runtime error: could not handle server reply."}, reply
+        )
+
+    @wrap_with_return_exception_responses
     def abort_job(self, job_id: str) -> FLAdminAPIResponse:
         if not job_id:
             raise APISyntaxError("job_id is required but not specified.")
@@ -409,6 +410,22 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
                     {"message": reply_data_full_response},
                     reply,
                 )
+        return FLAdminAPIResponse(
+            APIStatus.ERROR_RUNTIME, {"message": "Runtime error: could not handle server reply."}, reply
+        )
+
+    @wrap_with_return_exception_responses
+    def delete_job(self, job_id: str) -> FLAdminAPIResponse:
+        if not isinstance(job_id, str):
+            raise APISyntaxError("job_id must be str but got {}.".format(type(job_id)))
+        success, reply_data_full_response, reply = self._get_processed_cmd_reply_data(
+            AdminCommandNames.DELETE_RUN + " " + str(job_id)
+        )
+        if reply_data_full_response:
+            if "can not be deleted" in reply_data_full_response:
+                return FLAdminAPIResponse(APIStatus.ERROR_RUNTIME, {"message": reply_data_full_response})
+        if success:
+            return FLAdminAPIResponse(APIStatus.SUCCESS, {"message": reply_data_full_response}, reply)
         return FLAdminAPIResponse(
             APIStatus.ERROR_RUNTIME, {"message": "Runtime error: could not handle server reply."}, reply
         )

--- a/nvflare/fuel/hci/client/fl_admin_api_spec.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_spec.py
@@ -77,21 +77,6 @@ class FLAdminAPISpec(ABC):
         pass
 
     @abstractmethod
-    def delete_run(self, job_id: str) -> FLAdminAPIResponse:
-        """Deletes a specified run.
-
-        This deletes the run folder corresponding to the job id on the server and
-        all connected clients. This is not reversible.
-
-        Args:
-            job_id (str): job id to delete
-
-        Returns: FLAdminAPIResponse
-
-        """
-        pass
-
-    @abstractmethod
     def submit_job(self, job_folder: str) -> FLAdminAPIResponse:
         """Submit a job.
 
@@ -106,11 +91,11 @@ class FLAdminAPISpec(ABC):
         pass
 
     @abstractmethod
-    def clone_job(self, job_folder: str) -> FLAdminAPIResponse:
+    def clone_job(self, job_id: str) -> FLAdminAPIResponse:
         """Clone a job that exists by copying the job contents and providing a new job_id.
 
         Args:
-            job_folder (str): name of the job folder in upload_dir to submit
+            job_id (str): job id of the job to clone
 
         Returns: FLAdminAPIResponse
 
@@ -130,11 +115,35 @@ class FLAdminAPISpec(ABC):
         pass
 
     @abstractmethod
+    def download_job(self, job_id: str) -> FLAdminAPIResponse:
+        """Download the specified job in the system.
+
+        Args:
+            job_id (str): Job id for the job to download
+
+        Returns: FLAdminAPIResponse
+
+        """
+        pass
+
+    @abstractmethod
     def abort_job(self, job_id: str) -> FLAdminAPIResponse:
         """Abort a job that is running.
 
         Args:
-            job_id (str): the job_id to abort
+            job_id (str): the job id to abort
+
+        Returns: FLAdminAPIResponse
+
+        """
+        pass
+
+    @abstractmethod
+    def delete_job(self, job_id: str) -> FLAdminAPIResponse:
+        """Delete the specified job and workspace from the permanent store.
+
+        Args:
+            job_id (str): the job id to delete
 
         Returns: FLAdminAPIResponse
 


### PR DESCRIPTION
Since delete_run is now delete_job and download commands have been replaced with download_job, this makes the FLAdminAPI and documentation consistent with the changes.