### PR TITLE
Do not shutdown job runner when server turn to cold state

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -224,6 +224,8 @@ class ServerCommandKey(object):
     JOB_ID = "job_id"
     CLIENTS = "clients"
     COLLECTOR = "collector"
+    REMOVE_SNAPSHOT = "__remove_snapshot__"
+    ABORT_CLIENT_RUN = "__abort_client_run__"
 
 
 class FedEventHeader(object):

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -224,8 +224,7 @@ class ServerCommandKey(object):
     JOB_ID = "job_id"
     CLIENTS = "clients"
     COLLECTOR = "collector"
-    REMOVE_SNAPSHOT = "__remove_snapshot__"
-    ABORT_CLIENT_RUN = "__abort_client_run__"
+    TURN_TO_COLD = "__turn_to_cold__"
 
 
 class FedEventHeader(object):

--- a/nvflare/app_common/job_schedulers/job_scheduler.py
+++ b/nvflare/app_common/job_schedulers/job_scheduler.py
@@ -336,3 +336,13 @@ class DefaultJobScheduler(JobSchedulerSpec, FLComponent):
 
         self.log_debug(fl_ctx, "No job is scheduled.")
         return None, None
+
+    def restore_scheduled_job(self, job_id: str):
+        with self.lock:
+            if job_id not in self.scheduled_jobs:
+                self.scheduled_jobs.append(job_id)
+
+    def remove_scheduled_job(self, job_id: str):
+        with self.lock:
+            if job_id in self.scheduled_jobs:
+                self.scheduled_jobs.remove(job_id)

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -515,19 +515,19 @@ class FederatedServer(BaseServer):
             if self.admin_server:
                 self.admin_server.client_heartbeat(token, client_name)
 
+            abort_runs = self._sync_client_jobs(request, token)
             reply = self._generate_reply(
                 headers={CellMessageHeaderKeys.MESSAGE: "Heartbeat response"}, payload=None, fl_ctx=fl_ctx
             )
-            if isinstance(self.server_state, HotState):
-                abort_runs = self._sync_client_jobs(request, token)
-                if abort_runs:
-                    reply.set_header(CellMessageHeaderKeys.ABORT_JOBS, abort_runs)
 
-                    display_runs = ",".join(abort_runs)
-                    self.logger.debug(
-                        f"These jobs: {display_runs} are not running on the server. "
-                        f"Ask client: {client_name} to abort these runs."
-                    )
+            if abort_runs:
+                reply.set_header(CellMessageHeaderKeys.ABORT_JOBS, abort_runs)
+
+                display_runs = ",".join(abort_runs)
+                self.logger.debug(
+                    f"These jobs: {display_runs} are not running on the server. "
+                    f"Ask client: {client_name} to abort these runs."
+                )
             return reply
 
     def _sync_client_jobs(self, request, client_token):

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -455,7 +455,9 @@ class FederatedServer(BaseServer):
 
             state_check = self.server_state.register(fl_ctx)
 
-            self._handle_state_check(state_check, fl_ctx)
+            error = self._handle_state_check(state_check, fl_ctx)
+            if error is not None:
+                return make_cellnet_reply(rc=F3ReturnCode.COMM_ERROR, error=error)
 
             client = self.client_manager.authenticate(request, fl_ctx)
             if client and client.token:
@@ -474,6 +476,8 @@ class FederatedServer(BaseServer):
     def _handle_state_check(self, state_check, fl_ctx: FLContext):
         if state_check.get(ACTION) in [NIS, ABORT_RUN]:
             fl_ctx.set_prop(FLContextKey.COMMUNICATION_ERROR, state_check.get(MESSAGE), sticky=False)
