### PR TITLE
Enhance job run status

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -98,6 +98,7 @@ class ReservedKey(object):
     CURRENT_JOB_ID = "__current_job_id__"
     JOB_RUN_NUMBER = "__job_run_number__"
     JOB_DEPLOY_DETAIL = "__job_deploy_detail__"
+    FATAL_SYSTEM_ERROR = "__fatal_system_error__"
 
 
 class FLContextKey(object):
@@ -139,6 +140,7 @@ class FLContextKey(object):
     EFFECTIVE_JOB_SCOPE_NAME = "__effective_job_scope_name__"
     SCOPE_PROPERTIES = "__scope_props__"
     SCOPE_OBJECT = "__scope_object__"
+    FATAL_SYSTEM_ERROR = ReservedKey.FATAL_SYSTEM_ERROR
 
 
 class ReservedTopic(object):
@@ -192,6 +194,7 @@ class ServerCommandNames(object):
     AUX_SEND = "aux_send"
     SHOW_STATS = "show_stats"
     GET_ERRORS = "get_errors"
+    UPDATE_RUN_STATUS = "update_run_status"
 
 
 class ServerCommandKey(object):

--- a/nvflare/apis/server_engine_spec.py
+++ b/nvflare/apis/server_engine_spec.py
@@ -44,9 +44,7 @@ class ServerEngineSpec(ABC):
 
     @abstractmethod
     def update_job_run_status(self):
-        """To update the job run status to parent process.
-
-        """
+        """To update the job run status to parent process."""
         pass
 
     @abstractmethod

--- a/nvflare/apis/server_engine_spec.py
+++ b/nvflare/apis/server_engine_spec.py
@@ -43,6 +43,13 @@ class ServerEngineSpec(ABC):
         pass
 
     @abstractmethod
