### PR TITLE
Clean up AdminAPI

### DIFF
--- a/nvflare/fuel/f3/qat/admin.py
+++ b/nvflare/fuel/f3/qat/admin.py
@@ -15,7 +15,7 @@
 import argparse
 
 from nvflare.fuel.common.excepts import ConfigError
-from nvflare.fuel.f3.qat2.net_config import NetConfig
+from nvflare.fuel.f3.qat.net_config import NetConfig
 from nvflare.fuel.hci.client.cli import AdminClient, CredentialType
 from nvflare.fuel.hci.client.static_service_finder import StaticServiceFinder
 from nvflare.fuel.utils.config_service import ConfigService

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -101,11 +101,7 @@ class Session(SessionSpec):
             if not os.path.isfile(client_key):
                 raise ConfigError(f"client.key does not exist at {client_key}")
 
-        # Connect with admin client
-        if conf.overseer_agent:
-            service_finder = ServiceFinderByOverseer(conf.overseer_agent)
-        else:
-            service_finder = None
+        service_finder = ServiceFinderByOverseer(conf.overseer_agent)
 
         self.api = AdminAPI(
             ca_cert=ca_cert,

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -352,10 +352,10 @@ class AdminAPI(AdminAPISpec):
             poc: Whether to enable poc mode for using the proof of concept example without secure communication.
             debug: Whether to print debug messages, which can help with diagnosing problems. False by default.
             session_event_cb: the session event callback
-            session_timeout_interval: if specified, automatically close the session after inactive for this long
-            session_status_check_interval: how often to check session status with server
-            auto_login_timeout: will keep trying to auto-login within this interval
-            auto_login_interval: how often to try to auto-login
+            session_timeout_interval: if specified, automatically close the session after inactive for this long, unit is second
+            session_status_check_interval: how often to check session status with server, unit is second
+            auto_login_timeout: will keep trying to auto-login within this interval, unit is second
+            auto_login_interval: how often to try to auto-login, unit is second
         """
         super().__init__()
         if cmd_modules is None:

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -295,7 +295,7 @@ class _Operate(State):
             cur_ssid = api.ssid
 
         if new_host != cur_host or new_port != cur_port or cur_ssid != new_ssid:
-            # need to relogin
+            # need to re-login
             api.fire_session_event(SessionEventType.SP_ADDR_CHANGED, f"Server address changed to {new_host}:{new_port}")
             return _STATE_NAME_LOGIN
 
@@ -427,8 +427,8 @@ class AdminAPI(AdminAPISpec):
         self.sess_monitor_thread = None
         self.sess_monitor_active = False
 
-        if session_event_cb is not None:
-            assert callable(session_event_cb), "session_event_cb must be callable"
+        if session_event_cb is not None and not callable(session_event_cb):
+            raise RuntimeError("session_event_cb must be callable")
         self.session_event_cb = session_event_cb
 
         # create the FSM for session monitoring

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import socket
 import ssl
 import threading
@@ -447,6 +448,8 @@ class AdminAPI(AdminAPISpec):
         self._start_session_monitor()
 
     def fire_session_event(self, event_type: str, msg: str):
+        logger = logging.getLogger(self.__class__.__name__)
+        logger.info(f"firing event {event_type}: {msg}")
         if self.session_event_cb is not None:
             self.session_event_cb(event_type, msg)
 
@@ -539,7 +542,7 @@ class AdminAPI(AdminAPISpec):
                 return "Your session is ended due to inactivity"
 
             next_state = self.fsm.execute()
-            if not next_state:
+            if next_state is None:
                 if self.fsm.error:
                     return self.fsm.error
                 else:

--- a/nvflare/fuel/hci/client/api_spec.py
+++ b/nvflare/fuel/hci/client/api_spec.py
@@ -177,10 +177,12 @@ def service_address_changed_cb_signature(host: str, port: int, ssid: str):
     pass
 
 
-class ServiceFinder(object):
+class ServiceFinder(ABC):
+    @abstractmethod
     def start(self, service_address_changed_cb):
         pass
 
+    @abstractmethod
     def stop(self):
         pass
 

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -51,15 +51,13 @@ class AdminClient(cmd.Cmd):
     """Admin command prompt for submitting admin commands to the server through the CLI.
 
     Args:
-        host: cn provisioned for the server, with this fully qualified domain name resolving to the IP of the FL server. This may be set by the OverseerAgent.
-        port: port provisioned as admin_port for FL admin communication, by default provisioned as 8003, must be int if provided. This may be set by the OverseerAgent.
         prompt: prompt to use for the command prompt
         ca_cert: path to CA Cert file, by default provisioned rootCA.pem
         client_cert: path to admin client Cert file, by default provisioned as client.crt
         client_key: path to admin client Key file, by default provisioned as client.key
         credential_type: what type of credential to use
         cmd_modules: command modules to load and register
-        idp_agent: IdpAgent to obtain the primary service provider to set the host and port of the active server
+        service_finder: used to obtain the primary service provider to set the host and port of the active server
         debug: whether to print debug messages. False by default.
     """
 
@@ -77,7 +75,7 @@ class AdminClient(cmd.Cmd):
         session_timeout_interval=900,  # close the client after 15 minutes of inactivity
         debug: bool = False,
     ):
-        cmd.Cmd.__init__(self)
+        super().__init__()
         self.intro = "Type help or ? to list commands.\n"
         self.prompt = prompt
         self.user_name = "admin"

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -110,8 +110,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         session_event_cb=None,
         session_timeout_interval=None,
         session_status_check_interval=None,
-        auto_login_timeout: float = 5,
-        auto_login_interval: float = 1,
+        auto_login_max_tries: int = 5,
     ):
         """FLAdminAPI serves as foundation for communications to FL server through the AdminAPI.
 
@@ -132,8 +131,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
             session_event_cb: the session event callback
             session_timeout_interval: if specified, automatically close the session after inactive for this long
             session_status_check_interval: how often to check session status with server
-            auto_login_timeout: will keep trying to auto-login within this interval
-            auto_login_interval: how often to try to auto-login
+            auto_login_max_tries: maximum number of tries to auto-login.
         """
         service_finder = ServiceFinderByOverseer(overseer_agent)
 
@@ -152,8 +150,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
             session_event_cb=session_event_cb,
             session_timeout_interval=session_timeout_interval,
             session_status_check_interval=session_status_check_interval,
-            auto_login_timeout=auto_login_timeout,
-            auto_login_interval=auto_login_interval,
+            auto_login_max_tries=auto_login_max_tries,
         )
         self.upload_dir = upload_dir
         self.download_dir = download_dir

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -97,13 +97,13 @@ def default_stats_handling_cb(reply: FLAdminAPIResponse) -> bool:
 class FLAdminAPI(AdminAPI, FLAdminAPISpec):
     def __init__(
         self,
+        overseer_agent: OverseerAgent,
         ca_cert: str = "",
         client_cert: str = "",
         client_key: str = "",
         upload_dir: str = "",
         download_dir: str = "",
         cmd_modules: Optional[List] = None,
-        overseer_agent: OverseerAgent = None,
         user_name: str = None,
         poc=False,
         debug=False,
@@ -125,10 +125,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
             poc: Whether to enable poc mode for using the proof of concept example without secure communication.
             debug: Whether to print debug messages. False by default.
         """
-        if overseer_agent:
-            service_finder = ServiceFinderByOverseer(overseer_agent)
-        else:
-            service_finder = None
+        service_finder = ServiceFinderByOverseer(overseer_agent)
 
         AdminAPI.__init__(
             self,
@@ -962,11 +959,3 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
                     None,
                 )
             time.sleep(interval)
-
-    def login(self, username: str):
-        result = AdminAPI.login(self, username=username)
-        return FLAdminAPIResponse(status=result["status"], details=result["details"])
-
-    def login_with_poc(self, username: str, poc_key: str):
-        result = AdminAPI.login_with_poc(self, username=username, poc_key=poc_key)
-        return FLAdminAPIResponse(status=result["status"], details=result["details"])

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -107,6 +107,11 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         user_name: str = None,
         poc=False,
         debug=False,
+        session_event_cb=None,
+        session_timeout_interval=None,
+        session_status_check_interval=None,
+        auto_login_timeout: float = 5,
+        auto_login_interval: float = 1,
     ):
         """FLAdminAPI serves as foundation for communications to FL server through the AdminAPI.
 
@@ -124,6 +129,11 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
             user_name: Username to authenticate with FL server
             poc: Whether to enable poc mode for using the proof of concept example without secure communication.
             debug: Whether to print debug messages. False by default.
+            session_event_cb: the session event callback
+            session_timeout_interval: if specified, automatically close the session after inactive for this long
+            session_status_check_interval: how often to check session status with server
+            auto_login_timeout: will keep trying to auto-login within this interval
+            auto_login_interval: how often to try to auto-login
         """
         service_finder = ServiceFinderByOverseer(overseer_agent)
 
