### PR TITLE
Add NumPy + Client API example

### DIFF
--- a/examples/hello-world/ml-to-fl/README.md
+++ b/examples/hello-world/ml-to-fl/README.md
@@ -17,8 +17,9 @@ To configure the workflow, one can reference the config we have here and the doc
 
 We cover the following use cases:
 
-  1. PyTorch and PyTorch Lightning: [pt](./pt/README.md)
-  2. TensorFlow: [tf](./tf/README.md)
+  1. Configurations of NVFlare Client API: [np](./np/README.md)
+  2. PyTorch and PyTorch Lightning: [pt](./pt/README.md)
+  3. TensorFlow: [tf](./tf/README.md)
 
 
 Note: Avoid install TensorFlow and PyTorch on the same virtual environment due to library conflicts.

--- a/examples/hello-world/ml-to-fl/np/README.md
+++ b/examples/hello-world/ml-to-fl/np/README.md
@@ -1,0 +1,109 @@
+# Configurations of NVFlare Client API
+
+We will demonstrate how to send back model parameters or model parameters differences in different approaches in the following examples:
+
+  1. [Send model parameters back to the NVFlare server](#send-model-parameters-back-to-the-nvflare-server)
+  2. [Send model parameters differences back to the NVFlare server](#send-model-parameters-differences-back-to-the-nvflare-server)
+
+
+By default, our LauncherExecutor is going to launch the script to handle the task everytime the NVFlare Client receives a task.
+
+If your data setup is taking a long time, you don't want to launch the whole training script everytime
+(means the script need to do the data setup everytime).
+
+We demonstrate how to launch training script once and have training script keeps exchanging training parameters with NVFlare LauncherExecutor:
+
+  1. [Launch once for the whole job](#launch-once-for-the-whole-job)
+
+
+## Send model parameters back to the NVFlare server
+
+We use the mock training script in [./code/train_full.py](./code/train_full.py)
+
+Note that the mock training just do +1 and the mock evaluation just return 100.
+And we send back the FLModel with "params_type"="FULL" in [./code/train_full.py](./code/train_full.py)
+
+To send back the whole model parameters, we need to make sure the "params_transfer_type" is also "FULL".
+
+Let reuse the job templates from [sag_np](../../../../job_templates/sag_np/):
+
+```bash
+nvflare config -jt ../../../../job_templates/
+nvflare job list_templates
+nvflare job create -force -j ./jobs/np_param_full_transfer_full -w sag_np -sd ./code/ \
+-f config_fed_client.conf app_script=train_full.py params_transfer_type=FULL
+```
+
+Then we can run it using the NVFlare Simulator:
+
+```bash
+nvflare simulator -n 2 -t 2 ./jobs/np_param_full_transfer_full -w np_param_full_transfer_full_workspace
+```
+
+## Send model parameters differences back to the NVFlare server
+
+There are two ways to send model parameters differences back to the NVFlare server:
+
+1. Send the full parameters in training script, change params_transfer_type to "DIFF"
+2. Calculate the parameters differences in training script and send it back via "flare.send"
+
+For the first way, we can reuse the mock training script [./code/train_full.py](./code/train_full.py)
+
+But we need to pass different parameters when creating job:
+
+```bash
+nvflare job create -force -j ./jobs/np_param_full_transfer_diff -w sag_np -sd ./code/ \
+-f config_fed_client.conf app_script=train_full.py params_transfer_type=DIFF \
+-f config_fed_server.conf expected_data_kind=WEIGHT_DIFF
+```
+
+By setting "params_transfer_type=DIFF" we are using the NVFlare built-in parameter difference method to calculate differences.
+
+Then we can run it using the NVFlare Simulator:
+
+```bash
+nvflare simulator -n 2 -t 2 ./jobs/np_param_full_transfer_diff -w np_param_full_transfer_diff_workspace
+```
+
+For the second way, we write a new mock training script that calculate the model difference and send it back: [./code/train_diff.py](./code/train_diff.py)
+
+Note that we set the "params_type" to DIFF when creating flare.FLModel.
+
+Then we create the job using the following command:
+
+```bash
+nvflare job create -force -j ./jobs/np_param_diff_transfer_full -w sag_np -sd ./code/ \
+-f config_fed_client.conf app_script=train_diff.py \
+-f config_fed_server.conf expected_data_kind=WEIGHT_DIFF
+```
+
+The "params_transfer_type" is "FULL", means that we DO NOT calculate the difference again using the NVFlare built-in parameter difference method.
+
+Then we can run it using the NVFlare Simulator:
+
+```bash
+nvflare simulator -n 2 -t 2 ./jobs/np_param_diff_transfer_full -w np_param_diff_transfer_full_workspace
+```
+
+## Launch once for the whole job
+
+In some training scenarios, the data loading is taking a lot of time.
+And throughout the whole training job, we only want to load/setup the data once.
+
+In that case, we could use the "launch_once" option of "LauncherExecutor" and wraps our training script into a loop.
+
+We wraps the [./code/train_full.py](./code/train_full.py) into a loop: [./code/train_loop.py](./code/train_loop.py)
+
+Then we can create the job:
+
+```bash
+nvflare job create -force -j ./jobs/np_loop -w sag_np -sd ./code/ \
+-f config_fed_client.conf app_script=train_loop.py params_transfer_type=DIFF launch_once=true \
+-f config_fed_server.conf expected_data_kind=WEIGHT_DIFF
+```
+
+Then we can run it using the NVFlare Simulator:
+
+```bash
+nvflare simulator -n 2 -t 2 ./jobs/np_loop -w np_loop_workspace
+```

--- a/examples/hello-world/ml-to-fl/np/README.md
+++ b/examples/hello-world/ml-to-fl/np/README.md
@@ -99,8 +99,7 @@ Then we can create the job:
 
 ```bash
 nvflare job create -force -j ./jobs/np_loop -w sag_np -sd ./code/ \
--f config_fed_client.conf app_script=train_loop.py params_transfer_type=DIFF launch_once=true \
--f config_fed_server.conf expected_data_kind=WEIGHT_DIFF
+-f config_fed_client.conf app_script=train_loop.py params_transfer_type=FULL launch_once=true \
 ```
 
 Then we can run it using the NVFlare Simulator:

--- a/examples/hello-world/ml-to-fl/np/code/train_diff.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_diff.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nvflare.client as flare
+
+
+def train(input_arr):
+    # mock training with plus 1
+    return input_arr + 1
+
+
+def evaulate(input_arr):
+    # mock evaluation metrics
+    return 100
+
+
+def main():
+    # initializes NVFlare interface
+    flare.init()
+
+    # get model from NVFlare
+    input_model = flare.receive()
+    print(f"received weights is: {input_model.params}")
+
+    # get system information
+    sys_info = flare.system_info()
+    print(f"system info is: {sys_info}")
+
+    input_numpy_array = input_model.params["numpy_key"]
+
+    # training
+    output_numpy_array = train(input_numpy_array)
+
+    # evaluation
+    metrics = evaulate(input_numpy_array)
+
+    # calculate difference here
+    diff = output_numpy_array - input_numpy_array
+
+    # send back the model difference
+    print(f"send back: {diff}")
+    flare.send(flare.FLModel(params={"numpy_key": diff}, params_type="DIFF", metrics={"accuracy": metrics}))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello-world/ml-to-fl/np/code/train_diff.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_diff.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import nvflare.client as flare
 
 
 def train(input_arr):
+    output_arr = copy.deepcopy(input_arr)
     # mock training with plus 1
-    return input_arr + 1
+    return output_arr + 1
 
 
-def evaulate(input_arr):
+def evaluate(input_arr):
     # mock evaluation metrics
     return 100
 
@@ -43,7 +46,7 @@ def main():
     output_numpy_array = train(input_numpy_array)
 
     # evaluation
-    metrics = evaulate(input_numpy_array)
+    metrics = evaluate(input_numpy_array)
 
     # calculate difference here
     diff = output_numpy_array - input_numpy_array

--- a/examples/hello-world/ml-to-fl/np/code/train_full.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_full.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nvflare.client as flare
+
+
+def train(input_arr):
+    # mock training with plus 1
+    return input_arr + 1
+
+
+def evaulate(input_arr):
+    # mock evaluation metrics
+    return 100
+
+
+def main():
+    # initializes NVFlare interface
+    flare.init()
+
+    # get model from NVFlare
+    input_model = flare.receive()
+    print(f"received weights is: {input_model.params}")
+
+    # get system information
+    sys_info = flare.system_info()
+    print(f"system info is: {sys_info}")
+
+    input_numpy_array = input_model.params["numpy_key"]
+
+    # training
+    output_numpy_array = train(input_numpy_array)
+
+    # evaluation
+    metrics = evaulate(input_numpy_array)
+
+    # send back the model
+    print(f"send back: {output_numpy_array}")
+    flare.send(
+        flare.FLModel(params={"numpy_key": output_numpy_array}, params_type="FULL", metrics={"accuracy": metrics})
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello-world/ml-to-fl/np/code/train_full.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_full.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import nvflare.client as flare
 
 
 def train(input_arr):
+    output_arr = copy.deepcopy(input_arr)
     # mock training with plus 1
-    return input_arr + 1
+    return output_arr + 1
 
 
-def evaulate(input_arr):
+def evaluate(input_arr):
     # mock evaluation metrics
     return 100
 
@@ -43,7 +46,7 @@ def main():
     output_numpy_array = train(input_numpy_array)
 
     # evaluation
-    metrics = evaulate(input_numpy_array)
+    metrics = evaluate(input_numpy_array)
 
     # send back the model
     print(f"send back: {output_numpy_array}")

--- a/examples/hello-world/ml-to-fl/np/code/train_loop.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_loop.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nvflare.client as flare
+
+
+def train(input_arr):
+    # mock training with plus 1
+    return input_arr + 1
+
+
+def evaulate(input_arr):
+    # mock evaluation metrics
+    return 100
+
+
+def main():
+    # initializes NVFlare interface
+    flare.init()
+
+    # get system information
+    sys_info = flare.system_info()
+    print(f"system info is: {sys_info}")
+
+    total_rounds = sys_info["total_rounds"]
+
+    while True:
+        # get model from NVFlare
+        input_model = flare.receive()
+        print(f"received weights is: {input_model.params}")
+
+        input_numpy_array = input_model.params["numpy_key"]
+
+        # training
+        output_numpy_array = train(input_numpy_array)
+
+        # evaluation
+        metrics = evaulate(input_numpy_array)
+
+        sys_info = flare.system_info()
+        print(f"system info is: {sys_info}")
+        print(f"finish round: {input_model.current_round}")
+
+        # send back the model
+        print(f"send back: {output_numpy_array}")
+        flare.send(
+            flare.FLModel(
+                params={"numpy_key": output_numpy_array},
+                params_type="FULL",
+                metrics={"accuracy": metrics},
+                current_round=input_model.current_round,
+            )
+        )
+
+        if input_model.current_round == total_rounds - 1:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello-world/ml-to-fl/np/code/train_loop.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_loop.py
@@ -36,7 +36,8 @@ def main():
     sys_info = flare.system_info()
     print(f"system info is: {sys_info}")
 
-    for input_model in flare.receive_global_model():
+    while flare.is_running():
+        input_model = flare.receive()
         print(f"received weights is: {input_model.params}")
 
         input_numpy_array = input_model.params["numpy_key"]

--- a/examples/hello-world/ml-to-fl/np/code/train_loop.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_loop.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import nvflare.client as flare
 
 
 def train(input_arr):
+    output_arr = copy.deepcopy(input_arr)
     # mock training with plus 1
-    return input_arr + 1
+    return output_arr + 1
 
 
-def evaulate(input_arr):
+def evaluate(input_arr):
     # mock evaluation metrics
     return 100
 
@@ -33,11 +36,7 @@ def main():
     sys_info = flare.system_info()
     print(f"system info is: {sys_info}")
 
-    total_rounds = sys_info["total_rounds"]
-
-    while True:
-        # get model from NVFlare
-        input_model = flare.receive()
+    for input_model in flare.receive_global_model():
         print(f"received weights is: {input_model.params}")
 
         input_numpy_array = input_model.params["numpy_key"]
@@ -46,7 +45,7 @@ def main():
         output_numpy_array = train(input_numpy_array)
 
         # evaluation
-        metrics = evaulate(input_numpy_array)
+        metrics = evaluate(input_numpy_array)
 
         sys_info = flare.system_info()
         print(f"system info is: {sys_info}")
@@ -62,9 +61,6 @@ def main():
                 current_round=input_model.current_round,
             )
         )
-
-        if input_model.current_round == total_rounds - 1:
-            break
 
 
 if __name__ == "__main__":

--- a/job_templates/sag_np/config_fed_client.conf
+++ b/job_templates/sag_np/config_fed_client.conf
@@ -1,0 +1,81 @@
+{
+  # version of the configuration
+  format_version = 2
+
+  # This is the application script which will be invoked. Client can replace this script with user's own training script.
+  app_script = "cifar10.py"
+
+  # Additional arguments needed by the training code. For example, in lightning, these can be --trainer.batch_size=xxx.
+  app_config = ""
+
+  # Client Computing Executors.
+  executors = [
+    {
+      # tasks the executors are defined to handle
+      tasks = ["train"]
+
+      # This particular executor
+      executor {
+
+        # Executor name : ClientAPILauncherExecutor
+        # This is an executor for Client API. The underline data exchange is using FilePipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+
+        args {
+
+          # This executor take an component named "launcher"
+          launcher_id = "launcher"
+
+          # Timeout in seconds for waiting for a heartbeat from the training script. Defaults to 30 seconds.
+          # Please refer to the class docstring for all available arguments
+          heartbeat_timeout = 60
+
+          # data_exchange_path: is the directory location of the parameters exchange.
+          # If empty string, it will be set to the app_dir of the running job.
+          # You can also set it to an absolute path in your system.
+          data_exchange_path = ""
+
+          # format of the exchange parameters
+          params_exchange_format =  "numpy"
+
+          # if the transfer_type is FULL, then it will be sent directly
+          # if the transfer_type is DIFF, then we will calculate the
+          # difference VS received parameters and send the difference
+          params_transfer_type = "FULL"
+
+          # if training is true, the executor will expect
+          # the custom code need to send back the trained parameters
+          training = true
+
+          # if global_evaluation is true, the executor will expect the
+          # custom code to send back the evaluation metric
+          global_evaluation = true
+
+          # if launch_once is true, the executor will only call launcher.launch_task once
+          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
+          # everytime it receives a task from server
+          launch_once = false
+        }
+      }
+    }
+  ],
+
+  # this defined an array of task data filters. If provided, it will control the data from server controller to client executor
+  task_data_filters =  []
+
+  # this defined an array of task result filters. If provided, it will control the result from client executor to server controller
+  task_result_filters = []
+
+  components =  [
+    {
+      # This "launcher" component
+      id = "launcher"
+
+      # the name of component is SubprocessLauncher and path is the class path
+      path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+
+      # the launcher will invoke the scrupt
+      args.script = "python3 custom/{app_script}  {app_config} "
+    }
+  ]
+}

--- a/job_templates/sag_np/config_fed_client.conf
+++ b/job_templates/sag_np/config_fed_client.conf
@@ -26,14 +26,12 @@
           # This executor take an component named "launcher"
           launcher_id = "launcher"
 
+          # This executor needs Pipe component
+          pipe_id = "pipe"
+
           # Timeout in seconds for waiting for a heartbeat from the training script. Defaults to 30 seconds.
           # Please refer to the class docstring for all available arguments
           heartbeat_timeout = 60
-
-          # data_exchange_path: is the directory location of the parameters exchange.
-          # If empty string, it will be set to the app_dir of the running job.
-          # You can also set it to an absolute path in your system.
-          data_exchange_path = ""
 
           # format of the exchange parameters
           params_exchange_format =  "numpy"
@@ -43,18 +41,16 @@
           # difference VS received parameters and send the difference
           params_transfer_type = "FULL"
 
-          # if training is true, the executor will expect
-          # the custom code need to send back the trained parameters
-          training = true
-
-          # if global_evaluation is true, the executor will expect the
-          # custom code to send back the evaluation metric
-          global_evaluation = true
+          # if train_with_evaluation is true, the executor will expect
+          # the custom code need to send back both the trained parameters and the evaluation metric
+          # otherwise only trained parameters are expected
+          train_with_evaluation = true
 
           # if launch_once is true, the executor will only call launcher.launch_task once
           # for the whole job, if launch_once is false, the executor will call launcher.launch_task
           # everytime it receives a task from server
-          launch_once = false
+          launch_once = true
+
         }
       }
     }
