### PR TITLE
Fix AIO Exception Handling

### DIFF
--- a/nvflare/fuel/f3/comm_config.py
+++ b/nvflare/fuel/f3/comm_config.py
@@ -33,24 +33,42 @@ class VarName:
     SUBNET_HEARTBEAT_INTERVAL = "subnet_heartbeat_interval"
     SUBNET_TROUBLE_THRESHOLD = "subnet_trouble_threshold"
     COMM_DRIVER_PATH = "comm_driver_path"
+    USE_AIO_GRPC_VAR_NAME = "use_aio_grpc"
 
 
 class CommConfigurator:
+    _config_loaded = False
+    _configuration = None
+
     def __init__(self):
+        # only load once!
         self.logger = logging.getLogger(self.__class__.__name__)
-        config = None
-        for file_name in _comm_config_files:
-            try:
-                config = ConfigService.load_json(file_name)
-                if config:
-                    break
-            except FileNotFoundError:
-                self.logger.debug(f"config file {file_name} not found from config path")
-                config = None
-            except Exception as ex:
-                self.logger.error(f"failed to load config file {file_name}: {secure_format_exception(ex)}")
-                config = None
-        self.config = config
+        if not CommConfigurator._config_loaded:
+            config = None
+            for file_name in _comm_config_files:
+                try:
+                    config = ConfigService.load_json(file_name)
+                    if config:
+                        break
+                except FileNotFoundError:
+                    self.logger.debug(f"config file {file_name} not found from config path")
+                    config = None
+                except Exception as ex:
+                    self.logger.error(f"failed to load config file {file_name}: {secure_format_exception(ex)}")
+                    config = None
+
+            CommConfigurator._configuration = config
+            CommConfigurator._config_loaded = True
+        self.config = CommConfigurator._configuration
+
+    @staticmethod
+    def reset():
+        """Reset the configurator to allow reloading config files.
+
+        Returns:
+
+        """
+        CommConfigurator._config_loaded = False
 
     def get_config(self):
         return self.config
@@ -78,3 +96,18 @@ class CommConfigurator:
 
     def get_comm_driver_path(self, default):
         return ConfigService.get_str_var(VarName.COMM_DRIVER_PATH, self.config, default=default)
+
+    def use_aio_grpc(self, default):
+        return ConfigService.get_bool_var(VarName.USE_AIO_GRPC_VAR_NAME, self.config, default)
+
+    def get_int_var(self, name: str, default=None):
+        return ConfigService.get_int_var(name, self.config, default=default)
+
+    def get_float_var(self, name: str, default=None):
+        return ConfigService.get_float_var(name, self.config, default=default)
+
+    def get_bool_var(self, name: str, default=None):
+        return ConfigService.get_bool_var(name, self.config, default=default)
+
+    def get_str_var(self, name: str, default=None):
+        return ConfigService.get_str_var(name, self.config, default=default)

--- a/nvflare/fuel/f3/drivers/aio_context.py
+++ b/nvflare/fuel/f3/drivers/aio_context.py
@@ -42,10 +42,19 @@ class AioContext:
 
         return self.loop
 
+    def _handle_exception(self, loop, context):
+        try:
+            msg = context.get("exception", context["message"])
+            self.logger.debug(f"AIO Exception: {msg}")
+        except Exception as ex:
+            # ignore exception in the exception handler
+            self.logger.debug(f"exception in aio exception handler: {ex}")
+
     def run_aio_loop(self):
         self.logger.debug(f"{self.name}: started AioContext in thread {threading.current_thread().name}")
         # self.loop = asyncio.get_event_loop()
         self.loop = asyncio.new_event_loop()
+        self.loop.set_exception_handler(self._handle_exception)
         asyncio.set_event_loop(self.loop)
         self.logger.debug(f"{self.name}: got loop: {id(self.loop)}")
         self.ready.set()

--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -187,7 +187,7 @@ class Servicer(StreamerServicer):
                 connection.close()
                 self.logger.info(f"SERVER: closed connection {connection.name}")
                 self.server.driver.close_connection(connection)
-            self.logger.info(f"SERVER: finished Stream CB")
+            self.logger.info("SERVER: finished Stream CB")
 
 
 class Server:

