### PR TITLE
Add fl_ctx in convert method of ParamsConverter

### DIFF
--- a/nvflare/app_common/abstract/params_converter.py
+++ b/nvflare/app_common/abstract/params_converter.py
@@ -24,10 +24,10 @@ from nvflare.apis.shareable import Shareable
 class ParamsConverter(Filter, ABC):
     def process(self, shareable: Shareable, fl_ctx: FLContext) -> Shareable:
         dxo = from_shareable(shareable)
-        dxo.data = self.convert(dxo.data)
+        dxo.data = self.convert(dxo.data, fl_ctx)
         dxo.update_shareable(shareable)
         return shareable
 
     @abstractmethod
-    def convert(self, params: Any) -> Any:
+    def convert(self, params: Any, fl_ctx: FLContext) -> Any:
         pass

--- a/nvflare/app_opt/pt/params_converter.py
+++ b/nvflare/app_opt/pt/params_converter.py
@@ -20,10 +20,10 @@ from nvflare.app_common.abstract.params_converter import ParamsConverter
 
 
 class NumpyToPTParamsConverter(ParamsConverter):
-    def convert(self, params: Dict) -> Dict:
+    def convert(self, params: Dict, fl_ctx) -> Dict:
         return {k: torch.as_tensor(v) for k, v in params.items()}
 
 
 class PTToNumpyParamsConverter(ParamsConverter):
-    def convert(self, params: Dict) -> Dict:
+    def convert(self, params: Dict, fl_ctx) -> Dict:
         return {k: v.cpu().numpy() for k, v in params.items()}

--- a/nvflare/app_opt/tf/params_converter.py
+++ b/nvflare/app_opt/tf/params_converter.py
@@ -24,7 +24,7 @@ class NumpyToKerasModelParamsConverter(ParamsConverter):
     The result can be used by ```keras_model.get_layer(layer_name).set_weights(layer_weights)```
     """
 
-    def convert(self, params: Any) -> Any:
+    def convert(self, params: Any, fl_ctx) -> Any:
         """Unflattens layer weights dict."""
         return unflat_layer_weights_dict(params)
 
@@ -36,6 +36,6 @@ class KerasModelToNumpyParamsConverter(ParamsConverter):
     The layer_weights is from ```layer.get_weights()```
     """
 
-    def convert(self, params: Any) -> Any:
+    def convert(self, params: Any, fl_ctx) -> Any:
         """Flattens layer weights dict."""
         return flat_layer_weights_dict(params)


### PR DESCRIPTION
Sometimes for the second conversion (convert from 3rd party to NVFlare) we need contextual information from the first conversion (convert from NVFlare to 3rd party).

One example for that is the HE conversion, where we want to convert the params and reshape it to linear and then reshape it back afterwards.

We can set/read an attribute in the fl_ctx to represent the model_dict's original Tensor's shape, so we can enable HE using ParamsConverter mechanism.

### Description

- Add fl_ctx in convert method of ParamsConverter

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
