### PR TITLE
Add None to is_primitive to support null in conf/json files

### DIFF
--- a/nvflare/tool/job/config/config_indexer.py
+++ b/nvflare/tool/job/config/config_indexer.py
@@ -143,7 +143,13 @@ def build_list_reverse_order_index(
 
 
 def is_primitive(value):
-    return isinstance(value, int) or isinstance(value, float) or isinstance(value, str) or isinstance(value, bool)
+    return (
+        isinstance(value, int)
+        or isinstance(value, float)
+        or isinstance(value, str)
+        or isinstance(value, bool)
+        or value is None
+    )
 
 
 def has_none_primitives_in_list(values: List):

--- a/tests/unit_test/tool/job/config/config_indexer_test.py
+++ b/tests/unit_test/tool/job/config/config_indexer_test.py
@@ -42,7 +42,6 @@ class TestConfigIndex:
         )
 
         config = CF.from_dict(config_dict)
-        root_key = KeyIndex(key="", value=config, parent_key=None)
         x_key = KeyIndex(key="x", value=config.get("x"), parent_key=None)
 
         x1_key = KeyIndex(key="x1", value=config.get("x").get("x1"), parent_key=x_key)
@@ -149,6 +148,7 @@ class TestConfigIndex:
                               "path": "df_statistics.DFStatistics",
                               "args": {
                                 "data_path": "data.csv"
+                                "other_path": null
                               }
                             },
                             {
@@ -164,8 +164,9 @@ class TestConfigIndex:
                     """
         conf = CF.parse_string(config_str)
         key_indices = build_dict_reverse_order_index(config=conf)
-        result = {}
         exclude_key_list = []
         result = filter_config_name_and_values(exclude_key_list, key_indices)
         key_index = result["data_path"]
         assert key_index.value == "data.csv"
+        key_index = result["other_path"]
+        assert key_index.value is None


### PR DESCRIPTION
If the json or conf file contains a value of null, for example:

```
{
  "a": 100,
  "b": null
}
```
We should be able to parse / substitute it easily.

Bugs found and suggested fix by @holgerroth 

### Description

- Add value is None to is_primitive method

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
