### PR TITLE
Fix integration test configs timing issues

### DIFF
--- a/tests/integration_test/data/test_configs/ha/kill_server_after_training_complete.yml
+++ b/tests/integration_test/data/test_configs/ha/kill_server_after_training_complete.yml
@@ -31,6 +31,3 @@ tests:
         "result":
           "type": "run_state"
           "data": { "run_finished": True }
-    validators:
-      - path: tests.integration_test.src.validators.NumpySAGResultValidator
-        args: { expected_result: [ [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10, 11, 12 ] ] }

--- a/tests/integration_test/data/test_configs/ha/kill_server_during_training_after_first_round.yml
+++ b/tests/integration_test/data/test_configs/ha/kill_server_during_training_after_first_round.yml
@@ -30,6 +30,7 @@ tests:
           "kill server",
           "sleep 10",
           "start server",
+          "sleep 1"
         ]
         "result":
           "type": "run_state"

--- a/tests/integration_test/data/test_configs/ha/kill_server_during_training_before_first_round.yml
+++ b/tests/integration_test/data/test_configs/ha/kill_server_during_training_before_first_round.yml
@@ -30,6 +30,7 @@ tests:
           "kill server",
           "sleep 10",
           "start server",
+          "sleep 1"
         ]
         "result":
           "type": "run_state"

--- a/tests/integration_test/data/test_configs/ha/kill_server_during_training_sending_model.yml
+++ b/tests/integration_test/data/test_configs/ha/kill_server_during_training_sending_model.yml
@@ -22,6 +22,7 @@ tests:
           "kill server",
           "sleep 10",
           "start server",
+          "sleep 1"
         ]
         "result":
           "type": "run_state"


### PR DESCRIPTION
### Description

When server re-starts back, after its restoring the previous state.
Sometimes the "get_stats" command does NOT reflect the server state right away.
So we wait 1 seconds for the state to be restored in the server.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
