### PR TITLE
Fixed the SystemVarName.SECURE_MODE error in simulator

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -444,8 +444,9 @@ class SimulatorRunner(FLComponent):
         )
         server_app_runner = SimulatorServerAppRunner(self.server)
         snapshot = None
+        kv_list = [f"secure_train={self.server.secure_train}"]
         server_app_runner.start_server_app(
-            workspace, self.args, app_server_root, self.args.job_id, snapshot, self.logger
+            workspace, self.args, app_server_root, self.args.job_id, snapshot, self.logger, kv_list=kv_list
         )
 
         # start = time.time()

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -74,6 +74,7 @@ class ClientAppRunner(Runner):
         fl_ctx = FLContext()
         self._set_fl_context(fl_ctx, app_root, args, workspace, secure_train)
         client_config_file_name = os.path.join(app_root, args.client_config)
+        args.set.append(f"secure_train={secure_train}")
         conf = ClientJsonConfigurator(
             config_file_name=client_config_file_name, app_root=app_root, args=args, kv_list=args.set
         )


### PR DESCRIPTION
Fixes # 

Fixed the SystemVarName.SECURE_MODE wrong value when running Simulator.

### Description

Set up the proper kv_list value in the server and client FedJsonConfigurator.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
