### PR TITLE
Fix job runner multiple start issue

### DIFF
--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -271,9 +271,8 @@ class FederatedServer(BaseServer):
         self.tokens = None
         self.round_started = time.time()
 
-        self.tokens = dict()
-        for token, client in self.get_all_clients().items():
-            self.tokens[token] = self.task_meta_info(client.name)
+        with self.lock:
+            self.reset_tokens()
 
         self.cmd_modules = cmd_modules
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -19,8 +19,9 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from threading import Lock
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+from nvflare.apis.client import Client
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_constant import (
@@ -87,13 +88,11 @@ class BaseServer(ABC):
 
         self.heart_beat_timeout = heart_beat_timeout
         self.handlers = handlers
-        # self.cmd_modules = cmd_modules
 
         self.client_manager = ClientManager(
             project_name=self.project_name, min_num_clients=self.min_num_clients, max_num_clients=self.max_num_clients
         )
 
-        # self.grpc_server = None
         self.cell = None
         self.admin_server = None
         self.lock = Lock()
@@ -110,7 +109,12 @@ class BaseServer(ABC):
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def get_all_clients(self):
+    def get_all_clients(self) -> Dict[str, Client]:
+        """Get the list of registered clients.
+
+        Returns:
+            A dict of {client_token: client}
+        """
         return self.client_manager.get_clients()
 
     @abstractmethod
@@ -134,12 +138,9 @@ class BaseServer(ABC):
 
     def deploy(self, args, grpc_args=None, secure_train=False):
         """Start a grpc server and listening the designated port."""
-        # num_server_workers = grpc_args.get("num_server_workers", 1)
-        # num_server_workers = max(self.client_manager.get_min_clients(), num_server_workers)
         target = grpc_args["service"].get("target", "0.0.0.0:6007")
         scheme = grpc_args["service"].get("scheme", "grpc")
 
-        # grpc_options = grpc_args["service"].get("options", GRPC_DEFAULT_OPTIONS)
         if secure_train:
             root_cert = grpc_args[SecureTrainConst.SSL_ROOT_CERT]
             ssl_cert = grpc_args[SecureTrainConst.SSL_CERT]
@@ -204,7 +205,7 @@ class BaseServer(ABC):
         return client
 
     def notify_dead_client(self, client):
-        """Called to do further processing of the dead client
+        """Called to do further processing of the dead client.
 
         Args:
             client: the dead client
@@ -270,15 +271,13 @@ class FederatedServer(BaseServer):
         self.tokens = None
         self.round_started = time.time()
 
-        with self.lock:
-            self.reset_tokens()
+        self.tokens = dict()
+        for token, client in self.get_all_clients().items():
+            self.tokens[token] = self.task_meta_info(client.name)
 
         self.cmd_modules = cmd_modules
 
         self.builder = None
-
-        # Additional fields for CurrentTask meta_data in GetModel API.
-        self.current_model_meta_data = {}
 
         self.engine = self._create_server_engine(args, snapshot_persistor)
         self.run_manager = None
@@ -295,9 +294,6 @@ class FederatedServer(BaseServer):
         self.overseer_agent = overseer_agent
         self.server_state: ServerState = ColdState()
         self.snapshot_persistor = snapshot_persistor
-
-        # self._register_cellnet_cbs()
-        # mpm.add_cleanup_cb(self.engine.close)
 
     def _register_cellnet_cbs(self):
         self.cell.register_request_cb(
@@ -323,17 +319,13 @@ class FederatedServer(BaseServer):
         )
 
     def _listen_command(self, request: Message) -> Message:
-
-        assert isinstance(request, Message), "request must be CellMessage but got {}".format(type(request))
-
         job_id = request.get_header(CellMessageHeaderKeys.JOB_ID)
         command = request.get_header(MessageHeaderKey.TOPIC)
         data = fobs.loads(request.payload)
 
         if command == ServerCommandNames.GET_CLIENTS:
             if job_id in self.engine.run_processes:
-                clients = self.engine.run_processes.get(job_id).get(RunProcessKey.PARTICIPANTS)
-                # job_id = self.engine.run_processes.get(job_id).get(RunProcessKey.JOB_ID)
+                clients = self.engine.run_processes[job_id].get(RunProcessKey.PARTICIPANTS)
                 return_data = {ServerCommandKey.CLIENTS: clients, ServerCommandKey.JOB_ID: job_id}
             else:
                 return_data = {ServerCommandKey.CLIENTS: None, ServerCommandKey.JOB_ID: job_id}
@@ -383,12 +375,10 @@ class FederatedServer(BaseServer):
 
         cell.start()
         net_agent = NetAgent(cell)
-        # self.cell = cell
 
         self.command_agent = ServerCommandAgent(self.engine, cell)
         self.command_agent.start()
 
-        # mpm.add_cleanup_cb(self.command_agent.shutdown)
         mpm.add_cleanup_cb(net_agent.close)
         mpm.add_cleanup_cb(cell.stop)
 
@@ -418,8 +408,8 @@ class FederatedServer(BaseServer):
         This function is not thread-safe.
         """
         self.tokens = dict()
-        for client in self.get_all_clients().keys():
-            self.tokens[client] = self.task_meta_info(client.name)
+        for token, client in self.get_all_clients().items():
+            self.tokens[token] = self.task_meta_info(client.name)
 
     def _before_service(self, fl_ctx: FLContext):
         # before the service processing
@@ -457,9 +447,7 @@ class FederatedServer(BaseServer):
             state_check = self.server_state.register(fl_ctx)
 
             self._handle_state_check(state_check, fl_ctx)
-            # if state_check.get(ACTION) in [NIS, ABORT_RUN]:
-            #     return make_cellnet_reply(rc=F3ReturnCode.COMM_ERROR, error=state_check.get(MESSAGE))
-            # else:
+
             client = self.client_manager.authenticate(request, fl_ctx)
             if client and client.token:
                 self.tokens[client.token] = self.task_meta_info(client.name)
@@ -478,8 +466,6 @@ class FederatedServer(BaseServer):
         if state_check.get(ACTION) in [NIS, ABORT_RUN]:
             fl_ctx.set_prop(FLContextKey.COMMUNICATION_ERROR, state_check.get(MESSAGE), sticky=False)
 
-    # def Quit(self, request, context):
-    # @request_processing
     def quit_client(self, request: Message) -> Message:
         """Existing client quits the federated training process.
 
@@ -488,7 +474,6 @@ class FederatedServer(BaseServer):
 
         This function does not change min_num_clients and max_num_clients.
         """
-        # fire_event(EventType.CLIENT_QUIT, self.handlers, self.fl_ctx)
 
         with self.engine.new_context() as fl_ctx:
             client = self.client_manager.validate_client(request, fl_ctx)
@@ -557,7 +542,7 @@ class FederatedServer(BaseServer):
                 shareable.set_header(ServerCommandKey.FL_CLIENT, client.name)
                 fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
                 request = new_cell_message({}, fobs.dumps(shareable))
-                return_data = self.cell.fire_and_forget(
+                self.cell.fire_and_forget(
                     targets=fqcn,
                     channel=CellChannel.SERVER_COMMAND,
                     topic=ServerCommandNames.HANDLE_DEAD_JOB,
@@ -625,9 +610,6 @@ class FederatedServer(BaseServer):
 
                 time.sleep(self.check_engine_frequency)
 
-            # if engine_thread.is_alive():
-            #     engine_thread.join()
-
         finally:
             self.engine.engine_info.status = MachineStatus.STOPPED
             self.run_manager = None
@@ -656,21 +638,16 @@ class FederatedServer(BaseServer):
             self.logger.error(f"FL server execution exception: {secure_format_exception(e)}")
         finally:
             self.engine.update_job_run_status()
-            self.stop_run_engine_cell()
 
         self.engine.engine_info.status = MachineStatus.STOPPED
-
-    def stop_run_engine_cell(self):
-        # self.cell.stop()
-        # mpm.stop()
-        pass
 
     def deploy(self, args, grpc_args=None, secure_train=False):
         super().deploy(args, grpc_args, secure_train)
 
         target = grpc_args["service"].get("target", "0.0.0.0:6007")
-        self.server_state.host = target.split(":")[0]
-        self.server_state.service_port = target.split(":")[1]
+        with self.lock:
+            self.server_state.host = target.split(":")[0]
+            self.server_state.service_port = target.split(":")[1]
 
         self.overseer_agent = self._init_agent(args)
 
@@ -686,7 +663,6 @@ class FederatedServer(BaseServer):
         self._register_cellnet_cbs()
 
         self.overseer_agent.start(self.overseer_callback)
-        # mpm.add_cleanup_cb(self.overseer_agent.end)
 
     def _init_agent(self, args=None):
         kv_list = parse_vars(args.set)
@@ -705,28 +681,27 @@ class FederatedServer(BaseServer):
             return
 
         sp = overseer_agent.get_primary_sp()
-        # print(sp)
-        with self.engine.new_context() as fl_ctx:
-            self.server_state = self.server_state.handle_sd_callback(sp, fl_ctx)
+
+        with self.lock:
+            with self.engine.new_context() as fl_ctx:
+                self.server_state = self.server_state.handle_sd_callback(sp, fl_ctx)
 
         if isinstance(self.server_state, Cold2HotState):
-            server_thread = threading.Thread(target=self._turn_to_hot)
-            server_thread.start()
+            self._turn_to_hot()
 
-        if isinstance(self.server_state, Hot2ColdState):
-            server_thread = threading.Thread(target=self._turn_to_cold)
-            server_thread.start()
+        elif isinstance(self.server_state, Hot2ColdState):
+            self._turn_to_cold()
 
     def _turn_to_hot(self):
         # Restore Snapshot
         with self.snapshot_lock:
             fl_snapshot = self.snapshot_persistor.retrieve()
             if fl_snapshot:
-                for run_number, snapshot in fl_snapshot.run_snapshots.items():
+                for job_id, snapshot in fl_snapshot.run_snapshots.items():
                     if snapshot and not snapshot.completed:
                         # Restore the workspace
                         workspace_data = snapshot.get_component_snapshot(SnapshotKey.WORKSPACE).get("content")
-                        dst = os.path.join(self.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(run_number))
+                        dst = os.path.join(self.workspace, WorkspaceConstants.WORKSPACE_PREFIX + str(job_id))
                         if os.path.exists(dst):
                             shutil.rmtree(dst, ignore_errors=True)
 
@@ -735,24 +710,24 @@ class FederatedServer(BaseServer):
 
                         job_id = snapshot.get_component_snapshot(SnapshotKey.JOB_INFO).get(SnapshotKey.JOB_ID)
                         job_clients = snapshot.get_component_snapshot(SnapshotKey.JOB_INFO).get(SnapshotKey.JOB_CLIENTS)
-                        self.logger.info(f"Restore the previous snapshot. Run_number: {run_number}")
+                        self.logger.info(f"Restore the previous snapshot. JOB ID: {job_id}")
                         with self.engine.new_context() as fl_ctx:
-                            job_runner = self.engine.job_runner
-                            job_runner.restore_running_job(
-                                run_number=run_number,
+                            self.engine.job_runner.restore_running_job(
                                 job_id=job_id,
                                 job_clients=job_clients,
                                 snapshot=snapshot,
                                 fl_ctx=fl_ctx,
                             )
 
+        with self.lock:
             self.server_state = HotState(
                 host=self.server_state.host, port=self.server_state.service_port, ssid=self.server_state.ssid
             )
 
     def _turn_to_cold(self):
-        # Wrap-up server operations
-        self.server_state = ColdState(host=self.server_state.host, port=self.server_state.service_port)
+        self.engine.stop_all_jobs()
+        with self.lock:
+            self.server_state = ColdState(host=self.server_state.host, port=self.server_state.service_port)
 
     def stop_training(self):
         self.status = ServerStatus.STOPPED

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -394,7 +394,7 @@ class JobRunner(FLComponent):
                                 fl_ctx=fl_ctx,
                             )
                             with self.lock:
-                                self.running_jobs[ready_job.job_id] = ready_job
+                                self.running_jobs[job_id] = ready_job
                             job_manager.set_status(ready_job.job_id, RunStatus.RUNNING, fl_ctx)
                         except BaseException as e:
                             if job_id:

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -31,6 +31,7 @@ from nvflare.lighter.utils import verify_folder_signature
 from nvflare.private.admin_defs import Message, MsgHeader, ReturnCode
 from nvflare.private.defs import RequestHeader, TrainingTopic
 from nvflare.private.fed.server.admin import check_client_replies
+from nvflare.private.fed.server.server_state import HotState
 from nvflare.private.fed.utils.app_deployer import AppDeployer
 from nvflare.security.logging import secure_format_exception
 
@@ -61,6 +62,8 @@ class JobRunner(FLComponent):
             self.scheduler = engine.get_component(SystemComponents.JOB_SCHEDULER)
         elif event_type in [EventType.JOB_COMPLETED, EventType.JOB_ABORTED, EventType.JOB_CANCELLED]:
             self._save_workspace(fl_ctx)
+        elif event_type == EventType.SYSTEM_END:
+            self.stop()
 
     def _make_deploy_message(self, job: Job, app_data, app_name):
         message = Message(topic=TrainingTopic.DEPLOY, body=app_data)
@@ -290,10 +293,9 @@ class JobRunner(FLComponent):
     def _job_complete_process(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
-        while not self.ask_to_stop:
+        while not self.ask_to_stop and isinstance(engine.server.server_state, HotState):
             for job_id in list(self.running_jobs.keys()):
                 if job_id not in engine.run_processes.keys():
-                    # with self.lock:
                     job = self.running_jobs.get(job_id)
                     if job:
                         exception_run_processes = engine.exception_run_processes
@@ -328,16 +330,21 @@ class JobRunner(FLComponent):
         shutil.rmtree(run_dir)
 
     def run(self, fl_ctx: FLContext):
+        """Starts job runner."""
         engine = fl_ctx.get_engine()
-
-        thread = threading.Thread(target=self._job_complete_process, args=[fl_ctx])
-        thread.start()
-
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
         if job_manager:
-            while not self.ask_to_stop:
-                # approved_jobs = job_manager.get_jobs_by_status(RunStatus.APPROVED, fl_ctx)
+            while not isinstance(engine.server.server_state, HotState):
+                time.sleep(1.0)
+
+            thread = threading.Thread(target=self._job_complete_process, args=[fl_ctx])
+            thread.start()
+
+            while not self.ask_to_stop and isinstance(engine.server.server_state, HotState):
                 approved_jobs = job_manager.get_jobs_by_status(RunStatus.SUBMITTED, fl_ctx)
+                self.log_debug(
+                    fl_ctx, f"{fl_ctx.get_identity_name()} Got approved_jobs: {approved_jobs} from the job_manager"
+                )
 
                 if self.scheduler:
                     ready_job, sites = self.scheduler.schedule_job(
@@ -345,11 +352,10 @@ class JobRunner(FLComponent):
                     )
 
                     if ready_job:
-                        # with self.lock:
                         client_sites = {k: v for k, v in sites.items() if k != "server"}
                         job_id = None
                         try:
-                            self.log_info(fl_ctx, f"Got the job:{ready_job.job_id} from the scheduler to run")
+                            self.log_info(fl_ctx, f"Got the job: {ready_job.job_id} from the scheduler to run")
                             fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, ready_job.job_id)
                             job_id, failed_clients = self._deploy_job(ready_job, sites, fl_ctx)
                             job_manager.set_status(ready_job.job_id, RunStatus.DISPATCHED, fl_ctx)
@@ -385,7 +391,7 @@ class JobRunner(FLComponent):
                                 fl_ctx=fl_ctx,
                             )
                             with self.lock:
-                                self.running_jobs[job_id] = ready_job
+                                self.running_jobs[ready_job.job_id] = ready_job
                             job_manager.set_status(ready_job.job_id, RunStatus.RUNNING, fl_ctx)
                         except BaseException as e:
                             if job_id:
@@ -407,10 +413,13 @@ class JobRunner(FLComponent):
                             )
 
                 time.sleep(1.0)
+
+            thread.join()
         else:
             self.log_error(fl_ctx, "There's no Job Manager defined. Won't be able to run the jobs.")
 
-        thread.join()
+    def stop(self):
+        self.ask_to_stop = True
 
     def restore_running_job(self, run_number: str, job_id: str, job_clients, snapshot, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
@@ -433,7 +442,6 @@ class JobRunner(FLComponent):
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
         self._stop_run(job_id, fl_ctx)
 
-        # with self.lock:
         job = self.running_jobs.get(job_id)
         if job:
             self.log_info(fl_ctx, f"Stop the job run: {job_id}")

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -294,9 +294,6 @@ class JobRunner(FLComponent):
         engine = fl_ctx.get_engine()
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
         while not self.ask_to_stop:
-            if not isinstance(engine.server.server_state, HotState):
-                time.sleep(1.0)
-                continue
             for job_id in list(self.running_jobs.keys()):
                 if job_id not in engine.run_processes.keys():
                     job = self.running_jobs.get(job_id)

--- a/tests/integration_test/data/test_configs/ha/two_servers.yml
+++ b/tests/integration_test/data/test_configs/ha/two_servers.yml
@@ -1,0 +1,27 @@
+ha: True
+jobs_root_dir: ../../examples/hello-world
+cleanup: True
+project_yaml: ./data/projects/ha_2_servers_2_clients.yml
+
+
+tests:
+  - test_name: "upload a job, wait for it to finish"
+    event_sequence:
+      - "trigger":
+          "type": "server_log"
+          "data": "Server started"
+        "actions": [ "submit_job hello-numpy-sag/jobs/hello-numpy-sag" ]
+        "result":
+          "type": "run_state"
+          "data": { }
+      - "trigger":
+          "type": "run_state"
+          "data": { "run_finished": True }
+        "actions": [ "ensure_current_job_done" ]
+        "result":
+          "type": "run_state"
+          "data": { "run_finished": True }
+
+    validators:
+      - path: tests.integration_test.src.validators.NumpySAGResultValidator
+        args: { expected_result: [ [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10, 11, 12 ] ] }

--- a/tests/integration_test/test_configs.yml
+++ b/tests/integration_test/test_configs.yml
@@ -13,6 +13,7 @@ test_configs:
     - ./data/test_configs/ha/kill_server_during_training_after_first_round.yml
     - ./data/test_configs/ha/kill_server_during_training_before_first_round.yml
     - ./data/test_configs/ha/kill_server_during_training_sending_model.yml
+    - ./data/test_configs/ha/two_servers.yml
     - ./data/test_configs/ha/fladminapi.yml
   numpy:
     - ./data/test_configs/standalone_job/hello_numpy_examples.yml


### PR DESCRIPTION
In the old codes, when we start more than 1 server, all of the servers will start JobRunner by default and it keeps reading and updating the job storage at the same time which might cause racing and other issues.

We change "run" of JobRunner to wait for server state to become HOT

### Description

- JobRunner will not proceed until server turns to HOT state


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
