### PR TITLE
Fix CI

### DIFF
--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -51,7 +51,10 @@ class ClientRunInfo(object):
         self.start_time = None
 
 
-GET_CLIENTS_RETRY = 60
+# TODO: make this configurable
+#   this is the number of retries for client side child/job process to get clients from server
+#   we might need to think of removing the whole get clients from server logic from child process
+GET_CLIENTS_RETRY = 300
 
 
 class ClientRunManager(ClientEngineExecutorSpec):

--- a/tests/integration_test/data/test_configs/authorization/abort_job.yml
+++ b/tests/integration_test/data/test_configs/authorization/abort_job.yml
@@ -24,7 +24,7 @@ tests:
           "data": {}
       - "trigger":
           "type": "server_log"
-          "data": "Server started"
+          "data": "Abort"
         "actions": [ "mark_test_done" ]
         "result":
           "type": "run_state"
@@ -76,7 +76,7 @@ tests:
           "data": {}
       - "trigger":
           "type": "server_log"
-          "data": "Server started"
+          "data": "Abort"
         "actions": [ "mark_test_done" ]
         "result":
           "type": "run_state"
@@ -154,7 +154,7 @@ tests:
           "data": { }
       - "trigger":
           "type": "server_log"
-          "data": "Server started"
+          "data": "Abort"
         "actions": [ "mark_test_done" ]
         "result":
           "type": "run_state"

--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -407,13 +407,12 @@ class NVFTestDriver:
                     result = event_sequence[event_idx]["result"]
                     if result["type"] == "run_state":
                         # check result state only when server is up and running
-                        if self.server_status():
+                        if self.server_status() is not None:
                             # compare run_state to expected result data from the test case
-                            if any(list(run_state.values())):
-                                _check_run_state(state=run_state, expected_state=result["data"])
-                                event_idx += 1
+                            _check_run_state(state=run_state, expected_state=result["data"])
+                            event_idx += 1
                     elif result["type"] == "admin_api_response":
-                        if not self.admin_api_response:
+                        if self.admin_api_response is None:
                             raise RuntimeError("Missing admin_api_response.")
                         assert self.admin_api_response == result["data"]
                         event_idx += 1


### PR DESCRIPTION
### Description

Fixes integration tests issue.

During HA tests,
After we submit a job to server and then shutdown the first server,
the client child process will call client app runner `start_run`
and then it will call client run manager `get_all_clients_from_server`.
It could be that the second server is still starting, so it time out and complain can't get clients from server.

So we increase this timeout for the CI tests purpose.
Note that even if we increase the timeout, if the secondary server does not come back in time, the job can still failed.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
