### PR TITLE
Fix meta file processing in storage and improve schedule job retrieval

### DIFF
--- a/nvflare/apis/impl/job_def_manager.py
+++ b/nvflare/apis/impl/job_def_manager.py
@@ -20,7 +20,7 @@ import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import Job, JobDataKey, JobMetaKey, job_from_meta
@@ -30,21 +30,34 @@ from nvflare.apis.storage import StorageException, StorageSpec
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.zip_utils import unzip_all_from_bytes, zip_directory_to_bytes
 
+_OBJ_TAG_SCHEDULED = "scheduled"
+
+
+class JobInfo:
+    def __init__(self, meta: dict, job_id: str, uri: str):
+        self.meta = meta
+        self.job_id = job_id
+        self.uri = uri
+
 
 class _JobFilter(ABC):
     @abstractmethod
-    def filter_job(self, meta: dict) -> bool:
+    def filter_job(self, info: JobInfo) -> bool:
         pass
 
 
 class _StatusFilter(_JobFilter):
     def __init__(self, status_to_check):
         self.result = []
+        if not isinstance(status_to_check, list):
+            # turning to list
+            status_to_check = [status_to_check]
         self.status_to_check = status_to_check
 
-    def filter_job(self, meta: dict):
-        if meta[JobMetaKey.STATUS] == self.status_to_check:
-            self.result.append(job_from_meta(meta))
+    def filter_job(self, info: JobInfo):
+        status = info.meta.get(JobMetaKey.STATUS.value)
+        if status in self.status_to_check:
+            self.result.append(job_from_meta(info.meta))
         return True
 
 
@@ -52,25 +65,42 @@ class _AllJobsFilter(_JobFilter):
     def __init__(self):
         self.result = []
 
-    def filter_job(self, meta: dict):
-        self.result.append(job_from_meta(meta))
+    def filter_job(self, info: JobInfo):
+        self.result.append(job_from_meta(info.meta))
         return True
 
 
 class _ReviewerFilter(_JobFilter):
-    def __init__(self, reviewer_name, fl_ctx: FLContext):
+    def __init__(self, reviewer_name):
         """Not used yet, for use in future implementations."""
         self.result = []
         self.reviewer_name = reviewer_name
 
-    def filter_job(self, meta: dict):
-        approvals = meta.get(JobMetaKey.APPROVALS)
+    def filter_job(self, info: JobInfo):
+        approvals = info.meta.get(JobMetaKey.APPROVALS)
         if not approvals or self.reviewer_name not in approvals:
-            self.result.append(job_from_meta(meta))
+            self.result.append(job_from_meta(info.meta))
         return True
 
 
-# TODO:: use try block around storage calls
+class _ScheduleJobFilter(_JobFilter):
+
+    """
+    This filter is optimized for selecting jobs to schedule since it is used so frequently (every 1 sec).
+    """
+
+    def __init__(self, store):
+        self.store = store
+        self.result = []
+
+    def filter_job(self, info: JobInfo):
+        status = info.meta.get(JobMetaKey.STATUS.value)
+        if status == RunStatus.SUBMITTED.value:
+            self.result.append(job_from_meta(info.meta))
+        elif status:
+            # skip this job in all future calls (so the meta file of this job won't be read)
+            self.store.tag_object(uri=info.uri, tag=_OBJ_TAG_SCHEDULED)
+        return True
 
 
 class SimpleJobDefManager(JobDefManagerSpec):
@@ -217,28 +247,40 @@ class SimpleJobDefManager(JobDefManagerSpec):
         self._scan(job_filter, fl_ctx)
         return job_filter.result
 
-    def _scan(self, job_filter: _JobFilter, fl_ctx: FLContext):
+    def get_jobs_to_schedule(self, fl_ctx: FLContext) -> List[Job]:
+        job_filter = _ScheduleJobFilter(self._get_job_store(fl_ctx))
+        self._scan(job_filter, fl_ctx, skip_tag=_OBJ_TAG_SCHEDULED)
+        return job_filter.result
+
+    def _scan(self, job_filter: _JobFilter, fl_ctx: FLContext, skip_tag=None):
         store = self._get_job_store(fl_ctx)
