### PR TITLE
support getTask and submitResult timeout in job config

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -447,6 +447,12 @@ class ConfigVarName:
     # client and server: how long to wait before checking components end-run readiness again (if previous check fails)
     END_RUN_READINESS_CHECK_INTERVAL = "end_run_readiness_check_interval"
 
+    # client: timeout for getTask requests
+    GET_TASK_TIMEOUT = "get_task_timeout"
+
+    # client: timeout for submitTaskResult requests
+    SUBMIT_TASK_RESULT_TIMEOUT = "submit_task_result_timeout"
+
 
 class SystemVarName:
     """

--- a/nvflare/private/fed/client/client_engine_executor_spec.py
+++ b/nvflare/private/fed/client/client_engine_executor_spec.py
@@ -46,11 +46,11 @@ class ClientEngineExecutorSpec(ClientEngineSpec, EngineSpec, ABC):
     """The ClientEngineExecutorSpec defines the ClientEngine APIs running in the child process."""
 
     @abstractmethod
-    def get_task_assignment(self, fl_ctx: FLContext) -> TaskAssignment:
+    def get_task_assignment(self, fl_ctx: FLContext, timeout=None) -> TaskAssignment:
         pass
 
     @abstractmethod
-    def send_task_result(self, result: Shareable, fl_ctx: FLContext) -> bool:
+    def send_task_result(self, result: Shareable, fl_ctx: FLContext, timeout=None) -> bool:
         pass
 
     @abstractmethod

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -114,8 +114,8 @@ class ClientRunManager(ClientEngineExecutorSpec):
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def get_task_assignment(self, fl_ctx: FLContext) -> TaskAssignment:
-        pull_success, task_name, return_shareable = self.client.fetch_task(fl_ctx)
+    def get_task_assignment(self, fl_ctx: FLContext, timeout=None) -> TaskAssignment:
+        pull_success, task_name, return_shareable = self.client.fetch_task(fl_ctx, timeout)
         task = None
         if pull_success:
             shareable = self.client.extract_shareable(return_shareable, fl_ctx)
@@ -126,8 +126,8 @@ class ClientRunManager(ClientEngineExecutorSpec):
     def new_context(self) -> FLContext:
         return self.fl_ctx_mgr.new_context()
 
-    def send_task_result(self, result: Shareable, fl_ctx: FLContext) -> bool:
-        push_result = self.client.push_results(result, fl_ctx)  # push task execution results
+    def send_task_result(self, result: Shareable, fl_ctx: FLContext, timeout=None) -> bool:
+        push_result = self.client.push_results(result, fl_ctx, timeout)  # push task execution results
         if push_result == CellReturnCode.OK:
             return True
         else:

--- a/nvflare/private/fed/client/client_runner.py
+++ b/nvflare/private/fed/client/client_runner.py
@@ -145,6 +145,8 @@ class ClientRunner(TBI):
         self.task_check_timeout = self.get_positive_float_var(ConfigVarName.TASK_CHECK_TIMEOUT, 5.0)
         self.task_check_interval = self.get_positive_float_var(ConfigVarName.TASK_CHECK_INTERVAL, 5.0)
         self.job_heartbeat_interval = self.get_positive_float_var(ConfigVarName.JOB_HEARTBEAT_INTERVAL, 30.0)
+        self.get_task_timeout = self.get_positive_float_var(ConfigVarName.GET_TASK_TIMEOUT, None)
+        self.submit_task_result_timeout = self.get_positive_float_var(ConfigVarName.SUBMIT_TASK_RESULT_TIMEOUT, None)
         self._register_aux_message_handlers(engine)
 
     def find_executor(self, task_name):
@@ -442,7 +444,7 @@ class ClientRunner(TBI):
         """
         default_task_fetch_interval = self.default_task_fetch_interval
         self.log_debug(fl_ctx, "fetching task from server ...")
-        task = self.engine.get_task_assignment(fl_ctx)
+        task = self.engine.get_task_assignment(fl_ctx, self.get_task_timeout)
 
         if not task:
             self.log_debug(fl_ctx, "no task received - will try in {} secs".format(default_task_fetch_interval))
@@ -513,7 +515,7 @@ class ClientRunner(TBI):
 
         # try to send the result
         self.log_info(fl_ctx, "start to send task result to server")
-        reply_sent = self.engine.send_task_result(result, fl_ctx)
+        reply_sent = self.engine.send_task_result(result, fl_ctx, timeout=self.submit_task_result_timeout)
         if reply_sent:
             self.log_info(fl_ctx, "task result sent to server")
             return _TASK_CHECK_RESULT_OK

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -152,15 +152,15 @@ class Communicator:
 
         return token, ssid
 
