### PR TITLE
Allow easier import of SimulatorRunner

### DIFF
--- a/nvflare/__init__.py
+++ b/nvflare/__init__.py
@@ -15,3 +15,5 @@
 from . import _version
 
 __version__ = _version.get_versions()["version"]
+
+from nvflare.private.fed.app.simulator.simulator_runner import SimulatorRunner


### PR DESCRIPTION
Currently, we need to import SimulatorRunner using
```
from nvflare.private.fed.app.simulator.simulator_runner import SimulatorRunner
```

With this change, it should be possible to import via
```
from nvflare import SimulatorRunner
```