### PR TITLE
Fix docs links for 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 **NV**IDIA **F**ederated **L**earning **A**pplication **R**untime **E**nvironment
 
 
-[NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) enables researchers to collaborate and build AI models without sharing private data. 
+[NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) enables researchers to collaborate and build AI models without sharing private data. 
 
 NVIDIA FLARE is a standalone python library designed to enable federated learning amongst different parties using their local secure protected data for client-side training, at the same time it includes capabilities to coordinate and exchange progressing of results across all sites to achieve better global model while preserving data privacy. The participating clients can be in any part of the world. 
 
 NVIDIA FLARE builds on a flexible and modular architecture and is abstracted through APIs allowing developers & researchers to customize their implementation of functional learning components in a Federated Learning paradigm. 
 
-Learn more - [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html).
+Learn more - [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html).
 
 
 ## Installation
@@ -20,55 +20,55 @@ pip install nvflare
 
 ## Quick Start
 
- * [Getting Started](https://nvflare.readthedocs.io/en/main/getting_started.html)
- * [Examples](https://github.com/NVIDIA/NVFlare/tree/main/examples/)
+ * [Getting Started](https://nvflare.readthedocs.io/en/2.2/getting_started.html)
+ * [Examples](https://github.com/NVIDIA/NVFlare/tree/2.2/examples/)
 
 ## Release Highlights
 
 ### Release 2.2.1
 
-* [FL Simulator]( https://nvflare.readthedocs.io/en/main/user_guide/fl_simulator.html) -- 
+* [FL Simulator]( https://nvflare.readthedocs.io/en/2.2/user_guide/fl_simulator.html) -- 
   A lightweight simulator of a running NVFLARE FL deployment. It allows researchers to test and debug their application without provisioning 
  a real project. The FL jobs run on a server and multiple clients in the same process but 
  in a similar way to how it would run in a real deployment. Researchers can quickly 
  build out new components and jobs that can then be directly used in a real production deployment.
  
 
-* [FLARE Dashboard](https://nvflare.readthedocs.io/en/main/user_guide/dashboard_ui.html)
+* [FLARE Dashboard](https://nvflare.readthedocs.io/en/2.2/user_guide/dashboard_ui.html)
   NVFLARE's web UI. In its initial incarnation, the Flare Dashboard is used to help
   project setup, user registration, startup kits distribution and dynamic provisions.
-  Dashboard setup and apis can be found [here](https://nvflare.readthedocs.io/en/main/user_guide/dashboard_api.html)
+  Dashboard setup and apis can be found [here](https://nvflare.readthedocs.io/en/2.2/user_guide/dashboard_api.html)
 
-* [Site-policy management](https://nvflare.readthedocs.io/en/main/user_guide/site_policy_management.html) -- 
+* [Site-policy management](https://nvflare.readthedocs.io/en/2.2/user_guide/site_policy_management.html) -- 
   Prior to NVFLARE 2.2, all policies (resource management, authorization and privacy protection, logging configurations) 
   can only be defined by the Project Admin during provision time; and authorization policies are centrally enforced by the FL Server.
   NVFLARE 2.2 makes it possible for each site to define its own policies in the following areas:
   * Resource Management: the configuration of system resources that are solely the decisions of local IT.
-  * Authorization Policy: local authorization policy that determines what a user can or cannot do on the local site. see related [Federated Authorization](https://nvflare.readthedocs.io/en/main/user_guide/federated_authorization.html)
+  * Authorization Policy: local authorization policy that determines what a user can or cannot do on the local site. see related [Federated Authorization](https://nvflare.readthedocs.io/en/2.2/user_guide/federated_authorization.html)
   * Privacy Policy: local policy that specifies what types of studies are allowed and how to add privacy protection to the learning results produced by the FL client on the local site.
   * Logging Configuration: each site can now define its own logging configuration for system generated log messages.
   
-* [Federated XGBoost](<https://github.com/NVIDIA/NVFlare/tree/main/examples/xgboost>) --
+* [Federated XGBoost](<https://github.com/NVIDIA/NVFlare/tree/2.2/examples/xgboost>) --
   We developed federated XGBoost for data scientists to perform machine learning on tabular data with popular tree-based method. In this release, we provide several 
   approaches for the horizontal federated XGBoost algorithms. 
   * Histogram-based Collaboration -- leverages recently released (XGBoost 1.7.0) federated versions of open-source XGBoost histogram-based distributed training algorithms, achieving identical results as centralized training (trees trained on global data information).
   * Tree-based Collaboration -- individual trees are independently trained on each client's local data without aggregating the global sample gradient histogram information. 
   Trained trees are collected and passed to the server / other clients for aggregation and further boosting rounds.
   
-* [Federated Statistics](<https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics>) -- 
+* [Federated Statistics](<https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics>) -- 
   built-in federated statistics operators that can generate global statistics based on local client side statistics. 
   The results, for all features of all datasets at all sites as well as global aggregates, can be visualized via the visualization utility in the notebook.  
 
-* [MONAI Integration](<https://github.com/NVIDIA/NVFlare/tree/main/integration/monai/README.md>)
+* [MONAI Integration](<https://github.com/NVIDIA/NVFlare/tree/2.2/integration/monai/README.md>)
   In 2.2 release, we provided two implementations by leveraging MONAI [Bundle](https://docs.monai.io/en/latest/bundle_intro.html).
   * MONAI [ClientAlgo](https://docs.monai.io/en/latest/fl.html#monai.fl.client.ClientAlgo) Integration -- enable running MONAI bundles directly in a federated setting using NVFLARE
   * MONAI [ClientAlgoStats](https://docs.monai.io/en/latest/fl.html#monai.fl.client.ClientAlgoStats) Integration -- through NVFLARE Federated Statistics we can generate, compare and visualize all clients' data statistics generated from MONAI summary statistics
 
 * Tools and Production Support
-  * [Improved POC command](https://nvflare.readthedocs.io/en/main/user_guide/poc_command.html) 
-  * [Dynamic Provision](https://nvflare.readthedocs.io/en/main/user_guide/dynamic_provisioning.html)
-  * [Docker Compose](https://nvflare.readthedocs.io/en/main/user_guide/docker_compose.html)
-  * [Preflight Check](https://nvflare.readthedocs.io/en/main/user_guide/preflight_check.html#nvidia-flare-preflight-check)
+  * [Improved POC command](https://nvflare.readthedocs.io/en/2.2/user_guide/poc_command.html) 
+  * [Dynamic Provision](https://nvflare.readthedocs.io/en/2.2/user_guide/dynamic_provisioning.html)
+  * [Docker Compose](https://nvflare.readthedocs.io/en/2.2/user_guide/docker_compose.html)
+  * [Preflight Check](https://nvflare.readthedocs.io/en/2.2/user_guide/preflight_check.html#nvidia-flare-preflight-check)
 
     
 ### Migrations tips 

--- a/docs/example_applications_algorithms.rst
+++ b/docs/example_applications_algorithms.rst
@@ -4,7 +4,7 @@
 Example Applications
 ####################
 NVIDIA FLARE has several examples to help you get started with federated learning and to explore certain features in
-`the examples directory <https://github.com/NVIDIA/NVFlare/tree/main/examples>`_.
+`the examples directory <https://github.com/NVIDIA/NVFlare/tree/2.2/examples>`_.
 
 .. toctree::
    :maxdepth: 1
@@ -16,13 +16,13 @@ NVIDIA FLARE has several examples to help you get started with federated learnin
    examples/hello_pt_tb
    examples/hello_tf2
    examples/federated_statistics
-   Federated XGBoost (GitHub) <https://github.com/NVIDIA/NVFlare/blob/main/examples/xgboost>
-   Hello Cyclic Weight Transfer (GitHub) <https://github.com/NVIDIA/NVFlare/blob/main/examples/hello-cyclic>
-   Federated Learning with CIFAR-10 (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>
-   Hello MONAI Bundle (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-monai-bundle>
-   Differential Privacy for BraTS18 Segmentation (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/brats18>
-   Prostate Segmentation from Multi-source Data (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/prostate>
-   Federated Policies (GitHub) <https://github.com/NVIDIA/NVFlare/blob/main/examples/federated-policies>
+   Federated XGBoost (GitHub) <https://github.com/NVIDIA/NVFlare/blob/2.2/examples/xgboost>
+   Hello Cyclic Weight Transfer (GitHub) <https://github.com/NVIDIA/NVFlare/blob/2.2/examples/hello-cyclic>
+   Federated Learning with CIFAR-10 (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>
+   Hello MONAI Bundle (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-monai-bundle>
+   Differential Privacy for BraTS18 Segmentation (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/brats18>
+   Prostate Segmentation from Multi-source Data (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/prostate>
+   Federated Policies (GitHub) <https://github.com/NVIDIA/NVFlare/blob/2.2/examples/federated-policies>
 
 
 The following quickstart guides walk you through some of these examples:
@@ -32,7 +32,7 @@ The following quickstart guides walk you through some of these examples:
 
     * :ref:`Hello Scatter and Gather <hello_scatter_and_gather>` - Example using the Scatter And Gather (SAG) workflow with a Numpy trainer
     * :ref:`Hello Cross-Site Validation <hello_cross_val>` - Example using the Cross Site Model Eval workflow with a Numpy trainer
-    * `Hello Cyclic Weight Transfer (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-cyclic>`_ - Example using the CyclicController workflow to implement `Cyclic Weight Transfer <https://pubmed.ncbi.nlm.nih.gov/29617797/>`_ with TensorFlow as the deep learning training framework
+    * `Hello Cyclic Weight Transfer (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-cyclic>`_ - Example using the CyclicController workflow to implement `Cyclic Weight Transfer <https://pubmed.ncbi.nlm.nih.gov/29617797/>`_ with TensorFlow as the deep learning training framework
 
     1.2. Deep Learning
 
@@ -41,24 +41,24 @@ The following quickstart guides walk you through some of these examples:
     * :ref:`Hello TensorFlow <hello_tf2>` - Example image classifier using FedAvg and TensorFlow as the deep learning training frameworks
 
   2. **FL algorithms**
-    * `Federated Learning with CIFAR-10 (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_ - Includes examples of using FedAvg, FedProx, FedOpt, SCAFFOLD, homomorphic encryption, and streaming of TensorBoard metrics to the server during training
-    * `Federated XGBoost (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/xgboost>`_ - Includes examples of histogram-based and tree-based algorithms. Tree-based algorithms also includes bagging and cyclic approaches
+    * `Federated Learning with CIFAR-10 (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_ - Includes examples of using FedAvg, FedProx, FedOpt, SCAFFOLD, homomorphic encryption, and streaming of TensorBoard metrics to the server during training
+    * `Federated XGBoost (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/xgboost>`_ - Includes examples of histogram-based and tree-based algorithms. Tree-based algorithms also includes bagging and cyclic approaches
 
   3. **Medical Image Analysis**
-    * `Hello MONAI Bundle (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-monai-bundle>`_ - For an example of using NVIDIA FLARE to train a 3D medical image analysis model using federated averaging (FedAvg) and MONAI Bundle `MONAI <https://monai.io/>`_
-    * `Federated Learning with Differential Privacy for BraTS18 segmentation (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/brats18>`_ - Illustrates the use of differential privacy for training brain tumor segmentation models using federated learning
-    * `Federated Learning for Prostate Segmentation from Multi-source Data (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/prostate>`_ - Example of training a multi-institutional prostate segmentation model using `FedAvg <https://arxiv.org/abs/1602.05629>`_, `FedProx <https://arxiv.org/abs/1812.06127>`_, and `Ditto <https://arxiv.org/abs/2012.04221>`_
+    * `Hello MONAI Bundle (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-monai-bundle>`_ - For an example of using NVIDIA FLARE to train a 3D medical image analysis model using federated averaging (FedAvg) and MONAI Bundle `MONAI <https://monai.io/>`_
+    * `Federated Learning with Differential Privacy for BraTS18 segmentation (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/brats18>`_ - Illustrates the use of differential privacy for training brain tumor segmentation models using federated learning
+    * `Federated Learning for Prostate Segmentation from Multi-source Data (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/prostate>`_ - Example of training a multi-institutional prostate segmentation model using `FedAvg <https://arxiv.org/abs/1602.05629>`_, `FedProx <https://arxiv.org/abs/1812.06127>`_, and `Ditto <https://arxiv.org/abs/2012.04221>`_
 
   4. **Federated Statistics**
     * :ref:`Federated Statistic Overview <federated_statistics>` - Discuss the overall federated statistics features
-    * `Federated Statistics for medical imaging (Github) <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/image_stats/README.md>`_ - Example of gathering local image histogram to compute the global dataset histograms.
-    * `Federated Statistics for tabular data with DataFrame (Github) <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/df_stats/README.md>`_ - Example of gathering local statistics summary from Pandas DataFrame to compute the global dataset statistics.
-    * `Federated Statistics with Monai Statistics integration for Spleen CT Image (Github) <https://github.com/NVIDIA/NVFlare/tree/main/integration/monai/examples/spleen_ct_segmentation/README.md>`_ - Example demonstrated Monai statistics integration and few other features in federated statistics
+    * `Federated Statistics for medical imaging (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/image_stats/README.md>`_ - Example of gathering local image histogram to compute the global dataset histograms.
+    * `Federated Statistics for tabular data with DataFrame (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/df_stats/README.md>`_ - Example of gathering local statistics summary from Pandas DataFrame to compute the global dataset statistics.
+    * `Federated Statistics with Monai Statistics integration for Spleen CT Image (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/integration/monai/examples/spleen_ct_segmentation/README.md>`_ - Example demonstrated Monai statistics integration and few other features in federated statistics
 
   5. **Federated Site Policies**
     * `Federated Policies (Github) <https://github.com/NVIDIA/NVFlare/blob/dev/examples/federated-policies/README.rst>`_ - Discuss the federated site policies for authorization, resource and data privacy management
 
-For the complete collection of example applications, see https://github.com/NVIDIA/NVFlare/tree/main/examples.
+For the complete collection of example applications, see https://github.com/NVIDIA/NVFlare/tree/2.2/examples.
 
 Custom Code in Example Apps
 ===========================
@@ -67,9 +67,9 @@ Most hello-* examples use a custom folder within the FL application.
 Note that using a custom folder in the app needs to be :ref:`allowed <troubleshooting_byoc>` when using secure provisioning.
 By default, this option is disabled in the secure mode. POC mode, however, will work with custom code by default.
 
-In contrast, the `CIFAR-10 <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_,
-`prostate segmentation <https://github.com/NVIDIA/NVFlare/tree/main/examples/prostate>`_,
-and `BraTS18 segmentation <https://github.com/NVIDIA/NVFlare/tree/main/examples/brats18>`_ examples assume that the
+In contrast, the `CIFAR-10 <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_,
+`prostate segmentation <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/prostate>`_,
+and `BraTS18 segmentation <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/brats18>`_ examples assume that the
 learner code is already installed on the client's system and available in the PYTHONPATH.
 Hence, the app folders do not include the custom code there.
 The PYTHONPATH is set in the ``run_poc.sh`` or ``run_secure.sh`` scripts of the example.
@@ -92,13 +92,13 @@ FedProx
 ^^^^^^^
 `FedProx <https://arxiv.org/abs/1812.06127>`_ implements a :class:`Loss function <nvflare.app_common.pt.pt_fedproxloss.PTFedProxLoss>`
 to penalize a client's local weights based on deviation from the global model. An example configuration can be found in
-cifar10_fedprox of the `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_.
+cifar10_fedprox of the `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_.
 
 FedOpt
 ^^^^^^
 `FedOpt <https://arxiv.org/abs/2003.00295>`_ implements a :class:`ShareableGenerator <nvflare.app_common.pt.pt_fedopt.PTFedOptModelShareableGenerator>`
 that can use a specified Optimizer and Learning Rate Scheduler when updating the global model. An example configuration
-can be found in cifar10_fedopt of `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_.
+can be found in cifar10_fedopt of `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_.
 
 SCAFFOLD
 ^^^^^^^^
@@ -110,15 +110,15 @@ Ditto
 ^^^^^
 `Ditto <https://arxiv.org/abs/2012.04221>`_ uses a slightly modified version of the prostate Learner implementation,
 namely the `ProstateDittoLearner`, which decouples local personalized model from global model via an additional model
-training and a controllable prox term. See the `prostate segmentation example <https://github.com/NVIDIA/NVFlare/tree/main/examples/prostate>`_
+training and a controllable prox term. See the `prostate segmentation example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/prostate>`_
 for an example with ditto in addition to FedProx, FedAvg, and centralized training.
 
 Federated XGBoost
 ^^^^^^^^^^^^^^^^^
-* `Federated XGBoost (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/xgboost>`_ - Includes examples of histogram-based and tree-based algorithms. Tree-based algorithms also includes bagging and cyclic approaches
+* `Federated XGBoost (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/xgboost>`_ - Includes examples of histogram-based and tree-based algorithms. Tree-based algorithms also includes bagging and cyclic approaches
 
 Federated Analytics
 ^^^^^^^^^^^^^^^^^^^
-* `Federated Statistics for medical imaging (Github) <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/image_stats/README.md>`_ - Example of gathering local image histogram to compute the global dataset histograms.
-* `Federated Statistics for tabular data with DataFrame (Github) <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/df_stats/README.md>`_ - Example of gathering local statistics summary from Pandas DataFrame to compute the global dataset statistics.
-* `Federated Statistics with Monai Statistics integration for Spleen CT Image (Github) <https://github.com/NVIDIA/NVFlare/tree/main/integration/monai/examples/spleen_ct_segmentation/README.md>`_ - Example demonstrated Monai statistics integration and few other features in federated statistics
+* `Federated Statistics for medical imaging (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/image_stats/README.md>`_ - Example of gathering local image histogram to compute the global dataset histograms.
+* `Federated Statistics for tabular data with DataFrame (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/df_stats/README.md>`_ - Example of gathering local statistics summary from Pandas DataFrame to compute the global dataset statistics.
+* `Federated Statistics with Monai Statistics integration for Spleen CT Image (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/integration/monai/examples/spleen_ct_segmentation/README.md>`_ - Example demonstrated Monai statistics integration and few other features in federated statistics

--- a/docs/examples/federated_statistics.rst
+++ b/docs/examples/federated_statistics.rst
@@ -57,13 +57,13 @@ The main steps are:
     * provide server side configuration to specify target statistics and their configurations and output location
     * implement the local statistics generator (statistics_spec)
     * provide client side configuration to specify data input location
-    * The detailed example instructions can be found in `Data frame statistics <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/df_stats/README.md>`_
+    * The detailed example instructions can be found in `Data frame statistics <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/df_stats/README.md>`_
 
 COVID 19 Radiology Image Examples
 ---------------------------------
 The second example provided is an image histogram example. Different from the tabular data example, the image example show the following:
 
-* The `image_statistics.py <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/image_stats/image_stats_job/custom/image_statistics.py>`_ only needs to calculate the count and histogram target statistics, then user only needs to provide the calculation count, failure_count and histogram functions. There is no need to implement other metrics functions (sum, mean,std_dev etc.) ( get_failure_count by default return 0 )
+* The `image_statistics.py <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/image_stats/image_stats_job/custom/image_statistics.py>`_ only needs to calculate the count and histogram target statistics, then user only needs to provide the calculation count, failure_count and histogram functions. There is no need to implement other metrics functions (sum, mean,std_dev etc.) ( get_failure_count by default return 0 )
 * For each site's dataset, there are several thousands of images, the local histogram is aggregate histogram of all the image histograms.
 * The image files are large, we can't load everything in memory, then calculate the statistics. We will need to iterate through files for each calculation. For single feature, such as example. This is ok. If there are multiple features, such as multiple channels, reload image to memory for each channel to do histogram calculation is really wasteful.
 * Unlike `Data frame statistics <https://github.com/NVIDIA/NVFlare/blob/dev/examples/federated_statistics/df_stats/README.md>`_, the histogram bin's global range is pre-defined by user [0, 256] where in Data frame statistics, besides "Age", all other features histogram global bin range is dynamically estimated based on local min/max values
@@ -76,7 +76,7 @@ Here some of the image histogram ( the underline image files have only 1 channel
 Monai Stats with Spleen CT Image example
 ----------------------------------------
 
-This example `Spleen CT Image Statistics <https://github.com/NVIDIA/NVFlare/tree/main/integration/monai/examples/spleen_ct_segmentation>`_ demonstrated few more details in federated statistics.
+This example `Spleen CT Image Statistics <https://github.com/NVIDIA/NVFlare/tree/2.2/integration/monai/examples/spleen_ct_segmentation>`_ demonstrated few more details in federated statistics.
 
 * instead of locally calculate the histogram on each image, this example shows how to get the local statistics from monai via the MONAI FLARE integration.
 * to avoid the reloading the same image into memory for each feature. This example shows the one can use pre_run() method to load and cache the externally calculated statistics. The server side controller will pass the target metrics to pre_run method so it can be used to load the statistics.
@@ -175,4 +175,4 @@ Some of the local statistics (such as count, failure count, sum etc.) can be cal
 Summary
 =======
 We provided federated statistics operators that can easily aggregate and visualize the local statistics for different data site and features.
-We hope this feature will make it easier to perform federated data analysis. For more details, please look at `Federated Statistics (Github) <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics/README.md>`_
+We hope this feature will make it easier to perform federated data analysis. For more details, please look at `Federated Statistics (Github) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics/README.md>`_

--- a/docs/examples/hello_cross_val.rst
+++ b/docs/examples/hello_cross_val.rst
@@ -177,4 +177,4 @@ Congratulations!
 You've successfully run your numpy federated learning system with cross site validation.
 
 The full source code for this exercise can be found in
-`examples/hello-numpy-cross-val <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-numpy-cross-val/>`_.
+`examples/hello-numpy-cross-val <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-numpy-cross-val/>`_.

--- a/docs/examples/hello_pt.rst
+++ b/docs/examples/hello_pt.rst
@@ -238,4 +238,4 @@ Congratulations!
 You've successfully built and run your first federated learning system.
 
 The full source code for this exercise can be found in
-`examples/hello-pt <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-pt/>`_.
+`examples/hello-pt <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-pt/>`_.

--- a/docs/examples/hello_pt_tb.rst
+++ b/docs/examples/hello_pt_tb.rst
@@ -160,5 +160,5 @@ Congratulations!
 Now you will be able to see the live training metrics of each client from a central place on the server.
 
 The full source code for this exercise can be found in
-`examples/hello-pt-tb <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-pt-tb>`_.
+`examples/hello-pt-tb <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-pt-tb>`_.
 

--- a/docs/examples/hello_scatter_and_gather.rst
+++ b/docs/examples/hello_scatter_and_gather.rst
@@ -64,9 +64,9 @@ NVIDIA FLARE Client
 You will first notice that the ``hello-numpy-sag`` application does not contain a ``custom`` folder.
 
 The code for the client and server components has been implemented in the
-`nvflare/app-common/np <https://github.com/NVIDIA/NVFlare/tree/main/nvflare/app_common/np>`_ folder of the NVFlare code tree.
+`nvflare/app-common/np <https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/app_common/np>`_ folder of the NVFlare code tree.
 
-These files, for example the trainer in `np_trainer.py <https://github.com/NVIDIA/NVFlare/tree/main/nvflare/app_common/np/np_trainer.py>`_
+These files, for example the trainer in `np_trainer.py <https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/app_common/np/np_trainer.py>`_
 can be copied into a ``custom`` folder in the ``hello-numpy-sag`` application as ``custom_trainer.py`` and modified to perform additional tasks.
 
 The ``config_fed_client.json`` configuration discussed below would then be modified to point to this custom code by providing the custom path.
@@ -163,5 +163,5 @@ You've successfully built and run your first numpy federated learning system.
 You now have a decent grasp of the main FL concepts, and are ready to start exploring how NVIDIA FLARE can be applied to many other tasks.
 
 The full application for this exercise can be found in
-`examples/hello-numpy-sag <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-numpy-sag>`_,
-with the client and server components implemented in the `nvflare/app-common/np <https://github.com/NVIDIA/NVFlare/tree/main/nvflare/app_common/np>`_ folder of the NVFlare code tree.
+`examples/hello-numpy-sag <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-numpy-sag>`_,
+with the client and server components implemented in the `nvflare/app-common/np <https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/app_common/np>`_ folder of the NVFlare code tree.

--- a/docs/examples/hello_tf2.rst
+++ b/docs/examples/hello_tf2.rst
@@ -250,4 +250,4 @@ Congratulations!
 You've successfully built and run a federated learning system using TensorFlow 2.
 
 The full source code for this exercise can be found in
-`examples/hello-tf2 <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-tf2>`_.
+`examples/hello-tf2 <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-tf2>`_.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -102,7 +102,7 @@ and instructions for this can be found in the `NVIDIA Container Toolkit Install 
 
 A simple Dockerfile is used to capture the base requirements and dependencies.  In
 this case, we're building an environment that will support PyTorch-based workflows,
-in particular the `Hello PyTorch with Tensorboard Streaming <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-pt-tb>`_
+in particular the `Hello PyTorch with Tensorboard Streaming <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-pt-tb>`_
 example. The base for this build is the NGC PyTorch container.  On this base image,
 we will install the necessary dependencies and clone the NVIDIA FLARE GitHub
 source code into the root workspace directory. To create a Dockerfile, create a file named ``Dockerfile``
@@ -241,32 +241,32 @@ Tensorboard event files.
   simulator-example/workspace/
   ├── audit.log
   ├── local
-      │  └── log.config
+      │  └── log.config
       ├── simulate_job
-      │  ├── app_server
-      │  │   ├── config
-      │  │   ├── custom
-      │  │   └── FL_global_model.pt
-      │  ├── app_site-1
-      │  │   ├── audit.log
-      │  │   ├── config
-      │  │   ├── custom
-      │  │   └── log.txt
-      │  ├── app_site-2
-      │  │   ├── audit.log
-      │  │   ├── config
-      │  │   ├── custom
-      │  │   └── log.txt
-      │  ├── cross_site_val
-      │  │   ├── cross_val_results.json
-      │  │   ├── model_shareables
-      │  │   └── result_shareables
-      │  ├── log.txt
-      │  ├── models
-      │  │   └── local_model.pt
-      │  └── tb_events
-      │      ├── site-1
-      │      └── site-2
+      │  ├── app_server
+      │  │   ├── config
+      │  │   ├── custom
+      │  │   └── FL_global_model.pt
+      │  ├── app_site-1
+      │  │   ├── audit.log
+      │  │   ├── config
+      │  │   ├── custom
+      │  │   └── log.txt
+      │  ├── app_site-2
+      │  │   ├── audit.log
+      │  │   ├── config
+      │  │   ├── custom
+      │  │   └── log.txt
+      │  ├── cross_site_val
+      │  │   ├── cross_val_results.json
+      │  │   ├── model_shareables
+      │  │   └── result_shareables
+      │  ├── log.txt
+      │  ├── models
+      │  │   └── local_model.pt
+      │  └── tb_events
+      │      ├── site-1
+      │      └── site-2
       └── startup
 
 

--- a/docs/key_features.rst
+++ b/docs/key_features.rst
@@ -17,9 +17,9 @@ To accomplish these goals, a set of key new tools and features were developed, i
  - FL Simulator
  - FLARE Dashboard
  - Site-policy management
- - Federated XGboost <https://github.com/NVIDIA/NVFlare/tree/main/examples/xgboost>
- - Federated Statistics <https://github.com/NVIDIA/NVFlare/tree/main/examples/federated_statistics>
- - MONAI Integration <https://github.com/NVIDIA/NVFlare/tree/main/integration/monai>
+ - Federated XGboost <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/xgboost>
+ - Federated Statistics <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/federated_statistics>
+ - MONAI Integration <https://github.com/NVIDIA/NVFlare/tree/2.2/integration/monai>
 
 The sections below provide an overview of these features.  For more detailed documentation and usage information, refer to the :ref:`User Guide <user_guide>` and :ref:`Programming Guide <programming_guide>`.
 
@@ -80,7 +80,7 @@ Federated XGBoost
 
 XGBoost is a popular machine learning method used by applied data scientists in a wide variety of applications. In FLARE v2.2,
 we introcuce federated XGBoost integration, with a controller and executor that run distributed XGBoost training among a group
-of clients.  See the `hello-xgboost example <https://github.com/NVIDIA/NVFlare/tree/main/examples/xgboost>`_ to get started.
+of clients.  See the `hello-xgboost example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/xgboost>`_ to get started.
 
 Federated Statistics
 """"""""""""""""""""
@@ -176,10 +176,10 @@ Learning Algorithms
       a set of initial weights is distributed to client Workers who perform local training.  After local training,
       clients return their local weights as a Shareables that are aggregated (averaged).  This new set of global average
       weights is redistributed to clients and the process repeats for the specified number of rounds.
-    - `FedProx <https://arxiv.org/abs/1812.06127>`_ (example configuration can be found in cifar10_fedprox of `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_) -
+    - `FedProx <https://arxiv.org/abs/1812.06127>`_ (example configuration can be found in cifar10_fedprox of `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_) -
       implements a :class:`Loss function <nvflare.app_common.pt.pt_fedproxloss.PTFedProxLoss>` to penalize a client's
       local weights based on deviation from the global model.
-    - `FedOpt <https://arxiv.org/abs/2003.00295>`_ (example configuration can be found in cifar10_fedopt of `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_) -
+    - `FedOpt <https://arxiv.org/abs/2003.00295>`_ (example configuration can be found in cifar10_fedopt of `CIFAR-10 example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_) -
       implements a :class:`ShareableGenerator <nvflare.app_common.pt.pt_fedopt.PTFedOptModelShareableGenerator>` that
       can use a specified Optimizer and Learning Rate Scheduler when updating the global model.
 

--- a/docs/programming_guide/controllers/cross_site_model_evaluation.rst
+++ b/docs/programming_guide/controllers/cross_site_model_evaluation.rst
@@ -11,7 +11,7 @@ client dataset.
 The server's global model is also distributed to each client for evaluation on the client's local dataset for global
 model evaluation.
 
-The `hello-numpy-cross-val example <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-numpy-cross-val>`_ is a simple
+The `hello-numpy-cross-val example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-numpy-cross-val>`_ is a simple
 example that implements the :class:`cross site model evaluation workflow<nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval>`.
 
 .. note::
@@ -19,7 +19,7 @@ example that implements the :class:`cross site model evaluation workflow<nvflare
    Previously in NVFlare before version 2.0, cross-site validation was built into the framework itself, and there was an
    admin command to retrieve cross-site validation results. In NVFlare 2.0, with the ability to have customized
    workflows, cross-site validation is no longer in the NVFlare framework but is instead handled by the workflow. The
-   the `cifar10 example <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_ is configured to run cross-site
+   the `cifar10 example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_ is configured to run cross-site
    model evaluation and ``config_fed_server.json`` is configured with :class:`ValidationJsonGenerator<nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator>`
    to write the results to a JSON file on the server.
 

--- a/docs/programming_guide/controllers/cyclic_workflow.rst
+++ b/docs/programming_guide/controllers/cyclic_workflow.rst
@@ -13,5 +13,5 @@ flow implemented through the :meth:`control_flow()<control_flow>` method based o
 
 Example with Cyclic Workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-See the `Hello Cyclic Example <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-cyclic>`_ for an example application with
+See the `Hello Cyclic Example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-cyclic>`_ for an example application with
 the cyclic workflow.

--- a/docs/programming_guide/controllers/scatter_and_gather_workflow.rst
+++ b/docs/programming_guide/controllers/scatter_and_gather_workflow.rst
@@ -45,5 +45,5 @@ Below is the signature for an aggregator.
 
 Example with Scatter and Gather Workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-See the `Hello Numpy Scatter and Gather Example <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-numpy-sag>`_ for an example application with
+See the `Hello Numpy Scatter and Gather Example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-numpy-sag>`_ for an example application with
 the scatter and gather workflow.

--- a/docs/programming_guide/event_system.rst
+++ b/docs/programming_guide/event_system.rst
@@ -156,7 +156,7 @@ Local events are local to the client, and federated events or fed events are bro
 The :class:`ConvertToFedEvent<nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent>` widget will convert
 local events to federated events.
 
-One example of how this is applied in use is in log streaming as seen in the `hello-pt-tb example <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-pt-tb>`_.
+One example of how this is applied in use is in log streaming as seen in the `hello-pt-tb example <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-pt-tb>`_.
 
 The :class:`AnalyticsSender<nvflare.app_common.widgets.streaming.AnalyticsSender>` triggers an event called "analytix_log_stats",
 as a local event on the client. If we want server side to receive this event, we will need to convert the local event

--- a/docs/programming_guide/filters.rst
+++ b/docs/programming_guide/filters.rst
@@ -44,7 +44,7 @@ purpose of security. In fact, privacy and homomorphic encryption techniques are 
     - SVTPrivacy for differential privacy through sparse vector techniques (:mod:`nvflare.app_common.filters.svt_privacy`)
     - Homomorphic encryption filters to encrypt data before sharing (:mod:`nvflare.app_common.homomorphic_encryption.he_model_encryptor.py` and :mod:`nvflare.app_common.homomorphic_encryption.he_model_decryptor`)
 
-For an example application using SVTPrivacy, see `Differential Privacy for BraTS18 segmentation (GitHub) <https://github.com/NVIDIA/NVFlare/tree/main/examples/brats18>`_.
+For an example application using SVTPrivacy, see `Differential Privacy for BraTS18 segmentation (GitHub) <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/brats18>`_.
 
 DXO - Data Exchange Object
 ===========================

--- a/docs/real_world_fl.rst
+++ b/docs/real_world_fl.rst
@@ -13,7 +13,7 @@ help gather information to provision a project and distribute startup kits, see 
 For more details on what you can do with apps with custom components and
 the flexibility that the Controller and Worker APIs bring, see the :ref:`programming_guide`.
 
-You can also see some `example applications <https://github.com/NVIDIA/NVFlare/tree/main/examples>`_ integrating with
+You can also see some `example applications <https://github.com/NVIDIA/NVFlare/tree/2.2/examples>`_ integrating with
 `Clara Train <https://docs.nvidia.com/clara/clara-train-sdk/>`_ and
 `MONAI <https://github.com/Project-MONAI/tutorials/tree/master/federated_learning/nvflare>`_
 to see the capabilities of the system and how it can be operated.

--- a/docs/real_world_fl/FLAdminAPI.rst
+++ b/docs/real_world_fl/FLAdminAPI.rst
@@ -33,7 +33,7 @@ After using FLAdminAPI, the overseer_agent must be cleaned up with a call to:
 
 Usage
 -----
-See the example scripts ``run_fl.py`` in `CIFAR-10 <https://github.com/NVIDIA/NVFlare/tree/main/examples/cifar10>`_ for
+See the example scripts ``run_fl.py`` in `CIFAR-10 <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/cifar10>`_ for
 an example of how to use the FLAdminAPI with FLAdminAPIRunner.
 
 You can use the example as inspiration to write your own code using the FLAdminAPI to operate your FL system.

--- a/docs/release_notes/2.2.1/migration_notes.md
+++ b/docs/release_notes/2.2.1/migration_notes.md
@@ -7,15 +7,15 @@
 
 Prior to NVFLARE 2.1.4, NVFLARE is using python pickle to transfer data between client and server, since 2.1.4, 
 we switched to Flare Object Serializer (FOBS), you might experience failures if your code is still using Pickle. 
-To migrate the code or you experience error due to this, please refer to [Flare Object Serializer (FOBS)](https://github.com/NVIDIA/NVFlare/tree/main/nvflare/fuel/utils/fobs/README.rst)
+To migrate the code or you experience error due to this, please refer to [Flare Object Serializer (FOBS)](https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/fuel/utils/fobs/README.rst)
 
 Another type of failure is due to data types that are not supported by FOBS. By default FOBS supports some data types, if the data type (Custom Class or Class from 3rd parties)
-is not part of supported FOBS data type, then you need to follow [Flare Object Serializer (FOBS)](https://github.com/NVIDIA/NVFlare/tree/main/nvflare/fuel/utils/fobs/README.rst) instructions.
+is not part of supported FOBS data type, then you need to follow [Flare Object Serializer (FOBS)](https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/fuel/utils/fobs/README.rst) instructions.
 Essentially, to address this type of issue, you need to do the following steps: 
 * create a FobDecomposer class for the targeted data type
 
 * Registered the newly created FobDecomposer before the data type is transmitted between client and server.  
-The following examples are directly copied from [Flare Object Serializer (FOBS)](https://github.com/NVIDIA/NVFlare/tree/main/nvflare/fuel/utils/fobs/README.rst).
+The following examples are directly copied from [Flare Object Serializer (FOBS)](https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/fuel/utils/fobs/README.rst).
 ```
 from nvflare.fuel.utils import fobs
 
@@ -73,7 +73,7 @@ re-provision your project
 
 ### Use new Project.yml template
 
-Since 2.2.1, we enabled federated site policies which require the new project.yml template. Please refer [default project.yml](https://nvflare.readthedocs.io/en/main/programming_guide/provisioning_system.html#default-project-yml-file)  
+Since 2.2.1, we enabled federated site policies which require the new project.yml template. Please refer [default project.yml](https://nvflare.readthedocs.io/en/2.2/programming_guide/provisioning_system.html#default-project-yml-file)  
 
 ### New local directory
 With 2.2.1, the provision will produce not only the ```startup``` directory, but a ```local``` directory. 

--- a/docs/user_guide/nvflare_security.rst
+++ b/docs/user_guide/nvflare_security.rst
@@ -232,7 +232,7 @@ general-purpose data filtering mechanism for processing task data and results:
 This mechanism has been used for the purpose of data privacy protection on the client side. For example, differential
 privacy filters can be applied to model weights before sending to the server for aggregation.
 
-NVFLARE has implemented some commonly used privacy protection filters: https://github.com/NVIDIA/NVFlare/tree/main/nvflare/app_common/filters
+NVFLARE has implemented some commonly used privacy protection filters: https://github.com/NVIDIA/NVFlare/tree/2.2/nvflare/app_common/filters
 
 Admin Capabilities
 -------------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,28 +1,28 @@
 # NVIDIA FLARE Examples
 
-[NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) provides several examples to help you get started using federated learning for your own applications.
+[NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) provides several examples to help you get started using federated learning for your own applications.
 
-The provided examples cover different aspects of [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html), such as using the provided [Controllers](https://nvflare.readthedocs.io/en/main/programming_guide/controllers.html) for "scatter and gather" or "cyclic weight transfer" workflows and example [Executors](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.apis.executor.html) to implement your own training and validation pipelines. Some examples use the provided "task data" and "task result" [Filters](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.apis.html?#module-nvflare.apis.filter) for homomorphic encryption and decryption or differential privacy. Furthermore, we show how to use different components for FL algorithms such as [FedAvg](https://arxiv.org/abs/1602.05629), [FedProx](https://arxiv.org/abs/1812.06127), and [FedOpt](https://arxiv.org/abs/2003.00295). We also provide domain-specific examples for deep learning and medical image analysis.
+The provided examples cover different aspects of [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html), such as using the provided [Controllers](https://nvflare.readthedocs.io/en/2.2/programming_guide/controllers.html) for "scatter and gather" or "cyclic weight transfer" workflows and example [Executors](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.apis.executor.html) to implement your own training and validation pipelines. Some examples use the provided "task data" and "task result" [Filters](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.apis.html?#module-nvflare.apis.filter) for homomorphic encryption and decryption or differential privacy. Furthermore, we show how to use different components for FL algorithms such as [FedAvg](https://arxiv.org/abs/1602.05629), [FedProx](https://arxiv.org/abs/1812.06127), and [FedOpt](https://arxiv.org/abs/2003.00295). We also provide domain-specific examples for deep learning and medical image analysis.
 
-> **_NOTE:_** To run examples, please follow the instructions for [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) and any additional steps specified in the example readmes.
+> **_NOTE:_** To run examples, please follow the instructions for [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) and any additional steps specified in the example readmes.
 
 ## 0. Quickstart
-To get started with these examples, please follow the [Quickstart](https://nvflare.readthedocs.io/en/main/quickstart.html)in the NVIDIA FLARE Documentation.  This walks you through installation, creating a POC workspace, and deploying your first NVIDIA FLARE Application.  The following examples will detail any additional requirements in their READMEs.
+To get started with these examples, please follow the [Quickstart](https://nvflare.readthedocs.io/en/2.2/quickstart.html)in the NVIDIA FLARE Documentation.  This walks you through installation, creating a POC workspace, and deploying your first NVIDIA FLARE Application.  The following examples will detail any additional requirements in their READMEs.
 ## 1. Hello World Examples
 ### 1.1 Workflows
 * [Hello Scatter and Gather](./hello-numpy-sag/README.md)
-    * Example using "[ScatterAndGather](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.workflows.scatter_and_gather.html)" controller workflow.
+    * Example using "[ScatterAndGather](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.workflows.scatter_and_gather.html)" controller workflow.
 * [Hello Cross-Site Validation](./hello-numpy-cross-val/README.md)
-    * Example using [CrossSiteModelEval](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.workflows.cross_site_model_eval.html) controller workflow.
+    * Example using [CrossSiteModelEval](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.workflows.cross_site_model_eval.html) controller workflow.
 * [Hello Cyclic Weight Transfer](./hello-cyclic/README.md)
-    * Example using [CyclicController](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.workflows.cyclic_ctl.html) controller workflow to implement [Cyclic Weight Transfer](https://pubmed.ncbi.nlm.nih.gov/29617797/).
+    * Example using [CyclicController](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.workflows.cyclic_ctl.html) controller workflow to implement [Cyclic Weight Transfer](https://pubmed.ncbi.nlm.nih.gov/29617797/).
 ### 1.2 Deep Learning
 * [Hello PyTorch](./hello-pt/README.md)
-  * Example using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
+  * Example using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
 * [Hello PyTorch with TensorBoard](./hello-pt-tb/README.md)
   * Example building upon [Hello PyTorch](./hello-pt/README.md) showcasing the [TensorBoard](https://tensorflow.org/tensorboard) streaming capability from the clients to the server.
 * [Hello TensorFlow](./hello-tf2/README.md)
-  * Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
+  * Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) an image classifier using [FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629)) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
 
 ## 2. FL algorithms
 * [Federated Learning with CIFAR-10](./cifar10/README.md)

--- a/examples/brats18/README.md
+++ b/examples/brats18/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction to MONAI, BraTS and Differential Privacy
 ### MONAI
-This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) on medical image applications.
+This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) on medical image applications.
 It uses [MONAI](https://github.com/Project-MONAI/MONAI),
 which is a PyTorch-based, open-source framework for deep learning in healthcare imaging, part of the PyTorch Ecosystem.
 ### BraTS
@@ -21,7 +21,7 @@ To run this example, please make sure you have downloaded BraTS 2018 data, which
 In this example, we split BraTS18 dataset into [4 subsets](./dataset_brats18/datalist) for 4 clients. Each client requires at least a 12 GB GPU to run. 
 ### Differential Privacy (DP)
 [Differential Privacy (DP)](https://arxiv.org/abs/1910.00962) [7] is method for ensuring that Federated Learning (FL) preserves privacy by obfuscating the model updates sent from clients to the central server.
-This example shows the usage of a MONAI-based trainer for medical image applications with NVFlare, as well as the usage of DP filters in your FL training. DP is added as a filter in `config_fed_client.json`. Here, we use the "Sparse Vector Technique", i.e. the [SVTPrivacy](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.filters.svt_privacy.html) protocol, as utilized in [Li et al. 2019](https://arxiv.org/abs/1910.00962) [7] (see [Lyu et al. 2016](https://arxiv.org/abs/1603.01699) [8] for more information).
+This example shows the usage of a MONAI-based trainer for medical image applications with NVFlare, as well as the usage of DP filters in your FL training. DP is added as a filter in `config_fed_client.json`. Here, we use the "Sparse Vector Technique", i.e. the [SVTPrivacy](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.filters.svt_privacy.html) protocol, as utilized in [Li et al. 2019](https://arxiv.org/abs/1910.00962) [7] (see [Lyu et al. 2016](https://arxiv.org/abs/1603.01699) [8] for more information).
 
 ## (Optional) 1. Set up a virtual environment
 ```
@@ -117,7 +117,7 @@ As we use the POC workspace without `meta.json`, we control the client GPU direc
 
 To enable multitasking (if there are more computation resources - e.g. 4 x 32 GB GPUs), we can adjust the default value in `workspace_server/server/startup/fed_server.json` by setting `max_jobs: 2` (default value 1). Please adjust this properly according to resource available and task demand. 
 
-For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/main/user_guide/job.html).
+For details, please refer to the [documentation](https://nvflare.readthedocs.io/en/2.2/user_guide/job.html).
 
 ### 4.3 Training with POC FL setting
 The next scripts will start the FL server and clients automatically to run FL experiments on localhost.
@@ -173,7 +173,7 @@ bash ./workspace_brats/admin/startup/fl_admin.sh
 ``` 
 
 Then using `abort_job [JOB_ID]` to abort a job, where `[JOB_ID]` is the ID assigned by the system when submitting the job. 
-For a complete list of admin commands, see [here](https://nvflare.readthedocs.io/en/main/user_guide/operation.html).
+For a complete list of admin commands, see [here](https://nvflare.readthedocs.io/en/2.2/user_guide/operation.html).
 The `[JOB_ID]` can be found from site folder like `./workspace_brats/site-1`.
 
 To log into the POC workspace admin console no username is required 

--- a/examples/cifar10/cifar10-real-world/README.md
+++ b/examples/cifar10/cifar10-real-world/README.md
@@ -170,7 +170,7 @@ all the TensorBoard event values of the different clients.
 
 > **_NOTE:_** You can always use the admin console to manually abort a running job. 
   using `abort_job [JOB_ID]`. 
-> For a complete list of admin commands, see [here](https://nvflare.readthedocs.io/en/main/user_guide/operation.html).
+> For a complete list of admin commands, see [here](https://nvflare.readthedocs.io/en/2.2/user_guide/operation.html).
 
 > To log into the POC workspace admin console no username is required 
 > (use "admin" for commands requiring conformation with username). 

--- a/examples/federated_statistics/df_stats/README.md
+++ b/examples/federated_statistics/df_stats/README.md
@@ -3,7 +3,7 @@
 In this example, we will show how to generate federated statistics for data that be represented as Pandas Data Frame
 
 ## setup NVFLARE
-follow the [Quick Start Guide](https://nvflare.readthedocs.io/en/main/quickstart.html) to setup virtual environment and install NVFLARE
+follow the [Quick Start Guide](https://nvflare.readthedocs.io/en/2.2/quickstart.html) to setup virtual environment and install NVFLARE
 ```
 install required packages.
 ```

--- a/examples/hello-cyclic/README.md
+++ b/examples/hello-cyclic/README.md
@@ -1,13 +1,13 @@
 # Hello Cyclic Weight Transfer
 
 ["Cyclic Weight Transfer"](https://pubmed.ncbi.nlm.nih.gov/29617797/
-) (CWT) is an alternative to the scatter-and-gather approach used in [FedAvg](https://arxiv.org/abs/1602.05629). CWT uses the [CyclicController](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.workflows.cyclic_ctl.html) to pass the model weights from one site to the next for repeated fine-tuning.
+) (CWT) is an alternative to the scatter-and-gather approach used in [FedAvg](https://arxiv.org/abs/1602.05629). CWT uses the [CyclicController](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.workflows.cyclic_ctl.html) to pass the model weights from one site to the next for repeated fine-tuning.
 
 > **_NOTE:_** This example uses the [MNIST](http://yann.lecun.com/exdb/mnist/) handwritten digits dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions.
 Install additional requirements:
 
 ```

--- a/examples/hello-monai-bundle/README.md
+++ b/examples/hello-monai-bundle/README.md
@@ -1,3 +1,3 @@
 # Hello MONAI Bundle
 
-For an example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) to train a medical image analysis model using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [MONAI Bundle](https://docs.monai.io/en/latest/mb_specification.html), see [../../integration/monai/README.md](../../integration/monai/README.md).
+For an example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) to train a medical image analysis model using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [MONAI Bundle](https://docs.monai.io/en/latest/mb_specification.html), see [../../integration/monai/README.md](../../integration/monai/README.md).

--- a/examples/hello-numpy-cross-val/README.md
+++ b/examples/hello-numpy-cross-val/README.md
@@ -1,12 +1,12 @@
 # Hello Numpy Cross-Site Validation
 
-The cross-site model evaluation workflow uses the data from clients to run evaluation with the models of other clients. Data is not shared. Rather the collection of models is distributed to each client site to run local validation. The server collects the results of local validation to construct an all-to-all matrix of model performance vs. client dataset. It uses the [CrossSiteModelEval](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.workflows.cross_site_model_eval.html) controller workflow.
+The cross-site model evaluation workflow uses the data from clients to run evaluation with the models of other clients. Data is not shared. Rather the collection of models is distributed to each client site to run local validation. The server collects the results of local validation to construct an all-to-all matrix of model performance vs. client dataset. It uses the [CrossSiteModelEval](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.workflows.cross_site_model_eval.html) controller workflow.
 
 > **_NOTE:_** This example uses a Numpy-based trainer and will generate its data within the code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions.
 
 ### 2. Run the experiment
 

--- a/examples/hello-numpy-sag/README.md
+++ b/examples/hello-numpy-sag/README.md
@@ -1,13 +1,13 @@
 # Hello Numpy Scatter and Gather
 
-"[Scatter and Gather](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.workflows.scatter_and_gather.html)" is the standard workflow to implement Federated Averaging ([FedAvg](https://arxiv.org/abs/1602.05629)). 
+"[Scatter and Gather](https://nvflare.readthedocs.io/en/2.2/apidocs/nvflare.app_common.workflows.scatter_and_gather.html)" is the standard workflow to implement Federated Averaging ([FedAvg](https://arxiv.org/abs/1602.05629)). 
 This workflow follows the hub and spoke model for communicating the global model to each client for local training (i.e., "scattering") and aggregates the result to perform the global model update (i.e., "gathering").  
 
 > **_NOTE:_** This example uses a Numpy-based trainer and will generate its data within the code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions.
 
 ### 2. Run the experiment
 

--- a/examples/hello-pt-tb/README.md
+++ b/examples/hello-pt-tb/README.md
@@ -1,12 +1,12 @@
 # Hello PyTorch with Tensorboard Streaming
 
-Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework. This example also highlights the TensorBoard streaming capability from the clients to the server.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework. This example also highlights the TensorBoard streaming capability from the clients to the server.
 
 > **_NOTE:_** This example uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions.
 Install additional requirements:
 
 ```
@@ -53,4 +53,4 @@ For example:
 ssh -L {local_machine_port}:127.0.0.1:6006 user@server_ip)
 ```
 
-> **_NOTE:_** For a more in-depth guide about the TensorBoard streaming feature, see [Quickstart (PyTorch with TensorBoard)](https://nvflare.readthedocs.io/en/main/examples/hello_pt_tb.html).
+> **_NOTE:_** For a more in-depth guide about the TensorBoard streaming feature, see [Quickstart (PyTorch with TensorBoard)](https://nvflare.readthedocs.io/en/2.2/examples/hello_pt_tb.html).

--- a/examples/hello-pt/README.md
+++ b/examples/hello-pt/README.md
@@ -1,12 +1,12 @@
 # Hello PyTorch
 
-Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [PyTorch](https://pytorch.org/) as the deep learning training framework.
 
 > **_NOTE:_** This example uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions.
 Install additional requirements:
 
 ```

--- a/examples/hello-tf2/README.md
+++ b/examples/hello-tf2/README.md
@@ -1,12 +1,12 @@
 # Hello TensorFlow
 
-Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
+Example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) to train an image classifier using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [TensorFlow](https://tensorflow.org/) as the deep learning training framework.
 
 > **_NOTE:_** This example uses the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset and will load its data within the trainer code.
 
 ### 1. Install NVIDIA FLARE
 
-Follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions.
+Follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions.
 Install additional requirements:
 
 ```

--- a/examples/prostate/README.md
+++ b/examples/prostate/README.md
@@ -3,7 +3,7 @@
 ## Introduction to MONAI, Prostate and Multi-source Data
 
 ### MONAI
-This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) on medical image applications.
+This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) on medical image applications.
 It uses [MONAI](https://github.com/Project-MONAI/MONAI),
 which is a PyTorch-based, open-source framework for deep learning in healthcare imaging, part of the PyTorch Ecosystem.
 

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -3,7 +3,7 @@
 ## Introduction to XGBoost and HIGGS Data
 
 ### XGBoost
-These examples show how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) on tabular data applications.
+These examples show how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) on tabular data applications.
 They use [XGBoost](https://github.com/dmlc/xgboost),
 which is an optimized distributed gradient boosting library.
 
@@ -86,7 +86,7 @@ If you want to customize for your experiments, please check `utils/prepare_data_
 
 ## HIGGS job configs preparation under various training schemes
 
-Please follow the [Installation](https://nvflare.readthedocs.io/en/main/quickstart.html) instructions to install NVFlare.
+Please follow the [Installation](https://nvflare.readthedocs.io/en/2.2/quickstart.html) instructions to install NVFlare.
 
 We then prepare the NVFlare job configs for different settings by running
 ```

--- a/examples/xgboost/histogram-based/README.md
+++ b/examples/xgboost/histogram-based/README.md
@@ -24,7 +24,7 @@ bash run_experiment_centralized.sh
 
 ### Run federated experiments in real world
 
-To run in a federated setting, follow [Real-World FL](https://nvflare.readthedocs.io/en/main/real_world_fl.html) to
+To run in a federated setting, follow [Real-World FL](https://nvflare.readthedocs.io/en/2.2/real_world_fl.html) to
 start the overseer, FL servers and FL clients.
 
 You need to download the HIGGS data on each client site.

--- a/examples/xgboost/tree-based/README.md
+++ b/examples/xgboost/tree-based/README.md
@@ -68,7 +68,7 @@ bagging training boosts a forest consisting of individually trained trees from e
 
 ### Run federated experiments in real world
 
-To run in a federated setting, follow [Real-World FL](https://nvflare.readthedocs.io/en/main/real_world_fl.html) to
+To run in a federated setting, follow [Real-World FL](https://nvflare.readthedocs.io/en/2.2/real_world_fl.html) to
 start the overseer, FL servers and FL clients.
 
 You need to download the HIGGS data on each client site.

--- a/integration/monai/README.md
+++ b/integration/monai/README.md
@@ -23,7 +23,7 @@ NVFlare executes the `ClientAlgo` class using the `ClientAlgoExecutor` class pro
 
 ### Examples
 
-For an example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) to train a medical image analysis model using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [MONAI Bundle](https://docs.monai.io/en/latest/mb_specification.html), see the [examples/spleen_ct_segmentation](./examples/spleen_ct_segmentation).
+For an example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/2.2/index.html) to train a medical image analysis model using federated averaging ([FedAvg]([FedAvg](https://arxiv.org/abs/1602.05629))) and [MONAI Bundle](https://docs.monai.io/en/latest/mb_specification.html), see the [examples/spleen_ct_segmentation](./examples/spleen_ct_segmentation).
 
 ## Requirements
 

--- a/integration/monai/examples/spleen_ct_segmentation/README.md
+++ b/integration/monai/examples/spleen_ct_segmentation/README.md
@@ -138,4 +138,4 @@ To shut down the clients and server, run the following Admin commands:
 nvflare poc --stop
 ```
 
-> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/main/user_guide/operation.html).
+> **_NOTE:_** For more information about the Admin client, see [here](https://nvflare.readthedocs.io/en/2.2/user_guide/operation.html).


### PR DESCRIPTION
Makes the links throughout this branch point to 2.2 for readthedocs and github instead of main.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
