### PR TITLE
Randomize resource group to avoid duplicate resource group names [skip ci]

### DIFF
--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -1305,7 +1305,7 @@ azure_start_dsb_sh: |
   fi
   }
 
-  RESOURCE_GROUP=nvflare_dashboard_rg
+  RESOURCE_GROUP=nvflare_dashboard_rg_${RANDOM}_${RANDOM}
   VM_NAME=nvflare_dashboard
   VM_IMAGE=Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest
   VM_SIZE=Standard_B2ms


### PR DESCRIPTION
### Description

Randomize the resource group names so users can run dashboard more than one time and the resource names will be be duplicate.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
