### PR TITLE
fix job status and speed up fed event end_run

### DIFF
--- a/nvflare/fuel/f3/drivers/socket_conn.py
+++ b/nvflare/fuel/f3/drivers/socket_conn.py
@@ -62,12 +62,12 @@ class SocketConnection(Connection):
             if error.code == CommError.CLOSED:
                 log.debug(f"Connection {self.name} is closed by peer")
             else:
-                log.error(f"Connection {self.name} is closed due to error: {error}")
+                log.debug(f"Connection {self.name} is closed due to error: {error}")
         except Exception as ex:
             if self.closing:
                 log.debug(f"Connection {self.name} is closed")
             else:
-                log.error(f"Connection {self.name} is closed due to error: {ex}")
+                log.debug(f"Connection {self.name} is closed due to error: {ex}")
 
     def read_frame_loop(self):
         # read_frame throws exception on stale/bad connection so this is not a dead loop

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -59,6 +59,7 @@ from nvflare.private.scheduler_constants import ShareableHeader
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import InfoCollector
 from nvflare.widgets.widget import Widget, WidgetID
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode as CellMsgReturnCode
 
 from .client_manager import ClientManager
 from .job_runner import JobRunner
@@ -208,18 +209,18 @@ class ServerEngine(ServerEngineInternalSpec):
         process.wait()
         run_process_info = self.run_processes.get(job_id)
         if run_process_info:
-            process_finished = run_process_info.get(RunProcessKey.PROCESS_FINISHED, False)
             # Wait for the job process to finish UPDATE_RUN_STATUS process
             start_time = time.time()
-            while not process_finished:
-                if time.time() - start_time > 5.0:
-                    self.logger.error(f"Job:{job_id} UPDATE_RUN_STATUS didn't finish fast enough.")
+            max_wait = 2.0
+            while True:
+                process_finished = run_process_info.get(RunProcessKey.PROCESS_FINISHED, False)
+                if process_finished:
+                    break
+                if time.time() - start_time >= max_wait:
+                    self.logger.debug(f"Job:{job_id} UPDATE_RUN_STATUS didn't finish fast enough.")
                     break
                 time.sleep(0.1)
-
-            with self.lock:
-                if job_id in self.run_processes:
-                    run_process_info = self.run_processes.pop(job_id)
+            self.run_processes.pop(job_id, None)
         self.engine_info.status = MachineStatus.STOPPED
 
     def _start_runner_process(
@@ -310,6 +311,8 @@ class ServerEngine(ServerEngineInternalSpec):
                 job_id=job_id,
                 command_name=AdminCommandNames.ABORT,
                 command_data={},
+                timeout=1.0,
+                optional=True
             )
             self.logger.info(f"Abort server status: {status_message}")
         except BaseException:
@@ -325,10 +328,16 @@ class ServerEngine(ServerEngineInternalSpec):
 
     def _remove_run_processes(self, job_id):
         # wait for the run process to gracefully terminated, and ensure to remove from run_processes.
-        time.sleep(60.0)
-        if job_id in self.run_processes:
-            with self.lock:
-                self.run_processes.pop(job_id)
+        max_wait = 5.0
+        start = time.time()
+        while True:
+            if job_id not in self.run_processes:
+                # job already gone
+                return
+            if time.time() - start >= max_wait:
+                break
+            time.sleep(0.1)
+        self.run_processes.pop(job_id, None)
 
     def check_app_start_readiness(self, job_id: str) -> str:
         if job_id not in self.run_processes.keys():
@@ -474,7 +483,6 @@ class ServerEngine(ServerEngineInternalSpec):
     ) -> dict:
         try:
             if not targets:
-                # self.sync_clients_from_main_process()
                 targets = []
                 for t in self.get_clients():
                     targets.append(t.name)
@@ -488,12 +496,30 @@ class ServerEngine(ServerEngineInternalSpec):
             self.logger.error(f"Failed to send the aux_message: {topic} with exception: {secure_format_exception(e)}.")
 
     def sync_clients_from_main_process(self):