+            return state_check.get(MESSAGE)
+        return None
 
     def quit_client(self, request: Message) -> Message:
         """Existing client quits the federated training process.
@@ -499,7 +503,9 @@ class FederatedServer(BaseServer):
             self._before_service(fl_ctx)
 
             state_check = self.server_state.heartbeat(fl_ctx)
-            self._handle_state_check(state_check, fl_ctx)
+            error = self._handle_state_check(state_check, fl_ctx)
+            if error is not None:
+                return make_cellnet_reply(rc=F3ReturnCode.COMM_ERROR, error=error)
 
             token = request.get_header(CellMessageHeaderKeys.TOKEN)
             client_name = request.get_header(CellMessageHeaderKeys.CLIENT_NAME)

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -486,6 +486,7 @@ class JobRunner(FLComponent):
                 raise RuntimeError(f"Could not restore the server App for job: {job_id}.")
             with self.lock:
                 self.running_jobs[job_id] = job
+            self.scheduler.restore_scheduled_job(job_id)
         except Exception as e:
             self.log_error(
                 fl_ctx, f"Failed to restore the job: {job_id} to the running job table: {secure_format_exception(e)}."
@@ -532,3 +533,11 @@ class JobRunner(FLComponent):
             self.stop_run(job_id, fl_ctx)
 
         self.log_info(fl_ctx, "Stop all the running jobs.")
+        # also stop the job runner
+        self.ask_to_stop = True
+
+    def remove_running_job(self, job_id: str):
+        with self.lock:
+            if job_id in self.running_jobs:
+                del self.running_jobs[job_id]
+        self.scheduler.remove_scheduled_job(job_id)

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -532,4 +532,3 @@ class JobRunner(FLComponent):
             self.stop_run(job_id, fl_ctx)
 
         self.log_info(fl_ctx, "Stop all the running jobs.")
-        self.ask_to_stop = True

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -104,10 +104,9 @@ class AbortCommand(CommandProcessor):
         """
         server_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
         # for HA server switch over
-        remove_snapshot = data.get_header(ServerCommandKey.REMOVE_SNAPSHOT, True)
-        abort_client_run = data.get_header(ServerCommandKey.ABORT_CLIENT_RUN, True)
+        turn_to_cold = data.get_header(ServerCommandKey.TURN_TO_COLD, False)
         if server_runner:
