### PR TITLE
Imporve type error in FedXGBHistogramExecutor (#1179)

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based/executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based/executor.py
@@ -95,7 +95,6 @@ class FedXGBHistogramExecutor(FedXGBHistogramExecutorSpec, Executor, ABC):
             early_stopping_rounds=params.early_stopping_rounds,
             verbose_eval=params.verbose_eval,
             callbacks=[callback.EvaluationMonitor(rank=self.rank)],
-            obj="squared_log",
         )
 
         return bst


### PR DESCRIPTION
string `squared_log` will lead to type error.

This issue is originally fixed in dev branch by https://github.com/NVIDIA/NVFlare/pull/1179. This PR is intended to patch 2.2 branch

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>
Co-authored-by: Yuan-Ting Hsieh (謝沅廷) <yuantingh@nvidia.com>
Co-authored-by: Chester Chen <512707+chesterxgchen@users.noreply.github.com>