### PR TITLE
Rewrite double quote to heredocs to avoid bash/zsh issues

### DIFF
--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -22,7 +22,7 @@ import docker
 import nvflare
 from nvflare.apis.utils.format_check import name_check
 from nvflare.dashboard.application.blob import _write
-from nvflare.lighter import utils
+from nvflare.lighter import tplt_utils, utils
 
 supported_csp = ("azure", "aws")
 
@@ -127,6 +127,7 @@ def stop():
 def cloud(args):
     lighter_folder = os.path.dirname(utils.__file__)
     template = utils.load_yaml(os.path.join(lighter_folder, "impl", "master_template.yml"))
+    tplt = tplt_utils.Template(template)
     cwd = os.getcwd()
     csp = args.cloud
     dest = os.path.join(cwd, f"{csp}_start_dsb.sh")
@@ -135,7 +136,7 @@ def cloud(args):
     replacement_dict = {"NVFLARE": f"nvflare=={version}", "START_OPT": f"-i {args.image}" if args.image else ""}
     _write(
         dest,
-        utils.sh_replace(dsb_start, replacement_dict),
+        utils.sh_replace(tplt.get_cloud_script_header() + dsb_start, replacement_dict),
         "t",
         exe=True,
     )

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -1147,22 +1147,32 @@ azure_start_svr_sh: |
   if [ $container = true ]
   then
     echo "Installing and lauching container in $VM_NAME, may take a few minutes."
+    scripts=$(cat <<- 'EOF'
+    sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
+    sudo mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
+    EOF
+    )
     az vm run-command invoke \
       --output json \
       --resource-group $RESOURCE_GROUP \
       --command-id RunShellScript \
       --name $VM_NAME \
       --scripts \
-      "sudo apt-get update && \
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
-      sudo mkdir -p /etc/apt/keyrings && \
-      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-      echo \
-      \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-      sudo apt-get update && \
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io && \
-      sudo usermod -aG docker $ADMIN_USERNAME" > /tmp/docker_engine.json
+      "$scripts" > /tmp/docker_engine.json
+    az vm run-command invoke \
+      --output json \
+      --resource-group $RESOURCE_GROUP \
+      --command-id RunShellScript \
+      --name $VM_NAME \
+      --scripts \
+      "sudo usermod -aG docker $ADMIN_USERNAME" >> /tmp/docker_engine.json
     report_status "$?" "installing docker engine"
     az vm run-command invoke \
       --output json \
@@ -1323,23 +1333,34 @@ azure_start_cln_sh: |
   if [ $container = true ]
   then
     echo "Installing and lauching container in $VM_NAME, may take a few minutes."
+    scripts=$(cat <<- 'EOF'
+    sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
+    sudo mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
+    EOF
+    )
     az vm run-command invoke \
       --output json \
       --resource-group $RESOURCE_GROUP \
       --command-id RunShellScript \
       --name $VM_NAME \
       --scripts \
-      "sudo apt-get update && \
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
-      sudo mkdir -p /etc/apt/keyrings && \
-      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-      echo \
-      \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-      sudo apt-get update && \
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io && \
+      "$scripts" > /tmp/docker_engine.json
       sudo usermod -aG docker $ADMIN_USERNAME" > /tmp/docker_engine.json
     report_status "$?" "installing docker engine"
+    az vm run-command invoke \
+      --output json \
+      --resource-group $RESOURCE_GROUP \
+      --command-id RunShellScript \
+      --name $VM_NAME \
+      --scripts \
+      "sudo usermod -aG docker $ADMIN_USERNAME" >> /tmp/docker_engine.json
     az vm run-command invoke \
       --output json \
       --resource-group $RESOURCE_GROUP \
@@ -1463,22 +1484,33 @@ azure_start_dsb_sh: |
   report_status "$?" "updating network interface card"
 
   echo "Installing docker engine in $VM_NAME, may take a few minutes."
+  scripts=$(cat << 'EOF'
+  sudo apt-get update && \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
+  sudo mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+  echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  sudo apt-get update && \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
+  EOF
+  )
   az vm run-command invoke \
     --output json \
     --resource-group $RESOURCE_GROUP \
     --command-id RunShellScript \
     --name $VM_NAME \
     --scripts \
-    "sudo apt-get update && \
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
-    sudo mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-    echo \
-    \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    sudo apt-get update && \
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io && \
-    sudo usermod -aG docker $ADMIN_USERNAME" > /tmp/docker_engine.json
+    "$scripts" > /tmp/docker_engine.json
+  report_status "$?" "installing docker engine"
+  az vm run-command invoke \
+    --output json \
+    --resource-group $RESOURCE_GROUP \
+    --command-id RunShellScript \
+    --name $VM_NAME \
+    --scripts \
+    "sudo usermod -aG docker $ADMIN_USERNAME" >> /tmp/docker_engine.json
   report_status "$?" "installing docker engine"
     
   DEST_FOLDER=/home/${ADMIN_USERNAME}
@@ -1977,15 +2009,21 @@ aws_start_dsb_sh: |
 
   echo "Installing docker engine in $VM_NAME, may take a few minutes."
   DEST_SITE=${ADMIN_USERNAME}@${IP_ADDRESS}
-  ssh -t -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
-    "sudo apt-get update && \
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
-    sudo mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-    echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    sudo apt-get update && \
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io && \
-    sudo usermod -aG docker $ADMIN_USERNAME && exit" > /tmp/docker_engine.log
+  scripts=$(cat << 'EOF'
+  sudo apt-get update && \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg lsb-release && \
+  sudo mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+  echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  sudo apt-get update && \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
+  EOF
+  )
+  ssh -t -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} "$scripts" > /tmp/docker_engine.log
+  report_status "$?" "installing docker engine"
+  ssh -t -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} "sudo usermod -aG docker $ADMIN_USERNAME && exit" >> /tmp/docker_engine.log
   report_status "$?" "installing docker engine"
 
   echo "Installing nvflare in $VM_NAME, may take a few minutes."


### PR DESCRIPTION
### Description

Fix the quotes that do not work in bash/zsh.
Fix an issue that does not include script common header in cloud launch scripts.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
