### PR TITLE
Wrap training scripts inside main method

### DIFF
--- a/examples/hello-world/ml-to-fl/jobs/client_api1/app/custom/cifar10.py
+++ b/examples/hello-world/ml-to-fl/jobs/client_api1/app/custom/cifar10.py
@@ -25,95 +25,96 @@ import nvflare.client as flare
 # (optional) set a fix place so we don't need to download everytime
 DATASET_PATH = "/tmp/nvflare/data"
 # (optional) We change to use GPU to speed things up.
-# if you want to use CPU, change device=“cpu”
-device = "cuda:0"
-
-transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
-
-batch_size = 4
-
-trainset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=True, download=True, transform=transform)
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2)
-
-testset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=False, download=True, transform=transform)
-testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=2)
+# if you want to use CPU, change DEVICE=“cpu”
+DEVICE = "cuda:0"
 
 
-net = Net()
+def main():
+    transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
 
-# (1.1) initializes NVFlare client API
-flare.init()
-# (1.2) gets FLModel from NVFlare
-input_model = flare.receive()
+    batch_size = 4
 
-# (1.3) loads model from NVFlare
-net.load_state_dict(input_model.params)
+    trainset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=True, download=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=1)
 
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+    testset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=False, download=True, transform=transform)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=1)
+
+    net = Net()
+
+    # (1.1) initializes NVFlare client API
+    flare.init()
+    # (1.2) gets FLModel from NVFlare
+    input_model = flare.receive()
+
+    # (1.3) loads model from NVFlare
+    net.load_state_dict(input_model.params)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+
+    # (optional) use GPU to speed things up
+    net.to(DEVICE)
+    # (optional) calculate total steps
+    steps = 2 * len(trainloader)
+    for epoch in range(2):  # loop over the dataset multiple times
+
+        running_loss = 0.0
+        for i, data in enumerate(trainloader, 0):
+            # get the inputs; data is a list of [inputs, labels]
+            # (optional) use GPU to speed things up
+            inputs, labels = data[0].to(DEVICE), data[1].to(DEVICE)
+
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            if i % 2000 == 1999:  # print every 2000 mini-batches
+                print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
+                running_loss = 0.0
+
+    print("Finished Training")
+
+    PATH = "./cifar_net.pth"
+    torch.save(net.state_dict(), PATH)
+
+    net = Net()
+    net.load_state_dict(torch.load(PATH))
+    # (optional) use GPU to speed things up
+    net.to(DEVICE)
+
+    correct = 0
+    total = 0
+    # since we're not training, we don't need to calculate the gradients for our outputs
+    with torch.no_grad():
+        for data in testloader:
+            # (optional) use GPU to speed things up
+            images, labels = data[0].to(DEVICE), data[1].to(DEVICE)
+            # calculate outputs by running images through the network
+            outputs = net(images)
+            # the class with the highest energy is what we choose as prediction
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+
+    print(f"Accuracy of the network on the 10000 test images: {100 * correct // total} %")
+
+    # (1.4) construct trained FL model
+    output_model = flare.FLModel(
+        params=net.cpu().state_dict(),
+        metrics={"accuracy": 100 * correct // total},
+        meta={"NUM_STEPS_CURRENT_ROUND": steps},
+    )
+    # (1.5) send model back to NVFlare
+    flare.send(output_model)
 
 
-# (optional) use GPU to speed things up
-net.to(device)
-# (optional) calculate total steps
-steps = 2 * len(trainloader)
-for epoch in range(2):  # loop over the dataset multiple times
-
-    running_loss = 0.0
-    for i, data in enumerate(trainloader, 0):
-        # get the inputs; data is a list of [inputs, labels]
-        # (optional) use GPU to speed things up
-        inputs, labels = data[0].to(device), data[1].to(device)
-
-        # zero the parameter gradients
-        optimizer.zero_grad()
-
-        # forward + backward + optimize
-        outputs = net(inputs)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
-
-        # print statistics
-        running_loss += loss.item()
-        if i % 2000 == 1999:  # print every 2000 mini-batches
-            print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
-            running_loss = 0.0
-
-print("Finished Training")
-
-
-PATH = "./cifar_net.pth"
-torch.save(net.state_dict(), PATH)
-
-
-net = Net()
-net.load_state_dict(torch.load(PATH))
-# (optional) use GPU to speed things up
-net.to(device)
-
-
-correct = 0
-total = 0
-# since we're not training, we don't need to calculate the gradients for our outputs
-with torch.no_grad():
-    for data in testloader:
-        # (optional) use GPU to speed things up
-        images, labels = data[0].to(device), data[1].to(device)
-        # calculate outputs by running images through the network
-        outputs = net(images)
-        # the class with the highest energy is what we choose as prediction
-        _, predicted = torch.max(outputs.data, 1)
-        total += labels.size(0)
-        correct += (predicted == labels).sum().item()
-
-print(f"Accuracy of the network on the 10000 test images: {100 * correct // total} %")
-
-# (1.4) construct trained FL model
-output_model = flare.FLModel(
-    params=net.cpu().state_dict(),
-    metrics={"accuracy": 100 * correct // total},
-    meta={"NUM_STEPS_CURRENT_ROUND": steps},
-)
-# (1.5) send model back to NVFlare
-flare.send(output_model)
+if __name__ == "__main__":
+    main()

--- a/examples/hello-world/ml-to-fl/jobs/client_api2/app/custom/cifar10.py
+++ b/examples/hello-world/ml-to-fl/jobs/client_api2/app/custom/cifar10.py
@@ -25,103 +25,104 @@ import nvflare.client as flare
 # (optional) set a fix place so we don't need to download everytime
 DATASET_PATH = "/tmp/nvflare/data"
 # (optional) We change to use GPU to speed things up.
-# if you want to use CPU, change device=“cpu”
-device = "cuda:0"
-
-transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
-
-batch_size = 4
-
-trainset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=True, download=True, transform=transform)
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2)
-
-testset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=False, download=True, transform=transform)
-testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=2)
+# if you want to use CPU, change DEVICE=“cpu”
+DEVICE = "cuda:0"
 
 
-net = Net()
+def main():
+    transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
 
