### PR TITLE
Validate client name type in GlobalWeightsInitializer

### DIFF
--- a/nvflare/app_common/response_processors/global_weights_initializer.py
+++ b/nvflare/app_common/response_processors/global_weights_initializer.py
@@ -48,6 +48,10 @@ class GlobalWeightsInitializer(ResponseProcessor):
             raise ValueError(f"invalid weight_method '{weight_method}'")
         if weight_method == WeightMethod.CLIENT and not client_name:
             raise ValueError(f"client name not provided for weight method '{WeightMethod.CLIENT}'")
+        if weight_method == WeightMethod.CLIENT and not isinstance(client_name, str):
+            raise ValueError(
+                f"client name should be a single string for weight method '{WeightMethod.CLIENT}' but it is {client_name} "
+            )
 
         ResponseProcessor.__init__(self)
         self.weights_prop_name = weights_prop_name


### PR DESCRIPTION
Fixes # .

### Description

Validate client name type in GlobalWeightsInitializer to be single string when weight method is "client".

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
