### PR TITLE
remove github premerge workflow branch restriction [skip ci]

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -17,8 +17,6 @@ name: pre-merge
 on:
   # quick tests for pull requests and the releasing branches
   push:
-    branches:
-      - dev
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
### Description

Remove GITHUB premerge workflow branch restriction

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
