### PR TITLE
Add handle_dead_job to cyclic controller

### DIFF
--- a/nvflare/app_common/workflows/cyclic_ctl.py
+++ b/nvflare/app_common/workflows/cyclic_ctl.py
@@ -131,8 +131,10 @@ class CyclicController(Controller):
             self.system_panic("Not enough client sites.", fl_ctx)
         self._last_client = None
 
-    def _get_relay_orders(self):
+    def _get_relay_orders(self, fl_ctx: FLContext):
         targets = list(self._participating_clients)
+        if len(targets) <= 1:
+            self.system_panic("Not enough client sites.", fl_ctx)
         if self._order == RelayOrder.RANDOM:
             random.shuffle(targets)
         elif self._order == RelayOrder.RANDOM_WITHOUT_SAME_IN_A_ROW:
@@ -168,7 +170,7 @@ class CyclicController(Controller):
                 fl_ctx.set_prop(AppConstants.CURRENT_ROUND, self._current_round, private=True, sticky=True)
 
                 # Task for one cyclic
-                targets = self._get_relay_orders()
+                targets = self._get_relay_orders(fl_ctx)
                 targets_names = [t.name for t in targets]
                 self.log_debug(fl_ctx, f"Relay on {targets_names}")
 
@@ -242,3 +244,12 @@ class CyclicController(Controller):
             self._start_round = self._current_round
         finally:
             pass
+
+    def handle_dead_job(self, client_name: str, fl_ctx: FLContext):
+        super().handle_dead_job(client_name, fl_ctx)
+
+        new_client_list = []
+        for client in self._participating_clients:
+            if client_name != client.name:
+                new_client_list.append(client)
+        self._participating_clients = new_client_list


### PR DESCRIPTION
In CyclicController, if client job cell dead, it will keep cycling.
BUT we should NOT keep cycling if there is only 1 client remaining, that does not make sense.

### Description

- Add handle_dead_job to cyclic controller, remove the dead client job cell from `self._participating_clients`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
