### PR TITLE
cleanup error msg; fix sag wait; fix get_task timeout

### DIFF
--- a/nvflare/apis/impl/bcast_manager.py
+++ b/nvflare/apis/impl/bcast_manager.py
@@ -61,8 +61,12 @@ class BcastTaskManager(TaskManager):
             else:
                 clients_responded += 1
 
+        if clients_responded >= len(task.targets):
+            # all clients have responded!
+            return True, TaskCompletionStatus.OK
+
         # if min_responses is 0, need to have all client tasks responded
-        if task.props[_KEY_MIN_RESPS] == 0 and clients_not_responded:
+        if task.props[_KEY_MIN_RESPS] == 0 and clients_not_responded > 0:
             return False, TaskCompletionStatus.IGNORED
 
         # check if minimum responses are received

--- a/nvflare/apis/impl/controller.py
+++ b/nvflare/apis/impl/controller.py
@@ -72,7 +72,7 @@ def _get_client_task(target, task: Task):
 
 
 class Controller(Responder, ControllerSpec, ABC):
-    def __init__(self, task_check_period=0.5):
+    def __init__(self, task_check_period=0.05):
         """Manage life cycles of tasks and their destinations.
 
         Args:
@@ -355,11 +355,11 @@ class Controller(Responder, ControllerSpec, ABC):
         with self._task_lock:
             # task_id is the uuid associated with the client_task
             client_task = self._client_task_map.get(task_id, None)
-            self.logger.debug("Get submission from client task={} id={}".format(client_task, task_id))
+            self.log_debug(fl_ctx, "Get submission from client task={} id={}".format(client_task, task_id))
 
         if client_task is None:
             # cannot find a standing task for the submission
-            self.log_info(fl_ctx, "no standing task found for {}:{}".format(task_name, task_id))
+            self.log_debug(fl_ctx, "no standing task found for {}:{}".format(task_name, task_id))
             self.process_result_of_unknown_task(client, task_name, task_id, result, fl_ctx)
             return
 
@@ -382,7 +382,7 @@ class Controller(Responder, ControllerSpec, ABC):
 
             if task.result_received_cb is not None:
                 try:
-                    self.log_info(fl_ctx, "invoking result_received_cb ...")
+                    self.log_debug(fl_ctx, "invoking result_received_cb ...")
                     task.result_received_cb(client_task=client_task, fl_ctx=fl_ctx)
                 except BaseException as e:
                     # this task cannot proceed anymore
@@ -395,7 +395,7 @@ class Controller(Responder, ControllerSpec, ABC):
                     task.completion_status = TaskCompletionStatus.ERROR
                     task.exception = e
             else:
-                self.log_info(fl_ctx, "no result_received_cb")
+                self.log_debug(fl_ctx, "no result_received_cb")
 
             client_task.result_received_time = time.time()
 

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -66,6 +66,13 @@ class TargetMessage:
         self.channel = channel
         self.topic = topic
         self.message = message
+        message.add_headers(
+            {
+                MessageHeaderKey.TOPIC: topic,
+                MessageHeaderKey.CHANNEL: channel,
+                MessageHeaderKey.DESTINATION: target,
+            }
+        )
 
     def to_dict(self):
         return {

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -195,10 +195,11 @@ class Communicator:
             size = len(task.payload)
             task.payload = fobs.loads(task.payload)
             task_name = task.payload.get_header(ServerCommandKey.TASK_NAME)
-            self.logger.debug(
-                f"Received from {project_name} server "
-                f" ({size} Bytes). getTask: {task_name} time: {end_time - start_time} seconds"
-            )
+            if task_name not in [SpecialTaskName.END_RUN, SpecialTaskName.TRY_AGAIN]:
+                self.logger.info(
+                    f"Received from {project_name} server "
+                    f" ({size} Bytes). getTask: {task_name} time: {end_time - start_time} seconds"
+                )
         else:
             simulate_mode = fl_ctx.get_prop(FLContextKey.SIMULATE_MODE, False)
             if simulate_mode:

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -103,7 +103,7 @@ class FederatedClientBase:
             compression=compression,
             cell=cell,
             client_register_interval=client_args.get("client_register_interval", 2.0),
-            timeout=client_args.get("communication_timeout", 10.0),
+            timeout=client_args.get("communication_timeout", 30.0),
         )
 
         self.secure_train = secure_train

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -302,7 +302,7 @@ class ServerRunner(FLComponent):
             )
             return self._task_try_again()
 
-    def _try_to_get_task(self, client, fl_ctx, timeout=1.0, retry_interval=0.005):
+    def _try_to_get_task(self, client, fl_ctx, timeout=None, retry_interval=0.005):
         start = time.time()
         while True:
             with self.wf_lock:
@@ -337,10 +337,10 @@ class ServerRunner(FLComponent):
 
                     return task_name, task_id, task_data
 
-                if timeout == 0 or time.time() - start > timeout:
-                    break
+            if timeout is None or time.time() - start > timeout:
+                break
 
-                time.sleep(retry_interval)
+            time.sleep(retry_interval)
 
         # ask client to retry
         return "", "", None

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -1148,7 +1148,7 @@ class TestBroadcastBehavior(TestController):
 
     @pytest.mark.parametrize("min_responses", [1, 2, 3, 4])
     @pytest.mark.parametrize("wait_time_after_min_received", [1, 2])
-    def test_task_only_exit_when_wait_time_after_min_received(
+    def test_task_exit_quickly_when_all_responses_received(
         self, method, min_responses, wait_time_after_min_received
     ):
         controller, fl_ctx, clients = self.setup_system(num_of_clients=min_responses)
@@ -1185,16 +1185,7 @@ class TestBroadcastBehavior(TestController):
                 client=client, task_name="__test_task", task_id=client_task_id, result=result, fl_ctx=fl_ctx
             )
 
-        wait_time = 0
-        while wait_time <= wait_time_after_min_received:
-            assert controller.get_num_standing_tasks() == 1
-            for client in clients:
-                task_name_out, client_task_id, data = controller.process_task_request(client, fl_ctx)
-                assert task_name_out == ""
-                assert client_task_id == ""
-            time.sleep(1)
-            wait_time += 1
-
+        time.sleep(0.5)
         assert controller.get_num_standing_tasks() == 0
         assert task.completion_status == TaskCompletionStatus.OK
         launch_thread.join()


### PR DESCRIPTION
The PR addresses the following issues:

- Clean up log messages of AioGrpcDriver. All connection related messages are changed to debug level;
- Fixed broadcast function in controller to quickly end a task when all expected responses are received. It used to still wait for "wait time after min responses received". It was useful in v2.0 since the system didn't know how many responses to expect. But since 2.1, we already changed to job scheduling and expected clients are known.
- Extended the default timeout for get_task to 30 seconds. This is to accommodate tasks that may have huge amount of data.
- Added message headers earlier in cellnet so they can be included in log messages when endpoint finding fails.
- Updated controller_test.py. The test case test_task_only_exit_when_wait_time_after_min_received is no longer valid. Changed it to test_task_exit_quickly_when_all_responses_received.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
