### PR TITLE
Fix shutdown log messages and speed up shutdown process

### DIFF
--- a/nvflare/apis/impl/controller.py
+++ b/nvflare/apis/impl/controller.py
@@ -647,7 +647,7 @@ class Controller(Responder, ControllerSpec, ABC):
         """Ask all clients to abort the execution of the specified task.
 
         Args:
-            task (str): the task to be aborted
+            task (Task): the task to be aborted
             fl_ctx (FLContext): FLContext associated with this action
         """
         self.log_info(fl_ctx, "asked all clients to abort task {}".format(task.name))
@@ -657,7 +657,9 @@ class Controller(Responder, ControllerSpec, ABC):
         engine = self._engine
         request = Shareable()
         request["task_names"] = task_names
-        engine.send_aux_request(targets=None, topic=ReservedTopic.ABORT_ASK, request=request, timeout=0, fl_ctx=fl_ctx)
+        engine.send_aux_request(
+            targets=None, topic=ReservedTopic.ABORT_ASK, request=request, timeout=0, fl_ctx=fl_ctx, optional=True
+        )
 
     def abort_all_tasks(self, fl_ctx: FLContext):
         """Ask clients to abort the execution of all tasks.

--- a/nvflare/apis/server_engine_spec.py
+++ b/nvflare/apis/server_engine_spec.py
@@ -81,7 +81,9 @@ class ServerEngineSpec(EngineSpec, ABC):
         pass
 
     @abstractmethod
-    def send_aux_request(self, targets: [], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext) -> dict:
+    def send_aux_request(
+        self, targets: [], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext, optional=False
+    ) -> dict:
         """Send a request to specified clients via the aux channel.
 
         Implementation: simply calls the ServerAuxRunner's send_aux_request method.
@@ -92,14 +94,17 @@ class ServerEngineSpec(EngineSpec, ABC):
             request: request to be sent
             timeout: number of secs to wait for replies. 0 means fire-and-forget.
             fl_ctx: FL context
+            optional: whether this message is optional
 
         Returns: a dict of replies (client name => reply Shareable)
 
         """
         pass
 
-    def fire_and_forget_aux_request(self, targets: [], topic: str, request: Shareable, fl_ctx: FLContext) -> dict:
-        return self.send_aux_request(targets, topic, request, 0.0, fl_ctx)
+    def fire_and_forget_aux_request(
+        self, targets: [], topic: str, request: Shareable, fl_ctx: FLContext, optional=False
+    ) -> dict:
+        return self.send_aux_request(targets, topic, request, 0.0, fl_ctx, optional)
 
     @abstractmethod
     def get_widget(self, widget_id: str) -> Widget:

--- a/nvflare/private/aux_runner.py
+++ b/nvflare/private/aux_runner.py
@@ -115,7 +115,14 @@ class AuxRunner(FLComponent):
         return valid_reply
 
     def send_aux_request(
-        self, targets: list, topic: str, request: Shareable, timeout: float, fl_ctx: FLContext, bulk_send: bool = False
+        self,
+        targets: list,
+        topic: str,
+        request: Shareable,
+        timeout: float,
+        fl_ctx: FLContext,
+        bulk_send: bool = False,
+        optional: bool = False,
     ) -> dict:
         job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
         cmi = JobCellMessenger(self.engine, job_id)
@@ -159,7 +166,11 @@ class AuxRunner(FLComponent):
                 timeout=timeout,
                 fl_ctx=fl_ctx,
                 bulk_send=bulk_send,
+                optional=optional,
             )
-        except BaseException as e:
-            self.logger.error(f"Failed to send the message to targets: {targets}")
+        except BaseException:
+            if optional:
+                self.logger.debug(f"Failed to send the message to targets: {targets}")
+            else:
+                self.logger.error(f"Failed to send the message to targets: {targets}")
             return {}

--- a/nvflare/private/fed/client/client_engine_executor_spec.py
+++ b/nvflare/private/fed/client/client_engine_executor_spec.py
@@ -86,7 +86,13 @@ class ClientEngineExecutorSpec(ClientEngineSpec, EngineSpec, ABC):
 
     @abstractmethod
     def send_aux_request(
-        self, targets: Union[None, str, List[str]], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext
+        self,
+        targets: Union[None, str, List[str]],
+        topic: str,
+        request: Shareable,
+        timeout: float,
+        fl_ctx: FLContext,
+        optional=False,
     ) -> dict:
         """Send a request to Server via the aux channel.
 
@@ -98,6 +104,7 @@ class ClientEngineExecutorSpec(ClientEngineSpec, EngineSpec, ABC):
             request: request to be sent
             timeout: number of secs to wait for replies. 0 means fire-and-forget.
             fl_ctx: FL context
+            optional: whether the request is optional
 
         Returns:
             a dict of reply Shareable in the format of:
