### PR TITLE
Improve NewCell send request timeout handling

### DIFF
--- a/nvflare/fuel/f3/cellnet/new_cell.py
+++ b/nvflare/fuel/f3/cellnet/new_cell.py
@@ -14,17 +14,29 @@
 
 import logging
 import threading
+import time
 import uuid
 from typing import Dict, List, Union
 
 from nvflare.apis.fl_constant import ServerCommandNames
 from nvflare.fuel.f3.cellnet.cell import Cell
-from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessageType
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessageType, ReturnCode
+from nvflare.fuel.f3.cellnet.utils import make_reply
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.stream_cell import StreamCell
 from nvflare.fuel.f3.streaming.stream_const import StreamHeaderKey
 from nvflare.fuel.f3.streaming.stream_types import StreamFuture
 from nvflare.private.defs import CellChannel
+
+
+class SimpleWaiter(threading.Event):
+    def __init__(self, req_id, timeout, result):
+        super().__init__()
+        self.req_id = req_id
+        self.timeout = timeout
+        self.result = result
+        self.sending_complete = False
+        self.in_receiving = False
 
 
 class Adapter:
@@ -99,36 +111,131 @@ class NewCell(StreamCell):
                 channel=channel, topic=topic, targets=targets, message=message, optional=optional
             )
 
-    def send_request(self, channel, target, topic, request, timeout=None, optional=False):
+    def _get_result(self, req_id):
+        waiter = self.requests_dict.pop(req_id)
+        return waiter.result
+
+    def send_request(self, channel, target, topic, request, timeout, optional=False):
+        self.logger.debug(f"send_request: {channel=}, {target=}, {topic=}, {timeout=}")
         if channel != CellChannel.SERVER_COMMAND:
             return self.core_cell.send_request(
                 channel=channel, target=target, topic=topic, request=request, timeout=timeout, optional=optional
             )
 
         req_id = str(uuid.uuid4())
-
         request.add_headers({StreamHeaderKey.STREAM_REQ_ID: req_id})
-        future = self.send_blob(channel, topic, target, request)  # StreamCell API
 
         # this future can be used to check sending progress, but not for checking return blob
-        waiter = threading.Event()
-        self.requests_dict[req_id] = [waiter, None]
+        future = self.send_blob(channel, topic, target, request)
 
-        if not waiter.wait(timeout):
-            self.requests_dict.pop(req_id)
-            return Message()
-        _, result = self.requests_dict.pop(req_id)
-        return result
+        waiter = SimpleWaiter(req_id=req_id, timeout=timeout, result=make_reply(ReturnCode.TIMEOUT))
+        self.requests_dict[req_id] = waiter
+        """
+        when inside the while loop, following things could happen
+        1. future is done
+           we should exit this loop and start wait for reply
+
+        2. waiter is set
+           reply is ready and we can exit this loop
+
+        3. future is making progress
+           stay in the loop, reset timer
+
+        4. no progress, not timeout yet
+           stay in the loop
+
+        5. no progress, timeout
+           exit
+
+        """
+        self.logger.debug(f"{req_id=}: entering sending loop {timeout=}")
+        last_progress = 0
+        last_update_time = time.time()
+        while True:
+            if future.done():
+                self.logger.debug(f"{req_id=}: sending complete")
+                waiter.sending_complete = True
+                break
+            if waiter.is_set():
+                self.logger.debug(f"{req_id=}: reply ready")
+                return self._get_result(req_id)
+            time.sleep(1.0)
+            current_time = time.time()
+            current_progress = future.get_progress()
+            if current_progress == last_progress:
+                if current_time - last_update_time > timeout:
+                    self.logger.debug(f"{req_id=}: sending timeout")
+                    future.cancel()
+                    return self._get_result(req_id)
+                else:
+                    self.logger.debug(f"{req_id=}: no sending progress before timeout")
+            else:
+                self.logger.debug(f"{req_id=}: sending progress {current_progress=}")
+                last_progress = current_progress
+                last_update_time = current_time
+
+        if not waiter.sending_complete:
+            # should not be here
+            self.logger.error(f"{req_id=}: unknown waiter state")
+            return make_reply(ReturnCode.COMM_ERROR)
+
+        # Now enter the remote process wait loop
+        self.logger.debug(f"{req_id=}: entering remote process wait {timeout=}")
+        while True:
+            if waiter.is_set():
+                self.logger.debug(f"{req_id=}: reply ready")
+                return self._get_result(req_id)
+            time.sleep(1.0)
+            if waiter.in_receiving:  # roughly 1 second grace period
+                self.logger.debug(f"{req_id=}: in receiving")
+                break
+            if time.time() - last_update_time > timeout:
+                self.logger.debug(f"{req_id=}: remote processing timeout")
+                return self._get_result(req_id)
+
+        # Reaching here only because the in_receiving is True (thus inside receiving call back)
+        # Wait here until the wait is set (only done by receiving call back)
+        self.logger.debug(f"{req_id=}: entering preocessing reply wait")
+        # the following may wait forever
+        _ = waiter.wait()
+        self.logger.debug(f"{req_id=}: waiter set by processing reply")
+        return self._get_result(req_id)
 
     def _process_reply(self, future: StreamFuture):
