### PR TITLE
Don't catch BaseException

### DIFF
--- a/examples/advanced/cifar10/cifar10-real-world/figs/plot_tensorboard_events.py
+++ b/examples/advanced/cifar10/cifar10-real-world/figs/plot_tensorboard_events.py
@@ -127,7 +127,7 @@ def main():
             for k in xsite_keys:
                 try:
                     xsite_data[k].append(xsite_results["site-1"][k]["val_accuracy"])
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"No val_accuracy for {k} in {xsite_file}!")
 
     print("Training TB data:")

--- a/examples/advanced/cifar10/cifar10-sim/figs/plot_tensorboard_events.py
+++ b/examples/advanced/cifar10/cifar10-sim/figs/plot_tensorboard_events.py
@@ -115,7 +115,7 @@ def main():
             for k in xsite_keys:
                 try:
                     xsite_data[k].append(xsite_results["site-1"][k]["val_accuracy"])
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"No val_accuracy for {k} in {xsite_file}!")
 
     print("Training TB data:")

--- a/examples/advanced/cifar10/pt/learners/cifar10_learner.py
+++ b/examples/advanced/cifar10/pt/learners/cifar10_learner.py
@@ -276,7 +276,7 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
                     global_weights[var_name] = np.reshape(weights, local_var_dict[var_name].shape)
                     # update the local dict
                     local_var_dict[var_name] = torch.as_tensor(global_weights[var_name])
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"Convert weight from {var_name} failed") from e
         self.model.load_state_dict(local_var_dict)
 
@@ -338,7 +338,7 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
             try:
                 # load model to cpu as server might or might not have a GPU
                 model_data = torch.load(self.best_local_model_file, map_location="cpu")
-            except BaseException as e:
+            except Exception as e:
                 raise ValueError("Unable to load best model") from e
 
             # Create DXO and shareable from model data.
@@ -404,7 +404,7 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
                     # update the local dict
                     local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
                     n_loaded += 1
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"Convert weight from {var_name} failed") from e
         self.model.load_state_dict(local_var_dict)
         if n_loaded == 0:

--- a/examples/advanced/federated-statistics/df_stats/jobs/df_stats/app/custom/df_statistics.py
+++ b/examples/advanced/federated-statistics/df_stats/jobs/df_stats/app/custom/df_statistics.py
@@ -67,7 +67,7 @@ class DFStatistics(Statistics):
             self.log_info(fl_ctx, f"load data done for client {client_name}")
             return {"train": train, "test": test}
 
-        except BaseException as e:
+        except Exception as e:
             raise Exception(f"Load data for client {client_name} failed! {e}")
 
     def initialize(self, fl_ctx: FLContext):

--- a/examples/advanced/federated-statistics/image_stats/jobs/image_stats/app/custom/image_statistics.py
+++ b/examples/advanced/federated-statistics/image_stats/jobs/image_stats/app/custom/image_statistics.py
@@ -112,7 +112,7 @@ class ImageStatistics(Statistics):
                     self.logger.info(
                         f"{self.client_name}, adding {i + 1} of {len(self.data_list[dataset_name])}: {file}"
                     )
