### PR TITLE
add MONAI bundle persistor; update readme to include simulator commands

### DIFF
--- a/integration/monai/examples/spleen_ct_segmentation/README.md
+++ b/integration/monai/examples/spleen_ct_segmentation/README.md
@@ -71,7 +71,7 @@ In order to load a pretrained model provided in the MONAI bundle, define the `so
         "bundle_root": "config/spleen_ct_segmentation",
         "source_ckpt_filename": "models/model.pt"
       }
-    },
+    }
 ```
 
 > **_NOTE:_** For more information about the simulator, see [here](https://nvflare.readthedocs.io).

--- a/integration/monai/examples/spleen_ct_segmentation/README.md
+++ b/integration/monai/examples/spleen_ct_segmentation/README.md
@@ -62,11 +62,11 @@ With the default setting and running on multiple gpus (section 4.2), the expecte
 
 ![training curve](./tb_plot.png)
 
-In order to load a pretrained model provided in the MONAI bundle, define the `source_ckpt_filename` argument of `MONAIBundlePersistor` in "config_fed_server.json", e.g.:
+In order to load a pretrained model provided in the MONAI bundle, define the `source_ckpt_filename` argument of `MonaiBundlePersistor` in "config_fed_server.json", e.g.:
 ```
     {
       "id": "persistor",
-      "path": "monai_nvflare.monai_bundle_persistor.MONAIBundlePersistor",
+      "path": "monai_nvflare.monai_bundle_persistor.MonaiBundlePersistor",
       "args": {
         "bundle_root": "config/spleen_ct_segmentation",
         "source_ckpt_filename": "models/model.pt"

--- a/integration/monai/examples/spleen_ct_segmentation/README.md
+++ b/integration/monai/examples/spleen_ct_segmentation/README.md
@@ -41,7 +41,7 @@ In resource restricted environments where you need to simulate several clients (
 you can run the simulator using:
 
 ```
-python3 -u -m nvflare.private.fed.app.simulator.simulator job -o /tmp/nvflare/sim_spleen_ct_seg --thread 1 -n 2
+python3 -u -m nvflare.private.fed.app.simulator.simulator job --workspace /tmp/nvflare/sim_spleen_ct_seg --threads 1 --clients 2
 ```
 
 #### 4.2 Multiple threads, multiple gpus
@@ -50,7 +50,7 @@ We can also specify the client names via the `--client_list` argument
 and assign them to the appropriate GPU device using the `--gpu` argument.
 
 ```
-python3 -u -m nvflare.private.fed.app.simulator.simulator job -o /tmp/nvflare/sim_spleen_ct_seg --thread 2 --client_list site-1,site-2 --gpu 0,1
+python3 -u -m nvflare.private.fed.app.simulator.simulator job --workspace /tmp/nvflare/sim_spleen_ct_seg --threads 2 --clients 2 --gpu 0,1
 ```
 
 #### 4.3 TensorBoard visualization

--- a/integration/monai/examples/spleen_ct_segmentation/README.md
+++ b/integration/monai/examples/spleen_ct_segmentation/README.md
@@ -22,7 +22,7 @@ pip install -r virtualenv/requirements.txt
 
 ### 2. Download the Spleen Bundle
 ```
-python -m monai.bundle download --name "spleen_ct_segmentation_v0.1.1" --bundle_dir ./job/app/config
+python3 -m monai.bundle download --name "spleen_ct_segmentation_v0.1.1" --bundle_dir ./job/app/config
 ``` 
 
 ### 3. Download the data
@@ -30,21 +30,67 @@ Download the spleen CT data from the [MSD challenge](http://medicaldecathlon.com
 
 > **Note:** The dataset will be saved under `./data`. 
 ```
-python download_spleen_dataset.py
+python3 download_spleen_dataset.py
 sed -i "s|/workspace/data/Task09_Spleen|${PWD}/data/Task09_Spleen|g" job/app/config/spleen_ct_segmentation/configs/train.json
 ```
 
-### 4. Run NVFlare in POC mode
+### 4. Run experiment in simulator
+
+#### 4.1 Single thread, single gpu
+In resource restricted environments where you need to simulate several clients (-n 2 in this case) on the same GPU device, 
+you can run the simulator using:
+
+```
+python3 -u -m nvflare.private.fed.app.simulator.simulator job -o /tmp/nvflare/sim_spleen_ct_seg --thread 1 -n 2
+```
+
+#### 4.2 Multiple threads, multiple gpus
+If you have several gpus in your system, you can assign one for each client and use two threads. 
+We can also specify the client names via the `--client_list` argument 
+and assign them to the appropriate GPU device using the `--gpu` argument.
+
+```
+python3 -u -m nvflare.private.fed.app.simulator.simulator job -o /tmp/nvflare/sim_spleen_ct_seg --thread 2 --client_list site-1,site-2 --gpu 0,1
+```
+
+### 4.3 TensorBoard visualization
+To monitor the training job, you can start tensorboard:
+```
+tensorboard --logdir /tmp/nvflare/sim_spleen_ct_seg
+```
+With the default setting and running on multiple gpus (section 4.2), the expected TensorBoard training curves look like this when training from scratch:
+
+![training curve](./tb_plot.png)
+
+In order to load a pretrained model provided in the MONAI bundle, define the `source_ckpt_filename` argument of `MONAIBundlePersistor` in "config_fed_server.json", e.g.:
+```
+    {
+      "id": "persistor",
+      "path": "monai_nvflare.monai_bundle_persistor.MONAIBundlePersistor",
+      "args": {
+        "bundle_root": "config/spleen_ct_segmentation",
+        "source_ckpt_filename": "models/model.pt"
+      }
+    },
+```
+
+> **_NOTE:_** For more information about the simulator, see [here](https://nvflare.readthedocs.io).
+
+### 5. Run NVFlare in POC mode
+
+### 5.1 Prepare POC workspace
 To run FL experiments in POC mode, create your local FL workspace the below command.  
 ```
 nvflare poc -n 2 --prepare
 ```
+
+### 5.2 Start server and clients
 Then, start the FL system using without admin console
 ```
 nvflare poc --start -ex admin
 ```
 
-### 5. Run the experiment
+#### 5.3 Run the experiment
 Submit the job by running:
 ```
 ./submit_job.sh job
@@ -53,11 +99,8 @@ To monitor the training job, you can start tensorboard:
 ```
 tensorboard --logdir /tmp/nvflare/poc
 ```
-With the default setting, the expected TensorBoard training curves look like this:
 
-![training curve](./tb_plot.png)
-
-### 6. Shut down the server/clients
+#### 5.4 Shut down the server/clients
 
 To shut down the clients and server, run the following Admin commands:
 ```

--- a/integration/monai/examples/spleen_ct_segmentation/README.md
+++ b/integration/monai/examples/spleen_ct_segmentation/README.md
@@ -53,7 +53,7 @@ and assign them to the appropriate GPU device using the `--gpu` argument.
 python3 -u -m nvflare.private.fed.app.simulator.simulator job -o /tmp/nvflare/sim_spleen_ct_seg --thread 2 --client_list site-1,site-2 --gpu 0,1
 ```
 
-### 4.3 TensorBoard visualization
+#### 4.3 TensorBoard visualization
 To monitor the training job, you can start tensorboard:
 ```
 tensorboard --logdir /tmp/nvflare/sim_spleen_ct_seg
@@ -78,13 +78,13 @@ In order to load a pretrained model provided in the MONAI bundle, define the `so
 
 ### 5. Run NVFlare in POC mode
 
-### 5.1 Prepare POC workspace
+#### 5.1 Prepare POC workspace
 To run FL experiments in POC mode, create your local FL workspace the below command.  
 ```
 nvflare poc -n 2 --prepare
 ```
 
-### 5.2 Start server and clients
+#### 5.2 Start server and clients
 Then, start the FL system using without admin console
 ```
 nvflare poc --start -ex admin

--- a/integration/monai/examples/spleen_ct_segmentation/job/app/config/config_fed_server.json
+++ b/integration/monai/examples/spleen_ct_segmentation/job/app/config/config_fed_server.json
@@ -11,23 +11,10 @@
   "task_result_filters": [],
   "components": [
     {
-      "id": "network",
-      "path": "monai.networks.nets.unet.UNet",
-      "args": {
-        "spatial_dims": 3,
-        "in_channels": 1,
-        "out_channels": 2,
-        "channels": [16, 32, 64, 128, 256],
-        "strides": [2, 2, 2, 2],
-        "num_res_units": 2,
-        "norm": "batch"
-      }
-    },
-    {
       "id": "persistor",
-      "name": "PTFileModelPersistor",
+      "path": "monai_nvflare.monai_bundle_persistor.MONAIBundlePersistor",
       "args": {
-        "model": "network"
+        "bundle_root": "config/spleen_ct_segmentation"
       }
     },
     {

--- a/integration/monai/examples/spleen_ct_segmentation/job/app/config/config_fed_server.json
+++ b/integration/monai/examples/spleen_ct_segmentation/job/app/config/config_fed_server.json
@@ -12,7 +12,7 @@
   "components": [
     {
       "id": "persistor",
-      "path": "monai_nvflare.monai_bundle_persistor.MONAIBundlePersistor",
+      "path": "monai_nvflare.monai_bundle_persistor.MonaiBundlePersistor",
       "args": {
         "bundle_root": "config/spleen_ct_segmentation"
       }

--- a/integration/monai/monai_nvflare/monai_bundle_persistor.py
+++ b/integration/monai/monai_nvflare/monai_bundle_persistor.py
@@ -26,7 +26,7 @@ from nvflare.app_common.app_constant import DefaultCheckpointFileName
 from nvflare.app_common.pt.pt_file_model_persistor import PTFileModelPersistor
 
 
-class MONAIBundlePersistor(PTFileModelPersistor):
+class MonaiBundlePersistor(PTFileModelPersistor):
     def __init__(
         self,
         bundle_root: str,

--- a/integration/monai/monai_nvflare/monai_bundle_persistor.py
+++ b/integration/monai/monai_nvflare/monai_bundle_persistor.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from monai.bundle import ConfigParser
+from monai.bundle.config_item import ConfigItem
+from monai.fl.client.monai_algo import check_bundle_config
+from monai.fl.utils.constants import RequiredBundleKeys
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_constant import DefaultCheckpointFileName
+from nvflare.app_common.pt.pt_file_model_persistor import PTFileModelPersistor
+
+
+class MONAIBundlePersistor(PTFileModelPersistor):
+    def __init__(
+        self,
+        bundle_root: str,
+        config_train_filename: str = "configs/train.json",
+        network_def_key: str = "network_def",
+        exclude_vars=None,
+        global_model_file_name=DefaultCheckpointFileName.GLOBAL_MODEL,
+        best_global_model_file_name=DefaultCheckpointFileName.BEST_GLOBAL_MODEL,
+        source_ckpt_filename=None,
+    ):
+        """Persist pytorch-based from MONAI bundle configuration.
+
+        Args:
+            bundle_root (str): path of bundle.
+            config_train_filename (str, optional): bundle training config path relative to bundle_root;
+                defaults to "configs/train.json".
+            network_def_key (str, optional): key that defines network inside bundle
+            exclude_vars (str, optional): regex expression specifying weight vars to be excluded from training.
+                Defaults to None.
+            global_model_file_name (str, optional): file name for saving global model.
+                Defaults to DefaultCheckpointFileName.GLOBAL_MODEL.
+            best_global_model_file_name (str, optional): file name for saving best global model.
+                Defaults to DefaultCheckpointFileName.BEST_GLOBAL_MODEL.
+            source_ckpt_filename (str, optional): file name for source model checkpoint file relative to `bundle_root`.
+                Defaults to None.
+
+        Raises:
+            ValueError: when source_ckpt_filename does not exist
+        """
+        super().__init__(
+            model=None,  # will be set in handle_event
+            exclude_vars=exclude_vars,
+            global_model_file_name=global_model_file_name,
+            best_global_model_file_name=best_global_model_file_name,
+            source_ckpt_file_full_name=None,  # will be set in _parse_config
+        )
+
+        self.bundle_root = bundle_root
+        self.config_train_filename = config_train_filename
+        self.network_def_key = network_def_key
+        self.source_ckpt_filename = source_ckpt_filename
+
+        self.train_parser = None
+        self.network = None
+
+    def handle_event(self, event: str, fl_ctx: FLContext):
+        if event == EventType.START_RUN:
+            # get model from bundle network config
+            self._parse_config(fl_ctx)
+            self.model = self._get_model(fl_ctx)
+        # loading happens in superclass handle_event
+        super().handle_event(event=event, fl_ctx=fl_ctx)
+
+    def _parse_config(self, fl_ctx: FLContext):
+        self.train_parser = ConfigParser()
+
+        # Read bundle config files
+        app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+        self.bundle_root = os.path.join(app_root, self.bundle_root)
+
+        self.train_parser.read_config(os.path.join(self.bundle_root, self.config_train_filename))
+        check_bundle_config(self.train_parser)
+
+        # Override some config items
+        self.train_parser[RequiredBundleKeys.BUNDLE_ROOT] = self.bundle_root
+
+        if self.source_ckpt_filename:
+            self.source_ckpt_file_full_name = os.path.join(self.bundle_root, self.source_ckpt_filename)
+
+    def _get_model(self, fl_ctx: FLContext):
+        try:
+            # Get network config
+            network = self.train_parser.get_parsed_content(
+                self.network_def_key, default=ConfigItem(None, self.network_def_key)
+            )
+            if network is None:
+                raise ValueError(
+                    f"Couldn't parse the network definition from {self.config_train_filename}. "
+                    f"BUNDLE_ROOT was {self.bundle_root}."
+                )
+            return network
+        except Exception as e:
+            self.log_exception(fl_ctx, f"initialize exception: {e}")

--- a/integration/monai/monai_nvflare/monai_bundle_persistor.py
+++ b/integration/monai/monai_nvflare/monai_bundle_persistor.py
@@ -70,7 +70,6 @@ class MONAIBundlePersistor(PTFileModelPersistor):
         self.source_ckpt_filename = source_ckpt_filename
 
         self.train_parser = None
-        self.network = None
 
     def handle_event(self, event: str, fl_ctx: FLContext):
         if event == EventType.START_RUN:

--- a/nvflare/app_common/pt/pt_file_model_persistor.py
+++ b/nvflare/app_common/pt/pt_file_model_persistor.py
@@ -102,7 +102,7 @@ class PTFileModelPersistor(ModelPersistor):
         self.default_train_conf = None
 
         if source_ckpt_file_full_name and not os.path.exists(source_ckpt_file_full_name):
-            raise ValueError("specified source checkpoint model file {} does not exist")
+            raise ValueError(f"specified source checkpoint model file {source_ckpt_file_full_name} does not exist")
 
     def _initialize(self, fl_ctx: FLContext):
         app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
@@ -188,6 +188,7 @@ class PTFileModelPersistor(ModelPersistor):
                 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
                 data = torch.load(src_file_name, map_location=device)
                 # "checkpoint may contain 'model', 'optimizer', 'lr_scheduler', etc. or only contain model dict directly."
+                self.log_info(fl_ctx, f"Restored checkpoint from {src_file_name}")
             except:
                 self.log_exception(fl_ctx, "error loading checkpoint from {}".format(src_file_name))
                 self.system_panic(reason="cannot load model checkpoint", fl_ctx=fl_ctx)


### PR DESCRIPTION
- Allow to initialize the global model based on bundle configs.
- Update REAMDE to include simulator commands.
- Fixes error message in PTFileModelPersistor and logs info about restoring from ckpt.