### PR TITLE
FL hub support x-site val

### DIFF
--- a/nvflare/app_common/widgets/validation_json_generator.py
+++ b/nvflare/app_common/widgets/validation_json_generator.py
@@ -64,11 +64,22 @@ class ValidationJsonGenerator(Widget):
                         if data_client not in self._val_results:
                             self._val_results[data_client] = {}
                         self._val_results[data_client][model_owner] = dxo.data
+                    elif dxo.data_kind == DataKind.COLLECTION:
+                        # The DXO could contain multiple sub-DXOs (e.g. received from a T2 system)
+                        _dxos = dxo.data
+                        for _sub_data_client, _dxo in _dxos.items():
+                            _data_client = ".".join([data_client, _sub_data_client])
+                            _dxo.validate()
+                            if _data_client not in self._val_results:
+                                self._val_results[_data_client] = {}
+                            self._val_results[_data_client][model_owner] = _dxo.data
                     else:
                         self.log_error(
-                            fl_ctx, f"Expected dxo of kind METRICS but got {dxo.data_kind} instead.", fire_event=False
+                            fl_ctx,
+                            f"Expected dxo of kind METRICS or COLLECTION but got {dxo.data_kind} instead.",
+                            fire_event=False,
                         )
-                except:
+                except BaseException:
                     self.log_exception(fl_ctx, "Exception in handling validation result.", fire_event=False)
             else:
                 self.log_error(fl_ctx, "Validation result not found.", fire_event=False)

--- a/nvflare/app_common/workflows/cross_site_model_eval.py
+++ b/nvflare/app_common/workflows/cross_site_model_eval.py
@@ -19,7 +19,7 @@ from typing import Union
 
 from nvflare.apis.client import Client
 from nvflare.apis.controller_spec import ClientTask, Task
-from nvflare.apis.dxo import DXO, from_bytes, from_shareable
+from nvflare.apis.dxo import DXO, from_bytes, from_shareable, get_leaf_dxos
 from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.impl.controller import Controller
@@ -319,7 +319,7 @@ class CrossSiteModelEval(Controller):
             unique_name = "SRV_" + name
             unique_names.append(unique_name)
             try:
-                save_path = self._save_validation_content(unique_name, self._cross_val_models_dir, dxo, fl_ctx)
+                save_path = self._save_dxo_content(unique_name, self._cross_val_models_dir, dxo, fl_ctx)
             except:
                 self.log_exception(fl_ctx, f"Unable to save shareable contents of server model {unique_name}")
                 self.system_panic(f"Unable to save shareable contents of server model {unique_name}", fl_ctx)
@@ -335,9 +335,9 @@ class CrossSiteModelEval(Controller):
         return True
 
     def _accept_local_model(self, client_name: str, result: Shareable, fl_ctx: FLContext):
-        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL, result, private=False, sticky=False)
-        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL_OWNER, client_name, private=False, sticky=False)
-        fl_ctx.set_prop(AppConstants.CROSS_VAL_DIR, self._cross_val_dir, private=False, sticky=False)
+        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL, result, private=True, sticky=False)
+        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL_OWNER, client_name, private=True, sticky=False)
+        fl_ctx.set_prop(AppConstants.CROSS_VAL_DIR, self._cross_val_dir, private=True, sticky=False)
         self.fire_event(AppEventType.RECEIVE_BEST_MODEL, fl_ctx)
 
         # get return code
@@ -365,23 +365,30 @@ class CrossSiteModelEval(Controller):
             try:
                 self.log_debug(fl_ctx, "Extracting DXO from shareable.")
                 dxo = from_shareable(result)
-                save_path = self._save_validation_content(client_name, self._cross_val_models_dir, dxo, fl_ctx)
             except ValueError as e:
                 self.log_error(
                     fl_ctx,
-                    f"Unable to save shareable contents of {client_name}'s model. Exception: {secure_format_exception(e)}",
+                    f"Ignored bad result from {client_name}: {secure_format_exception(e)}",
                 )
-                self.log_warning(fl_ctx, f"Ignoring client {client_name}'s model.")
                 return
 
-            self.log_info(fl_ctx, f"Received local model from client {client_name}.")
+            # The DXO could contain multiple sub-DXOs (e.g. received from a T2 system)
+            leaf_dxos, errors = get_leaf_dxos(dxo, client_name)
+            if errors:
+                for err in errors:
+                    self.log_error(fl_ctx, f"Bad result from {client_name}: {err}")
+            for k, v in leaf_dxos.items():
+                self._save_client_model(k, v, fl_ctx)
 
-            self._client_models[client_name] = save_path
+    def _save_client_model(self, model_name: str, dxo: DXO, fl_ctx: FLContext):
+        save_path = self._save_dxo_content(model_name, self._cross_val_models_dir, dxo, fl_ctx)
+        self.log_info(fl_ctx, f"Saved client model {model_name} to {save_path}")
+        self._client_models[model_name] = save_path
 
