### PR TITLE
Fixed job could not run when overseer is offline.

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -66,10 +66,15 @@ class ClientTaskWorker(FLComponent):
         args.token = client.token
 
         client_app_runner = SimulatorClientAppRunner()
-        client_runner = client_app_runner.create_client_runner(app_client_root, args, args.config_folder, client, False)
-        client_app_runner.sync_up_parents_process(client)
-        client_runner.engine.cell = client.cell
-        client_runner.init_run(app_client_root, args)
+        client_app_runner.client_runner = client_app_runner.create_client_runner(
+            app_client_root, args, args.config_folder, client, False
+        )
+        client_runner = client_app_runner.client_runner
+        with client_runner.engine.new_context() as fl_ctx:
+            client_app_runner.start_command_agent(args, client, fl_ctx)
+            client_app_runner.sync_up_parents_process(client)
+            client_runner.engine.cell = client.cell
+            client_runner.init_run(app_client_root, args)
 
     def do_one_task(self, client):
         stop_run = False

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -38,12 +38,14 @@ class ClientAppRunner(Runner):
         self.timeout = time_out
         self.client_runner = None
 
-    def start_run(self, app_root, args, config_folder, federated_client, secure_train):
+    def start_run(self, app_root, args, config_folder, federated_client, secure_train, sp):
         self.client_runner = self.create_client_runner(app_root, args, config_folder, federated_client, secure_train)
+
         federated_client.set_client_runner(self.client_runner)
-        while federated_client.communicator.cell is None:
-            self.logger.info("Waiting for the client job cell to be created ....")
-            time.sleep(1.0)
+        federated_client.set_primary_sp(sp)
+
+        with self.client_runner.engine.new_context() as fl_ctx:
+            self.start_command_agent(args, federated_client, fl_ctx)
 
         self.sync_up_parents_process(federated_client)
 
@@ -89,7 +91,7 @@ class ClientAppRunner(Runner):
             run_manager.add_handler(client_runner)
             fl_ctx.set_prop(FLContextKey.RUNNER, client_runner, private=True)
 
-            self.start_command_agent(args, client_runner, federated_client, fl_ctx)
+            # self.start_command_agent(args, client_runner, federated_client, fl_ctx)
         return client_runner
 
     def create_run_manager(self, args, conf, federated_client, workspace):
@@ -103,16 +105,11 @@ class ClientAppRunner(Runner):
             conf=conf,
         )
 
-    def start_command_agent(self, args, client_runner, federated_client, fl_ctx):
-        while federated_client.cell is None:
-            self.logger.info("Waiting for the client cell to be created ....")
-            time.sleep(1.0)
-
+    def start_command_agent(self, args, federated_client, fl_ctx):
         # Start the command agent
-        # self.command_agent = CommandAgent(federated_client, int(args.listen_port), client_runner)
-        self.command_agent = CommandAgent(federated_client, client_runner)
+        self.command_agent = CommandAgent(federated_client)
         self.command_agent.start(fl_ctx)
-        client_runner.command_agent = self.command_agent
+        self.command_agent.register_cell_cb()
 
     def sync_up_parents_process(self, federated_client):
         run_manager = federated_client.run_manager

--- a/nvflare/private/fed/client/command_agent.py
+++ b/nvflare/private/fed/client/command_agent.py
@@ -28,16 +28,13 @@ from .admin_commands import AdminCommands
 
 
 class CommandAgent(object):
-    def __init__(self, federated_client, client_runner) -> None:
+    def __init__(self, federated_client) -> None:
         """To init the CommandAgent.
 
         Args:
             federated_client: FL client object
-            listen_port: port to listen the command
-            client_runner: ClientRunner object
         """
         self.federated_client = federated_client
-        self.client_runner = client_runner
         self.thread = None
         self.asked_to_stop = False
 

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -158,12 +158,12 @@ class FederatedClientBase:
     def set_sp(self, project_name, sp: SP):
         if sp and sp.primary is True:
             server = self.servers[project_name].get("target")
-            scheme = self.servers[project_name].get("scheme", "grpc")
             location = sp.name + ":" + sp.fl_port
             if server != location:
                 self.servers[project_name]["target"] = location
                 self.sp_established = True
 
+                scheme = self.servers[project_name].get("scheme", "grpc")
                 scheme_location = scheme + "://" + location
                 if self.cell:
                     self.cell.change_server_root(scheme_location)
@@ -221,7 +221,6 @@ class FederatedClientBase:
                 time.sleep(self.cell_check_frequency)
             self.logger.info(f"Got client_runner after {time.time()-start} seconds")
             self.client_runner.engine.cell = self.cell
-            self.client_runner.command_agent.register_cell_cb()
         else:
             start = time.time()
             self.logger.info("Wait for engine to be created.")


### PR DESCRIPTION
Fixes # .

### Description

Fixed the issue when overseer is offline, the client job could not start to run issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
