### PR TITLE
Fixed a save_workspace error.

### DIFF
--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -350,8 +350,8 @@ class JobRunner(FLComponent):
                                     job_manager.set_status(job.job_id, RunStatus.FINISHED_EXECUTION_EXCEPTION, fl_ctx)
                             else:
                                 job_manager.set_status(job.job_id, RunStatus.FINISHED_COMPLETED, fl_ctx)
-                            with self.lock:
-                                del self.running_jobs[job_id]
+                        with self.lock:
+                            del self.running_jobs[job_id]
                         fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, job.job_id)
                         self.fire_event(EventType.JOB_COMPLETED, fl_ctx)
                         self.log_debug(fl_ctx, f"Finished running job:{job.job_id}")


### PR DESCRIPTION
Fixes # .

### Description

Fixed a save_workspace error, caused by a wrong indent.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
