### PR TITLE
Hide cell cmds

### DIFF
--- a/nvflare/fuel/f3/cellnet/net_manager.py
+++ b/nvflare/fuel/f3/cellnet/net_manager.py
@@ -29,12 +29,11 @@ def _to_int(s: str):
 
 
 class NetManager(CommandModule):
-    def __init__(self, agent: NetAgent, for_test=False):
+    def __init__(self, agent: NetAgent, diagnose=False):
         self.agent = agent
-        self.for_test = for_test
+        self.diagnose = diagnose
 
     def get_spec(self) -> CommandModuleSpec:
-        visible = self.for_test
         return CommandModuleSpec(
             name="cellnet",
             cmd_specs=[
@@ -43,123 +42,123 @@ class NetManager(CommandModule):
                     description="get system cells info",
                     usage="cells",
                     handler_func=self._cmd_cells,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="route",
                     description="send message to a cell and show route",
                     usage="route to_cell [from_cell]",
                     handler_func=self._cmd_route,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="peers",
                     description="show connected peers of a cell",
                     usage="peers target_cell",
                     handler_func=self._cmd_peers,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="conns",
                     description="show connectors of a cell",
                     usage="conns target_cell",
                     handler_func=self._cmd_connectors,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="url_use",
                     description="show use of a url",
                     usage="url_use url",
                     handler_func=self._cmd_url_use,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="speed",
                     description="test communication speed between cells",
                     usage="speed from_fqcn to_fqcn [num_tries] [payload_size]",
                     handler_func=self._cmd_speed_test,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="stress",
                     description="stress test communication among cells",
                     usage="stress [num_tries] [timeout]",
                     handler_func=self._cmd_stress_test,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="bulk",
                     description="test bulk message processing",
                     usage="bulk",
                     handler_func=self._cmd_bulk_test,
-                    visible=visible,
-                    enabled=self.for_test,
+                    visible=self.diagnose,
+                    enabled=self.diagnose,
                 ),
                 CommandSpec(
                     name="change_root",
                     description="change to a new root server",
                     usage="change_root url",
                     handler_func=self._cmd_change_root,
-                    visible=visible,
-                    enabled=self.for_test,
+                    visible=self.diagnose,
+                    enabled=self.diagnose,
                 ),
                 CommandSpec(
                     name="msg_stats",
                     description="show request stats",
                     usage="msg_stats target [mode]",
                     handler_func=self._cmd_msg_stats,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="list_pools",
                     description="list stats pools",
                     usage="list_pools target",
                     handler_func=self._cmd_list_pools,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="show_pool",
                     description="show stats pool detail",
                     usage="show_pool target pool_name [mode]",
                     handler_func=self._cmd_show_pool,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="show_comm_config",
                     description="show communication config",
                     usage="show_comm_config target",
                     handler_func=self._cmd_show_comm_config,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="show_config_vars",
                     description="show all defined config var values",
                     usage="show_config_vars target",
                     handler_func=self._cmd_show_config_vars,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="process_info",
                     description="show process information",
                     usage="process_info target",
                     handler_func=self._cmd_process_info,
-                    visible=visible,
+                    visible=self.diagnose,
                 ),
                 CommandSpec(
                     name="stop_cell",
                     description="stop a cell and its children",
                     usage="stop_cell target",
                     handler_func=self._cmd_stop_cell,
-                    visible=visible,
-                    enabled=self.for_test,
+                    visible=self.diagnose,
+                    enabled=self.diagnose,
                 ),
                 CommandSpec(
                     name="stop_net",
                     description="stop the whole cellnet",
                     usage="stop_net",
                     handler_func=self._cmd_stop_net,
-                    visible=visible,
-                    enabled=self.for_test,
+                    visible=self.diagnose,
+                    enabled=self.diagnose,
                 ),
             ],
         )

