### PR TITLE
Add garbage collection at the end of each round in cyclic controller

### DIFF
--- a/nvflare/app_common/workflows/cyclic_ctl.py
+++ b/nvflare/app_common/workflows/cyclic_ctl.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import random
 
 from nvflare.apis.client import Client
@@ -204,6 +205,7 @@ class CyclicController(Controller):
                     self._engine.persist_components(fl_ctx, completed=False)
 
                 self.log_debug(fl_ctx, "Ending current round={}.".format(self._current_round))
+                gc.collect()
 
             self.log_debug(fl_ctx, "Cyclic ended.")
         except Exception as e:


### PR DESCRIPTION
### Description

This PR adds a call to garbage collection at the end of each round so that the server can reclaim unused memory more often.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
