### PR TITLE
Fix an issue in lighter utils CI tests

### DIFF
--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import tempfile
 
+import pytest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
@@ -124,6 +125,7 @@ def prepare_folders():
     return folder, server_pri_key, server_cert
 
 
+@pytest.mark.xdist_group(name="lighter_utils_group")
 class TestSignFolder:
     def test_verify_folder(self):
         folder, server_pri_key, server_cert = prepare_folders()


### PR DESCRIPTION
### Description

During CI tests with pytest xdist, two test cases in lighter/util may fail due to damaged test data caused by race conditions.  This PR puts those two cases in a group so they will run one by one.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
