### PR TITLE
Update data_exchange_object.rst [skip ci]

### DIFF
--- a/docs/programming_guide/data_exchange_object.rst
+++ b/docs/programming_guide/data_exchange_object.rst
@@ -8,7 +8,7 @@ The Data Exchange Format (:class:`nvflare.apis.dxo.DXO`) in NVIDIA FLARE standar
 
 .. literalinclude:: ../../nvflare/apis/dxo.py
     :language: python
-    :lines: 29-40
+    :lines: 47-69
 
 ``data_kind`` keeps track of the kind of data for example "WEIGHTS" or "WEIGHT_DIFF".
 


### PR DESCRIPTION
In the docs, the line numbers for this code preview are incorrect and yield this in the docs:
<img width="1075" alt="Screenshot 2023-06-29 at 9 26 03 PM" src="https://github.com/NVIDIA/NVFlare/assets/24256419/8511696b-7fe3-4f82-9c0a-d326938fc7dc">

(source: https://nvflare.readthedocs.io/en/main/programming_guide/data_exchange_object.html)

Fixes # .

### Description

This shifts the line numbers so that they correctly render the DXO class. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [x] Documentation updated.
