### PR TITLE
Fix signing jobs in POC

### DIFF
--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -29,7 +29,15 @@ from nvflare.fuel.hci.table import Table
 from nvflare.fuel.utils.fsm import FSM, State
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
 
-from .api_spec import AdminAPISpec, CommandContext, CommandCtxKey, CommandInfo, ReplyProcessor, ServiceFinder
+from .api_spec import (
+    AdminAPISpec,
+    ApiPocValue,
+    CommandContext,
+    CommandCtxKey,
+    CommandInfo,
+    ReplyProcessor,
+    ServiceFinder,
+)
 from .api_status import APIStatus
 
 _CMD_TYPE_UNKNOWN = 0
@@ -365,7 +373,7 @@ class AdminAPI(AdminAPISpec):
 
         self.poc = poc
         if self.poc:
-            self.poc_key = "admin"
+            self.poc_key = ApiPocValue.ADMIN
         else:
             if len(ca_cert) <= 0:
                 raise Exception("missing CA Cert file name")

--- a/nvflare/fuel/hci/client/api_spec.py
+++ b/nvflare/fuel/hci/client/api_spec.py
@@ -77,6 +77,10 @@ class CommandContext(SimpleContext):
         return self.get_prop(CommandCtxKey.JSON_PROCESSOR)
 
 
+class ApiPocValue(object):
+    ADMIN = "admin"
+
+
 class CommandInfo(enum.Enum):
 
     OK = 0

--- a/nvflare/fuel/hci/client/file_transfer.py
+++ b/nvflare/fuel/hci/client/file_transfer.py
@@ -30,7 +30,7 @@ from nvflare.fuel.utils.zip_utils import split_path, unzip_all_from_bytes, zip_d
 from nvflare.lighter.utils import load_private_key_file, sign_folders
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
 
-from .api_spec import CommandContext, ReplyProcessor
+from .api_spec import ApiPocValue, CommandContext, ReplyProcessor
 from .api_status import APIStatus
 
 
@@ -325,9 +325,11 @@ class FileTransferModule(CommandModule):
 
         # sign folders and files
         api = ctx.get_api()
-        client_key_file_path = api.client_key
-        private_key = load_private_key_file(client_key_file_path)
-        sign_folders(full_path, private_key, api.client_cert)
+        if api.poc_key != ApiPocValue.ADMIN:
+            # we are not in POC mode
+            client_key_file_path = api.client_key
+            private_key = load_private_key_file(client_key_file_path)
+            sign_folders(full_path, private_key, api.client_cert)
 
         # zip the data
         data = zip_directory_to_bytes(self.upload_dir, folder_name)
@@ -336,7 +338,6 @@ class FileTransferModule(CommandModule):
         b64str = bytes_to_b64str(data)
         parts = [cmd_entry.full_command_name(), folder_name, b64str]
         command = join_args(parts)
-        api = ctx.get_api()
         return api.server_execute(command)
 
     def download_folder(self, args, ctx: CommandContext):

--- a/nvflare/private/fed/client/training_cmds.py
+++ b/nvflare/private/fed/client/training_cmds.py
@@ -15,6 +15,9 @@
 import json
 from typing import List
 
+from nvflare.apis.workspace import Workspace
+from nvflare.fuel.utils.argument_utils import parse_vars
+from nvflare.lighter.utils import verify_folder_signature
 from nvflare.private.admin_defs import Message, error_reply, ok_reply
 from nvflare.private.defs import RequestHeader, ScopeInfoKey, TrainingTopic
 from nvflare.private.fed.client.admin import RequestProcessor
@@ -118,6 +121,14 @@ class DeployProcessor(RequestProcessor):
         )
         if err:
             return error_reply(err)
+
+        kv_list = parse_vars(engine.args.set)
+        secure_train = kv_list.get("secure_train", True)
+        if secure_train:
+            workspace = Workspace(root_dir=engine.args.workspace, site_name=client_name)
+            app_path = workspace.get_app_dir(job_id)
+            if not verify_folder_signature(app_path):
+                return error_reply(f"app {app_name} does not pass signature verification")
         return ok_reply(body=f"deployed {app_name} to {client_name}")
 
 

--- a/nvflare/private/fed/utils/app_deployer.py
+++ b/nvflare/private/fed/utils/app_deployer.py
@@ -19,7 +19,6 @@ import shutil
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.utils.zip_utils import unzip_all_from_bytes
-from nvflare.lighter.utils import verify_folder_signature
 from nvflare.private.privacy_manager import PrivacyService
 from nvflare.security.logging import secure_format_exception
 
@@ -59,11 +58,6 @@ class AppDeployer(object):
                 os.makedirs(app_path)
 
             unzip_all_from_bytes(self.app_data, app_path)
-
-            verified = verify_folder_signature(app_path)
-
-            if not verified:
-                return "signature verification failed"
 
             with open(app_file, "wt") as f:
                 f.write(f"{self.app_name}")


### PR DESCRIPTION
This fix is for handling job signing in POC mode.  Basically, all jobs should not be signed and should not be verified in POC as there are no private keys/certificates.