### PR TITLE
Add notebook with FLARE API to example [skip ci]

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -287,3 +287,49 @@ For this example run over 5 epochs, the training loss:
 Now that we've explored an example application with the FL Simulator, we can look at what it takes to bring
 this type of application to a secure, distributed deployment in the :ref:`Real World Federated Learning <real_world_fl>`
 section.
+
+
+.. _setting_up_poc:
+
+Setting Up the Application Environment in POC Mode
+==================================================
+
+.. warning::
+
+    POC mode is not intended to be secure and should not be run in any type of production environment or any environment
+    where the server's ports are exposed. For actual deployment and even development, it is recommended to use a
+    :ref:`secure provisioned setup <provisioned_setup>` or :ref:`starting_fl_simulator`.
+
+To get started with a proof of concept (POC) setup after :ref:`installation`, run this command to generate a poc folder
+with an overseer, server, two clients, and one admin client:
+
+.. code-block:: shell
+
+    $ nvflare poc --prepare -n 2
+
+For more details, see :ref:`poc_command`.
+
+.. _starting_poc:
+
+Starting the Application Environment in POC Mode
+================================================
+
+Once you are ready to start the FL system, you can run the following command
+to start the server and client systems and an admin console:
+
+.. code-block::
+
+  nvflare poc --start
+
+To start the server and client systems without an admin console:
+
+.. code-block::
+
+  nvflare poc --start -ex admin
+
+For more details, see :ref:`poc_command`.
+
+.. tip::
+
+   For anything more than the most basic proof of concept examples, it is recommended that you use a
+   :ref:`secure provisioned setup <provisioned_setup>`.

--- a/docs/real_world_fl/FLAdminAPI.rst
+++ b/docs/real_world_fl/FLAdminAPI.rst
@@ -3,7 +3,10 @@ FLAdminAPI
 
 :class:`FLAdminAPI<nvflare.fuel.hci.client.fl_admin_api.FLAdminAPI>` is a wrapper for admin commands that can be issued
 by an admin client to the FL server. You can use a provisioned admin client's certs and keys to initialize an instance
-of FLAdminAPI to programmatically submit commands to the FL server. :ref:`flare_api` is the redesigned version of this.
+of FLAdminAPI to programmatically submit commands to the FL server.
+
+As of version 2.3.0, FLAdminAPI will continue to exist as is, but :ref:`flare_api` is a redesigned version of this
+intended to provide a better user experience, so it is recommended to use :ref:`flare_api` instead.
 
 Initialization
 --------------

--- a/docs/real_world_fl/operation.rst
+++ b/docs/real_world_fl/operation.rst
@@ -74,4 +74,11 @@ commands shown as examples of how they may be run with a description.
    whitespace before the filename. For example, you may run ``sys_info server >serverinfo.txt``. To only save the
    file output without printing it, use two greater-than symbols ">>" instead: ``sys_info server >>serverinfo.txt``.
 
-.. include:: FLAdminAPI.rst
+The FLARE API is the redesigned FLAdminAPI with a better user experience introduced in version 2.3.0. If you do not have
+existing code using the FLAdminAPI, it is recommended to just use the FLARE API.
+
+.. toctree::
+   :maxdepth: 1
+
+   FLAdminAPI
+   flare_api

