### PR TITLE
Complete the TODO places of generating peer fl context

### DIFF
--- a/nvflare/private/fed/client/command_agent.py
+++ b/nvflare/private/fed/client/command_agent.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
-from nvflare.apis.utils.fl_context_utils import get_serializable_data
+from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
 from nvflare.fuel.f3.cellnet.core_cell import Message as CellMessage
 from nvflare.fuel.f3.cellnet.core_cell import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.core_cell import make_reply as make_cellnet_reply
@@ -84,8 +83,7 @@ class CommandAgent(object):
             topic = request.get_header(MessageHeaderKey.TOPIC)
             reply = self.engine.dispatch(topic=topic, request=shareable, fl_ctx=fl_ctx)
 
-            shared_fl_ctx = FLContext()
-            shared_fl_ctx.set_public_props(copy.deepcopy(get_serializable_data(fl_ctx).get_all_public_props()))
+            shared_fl_ctx = gen_new_peer_ctx(fl_ctx)
             reply.set_header(key=FLContextKey.PEER_CONTEXT, value=shared_fl_ctx)
 
             if reply is not None:

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -14,7 +14,6 @@
 
 """FL Admin commands."""
 
-import copy
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -29,7 +28,7 @@ from nvflare.apis.fl_constant import (
 )
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.apis.utils.fl_context_utils import get_serializable_data
+from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
 from nvflare.private.defs import SpecialTaskName, TaskConstant
 from nvflare.widgets.widget import WidgetID
 
@@ -180,8 +179,8 @@ class GetTaskCommand(CommandProcessor, ServerStateCheck):
         shareable.set_header(key=FLContextKey.TASK_ID, value=task_id)
 
         shareable.set_header(key=ServerCommandKey.TASK_NAME, value=taskname)
-        shared_fl_ctx = FLContext()
-        shared_fl_ctx.set_public_props(copy.deepcopy(get_serializable_data(fl_ctx).get_all_public_props()))
+
+        shared_fl_ctx = gen_new_peer_ctx(fl_ctx)
         shareable.set_header(key=FLContextKey.PEER_CONTEXT, value=shared_fl_ctx)
 
         if taskname != SpecialTaskName.TRY_AGAIN:


### PR DESCRIPTION
### Description

This PR replaces the statements generating peer fl context with the new utility function in the remaining places that require sending the peer fl context.

On large models, the utility function takes about 50ms to finish, compared to the previous statements which takes about 3~4 seconds.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
