### PR TITLE
Add test driver with FLARE API

### DIFF
--- a/tests/integration_test/data/test_configs/standalone_job/internal_pt.yml
+++ b/tests/integration_test/data/test_configs/standalone_job/internal_pt.yml
@@ -23,9 +23,7 @@ tests:
     validators:
       - path: tests.integration_test.src.validators.PTModelValidator
     setup:
-      - python -c "from torchvision.datasets import CIFAR10; CIFAR10(root='/tmp/nvflare/cifar10_data', download=True)"
-    teardown:
-      - rm -rf /tmp/nvflare/cifar10_data
+      - python -c "from torchvision.datasets import CIFAR10; CIFAR10(root='/tmp/nvflare/cifar10_data', download=False)"
   - test_name: "run pt_use_name"
     event_sequence:
       - "trigger":
@@ -44,9 +42,7 @@ tests:
     validators:
       - path: tests.integration_test.src.validators.PTModelValidator
     setup:
-      - python -c "from torchvision.datasets import CIFAR10; CIFAR10(root='/tmp/nvflare/cifar10_data', download=True)"
-    teardown:
-      - rm -rf /tmp/nvflare/cifar10_data
+      - python -c "from torchvision.datasets import CIFAR10; CIFAR10(root='/tmp/nvflare/cifar10_data', download=False)"
   - test_name: "run pt_init_client"
     event_sequence:
       - "trigger":
@@ -65,9 +61,7 @@ tests:
     validators:
       - path: tests.integration_test.src.validators.PTModelValidator
     setup:
-      - python -c "from torchvision.datasets import CIFAR10; CIFAR10(root='/tmp/nvflare/cifar10_data', download=True)"
-    teardown:
-      - rm -rf /tmp/nvflare/cifar10_data
+      - python -c "from torchvision.datasets import CIFAR10; CIFAR10(root='/tmp/nvflare/cifar10_data', download=False)"
   - test_name: "run tb_streaming"
     event_sequence:
       - "trigger":

--- a/tests/integration_test/src/__init__.py
+++ b/tests/integration_test/src/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .nvf_test_driver import NVFTestDriver, NVFTestError
+from .nvf_test_driver_flare_api import NVFFLAREAPITestDriver
 from .oa_laucher import OALauncher
 from .poc_site_launcher import POCSiteLauncher
 from .provision_site_launcher import ProvisionSiteLauncher

--- a/tests/integration_test/src/action_handlers_flare_api.py
+++ b/tests/integration_test/src/action_handlers_flare_api.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import typing
+from nvflare.fuel.flare_api.flare_api import Session
+from nvflare.fuel.hci.client.api_status import APIStatus
+
+if typing.TYPE_CHECKING:
+    from .nvf_test_driver_flare_api import NVFFLAREAPITestDriver
+
+import time
+from abc import ABC, abstractmethod
+
+from tests.integration_test.src.utils import check_job_done_FLARE_API, run_admin_api_tests
+
+
+class _CmdHandler(ABC):
+    @abstractmethod
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        pass
+
+
+class _StartHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        if command_args[0] == "server":
+            if len(command_args) == 2:
+                # if server id is provided
+                server_ids = [command_args[1]]
+            else:
+                # start all servers
+                server_ids = list(admin_controller.site_launcher.server_properties.keys())
+            for sid in server_ids:
+                admin_controller.site_launcher.start_server(sid)
+        elif command_args[0] == "client":
+            if len(command_args) == 2:
+                # if client id is provided
+                client_ids = [command_args[1]]
+            else:
+                # start all clients
+                client_ids = list(admin_controller.site_launcher.client_properties.keys())
+            for cid in client_ids:
+                admin_controller.site_launcher.start_client(cid)
+        elif command_args[0] == "overseer":
+            admin_controller.site_launcher.start_overseer()
+        else:
+            raise RuntimeError(f"Target {command_args[0]} is not supported.")
+
+
+class _KillHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        if command_args[0] == "server":
+            if len(command_args) == 2:
+                # if server id is provided
+                server_id = command_args[1]
+            else:
+                # kill active server
+                server_id = admin_controller.site_launcher.get_active_server_id(admin_api.api.port)
+            admin_controller.site_launcher.stop_server(server_id)
+        elif command_args[0] == "overseer":
+            admin_controller.site_launcher.stop_overseer()
+        elif command_args[0] == "client":
+            if len(command_args) == 2:
+                # if client id is provided
+                client_ids = [command_args[1]]
+            else:
+                # close all clients
+                client_ids = list(admin_controller.site_launcher.client_properties.keys())
+            for cid in client_ids:
+                admin_api.api.do_command("remove_client " + admin_controller.site_launcher.client_properties[cid].name)
+                admin_controller.site_launcher.stop_client(cid)
+
+
+class _SleepHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        time.sleep(int(command_args[0]))
+
+
+class _AdminCommandsHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        pass
+        # run_admin_api_tests(admin_api)
+
+
+class _NoopHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        pass
+
+
+class _TestDoneHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        admin_controller.test_done = True
+
+
+class _SubmitJobHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        job_name = str(command_args[0])
+
+        response = admin_api.submit_job(job_name)
+        if response:
+            admin_controller.job_id = response
+            admin_controller.last_job_name = job_name
+        # if response["status"] == APIStatus.ERROR_RUNTIME:
+        #     admin_controller.admin_api_response = response.get("raw", {}).get("data")
+        # elif response["status"] == APIStatus.ERROR_AUTHORIZATION:
+        #     admin_controller.admin_api_response = response["details"]
+        # elif response["status"] == APIStatus.SUCCESS:
+        #     admin_controller.job_id = response["details"]["job_id"]
+        #     admin_controller.last_job_name = job_name
+
+
+class _CloneJobHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        response = admin_api.clone_job(admin_controller.job_id)
+        # if response["status"] == APIStatus.ERROR_RUNTIME:
+        #     admin_controller.admin_api_response = response.get("raw", {}).get("data")
+        # elif response["status"] == APIStatus.ERROR_AUTHORIZATION:
+        #     admin_controller.admin_api_response = response["details"]
+        # if response["status"] == APIStatus.SUCCESS:
+        #     admin_controller.job_id = response["details"]["job_id"]
+
+
+class _AbortJobHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        response = admin_api.abort_job(admin_controller.job_id)
+        # if response["status"] == APIStatus.ERROR_RUNTIME:
+        #     admin_controller.admin_api_response = response.get("raw", {}).get("data")
+        # elif response["status"] == APIStatus.ERROR_AUTHORIZATION:
+        #     admin_controller.admin_api_response = response["details"]
+
+
+class _ListJobHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        response = admin_api.list_jobs()
+        # assert response["status"] == APIStatus.SUCCESS
+
+
+class _ShellCommandHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        if str(command_args[0]) == "ls":
+            response = admin_api.ls_target(str(command_args[1]))
+            # if response["status"] == APIStatus.ERROR_RUNTIME:
+            #     admin_controller.admin_api_response = response.get("raw", {}).get("data")
+            # elif response["status"] == APIStatus.ERROR_AUTHORIZATION:
+            #     admin_controller.admin_api_response = response["details"]["message"]
+            # elif response["status"] == APIStatus.SUCCESS:
+            #     admin_controller.admin_api_response = " ".join(response["details"]["message"].splitlines())
+
+
+class _CheckJobHandler(_CmdHandler):
+    def handle(self, command_args: list, admin_controller: NVFFLAREAPITestDriver, admin_api: Session):
+        timeout = 1
+        if command_args:
+            timeout = float(command_args[0])
+        start_time = time.time()
+        result = False
+        if admin_controller.job_id:
+            while time.time() - start_time < timeout:
+                result = check_job_done_FLARE_API(job_id=admin_controller.job_id, admin_api=admin_controller.super_admin_api)
+                if result:
+                    break
+                time.sleep(0.5)
+        admin_controller.test_done = result

