### PR TITLE
update links for 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 **NV**IDIA **F**ederated **L**earning **A**pplication **R**untime **E**nvironment
 
 
-[NVIDIA FLARE](https://nvidia.github.io/NVFlare) enables researchers to collaborate and build AI models without sharing private data. 
+[NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) enables researchers to collaborate and build AI models without sharing private data. 
 
 NVIDIA FLARE is a standalone python library designed to enable federated learning amongst different parties using their local secure protected data for client-side training, at the same time it includes capabilities to coordinate and exchange progressing of results across all sites to achieve better global model while preserving data privacy. The participating clients can be in any part of the world. 
 
 NVIDIA FLARE builds on a flexible and modular architecture and is abstracted through APIs allowing developers & researchers to customize their implementation of functional learning components in a Federated Learning paradigm. 
 
-Learn more - [NVIDIA FLARE](https://nvidia.github.io/NVFlare).
+Learn more - [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html).
 
 
 ## Installation

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,28 +1,28 @@
 # NVIDIA FLARE Examples
 
-[NVIDIA FLARE](https://nvidia.github.io/NVFlare) provides several examples to help you get started using federated learning for your own applications.
+[NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) provides several examples to help you get started using federated learning for your own applications.
 
-The provided examples cover different aspects of [NVIDIA FLARE](https://nvidia.github.io/NVFlare), such as using the provided [Controllers](https://nvidia.github.io/NVFlare/programming_guide/controllers.html) for "scatter and gather" or "cyclic weight transfer" workflows and example [Executors](https://nvidia.github.io/NVFlare/apidocs/nvflare.apis.html?#module-nvflare.apis.executor) to implement your own training and validation pipelines. Some examples use the provided "task data" and "task result" [Filters](https://nvidia.github.io/NVFlare/apidocs/nvflare.apis.html?#module-nvflare.apis.filter) for homomorphic encryption and decryption or differential privacy. Furthermore, we show how to use different components for FL algorithms such as [FedAvg](https://arxiv.org/abs/1602.05629), [FedProx](https://arxiv.org/abs/1812.06127), and [FedOpt](https://arxiv.org/abs/2003.00295). We also provide domain-specific examples for deep learning and medical image analysis.
+The provided examples cover different aspects of [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html), such as using the provided [Controllers](https://nvflare.readthedocs.io/en/2.1.1/programming_guide/controllers.html) for "scatter and gather" or "cyclic weight transfer" workflows and example [Executors](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.apis.html?#module-nvflare.apis.executor) to implement your own training and validation pipelines. Some examples use the provided "task data" and "task result" [Filters](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.apis.html?#module-nvflare.apis.filter) for homomorphic encryption and decryption or differential privacy. Furthermore, we show how to use different components for FL algorithms such as [FedAvg](https://arxiv.org/abs/1602.05629), [FedProx](https://arxiv.org/abs/1812.06127), and [FedOpt](https://arxiv.org/abs/2003.00295). We also provide domain-specific examples for deep learning and medical image analysis.
 
-> **_NOTE:_** To run examples, please follow the instructions for [Installation](https://nvidia.github.io/NVFlare/installation.html) and any additional steps specified in the example readmes.
+> **_NOTE:_** To run examples, please follow the instructions for [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) and any additional steps specified in the example readmes.
 
 ## 0. Quickstart
 To get started with these examples, please follow the [Quickstart](https://nvflare.readthedocs.io/en/main/quickstart.html)in the NVIDIA FLARE Documentation.  This walks you through installation, creating a POC workspace, and deploying your first NVIDIA FLARE Application.  The following examples will detail any additional requirements in their READMEs.
 ## 1. Hello World Examples
 ### 1.1 Workflows
 * [Hello Scatter and Gather](./hello-numpy-sag/README.md)
-    * Example using "[ScatterAndGather](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.scatter_and_gather)" controller workflow.
+    * Example using "[ScatterAndGather](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.scatter_and_gather)" controller workflow.
 * [Hello Cross-Site Validation](./hello-numpy-cross-val/README.md)
-    * Example using [CrossSiteModelEval](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.workflows.html#nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval) controller workflow.
+    * Example using [CrossSiteModelEval](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.workflows.html#nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval) controller workflow.
 * [Hello Cyclic Weight Transfer](./hello-cyclic/README.md)
-    * Example using [CyclicController](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.cyclic_ctl) controller workflow to implement [Cyclic Weight Transfer](https://pubmed.ncbi.nlm.nih.gov/29617797/).
+    * Example using [CyclicController](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.cyclic_ctl) controller workflow to implement [Cyclic Weight Transfer](https://pubmed.ncbi.nlm.nih.gov/29617797/).
 ### 1.2 Deep Learning
 * [Hello PyTorch](./hello-pt/README.md)
-  * Example using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
+  * Example using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
 * [Hello PyTorch with TensorBoard](./hello-pt-tb/README.md)
   * Example building upon [Hello PyTorch](./hello-pt/README.md) showcasing the [TensorBoard](https://tensorflow.org/tensorboard) streaming capability from the clients to the server.
 * [Hello TensorFlow](./hello-tf2/README.md)
-  * Example of using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
+  * Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
 
 ## 2. FL algorithms
 * [Federated Learning with CIFAR-10](./cifar10/README.md)
@@ -30,7 +30,7 @@ To get started with these examples, please follow the [Quickstart](https://nvfla
 
 ## 3. Medical Image Analysis
 * [Hello MONAI](./hello-monai/README.md)
-   * Example using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) to train a medical image analysis model using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [MONAI](https://monai.io/)
+   * Example using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) to train a medical image analysis model using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [MONAI](https://monai.io/)
 * [Federated Learning with Differential Privacy for BraTS18 segmentation](./brats18/README.md)
    * Illustrates the use of differential privacy for training brain tumor segmentation models using federated learning.
 * [Federated Learning for Prostate Segmentation from Multi-source Data](./prostate/README.md)

--- a/examples/brats18/README.md
+++ b/examples/brats18/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction to MONAI, BraTS and Differential Privacy
 ### MONAI
-This example shows how to use [NVIDIA FLARE](https://nvidia.github.io/NVFlare) on medical image applications.
+This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) on medical image applications.
 It uses [MONAI](https://github.com/Project-MONAI/MONAI),
 which is a PyTorch-based, open-source framework for deep learning in healthcare imaging, part of the PyTorch Ecosystem.
 ### BraTS
@@ -21,7 +21,7 @@ To run this example, please make sure you have downloaded BraTS 2018 data, which
 In this example, we split BraTS18 dataset into [4 subsets](./dataset_brats18/datalist) for 4 clients. Each client requires at least a 12 GB GPU to run. 
 ### Differential Privacy (DP)
 [Differential Privacy (DP)](https://arxiv.org/abs/1910.00962) [7] is method for ensuring that Federated Learning (FL) preserves privacy by obfuscating the model updates sent from clients to the central server.
-This example shows the usage of a MONAI-based trainer for medical image applications with NVFlare, as well as the usage of DP filters in your FL training. DP is added as a filter in `config_fed_client.json`. Here, we use the "Sparse Vector Technique", i.e. the [SVTPrivacy](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.filters.html#nvflare.app_common.filters.svt_privacy.SVTPrivacy) protocol, as utilized in [Li et al. 2019](https://arxiv.org/abs/1910.00962) [7] (see [Lyu et al. 2016](https://arxiv.org/abs/1603.01699) [8] for more information).
+This example shows the usage of a MONAI-based trainer for medical image applications with NVFlare, as well as the usage of DP filters in your FL training. DP is added as a filter in `config_fed_client.json`. Here, we use the "Sparse Vector Technique", i.e. the [SVTPrivacy](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.filters.html#nvflare.app_common.filters.svt_privacy.SVTPrivacy) protocol, as utilized in [Li et al. 2019](https://arxiv.org/abs/1910.00962) [7] (see [Lyu et al. 2016](https://arxiv.org/abs/1603.01699) [8] for more information).
 
 ## (Optional) 1. Set up a virtual environment
 ```
@@ -75,7 +75,7 @@ To enable multitasking (if there are more computation resources - e.g. 4 x 32 GB
 
 (Optional) If using secure workspace, in secure project configuration `secure_project.yml`, we can set the available GPU indices as `gpu: [0, 1, 2, 3]` using the `ListResourceManager` and `max_jobs: 2` in `DefaultJobScheduler`.
 
-For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.0/user_guide/job.html).
+For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.1/user_guide/job.html).
 
 ## 3. Run automated experiments
 The next scripts will start the FL server and clients automatically to run FL experiments on localhost.

--- a/examples/cifar10/README.md
+++ b/examples/cifar10/README.md
@@ -41,7 +41,7 @@ python3 -m nvflare.lighter.provision -p ./secure_project.yml
 cp -r ./workspace/secure_project/prod_00 ./secure_workspace
 cd ..
 ```
-For more information about secure provisioning see the [documentation](https://nvflare.readthedocs.io/en/2.1.0/user_guide/provisioning_tool.html).
+For more information about secure provisioning see the [documentation](https://nvflare.readthedocs.io/en/2.1.1/user_guide/provisioning_tool.html).
 
 For starting the FL system with 8 clients in the secure workspace, run
 ```
@@ -75,7 +75,7 @@ we set the available GPU indices as `gpu: [0, 1]` using the `ListResourceManager
 For the POC workspace, adjust the default values in `./workspaces/poc_workspace/site-*/startup/fed_client.json` 
 and `./workspaces/poc_workspace/server/startup/fed_server.json`. 
 
-For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.0/user_guide/job.html).
+For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.1/user_guide/job.html).
 
 ### 2.3 Download the CIFAR-10 dataset 
 To speed up the following experiments, first download the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset:
@@ -140,7 +140,7 @@ You can copy the whole block into the terminal, and it will execute each experim
 
 > **_NOTE:_** You can always use the admin console to manually abort the automatically started runs 
   using `abort_job [RUN_ID]`. 
-> For a complete list of admin commands, see [here](https://nvflare.readthedocs.io/en/2.1.0/user_guide/admin_commands.html).
+> For a complete list of admin commands, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/admin_commands.html).
 
 > To log into the POC workspace admin console no username is required 
 > (use "admin" for commands requiring conformation with username). 

--- a/examples/federated_analysis/README.md
+++ b/examples/federated_analysis/README.md
@@ -72,7 +72,7 @@ To do this, you need to log into the NVFlare admin console.
 3. Start the admin console: `./workspaces/poc_workspace/admin/startup/fl_admin.sh`
 4. Inside the console, submit the job: `submit_job [PWD]/configs/fed_analysis` (replace `[PWD]` with your current path) 
 
-For a complete list of avialble admin console commands, see [here](https://nvflare.readthedocs.io/en/2.1.0/user_guide/admin_commands.html).
+For a complete list of avialble admin console commands, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/admin_commands.html).
 
 ### 3.2 List the submitted job
 
@@ -105,7 +105,7 @@ For example, the gathered local and global histograms will look like this.
 ![Example local and global histograms](./histograms_example.svg)
 
 ## 5. Get results using the admin client  
-In real-world FL scenarios, the researcher might not have direct access to the server machine. Hence, the researcher can use the admin client console to control the experimentation (see [here](https://nvflare.readthedocs.io/en/2.1.0/user_guide/admin_commands.html) for details).
+In real-world FL scenarios, the researcher might not have direct access to the server machine. Hence, the researcher can use the admin client console to control the experimentation (see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/admin_commands.html) for details).
 
 After completing the federated analysis run, you can check the histogram files have been created by running `ls server [RUN_ID]`:
 ```

--- a/examples/hello-cyclic/README.md
+++ b/examples/hello-cyclic/README.md
@@ -1,13 +1,13 @@
 # Hello Cyclic Weight Transfer
 
 ["Cyclic Weight Transfer"](https://pubmed.ncbi.nlm.nih.gov/29617797/
-) (CWT) is an alternative to the scatter-and-gather approach used in [FedAvg](https://arxiv.org/abs/1602.05629). CWT uses the [CyclicController](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.cyclic_ctl) to pass the model weights from one site to the next for repeated fine-tuning.
+) (CWT) is an alternative to the scatter-and-gather approach used in [FedAvg](https://arxiv.org/abs/1602.05629). CWT uses the [CyclicController](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.cyclic_ctl) to pass the model weights from one site to the next for repeated fine-tuning.
 
 > **_NOTE:_** This example uses the [MNIST](http://yann.lecun.com/exdb/mnist/) handwritten digits dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 Install additional requirements:
 
 ```
@@ -16,7 +16,7 @@ pip3 install tensorflow
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -35,4 +35,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvidia.github.io/NVFlare/user_guide/admin_commands.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/operation.html).

--- a/examples/hello-monai/README.md
+++ b/examples/hello-monai/README.md
@@ -1,12 +1,12 @@
 # Hello MONAI
 
-Example of using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) to train a medical image analysis model using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [MONAI](https://monai.io/), the "Medical Open Network for Artificial Intelligence", as the deep learning training framework.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) to train a medical image analysis model using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [MONAI](https://monai.io/), the "Medical Open Network for Artificial Intelligence", as the deep learning training framework.
 
 See this [Tutorial](https://github.com/Project-MONAI/tutorials/tree/master/federated_learning/nvflare/nvflare_spleen_example) for an example of how to use this trainer for 3D spleen segmentation in computed tomography.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 Install additional requirements:
 
 ```
@@ -15,7 +15,7 @@ pip3 install monai
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -35,4 +35,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvidia.github.io/NVFlare/user_guide/admin_commands.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/operation.html).

--- a/examples/hello-numpy-cross-val/README.md
+++ b/examples/hello-numpy-cross-val/README.md
@@ -1,16 +1,16 @@
 # Hello Numpy Cross-Site Validation
 
-The cross-site model evaluation workflow uses the data from clients to run evaluation with the models of other clients. Data is not shared. Rather the collection of models is distributed to each client site to run local validation. The server collects the results of local validation to construct an all-to-all matrix of model performance vs. client dataset. It uses the [CrossSiteModelEval](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.workflows.html#nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval) controller workflow.
+The cross-site model evaluation workflow uses the data from clients to run evaluation with the models of other clients. Data is not shared. Rather the collection of models is distributed to each client site to run local validation. The server collects the results of local validation to construct an all-to-all matrix of model performance vs. client dataset. It uses the [CrossSiteModelEval](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.workflows.html#nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval) controller workflow.
 
 > **_NOTE:_** This example uses a Numpy-based trainer and will generate its data within the code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -29,4 +29,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvidia.github.io/NVFlare/user_guide/admin_commands.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/operation.html).

--- a/examples/hello-numpy-sag/README.md
+++ b/examples/hello-numpy-sag/README.md
@@ -1,17 +1,17 @@
 # Hello Numpy Scatter and Gather
 
-"[Scatter and Gather](https://nvidia.github.io/NVFlare/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.scatter_and_gather)" is the standard workflow to implement Federated Averaging ([FedAvg](https://arxiv.org/abs/1602.05629)). 
+"[Scatter and Gather](https://nvflare.readthedocs.io/en/2.1.1/apidocs/nvflare.app_common.workflows.html?#module-nvflare.app_common.workflows.scatter_and_gather)" is the standard workflow to implement Federated Averaging ([FedAvg](https://arxiv.org/abs/1602.05629)). 
 This workflow follows the hub and spoke model for communicating the global model to each client for local training (i.e., "scattering") and aggregates the result to perform the global model update (i.e., "gathering").  
 
 > **_NOTE:_** This example uses a Numpy-based trainer and will generate its data within the code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -30,4 +30,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvidia.github.io/NVFlare/user_guide/admin_commands.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/operation.html).

--- a/examples/hello-pt-tb/README.md
+++ b/examples/hello-pt-tb/README.md
@@ -1,12 +1,12 @@
 # Hello PyTorch with Tensorboard Streaming
 
-Example of using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework. This example also highlights the TensorBoard streaming capability from the clients to the server.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework. This example also highlights the TensorBoard streaming capability from the clients to the server.
 
 > **_NOTE:_** This example uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 Install additional requirements:
 
 ```
@@ -15,7 +15,7 @@ pip3 install torch torchvision tensorboard
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -61,4 +61,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For a more in-depth guide about the TensorBoard streaming feature, see [Quickstart (PyTorch with TensorBoard)](https://nvidia.github.io/NVFlare/examples/hello_pt_tb.html).
+> **_NOTE:_** For a more in-depth guide about the TensorBoard streaming feature, see [Quickstart (PyTorch with TensorBoard)](https://nvflare.readthedocs.io/en/2.1.1/examples/hello_pt_tb.html).

--- a/examples/hello-pt/README.md
+++ b/examples/hello-pt/README.md
@@ -1,12 +1,12 @@
 # Hello PyTorch
 
-Example of using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
 
 > **_NOTE:_** This example uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 Install additional requirements:
 
 ```
@@ -15,7 +15,7 @@ pip3 install torch torchvision
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -34,4 +34,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvidia.github.io/NVFlare/user_guide/admin_commands.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/operation.html).

--- a/examples/hello-tf2/README.md
+++ b/examples/hello-tf2/README.md
@@ -1,12 +1,12 @@
 # Hello TensorFlow
 
-Example of using [NVIDIA FLARE](https://nvidia.github.io/NVFlare) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
 
 > **_NOTE:_** This example uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvidia.github.io/NVFlare/installation.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions.
 Install additional requirements:
 
 ```
@@ -15,7 +15,7 @@ pip3 install tensorflow
 
 ### 2. Set up your FL workspace
 
-Follow the [Quickstart](https://nvidia.github.io/NVFlare/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
+Follow the [Quickstart](https://nvflare.readthedocs.io/en/2.1.1/quickstart.html) instructions to set up your POC ("proof of concept") workspace.
 
 ### 3. Run the experiment
 
@@ -34,4 +34,4 @@ shutdown client
 shutdown server
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvidia.github.io/NVFlare/user_guide/admin_commands.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.1.1/user_guide/operation.html).

--- a/examples/prostate/README.md
+++ b/examples/prostate/README.md
@@ -3,7 +3,7 @@
 ## Introduction to MONAI, Prostate and Multi-source Data
 
 ### MONAI
-This example shows how to use [NVIDIA FLARE](https://nvidia.github.io/NVFlare) on medical image applications.
+This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.1.1/index.html) on medical image applications.
 It uses [MONAI](https://github.com/Project-MONAI/MONAI),
 which is a PyTorch-based, open-source framework for deep learning in healthcare imaging, part of the PyTorch Ecosystem.
 

--- a/examples/prostate/prostate_2D/README.md
+++ b/examples/prostate/prostate_2D/README.md
@@ -44,7 +44,7 @@ To enable multi-tasking, here we adjust the default value in `workspace_server/s
 
 (Optional) If using secure workspace, in secure project configuration `secure_project.yml`, we can set the available GPU indices as `gpu: [0, 1]` using the `ListResourceManager` and `max_jobs: 2` in `DefaultJobScheduler`.
 
-For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.0/user_guide/job.html).
+For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.1/user_guide/job.html).
 
 ## 2. Run automated experiments
 The next scripts will start the FL server and clients automatically to run FL experiments on localhost.

--- a/examples/prostate/prostate_3D/README.md
+++ b/examples/prostate/prostate_3D/README.md
@@ -44,7 +44,7 @@ To enable multi-tasking, here we adjust the default value in `workspace_server/s
 
 (Optional) If using secure workspace, in secure project configuration `secure_project.yml`, we can set the available GPU indices as `gpu: [0, 1]` using the `ListResourceManager` and `max_jobs: 2` in `DefaultJobScheduler`.
 
-For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.0/user_guide/job.html).
+For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.1.1/user_guide/job.html).
 
 ## 2. Run automated experiments
 The next scripts will start the FL server and clients automatically to run FL experiments on localhost.


### PR DESCRIPTION
removing links to https://nvidia.github.io/NVFlare
replacing with https://nvflare.readthedocs.io/en/2.1.1

There is no longer a page for install separately after the docs reorganization, and that content is now on quickstart, so those links were updated to quickstart.