### PR TITLE
[main] include exception type

### DIFF
--- a/nvflare/security/logging.py
+++ b/nvflare/security/logging.py
@@ -130,4 +130,4 @@ def secure_format_exception(e: Exception) -> str:
     if is_secure():
         return str(type(e))
     else:
-        return f"{str(type(e))}: {str(e)}"
+        return f"{type(e).__name__}: {str(e)}"

--- a/nvflare/security/logging.py
+++ b/nvflare/security/logging.py
@@ -130,4 +130,4 @@ def secure_format_exception(e: Exception) -> str:
     if is_secure():
         return str(type(e))
     else:
-        return str(e)
+        return f"{str(type(e))}: {str(e)}"

--- a/tests/unit_test/fuel/utils/component_builder_test.py
+++ b/tests/unit_test/fuel/utils/component_builder_test.py
@@ -77,9 +77,9 @@ class TestComponentBuilder:
 
         # the failure message changes since 3.10
         if is_python_greater_than_309():
-            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: NPModelLocator.__init__() got an unexpected keyword argument 'xyz'."
+            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: NPModelLocator.__init__() got an unexpected keyword argument 'xyz'."
         else:
-            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: __init__() got an unexpected keyword argument 'xyz'."
+            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: __init__() got an unexpected keyword argument 'xyz'."
 
         assert isinstance(config, dict)
         b = None
@@ -135,9 +135,9 @@ class TestComponentBuilder:
 
         # the failure message changes since 3.10
         if is_python_greater_than_309():
-            msg = "failed to instantiate class: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: NPModelLocator.__init__() got an unexpected keyword argument 'abc'."
+            msg = "failed to instantiate class: <class 'ValueError'>: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: NPModelLocator.__init__() got an unexpected keyword argument 'abc'."
         else:
-            msg = "failed to instantiate class: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: __init__() got an unexpected keyword argument 'abc'."
+            msg = "failed to instantiate class: <class 'ValueError'>: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: __init__() got an unexpected keyword argument 'abc'."
 
         builder = MockComponentBuilder()
         assert isinstance(config, dict)

--- a/tests/unit_test/fuel/utils/component_builder_test.py
+++ b/tests/unit_test/fuel/utils/component_builder_test.py
@@ -77,9 +77,9 @@ class TestComponentBuilder:
 
         # the failure message changes since 3.10
         if is_python_greater_than_309():
-            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: NPModelLocator.__init__() got an unexpected keyword argument 'xyz'."
+            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: TypeError: NPModelLocator.__init__() got an unexpected keyword argument 'xyz'."
         else:
-            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: __init__() got an unexpected keyword argument 'xyz'."
+            msg = "Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: TypeError: __init__() got an unexpected keyword argument 'xyz'."
 
         assert isinstance(config, dict)
         b = None
@@ -135,9 +135,9 @@ class TestComponentBuilder:
 
         # the failure message changes since 3.10
         if is_python_greater_than_309():
-            msg = "failed to instantiate class: <class 'ValueError'>: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: NPModelLocator.__init__() got an unexpected keyword argument 'abc'."
+            msg = "failed to instantiate class: ValueError: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: TypeError: NPModelLocator.__init__() got an unexpected keyword argument 'abc'."
         else:
-            msg = "failed to instantiate class: <class 'ValueError'>: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: <class 'TypeError'>: __init__() got an unexpected keyword argument 'abc'."
+            msg = "failed to instantiate class: ValueError: Class nvflare.app_common.np.np_model_locator.NPModelLocator has parameters error: TypeError: __init__() got an unexpected keyword argument 'abc'."
 
         builder = MockComponentBuilder()
         assert isinstance(config, dict)


### PR DESCRIPTION
### Description

- Include exception type
- Fix unit test for https://github.com/NVIDIA/NVFlare/pull/1742 by @taleinat 

By Tal:

The `str()` of an exception normally doesn't include its type. Including the type of the exception is very useful.

In the rare cases of exceptions with no details in their string representation, this is especially significant.

This is similar to the format used in Python exception tracebacks:

```python
>>> int("a")
Traceback (most recent call last):
  File "<pyshell#>", line 1, in <module>
ValueError: invalid literal for int() with base 10: 'a'

>>> try:
	int("a")
except ValueError as exc:
	print(str(exc))

invalid literal for int() with base 10: 'a'
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
