### PR TITLE
Fix abort job with only connected clients

### DIFF
--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -20,6 +20,7 @@ import shutil
 from typing import Dict, List
 
 import nvflare.fuel.hci.file_transfer_defs as ftd
+from nvflare.apis.client import Client
 from nvflare.apis.fl_constant import AdminCommandNames, RunProcessKey
 from nvflare.apis.job_def import Job, JobDataKey, JobMetaKey, TopDir
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
@@ -215,7 +216,7 @@ class JobCommandModule(CommandModule, CommandUtil):
             conn.append_error(f"Job: {job_id} is not running.")
             return False
 
-        participants = run_process.get(RunProcessKey.PARTICIPANTS, [])
+        participants: Dict[str, Client] = run_process.get(RunProcessKey.PARTICIPANTS, {})
         wrong_clients = []
         for client in client_names:
             client_valid = False


### PR DESCRIPTION
### Description

When we abort a job, we should just send abort job messages to the clients that are connected.
The clients that are connected at job launching time might be already dead/dropped.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
