### PR TITLE
fix api status and dead job message

### DIFF
--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -546,6 +546,7 @@ class FederatedServer(BaseServer):
                     channel=CellChannel.SERVER_COMMAND,
                     topic=ServerCommandNames.HANDLE_DEAD_JOB,
                     message=request,
+                    optional=True,
                 )
         except BaseException:
             self.logger.info("Could not connect to server runner process")

--- a/nvflare/private/fed/utils/app_authz.py
+++ b/nvflare/private/fed/utils/app_authz.py
@@ -54,6 +54,6 @@ class AppAuthzService(object):
 
         authorized, err = AuthorizationService.authorize(ctx)
         if not authorized:
-            return False, "BYOC not authorized"
+            return False, "BYOC not permitted"
 
         return True, ""


### PR DESCRIPTION
### Description

This PR addresses the following issues:
- NVBug 4019370. The fix is to silent log messages to DEBUG level for the dead_job notification messages. These messages are optional in nature.
- NVBug 3831404. The API status logic is confused between user "not authorized" and "BYOC not authorized". Changed the text to "BYOC not permitted" to avoid the conflict.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