-            self._send_validation_task(client_name, fl_ctx)
+        # Send a model to this client to validate
+        self._send_validation_task(model_name, fl_ctx)
 
     def _send_validation_task(self, model_name: str, fl_ctx: FLContext):
-        """Sends the model to all participating clients for validation."""
         self.log_info(fl_ctx, f"Sending {model_name} model to all participating clients for validation.")
 
         # Create validation task and broadcast to all participating clients.
@@ -434,22 +441,37 @@ class CrossSiteModelEval(Controller):
 
             self._val_results[client_name][model_owner] = {}
         else:
-            save_file_name = client_name + "_" + model_owner
-
             try:
                 dxo = from_shareable(result)
-                self._save_validation_content(save_file_name, self._cross_val_results_dir, dxo, fl_ctx)
-                self._val_results[client_name][model_owner] = os.path.join(self._cross_val_results_dir, save_file_name)
-
-                self.log_info(fl_ctx, f"Client {client_name} sent results for validating {model_owner} model.")
             except ValueError as e:
                 reason = (
-                    f"Unable to save validation result from {client_name} of {model_owner}'s model. "
+                    f"Bad validation result from {client_name} on model {model_owner}. "
                     f"Exception: {secure_format_exception(e)}"
                 )
                 self.log_exception(fl_ctx, reason)
+                return
 
-    def _save_validation_content(self, name: str, save_dir: str, dxo: DXO, fl_ctx: FLContext) -> str:
+            # The DXO could contain multiple sub-DXOs (e.g. received from a T2 system)
+            leaf_dxos, errors = get_leaf_dxos(dxo, client_name)
+            if errors:
+                for err in errors:
+                    self.log_error(fl_ctx, f"Bad result from {client_name}: {err}")
+            for k, v in leaf_dxos.items():
+                self._save_validation_result(k, model_owner, v, fl_ctx)
+
+    def _save_validation_result(self, client_name: str, model_name: str, dxo, fl_ctx):
+        file_name = client_name + "_" + model_name
+        file_path = self._save_dxo_content(file_name, self._cross_val_results_dir, dxo, fl_ctx)
+        client_results = self._val_results.get(client_name, None)
+        if not client_results:
+            client_results = {}
+            self._val_results[client_name] = client_results
+        client_results[model_name] = file_path
+        self.log_info(
+            fl_ctx, f"Saved validation result from client '{client_name}' on model '{model_name}' in {file_path}"
+        )
+
+    def _save_dxo_content(self, name: str, save_dir: str, dxo: DXO, fl_ctx: FLContext) -> str:
         """Saves shareable to given directory within the app_dir.
 
         Args:
@@ -474,9 +496,7 @@ class CrossSiteModelEval(Controller):
             with open(data_filename, "wb") as f:
                 f.write(bytes_to_save)
         except Exception as e:
-            raise ValueError(f"Unable to save shareable contents: {secure_format_exception(e)}")
-
-        self.log_debug(fl_ctx, f"Saved cross validation model with name: {name}.")
+            raise ValueError(f"Unable to save DXO content: {secure_format_exception(e)}")
 
         return data_filename
 


### PR DESCRIPTION
Update `CrossSiteModelEval` and `ValidationJsonGenerator` to support running x-site validation across two-tier systems. New cross-site validation file will look like so for a two-tier system with two FL subsystems (a: 1 client, b: 2 clients):

```
{
	"t1_client_b.site_b-2": {
		"SRV_server": {
			"accuracy": 6.532757427168795
		},
		"t1_client_b.site_b-1": {
			"accuracy": 6.352441674352294
		},
		"t1_client_b.site_b-2": {
			"accuracy": 6.449757971404188
		},
		"t1_client_a.site_a-1": {
			"accuracy": 6.154314397776378
		}
	},
	"t1_client_b.site_b-1": {
		"SRV_server": {
			"accuracy": 6.677408194925146
		},
		"t1_client_b.site_b-1": {
			"accuracy": 6.801406311216431
		},
		"t1_client_b.site_b-2": {
			"accuracy": 6.61654289819263
		},
		"t1_client_a.site_a-1": {
			"accuracy": 6.427272280826015
		}
	},
	"t1_client_a.site_a-1": {
		"SRV_server": {
			"accuracy": 6.798050466105188
		},
		"t1_client_b.site_b-1": {
			"accuracy": 6.385757488651174
		},
		"t1_client_b.site_b-2": {
			"accuracy": 6.229084115505082
		},
		"t1_client_a.site_a-1": {
			"accuracy": 6.385870448071407
		}
	}
}
```