@@ -107,13 +114,16 @@ class ClientEngineExecutorSpec(ClientEngineSpec, EngineSpec, ABC):
         pass
 
     @abstractmethod
-    def fire_and_forget_aux_request(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:
+    def fire_and_forget_aux_request(
+        self, topic: str, request: Shareable, fl_ctx: FLContext, optional=False
+    ) -> Shareable:
         """Send an async request to Server via the aux channel.
 
         Args:
             topic: topic of the request
             request: request to be sent
             fl_ctx: FL context
+            optional: whether the request is optional
 
         Returns:
 
@@ -128,6 +138,7 @@ class ClientEngineExecutorSpec(ClientEngineSpec, EngineSpec, ABC):
             config_dict: config dict
 
         """
+        pass
 
     @abstractmethod
     def abort_app(self, job_id: str, fl_ctx: FLContext):

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -187,7 +187,13 @@ class ClientRunManager(ClientEngineExecutorSpec):
         return self.cell
 
     def send_aux_request(
-        self, targets: Union[None, str, List[str]], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext
+        self,
+        targets: Union[None, str, List[str]],
+        topic: str,
+        request: Shareable,
+        timeout: float,
+        fl_ctx: FLContext,
+        optional=False,
     ) -> dict:
         if not targets:
             targets = [FQCN.ROOT_SERVER]
@@ -203,7 +209,7 @@ class ClientRunManager(ClientEngineExecutorSpec):
                 else:
                     targets = [targets]
         if targets:
-            return self.aux_runner.send_aux_request(targets, topic, request, timeout, fl_ctx)
+            return self.aux_runner.send_aux_request(targets, topic, request, timeout, fl_ctx, optional=optional)
         else:
             return {}
 
@@ -223,8 +229,10 @@ class ClientRunManager(ClientEngineExecutorSpec):
     def register_aux_message_handler(self, topic: str, message_handle_func):
         self.aux_runner.register_aux_message_handler(topic, message_handle_func)
 
-    def fire_and_forget_aux_request(self, topic: str, request: Shareable, fl_ctx: FLContext) -> dict:
-        return self.send_aux_request(targets=None, topic=topic, request=request, timeout=0.0, fl_ctx=fl_ctx)
+    def fire_and_forget_aux_request(self, topic: str, request: Shareable, fl_ctx: FLContext, optional=False) -> dict:
+        return self.send_aux_request(
+            targets=None, topic=topic, request=request, timeout=0.0, fl_ctx=fl_ctx, optional=optional
+        )
 
     def abort_app(self, job_id: str, fl_ctx: FLContext):
         runner = fl_ctx.get_prop(key=FLContextKey.RUNNER, default=None)

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -386,7 +386,8 @@ class ClientRunner(FLComponent):
             self.log_debug(fl_ctx, "server asked to try again - will try in {} secs".format(task_fetch_interval))
             return task_fetch_interval, False
 
-        self.log_info(fl_ctx, "got task assignment: name={}, id={}".format(task.name, task.task_id))
+        if task.name not in [SpecialTaskName.END_RUN, SpecialTaskName.TRY_AGAIN]:
+            self.log_info(fl_ctx, "got task assignment: name={}, id={}".format(task.name, task.task_id))
 
         task_data = task.data
         if not isinstance(task_data, Shareable):

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -18,7 +18,9 @@ import time
 from typing import List, Optional
 
 from nvflare.apis.filter import Filter
-from nvflare.apis.fl_constant import FLContextKey, ServerCommandKey, ServerCommandNames
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_constant import ReturnCode as ShareableRC
+from nvflare.apis.fl_constant import ServerCommandKey, ServerCommandNames
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import FLCommunicationError
 from nvflare.apis.shareable import Shareable
@@ -184,6 +186,7 @@ class Communicator:
             topic=ServerCommandNames.GET_TASK,
             request=task_message,
             timeout=self.timeout,
+            optional=True,
         )
         end_time = time.time()
         return_code = task.get_header(MessageHeaderKey.RETURN_CODE)
@@ -192,7 +195,7 @@ class Communicator:
             size = len(task.payload)
             task.payload = fobs.loads(task.payload)
             task_name = task.payload.get_header(ServerCommandKey.TASK_NAME)