-        jid_paths = store.list_objects(self.uri_root)
-        if not jid_paths:
+        obj_uris = store.list_objects(self.uri_root, without_tag=skip_tag)
+        self.log_debug(fl_ctx, f"objects to scan: {len(obj_uris)}")
+        if not obj_uris:
             return
 
-        for jid_path in jid_paths:
-            jid = pathlib.PurePath(jid_path).name
-
-            meta = store.get_meta(self.job_uri(jid))
+        for uri in obj_uris:
+            jid = pathlib.PurePath(uri).name
+            job_uri = self.job_uri(jid)
+            meta = store.get_meta(job_uri)
             if meta:
-                ok = job_filter.filter_job(meta)
+                ok = job_filter.filter_job(JobInfo(meta, jid, job_uri))
                 if not ok:
                     break
 
-    def get_jobs_by_status(self, status, fl_ctx: FLContext) -> List[Job]:
+    def get_jobs_by_status(self, status: Union[RunStatus, List[RunStatus]], fl_ctx: FLContext) -> List[Job]:
+        """Get jobs that are in the specified status
+        Args:
+            status: a single status value or a list of status values
+            fl_ctx: the FL context
+        Returns: list of jobs that are in specified status
+        """
         job_filter = _StatusFilter(status)
         self._scan(job_filter, fl_ctx)
         return job_filter.result
 
     def get_jobs_waiting_for_review(self, reviewer_name: str, fl_ctx: FLContext) -> List[Job]:
-        job_filter = _ReviewerFilter(reviewer_name, fl_ctx)
+        job_filter = _ReviewerFilter(reviewer_name)
         self._scan(job_filter, fl_ctx)
         return job_filter.result
 

--- a/nvflare/apis/job_def_manager_spec.py
+++ b/nvflare/apis/job_def_manager_spec.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_context import FLContext
@@ -136,6 +136,15 @@ class JobDefManagerSpec(FLComponent, ABC):
         pass
 
     @abstractmethod
+    def get_jobs_to_schedule(self, fl_ctx: FLContext) -> List[Job]:
+        """Get job candidates for scheduling.
+        Args:
+            fl_ctx: FL context
+        Returns: list of jobs for scheduling
+        """
+        pass
+
+    @abstractmethod
     def get_all_jobs(self, fl_ctx: FLContext) -> List[Job]:
         """Gets all Jobs in the system.
 
@@ -148,11 +157,11 @@ class JobDefManagerSpec(FLComponent, ABC):
         pass
 
     @abstractmethod
-    def get_jobs_by_status(self, run_status: RunStatus, fl_ctx: FLContext) -> List[Job]:
+    def get_jobs_by_status(self, run_status: Union[RunStatus, List[RunStatus]], fl_ctx: FLContext) -> List[Job]:
         """Gets Jobs of a specified status.
 
         Args:
-            run_status (RunStatus): status to filter for
+            run_status (RunStatus): status to filter for: a single or a list of status values
             fl_ctx (FLContext): FLContext information
 
         Returns:

--- a/nvflare/apis/storage.py
+++ b/nvflare/apis/storage.py
@@ -90,11 +90,12 @@ class StorageSpec(ABC):
         pass
 
     @abstractmethod
-    def list_objects(self, path: str) -> List[str]:
+    def list_objects(self, path: str, without_tag=None) -> List[str]:
         """Lists all objects in the specified path.
 
         Args:
             path: the path to the objects
+            without_tag: skip the objects with this specified tag
 
         Returns:
             list of URIs of objects
@@ -160,5 +161,17 @@ class StorageSpec(ABC):
         Args:
             uri: URI of the object
 
+        """
+        pass
+
+    @abstractmethod
+    def tag_object(self, uri: str, tag: str, data=None):
+        """Tag an object with specified tag and data.
+        Args:
+            uri: URI of the object
+            tag: tag to be placed on the object
+            data: data associated with the tag.
+
+        Returns: None
         """
         pass

--- a/nvflare/app_common/storages/filesystem_storage.py
+++ b/nvflare/app_common/storages/filesystem_storage.py
@@ -297,6 +297,15 @@ class FilesystemStorage(StorageSpec):
         return full_uri
 
     def tag_object(self, uri: str, tag: str, data=None):
+        """Tag an object with specified tag and data.
+
+        Args:
+            uri: URI of the object
+            tag: tag to be placed on the object
+            data: data associated with the tag.
+
+        Returns: None
+        """
         full_path = self._object_path(uri)
         mark_file = os.path.join(full_path, tag)
         with open(mark_file, "w") as f:

