### PR TITLE
Add lightning API and example

### DIFF
--- a/examples/advanced/lightning/README.md
+++ b/examples/advanced/lightning/README.md
@@ -1,0 +1,2 @@
+This example showcase how to use NVFlare client lightning API to transform your local standalone training code written in lightning into FL!
+

--- a/examples/advanced/lightning/jobs/autoencoder/app/config/config_fed_client.json
+++ b/examples/advanced/lightning/jobs/autoencoder/app/config/config_fed_client.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 2,
+
+  "executors": [
+    {
+      "tasks": ["train"],
+      "executor": {
+        "name": "PTFilePipeLauncherExecutor",
+        "args": {
+          "launcher_id": "launcher",
+          "heartbeat_timeout": 60
+        }
+      }
+    }
+  ],
+  "task_result_filters": [
+  ],
+  "task_data_filters": [
+  ],
+  "components": [
+    {
+      "id": "launcher",
+      "name": "SubprocessLauncher",
+      "args": {
+        "script": "python custom/train.py"
+      }
+    }
+  ]
+}

--- a/examples/advanced/lightning/jobs/autoencoder/app/config/config_fed_server.json
+++ b/examples/advanced/lightning/jobs/autoencoder/app/config/config_fed_server.json
@@ -1,0 +1,39 @@
+{
+  "format_version": 2,
+
+  "server": {
+    "heart_beat_timeout": 600
+  },
+  "task_data_filters": [],
+  "task_result_filters": [],
+  "components": [
+    {
+      "id": "shareable_generator",
+      "path": "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator",
+      "args": {}
+    },
+    {
+      "id": "aggregator",
+      "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
+      "args": {
+        "expected_data_kind": "WEIGHTS"
+      }
+    }
+  ],
+  "workflows": [
+      {
+        "id": "scatter_and_gather",
+        "name": "ScatterAndGather",
+        "args": {
+            "min_clients" : 2,
+            "num_rounds" : 5,
+            "start_round": 0,
+            "wait_time_after_min_received": 0,
+            "aggregator_id": "aggregator",
+            "shareable_generator_id": "shareable_generator",
+            "train_task_name": "train",
+            "train_timeout": 0
+        }
+      }
+  ]
+}

