### PR TITLE
Enhance the job run process not to kill its own process, instead let …

### DIFF
--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -29,7 +29,7 @@ from nvflare.fuel.sec.security_content_service import SecurityContentService
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.private.defs import AppFolderConstants
 from nvflare.private.fed.app.fl_conf import FLServerStarterConfiger
-from nvflare.private.fed.app.utils import check_parent_alive
+from nvflare.private.fed.app.utils import monitor_parent_process
 from nvflare.private.fed.server.server_app_runner import ServerAppRunner
 from nvflare.private.fed.utils.fed_utils import add_logfile_handler, fobs_initialize
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
@@ -73,10 +73,6 @@ def main():
         sys.path.append(app_custom_folder)
 
     try:
-        # start parent process checking thread
-        thread = threading.Thread(target=check_parent_alive, args=(parent_pid, stop_event))
-        thread.start()
-
         os.chdir(args.workspace)
         fobs_initialize()
 
@@ -123,7 +119,11 @@ def main():
             if args.snapshot:
                 snapshot = server.snapshot_persistor.retrieve_run(args.job_id)
 
-            server_app_runner = ServerAppRunner()
+            server_app_runner = ServerAppRunner(server)
+            # start parent process checking thread
+            thread = threading.Thread(target=monitor_parent_process, args=(server_app_runner, parent_pid, stop_event))
+            thread.start()
+
             server_app_runner.start_server_app(
                 workspace, server, args, args.app_root, args.job_id, snapshot, logger, args.set
             )

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -124,9 +124,7 @@ def main():
             thread = threading.Thread(target=monitor_parent_process, args=(server_app_runner, parent_pid, stop_event))
             thread.start()
 
-            server_app_runner.start_server_app(
-                workspace, server, args, args.app_root, args.job_id, snapshot, logger, args.set
-            )
+            server_app_runner.start_server_app(workspace, args, args.app_root, args.job_id, snapshot, logger, args.set)
         finally:
             if deployer:
                 deployer.close()

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -69,7 +69,7 @@ class SimulatorRunner(FLComponent):
         self.ask_to_stop = False
 
         self.simulator_root = None
-        self.services = None
+        self.server = None
         self.deployer = SimulatorDeployer()
         self.client_names = []
         self.federated_clients = []
@@ -197,7 +197,7 @@ class SimulatorRunner(FLComponent):
 
             # Deploy the FL server
             self.logger.info("Create the Simulator Server.")
-            simulator_server, self.services = self.deployer.create_fl_server(self.args)
+            simulator_server, self.server = self.deployer.create_fl_server(self.args)
             # self.services.deploy(self.args, grpc_args=simulator_server)
 
             self.logger.info("Deploy the Apps.")
@@ -328,12 +328,12 @@ class SimulatorRunner(FLComponent):
         if self.setup():
             try:
                 self.create_clients()
