### PR TITLE
Fix cell and core cell

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -242,12 +242,13 @@ class Cell(StreamCell):
 
         # this future can be used to check sending progress, but not for checking return blob
         self.logger.debug(f"{req_id=}, {channel=}, {topic=}, {target=}, {timeout=}: send_request about to send_blob")
+
+        waiter = SimpleWaiter(req_id=req_id, result=make_reply(ReturnCode.TIMEOUT))
+        self.requests_dict[req_id] = waiter
         future = self.send_blob(
             channel=channel, topic=topic, target=target, message=request, secure=secure, optional=optional
         )
 
-        waiter = SimpleWaiter(req_id=req_id, result=make_reply(ReturnCode.TIMEOUT))
-        self.requests_dict[req_id] = waiter
         self.logger.debug(f"{req_id=}: Waiting starts")
 
         # Three stages, sending, waiting for receiving first byte, receiving

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -1124,6 +1124,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                 err = ReturnCode.MSG_TOO_BIG
             else:
                 direct_cell = self.ALL_CELLS.get(to_endpoint.name)
+                msg_size_mbs = self._msg_size_mbs(message)
                 if direct_cell:
                     # create a thread and fire the cell's process_message!
                     # self.DIRECT_MSG_EXECUTOR.submit(self._send_direct_message, direct_cell, message)
@@ -1131,9 +1132,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
                 else:
                     self.communicator.send(to_endpoint, CoreCell.APP_ID, message)
-                self.sent_msg_size_pool.record_value(
-                    category=self._stats_category(message), value=self._msg_size_mbs(message)
-                )
+                self.sent_msg_size_pool.record_value(category=self._stats_category(message), value=msg_size_mbs)
         except Exception as ex:
             err_text = f"Failed to send message to {to_endpoint.name}: {secure_format_exception(ex)}"
             self.log_error(err_text, message)


### PR DESCRIPTION
### Issue

1. There will be a racing condition if the "send_blob" return right away, so we need to setup the waiter first in cell.py
2. The "_msg_size_mbs" needs to be called before "self._send_direct_message" because "self._send_direct_message" will transform the bytes back to objects, then it will lead to "_msg_size_mbs" failed.

### Description

- Move setup waiter in the front of "send_blob" in cell.py
- Move _msg_size_mbs call in the front of "_send_direct_message" in core_cell.py

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