--- a/nvflare/app_common/storages/s3_storage.py
+++ b/nvflare/app_common/storages/s3_storage.py
@@ -179,11 +179,12 @@ class S3Storage(StorageSpec):
         except MinioException as e:
             raise StorageException("error putting object into bucket: {}".format(secure_format_exception(e)))
 
-    def list_objects(self, path: str) -> List[str]:
+    def list_objects(self, path: str, without_tag=None) -> List[str]:
         """List all objects in the specified path.
 
         Args:
             path: the path to the objects
+            without_tag: skip the objects with this specified tag
 
         Returns:
             list of URIs of objects
@@ -292,3 +293,14 @@ class S3Storage(StorageSpec):
             self.s3_client.remove_object(self.bucket_name, uri)
         except MinioException as e:
             raise StorageException(f"error removing object ({uri}): {secure_format_exception(e)}.")
+
+    def tag_object(self, uri: str, tag: str, data=None):
+        """Tag an object with specified tag and data.
+        Args:
+            uri: URI of the object
+            tag: tag to be placed on the object
+            data: data associated with the tag.
+
+        Returns: None
+        """
+        pass

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -324,8 +324,8 @@ class JobRunner(FLComponent):
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
         if job_manager:
             while not self.ask_to_stop:
-                # approved_jobs = job_manager.get_jobs_by_status(RunStatus.APPROVED, fl_ctx)
-                approved_jobs = job_manager.get_jobs_by_status(RunStatus.SUBMITTED, fl_ctx)
+                time.sleep(1.0)
+                approved_jobs = job_manager.get_jobs_to_schedule(fl_ctx)
                 if self.scheduler:
                     (ready_job, sites) = self.scheduler.schedule_job(job_candidates=approved_jobs, fl_ctx=fl_ctx)
                     if ready_job:
@@ -376,8 +376,6 @@ class JobRunner(FLComponent):
                                 self.log_error(
                                     fl_ctx, f"Failed to run the Job ({ready_job.job_id}): {secure_format_exception(e)}"
                                 )
-
-                time.sleep(1.0)
         else:
             self.log_error(fl_ctx, "There's no Job Manager defined. Won't be able to run the jobs.")
 

--- a/tests/unit_test/app_common/storages/storage_test.py
+++ b/tests/unit_test/app_common/storages/storage_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
 import json
 import os
 import random
@@ -42,7 +41,7 @@ def random_data():
 
 
 def random_meta():
-    return {random.getrandbits(8): random.getrandbits(8) for _ in range(32)}
+    return {random_string(20): random.getrandbits(8) for _ in range(32)}
 
 
 ROOT_DIR = os.path.abspath(os.sep)
@@ -95,7 +94,7 @@ class TestStorage:
 
                 with open(os.path.join(test_filepath, "meta"), "wb") as f:
                     meta = random_meta()
-                    f.write(json.dumps(str(meta)).encode("utf-8"))
+                    f.write(json.dumps(meta).encode("utf-8"))
 
                 storage.create_object(filepath, data, meta, overwrite_existing=True)
 
@@ -109,7 +108,7 @@ class TestStorage:
                 with open(os.path.join(test_dir_path, "data"), "rb") as f:
                     data = f.read()
                 with open(os.path.join(test_dir_path, "meta"), "rb") as f:
-                    meta = ast.literal_eval(json.loads(f.read().decode("utf-8")))
+                    meta = json.loads(f.read().decode("utf-8"))
 
                 assert storage.get_data(dir_path) == data
                 assert storage.get_detail(dir_path)[1] == data


### PR DESCRIPTION
Fixes # .

### Description

This is the same as PR https://github.com/NVIDIA/NVFlare/pull/2186, but applied to 2.2:

- Currently the meta file stored in the job store could cause memory exhaustion since it uses ast.literal_eval to convert the content in meta file. This PR fixed this issue by using simple JSON files.
- The job scheduler retrieves job candidates for scheduling every second. This requires the scanning of the whole job store and reading each job's meta file. This is a lot of wasted processing since job's status never goes back to SUBMITTED. Added an enhancement such that if a job's status is not SUBMITTED, it will be skipped in future retrievals.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