-# (1.1) initializes NVFlare client API
-flare.init()
-# (1.2) gets FLModel from NVFlare
-input_model = flare.receive()
+    batch_size = 4
 
-# (1.3) loads model from NVFlare
-net.load_state_dict(input_model.params)
+    trainset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=True, download=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=1)
 
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+    testset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=False, download=True, transform=transform)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=1)
 
-
-# (optional) use GPU to speed things up
-net.to(device)
-# (optional) calculate total steps
-steps = 2 * len(trainloader)
-for epoch in range(2):  # loop over the dataset multiple times
-
-    running_loss = 0.0
-    for i, data in enumerate(trainloader, 0):
-        # get the inputs; data is a list of [inputs, labels]
-        # (optional) use GPU to speed things up
-        inputs, labels = data[0].to(device), data[1].to(device)
-
-        # zero the parameter gradients
-        optimizer.zero_grad()
-
-        # forward + backward + optimize
-        outputs = net(inputs)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
-
-        # print statistics
-        running_loss += loss.item()
-        if i % 2000 == 1999:  # print every 2000 mini-batches
-            print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
-            running_loss = 0.0
-
-print("Finished Training")
-
-
-PATH = "./cifar_net.pth"
-torch.save(net.state_dict(), PATH)
-
-
-# (2.0) wraps evaluation logic into a method to re-use for
-#       evaluation on both trained and received model
-def evaluate(input_weights):
     net = Net()
-    net.load_state_dict(input_weights)
+
+    # (1.1) initializes NVFlare client API
+    flare.init()
+    # (1.2) gets FLModel from NVFlare
+    input_model = flare.receive()
+
+    # (1.3) loads model from NVFlare
+    net.load_state_dict(input_model.params)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+
     # (optional) use GPU to speed things up
-    net.to(device)
+    net.to(DEVICE)
+    # (optional) calculate total steps
+    steps = 2 * len(trainloader)
+    for epoch in range(2):  # loop over the dataset multiple times
 
-    correct = 0
-    total = 0
-    # since we're not training, we don't need to calculate the gradients for our outputs
-    with torch.no_grad():
-        for data in testloader:
+        running_loss = 0.0
+        for i, data in enumerate(trainloader, 0):
+            # get the inputs; data is a list of [inputs, labels]
             # (optional) use GPU to speed things up
-            images, labels = data[0].to(device), data[1].to(device)
-            # calculate outputs by running images through the network
-            outputs = net(images)
-            # the class with the highest energy is what we choose as prediction
-            _, predicted = torch.max(outputs.data, 1)
-            total += labels.size(0)
-            correct += (predicted == labels).sum().item()
+            inputs, labels = data[0].to(DEVICE), data[1].to(DEVICE)
 
