### PR TITLE
Add support for AWS cloud launch scripts (dashboard/server/client)

### DIFF
--- a/nvflare/dashboard/application/__init__.py
+++ b/nvflare/dashboard/application/__init__.py
@@ -23,6 +23,7 @@ jwt = JWTManager()
 
 
 def init_app():
+    os.makedirs("/var/tmp/nvflare/dashboard", exist_ok=True)
     static_folder = os.environ.get("NVFL_DASHBOARD_STATIC_FOLDER", "static")
     app = Flask(__name__, static_url_path="", static_folder=static_folder)
     app.config.from_object("nvflare.dashboard.config.Config")
@@ -41,4 +42,6 @@ def init_app():
             email = credential.split(":")[0]
             pwd = credential.split(":")[1]
             Store.seed_user(email, pwd)
+    with open(os.path.join("/var/tmp/nvflare/dashboard", ".db_init_done"), "ab") as f:
+        f.write(bytes())
     return app

--- a/nvflare/dashboard/application/blob.py
+++ b/nvflare/dashboard/application/blob.py
@@ -154,6 +154,12 @@ def gen_server(key, first_server=True):
                 "t",
                 exe=True,
             )
+            _write(
+                os.path.join(dest_dir, get_csp_start_script_name("aws")),
+                utils.sh_replace(get_csp_template("aws", "svr", template), {"server_name": entity.name}),
+                "t",
+                exe=True,
+            )
         signatures = utils.sign_all(dest_dir, deserialize_ca_key(project.root_key))
         json.dump(signatures, open(os.path.join(dest_dir, "signature.json"), "wt"))
 
@@ -256,6 +262,12 @@ def gen_client(key, id):
         _write(
             os.path.join(dest_dir, get_csp_start_script_name("azure")),
             get_csp_template("azure", "cln", template),
+            "t",
+            exe=True,
+        )
+        _write(
+            os.path.join(dest_dir, get_csp_start_script_name("aws")),
+            get_csp_template("aws", "cln", template),
             "t",
             exe=True,
         )

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -43,7 +43,7 @@ def start(args):
         environment["NVFL_DASHBOARD_PP"] = passphrase
     if args.cred:
         environment.update({"NVFL_CREDENTIAL": args.cred})
