### PR TITLE
Fixed the shared object issue in the controller task return.

### DIFF
--- a/nvflare/apis/impl/controller.py
+++ b/nvflare/apis/impl/controller.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import threading
 import time
 from abc import ABC
@@ -287,7 +287,7 @@ class Controller(Responder, ControllerSpec, ABC):
                 task.last_client_task_map[client.name] = client_task_to_send
                 task.client_tasks.append(client_task_to_send)
                 self._client_task_map[client_task_to_send.id] = client_task_to_send
-            return task_name, client_task_to_send.id, task_data
+            return task_name, client_task_to_send.id, copy.deepcopy(task_data)
 
     def handle_exception(self, task_id: str, fl_ctx: FLContext) -> None:
         """Called to cancel one task as its client_task is causing exception at upper level.

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -15,6 +15,7 @@
 """FL Admin commands."""
 
 import copy
+import logging
 import time
 from abc import ABC, abstractmethod
 from typing import List
@@ -37,6 +38,9 @@ NO_OP_REPLY = "__no_op_reply"
 
 class CommandProcessor(ABC):
     """The CommandProcessor is responsible for processing a command from parent process."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     @abstractmethod
     def get_command_name(self) -> str:
@@ -146,12 +150,6 @@ class GetTaskCommand(CommandProcessor):
             shareable.set_header(TaskConstant.WAIT_TIME, 1.0)
         else:
             taskname, task_id, shareable = server_runner.process_task_request(client, fl_ctx)
-        # data = {
-        #     ServerCommandKey.TASK_NAME: taskname,
-        #     ServerCommandKey.TASK_ID: task_id,
-        #     ServerCommandKey.SHAREABLE: shareable,
-        #     ServerCommandKey.FL_CONTEXT: copy.deepcopy(get_serializable_data(fl_ctx).props),
-        # }
 
         # we need TASK_ID back as a cookie
         if not shareable:
@@ -166,7 +164,8 @@ class GetTaskCommand(CommandProcessor):
         shared_fl_ctx.set_public_props(copy.deepcopy(get_serializable_data(fl_ctx).get_all_public_props()))
         shareable.set_header(key=FLContextKey.PEER_CONTEXT, value=shared_fl_ctx)
 
-        # return fobs.dumps(data)
+        self.logger.info(f"return task to client.  client_name:{client.name}  task_id:{task_id}  "
+                         f"sharable_header_task_id: {shareable.get_header(key=FLContextKey.TASK_ID)}")
         return shareable
 
 
@@ -191,13 +190,6 @@ class SubmitUpdateCommand(CommandProcessor):
         Returns:
 
         """
-        # shareable = data.get(ReservedKey.SHAREABLE)
-        # shared_fl_ctx = data.get(ReservedKey.SHARED_FL_CONTEXT)
-        # client = shareable.get_header(ServerCommandKey.FL_CLIENT)
-        # fl_ctx.set_peer_context(shared_fl_ctx)
-        # contribution_task_name = shareable.get_header(ServerCommandKey.TASK_NAME)
-        # task_id = shareable.get_cookie(FLContextKey.TASK_ID)
-        # server_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
 
         shared_fl_ctx = data.get_header(ServerCommandKey.PEER_FL_CONTEXT)
         data.set_header(ServerCommandKey.PEER_FL_CONTEXT, FLContext())
@@ -209,6 +201,7 @@ class SubmitUpdateCommand(CommandProcessor):
         task_id = data.get_cookie(FLContextKey.TASK_ID)
         server_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
         server_runner.process_submission(client, contribution_task_name, task_id, data, fl_ctx)
+        self.logger.info(f"submit_update process. client_name:{client.name}   task_id:{task_id}")
 
         return ""
 

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -164,8 +164,10 @@ class GetTaskCommand(CommandProcessor):
         shared_fl_ctx.set_public_props(copy.deepcopy(get_serializable_data(fl_ctx).get_all_public_props()))
         shareable.set_header(key=FLContextKey.PEER_CONTEXT, value=shared_fl_ctx)
 
-        self.logger.info(f"return task to client.  client_name:{client.name}  task_id:{task_id}  "
-                         f"sharable_header_task_id: {shareable.get_header(key=FLContextKey.TASK_ID)}")
+        self.logger.info(
+            f"return task to client.  client_name:{client.name}  task_id:{task_id}  "
+            f"sharable_header_task_id: {shareable.get_header(key=FLContextKey.TASK_ID)}"
+        )
         return shareable
 
 

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -289,7 +289,7 @@ class ServerRunner(FLComponent):
 
             self.log_debug(fl_ctx, "firing event EventType.AFTER_TASK_DATA_FILTER")
             self.fire_event(EventType.AFTER_TASK_DATA_FILTER, fl_ctx)
-            self.log_info(fl_ctx, "sent task assignment to client")
+            self.log_info(fl_ctx, f"sent task assignment to client. client_name:{client.name} task_id:{task_id}")
 
             audit_event_id = add_job_audit_event(fl_ctx=fl_ctx, msg=f'sent task to client "{client.name}"')
             task_data.set_header(ReservedHeaderKey.AUDIT_EVENT_ID, audit_event_id)


### PR DESCRIPTION
Fixes # .

Fixed the simulator delay with large number of clients run.

### Description

A shared memory object issue in the controller task return caused the concurrent clients get_task request got the same task to run. This caused the simulator clients ran for multiple times.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
