### PR TITLE
Fix controller timing issue

### DIFF
--- a/nvflare/apis/impl/controller.py
+++ b/nvflare/apis/impl/controller.py
@@ -181,12 +181,6 @@ class Controller(Responder, ControllerSpec, ABC):
 
                 if client_task_to_check is not None:
                     # this client has been sent the task already
-                    if not isinstance(client_task_to_check, ClientTask):
-                        raise TypeError(
-                            "client_task_to_check must be an instance of ClientTask, but got {}".format(
-                                type(client_task_to_check)
-                            )
-                        )
                     if client_task_to_check.result_received_time is None:
                         # controller has not received result from client
                         # something wrong happens when client working on this task, so resend the task
@@ -213,14 +207,11 @@ class Controller(Responder, ControllerSpec, ABC):
                         # do not send this task, but continue to check next task
                         continue
                     else:
-                        # send the task and remember the client_task
+                        # creates the client_task to be checked for sending
                         client_task_to_send = ClientTask(client, task)
-                        task.last_client_task_map[client.name] = client_task_to_send
-                        task.client_tasks.append(client_task_to_send)
-                        self._client_task_map[client_task_to_send.id] = client_task_to_send
                         break
 
-        # NOTE: move task sending process outside the lock
+        # NOTE: move task sending process outside the task lock
         # This is to minimize the locking time and to avoid potential deadlock:
         # the CB could schedule another task, which requires lock
         self.logger.debug("Determining based on client_task_to_send: {}".format(client_task_to_send))
@@ -282,9 +273,16 @@ class Controller(Responder, ControllerSpec, ABC):
 
             self.logger.debug("after_task_sent_cb done on client_task_to_send: {}".format(client_task_to_send))
 
+        with self._task_lock:
+            # sent the ClientTask and remember it
             now = time.time()
             client_task_to_send.task_sent_time = now
             client_task_to_send.task_send_count += 1
+
+            if not resend_task:
+                task.last_client_task_map[client.name] = client_task_to_send
+                task.client_tasks.append(client_task_to_send)
+                self._client_task_map[client_task_to_send.id] = client_task_to_send
             return task_name, client_task_to_send.id, task_data
 
     def handle_exception(self, task_id: str, fl_ctx: FLContext) -> None:

--- a/nvflare/apis/impl/seq_relay_manager.py
+++ b/nvflare/apis/impl/seq_relay_manager.py
@@ -183,16 +183,17 @@ class SequentialRelayTaskManager(TaskManager):
         """
         # are we waiting for any client?
         win_start_idx, win_end_idx = self._determine_window(task)
-        last_send_idx = task.props[_KEY_LAST_SEND_IDX]
-        last_client_task = None
-        if last_send_idx >= 0:
-            # see whether the result has been received
-            last_client_task = task.last_client_task_map[task.targets[last_send_idx]]
 
         self.logger.debug("check_task_exit: win_start_idx={}, win_end_idx={}".format(win_start_idx, win_end_idx))
         if win_start_idx < 0 and win_end_idx == 0:
-            if last_client_task and last_client_task.result_received_time is not None:
-                return True, TaskCompletionStatus.OK
+            last_send_idx = task.props[_KEY_LAST_SEND_IDX]
+            last_send_target = task.targets[last_send_idx]
+
+            if last_send_idx >= 0 and last_send_target in task.last_client_task_map:
+                # see whether the result has been received
+                last_client_task = task.last_client_task_map[last_send_target]
+                if last_client_task.result_received_time is not None:
+                    return True, TaskCompletionStatus.OK
             return True, TaskCompletionStatus.TIMEOUT
         else:
             return False, TaskCompletionStatus.IGNORED

--- a/nvflare/apis/impl/seq_relay_manager.py
+++ b/nvflare/apis/impl/seq_relay_manager.py
@@ -107,11 +107,13 @@ class SequentialRelayTaskManager(TaskManager):
 
         """
         # adjust client window
