### PR TITLE
Improve server side docker.sh

### DIFF
--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -684,14 +684,15 @@ docker_svr_sh: |
   #NETARG="-p {~~admin_port~~}:{~~admin_port~~} -p {~~fed_learn_port~~}:{~~fed_learn_port~~}"
   DOCKER_IMAGE={~~docker_image~~}
   echo "Starting docker with $DOCKER_IMAGE"
+  svr_name="${SVR_NAME:-flserver}"
   mode="${1:-r}"
   if [ $mode = "-d" ]
   then
-    docker run -d --rm --name=flserver -v $DIR/..:/workspace/ -w /workspace \
+    docker run -d --rm --name=$svr_name -v $DIR/..:/workspace/ -w /workspace \
     --ipc=host $NETARG $DOCKER_IMAGE /bin/bash -c \
     "python -u -m nvflare.private.fed.app.server.server_train -m /workspace -s fed_server.json --set secure_train=true config_folder=config org={~~org_name~~}"
   else
-    docker run --rm -it --name=flserver -v $DIR/..:/workspace/ -w /workspace/ --ipc=host $NETARG $DOCKER_IMAGE /bin/bash
+    docker run --rm -it --name=$svr_name -v $DIR/..:/workspace/ -w /workspace/ --ipc=host $NETARG $DOCKER_IMAGE /bin/bash
   fi
 
 docker_adm_sh: |


### PR DESCRIPTION
### Description

This PR allows users to set env var `SVR_NAME` before running server's docker.sh so that the docker name will be `$SVR_NAME`.  When running docker.sh without setting `SVR_NAME`, the default `flserver` will be used as docker name.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
