### PR TITLE
Improve grpc 24

### DIFF
--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -44,6 +44,7 @@ from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.communicator import Communicator, MessageReceiver
 from nvflare.fuel.f3.connection import Connection
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
+from nvflare.fuel.f3.drivers.net_utils import enhance_credential_info
 from nvflare.fuel.f3.endpoint import Endpoint, EndpointMonitor, EndpointState
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.mpm import MainProcessMonitor
@@ -158,7 +159,7 @@ class _BulkSender:
 
     def queue_message(self, channel: str, topic: str, message: Message):
         if self.secure:
-            message.add_headers({MessageHeaderKey.SECURE, True})
+            message.add_headers({MessageHeaderKey.SECURE: True})
 
         encode_payload(message)
         self.cell.encrypt_payload(message)
@@ -370,6 +371,9 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         self.agent_lock = threading.Lock()
 
         self.logger.debug(f"Creating Cell: {self.my_info.fqcn}")
+
+        if credentials:
+            enhance_credential_info(credentials)
 
         ep = Endpoint(
             name=fqcn,

--- a/nvflare/fuel/f3/comm_config.py
+++ b/nvflare/fuel/f3/comm_config.py
@@ -113,3 +113,15 @@ class CommConfigurator:
 
     def get_streaming_read_timeout(self, default):
         return ConfigService.get_int_var(VarName.STREAMING_READ_TIMEOUT, self.config, default)
+
+    def get_int_var(self, name: str, default=None):
+        return ConfigService.get_int_var(name, self.config, default=default)
+
+    def get_float_var(self, name: str, default=None):
+        return ConfigService.get_float_var(name, self.config, default=default)
+
+    def get_bool_var(self, name: str, default=None):
+        return ConfigService.get_bool_var(name, self.config, default=default)
+
+    def get_str_var(self, name: str, default=None):
+        return ConfigService.get_str_var(name, self.config, default=default)

--- a/nvflare/fuel/f3/drivers/aio_context.py
+++ b/nvflare/fuel/f3/drivers/aio_context.py
@@ -42,10 +42,19 @@ class AioContext:
 
         return self.loop
 
+    def _handle_exception(self, loop, context):
+        try:
+            msg = context.get("exception", context["message"])
+            self.logger.debug(f"AIO Exception: {msg}")
+        except Exception as ex:
+            # ignore exception in the exception handler
+            self.logger.debug(f"exception in aio exception handler: {ex}")
+
     def run_aio_loop(self):
         self.logger.debug(f"{self.name}: started AioContext in thread {threading.current_thread().name}")
         # self.loop = asyncio.get_event_loop()
         self.loop = asyncio.new_event_loop()
+        self.loop.set_exception_handler(self._handle_exception)
         asyncio.set_event_loop(self.loop)
         self.logger.debug(f"{self.name}: got loop: {id(self.loop)}")
         self.ready.set()

--- a/nvflare/fuel/f3/drivers/grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/grpc_driver.py
@@ -68,12 +68,15 @@ class StreamConnection(Connection):
             if self.context:
                 try:
                     self.context.abort(grpc.StatusCode.CANCELLED, "service closed")
-                except:
+                except Exception as ex:
                     # ignore any exception when aborting
-                    pass
+                    self.logger.debug(f"exception aborting GRPC context: {secure_format_exception(ex)} ")
                 self.context = None
             if self.channel:
-                self.channel.close()
+                try:
+                    self.channel.close()
+                except Exception as ex:
+                    self.logger.debug(f"exception closing GRPC channel: {secure_format_exception(ex)} ")
                 self.channel = None
 
     def send_frame(self, frame: Union[bytes, bytearray, memoryview]):
@@ -85,7 +88,7 @@ class StreamConnection(Connection):
         except BaseException as ex:
             raise CommError(CommError.ERROR, f"Error sending frame: {ex}")
 
-    def read_loop(self, msg_iter, q: QQ):
+    def read_loop(self, msg_iter):
         ct = threading.current_thread()
         self.logger.debug(f"{self.side}: started read_loop in thread {ct.name}")
         try:
@@ -102,9 +105,9 @@ class StreamConnection(Connection):
         except Exception as ex:
             if not self.closing:
                 self.logger.debug(f"{self.side}: exception {type(ex)} in read_loop")
-        if q:
+        if self.oq:
             self.logger.debug(f"{self.side}: closing queue")
-            q.close()
+            self.oq.close()
         self.logger.debug(f"{self.side} in {ct.name}: done read_loop")
 
     def generate_output(self):
@@ -141,26 +144,19 @@ class Servicer(StreamerServicer):
             self.logger.debug(f"SERVER created connection in thread {ct.name}")
             self.server.driver.add_connection(connection)
             self.logger.debug(f"SERVER created read_loop thread in thread {ct.name}")
-            t = threading.Thread(target=connection.read_loop, args=(request_iterator, oq))
+            t = threading.Thread(target=connection.read_loop, args=(request_iterator,), daemon=True)
             t.start()
-
-            # DO NOT use connection.generate_output()!
-            self.logger.debug(f"SERVER: generate_output in thread {ct.name}")
-            for i in oq:
-                assert isinstance(i, Frame)
-                self.logger.debug(f"SERVER: outgoing frame #{i.seq}")
-                yield i
-            self.logger.debug(f"SERVER: done generate_output in thread {ct.name}")
-
-        except BaseException as ex:
-            self.logger.error(f"Connection closed due to error: {ex}")
+            yield from connection.generate_output()
+        except Exception as ex:
+            self.logger.error(f"Connection closed due to error: {secure_format_exception(ex)}")
         finally:
             if t is not None:
                 t.join()
             if connection:
+                connection.close()
                 self.logger.debug(f"SERVER: closing connection {connection.name}")
                 self.server.driver.close_connection(connection)
-            self.logger.debug(f"SERVER: cleanly finished Stream CB in thread {ct.name}")
+            self.logger.debug(f"SERVER: finished Stream CB in thread {ct.name}")
 
 
 class Server:
@@ -262,9 +258,9 @@ class GrpcDriver(BaseDriver):
         self.logger.debug("CLIENT: added connection")
         try:
             received = stub.Stream(connection.generate_output())
-            connection.read_loop(received, oq)
-        except BaseException as ex:
-            self.logger.info(f"CLIENT: connection done: {type(ex)}")
+            connection.read_loop(received)
+        except Exception as ex:
+            self.logger.info(f"CLIENT: connection done: {secure_format_exception(ex)}")
         connection.close()
         self.close_connection(connection)
         self.logger.info(f"CLIENT: finished connection {connection}")

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -39,7 +39,7 @@ from nvflare.security.logging import secure_format_exception, secure_format_trac
 FRAME_THREAD_POOL_SIZE = 100
 CONN_THREAD_POOL_SIZE = 16
 INIT_WAIT = 1
-MAX_WAIT = 60
+MAX_WAIT = 10
 SILENT_RECONNECT_TIME = 5
 SELF_ADDR = "0.0.0.0:0"
 

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -19,9 +19,9 @@ from typing import Callable, Dict, Tuple
 from nvflare.fuel.f3.cellnet.core_cell import CoreCell
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.cellnet.registry import Callback, Registry
+from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.connection import BytesAlike
 from nvflare.fuel.f3.message import Message
-from nvflare.fuel.f3.streaming.byte_streamer import ByteStreamer
 from nvflare.fuel.f3.streaming.stream_const import (
     EOS,
     STREAM_ACK_TOPIC,
@@ -91,7 +91,7 @@ class RxStream(Stream):
                 log.debug(f"Read block is unblocked multiple times: {count}")
 
             self.task.waiter.clear()
-            timeout = ByteStreamer.comm_config.get_streaming_read_timeout(READ_TIMEOUT)
+            timeout = CommConfigurator().get_streaming_read_timeout(READ_TIMEOUT)
             if not self.task.waiter.wait(timeout):
                 error = StreamError(f"{self.task} read timed out after {timeout} seconds")
                 self.byte_receiver.stop_task(self.task, error)
@@ -115,7 +115,7 @@ class RxStream(Stream):
 
             self.task.offset += len(result)
 
-            ack_interval = ByteStreamer.comm_config.get_streaming_ack_interval(ACK_INTERVAL)
+            ack_interval = CommConfigurator().get_streaming_ack_interval(ACK_INTERVAL)
             if not self.task.last_chunk_received and (self.task.offset - self.task.offset_ack > ack_interval):
                 # Send ACK
                 message = Message()
@@ -235,7 +235,7 @@ class ByteReceiver:
 
             else:
                 # Out-of-seq chunk reassembly
-                max_out_seq = ByteStreamer.comm_config.get_streaming_max_out_seq_chunks(MAX_OUT_SEQ_CHUNKS)
+                max_out_seq = CommConfigurator().get_streaming_max_out_seq_chunks(MAX_OUT_SEQ_CHUNKS)
                 if len(task.out_seq_buffers) >= max_out_seq:
                     self.stop_task(task, StreamError(f"Too many out-of-sequence chunks: {len(task.out_seq_buffers)}"))
                     return

--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -64,8 +64,6 @@ class TxTask:
 
 
 class ByteStreamer:
-    comm_config = CommConfigurator()
-
     def __init__(self, cell: CoreCell):
         self.cell = cell
         self.cell.register_request_cb(channel=STREAM_CHANNEL, topic=STREAM_ACK_TOPIC, cb=self._ack_handler)
@@ -74,7 +72,7 @@ class ByteStreamer:
 
     @staticmethod
     def get_chunk_size():
-        return ByteStreamer.comm_config.get_streaming_chunk_size(STREAM_CHUNK_SIZE)
+        return CommConfigurator().get_streaming_chunk_size(STREAM_CHUNK_SIZE)
 
     def send(
         self, channel: str, topic: str, target: str, headers: dict, stream: Stream, secure=False, optional=False
@@ -104,11 +102,11 @@ class ByteStreamer:
             # Flow control
             window = task.offset - task.offset_ack
             # It may take several ACKs to clear up the window
-            window_size = ByteStreamer.comm_config.get_streaming_window_size(STREAM_WINDOW_SIZE)
+            window_size = CommConfigurator().get_streaming_window_size(STREAM_WINDOW_SIZE)
             while window > window_size:
                 log.debug(f"{task} window size {window} exceeds limit: {window_size}")
                 task.ack_waiter.clear()
-                ack_wait = ByteStreamer.comm_config.get_streaming_ack_wait(STREAM_ACK_WAIT)
+                ack_wait = CommConfigurator().get_streaming_ack_wait(STREAM_ACK_WAIT)
                 if not task.ack_waiter.wait(timeout=ack_wait):
                     self._stop_task(task, StreamError(f"{task} ACK timeouts after {ack_wait} seconds"))
                     return

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 
 from nvflare.apis.executor import Executor
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import SystemConfigs
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.json_scanner import Node

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -141,7 +141,7 @@ class ClientJsonConfigurator(FedJsonConfigurator):
         )
 
         ConfigService.initialize(
-            section_files={SystemConfigs.APPLICATION_CONF: os.path.basename(self.config_files[0])},
+            section_files={},
             config_path=[self.app_root],
             parsed_args=self.args,
             var_dict=self.cmd_vars,

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import SystemConfigs
 from nvflare.apis.responder import Responder
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -163,7 +163,7 @@ class ServerJsonConfigurator(FedJsonConfigurator):
         )
 
         ConfigService.initialize(
-            section_files={SystemConfigs.APPLICATION_CONF: os.path.basename(self.config_files[0])},
+            section_files={},
             config_path=[self.app_root],
             parsed_args=self.args,
             var_dict=self.cmd_vars,

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -484,7 +484,7 @@ class ServerRunner(FLComponent):
                 )
 
     def _handle_job_heartbeat(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:
-        self.log_info(fl_ctx, "received client job_heartbeat aux request")
+        self.log_debug(fl_ctx, "received client job_heartbeat")
         return make_reply(ReturnCode.OK)
 
     def _handle_task_check(self, topic: str, request: Shareable, fl_ctx: FLContext) -> Shareable:


### PR DESCRIPTION
Fixes # .

### Description

This PR applies 2.3 enhancements to 2.4:
- Improve connection handling of GRPC drivers
- Set event loop's exception handler
- Reduce max wait for connection reconnect
- Enhance credential info
- Remove application conf section when initializing ConfigService. 
- Fixed byte_streamer to not create CommConfigurator during class creation, since the ConfigServer.initialize may not have been called!

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