--- a/nvflare/fuel/f3/drivers/grpc/qq.py
+++ b/nvflare/fuel/f3/drivers/grpc/qq.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import queue
+
+
+class QueueClosed(Exception):
+    pass
+
+
+class QQ:
+    def __init__(self):
+        self.q = queue.Queue()
+        self.closed = False
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def close(self):
+        self.closed = True
+
+    def append(self, i):
+        if self.closed:
+            raise QueueClosed("queue stopped")
+        self.q.put_nowait(i)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.closed:
+            raise StopIteration()
+        while True:
+            try:
+                return self.q.get(block=True, timeout=0.1)
+            except queue.Empty:
+                if self.closed:
+                    self.logger.debug("Queue closed - stop iteration")
+                    raise StopIteration()
+            except Exception as e:
+                self.logger.error(f"queue exception {type(e)}")
+                raise e

--- a/nvflare/fuel/f3/drivers/grpc/utils.py
+++ b/nvflare/fuel/f3/drivers/grpc/utils.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import grpc
+
+from nvflare.fuel.f3.comm_config import CommConfigurator
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+
+
+def use_aio_grpc():
+    configurator = CommConfigurator()
+    return configurator.use_aio_grpc(default=True)
+
+
+def get_grpc_client_credentials(params: dict):
+    root_cert = _read_file(params.get(DriverParams.CA_CERT.value))
+    cert_chain = _read_file(params.get(DriverParams.CLIENT_CERT))
+    private_key = _read_file(params.get(DriverParams.CLIENT_KEY))
+    return grpc.ssl_channel_credentials(
+        certificate_chain=cert_chain, private_key=private_key, root_certificates=root_cert
+    )
+
+
+def get_grpc_server_credentials(params: dict):
+    root_cert = _read_file(params.get(DriverParams.CA_CERT.value))
+    cert_chain = _read_file(params.get(DriverParams.SERVER_CERT))
+    private_key = _read_file(params.get(DriverParams.SERVER_KEY))
+
+    return grpc.ssl_server_credentials(
+        [(private_key, cert_chain)],
+        root_certificates=root_cert,
+        require_client_auth=True,
+    )
+
+
+def _read_file(file_name: str):
+    if not file_name:
+        return None
+
+    with open(file_name, "rb") as f:
+        return f.read()

