### PR TITLE
Fix meta file processing in storage and improve schedule job retrieval

### DIFF
--- a/nvflare/apis/impl/job_def_manager.py
+++ b/nvflare/apis/impl/job_def_manager.py
@@ -30,7 +30,7 @@ from nvflare.apis.storage import WORKSPACE, StorageException, StorageSpec
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.zip_utils import unzip_all_from_bytes, zip_directory_to_bytes
 
-_OBJ_MARK_SCHEDULED = "scheduled"
+_OBJ_TAG_SCHEDULED = "scheduled"
 
 
 class JobInfo:
@@ -99,7 +99,7 @@ class _ScheduleJobFilter(_JobFilter):
             self.result.append(job_from_meta(info.meta))
         elif status:
             # skip this job in all future calls (so the meta file of this job won't be read)
-            self.store.mark_object(uri=info.uri, mark=_OBJ_MARK_SCHEDULED)
+            self.store.tag_object(uri=info.uri, tag=_OBJ_TAG_SCHEDULED)
         return True
 
 
@@ -274,12 +274,12 @@ class SimpleJobDefManager(JobDefManagerSpec):
 
     def get_jobs_to_schedule(self, fl_ctx: FLContext) -> List[Job]:
         job_filter = _ScheduleJobFilter(self._get_job_store(fl_ctx))
-        self._scan(job_filter, fl_ctx, skip_mark=_OBJ_MARK_SCHEDULED)
+        self._scan(job_filter, fl_ctx, skip_tag=_OBJ_TAG_SCHEDULED)
         return job_filter.result
 
-    def _scan(self, job_filter: _JobFilter, fl_ctx: FLContext, skip_mark=None):
+    def _scan(self, job_filter: _JobFilter, fl_ctx: FLContext, skip_tag=None):
         store = self._get_job_store(fl_ctx)
-        obj_uris = store.list_objects(self.uri_root, skip_mark)
+        obj_uris = store.list_objects(self.uri_root, without_tag=skip_tag)
         self.log_debug(fl_ctx, f"objects to scan: {len(obj_uris)}")
         if not obj_uris:
             return

--- a/nvflare/apis/impl/job_def_manager.py
+++ b/nvflare/apis/impl/job_def_manager.py
@@ -293,7 +293,7 @@ class SimpleJobDefManager(JobDefManagerSpec):
                 if not ok:
                     break
 
-    def get_jobs_by_status(self, status, fl_ctx: FLContext) -> List[Job]:
+    def get_jobs_by_status(self, status: Union[RunStatus, List[RunStatus]], fl_ctx: FLContext) -> List[Job]:
         """Get jobs that are in the specified status
 
         Args:

--- a/nvflare/apis/job_def_manager_spec.py
+++ b/nvflare/apis/job_def_manager_spec.py
@@ -145,6 +145,17 @@ class JobDefManagerSpec(FLComponent, ABC):
         """
         pass
 
+    def get_jobs_to_schedule(self, fl_ctx: FLContext) -> List[Job]:
+        """Get job candidates for scheduling.
+
+        Args:
+            fl_ctx: FL context
+
+        Returns: list of jobs for scheduling
+
+        """
+        pass
+
     @abstractmethod
     def get_all_jobs(self, fl_ctx: FLContext) -> List[Job]:
         """Gets all Jobs in the system.
@@ -162,7 +173,7 @@ class JobDefManagerSpec(FLComponent, ABC):
         """Gets Jobs of a specified status.
 
         Args:
-            run_status (RunStatus): status to filter for
+            run_status (RunStatus): status to filter for: a single or a list of status values
             fl_ctx (FLContext): FLContext information
 
         Returns:

--- a/nvflare/apis/job_def_manager_spec.py
+++ b/nvflare/apis/job_def_manager_spec.py
@@ -169,11 +169,11 @@ class JobDefManagerSpec(FLComponent, ABC):
         pass
 
     @abstractmethod
