### PR TITLE
Fix app_opt PTFileModelPersistor typo

### DIFF
--- a/nvflare/app_opt/pt/file_model_persistor.py
+++ b/nvflare/app_opt/pt/file_model_persistor.py
@@ -111,7 +111,7 @@ class PTFileModelPersistor(ModelPersistor):
         self.default_train_conf = None
 
         if source_ckpt_file_full_name and not os.path.exists(source_ckpt_file_full_name):
-            raise ValueError("specified source checkpoint model file {} does not exist")
+            raise ValueError(f"specified source checkpoint model file {source_ckpt_file_full_name} does not exist")
 
     def _initialize(self, fl_ctx: FLContext):
         app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)


### PR DESCRIPTION
### Description

Fix app_opt PTFileModelPersistor typo

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
