### PR TITLE
Fixed a race condition issue during the server start

### DIFF
--- a/nvflare/private/fed/app/deployer/server_deployer.py
+++ b/nvflare/private/fed/app/deployer/server_deployer.py
@@ -22,6 +22,7 @@ from nvflare.private.fed.server.fed_server import FederatedServer
 from nvflare.private.fed.server.job_runner import JobRunner
 from nvflare.private.fed.server.run_manager import RunManager
 from nvflare.private.fed.server.server_cmd_modules import ServerCommandModules
+from nvflare.private.fed.server.server_status import ServerStatus
 
 
 class ServerDeployer:
@@ -121,6 +122,7 @@ class ServerDeployer:
             services.engine.fire_event(EventType.SYSTEM_BOOTSTRAP, fl_ctx)
 
             threading.Thread(target=self._start_job_runner, args=[job_runner, fl_ctx]).start()
+            services.status = ServerStatus.STARTED
 
             services.engine.fire_event(EventType.SYSTEM_START, fl_ctx)
             print("deployed FL server trainer.")

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -779,6 +779,9 @@ class FederatedServer(BaseServer):
         return self.overseer_agent
 
     def _check_server_state(self, overseer_agent):
+        if self.status != ServerStatus.STARTED:
+            return
+
         if overseer_agent.is_shutdown():
             self.engine.shutdown_server()
             return


### PR DESCRIPTION
Fixes # .

### Description

Fixed an issue during the server start and job_runner has not been created yet, the overseer call_back to turn the server to hot.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