-    def get_jobs_by_status(self, run_status: RunStatus, fl_ctx: FLContext) -> List[Job]:
+    def get_jobs_by_status(self, run_status: Union[RunStatus, List[RunStatus]], fl_ctx: FLContext) -> List[Job]:
         """Gets Jobs of a specified status.
 
         Args:
-            run_status (RunStatus): status to filter for: a single or a list of status values
+            run_status: status to filter for: a single or a list of status values
             fl_ctx (FLContext): FLContext information
 
         Returns:

--- a/nvflare/apis/job_def_manager_spec.py
+++ b/nvflare/apis/job_def_manager_spec.py
@@ -145,6 +145,7 @@ class JobDefManagerSpec(FLComponent, ABC):
         """
         pass
 
+    @abstractmethod
     def get_jobs_to_schedule(self, fl_ctx: FLContext) -> List[Job]:
         """Get job candidates for scheduling.
 

--- a/nvflare/apis/storage.py
+++ b/nvflare/apis/storage.py
@@ -97,12 +97,12 @@ class StorageSpec(ABC):
         pass
 
     @abstractmethod
-    def list_objects(self, path: str, skip_mark=None) -> List[str]:
+    def list_objects(self, path: str, without_tag=None) -> List[str]:
         """Lists all objects in the specified path.
 
         Args:
             path: the path to the objects
-            skip_mark: skip the objects with this specified mark
+            without_tag: skip the objects with this specified tag
 
         Returns:
             list of URIs of objects
@@ -188,13 +188,13 @@ class StorageSpec(ABC):
         pass
 
     @abstractmethod
-    def mark_object(self, uri: str, mark: str, data=None):
-        """Mark an object with specified mark and data
+    def tag_object(self, uri: str, tag: str, data=None):
+        """Tag an object with specified tag and data.
 
         Args:
             uri: URI of the object
-            mark: mark to be placed on the object
-            data: data associated with the mark.
+            tag: tag to be placed on the object
+            data: data associated with the tag.
 
         Returns: None
 

--- a/nvflare/apis/storage.py
+++ b/nvflare/apis/storage.py
@@ -97,11 +97,12 @@ class StorageSpec(ABC):
         pass
 
     @abstractmethod
-    def list_objects(self, path: str) -> List[str]:
+    def list_objects(self, path: str, skip_mark=None) -> List[str]:
         """Lists all objects in the specified path.
 
         Args:
             path: the path to the objects
+            skip_mark: skip the objects with this specified mark
 
         Returns:
             list of URIs of objects
@@ -182,6 +183,20 @@ class StorageSpec(ABC):
 
         Args:
             uri: URI of the object
+
+        """
+        pass
+
+    @abstractmethod
+    def mark_object(self, uri: str, mark: str, data=None):
+        """Mark an object with specified mark and data
+
+        Args:
+            uri: URI of the object
+            mark: mark to be placed on the object
+            data: data associated with the mark.
+
+        Returns: None
 
         """
         pass

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -395,9 +395,14 @@ class JobRunner(FLComponent):
             thread.start()
 
             while not self.ask_to_stop:
+                time.sleep(1.0)
                 if not isinstance(engine.server.server_state, HotState):
-                    time.sleep(1.0)
                     continue
