### PR TITLE
Wait for all the clients to shutdown first before shutdown server for simulator

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -402,6 +402,12 @@ class SimulatorRunner(FLComponent):
             workspace, self.services, self.args, app_server_root, self.args.job_id, snapshot, self.logger
         )
 
+        start = time.time()
+        while self.services.engine.client_manager.clients:
+            # Wait for the clients to shutdown and quite first.
+            time.sleep(0.1)
+            if time.time() - start > 30.:
+                break
         self.services.close()
 
 

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -234,7 +234,8 @@ class HandleDeadJobCommand(CommandProcessor):
         """
         client_name = data.get_header(ServerCommandKey.FL_CLIENT)
         server_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
-        server_runner.handle_dead_job(client_name, fl_ctx)
+        if server_runner:
+            server_runner.handle_dead_job(client_name, fl_ctx)
         return ""
 
 

--- a/nvflare/private/fed/simulator/simulator_server.py
+++ b/nvflare/private/fed/simulator/simulator_server.py
@@ -144,4 +144,4 @@ class SimulatorServer(FederatedServer):
     def stop_run_engine_cell(self):
         self.engine.ask_to_stop()
         self.job_cell.stop()
-        super().stop_run_engine_cell()
+        # super().stop_run_engine_cell()


### PR DESCRIPTION

Fixes # .

Fixed the issue the simulator could not shutdown when the controller failed before client start.

### Description

For simulator wait for all the clients shutdown first, then shutdown the server. otherwise, the client heartbeat could not reach the server.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
