### PR TITLE
Fixed the simulator could not stop due to controller failed to initia…

### DIFF
--- a/nvflare/private/fed/app/deployer/simulator_deployer.py
+++ b/nvflare/private/fed/app/deployer/simulator_deployer.py
@@ -70,9 +70,10 @@ class SimulatorDeployer(ServerDeployer):
 
         self._create_client_cell(client_config, client_name, federated_client)
 
-        client_engine = SimulatorParentClientEngine(client_name)
-        federated_client.set_client_engine(client_engine)
         federated_client.register()
+
+        client_engine = SimulatorParentClientEngine(federated_client, federated_client.token, args)
+        federated_client.set_client_engine(client_engine)
         # federated_client.start_heartbeat()
         federated_client.run_manager = None
 

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -337,7 +337,7 @@ class SimulatorRunner(FLComponent):
 
                 # Start the client heartbeat calls.
                 for client in self.federated_clients:
-                    client.start_heartbeat()
+                    client.start_heartbeat(interval=2)
 
                 if self.args.gpu:
                     gpus = self.args.gpu.split(",")

--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -347,7 +347,8 @@ class ProcessExecutor(ClientExecutor):
                         )
                         self.logger.debug("abort sent")
 
-                        threading.Thread(target=self._terminate_process, args=[child_process, job_id]).start()
+                        if child_process:
+                            threading.Thread(target=self._terminate_process, args=[child_process, job_id]).start()
                         self.run_processes.pop(job_id)
                         break
                     except Exception as e:

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -187,6 +187,7 @@ class Communicator:
             )
         else:
             task = None
+            self.logger.warning(f"Failed to get_task from {project_name} server. Will try it again.")
             time.sleep(5)
 
         return task
@@ -278,7 +279,8 @@ class Communicator:
 
         return server_message
 
-    def send_heartbeat(self, servers, task_name, token, ssid, client_name, engine: ClientEngineInternalSpec):
+    def send_heartbeat(self, servers, task_name, token, ssid, client_name, engine: ClientEngineInternalSpec, interval):
+        wait_times = int(interval / 2)
         while not self.heartbeat_done:
             try:
                 job_ids = engine.get_all_job_ids()
@@ -311,8 +313,7 @@ class Communicator:
                 except BaseException as ex:
                     raise FLCommunicationError("error:client_quit", ex)
 
-                # time.sleep(30)
-                for i in range(15):
+                for i in range(wait_times):
                     time.sleep(2)
                     if self.heartbeat_done:
                         break

--- a/nvflare/private/fed/simulator/simulator_client_engine.py
+++ b/nvflare/private/fed/simulator/simulator_client_engine.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvflare.apis.fl_context import FLContextManager
+from nvflare.apis.fl_constant import RunProcessKey
 from nvflare.private.fed.client.client_engine import ClientEngine
+from nvflare.private.fed.client.client_status import ClientStatus
 from nvflare.private.fed.simulator.simulator_const import SimulatorConstants
 
 
@@ -23,10 +24,15 @@ class SimulatorClientEngine(ClientEngine):
 
 
 class SimulatorParentClientEngine(ClientEngine):
-    def __init__(self, client_name):
-        self.fl_ctx_mgr = FLContextManager(
-            engine=self, identity_name=client_name, job_id="", public_stickers={}, private_stickers={}
-        )
+    def __init__(self, client, client_token, args, rank=0):
+        super().__init__(client, client_token, args, rank)
+
+        self.client_executor.run_processes[SimulatorConstants.JOB_NAME] = {
+            RunProcessKey.LISTEN_PORT: None,
+            RunProcessKey.CONNECTION: None,
+            RunProcessKey.CHILD_PROCESS: None,
+            RunProcessKey.STATUS: ClientStatus.STARTED,
+        }
 
     def get_all_job_ids(self):
         return [SimulatorConstants.JOB_NAME]


### PR DESCRIPTION
Fixed the simulator could not stop due to controller failed to initialize issue.

### Description

Because the controller failed to start due to initialization error, the server job cell could not start. Client running job need to make use of the heartbeat call sync up process to terminate the client job run.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
