### PR TITLE
Docker compose

### DIFF
--- a/nvflare/lighter/impl/docker.py
+++ b/nvflare/lighter/impl/docker.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import os
+import shutil
+
+import yaml
+
+from nvflare.lighter.spec import Builder
+
+
+class DockerBuilder(Builder):
+    def __init__(self, base_image="python:3.8", requirements_file="requirements.txt"):
+        """Build docker compose file."""
+        self.base_image = base_image
+        self.requirements_file = requirements_file
+
+    def _build_overseer(self, overseer, ctx):
+        protocol = overseer.props.get("protocol", "http")
+        default_port = "443" if protocol == "https" else "80"
+        port = overseer.props.get("port", default_port)
+        info_dict = copy.deepcopy(self.services["__overseer__"])
+        info_dict["volumes"] = [f"./{overseer.name}:/workspace"]
+        info_dict["ports"] = [f"{port}:{port}"]
+        info_dict["build"] = "nvflare_compose"
+        self.services[overseer.name] = info_dict
+
+    def _build_server(self, server, ctx):
+        fed_learn_port = server.props.get("fed_learn_port", 8002)
+        admin_port = server.props.get("admin_port", 8003)
+
+        info_dict = copy.deepcopy(self.services["__flserver__"])
+        info_dict["volumes"] = [f"./{server.name}:/workspace"]
+        info_dict["ports"] = [f"{fed_learn_port}:{fed_learn_port}", f"{admin_port}:{admin_port}"]
+        for i in range(len(info_dict["command"])):
+            if info_dict["command"][i] == "flserver":
+                info_dict["command"][i] = server.name
+                break
+        self.services[server.name] = info_dict
+
+    def _build_client(self, client, ctx):
+        info_dict = copy.deepcopy(self.services["__flclient__"])
+        info_dict["volumes"] = [f"./{client.name}:/workspace"]
+        for i in range(len(info_dict["command"])):
+            if info_dict["command"][i] == "flclient":
+                info_dict["command"][i] = client.name
+            if info_dict["command"][i] == "uid=__flclient__":
+                info_dict["command"][i] = f"uid={client.name}"
+
+        self.services[client.name] = info_dict
+
+    def build(self, project, ctx):
+        self.template = ctx.get("template")
+        self.compose = yaml.safe_load(self.template.get("compose_yaml"))
+        self.services = self.compose.get("services")
+        self.compose_file_path = os.path.join(self.get_wip_dir(ctx), "compose.yaml")
+        overseer = project.get_participants_by_type("overseer")
+        self._build_overseer(overseer, ctx)
+        servers = project.get_participants_by_type("server", first_only=False)
+        for server in servers:
+            self._build_server(server, ctx)
+        for client in project.get_participants_by_type("client", first_only=False):
+            self._build_client(client, ctx)
+        self.services.pop("__overseer__")
+        self.services.pop("__flserver__")
+        self.services.pop("__flclient__")
+        self.compose["services"] = self.services
+        with open(self.compose_file_path, "wt") as f:
+            yaml.dump(self.compose, f)
+        compose_build_dir = os.path.join(self.get_wip_dir(ctx), "nvflare_compose")
+        os.mkdir(compose_build_dir)
+        with open(os.path.join(compose_build_dir, "Dockerfile"), "wt") as f:
+            f.write(f"FROM {self.base_image}\n")
+            f.write(self.template.get("dockerfile"))
+        try:
+            shutil.copyfile(self.requirements_file, os.path.join(compose_build_dir, "requirements.txt"))
+        except BaseException:
+            f = open(os.path.join(compose_build_dir, "requirements.txt"), "wt")
+            f.close()

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -475,3 +475,62 @@ docker_adm_sh: |
   DOCKER_IMAGE={~~docker_image~~}
   echo "Starting docker with $DOCKER_IMAGE"
   docker run --rm -it --name=fladmin -v $DIR/..:/workspace/ -w /workspace/ $DOCKER_IMAGE /bin/bash