-            except BaseException as e:
+            except Exception as e:
                 self.failure_images += 1
                 self.logger.critical(
                     f"Failed to load file {file} with exception: {e.__str__()}. " f"Skipping this image..."

--- a/examples/advanced/vertical_federated_learning/cifar10-splitnn/src/splitnn/cifar10_learner_splitnn.py
+++ b/examples/advanced/vertical_federated_learning/cifar10-splitnn/src/splitnn/cifar10_learner_splitnn.py
@@ -113,7 +113,7 @@ class CIFAR10LearnerSplitNN(Learner):
                 if "args" not in self.model:
                     self.model["args"] = {}
                 self.model = engine.build_component(self.model)
-            except BaseException as e:
+            except Exception as e:
                 self.system_panic(
                     f"Exception while parsing `model`: " f"{self.model} with Exception {e}",
                     fl_ctx,

--- a/nvflare/apis/impl/controller.py
+++ b/nvflare/apis/impl/controller.py
@@ -245,7 +245,7 @@ class Controller(Responder, ControllerSpec, ABC):
             if task.before_task_sent_cb is not None:
                 try:
                     task.before_task_sent_cb(client_task=client_task_to_send, fl_ctx=fl_ctx)
-                except BaseException as e:
+                except Exception as e:
                     self.log_exception(
                         fl_ctx,
                         "processing error in before_task_sent_cb on task {} ({}): {}".format(
@@ -270,7 +270,7 @@ class Controller(Responder, ControllerSpec, ABC):
             if task.after_task_sent_cb is not None:
                 try:
                     task.after_task_sent_cb(client_task=client_task_to_send, fl_ctx=fl_ctx)
-                except BaseException as e:
+                except Exception as e:
                     self.log_exception(
                         fl_ctx,
                         "processing error in after_task_sent_cb on task {} ({}): {}".format(
@@ -408,7 +408,7 @@ class Controller(Responder, ControllerSpec, ABC):
                 try:
                     self.log_debug(fl_ctx, "invoking result_received_cb ...")
                     task.result_received_cb(client_task=client_task, fl_ctx=fl_ctx)
-                except BaseException as e:
+                except Exception as e:
                     # this task cannot proceed anymore
                     self.log_exception(
                         fl_ctx,
@@ -905,7 +905,7 @@ class Controller(Responder, ControllerSpec, ABC):
                     if exit_task.task_done_cb is not None:
                         try:
                             exit_task.task_done_cb(task=exit_task, fl_ctx=fl_ctx)
-                        except BaseException as e:
+                        except Exception as e:
                             self.log_exception(
                                 fl_ctx,
                                 "processing error in task_done_cb error on task {}: {}".format(

--- a/nvflare/apis/utils/fl_context_utils.py
+++ b/nvflare/apis/utils/fl_context_utils.py
@@ -31,7 +31,7 @@ def get_serializable_data(fl_ctx: FLContext):
             try:
                 fobs.dumps(v)
                 new_fl_ctx.props[k] = v
-            except BaseException as e:
+            except Exception as e:
                 msg = f"Object in FLContext with key {k} and type {type(v)} is not serializable (discarded): {secure_format_exception(e)}"
                 logger.warning(generate_log_message(fl_ctx, msg))
 

--- a/nvflare/app_common/aggregators/collect_and_assemble_aggregator.py
+++ b/nvflare/app_common/aggregators/collect_and_assemble_aggregator.py
@@ -66,7 +66,7 @@ class CollectAndAssembleAggregator(Aggregator):
         contributor_name = shareable.get_peer_prop(key=ReservedKey.IDENTITY_NAME, default="?")
         try:
             dxo = from_shareable(shareable)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, "shareable data is not a valid DXO")
             return None
 

--- a/nvflare/app_common/aggregators/intime_accumulate_model_aggregator.py
+++ b/nvflare/app_common/aggregators/intime_accumulate_model_aggregator.py
@@ -175,7 +175,7 @@ class InTimeAccumulateWeightedAggregator(Aggregator):
         """
         try:
             dxo = from_shareable(shareable)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, "shareable data is not a valid DXO")
             return False
 

--- a/nvflare/app_common/executors/error_handling_executor.py
+++ b/nvflare/app_common/executors/error_handling_executor.py
@@ -85,7 +85,7 @@ class ErrorHandlingExecutor(Executor, ABC):
             )
             return make_reply(ReturnCode.EXECUTION_RESULT_ERROR)
 
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, f"{self.__class__.__name__} executes task {task_name} failed.")
             return make_reply(ReturnCode.EXECUTION_RESULT_ERROR)
 

--- a/nvflare/app_common/executors/multi_process_executor.py
+++ b/nvflare/app_common/executors/multi_process_executor.py
@@ -141,7 +141,7 @@ class MultiProcessExecutor(Executor):
                             topic=MultiProcessCommandNames.FIRE_EVENT,
                             message=request,
                         )
-                    except BaseException:
+                    except Exception:
                         # Warning: Have to set fire_event=False, otherwise it will cause dead loop on the event handling!!!
                         self.log_warning(
                             fl_ctx,
@@ -231,7 +231,7 @@ class MultiProcessExecutor(Executor):
                 if reply.get_header(MessageHeaderKey.RETURN_CODE) != F3ReturnCode.OK:
                     self.log_exception(fl_ctx, "error initializing multi_process executor")
                     raise ValueError(reply.get_header(MessageHeaderKey.ERROR))
-        except BaseException as e:
+        except Exception as e:
             self.log_exception(fl_ctx, f"error initializing multi_process executor: {secure_format_exception(e)}")
 
     def receive_execute_result(self, request: CellMessage) -> CellMessage:
@@ -299,7 +299,7 @@ class MultiProcessExecutor(Executor):
                 topic=MultiProcessCommandNames.TASK_EXECUTION,
                 message=request,
             )
-        except BaseException:
+        except Exception:
             self.log_error(fl_ctx, "Multi-Process Execution error.")
             return make_reply(ReturnCode.EXECUTION_RESULT_ERROR)
 

--- a/nvflare/app_common/executors/statistics/statistics_task_handler.py
+++ b/nvflare/app_common/executors/statistics/statistics_task_handler.py
@@ -107,7 +107,7 @@ class StatisticsTaskHandler(TaskHandler):
                     statistics_result[tm.name][ds_name][feature.feature_name] = fn(
                         ds_name, feature.feature_name, tm, shareable, fl_ctx
                     )
-                except BaseException as e:
+                except Exception as e:
                     self.log_exception(
                         fl_ctx,
                         f"Failed to populate result  statistics of dataset {ds_name}"

--- a/nvflare/app_common/np/np_trainer.py
+++ b/nvflare/app_common/np/np_trainer.py
@@ -66,7 +66,7 @@ class NPTrainer(Executor):
         # First we extract DXO from the shareable.
         try:
             incoming_dxo = from_shareable(shareable)
-        except BaseException as e:
+        except Exception as e:
             self.system_panic(
                 f"Unable to convert shareable to model definition. Exception {secure_format_exception(e)}", fl_ctx
             )

--- a/nvflare/app_common/response_processors/global_weights_initializer.py
+++ b/nvflare/app_common/response_processors/global_weights_initializer.py
@@ -96,7 +96,7 @@ class GlobalWeightsInitializer(ResponseProcessor):
 
         try:
             dxo = from_shareable(response)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, f"bad response from client {client.name}: " f"it does not contain DXO")
             return False
 

--- a/nvflare/app_common/workflows/cross_site_model_eval.py
+++ b/nvflare/app_common/workflows/cross_site_model_eval.py
@@ -231,7 +231,7 @@ class CrossSiteModelEval(Controller):
                     return
                 self.log_debug(fl_ctx, "Checking standing tasks to see if cross site validation finished.")
                 time.sleep(self._task_check_period)
-        except BaseException as e:
+        except Exception as e:
             error_msg = f"Exception in cross site validator control_flow: {secure_format_exception(e)}"
             self.log_exception(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)

--- a/nvflare/app_common/workflows/cyclic_ctl.py
+++ b/nvflare/app_common/workflows/cyclic_ctl.py
@@ -206,7 +206,7 @@ class CyclicController(Controller):
                 self.log_debug(fl_ctx, "Ending current round={}.".format(self._current_round))
 
             self.log_debug(fl_ctx, "Cyclic ended.")
-        except BaseException as e:
+        except Exception as e:
             error_msg = f"Cyclic control_flow exception: {secure_format_exception(e)}"
             self.log_error(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -286,7 +286,7 @@ class ScatterAndGather(Controller):
 
             self._phase = AppConstants.PHASE_FINISHED
             self.log_info(fl_ctx, "Finished ScatterAndGather Training.")
-        except BaseException as e:
+        except Exception as e:
             error_msg = f"Exception in ScatterAndGather control_flow: {secure_format_exception(e)}"
             self.log_exception(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)

--- a/nvflare/app_common/workflows/scatter_and_gather_scaffold.py
+++ b/nvflare/app_common/workflows/scatter_and_gather_scaffold.py
@@ -222,7 +222,7 @@ class ScatterAndGatherScaffold(ScatterAndGather):
 
             self._phase = AppConstants.PHASE_FINISHED
             self.log_info(fl_ctx, "Finished ScatterAndGatherScaffold Training.")
-        except BaseException as e:
+        except Exception as e:
             error_msg = f"Exception in ScatterAndGatherScaffold control_flow: {secure_format_exception(e)}"
             self.log_exception(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)

--- a/nvflare/app_common/workflows/splitnn_workflow.py
+++ b/nvflare/app_common/workflows/splitnn_workflow.py
@@ -254,7 +254,7 @@ class SplitNNController(Controller):
 
             self._phase = AppConstants.PHASE_FINISHED
             self.log_debug(fl_ctx, "SplitNN training ended.")
-        except BaseException as e:
+        except Exception as e:
             error_msg = f"SplitNN control_flow exception {secure_format_exception(e)}"
             self.log_error(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)

--- a/nvflare/app_opt/he/model_shareable_generator.py
+++ b/nvflare/app_opt/he/model_shareable_generator.py
@@ -52,7 +52,7 @@ def add_to_global_weights(new_val, base_weights, v_name):
         # update the global model
         updated_vars = new_val + global_var
 
-    except BaseException as e:
+    except Exception as e:
         raise ValueError(f"add_to_global_weights Exception: {secure_format_exception(e)}") from e
 
     return updated_vars, n_vars_total
@@ -138,7 +138,7 @@ class HEModelShareableGenerator(ShareableGenerator):
         self.log_info(fl_ctx, "shareable_to_learnable...")
         try:
             return self._shareable_to_learnable(shareable, fl_ctx)
-        except BaseException as e:
+        except Exception as e:
             self.log_exception(fl_ctx, "error converting shareable to model")
             raise ValueError(f"{self._name} Exception {secure_format_exception(e)}") from e
 

--- a/nvflare/app_opt/pt/fedopt.py
+++ b/nvflare/app_opt/pt/fedopt.py
@@ -126,7 +126,7 @@ class PTFedOptModelShareableGenerator(FullModelShareableGenerator):
                 self.optimizer = engine.build_component(self.optimizer_args)
                 # get optimizer name for log
                 self.optimizer_name = self._get_component_name(self.optimizer_args)
-            except BaseException as e:
+            except Exception as e:
                 self.system_panic(
                     f"Exception while parsing `optimizer_args`({self.optimizer_args}): {secure_format_exception(e)}",
                     fl_ctx,
@@ -142,7 +142,7 @@ class PTFedOptModelShareableGenerator(FullModelShareableGenerator):
                         self.lr_scheduler_args["args"] = {}
                     self.lr_scheduler_args["args"]["optimizer"] = self.optimizer
                     self.lr_scheduler = engine.build_component(self.lr_scheduler_args)
-                except BaseException as e:
+                except Exception as e:
                     self.system_panic(
                         f"Exception while parsing `lr_scheduler_args`({self.lr_scheduler_args}): {secure_format_exception(e)}",
                         fl_ctx,

--- a/nvflare/app_opt/pt/file_model_persistor.py
+++ b/nvflare/app_opt/pt/file_model_persistor.py
@@ -123,7 +123,7 @@ class PTFileModelPersistor(ModelPersistor):
                 try:
                     with open(env_config_file_name) as file:
                         env = json.load(file)
-                except BaseException:
+                except Exception:
                     self.system_panic(
                         reason="error opening env config file {}".format(env_config_file_name), fl_ctx=fl_ctx
                     )
@@ -197,7 +197,7 @@ class PTFileModelPersistor(ModelPersistor):
                 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
                 data = torch.load(src_file_name, map_location=device)
                 # "checkpoint may contain 'model', 'optimizer', 'lr_scheduler', etc. or only contain model dict directly."
-            except BaseException:
+            except Exception:
                 self.log_exception(fl_ctx, "error loading checkpoint from {}".format(src_file_name))
                 self.system_panic(reason="cannot load model checkpoint", fl_ctx=fl_ctx)
                 return None
@@ -206,7 +206,7 @@ class PTFileModelPersistor(ModelPersistor):
             # note that, if set "determinism" in the config, the init model weights will always be the same
             try:
                 data = self.model.state_dict() if self.model is not None else OrderedDict()
-            except BaseException:
+            except Exception:
                 self.log_exception(fl_ctx, "error getting state_dict from model object")
                 self.system_panic(reason="cannot create state_dict from model object", fl_ctx=fl_ctx)
                 return None
@@ -241,7 +241,7 @@ class PTFileModelPersistor(ModelPersistor):
             data = torch.load(location, map_location=device)
             persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
             return persistence_manager.to_model_learnable(self.exclude_vars)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, "error loading checkpoint from {}".format(model_file))
             return {}
 

--- a/nvflare/app_opt/pt/he_model_reader_writer.py
+++ b/nvflare/app_opt/pt/he_model_reader_writer.py
@@ -64,5 +64,5 @@ class HEPTModelReaderWriter(PTModelReaderWriter):
             self.logger.debug(f"updated_local_model: {len(updated_local_model)}")
             net.load_state_dict(updated_local_model)
             return assign_ops
-        except BaseException as e:
+        except Exception as e:
             raise RuntimeError(f"{self._name} apply_model Exception: {secure_format_exception(e)}")

--- a/nvflare/app_opt/xgboost/histogram_based/controller.py
+++ b/nvflare/app_opt/xgboost/histogram_based/controller.py
@@ -159,7 +159,7 @@ class XGBFedController(Controller):
 
             self.log_info(fl_ctx, "Finish training phase.")
 
-        except BaseException as e:
+        except Exception as e:
             err = secure_format_traceback()
             error_msg = f"Exception in control_flow: {secure_format_exception(e)}: {err}"
             self.log_exception(fl_ctx, error_msg)

--- a/nvflare/app_opt/xgboost/histogram_based/executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based/executor.py
@@ -212,7 +212,7 @@ class FedXGBHistogramExecutor(FedXGBHistogramExecutorSpec, Executor, ABC):
                 run_dir = workspace.get_run_dir(run_number)
                 bst.save_model(os.path.join(run_dir, "test.model.json"))
                 xgb.collective.communicator_print("Finished training\n")
-        except BaseException as e:
+        except Exception as e:
             secure_log_traceback()
             self.log_error(fl_ctx, f"Exception happens when running xgb train: {secure_format_exception(e)}")
             return make_reply(ReturnCode.EXECUTION_EXCEPTION)

--- a/nvflare/app_opt/xgboost/tree_based/bagging_aggregator.py
+++ b/nvflare/app_opt/xgboost/tree_based/bagging_aggregator.py
@@ -51,7 +51,7 @@ class XGBBaggingAggregator(Aggregator):
         """
         try:
             dxo = from_shareable(shareable)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, "shareable data is not a valid DXO")
             return False
 

--- a/nvflare/dashboard/application/store.py
+++ b/nvflare/dashboard/application/store.py
@@ -176,7 +176,7 @@ class Store(object):
         try:
             db.session.add(client)
             db.session.commit()
-        except BaseException as e:
+        except Exception as e:
             log.error(f"Error while creating client: {e}")
             return None
         return add_ok({"client": _dict_or_empty(client)})
@@ -221,7 +221,7 @@ class Store(object):
         try:
             db.session.add(client)
             db.session.commit()
-        except BaseException as e:
+        except Exception as e:
             log.error(f"Error while patching client: {e}")
             return None
         return add_ok({"client": _dict_or_empty(client)})
@@ -244,7 +244,7 @@ class Store(object):
         try:
             db.session.add(client)
             db.session.commit()
-        except BaseException as e:
+        except Exception as e:
             log.error(f"Error while patching client: {e}")
             return None
         return add_ok({"client": _dict_or_empty(client)})
@@ -286,7 +286,7 @@ class Store(object):
             user.role_id = role.id
             db.session.add(user)
             db.session.commit()
-        except BaseException as e:
+        except Exception as e:
             log.error(f"Error while creating user: {e}")
             return None
         return add_ok({"user": _dict_or_empty(user)})

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -249,7 +249,7 @@ class AdminClient(cmd.Cmd):
             return self._do_default(line)
         except KeyboardInterrupt:
             self.write_stdout("\n")
-        except BaseException as e:
+        except Exception as e:
             if self.debug:
                 secure_log_traceback()
             self.write_stdout(f"exception occurred: {secure_format_exception(e)}")
@@ -288,7 +288,7 @@ class AdminClient(cmd.Cmd):
             line = join_args(args)
             try:
                 out_file = open(out_file_name, "w")
-            except BaseException as e:
+            except Exception as e:
                 self.write_error(f"cannot open file {out_file_name}: {secure_format_exception(e)}")
                 return
 

--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -882,7 +882,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
                 else:
                     print("Could not get reply from check status client, trying again later")
                     failed_attempts += 1
-            except BaseException as e:
+            except Exception as e:
                 print(f"Could not get clients stats, trying again later. Exception: {secure_format_exception(e)}")
                 failed_attempts += 1
 
@@ -944,7 +944,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
                     # if attribute cannot be found, check if app is no longer running to return APIStatus.SUCCESS
                     if reply.get("details").get("message") == "App is not running":
                         return FLAdminAPIResponse(APIStatus.SUCCESS, {"message": "Waited until app not running."}, None)
-            except BaseException as e:
+            except Exception as e:
                 print(f"Could not get server stats, trying again later. Exception: {secure_format_exception(e)}")
                 failed_attempts += 1
 

--- a/nvflare/fuel/hci/cmd_arg_utils.py
+++ b/nvflare/fuel/hci/cmd_arg_utils.py
@@ -59,7 +59,7 @@ class ArgValidator(argparse.ArgumentParser):
         try:
             result = self.parse_args(args)
             return self.err, result
-        except BaseException:
+        except Exception:
             return 'argument error; try "? cmdName to show supported usage for a command"', None
 
     def get_usage(self) -> str:

--- a/nvflare/fuel/hci/proto.py
+++ b/nvflare/fuel/hci/proto.py
@@ -207,7 +207,7 @@ def validate_proto(line: str):
                     assert isinstance(row, list)
 
         return json_data
-    except BaseException:
+    except Exception:
         return None
 
 

--- a/nvflare/fuel/hci/server/file_transfer.py
+++ b/nvflare/fuel/hci/server/file_transfer.py
@@ -177,7 +177,7 @@ class FileTransferModule(CommandModule, CommandUtil):
                 conn.append_error("logic error: unzip failed to create folder {}".format(tmp_folder_path))
                 return False, None
             return True, None
-        except BaseException as e:
+        except Exception as e:
             secure_log_traceback()
             conn.append_error(f"exception occurred: {secure_format_exception(e)}")
             return False, None

--- a/nvflare/fuel/hci/server/hci.py
+++ b/nvflare/fuel/hci/server/hci.py
@@ -78,7 +78,7 @@ class _MsgHandler(socketserver.BaseRequestHandler):
 
             if not conn.ended:
                 conn.close()
-        except BaseException:
+        except Exception:
             secure_log_traceback()
 
 

--- a/nvflare/fuel/hci/server/reg.py
+++ b/nvflare/fuel/hci/server/reg.py
@@ -103,7 +103,7 @@ class ServerCommandRegister(CommandRegister):
     def process_command(self, conn: Connection, command: str):
         try:
             self._do_command(conn, command)
-        except BaseException as e:
+        except Exception as e:
             secure_log_traceback()
             conn.append_error(f"Exception Occurred: {secure_format_exception(e)}")
 

--- a/nvflare/fuel/utils/component_builder.py
+++ b/nvflare/fuel/utils/component_builder.py
@@ -73,7 +73,7 @@ class ComponentBuilder:
                 try:
                     t = self.build_component(v)
                     class_args[k] = t
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"failed to instantiate class: {secure_format_exception(e)} ")
 
         class_path = self.get_class_path(config_dict)

--- a/nvflare/fuel/utils/fsm.py
+++ b/nvflare/fuel/utils/fsm.py
@@ -68,7 +68,7 @@ class FSM(object):
     def execute(self, **kwargs) -> State:
         try:
             self.current_state = self._try_execute(**kwargs)
-        except BaseException as e:
+        except Exception as e:
             self.error = f"exception occurred in state execution: {secure_format_exception(e)}"
             self.current_state = None
         return self.current_state

--- a/nvflare/fuel/utils/json_scanner.py
+++ b/nvflare/fuel/utils/json_scanner.py
@@ -96,7 +96,7 @@ class JsonScanner(object):
     def _do_scan(self, node: Node):
         try:
             node.processor.process_element(node)
-        except BaseException as e:
+        except Exception as e:
             secure_log_traceback(self.logger)
 
             if self.location:
@@ -126,7 +126,7 @@ class JsonScanner(object):
         if node.exit_cb is not None:
             try:
                 node.exit_cb(node)
-            except BaseException as e:
+            except Exception as e:
                 if self.location:
                     raise ConfigError(
                         "Error post-processing {} in JSON element: {}, exception: {}".format(

--- a/nvflare/ha/overseer/overseer.py
+++ b/nvflare/ha/overseer/overseer.py
@@ -31,7 +31,7 @@ from nvflare.ha.overseer.utils import (
 heartbeat_timeout = os.environ.get("NVFL_OVERSEER_HEARTBEAT_TIMEOUT", "10")
 try:
     heartbeat_timeout = int(heartbeat_timeout)
-except BaseException:
+except Exception:
     heartbeat_timeout = 10
 
 

--- a/nvflare/lighter/impl/docker.py
+++ b/nvflare/lighter/impl/docker.py
@@ -97,6 +97,6 @@ class DockerBuilder(Builder):
             f.write(self.template.get("dockerfile"))
         try:
             shutil.copyfile(self.requirements_file, os.path.join(compose_build_dir, "requirements.txt"))
-        except BaseException:
+        except Exception:
             f = open(os.path.join(compose_build_dir, "requirements.txt"), "wt")
             f.close()

--- a/nvflare/lighter/poc.py
+++ b/nvflare/lighter/poc.py
@@ -49,7 +49,7 @@ def unpack_poc(dest_poc_folder) -> bool:
 def copy_from_src(src_poc_folder, dest_poc_folder):
     try:
         shutil.copytree(src_poc_folder, dest_poc_folder)
-    except BaseException as e:
+    except Exception as e:
         print(f"Unable to copy poc folder from {src_poc_folder}, Exit. {e} ")
         exit(1)
 
@@ -65,7 +65,7 @@ def clone_poc_folder(src_poc_folder, dest_poc_folder):
             if dir == "admin":
                 try:
                     os.mkdir(os.path.join(root, dir, "local"))
-                except BaseException:
+                except Exception:
                     pass
                 break
         for file in files:

--- a/nvflare/lighter/provision.py
+++ b/nvflare/lighter/provision.py
@@ -109,7 +109,7 @@ def handle_provision(args):
             extra = load_yaml(os.path.join(current_path, args.add_user))
             extra.update({"type": "admin"})
             participants.append(Participant(**extra))
-        except BaseException:
+        except Exception:
             print("** Error during adding user **")
             print("The yaml file format is")
             print(adding_user_error_msg)
@@ -119,7 +119,7 @@ def handle_provision(args):
             extra = load_yaml(os.path.join(current_path, args.add_client))
             extra.update({"type": "client"})
             participants.append(Participant(**extra))
-        except BaseException as e:
+        except Exception as e:
             print("** Error during adding client **")
             print("The yaml file format is")
             print(adding_client_error_msg)

--- a/nvflare/lighter/spec.py
+++ b/nvflare/lighter/spec.py
@@ -176,7 +176,7 @@ class Provisioner(object):
             for b in self.builders[::-1]:
                 b.finalize(ctx)
 
-        except BaseException as ex:
+        except Exception as ex:
             prod_dir = ctx.get("current_prod_dir")
             if prod_dir:
                 shutil.rmtree(prod_dir)

--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -111,7 +111,7 @@ def verify_folder_signature(folder):
                         algorithm=hashes.SHA256(),
                     )
         return True
-    except BaseException as e:
+    except Exception as e:
         return False
 
 

--- a/nvflare/private/aux_runner.py
+++ b/nvflare/private/aux_runner.py
@@ -108,7 +108,7 @@ class AuxRunner(FLComponent):
             return make_reply(ReturnCode.BAD_PEER_CONTEXT)
         try:
             reply = handler_f(topic=topic, request=request, fl_ctx=fl_ctx)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, "processing error in message handling")
             return make_reply(ReturnCode.HANDLER_EXCEPTION)
 
@@ -187,7 +187,7 @@ class AuxRunner(FLComponent):
                 bulk_send=bulk_send,
                 optional=optional,
             )
-        except BaseException:
+        except Exception:
             if optional:
                 self.logger.debug(f"Failed to send aux message {topic} to targets: {targets}")
                 self.logger.debug(secure_format_traceback())

--- a/nvflare/private/fed/app/client/client_train.py
+++ b/nvflare/private/fed/app/client/client_train.py
@@ -66,7 +66,7 @@ def main():
             f = workspace.get_file_path_in_root(name)
             if os.path.exists(f):
                 os.remove(f)
-        except BaseException:
+        except Exception:
             print("Could not remove the {} file.  Please check your system before starting FL.".format(name))
             sys.exit(-1)
 

--- a/nvflare/private/fed/app/client/sub_worker_process.py
+++ b/nvflare/private/fed/app/client/sub_worker_process.py
@@ -125,7 +125,7 @@ class EventRelayer(FLComponent):
                     )
                     # update the fl_ctx from the child process return data.
                     fl_ctx.props.update(return_data.payload[CommunicationMetaData.FL_CTX].props)
-                except BaseException:
+                except Exception:
                     self.log_warning(
                         fl_ctx, f"Failed to relay the event to parent process. Event: {event_type}", fire_event=False
                     )

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -76,7 +76,7 @@ def main():
 
     try:
         remove_restart_file(workspace)
-    except BaseException:
+    except Exception:
         print("Could not remove the restart.fl / shutdown.fl file.  Please check your system before starting FL.")
         sys.exit(-1)
 
@@ -135,7 +135,7 @@ def main():
         sp = _create_sp(args)
         client_app_runner.start_run(app_root, args, config_folder, federated_client, secure_train, sp)
 
-    except BaseException as e:
+    except Exception as e:
         if logger:
             logger.error(f"FL client execution exception: {secure_format_exception(e)}")
         raise e

--- a/nvflare/private/fed/app/deployer/simulator_deployer.py
+++ b/nvflare/private/fed/app/deployer/simulator_deployer.py
@@ -143,7 +143,7 @@ class SimulatorDeployer(ServerDeployer):
                 try:
                     data = json.load(file)
                     augment(to_dict=client_config, from_dict=data, from_override_to=False)
-                except BaseException as e:
+                except Exception as e:
                     raise RuntimeError(f"Error processing config file {resources}: {secure_format_exception(e)}")
 
         build_ctx = {

--- a/nvflare/private/fed/app/fl_conf.py
+++ b/nvflare/private/fed/app/fl_conf.py
@@ -105,7 +105,7 @@ class FLServerStarterConfiger(JsonConfigurator):
                     server[SSLConstants.ROOT_CERT] = self.workspace.get_file_path_in_startup(
                         server[SSLConstants.ROOT_CERT]
                     )
-        except BaseException:
+        except Exception:
             raise ValueError(f"Server config error: '{self.server_config_file_names}'")
 
     def build_component(self, config_dict):
@@ -299,7 +299,7 @@ class FLClientStarterConfiger(JsonConfigurator):
                 client[SSLConstants.CERT] = self.workspace.get_file_path_in_startup(client[SSLConstants.CERT])
             if client.get(SSLConstants.ROOT_CERT):
                 client[SSLConstants.ROOT_CERT] = self.workspace.get_file_path_in_startup(client[SSLConstants.ROOT_CERT])
-        except BaseException:
+        except Exception:
             raise ValueError(f"Client config error: '{self.client_config_file_names}'")
 
     def finalize_config(self, config_ctx: ConfigContext):

--- a/nvflare/private/fed/app/server/server_train.py
+++ b/nvflare/private/fed/app/server/server_train.py
@@ -66,7 +66,7 @@ def main():
             f = workspace.get_file_path_in_root(name)
             if os.path.exists(f):
                 os.remove(f)
-        except BaseException:
+        except Exception:
             print(f"Could not remove file '{name}'.  Please check your system before starting FL.")
             sys.exit(-1)
 

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -219,7 +219,7 @@ class SimulatorRunner(FLComponent):
 
             return True
 
-        except BaseException as e:
+        except Exception as e:
             self.logger.error(f"Simulator setup error: {secure_format_exception(e)}")
             return False
 
@@ -385,7 +385,7 @@ class SimulatorRunner(FLComponent):
                 self.server.abort_run()
                 server_thread.join()
                 run_status = 0
-            except BaseException as e:
+            except Exception as e:
                 self.logger.error(f"Simulator run error: {secure_format_exception(e)}")
                 run_status = 2
             finally:
@@ -470,7 +470,7 @@ class SimulatorClientRunner(FLComponent):
 
             # wait for the server and client running thread to finish.
             executor.shutdown()
-        except BaseException as e:
+        except Exception as e:
             self.logger.error(f"SimulatorClientRunner run error: {secure_format_exception(e)}")
         finally:
             for client in self.federated_clients:
@@ -506,7 +506,7 @@ class SimulatorClientRunner(FLComponent):
                 stop_run, client_to_run = self.do_one_task(client, num_of_threads, gpu, lock, timeout=timeout)
 
                 client.simulate_running = False
-        except BaseException as e:
+        except Exception as e:
             self.logger.error(f"run_client_thread error: {secure_format_exception(e)}")
 
     def do_one_task(self, client, num_of_threads, gpu, lock, timeout=60.0):
@@ -568,7 +568,7 @@ class SimulatorClientRunner(FLComponent):
             try:
                 address = ("localhost", open_port)
                 conn = Client(address, authkey=CommunicationMetaData.CHILD_PASSWORD.encode())
-            except BaseException:
+            except Exception:
                 if time.time() - start > timeout:
                     raise RuntimeError(
                         f"Failed to create connection to the child process in {self.__class__.__name__},"

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -152,7 +152,7 @@ class ClientTaskWorker(FLComponent):
                     break
                 time.sleep(interval)
 
-        except BaseException as e:
+        except Exception as e:
             self.logger.error(f"ClientTaskWorker run error: {secure_format_exception(e)}")
         finally:
             if client:

--- a/nvflare/private/fed/client/admin.py
+++ b/nvflare/private/fed/client/admin.py
@@ -150,7 +150,7 @@ class FedAdminAgent(object):
                     else:
                         if not isinstance(reply, Message):
                             raise RuntimeError(f"processor for topic {topic} failed to produce valid reply")
-            except BaseException as e:
+            except Exception as e:
                 secure_log_traceback()
                 reply = error_reply(f"exception_occurred: {secure_format_exception(e)}")
         else:

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -265,6 +265,6 @@ def shutdown_client(federated_client, touch_file):
         federated_client.status = ClientStatus.STOPPED
         # federated_client.cell.stop()
         security_close()
-    except BaseException as e:
+    except Exception as e:
         secure_log_traceback()
         print(f"Failed to shutdown client: {secure_format_exception(e)}")

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -195,7 +195,7 @@ class ClientRunner(FLComponent):
             for f in filter_list:
                 try:
                     task_data = f.process(task_data, fl_ctx)
-                except BaseException:
+                except Exception:
                     self.log_exception(fl_ctx, "processing error in Task Data Filter {}".format(type(f)))
                     return self._reply_and_audit(
                         reply=make_reply(ReturnCode.TASK_DATA_FILTER_ERROR),
@@ -278,7 +278,7 @@ class ClientRunner(FLComponent):
                 fl_ctx=fl_ctx,
                 msg=f"submit result: {ReturnCode.EXECUTION_RESULT_ERROR}",
             )
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, "processing error in task executor {}".format(type(executor)))
             return self._reply_and_audit(
                 reply=make_reply(ReturnCode.EXECUTION_EXCEPTION),
@@ -307,7 +307,7 @@ class ClientRunner(FLComponent):
             for f in filter_list:
                 try:
                     reply = f.process(reply, fl_ctx)
-                except BaseException:
+                except Exception:
                     self.log_exception(fl_ctx, "processing error in Task Result Filter {}".format(type(f)))
                     return self._reply_and_audit(
                         reply=make_reply(ReturnCode.TASK_RESULT_FILTER_ERROR),
@@ -425,7 +425,7 @@ class ClientRunner(FLComponent):
 
         try:
             self._try_run()
-        except BaseException as e:
+        except Exception as e:
             with self.engine.new_context() as fl_ctx:
                 self.log_exception(fl_ctx, f"processing error in RUN execution: {secure_format_exception(e)}")
         finally:

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -143,7 +143,7 @@ class Communicator:
                 else:
                     break
 
-            except BaseException as ex:
+            except Exception as ex:
                 raise FLCommunicationError("error:client_registration", ex)
 
         return token, ssid
@@ -307,7 +307,7 @@ class Communicator:
 
             server_message = result.get_header(CellMessageHeaderKeys.MESSAGE)
 
-        except BaseException as ex:
+        except Exception as ex:
             raise FLCommunicationError("error:client_quit", ex)
 
         return server_message
@@ -350,14 +350,14 @@ class Communicator:
                         if return_code != ReturnCode.OK:
                             break
 
-                except BaseException as ex:
+                except Exception as ex:
                     raise FLCommunicationError("error:client_quit", ex)
 
                 for i in range(wait_times):
                     time.sleep(2)
                     if self.heartbeat_done:
                         break
-            except BaseException as e:
+            except Exception as e:
                 self.logger.info(f"Failed to send heartbeat. Will try again. Exception: {secure_format_exception(e)}")
                 time.sleep(5)
 

--- a/nvflare/private/fed/client/scheduler_cmds.py
+++ b/nvflare/private/fed/client/scheduler_cmds.py
@@ -79,7 +79,7 @@ class CheckResourceProcessor(RequestProcessor):
                     is_resource_enough, token = resource_manager.check_resources(
                         resource_requirement=resource_spec, fl_ctx=fl_ctx
                     )
-            except BaseException:
+            except Exception:
                 result.set_return_code(ReturnCode.EXECUTION_EXCEPTION)
 
         result.set_header(ShareableHeader.IS_RESOURCE_ENOUGH, is_resource_enough)

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -565,7 +565,7 @@ class FederatedServer(BaseServer):
                     message=request,
                     optional=True,
                 )
-        except BaseException:
+        except Exception:
             self.logger.info("Could not connect to server runner process")
 
     def notify_dead_client(self, client):
@@ -664,7 +664,7 @@ class FederatedServer(BaseServer):
         self.engine.engine_info.status = MachineStatus.STARTED
         try:
             self.server_runner.run()
-        except BaseException as e:
+        except Exception as e:
             self.logger.error(f"FL server execution exception: {secure_format_exception(e)}")
         finally:
             # self.engine.update_job_run_status()
@@ -760,7 +760,7 @@ class FederatedServer(BaseServer):
         self.checking_server_state = True
         try:
             self._check_server_state(overseer_agent)
-        except BaseException as ex:
+        except Exception as ex:
             self.logger.error(f"exception in checking server state: {secure_format_exception(ex)}")
         finally:
             self.checking_server_state = False

--- a/nvflare/private/fed/server/info_coll_cmd.py
+++ b/nvflare/private/fed/server/info_coll_cmd.py
@@ -169,5 +169,5 @@ class InfoCollectorCommandModule(JobCommandModule, CommandUtil):
             try:
                 body = json.loads(r.reply.body)
                 conn.append_any(body)
-            except BaseException:
+            except Exception:
                 conn.append_string("Bad responses from clients")

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -375,7 +375,7 @@ class JobCommandModule(CommandModule, CommandUtil):
             with engine.new_context() as fl_ctx:
                 job_def_manager.delete(job_id, fl_ctx)
                 conn.append_string(f"Job {job_id} deleted.")
-        except BaseException as e:
+        except Exception as e:
             conn.append_error(
                 f"exception occurred: {secure_format_exception(e)}",
                 meta=make_meta(MetaStatusValue.INTERNAL_ERROR, f"exception {type(e)}"),
@@ -428,7 +428,7 @@ class JobCommandModule(CommandModule, CommandUtil):
                         message = "Abort signal has been sent to the server app."
                         conn.append_string(message)
                         conn.append_success("", meta=make_meta(MetaStatusValue.OK, message))
-        except BaseException as e:
+        except Exception as e:
             conn.append_error(
                 f"Exception occurred trying to abort job: {secure_format_exception(e)}",
                 meta=make_meta(MetaStatusValue.INTERNAL_ERROR, f"exception {type(e)}"),
@@ -461,7 +461,7 @@ class JobCommandModule(CommandModule, CommandUtil):
                 meta = job_def_manager.create(job_meta, data_bytes, fl_ctx)
                 new_job_id = meta.get(JobMetaKey.JOB_ID)
                 conn.append_string("Cloned job {} as: {}".format(job_id, new_job_id))
-        except BaseException as e:
+        except Exception as e:
             conn.append_error(
                 f"Exception occurred trying to clone job: {secure_format_exception(e)}",
                 meta=make_meta(MetaStatusValue.INTERNAL_ERROR, f"exception {type(e)}"),
@@ -600,7 +600,7 @@ class JobCommandModule(CommandModule, CommandUtil):
                 job_id = meta.get(JobMetaKey.JOB_ID)
                 conn.append_string(f"Submitted job: {job_id}")
                 conn.append_success("", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_ID: job_id}))
-        except BaseException as e:
+        except Exception as e:
             conn.append_error(
                 f"Exception occurred trying to submit job: {secure_format_exception(e)}",
                 meta=make_meta(MetaStatusValue.INTERNAL_ERROR, f"exception {type(e)} occurred"),
@@ -659,6 +659,6 @@ class JobCommandModule(CommandModule, CommandUtil):
             conn.append_string(b64str, meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_ID: job_id}))
         except FileNotFoundError:
             conn.append_error("No record found for job '{}'".format(job_id))
-        except BaseException:
+        except Exception:
             secure_log_traceback()
             conn.append_error("Exception occurred during attempt to zip data to send for job: {}".format(job_id))

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -443,7 +443,7 @@ class JobRunner(FLComponent):
                             with self.lock:
                                 self.running_jobs[job_id] = ready_job
                             job_manager.set_status(ready_job.job_id, RunStatus.RUNNING, fl_ctx)
-                        except BaseException as e:
+                        except Exception as e:
                             if job_id:
                                 if job_id in self.running_jobs:
                                     with self.lock:

--- a/nvflare/private/fed/server/server_app_runner.py
+++ b/nvflare/private/fed/server/server_app_runner.py
@@ -63,7 +63,7 @@ class ServerAppRunner(Runner):
             self.sync_up_parents_process(args)
 
             self.server.start_run(job_id, app_root, conf, args, snapshot)
-        except BaseException as e:
+        except Exception as e:
             with self.server.engine.new_context() as fl_ctx:
                 fl_ctx.set_prop(key=FLContextKey.FATAL_SYSTEM_ERROR, value=True, private=True, sticky=True)
             logger.exception(f"FL server execution exception: {secure_format_exception(e)}")

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -345,7 +345,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 optional=True,
             )
             self.logger.info(f"Abort server status: {status_message}")
-        except BaseException:
+        except Exception:
             with self.lock:
                 child_process = self.run_processes.get(job_id, {}).get(RunProcessKey.CHILD_PROCESS, None)
                 if child_process:
@@ -429,7 +429,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 command_name=ServerCommandNames.GET_RUN_INFO,
                 command_data={},
             )
-        except BaseException:
+        except Exception:
             self.logger.error(f"Failed to get_app_run_info for run: {job_id}")
         return run_info
 
@@ -660,7 +660,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 self.logger.info(f"persist the snapshot to: {self.server.snapshot_location}")
             else:
                 self.logger.info(f"The snapshot: {self.server.snapshot_location} has been removed.")
-        except BaseException as e:
+        except Exception as e:
             self.logger.error(f"Failed to persist the components. {secure_format_exception(e)}")
 
     def restore_components(self, snapshot: RunSnapshot, fl_ctx: FLContext):
@@ -681,7 +681,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 command_name=ServerCommandNames.SHOW_STATS,
                 command_data={},
             )
-        except BaseException:
+        except Exception:
             self.logger.error(f"Failed to show_stats for JOB: {job_id}")
 
         if stats is None:
@@ -696,7 +696,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 command_name=ServerCommandNames.GET_ERRORS,
                 command_data={},
             )
-        except BaseException:
+        except Exception:
             self.logger.error(f"Failed to get_errors for JOB: {job_id}")
 
         if errors is None:
@@ -711,7 +711,7 @@ class ServerEngine(ServerEngineInternalSpec):
                 command_name=ServerCommandNames.RESET_ERRORS,
                 command_data={},
             )
-        except BaseException:
+        except Exception:
             self.logger.error(f"Failed to reset_errors for JOB: {job_id}")
 
         return f"reset the server error stats for job: {job_id}"

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -113,7 +113,7 @@ class ServerRunner(FLComponent):
 
                 with self.engine.new_context() as fl_ctx:
                     wf.responder.control_flow(self.abort_signal, fl_ctx)
-            except BaseException as e:
+            except Exception as e:
                 with self.engine.new_context() as fl_ctx:
                     self.log_exception(fl_ctx, "Exception in workflow {}: {}".format(wf.id, secure_format_exception(e)))
                 self.system_panic("Exception in workflow {}: {}".format(wf.id, secure_format_exception(e)), fl_ctx)
@@ -131,7 +131,7 @@ class ServerRunner(FLComponent):
                     self.log_info(fl_ctx, f"Workflow: {wf.id} finalizing ...")
                     try:
                         wf.responder.finalize_run(fl_ctx)
-                    except BaseException as e:
+                    except Exception as e:
                         self.log_exception(
                             fl_ctx, "Error finalizing workflow {}: {}".format(wf.id, secure_format_exception(e))
                         )
@@ -155,7 +155,7 @@ class ServerRunner(FLComponent):
         self.status = "started"
         try:
             self._execute_run()
-        except BaseException as e:
+        except Exception as e:
             with self.engine.new_context() as fl_ctx:
                 self.log_exception(fl_ctx, f"Error executing RUN: {secure_format_exception(e)}")
         finally:
@@ -277,7 +277,7 @@ class ServerRunner(FLComponent):
                 for f in filter_list:
                     try:
                         task_data = f.process(task_data, fl_ctx)
-                    except BaseException as e:
+                    except Exception as e:
                         self.log_exception(
                             fl_ctx,
                             "processing error in task data filter {}: {}; "
@@ -297,7 +297,7 @@ class ServerRunner(FLComponent):
             task_data.set_header(ReservedHeaderKey.AUDIT_EVENT_ID, audit_event_id)
             task_data.set_header(TaskConstant.WAIT_TIME, self.config.task_request_interval)
             return task_name, task_id, task_data
-        except BaseException as e:
+        except Exception as e:
             self.log_exception(
                 fl_ctx,
                 f"Error processing client task request: {secure_format_exception(e)}; asked client to try again later",
@@ -354,7 +354,7 @@ class ServerRunner(FLComponent):
                     return
 
                 self.current_wf.responder.handle_dead_job(client_name=client_name, fl_ctx=fl_ctx)
-            except BaseException as e:
+            except Exception as e:
                 self.log_exception(
                     fl_ctx, f"Error processing dead job by workflow {self.current_wf.id}: {secure_format_exception(e)}"
                 )
@@ -443,7 +443,7 @@ class ServerRunner(FLComponent):
                     for f in filter_list:
                         try:
                             result = f.process(result, fl_ctx)
-                        except BaseException as e:
+                        except Exception as e:
                             self.log_exception(
                                 fl_ctx,
                                 "Error processing in task result filter {}: {}".format(
@@ -467,7 +467,7 @@ class ServerRunner(FLComponent):
 
                 self.log_debug(fl_ctx, "firing event EventType.AFTER_PROCESS_SUBMISSION")
                 self.fire_event(EventType.AFTER_PROCESS_SUBMISSION, fl_ctx)
-            except BaseException as e:
+            except Exception as e:
                 self.log_exception(
                     fl_ctx,
                     "Error processing client result by {}: {}".format(self.current_wf.id, secure_format_exception(e)),

--- a/nvflare/private/fed/server/sys_cmd.py
+++ b/nvflare/private/fed/server/sys_cmd.py
@@ -39,7 +39,7 @@ def _parse_replies(conn, replies):
             else:
                 try:
                     resources = json.loads(r.reply.body)
-                except BaseException as e:
+                except Exception as e:
                     resources = f"Bad replies: {secure_format_exception(e)}"
         else:
             resources = "No replies"
@@ -126,7 +126,7 @@ class SystemCommandModule(CommandModule, CommandUtil):
                                 "%.1f" % (psutil.virtual_memory().available * 100 / psutil.virtual_memory().total),
                             ]
                         )
-                    except BaseException:
+                    except Exception:
                         conn.append_string(": Bad replies")
             else:
                 conn.append_string(": No replies")

--- a/nvflare/private/fed/server/training_cmds.py
+++ b/nvflare/private/fed/server/training_cmds.py
@@ -318,7 +318,7 @@ class TrainingCommandModule(CommandModule, CommandUtil):
                                     table.add_row([client_name, app_name, job_id, status])
                             else:
                                 table.add_row([client_name, app_name, job_id, "No Jobs"])
-                    except BaseException as e:
+                    except Exception as e:
                         self.logger.error(f"Bad reply from client: {secure_format_exception(e)}")
             else:
                 table.add_row([client_name, app_name, job_id, "No Reply"])
@@ -353,7 +353,7 @@ class TrainingCommandModule(CommandModule, CommandUtil):
                             conn.append_error(
                                 f"bad response from client {client_name}: expect dict but got {type(body)}"
                             )
-                    except BaseException as e:
+                    except Exception as e:
                         self.logger.error(f"Bad reply from client: {secure_format_exception(e)}")
                         conn.append_error(f"bad response from client {client_name}: {secure_format_exception(e)}")
             else:

--- a/nvflare/private/fed/simulator/simulator_server.py
+++ b/nvflare/private/fed/simulator/simulator_server.py
@@ -105,7 +105,7 @@ class SimulatorServer(FederatedServer):
         try:
             with self.engine.lock:
                 reply = self.engine.dispatch(topic=topic, request=shareable, fl_ctx=fl_ctx)
-        except BaseException:
+        except Exception:
             self.logger.info("Could not connect to server runner process - asked client to end the run")
             reply = make_reply(ReturnCode.COMMUNICATION_ERROR)
 

--- a/nvflare/private/fed/utils/app_deployer.py
+++ b/nvflare/private/fed/utils/app_deployer.py
@@ -81,5 +81,5 @@ class AppDeployer(object):
             if not authorized:
                 return "not authorized"
 
-        except BaseException as e:
+        except Exception as e:
             raise Exception(f"exception {secure_format_exception(e)} when deploying app {self.app_name}")

--- a/nvflare/private/json_configer.py
+++ b/nvflare/private/json_configer.py
@@ -81,7 +81,7 @@ class JsonConfigurator(JsonObjectProcessor, ComponentBuilder):
                 try:
                     data = json.load(file)
                     augment(to_dict=config_data, from_dict=data, from_override_to=False)
-                except BaseException as e:
+                except Exception as e:
                     print("Error processing config file {}: {}".format(file, secure_format_exception(e)))
                     raise e
 

--- a/nvflare/tool/api_utils.py
+++ b/nvflare/tool/api_utils.py
@@ -82,7 +82,7 @@ def wait_for_system_shutdown(sess: Session, timeout_in_sec: int = 30):
                 print("waiting system to shutdown")
             cnt += 1
             time.sleep(0.1)
-        except BaseException:
+        except Exception:
             # Server is already shutdown
             return
 

--- a/nvflare/widgets/fed_event.py
+++ b/nvflare/widgets/fed_event.py
@@ -161,7 +161,7 @@ class FedEventRunner(Widget):
                 event_type = event_to_post.get_header(FedEventHeader.EVENT_TYPE)
                 try:
                     self.engine.fire_event(event_type=event_type, fl_ctx=fl_ctx)
-                except BaseException as e:
+                except Exception as e:
                     if self.asked_to_stop:
                         self.log_warning(fl_ctx, f"event {event_to_post} fired unsuccessfully during END_RUN")
                     else:

--- a/research/auto-fed-rl/src/autofedrl/autofedrl_fedopt.py
+++ b/research/auto-fed-rl/src/autofedrl/autofedrl_fedopt.py
@@ -128,7 +128,7 @@ class AutoFedRLFedOptModelShareableGenerator(FullModelShareableGenerator):
                 self.optimizer = engine.build_component(self.optimizer_args)
                 # get optimizer name for log
                 self.optimizer_name = self._get_component_name(self.optimizer_args)
-            except BaseException as e:
+            except Exception as e:
                 self.system_panic(
                     f"Exception while parsing `optimizer_args`({self.optimizer_args}): {secure_format_exception(e)}",
                     fl_ctx,
@@ -144,7 +144,7 @@ class AutoFedRLFedOptModelShareableGenerator(FullModelShareableGenerator):
                         self.lr_scheduler_args["args"] = {}
                     self.lr_scheduler_args["args"]["optimizer"] = self.optimizer
                     self.lr_scheduler = engine.build_component(self.lr_scheduler_args)
-                except BaseException as e:
+                except Exception as e:
                     self.system_panic(
                         f"Exception while parsing `lr_scheduler_args`({self.lr_scheduler_args}): {secure_format_exception(e)}",
                         fl_ctx,

--- a/research/auto-fed-rl/src/autofedrl/autofedrl_scatter_and_gather.py
+++ b/research/auto-fed-rl/src/autofedrl/autofedrl_scatter_and_gather.py
@@ -247,7 +247,7 @@ class ScatterAndGatherAutoFedRL(ScatterAndGather):
 
             self._phase = AppConstants.PHASE_FINISHED
             self.log_info(fl_ctx, "Finished ScatterAndGather Training.")
-        except BaseException as e:
+        except Exception as e:
             traceback.print_exc()
             error_msg = f"Exception in ScatterAndGather control_flow: {e}"
             self.log_exception(fl_ctx, error_msg)

--- a/research/auto-fed-rl/src/autofedrl/pt_autofedrl.py
+++ b/research/auto-fed-rl/src/autofedrl/pt_autofedrl.py
@@ -170,7 +170,7 @@ class PTAutoFedRLSearchSpace(FLComponent):
                 self.optimizer = engine.build_component(self.optimizer_args)
                 # Get optimizer name for log
                 self.optimizer_name = self._get_component_name(self.optimizer_args)
-            except BaseException as e:
+            except Exception as e:
                 self.system_panic(
                     f"Exception while parsing `optimizer_args`: " f"{self.optimizer_args} with Exception {e}",
                     fl_ctx,

--- a/research/fed-sm/jobs/fedsm_prostate/app/custom/persistors/pt_file_fedsm_model_persistor.py
+++ b/research/fed-sm/jobs/fedsm_prostate/app/custom/persistors/pt_file_fedsm_model_persistor.py
@@ -207,6 +207,6 @@ class PTFileFedSMModelPersistor(PTFileModelPersistor):
             data = torch.load(location, map_location=device)
             persistence_manager = PTModelPersistenceFormatManagerFedSM(data, default_train_conf=self.default_train_conf)
             return persistence_manager.to_model_learnable(self.exclude_vars)
-        except BaseException:
+        except Exception:
             self.log_exception(fl_ctx, f"error loading checkpoint from {model_file}")
             return {}

--- a/research/fed-sm/jobs/fedsm_prostate/app/custom/workflows/scatter_and_gather_fedsm.py
+++ b/research/fed-sm/jobs/fedsm_prostate/app/custom/workflows/scatter_and_gather_fedsm.py
@@ -281,7 +281,7 @@ class ScatterAndGatherFedSM(ScatterAndGather):
 
             self._phase = AppConstants.PHASE_FINISHED
             self.log_info(fl_ctx, "Finished ScatterAndGatherFedSM Training.")
-        except BaseException as e:
+        except Exception as e:
             traceback.print_exc()
             error_msg = f"Exception in ScatterAndGatherFedSM control_flow: {e}"
             self.log_exception(fl_ctx, error_msg)

--- a/research/quantifying-data-leakage/src/nvflare_gradinv/filters/rdlv_filter.py
+++ b/research/quantifying-data-leakage/src/nvflare_gradinv/filters/rdlv_filter.py
@@ -242,7 +242,7 @@ class RelativeDataLeakageValueFilter(DXOFilter):
                     rdlv = np.min(img_recon_sim_reduced, axis=0)
                 else:
                     raise ValueError(f"No such `rdlv_reduce` supported {self.rdlv_reduce}")
-            except BaseException as e:
+            except Exception as e:
                 raise RuntimeError("Computing RDLV failed!") from e
 
             self.log_info(fl_ctx, f"RDLV: {rdlv}")

--- a/research/quantifying-data-leakage/src/nvflare_gradinv/learners/cxr_learner.py
+++ b/research/quantifying-data-leakage/src/nvflare_gradinv/learners/cxr_learner.py
@@ -213,7 +213,7 @@ class CXRLearner(Learner):
                 data_list_key=self.test_set,
                 base_dir=self.data_root,
             )
-        except BaseException as e:
+        except Exception as e:
             test_list = []
             self.log_warning(fl_ctx, f"Could not create test_list: {e}")
         self.log_info(
@@ -397,7 +397,7 @@ class CXRLearner(Learner):
                     # update the local dict
                     local_var_dict[var_name] = torch.as_tensor(global_weights[var_name])
                     n_loaded += 1
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"Convert weight from {var_name} failed") from e
         if n_loaded == 0:
             raise ValueError(f"No weights loaded for training! Received weight dict is {global_weights}")
@@ -487,7 +487,7 @@ class CXRLearner(Learner):
             try:
                 # load model to cpu as server might or might not have a GPU
                 model_data = torch.load(self.best_local_model_file, map_location="cpu")
-            except BaseException as e:
+            except Exception as e:
                 raise ValueError("Unable to load best model") from e
 
             # Create DXO and shareable from model data.
@@ -568,7 +568,7 @@ class CXRLearner(Learner):
                     # update the local dict
                     local_var_dict[var_name] = torch.as_tensor(torch.reshape(weights, local_var_dict[var_name].shape))
                     n_loaded += 1
-                except BaseException as e:
+                except Exception as e:
                     raise ValueError(f"Convert weight from {var_name} failed for {validate_type}") from e
         self.model.load_state_dict(local_var_dict)
         if n_loaded == 0:

--- a/tests/integration_test/data/apps/np_sag_weights_diff/custom/np_trainer.py
+++ b/tests/integration_test/data/apps/np_sag_weights_diff/custom/np_trainer.py
@@ -45,7 +45,7 @@ class NPTrainer(BaseNPTrainer):
         # First we extract DXO from the shareable.
         try:
             incoming_dxo = from_shareable(shareable)
-        except BaseException as e:
+        except Exception as e:
             self.system_panic(f"Unable to convert shareable to model definition. Exception {e.__str__()}", fl_ctx)
             return make_reply(ReturnCode.BAD_TASK_DATA)
 

--- a/tests/unit_test/app_common/executors/statistics/mock_df_stats_executor.py
+++ b/tests/unit_test/app_common/executors/statistics/mock_df_stats_executor.py
@@ -39,7 +39,7 @@ def load_data() -> Dict[str, pd.DataFrame]:
 
         return {"train": train, "test": test}
 
-    except BaseException as e:
+    except Exception as e:
         raise Exception(f"Load data failed! {e}")
 
 


### PR DESCRIPTION
### Description

`BaseException` includes `SystemExit` and `KeyboardInterrupt`, so catching it can interfere with proper process termination. It also includes `GeneratorExit` which can cause some very strange behaviors.

Catching `BaseException` should only be necessary in highly exceptional cases. Clearly, though, in this codebase it is used wherever `except Exception` would normally be used, i.e. to catch any type of "normal" exception (what a lovely oxymoron!).

I reviewed some of the places where this replacement is done in this PR, but not all of them.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