-    elif not os.path.exists(os.path.join(folder, "db.sqlite")):
+    elif not os.path.exists(os.path.join(folder, ".db_init_done")):
         need_email = True
         while need_email:
             answer = input(
@@ -121,9 +121,6 @@ def cloud(args):
     template = utils.load_yaml(os.path.join(lighter_folder, "impl", "master_template.yml"))
     cwd = os.getcwd()
     csp = args.cloud
-    if csp not in supported_csp:
-        print(f"Currently support either azure or aws, but {csp} is requested.")
-        exit(1)
     dest = os.path.join(cwd, f"{csp}_start_dsb.sh")
     _write(
         dest,
@@ -171,14 +168,20 @@ def define_dashboard_parser(parser):
 
 
 def handle_dashboard(args):
+    support_csp_string = ", ".join(supported_csp)
     if args.stop:
         stop()
     elif args.start:
         start(args)
-    elif args.cloud in supported_csp:
-        cloud(args)
+    elif args.cloud:
+        if args.cloud in supported_csp:
+            cloud(args)
+        else:
+            print(
+                f"Currently --cloud support the following options: {support_csp_string}.  However, {args.cloud} is requested."
+            )
     else:
-        print("Add -h option to see usage")
+        print("Please use -h option to see usage")
 
 
 if __name__ == "__main__":

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -23,6 +23,8 @@ from nvflare.apis.utils.format_check import name_check
 from nvflare.dashboard.application.blob import _write
 from nvflare.lighter import utils
 
+supported_csp = ("azure", "aws")
+
 
 def start(args):
     cwd = os.getcwd()
@@ -39,7 +41,9 @@ def start(args):
     passphrase = args.passphrase
     if passphrase:
         environment["NVFL_DASHBOARD_PP"] = passphrase
-    if not os.path.exists(os.path.join(folder, "db.sqlite")):
+    if args.cred:
+        environment.update({"NVFL_CREDENTIAL": args.cred})
+    elif not os.path.exists(os.path.join(folder, "db.sqlite")):
         need_email = True
         while need_email:
             answer = input(
@@ -117,7 +121,10 @@ def cloud(args):
     template = utils.load_yaml(os.path.join(lighter_folder, "impl", "master_template.yml"))
     cwd = os.getcwd()
     csp = args.cloud
-    dest = os.path.join(cwd, f"{csp}_start.sh")
+    if csp not in supported_csp:
+        print(f"Currently support either azure or aws, but {csp} is requested.")
+        exit(1)
+    dest = os.path.join(cwd, f"{csp}_start_dsb.sh")
     _write(
         dest,
         template[f"{csp}_start_dsb_sh"],
@@ -145,7 +152,10 @@ def main():
 
 def define_dashboard_parser(parser):
     parser.add_argument(
-        "--cloud", type=str, default="", help="launch dashboard on cloud service provider (ex: --cloud azure)"
+        "--cloud",
+        type=str,
+        default="",
+        help="launch dashboard on cloud service provider (ex: --cloud azure or --cloud aws)",
     )
     parser.add_argument("--start", action="store_true", help="start dashboard")
     parser.add_argument("--stop", action="store_true", help="stop dashboard")
@@ -157,18 +167,18 @@ def define_dashboard_parser(parser):
         "--passphrase", help="Passphrase to encrypt/decrypt root CA private key.  !!! Do not share it with others. !!!"
     )
     parser.add_argument("-e", "--env", action="append", help="additonal environment variables: var1=value1")
+    parser.add_argument("--cred", help="set credential directly in the form of USER_EMAIL:PASSWORD")
 
 
 def handle_dashboard(args):
-    if has_no_arguments():
-        print("Add -h option to see usage")
-        exit(0)
     if args.stop:
         stop()
     elif args.start:
         start(args)
-    elif args.cloud == "azure":
+    elif args.cloud in supported_csp:
         cloud(args)
+    else:
+        print("Add -h option to see usage")
 
 
 if __name__ == "__main__":

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -397,8 +397,11 @@ start_cln_sh: |
       azure)
         $DIR/azure_start.sh ${all_arguments}
         ;;
+      aws)
+        $DIR/aws_start.sh ${all_arguments}
+        ;;
       *)
-        echo "Only on-prem or Azure is currently supported."
+        echo "Only on-prem or azure or aws is currently supported."
     esac
   else
     $DIR/sub_start.sh &
@@ -436,8 +439,11 @@ start_svr_sh: |
       azure)
         $DIR/azure_start.sh ${all_arguments}
         ;;
+      aws)
+        $DIR/aws_start.sh ${all_arguments}
+        ;;
       *)
-        echo "Only on-prem or Azure is currently supported."
+        echo "Only on-prem or azure or aws is currently supported."
     esac
   else
     $DIR/sub_start.sh &
@@ -1551,3 +1557,399 @@ adm_notebook: |
   "nbformat": 4,
   "nbformat_minor": 5
   }
