### PR TITLE
silent abort message logging

### DIFF
--- a/nvflare/private/fed/server/admin.py
+++ b/nvflare/private/fed/server/admin.py
@@ -253,7 +253,7 @@ class FedAdminServer(AdminServer):
                 result[r.client_token] = r.reply
         return result
 
-    def send_requests(self, requests: dict, timeout_secs=2.0) -> [ClientReply]:
+    def send_requests(self, requests: dict, timeout_secs=2.0, optional=False) -> [ClientReply]:
         """Send requests to clients.
 
         NOTE::
@@ -265,13 +265,19 @@ class FedAdminServer(AdminServer):
         Args:
             requests: A dict of requests: {client token: request or list of requests}
             timeout_secs: how long to wait for reply before timeout
+            optional: whether the requests are optional
 
         Returns:
             A list of ClientReply
         """
 
         return send_requests(
-            cell=self.cell, command="admin", requests=requests, clients=self.clients, timeout_secs=timeout_secs
+            cell=self.cell,
+            command="admin",
+            requests=requests,
+            clients=self.clients,
+            timeout_secs=timeout_secs,
+            optional=optional,
         )
 
     def stop(self):

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -101,7 +101,7 @@ class JobCommandModule(CommandModule, CommandUtil):
                 CommandSpec(
                     name=AdminCommandNames.LIST_JOBS,
                     description="list submitted jobs",
-                    usage=f"{AdminCommandNames.LIST_JOBS} [-n name_prefix] [-d] [-u] [-m num_of_jobs] [job_id_prefix]",
+                    usage=f"{AdminCommandNames.LIST_JOBS} [-n name_prefix] [-d] [-u] [-r] [-m num_of_jobs] [job_id_prefix]",
                     handler_func=self.list_jobs,
                     authz_func=self.command_authz_required,
                 ),
@@ -213,7 +213,7 @@ class JobCommandModule(CommandModule, CommandUtil):
         run_process = engine.run_processes.get(job_id, {})
         if not run_process:
             conn.append_error(f"Job: {job_id} is not running.")
-            return
+            return False
 
         participants = run_process.get(RunProcessKey.PARTICIPANTS, [])
         wrong_clients = []
@@ -229,7 +229,7 @@ class JobCommandModule(CommandModule, CommandUtil):
         if wrong_clients:
             display_clients = ",".join(wrong_clients)
             conn.append_error(f"{display_clients} are not in the job running list.")
-            return
+            return False
 
         err = engine.check_app_start_readiness(job_id)
         if err:

--- a/nvflare/private/fed/server/message_send.py
+++ b/nvflare/private/fed/server/message_send.py
@@ -33,7 +33,9 @@ class ClientReply(object):
         self.reply = reply
 
 
-def send_requests(cell, command: str, requests: dict, clients, job_id=None, timeout_secs=2.0) -> [ClientReply]:
+def send_requests(
+    cell, command: str, requests: dict, clients, job_id=None, timeout_secs=2.0, optional=False
+) -> [ClientReply]:
     """Send requests to clients.
 
     NOTE::
@@ -43,8 +45,13 @@ def send_requests(cell, command: str, requests: dict, clients, job_id=None, time
         This is a blocking call - returned only after all responses are received or timeout.
 
     Args:
+        cell: the source cell
+        command: the command to be sent
+        clients: the clients the command will be sent to
         requests: A dict of requests: {client token: request or list of requests}
+        job_id: id of the job that the command is applied to
         timeout_secs: how long to wait for reply before timeout
+        optional: whether the message is optional
 
     Returns:
         A list of ClientReply
@@ -82,11 +89,11 @@ def send_requests(cell, command: str, requests: dict, clients, job_id=None, time
 
     if timeout_secs <= 0.0:
         # this is fire-and-forget!
-        cell.fire_multi_requests_and_forget(target_msgs)
+        cell.fire_multi_requests_and_forget(target_msgs, optional=optional)
         return []
     else:
         result = []
-        replies = cell.broadcast_multi_requests(target_msgs, timeout_secs)
+        replies = cell.broadcast_multi_requests(target_msgs, timeout_secs, optional=optional)
         for name, reply in replies.items():
             assert isinstance(reply, CellMessage)
             result.append(ClientReply(client_token=name_to_token[name], req=name_to_req[name], reply=reply.payload))


### PR DESCRIPTION
### Description

When aborting a job, the server sends abort commands to all clients and wait for their responses. However since some of the job cells may already be gone, the server will timeout and creates an error log message.

This PR makes the abort request "optional", and create the timeout message in DEBUG level.

This PR fixes NVBug 4027037.

This PR also added some minor improvements:
- Updated the help info of the "list_jobs" command with the "-r" option
- Added/fixed some docstrings.
- Shorten the wait time of the abort command to 2.0 secs from 10 secs


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
