### PR TITLE
add install dependencies command argument and allow install dependencies [skip ci]

### DIFF
--- a/runtest.sh
+++ b/runtest.sh
@@ -226,7 +226,7 @@ function help() {
     echo "    -f | --fix-format             : auto fix style formats, import"
     echo "    -u | --unit-tests             : unit tests"
     echo "    -r | --test-report            : used with -u command, turn on unit test report flag. It has no effect without -u "
-    echo "    -p | --dependencies           : [re]install dependencies"
+    echo "    -p | --dependencies           : install dependencies"
     echo "    -c | --coverage               : used with -u command, turn on coverage flag,  It has no effect without -u "
     echo "    -d | --dry-run                : set dry run flag, print out command"
     echo "         --clean                  : clean py and other artifacts generated, clean flag to allow re-install dependencies"


### PR DESCRIPTION
Fixes # .

### Description
 1. Add CLI argument for runtest.sh to allow one only run install dependencies
 2. the runtest.sh try to avoid repeated dependency installation during test and add marker file in /tmp/.flare_deps_installed. If the  file exists, then the install dependencies will not run again. 
    Although this is good for some time, but newly add dependencies are not installed in the local machine ( unless you manually install them). 
    ./runtest.sh -p  will allow one remove the marker file if exists and install the dependencies 



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
