### PR TITLE
Look for not authorized instead of Authorization Error when parsing

### DIFF
--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -255,7 +255,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
                 raise LookupError(reply_data_full_response)
             if "unknown site" in reply_data_full_response:
                 raise LookupError(reply_data_full_response)
-            if "Authorization Error" in reply_data_full_response:
+            if "not authorized" in reply_data_full_response:
                 raise PermissionError(reply_data_full_response)
         if reply.get("status") != APIStatus.SUCCESS:
             raise RuntimeError(reply.get("details"))

--- a/nvflare/private/fed/client/admin.py
+++ b/nvflare/private/fed/client/admin.py
@@ -216,7 +216,7 @@ class FedAdminAgent(object):
                                 if err:
                                     reply = error_reply(err)
                                 elif not authorized:
-                                    reply = error_reply("not_authorized")
+                                    reply = error_reply("not authorized")
                             else:
                                 reply = error_reply("requires authz but missing admin command")
 


### PR DESCRIPTION
- If client side auth error, it only give back "not authorized"