### PR TITLE
Support graceful end_run processing

### DIFF
--- a/nvflare/apis/event_type.py
+++ b/nvflare/apis/event_type.py
@@ -22,6 +22,7 @@ class EventType(object):
     START_RUN = "_start_run"
     ABOUT_TO_END_RUN = "_about_to_end_run"
     END_RUN = "_end_run"
+    CHECK_END_RUN_READINESS = "_check_end_run_readiness"
     SWAP_IN = "_swap_in"
     SWAP_OUT = "_swap_out"
     START_WORKFLOW = "_start_workflow"

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -173,6 +173,7 @@ class FLContextKey(object):
     CONFIG_CTX = "__config_ctx__"
     FILTER_DIRECTION = "__filter_dir__"
     ROOT_URL = "__root_url__"  # the URL for accessing the FL Server
+    NOT_READY_TO_END_RUN = "not_ready_to_end_run__"  # component sets this to indicate it's not ready to end run yet
 
 
 class ReservedTopic(object):

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -430,9 +430,22 @@ class FilterKey:
 
 
 class ConfigVarName:
+    # These variables can be set in job config files (config_fed_server or config_fed_client)
+    RUNNER_SYNC_TIMEOUT = "runner_sync_timeout"  # client: runner sync message timeout
+    MAX_RUNNER_SYNC_TRIES = "max_runner_sync_tries"  # client: max number of runner sync attempts
+    TASK_CHECK_TIMEOUT = "task_check_timeout"  # client: timeout for task_check message (before submitting task)
 
-    RUNNER_SYNC_TIMEOUT = "runner_sync_timeout"
-    MAX_RUNNER_SYNC_TRIES = "max_runner_sync_tries"
+    # client: how long to wait before sending task_check again (if previous task_check fails)
+    TASK_CHECK_INTERVAL = "task_check_interval"
+
+    # client: how often to send job heartbeats
+    JOB_HEARTBEAT_INTERVAL = "job_heartbeat_interval"
+
+    # client and server: max time to wait for components to become ready for end-run
+    END_RUN_READINESS_TIMEOUT = "end_run_readiness_timeout"
+
+    # client and server: how long to wait before checking components end-run readiness again (if previous check fails)
+    END_RUN_READINESS_CHECK_INTERVAL = "end_run_readiness_check_interval"
 
 
 class SystemVarName:

--- a/nvflare/apis/fl_context.py
+++ b/nvflare/apis/fl_context.py
@@ -193,12 +193,12 @@ class FLContext(object):
             else:
                 return None
 
-    def remove_prop(self, key: str):
+    def remove_prop(self, key: str, force_removal=False):
         if not isinstance(key, str):
             return
 
-        if key.startswith("__"):
-            # do not allow removal of reserved props!
+        if key.startswith("__") and not force_removal:
+            # do not allow removal of reserved props unless forced!
             return
 
         with _update_lock:

--- a/nvflare/apis/fl_exception.py
+++ b/nvflare/apis/fl_exception.py
@@ -57,3 +57,9 @@ class TaskExecutionError(Exception):
     """Raised when a task execution failed"""
 
     pass
+
+
+class NotReadyToEndRun(Exception):
+    """Raised when a component is not ready to end run"""
+
+    pass

--- a/nvflare/fuel/utils/config_service.py
+++ b/nvflare/fuel/utils/config_service.py
@@ -229,8 +229,27 @@ class ConfigService:
         if env_var_name in os.environ:
             return os.environ.get(env_var_name)
 
-        if isinstance(conf, dict):
-            return conf.get(name)
+        if conf is None:
+            return None
+
+        # conf could be a single config source (a section name or a dict)
+        # conf could also be a list of config sources
+        if not isinstance(conf, list):
+            conf = [conf]
+
+        # check each conf source until the var is found
+        for src in conf:
+            if isinstance(src, str):
+                # this is a section name
+                src = cls.get_section(src)
+
+            if isinstance(src, dict):
+                v = src.get(name)
+                if v is not None:
+                    return v
+
+        # not found from any source
+        return None
 
     @classmethod
     def _int_var(cls, name: str, conf=None, default=None):

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -152,6 +152,7 @@ class ClientJsonConfigurator(FedJsonConfigurator):
             components=self.components,
             handlers=self.handlers,
             default_task_fetch_interval=self._default_task_fetch_interval,
