### PR TITLE
Make task_request_interval and task_check_period configurable

### DIFF
--- a/examples/xgboost/custom/xgboost_tree_fed_higgs_learner.py
+++ b/examples/xgboost/custom/xgboost_tree_fed_higgs_learner.py
@@ -39,6 +39,7 @@ class XGBoostTreeFedHiggsLearner(XGBoostTreeFedLearner):
         max_depth: int = 8,
         eval_metric: str = "auc",
         nthread: int = 16,
+        tree_method: str = "hist",
         train_task_name: str = AppConstants.TASK_TRAIN,
     ):
         super().__init__(
@@ -52,6 +53,7 @@ class XGBoostTreeFedHiggsLearner(XGBoostTreeFedLearner):
             max_depth=max_depth,
             eval_metric=eval_metric,
             nthread=nthread,
+            tree_method=tree_method,
             train_task_name=train_task_name,
         )
         self.data_split_filename = data_split_filename

--- a/examples/xgboost/job_configs/higgs_base/higgs_base/config/config_fed_client.json
+++ b/examples/xgboost/job_configs/higgs_base/higgs_base/config/config_fed_client.json
@@ -33,6 +33,7 @@
         "objective": "binary:logistic",
         "max_depth": 8,
         "eval_metric": "auc",
+        "tree_method": "hist",
         "nthread": 16
       }
     }

--- a/examples/xgboost/job_configs/higgs_base/higgs_base/config/config_fed_server_bagging.json
+++ b/examples/xgboost/job_configs/higgs_base/higgs_base/config/config_fed_server_bagging.json
@@ -2,7 +2,8 @@
   "format_version": 2,
 
   "server": {
-    "heart_beat_timeout": 600
+    "heart_beat_timeout": 600,
+    "task_request_interval": 0.05
   },
 
   "task_data_filters": [],
@@ -40,7 +41,10 @@
         "persistor_id": "persistor",
         "shareable_generator_id": "shareable_generator",
         "train_task_name": "train",
-        "train_timeout": 0
+        "train_timeout": 0,
+        "task_check_period": 0.01,
+        "persist_every_n_rounds": 1,
+        "snapshot_every_n_rounds": 0
       }
     }
   ]

--- a/examples/xgboost/submit_job.py
+++ b/examples/xgboost/submit_job.py
@@ -37,10 +37,7 @@ def main():
 
     # Submit job
     api_command_wrapper(runner.api.submit_job(args.job))
-
-    # finish
     runner.api.logout()
-    runner.api.overseer_agent.end()
 
 
 if __name__ == "__main__":

--- a/nvflare/apis/impl/controller.py
+++ b/nvflare/apis/impl/controller.py
@@ -341,7 +341,7 @@ class Controller(Responder, ControllerSpec, ABC):
         with self._task_lock:
             # task_id is the uuid associated with the client_task
             client_task = self._client_task_map.get(task_id, None)
-            self.logger.debug("Get submission={} from client task={} id={}".format(result, client_task, task_id))
+            self.logger.debug("Get submission from client task={} id={}".format(client_task, task_id))
 
         if client_task is None:
             # cannot find a standing task for the submission

--- a/nvflare/app_common/executors/learner_executor.py
+++ b/nvflare/app_common/executors/learner_executor.py
@@ -92,7 +92,9 @@ class LearnerExecutor(Executor):
         shareable.set_header(AppConstants.VALIDATE_TYPE, ValidateType.BEFORE_TRAIN_VALIDATE)
         validate_result: Shareable = self.learner.validate(shareable, fl_ctx, abort_signal)
 
+        self.log_info(fl_ctx, "Start learner training")
         train_result = self.learner.train(shareable, fl_ctx, abort_signal)
+        self.log_info(fl_ctx, "End learner training")
         if not (train_result and isinstance(train_result, Shareable)):
             return make_reply(ReturnCode.EMPTY_RESULT)
 

--- a/nvflare/app_common/learners/xgboost_tree_fed_learner.py
+++ b/nvflare/app_common/learners/xgboost_tree_fed_learner.py
@@ -42,6 +42,7 @@ class XGBoostTreeFedLearner(Learner):
         max_depth: int = 8,
         eval_metric: str = "auc",
         nthread: int = 16,
+        tree_method: str = "hist",
         train_task_name: str = AppConstants.TASK_TRAIN,
     ):
         super().__init__()
@@ -55,6 +56,7 @@ class XGBoostTreeFedLearner(Learner):
         self.max_depth = max_depth
         self.eval_metric = eval_metric
         self.nthread = nthread
