### PR TITLE
Update job path in getting started guide docs for 2.3 [skip ci]

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -41,7 +41,7 @@ using the following script:
 
 .. code-block:: shell
 
-   nvflare simulator -w /tmp/nvflare/hello-numpy-sag -n 2 -t 2 examples/hello-world/hello-numpy-sag
+   nvflare simulator -w /tmp/nvflare/hello-numpy-sag -n 2 -t 2 examples/hello-world/hello-numpy-sag/jobs/hello-numpy-sag
 
 Now you can watch the simulator run two clients (n=2) with two threads (t=2)
 and logs are saved in the `/tmp/nvflare/hello-numpy-sag` workspace.


### PR DESCRIPTION
Fixes job path in docs on getting started page: https://github.com/NVIDIA/NVFlare/discussions/1730.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
