### PR TITLE
Improve the way to generate serialized peer fl context

### DIFF
--- a/nvflare/apis/utils/fl_context_utils.py
+++ b/nvflare/apis/utils/fl_context_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 
 from nvflare.apis.fl_constant import FLContextKey, NonSerializableKeys
@@ -36,6 +37,16 @@ def get_serializable_data(fl_ctx: FLContext):
                 logger.warning(generate_log_message(fl_ctx, msg))
 
     return new_fl_ctx
+
+
+def gen_new_peer_ctx(fl_ctx: FLContext, need_deep_copy=False):
+    tmp_ctx = FLContext()
+    pub_props = fl_ctx.get_all_public_props()
+    if need_deep_copy:
+        pub_props = copy.deepcopy(pub_props)
+    tmp_ctx.set_public_props(pub_props)
+    new_peer_ctx = get_serializable_data(tmp_ctx)
+    return new_peer_ctx
 
 
 def generate_log_message(fl_ctx: FLContext, msg: str):

--- a/nvflare/private/fed/server/server_command_agent.py
+++ b/nvflare/private/fed/server/server_command_agent.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 
 from nvflare.apis.fl_constant import FLContextKey, ServerCommandKey
-from nvflare.apis.fl_context import FLContext
-from nvflare.apis.utils.fl_context_utils import get_serializable_data
+from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.core_cell import MessageHeaderKey, ReturnCode, make_reply
 from nvflare.fuel.f3.message import Message as CellMessage
@@ -117,8 +115,9 @@ class ServerCommandAgent(object):
             engine = fl_ctx.get_engine()
             reply = engine.dispatch(topic=topic, request=data, fl_ctx=fl_ctx)
 
-            shared_fl_ctx = FLContext()
-            shared_fl_ctx.set_public_props(copy.deepcopy(get_serializable_data(fl_ctx).get_all_public_props()))
+            self.logger.debug("Before gen_new_peer_ctx")
+            shared_fl_ctx = gen_new_peer_ctx(fl_ctx)
+            self.logger.debug("After gen_new_peer_ctx")
             reply.set_header(key=FLContextKey.PEER_CONTEXT, value=shared_fl_ctx)
 
             if reply is not None:


### PR DESCRIPTION
### Description

This PR adds a utility function that generate the serialized peer fl context.  The original way took about 4 seconds if the model size is large.  This new utility function takes almost no time.

Currently, this PR only changes the part handling aux_communication to the new utility function.  Other areas will be changed once this utility function is working properly and is tested thoroughly on aux_communication.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
