### PR TITLE
nvflare poc  syntax update  and add NVFLARE_POC_WORKSPACE env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+cov.xml
+unit_test.xml
 
 # Translations
 *.mo
@@ -141,3 +143,6 @@ variables.*
 *.hdf5
 
 wrksp/*
+
+# IDE
+*.iml

--- a/nvflare/lighter/poc.py
+++ b/nvflare/lighter/poc.py
@@ -75,7 +75,9 @@ def get_dest_poc_dir(dest_poc):
 
 
 def generate_poc(num_clients, poc_workspace):
-    answer = input("This will delete poc folder in current directory and create a new one. Is it OK to proceed? (y/N) ")
+    answer = input(
+        f"This will delete poc folder in {poc_workspace} directory and create a new one. Is it OK to proceed? (y/N) "
+    )
     if answer.strip().upper() == "Y":
         dest_poc_folder = get_dest_poc_dir(poc_workspace)
         src_poc_folder = get_src_poc_dir()


### PR DESCRIPTION
1) Remove workspace option, using nvflare_poc.json config as replacement
Main idea behind it:
* -w workspace is a lot word to type
* when start/stop/clean poc, one need to always -w worksapce to make sure the workspace is correct, which is too much typing, nvflare poc --start/stop/clean is just much simpler.
* current default workspace is hard-coded to /tmp/nvflare/poc. One can't change it. so instead of using -w worksapce, we add the configuration to allow user to change it

* the optional env variable NVFLARE_POC_WORKSPACE="/tmp/nvflare/poc2"

if the NVFLARE_POC_WORKSPACEis specified, it will be used instead of default. This way, the workspace will be created at /tmp/nvflare/poc2 with above config using command nvflare poc --prepare

2) replace hard-coded "transfer" directory with upload_dir read from admin/startup/fed_admin.json config