### PR TITLE
Update job templates and README

### DIFF
--- a/examples/advanced/llm_hf/README.md
+++ b/examples/advanced/llm_hf/README.md
@@ -50,9 +50,10 @@ python3 ./utils/hf_sft_peft.py --output_path ./workspace_centralized/llama2-7b-d
 ### Pre: Launch Modes
 Before we start adapting the local training script to federated application, we first need to understand the launch modes of NVFlare client API.
 In our [client settings](../../../job_templates/sag_pt/config_fed_client.conf), we have two launch modes by switching the `--launch_once` flag:
-* If launch_once is true, the executor will only call launcher.launch_task once for the whole job
-* If launch_once is false, the executor will call launcher.launch_task everytime it receives a task from server
-So if it is false, the executor will create new objects every round. If it is true, the executor will reuse the same objects for all rounds.
+* If launch_once is true, the SubprocessLauncher will launch an external process once for the whole job
+* If launch_once is false, the SubprocessLauncher will launch an external process everytime it receives a task from server
+So if it is false, the SubprocessLauncher will create new processes every round.
+If it is true, the SubprocessLauncher will reuse the same process for all rounds.
 
 Turning `launch_once` to `false` can be useful in some scenarios like quick prototyping, but for the application of LLM where setup stage can take significant resources, we would want to only setup once. Hence, the below steps are for `launch_once = true` scenario.
 

--- a/examples/hello-world/step-by-step/cifar10/cse/cse.ipynb
+++ b/examples/hello-world/step-by-step/cifar10/cse/cse.ipynb
@@ -27,7 +27,7 @@
     "We will be using the [Client API FL code](../code/fl/train.py) trainer converted from the original [Training a Classifer](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html) example.\n",
     "\n",
     "Key changes when writing a FL code to support multiple tasks:\n",
-    "- When using the default `launch_once` Client API Launcher Executor parameter, we encapsulate our code in `while flare.is_running():` loop so we can call `flare.receive()` and perform various tasks. This is useful when launching everytime would be inefficient, such as when having to perform data setup every time.\n",
+    "- When using the default `launch_once` parameter of "SubprocessLauncher", we encapsulate our code in `while flare.is_running():` loop so we can call `flare.receive()` and perform various tasks. This is useful when launching everytime would be inefficient, such as when having to perform data setup every time.\n",
     "- We use `flare.is_train()`, `flare.is_evaluate()`, and `flare.is_submit_model()` for implementing the `train`, `validate`, and `submit_model` tasks depending on the mode.\n",
     "\n",
     "```\n",

--- a/examples/hello-world/step-by-step/cifar10/cse/cse.ipynb
+++ b/examples/hello-world/step-by-step/cifar10/cse/cse.ipynb
@@ -27,7 +27,7 @@
     "We will be using the [Client API FL code](../code/fl/train.py) trainer converted from the original [Training a Classifer](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html) example.\n",
     "\n",
     "Key changes when writing a FL code to support multiple tasks:\n",
-    "- When using the default `launch_once` parameter of "SubprocessLauncher", we encapsulate our code in `while flare.is_running():` loop so we can call `flare.receive()` and perform various tasks. This is useful when launching everytime would be inefficient, such as when having to perform data setup every time.\n",
+    "- When using the default `launch_once` parameter of `SubprocessLauncher`, we encapsulate our code in `while flare.is_running():` loop so we can call `flare.receive()` and perform various tasks. This is useful when launching everytime would be inefficient, such as when having to perform data setup every time.\n",
     "- We use `flare.is_train()`, `flare.is_evaluate()`, and `flare.is_submit_model()` for implementing the `train`, `validate`, and `submit_model` tasks depending on the mode.\n",
     "\n",
     "```\n",

--- a/job_templates/cyclic_cc_pt/config_fed_client.conf
+++ b/job_templates/cyclic_cc_pt/config_fed_client.conf
@@ -21,9 +21,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
 
