### PR TITLE
Fix configuration for readthedocs to build docs with new requirements [skip ci]

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,7 @@ sphinx:
 python:
   version: 3.8
   install:
-    - requirements: requirements-doc.txt
+    - method: pip
+      path: .[doc]
 #  system_packages: true
 


### PR DESCRIPTION
The build process in readthedocs for the documentation was failing. This should fix it.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
