### PR TITLE
Helm chart

### DIFF
--- a/nvflare/fuel/hci/server/hci.py
+++ b/nvflare/fuel/hci/server/hci.py
@@ -107,7 +107,7 @@ class AdminServer(socketserver.ThreadingTCPServer):
             server_key: server's private key file
             accepted_client_cns: list of accepted Common Names from client, if specified
         """
-        socketserver.TCPServer.__init__(self, (host, port), _MsgHandler, False)
+        socketserver.TCPServer.__init__(self, ("0.0.0.0", port), _MsgHandler, False)
 
         self.use_ssl = False
         if ca_cert and server_cert:

--- a/nvflare/lighter/impl/helm_chart.py
+++ b/nvflare/lighter/impl/helm_chart.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import yaml
+
+from nvflare.lighter.spec import Builder
+
+
+class HelmChartBuilder(Builder):
+    def __init__(self, docker_image):
+        """Build Helm Chart."""
+        self.docker_image = docker_image
+
+    def initialize(self, ctx):
+        self.helm_chart_directory = os.path.join(self.get_wip_dir(ctx), "nvflare_hc")
+        os.mkdir(self.helm_chart_directory)
+
+    def _build_overseer(self, overseer, ctx):
+        protocol = overseer.props.get("protocol", "http")
+        default_port = "443" if protocol == "https" else "80"
+        port = overseer.props.get("port", default_port)
+        self.deployment_overseer["spec"]["template"]["spec"]["volumes"][0]["hostPath"][
+            "path"
+        ] = "{{ .Values.workspace }}"
+        self.deployment_overseer["spec"]["template"]["spec"]["containers"][0]["ports"][0]["containerPort"] = port
+        self.deployment_overseer["spec"]["template"]["spec"]["containers"][0]["image"] = self.docker_image
+        self.deployment_overseer["spec"]["template"]["spec"]["containers"][0]["command"][
+            0
+        ] = f"/workspace/{overseer.name}/startup/start.sh"
+        with open(os.path.join(self.helm_chart_templates_directory, "deployment_overseer.yaml"), "wt") as f:
+            yaml.dump(self.deployment_overseer, f)
+
+        self.service_overseer["spec"]["ports"][0]["port"] = port
+        self.service_overseer["spec"]["ports"][0]["targetPort"] = port
+        with open(os.path.join(self.helm_chart_templates_directory, "service_overseer.yaml"), "wt") as f:
+            yaml.dump(self.service_overseer, f)
+
+    def _build_server(self, server, ctx):
+        fed_learn_port = server.props.get("fed_learn_port", 30002)
+        admin_port = server.props.get("admin_port", 30003)
+        idx = ctx["index"]
+
+        self.deployment_server["metadata"]["name"] = f"{server.name}"
+        self.deployment_server["metadata"]["labels"]["system"] = f"{server.name}"
+
+        self.deployment_server["spec"]["selector"]["matchLabels"]["system"] = f"{server.name}"
+
+        self.deployment_server["spec"]["template"]["metadata"]["labels"]["system"] = f"{server.name}"
+        self.deployment_server["spec"]["template"]["spec"]["volumes"][0]["hostPath"]["path"] = "{{ .Values.workspace }}"
+        self.deployment_server["spec"]["template"]["spec"]["volumes"][1]["hostPath"]["path"] = "{{ .Values.persist }}"
+        self.deployment_server["spec"]["template"]["spec"]["containers"][0]["name"] = f"{server.name}"
+        self.deployment_server["spec"]["template"]["spec"]["containers"][0]["image"] = self.docker_image
+        self.deployment_server["spec"]["template"]["spec"]["containers"][0]["ports"][0][
+            "containerPort"
+        ] = fed_learn_port
+        self.deployment_server["spec"]["template"]["spec"]["containers"][0]["ports"][1]["containerPort"] = admin_port
+        cmd_args = self.deployment_server["spec"]["template"]["spec"]["containers"][0]["args"]
+        for i, item in enumerate(cmd_args):
+            if "/workspace/server" in item:
+                cmd_args[i] = f"/workspace/{server.name}"
+        self.deployment_server["spec"]["template"]["spec"]["containers"][0]["args"] = cmd_args
+        with open(os.path.join(self.helm_chart_templates_directory, f"deployment_server{idx}.yaml"), "wt") as f:
+            yaml.dump(self.deployment_server, f)
+
+        self.service_server["metadata"]["name"] = f"{server.name}"
+        self.service_server["metadata"]["labels"]["system"] = f"{server.name}"
+
+        self.service_server["spec"]["selector"]["system"] = f"{server.name}"
+        self.service_server["spec"]["ports"][0]["name"] = "fl-port"
+        self.service_server["spec"]["ports"][0]["port"] = fed_learn_port
+        self.service_server["spec"]["ports"][0]["targetPort"] = fed_learn_port
+        self.service_server["spec"]["ports"][1]["name"] = "admin-port"
+        self.service_server["spec"]["ports"][1]["port"] = admin_port
+        self.service_server["spec"]["ports"][1]["targetPort"] = admin_port
+
+        with open(os.path.join(self.helm_chart_templates_directory, f"service_server{idx}.yaml"), "wt") as f:
+            yaml.dump(self.service_server, f)
+
+    def build(self, project, ctx):
+        self.template = ctx.get("template")
+        with open(os.path.join(self.helm_chart_directory, "Chart.yaml"), "wt") as f:
+            yaml.dump(yaml.safe_load(self.template.get("helm_chart_chart")), f)
+
+        with open(os.path.join(self.helm_chart_directory, "values.yaml"), "wt") as f:
+            yaml.dump(yaml.safe_load(self.template.get("helm_chart_values")), f)
+
+        self.service_overseer = yaml.safe_load(self.template.get("helm_chart_service_overseer"))
+        self.service_server = yaml.safe_load(self.template.get("helm_chart_service_server"))
+
+        self.deployment_overseer = yaml.safe_load(self.template.get("helm_chart_deployment_overseer"))
+        self.deployment_server = yaml.safe_load(self.template.get("helm_chart_deployment_server"))
+
+        self.helm_chart_templates_directory = os.path.join(self.helm_chart_directory, "templates")
+        os.mkdir(self.helm_chart_templates_directory)
+        overseer = project.get_participants_by_type("overseer")
+        self._build_overseer(overseer, ctx)
+        servers = project.get_participants_by_type("server", first_only=False)
+        for index, server in enumerate(servers):
+            ctx["index"] = index
+            self._build_server(server, ctx)

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -64,7 +64,7 @@ readme_fs: |
   Please always safeguard the server.key.
 
 gunicorn_conf_py: |
-  bind="{~~hostname~~}:{~~port~~}"
+  bind="0.0.0.0:{~~port~~}"
   cert_reqs=2
   do_handshake_on_connect=True
   timeout=30
@@ -534,3 +534,138 @@ dockerfile: |
   RUN pip install nvflare
   COPY requirements.txt requirements.txt
   RUN pip install -r requirements.txt
+
+helm_chart_chart: |
+  apiVersion: v2
+  name: nvflare
+  description: A Helm chart for NVFlare overseer and servers
+  type: application
+  version: 0.1.0
+  appVersion: "2.2.0"
+
+helm_chart_service_overseer: |
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: overseer
+  spec:
+    selector:
+      system: overseer
+    ports:
+      - protocol: TCP
+        port: 8443
+        targetPort: overseer-port
+
+helm_chart_service_server: |
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: server
+    labels:
+      system: server
+  spec:
+    selector:
+      system: server
+    ports:
+      - name: fl-port
+        protocol: TCP
+        port: 8002
+        targetPort: fl-port
+      - name: admin-port
+        protocol: TCP
+        port: 8003
+        targetPort: admin-port
+
+helm_chart_deployment_overseer: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: overseer
+    labels:
+      system: overseer
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        system: overseer
+    template:
+      metadata:
+        labels:
+          system: overseer
+      spec:
+        volumes:
+          - name: workspace
+            hostPath:
+              path:
+              type: Directory
+        containers:
+          - name: overseer
+            image: nvflare-min:2.2.0
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
+            command: ["/workspace/overseer/startup/start.sh"]
+            ports:
+              - name: overseer-port
+                containerPort: 8443
+                protocol: TCP
+helm_chart_deployment_server: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: server
+    labels:
+      system: server
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        system: server
+    template:
+      metadata:
+        labels:
+          system: server
+      spec:
+        volumes:
+          - name: workspace
+            hostPath:
+              path:
+              type: Directory
+          - name: persist
+            hostPath:
+              path: /tmp/nvflare
+              type: Directory
+        containers:
+          - name: server1
+            image: nvflare-min:2.2.0
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
+              - name: persist
+                mountPath: /tmp/nvflare
+            command: ["/usr/local/bin/python3"]
+            args:
+              [
+                "-u",
+                "-m",
+                "nvflare.private.fed.app.server.server_train",
+                "-m",
+                "/workspace/server",
+                "-s",
+                "fed_server.json",
+                "--set",
+                "secure_train=true",
+                "config_folder=config",
+              ]
+            ports:
+              - containerPort: 8002
+                protocol: TCP
+              - containerPort: 8003
+                protocol: TCP
+helm_chart_values: |
+  workspace: /home/nvflare
+  persist: /home/nvflare
+
+

--- a/nvflare/lighter/project.yml
+++ b/nvflare/lighter/project.yml
@@ -28,14 +28,14 @@ server_components: &svr_comps
 
 participants:
   # change overseer.example.com to the FQDN of the overseer
-  - name: overseer.example.com
+  - name: overseer
     type: overseer
     org: nvidia
     protocol: https
     api_root: /api/v1
     port: 8443
   # change example.com to the FQDN of the server
-  - name: server1.example.com
+  - name: server1
     type: server
     org: nvidia
     fed_learn_port: 8002
@@ -44,7 +44,7 @@ participants:
     enable_byoc: true
     components:
       <<: *svr_comps
-  - name: server2.example.com
+  - name: server2
     type: server
     org: nvidia
     fed_learn_port: 8102
@@ -87,6 +87,9 @@ builders:
     args:
       base_image: python:3.8
       requirements_file: docker_compose_requirements.txt
+  - path: nvflare.lighter.impl.helm_chart.HelmChartBuilder
+    args:
+      docker_image: localhost:32000/nvfl-min:0.0.1
   - path: nvflare.lighter.impl.static_file.StaticFileBuilder
     args:
       # config_folder can be set to inform NVIDIA FLARE where to get configuration

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -174,7 +174,9 @@ class BaseServer(ABC):
                 root_certificates=root_ca,
                 require_client_auth=True,
             )
-            self.grpc_server.add_secure_port(target, server_credentials)
+            port = target.split(":")[1]
+            tmp_target = f"0.0.0.0:{port}"
+            self.grpc_server.add_secure_port(tmp_target, server_credentials)
             self.logger.info("starting secure server at %s", target)
         else:
             self.grpc_server.add_insecure_port(target)


### PR DESCRIPTION
Users can deploy overseer and servers to kubernetes cluster with Helm Chart
1. Need to edit ConfigMap of ingress tcp conf and DaemonSet of nginx ingress
2. overseer and server names must be a DNS-1035 label (lower case alphanumeric or '-')
3. machine running clients or consoles must set /etc/hosts for resolving overseer and server names.
