### PR TITLE
Ha fix

### DIFF
--- a/nvflare/private/fed/app/client/client_train.py
+++ b/nvflare/private/fed/app/client/client_train.py
@@ -121,7 +121,7 @@ def main():
             print("The client could not register to server. ")
             raise RuntimeError("Login failed.")
 
-        federated_client.start_heartbeat()
+        federated_client.start_heartbeat(interval=kv_list.get("heart_beat_interval", 10.))
 
         admin_agent = create_admin_agent(
             deployer.req_processors,

--- a/nvflare/private/fed/app/client/client_train.py
+++ b/nvflare/private/fed/app/client/client_train.py
@@ -121,7 +121,7 @@ def main():
             print("The client could not register to server. ")
             raise RuntimeError("Login failed.")
 
-        federated_client.start_heartbeat(interval=kv_list.get("heart_beat_interval", 10.))
+        federated_client.start_heartbeat(interval=kv_list.get("heart_beat_interval", 10.0))
 
         admin_agent = create_admin_agent(
             deployer.req_processors,

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -28,8 +28,8 @@ from nvflare.fuel.sec.audit import AuditService
 from nvflare.fuel.sec.security_content_service import SecurityContentService
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.private.defs import AppFolderConstants
-from nvflare.private.fed.app.utils import check_parent_alive
 from nvflare.private.fed.app.fl_conf import FLServerStarterConfiger
+from nvflare.private.fed.app.utils import check_parent_alive
 from nvflare.private.fed.server.server_app_runner import ServerAppRunner
 from nvflare.private.fed.utils.fed_utils import add_logfile_handler, fobs_initialize
 from nvflare.security.logging import secure_format_exception, secure_log_traceback

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -18,6 +18,7 @@ import argparse
 import logging
 import os
 import sys
+import threading
 
 from nvflare.apis.fl_constant import JobConstants
 from nvflare.apis.workspace import Workspace
@@ -27,6 +28,7 @@ from nvflare.fuel.sec.audit import AuditService
 from nvflare.fuel.sec.security_content_service import SecurityContentService
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.private.defs import AppFolderConstants
+from nvflare.private.fed.app.utils import check_parent_alive
 from nvflare.private.fed.app.fl_conf import FLServerStarterConfiger
 from nvflare.private.fed.server.server_app_runner import ServerAppRunner
 from nvflare.private.fed.utils.fed_utils import add_logfile_handler, fobs_initialize
@@ -62,12 +64,19 @@ def main():
     args.log_config = None
     args.snapshot = kv_list.get("restore_snapshot")
 
+    # get parent process id
+    parent_pid = os.getppid()
+    stop_event = threading.Event()
     workspace = Workspace(root_dir=args.workspace, site_name="server")
     app_custom_folder = workspace.get_client_custom_dir()
     if os.path.isdir(app_custom_folder):
         sys.path.append(app_custom_folder)
 
     try:
+        # start parent process checking thread
+        thread = threading.Thread(target=check_parent_alive, args=(parent_pid, stop_event))
+        thread.start()
+
         os.chdir(args.workspace)
         fobs_initialize()
 
@@ -121,6 +130,7 @@ def main():
         finally:
             if deployer:
                 deployer.close()
+            stop_event.set()
             AuditService.close()
 
     except ConfigError as e:

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -62,7 +62,7 @@ class Communicator:
         compression=None,
         cell: Cell = None,
         client_register_interval=2,
-        timeout=5.,
+        timeout=5.0,
     ):
         """To init the Communicator.
 
@@ -127,7 +127,7 @@ class Communicator:
                     channel=CellChannel.SERVER_MAIN,
                     topic=CellChannelTopic.Register,
                     request=login_message,
-                    timeout=self.timeout
+                    timeout=self.timeout,
                 )
                 return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
                 if return_code == ReturnCode.UNAUTHENTICATED:
@@ -177,8 +177,11 @@ class Communicator:
 
         fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
         task = self.cell.send_request(
-            target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=ServerCommandNames.GET_TASK, request=task_message,
-            timeout=self.timeout
+            target=fqcn,
+            channel=CellChannel.SERVER_COMMAND,
+            topic=ServerCommandNames.GET_TASK,
+            request=task_message,
+            timeout=self.timeout,
         )
         end_time = time.time()
         return_code = task.get_header(MessageHeaderKey.RETURN_CODE)
@@ -249,7 +252,7 @@ class Communicator:
             channel=CellChannel.SERVER_COMMAND,
             topic=ServerCommandNames.SUBMIT_UPDATE,
             request=task_message,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
         end_time = time.time()
         return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
@@ -285,7 +288,7 @@ class Communicator:
                 channel=CellChannel.SERVER_MAIN,
                 topic=CellChannelTopic.Quit,
                 request=quit_message,
-                timeout=self.timeout
+                timeout=self.timeout,
             )
             return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
             if return_code == ReturnCode.UNAUTHENTICATED:
@@ -321,7 +324,7 @@ class Communicator:
                         channel=CellChannel.SERVER_MAIN,
                         topic=CellChannelTopic.HEART_BEAT,
                         request=heartbeat_message,
-                        timeout=self.timeout
+                        timeout=self.timeout,
                     )
                     return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
                     if return_code == ReturnCode.UNAUTHENTICATED:

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -62,6 +62,7 @@ class Communicator:
         compression=None,
         cell: Cell = None,
         client_register_interval=2,
+        timeout=5.,
     ):
         """To init the Communicator.
 
@@ -81,6 +82,7 @@ class Communicator:
         self.client_state_processors = client_state_processors
         self.compression = compression
         self.client_register_interval = client_register_interval
+        self.timeout = timeout
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
@@ -125,6 +127,7 @@ class Communicator:
                     channel=CellChannel.SERVER_MAIN,
                     topic=CellChannelTopic.Register,
                     request=login_message,
+                    timeout=self.timeout
                 )
                 return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
                 if return_code == ReturnCode.UNAUTHENTICATED:
