### PR TITLE
Get rid of hello-examples warnings

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -9,13 +9,11 @@ client_token.txt
 audit.log
 transfer
 workspaces
+*__nvfl*
 
 # python
 __pycache__
 .pyc
-
-# virtual environments
-nvflare_cifar10
 
 # data
 dataset

--- a/examples/hello-world/hello-numpy-cross-val/jobs/hello-numpy-cross-val/app/config/config_fed_server.json
+++ b/examples/hello-world/hello-numpy-cross-val/jobs/hello-numpy-cross-val/app/config/config_fed_server.json
@@ -20,7 +20,11 @@
       "id": "aggregator",
       "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
       "args": {
-        "expected_data_kind": "WEIGHTS"
+        "expected_data_kind": "WEIGHTS",
+        "aggregation_weights": {
+          "site-1": 1.0,
+          "site-2": 1.0
+        }
       }
     },
     {

--- a/examples/hello-world/hello-numpy-sag/jobs/hello-numpy-sag/app/config/config_fed_server.json
+++ b/examples/hello-world/hello-numpy-sag/jobs/hello-numpy-sag/app/config/config_fed_server.json
@@ -20,7 +20,11 @@
       "id": "aggregator",
       "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
       "args": {
-        "expected_data_kind": "WEIGHTS"
+        "expected_data_kind": "WEIGHTS",
+        "aggregation_weights": {
+          "site-1": 1.0,
+          "site-2": 1.0
+        }
       }
     }
   ],

--- a/examples/hello-world/hello-pt/jobs/hello-pt/app/config/config_fed_server.json
+++ b/examples/hello-world/hello-pt/jobs/hello-pt/app/config/config_fed_server.json
@@ -21,7 +21,11 @@
       "id": "aggregator",
       "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
       "args": {
-        "expected_data_kind": "WEIGHTS"
+        "expected_data_kind": "WEIGHTS",
+        "aggregation_weights": {
+          "site-1": 1.0,
+          "site-2": 1.0
+        }
       }
     },
     {

--- a/examples/hello-world/hello-tf2/jobs/hello-tf2/app/config/config_fed_server.json
+++ b/examples/hello-world/hello-tf2/jobs/hello-tf2/app/config/config_fed_server.json
@@ -22,7 +22,11 @@
       "id": "aggregator",
       "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
       "args": {
-        "expected_data_kind": "WEIGHTS"
+        "expected_data_kind": "WEIGHTS",
+        "aggregation_weights": {
+          "site-1": 1.0,
+          "site-2": 1.0
+        }
       }
     }
   ],

--- a/nvflare/app_common/np/np_trainer.py
+++ b/nvflare/app_common/np/np_trainer.py
@@ -17,7 +17,7 @@ import time
 
 import numpy as np
 
-from nvflare.apis.dxo import DXO, DataKind, from_shareable, MetaKey
+from nvflare.apis.dxo import DXO, DataKind, MetaKey, from_shareable
 from nvflare.apis.executor import Executor
 from nvflare.apis.fl_constant import FLContextKey, ReturnCode
 from nvflare.apis.fl_context import FLContext

--- a/nvflare/app_common/np/np_trainer.py
+++ b/nvflare/app_common/np/np_trainer.py
@@ -17,7 +17,7 @@ import time
 
 import numpy as np
 
-from nvflare.apis.dxo import DXO, DataKind, from_shareable
+from nvflare.apis.dxo import DXO, DataKind, from_shareable, MetaKey
 from nvflare.apis.executor import Executor
 from nvflare.apis.fl_constant import FLContextKey, ReturnCode
 from nvflare.apis.fl_context import FLContext
@@ -124,7 +124,7 @@ class NPTrainer(Executor):
             return make_reply(ReturnCode.TASK_ABORTED)
 
         # Prepare a DXO for our updated model. Create shareable and return
-        outgoing_dxo = DXO(data_kind=incoming_dxo.data_kind, data=np_data, meta={})
+        outgoing_dxo = DXO(data_kind=incoming_dxo.data_kind, data=np_data, meta={MetaKey.NUM_STEPS_CURRENT_ROUND: 1})
         return outgoing_dxo.to_shareable()
 
     def _submit_model(self, fl_ctx: FLContext, abort_signal: Signal):


### PR DESCRIPTION
### Description

If weights not provided, the aggregator is going to log warnings.
Provide weights for up to 2 clients for hello-examples.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