+
+aws_start_svr_sh: |
+  #!/usr/bin/env bash
+
+  set +e
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  cd $DIR/..
+
+  function report_status() {
+    status="$1"
+    if [ "${status}" -ne 0 ]
+    then
+      echo "$2 failed"
+      exit "${status}"
+    fi
+  }
+
+  function check_binary() {
+    echo -n "Checking if $1 exists. => "
+    if ! command -v $1 &> /dev/null
+    then
+      echo "not found. $2"
+      exit 1
+    else
+      echo "found"
+    fi
+  }
+
+  function prompt() {
+    local __default="$1"
+    read -p "$2" ans
+    if [[ ! -z "$ans" ]]
+    then
+      eval $__default="'$ans'"
+    fi
+  }
+
+  # parse arguments
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --config)
+        config_file=$2
+        shift
+      ;;
+    esac
+    shift
+  done
+
+  VM_NAME=nvflare_server
+  AMI_IMAGE=ami-04bad3c587fe60d89
+  EC2_TYPE=t2.small
+  SECURITY_GROUP=nvflare_server_sg
+  DEST_FOLDER=/var/tmp/cloud
+  REGION=us-west-2
+  KEY_PAIR=NVFlareServerKeyPair
+  KEY_FILE=${KEY_PAIR}.pem
+
+  echo "This script requires aws (AWS CLI), sshpass and jq.  Now checking if they are installed."
+
+  check_binary aws "Please see https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html on how to install it on your system."
+  check_binary sshpass "Please install it first."
+  check_binary jq "Please install it first."
+
+  while true
+  do
+    prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
+    prompt EC2_TYPE "Cloud EC2 type, press ENTER to accept default ${EC2_TYPE}: "
+    prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
+    if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
+    then
+      break
+    fi
+  done
+
+  echo "If the server requires additional dependencies, please copy the requirements.txt to ${DIR}."
+  prompt ans "Press ENTER when it's done or no additional dependencies. "
+
+  # Generate key pair
+
+  echo "Generating key pair for VM"
+
+  aws ec2 delete-key-pair --key-name $KEY_PAIR > /dev/null 2>&1
+  rm -rf $KEY_FILE
+  aws ec2 create-key-pair --key-name $KEY_PAIR --query 'KeyMaterial' --output text > $KEY_FILE
+  chmod 400 $KEY_FILE
+
+  # Generate Security Group
+
+  aws ec2 delete-security-group --group-name $SECURITY_GROUP > /dev/null 2>&1
+  sleep 10
+  sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
+  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 8002-8003 --cidr 0.0.0.0/0 >> /tmp/sec_grp.log
+
+  # Start provisioning
+
+  echo "Creating VM at region $REGION, may take a few minutes."
+
+  aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id > vm_create.json
+  instance_id=$(jq -r .Instances[0].InstanceId vm_create.json)
+
+  aws ec2 wait instance-status-ok --instance-ids $instance_id
+  aws ec2 describe-instances --instance-ids $instance_id > vm_result.json
+
+  IP_ADDRESS=$(jq -r .Reservations[0].Instances[0].PublicIpAddress vm_result.json)
+
+  echo "VM created with IP address: ${IP_ADDRESS}"
+
+  echo "Copying files to $VM_NAME"
+  DEST_SITE=ubuntu@${IP_ADDRESS}
+  DEST=${DEST_SITE}:${DEST_FOLDER}
+  echo "Destination folder is ${DEST}"
+  scp -q -i $KEY_FILE -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $PWD $DEST
+  report_status "$?" "copying startup kits to VM"
+
+  echo "Installing packages in $VM_NAME, may take a few minutes."
+
+  ssh -f -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+  "pwd && wget -q https://bootstrap.pypa.io/get-pip.py && \
+  python3 get-pip.py && python3 -m pip install nvflare && \
+  touch ${DEST_FOLDER}/startup/requirements.txt && \
+  python3 -m pip install -r ${DEST_FOLDER}/startup/requirements.txt && \
+  nohup ${DEST_FOLDER}/startup/start.sh && sleep 20 && \
+  exit" > /tmp/nvflare.log 2>&1 
+
+  report_status "$?" "installing packages"
+
+  echo "System was provisioned"
+
+aws_start_cln_sh: |
+  #!/usr/bin/env bash
+
+  set +e
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  cd $DIR/..
+
+  function report_status() {
+    status="$1"
+    if [ "${status}" -ne 0 ]
+    then
+      echo "$2 failed"
+      exit "${status}"
+    fi
+  }
+
+  function check_binary() {
+    echo -n "Checking if $1 exists. => "
+    if ! command -v $1 &> /dev/null
+    then
+      echo "not found. $2"
+      exit 1
+    else
+      echo "found"
+    fi
+  }
+
+  function prompt() {
+    local __default="$1"
+    read -p "$2" ans
+    if [[ ! -z "$ans" ]]
+    then
+      eval $__default="'$ans'"
+    fi
+  }
+
+  # parse arguments
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --config)
+        config_file=$2
+        shift
+      ;;
+    esac
+    shift
+  done
+
+  VM_NAME=nvflare_client
+  AMI_IMAGE=ami-04bad3c587fe60d89
+  EC2_TYPE=t2.small
+  SECURITY_GROUP=nvflare_client_sg
+  DEST_FOLDER=/var/tmp/cloud
+  REGION=us-west-2
+  KEY_PAIR=NVFlareClientKeyPair
+  KEY_FILE=${KEY_PAIR}.pem
+
+  echo "This script requires aws (AWS CLI), sshpass and jq.  Now checking if they are installed."
+
+  check_binary aws "Please see https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html on how to install it on your system."
+  check_binary sshpass "Please install it first."
+  check_binary jq "Please install it first."
+
+  while true
+  do
+    prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
+    prompt EC2_TYPE "Cloud EC2 type, press ENTER to accept default ${EC2_TYPE}: "
+    prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
+    if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
+    then
+      break
+    fi
+  done
+
+  echo "If the client requires additional dependencies, please copy the requirements.txt to ${DIR}."
+  prompt ans "Press ENTER when it's done or no additional dependencies. "
+
+  # Generate key pair
+
+  echo "Generating key pair for VM"
+
+  aws ec2 delete-key-pair --key-name $KEY_PAIR > /dev/null 2>&1
+  rm -rf $KEY_FILE
+  aws ec2 create-key-pair --key-name $KEY_PAIR --query 'KeyMaterial' --output text > $KEY_FILE
+  chmod 400 $KEY_FILE
+
+  # Generate Security Group
+
+  aws ec2 delete-security-group --group-name $SECURITY_GROUP > /dev/null 2>&1
+  sleep 10
+  sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
+  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+
+  # Start provisioning
+
+  echo "Creating VM at region $REGION, may take a few minutes."
+
+  aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id > vm_create.json
+  instance_id=$(jq -r .Instances[0].InstanceId vm_create.json)
+
+  aws ec2 wait instance-status-ok --instance-ids $instance_id
+  aws ec2 describe-instances --instance-ids $instance_id > vm_result.json
+
+  IP_ADDRESS=$(jq -r .Reservations[0].Instances[0].PublicIpAddress vm_result.json)
+
+  echo "VM created with IP address: ${IP_ADDRESS}"
+
+  echo "Copying files to $VM_NAME"
+  DEST_SITE=ubuntu@${IP_ADDRESS}
+  DEST=${DEST_SITE}:${DEST_FOLDER}
+  echo "Destination folder is ${DEST}"
+  scp -q -i $KEY_FILE -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $PWD $DEST
+  report_status "$?" "copying startup kits to VM"
+
+  echo "Installing packages in $VM_NAME, may take a few minutes."
+
+  ssh -f -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+  "pwd && wget -q https://bootstrap.pypa.io/get-pip.py && \
+  python3 get-pip.py && python3 -m pip install nvflare && \
+  touch ${DEST_FOLDER}/startup/requirements.txt && \
+  python3 -m pip install -r ${DEST_FOLDER}/startup/requirements.txt && \
+  nohup ${DEST_FOLDER}/startup/start.sh && sleep 20 && \
+  exit" > /tmp/nvflare.log 2>&1 
+
+  report_status "$?" "installing packages"
+
+  echo "System was provisioned"
+
+aws_start_dsb_sh: |
+  #!/usr/bin/env bash
+
+  function report_status() {
+    status="$1"
+    if [ "${status}" -ne 0 ]
+    then
+      echo "$2 failed"
+      exit "${status}"
+    fi
+  }
+
+  function check_binary() {
+    echo -n "Checking if $1 exists. => "
+    if ! command -v $1 &> /dev/null
+    then
+      echo "not found $2"
+      exit 1
+    else
+      echo "found"
+    fi
+  }
+  
+  function prompt() {
+  local __default="$1"
+  read -p "$2" ans
+  if [[ ! -z "$ans" ]]
+  then
+    eval $__default="'$ans'"
+  fi
+  }
+
+  VM_NAME=nvflare_dashboard
+  AMI_IMAGE=ami-04bad3c587fe60d89
+  EC2_TYPE=t2.small
+  SECURITY_GROUP=nvflare_dashboard_sg
+  REGION=us-west-2
+  ADMIN_USERNAME=ubuntu
+  DEST_FOLDER=/home/${ADMIN_USERNAME}
+  KEY_PAIR=NVFlareDashboardKeyPair
+  KEY_FILE=${KEY_PAIR}.pem
+  
+  echo "This script requires aws (AWS CLI), sshpass and jq.  Now checking if they are installed."
+
+  check_binary aws "Please see https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html on how to install it on your system."
+  check_binary sshpass "Please install it first."
+  check_binary jq "Please install it first."
+
+  while true
+  do
+    prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
+    prompt EC2_TYPE "Cloud EC2 type, press ENTER to accept default ${EC2_TYPE}: "
+    prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
+    if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
+    then
+      break
+    fi
+  done
+
+
+  echo "One initial user will be created when starting dashboard."
+  echo "Please enter the email address for this user."
+  read email
+  credential="${email}:$RANDOM"
+
+  # Generate key pair
+
+  echo "Generating key pair for VM"
+
+  aws ec2 delete-key-pair --key-name $KEY_PAIR > /dev/null 2>&1
+  rm -rf $KEY_FILE
+  aws ec2 create-key-pair --key-name $KEY_PAIR --query 'KeyMaterial' --output text > $KEY_FILE
+  chmod 400 $KEY_FILE
+
+  # Generate Security Group
+
+  aws ec2 delete-security-group --group-name $SECURITY_GROUP > /dev/null 2>&1
+  sleep 10  
+  sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
+  echo "Security group id: ${sg_id}"
+  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 443 --cidr 0.0.0.0/0 >> /tmp/sec_grp.log
+
+  # Start provisioning
+
+  echo "Creating VM at region $REGION, may take a few minutes."
+
+  aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id > vm_create.json
+  instance_id=$(jq -r .Instances[0].InstanceId vm_create.json)
+
+  aws ec2 wait instance-status-ok --instance-ids $instance_id
+  aws ec2 describe-instances --instance-ids $instance_id > vm_result.json
+
+  IP_ADDRESS=$(jq -r .Reservations[0].Instances[0].PublicIpAddress vm_result.json)
+
+  echo "VM created with IP address: ${IP_ADDRESS}"
+
+  echo "Installing docker engine in $VM_NAME, may take a few minutes."
+  DEST_SITE=${ADMIN_USERNAME}@${IP_ADDRESS}
+  ssh -t -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    "sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
+    sudo mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io && \
+    sudo usermod -aG docker $ADMIN_USERNAME && exit" > /tmp/docker_engine.log
+  report_status "$?" "installing docker engine"
+
+  echo "Installing nvflare in $VM_NAME, may take a few minutes."
+  ssh -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    "export PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin && \
+    wget -q https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && \
+    python3 -m pip install nvflare && \
+    mkdir -p ./cert && \
+    exit" > /tmp/nvflare.json
+  report_status "$?" "installing nvflare"
+
+  echo "Checking if certificate (web.crt) and private key (web.key) are available"
+  if [[ -f "web.crt" && -f "web.key" ]]; then
+    CERT_FOLDER=${DEST_SITE}:${DEST_FOLDER}/cert
+    echo "Cert folder is ${CERT_FOLDER}"
+    scp -i $KEY_FILE -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null web.{crt,key} $CERT_FOLDER
+    report_status "$?" "copying cert/key to VM ${CERT_FOLDER} folder"
+  else
+    echo "No web.crt and web.key found"
+  fi
+
+  echo "Starting dashboard"
+  ssh -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    "export PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin && \
+    python3 -m nvflare.dashboard.cli --start -f ${DEST_FOLDER} --cred ${credential}" > /tmp/dashboard.json
+
+  echo "Dashboard running at IP adress ${IP_ADDRESS}, listening to port 443."
+  echo "Project admin credential (username:password) is ${credential} ."


### PR DESCRIPTION
### Description

This PR enables generating AWS cloud scripts for dashboard, server and client.
The command for all of them is similar to azure, just replace azure with aws on the --cloud option.
For example, to launch a server in AWS, type ./start.sh --cloud aws

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