--- a/nvflare/fuel/f3/cellnet/net_manager.py
+++ b/nvflare/fuel/f3/cellnet/net_manager.py
@@ -29,10 +29,12 @@ def _to_int(s: str):
 
 
 class NetManager(CommandModule):
-    def __init__(self, agent: NetAgent):
+    def __init__(self, agent: NetAgent, for_test=False):
         self.agent = agent
+        self.for_test = for_test
 
     def get_spec(self) -> CommandModuleSpec:
+        visible = self.for_test
         return CommandModuleSpec(
             name="cellnet",
             cmd_specs=[
@@ -41,119 +43,123 @@ class NetManager(CommandModule):
                     description="get system cells info",
                     usage="cells",
                     handler_func=self._cmd_cells,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="route",
                     description="send message to a cell and show route",
                     usage="route to_cell [from_cell]",
                     handler_func=self._cmd_route,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="peers",
                     description="show connected peers of a cell",
                     usage="peers target_cell",
                     handler_func=self._cmd_peers,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="conns",
                     description="show connectors of a cell",
                     usage="conns target_cell",
                     handler_func=self._cmd_connectors,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="url_use",
                     description="show use of a url",
                     usage="url_use url",
                     handler_func=self._cmd_url_use,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="speed",
                     description="test communication speed between cells",
                     usage="speed from_fqcn to_fqcn [num_tries] [payload_size]",
                     handler_func=self._cmd_speed_test,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="stress",
                     description="stress test communication among cells",
                     usage="stress [num_tries] [timeout]",
                     handler_func=self._cmd_stress_test,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="bulk",
                     description="test bulk message processing",
                     usage="bulk",
                     handler_func=self._cmd_bulk_test,
-                    visible=True,
+                    visible=visible,
+                    enabled=self.for_test,
                 ),
                 CommandSpec(
                     name="change_root",
                     description="change to a new root server",
                     usage="change_root url",
                     handler_func=self._cmd_change_root,
-                    visible=True,
+                    visible=visible,
+                    enabled=self.for_test,
                 ),
                 CommandSpec(
                     name="msg_stats",
                     description="show request stats",
                     usage="msg_stats target [mode]",
                     handler_func=self._cmd_msg_stats,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="list_pools",
                     description="list stats pools",
                     usage="list_pools target",
                     handler_func=self._cmd_list_pools,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="show_pool",
                     description="show stats pool detail",
                     usage="show_pool target pool_name [mode]",
                     handler_func=self._cmd_show_pool,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="show_comm_config",
                     description="show communication config",
                     usage="show_comm_config target",
                     handler_func=self._cmd_show_comm_config,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="show_config_vars",
                     description="show all defined config var values",
                     usage="show_config_vars target",
                     handler_func=self._cmd_show_config_vars,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="process_info",
                     description="show process information",
                     usage="process_info target",
                     handler_func=self._cmd_process_info,
-                    visible=True,
+                    visible=visible,
                 ),
                 CommandSpec(
                     name="stop_cell",
                     description="stop a cell and its children",
                     usage="stop_cell target",
                     handler_func=self._cmd_stop_cell,
-                    visible=True,
+                    visible=visible,
+                    enabled=self.for_test,
                 ),
                 CommandSpec(
                     name="stop_net",
                     description="stop the whole cellnet",
-                    usage="shutdown",
+                    usage="stop_net",
                     handler_func=self._cmd_stop_net,
-                    visible=True,
+                    visible=visible,
+                    enabled=self.for_test,
                 ),
             ],
         )

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -169,8 +169,11 @@ class _CmdListReplyProcessor(ReplyProcessor):
             usage = row[3]
             confirm = row[4]
             client_cmd = None
+            visible = True
             if len(row) > 5:
                 client_cmd = row[5]
+            if len(row) > 6:
+                visible = row[6].lower() in ["true", "yes"]
 
             # if confirm == 'auth' and not client.require_login:
             # the user is not authenticated - skip this command
@@ -182,7 +185,7 @@ class _CmdListReplyProcessor(ReplyProcessor):
                 usage=usage,
                 handler=None,
                 authz_func=None,
