### PR TITLE
SFM Heartbeat Support

### DIFF
--- a/nvflare/fuel/f3/cellnet/defs.py
+++ b/nvflare/fuel/f3/cellnet/defs.py
@@ -27,7 +27,6 @@ class MessageHeaderKey:
     REQ_ID = CELLNET_PREFIX + "req_id"
     REPLY_EXPECTED = CELLNET_PREFIX + "reply_expected"
     TOPIC = CELLNET_PREFIX + "topic"
-    WAIT_UNTIL = CELLNET_PREFIX + "wait_until"
     ORIGIN = CELLNET_PREFIX + "origin"
     DESTINATION = CELLNET_PREFIX + "destination"
     FROM_CELL = CELLNET_PREFIX + "from"

--- a/nvflare/fuel/f3/comm_config.py
+++ b/nvflare/fuel/f3/comm_config.py
@@ -33,6 +33,7 @@ class VarName:
     SUBNET_HEARTBEAT_INTERVAL = "subnet_heartbeat_interval"
     SUBNET_TROUBLE_THRESHOLD = "subnet_trouble_threshold"
     COMM_DRIVER_PATH = "comm_driver_path"
+    HEARTBEAT_INTERVAL = "heartbeat_interval"
 
 
 class CommConfigurator:
@@ -67,3 +68,6 @@ class CommConfigurator:
 
     def get_comm_driver_path(self, default):
         return ConfigService.get_str_var(VarName.COMM_DRIVER_PATH, self.config, default=default)
+
+    def get_heartbeat_interval(self, default):
+        return ConfigService.get_int_var(VarName.HEARTBEAT_INTERVAL, self.config, default)

--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -257,7 +257,7 @@ class AioGrpcDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: True}
+        return {DriverCap.SEND_HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
 
     async def _start_server(self, connector: ConnectorInfo, aio_ctx: AioContext, conn_ctx: _ConnCtx):
         self.connector = connector

--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -39,7 +39,7 @@ from .net_utils import MAX_FRAME_SIZE, get_address, get_tcp_urls, ssl_required
 GRPC_DEFAULT_OPTIONS = [
     ("grpc.max_send_message_length", MAX_FRAME_SIZE),
     ("grpc.max_receive_message_length", MAX_FRAME_SIZE),
-    ("grpc.keepalive_time_ms", 120000),
+    ("grpc.keepalive_time_ms", 300000),
     ("grpc.http2.max_pings_without_data", 0),
 ]
 
@@ -257,7 +257,7 @@ class AioGrpcDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
+        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: True}
 
     async def _start_server(self, connector: ConnectorInfo, aio_ctx: AioContext, conn_ctx: _ConnCtx):
         self.connector = connector

--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -39,7 +39,7 @@ from .net_utils import MAX_FRAME_SIZE, get_address, get_tcp_urls, ssl_required
 GRPC_DEFAULT_OPTIONS = [
     ("grpc.max_send_message_length", MAX_FRAME_SIZE),
     ("grpc.max_receive_message_length", MAX_FRAME_SIZE),
-    ("grpc.keepalive_time_ms", 300000),
+    ("grpc.keepalive_time_ms", 120000),
     ("grpc.http2.max_pings_without_data", 0),
 ]
 

--- a/nvflare/fuel/f3/drivers/aio_http_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_http_driver.py
@@ -103,7 +103,7 @@ class AioHttpDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
+        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: True}
 
     def listen(self, connector: ConnectorInfo):
         self._event_loop(Mode.PASSIVE, connector)
@@ -156,13 +156,17 @@ class AioHttpDriver(BaseDriver):
             scheme = "wss"
         else:
             scheme = "ws"
-        async with websockets.connect(f"{scheme}://{host}:{port}", ssl=self.ssl_context, max_size=MAX_FRAME_SIZE) as ws:
+        async with websockets.connect(
+            f"{scheme}://{host}:{port}", ssl=self.ssl_context, ping_interval=None, max_size=MAX_FRAME_SIZE
+        ) as ws:
             await self._handler(ws)
 
     async def _async_listen(self, host, port):
         self.ssl_context = net_utils.get_ssl_context(self.connector.params, True)
 
-        async with websockets.serve(self._handler, host, port, ssl=self.ssl_context, max_size=MAX_FRAME_SIZE):
+        async with websockets.serve(
+            self._handler, host, port, ssl=self.ssl_context, ping_interval=None, max_size=MAX_FRAME_SIZE
+        ):
             await self.stop_event
 
     async def _handler(self, websocket):

