### PR TITLE
Fix auto integration tests

### DIFF
--- a/examples/advanced/sklearn-svm/README.md
+++ b/examples/advanced/sklearn-svm/README.md
@@ -8,7 +8,9 @@ This example shows how to use [NVIDIA FLARE](https://nvflare.readthedocs.io/en/m
 It uses [Scikit-learn](https://scikit-learn.org/), a widely used open-source machine learning library that supports supervised and unsupervised learning.
 Follow along in this [notebook](./sklearn_svm_cancer.ipynb) for an interactive experience.
 ### cuML
-This example also illustrates using [cuML](https://docs.rapids.ai/api/cuml/stable/) as backend instead of Scikit-learn.
+You can also use [cuML](https://docs.rapids.ai/api/cuml/stable/) as backend instead of Scikit-learn.
+Please install cuml following instructions: https://rapids.ai/start.html
+
 ### Tabular data
 The data used in this example is tabular in a format that can be handled by [pandas](https://pandas.pydata.org/), such that:
 - rows correspond to data samples.

--- a/examples/advanced/sklearn-svm/prepare_job_config.sh
+++ b/examples/advanced/sklearn-svm/prepare_job_config.sh
@@ -14,7 +14,7 @@ for site_num in 3;
 do
     for split_mode in uniform;
     do
-        for backend in sklearn cuml;
+        for backend in sklearn;
         do
           python3 utils/prepare_job_config.py \
           --task_name "${task_name}" \

--- a/examples/advanced/sklearn-svm/requirements.txt
+++ b/examples/advanced/sklearn-svm/requirements.txt
@@ -1,6 +1,5 @@
 nvflare>=2.3.0
 pandas
 scikit-learn
-cuml
 joblib
 tensorboard

--- a/examples/advanced/sklearn-svm/run_experiment_simulator.sh
+++ b/examples/advanced/sklearn-svm/run_experiment_simulator.sh
@@ -6,7 +6,7 @@ for site_num in 3;
 do
     for split_mode in uniform;
     do
-        for backend in sklearn cuml;
+        for backend in sklearn;
         do
             nvflare simulator jobs/${task_name}_${site_num}_${split_mode}_${backend} \
                 -w "${PWD}"/workspaces/${task_name}_${site_num}_${split_mode}_${backend} \

--- a/nvflare/fuel/utils/config_factory.py
+++ b/nvflare/fuel/utils/config_factory.py
@@ -15,7 +15,7 @@
 import logging
 import os
 import pathlib
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from nvflare.fuel.utils.config import Config, ConfigFormat, ConfigLoader
 from nvflare.fuel.utils.import_utils import optional_import
@@ -44,7 +44,7 @@ class ConfigFactory:
     @staticmethod
     def search_config_format(
         init_file_path, search_dirs: Optional[List[str]] = None
-    ) -> (Optional[ConfigFormat], Optional[str]):
+    ) -> Tuple[Optional[ConfigFormat], Optional[str]]:
 
         """find the configuration format and the location (file_path) for given initial init_file_path and search directories.
             for example, the initial config file path given is config_client.json

--- a/nvflare/private/fed/app/default_app_validator.py
+++ b/nvflare/private/fed/app/default_app_validator.py
@@ -17,9 +17,10 @@ from typing import Dict, Tuple
 
 from nvflare.apis.app_validation import AppValidationKey, AppValidator
 from nvflare.apis.fl_constant import JobConstants, SiteType, WorkspaceConstants
+from nvflare.fuel.utils.config_factory import ConfigFactory
 
 
-def _check_config(app_root: str, config_folder: str, site_type: str):
+def _config_exists(app_root: str, config_folder: str, site_type: str):
     if site_type == SiteType.SERVER:
         config_to_check = JobConstants.SERVER_JOB_CONFIG
     elif site_type == SiteType.CLIENT:
@@ -27,7 +28,12 @@ def _check_config(app_root: str, config_folder: str, site_type: str):
     else:
         config_to_check = None
 
-    if config_to_check and not os.path.exists(os.path.join(app_root, config_folder, config_to_check)):
+    def match(parent: str, config_file: str) -> bool:
+        return os.path.exists(os.path.join(parent, config_file))
+
+    if config_to_check and not ConfigFactory.match_config(
+        os.path.join(app_root, config_folder), config_to_check, match
+    ):
         return f"Missing required config {config_to_check} inside app/config folder."
     return ""
 
@@ -43,7 +49,7 @@ class DefaultAppValidator(AppValidator):
         if not os.path.exists(os.path.join(app_root, self._config_folder)):
             return "Missing config folder inside app folder.", {}
 
-        err = _check_config(app_root=app_root, config_folder=self._config_folder, site_type=self._site_type)
+        err = _config_exists(app_root=app_root, config_folder=self._config_folder, site_type=self._site_type)
         if err:
             return err, {}
 

--- a/nvflare/private/fed/app/default_app_validator.py
+++ b/nvflare/private/fed/app/default_app_validator.py
@@ -20,7 +20,7 @@ from nvflare.apis.fl_constant import JobConstants, SiteType, WorkspaceConstants
 from nvflare.fuel.utils.config_factory import ConfigFactory
 
 
-def _config_exists(app_root: str, config_folder: str, site_type: str):
+def _config_exists(app_root: str, config_folder: str, site_type: str) -> str:
     if site_type == SiteType.SERVER:
         config_to_check = JobConstants.SERVER_JOB_CONFIG
     elif site_type == SiteType.CLIENT:
@@ -28,18 +28,13 @@ def _config_exists(app_root: str, config_folder: str, site_type: str):
     else:
         config_to_check = None
 
-    def match(parent: str, config_file: str) -> bool:
-        return os.path.exists(os.path.join(parent, config_file))
-
-    if config_to_check and not ConfigFactory.match_config(
-        os.path.join(app_root, config_folder), config_to_check, match
-    ):
-        return f"Missing required config {config_to_check} inside app/config folder."
+    if config_to_check and ConfigFactory.load_config(config_to_check, [os.path.join(app_root, config_folder)]) is None:
+        return f"Missing required config {config_to_check} inside {os.path.join(app_root, config_folder)} folder."
     return ""
 
 
 class DefaultAppValidator(AppValidator):
-    def __init__(self, site_type: str, config_folder="config"):
+    def __init__(self, site_type: str, config_folder: str = "config"):
         self._site_type = site_type
         self._config_folder = config_folder
 


### PR DESCRIPTION
Fixes integration tests automatic stage.

### Description

- CUML change their installation method, I remove the entry from requirements.txt and add text to refer users to correct installation
- nvflare/private/fed/app/default_app_validator.py WAS checking for "config_fed_server.json" and "config_fed_client.json", follow changes in PR #1824 to check for general "config_fed_server" and "config_fed_client", NOTE that there are several places throughout our code base use `JobConstants.SERVER_JOB_CONFIG` and `JobConstants.CLIENT_JOB_CONFIG` we might need to fix them

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