--- a/nvflare/fuel/f3/drivers/grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/grpc_driver.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from concurrent import futures
+from typing import Any, Dict, List, Union
+
+import grpc
+
+from nvflare.fuel.f3.comm_config import CommConfigurator
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.connection import Connection
+from nvflare.fuel.f3.drivers.driver import ConnectorInfo
+from nvflare.fuel.f3.drivers.grpc.streamer_pb2_grpc import (
+    StreamerServicer,
+    StreamerStub,
+    add_StreamerServicer_to_server,
+)
+from nvflare.fuel.utils.obj_utils import get_logger
+from nvflare.security.logging import secure_format_exception
+
+from .base_driver import BaseDriver
+from .driver_params import DriverCap, DriverParams
+from .grpc.qq import QQ
+from .grpc.streamer_pb2 import Frame
+from .grpc.utils import get_grpc_client_credentials, get_grpc_server_credentials, use_aio_grpc
+from .net_utils import MAX_FRAME_SIZE, get_address, get_tcp_urls, ssl_required
+
+GRPC_DEFAULT_OPTIONS = [
+    ("grpc.max_send_message_length", MAX_FRAME_SIZE),
+    ("grpc.max_receive_message_length", MAX_FRAME_SIZE),
+]
+
+
+class StreamConnection(Connection):
+
+    seq_num = 0
+
+    def __init__(self, oq: QQ, connector: ConnectorInfo, conn_props: dict, side: str, context=None, channel=None):
+        super().__init__(connector)
+        self.side = side
+        self.oq = oq
+        self.closing = False
+        self.conn_props = conn_props
+        self.context = context  # for server side
+        self.channel = channel  # for client side
+        self.lock = threading.Lock()
+        self.logger = get_logger(self)
+
+    def get_conn_properties(self) -> dict:
+        return self.conn_props
+
+    def close(self):
+        self.closing = True
+        with self.lock:
+            self.oq.close()
+            if self.context:
+                try:
+                    self.context.abort(grpc.StatusCode.CANCELLED, "service closed")
+                except:
+                    # ignore any exception when aborting
+                    pass
+                self.context = None
+            if self.channel:
+                self.channel.close()
+                self.channel = None
+
+    def send_frame(self, frame: Union[bytes, bytearray, memoryview]):
+        try:
+            StreamConnection.seq_num += 1
+            seq = StreamConnection.seq_num
+            self.logger.debug(f"{self.side}: queued frame #{seq}")
+            self.oq.append(Frame(seq=seq, data=bytes(frame)))
+        except BaseException as ex:
+            raise CommError(CommError.ERROR, f"Error sending frame: {ex}")
+
+    def read_loop(self, msg_iter, q: QQ):
+        ct = threading.current_thread()
+        self.logger.debug(f"{self.side}: started read_loop in thread {ct.name}")
+        try:
+            for f in msg_iter:
+                if self.closing:
+                    break
+
+                assert isinstance(f, Frame)
+                self.logger.debug(f"{self.side} in {ct.name}: incoming frame #{f.seq}")
+                if self.frame_receiver:
+                    self.frame_receiver.process_frame(f.data)
+                else:
+                    self.logger.error(f"{self.side}: Frame receiver not registered for connection: {self.name}")
+        except Exception as ex:
+            if not self.closing:
+                self.logger.debug(f"{self.side}: exception {type(ex)} in read_loop")
+        if q:
+            self.logger.debug(f"{self.side}: closing queue")
+            q.close()
+        self.logger.debug(f"{self.side} in {ct.name}: done read_loop")
+
+    def generate_output(self):
+        ct = threading.current_thread()
+        self.logger.debug(f"{self.side}: generate_output in thread {ct.name}")
+        for i in self.oq:
+            assert isinstance(i, Frame)
+            self.logger.debug(f"{self.side}: outgoing frame #{i.seq}")
+            yield i
+        self.logger.debug(f"{self.side}: done generate_output in thread {ct.name}")
+
+
+class Servicer(StreamerServicer):
+    def __init__(self, server):
+        self.server = server
+        self.logger = get_logger(self)
+
+    def Stream(self, request_iterator, context):
+        connection = None
+        oq = QQ()
+        t = None
+        ct = threading.current_thread()
+        conn_props = {
+            DriverParams.PEER_ADDR.value: context.peer(),
+            DriverParams.LOCAL_ADDR.value: get_address(self.server.connector.params),
+        }
+        cn_names = context.auth_context().get("x509_common_name")
+        if cn_names:
+            conn_props[DriverParams.PEER_CN.value] = cn_names[0].decode("utf-8")
+
+        try:
+            self.logger.debug(f"SERVER started Stream CB in thread {ct.name}")
+            connection = StreamConnection(oq, self.server.connector, conn_props, "SERVER", context=context)
+            self.logger.debug(f"SERVER created connection in thread {ct.name}")
+            self.server.driver.add_connection(connection)
+            self.logger.debug(f"SERVER created read_loop thread in thread {ct.name}")
+            t = threading.Thread(target=connection.read_loop, args=(request_iterator, oq))
+            t.start()
+
+            # DO NOT use connection.generate_output()!
+            self.logger.debug(f"SERVER: generate_output in thread {ct.name}")
+            for i in oq:
+                assert isinstance(i, Frame)
+                self.logger.debug(f"SERVER: outgoing frame #{i.seq}")
+                yield i
+            self.logger.debug(f"SERVER: done generate_output in thread {ct.name}")
+
+        except BaseException as ex:
+            self.logger.error(f"Connection closed due to error: {ex}")
+        finally:
+            if t is not None:
+                t.join()
+            if connection:
+                self.logger.debug(f"SERVER: closing connection {connection.name}")
+                self.server.driver.close_connection(connection)
+            self.logger.debug(f"SERVER: cleanly finished Stream CB in thread {ct.name}")
+
+
+class Server:
+    def __init__(
+        self,
+        driver,
+        connector,
+        max_workers,
+        options,
+    ):
+        self.driver = driver
+        self.logger = get_logger(self)
+        self.connector = connector
+        self.grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers), options=options)
+        servicer = Servicer(self)
+        add_StreamerServicer_to_server(servicer, self.grpc_server)
+
+        params = connector.params
+        addr = get_address(params)
+        try:
+            self.logger.debug(f"SERVER: connector params: {params}")
+            secure = ssl_required(params)
+            if secure:
+                credentials = get_grpc_server_credentials(params)
+                self.grpc_server.add_secure_port(addr, server_credentials=credentials)
+                self.logger.info(f"added secure port at {addr}")
+            else:
+                self.grpc_server.add_insecure_port(addr)
+                self.logger.info(f"added insecure port at {addr}")
+        except Exception as ex:
+            error = f"cannot listen on {addr}: {type(ex)}: {secure_format_exception(ex)}"
+            self.logger.debug(error)
+
+    def start(self):
+        self.grpc_server.start()
+        self.grpc_server.wait_for_termination()
+
+    def shutdown(self):
+        self.grpc_server.stop(grace=0.5)
+
+
+class GrpcDriver(BaseDriver):
+    def __init__(self):
+        BaseDriver.__init__(self)
+        self.server = None
+        self.closing = False
+        self.max_workers = 100
+        self.options = GRPC_DEFAULT_OPTIONS
+        self.logger = get_logger(self)
+        configurator = CommConfigurator()
+        config = configurator.get_config()
+        if config:
+            my_params = config.get("grpc")
+            if my_params:
+                self.max_workers = my_params.get("max_workers", 100)
+                self.options = my_params.get("options")
+        self.logger.debug(f"GRPC Config: max_workers={self.max_workers}, options={self.options}")
+
+    @staticmethod
+    def supported_transports() -> List[str]:
+        if use_aio_grpc():
+            return ["nagrpc", "nagrpcs"]
+        else:
+            return ["grpc", "grpcs"]
+
+    @staticmethod
+    def capabilities() -> Dict[str, Any]:
+        return {DriverCap.HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: True}
+
+    def listen(self, connector: ConnectorInfo):
+        self.logger.info(f"starting grpc connector: {connector}")
+        self.connector = connector
+        self.server = Server(self, connector, max_workers=self.max_workers, options=self.options)
+        self.server.start()
+
+    def connect(self, connector: ConnectorInfo):
+        self.logger.debug("CLIENT: trying connect ...")
+        params = connector.params
+        address = get_address(params)
+        conn_props = {DriverParams.PEER_ADDR.value: address}
+
+        secure = ssl_required(params)
+        if secure:
+            self.logger.debug("CLIENT: creating secure channel")
+            channel = grpc.secure_channel(
+                address, options=self.options, credentials=get_grpc_client_credentials(params)
+            )
+            self.logger.info(f"created secure channel at {address}")
+        else:
+            self.logger.info("CLIENT: creating insecure channel")
+            channel = grpc.insecure_channel(address, options=self.options)
+            self.logger.info(f"created insecure channel at {address}")
+
+        self.logger.debug("CLIENT: created channel")
+        stub = StreamerStub(channel)
+        self.logger.debug("CLIENT: got stub")
+        oq = QQ()
+        connection = StreamConnection(oq, connector, conn_props, "CLIENT", channel=channel)
+        self.add_connection(connection)
+        self.logger.debug("CLIENT: added connection")
+        try:
+            received = stub.Stream(connection.generate_output())
+            connection.read_loop(received, oq)
+        except BaseException as ex:
+            self.logger.info(f"CLIENT: connection done: {type(ex)}")
+        connection.close()
+        self.close_connection(connection)
+        self.logger.info(f"CLIENT: finished connection {connection}")
+
+    @staticmethod
+    def get_urls(scheme: str, resources: dict) -> (str, str):
+        secure = resources.get(DriverParams.SECURE)
+        if secure:
+            if use_aio_grpc():
+                scheme = "nagrpcs"
+            else:
+                scheme = "grpcs"
+        return get_tcp_urls(scheme, resources)
+
+    def shutdown(self):
+        if self.closing:
+            return
+        self.closing = True
+        self.close_all()
+        if self.server:
+            self.server.shutdown()

