### PR TITLE
fix controller dead client handling; added stats pool to_dict

### DIFF
--- a/nvflare/fuel/f3/cellnet/net_manager.py
+++ b/nvflare/fuel/f3/cellnet/net_manager.py
@@ -16,9 +16,7 @@ from nvflare.fuel.f3.cellnet.net_agent import NetAgent
 from nvflare.fuel.hci.conn import Connection
 from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandSpec
 from nvflare.fuel.hci.server.constants import ConnProps
-from nvflare.fuel.utils.stats_utils import StatsMode
-
-_VALID_MODES = [StatsMode.COUNT, StatsMode.PERCENT, StatsMode.AVERAGE, StatsMode.MAX, StatsMode.MIN]
+from nvflare.fuel.utils.stats_utils import VALID_HIST_MODES, parse_hist_mode
 
 
 def _to_int(s: str):
@@ -329,22 +327,6 @@ class NetManager(CommandModule):
         conn.append_dict(result)
 
     @staticmethod
-    def _parse_mode(mode: str) -> str:
-        if not mode:
-            return StatsMode.COUNT
-
-        if mode.startswith("p"):
-            return StatsMode.PERCENT
-        elif mode.startswith("c"):
-            return StatsMode.COUNT
-        elif mode.startswith("a"):
-            return StatsMode.AVERAGE
-
-        if mode not in _VALID_MODES:
-            return ""
-        return mode
-
-    @staticmethod
     def _show_table_dict(conn: Connection, d: dict):
         t = conn.append_table(d.get("headers"))
         rows = d.get("rows")
@@ -361,10 +343,10 @@ class NetManager(CommandModule):
         mode = ""
         if len(args) > 2:
             mode = args[2]
-        mode = self._parse_mode(mode)
+        mode = parse_hist_mode(mode)
 
         if not mode:
-            conn.append_error(f"invalid mode '{mode}': must be one of {_VALID_MODES}")
+            conn.append_error(f"invalid mode '{mode}': must be one of {VALID_HIST_MODES}")
             return
 
         reply = self.agent.get_msg_stats_table(target, mode)
@@ -387,10 +369,10 @@ class NetManager(CommandModule):
         mode = ""
         if len(args) > 3:
             mode = args[3]
-        mode = self._parse_mode(mode)
+        mode = parse_hist_mode(mode)
 
         if not mode:
-            conn.append_error(f"invalid mode '{mode}': must be one of {_VALID_MODES}")
+            conn.append_error(f"invalid mode '{mode}': must be one of {VALID_HIST_MODES}")
             return
 
         reply = self.agent.show_pool(target, pool_name, mode)

--- a/nvflare/fuel/f3/stats_pool.py
+++ b/nvflare/fuel/f3/stats_pool.py
@@ -98,3 +98,22 @@ class StatsPoolManager:
                     raise ValueError(f"unknown type of pool '{k}'")
                 result[k] = {"type": t, "pool": v.to_dict()}
             return result
+
+    @classmethod
+    def from_dict(cls, d: dict):
+        cls.pools = {}
+        for k, v in d.items():
+            t = v.get("type")
+            if not t:
+                raise ValueError("missing pool type")
+            pd = v.get("pool")
+            if not pd:
+                raise ValueError("missing pool data")
+
+            if t == "hist":
+                p = HistPool.from_dict(pd)
+            elif t == "counter":
+                p = CounterPool.from_dict(pd)
+            else:
+                raise ValueError(f"invalid pool type {t}")
+            cls.pools[k] = p

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -431,11 +431,7 @@ class Session(SessionSpec):
             if not job_status:
                 raise InternalError(f"missing status in job {job_id}")
 
-            if job_status in [
-                RunStatus.FINISHED_EXECUTION_EXCEPTION.value,
-                RunStatus.FINISHED_COMPLETED.value,
-                RunStatus.FINISHED_ABORTED,
-            ]:
+            if job_status.startswith("FINISHED"):
                 return MonitorReturnCode.JOB_FINISHED
 
             time.sleep(poll_interval)

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -17,7 +17,7 @@ import time
 from typing import List, Optional
 
 from nvflare.apis.fl_constant import AdminCommandNames
-from nvflare.apis.job_def import JobMetaKey, RunStatus
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.hci.client.api import AdminAPI, APIStatus, ResultKey

--- a/nvflare/fuel/utils/stats_utils.py
+++ b/nvflare/fuel/utils/stats_utils.py
@@ -311,3 +311,23 @@ def new_message_size_pool(name: str, description="", marks=None) -> HistPool:
     if not marks:
         marks = (0.01, 0.1, 1, 10, 50, 100, 200, 500, 800, 1000)
     return HistPool(name=name, description=description, marks=marks, unit="MB")
+
+
+VALID_HIST_MODES = [StatsMode.COUNT, StatsMode.PERCENT, StatsMode.AVERAGE, StatsMode.MAX, StatsMode.MIN]
+
+
+def parse_hist_mode(mode: str) -> str:
+    if not mode:
+        return StatsMode.COUNT
+
+    if mode.startswith("p"):
+        return StatsMode.PERCENT
+    elif mode.startswith("c"):
+        return StatsMode.COUNT
+    elif mode.startswith("a"):
+        return StatsMode.AVERAGE
+
+    if mode not in VALID_HIST_MODES:
+        return ""
+    else:
+        return mode


### PR DESCRIPTION
### Description

The PR addresses the following issues:
- In controller.py, there is a bug in setting the dead client report time. The report time should only record the first time the report is received, not resetting it repeatedly; otherwise the dead client logic will never be triggered.
- Also changed to use config service for dead client/job processing parameters.
- Added stats pool to_dict logic to enable pool stats to be written to file.
- Modified flare_api to use a generic way to detect job completion.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
