### PR TITLE
fix job config section

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -360,7 +360,6 @@ class SiteType:
 class SystemConfigs:
     STARTUP_CONF = "start_config"
     RESOURCES_CONF = "resources_config"
-    APPLICATION_CONF = "application_config"
 
 
 class SecureTrainConst:

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -142,7 +142,7 @@ class ClientJsonConfigurator(FedJsonConfigurator):
         )
 
         ConfigService.initialize(
-            section_files={SystemConfigs.APPLICATION_CONF: os.path.basename(self.config_files[0])},
+            section_files={},
             config_path=[self.args.workspace],
             parsed_args=self.args,
             var_dict=self.cmd_vars,

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 
 from nvflare.apis.executor import Executor
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import SystemConfigs
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.json_scanner import Node

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -161,7 +161,7 @@ class ServerJsonConfigurator(FedJsonConfigurator):
         )
 
         ConfigService.initialize(
-            section_files={SystemConfigs.APPLICATION_CONF: os.path.basename(self.config_files[0])},
+            section_files={},
             config_path=[self.args.workspace],
             parsed_args=self.args,
             var_dict=self.cmd_vars,

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import SystemConfigs
 from nvflare.apis.responder import Responder
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService


### PR DESCRIPTION
Fixes # .

### Description

This PR fixes a bug that could cause the whole system to become unworkable when a job's config files contain errors. At the end of job config processing, the config service is initialized with the section file to be the job's server/client config. However the config path is set to workspace! Since a workspace could contain many jobs, if any job happens to have a bad config file in it, and the config service happens to use it when searching the section file, the current job will crash.

The fix simply removes this section file since it is not used in our system at all.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
