### PR TITLE
avoid POC start race condition

### DIFF
--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -823,6 +823,7 @@ def _run_poc(
         elif service_name == service_config[SC.FLARE_SERVER]:
             async_process(service_name, cmd_path, None, service_config)
         else:
+            time.sleep(1)
             async_process(service_name, cmd_path, gpu_assignments[service_name], service_config)
 
 


### PR DESCRIPTION
Fixes # .
   Some times 
   nvflare poc start 
   
   will have 
```
  Communication failure -- try later
```
   this is due to the server is not fully ready and clients are trying to connect.  Just add 1 second wait before start the clients

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
