### PR TITLE
Remove mlflow.utils.time_utils dependency.

### DIFF
--- a/nvflare/app_opt/tracking/mlflow/mlflow_receiver.py
+++ b/nvflare/app_opt/tracking/mlflow/mlflow_receiver.py
@@ -20,7 +20,6 @@ from typing import Dict, Optional
 import mlflow
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.tracking.client import MlflowClient
-from mlflow.utils.time_utils import get_current_time_millis
 
 from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
 from nvflare.apis.dxo import from_shareable
@@ -35,6 +34,10 @@ class MlflowConstants:
     EXPERIMENT_TAG = "experiment_tag"
     RUN_TAG = "run_tag"
     EXPERIMENT_NAME = "experiment_name"
+
+
+def get_current_time_millis():
+    return int(round(time.time() * 1000))
 
 
 class MLflowReceiver(AnalyticsReceiver):


### PR DESCRIPTION
Fixes # .
   https://github.com/NVIDIA/NVFlare/issues/2081

### Description

remove the get_current_time_mills with a local function

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
