### PR TITLE
Include exception type in error logs

### DIFF
--- a/nvflare/security/logging.py
+++ b/nvflare/security/logging.py
@@ -130,4 +130,4 @@ def secure_format_exception(e: BaseException) -> str:
     if is_secure():
         return str(type(e))
     else:
-        return str(e)
+        return f"{str(type(e))}: {str(e)}"


### PR DESCRIPTION
### Description

The `str()` of an exception normally doesn't include its type. Including the type of the exception is very useful.

In the rare cases of exceptions with no details in their string representation, this is especially significant.

This is similar to the format used in Python exception tracebacks:

```python
>>> int("a")
Traceback (most recent call last):
  File "<pyshell#>", line 1, in <module>
ValueError: invalid literal for int() with base 10: 'a'

>>> try:
	int("a")
except ValueError as exc:
	print(str(exc))

invalid literal for int() with base 10: 'a'
```



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
