### PR TITLE
Added GPU group support for simulator.

### DIFF
--- a/tests/unit_test/private/fed/app/simulator/simulator_runner_test.py
+++ b/tests/unit_test/private/fed/app/simulator/simulator_runner_test.py
@@ -86,3 +86,31 @@ class TestSimulatorRunner:
         runner = SimulatorRunner(job_folder="", workspace="")
         split_names = runner.split_clients(client_names, gpus)
         assert sorted(split_names) == sorted(expected_split_names)
+
+    @pytest.mark.parametrize(
+        "gpus, expected_gpus",
+        [
+            ("[0,1],[1, 2]", ["0,1", "1,2"]),
+            ("[0,1],[3]", ["0,1", "3"]),
+            ("[0,1],[ 3 ]", ["0,1", "3"]),
+        ],
+    )
+    def test_split_gpus_success(self, gpus, expected_gpus):
+        runner = SimulatorRunner(job_folder="", workspace="")
+        split_gpus, _ = runner.split_gpus(gpus)
+        assert split_gpus == expected_gpus
+
+    @pytest.mark.parametrize(
+        "gpus",
+        [
+            "[0,1],3",
+            "0,1,2",
+        ],
+    )
+    def test_split_gpus_fail(self, gpus):
+        runner = SimulatorRunner(job_folder="", workspace="")
+        split_gpus, success = runner.split_gpus(gpus)
+        assert split_gpus is None
+        assert success is False
+
+


### PR DESCRIPTION
Fixes # .

### Description

Add support to enable multi-gpu training for Simulator. Provide the GPU group option to the format like: "-gpu [0,1],[1,2],[3]"

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