+
+compose_yaml: |
+  services:
+    __overseer__:
+      build: ./nvflare
+      image: nvflare-service
+      volumes:
+        - .:/workspace
+      command: ["/workspace/startup/start.sh"]
+      ports:
+        - "8443:8443"
+
+    __flserver__:
+      image: nvflare-service
+      ports:
+        - "8002:8002"
+        - "8003:8003"
+      volumes:
+        - .:/workspace
+        - nvflare_svc_persist:/tmp/nvflare/
+      command: ["/usr/local/bin/python3",
+            "-u",
+            "-m",
+            "nvflare.private.fed.app.server.server_train",
+            "-m",
+            "/workspace",
+            "-s",
+            "fed_server.json",
+            "--set",
+            "secure_train=true",
+            "config_folder=config",
+          ]
+
+    __flclient__:
+      image: nvflare-service
+      volumes:
+        - .:/workspace
+      command: ["/usr/local/bin/python3",
+            "-u",
+            "-m",
+            "nvflare.private.fed.app.client.client_train",
+            "-m",
+            "/workspace",
+            "-s",
+            "fed_client.json",
+            "--set",
+            "secure_train=true",
+            "uid=__flclient__",
+            "config_folder=config",
+          ]
+
+  volumes:
+    nvflare_svc_persist:
+
+dockerfile: |
+  RUN pip install -U pip
+  RUN pip install nvflare
+  COPY requirements.txt requirements.txt
+  RUN pip install -r requirements.txt

--- a/nvflare/lighter/impl/workspace.py
+++ b/nvflare/lighter/impl/workspace.py
@@ -71,6 +71,8 @@ class WorkspaceBuilder(Builder):
     def build(self, project: Project, ctx: dict):
         dirs = [self.get_kit_dir(p, ctx) for p in project.participants]
         self._make_dir(dirs)
+        dirs = [self.get_transfer_dir(p, ctx) for p in project.participants]
+        self._make_dir(dirs)
 
     def finalize(self, ctx: dict):
         if ctx["last_prod_stage"] >= 99:

--- a/nvflare/lighter/project.yml
+++ b/nvflare/lighter/project.yml
@@ -35,7 +35,7 @@ participants:
     api_root: /api/v1
     port: 8443
   # change example.com to the FQDN of the server
-  - name: example1.com
+  - name: server1.example.com
     type: server
     org: nvidia
     fed_learn_port: 8002
@@ -44,11 +44,11 @@ participants:
     enable_byoc: true
     components:
       <<: *svr_comps
-  - name: example2.com
+  - name: server2.example.com
     type: server
     org: nvidia
-    fed_learn_port: 8002
-    admin_port: 8003
+    fed_learn_port: 8102
+    admin_port: 8103
     # enable_byoc loads python codes in app.  Default is false.
     enable_byoc: true
     components:
@@ -83,6 +83,10 @@ builders:
     args:
       template_file: master_template.yml
   - path: nvflare.lighter.impl.template.TemplateBuilder
+  - path: nvflare.lighter.impl.docker.DockerBuilder
+    args:
+      base_image: python:3.8
+      requirements_file: docker_compose_requirements.txt
   - path: nvflare.lighter.impl.static_file.StaticFileBuilder
     args:
       # config_folder can be set to inform NVIDIA FLARE where to get configuration

--- a/nvflare/lighter/spec.py
+++ b/nvflare/lighter/spec.py
@@ -102,6 +102,9 @@ class Builder(ABC):
     def get_kit_dir(self, participate: Participant, ctx: dict):
         return os.path.join(self.get_wip_dir(ctx), participate.name, "startup")
 
+    def get_transfer_dir(self, participate: Participant, ctx: dict):
+        return os.path.join(self.get_wip_dir(ctx), participate.name, "transfer")
+
     def get_state_dir(self, ctx: dict):
         return ctx.get("state_dir")
 


### PR DESCRIPTION
Edit project.yml as before
After provision, one file (compose.yaml) and a folder (nvflare_compose) are created.
Users can do `docker compose build` and `docker compose up` (or `docker-compose build` and `docker-compose up` for old syntax) to launch the overseer, servers and clients in docker compose manner.

The admin client can reach that formation if the /etc/hosts include the ip and hostnames of those participants.