### PR TITLE
Fix bug in RFXGBoost notebook that prevented correct rendering [skip ci]

### DIFF
--- a/examples/advanced/random_forest/random_forest.ipynb
+++ b/examples/advanced/random_forest/random_forest.ipynb
@@ -80,7 +80,7 @@
     "### Download and Store Data\n",
     "To run the examples, we first download the dataset from the HIGGS link above.\n",
     "By default, we assume the dataset is downloaded, uncompressed, and stored in `DATASET_ROOT/HIGGS.csv`.\n",
-    "Please note that the UCI's website may experience occasional downtime.\n"
+    "Please note that the UCI's website may experience occasional downtime.\n",
     "\n",
     "### Generate Data Split\n",
     "Since HIGGS dataset is already randomly recorded,\n",


### PR DESCRIPTION
Missing comma broke syntax & caused compilation error.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [x] Documentation updated.