--- a/nvflare/fuel/f3/drivers/grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/grpc_driver.py
@@ -152,7 +152,7 @@ class Servicer(StreamerServicer):
             if connection:
                 self.logger.debug(f"SERVER: closing connection {connection.name}")
                 self.server.driver.close_connection(connection)
-            self.logger.debug(f"SERVER: cleanly finished Stream CB in thread {ct.name}")
+            self.logger.info("SERVER: finished Stream CB")
 
 
 class Server:

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -79,7 +79,8 @@ def get_ssl_context(params: dict, ssl_server: bool) -> Optional[SSLContext]:
 def get_address(params: dict) -> str:
     host = params.get(DriverParams.HOST.value, "0.0.0.0")
     port = params.get(DriverParams.PORT.value, 0)
-
+    if not host:
+        host = "0.0.0.0"
     return f"{host}:{port}"
 
 

--- a/nvflare/fuel/f3/qat/admin.py
+++ b/nvflare/fuel/f3/qat/admin.py
@@ -15,7 +15,7 @@
 import argparse
 
 from nvflare.fuel.common.excepts import ConfigError
-from nvflare.fuel.f3.qat2.net_config import NetConfig
+from nvflare.fuel.f3.qat.net_config import NetConfig
 from nvflare.fuel.hci.client.cli import AdminClient, CredentialType
 from nvflare.fuel.hci.client.static_service_finder import StaticServiceFinder
 from nvflare.fuel.utils.config_service import ConfigService

--- a/nvflare/fuel/f3/qat/run_cell.py
+++ b/nvflare/fuel/f3/qat/run_cell.py
@@ -16,7 +16,7 @@ import argparse
 import logging
 
 from nvflare.fuel.f3.mpm import MainProcessMonitor as Mpm
