### PR TITLE
Always sync sticky automatically

### DIFF
--- a/nvflare/apis/fl_context.py
+++ b/nvflare/apis/fl_context.py
@@ -90,6 +90,9 @@ class FLContext(object):
                     f"{self._to_string(existing_mask)}, cannot change to {self._to_string(mask)}"
                 )
                 return False
+
+        if sticky:
+            self._sync_sticky()
         return True
 
     def get_prop(self, key, default=None):
@@ -156,7 +159,7 @@ class FLContext(object):
                 new_fl_ctx.props[k] = {"value": v["value"], "mask": v["mask"]}
         return new_fl_ctx
 
-    def sync_sticky(self):
+    def _sync_sticky(self):
         ctx_manager = self.get_prop(key=ReservedKey.MANAGER, default=None)
         if not ctx_manager:
             raise ValueError("FLContextManager does not exist.")

--- a/nvflare/app_common/pt/pt_file_model_persistor.py
+++ b/nvflare/app_common/pt/pt_file_model_persistor.py
@@ -166,8 +166,6 @@ class PTFileModelPersistor(ModelPersistor):
             )
             return
 
-        fl_ctx.sync_sticky()
-
     def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
         """Convert initialised model into Learnable/Model format.
 

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -257,7 +257,6 @@ class ScatterAndGather(Controller):
                 self.fire_event(AppEventType.BEFORE_SHAREABLE_TO_LEARNABLE, fl_ctx)
                 self._global_weights = self.shareable_gen.shareable_to_learnable(aggr_result, fl_ctx)
                 fl_ctx.set_prop(AppConstants.GLOBAL_MODEL, self._global_weights, private=True, sticky=True)
-                fl_ctx.sync_sticky()
                 self.fire_event(AppEventType.AFTER_SHAREABLE_TO_LEARNABLE, fl_ctx)
 
                 if self._check_abort_signal(fl_ctx, abort_signal):

--- a/nvflare/app_common/workflows/scatter_and_gather_scaffold.py
+++ b/nvflare/app_common/workflows/scatter_and_gather_scaffold.py
@@ -198,7 +198,6 @@ class ScatterAndGatherScaffold(ScatterAndGather):
                 )
 
                 fl_ctx.set_prop(AppConstants.GLOBAL_MODEL, self._global_weights, private=True, sticky=True)
-                fl_ctx.sync_sticky()
                 self.fire_event(AppEventType.AFTER_SHAREABLE_TO_LEARNABLE, fl_ctx)
 
                 if self._check_abort_signal(fl_ctx, abort_signal):

--- a/nvflare/app_opt/xgboost/tree_based/model_persistor.py
+++ b/nvflare/app_opt/xgboost/tree_based/model_persistor.py
@@ -36,7 +36,6 @@ class XGBModelPersistor(ModelPersistor):
         self.save_path = os.path.join(self.log_dir, self.save_name)
         if not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir)
-        fl_ctx.sync_sticky()
 
     def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
         """Initialize and load the Model.

--- a/tests/integration_test/data/apps/cyclic/custom/tf2_model_persistor.py
+++ b/tests/integration_test/data/apps/cyclic/custom/tf2_model_persistor.py
@@ -69,8 +69,6 @@ class TF2ModelPersistor(ModelPersistor):
         if not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir)
 
-        fl_ctx.sync_sticky()
-
     def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
         """Initializes and loads the Model.
 


### PR DESCRIPTION
Always call sync_sticky() when adding a sticky property to fl_ctx.

Avoids racing conditions where other components want to access a sticky property that hasn't synced yet.