### PR TITLE
Add codes to generate docker.sh

### DIFF
--- a/nvflare/dashboard/application/blob.py
+++ b/nvflare/dashboard/application/blob.py
@@ -119,6 +119,7 @@ def gen_server(key, first_server=True):
         "fed_learn_port": fl_port,
         "config_folder": "config",
         "ha_mode": "true" if project.ha_mode else "false",
+        "docker_image": project.app_location.split(" ")[-1] if project.app_location else "nvflare/nvflare",
         "org_name": "",
     }
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -127,6 +128,12 @@ def gen_server(key, first_server=True):
         os.mkdir(server_dir)
         os.mkdir(dest_dir)
         _write(os.path.join(dest_dir, "fed_server.json"), json.dumps(config, indent=2), "t")
+        _write(
+            os.path.join(dest_dir, "docker.sh"),
+            utils.sh_replace(template["docker_svr_sh"], replacement_dict),
+            "t",
+            exe=True,
+        )
         _write(
             os.path.join(dest_dir, "start.sh"),
             utils.sh_replace(template["start_svr_sh"], replacement_dict),
@@ -217,7 +224,7 @@ def gen_client(key, id):
     replacement_dict = {
         "client_name": entity.name,
         "config_folder": "config",
-        "docker_image": "",
+        "docker_image": project.app_location.split(" ")[-1] if project.app_location else "nvflare/nvflare",
         "org_name": entity.org,
     }
     if project.ha_mode:
@@ -240,6 +247,12 @@ def gen_client(key, id):
         os.mkdir(dest_dir)
 
         _write(os.path.join(dest_dir, "fed_client.json"), json.dumps(config, indent=2), "t")
+        _write(
+            os.path.join(dest_dir, "docker.sh"),
+            utils.sh_replace(template["docker_cln_sh"], replacement_dict),
+            "t",
+            exe=True,
+        )
         _write(
             os.path.join(dest_dir, "start.sh"),
             template["start_cln_sh"],


### PR DESCRIPTION
### Description

This PR enables dashboard to generate docker.sh in the downloaded startup kits.
The docker.sh file will be identical to that generated by provision CLI.
The docker image used in the docker.sh is from the text in `Docker Download Link` when project admin configures the project.  For example, if project admin sets it to `docker pull pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime` the docker image inside docker.sh will be `pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