-from nvflare.fuel.f3.qat2.cell_runner import CellRunner
+from nvflare.fuel.f3.qat.cell_runner import CellRunner
 from nvflare.fuel.utils.config_service import ConfigService
 
 

--- a/nvflare/fuel/f3/qat/run_server.py
+++ b/nvflare/fuel/f3/qat/run_server.py
@@ -16,7 +16,7 @@ import argparse
 import logging
 
 from nvflare.fuel.f3.mpm import MainProcessMonitor
-from nvflare.fuel.f3.qat2.server import Server
+from nvflare.fuel.f3.qat.server import Server
 from nvflare.fuel.utils.config_service import ConfigService
 
 

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -37,7 +37,7 @@ from nvflare.security.logging import secure_format_exception, secure_format_trac
 FRAME_THREAD_POOL_SIZE = 100
 CONN_THREAD_POOL_SIZE = 16
 INIT_WAIT = 1
-MAX_WAIT = 60
+MAX_WAIT = 10
 SILENT_RECONNECT_TIME = 5
 SELF_ADDR = "0.0.0.0:0"
 

--- a/nvflare/fuel/utils/config_service.py
+++ b/nvflare/fuel/utils/config_service.py
@@ -200,6 +200,8 @@ class ConfigService:
 
         if isinstance(conf, dict):
             return conf.get(name)
+        else:
+            return None
 
     @classmethod
     def _int_var(cls, name: str, conf=None, default=None):

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -499,7 +499,7 @@ class ServerRunner(FLComponent):
                 )
 
     def _handle_job_heartbeat(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:
-        self.log_info(fl_ctx, "received client job_heartbeat aux request")
+        self.log_debug(fl_ctx, "received client job_heartbeat")
         return make_reply(ReturnCode.OK)
 
     def _handle_task_check(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:

--- a/tests/unit_test/fuel/f3/communicator_test.py
+++ b/tests/unit_test/fuel/f3/communicator_test.py
@@ -86,6 +86,7 @@ class TestCommunicator:
             ("grpc", "3000-4000"),
             ("http", "4000-5000"),
             ("atcp", "5000-6000"),
+            ("nagrpc", "6000-7000"),
         ],
     )
     def test_sfm_message(self, comm_a, comm_b, scheme, port_range):

--- a/tests/unit_test/fuel/f3/drivers/custom_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/custom_driver_test.py
@@ -18,12 +18,14 @@ import pytest
 from nvflare.fuel.f3 import communicator
 
 # Setup custom driver path before communicator module initialization
+from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.utils.config_service import ConfigService
 
 
 class TestCustomDriver:
     @pytest.fixture
     def manager(self):
+        CommConfigurator.reset()
         rel_path = "../../../data/custom_drivers/config"
         config_path = os.path.normpath(os.path.join(os.path.dirname(__file__), rel_path))
         ConfigService.initialize({}, [config_path])

--- a/tests/unit_test/fuel/f3/drivers/driver_manager_test.py
+++ b/tests/unit_test/fuel/f3/drivers/driver_manager_test.py
@@ -20,6 +20,7 @@ from nvflare.fuel.f3.drivers.aio_grpc_driver import AioGrpcDriver
 from nvflare.fuel.f3.drivers.aio_http_driver import AioHttpDriver
 from nvflare.fuel.f3.drivers.aio_tcp_driver import AioTcpDriver
 from nvflare.fuel.f3.drivers.driver_manager import DriverManager
+from nvflare.fuel.f3.drivers.grpc_driver import GrpcDriver
 from nvflare.fuel.f3.drivers.tcp_driver import TcpDriver
 
 
@@ -37,6 +38,8 @@ class TestDriverManager:
             ("stcp", TcpDriver),
             ("grpc", AioGrpcDriver),
             ("grpcs", AioGrpcDriver),
+            ("nagrpc", GrpcDriver),
+            ("nagrpcs", GrpcDriver),
             ("http", AioHttpDriver),
             ("https", AioHttpDriver),
             ("ws", AioHttpDriver),

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -26,7 +26,6 @@ from cryptography.x509.oid import NameOID
 from nvflare.lighter.impl.cert import serialize_cert
 from nvflare.lighter.utils import sign_folders, verify_folder_signature
 
-
 folders = ["folder1", "folder2"]
 files = ["file1", "file2"]
 


### PR DESCRIPTION
Fixes # .

### Description

- Added exception handler for AIO event loop. This is necessary to gracefully shutdown AIO tasks that ran into exceptions.
- Ensure that the GRPC channel is closed only once to prevent potential exception.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
