### PR TITLE
Switch to --use-device-code for all az login cases [skip ci]

### DIFF
--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -993,7 +993,7 @@ azure_start_svr_sh: |
   echo "If the client requires additional dependencies, please copy the requirements.txt to ${DIR}."
   prompt ans "Press ENTER when it's done or no additional dependencies. "
 
-  az login
+  az login --use-device-code
 
   # Start provisioning
 
@@ -1195,7 +1195,7 @@ azure_start_cln_sh: |
   echo "If the client requires additional dependencies, please copy the requirements.txt to ${DIR}."
   prompt ans "Press ENTER when it's done or no additional dependencies. "
 
-  az login
+  az login --use-device-code
 
   # Start provisioning
 
@@ -1326,7 +1326,7 @@ azure_start_dsb_sh: |
   echo "Please enter the email address for this user."
   read email
 
-  az login
+  az login --use-device-code
   # Start provisioning
   echo "Creating Resource Group $RESOURCE_GROUP at Location $LOCATION"
   az group create --output none --name $RESOURCE_GROUP --location $LOCATION


### PR DESCRIPTION
### Description

It's easier for users to be authenticated in Azure with az login --use-device-code as it does not rely on the browsers on that running machine.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
