### PR TITLE
Fixed the simulator threads option for multi_gpu case.

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -180,11 +180,17 @@ class SimulatorRunner(FLComponent):
                         f"the number of GPUS: ({len(gpus)})"
                     )
                     return False
-                if len(gpus) > 1 and self.args.threads and self.args.threads > 1:
-                    self.logger.info(
-                        "When running with multi GPU, each GPU will run with only 1 thread. " "Set the Threads to 1."
-                    )
+                if len(gpus) > 1:
+                    if self.args.threads and self.args.threads > 1:
+                        self.logger.info(
+                            "When running with multi GPU, each GPU will run with only 1 thread. "
+                            "Set the Threads to 1."
+                        )
                     self.args.threads = 1
+                elif len(gpus) == 1:
+                    if self.args.threads is None:
+                        self.args.threads = 1
+                        self.logger.warn("The number of threads is not provided. Set it to default: 1")
 
             if self.args.threads and self.args.threads > len(self.client_names):
                 self.logger.error("The number of threads to run can not be larger than the number of clients.")


### PR DESCRIPTION
Fixes # .

Fixed the simulator threads option issue when using multi-gpu

### Description

- When using multi_gpu simulator, set the threads to 1,
- when using single gpu in the --gpu option, use the default value 1, or use the user choose threads number. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
