### PR TITLE
Randomize azure client resource group

### DIFF
--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -1152,7 +1152,7 @@ azure_start_cln_sh: |
       shift
   done
 
-  RESOURCE_GROUP=nvflare_client_rg
+  RESOURCE_GROUP=nvflare_client_rg_${RANDOM}_${RANDOM}
   VM_NAME=nvflare_client
   VM_IMAGE=Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest
   VM_SIZE=Standard_B2ms


### PR DESCRIPTION
### Description

When launching multiple clients on Azure, the same resource name is used.  This PR randomizes the resource group name on client script so the issue can be avoided.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
