### PR TITLE
Update fl_component.rst [skip ci]

### DIFF
--- a/docs/programming_guide/fl_component.rst
+++ b/docs/programming_guide/fl_component.rst
@@ -9,7 +9,7 @@ example trainer are all FLComponents now.
 
 .. literalinclude:: ../../nvflare/apis/fl_component.py
     :language: python
-    :lines: 7-21
+    :lines: 28-90
 
 Each ``FLComponent`` is automatically added as an event handler in the system when a new instance is created.
 You can implement the :meth:`handle_event<handle_event>` to plugin additional customized actions to the FL workflows.


### PR DESCRIPTION
Documentation lines are not in sync with additions to the underlying document being referenced. Updated to include fire_event and fire_fed_event

https://github.com/NVIDIA/NVFlare/blob/main/nvflare/apis/fl_component.py#L28-L90

Current view ([link](https://nvflare.readthedocs.io/en/main/programming_guide/fl_component.html))
<img width="1071" alt="Screenshot 2023-06-29 at 9 56 41 PM" src="https://github.com/NVIDIA/NVFlare/assets/24256419/445c0136-5c5f-474e-b9cc-ef1ded64cf42">
### Description
My changes include the relevant lines from the fl_component.py src

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [x] Documentation updated.
