### PR TITLE
Fixed the job status update and abort_job command.

### DIFF
--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -123,6 +123,7 @@ def main():
 
     app_root = workspace.get_app_dir(str(args.job_id))
 
+    logger = None
     try:
         # start parent process checking thread
         thread = threading.Thread(target=check_parent_alive, args=(parent_pid, stop_event))
@@ -156,8 +157,8 @@ def main():
         client_app_runner.start_run(app_root, args, config_folder, federated_client, secure_train)
 
     except BaseException as e:
-        logger = logging.getLogger("worker_process")
-        logger.error(f"FL client execution exception: {secure_format_exception(e)}")
+        if logger:
+            logger.error(f"FL client execution exception: {secure_format_exception(e)}")
         raise e
     finally:
         stop_event.set()

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -192,9 +192,16 @@ class Communicator:
                 f" ({size} Bytes). getTask: {task_name} time: {end_time - start_time} seconds"
             )
         else:
-            task = None
-            self.logger.warning(f"Failed to get_task from {project_name} server. Will try it again.")
-            time.sleep(5)
+            simulate_mode = fl_ctx.get_prop(FLContextKey.SIMULATE_MODE, False)
+            if simulate_mode:
+                new_shareable = Shareable()
+                new_shareable.set_header(key=ServerCommandKey.TASK_NAME, value=SpecialTaskName.END_RUN)
+                task.payload = new_shareable
+                self.logger.info("Simulator job could not fetch_task. End job run.")
+            else:
+                task = None
+                self.logger.warning(f"Failed to get_task from {project_name} server. Will try it again.")
+                time.sleep(5)
 
         return task
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -630,8 +630,9 @@ class FederatedServer(BaseServer):
         self.engine.engine_info.status = MachineStatus.STOPPED
 
     def stop_run_engine_cell(self):
-        self.cell.stop()
+        # self.cell.stop()
         # mpm.stop()
+        pass
 
     def deploy(self, args, grpc_args=None, secure_train=False):
         super().deploy(args, grpc_args, secure_train)

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -522,7 +522,8 @@ class ServerEngine(ServerEngineInternalSpec):
             with self.new_context() as fl_ctx:
                 execution_error = fl_ctx.get_prop(FLContextKey.FATAL_SYSTEM_ERROR, False)
                 data = {"execution_error": execution_error}
-                request = new_cell_message({}, fobs.dumps(data))
+                job_id = fl_ctx.get_job_id()
+                request = new_cell_message({CellMessageHeaderKeys.JOB_ID: job_id}, fobs.dumps(data))
                 return_data = self.server.cell.fire_and_forget(
                     targets=FQCN.ROOT_SERVER,
                     channel=CellChannel.SERVER_PARENT_LISTENER,


### PR DESCRIPTION
Fixes # .

Fixed the issue job status not updated properly with the MPM change.
Fixed the issue abort_job command hang with the MPM change.

### Description

Update the job status with proper complete, aborted and execution exception after the job complete.
Remove the improper cell.stop() to allow the abort_job command passed to the server job process.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