@@ -74,8 +70,21 @@
       # the name of component is SubprocessLauncher and path is the class path
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the scrupt
+      # the launcher will invoke the script
       args.script = "python3 custom/{app_script}  {app_config} "
+    },
+    {
+      id = "pipe"
+
+      path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
+
+      args {
+        mode = "PASSIVE"
+        # root_path: is the directory location of the parameters exchange.
+        # If empty string, it will be set to the app_dir of the running job.
+        # You can also set it to an absolute path in your system.
+        root_path = ""
+      }
     }
   ]
 }

--- a/job_templates/sag_np/config_fed_server.conf
+++ b/job_templates/sag_np/config_fed_server.conf
@@ -1,0 +1,93 @@
+{
+  # version of the configuration
+  format_version = 2
+
+  # task data filter: if filters are provided, the filter will filter the data flow out of server to client.
+  task_data_filters =[]
+
+  # task result filter: if filters are provided, the filter will filter the result flow out of client to server.
+  task_result_filters = []
+
+ # workflows: Array of workflows the control the Federated Learning workflow lifecycle.
+ # One can specify mutliple workflows. The NVFLARE will run them in the order specified.
+  workflows = [
+      {
+        # 1st workflow"
+        id = "scatter_and_gather"
+
+        # name = ScatterAndGather, path is the class path of the scatterAndGatter controller.
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
+        args {
+            # argument of the ScatterAndGather class.
+            # min number of clients required for ScatterAndGather controller to move to the next round
+            # during the workflow cycle. The controller will wait until the min_clinets returned from clients
+            # before move to the next step.
+            min_clients = 2
+
+            # number of global round of the training.
+            num_rounds = 5
+
+            # starting round is 0-based
+            start_round = 0
+
+            # after received min number of clients' result,
+            # how much time should we wait further before move to the next step
+            wait_time_after_min_received = 0
+
+            # For ScatterAndGatter, the server will aggregate the weights based on the client's result.
+            # the aggregagtor component id is named here. One can use the this ID to find the corresponding
+            # aggregator component listed beflow
+            #
+            aggregator_id = "aggregator"
+
+            # The Scatter and Gather controller use an persistor to load the model and save the model.
+            # The persistent component can be identified by component ID specified here.
+            persistor_id = "persistor"
+
+            # Shareable to a communication message, i.e. shared between clients and server.
+            # Sahreable generator is a component that responsible to take the model convert to/from this communication message: shearable.
+            # The component can be identified via "shareable_generator_id"
+            shareable_generator_id =  "shareable_generator"
+
+            # train task name: Client will start training once received such task.
+            train_task_name =  "train"
+
+            # train timeout in second. If zero, meaning no timeout.
+            train_timeout =  0
+        }
+      }
+  ]
+
+  # List of components used in the server side workflow.
+  components = [
+    {
+      # This is the persistence component used in above workflow.
+      # NPModelPersistor is a Pytorch persistor which save/read the model to/from file.
+      id = "persistor"
+      path = "nvflare.app_common.np.np_model_persistor.NPModelPersistor"
+
+    },
+    {
+      # This is the generator that convert the model to shareable communication message structure used in workflow
+      id = "shareable_generator"
+      path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
+      args = {}
+    },
+    {
+      # This is the aggregator that perform the weighted average aggregation.
+      # the aggregation is "in-time", so it doesn't wait for client results, but aggregates as soon as it received the data.
+      id = "aggregator"
+      path = "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator"
+      args.expected_data_kind = "WEIGHTS"
+    },
+    {
+      # This component is not directly used in Workflow.
+      # it select the best model based on the incoming global validation metrics.
+      id = "model_selector"
+      path =  "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+      # need to make sure this "key_metric" match what server side received
+      args.key_metric = "accuracy"
+    }
+  ]
+
+}