+        self.tree_method = tree_method
         self.train_task_name = train_task_name
         # Currently we support boosting 1 tree per round
         # could further extend
@@ -132,6 +134,7 @@ class XGBoostTreeFedLearner(Learner):
         param["max_depth"] = self.max_depth
         param["eval_metric"] = self.eval_metric
         param["nthread"] = self.nthread
+        param["tree_method"] = self.tree_method
         return param
 
     def get_training_parameters_bagging(self):

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import traceback
+from typing import Any
 
 from nvflare.apis.client import Client
 from nvflare.apis.fl_constant import ReturnCode
@@ -27,6 +29,14 @@ from nvflare.app_common.app_event_type import AppEventType
 from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
 
+def _check_non_neg_int(data: Any, name: str):
+    if not isinstance(data, int):
+        raise ValueError(f"{name} must be int but got {type(data)}")
+
+    if data < 0:
+        raise ValueError(f"{name} must be greater than or equal to 0.")
+
+
 class ScatterAndGather(Controller):
     def __init__(
         self,
@@ -40,6 +50,9 @@ class ScatterAndGather(Controller):
         train_task_name=AppConstants.TASK_TRAIN,
         train_timeout: int = 0,
         ignore_result_error: bool = False,
+        task_check_period: float = 0.5,
+        persist_every_n_rounds: int = 1,
+        snapshot_every_n_rounds: int = 1,
     ):
         """The controller for ScatterAndGather Workflow.
 
@@ -62,26 +75,31 @@ class ScatterAndGather(Controller):
             train_timeout (int, optional): Time to wait for clients to do local training.
             ignore_result_error (bool, optional): whether this controller can proceed if client result has errors.
                 Defaults to False.
+            task_check_period (float, optional): interval for checking status of tasks. Defaults to 0.5.
+            persist_every_n_rounds (int, optional): persist the global model every n rounds. Defaults to 1.
+                If n is 0 then no persist.
+            snapshot_every_n_rounds (int, optional): persist the server state every n rounds. Defaults to 1.
+                If n is 0 then no persist.
 
         Raises:
             TypeError: when any of input arguments does not have correct type
             ValueError: when any of input arguments is out of range
         """
-        Controller.__init__(self)
+        Controller.__init__(self, task_check_period=task_check_period)
 
         # Check arguments
         if not isinstance(min_clients, int):
             raise TypeError("min_clients must be int but got {}".format(type(min_clients)))
-        if not isinstance(num_rounds, int):
-            raise TypeError("num_rounds must be int but got {}".format(type(num_rounds)))
-        if not isinstance(start_round, int):
-            raise TypeError("start_round must be int but got {}".format(type(start_round)))
-        if not isinstance(wait_time_after_min_received, int):
-            raise TypeError(
-                "wait_time_after_min_received must be int but got {}".format(type(wait_time_after_min_received))
-            )
-        if not isinstance(train_timeout, int):
-            raise TypeError("train_timeout must be int but got {}".format(type(train_timeout)))
+        elif min_clients <= 0:
+            raise ValueError("min_clients must be greater than 0.")
+
+        _check_non_neg_int(num_rounds, "num_rounds")
+        _check_non_neg_int(start_round, "start_round")
+        _check_non_neg_int(wait_time_after_min_received, "wait_time_after_min_received")
+        _check_non_neg_int(train_timeout, "train_timeout")
+        _check_non_neg_int(persist_every_n_rounds, "persist_every_n_rounds")
+        _check_non_neg_int(snapshot_every_n_rounds, "snapshot_every_n_rounds")
+
         if not isinstance(aggregator_id, str):
             raise TypeError("aggregator_id must be a string but got {}".format(type(aggregator_id)))
         if not isinstance(persistor_id, str):
@@ -90,14 +108,11 @@ class ScatterAndGather(Controller):
             raise TypeError("shareable_generator_id must be a string but got {}".format(type(shareable_generator_id)))
         if not isinstance(train_task_name, str):
             raise TypeError("train_task_name must be a string but got {}".format(type(train_task_name)))
-        if min_clients <= 0:
-            raise ValueError("min_clients must be greater than 0.")
-        if num_rounds < 0:
-            raise ValueError("num_rounds must be greater than or equal to 0.")
-        if start_round < 0:
-            raise ValueError("start_round must be greater than or equal to 0.")
-        if wait_time_after_min_received < 0:
-            raise ValueError("wait_time_after_min_received must be greater than or equal to 0.")
+
+        if not isinstance(task_check_period, (int, float)):
+            raise TypeError(f"task_check_period must be an int or float but got {type(task_check_period)}")
+        elif task_check_period <= 0:
+            raise ValueError("task_check_period must be greater than 0.")
 
         self.aggregator_id = aggregator_id
         self.persistor_id = persistor_id