-    print(f"Accuracy of the network on the 10000 test images: {100 * correct // total} %")
-    return 100 * correct // total
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            if i % 2000 == 1999:  # print every 2000 mini-batches
+                print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
+                running_loss = 0.0
+
+    print("Finished Training")
+
+    PATH = "./cifar_net.pth"
+    torch.save(net.state_dict(), PATH)
+
+    # (2.0) wraps evaluation logic into a method to re-use for
+    #       evaluation on both trained and received model
+    def evaluate(input_weights):
+        net = Net()
+        net.load_state_dict(input_weights)
+        # (optional) use GPU to speed things up
+        net.to(DEVICE)
+
+        correct = 0
+        total = 0
+        # since we're not training, we don't need to calculate the gradients for our outputs
+        with torch.no_grad():
+            for data in testloader:
+                # (optional) use GPU to speed things up
+                images, labels = data[0].to(DEVICE), data[1].to(DEVICE)
+                # calculate outputs by running images through the network
+                outputs = net(images)
+                # the class with the highest energy is what we choose as prediction
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+
+        print(f"Accuracy of the network on the 10000 test images: {100 * correct // total} %")
+        return 100 * correct // total
+
+    # (2.1) evaluation on local trained model
+    local_accuracy = evaluate(torch.load(PATH))
+    # (2.2) evaluate on received model
+    accuracy = evaluate(input_model.params)
+    # (2.3) construct trained FL model
+    output_model = flare.FLModel(
+        params=net.cpu().state_dict(),
+        metrics={"accuracy": accuracy},
+        meta={"NUM_STEPS_CURRENT_ROUND": steps},
+    )
+    # (1.5) send model back to NVFlare
+    flare.send(output_model)
 
 
-# (2.1) evaluation on local trained model
-local_accuracy = evaluate(torch.load(PATH))
-# (2.2) evaluate on received model
-accuracy = evaluate(input_model.params)
-# (2.3) construct trained FL model
-output_model = flare.FLModel(
-    params=net.cpu().state_dict(),
-    metrics={"accuracy": accuracy},
-    meta={"NUM_STEPS_CURRENT_ROUND": steps},
-)
-# (1.5) send model back to NVFlare
-flare.send(output_model)
+if __name__ == "__main__":
+    main()

--- a/examples/hello-world/ml-to-fl/jobs/decorator/app/custom/cifar10.py
+++ b/examples/hello-world/ml-to-fl/jobs/decorator/app/custom/cifar10.py
@@ -24,95 +24,100 @@ import nvflare.client as flare
 
 # (optional) set a fix place so we don't need to download everytime
 DATASET_PATH = "/tmp/nvflare/data"
+# (optional) We change to use GPU to speed things up.
+# if you want to use CPU, change DEVICE=“cpu”
+DEVICE = "cuda:0"
 PATH = "./cifar_net.pth"
 
-transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
 
-batch_size = 4
+def main():
+    transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
 
-trainset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=True, download=True, transform=transform)
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2)
+    batch_size = 4
 
