### PR TITLE
Add warnings to ModuleScanner

### DIFF
--- a/nvflare/app_common/pt/__init__.py
+++ b/nvflare/app_common/pt/__init__.py
@@ -11,9 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import warnings
-
-warnings.warn(
-    f"This module: {__file__} is deprecated. Please use nvflare.app_opt.pt.", category=FutureWarning, stacklevel=2
-)

--- a/nvflare/fuel/utils/class_utils.py
+++ b/nvflare/fuel/utils/class_utils.py
@@ -20,6 +20,8 @@ from typing import List
 
 from nvflare.security.logging import secure_format_exception
 
+DEPRECATED_PACKAGES = ["nvflare.app_common.pt"]
+
 
 def get_class(class_path):
     module_name, class_name = class_path.rsplit(".", 1)
@@ -81,6 +83,8 @@ class ModuleScanner:
 
             for module_info in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + "."):
                 module_name = module_info.name
+                if any(module_name.startswith(deprecated_package) for deprecated_package in DEPRECATED_PACKAGES):
+                    continue
                 if module_name.startswith(base):
                     if not self.exclude_libs or (".libs" not in module_name):
                         if any(module_name.startswith(base + "." + name + ".") for name in self.module_names):

--- a/nvflare/fuel/utils/class_utils.py
+++ b/nvflare/fuel/utils/class_utils.py
@@ -14,6 +14,7 @@
 
 import importlib
 import inspect
+import logging
 import pkgutil
 from typing import List
 
@@ -57,17 +58,6 @@ def instantiate_class(class_path, init_params):
     return instance
 
 
-def get_object_method(obj, method_name):
-    op = getattr(obj, method_name, None)
-    if op is None or not callable(op):
-        return None
-    return op
-
-
-def get_instance_method(instance, method_name):
-    return get_object_method(instance, method_name)
-
-
 class ModuleScanner:
     def __init__(self, base_pkgs: List[str], module_names: List[str], exclude_libs=True):
         """Scanner to look for and load specified module names.
@@ -80,6 +70,8 @@ class ModuleScanner:
         self.base_pkgs = base_pkgs
         self.module_names = module_names
         self.exclude_libs = exclude_libs
+
+        self._logger = logging.getLogger(self.__class__.__name__)
         self._class_table = {}
         self._create_classes_table()
 
@@ -87,17 +79,25 @@ class ModuleScanner:
         for base in self.base_pkgs:
             package = importlib.import_module(base)
 
-            for importer, modname, ispkg in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + "."):
-
-                if modname.startswith(base):
-                    if not self.exclude_libs or (".libs" not in modname):
-                        if any(modname.startswith(base + "." + name + ".") for name in self.module_names):
+            for module_info in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + "."):
+                module_name = module_info.name
+                if module_name.startswith(base):
+                    if not self.exclude_libs or (".libs" not in module_name):
+                        if any(module_name.startswith(base + "." + name + ".") for name in self.module_names):
                             try:
-                                module = importlib.import_module(modname)
+                                module = importlib.import_module(module_name)
                                 for name, obj in inspect.getmembers(module):
-                                    if inspect.isclass(obj) and obj.__module__ == modname:
-                                        self._class_table[name] = modname
-                            except (ModuleNotFoundError, RuntimeError):
+                                    if (
+                                        not name.startswith("_")
+                                        and inspect.isclass(obj)
+                                        and obj.__module__ == module_name
+                                    ):
+                                        self._class_table[name] = module_name
+                            except (ModuleNotFoundError, RuntimeError) as e:
+                                self._logger.warning(
+                                    f"Try to import module {module_name}, but failed: {e}. "
+                                    f"Please ignore this if you are not using that file."
+                                )
                                 pass
 
     def get_module_name(self, class_name):

--- a/nvflare/fuel/utils/class_utils.py
+++ b/nvflare/fuel/utils/class_utils.py
@@ -96,7 +96,7 @@ class ModuleScanner:
                             except (ModuleNotFoundError, RuntimeError) as e:
                                 self._logger.warning(
                                     f"Try to import module {module_name}, but failed: {e}. "
-                                    f"Please ignore this if you are not using that file."
+                                    f"Please ignore this if you are not using files in module: {module_name}."
                                 )
                                 pass
 


### PR DESCRIPTION
### Description

If a file requires an optional dependencies, then during our configuration process, the ModuleScanner should not go silent.

- It would be good to inform the users what package are missing if they want to use that file.
- Also remove unused methods
- filter out deprecation package so it won't print unnecessary messages.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
