### PR TITLE
Changed the simulator to use client_runner.run_abort_signal.triggered

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -100,7 +100,7 @@ class ClientTaskWorker(FLComponent):
                         )
 
                     # if any client got the END_RUN event, stop the simulator run.
-                    if client_runner.end_run_fired or client_runner.asked_to_stop:
+                    if client_runner.run_abort_signal.triggered:
                         stop_run = True
                         self.logger.info("End the Simulator run.")
                         break


### PR DESCRIPTION
… due to https://github.com/NVIDIA/NVFlare/pull/1881 change.

Fixes # .

### Description

Fixed the simulator error when checking the end_run due to https://github.com/NVIDIA/NVFlare/pull/1881 change.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