@@ -110,9 +125,11 @@ class ScatterAndGather(Controller):
         # config data
         self._min_clients = min_clients
         self._num_rounds = num_rounds
-        self._wait_time_after_min_received = wait_time_after_min_received  # 5 minutes
+        self._wait_time_after_min_received = wait_time_after_min_received
         self._start_round = start_round
         self._train_timeout = train_timeout
+        self._persist_every_n_rounds = persist_every_n_rounds
+        self._snapshot_every_n_rounds = snapshot_every_n_rounds
         self.ignore_result_error = ignore_result_error
 
         # workflow phases: init, train, validate
@@ -167,7 +184,6 @@ class ScatterAndGather(Controller):
             fl_ctx.set_prop(AppConstants.NUM_ROUNDS, self._num_rounds, private=True, sticky=False)
             self.fire_event(AppEventType.TRAINING_STARTED, fl_ctx)
 
-            # for self._current_round in range(self._start_round, self._start_round + self._num_rounds):
             if self._current_round is None:
                 self._current_round = self._start_round
             while self._current_round < self._start_round + self._num_rounds:
@@ -206,10 +222,12 @@ class ScatterAndGather(Controller):
                 if self._check_abort_signal(fl_ctx, abort_signal):
                     return
 
+                self.log_info(fl_ctx, "Start aggregation.")
                 self.fire_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
                 aggr_result = self.aggregator.aggregate(fl_ctx)
                 fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, aggr_result, private=True, sticky=False)
                 self.fire_event(AppEventType.AFTER_AGGREGATION, fl_ctx)
+                self.log_info(fl_ctx, "End aggregation.")
 
                 if self._check_abort_signal(fl_ctx, abort_signal):
                     return
@@ -223,17 +241,21 @@ class ScatterAndGather(Controller):
                 if self._check_abort_signal(fl_ctx, abort_signal):
                     return
 
-                self.fire_event(AppEventType.BEFORE_LEARNABLE_PERSIST, fl_ctx)
-                self.persistor.save(self._global_weights, fl_ctx)
-                self.fire_event(AppEventType.AFTER_LEARNABLE_PERSIST, fl_ctx)
+                if self._persist_every_n_rounds != 0 and (self._current_round + 1) % self._persist_every_n_rounds == 0:
+                    self.log_info(fl_ctx, "Start persist model on server.")
+                    self.fire_event(AppEventType.BEFORE_LEARNABLE_PERSIST, fl_ctx)
+                    self.persistor.save(self._global_weights, fl_ctx)
+                    self.fire_event(AppEventType.AFTER_LEARNABLE_PERSIST, fl_ctx)
+                    self.log_info(fl_ctx, "End persist model on server.")
 
                 self.fire_event(AppEventType.ROUND_DONE, fl_ctx)
                 self.log_info(fl_ctx, f"Round {self._current_round} finished.")
 
                 self._current_round += 1
 
-                # Call the self._engine to persist the snapshot of all the FLComponents
-                self._engine.persist_components(fl_ctx, completed=False)
+                if self._snapshot_every_n_rounds != 0 and self._current_round % self._snapshot_every_n_rounds == 0:
+                    # Call the self._engine to persist the snapshot of all the FLComponents
+                    self._engine.persist_components(fl_ctx, completed=False)
 
             self._phase = AppConstants.PHASE_FINISHED
             self.log_info(fl_ctx, "Finished ScatterAndGather Training.")

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -112,7 +112,6 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
             client_key: path to admin client Key file, by default provisioned as client.key
             upload_dir: File transfer upload directory. Folders uploaded to the server to be deployed must be here. Folder must already exist and be accessible.
             download_dir: File transfer download directory. Can be same as upload_dir. Folder must already exist and be accessible.
-            server_cn: server cn (only used for validating server cn)
             cmd_modules: command modules to load and register. Note that FileTransferModule is initialized here with upload_dir and download_dir if cmd_modules is None.
             overseer_agent: initialized OverseerAgent to obtain the primary service provider to set the host and port of the active server
             user_name: Username to authenticate with FL server

--- a/nvflare/fuel/hci/client/fl_admin_api_runner.py
+++ b/nvflare/fuel/hci/client/fl_admin_api_runner.py
@@ -15,6 +15,7 @@
 import os
 import time
 
