### PR TITLE
fix job listing

### DIFF
--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -268,6 +268,7 @@ class Session(SessionSpec):
         limit: Optional[int] = None,
         id_prefix: str = None,
         name_prefix: str = None,
+        reverse: bool = False,
     ) -> List[dict]:
         """Get the job info from the server
 
@@ -276,12 +277,15 @@ class Session(SessionSpec):
             limit: maximum number of jobs to show, with 0 to show all (defaults to 5)
             id_prefix: if included, only return jobs with the beginning of the job ID matching the id_prefix
             name_prefix: if included, only return jobs with the beginning of the job name matching the name_prefix
+            reverse: if specified, list jobs in the reverse order of submission times
         Returns: a dict of job metadata
 
         """
         command = AdminCommandNames.LIST_JOBS
         if detailed:
             command = command + " -d"
+        if reverse:
+            command = command + " -r"
         if limit:
             if not isinstance(limit, int):
                 raise InvalidArgumentError(f"limit must be int but got {type(limit)}")

--- a/nvflare/fuel/sec/authz.py
+++ b/nvflare/fuel/sec/authz.py
@@ -44,7 +44,13 @@ class Person(object):
         self.role = _normalize_str(role, FieldNames.USER_ROLE)
 
     def __str__(self):
-        return f"{self.name}:{self.org}:{self.role}"
+        name = self.name if self.name else "None"
+        org = self.org if self.org else "None"
+        role = self.role if self.role else "None"
+        if (not name) and (not org) and (not role):
+            return "None"
+        else:
+            return f"{name}:{org}:{role}"
 
 
 class AuthzContext(object):

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -61,6 +61,7 @@ def _create_list_job_cmd_parser():
     parser.add_argument("job_id", nargs="?", help="Job ID prefix")
     parser.add_argument("-d", action="store_true", help="Show detailed list")
     parser.add_argument("-u", action="store_true", help="List jobs submitted by the same user")
+    parser.add_argument("-r", action="store_true", help="List jobs in reverse order of submission time")
     parser.add_argument("-n", help="Filter by job name prefix")
     parser.add_argument(
         "-m",
@@ -322,7 +323,8 @@ class JobCommandModule(CommandModule, CommandUtil):
                     conn.append_string("No jobs matching the specified criteria.")
                     return
 
-                filtered_jobs.sort(key=lambda job: job.meta.get(JobMetaKey.SUBMIT_TIME.value, 0.0), reverse=True)
+                reverse = True if parsed_args.r else False
+                filtered_jobs.sort(key=lambda job: job.meta.get(JobMetaKey.SUBMIT_TIME.value, 0.0), reverse=reverse)
 
                 if max_jobs_listed:
                     filtered_jobs = filtered_jobs[:max_jobs_listed]

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -20,12 +20,13 @@ import pytest
 from nvflare.private.fed.server.job_cmds import _create_list_job_cmd_parser
 
 TEST_CASES = [
-    (["-d", "-u", "12345", "-n", "hello_", "-m", "3"], Namespace(u=True, d=True, job_id="12345", m=3, n="hello_")),
-    (["12345", "-d", "-u", "-n", "hello_", "-m", "3"], Namespace(u=True, d=True, job_id="12345", m=3, n="hello_")),
-    (["-d", "-u", "-n", "hello_", "-m", "3"], Namespace(u=True, d=True, job_id=None, m=3, n="hello_")),
-    (["-u", "-n", "hello_", "-m", "5"], Namespace(u=True, d=False, job_id=None, m=5, n="hello_")),
-    (["-u"], Namespace(u=True, d=False, job_id=None, m=None, n=None)),
-    (["nvflare"], Namespace(u=False, d=False, job_id="nvflare", m=None, n=None)),
+    (["-d", "-u", "12345", "-n", "hello_", "-m", "3"], Namespace(u=True, d=True, job_id="12345", m=3, n="hello_", r=False)),
+    (["12345", "-d", "-u", "-n", "hello_", "-m", "3"], Namespace(u=True, d=True, job_id="12345", m=3, n="hello_", r=False)),
+    (["-d", "-u", "-n", "hello_", "-m", "3"], Namespace(u=True, d=True, job_id=None, m=3, n="hello_", r=False)),
+    (["-u", "-n", "hello_", "-m", "5"], Namespace(u=True, d=False, job_id=None, m=5, n="hello_", r=False)),
+    (["-u"], Namespace(u=True, d=False, job_id=None, m=None, n=None, r=False)),
+    (["-r"], Namespace(u=False, d=False, job_id=None, m=None, n=None, r=True)),
+    (["nvflare"], Namespace(u=False, d=False, job_id="nvflare", m=None, n=None, r=False)),
 ]
 
 


### PR DESCRIPTION
### Description

This PR improves list_jobs behavior based on user feedback:
- By default, jobs are listed in the order of submission times. A new "-r" option is added to list the jobs in the reverse order of submission times.
- Updated flare_api's list_jobs() method with a "reverse=False" arg to be consistent with the command behavior.

This PR also improves user/submitter info format when printing authz info. The info is usually printed as "name:org:role". If the user is not available, current format becomes "::", which is hard to read, as pointed out in NVBug 4011685.

This PR improves it as follows:
- If the user/submitter is not available, prints "None"
- If the user/submitter is available but some attributes (name, org, role) are not available, use "None" for the missing attribute.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