--- a/job_templates/sag_np/config_fed_server.conf
+++ b/job_templates/sag_np/config_fed_server.conf
@@ -9,18 +9,18 @@
   task_result_filters = []
 
  # workflows: Array of workflows the control the Federated Learning workflow lifecycle.
- # One can specify mutliple workflows. The NVFLARE will run them in the order specified.
+ # One can specify multiple workflows. The NVFLARE will run them in the order specified.
   workflows = [
       {
         # 1st workflow"
         id = "scatter_and_gather"
 
-        # name = ScatterAndGather, path is the class path of the scatterAndGatter controller.
+        # name = ScatterAndGather, path is the class path of the ScatterAndGather controller.
         path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
         args {
             # argument of the ScatterAndGather class.
             # min number of clients required for ScatterAndGather controller to move to the next round
-            # during the workflow cycle. The controller will wait until the min_clinets returned from clients
+            # during the workflow cycle. The controller will wait until the min_clients returned from clients
             # before move to the next step.
             min_clients = 2
 
@@ -34,9 +34,9 @@
             # how much time should we wait further before move to the next step
             wait_time_after_min_received = 0
 
-            # For ScatterAndGatter, the server will aggregate the weights based on the client's result.
-            # the aggregagtor component id is named here. One can use the this ID to find the corresponding
-            # aggregator component listed beflow
+            # For ScatterAndGather, the server will aggregate the weights based on the client's result.
+            # the aggregator component id is named here. One can use the this ID to find the corresponding
+            # aggregator component listed below
             #
             aggregator_id = "aggregator"
 
@@ -45,7 +45,7 @@
             persistor_id = "persistor"
 
             # Shareable to a communication message, i.e. shared between clients and server.
-            # Sahreable generator is a component that responsible to take the model convert to/from this communication message: shearable.
+            # Shareable generator is a component that responsible to take the model convert to/from this communication message: Shareable.
             # The component can be identified via "shareable_generator_id"
             shareable_generator_id =  "shareable_generator"
 

--- a/job_templates/sag_np/info.conf
+++ b/job_templates/sag_np/info.conf
@@ -1,0 +1,5 @@
+{
+    description = "scatter & gather workflow using numpy"
+    client_category = "client_api"
+    controller_type = "server"
+}

--- a/job_templates/sag_np/info.md
+++ b/job_templates/sag_np/info.md
@@ -1,0 +1,11 @@
+# Job Template Information Card
+
+## sag_pt
+    name = "sag_np"
+    description = "Scatter and Gather Workflow using NumPy" 
+    class_name  =  "ScatterAndGather"
+    controller_type = "server"
+    executor_type = "launcher_executor"
+    contributor = "NVIDIA"
+    init_publish_date = "2023-09-11"
+    last_updated_date = "2023-09-11" # yyyy-mm-dd

--- a/job_templates/sag_np/info.md
+++ b/job_templates/sag_np/info.md
@@ -1,6 +1,6 @@
 # Job Template Information Card
 
-## sag_pt
+## sag_np
     name = "sag_np"
     description = "Scatter and Gather Workflow using NumPy" 
     class_name  =  "ScatterAndGather"

--- a/job_templates/sag_np/info.md
+++ b/job_templates/sag_np/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-09-11"
-    last_updated_date = "2023-09-11" # yyyy-mm-dd
+    last_updated_date = "2023-11-06" # yyyy-mm-dd

--- a/job_templates/sag_np/meta.conf
+++ b/job_templates/sag_np/meta.conf
@@ -1,0 +1,10 @@
+{
+  name = "sag_np"
+  resource_spec = {}
+  deploy_map {
+    # change deploy map as needed.
+    app = ["@ALL"]
+  }
+  min_clients = 2
+  mandatory_clients = []
+}


### PR DESCRIPTION
### Description

Adds different NumPy based mock training example to showcase different configurations of Client API.
Also showcase how to launch_once and use a training loop in custom/user training script.

- Add README of different configurations options of NVFlare Client API
- Add "sag_np" job template 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
