### PR TITLE
Kill stream threads on shutdown

### DIFF
--- a/nvflare/fuel/f3/streaming/stream_utils.py
+++ b/nvflare/fuel/f3/streaming/stream_utils.py
@@ -17,6 +17,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 from nvflare.fuel.f3.connection import BytesAlike
+from nvflare.fuel.f3.mpm import MainProcessMonitor
 
 STREAM_THREAD_POOL_SIZE = 128
 
@@ -91,3 +92,10 @@ class FastBuffer:
 
     def __len__(self):
         return self.size
+
+
+def stream_shutdown():
+    stream_thread_pool.shutdown(wait=True)
+
+
+MainProcessMonitor.add_cleanup_cb(stream_shutdown)


### PR DESCRIPTION
Fixes FLARE_1505

### Description

Registered a cleanup CB for MPM to shutdown thread pool used by streaming.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