-        return_data = self._get_clients_data(self.args.job_id)
-        clients = return_data.get(ServerCommandKey.CLIENTS)
-        self.client_manager.clients = clients
-
-    def _get_clients_data(self, job_id):
+        # repeatedly ask the parent process to get participating clients until we receive the result
+        # or timed out after 30 secs (already tried 30 times).
         start = time.time()
+        max_wait = 30.0
+        job_id = self.args.job_id
+        while True:
+            clients = self._retrieve_clients_data(job_id)
+            if clients:
+                self.client_manager.clients = clients
+                self.logger.debug(f"received participating clients {clients}")
+                return
+
+            if time.time() - start >= max_wait:
+                self.logger.critical(f"Cannot get participating clients for job {job_id} after {max_wait} seconds")
+                raise RuntimeError("Exiting job process: Cannot get participating clients for job {job_id}")
+
+            self.logger.debug("didn't receive clients info - retry in 1 second")
+            time.sleep(1.0)
+
+    def _get_participating_clients(self):
+        # called from server's job cell
+        return self.client_manager.clients
+
+    def _retrieve_clients_data(self, job_id):
         request = new_cell_message({CellMessageHeaderKeys.JOB_ID: job_id}, fobs.dumps({}))
         return_data = self.server.cell.send_request(
             target=FQCN.ROOT_SERVER,
@@ -501,15 +527,18 @@ class ServerEngine(ServerEngineInternalSpec):
             topic=ServerCommandNames.GET_CLIENTS,
             request=request,
             timeout=5.0,
+            optional=True,
         )
+        rc = return_data.get_header(MessageHeaderKey.RETURN_CODE, CellMsgReturnCode.OK)
+        if rc != CellMsgReturnCode.OK:
+            self.logger.debug(f"cannot retrieve clients from parent: {rc}")
+            return None
+
         data = fobs.loads(return_data.payload)
-        if data.get(ServerCommandKey.CLIENTS):
-            return data
-        else:
-            if time.time() - start > self.kv_list.get("get_client_timeout", 10.0):
-                raise RuntimeError("Could not get the participants from parent process.")
-            time.sleep(1.0)
-            return self._get_clients_data(job_id)
+        clients = data.get(ServerCommandKey.CLIENTS, None)
+        if clients is None:
+            self.logger.error(f"parent failed to return clients info for job {job_id}")
+        return clients
 
     def update_job_run_status(self):
         with self.new_context() as fl_ctx:
@@ -525,17 +554,30 @@ class ServerEngine(ServerEngineInternalSpec):
             )
 
     def send_command_to_child_runner_process(
-        self, job_id: str, command_name: str, command_data, return_result=True, timeout=5.0
+        self, job_id: str, command_name: str, command_data, timeout=5.0, optional=False
     ):
-        result = None
         with self.lock:
             fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
             request = new_cell_message({}, fobs.dumps(command_data))
-            return_data = self.server.cell.send_request(
-                target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=command_name, request=request, timeout=timeout
-            )
-            result = fobs.loads(return_data.payload)
+            if timeout <= 0.0:
+                self.server.cell.fire_and_forget(
+                    targets=fqcn,
+                    channel=CellChannel.SERVER_COMMAND,
+                    topic=command_name,
+                    request=request,
+                    optional=optional
+                )
+                return None
 
+            return_data = self.server.cell.send_request(
+                target=fqcn, channel=CellChannel.SERVER_COMMAND, topic=command_name,
+                request=request, timeout=timeout, optional=optional
+            )
+            rc = return_data.get_header(MessageHeaderKey.RETURN_CODE, CellMsgReturnCode.OK)
+            if rc == CellMsgReturnCode.OK:
+                result = fobs.loads(return_data.payload)
+            else:
+                result = None
         return result
 
     def persist_components(self, fl_ctx: FLContext, completed: bool):
@@ -565,9 +607,7 @@ class ServerEngine(ServerEngineInternalSpec):
 
             job_info = fl_ctx.get_prop(FLContextKey.JOB_INFO)
             if not job_info:
-                return_data = self._get_clients_data(job_id)
-                job_id = return_data.get(ServerCommandKey.JOB_ID)
-                job_clients = return_data.get(ServerCommandKey.CLIENTS)
+                job_clients = self._get_participating_clients()
                 fl_ctx.set_prop(FLContextKey.JOB_INFO, (job_id, job_clients))
             else:
                 (job_id, job_clients) = job_info

--- a/nvflare/widgets/fed_event.py
+++ b/nvflare/widgets/fed_event.py
@@ -27,7 +27,7 @@ FED_EVENT_TOPIC = "fed.event"
 
 
 class FedEventRunner(Widget):
-    def __init__(self, topic=FED_EVENT_TOPIC):
+    def __init__(self, topic=FED_EVENT_TOPIC, regular_interval=0.01, grace_period=2.0):
         """Init FedEventRunner.
 
         The FedEventRunner handles posting and receiving of fed events.
@@ -41,10 +41,8 @@ class FedEventRunner(Widget):
         self.topic = topic
         self.abort_signal = None
         self.asked_to_stop = False
-        self.asked_to_flush = False
-        self.regular_interval = 0.001
-        self.grace_period = 2
-        self.flush_wait = 2
+        self.regular_interval = regular_interval
+        self.grace_period = grace_period
         self.engine = None
         self.last_timestamps = {}  # client name => last_timestamp
         self.in_events = []
@@ -59,12 +57,6 @@ class FedEventRunner(Widget):
             self.asked_to_stop = False
             self.asked_to_flush = False
             self.poster.start()
-        elif event_type == EventType.ABOUT_TO_END_RUN:
-            self.asked_to_flush = True
-            # delay self.flush_wait seconds so
-            # _post can empty the queue before
-            # END_RUN is fired
-            time.sleep(self.flush_wait)
         elif event_type == EventType.END_RUN:
             self.asked_to_stop = True
             if self.poster.is_alive():
@@ -138,32 +130,26 @@ class FedEventRunner(Widget):
         be handled by receiving side.
         """
         sleep_time = self.regular_interval
-        countdown = self.grace_period
         while True:
             time.sleep(sleep_time)
             if self.abort_signal.triggered:
                 break
             n = len(self.in_events)
             if n > 0:
-                if self.asked_to_flush:
-                    sleep_time = 0
-                else:
-                    sleep_time = self.regular_interval
+                sleep_time = 0.0
                 with self.in_lock:
                     event_to_post = self.in_events.pop(0)
             elif self.asked_to_stop:
-                # the queue is empty, and we are asked to stop.
-                # wait self.grace_period seconds , then exit.
-                if countdown < 0:
-                    break
-                else:
-                    countdown = countdown - 1
-                    time.sleep(1)
+                time.sleep(self.grace_period)
+                if len(self.in_events) > 0:
                     continue
+                else:
+                    break
             else:
-                sleep_time = min(sleep_time * 2, 1)
+                sleep_time = self.regular_interval
                 continue
 
+            self.logger.info(f"========== got fed event: {event_type}")
             with self.engine.new_context() as fl_ctx:
                 if self.asked_to_stop:
                     self.log_warning(fl_ctx, f"{n} items remained in in_events.  Will stop when it reaches 0.")
@@ -181,9 +167,9 @@ class FedEventRunner(Widget):
 
 
 class ServerFedEventRunner(FedEventRunner):
-    def __init__(self, topic=FED_EVENT_TOPIC):
+    def __init__(self, topic=FED_EVENT_TOPIC, regular_interval=0.01, grace_period=2.0):
         """Init ServerFedEventRunner."""
-        FedEventRunner.__init__(self, topic)
+        FedEventRunner.__init__(self, topic, regular_interval, grace_period)
 
     def fire_and_forget_request(self, request: Shareable, fl_ctx: FLContext, targets=None):
         if not isinstance(self.engine, ServerEngineSpec):


### PR DESCRIPTION
### Description

This PR addresses the following issues:

- NVBug 4029429. Consolidated API status for authorization error.
- NVBug 4007603. Modified the server's job status update/waiting logic
- NVBug 4029376. The error was caused by the race condition that the job cell tries to retrieve client list from the server before its connection to the server is fully established. Changed to keep trying until result is received or timed out. Note: there is a similar case on the client side that Yuhong will address.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