-                self.services.engine.run_processes[SimulatorConstants.JOB_NAME] = {
+                self.server.engine.run_processes[SimulatorConstants.JOB_NAME] = {
                     RunProcessKey.LISTEN_PORT: None,
                     RunProcessKey.CONNECTION: None,
                     RunProcessKey.CHILD_PROCESS: None,
                     RunProcessKey.JOB_ID: SimulatorConstants.JOB_NAME,
-                    RunProcessKey.PARTICIPANTS: self.services.engine.client_manager.clients,
+                    RunProcessKey.PARTICIPANTS: self.server.engine.client_manager.clients,
                 }
 
                 self.logger.info("Deploy and start the Server App.")
@@ -341,7 +341,7 @@ class SimulatorRunner(FLComponent):
                 server_thread.start()
 
                 # wait for the server app is started
-                while self.services.engine.engine_info.status != MachineStatus.STARTED:
+                while self.server.engine.engine_info.status != MachineStatus.STARTED:
                     time.sleep(1.0)
                     if not server_thread.is_alive():
                         raise RuntimeError("Could not start the Server App.")
@@ -391,17 +391,17 @@ class SimulatorRunner(FLComponent):
         os.makedirs(local, exist_ok=True)
         workspace = Workspace(root_dir=self.args.workspace, site_name="server")
 
-        self.services.job_cell = self.services.create_job_cell(
+        self.server.job_cell = self.server.create_job_cell(
             SimulatorConstants.JOB_NAME,
-            self.services.cell.get_root_url_for_child(),
-            self.services.cell.get_internal_listener_url(),
+            self.server.cell.get_root_url_for_child(),
+            self.server.cell.get_internal_listener_url(),
             False,
             None,
         )
-        server_app_runner = SimulatorServerAppRunner(self.services)
+        server_app_runner = SimulatorServerAppRunner(self.server)
         snapshot = None
         server_app_runner.start_server_app(
-            workspace, self.services, self.args, app_server_root, self.args.job_id, snapshot, self.logger
+            workspace, self.args, app_server_root, self.args.job_id, snapshot, self.logger
         )
 
         # start = time.time()
@@ -411,8 +411,8 @@ class SimulatorRunner(FLComponent):
         #     if time.time() - start > 30.:
         #         break
 
-        self.services.admin_server.stop()
-        self.services.close()
+        self.server.admin_server.stop()
+        self.server.close()
 
 
 class SimulatorClientRunner(FLComponent):

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -398,7 +398,7 @@ class SimulatorRunner(FLComponent):
             False,
             None,
         )
-        server_app_runner = SimulatorServerAppRunner()
+        server_app_runner = SimulatorServerAppRunner(self.services)
         snapshot = None
         server_app_runner.start_server_app(
             workspace, self.services, self.args, app_server_root, self.args.job_id, snapshot, self.logger

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -29,8 +29,8 @@ from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.hci.server.authz import AuthorizationService
 from nvflare.fuel.sec.audit import AuditService
-from nvflare.private.fed.app.client.worker_process import check_parent_alive
 from nvflare.private.fed.app.deployer.base_client_deployer import BaseClientDeployer
+from nvflare.private.fed.app.utils import check_parent_alive
 from nvflare.private.fed.client.client_engine import ClientEngine
 from nvflare.private.fed.client.client_status import ClientStatus
 from nvflare.private.fed.client.fed_client import FederatedClient

--- a/nvflare/private/fed/app/utils.py
+++ b/nvflare/private/fed/app/utils.py
@@ -21,8 +21,17 @@ import psutil
 
 from nvflare.fuel.hci.security import hash_password
 from nvflare.private.defs import SSLConstants
+from nvflare.private.fed.runner import Runner
 from nvflare.private.fed.server.admin import FedAdminServer
 from nvflare.private.fed.server.fed_server import FederatedServer
+
+
+def monitor_parent_process(runner: Runner, parent_pid, stop_event: threading.Event):
+    while True:
+        if stop_event.is_set() or not psutil.pid_exists(parent_pid):
+            runner.stop()
+            break
+        time.sleep(1)
 
 
 def check_parent_alive(parent_pid, stop_event: threading.Event):

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -215,6 +215,7 @@ class ClientRunManager(ClientEngineExecutorSpec):
             channel=CellChannel.SERVER_PARENT_LISTENER,
             topic=ServerCommandNames.GET_CLIENTS,
             request=get_clients_message,
+            timeout=5.0,
         )
         data = fobs.loads(return_data.payload)
         self.all_clients = data.get(ServerCommandKey.CLIENTS)

--- a/nvflare/private/fed/runner.py
+++ b/nvflare/private/fed/runner.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import abstractmethod
+
 
 class Runner:
     def start(self):
         """Method call at the start of the Runner process."""
         pass
 
+    @abstractmethod
     def stop(self):
         """Method call at the end of the Runner process."""

--- a/nvflare/private/fed/runner.py
+++ b/nvflare/private/fed/runner.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Runner:
+    def start(self):
+        """Method call at the start of the Runner process."""
+        pass
+
+    def stop(self):
+        """Method call at the end of the Runner process."""

--- a/nvflare/private/fed/server/server_app_runner.py
+++ b/nvflare/private/fed/server/server_app_runner.py
@@ -48,7 +48,7 @@ class ServerAppRunner(Runner):
         super().__init__()
         self.server = server
 
-    def start_server_app(self, workspace: Workspace, server, args, app_root, job_id, snapshot, logger, kv_list=None):
+    def start_server_app(self, workspace: Workspace, args, app_root, job_id, snapshot, logger, kv_list=None):
 
         try:
             server_config_file_name = os.path.join(app_root, args.server_config)
@@ -56,29 +56,29 @@ class ServerAppRunner(Runner):
             conf = ServerJsonConfigurator(config_file_name=server_config_file_name, args=args, kv_list=kv_list)
             conf.configure()
 
-            _set_up_run_config(workspace, server, conf)
+            _set_up_run_config(workspace, self.server, conf)
 
-            if not isinstance(server.engine, ServerEngine):
-                raise TypeError(f"server.engine must be ServerEngine. Got type:{type(server.engine).__name__}")
-            self.sync_up_parents_process(args, server)
+            if not isinstance(self.server.engine, ServerEngine):
+                raise TypeError(f"server.engine must be ServerEngine. Got type:{type(self.server.engine).__name__}")
+            self.sync_up_parents_process(args)
 
-            server.start_run(job_id, app_root, conf, args, snapshot)
+            self.server.start_run(job_id, app_root, conf, args, snapshot)
         except BaseException as e:
-            with server.engine.new_context() as fl_ctx:
+            with self.server.engine.new_context() as fl_ctx:
                 fl_ctx.set_prop(key=FLContextKey.FATAL_SYSTEM_ERROR, value=True, private=True, sticky=True)
             logger.exception(f"FL server execution exception: {secure_format_exception(e)}")
             raise e
         finally:
             # self.update_job_run_status(server)
-            server.status = ServerStatus.STOPPED
-            server.engine.engine_info.status = MachineStatus.STOPPED
-            server.stop_training()
+            self.server.status = ServerStatus.STOPPED
+            self.server.engine.engine_info.status = MachineStatus.STOPPED
+            self.server.stop_training()
 
-    def sync_up_parents_process(self, args, server):
-        server.engine.sync_clients_from_main_process()
+    def sync_up_parents_process(self, args):
+        self.server.engine.sync_clients_from_main_process()
 
-    def update_job_run_status(self, server):
-        server.engine.update_job_run_status()
+    def update_job_run_status(self):
+        self.server.engine.update_job_run_status()
 
     def stop(self):
         self.server.engine.asked_to_stop = True

--- a/nvflare/private/fed/server/server_app_runner.py
+++ b/nvflare/private/fed/server/server_app_runner.py
@@ -17,6 +17,7 @@ import os
 from nvflare.apis.fl_constant import FLContextKey, MachineStatus
 from nvflare.apis.workspace import Workspace
 from nvflare.private.fed.app.fl_conf import create_privacy_manager
+from nvflare.private.fed.runner import Runner
 from nvflare.private.fed.server.server_engine import ServerEngine
 from nvflare.private.fed.server.server_json_config import ServerJsonConfigurator
 from nvflare.private.fed.server.server_status import ServerStatus
@@ -42,7 +43,11 @@ def _set_up_run_config(workspace: Workspace, server, conf):
     server.handlers = conf.handlers
 
 
-class ServerAppRunner:
+class ServerAppRunner(Runner):
+    def __init__(self, server) -> None:
+        super().__init__()
+        self.server = server
+
     def start_server_app(self, workspace: Workspace, server, args, app_root, job_id, snapshot, logger, kv_list=None):
 
         try:
@@ -74,3 +79,6 @@ class ServerAppRunner:
 
     def update_job_run_status(self, server):
         server.engine.update_job_run_status()
+
+    def stop(self):
+        self.server.engine.asked_to_stop = True

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -491,6 +491,7 @@ class ServerEngine(ServerEngineInternalSpec):
             channel=CellChannel.SERVER_PARENT_LISTENER,
             topic=ServerCommandNames.GET_CLIENTS,
             request=request,
+            timeout=5.0,
         )
         data = fobs.loads(return_data.payload)
         if data.get(ServerCommandKey.CLIENTS):
