### PR TITLE
change NP model locations

### DIFF
--- a/nvflare/app_common/np/np_model_locator.py
+++ b/nvflare/app_common/np/np_model_locator.py
@@ -60,9 +60,8 @@ class NPModelLocator(ModelLocator):
         if model_name == NPModelLocator.SERVER_MODEL_NAME:
             try:
                 job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
-                run_dir = engine.get_workspace().get_run_dir(job_id)
-                model_path = os.path.join(run_dir, self.model_dir)
-
+                ws_dir = engine.get_workspace().get_root_dir()
+                model_path = os.path.join(ws_dir, self.model_dir, job_id)
                 model_load_path = os.path.join(model_path, self.model_file_name)
                 np_data = None
                 try:


### PR DESCRIPTION
Fixes # .FLARE-87, NVBugs 115662

### Description

**Problem or Feature ask**
This is a long standing ask from customer for ability to be able to run cross-site validation on demand after train 
Use case is upload cross site validation config to run it after the fact or run for all Runs (including previous runs) 

**Analysis**
The ask is more general than simple cross-site validation re-run. but can we run individual workflow. As training and evaluation are two workflow. The ask is essentially to selectively run individual workflow as needed.
For cross validation specifically, we need to tell the system to only run evaluation workflow, but not training. And the model persisted (or provided), should be able to located and used in the sub-sequence cross validation run.

the current location of the model persistor and locator are looking at the workspace/<job_id>/models/<model_file>
but simulator will **wipe out** the directory ``workspace/<job_id>``` before each run, thus make the models unavailable.

**Changes**

Change part 1 is in implemented at 
https://github.com/NVIDIA/NVFlare/pull/1542

This PR changes related to the location of the model.,  we changed persistor to save and load the model from new location

workspace/**models/<job_id>**/<model_file>

instead of 

workspace/**<job_id>/models**/<model_file>

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
