### PR TITLE
CLI Job upgrade, convert string to number if possible

### DIFF
--- a/nvflare/tool/job/config/configer.py
+++ b/nvflare/tool/job/config/configer.py
@@ -132,6 +132,17 @@ def split_array_key(key: str) -> Tuple:
         return parent, index, key
 
 
+def convert_to_number(value: str):
+    if not value:
+        return value
+    if value.isdigit():
+        return int(value)
+    elif value.replace(".", "").isdigit():
+        return float(value)
+    else:
+        return value
+
+
 def merge_configs(
     app_indices_configs: Dict[str, Dict[str, tuple]], app_cli_file_configs: Dict[str, Dict[str, Dict]]
 ) -> Dict[str, Dict[str, tuple]]:
@@ -158,6 +169,7 @@ def merge_configs(
                     cli_configs = cli_file_configs.get(basename, None)
                     if cli_configs:
                         for key, cli_value in cli_configs.items():
+                            cli_value = convert_to_number(cli_value)
                             if key not in key_indices:
                                 # not every client has app_config, app_script
                                 if key not in [APP_SCRIPT_KEY, APP_CONFIG_KEY]:


### PR DESCRIPTION
Fixes # .
 -f x=1 
x and 1 both are treated as string in the CLI Job command. This PR will convert "1" back to 1 if possible
 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