--- a/examples/advanced/lightning/jobs/autoencoder/app/custom/train.py
+++ b/examples/advanced/lightning/jobs/autoencoder/app/custom/train.py
@@ -1,0 +1,200 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MNIST autoencoder example.
+
+To run: python autoencoder.py --trainer.max_epochs=50
+"""
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from lightning_utilities.core.rank_zero import rank_zero_only
+from pytorch_lightning import LightningDataModule, LightningModule, Trainer, callbacks, cli_lightning_logo
+from pytorch_lightning.cli import LightningCLI
+from pytorch_lightning.demos.mnist_datamodule import MNIST
+from pytorch_lightning.utilities.imports import _TORCHVISION_AVAILABLE
+from torch import nn
+from torch.utils.data import DataLoader, random_split
+
+# (0) import nvflare client lightning API
+import nvflare.client.lightning as flare
+
+if _TORCHVISION_AVAILABLE:
+    import torchvision
+    from torchvision import transforms
+    from torchvision.utils import save_image
+
+DATASETS_PATH = "/tmp/nvflare/mnist"
+
+
+class ImageSampler(callbacks.Callback):
+    def __init__(
+        self,
+        num_samples: int = 3,
+        nrow: int = 8,
+        padding: int = 2,
+        normalize: bool = True,
+        norm_range: Optional[Tuple[int, int]] = None,
+        scale_each: bool = False,
+        pad_value: int = 0,
+    ) -> None:
+        """
+        Args:
+            num_samples: Number of images displayed in the grid. Default: ``3``.
+            nrow: Number of images displayed in each row of the grid.
+                The final grid size is ``(B / nrow, nrow)``. Default: ``8``.
+            padding: Amount of padding. Default: ``2``.
+            normalize: If ``True``, shift the image to the range (0, 1),
+                by the min and max values specified by :attr:`range`. Default: ``False``.
+            norm_range: Tuple (min, max) where min and max are numbers,
+                then these numbers are used to normalize the image. By default, min and max
+                are computed from the tensor.
+            scale_each: If ``True``, scale each image in the batch of
+                images separately rather than the (min, max) over all images. Default: ``False``.
+            pad_value: Value for the padded pixels. Default: ``0``.
+        """
+        if not _TORCHVISION_AVAILABLE:  # pragma: no cover
+            raise ModuleNotFoundError("You want to use `torchvision` which is not installed yet.")
+
+        super().__init__()
+        self.num_samples = num_samples
+        self.nrow = nrow
+        self.padding = padding
+        self.normalize = normalize
+        self.norm_range = norm_range
+        self.scale_each = scale_each
+        self.pad_value = pad_value
+
+    def _to_grid(self, images):
+        return torchvision.utils.make_grid(
+            tensor=images,
+            nrow=self.nrow,
+            padding=self.padding,
+            normalize=self.normalize,
+            range=self.norm_range,
+            scale_each=self.scale_each,
+            pad_value=self.pad_value,
+        )
+
+    @rank_zero_only
+    def on_train_epoch_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        if not _TORCHVISION_AVAILABLE:
+            return
+
+        images, _ = next(iter(DataLoader(trainer.datamodule.mnist_val, batch_size=self.num_samples)))
+        images_flattened = images.view(images.size(0), -1)
+
+        # generate images
+        with torch.no_grad():
+            pl_module.eval()
+            images_generated = pl_module(images_flattened.to(pl_module.device))
+            pl_module.train()
+
+        if trainer.current_epoch == 0:
+            save_image(self._to_grid(images), f"grid_ori_{trainer.current_epoch}.png")
+        save_image(self._to_grid(images_generated.reshape(images.shape)), f"grid_generated_{trainer.current_epoch}.png")
+
+
+class LitAutoEncoder(LightningModule):
+    """
+    >>> LitAutoEncoder()  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    LitAutoEncoder(
+      (encoder): ...
+      (decoder): ...
+    )
+    """
+
+    def __init__(self, hidden_dim: int = 64, learning_rate=10e-3):
+        super().__init__()
+        self.save_hyperparameters()
+        self.encoder = nn.Sequential(nn.Linear(28 * 28, hidden_dim), nn.ReLU(), nn.Linear(hidden_dim, 3))
+        self.decoder = nn.Sequential(nn.Linear(3, hidden_dim), nn.ReLU(), nn.Linear(hidden_dim, 28 * 28))
+
+    def forward(self, x):
+        z = self.encoder(x)
+        return self.decoder(z)
+
+    def training_step(self, batch, batch_idx):
+        return self._common_step(batch, batch_idx, "train")
+
+    def validation_step(self, batch, batch_idx):
+        self._common_step(batch, batch_idx, "val")
+
+    def test_step(self, batch, batch_idx):
+        self._common_step(batch, batch_idx, "test")
+
+    def predict_step(self, batch, batch_idx, dataloader_idx=None):
+        x = self._prepare_batch(batch)
+        return self(x)
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.learning_rate)
+
+    def _prepare_batch(self, batch):
+        x, _ = batch
+        return x.view(x.size(0), -1)
+
+    def _common_step(self, batch, batch_idx, stage: str):
+        x = self._prepare_batch(batch)
+        loss = F.mse_loss(x, self(x))
+        self.log(f"{stage}_loss", loss, on_step=True)
+        return loss
+
+
+class MyDataModule(LightningDataModule):
+    def __init__(self, batch_size: int = 32):
+        super().__init__()
+        dataset = MNIST(DATASETS_PATH, train=True, download=True, transform=transforms.ToTensor())
+        self.mnist_test = MNIST(DATASETS_PATH, train=False, download=True, transform=transforms.ToTensor())
+        self.mnist_train, self.mnist_val = random_split(dataset, [55000, 5000])
+        self.batch_size = batch_size
+
+    def train_dataloader(self):
+        return DataLoader(self.mnist_train, batch_size=self.batch_size)
+
+    def val_dataloader(self):
+        return DataLoader(self.mnist_val, batch_size=self.batch_size)
+
+    def test_dataloader(self):
+        return DataLoader(self.mnist_test, batch_size=self.batch_size)
+
+    def predict_dataloader(self):
+        return DataLoader(self.mnist_test, batch_size=self.batch_size)
+
+
+def cli_main():
+    # (1) init nvflare environment
+    flare.init()
+    # (2) patch the LightningModule
+    flare.patch(LitAutoEncoder)
+    cli = LightningCLI(
+        LitAutoEncoder,
+        MyDataModule,
+        seed_everything_default=1234,
+        run=False,  # used to de-activate automatic fitting.
+        trainer_defaults={"callbacks": ImageSampler(), "max_epochs": 1},
+        save_config_kwargs={"overwrite": True},
+    )
+    cli.trainer.fit(cli.model, datamodule=cli.datamodule)
+    cli.trainer.test(ckpt_path="best", datamodule=cli.datamodule)
+    cli.trainer.test(cli.model.get_fl_model(), datamodule=cli.datamodule)
+    predictions = cli.trainer.predict(ckpt_path="best", datamodule=cli.datamodule)
+    print(predictions[0])
+
+
+if __name__ == "__main__":
+    cli_lightning_logo()
+    cli_main()

--- a/examples/advanced/lightning/jobs/autoencoder/meta.json
+++ b/examples/advanced/lightning/jobs/autoencoder/meta.json
@@ -1,0 +1,11 @@
+{
+    "name": "lightning",
+    "resource_spec": {},
+    "min_clients" : 2,
+    "deploy_map": {
+      "app": [
+        "@ALL"
+      ]
+    }
+  }
+  

--- a/examples/advanced/lightning/requirements.txt
+++ b/examples/advanced/lightning/requirements.txt
@@ -1,0 +1,3 @@
+nvflare[PT]>=2.4.0
+jsonargparse[signatures]>=4.17.0
+pytorch_lightning

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -23,7 +23,7 @@ from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.aggregator import Aggregator
 from nvflare.app_common.abstract.learnable_persistor import LearnablePersistor
-from nvflare.app_common.abstract.model import ModelLearnable
+from nvflare.app_common.abstract.model import ModelLearnable, make_model_learnable
 from nvflare.app_common.abstract.shareable_generator import ShareableGenerator
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
@@ -47,7 +47,7 @@ class ScatterAndGather(Controller):
         start_round: int = 0,
         wait_time_after_min_received: int = 10,
         aggregator_id=AppConstants.DEFAULT_AGGREGATOR_ID,
-        persistor_id=AppConstants.DEFAULT_PERSISTOR_ID,
+        persistor_id="",
         shareable_generator_id=AppConstants.DEFAULT_SHAREABLE_GENERATOR_ID,
         train_task_name=AppConstants.TASK_TRAIN,
         train_timeout: int = 0,
@@ -143,7 +143,7 @@ class ScatterAndGather(Controller):
 
         # workflow phases: init, train, validate
         self._phase = AppConstants.PHASE_INIT
-        self._global_weights = None
+        self._global_weights = make_model_learnable({}, {})
         self._current_round = None
 
     def start_controller(self, fl_ctx: FLContext) -> None:
@@ -167,40 +167,42 @@ class ScatterAndGather(Controller):
             )
             return
 
-        self.persistor = self._engine.get_component(self.persistor_id)
-        if not isinstance(self.persistor, LearnablePersistor):
-            self.system_panic(
-                f"Model Persistor {self.persistor_id} must be a LearnablePersistor type object, "
-                f"but got {type(self.persistor)}",
-                fl_ctx,
-            )
-            return
+        if self.persistor_id:
+            self.persistor = self._engine.get_component(self.persistor_id)
+            if not isinstance(self.persistor, LearnablePersistor):
+                self.system_panic(
+                    f"Model Persistor {self.persistor_id} must be a LearnablePersistor type object, "
+                    f"but got {type(self.persistor)}",
+                    fl_ctx,
+                )
+                return
 
         # initialize global model
         fl_ctx.set_prop(AppConstants.START_ROUND, self._start_round, private=True, sticky=True)
         fl_ctx.set_prop(AppConstants.NUM_ROUNDS, self._num_rounds, private=True, sticky=False)
-        self._global_weights = self.persistor.load(fl_ctx)
+        if self.persistor_id:
+            self._global_weights = self.persistor.load(fl_ctx)
 
-        if not isinstance(self._global_weights, ModelLearnable):
-            self.system_panic(
-                reason=f"Expected global weights to be of type `ModelLearnable` but received {type(self._global_weights)}",
-                fl_ctx=fl_ctx,
-            )
-            return
+            if not isinstance(self._global_weights, ModelLearnable):
+                self.system_panic(
+                    reason=f"Expected global weights to be of type `ModelLearnable` but received {type(self._global_weights)}",
+                    fl_ctx=fl_ctx,
+                )
+                return
 
-        if self._global_weights.is_empty():
-            if not self.allow_empty_global_weights:
-                # if empty not allowed, further check whether it is available from fl_ctx
-                self._global_weights = fl_ctx.get_prop(AppConstants.GLOBAL_MODEL)
-                if not isinstance(self._global_weights, ModelLearnable):
-                    self.system_panic(
-                        reason=f"Expected global weights to be of type `ModelLearnable` but received {type(self._global_weights)}",
-                        fl_ctx=fl_ctx,
-                    )
-                    return
+            if self._global_weights.is_empty():
+                if not self.allow_empty_global_weights:
+                    # if empty not allowed, further check whether it is available from fl_ctx
+                    self._global_weights = fl_ctx.get_prop(AppConstants.GLOBAL_MODEL)
+                    if not isinstance(self._global_weights, ModelLearnable):
+                        self.system_panic(
+                            reason=f"Expected global weights to be of type `ModelLearnable` but received {type(self._global_weights)}",
+                            fl_ctx=fl_ctx,
+                        )
+                        return
 
-        fl_ctx.set_prop(AppConstants.GLOBAL_MODEL, self._global_weights, private=True, sticky=True)
-        self.fire_event(AppEventType.INITIAL_MODEL_LOADED, fl_ctx)
+            fl_ctx.set_prop(AppConstants.GLOBAL_MODEL, self._global_weights, private=True, sticky=True)
+            self.fire_event(AppEventType.INITIAL_MODEL_LOADED, fl_ctx)
 
     def control_flow(self, abort_signal: Signal, fl_ctx: FLContext) -> None:
         try:
@@ -277,14 +279,16 @@ class ScatterAndGather(Controller):
                 if self._check_abort_signal(fl_ctx, abort_signal):
                     return
 
-                if (
-                    self._persist_every_n_rounds != 0 and (self._current_round + 1) % self._persist_every_n_rounds == 0
-                ) or self._current_round == self._start_round + self._num_rounds - 1:
-                    self.log_info(fl_ctx, "Start persist model on server.")
-                    self.fire_event(AppEventType.BEFORE_LEARNABLE_PERSIST, fl_ctx)
-                    self.persistor.save(self._global_weights, fl_ctx)
-                    self.fire_event(AppEventType.AFTER_LEARNABLE_PERSIST, fl_ctx)
-                    self.log_info(fl_ctx, "End persist model on server.")
+                if self.persistor_id:
+                    if (
+                        self._persist_every_n_rounds != 0
+                        and (self._current_round + 1) % self._persist_every_n_rounds == 0
+                    ) or self._current_round == self._start_round + self._num_rounds - 1:
+                        self.log_info(fl_ctx, "Start persist model on server.")
+                        self.fire_event(AppEventType.BEFORE_LEARNABLE_PERSIST, fl_ctx)
+                        self.persistor.save(self._global_weights, fl_ctx)
+                        self.fire_event(AppEventType.AFTER_LEARNABLE_PERSIST, fl_ctx)
+                        self.log_info(fl_ctx, "End persist model on server.")
 
                 self.fire_event(AppEventType.ROUND_DONE, fl_ctx)
                 self.log_info(fl_ctx, f"Round {self._current_round} finished.")

--- a/nvflare/app_opt/pt/file_pipe_launcher_executor.py
+++ b/nvflare/app_opt/pt/file_pipe_launcher_executor.py
@@ -15,6 +15,7 @@
 
 from typing import Optional
 
+from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.executors.file_pipe_launcher_executor import FilePipeLauncherExecutor
 from nvflare.app_opt.pt.decomposers import TensorDecomposer
 from nvflare.app_opt.pt.params_converter import NumpyToPTParamsConverter, PTToNumpyParamsConverter
@@ -30,12 +31,14 @@ class PTFilePipeLauncherExecutor(FilePipeLauncherExecutor):
         launcher_id: Optional[str] = None,
         launch_timeout: Optional[float] = None,
         task_wait_time: Optional[float] = None,
-        task_read_wait_time: Optional[float] = 30.0,
+        task_read_wait_time: Optional[float] = None,
         result_poll_interval: float = 0.1,
         read_interval: float = 0.1,
         heartbeat_interval: float = 5.0,
         heartbeat_timeout: float = 30.0,
         workers: int = 1,
+        from_nvflare_converter_id: Optional[str] = None,
+        to_nvflare_converter_id: Optional[str] = None,
     ) -> None:
         """Initializes the PTFilePipeLauncherExecutor.
 