-                visible=True,
+                visible=visible,
                 confirm=confirm,
                 client_cmd=client_cmd,
                 map_client_cmd=True,

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -179,14 +179,14 @@ class AdminClient(cmd.Cmd):
     def emptyline(self):
         return
 
-    def _show_one_command(self, cmd_name, reg):
+    def _show_one_command(self, cmd_name, reg, show_invisible=False):
         entries = reg.get_command_entries(cmd_name)
         if len(entries) <= 0:
             self.write_string("Undefined command {}\n".format(cmd_name))
             return
 
         for e in entries:
-            if not e.visible:
+            if not e.visible and not show_invisible:
                 continue
 
             if len(e.scope.name) > 0:
@@ -237,7 +237,7 @@ class AdminClient(cmd.Cmd):
                 self.write_string("Server Commands")
                 self.write_string("---------------")
                 for cmd_name in server_cmds:
-                    self._show_one_command(cmd_name, self.api.server_cmd_reg)
+                    self._show_one_command(cmd_name, self.api.server_cmd_reg, show_invisible=True)
 
     def complete(self, text, state):
         results = [x + " " for x in self.api.all_cmds if x.startswith(text)] + [None]

--- a/nvflare/fuel/hci/server/builtin.py
+++ b/nvflare/fuel/hci/server/builtin.py
@@ -38,14 +38,7 @@ class BuiltInCmdModule(CommandModule):
                     usage="_commands",
                     handler_func=self.handle_list_commands,
                     visible=False,
-                ),
-                CommandSpec(
-                    name="echo",
-                    description="echo user input back to client",
-                    usage="echo args ...",
-                    handler_func=self.handle_echo,
-                    visible=False,
-                ),
+                )
             ],
         )
 
@@ -69,22 +62,20 @@ class BuiltInCmdModule(CommandModule):
 
     def handle_list_commands(self, conn: Connection, args: List[str]):
         if len(args) <= 1:
-            table = conn.append_table(["Scope", "Command", "Description", "Usage", "Confirm", "ClientCmd"])
+            table = conn.append_table(["Scope", "Command", "Description", "Usage", "Confirm", "ClientCmd", "Visible"])
 
             for scope_name in sorted(self.reg.scopes):
                 scope = self.reg.scopes[scope_name]
                 for cmd_name in sorted(scope.entries):
+                    assert isinstance(cmd_name, str)
                     e = scope.entries[cmd_name]
                     assert isinstance(e, CommandEntry)
-                    if e.visible:
-                        table.add_row([scope_name, cmd_name, e.desc, e.usage, e.confirm, e.client_cmd])
+                    if not cmd_name.startswith("_"):
+                        # NOTE: command name that starts with _ is internal command and should not be sent to client!
+                        table.add_row([scope_name, cmd_name, e.desc, e.usage, e.confirm, e.client_cmd, str(e.visible)])
         else:
             for cmd_name in args[1:]:
                 self._show_command(conn, cmd_name)
-
-    def handle_echo(self, conn: Connection, args: List[str]):
-        for a in args:
-            conn.append_string(a)
 
 
 def new_command_register_with_builtin_module(app_ctx):


### PR DESCRIPTION
F3/Cellnet introduces many new admin commands for testing and analyzing the cell performance of the cell network. However these commands are not ready to be publicized. This PR makes such commands invisible or disabled:
- If a command could cause interruptive changes to the system (e.g. stop_net, stop_cell, etc), it is disabled
- Otherwise the command is made invisible to end user. The command is still accessible to the user.

Changes are in the following areas:
- Admin server is changed to send invisible commands to the client with visibility info. Internal commands are not sent.
- Admin client hides invisible commands from the user, but they are available to the user if the user knows the command name.
- The NetManager (which implements these commands) can be used in "for_test" mode. In this mode, all commands are enabled and visible. This is only used for independent cellnet testing.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