-testset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=False, download=True, transform=transform)
-testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=2)
+    trainset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=True, download=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2)
+
+    testset = torchvision.datasets.CIFAR10(root=DATASET_PATH, train=False, download=True, transform=transform)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=2)
+
+    net = Net()
+
+    # (1.1) initializes NVFlare client API
+    flare.init()
+
+    # (1.2) wraps training logic into a method
+    @flare.train
+    def train(input_model=None, total_epochs=2, lr=0.001, device="cpu"):
+        net.load_state_dict(input_model.params)
+
+        criterion = nn.CrossEntropyLoss()
+        optimizer = optim.SGD(net.parameters(), lr=lr, momentum=0.9)
+
+        # (optional) use GPU to speed things up
+        net.to(device)
+        # (optional) calculate total steps
+        steps = 2 * len(trainloader)
+        for epoch in range(total_epochs):  # loop over the dataset multiple times
+
+            running_loss = 0.0
+            for i, data in enumerate(trainloader, 0):
+                # get the inputs; data is a list of [inputs, labels]
+                # (optional) use GPU to speed things up
+                inputs, labels = data[0].to(device), data[1].to(device)
+
+                # zero the parameter gradients
+                optimizer.zero_grad()
+
+                # forward + backward + optimize
+                outputs = net(inputs)
+                loss = criterion(outputs, labels)
+                loss.backward()
+                optimizer.step()
+
+                # print statistics
+                running_loss += loss.item()
+                if i % 2000 == 1999:  # print every 2000 mini-batches
+                    print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
+                    running_loss = 0.0
+
+        print("Finished Training")
+        torch.save(net.state_dict(), PATH)
+
+        # (1.3) construct trained FL model
+        output_model = flare.FLModel(params=net.cpu().state_dict(), meta={"NUM_STEPS_CURRENT_ROUND": steps})
+        return output_model
+
+    # (1.4) wraps evaluate logic into a method
+    @flare.evaluate
+    def evaluate(input_model=None, device="cpu"):
+        net.load_state_dict(input_model.params)
+        # (optional) use GPU to speed things up
+        net.to(device)
+
+        correct = 0
+        total = 0
+        # since we're not training, we don't need to calculate the gradients for our outputs
+        with torch.no_grad():
+            for data in testloader:
+                # (optional) use GPU to speed things up
+                images, labels = data[0].to(device), data[1].to(device)
+                # calculate outputs by running images through the network
+                outputs = net(images)
+                # the class with the highest energy is what we choose as prediction
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+
+        print(f"Accuracy of the network on the 10000 test images: {100 * correct // total} %")
+        # (1.5) return evaluation metrics
+        return 100 * correct // total
+
+    # (1.6) call evaluate method
+    evaluate(device=DEVICE)
+    # (1.7) call train method
+    train(total_epochs=2, lr=0.001, device=DEVICE)
 
 
-net = Net()
-
-# (1.1) initializes NVFlare client API
-flare.init()
-
-
-# (1.2) wraps training logic into a method
-@flare.train
-def train(input_model=None, total_epochs=2, lr=0.001, device="cuda:0"):
-    net.load_state_dict(input_model.params)
-
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.SGD(net.parameters(), lr=lr, momentum=0.9)
-
-    # (optional) use GPU to speed things up
-    net.to(device)
-    # (optional) calculate total steps
-    steps = 2 * len(trainloader)
-    for epoch in range(total_epochs):  # loop over the dataset multiple times
-
-        running_loss = 0.0
-        for i, data in enumerate(trainloader, 0):
-            # get the inputs; data is a list of [inputs, labels]
-            # (optional) use GPU to speed things up
-            inputs, labels = data[0].to(device), data[1].to(device)
-
-            # zero the parameter gradients
-            optimizer.zero_grad()
-
-            # forward + backward + optimize
-            outputs = net(inputs)
-            loss = criterion(outputs, labels)
-            loss.backward()
-            optimizer.step()
-
-            # print statistics
-            running_loss += loss.item()
-            if i % 2000 == 1999:  # print every 2000 mini-batches
-                print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
-                running_loss = 0.0
-
-    print("Finished Training")
-    torch.save(net.state_dict(), PATH)
-
-    # (1.3) construct trained FL model
-    output_model = flare.FLModel(params=net.cpu().state_dict(), meta={"NUM_STEPS_CURRENT_ROUND": steps})
-    return output_model
-
-
-# (1.4) wraps evaluate logic into a method
-@flare.evaluate
-def evaluate(input_model=None, device="cuda:0"):
-    net.load_state_dict(input_model.params)
-    # (optional) use GPU to speed things up
-    net.to(device)
-
-    correct = 0
-    total = 0
-    # since we're not training, we don't need to calculate the gradients for our outputs
-    with torch.no_grad():
-        for data in testloader:
-            # (optional) use GPU to speed things up
-            images, labels = data[0].to(device), data[1].to(device)
-            # calculate outputs by running images through the network
-            outputs = net(images)
-            # the class with the highest energy is what we choose as prediction
-            _, predicted = torch.max(outputs.data, 1)
-            total += labels.size(0)
-            correct += (predicted == labels).sum().item()
-
-    print(f"Accuracy of the network on the 10000 test images: {100 * correct // total} %")
-    # (1.5) return evaluation metrics
-    return 100 * correct // total
-
-
-# (1.6) call evaluate method
-evaluate()
-# (1.7) call train method
-train(total_epochs=2, lr=0.001)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes issues running on MacOS.

### Description

Starting Python3.8+, Python is using "spawn" for MacOS multiprocessing: https://docs.python.org/3/whatsnew/3.8.html#multiprocessing
And for "spawn" method, ONE has to safe guard the main method using `if __name__ == '__main__':`: https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
Otherwise, when DataLoader num_worker >0, things will not work: https://github.com/pytorch/pytorch/issues/46648

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
