### PR TITLE
Install all requirements first in auto test config

### DIFF
--- a/tests/integration_test/src/utils.py
+++ b/tests/integration_test/src/utils.py
@@ -341,11 +341,11 @@ def generate_test_config_yaml_for_example(
             f"cp {requirements_file} {new_requirements_file}",
             f"sed -i '/{exclude_requirements}/d' {new_requirements_file}",
             f"pip install -r {new_requirements_file}",
-            f"python convert_to_test_job.py --job {job_dir} --post {postfix}",
-            f"rm -f {new_requirements_file}",
         ]
         if example.prepare_data_script is not None:
-            setup.insert(1, f"bash {example.prepare_data_script}")
+            setup.append(f"bash {example.prepare_data_script}")
+        setup.append(f"python convert_to_test_job.py --job {job_dir} --post {postfix}")
+        setup.append(f"rm -f {new_requirements_file}")
 
         config = {
             "ha": True,


### PR DESCRIPTION
### Description

Need to install requirements.txt before run prepare_data.sh

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