+from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.hci.client.fl_admin_api import FLAdminAPI
 from nvflare.fuel.hci.client.fl_admin_api_spec import TargetType
@@ -65,16 +66,18 @@ class FLAdminAPIRunner:
 
         try:
             os.chdir(admin_dir)
-            workspace = os.path.join(admin_dir, "startup")
-            conf = FLAdminClientStarterConfigurator(app_root=workspace, admin_config_file_name="fed_admin.json")
+            workspace = Workspace(root_dir=admin_dir)
+            conf = FLAdminClientStarterConfigurator(workspace)
             conf.configure()
         except ConfigError as ex:
             print("ConfigError:", str(ex))
+            return
 
         try:
             admin_config = conf.config_data["admin"]
         except KeyError:
             print("Missing admin section in fed_admin configuration.")
+            return
 
         ca_cert = admin_config.get("ca_cert", "")
         client_cert = admin_config.get("client_cert", "")

--- a/nvflare/private/fed/app/client/client_train.py
+++ b/nvflare/private/fed/app/client/client_train.py
@@ -116,7 +116,6 @@ def main():
         servers = [{t["name"]: t["service"]} for t in deployer.server_config]
         admin_agent = create_admin_agent(
             deployer.client_config,
-            deployer.client_name,
             deployer.req_processors,
             deployer.secure_train,
             sorted(servers)[0],
@@ -139,7 +138,6 @@ def main():
 
 def create_admin_agent(
     client_args,
-    client_id,
     req_processors,
     secure_train,
     server_args,
@@ -152,7 +150,6 @@ def create_admin_agent(
 
     Args:
         client_args: start client command args
-        client_id: client name
         req_processors: request processors
         secure_train: True/False
         server_args: FL server args
@@ -164,11 +161,14 @@ def create_admin_agent(
     Returns:
         A FedAdminAgent.
     """
+    root_cert = client_args[SSLConstants.ROOT_CERT] if secure_train else None
+    ssl_cert = client_args[SSLConstants.CERT] if secure_train else None
+    private_key = client_args[SSLConstants.PRIVATE_KEY] if secure_train else None
     sender = AdminMessageSender(
         client_name=federated_client.token,
-        root_cert=client_args[SSLConstants.ROOT_CERT],
-        ssl_cert=client_args[SSLConstants.CERT],
-        private_key=client_args[SSLConstants.PRIVATE_KEY],
+        root_cert=root_cert,
+        ssl_cert=ssl_cert,
+        private_key=private_key,
         server_args=server_args,
         secure=secure_train,
         is_multi_gpu=is_multi_gpu,

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -86,7 +86,7 @@ class ClientTaskWorker(FLComponent):
             client_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
             self.fire_event(EventType.SWAP_IN, fl_ctx)
 
-            interval, task_processed = client_runner.run_one_task(fl_ctx)
+            interval, task_processed = client_runner.fetch_and_run_one_task(fl_ctx)
             self.logger.info(f"Finished one task run for client: {client.client_name}")
 
             # if any client got the END_RUN event, stop the simulator run.

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -21,7 +21,7 @@ from nvflare.private.defs import EngineConstant
 from nvflare.private.fed.app.fl_conf import create_privacy_manager
 from nvflare.private.fed.client.client_json_config import ClientJsonConfigurator
 from nvflare.private.fed.client.client_run_manager import ClientRunManager
-from nvflare.private.fed.client.client_runner import ClientRunner, ClientRunnerConfig
+from nvflare.private.fed.client.client_runner import ClientRunner
 from nvflare.private.fed.client.client_status import ClientStatus
 from nvflare.private.fed.client.command_agent import CommandAgent
 from nvflare.private.privacy_manager import PrivacyService
@@ -48,7 +48,6 @@ class ClientAppRunner:
             sys.path.append(app_custom_folder)
 
         runner_config = conf.runner_config
-        assert isinstance(runner_config, ClientRunnerConfig)
 
         # configure privacy control!
         privacy_manager = create_privacy_manager(workspace, names_only=False)
@@ -60,7 +59,7 @@ class ClientAppRunner:
         # initialize Privacy Service
         PrivacyService.initialize(privacy_manager)
 
-        run_manager = self.create_run_manageer(args, conf, federated_client, workspace)
+        run_manager = self.create_run_manager(args, conf, federated_client, workspace)
         federated_client.run_manager = run_manager
         with run_manager.new_context() as fl_ctx:
             fl_ctx.set_prop(FLContextKey.CLIENT_NAME, args.client_name, private=False)
@@ -78,7 +77,7 @@ class ClientAppRunner:
             self.start_command_agent(args, client_runner, federated_client, fl_ctx)
         return client_runner
 
-    def create_run_manageer(self, args, conf, federated_client, workspace):
+    def create_run_manager(self, args, conf, federated_client, workspace):
         return ClientRunManager(
             client_name=args.client_name,
             job_id=args.job_id,

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -55,12 +55,18 @@ class ClientJsonConfigurator(FedJsonConfigurator):
         self.runner_config = None
         self.executors = []
         self.current_exe = None
+        self._default_task_fetch_interval = None
 
     def process_config_element(self, config_ctx: ConfigContext, node: Node):
         FedJsonConfigurator.process_config_element(self, config_ctx, node)
 
         element = node.element
         path = node.path()
+
+        # default task fetch interval
+        if re.search(r"default_task_fetch_interval", path):
+            self._default_task_fetch_interval = element
+            return
 
         # executors
         if re.search(r"^executors\.#[0-9]+$", path):
@@ -114,4 +120,5 @@ class ClientJsonConfigurator(FedJsonConfigurator):
             task_result_filters=self.result_filter_table,
             components=self.components,
             handlers=self.handlers,
+            default_task_fetch_interval=self._default_task_fetch_interval
         )

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -120,5 +120,5 @@ class ClientJsonConfigurator(FedJsonConfigurator):
             task_result_filters=self.result_filter_table,
             components=self.components,
             handlers=self.handlers,
-            default_task_fetch_interval=self._default_task_fetch_interval
+            default_task_fetch_interval=self._default_task_fetch_interval,
         )

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -64,7 +64,7 @@ class ClientRunManager(ClientEngineExecutorSpec):
         Args:
             client_name: client name
             job_id: job id
-            workspace: workspacee
+            workspace: workspace
             client: FL client object
             components: available FL components
             handlers: available handlers
@@ -103,7 +103,6 @@ class ClientRunManager(ClientEngineExecutorSpec):
         task = None
         if pull_success:
             shareable = self.client.extract_shareable(remote_tasks, fl_ctx)
-            # task_id = fl_ctx.get_peer_context().get_cookie(FLContextKey.TASK_ID)
             task_id = shareable.get_header(key=FLContextKey.TASK_ID)
             task = TaskAssignment(name=task_name, task_id=task_id, data=shareable)
         return task

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -37,7 +37,7 @@ class ClientRunnerConfig(object):
         task_result_filters: dict,  # task_name => list of filters
         handlers=None,  # list of event handlers
         components=None,  # dict of extra python objects: id => object
-        default_task_fetch_interval=None
+        default_task_fetch_interval=None,
     ):
         """To init ClientRunnerConfig.
 

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -37,6 +37,7 @@ class ClientRunnerConfig(object):
         task_result_filters: dict,  # task_name => list of filters
         handlers=None,  # list of event handlers
         components=None,  # dict of extra python objects: id => object
+        default_task_fetch_interval=None
     ):
         """To init ClientRunnerConfig.
 
@@ -46,12 +47,15 @@ class ClientRunnerConfig(object):
             task_result_filters: task_name => list of result filters
             handlers: list of event handlers
             components: dict of extra python objects: id => object
+            default_task_fetch_interval: default task fetch interval before getting the correct value from server.
+                if not set, will be set to 0.1.
         """
         self.task_table = task_table
         self.task_data_filters = task_data_filters
         self.task_result_filters = task_result_filters
         self.handlers = handlers
         self.components = components
+        self.default_task_fetch_interval = 0.1 if default_task_fetch_interval is None else default_task_fetch_interval
 
         if not components:
             self.components = {}
@@ -89,6 +93,7 @@ class ClientRunner(FLComponent):
         self.task_table = config.task_table
         self.task_data_filters = config.task_data_filters
         self.task_result_filters = config.task_result_filters
+        self.default_task_fetch_interval = config.default_task_fetch_interval
 
         self.job_id = job_id
         self.engine = engine
@@ -359,7 +364,7 @@ class ClientRunner(FLComponent):
         Returns:
             A tuple of (task_fetch_interval, task_processed).
         """
-        default_task_fetch_interval = 0.1
+        default_task_fetch_interval = self.default_task_fetch_interval
         self.log_debug(fl_ctx, "fetching task from server ...")
         task = self.engine.get_task_assignment(fl_ctx)
 

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -77,15 +77,13 @@ class ClientRunner(FLComponent):
         config: ClientRunnerConfig,
         job_id,
         engine: ClientEngineExecutorSpec,
-        task_fetch_interval: int = 5,  # fetch task every 5 secs
     ):
-        """To init the ClientRunner.
+        """Initializes the ClientRunner.
 
         Args:
             config: ClientRunnerConfig
             job_id: job id
             engine: ClientEngine object
-            task_fetch_interval:  fetch task interval
         """
         FLComponent.__init__(self)
         self.task_table = config.task_table
@@ -94,7 +92,6 @@ class ClientRunner(FLComponent):
 
         self.job_id = job_id
         self.engine = engine
-        self.task_fetch_interval = task_fetch_interval
         self.run_abort_signal = Signal()
         self.task_abort_signal = None
         self.current_executor = None
@@ -342,75 +339,77 @@ class ClientRunner(FLComponent):
         return self._reply_and_audit(reply=reply, ref=server_audit_event_id, fl_ctx=fl_ctx, msg="submit result OK")
 
     def _try_run(self):
-        task_fetch_interval = self.task_fetch_interval
         while not self.asked_to_stop:
             with self.engine.new_context() as fl_ctx:
                 if self.run_abort_signal.triggered:
                     self.log_info(fl_ctx, "run abort signal received")
                     break
 
-                time.sleep(task_fetch_interval)
+                task_fetch_interval, _ = self.fetch_and_run_one_task(fl_ctx)
 
                 if self.run_abort_signal.triggered:
                     self.log_info(fl_ctx, "run abort signal received")
                     break
 
-                task_fetch_interval, _ = self.run_one_task(fl_ctx)
+                time.sleep(task_fetch_interval)
 
-    def run_one_task(self, fl_ctx):
-        # reset to default fetch interval
-        task_fetch_interval = self.task_fetch_interval
+    def fetch_and_run_one_task(self, fl_ctx) -> (float, bool):
+        """Fetches and runs a task.
+
+        Returns:
+            A tuple of (task_fetch_interval, task_processed).
+        """
+        default_task_fetch_interval = 0.1
         self.log_debug(fl_ctx, "fetching task from server ...")
         task = self.engine.get_task_assignment(fl_ctx)
-        task_processed = False
-        if not task:
-            self.log_debug(fl_ctx, "no task received - will try in {} secs".format(task_fetch_interval))
-            # continue
 
+        if not task:
+            self.log_debug(fl_ctx, "no task received - will try in {} secs".format(default_task_fetch_interval))
+            return default_task_fetch_interval, False
         elif task.name == SpecialTaskName.END_RUN:
             self.log_info(fl_ctx, "server asked to end the run")
-            # break
             self.asked_to_stop = True
-
+            return default_task_fetch_interval, False
         elif task.name == SpecialTaskName.TRY_AGAIN:
             task_data = task.data
+            task_fetch_interval = default_task_fetch_interval
             if task_data and isinstance(task_data, Shareable):
-                task_fetch_interval = task_data.get(TaskConstant.WAIT_TIME, self.task_fetch_interval)
+                task_fetch_interval = task_data.get(TaskConstant.WAIT_TIME, task_fetch_interval)
             self.log_debug(fl_ctx, "server asked to try again - will try in {} secs".format(task_fetch_interval))
-            # continue
+            return task_fetch_interval, False
 
+        self.log_info(fl_ctx, "got task assignment: name={}, id={}".format(task.name, task.task_id))
+
+        task_data = task.data
+        if not isinstance(task_data, Shareable):
+            raise TypeError("task_data must be Shareable, but got {}".format(type(task_data)))
+        task_fetch_interval = task_data[TaskConstant.WAIT_TIME]
+
+        # create a new task abort signal
+        task_reply = self._process_task(task, fl_ctx)
+
+        if not isinstance(task_reply, Shareable):
+            raise TypeError("task_reply must be Shareable, but got {}".format(type(task_reply)))
+        self.log_debug(fl_ctx, "firing event EventType.BEFORE_SEND_TASK_RESULT")
+        self.fire_event(EventType.BEFORE_SEND_TASK_RESULT, fl_ctx)
+
+        # set the cookie in the reply!
+        cookie_jar = task_data.get_cookie_jar()
+        if cookie_jar:
+            task_reply.set_cookie_jar(cookie_jar)
+
+        reply_sent = self.engine.send_task_result(task_reply, fl_ctx)
+        if reply_sent:
+            self.log_info(fl_ctx, "result sent to server for task: name={}, id={}".format(task.name, task.task_id))
         else:
-            self.log_info(fl_ctx, "got task assignment: name={}, id={}".format(task.name, task.task_id))
+            self.log_error(
+                fl_ctx,
+                "failed to send result to server for task: name={}, id={}".format(task.name, task.task_id),
+            )
+        self.log_debug(fl_ctx, "firing event EventType.AFTER_SEND_TASK_RESULT")
+        self.fire_event(EventType.AFTER_SEND_TASK_RESULT, fl_ctx)
 
-            # create a new task abort signal
-            task_reply = self._process_task(task, fl_ctx)
-
-            if not isinstance(task_reply, Shareable):
-                raise TypeError("task_reply must be Shareable, but got {}".format(type(task_reply)))
-            self.log_debug(fl_ctx, "firing event EventType.BEFORE_SEND_TASK_RESULT")
-            self.fire_event(EventType.BEFORE_SEND_TASK_RESULT, fl_ctx)
-
-            # set the cookie in the reply!
-            task_data = task.data
-            if not isinstance(task_data, Shareable):
-                raise TypeError("task_data must be Shareable, but got {}".format(type(task_data)))
-
-            cookie_jar = task_data.get_cookie_jar()
-            if cookie_jar:
-                task_reply.set_cookie_jar(cookie_jar)
-
-            reply_sent = self.engine.send_task_result(task_reply, fl_ctx)
-            if reply_sent:
-                self.log_info(fl_ctx, "result sent to server for task: name={}, id={}".format(task.name, task.task_id))
-            else:
-                self.log_error(
-                    fl_ctx,
-                    "failed to send result to server for task: name={}, id={}".format(task.name, task.task_id),
-                )
-            self.log_debug(fl_ctx, "firing event EventType.AFTER_SEND_TASK_RESULT")
-            self.fire_event(EventType.AFTER_SEND_TASK_RESULT, fl_ctx)
-            task_processed = True
-        return task_fetch_interval, task_processed
+        return task_fetch_interval, True
 
     def run(self, app_root, args):
         self.init_run(app_root, args)

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -374,7 +374,7 @@ class ClientRunner(FLComponent):
             task_data = task.data
             task_fetch_interval = default_task_fetch_interval
             if task_data and isinstance(task_data, Shareable):
-                task_fetch_interval = task_data.get(TaskConstant.WAIT_TIME, task_fetch_interval)
+                task_fetch_interval = task_data.get_header(TaskConstant.WAIT_TIME, task_fetch_interval)
             self.log_debug(fl_ctx, "server asked to try again - will try in {} secs".format(task_fetch_interval))
             return task_fetch_interval, False
 
@@ -383,7 +383,7 @@ class ClientRunner(FLComponent):
         task_data = task.data
         if not isinstance(task_data, Shareable):
             raise TypeError("task_data must be Shareable, but got {}".format(type(task_data)))
-        task_fetch_interval = task_data[TaskConstant.WAIT_TIME]
+        task_fetch_interval = task_data.get_header(TaskConstant.WAIT_TIME, default_task_fetch_interval)
 
         # create a new task abort signal
         task_reply = self._process_task(task, fl_ctx)

--- a/nvflare/private/fed/client/scheduler_cmds.py
+++ b/nvflare/private/fed/client/scheduler_cmds.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import json
 from typing import List
 

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -620,6 +620,7 @@ class ServerEngine(ServerEngineInternalSpec):
         return command_conn
 
     def persist_components(self, fl_ctx: FLContext, completed: bool):
+        self.logger.info("Start saving snapshot on server.")
 
         # Call the State Persistor to persist all the component states
         # 1. call every component to generate the component states data

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -89,8 +89,8 @@ class ServerJsonConfigurator(FedJsonConfigurator):
             if not isinstance(element, int) and not isinstance(element, float):
                 raise ConfigError('"task_request_interval" must be a number, but got {}'.format(type(element)))
 
-            if element < 1:
-                raise ConfigError('"task_request_interval" must >= 1, but got {}'.format(element))
+            if element <= 0:
+                raise ConfigError('"task_request_interval" must > 0, but got {}'.format(element))
 
             return
 

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -195,7 +195,7 @@ class ServerRunner(FLComponent):
 
     def _task_try_again(self) -> (str, str, Shareable):
         task_data = Shareable()
-        task_data[TaskConstant.WAIT_TIME] = self.config.task_request_interval
+        task_data.set_header(TaskConstant.WAIT_TIME, self.config.task_request_interval)
         return SpecialTaskName.TRY_AGAIN, "", task_data
 
     def process_task_request(self, client: Client, fl_ctx: FLContext) -> (str, str, Shareable):
@@ -311,7 +311,7 @@ class ServerRunner(FLComponent):
 
             audit_event_id = add_job_audit_event(fl_ctx=fl_ctx, msg=f'sent task to client "{client.name}"')
             task_data.set_header(ReservedHeaderKey.AUDIT_EVENT_ID, audit_event_id)
-            task_data[TaskConstant.WAIT_TIME] = self.config.task_request_interval
+            task_data.set_header(TaskConstant.WAIT_TIME, self.config.task_request_interval)
             return task_name, task_id, task_data
         except BaseException as e:
             self.log_exception(fl_ctx, f"Error processing client task request: {e}; asked client to try again later")

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -33,7 +33,7 @@ class ServerRunnerConfig(object):
     def __init__(
         self,
         heartbeat_timeout: int,
-        task_request_interval: int,
+        task_request_interval: float,
         workflows: [],
         task_data_filters: dict,
         task_result_filters: dict,
@@ -44,7 +44,7 @@ class ServerRunnerConfig(object):
 
         Args:
             heartbeat_timeout (int): Client heartbeat timeout in seconds
-            task_request_interval (int): Task request interval in seconds
+            task_request_interval (float): Task request interval in seconds
             workflows (list): A list of workflow
             task_data_filters (dict):  A dict of  {task_name: list of filters apply to data (pre-process)}
             task_result_filters (dict): A dict of {task_name: list of filters apply to result (post-process)}
@@ -194,9 +194,9 @@ class ServerRunner(FLComponent):
             self.abort(fl_ctx)
 
     def _task_try_again(self) -> (str, str, Shareable):
-        task = Shareable()
-        task[TaskConstant.WAIT_TIME] = self.config.task_request_interval
-        return SpecialTaskName.TRY_AGAIN, "", task
+        task_data = Shareable()
+        task_data[TaskConstant.WAIT_TIME] = self.config.task_request_interval
+        return SpecialTaskName.TRY_AGAIN, "", task_data
 
     def process_task_request(self, client: Client, fl_ctx: FLContext) -> (str, str, Shareable):
         """Process task request from a client.
@@ -311,7 +311,7 @@ class ServerRunner(FLComponent):
 
             audit_event_id = add_job_audit_event(fl_ctx=fl_ctx, msg=f'sent task to client "{client.name}"')
             task_data.set_header(ReservedHeaderKey.AUDIT_EVENT_ID, audit_event_id)
-
+            task_data[TaskConstant.WAIT_TIME] = self.config.task_request_interval
             return task_name, task_id, task_data
         except BaseException as e:
             self.log_exception(fl_ctx, f"Error processing client task request: {e}; asked client to try again later")

--- a/nvflare/private/fed/simulator/simulator_app_runner.py
+++ b/nvflare/private/fed/simulator/simulator_app_runner.py
@@ -26,7 +26,7 @@ class SimulatorClientAppRunner(ClientAppRunner):
     def start_command_agent(self, args, client_runner, federated_client, fl_ctx):
         pass
 
-    def create_run_manageer(self, args, conf, federated_client, workspace):
+    def create_run_manager(self, args, conf, federated_client, workspace):
         return SimulatorClientRunManager(
             client_name=args.client_name,
             job_id=args.job_id,

--- a/nvflare/private/json_configer.py
+++ b/nvflare/private/json_configer.py
@@ -48,7 +48,6 @@ class JsonConfigurator(JsonObjectProcessor, ComponentBuilder):
             module_names: module names need to be scanned
             exclude_libs: True/False to exclude the libs folder
             num_passes: number of passes to parsing the config
-            extra_config_files: additional JSON config files to be merged
         """
         JsonObjectProcessor.__init__(self)
 


### PR DESCRIPTION
- Make `task_request_interval` configurable
- Make `task_check_period` configurable
- Change `task_fetch_interval` to be set by server side config's `task_request_interval`
- Fix `create_run_manageer` typo -> `create_run_manager`
- Fix `nvflare/private/fed/app/client/client_train.py`
- Fix `nvflare/fuel/hci/client/fl_admin_api_runner.py`

Make the following changes to `ScatterAndGather` workflow:
- Add `task_check_period` parameter, this means how often the controller checks for tasks
- Add `persist_every_n_rounds` parameter, this means how often do we want to call the model persistor to save the global model on server
- Add `snapshot_every_n_rounds`, parameter, this means how often do we want to persist the entire server snapshot