@@ -49,11 +48,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -64,7 +58,7 @@
         # client-side controller for cyclic workflow
         path = "nvflare.app_common.ccwf.CyclicClientController"
         args {
-          # maps to the train task of the PTClientAPILauncherExecutor
+          # learn_task_name: needs to have an executor that handles this task
           learn_task_name = "train"
           persistor_id = "persistor"
           shareable_generator_id = "shareable_generator"
@@ -83,14 +77,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -103,10 +102,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
     # required components for the client-controlled workflow defined on client-side

--- a/job_templates/cyclic_cc_pt/config_fed_client.conf
+++ b/job_templates/cyclic_cc_pt/config_fed_client.conf
@@ -21,8 +21,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
 

--- a/job_templates/cyclic_cc_pt/info.md
+++ b/job_templates/cyclic_cc_pt/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-10-13"
-    last_updated_date = "2023-11-07" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/cyclic_pt/config_fed_client.conf
+++ b/job_templates/cyclic_pt/config_fed_client.conf
@@ -17,8 +17,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"

--- a/job_templates/cyclic_pt/config_fed_client.conf
+++ b/job_templates/cyclic_pt/config_fed_client.conf
@@ -17,9 +17,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -44,11 +43,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -62,14 +56,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -82,10 +81,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/cyclic_pt/config_fed_server.conf
+++ b/job_templates/cyclic_pt/config_fed_server.conf
@@ -31,7 +31,7 @@
         task_assignment_timeout = 8
         persistor_id = "persistor"
         shareable_generator_id = "shareable_generator"
-        # maps to the supported train task of the client-side PTClientAPILauncherExecutor
+        # task name: client side needs to have an executor that handles this task
         task_name = "train"
       }
     }

