### PR TITLE
Fix LauncherExecutor racing issue

### DIFF
--- a/nvflare/app_common/executors/task_exchanger.py
+++ b/nvflare/app_common/executors/task_exchanger.py
@@ -245,6 +245,7 @@ class TaskExchanger(Executor):
     def pause_pipe_handler(self):
         """Stops pipe_handler heartbeat."""
         self.pipe_handler.pause()
+        self.clear_pipe()
 
     def resume_pipe_handler(self):
         """Resumes pipe_handler heartbeat."""


### PR DESCRIPTION
In the current code, the `LauncherExecutor` will remove the pipe directory when it see fits.
This is wrong, we move this logic to `TaskExchanger`'s `pause_pipe_handler` method (where it cleans up the old content)
And we add lock to prevent racing condition of `self._job_end` and `self._received_result`

### Description

- Move `self.clear_pipe()` to `TaskExchanger`'s `pause_pipe_handler` method
- Add and use lock when setting/unsetting `self._job_end` and `self._received_result`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