+
+                if not engine.get_clients():
+                    # no clients registered yet - don't try to schedule!
+                    continue
+
                 approved_jobs = job_manager.get_jobs_to_schedule(fl_ctx)
                 self.log_debug(
                     fl_ctx, f"{fl_ctx.get_identity_name()} Got approved_jobs: {approved_jobs} from the job_manager"
@@ -477,9 +482,6 @@ class JobRunner(FLComponent):
                             self.log_error(
                                 fl_ctx, f"Failed to run the Job ({ready_job.job_id}): {secure_format_exception(e)}"
                             )
-
-                time.sleep(1.0)
-
             thread.join()
         else:
             self.log_error(fl_ctx, "There's no Job Manager defined. Won't be able to run the jobs.")

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -398,7 +398,7 @@ class JobRunner(FLComponent):
                 if not isinstance(engine.server.server_state, HotState):
                     time.sleep(1.0)
                     continue
-                approved_jobs = job_manager.get_jobs_by_status(RunStatus.SUBMITTED, fl_ctx)
+                approved_jobs = job_manager.get_jobs_to_schedule(fl_ctx)
                 self.log_debug(
                     fl_ctx, f"{fl_ctx.get_identity_name()} Got approved_jobs: {approved_jobs} from the job_manager"
                 )
@@ -543,12 +543,7 @@ class JobRunner(FLComponent):
 
     @staticmethod
     def _get_all_running_jobs(job_manager, fl_ctx):
-        all_jobs = []
-        dispatched_jobs = job_manager.get_jobs_by_status(RunStatus.DISPATCHED, fl_ctx)
-        all_jobs.extend(dispatched_jobs)
-        running_jobs = job_manager.get_jobs_by_status(RunStatus.RUNNING, fl_ctx)
-        all_jobs.extend(running_jobs)
-        return all_jobs
+        return job_manager.get_jobs_by_status([RunStatus.RUNNING, RunStatus.DISPATCHED], fl_ctx)
 
     def stop_run(self, job_id: str, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()

--- a/tests/unit_test/app_common/storages/storage_test.py
+++ b/tests/unit_test/app_common/storages/storage_test.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
 import json
 import os
 import random
+import string
 import tempfile
 from collections import defaultdict
 from pathlib import Path
@@ -42,7 +42,7 @@ def random_data():
 
 
 def random_meta():
-    return {random.getrandbits(8): random.getrandbits(8) for _ in range(32)}
+    return {random_string(20): random.getrandbits(8) for _ in range(32)}
 
 
 ROOT_DIR = os.path.abspath(os.sep)
@@ -95,7 +95,7 @@ class TestStorage:
 
                 with open(os.path.join(test_filepath, "meta"), "wb") as f:
                     meta = random_meta()
-                    f.write(json.dumps(str(meta)).encode("utf-8"))
+                    f.write(json.dumps(meta).encode("utf-8"))
 
                 storage.create_object(filepath, data, meta, overwrite_existing=True)
 
@@ -109,7 +109,7 @@ class TestStorage:
                 with open(os.path.join(test_dir_path, "data"), "rb") as f:
                     data = f.read()
                 with open(os.path.join(test_dir_path, "meta"), "rb") as f:
-                    meta = ast.literal_eval(json.loads(f.read().decode("utf-8")))
+                    meta = json.loads(f.read().decode("utf-8"))
 
                 assert storage.get_data(dir_path) == data
                 assert storage.get_detail(dir_path)[1] == data

--- a/tests/unit_test/app_common/storages/storage_test.py
+++ b/tests/unit_test/app_common/storages/storage_test.py
@@ -15,7 +15,6 @@
 import json
 import os
 import random
-import string
 import tempfile
 from collections import defaultdict
 from pathlib import Path


### PR DESCRIPTION
Fixes # .

### Description

This PR address the following issues:

- Currently the meta file stored in the job store could cause memory exhaustion since it uses ast.literal_eval to convert the content in meta file. This PR fixed this issue by using simple JSON files.
- The job scheduler retrieves job candidates for scheduling every second. This requires the scanning of the whole job store and reading each job's meta file. This is a lot of wasted processing since job's status never goes back to SUBMITTED. Added an enhancement such that if a job's status is not SUBMITTED, it will be skipped in future retrievals. 
- Improved job_runner to avoid wasted scheduling attempts when no clients are online. Not only the scheduling attempts are wasted, but it could also delay the scheduling of pending submitted jobs since it will consider the schedule failed and delay its scheduling.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
