### PR TITLE
[WIP] Support dashboard local deployment and image/version option

### DIFF
--- a/nvflare/dashboard/application/__init__.py
+++ b/nvflare/dashboard/application/__init__.py
@@ -23,7 +23,8 @@ jwt = JWTManager()
 
 
 def init_app():
-    os.makedirs("/var/tmp/nvflare/dashboard", exist_ok=True)
+    web_root = os.environ.get("NVFL_WEB_ROOT", "/var/tmp/nvflare/dashboard")
+    os.makedirs(web_root, exist_ok=True)
     static_folder = os.environ.get("NVFL_DASHBOARD_STATIC_FOLDER", "static")
     app = Flask(__name__, static_url_path="", static_folder=static_folder)
     app.config.from_object("nvflare.dashboard.config.Config")
@@ -42,6 +43,6 @@ def init_app():
             email = credential.split(":")[0]
             pwd = credential.split(":")[1]
             Store.seed_user(email, pwd)
-    with open(os.path.join("/var/tmp/nvflare/dashboard", ".db_init_done"), "ab") as f:
+    with open(os.path.join(web_root, ".db_init_done"), "ab") as f:
         f.write(bytes())
     return app


### PR DESCRIPTION
### Description

This PR includes two feature additions which both have the same impediment.

**Image option:**  
If we start a project with NVFlare v2.x.x, then a new breaking version v3.x.x comes along, I want to continue to host my dashboard with the v2.x.x image. I notice this was abandoned in #921.

**Local deployment:**  
If I'm already in a Docker container, the current dashboard CLI forces me to use docker-in-docker or docker-out-of-docker which both have security implications I'd like to avoid. I want to be able to launch the dashboard without spinning up a new container.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

### Work done so far
* Added -i/--image option to dashboard/cli.py. If not present, then the dashboard Flask server is launched locally. If present, defaults to latest nvflare/nvflare image and accepts any other image name.
* Adjusted cli and app init to rely on NVFL_WEB_ROOT and NVFL_WEB_PORT environment variables where needed for local support.

### Blockers
The dashboard expects static files at `nvflare/dashboard/application/static/`. This directory seems to _only_ exist within the nvflare/nvflare image. I can't locate the static files in the git repo nor in the installed nvflare python package files. Where do the static files exist?

At the moment, this limitation means that the only supported image is nvflare/nvflare and if you deploy it locally you must do so from a container using the nvflare/nvflare image.

### Additional comments
Ideally the image tags under nvflare/nvflare would reference the version number, e.g. nvflare/nvflare:2.2.5.