### PR TITLE
Add non-DXO shareable support to FLModelUtil

### DIFF
--- a/nvflare/apis/dxo.py
+++ b/nvflare/apis/dxo.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import List, Union
+from typing import List, Optional, Union
 
 from nvflare.apis.fl_constant import FLMetaKey
 from nvflare.apis.shareable import ReservedHeaderKey, Shareable
@@ -30,6 +30,7 @@ class DataKind(object):
     COLLECTION = "COLLECTION"  # Dict or List of DXO objects
     STATISTICS = "STATISTICS"
     PSI = "PSI"
+    META = "META"  # only contains meta
 
 
 class MetaKey(FLMetaKey):
@@ -43,7 +44,7 @@ _KEY_DXO = "DXO"
 
 
 class DXO(object):
-    def __init__(self, data_kind: str, data: dict, meta: dict = None):
+    def __init__(self, data_kind: str, data: Optional[dict] = None, meta: Optional[dict] = None):
         """Init the DXO.
 
         The Data Exchange Object standardizes the data passed between communicating parties.

--- a/nvflare/apis/dxo.py
+++ b/nvflare/apis/dxo.py
@@ -30,7 +30,7 @@ class DataKind(object):
     COLLECTION = "COLLECTION"  # Dict or List of DXO objects
     STATISTICS = "STATISTICS"
     PSI = "PSI"
-    META = "META"  # only contains meta
+    NONE = "NONE"  # only contains meta
 
 
 class MetaKey(FLMetaKey):

--- a/nvflare/app_common/ccwf/cse_client_ctl.py
+++ b/nvflare/app_common/ccwf/cse_client_ctl.py
@@ -14,6 +14,7 @@
 import threading
 
 from nvflare.apis.controller_spec import Task
+from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.fl_constant import FLContextKey, ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
@@ -216,8 +217,10 @@ class CrossSiteEvalClientController(ClientSideController):
             return make_reply(ReturnCode.BAD_REQUEST_DATA)
 
         if not self.local_model:
+            dxo = DXO(data_kind=DataKind.META)
             task_data = Shareable()
             task_data.set_header(AppConstants.SUBMIT_MODEL_NAME, model_name)
+            dxo.update_shareable(task_data)
 
             abort_signal = Signal()
             try:

--- a/nvflare/app_common/ccwf/cse_client_ctl.py
+++ b/nvflare/app_common/ccwf/cse_client_ctl.py
@@ -14,7 +14,6 @@
 import threading
 
 from nvflare.apis.controller_spec import Task
-from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.fl_constant import FLContextKey, ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
@@ -217,10 +216,8 @@ class CrossSiteEvalClientController(ClientSideController):
             return make_reply(ReturnCode.BAD_REQUEST_DATA)
 
         if not self.local_model:
-            dxo = DXO(data_kind=DataKind.META)
             task_data = Shareable()
             task_data.set_header(AppConstants.SUBMIT_MODEL_NAME, model_name)
-            dxo.update_shareable(task_data)
 
             abort_signal = Signal()
             try:

--- a/nvflare/app_common/utils/fl_model_utils.py
+++ b/nvflare/app_common/utils/fl_model_utils.py
@@ -111,7 +111,7 @@ class FLModelUtils:
 
         if dxo.data_kind == DataKind.METRICS:
             metrics = dxo.data
-        else:
+        elif dxo.data_kind != DataKind.META:
             params_type = data_kind_to_params_type.get(dxo.data_kind)
             if params_type is None:
                 raise ValueError(f"Invalid shareable with dxo that has data kind: {dxo.data_kind}")


### PR DESCRIPTION
### Description 

- Support raw Shareable for FLModelUtils

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
