### PR TITLE
Fix job cli boolean replacement issue

### DIFF
--- a/nvflare/tool/job/config/config_indexer.py
+++ b/nvflare/tool/job/config/config_indexer.py
@@ -33,6 +33,7 @@ class KeyIndex:
 
 
 def build_reverse_order_index(config_file_path: str) -> Tuple:
+    # use pyhocon to load config
     config, config_file_path = load_pyhocon_conf(config_file_path)
 
     components: list = config.get("components", None)
@@ -64,6 +65,7 @@ def build_reverse_order_index(config_file_path: str) -> Tuple:
 
 
 def load_pyhocon_conf(config_file_path) -> Tuple[ConfigTree, str]:
+    """Loads config using pyhocon."""
     try:
         temp_conf: Config = ConfigFactory.load_config(config_file_path)
         if temp_conf:

--- a/nvflare/tool/job/config/configer.py
+++ b/nvflare/tool/job/config/configer.py
@@ -122,11 +122,12 @@ def merge_configs(
     """Merges configurations from indices_configs and cli_file_configs.
 
     Args:
-        app_indices_configs (Dict[str,Dict[str, tuple]]): A dictionary containing indices and configurations.
+        app_indices_configs (Dict[str, Dict[str, tuple]]): A dictionary containing indices and configurations.
         app_cli_file_configs (Dict[str, Dict[str, Dict]]): A dictionary containing CLI configurations.
 
     Returns:
-        Dict[str, Dict[str, Tuple]]: A dictionary containing merged configurations.
+        Dict[str, Dict[str, Tuple]]: A dictionary of {app_name: merged configurations}.
+            Each of the merged configurations can be expressed in a Tuple: config, excluded_key_List, key_indices
     """
     app_merged = {}
     for app_name in app_indices_configs:

--- a/tests/unit_test/data/jobs/launch_everytime/app/config/config_fed_client.conf
+++ b/tests/unit_test/data/jobs/launch_everytime/app/config/config_fed_client.conf
@@ -1,0 +1,34 @@
+{
+  format_version = 2
+  app_script = "cifar10_fl.py"
+  app_config = ""
+
+  executors = [
+    {
+      tasks = ["train"]
+
+      executor {
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        args {
+          launcher_id = "launcher"
+          heartbeat_timeout = 60
+          data_exchange_path = ""
+          params_exchange_format =  "pytorch"
+          params_transfer_type = "DIFF"
+          training = true
+          global_evaluation = true
+          launch_once = false
+        }
+      }
+    }
+  ],
+  task_data_filters =  []
+  task_result_filters = []
+  components =  [
+    {
+      id = "launcher"
+      path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+      args.script = "python3 custom/{app_script}  {app_config} "
+    }
+  ]
+}

--- a/tests/unit_test/data/jobs/launch_everytime/app/config/config_fed_server.conf
+++ b/tests/unit_test/data/jobs/launch_everytime/app/config/config_fed_server.conf
@@ -1,0 +1,46 @@
+{
+  format_version = 2
+  task_data_filters =[]
+  task_result_filters = []
+  model_class_path = "net.Net"
+  workflows = [
+      {
+        id = "scatter_and_gather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
+        args {
+            min_clients = 2
+            num_rounds = 2
+            start_round = 0
+            wait_time_after_min_received = 0
+            aggregator_id = "aggregator"
+            persistor_id = "persistor"
+            shareable_generator_id =  "shareable_generator"
+            train_task_name =  "train"
+            train_timeout =  0
+        }
+      }
+  ]
+
+  components = [
+    {
+      id = "persistor"
+      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      args.model.path = "{model_class_path}"
+    },
+    {
+      id = "shareable_generator"
+      path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
+      args = {}
+    },
+    {
+      id = "aggregator"
+      path = "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator"
+      args.expected_data_kind = "WEIGHT_DIFF"
+    },
+    {
+      id = "model_selector"
+      path =  "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+      args.key_metric = "accuracy"
+    }
+  ]
+}

--- a/tests/unit_test/data/jobs/launch_everytime/meta.conf
+++ b/tests/unit_test/data/jobs/launch_everytime/meta.conf
@@ -1,0 +1,9 @@
+{
+  name = "sag_pt"
+  resource_spec = {}
+  deploy_map {
+    app = ["@ALL"]
+  }
+  min_clients = 2
+  mandatory_clients = []
+}

--- a/tests/unit_test/data/jobs/launch_once/app/config/config_fed_client.conf
+++ b/tests/unit_test/data/jobs/launch_once/app/config/config_fed_client.conf
@@ -1,0 +1,34 @@
+{
+  format_version = 2
+  app_script = "cifar10_fl.py"
+  app_config = ""
+
+  executors = [
+    {
+      tasks = ["train"]
+
+      executor {
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        args {
+          launcher_id = "launcher"
+          heartbeat_timeout = 60
+          data_exchange_path = ""
+          params_exchange_format =  "pytorch"
+          params_transfer_type = "DIFF"
+          training = true
+          global_evaluation = true
+          launch_once = true
+        }
+      }
+    }
+  ],
+  task_data_filters =  []
+  task_result_filters = []
+  components =  [
+    {
+      id = "launcher"
+      path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+      args.script = "python3 custom/{app_script}  {app_config} "
+    }
+  ]
+}

--- a/tests/unit_test/data/jobs/launch_once/app/config/config_fed_server.conf
+++ b/tests/unit_test/data/jobs/launch_once/app/config/config_fed_server.conf
@@ -1,0 +1,46 @@
+{
+  format_version = 2
+  task_data_filters =[]
+  task_result_filters = []
+  model_class_path = "net.Net"
+  workflows = [
+      {
+        id = "scatter_and_gather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
+        args {
+            min_clients = 2
+            num_rounds = 2
+            start_round = 0
+            wait_time_after_min_received = 0
+            aggregator_id = "aggregator"
+            persistor_id = "persistor"
+            shareable_generator_id =  "shareable_generator"
+            train_task_name =  "train"
+            train_timeout =  0
+        }
+      }
+  ]
+
+  components = [
+    {
+      id = "persistor"
+      path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
+      args.model.path = "{model_class_path}"
+    },
+    {
+      id = "shareable_generator"
+      path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
+      args = {}
+    },
+    {
+      id = "aggregator"
+      path = "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator"
+      args.expected_data_kind = "WEIGHT_DIFF"
+    },
+    {
+      id = "model_selector"
+      path =  "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+      args.key_metric = "accuracy"
+    }
+  ]
+}

--- a/tests/unit_test/data/jobs/launch_once/meta.conf
+++ b/tests/unit_test/data/jobs/launch_once/meta.conf
@@ -1,0 +1,9 @@
+{
+  name = "sag_pt"
+  resource_spec = {}
+  deploy_map {
+    app = ["@ALL"]
+  }
+  min_clients = 2
+  mandatory_clients = []
+}

--- a/tests/unit_test/tool/job/config/configer_test.py
+++ b/tests/unit_test/tool/job/config/configer_test.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+from typing import List
+
+from nvflare.tool.job.config.configer import DEFAULT_APP_NAME, build_config_file_indices, get_cli_config, merge_configs
+
+
+def _create_test_args(config_file: List, job_name: str = "launch_once"):
+    args = argparse.Namespace()
+    args.config_file = config_file
+    args.debug = False
+    args.force = True
+    args.job_folder = os.path.join(os.path.dirname(__file__), f"../../../data/jobs/{job_name}")
+    args.job_sub_cmd = "create"
+    args.sub_command = "job"
+    return args
+
+
+def _get_merged_configs(args):
+    cli_configs = get_cli_config(args, [DEFAULT_APP_NAME])
+    app_indices = build_config_file_indices(args.job_folder, [DEFAULT_APP_NAME])
+    merged_configs = merge_configs(app_indices_configs=app_indices, app_cli_file_configs=cli_configs)
+    return merged_configs
+
+
+class TestConfiger:
+    def test_get_cli_config(self):
+        args = _create_test_args(
+            config_file=[["config_fed_client.conf", "app_script=cifar10_fl.py", "launch_once=False"]],
+            job_name="launch_once",
+        )
+        result = get_cli_config(args, [DEFAULT_APP_NAME])
+        assert result == {
+            DEFAULT_APP_NAME: {"config_fed_client.conf": {"app_script": "cifar10_fl.py", "launch_once": "False"}}
+        }
+
+    def test_merge_configs(self):
+        args = _create_test_args(
+            config_file=[["config_fed_client.conf", "app_script=cifar10_fl.py", "launch_once=False"]],
+            job_name="launch_once",
+        )
+        result_merged = _get_merged_configs(args)
+
+        args = _create_test_args(config_file=[["config_fed_client.conf"]], job_name="launch_everytime")
+        expected_merged = _get_merged_configs(args)
+
+        assert result_merged == expected_merged
+
+    def test_merge_configs_lower_case_false(self):
+        args = _create_test_args(
+            config_file=[["config_fed_client.conf", "app_script=cifar10_fl.py", "launch_once=false"]],
+            job_name="launch_once",
+        )
+        result_merged = _get_merged_configs(args)
+
+        args = _create_test_args(config_file=[["config_fed_client.conf"]], job_name="launch_everytime")
+        expected_merged = _get_merged_configs(args)
+
+        assert result_merged == expected_merged


### PR DESCRIPTION
### Issue

I encounter a situation where in config:
```
launch_once = true
```

And in CLI I use `-f config_fed_client.conf app_script=train_diff.py launch_once=false`

In the old logic, we will do this type conversion: bool("false") which equal to True.

Instead, we should be utilizing the same parsing rule as pyhocon and treat this value as boolean "False".

### Description

- Use pyhocon to do type conversion
- Remove unused argument

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
