### PR TITLE
Fix validation transform bug

### DIFF
--- a/examples/advanced/prostate/prostate_2D/custom/learners/supervised_monai_prostate_learner.py
+++ b/examples/advanced/prostate/prostate_2D/custom/learners/supervised_monai_prostate_learner.py
@@ -168,7 +168,7 @@ class SupervisedMonaiProstateLearner(SupervisedLearner):
             )
             self.valid_dataset = Dataset(
                 data=valid_list,
-                transform=self.transform_valid,
+                transform=self.transform,
             )
 
         self.train_loader = DataLoader(


### PR DESCRIPTION
Fixes #1342.

### Description

Fix the missing validation transform for prostate 2D example when cache_ratio=0, it should be w/o "_valid"

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