-    def pull_task(self, servers, project_name, token, ssid, fl_ctx: FLContext):
+    def pull_task(self, project_name, token, ssid, fl_ctx: FLContext, timeout=None):
         """Get a task from server.
 
         Args:
-            servers: FL servers
             project_name: FL study project name
             token: client token
             ssid: service session ID
             fl_ctx: FLContext
+            timeout: how long to wait for response from server
 
         Returns:
             A CurrentTask message from server
@@ -182,13 +182,16 @@ class Communicator:
         )
         job_id = str(shared_fl_ctx.get_prop(FLContextKey.CURRENT_RUN))
 
+        if not timeout:
+            timeout = self.timeout
+
         fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
         task = self.cell.send_request(
             target=fqcn,
             channel=CellChannel.SERVER_COMMAND,
             topic=ServerCommandNames.GET_TASK,
             request=task_message,
-            timeout=self.timeout,
+            timeout=timeout,
             optional=True,
         )
         end_time = time.time()
@@ -214,12 +217,11 @@ class Communicator:
         return task
 
     def submit_update(
-        self, servers, project_name, token, ssid, fl_ctx: FLContext, client_name, shareable, execute_task_name
+        self, project_name, token, ssid, fl_ctx: FLContext, client_name, shareable, execute_task_name, timeout=None
     ):
         """Submit the task execution result back to the server.
 
         Args:
-            servers: FL servers
             project_name: server project name
             token: client token
             ssid: service session ID
@@ -227,6 +229,7 @@ class Communicator:
             client_name: client name
             shareable: execution task result shareable
             execute_task_name: execution task name
+            timeout: how long to wait for response from server
 
         Returns:
             ReturnCode
@@ -255,13 +258,16 @@ class Communicator:
         )
         job_id = str(shared_fl_ctx.get_prop(FLContextKey.CURRENT_RUN))
 
+        if not timeout:
+            timeout = self.timeout
+
         fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
         result = self.cell.send_request(
             target=fqcn,
             channel=CellChannel.SERVER_COMMAND,
             topic=ServerCommandNames.SUBMIT_UPDATE,
             request=task_message,
-            timeout=self.timeout,
+            timeout=timeout,
             optional=optional,
         )
         end_time = time.time()

--- a/nvflare/private/fed/client/fed_client.py
+++ b/nvflare/private/fed/client/fed_client.py
@@ -80,10 +80,10 @@ class FederatedClient(FederatedClientBase):
 
         self.executors = executors
 
-    def fetch_task(self, fl_ctx: FLContext):
+    def fetch_task(self, fl_ctx: FLContext, timeout=None):
         fire_event(EventType.BEFORE_PULL_TASK, self.handlers, fl_ctx)
 
-        pull_success, task_name, shareable = self.pull_task(fl_ctx)
+        pull_success, task_name, shareable = self.pull_task(fl_ctx, timeout)
         fire_event(EventType.AFTER_PULL_TASK, self.handlers, fl_ctx)
         if task_name == SpecialTaskName.TRY_AGAIN:
             self.logger.debug(f"pull_task completed. Task name:{task_name} Status:{pull_success} ")

--- a/nvflare/private/fed/tbi.py
+++ b/nvflare/private/fed/tbi.py
@@ -39,12 +39,18 @@ class TBI(FLComponent):
         #   the job config could define variable var_name;
         #   the user could define OS env var NVFLARE_VAR_NAME (the var_name turned to uppercase)
         value = ConfigService.get_float_var(name=var_name, conf=SystemConfigs.APPLICATION_CONF, default=default)
-        return value if value > 0 else default
+        if value is None:
+            return default
+        else:
+            return value if value > 0.0 else default
 
     @staticmethod
     def get_positive_int_var(var_name, default):
         value = ConfigService.get_int_var(name=var_name, conf=SystemConfigs.APPLICATION_CONF, default=default)
-        return value if value > 0 else default
+        if value is None:
+            return default
+        else:
+            return value if value > 0 else default
 
     def _any_component_is_not_ready(self, fl_ctx: FLContext) -> bool:
         any_component_not_ready = fl_ctx.get_prop(FLContextKey.NOT_READY_TO_END_RUN, False)


### PR DESCRIPTION
Fixes # .

### Description

The timeout values for getTask and submitUpdate (task result) should/could be related to the task sizes of the job.

However, currently these timeout values can only be configured in "local/resources.json".  Since this file is for site admin to maintain and not accessible to end users, users won't be able to configure these values for their jobs. 

This PR makes it possible for the user to set the timeout values in config_fed_client.json of the job. If the values are not configured in config_fed_client.json, values from local/resources.json will be used.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