--- a/nvflare/fuel/f3/drivers/aio_http_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_http_driver.py
@@ -103,7 +103,7 @@ class AioHttpDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: True}
+        return {DriverCap.SEND_HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
 
     def listen(self, connector: ConnectorInfo):
         self._event_loop(Mode.PASSIVE, connector)

--- a/nvflare/fuel/f3/drivers/aio_tcp_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_tcp_driver.py
@@ -41,7 +41,7 @@ class AioTcpDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: True}
+        return {DriverCap.SEND_HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
 
     def listen(self, connector: ConnectorInfo):
         self._run(connector, Mode.PASSIVE)

--- a/nvflare/fuel/f3/drivers/driver_params.py
+++ b/nvflare/fuel/f3/drivers/driver_params.py
@@ -43,5 +43,5 @@ class DriverParams(str, Enum):
 
 class DriverCap(str, Enum):
 
-    HEARTBEAT = "heartbeat"
+    SEND_HEARTBEAT = "send_heartbeat"
     SUPPORT_SSL = "support_ssl"

--- a/nvflare/fuel/f3/drivers/tcp_driver.py
+++ b/nvflare/fuel/f3/drivers/tcp_driver.py
@@ -67,7 +67,7 @@ class TcpDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: True}
+        return {DriverCap.SEND_HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
 
     def listen(self, connector: ConnectorInfo):
         self.connector = connector

--- a/nvflare/fuel/f3/sfm/heartbeat_monitor.py
+++ b/nvflare/fuel/f3/sfm/heartbeat_monitor.py
@@ -61,7 +61,7 @@ class HeartbeatMonitor(Thread):
 
             driver = sfm_conn.conn.connector.driver
             caps = driver.capabilities()
-            if caps and caps.get(DriverCap.HEARTBEAT.value, False):
+            if caps and not caps.get(DriverCap.SEND_HEARTBEAT.value, False):
                 continue
 
             if self.curr_time - sfm_conn.last_activity > self.interval:

--- a/nvflare/fuel/f3/sfm/heartbeat_monitor.py
+++ b/nvflare/fuel/f3/sfm/heartbeat_monitor.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import time
+from threading import Event, Thread
+from typing import Dict
+
+from nvflare.fuel.f3.comm_config import CommConfigurator
+from nvflare.fuel.f3.drivers.driver_params import DriverCap
+from nvflare.fuel.f3.sfm.constants import Types
+from nvflare.fuel.f3.sfm.sfm_conn import SfmConnection
+
+log = logging.getLogger(__name__)
+
+HEARTBEAT_TICK = 5
+DEFAULT_HEARTBEAT_INTERVAL = 60
+
+
+class HeartbeatMonitor(Thread):
+    def __init__(self, conns: Dict[str, SfmConnection]):
+        Thread.__init__(self)
+
+        self.thread_name = "hb_mon"
+        self.conns = conns
+        self.stopped = Event()
+        self.curr_time = 0
+        self.interval = CommConfigurator().get_heartbeat_interval(DEFAULT_HEARTBEAT_INTERVAL)
+        if self.interval < HEARTBEAT_TICK:
+            log.warning(f"Heartbeat interval is too small ({self.interval} < {HEARTBEAT_TICK})")
+
+    def stop(self):
+        self.stopped.set()
+
+    def run(self):
+
+        while not self.stopped.is_set():
+            try:
+                self.curr_time = time.time()
+                self._check_heartbeat()
+            except Exception as ex:
+                log.error(f"Heartbeat check failed: {ex}")
+
+            self.stopped.wait(HEARTBEAT_TICK)
+
+        log.debug("Heartbeat monitor stopped")
+
+    def _check_heartbeat(self):
+
+        for sfm_conn in self.conns.values():
+
+            driver = sfm_conn.conn.connector.driver
+            caps = driver.capabilities()
+            if caps and caps.get(DriverCap.HEARTBEAT.value, False):
+                continue
+
+            if self.curr_time - sfm_conn.last_activity > self.interval:
+                sfm_conn.send_heartbeat(Types.PING)
+                log.debug(f"Heartbeat sent to connection: {sfm_conn.conn}")

--- a/nvflare/fuel/f3/sfm/sfm_conn.py
+++ b/nvflare/fuel/f3/sfm/sfm_conn.py
@@ -87,6 +87,20 @@ class SfmConnection:
 
         self.send_dict(frame_type, 1, data)
 
+    def send_heartbeat(self, frame_type: int, data: Optional[dict] = None):
+        """Send Ping or Pong"""
+
+        if frame_type not in (Types.PING, Types.PONG):
+            log.error(f"Heartbeat type must be PING or PONG, not {frame_type}")
+            return
+
+        if not self.sfm_endpoint:
+            log.error("Trying to send heartbeat before SFM Endpoint is established")
+            return
+
+        stream_id = self.sfm_endpoint.next_stream_id()
+        self.send_dict(frame_type, stream_id, data)
+
     def send_data(self, app_id: int, stream_id: int, headers: Optional[dict], payload: BytesAlike):
         """Send user data"""
 

--- a/tests/unit_test/data/custom_drivers/com/example/warp_driver.py
+++ b/tests/unit_test/data/custom_drivers/com/example/warp_driver.py
@@ -30,7 +30,7 @@ class WarpDriver(BaseDriver):
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
-        return {DriverCap.HEARTBEAT.value: False, DriverCap.SUPPORT_SSL.value: False}
+        return {DriverCap.SEND_HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: False}
 
     def listen(self, connector: ConnectorInfo):
         self.connector = connector


### PR DESCRIPTION
Fixes FLARE-952 and FLARE-1438

### Description

1. Added heartbeat support to SFM. The heartbeat interval is controlled by comm parameter heartbeat_interval.
2. Disabled WAIT_TIL in Cellnet to get around the clock drift issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
