### PR TITLE
Improve XGBoost examples

### DIFF
--- a/examples/xgboost/histogram-based/requirements.txt
+++ b/examples/xgboost/histogram-based/requirements.txt
@@ -1,1 +1,2 @@
 xgboost==1.7.0rc1
+scikit-learn

--- a/examples/xgboost/histogram-based/run_experiment_centralized.sh
+++ b/examples/xgboost/histogram-based/run_experiment_centralized.sh
@@ -4,5 +4,6 @@ DATASET_PATH="$HOME/dataset/HIGGS.csv"
 if [ ! -f "${DATASET_PATH}" ]
 then
     echo "Please check if you saved HIGGS dataset in ${DATASET_PATH}"
+    exit 1
 fi
 python3 ../utils/baseline_centralized.py --num_parallel_tree 1 --train_in_one_session --data_path "${DATASET_PATH}"

--- a/examples/xgboost/utils/baseline_centralized.py
+++ b/examples/xgboost/utils/baseline_centralized.py
@@ -131,7 +131,10 @@ def main():
     start = time.time()
     if args.train_in_one_session:
         bst = xgb.train(
-            xgb_params, dmat_train, num_boost_round=num_rounds, evals=[(dmat_valid, "validate"), (dmat_train, "train")]
+            xgb_params,
+            dmat_train,
+            num_boost_round=num_rounds,
+            evals=[(dmat_valid, "validate"), (dmat_train, "train")]
         )
     else:
         bst = train_one_by_one(


### PR DESCRIPTION
1. scikit-learn is being used in centrailized case
2. exit code immediately if data path is not found
3. format code and make it easier to compare with federated learning case

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>