--- a/tests/integration_test/src/run_local_test.py
+++ b/tests/integration_test/src/run_local_test.py
@@ -1,0 +1,14 @@
+
+from tests.integration_test.src.nvf_test_driver_flare_api import NVFFLAREAPITestDriver
+from tests.integration_test.src.utils import check_job_done_FLARE_API
+
+
+if __name__ == "__main__":
+    test_driver = NVFFLAREAPITestDriver(
+    download_root_dir="/tmp/tmp_a5jpli4/admin/transfer", site_launcher=None, poll_period=1
+        )
+    test_driver.initialize_super_user(
+        workspace_root_dir="/tmp/tmp_a5jpli4", upload_root_dir="/workspace/repos/NVFlare_experiment2/tests/integration_test/data/apps", poc=True, super_user_name="admin"
+    )
+    
+    print(check_job_done_FLARE_API(job_id="f113af4e-b5bf-41f1-b773-a85a7c2d64af", admin_api=test_driver.super_admin_api))

--- a/tests/integration_test/system_test.py
+++ b/tests/integration_test/system_test.py
@@ -22,6 +22,7 @@ import pytest
 
 from tests.integration_test.src import (
     NVFTestDriver,
+    NVFFLAREAPITestDriver,
     NVFTestError,
     POCSiteLauncher,
     ProvisionSiteLauncher,
@@ -142,9 +143,21 @@ def setup_and_teardown_system(request):
 
         download_root_dir = os.path.join(test_temp_dir, "download_result")
         os.mkdir(download_root_dir)
-        test_driver = NVFTestDriver(
-            site_launcher=site_launcher, download_root_dir=download_root_dir, poll_period=poll_period
-        )
+        use_FLARE_API = False
+        if use_FLARE_API:
+            # for some reason admin does not have a local folder but it is required to start the FLARE API.
+            try:
+                os.mkdir(os.path.join(os.path.abspath(workspace_root), super_user_name, "local"))
+            except FileExistsError:
+                pass
+            test_driver = NVFFLAREAPITestDriver(
+                site_launcher=site_launcher, download_root_dir=download_root_dir, poll_period=poll_period
+            )
+        else:
+            # use previous test driver with FLAdminAPI
+            test_driver = NVFTestDriver(
+                site_launcher=site_launcher, download_root_dir=download_root_dir, poll_period=poll_period
+            )
         test_driver.initialize_super_user(
             workspace_root_dir=workspace_root, upload_root_dir=jobs_root_dir, poc=poc, super_user_name=super_user_name
         )


### PR DESCRIPTION
Still debugging some tests, currently using the underlying api of FLARE API's session's do_command to get results that are the same as before, with wrapping in some cases to match previous FLAdminAPI response.

Ultimately, we will still need to determine whether to run all tests with both previous driver and FLARE API, or just some with this one, or which.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