-        last_send_idx = task.props[_KEY_LAST_SEND_IDX]
         task_result_timeout = task.props[_KEY_TASK_RESULT_TIMEOUT]
-        if last_send_idx >= 0:
+        last_send_idx = task.props[_KEY_LAST_SEND_IDX]
+        last_send_target = task.targets[last_send_idx]
+
+        if last_send_idx >= 0 and last_send_target in task.last_client_task_map:
             # see whether the result has been received
-            last_task = task.last_client_task_map[task.targets[last_send_idx]]
+            last_task = task.last_client_task_map[last_send_target]
             self.logger.debug("last_task={}".format(last_task))
 
             if last_task.result_received_time is None:

--- a/runtest.sh
+++ b/runtest.sh
@@ -270,7 +270,7 @@ do
         ;;
 
         -u |--unit*)
-            cmd_prefix="python3 -m pytest --numprocesses=auto "
+            cmd_prefix="python3 -m pytest --numprocesses=auto -v "
 
             echo "coverage_report=" ${coverage_report}
             if [ "${coverage_report}" == true ]; then
@@ -308,7 +308,7 @@ if [[ -z $cmd ]]; then
         check_style_type_import nvflare tests;
         fix_style_import nvflare;
         fix_style_import tests;
-        python3 -m pytest --numprocesses=auto --cov=nvflare --cov-report html:cov_html --cov-report xml:cov.xml --junitxml=unit_test.xml tests/unit_test;
+        python3 -m pytest --numprocesses=auto -v --cov=nvflare --cov-report html:cov_html --cov-report xml:cov.xml --junitxml=unit_test.xml tests/unit_test;
         "
 else
     cmd="$cmd $target"

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -1148,9 +1148,7 @@ class TestBroadcastBehavior(TestController):
 
     @pytest.mark.parametrize("min_responses", [1, 2, 3, 4])
     @pytest.mark.parametrize("wait_time_after_min_received", [1, 2])
-    def test_task_exit_quickly_when_all_responses_received(
-        self, method, min_responses, wait_time_after_min_received
-    ):
+    def test_task_exit_quickly_when_all_responses_received(self, method, min_responses, wait_time_after_min_received):
         controller, fl_ctx, clients = self.setup_system(num_of_clients=min_responses)
 
         input_data = Shareable()

--- a/tests/unit_test/fuel/utils/component_builder_test.py
+++ b/tests/unit_test/fuel/utils/component_builder_test.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+from platform import python_version
 
 import pytest
-from platform import python_version
 
 from nvflare.app_common.np.np_model_locator import NPModelLocator
 from tests.unit_test.fuel.utils.mock_component_builder import MockComponentBuilder
@@ -141,14 +141,14 @@ class TestComponentBuilder:
         builder = MockComponentBuilder()
         assert isinstance(config, dict)
 
-        with pytest.raises(ValueError, match=re.escape(msg),):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(msg),
+        ):
             b = builder.build_component(config)
 
     def test_component_wo_args(self):
-        config = {
-            "id": "id",
-            "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponentWithDictArgs"
-        }
+        config = {"id": "id", "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponentWithDictArgs"}
         builder = MockComponentBuilder()
         assert isinstance(config, dict)
         b = builder.build_component(config)
@@ -177,9 +177,7 @@ class TestComponentBuilder:
             "args": {
                 "model": {
                     "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponentWithPathArgs",
-                    "args": {
-                        "path": "/tmp/nvflare"
-                    }
+                    "args": {"path": "/tmp/nvflare"},
                 }
             },
         }


### PR DESCRIPTION
### Description

The problem is related to this part of codes: https://github.com/NVIDIA/NVFlare/blob/dev/nvflare/apis/impl/seq_relay_manager.py#L112-L120 

The old controller code has a rare chance that a `client_task` has already been put inside the `task.last_client_task_map[client.name]` BUT its `task_sent_time` is None, which will cause this following line to failed:

`if task_result_timeout and time.time() - last_task.task_sent_time > task_result_timeout:`


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
