### PR TITLE
Make CsvRecordHandler thread safe

### DIFF
--- a/nvflare/fuel/f3/qat/time_comm.py
+++ b/nvflare/fuel/f3/qat/time_comm.py
@@ -17,6 +17,30 @@ import os
 
 from nvflare.fuel.f3.stats_pool import CsvRecordReader
 
+"""
+This tool can be used to compute the total time spent on communication for a job.
+
+NOTE: if all processes (server and clients) are run on the same host, then the numbers are accurate.
+If processes are running on different hosts, then these hosts must be synchronized by NTP (Network Time Protocol).
+
+Before starting this tool, you must collect the stats_pool_records.csv files for all the processes into a folder. 
+These files must all have the suffix of ".csv". For FL clients, these files are located in their workspaces.
+For FL server, you need to download the job first (using admin console or flare api) and then find it in the downloaded 
+workspace of the job.
+
+Once you have all the csv files in the same folder, you can start this tool with the following args:
+
+    -d: the directory that contains the csv files. Required.
+    -o: the output file that will contain the result. Optional.
+    
+If the output file name is not specified, it will be default to "comm.txt".
+The result is printed to the screen and written to the output file.
+
+The output file will be placed into the same folder that contains the csv files. 
+Do not name your output file as CSV file!
+
+"""
+
 
 def _print(data: str, out_file):
     print(data)

--- a/nvflare/fuel/f3/qat/time_comm.py
+++ b/nvflare/fuel/f3/qat/time_comm.py
@@ -35,7 +35,7 @@ Once you have all the csv files in the same folder, you can start this tool with
 
     -d: the directory that contains the csv files. Required.
     -o: the output file that will contain the result. Optional.
-    
+
 If the output file name is not specified, it will be default to "comm.txt".
 The result is printed to the screen and written to the output file.
 

--- a/nvflare/fuel/f3/qat/time_comm.py
+++ b/nvflare/fuel/f3/qat/time_comm.py
@@ -20,13 +20,16 @@ from nvflare.fuel.f3.stats_pool import CsvRecordReader
 """
 This tool can be used to compute the total time spent on communication for a job.
 
-NOTE: if all processes (server and clients) are run on the same host, then the numbers are accurate.
-If processes are running on different hosts, then these hosts must be synchronized by NTP (Network Time Protocol).
+NOTE: if all processes (server and clients) are run on the same host, then the computed results are accurate.
+If processes are run on different hosts, then these hosts must be synchronized with NTP (Network Time Protocol).
 
-Before starting this tool, you must collect the stats_pool_records.csv files for all the processes into a folder. 
+Before starting this tool, you must collect the stats_pool_records.csv files of all the processes into a folder. 
 These files must all have the suffix of ".csv". For FL clients, these files are located in their workspaces.
 For FL server, you need to download the job first (using admin console or flare api) and then find it in the downloaded 
 workspace of the job.
+
+Since these files have the same name in their workspaces, you must rename them when copying into the same folder.
+You can simply use the client names for clients and "server" for server file.
 
 Once you have all the csv files in the same folder, you can start this tool with the following args:
 
@@ -37,7 +40,7 @@ If the output file name is not specified, it will be default to "comm.txt".
 The result is printed to the screen and written to the output file.
 
 The output file will be placed into the same folder that contains the csv files. 
-Do not name your output file as CSV file!
+Do not name your output file with the suffix ".csv"!
 
 """
 