-        req_id = future.headers.get(StreamHeaderKey.STREAM_REQ_ID, -1)
-        if req_id not in self.requests_dict:
-            return
         headers = future.headers
-        response_blob = future.result()
-        waiter, _ = self.requests_dict.get(req_id, [None, None])
-        self.requests_dict[req_id] = [waiter, Message(headers, response_blob)]
-        waiter.set()
+        req_id = headers.get(StreamHeaderKey.STREAM_REQ_ID, -1)
+        try:
+            waiter = self.requests_dict[req_id]
+        except KeyError as e:
+            self.logger.warning(f"Receiving unknown {req_id=}, discarded")
+            return
+        waiter.in_receiving = True
+        last_progress = 0
+        last_update_time = time.time()
+        timeout = waiter.timeout
+        self.logger.debug(f"{req_id=}: entering receiving loop {timeout=}")
+        while True:
+            if future.done():
+                self.logger.debug(f"{req_id=}: receiving complete")
+                waiter.result = Message(headers, future.result())
+                waiter.set()
+                break
+            time.sleep(1.0)
+            current_time = time.time()
+            current_progress = future.get_progress()
+            if current_progress == last_progress:
+                if current_time - last_update_time > timeout:
+                    self.logger.debug(f"{req_id=}: receiving timeout")
+                    future.cancel()
+                    waiter.receiving_timeout = True
+                    waiter.set()
+                    break
+                else:
+                    self.logger.debug(f"{req_id=}: no receiving progress before timeout")
+            else:
+                self.logger.debug(f"{req_id=}: receiving progress {current_progress=}")
+                last_progress = current_progress
+                last_update_time = current_time
 
     def register_request_cb(self, channel: str, topic: str, cb, *args, **kwargs):
         """
@@ -151,9 +258,9 @@ class NewCell(StreamCell):
             ServerCommandNames.GET_TASK,
             ServerCommandNames.SUBMIT_UPDATE,
         ]:
-            # self.logger.info(f"Register blob CB for {channel=}, {topic=}")
+            self.logger.debug(f"Register blob CB for {channel=}, {topic=}")
             adapter = Adapter(cb, self.core_cell.my_info, self)
             self.register_blob_cb(channel, topic, adapter.call, *args, **kwargs)
         else:
-            # self.logger.info(f"Register regular CB for {channel=}, {topic=}")
+            self.logger.debug(f"Register regular CB for {channel=}, {topic=}")
             self.core_cell.register_request_cb(channel, topic, cb, *args, **kwargs)


### PR DESCRIPTION
### Description

This PR improves the send_request timeout handling.  Originally, timeout is used to check if the last byte of reply arrives in time.  This PR change the timeout for sending progress, remote processing and receiving progress.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
