### PR TITLE
Remove gen2 restriction from ad-hoc policy

### DIFF
--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -117,12 +117,13 @@ class ConnectorManager:
 
     def is_adhoc_allowed(self, c1: FqcnInfo, c2: FqcnInfo) -> bool:
         """
-        Is adhoc connection allowed between the two cells?
-        Args:
-            c1:
-            c2:
+        Is ad-hoc connection allowed between the two cells?
 
-        Returns:
+        Args:
+            c1: FQCN info of cell one
+            c2: FQCN info of cell two. c2 will offer listener if ad-hoc is allowed.
+
+        Returns: whether ad-hoc connection is allowed between the two cells
 
         """
         if not self.adhoc_allowed:
@@ -132,10 +133,7 @@ class ConnectorManager:
             # same family
             return False
 
-        # we only allow gen2 (or above) cells to directly connect
-        if c1.gen >= 2 and c2.gen >= 2:
-            return True
-        return False
+        return True
 
     @staticmethod
     def _validate_conn_config(config: dict, key: str) -> Union[None, dict]:


### PR DESCRIPTION
Fixes # .

### Description

Currently ad-hoc connections are only allowed between gen2 cells. With this restriction, the two endpoints of a CellPipe won't be able to communicate directly.

This PR removes this restriction.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
