### PR TITLE
Fixed the admin tool requires the resources path.

### DIFF
--- a/nvflare/fuel/hci/client/config.py
+++ b/nvflare/fuel/hci/client/config.py
@@ -44,8 +44,10 @@ class FLAdminClientStarterConfigurator(JsonConfigurator):
             sys.path.append(custom_dir)
 
         admin_config_file_path = workspace.get_admin_startup_file_path()
+        config_files = [admin_config_file_path]
         resources_file_path = workspace.get_resources_file_path()
-        config_files = [admin_config_file_path, resources_file_path]
+        if resources_file_path:
+            config_files.append(resources_file_path)
 
         JsonConfigurator.__init__(
             self,


### PR DESCRIPTION
Fixes # .

Fixed a bug the admin tool requires the resources path error.

### Description

Made the resources folder in the admin tool optional.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
