### PR TITLE
Fix stats global key bug

### DIFF
--- a/nvflare/app_common/workflows/statistics_controller.py
+++ b/nvflare/app_common/workflows/statistics_controller.py
@@ -420,8 +420,8 @@ class StatisticsController(Controller):
                         buckets = StatisticsController._apply_histogram_precision(hist.bins, self.precision)
                         result[feature_name][statistic][StC.GLOBAL][ds] = buckets
                     else:
-                        result[feature_name][statistic].update(
-                            {StC.GLOBAL: {ds: round(self.global_statistics[statistic][ds][feature_name], precision)}}
+                        result[feature_name][statistic][StC.GLOBAL].update(
+                            {ds: round(self.global_statistics[statistic][ds][feature_name], precision)}
                         )
 
         return result


### PR DESCRIPTION
Prevent `{StC.GLOBAL: {ds:` from being overwritten in `update()`

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
