### PR TITLE
Avoid the simulator cell error after END_RUN.

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -444,16 +444,14 @@ class SimulatorClientRunner(FLComponent):
             self.logger.error(f"SimulatorClientRunner run error: {secure_format_exception(e)}")
         finally:
             for client in self.federated_clients:
-                # touch_file = os.path.join(client.app_client_root, "shutdown.fl")
-                # shutdown_client(client, touch_file)
+                threading.Thread(target=self._shutdown_client, args=[client]).start()
 
-                client.communicator.heartbeat_done = True
-                # time.sleep(3)
-                client.terminate()
-                client.status = ClientStatus.STOPPED
-
-                client.communicator.cell.stop()
-            # self.deployer.close()
+    def _shutdown_client(self, client):
+        client.communicator.heartbeat_done = True
+        time.sleep(3)
+        client.terminate()
+        client.status = ClientStatus.STOPPED
+        client.communicator.cell.stop()
 
     def run_client_thread(self, num_of_threads, gpu, lock, timeout=60):
         stop_run = False

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -164,14 +164,13 @@ class FederatedClientBase:
                 self.servers[project_name]["target"] = location
                 self.sp_established = True
 
+                scheme_location = scheme + "://" + location
                 if self.cell:
-                    # self.net_agent.close()
-                    # self.cell.stop()
-                    self.cell.change_server_root(scheme + "://" + location)
+                    self.cell.change_server_root(scheme_location)
                 else:
                     self._create_cell(location, scheme)
 
-                self.logger.info(f"Got the new primary SP: {scheme + location}")
+                self.logger.info(f"Got the new primary SP: {scheme_location}")
 
             if self.ssid and self.ssid != sp.service_session_id:
                 self.ssid = sp.service_session_id


### PR DESCRIPTION
Fixes # .

### Description

- To avoid the cell error at the END_RUN of simulator.
- fixed a minor display issue when client setup SP.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
