### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -359,7 +359,7 @@ with an overseer, server, two clients, and one admin client:
 
 .. code-block:: shell
 
-    $ nvflare poc prepare -n 2
+    $ nvflare poc --prepare -n 2
 
 For more details, see :ref:`poc_command`.
 
@@ -373,12 +373,12 @@ to start the server and client systems and an admin console:
 
 .. code-block::
 
-  nvflare poc start
+  nvflare poc --start
 
 To start the server and client systems without an admin console:
 
 .. code-block::
 
-  nvflare poc start -ex admin@nvidia.com
+  nvflare poc --start -ex admin@nvidia.com
 
 For more details, see :ref:`poc_command`.


### PR DESCRIPTION
Fixes # .

### Description

The commands for POC start and prepare were not listed correctly.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
