### PR TITLE
update model selector 2.0

### DIFF
--- a/nvflare/app_common/app_event_type.py
+++ b/nvflare/app_common/app_event_type.py
@@ -16,9 +16,6 @@
 class AppEventType(object):
     """Defines application events."""
 
-    START_ROUND = "_start_round"
-    END_ROUND = "_end_round"
-
     BEFORE_AGGREGATION = "_before_aggregation"
     END_AGGREGATION = "_end_aggregation"
 


### PR DESCRIPTION
- Normalize the weighted sum to add to 1.0, following the approach in DXO aggregators.
- Change the behavior of some logging messages to increase user-friendliness.
- Fix event type used for `_before_accept()` logic (using now `AppEventType.BEFORE_CONTRIBUTION_ACCEPT`).