@@ -174,7 +177,8 @@ class Communicator:
 
         fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
         task = self.cell.send_request(
-            target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=ServerCommandNames.GET_TASK, request=task_message
+            target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=ServerCommandNames.GET_TASK, request=task_message,
+            timeout=self.timeout
         )
         end_time = time.time()
         return_code = task.get_header(MessageHeaderKey.RETURN_CODE)
@@ -245,6 +249,7 @@ class Communicator:
             channel=CellChannel.SERVER_COMMAND,
             topic=ServerCommandNames.SUBMIT_UPDATE,
             request=task_message,
+            timeout=self.timeout
         )
         end_time = time.time()
         return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
@@ -280,6 +285,7 @@ class Communicator:
                 channel=CellChannel.SERVER_MAIN,
                 topic=CellChannelTopic.Quit,
                 request=quit_message,
+                timeout=self.timeout
             )
             return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
             if return_code == ReturnCode.UNAUTHENTICATED:
@@ -315,6 +321,7 @@ class Communicator:
                         channel=CellChannel.SERVER_MAIN,
                         topic=CellChannelTopic.HEART_BEAT,
                         request=heartbeat_message,
+                        timeout=self.timeout
                     )
                     return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
                     if return_code == ReturnCode.UNAUTHENTICATED:

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -103,6 +103,7 @@ class FederatedClientBase:
             compression=compression,
             cell=cell,
             client_register_interval=client_args.get("client_register_interval", 2.0),
+            timeout=client_args.get("communication_timeout", 5.0),
         )
 
         self.secure_train = secure_train


### PR DESCRIPTION
Fixes # .

Fix the FCI integration HA server switch issue. (along with the underneath F3 communication layer change.)

### Description

Enable the HA server switch for the FCI APIs integration. 
Reasons for the HA failure:

- server job runner process not properly shutdown when the server parent process terminated.
- Client communication (pull_task and heartbeat, submit_result, )not properly timeout.
- Client cell connection to the dead server not properly dropped. (Fixed in https://github.com/NVIDIA/NVFlare/pull/1399) 
- Cellnet add another protection to ensure the cell connection drop. (https://github.com/NVIDIA/NVFlare/pull/1405)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
