### PR TITLE
Ensure to end the simulator run after client exception.

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -384,6 +384,9 @@ class SimulatorRunner(FLComponent):
                     executor.submit(lambda p: self.client_run(*p), [clients, gpus[index]])
 
                 executor.shutdown()
+
+                # Abort the server after all clients finished run
+                self.server.abort_run()
                 server_thread.join()
                 run_status = 0
             except BaseException as e:

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -388,7 +388,10 @@ class FederatedClientBase:
 
     def run_heartbeat(self, interval):
         """Periodically runs the heartbeat."""
-        self.heartbeat(interval)
+        try:
+            self.heartbeat(interval)
+        except:
+            self.logger.error("Failed to start run_heartbeat.")
 
     def start_heartbeat(self, interval=30):
         heartbeat_thread = threading.Thread(target=self.run_heartbeat, args=[interval])


### PR DESCRIPTION
Fixes # .

### Description

Ensure to end the simulator after client exception, for example, too many files open error.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
