### PR TITLE
fixed peer context handling in aux runner

### DIFF
--- a/nvflare/private/fed/server/server_command_agent.py
+++ b/nvflare/private/fed/server/server_command_agent.py
@@ -99,11 +99,6 @@ class ServerCommandAgent(object):
 
         topic = request.get_header(MessageHeaderKey.TOPIC)
         with self.engine.new_context() as fl_ctx:
-            shared_fl_ctx = data.get_header(ReservedHeaderKey.PEER_PROPS)
-            # shared_fl_ctx.set_prop(FLContextKey.SHAREABLE, data, private=True)
-
-            fl_ctx.set_peer_context(shared_fl_ctx)
-
             engine = fl_ctx.get_engine()
             reply = engine.dispatch(topic=topic, request=data, fl_ctx=fl_ctx)
 

--- a/nvflare/private/fed/server/server_command_agent.py
+++ b/nvflare/private/fed/server/server_command_agent.py
@@ -17,7 +17,6 @@ import logging
 
 from nvflare.apis.fl_constant import FLContextKey, ServerCommandKey
 from nvflare.apis.fl_context import FLContext
-from nvflare.apis.shareable import ReservedHeaderKey
 from nvflare.apis.utils.fl_context_utils import get_serializable_data
 from nvflare.fuel.f3.cellnet.cell import Cell, MessageHeaderKey, ReturnCode, make_reply
 from nvflare.fuel.f3.message import Message as CellMessage

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -106,7 +106,7 @@ class MockServerEngine(ServerEngineSpec):
     def register_aux_message_handler(self, topic: str, message_handle_func):
         pass
 
-    def send_aux_request(self, targets: [], topic: str, request, timeout: float, fl_ctx: FLContext) -> dict:
+    def send_aux_request(self, targets: [], topic: str, request, timeout: float, fl_ctx: FLContext, optional=False) -> dict:
         pass
 
     def get_widget(self, widget_id: str):


### PR DESCRIPTION
This PR fixes NVBug 4013497. The problem is caused by aux_runner's peer FL context handling logic. It used CellMessageInterface (CMI) for sending the message but didn't use it for handling incoming messages, and the peer FL context props were not handled properly. The CMI was designed to be a layer between cellnet and all upper layer modules. However it was only used for handling aux messages. This could cause other unwanted side effect.

This PR changes to not use CMI at all and handles peer props explicitly.
We can integrate CMI properly in a later version.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
