### PR TITLE
Clean up ClientRunner and Communicator

### DIFF
--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -15,7 +15,7 @@
 import threading
 import time
 
-from nvflare.apis.client_engine_spec import ClientEngineSpec, TaskAssignment
+from nvflare.apis.client_engine_spec import TaskAssignment
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_constant import FLContextKey, ReservedKey, ReservedTopic, ReturnCode
@@ -23,6 +23,7 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.signal import Signal
 from nvflare.private.defs import SpecialTaskName, TaskConstant
+from nvflare.private.fed.client.client_engine_executor_spec import ClientEngineExecutorSpec
 from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
 
@@ -56,7 +57,7 @@ class ClientRunner(FLComponent):
         self,
         config: ClientRunnerConfig,
         job_id,
-        engine: ClientEngineSpec,
+        engine: ClientEngineExecutorSpec,
         task_fetch_interval: int = 5,  # fetch task every 5 secs
     ):
         """To init the ClientRunner.
@@ -88,10 +89,6 @@ class ClientRunner(FLComponent):
         engine.register_aux_message_handler(topic=ReservedTopic.ABORT_ASK, message_handle_func=self._handle_abort_task)
 
     def _process_task(self, task: TaskAssignment, fl_ctx: FLContext) -> Shareable:
-        engine = fl_ctx.get_engine()
-        if not isinstance(engine, ClientEngineSpec):
-            raise TypeError("engine must be ClientEngineSpec, but got {}".format(type(engine)))
-
         if not isinstance(task.data, Shareable):
             self.log_error(
                 fl_ctx, "got invalid task data in assignment: expect Shareable, but got {}".format(type(task.data))

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -452,7 +452,7 @@ class Communicator:
                 self.should_stop = False
                 return
 
-        self.logger.error(f"Action: {action} grpc communication error.")
+        self.logger.error(f"Action: {action} grpc communication error: {grpc_error}.")
         if grpc.StatusCode.UNAVAILABLE == status_code:
             self.logger.error(f"Could not connect to server: {service.get('target')}\t {grpc_error.details()}")
             self.should_stop = True


### PR DESCRIPTION
The engine in client runner should be an instance of ClientEngineExecutorSpec