### PR TITLE
Check nvidia-smi exists before using it

### DIFF
--- a/nvflare/fuel/utils/gpu_utils.py
+++ b/nvflare/fuel/utils/gpu_utils.py
@@ -38,9 +38,7 @@ def use_nvidia_smi(query: str, report_format: str = "csv"):
 
 def _parse_gpu_mem(result: str = None, unit: str = "MiB") -> List:
     gpu_memory = []
-    if not result:
-        print("Failed to get gpu memory, assume no gpu device.")
-    else:
+    if result:
         for i in result[1:]:
             mem, mem_unit = i.split(" ")
             if mem_unit != unit:


### PR DESCRIPTION
avoid user confusion with failed to find nvidia-smi message
1) check if the nvidia-smi before using it, avoid file not exception
2) remove output "Failed to get gpu device IDs, assume no gpu device." message as it seems to be confuse user. 