+            config_data=self.config_data,
         )
 
         ConfigService.initialize(

--- a/nvflare/private/fed/client/client_json_config.py
+++ b/nvflare/private/fed/client/client_json_config.py
@@ -16,7 +16,7 @@ import re
 
 from nvflare.apis.executor import Executor
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import SystemVarName
+from nvflare.apis.fl_constant import SystemConfigs, SystemVarName
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.json_scanner import Node
@@ -152,7 +152,6 @@ class ClientJsonConfigurator(FedJsonConfigurator):
             components=self.components,
             handlers=self.handlers,
             default_task_fetch_interval=self._default_task_fetch_interval,
-            config_data=self.config_data,
         )
 
         ConfigService.initialize(
@@ -160,4 +159,9 @@ class ClientJsonConfigurator(FedJsonConfigurator):
             config_path=[self.app_root],
             parsed_args=self.args,
             var_dict=self.cmd_vars,
+        )
+
+        ConfigService.add_section(
+            section_name=SystemConfigs.APPLICATION_CONF,
+            data=self.config_data,
         )

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -29,6 +29,7 @@ from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.private.defs import SpecialTaskName, TaskConstant
 from nvflare.private.fed.client.client_engine_executor_spec import ClientEngineExecutorSpec, TaskAssignment
+from nvflare.private.fed.tbi import TBI
 from nvflare.private.json_configer import ConfigError
 from nvflare.private.privacy_manager import Scope
 from nvflare.security.logging import secure_format_exception
@@ -78,7 +79,6 @@ class ClientRunnerConfig(object):
         handlers=None,  # list of event handlers
         components=None,  # dict of extra python objects: id => object
         default_task_fetch_interval: float = 0.5,
-        config_data=None,
     ):
         """To init ClientRunnerConfig.
 
@@ -97,7 +97,6 @@ class ClientRunnerConfig(object):
         self.handlers = handlers
         self.components = components
         self.default_task_fetch_interval = default_task_fetch_interval
-        self.config_data = config_data
 
         if not components:
             self.components = {}
@@ -117,7 +116,7 @@ class ClientRunnerConfig(object):
             self.handlers.append(component)
 
 
-class ClientRunner(FLComponent):
+class ClientRunner(TBI):
     def __init__(
         self,
         config: ClientRunnerConfig,
@@ -132,7 +131,7 @@ class ClientRunner(FLComponent):
             engine: ClientEngine object
         """
 
-        FLComponent.__init__(self)
+        TBI.__init__(self)
         self.task_router = config.task_router
         self.task_data_filters = config.task_data_filters
         self.task_result_filters = config.task_result_filters
@@ -655,32 +654,9 @@ class ClientRunner(FLComponent):
             self.fire_event(EventType.ABOUT_TO_END_RUN, fl_ctx)
             self.log_info(fl_ctx, "ABOUT_TO_END_RUN fired")
 
-            # check with all components for their readiness to end run
-            # use ConfigService to determine max wait time for readiness check:
-            #   the job config could define variable "end_run_readiness_timeout"
-            #   the user could define OS env var NVFLARE_END_RUN_READINESS_TIMEOUT
-            max_wait = ConfigService.get_float_var(
-                name="end_run_readiness_timeout", conf=self.config.config_data, default=5.0
-            )
-            check_start_time = time.time()
-            while True:
-                fl_ctx.remove_prop(FLContextKey.NOT_READY_TO_END_RUN)
-                self.log_info(fl_ctx, "Firing CHECK_END_RUN_READINESS ...")
-                self.fire_event(EventType.CHECK_END_RUN_READINESS, fl_ctx)
-                any_component_not_ready = fl_ctx.get_prop(FLContextKey.NOT_READY_TO_END_RUN, False)
-                if any_component_not_ready:
-                    if time.time() - check_start_time > max_wait:
-                        # we have waited too long
-                        self.log_warning(
-                            fl_ctx, f"quit waiting for component ready-to-end-run after {max_wait} seconds"
-                        )
-                        break
-                    else:
-                        time.sleep(0.5)
-                else:
-                    # all components are ready to end
-                    break
+            self.check_end_run_readiness(fl_ctx)
 
