### PR TITLE
Fixed the simulator hang due to missing import.

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -449,7 +449,8 @@ class SimulatorClientRunner(FLComponent):
     def _shutdown_client(self, client):
         client.communicator.heartbeat_done = True
         time.sleep(3)
-        client.terminate()
+        # client.terminate()
+        client.close()
         client.status = ClientStatus.STOPPED
         client.communicator.cell.stop()
 

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -85,7 +85,8 @@ class ClientTaskWorker(FLComponent):
                 if client_runner.end_run_fired or client_runner.asked_to_stop:
                     stop_run = True
                     self.logger.info("End the Simulator run.")
-        except Exception:
+        except Exception as e:
+            self.logger.error(f"do_one_task execute exception: {e}")
             interval = 1.0
             stop_run = True
 

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -70,30 +70,35 @@ class ClientTaskWorker(FLComponent):
     def do_one_task(self, client):
         stop_run = False
         # Create the ClientRunManager and ClientRunner for the new client to run
-        if client.run_manager is None:
-            self.create_client_runner(client)
-            self.logger.info(f"Initialize ClientRunner for client: {client.client_name}")
-        with client.run_manager.new_context() as fl_ctx:
-            client_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
-            self.fire_event(EventType.SWAP_IN, fl_ctx)
+        try:
+            if client.run_manager is None:
+                self.create_client_runner(client)
+                self.logger.info(f"Initialize ClientRunner for client: {client.client_name}")
+            with client.run_manager.new_context() as fl_ctx:
+                client_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
+                self.fire_event(EventType.SWAP_IN, fl_ctx)
 
-            interval, task_processed = client_runner.fetch_and_run_one_task(fl_ctx)
-            self.logger.info(f"Finished one task run for client: {client.client_name}")
+                interval, task_processed = client_runner.fetch_and_run_one_task(fl_ctx)
+                self.logger.info(f"Finished one task run for client: {client.client_name}")
 
-            # if any client got the END_RUN event, stop the simulator run.
-            if client_runner.end_run_fired or client_runner.asked_to_stop:
-                stop_run = True
-                self.logger.info("End the Simulator run.")
+                # if any client got the END_RUN event, stop the simulator run.
+                if client_runner.end_run_fired or client_runner.asked_to_stop:
+                    stop_run = True
+                    self.logger.info("End the Simulator run.")
+        except Exception:
+            interval = 1.0
+            stop_run = True
 
         return interval, stop_run
 
     def release_resources(self, client):
-        with client.run_manager.new_context() as fl_ctx:
-            self.fire_event(EventType.SWAP_OUT, fl_ctx)
+        if client.run_manager:
+            with client.run_manager.new_context() as fl_ctx:
+                self.fire_event(EventType.SWAP_OUT, fl_ctx)
 
-            # client.run_manager.aux_runner.abort_signal.trigger("True")
+                # client.run_manager.aux_runner.abort_signal.trigger("True")
 
-            fl_ctx.set_prop(FLContextKey.RUNNER, None, private=True)
+                fl_ctx.set_prop(FLContextKey.RUNNER, None, private=True)
         self.logger.info(f"Clean up ClientRunner for : {client.client_name} ")
 
     def run(self, args, conn):

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -97,8 +97,6 @@ class ClientTaskWorker(FLComponent):
             with client.run_manager.new_context() as fl_ctx:
                 self.fire_event(EventType.SWAP_OUT, fl_ctx)
 
-                # client.run_manager.aux_runner.abort_signal.trigger("True")
-
                 fl_ctx.set_prop(FLContextKey.RUNNER, None, private=True)
         self.logger.info(f"Clean up ClientRunner for : {client.client_name} ")
 


### PR DESCRIPTION
Fixes # .

### Description

Fix the simulator hang due to the client executor missing import, or initialization error.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