@@ -514,13 +515,15 @@ class ServerEngine(ServerEngineInternalSpec):
                 message=request,
             )
 
-    def send_command_to_child_runner_process(self, job_id: str, command_name: str, command_data, return_result=True):
+    def send_command_to_child_runner_process(
+        self, job_id: str, command_name: str, command_data, return_result=True, timeout=5.0
+    ):
         result = None
         with self.lock:
             fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
             request = new_cell_message({}, fobs.dumps(command_data))
             return_data = self.server.cell.send_request(
-                target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=command_name, request=request
+                target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=command_name, request=request, timeout=timeout
             )
             result = fobs.loads(return_data.payload)
 

--- a/nvflare/private/fed/simulator/simulator_app_runner.py
+++ b/nvflare/private/fed/simulator/simulator_app_runner.py
@@ -40,6 +40,9 @@ class SimulatorClientAppRunner(ClientAppRunner):
 
 
 class SimulatorServerAppRunner(ServerAppRunner):
+    def __init__(self, server) -> None:
+        super().__init__(server)
+
     def sync_up_parents_process(self, args, server):
         pass
 

--- a/nvflare/private/fed/simulator/simulator_app_runner.py
+++ b/nvflare/private/fed/simulator/simulator_app_runner.py
@@ -43,8 +43,8 @@ class SimulatorServerAppRunner(ServerAppRunner):
     def __init__(self, server) -> None:
         super().__init__(server)
 
-    def sync_up_parents_process(self, args, server):
+    def sync_up_parents_process(self, args):
         pass
 
-    def update_job_run_status(self, server):
+    def update_job_run_status(self):
         pass


### PR DESCRIPTION

Fixes # .

Fix the random job need to wait for 3600 seconds to shutdown, then start the 2nd job in CI issue.

### Description

Instead of monitor the job finish and kill its own process, send the stop() to the Runner to stop the main loop. Then let the process shutdown to MPM to manage.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
