### PR TITLE
Upgrade flask to 2.2.5 to address CVE-2023-30861.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ zip_safe = True
 python_requires = >= 3.8
 install_requires =
     cryptography>=36.0.0
-    Flask==2.1.2
+    Flask==2.2.5
     Flask-JWT-Extended==4.4.3
     Flask-SQLAlchemy==2.5.1
     SQLAlchemy==1.4.31


### PR DESCRIPTION
Fixes CVE-2023-30861

### Description

CVE-2023-30861 instructs to upgrade flask to 2.2.5.  This PR sets the flask version to that.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
