### PR TITLE
Imporve type error in FedXGBHistogramExecutor

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based/executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based/executor.py
@@ -95,7 +95,6 @@ class FedXGBHistogramExecutor(FedXGBHistogramExecutorSpec, Executor, ABC):
             early_stopping_rounds=params.early_stopping_rounds,
             verbose_eval=params.verbose_eval,
             callbacks=[callback.EvaluationMonitor(rank=self.rank)],
-            obj="squared_log",
         )
 
         return bst


### PR DESCRIPTION
string `squared_log` will lead to type error.

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

Address https://github.com/NVIDIA/NVFlare/issues/1180