### PR TITLE
Fix the shared volume settings among servers in compose.yaml

### DIFF
--- a/nvflare/lighter/impl/docker.py
+++ b/nvflare/lighter/impl/docker.py
@@ -42,7 +42,7 @@ class DockerBuilder(Builder):
         admin_port = server.props.get("admin_port", 8003)
 
         info_dict = copy.deepcopy(self.services["__flserver__"])
-        info_dict["volumes"] = [f"./{server.name}:/workspace"]
+        info_dict["volumes"][0] = f"./{server.name}:/workspace"
         info_dict["ports"] = [f"{fed_learn_port}:{fed_learn_port}", f"{admin_port}:{admin_port}"]
         for i in range(len(info_dict["command"])):
             if info_dict["command"][i] == "flserver":


### PR DESCRIPTION
The shared volume among all servers, for snapshot/job persistence, was accidentally removed during creating compose.yaml.