### PR TITLE
Add back sections for migrating that were removed

### DIFF
--- a/docs/release_notes/flare_220.rst
+++ b/docs/release_notes/flare_220.rst
@@ -1,6 +1,9 @@
+************************
 What's New in FLARE v2.2
-========================
+************************
 
+Goals of v2.2 and New Features
+==============================
 With FLARE v2.2, the primary goals were to:
  - Accelerate the federated learning workflow
  - Simplify deploying a federated learning project in the real-world
@@ -112,6 +115,9 @@ logging, when enabled, limits client output to only file and line numbers in the
 traceback, preventing unintentionally disclosing site-specific information to the project administrator.  Secure
 auditing keeps a site-specific log of all access and commands performed by the project admin.
 
+Migration to 2.2.1: Notes and Tips
+==================================
+
 Stop using Pickle in favor of using FOBS to serialize/deserialize data between Client and Server
 ------------------------------------------------------------------------------------------------
 Prior to NVFLARE 2.1.4, NVFLARE used python's `pickle <https://docs.python.org/3/library/pickle.html>`_ to transfer data between the FL clients and server.
@@ -187,6 +193,14 @@ On the receiving end:
   
     shareable[CUSTOM_DATA] = custom_data
 
+Replace TLS certificates
+------------------------
+With 2.2.1, the authorization model has been changed so previous startup kits (which contain the old TLS certificates) will no longer work. You will need to clean up
+the old setartup kits and re-provision your project.
+
+Use new Project.yml template
+----------------------------
+With 2.2.1, federated site policies require the new project.yml template. Please refer to :ref:`project_yml`.
 
 New local directory
 -------------------
@@ -194,7 +208,7 @@ With 2.2.1, the provision command will produce not only the ``startup`` director
 The resource allocation that used to be in ``project.yml`` is now expected in a ``resources.json`` file in this new ``local`` directory, and each
 sites/clients needs to manage this separately for each location.
 You need to place/modify your own site's ``authorization.json`` and ``privacy.json`` files in the ``local`` directory as well if you want to
-change the default policies. 
+change the default policies.
 
 The default configurations are provided in each site's local directory:
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -109,6 +109,10 @@ There should be no visible changes in terms of the configuration and usage patte
 layer has been improved to allow for greater flexibility and performance. These new communication features will be made generally available in next release.
 
 
+Migration to 2.3: Notes and Tips
+================================
+See :ref:`migrating_to_flare_api` for details on migrating to the new FLARE API.
+
 **************************
 Previous Releases of FLARE
 **************************


### PR DESCRIPTION
Adds back the sections in the documentation for migration to new versions of FLARE.

### Description

There were .md files that had information for migration to new versions, and this previous commit removed them: https://github.com/NVIDIA/NVFlare/commit/0a3bb6ac0658e54b6d74389753fc101a8213f4fa

This adds the sections into the rst under the what's new section.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
