### PR TITLE
Fixed the recursive FLComponents creation.

### DIFF
--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -93,6 +93,7 @@ class ClientAppRunner(Runner):
 
         run_manager = self.create_run_manager(args, conf, federated_client, workspace)
         federated_client.run_manager = run_manager
+        federated_client.handlers = conf.runner_config.handlers
         with run_manager.new_context() as fl_ctx:
             self._set_fl_context(fl_ctx, app_root, args, workspace, secure_train)
             client_runner = ClientRunner(config=conf.runner_config, job_id=args.job_id, engine=run_manager)

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -102,8 +102,8 @@ class ClientJsonConfigurator(FedJsonConfigurator):
             self.current_exe.executor = self.authorize_and_build_component(element, config_ctx, node)
             return
 
-    def authorize_and_build_component(self, config_dict, config_ctx, node):
-        t = super().authorize_and_build_component(config_dict, config_ctx, node)
+    def build_component(self, config_dict):
+        t = super().build_component(config_dict)
         if isinstance(t, FLComponent):
             self.handlers.append(t)
         return t

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -406,8 +406,7 @@ class ClientRunner(FLComponent):
         """
         default_task_fetch_interval = self.default_task_fetch_interval
         self.log_debug(fl_ctx, "fetching task from server ...")
-        temp_fl_ctx = copy.copy(fl_ctx)
-        task = self.engine.get_task_assignment(temp_fl_ctx)
+        task = self.engine.get_task_assignment(fl_ctx)
 
         if not task:
             self.log_debug(fl_ctx, "no task received - will try in {} secs".format(default_task_fetch_interval))

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import threading
 import time
 
@@ -406,7 +406,8 @@ class ClientRunner(FLComponent):
         """
         default_task_fetch_interval = self.default_task_fetch_interval
         self.log_debug(fl_ctx, "fetching task from server ...")
-        task = self.engine.get_task_assignment(fl_ctx)
+        temp_fl_ctx = copy.copy(fl_ctx)
+        task = self.engine.get_task_assignment(temp_fl_ctx)
 
         if not task:
             self.log_debug(fl_ctx, "no task received - will try in {} secs".format(default_task_fetch_interval))

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import threading
 import time
 

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -138,8 +138,8 @@ class ServerJsonConfigurator(FedJsonConfigurator):
             ids.append(t.id)
         return ids
 
-    def authorize_and_build_component(self, config_dict, config_ctx, node):
-        t = super().authorize_and_build_component(config_dict, config_ctx, node)
+    def build_component(self, config_dict):
+        t = super().build_component(config_dict)
         if isinstance(t, FLComponent):
             self.handlers.append(t)
         return t

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -106,10 +106,10 @@ class ServerRunner(FLComponent):
                 with self.engine.new_context() as fl_ctx:
                     self.log_info(fl_ctx, "starting workflow {} ({}) ...".format(wf.id, type(wf.responder)))
 
+                    fl_ctx.set_prop(FLContextKey.WORKFLOW, wf.id, sticky=True)
                     wf.responder.initialize_run(fl_ctx)
 
                     self.log_info(fl_ctx, "Workflow {} ({}) started".format(wf.id, type(wf.responder)))
-                    fl_ctx.set_prop(FLContextKey.WORKFLOW, wf.id, sticky=True)
                     self.log_debug(fl_ctx, "firing event EventType.START_WORKFLOW")
                     self.fire_event(EventType.START_WORKFLOW, fl_ctx)
 


### PR DESCRIPTION
Fixes # .

### Description

- Fixed the recursive FLComponent creation missing the event handling issue.
- Fixed the client job process missing the proper FLcomponent handlers issue.
- Server Runner set the workflow ID in the FLContext before the initialize_run(fl_ctx).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