--- a/nvflare/fuel/f3/qat/time_comm.py
+++ b/nvflare/fuel/f3/qat/time_comm.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+from nvflare.fuel.f3.stats_pool import CsvRecordReader
+
+
+def compute_time(file_name: str, pool_name: str):
+    result = 0.0
+    max_time = 0.0
+    min_time = 1000
+    count = 0
+
+    print(f"Processing record file: {file_name}")
+    reader = CsvRecordReader(file_name)
+    for rec in reader:
+        if rec.pool_name != pool_name:
+            continue
+        count += 1
+        result += rec.value
+        if max_time < rec.value:
+            max_time = rec.value
+        if min_time > rec.value:
+            min_time = rec.value
+
+    print(f"    Max={max_time};  Min={min_time};  Avg={result/count}; Count={count}; Total={result}")
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stats_dir", "-d", type=str, help="directory that contains stats record files", required=True)
+    args = parser.parse_args()
+
+    stats_dir = args.stats_dir
+    files = os.listdir(stats_dir)
+    if not files:
+        print(f"no stats files in {stats_dir}")
+        return -1
+
+    total = 0.0
+    for fn in files:
+        if not fn.endswith(".csv"):
+            continue
+        t = compute_time(
+            file_name=os.path.join(stats_dir, fn),
+            pool_name="msg_travel",
+        )
+        total += t
+
+    print(f"Total comm time: {total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/nvflare/fuel/f3/stats_pool.py
+++ b/nvflare/fuel/f3/stats_pool.py
@@ -519,25 +519,22 @@ class CsvRecordHandler(RecordWriter):
     @staticmethod
     def read_records(csv_file_name: str):
         pools = {}
-        with open(csv_file_name) as f:
-            reader = csv.reader(f)
-            for row in reader:
-                if len(row) < 4:
-                    raise ValueError(f"'{csv_file_name}' is not a valid stats pool record file: row too short")
-                pool_name = row[0]
-                cat_name = row[1]
-                report_time = float(row[2])
-                value = float(row[3])
+        reader = CsvRecordReader(csv_file_name)
+        for rec in reader:
+            pool_name = rec.pool_name
+            cat_name = rec.category
+            report_time = rec.report_time
+            value = rec.value
 
-                cats = pools.get(pool_name)
-                if not cats:
-                    cats = {}
-                    pools[pool_name] = cats
-                recs = cats.get(cat_name)
-                if not recs:
-                    recs = []
-                    cats[cat_name] = recs
-                recs.append((report_time, value))
+            cats = pools.get(pool_name)
+            if not cats:
+                cats = {}
+                pools[pool_name] = cats
+            recs = cats.get(cat_name)
+            if not recs:
+                recs = []
+                cats[cat_name] = recs
+            recs.append((report_time, value))
         return pools
 
 
@@ -560,8 +557,8 @@ class CsvRecordReader:
 
     def __next__(self):
         row = next(self.reader)
-        if len(row) < 4:
-            raise ValueError(f"'{self.csv_file_name}' is not a valid stats pool record file: row too short")
+        if len(row) != 4:
+            raise ValueError(f"'{self.csv_file_name}' is not a valid stats pool record file: bad row length {len(row)}")
         pool_name = row[0]
         cat_name = row[1]
         report_time = float(row[2])

--- a/nvflare/fuel/f3/stats_pool.py
+++ b/nvflare/fuel/f3/stats_pool.py
@@ -44,6 +44,8 @@ VALID_HIST_MODES = [StatsMode.COUNT, StatsMode.PERCENT, StatsMode.AVERAGE, Stats
 
 
 def format_value(v: float, n=3):
+    if v is None:
+        return "n/a"
     fmt = "{:." + str(n) + "e}"
     return fmt.format(v)
 
@@ -95,9 +97,15 @@ class _Bin:
         b.count = d.get(_KEY_COUNT, 0)
         b.total = d.get(_KEY_TOTAL, 0)
         m = d.get(_KEY_MIN)
-        b.min = m if m else None
+        if isinstance(m, str):
+            b.min = None
+        else:
+            b.min = m
         x = d.get(_KEY_MAX)
-        b.min = x if x else None
+        if isinstance(x, str):
+            b.max = None
+        else:
+            b.max = x
         return b
 
 

--- a/nvflare/fuel/f3/stats_pool.py
+++ b/nvflare/fuel/f3/stats_pool.py
@@ -539,3 +539,31 @@ class CsvRecordHandler(RecordWriter):
                     cats[cat_name] = recs
                 recs.append((report_time, value))
         return pools
+
+
+class StatsRecord:
+    def __init__(self, pool_name, category, report_time, value):
+        self.pool_name = pool_name
+        self.category = category
+        self.report_time = report_time
+        self.value = value
+
+
+class CsvRecordReader:
+    def __init__(self, csv_file_name: str):
+        self.csv_file_name = csv_file_name
+        self.file = open(csv_file_name)
+        self.reader = csv.reader(self.file)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        row = next(self.reader)
+        if len(row) < 4:
+            raise ValueError(f"'{self.csv_file_name}' is not a valid stats pool record file: row too short")
+        pool_name = row[0]
+        cat_name = row[1]
+        report_time = float(row[2])
+        value = float(row[3])
+        return StatsRecord(pool_name, cat_name, report_time, value)


### PR DESCRIPTION
Fixes # .

### Description

CSV's writerow method is not thread safe. When it is called from different threads at the same time, its behavior is unpredictable. This PR put the call into a lock clause to ensure thread safety. Also added sanity check of inputs.

To make it easy to read stats record file (csv format), added CsvRecordReader.
Added the time_comm tool to compute total communication time of a job. This tool is implemented with the use of CsvRecordReader.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
