### PR TITLE
Update InitializeGlobalWeights workflow to not require clients

### DIFF
--- a/nvflare/app_common/workflows/initialize_global_weights.py
+++ b/nvflare/app_common/workflows/initialize_global_weights.py
@@ -28,7 +28,6 @@ class InitializeGlobalWeights(BroadcastAndProcess):
         weights_prop_name=AppConstants.GLOBAL_MODEL,
         weight_method: str = WeightMethod.FIRST,
         weights_client_name=None,
-        clients=None,
     ):
         """A controller for initializing global model weights based on reported weights from clients.
 
@@ -38,9 +37,9 @@ class InitializeGlobalWeights(BroadcastAndProcess):
             wait_time_after_min_received: how long (secs) to wait after min responses are received
             task_timeout: max amount of time to wait for the task to end. 0 means never time out.
             weights_prop_name: name of the FL Context property to store the global weights
-            weight_method: method for determining global model weights
-            weights_client_name: name of the client if the method is "client".
-            clients: list of clients to send the task to. None means all clients.
+            weight_method: method for determining global model weights. Defaults to `WeightMethod.FIRST`.
+            weights_client_name: name of the client if the method is "client". Defaults to None.
+                If `None`, the task will be sent to all clients (to be used with `weight_method=WeightMethod.FIRST`).
         """
         BroadcastAndProcess.__init__(
             self,
@@ -51,5 +50,5 @@ class InitializeGlobalWeights(BroadcastAndProcess):
             min_responses_required=min_responses_required,
             wait_time_after_min_received=wait_time_after_min_received,
             timeout=task_timeout,
-            clients=clients,
+            clients=weights_client_name,
         )


### PR DESCRIPTION
Fixes # .

### Description

weights_client_name argument should be enough to configure the workflow:

- `weights_client_name=None` if weight_method is "first" (Default)
`weights_client_name="client_name"` if weight_method is "client"

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
