### PR TITLE
Randomize security group in AWS dashboard and client scripts

### DIFF
--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -1457,8 +1457,6 @@ azure_start_dsb_sh: |
 
   credential=$(jq -r .value[0].message /tmp/dashboard.json | grep "Project admin")
   # echo "The VM was created with user: ${ADMIN_USERNAME} and password: ${PASSWORD}"
-  echo "Dashboard: ${credential}, running at IP address ${IP_ADDRESS}"
-  echo "To stop the dashboard, run az group delete -n ${RESOURCE_GROUP}"
   if [ "$secure" = true ]
   then
     echo "URL is https://${IP_ADDRESS}"
@@ -1466,6 +1464,8 @@ azure_start_dsb_sh: |
     echo "URL is http://${IP_ADDRESS}:443"
   fi
   echo "Note: you may need to configure DNS server with your DNS hostname and the above IP address."
+  echo "Project admin credential (username:password) is ${credential} ."
+  echo "To stop the dashboard, run az group delete -n ${RESOURCE_GROUP}"
 
 adm_notebook: |
   {
@@ -1716,6 +1716,9 @@ aws_start_svr_sh: |
   echo "System was provisioned"
   echo "To terminate the EC2 instance, run the following command."
   echo "aws ec2 terminate-instances --instance-ids ${instance_id}"
+  echo "Other resources provisioned"
+  echo "security group: ${SECURITY_GROUP}"
+  echo "key pair: ${KEY_PAIR}"
 
 aws_start_cln_sh: |
   #!/usr/bin/env bash
@@ -1769,7 +1772,7 @@ aws_start_cln_sh: |
   VM_NAME=nvflare_client
   AMI_IMAGE=ami-04bad3c587fe60d89
   EC2_TYPE=t2.small
-  SECURITY_GROUP=nvflare_client_sg
+  SECURITY_GROUP=nvflare_client_sg_$RANDOM
   DEST_FOLDER=/var/tmp/cloud
   REGION=us-west-2
   KEY_PAIR=NVFlareClientKeyPair
@@ -1805,9 +1808,7 @@ aws_start_cln_sh: |
   chmod 400 $KEY_FILE
 
   # Generate Security Group
-
-  aws ec2 delete-security-group --group-name $SECURITY_GROUP > /dev/null 2>&1
-  sleep 10
+  # Try not reusing existing security group because we have to modify it for our own need.
   sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
   aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
 
@@ -1847,6 +1848,10 @@ aws_start_cln_sh: |
   echo "System was provisioned"
   echo "To terminate the EC2 instance, run the following command."
   echo "aws ec2 terminate-instances --instance-ids ${instance_id}"
+  echo "Other resources provisioned"
+  echo "security group: ${SECURITY_GROUP}"
+  echo "key pair: ${KEY_PAIR}"
+
 
 aws_start_dsb_sh: |
   #!/usr/bin/env bash
@@ -1883,7 +1888,7 @@ aws_start_dsb_sh: |
   VM_NAME=nvflare_dashboard
   AMI_IMAGE=ami-04bad3c587fe60d89
   EC2_TYPE=t2.small
-  SECURITY_GROUP=nvflare_dashboard_sg
+  SECURITY_GROUP=nvflare_dashboard_sg_$RANDOM
   REGION=us-west-2
   ADMIN_USERNAME=ubuntu
   DEST_FOLDER=/home/${ADMIN_USERNAME}
@@ -1895,18 +1900,6 @@ aws_start_dsb_sh: |
   check_binary aws "Please see https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html on how to install it on your system."
   check_binary sshpass "Please install it first."
   check_binary jq "Please install it first."
-
-  while true
-  do
-    prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
-    prompt EC2_TYPE "Cloud EC2 type, press ENTER to accept default ${EC2_TYPE}: "
-    prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
-    if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
-    then
-      break
-    fi
-  done
-
 
   echo "One initial user will be created when starting dashboard."
   echo "Please enter the email address for this user."
@@ -1924,8 +1917,6 @@ aws_start_dsb_sh: |
 
   # Generate Security Group
 
-  aws ec2 delete-security-group --group-name $SECURITY_GROUP > /dev/null 2>&1
-  sleep 10  
   sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
   echo "Security group id: ${sg_id}"
   aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
@@ -1995,4 +1986,6 @@ aws_start_dsb_sh: |
   echo "Project admin credential (username:password) is ${credential} ."
   echo "To terminate the EC2 instance, run the following command."
   echo "aws ec2 terminate-instances --instance-ids ${instance_id}"
-
+  echo "Other resources provisioned"
+  echo "security group: ${SECURITY_GROUP}"
+  echo "key pair: ${KEY_PAIR}"


### PR DESCRIPTION
### Description

Security groups can not be reused because the rules attached to them are specific for the VM.  Therefore, this PR randomizes the security group names to avoid reuse.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