@@ -45,14 +48,18 @@ class PTFilePipeLauncherExecutor(FilePipeLauncherExecutor):
             pipe_id (Optional[str]): Identifier used to get the Pipe from NVFlare components.
             pipe_name (str): Name of the pipe. Defaults to "pipe".
             launcher_id (Optional[str]): Identifier used to get the Launcher from NVFlare components.
-            launch_timeout (Optional[float]): Timeout for the "launch" method to end. None means forever.
-            task_wait_time (Optional[float]): Time to wait for tasks to complete before exiting the executor.
-            task_read_wait_time (Optional[float]): Time to wait for task results from the pipe. Defaults to 30.0.
+            launch_timeout (Optional[float]): Timeout for the "launch" method to end. None means never timeout.
+            task_wait_time (Optional[float]): Time to wait for tasks to complete before exiting the executor. None means never timeout.
+            task_read_wait_time (Optional[float]): Time to wait for task results from the pipe. None means no wait.
             result_poll_interval (float): Interval for polling task results from the pipe. Defaults to 0.1.
             read_interval (float): Interval for reading from the pipe. Defaults to 0.1.
             heartbeat_interval (float): Interval for sending heartbeat to the peer. Defaults to 5.0.
             heartbeat_timeout (float): Timeout for waiting for a heartbeat from the peer. Defaults to 30.0.
             workers (int): Number of worker threads needed.