+            # now ready to end run
             self.fire_event(EventType.END_RUN, fl_ctx)
             self.log_info(fl_ctx, "END_RUN fired")
 

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -15,7 +15,7 @@
 import re
 
 from nvflare.apis.fl_component import FLComponent
-from nvflare.apis.fl_constant import SystemVarName
+from nvflare.apis.fl_constant import SystemConfigs, SystemVarName
 from nvflare.apis.responder import Responder
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
@@ -173,7 +173,6 @@ class ServerJsonConfigurator(FedJsonConfigurator):
             task_result_filters=self.result_filter_table,
             components=self.components,
             handlers=self.handlers,
-            config_data=self.config_data,  # the config_data dict
         )
 
         ConfigService.initialize(
@@ -181,4 +180,9 @@ class ServerJsonConfigurator(FedJsonConfigurator):
             config_path=[self.app_root],
             parsed_args=self.args,
             var_dict=self.cmd_vars,
+        )
+
+        ConfigService.add_section(
+            section_name=SystemConfigs.APPLICATION_CONF,
+            data=self.config_data,
         )

--- a/nvflare/private/fed/server/server_json_config.py
+++ b/nvflare/private/fed/server/server_json_config.py
@@ -173,6 +173,7 @@ class ServerJsonConfigurator(FedJsonConfigurator):
             task_result_filters=self.result_filter_table,
             components=self.components,
             handlers=self.handlers,
+            config_data=self.config_data,  # the config_data dict
         )
 
         ConfigService.initialize(

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -498,7 +498,7 @@ class ServerRunner(TBI):
             self.log_error(fl_ctx, f"missing {ReservedHeaderKey.TASK_ID} in task_check request")
             return make_reply(ReturnCode.BAD_REQUEST_DATA)
 
-        self.log_info(fl_ctx, f"received task_check on task {task_id}")
+        self.log_debug(fl_ctx, f"received task_check on task {task_id}")
 
         with self.wf_lock:
             if self.current_wf is None or self.current_wf.responder is None:
@@ -507,7 +507,7 @@ class ServerRunner(TBI):
 
             task = self.current_wf.responder.process_task_check(task_id=task_id, fl_ctx=fl_ctx)
             if task:
-                self.log_info(fl_ctx, f"task {task_id} is still good")
+                self.log_debug(fl_ctx, f"task {task_id} is still good")
                 return make_reply(ReturnCode.OK)
             else:
                 self.log_info(fl_ctx, f"task {task_id} is not found")

--- a/nvflare/private/fed/server/server_runner.py
+++ b/nvflare/private/fed/server/server_runner.py
@@ -25,8 +25,8 @@ from nvflare.apis.shareable import ReservedHeaderKey, Shareable, make_reply
 from nvflare.apis.signal import Signal
 from nvflare.apis.utils.fl_context_utils import add_job_audit_event
 from nvflare.apis.utils.task_utils import apply_filters
-from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.private.defs import SpecialTaskName, TaskConstant
+from nvflare.private.fed.tbi import TBI
 from nvflare.private.privacy_manager import Scope
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
@@ -42,7 +42,6 @@ class ServerRunnerConfig(object):
         task_result_filters: dict,
         handlers=None,
         components=None,
-        config_data=None,
     ):
         """Configuration for ServerRunner.
 
@@ -62,7 +61,6 @@ class ServerRunnerConfig(object):
         self.task_result_filters = task_result_filters
         self.handlers = handlers
         self.components = components
-        self.config_data = config_data
 
     def add_component(self, comp_id: str, component: object):
         if not isinstance(comp_id, str):
@@ -76,7 +74,7 @@ class ServerRunnerConfig(object):
             self.handlers.append(component)
 
 
-class ServerRunner(FLComponent):
+class ServerRunner(TBI):
 
     ABORT_RETURN_CODES = [
         ReturnCode.RUN_MISMATCH,
@@ -92,7 +90,7 @@ class ServerRunner(FLComponent):
             job_id (str): The number to distinguish each experiment
             engine (ServerEngineSpec): server engine
         """