@@ -139,6 +149,11 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
             user_name=user_name,
             poc=poc,
             debug=debug,
+            session_event_cb=session_event_cb,
+            session_timeout_interval=session_timeout_interval,
+            session_status_check_interval=session_status_check_interval,
+            auto_login_timeout=auto_login_timeout,
+            auto_login_interval=auto_login_interval,
         )
         self.upload_dir = upload_dir
         self.download_dir = download_dir

--- a/nvflare/fuel/hci/client/overseer_service_finder.py
+++ b/nvflare/fuel/hci/client/overseer_service_finder.py
@@ -21,9 +21,8 @@ from .api_spec import ServiceFinder
 
 class ServiceFinderByOverseer(ServiceFinder):
     def __init__(self, overseer_agent: OverseerAgent):
-        assert isinstance(overseer_agent, OverseerAgent), "overseer_agent must be OverseerAgent but got {}".format(
-            type(overseer_agent)
-        )
+        if not isinstance(overseer_agent, OverseerAgent):
+            raise TypeError(f"overseer_agent must be OverseerAgent but got {type(overseer_agent)}")
 
         self.overseer_agent = overseer_agent
         self.sp_address_changed_cb = None

--- a/nvflare/fuel/hci/client/static_service_finder.py
+++ b/nvflare/fuel/hci/client/static_service_finder.py
@@ -23,3 +23,6 @@ class StaticServiceFinder(ServiceFinder):
 
     def start(self, service_address_changed_cb):
         service_address_changed_cb(self.host, self.port, self.ssid)