+    def update_job_run_status(self):
+        """To update the job run status to parent process.
+
+        """
+        pass
+
+    @abstractmethod
     def validate_clients(self, client_names: List[str]) -> Tuple[List[Client], List[str]]:
         """Validate specified client names.
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -723,7 +723,6 @@ class FederatedServer(BaseServer, fed_service.FederatedTrainingServicer, admin_s
 
         finally:
             self.engine.engine_info.status = MachineStatus.STOPPED
-            # self.engine.run_manager = None
             self.run_manager = None
 
     def create_run_manager(self, workspace, job_id):

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -723,7 +723,7 @@ class FederatedServer(BaseServer, fed_service.FederatedTrainingServicer, admin_s
 
         finally:
             self.engine.engine_info.status = MachineStatus.STOPPED
-            self.engine.run_manager = None
+            # self.engine.run_manager = None
             self.run_manager = None
 
     def create_run_manager(self, workspace, job_id):

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -285,10 +285,10 @@ class JobRunner(FLComponent):
                     with self.lock:
                         job = self.running_jobs.get(job_id)
                         if job:
-                            execution_exception_run_processes = engine.execution_exception_run_processes
-                            if job_id in execution_exception_run_processes:
+                            exception_run_processes = engine.exception_run_processes
+                            if job_id in exception_run_processes:
                                 self.log_info(fl_ctx, f"Try to abort run ({job_id}) on clients.")
-                                run_process = execution_exception_run_processes[job_id]
+                                run_process = exception_run_processes[job_id]
 
                                 # stop client run
                                 client_sites = run_process.get(RunProcessKey.PARTICIPANTS)
@@ -301,6 +301,7 @@ class JobRunner(FLComponent):
                             fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, job.job_id)
                             self.fire_event(EventType.JOB_COMPLETED, fl_ctx)
                             self.log_debug(fl_ctx, f"Finished running job:{job.job_id}")
+                    engine.remove_exception_process(job_id)
             time.sleep(1.0)
 
     def _save_workspace(self, fl_ctx: FLContext):

--- a/nvflare/private/fed/server/server_app_runner.py
+++ b/nvflare/private/fed/server/server_app_runner.py
@@ -64,6 +64,7 @@ class ServerAppRunner:
             logger.exception(f"FL server execution exception: {secure_format_exception(e)}")
             raise e
         finally:
+            self.update_job_run_sstatus(server)
             server.status = ServerStatus.STOPPED
             server.engine.engine_info.status = MachineStatus.STOPPED
             server.stop_training()
@@ -71,3 +72,6 @@ class ServerAppRunner:
     def sync_up_parents_process(self, args, server):
         server.engine.create_parent_connection(int(args.conn))
         server.engine.sync_clients_from_main_process()
+
+    def update_job_run_sstatus(self, server):
+        server.engine.update_job_run_status()

--- a/nvflare/private/fed/server/server_app_runner.py
+++ b/nvflare/private/fed/server/server_app_runner.py
@@ -14,7 +14,7 @@
 
 import os
 
-from nvflare.apis.fl_constant import MachineStatus, FLContextKey
+from nvflare.apis.fl_constant import FLContextKey, MachineStatus
 from nvflare.apis.workspace import Workspace
 from nvflare.private.fed.app.fl_conf import create_privacy_manager
 from nvflare.private.fed.server.server_engine import ServerEngine

--- a/nvflare/private/fed/server/server_app_runner.py
+++ b/nvflare/private/fed/server/server_app_runner.py
@@ -14,7 +14,7 @@
 
 import os
 
-from nvflare.apis.fl_constant import MachineStatus
+from nvflare.apis.fl_constant import MachineStatus, FLContextKey
 from nvflare.apis.workspace import Workspace
 from nvflare.private.fed.app.fl_conf import create_privacy_manager
 from nvflare.private.fed.server.server_engine import ServerEngine
@@ -61,10 +61,12 @@ class ServerAppRunner:
 
             server.start_run(job_id, app_root, conf, args, snapshot)
         except BaseException as e:
+            with server.engine.new_context() as fl_ctx:
+                fl_ctx.set_prop(key=FLContextKey.FATAL_SYSTEM_ERROR, value=True, private=True, sticky=True)
             logger.exception(f"FL server execution exception: {secure_format_exception(e)}")
             raise e
         finally:
-            self.update_job_run_sstatus(server)
+            self.update_job_run_status(server)
             server.status = ServerStatus.STOPPED
             server.engine.engine_info.status = MachineStatus.STOPPED
             server.stop_training()
@@ -73,5 +75,5 @@ class ServerAppRunner:
         server.engine.create_parent_connection(int(args.conn))
         server.engine.sync_clients_from_main_process()
 
-    def update_job_run_sstatus(self, server):
+    def update_job_run_status(self, server):
         server.engine.update_job_run_status()

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -266,7 +266,11 @@ class ServerEngine(ServerEngineInternalSpec):
             except BaseException:
                 with self.lock:
                     if job_id in self.run_processes:
-                        self.run_processes.pop(job_id)
+                        run_process_info = self.run_processes.pop(job_id)
+                        return_code = run_process_info[RunProcessKey.CHILD_PROCESS].poll()
+                        # if process exit but with Execution exception
+                        if return_code and return_code != 0:
+                            self.exception_run_processes[job_id] = run_process_info
                 self.engine_info.status = MachineStatus.STOPPED
                 break
 

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -578,10 +578,11 @@ class ServerEngine(ServerEngineInternalSpec):
         with self.parent_conn_lock:
             with self.new_context() as fl_ctx:
                 execution_error = fl_ctx.get_prop(FLContextKey.FATAL_SYSTEM_ERROR, False)
-                data = {ServerCommandKey.COMMAND: ServerCommandNames.UPDATE_RUN_STATUS,
-                        ServerCommandKey.DATA: {
-                            "execution_error": execution_error,
-                        }
+                data = {
+                    ServerCommandKey.COMMAND: ServerCommandNames.UPDATE_RUN_STATUS,
+                    ServerCommandKey.DATA: {
+                        "execution_error": execution_error,
+                    },
                 }
                 self.parent_conn.send(data)
 

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -187,6 +187,7 @@ class ServerRunner(FLComponent):
                             info={"job_id": self.job_id, "status": self.status, "workflow": self.current_wf.id},
                         )
         elif event_type == EventType.FATAL_SYSTEM_ERROR:
+            fl_ctx.set_prop(key=FLContextKey.FATAL_SYSTEM_ERROR, value=True, private=True, sticky=True)
             reason = fl_ctx.get_prop(key=FLContextKey.EVENT_DATA, default="")
             self.log_error(fl_ctx, "Aborting current RUN due to FATAL_SYSTEM_ERROR received: {}".format(reason))
             self.abort(fl_ctx)

--- a/nvflare/private/fed/simulator/simulator_app_runner.py
+++ b/nvflare/private/fed/simulator/simulator_app_runner.py
@@ -45,3 +45,7 @@ class SimulatorClientAppRunner(ClientAppRunner):
 class SimulatorServerAppRunner(ServerAppRunner):
     def sync_up_parents_process(self, args, server):
         pass
+
+    def update_job_run_sstatus(self, server):
+        pass
+

--- a/nvflare/private/fed/simulator/simulator_app_runner.py
+++ b/nvflare/private/fed/simulator/simulator_app_runner.py
@@ -46,6 +46,6 @@ class SimulatorServerAppRunner(ServerAppRunner):
     def sync_up_parents_process(self, args, server):
         pass
 
-    def update_job_run_sstatus(self, server):
+    def update_job_run_status(self, server):
         pass
 

--- a/nvflare/private/fed/simulator/simulator_app_runner.py
+++ b/nvflare/private/fed/simulator/simulator_app_runner.py
@@ -48,4 +48,3 @@ class SimulatorServerAppRunner(ServerAppRunner):
 
     def update_job_run_status(self, server):
         pass
-

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -141,6 +141,9 @@ class MockServerEngine(ServerEngineSpec):
                         resource_requirement=resource_reqs[site_name], token=token, fl_ctx=fl_ctx
                     )
 
+    def update_job_run_status(self):
+        pass
+
 
 def create_servers(server_num, sites: List[Site]):
     servers = []


### PR DESCRIPTION
Added update_job_run_status to update the proper job run status.

Description:
At the end of ServerAppRunner application job run, it will check if the job run has FLContextKey.FATAL_SYSTEM_ERROR been reported. If it does, then post the job execution exception status to the parent process to update the job FINISHED:FINISHED_EXECUTION_EXCEPTION outcome. Otherwise, the job outcome will be FINISHED:COMPLETED.

system panic and server job exception will mark as FLContextKey.FATAL_SYSTEM_ERROR.