+            from_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.
+                This converter will be called when model is get from nvflare controller side to executor side.
+            to_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.
+                This converter will be called when model is get from nvflare executor side to controller side.
         """
         super().__init__(
             pipe_id=pipe_id,
@@ -66,8 +73,15 @@ class PTFilePipeLauncherExecutor(FilePipeLauncherExecutor):
             heartbeat_interval=heartbeat_interval,
             heartbeat_timeout=heartbeat_timeout,
             workers=workers,
+            from_nvflare_converter_id=from_nvflare_converter_id,
+            to_nvflare_converter_id=to_nvflare_converter_id,
         )
         fobs.register(TensorDecomposer)
         self._data_exchange_path = data_exchange_path
-        self._from_nvflare_converter = NumpyToPTParamsConverter()
-        self._to_nvflare_converter = PTToNumpyParamsConverter()
+
+    def initialize(self, fl_ctx: FLContext) -> None:
+        super().initialize(fl_ctx)
+        if self._from_nvflare_converter is None:
+            self._from_nvflare_converter = NumpyToPTParamsConverter()
+        if self._to_nvflare_converter is None:
+            self._to_nvflare_converter = PTToNumpyParamsConverter()

--- a/nvflare/client/lightning/__init__.py
+++ b/nvflare/client/lightning/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .api import init as init
+from .api import patch as patch

--- a/nvflare/client/lightning/api.py
+++ b/nvflare/client/lightning/api.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+
+import pytorch_lightning as pl
+
+import nvflare.client as flare
+
+
+def init():
+    config_file = "nvf_lightning.json"
+    config = {"exchange_path": "./", "exchange_format": "pytorch", "params_type": "FULL"}
+    with open(config_file, "w") as f:
+        json.dump(config, f)
+    flare.init(config=config_file)
+
+
+def patch(cls: pl.LightningModule) -> None:
+    if not issubclass(cls, pl.LightningModule):
+        raise RuntimeError("only support LightningModule")
+
+    if hasattr(cls, "on_train_start"):
+        cls.on_train_start = train_start(cls.on_train_start)
+    else:
+        cls.on_train_start = _fl_train_start
+
+    if hasattr(cls, "on_train_end"):
+        cls.on_train_end = train_end(cls.on_train_end)
+    else:
+        cls.on_train_end = _fl_train_end
+
+    cls.get_fl_model = get_fl_model
+
+
+def _fl_train_start(self):
+    model, metadata = flare.receive_model()
+    if model:
+        weights = model
+        self.fl_model = weights
+        self.load_state_dict(weights)
+
+
+def _fl_train_end(self):
+    weights = self.state_dict()
+    flare.submit_model(weights)
+
+
+def get_fl_model(self):
+    # make new copy of self, and then load fl_model
+    new_module = copy.copy(self)
+    if self.fl_model is not None:
+        new_module.load_state_dict(self.fl_model)
+    return new_module
+
+
+def train_start(func):
+    """Decorator factory."""
+
+    def wrapper(self, *args, **kwargs):
+        _fl_train_start(self)
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def train_end(func):
+    """Decorator factory."""
+
+    def wrapper(self, *args, **kwargs):
+        r = func(self, *args, **kwargs)
+        _fl_train_end(self)
+        return r
+
+    return wrapper


### PR DESCRIPTION
### Description

- Adds lightning client API (`init` and `patch`)
- Adds an example showcase the usage
- Adds ParamsConverter to LauncherExecutor and related child classes
- Change ScatterAndGather to NOT require server side model persistor

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