--- a/examples/hello-numpy-sag/hello_numpy_sag.ipynb
+++ b/examples/hello-numpy-sag/hello_numpy_sag.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e129ede5",
+   "metadata": {},
+   "source": [
+    "   # Hello Numpy SAG"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9bf7e391",
+   "metadata": {},
+   "source": [
+    "In this notebook, Hello Numpy SAG is run with the FLARE API to execute commands for submitting the job and following along to see the progress."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "bbca0050",
+   "metadata": {},
+   "source": [
+    "### 1. Install NVIDIA FLARE\n",
+    "\n",
+    "Follow the [Installation](https://nvflare.readthedocs.io/en/main/getting_started.html#installation) instructions to set up an environment that has NVIDIA FLARE installed if you do not have one already. You will need an environment to run a provisioned FL system."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e5d7e675",
+   "metadata": {},
+   "source": [
+    "### 2. Provision and Start FL System\n",
+    "\n",
+    "In the rest of this example, we assume that 'nvflare provision' has been run in a workspace (set to '/workspace' below, but you can change this to the location you run provision from) to set up a project named `hello-example` with a server and two clients. Feel free to use an existing provisioned NVFLARE project if you have that available, or to try things out, you could set up and start a system in [POC mode](https://nvflare.readthedocs.io/en/main/getting_started.html#setting-up-the-application-environment-in-poc-mode).\n",
+    "\n",
+    "Use the 'start.sh' scripts to start the server and clients in seperate terminals to start the system."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "6fe3165d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### 3. Connect to the FL System with the FLARE API\n",
+    "\n",
+    "Use `new_secure_session()` to initiate a session connecting to the FL Server with the FLARE API. The necessary arguments are the username of the admin user you are using and the corresponding startup kit location (if you are using POC mode, you will need to use `new_insecure_session()` with the startup kit location as the only argument).\n",
+    "\n",
+    "In the code example below, we get the `admin_user_dir` by concatenating the workspace root with the default directories that are created if you provision a project with a given project name. You can change the values to what applies to your system if needed.\n",
+    "\n",
+    "Note that if debug mode is not enabled, there is no output after initiating a session successfully, so instead we print the output of `get_system_info()`. If you are unable to connect and initiate a session, make sure that your FL Server is running and that the configurations are correct with the right path to the admin startup kit directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "c3dbde69",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SystemInfo\n",
+      "  server_info: status: stopped, start_time: Tue Jan 17 21:38:18 2023\n",
+      "  client_info: \n",
+      "site_a(last_connect_time: Wed Jan 18 17:46:19 2023)\n",
+      "site_b(last_connect_time: Wed Jan 18 17:46:22 2023)\n",
+      "  job_info: \n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from nvflare.fuel.flare_api.flare_api import new_secure_session\n",
+    "\n",
+    "project_name = \"hello-example\"\n",
+    "username = \"admin@nvidia.com\"\n",
+    "workspace_root = \"/workspace\"\n",
+    "admin_user_dir = os.path.join(workspace_root, \"workspace\", project_name, \"prod_00\", username)\n",
+    "\n",
+    "sess = new_secure_session(\n",
+    "    username=username,\n",
+    "    startup_kit_location=admin_user_dir\n",
+    ")\n",
+    "print(sess.get_system_info())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "405edb37",
+   "metadata": {},
+   "source": [
+    "### 4. Submit the Job with the FLARE API\n",
+    "\n",
+    "With a session successfully connected, you can use `submit_job()` to submit your job. You can change `path_to_example_job` to the location of the job you are submitting. If your session is not active, go back to the previous step and connect with a session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "c8f08cef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a20aadea-1ca2-4134-bf10-594e7d4a3f7e was submitted\n"
+     ]
+    }
+   ],
+   "source": [
+    "path_to_example_job = \"/workspace/NVFlare/examples/hello-numpy-sag\"\n",
+    "job_id = sess.submit_job(path_to_example_job)\n",
+    "print(job_id + \" was submitted\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "42317cf3",
+   "metadata": {},
+   "source": [
+    "### 5. After Submitting the Job\n",
+    "\n",
+    "You should be able to see the output in the terminals where you are running your FL Server and Clients when you submitted the job. You can also use `monitor_job()` to follow along and give you updates on the progress until the job is done.\n",
+    "\n",
+    "By default, `monitor_job()` only has one required arguement, the `job_id` of the job you are waiting for, and the default behavior is to wait until the job is complete before returning a Return Code of `JOB_FINISHED`.\n",
+    "\n",
+    "In order to follow along and see a more meaningful result, the following cell contains a `sample_cb()` callback that keeps track of the number of times the callback is run and prints the `job_meta` the first three times and the final time before `monitor_job()` completes with every other call just printing a dot to save output space. This callback is just an example of what can be done with additional arguments and the `job_meta` information of the job that is being monitored."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "03fd93d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'hello-numpy-sag', 'resource_spec': {}, 'min_clients': 2, 'deploy_map': {'app': ['@ALL']}, 'job_folder_name': 'hello-numpy-sag', 'submitter_name': 'super@a.org', 'submitter_org': 'org_a', 'submitter_role': 'project_admin', 'job_id': 'a20aadea-1ca2-4134-bf10-594e7d4a3f7e', 'submit_time': 1674074617.5951204, 'submit_time_iso': '2023-01-18T15:43:37.595120-05:00', 'start_time': '2023-01-18 15:43:39.186674', 'duration': 'N/A', 'status': 'RUNNING', 'job_deploy_detail': ['server: OK', 'site_a: OK', 'site_b: OK'], 'schedule_count': 1, 'last_schedule_time': 1674074618.1703234, 'schedule_history': ['2023-01-18 15:43:38: scheduled']}\n",
+      "{'count': 0}\n",
+      "{'name': 'hello-numpy-sag', 'resource_spec': {}, 'min_clients': 2, 'deploy_map': {'app': ['@ALL']}, 'job_folder_name': 'hello-numpy-sag', 'submitter_name': 'super@a.org', 'submitter_org': 'org_a', 'submitter_role': 'project_admin', 'job_id': 'a20aadea-1ca2-4134-bf10-594e7d4a3f7e', 'submit_time': 1674074617.5951204, 'submit_time_iso': '2023-01-18T15:43:37.595120-05:00', 'start_time': '2023-01-18 15:43:39.186674', 'duration': 'N/A', 'status': 'RUNNING', 'job_deploy_detail': ['server: OK', 'site_a: OK', 'site_b: OK'], 'schedule_count': 1, 'last_schedule_time': 1674074618.1703234, 'schedule_history': ['2023-01-18 15:43:38: scheduled']}\n",
+      "{'count': 1}\n",
+      "{'name': 'hello-numpy-sag', 'resource_spec': {}, 'min_clients': 2, 'deploy_map': {'app': ['@ALL']}, 'job_folder_name': 'hello-numpy-sag', 'submitter_name': 'super@a.org', 'submitter_org': 'org_a', 'submitter_role': 'project_admin', 'job_id': 'a20aadea-1ca2-4134-bf10-594e7d4a3f7e', 'submit_time': 1674074617.5951204, 'submit_time_iso': '2023-01-18T15:43:37.595120-05:00', 'start_time': '2023-01-18 15:43:39.186674', 'duration': 'N/A', 'status': 'RUNNING', 'job_deploy_detail': ['server: OK', 'site_a: OK', 'site_b: OK'], 'schedule_count': 1, 'last_schedule_time': 1674074618.1703234, 'schedule_history': ['2023-01-18 15:43:38: scheduled']}\n",
+      "{'count': 2}\n",
+      ".....................\n",
+      "{'name': 'hello-numpy-sag', 'resource_spec': {}, 'min_clients': 2, 'deploy_map': {'app': ['@ALL']}, 'job_folder_name': 'hello-numpy-sag', 'submitter_name': 'super@a.org', 'submitter_org': 'org_a', 'submitter_role': 'project_admin', 'job_id': 'a20aadea-1ca2-4134-bf10-594e7d4a3f7e', 'submit_time': 1674074617.5951204, 'submit_time_iso': '2023-01-18T15:43:37.595120-05:00', 'start_time': '2023-01-18 15:43:39.186674', 'duration': '0:00:47.512746', 'status': 'FINISHED:COMPLETED', 'job_deploy_detail': ['server: OK', 'site_a: OK', 'site_b: OK'], 'schedule_count': 1, 'last_schedule_time': 1674074618.1703234, 'schedule_history': ['2023-01-18 15:43:38: scheduled']}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<MonitorReturnCode.JOB_FINISHED: 0>"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from nvflare.fuel.flare_api.flare_api import Session\n",
+    "\n",
+    "def sample_cb(\n",
+    "        session: Session, job_id: str, job_meta, *cb_args, **cb_kwargs\n",
+    "    ) -> bool:\n",
+    "    if job_meta[\"status\"] == \"RUNNING\":\n",
+    "        if cb_kwargs[\"cb_run_counter\"][\"count\"] < 3:\n",
+    "            print(job_meta)\n",
+    "            print(cb_kwargs[\"cb_run_counter\"])\n",
+    "        else:\n",
+    "            print(\".\", end=\"\")\n",
+    "    else:\n",
+    "        print(\"\\n\" + str(job_meta))\n",
+    "    \n",
+    "    cb_kwargs[\"cb_run_counter\"][\"count\"] += 1\n",
+    "    return True\n",
+    "\n",
+    "sess.monitor_job(job_id, cb=sample_cb, cb_run_counter={\"count\":0})"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "31ccb6a6",
+   "metadata": {},
+   "source": [
+    "### 6. Shutting Down the FL System\n",
+    "\n",
+    "As of now, there is no specific FLARE API command for shutting down the FL system, but the FLARE API can use the `do_command()` function of the underlying AdminAPI to submit any commands that the FLARE Console supports including shutdown commands to the clients and server:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "b0d8aa9c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'status': <APIStatus.ERROR_INACTIVE_SESSION: 'ERROR_INACTIVE_SESSION'>, 'details': 'Session is inactive, please try later'}\n",
+      "{'status': <APIStatus.ERROR_INACTIVE_SESSION: 'ERROR_INACTIVE_SESSION'>, 'details': 'Session is inactive, please try later'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sess.api.do_command(\"shutdown client\"))\n",
+    "print(sess.api.do_command(\"shutdown server\"))\n",
+    "\n",
+    "sess.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "local-venv",
+   "language": "python",
+   "name": "local-venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
For hello scatter and gather, this is a Jupyter notebook using the new FLARE API to run the example. We can copy and modify the app name for other examples if this looks good and we want to include notebooks for those as well.

Also, add back the setting up and starting poc to the getting started page so the previous links work and the information is available.