### PR TITLE
Lightning api: add strict option for load_state_dict

### DIFF
--- a/nvflare/app_opt/lightning/api.py
+++ b/nvflare/app_opt/lightning/api.py
@@ -37,8 +37,16 @@ from .callbacks import RestoreState
 FL_META_KEY = "__fl_meta__"
 
 
-def patch(trainer: pl.Trainer, restore_state: bool = True):
-    fl_callback = FLCallback(rank=trainer.global_rank)
+def patch(trainer: pl.Trainer, restore_state: bool = True, load_state_dict_strict: bool = True):
+    """Patch the lightning trainer for usage with NVFlare.
+
+    Args:
+        trainer: the PyTorch Lightning trainer.
+        restore_state: whether to restore optimizer and learning rate scheduler states. Defaults to `True`.
+        load_state_dict_strict: exposes `strict` argument of `torch.nn.Module.load_state_dict()` used load the received model. Defaults to `True`.
+        See https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.load_state_dict for details.
+    """
+    fl_callback = FLCallback(rank=trainer.global_rank, load_state_dict_strict=load_state_dict_strict)
     callbacks = trainer.callbacks
     if isinstance(callbacks, list):
         callbacks.append(fl_callback)
@@ -54,7 +62,14 @@ def patch(trainer: pl.Trainer, restore_state: bool = True):
 
 
 class FLCallback(Callback):
-    def __init__(self, rank: int = 0):
+    def __init__(self, rank: int = 0, load_state_dict_strict: bool = True):
+        """FL callback for lightning API.
+
+        Args:
+            rank: global rank of the PyTorch Lightning trainer.
+            load_state_dict_strict: exposes `strict` argument of `torch.nn.Module.load_state_dict()` used load the received model. Defaults to `True`.
+            See https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.load_state_dict for details.
+        """
         super(FLCallback, self).__init__()
         init(rank=str(rank))
         self.train_with_evaluation = get_config().get(ConfigKey.TRAIN_WITH_EVAL, False)
@@ -68,6 +83,7 @@ class FLCallback(Callback):
         self._is_training = False
         self._is_evaluation = False
         self._is_submit_model = False
+        self._load_state_dict_strict = load_state_dict_strict
 
     def reset_state(self, trainer):
         """Resets the state.
@@ -144,7 +160,7 @@ class FLCallback(Callback):
         model = self._receive_model(trainer)
         if model:
             if model.params:
-                pl_module.load_state_dict(model.params)
+                pl_module.load_state_dict(model.params, strict=self._load_state_dict_strict)
             if model.current_round is not None:
                 self.current_round = model.current_round
 


### PR DESCRIPTION
Fixes # .

### Description

Add an option for setting the `strict` option in load_state_dict() when the global model is loaded. For example, `strict=False` is needed in case personalization techniques are used where the global state dict might not contain all keys of the client model.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
