### PR TITLE
Fix communicator_test.py

### DIFF
--- a/tests/unit_test/fuel/f3/communicator_test.py
+++ b/tests/unit_test/fuel/f3/communicator_test.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import logging
 import time
+from threading import Event
 
 import pytest
 
@@ -32,66 +34,72 @@ MESSAGE_FROM_A = "Test message from a"
 MESSAGE_FROM_B = "Test message from b"
 
 
+class CommState:
+    def __init__(self):
+        self.a_ready_event = Event()
+        self.a_received_event = Event()
+        self.b_ready_event = Event()
+        self.b_received_event = Event()
+
+
 class Monitor(EndpointMonitor):
-    def __init__(self, tester):
-        self.tester = tester
+    def __init__(self, comm_state: CommState):
+        self.comm_state = comm_state
 
     def state_change(self, endpoint: Endpoint):
         if endpoint.state == EndpointState.READY:
             if endpoint.name == NODE_A:
-                self.tester.a_ready = True
+                self.comm_state.a_ready_event.set()
             else:
-                self.tester.b_ready = True
+                self.comm_state.b_ready_event.set()
 
 
 class Receiver(MessageReceiver):
-    def __init__(self, tester):
-        self.tester = tester
+    def __init__(self, comm_state: CommState):
+        self.comm_state = comm_state
 
     def process_message(self, endpoint: Endpoint, connection: Connection, app_id: int, message: Message):
         text = message.payload.decode("utf-8")
         if endpoint.name == NODE_A:
             assert text == MESSAGE_FROM_A
-            self.tester.a_received = True
+            self.comm_state.a_received_event.set()
         else:
             assert text == MESSAGE_FROM_B
-            self.tester.b_received = True
+            self.comm_state.b_received_event.set()
 
 
-@pytest.mark.xdist_group(name="test_f3_communicator")
+def get_comm_a(comm_state):
+    local_endpoint = Endpoint(NODE_A, {"foo": "test"})
+    comm = Communicator(local_endpoint)
+    comm.register_monitor(Monitor(comm_state))
+    comm.register_message_receiver(APP_ID, Receiver(comm_state))
+    return comm
+
+
+def get_comm_b(comm_state):
+    local_endpoint = Endpoint(NODE_B, {"bar": 123})
+    comm = Communicator(local_endpoint)
+    comm.register_monitor(Monitor(comm_state))
+    comm.register_message_receiver(APP_ID, Receiver(comm_state))
+    return comm
+
+
 class TestCommunicator:
-    @pytest.fixture
-    def comm_a(self):
-        local_endpoint = Endpoint(NODE_A, {"foo": "test"})
-        comm = Communicator(local_endpoint)
-        comm.register_monitor(Monitor(self))
-        comm.register_message_receiver(APP_ID, Receiver(self))
-        self.a_ready = False
-        self.a_received = False
-        return comm
-
-    @pytest.fixture
-    def comm_b(self):
-        local_endpoint = Endpoint(NODE_B, {"bar": 123})
-        comm = Communicator(local_endpoint)
-        comm.register_monitor(Monitor(self))
-        comm.register_message_receiver(APP_ID, Receiver(self))
-        self.b_ready = False
-        self.b_received = False
-        return comm
-
     @pytest.mark.parametrize(
         "scheme, port_range",
         [
             ("tcp", "2000-3000"),
             ("grpc", "3000-4000"),
-            ("http", "4000-5000"),
+            # ("http", "4000-5000"), TODO (YT): We disable this, as it is causing our jenkins hanging
             ("atcp", "5000-6000"),
         ],
     )
-    def test_sfm_message(self, comm_a, comm_b, scheme, port_range):
+    def test_sfm_message(self, scheme, port_range):
+        comm_state = CommState()
+        comm_a = get_comm_a(comm_state)
+        comm_b = get_comm_b(comm_state)
 
-        handle1, url = comm_a.start_listener(scheme, {"ports": port_range})
+        _, url = comm_a.start_listener(scheme, {"ports": port_range})
         comm_a.start()
 
         # Check port is in the range
@@ -106,17 +114,16 @@ class TestCommunicator:
         comm_b.add_connector(url, Mode.ACTIVE)
         comm_b.start()
 
-        while not self.a_ready or not self.b_ready:
+        while not comm_state.a_ready_event.wait(10) or not comm_state.b_ready_event.wait(10):
             log.info("Waiting for both endpoints to be ready")
             time.sleep(0.1)
 
         comm_a.send(Endpoint(NODE_B), APP_ID, Message({}, MESSAGE_FROM_A.encode("utf-8")))
-
         comm_b.send(Endpoint(NODE_A), APP_ID, Message({}, MESSAGE_FROM_B.encode("utf-8")))
 
         time.sleep(1)
 
-        assert self.a_received and self.b_received
+        assert comm_state.a_received_event.is_set() and comm_state.b_received_event.is_set()
 
         comm_b.stop()
         comm_a.stop()


### PR DESCRIPTION
### Description

This test had racing issue.
Multiple threads could try to modify a_ready/b_ready.

Changed to disable it for now.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
