### PR TITLE
Fix remove path in JOB CLI

### DIFF
--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -184,7 +184,7 @@ def remove_non_python_files(custom_dir):
                 os.remove(file_path)
         for d in dirs:
             if d == "__pycache__" or d.endswith(".pyc"):
-                shutil.rmtree(d)
+                shutil.rmtree(os.path.join(root, d))
 
 
 def remove_extra_files(config_dir):


### PR DESCRIPTION
### Description

In `for root, dirs, files in os.walk(custom_dir):`, the dirs are child directories.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
