### PR TITLE
Display messages to users when cloud scripts unable to find public ip…

### DIFF
--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -1762,8 +1762,13 @@ aws_start_svr_sh: |
   report_status "$?" "Only one NVFL server VM and its security group is allowed.  $SECURITY_GROUP exists and thus creating duplicate security group"
   sg_id=$(echo $sg_result | jq -r .GroupId)
   my_public_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
-  report_status "$?" "getting my public IP"
-  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+  if [ "$?" -ne 0 ]
+    then
+      echo "getting my public IP failed, please manually configure the inbound rule to limit SSH access"
+      aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+    else
+      aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+  fi
   aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 8002-8003 --cidr 0.0.0.0/0 >> /tmp/sec_grp.log
   report_status "$?" "creating security group rules"
 
@@ -1893,8 +1898,13 @@ aws_start_cln_sh: |
   sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
   report_status "$?" "creating security group"
   my_public_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
-  report_status "$?" "getting my public IP"
-  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+  if [ "$?" -ne 0 ]
+    then
+      echo "getting my public IP failed, please manually limit the inbound rule on SSH access"
+      aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+    else
+      aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+  fi
   report_status "$?" "creating security group rules"
 
   # Start provisioning
@@ -1987,8 +1997,13 @@ aws_start_dsb_sh: |
   report_status "$?" "creating security group"
   echo "Security group id: ${sg_id}"
   my_public_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
-  report_status "$?" "getting my public IP"
-  aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+  if [ "$?" -ne 0 ]
+    then
+      echo "getting my public IP failed, please manually limit the inbound rule on SSH access"
+      aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+    else
+      aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+  fi
   aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 443 --cidr 0.0.0.0/0 >> /tmp/sec_grp.log
   report_status "$?" "creating security group rules"
 


### PR DESCRIPTION
### Description

Sometimes, the command `dig` and `opendns.com` can't resolve the public IP address, due to user's DNS configuration.  This PR allows the scripts to continue when the above case happens.  This PR also displays a message to remind users configuring inbound rules.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