-            server_runner.abort(fl_ctx=fl_ctx, remove_snapshot=remove_snapshot, abort_client_run=abort_client_run)
+            server_runner.abort(fl_ctx=fl_ctx, turn_to_cold=turn_to_cold)
             # wait for the runner process gracefully abort the run.
             engine = fl_ctx.get_engine()
             start_time = time.time()

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -103,8 +103,11 @@ class AbortCommand(CommandProcessor):
 
         """
         server_runner = fl_ctx.get_prop(FLContextKey.RUNNER)
+        # for HA server switch over
+        remove_snapshot = data.get_header(ServerCommandKey.REMOVE_SNAPSHOT, True)
+        abort_client_run = data.get_header(ServerCommandKey.ABORT_CLIENT_RUN, True)
         if server_runner:
-            server_runner.abort(fl_ctx)
+            server_runner.abort(fl_ctx=fl_ctx, remove_snapshot=remove_snapshot, abort_client_run=abort_client_run)
             # wait for the runner process gracefully abort the run.
             engine = fl_ctx.get_engine()
             start_time = time.time()

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -227,6 +227,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 return_code = process.poll()
                 # if process exit but with Execution exception
                 if return_code and return_code != 0:
+                    self.logger.info(f"Job: {job_id} child process exit with return code {return_code}")
                     run_process_info[RunProcessKey.PROCESS_RETURN_CODE] = return_code
                     self.exception_run_processes[job_id] = run_process_info
                 self.run_processes.pop(job_id, None)
@@ -779,6 +780,12 @@ class ServerEngine(ServerEngineInternalSpec):
     def stop_all_jobs(self):
         fl_ctx = self.new_context()
         self.job_runner.stop_all_runs(fl_ctx)
+        self.job_runner.stop()
+
+    def pause_server_jobs(self):
+        running_jobs = list(self.run_processes.keys())
+        for job_id in running_jobs:
+            self.abort_app_on_server(job_id)
 
     def close(self):
         self.executor.shutdown()

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -328,14 +328,13 @@ class ServerEngine(ServerEngineInternalSpec):
             return "Server app is starting, please wait for started before abort."
         return ""
 
-    def abort_app_on_server(self, job_id: str, abort_client_run: bool = True, remove_snapshot: bool = True) -> str:
+    def abort_app_on_server(self, job_id: str, turn_to_cold: bool = False) -> str:
         if job_id not in self.run_processes.keys():
             return "Server app has not started."
 
         self.logger.info("Abort the server app run.")
         command_data = Shareable()
-        command_data.set_header(ServerCommandKey.ABORT_CLIENT_RUN, abort_client_run)
-        command_data.set_header(ServerCommandKey.REMOVE_SNAPSHOT, remove_snapshot)
+        command_data.set_header(ServerCommandKey.TURN_TO_COLD, turn_to_cold)
 
         try:
             status_message = self.send_command_to_child_runner_process(
@@ -792,7 +791,7 @@ class ServerEngine(ServerEngineInternalSpec):
         running_jobs = list(self.run_processes.keys())
         for job_id in running_jobs:
             self.job_runner.remove_running_job(job_id)
-            self.abort_app_on_server(job_id, abort_client_run=False, remove_snapshot=False)
+            self.abort_app_on_server(job_id, turn_to_cold=True)
 
     def close(self):
         self.executor.shutdown()

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -90,6 +90,8 @@ class ServerRunner(FLComponent):
         self.current_wf = None
         self.current_wf_index = 0
         self.status = "init"
+        self.remove_snapshot = True
+        self.abort_client_run = True
 
     def _execute_run(self):
         while self.current_wf_index < len(self.config.workflows):
@@ -165,17 +167,19 @@ class ServerRunner(FLComponent):
                     self.fire_event(EventType.ABOUT_TO_END_RUN, fl_ctx)
                     self.log_info(fl_ctx, "ABOUT_TO_END_RUN fired")
 
-                    # ask all clients to end run!
-                    self.engine.send_aux_request(
-                        targets=None,
-                        topic=ReservedTopic.END_RUN,
-                        request=Shareable(),
-                        timeout=0.0,
-                        fl_ctx=fl_ctx,
-                        optional=True,
-                    )
+                    if self.abort_client_run:
+                        # ask all clients to end run!
+                        self.engine.send_aux_request(
+                            targets=None,
+                            topic=ReservedTopic.END_RUN,
+                            request=Shareable(),
+                            timeout=0.0,
+                            fl_ctx=fl_ctx,
+                            optional=True,
+                        )
 
-                    self.engine.persist_components(fl_ctx, completed=True)
+                    if self.remove_snapshot:
+                        self.engine.persist_components(fl_ctx, completed=True)
                     self.fire_event(EventType.END_RUN, fl_ctx)
                     self.log_info(fl_ctx, "END_RUN fired")
 
@@ -469,9 +473,11 @@ class ServerRunner(FLComponent):
                     "Error processing client result by {}: {}".format(self.current_wf.id, secure_format_exception(e)),
                 )
 
-    def abort(self, fl_ctx: FLContext):
+    def abort(self, fl_ctx: FLContext, abort_client_run: bool = True, remove_snapshot: bool = True):
         self.status = "done"
         self.abort_signal.trigger(value=True)
+        self.abort_client_run = abort_client_run
+        self.remove_snapshot = remove_snapshot
         self.log_info(fl_ctx, "asked to abort - triggered abort_signal to stop the RUN")
 
     def get_persist_state(self, fl_ctx: FLContext) -> dict:


### PR DESCRIPTION
### Description

If we have 2 servers, and keep promoting each other.
p1 -> p2 -> p1 (job runner dead)

We will shutdown the job runner then server is not functioning.

After HOT turn to COLD.
We should NOT shutdown job runner, but instead have it standby.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
