### PR TITLE
Add config_type to distinguish

### DIFF
--- a/examples/advanced/cifar10/cifar10-sim/jobs/cifar10_fedopt/cifar10_fedopt/config/config_fed_server.json
+++ b/examples/advanced/cifar10/cifar10-sim/jobs/cifar10_fedopt/cifar10_fedopt/config/config_fed_server.json
@@ -45,14 +45,16 @@
           "args": {
             "lr": 1.0,
             "momentum": 0.6
-          }
+          },
+          "config_type": "dict"
         },
         "lr_scheduler_args": {
           "path": "torch.optim.lr_scheduler.CosineAnnealingLR",
           "args": {
             "T_max": "{num_rounds}",
             "eta_min": 0.9
-          }
+          },
+          "config_type": "dict"
         }
       }
     },

--- a/nvflare/fuel/utils/component_builder.py
+++ b/nvflare/fuel/utils/component_builder.py
@@ -11,10 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from abc import abstractmethod
 
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.utils.class_utils import instantiate_class
+
+
+class ConfigType:
+    COMPONENT = "component"
+    DICT = "dict"
 
 
 class ComponentBuilder:
@@ -36,6 +42,11 @@ class ComponentBuilder:
             except ConfigError:
                 # this is not a valid class path
                 return False
+
+        # use config_type to distinguish between components and regular dictionaries
+        config_type = config_dict.get("config_type", ConfigType.COMPONENT)
+        if config_type != ConfigType.COMPONENT:
+            return False
 
         # regardless it has args or not. if path/name and valid class path, very likely we have
         # class config.

--- a/tests/unit_test/fuel/utils/component_builder_test.py
+++ b/tests/unit_test/fuel/utils/component_builder_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import re
 from platform import python_version
 
@@ -186,3 +187,40 @@ class TestComponentBuilder:
         b = builder.build_component(config)
         assert isinstance(b, MyComponent)
         assert isinstance(b.mode, MyComponentWithPathArgs)
+
+    def test_nested_component_component_type(self):
+        config = {
+            "id": "id",
+            "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponent",
+            "args": {
+                "model": {
+                    "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponentWithDictArgs",
+                    "config_type": "component",
+                }
+            },
+        }
+        builder = MockComponentBuilder()
+        assert isinstance(config, dict)
+        b = builder.build_component(config)
+        assert isinstance(b, MyComponent)
+        assert isinstance(b.mode, MyComponentWithDictArgs)
+
+    def test_nested_dict_component_type(self):
+        config = {
+            "id": "id",
+            "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponent",
+            "args": {
+                "model": {
+                    "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponentWithDictArgs",
+                    "config_type": "dict",
+                }
+            },
+        }
+        builder = MockComponentBuilder()
+        assert isinstance(config, dict)
+        b = builder.build_component(config)
+        assert isinstance(b, MyComponent)
+        assert b.mode == {
+            "path": "tests.unit_test.fuel.utils.component_builder_test.MyComponentWithDictArgs",
+            "config_type": "dict",
+        }


### PR DESCRIPTION
### Description

For `PTFedOptModelShareableGenerator` we do want to treat those args as dictionary but NOT nested components.

This PR adds a "config_type" to distinguish between a dictionary should be built as component or just pass in as a regular dictionary. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