-            self.logger.info(
+            self.logger.debug(
                 f"Received from {project_name} server "
                 f" ({size} Bytes). getTask: {task_name} time: {end_time - start_time} seconds"
             )
@@ -234,6 +237,8 @@ class Communicator:
 
         # shareable.add_cookie(name=FLContextKey.TASK_ID, data=task_id)
         shareable.set_header(FLContextKey.TASK_NAME, execute_task_name)
+        rc = shareable.get_return_code()
+        optional = rc == ShareableRC.TASK_ABORTED
 
         task_message = new_cell_message(
             {
@@ -253,6 +258,7 @@ class Communicator:
             topic=ServerCommandNames.SUBMIT_UPDATE,
             request=task_message,
             timeout=self.timeout,
+            optional=optional,
         )
         end_time = time.time()
         return_code = result.get_header(MessageHeaderKey.RETURN_CODE)

--- a/nvflare/private/fed/cmi.py
+++ b/nvflare/private/fed/cmi.py
@@ -160,6 +160,7 @@ class JobCellMessenger(CellMessageInterface):
         timeout: float,
         fl_ctx: FLContext,
         bulk_send=False,
+        optional=False,
     ) -> dict:
         """Send request to the job cells of other target sites.
         Args:
@@ -170,6 +171,7 @@ class JobCellMessenger(CellMessageInterface):
             timeout (float): how long to wait for result. 0 means fire-and-forget
             fl_ctx (FLContext): the FL context
             bulk_send: whether to bulk send this request (only applies in the fire-and-forget situation)
+            optional: whether the request is optional
         Returns:
             A dict of Shareables
         """
@@ -216,7 +218,7 @@ class JobCellMessenger(CellMessageInterface):
         cell_msg = self.new_cmi_message(fl_ctx, payload=request)
         if timeout > 0:
             cell_replies = cell.broadcast_request(
-                channel=channel, topic=topic, request=cell_msg, targets=target_fqcns, timeout=timeout
+                channel=channel, topic=topic, request=cell_msg, targets=target_fqcns, timeout=timeout, optional=optional
             )
 
             replies = {}
@@ -240,9 +242,6 @@ class JobCellMessenger(CellMessageInterface):
                 cell.queue_message(channel=channel, topic=topic, message=cell_msg, targets=target_fqcns)
             else:
                 cell.fire_and_forget(
-                    channel=channel,
-                    topic=topic,
-                    message=cell_msg,
-                    targets=target_fqcns,
+                    channel=channel, topic=topic, message=cell_msg, targets=target_fqcns, optional=optional
                 )
             return {}

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -469,7 +469,9 @@ class ServerEngine(ServerEngineInternalSpec):
     def register_aux_message_handler(self, topic: str, message_handle_func):
         self.run_manager.aux_runner.register_aux_message_handler(topic, message_handle_func)
 
-    def send_aux_request(self, targets: [], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext) -> dict:
+    def send_aux_request(
+        self, targets: [], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext, optional=False
+    ) -> dict:
         try:
             if not targets:
                 # self.sync_clients_from_main_process()
@@ -478,7 +480,7 @@ class ServerEngine(ServerEngineInternalSpec):
                     targets.append(t.name)
             if targets:
                 return self.run_manager.aux_runner.send_aux_request(
-                    targets=targets, topic=topic, request=request, timeout=timeout, fl_ctx=fl_ctx
+                    targets=targets, topic=topic, request=request, timeout=timeout, fl_ctx=fl_ctx, optional=optional
                 )
             else:
                 return {}

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -167,7 +167,12 @@ class ServerRunner(FLComponent):
 
                     # ask all clients to end run!
                     self.engine.send_aux_request(
-                        targets=None, topic=ReservedTopic.END_RUN, request=Shareable(), timeout=0.0, fl_ctx=fl_ctx
+                        targets=None,
+                        topic=ReservedTopic.END_RUN,
+                        request=Shareable(),
+                        timeout=0.0,
+                        fl_ctx=fl_ctx,
+                        optional=True,
                     )
 
                     self.fire_event(EventType.END_RUN, fl_ctx)

--- a/nvflare/private/fed/simulator/simulator_server.py
+++ b/nvflare/private/fed/simulator/simulator_server.py
@@ -35,9 +35,11 @@ class SimulatorServerEngine(ServerEngine):
     def update_job_run_status(self):
         pass
 
-    def send_aux_request(self, targets: [], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext) -> dict:
+    def send_aux_request(
+        self, targets: [], topic: str, request: Shareable, timeout: float, fl_ctx: FLContext, optional=False
+    ) -> dict:
         if topic != ReservedTopic.END_RUN:
-            return super().send_aux_request(targets, topic, request, timeout, fl_ctx)
+            return super().send_aux_request(targets, topic, request, timeout, fl_ctx, optional)
         else:
             return {}
 


### PR DESCRIPTION
This PR addresses the following issues:
- Clean up unnecessary error log messages during shutdown (NVBug 4005501. These messages are changed to debug level. This is implemented by setting requests generated during shutdown as "optional".
- Speed up job abort and termination process. Removed the artificial 10 secs delay to monitor the job process. This should at least partially solve NVBugs 4011353 and 4011356.
- Changed task retrieval log in communicator.py and client_runner.py to debug level, to reduce unnecessary log messages.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
