### PR TITLE
Fix incorrect server status after job aborted and server restarted

### DIFF
--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -335,9 +335,10 @@ class FederatedServer(BaseServer):
             execution_error = data.get("execution_error")
             with self.lock:
                 run_process_info = self.engine.run_processes.get(job_id)
-                if execution_error:
-                    self.engine.exception_run_processes[job_id] = run_process_info
-                run_process_info[RunProcessKey.PROCESS_FINISHED] = True
+                if run_process_info is not None:
+                    if execution_error:
+                        self.engine.exception_run_processes[job_id] = run_process_info
+                    run_process_info[RunProcessKey.PROCESS_FINISHED] = True
                 reply = make_cellnet_reply(F3ReturnCode.OK, "", None)
                 return reply
         elif command == ServerCommandNames.HEARTBEAT:

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -63,7 +63,7 @@ class JobRunner(FLComponent):
         if event_type == EventType.SYSTEM_START:
             engine = fl_ctx.get_engine()
             self.scheduler = engine.get_component(SystemComponents.JOB_SCHEDULER)
-        elif event_type in [EventType.JOB_COMPLETED, EventType.JOB_ABORTED, EventType.JOB_CANCELLED]:
+        elif event_type in [EventType.JOB_COMPLETED, EventType.END_RUN]:
             self._save_workspace(fl_ctx)
         elif event_type == EventType.SYSTEM_END:
             self.stop()

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -175,9 +175,9 @@ class ServerRunner(FLComponent):
                         optional=True,
                     )
 
+                    self.engine.persist_components(fl_ctx, completed=True)
                     self.fire_event(EventType.END_RUN, fl_ctx)
                     self.log_info(fl_ctx, "END_RUN fired")
-                    self.engine.persist_components(fl_ctx, completed=True)
 
             self.log_info(fl_ctx, "Server runner finished.")
 


### PR DESCRIPTION
### Description

After a job was aborted, the server status was "Stopped."  However, after this server was restarted, it picked that aborted job and continue running that job.  This PR fixed this issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