-        FLComponent.__init__(self)
+        TBI.__init__(self)
         self.job_id = job_id
         self.config = config
         self.engine = engine
@@ -207,33 +205,9 @@ class ServerRunner(FLComponent):
 
                         self.engine.persist_components(fl_ctx, completed=True)
 
-                    # check with all components for their readiness to end run
-                    # use ConfigService to determine max wait time for readiness check:
-                    #   the job config could define variable "end_run_readiness_timeout"
-                    #   the user could define OS env var NVFLARE_END_RUN_READINESS_TIMEOUT
-                    max_wait = ConfigService.get_float_var(
-                        name="end_run_readiness_timeout", conf=self.config.config_data, default=5.0
-                    )
-                    check_start_time = time.time()
-                    while True:
-                        fl_ctx.remove_prop(FLContextKey.NOT_READY_TO_END_RUN)
-                        self.log_info(fl_ctx, "Firing CHECK_END_RUN_READINESS ...")
-                        self.fire_event(EventType.CHECK_END_RUN_READINESS, fl_ctx)
-                        any_component_not_ready = fl_ctx.get_prop(FLContextKey.NOT_READY_TO_END_RUN, False)
-                        if any_component_not_ready:
-                            if time.time() - check_start_time > max_wait:
-                                # we have waited too long
-                                self.log_warning(
-                                    fl_ctx, f"quit waiting for component ready-to-end-run after {max_wait} seconds"
-                                )
-                                break
-                            else:
-                                time.sleep(0.5)
-                        else:
-                            # all components are ready to end
-                            break
+                    self.check_end_run_readiness(fl_ctx)
 
-                    # Now really end the run!
+                    # Now ready to end the run!
                     self.fire_event(EventType.END_RUN, fl_ctx)
                     self.log_info(fl_ctx, "END_RUN fired")
 

--- a/nvflare/private/fed/server/training_cmds.py
+++ b/nvflare/private/fed/server/training_cmds.py
@@ -219,6 +219,10 @@ class TrainingCommandModule(CommandModule, CommandUtil):
                 conn.append_error(err, meta={MetaKey.SERVER_STATUS: MetaStatusValue.ERROR, MetaKey.INFO: err})
             else:
                 conn.append_string("Server scheduled for restart", meta={MetaKey.SERVER_STATUS: MetaStatusValue.OK})
+
+                # ask the admin client to shut down since its current session will become invalid after
+                # the server is restarted.
+                conn.append_shutdown("Goodbye!")
         elif target_type == self.TARGET_TYPE_CLIENT:
             clients = conn.get_prop(self.TARGET_CLIENT_TOKENS)
             if not clients:

--- a/nvflare/private/fed/tbi.py
+++ b/nvflare/private/fed/tbi.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_component import FLComponent
+from nvflare.apis.fl_constant import FLContextKey, SystemConfigs
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.fl_exception import NotReadyToEndRun
+from nvflare.fuel.utils.config_service import ConfigService
+
+
+class TBI(FLComponent):
+
+    """(TBI) Task Based Interaction is the base class for ServerRunner and ClientRunner that implement details of
+    task based interactions.
+
+    TBI implements common behavior of ServerRunner and ClientRunner.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def _any_component_is_not_ready(self, fl_ctx: FLContext) -> bool:
+        any_component_not_ready = fl_ctx.get_prop(FLContextKey.NOT_READY_TO_END_RUN, False)
+
+        if any_component_not_ready:
+            self.log_debug(fl_ctx, "NOT_READY_TO_END_RUN property is set")
+            return True
+
+        # check any one has raised NotReadyToEndRun exception
+        exceptions = fl_ctx.get_prop(FLContextKey.EXCEPTIONS)
+        if isinstance(exceptions, dict):
+            for handler_name, ex in exceptions.items():
+                if isinstance(ex, NotReadyToEndRun):
+                    self.log_debug(fl_ctx, f"component {handler_name} is not ready to end run")
+                    return True
+        return False
+
+    def check_end_run_readiness(self, fl_ctx: FLContext):
+        """Check with all components for their readiness to end run
+
+        Args:
+            fl_ctx: the FL context
+
+        Returns:
+
+        """
+        default_max_wait = 5.0
+        default_check_interval = 0.5
+
+        # use ConfigService to determine max wait time for readiness check:
+        #   the job config could define variable "end_run_readiness_timeout"
+        #   the user could define OS env var NVFLARE_END_RUN_READINESS_TIMEOUT
+        max_wait = ConfigService.get_float_var(
+            name="end_run_readiness_timeout", conf=SystemConfigs.APPLICATION_CONF, default=default_max_wait
+        )
+        if max_wait <= 0:
+            max_wait = default_max_wait
+
+        # use ConfigService to determine interval for readiness check:
+        #   the job config could define variable "end_run_readiness_check_interval"
+        #   the user could define OS env var NVFLARE_END_RUN_READINESS_CHECK_INTERVAL
+        check_interval = ConfigService.get_float_var(
+            name="end_run_readiness_check_interval", conf=SystemConfigs.APPLICATION_CONF, default=default_check_interval
+        )
+        if check_interval <= 0:
+            check_interval = default_check_interval
+
+        self.log_debug(fl_ctx, f"=== end_run_readiness: {max_wait=} {check_interval=}")
+        check_start_time = time.time()
+        while True:
+            fl_ctx.remove_prop(FLContextKey.NOT_READY_TO_END_RUN, force_removal=True)
+            fl_ctx.remove_prop(FLContextKey.EXCEPTIONS, force_removal=True)
+
+            self.log_info(fl_ctx, "Firing CHECK_END_RUN_READINESS ...")
+            self.fire_event(EventType.CHECK_END_RUN_READINESS, fl_ctx)
+
+            if self._any_component_is_not_ready(fl_ctx):
+                if time.time() - check_start_time > max_wait:
+                    # we have waited too long
+                    self.log_warning(fl_ctx, f"quit waiting for component ready-to-end-run after {max_wait} seconds")
+                    return
+                else:
+                    time.sleep(check_interval)
+            else:
+                # all components are ready to end
+                return


### PR DESCRIPTION
Fixes # .

### Description

Currently when the server_runner reaches the end of the work (all workflows are done), it returns and causes the job processing to end immediately. This will cause all communications to stop. The client_runner has the same behavior.

This could be problematic if some components still have unfinished work (e.g. the ServerFedEventRunner may still have unprocessed incoming log records).

This PR tries to fix this potential hole:

- Before ending the process, the runner fires a new event EventType.CHECK_END_RUN_READINESS to "ask" all components whether they are ready to end the run. 
- A component listens to this event. In its event handler, if the component has unfinished work, it sets the FLContextKey.NOT_READY_TO_END_RUN property into the fl_context.
- The runner looks for the FLContextKey.NOT_READY_TO_END_RUN prop from fl_context after the event is done. If no component sets this prop, then everyone is ready to end run; otherwise the runner will wait for a while and then ask again.
- This process keeps repeating until all components are ready to end, or the configured "end_run_readiness_timeout" is reached.
- The ServerFedEventRunner is modified to handle EventType.CHECK_END_RUN_READINESS to ensure that the all incoming events are processed before ending the run.
- Changed to pass the job config data to the runner such that variables defined in the config could be used in the processing logic (e.g. the end_run_readiness_timeout could be defined in the config file).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