+
+    def stop(self):
+        pass

--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -132,7 +132,7 @@ def _create_admin_api(workspace_root_dir, upload_root_dir, download_root_dir, ad
         ca_cert=ca_cert,
         client_key=client_key,
         client_cert=client_cert,
-        auto_login_timeout_interval=20,
+        auto_login_timeout=20,
         auto_login_interval=1
     )
     return admin_api

--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -132,8 +132,7 @@ def _create_admin_api(workspace_root_dir, upload_root_dir, download_root_dir, ad
         ca_cert=ca_cert,
         client_key=client_key,
         client_cert=client_cert,
-        auto_login_timeout=20,
-        auto_login_interval=1
+        auto_login_max_tries=20,
     )
     return admin_api
 

--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -132,6 +132,8 @@ def _create_admin_api(workspace_root_dir, upload_root_dir, download_root_dir, ad
         ca_cert=ca_cert,
         client_key=client_key,
         client_cert=client_cert,
+        auto_login_timeout_interval=20,
+        auto_login_interval=1
     )
     return admin_api
 


### PR DESCRIPTION
### Description

- Remove login/login_with_poc function in `FLAdminAPI` as it conflicts with auto_login
- Our `AdminAPI` required `ServiceFinder` and it can't be None
- Make `auto_login_timeout` and `auto_login_interval` as arguments instead of hard-code
- Fix code style

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
