### PR TITLE
Use --dist loadgroup for pytest

### DIFF
--- a/runtest.sh
+++ b/runtest.sh
@@ -301,7 +301,7 @@ if [[ -z $cmd ]]; then
     cmd="check_license;
         check_style_type_import "${DIR_TO_CHECK[@]}";
         fix_style_import "${DIR_TO_CHECK[@]}";
-        python3 -m pytest --numprocesses=auto -v --cov=nvflare --cov-report html:cov_html --cov-report xml:cov.xml --junitxml=unit_test.xml tests/unit_test;
+        python3 -m pytest --numprocesses=auto -v --cov=nvflare --cov-report html:cov_html --cov-report xml:cov.xml --junitxml=unit_test.xml --dist loadgroup tests/unit_test;
         "
 else
     cmd="$cmd $target"


### PR DESCRIPTION
### Issue

Some tests can NOT be run in parallel, so we add "@pytest.mark.xdist_group".
However that only works if we run pytest using flag `--dist loadgroup`

### Description

- Add `--dist loadgroup` for running pytest.
(Follows: https://pytest-xdist.readthedocs.io/en/latest/distribution.html#running-tests-across-multiple-cpus)



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
