### PR TITLE
Fixed cell not been stopped properly when config error.

### DIFF
--- a/nvflare/fuel/f3/mpm.py
+++ b/nvflare/fuel/f3/mpm.py
@@ -140,7 +140,11 @@ class MainProcessMonitor:
         # call and wait for the main_func to complete
         logger = cls.logger()
         logger.debug(f"=========== {cls.name}: started to run forever")
-        rc = main_func()
+        rc = 0
+        try:
+            rc = main_func()
+        except:
+            logger.error("main_func execute exception.")
 
         # start shutdown process
         cls._stopping = True

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -209,6 +209,9 @@ class FederatedClientBase:
         self.cell.start()
         self.communicator.cell = self.cell
         self.net_agent = NetAgent(self.cell)
+        mpm.add_cleanup_cb(self.net_agent.close)
+        mpm.add_cleanup_cb(self.cell.stop)
+
         if self.args.job_id:
             start = time.time()
             self.logger.info("Wait for client_runner to be created.")
@@ -229,8 +232,6 @@ class FederatedClientBase:
             self.logger.info(f"Got engine after {time.time() - start} seconds")
             self.engine.cell = self.cell
             self.engine.admin_agent.register_cell_cb()
-        mpm.add_cleanup_cb(self.net_agent.close)
-        mpm.add_cleanup_cb(self.cell.stop)
 
     def _switch_ssid(self):
         if self.engine:


### PR DESCRIPTION
Fixes # .
Fix the error the job keeps running when there's config error.

### Description

- MPM catch main_func execution exception.
- stop the cell when there's config error.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