--- a/job_templates/cyclic_pt/info.md
+++ b/job_templates/cyclic_pt/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-10-13"
-    last_updated_date = "2023-11-07" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sag_cse_pt/config_fed_client.conf
+++ b/job_templates/sag_cse_pt/config_fed_client.conf
@@ -19,8 +19,8 @@
       ]
       executor {
         id = "Executor"
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
         args {
           # launcher_id is used to locate the Launcher object in "components"
           launcher_id = "launcher"

--- a/job_templates/sag_cse_pt/config_fed_client.conf
+++ b/job_templates/sag_cse_pt/config_fed_client.conf
@@ -19,9 +19,8 @@
       ]
       executor {
         id = "Executor"
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
         args {
           # launcher_id is used to locate the Launcher object in "components"
           launcher_id = "launcher"
@@ -38,10 +37,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
           # tasks for different modes
           train_task_name = "train"
           evaluate_task_name = "validate"
@@ -59,14 +54,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     },
     {
       id = "pipe"
@@ -80,9 +80,8 @@
         mode = "PASSIVE"
 
         # root_path: is the directory location of the parameters exchange.
-        # If empty string, it will be set to the app_dir of the running job.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sag_cse_pt/info.md
+++ b/job_templates/sag_cse_pt/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-11-06"
-    last_updated_date = "2023-11-06"
+    last_updated_date = "2023-12-01"

--- a/job_templates/sag_gnn/app_1/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_1/config_fed_client.conf
@@ -17,8 +17,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"

--- a/job_templates/sag_gnn/app_1/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_1/config_fed_client.conf
@@ -17,9 +17,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -44,11 +43,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -62,14 +56,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -82,10 +81,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sag_gnn/app_2/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_2/config_fed_client.conf
@@ -17,8 +17,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"

--- a/job_templates/sag_gnn/app_2/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_2/config_fed_client.conf
@@ -17,9 +17,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -44,11 +43,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -62,14 +56,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -82,10 +81,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sag_gnn/info.md
+++ b/job_templates/sag_gnn/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-10-31"
-    last_updated_date = "2023-11-07" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sag_nemo/app_1/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_1/config_fed_client.conf
@@ -20,8 +20,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -67,7 +67,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -m torch.distributed.run {ddp_config} custom/{app_script} {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_nemo/app_1/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_1/config_fed_client.conf
@@ -20,9 +20,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -47,11 +46,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -65,14 +59,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 -m torch.distributed.run {ddp_config} custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -85,10 +84,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sag_nemo/app_2/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_2/config_fed_client.conf
@@ -20,8 +20,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -67,7 +67,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -m torch.distributed.run {ddp_config} custom/{app_script} {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_nemo/app_2/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_2/config_fed_client.conf
@@ -20,9 +20,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -47,11 +46,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -65,14 +59,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 -m torch.distributed.run {ddp_config} custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -85,10 +84,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sag_nemo/app_3/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_3/config_fed_client.conf
@@ -20,8 +20,8 @@
       # This particular executor
       executor {
 
-        # This is an executor for Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
+        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -67,7 +67,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -m torch.distributed.run {ddp_config} custom/{app_script} {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_nemo/app_3/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_3/config_fed_client.conf
@@ -20,9 +20,8 @@
       # This particular executor
       executor {
 
-        # Executor name : PTClientAPILauncherExecutor
-        # This is an executor for pytorch + Client API. The underline data exchange is using Pipe.
-        path = "nvflare.app_opt.pt.client_api_launcher_executor.PTClientAPILauncherExecutor"
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_common.executors.client_api_launcher_executor.ClientAPILauncherExecutor"
 
         args {
           # launcher_id is used to locate the Launcher object in "components"
@@ -47,11 +46,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -65,14 +59,19 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 -m torch.distributed.run {ddp_config} custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -85,10 +84,9 @@
         # PASSIVE is the one listening.
         mode = "PASSIVE"
 
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sag_nemo/info.md
+++ b/job_templates/sag_nemo/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-10-24"
-    last_updated_date = "2023-11-07" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sag_np/config_fed_client.conf
+++ b/job_templates/sag_np/config_fed_client.conf
@@ -59,10 +59,10 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the name of component is SubprocessLauncher and path is the class path
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
       args {
@@ -81,7 +81,6 @@
       args {
         mode = "PASSIVE"
         # root_path: is the directory location of the parameters exchange.
-        # If empty string, it will be set to the app_dir of the running job.
         # You can also set it to an absolute path in your system.
         root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }

--- a/job_templates/sag_np/info.md
+++ b/job_templates/sag_np/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-09-11"
-    last_updated_date = "2023-11-29" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sag_np_cell_pipe/config_fed_client.conf
+++ b/job_templates/sag_np_cell_pipe/config_fed_client.conf
@@ -59,10 +59,10 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the name of component is SubprocessLauncher and path is the class path
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
       args {

--- a/job_templates/sag_np_cell_pipe/info.md
+++ b/job_templates/sag_np_cell_pipe/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-11-29"
-    last_updated_date = "2023-11-29" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sag_pt/config_fed_client.conf
+++ b/job_templates/sag_pt/config_fed_client.conf
@@ -56,10 +56,10 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
       args {
@@ -76,13 +76,8 @@
       path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
 
       args {
-        # Mode of the endpoint. A pipe has two endpoints.
-        # An endpoint can be either the one that initiates communication or the one listening.
-        # PASSIVE is the one listening.
         mode = "PASSIVE"
-
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
         root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }

--- a/job_templates/sag_pt/info.md
+++ b/job_templates/sag_pt/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-09-11"
-    last_updated_date = "2023-11-29" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sag_tf/config_fed_client.conf
+++ b/job_templates/sag_tf/config_fed_client.conf
@@ -47,14 +47,30 @@ task_data_filters = []
 task_result_filters = []
 components = [
   {
+    # component id is "launcher"
     id = "launcher"
+
+    # the class path of this component
     path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+
     args {
       # the launcher will invoke the script
       script = "python3 custom/{app_script}  {app_config} "
       # if launch_once is true, the SubprocessLauncher will launch once for the whole job
       # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
       launch_once = true
+    }
+  }
+  {
+    id = "pipe"
+
+    path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
+
+    args {
+      mode = "PASSIVE"
+      # root_path: is the directory location of the parameters exchange.
+      # You can also set it to an absolute path in your system.
+      root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
     }
   }
   {
@@ -72,22 +88,5 @@ components = [
     # convert a dict of {layer_name: layer.get_weights()} to flattened numpy dict
     path = "nvflare.app_opt.tf.params_converter.KerasModelToNumpyParamsConverter"
     args {}
-  }
-  {
-    id = "pipe"
-
-    path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
-
-    args {
-      # Mode of the endpoint. A pipe has two endpoints.
-      # An endpoint can be either the one that initiates communication or the one listening.
-      # PASSIVE is the one listening.
-      mode = "PASSIVE"
-
-      # root_path: is the directory location of the data exchange.
-      # If empty string, it will be set to the app_dir of the running job.
-      # You can also set it to an absolute path in your system.
-      root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
-    }
   }
 ]

--- a/job_templates/sag_tf/info.md
+++ b/job_templates/sag_tf/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-09-11"
-    last_updated_date = "2023-11-29" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sklearn_kmeans/config_fed_client.conf
+++ b/job_templates/sklearn_kmeans/config_fed_client.conf
@@ -44,11 +44,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -62,30 +57,30 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
-    }
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
+    },
     {
       id = "pipe"
 
       path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
 
       args {
-        # Mode of the endpoint. A pipe has two endpoints.
-        # An endpoint can be either the one that initiates communication or the one listening.
-        # PASSIVE is the one listening.
         mode = "PASSIVE"
-
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sklearn_kmeans/info.md
+++ b/job_templates/sklearn_kmeans/info.md
@@ -6,4 +6,4 @@
     controller_type = "server"
     contributor = "NVIDIA"
     init_publish_date = "2023-11-28"
-    last_updated_date = "2023-11-28" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sklearn_linear/config_fed_client.conf
+++ b/job_templates/sklearn_linear/config_fed_client.conf
@@ -62,30 +62,30 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
-    }
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
+    },
     {
       id = "pipe"
 
       path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
 
       args {
-        # Mode of the endpoint. A pipe has two endpoints.
-        # An endpoint can be either the one that initiates communication or the one listening.
-        # PASSIVE is the one listening.
         mode = "PASSIVE"
-
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sklearn_linear/info.md
+++ b/job_templates/sklearn_linear/info.md
@@ -6,4 +6,4 @@
     controller_type = "server"
     contributor = "NVIDIA"
     init_publish_date = "2023-11-17"
-    last_updated_date = "2023-11-28" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/sklearn_svm/config_fed_client.conf
+++ b/job_templates/sklearn_svm/config_fed_client.conf
@@ -62,30 +62,30 @@
 
   components =  [
     {
-      # This "launcher" component
+      # component id is "launcher"
       id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
-    }
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
+    },
     {
       id = "pipe"
 
       path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
 
       args {
-        # Mode of the endpoint. A pipe has two endpoints.
-        # An endpoint can be either the one that initiates communication or the one listening.
-        # PASSIVE is the one listening.
         mode = "PASSIVE"
-
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/sklearn_svm/info.md
+++ b/job_templates/sklearn_svm/info.md
@@ -6,4 +6,4 @@
     controller_type = "server"
     contributor = "NVIDIA"
     init_publish_date = "2023-11-28"
-    last_updated_date = "2023-11-28" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd

--- a/job_templates/swarm_cse_pt/config_fed_client.conf
+++ b/job_templates/swarm_cse_pt/config_fed_client.conf
@@ -29,10 +29,6 @@ executors = [
         # the custom code need to send back both the trained parameters and the evaluation metric
         # otherwise only trained parameters are expected
         train_with_evaluation = true
-        # if launch_once is true, the executor will only call launcher.launch_task once
-        # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-        # everytime it receives a task from server
-        launch_once = true
         # tasks for different modes
         train_task_name = "train"
         evaluate_task_name = "validate"
@@ -81,10 +77,18 @@ task_result_filters = []
 task_data_filters = []
 components = [
   {
+    # component id is "launcher"
     id = "launcher"
+
+    # the class path of this component
     path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+
     args {
-      script = "python3 custom/train.py"
+      # the launcher will invoke the script
+      script = "python3 custom/{app_script}  {app_config} "
+      # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+      # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+      launch_once = true
     }
   }
   {
@@ -93,15 +97,10 @@ components = [
     path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
 
     args {
-      # Mode of the endpoint. A pipe has two endpoints.
-      # An endpoint can be either the one that initiates communication or the one listening.
-      # PASSIVE is the one listening.
       mode = "PASSIVE"
-
       # root_path: is the directory location of the parameters exchange.
-      # If empty string, it will be set to the app_dir of the running job.
       # You can also set it to an absolute path in your system.
-      root_path = ""
+      root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
     }
   }
   {

--- a/job_templates/swarm_cse_pt/info.md
+++ b/job_templates/swarm_cse_pt/info.md
@@ -8,4 +8,4 @@
     executor_type = "launcher_executor"
     contributor = "NVIDIA"
     init_publish_date = "2023-09-18"
-    last_updated_date = "2023-11-06"
+    last_updated_date = "2023-12-01"

--- a/job_templates/xgboost_tree/config_fed_client.conf
+++ b/job_templates/xgboost_tree/config_fed_client.conf
@@ -44,11 +44,6 @@
           # the custom code need to send back both the trained parameters and the evaluation metric
           # otherwise only trained parameters are expected
           train_with_evaluation = true
-
-          # if launch_once is true, the executor will only call launcher.launch_task once
-          # for the whole job, if launch_once is false, the executor will call launcher.launch_task
-          # everytime it receives a task from server
-          launch_once = true
         }
       }
     }
@@ -62,14 +57,19 @@
 
   components =  [
     {
-      # This "launcher" component
-      id = "launcher"
+    # component id is "launcher"
+    id = "launcher"
 
-      # the class path of the component
+      # the class path of this component
       path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
 
-      # the launcher will invoke the script
-      args.script = "python3 custom/{app_script}  {app_config} "
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
     }
     {
       id = "pipe"
@@ -77,15 +77,10 @@
       path = "nvflare.fuel.utils.pipe.file_pipe.FilePipe"
 
       args {
-        # Mode of the endpoint. A pipe has two endpoints.
-        # An endpoint can be either the one that initiates communication or the one listening.
-        # PASSIVE is the one listening.
         mode = "PASSIVE"
-
-        # root_path: is the directory location of the data exchange.
-        # If empty string, it will be set to the app_dir of the running job.
+        # root_path: is the directory location of the parameters exchange.
         # You can also set it to an absolute path in your system.
-        root_path = ""
+        root_path = "{WORKSPACE}/{JOB_ID}/{SITE_NAME}"
       }
     }
   ]

--- a/job_templates/xgboost_tree/info.md
+++ b/job_templates/xgboost_tree/info.md
@@ -6,4 +6,4 @@
     controller_type = "server"
     contributor = "NVIDIA"
     init_publish_date = "2023-11-28"
-    last_updated_date = "2023-11-28" # yyyy-mm-dd
+    last_updated_date = "2023-12-01" # yyyy-mm-dd


### PR DESCRIPTION
### Description

Follow up PR of re-factoring PR https://github.com/NVIDIA/NVFlare/pull/2164

1. Add `Pipe` explanation in ml-to-fl/np/README.md

2. Two major changes to configs:
    - The "launch_once" argument is moved to "SubprocessLauncher", modify configs and READMEs accordingly
    - The "root_path" argument of "FilePipe" is changed from an empty string to "{WORKSPACE}/{JOB_ID}/{SITE_NAME}" follows PR https://github.com/NVIDIA/NVFlare/pull/2145, this is more clear to the users

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
