### PR TITLE
Removed the grpc keep alive settings

### DIFF
--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -39,8 +39,6 @@ from .net_utils import MAX_FRAME_SIZE, get_address, get_tcp_urls, ssl_required
 GRPC_DEFAULT_OPTIONS = [
     ("grpc.max_send_message_length", MAX_FRAME_SIZE),
     ("grpc.max_receive_message_length", MAX_FRAME_SIZE),
-    ("grpc.keepalive_time_ms", 120000),
-    ("grpc.http2.max_pings_without_data", 0),
 ]
 
 


### PR DESCRIPTION
Fixes # .

### Description

Removed the settings for sending the grpc keep alive pings.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
