### PR TITLE
Update cert reading (get_identity_info) and component (resource manager)

### DIFF
--- a/nvflare/fuel/hci/security.py
+++ b/nvflare/fuel/hci/security.py
@@ -64,6 +64,33 @@ def make_session_token():
     return str(t)
 
 
+def get_identity_info(cert: dict):
+    """Gets the identity information from the provided certificate.
+
+    Args:
+        cert: certificate
+
+    Returns: if the cert is None, returning None.
+             if the cert is a dictinary, returning a dictionary containing three keys, common_name, organization and role.
+
+    """
+    if cert is None:
+        return None
+
+    cn = None
+    role = None
+    organization = None
+    for sub in cert.get("subject", ()):
+        for key, value in sub:
+            if key == "commonName":
+                cn = value
+            elif key == "unstructuredName":
+                role = value
+            elif key == "organizationName":
+                organization = value
+    return {"common_name": cn, "organization": organization, "role": role}
+
+
 def get_certificate_common_name(cert: dict):
     """Gets the common name of the provided certificate.
 
@@ -80,41 +107,3 @@ def get_certificate_common_name(cert: dict):
         for key, value in sub:
             if key == "commonName":
                 return value
-
-
-def get_certificate_roles(cert: dict):
-    """Gets the roles from the unstructuredName field of the provided certificate.
-
-    Args:
-        cert: certificate
-
-    Returns: roles of provided cert
-
-    """
-    if cert is None:
-        return None
-
-    for sub in cert.get("subject", ()):
-        for key, value in sub:
-            if key == "unstructuredName":
-                return value.split("|")
-    return None
-
-
-def get_certificate_org(cert: dict):
-    """Gets the organization from the provided certificate.
-
-    Args:
-        cert: certificate
-
-    Returns: organization of provided cert
-
-    """
-    if cert is None:
-        return None
-
-    for sub in cert.get("subject", ()):
-        for key, value in sub:
-            if key == "organizationName":
-                return value
-    return None

--- a/nvflare/lighter/impl/cert.py
+++ b/nvflare/lighter/impl/cert.py
@@ -122,10 +122,10 @@ class CertBuilder(Builder):
         subject = participant.subject
         subject_org = participant.org
         if participant.type == "admin":
-            roles = participant.props.get("roles")
+            role = participant.props.get("role")
         else:
-            roles = None
-        cert = self._generate_cert(subject, subject_org, self.issuer, self.pri_key, pub_key, roles=roles)
+            role = None
+        cert = self._generate_cert(subject, subject_org, self.issuer, self.pri_key, pub_key, role=role)
         return pri_key, cert
 
     def _generate_keys(self):
@@ -134,9 +134,9 @@ class CertBuilder(Builder):
         return pri_key, pub_key
 
     def _generate_cert(
-        self, subject, subject_org, issuer, signing_pri_key, subject_pub_key, valid_days=360, ca=False, roles=None
+        self, subject, subject_org, issuer, signing_pri_key, subject_pub_key, valid_days=360, ca=False, role=None
     ):
-        x509_subject = self._x509_name(subject, subject_org, roles)
+        x509_subject = self._x509_name(subject, subject_org, role)
         x509_issuer = self._x509_name(issuer)
         builder = (
             x509.CertificateBuilder()
@@ -167,16 +167,12 @@ class CertBuilder(Builder):
             )
         return builder.sign(signing_pri_key, hashes.SHA256(), default_backend())
 
-    def _x509_name(self, cn_name, org_name=None, roles=None):
+    def _x509_name(self, cn_name, org_name=None, role=None):
         name = [x509.NameAttribute(NameOID.COMMON_NAME, cn_name)]
         if org_name is not None:
             name.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_name))
-        if roles:
-            if isinstance(roles, list):
-                role_list = "|".join(roles)
-            else:
-                role_list = roles
-            name.append(x509.NameAttribute(NameOID.UNSTRUCTURED_NAME, role_list))
+        if role:
+            name.append(x509.NameAttribute(NameOID.UNSTRUCTURED_NAME, role))
         return x509.Name(name)
 
     def finalize(self, ctx):

--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -82,11 +82,11 @@ class StaticFileBuilder(Builder):
         admins = self.project.get_participants_by_type("admin", first_only=False)
         privilege_dict = dict()
         for admin in admins:
-            for role in admin.props.get("roles", {}):
-                if role in privilege_dict:
-                    privilege_dict[role].append(admin.subject)
-                else:
-                    privilege_dict[role] = [admin.subject]
+            role = admin.props.get("role")
+            if role in privilege_dict:
+                privilege_dict[role].append(admin.subject)
+            else:
+                privilege_dict[role] = [admin.subject]
         self._write(
             os.path.join(dest_dir, "privilege.yml"),
             yaml.dump(privilege_dict, Dumper=yaml.Dumper),

--- a/nvflare/lighter/project.yml
+++ b/nvflare/lighter/project.yml
@@ -54,7 +54,7 @@ participants:
   - name: admin@nvidia.com
     type: admin
     org: nvidia
-    role: proj_admin
+    role: project_admin
 
 # The same methods in all builders are called in their order defined in builders section
 builders:

--- a/nvflare/lighter/project.yml
+++ b/nvflare/lighter/project.yml
@@ -54,8 +54,7 @@ participants:
   - name: admin@nvidia.com
     type: admin
     org: nvidia
-    roles:
-      - super
+    role: proj_admin
 
 # The same methods in all builders are called in their order defined in builders section
 builders:

--- a/nvflare/lighter/provision.py
+++ b/nvflare/lighter/provision.py
@@ -27,26 +27,22 @@ from nvflare.lighter.utils import load_yaml
 
 adding_client_error_msg = """
 name: $SITE-NAME
-type: client
 org: $ORGANIZATION_NAME
-enable_byoc: $BOOLEAN
 components:
     resource_manager:    # This id is reserved by system.  Do not change it.
-        path: nvflare.app_common.resource_managers.list_resource_manager.ListResourceManager
+        path: nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager
         args:
-        resources:
-            gpu: [0, 1, 2, 3]
+            num_of_gpus: 4,
+            mem_per_gpu_in_GiB: 16
     resource_consumer:    # This id is reserved by system.  Do not change it.
         path: nvflare.app_common.resource_consumers.gpu_resource_consumer.GPUResourceConsumer
         args:
-        gpu_resource_key: gpu
 """
 
 adding_user_error_msg = """
 name: $USER_EMAIL_ADDRESS
 org: $ORGANIZATION_NAME
-roles:
-    - $ROLE
+role: $ROLE
 """
 
 


### PR DESCRIPTION
Three identity info is retrieved from get_identity_info, common_name, organization and role.
The existing get_certificate_common_name function is not removed for compatibility.
All users have at most one role.
Default client site resource manager changed to GPUResourceManager and args format changed, too.