### PR TITLE
Don't run init() twice

### DIFF
--- a/nvflare/client/api.py
+++ b/nvflare/client/api.py
@@ -79,7 +79,8 @@ def init(
         rank = os.environ.get("RANK", "0")
 
     if PROCESS_MODEL_REGISTRY:
-        raise RuntimeError("Can't call init twice.")
+        print("Warning: called init() more than once. The subsequence calls are ignored")
+        return
 
     client_config = _create_client_config(config=config)
 


### PR DESCRIPTION
Fixes # .

### Description

Avoid running init() twice. A warning will be printed `Warning: called init() more than once. The subsequence calls are ignored`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
