### PR TITLE
Fix excepthook error

### DIFF
--- a/nvflare/fuel/f3/drivers/grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/grpc_driver.py
@@ -196,6 +196,7 @@ class Server:
 
     def shutdown(self):
         self.grpc_server.stop(grace=0.5)
+        self.grpc_server = None
 
 
 class GrpcDriver(BaseDriver):


### PR DESCRIPTION
Fixes # .

### Description

This PR attempts to fix the "excepthook error" that sometimes occurs at the end of the FL server. According to Ming Chen's investigation, this error could be caused by the improper shutdown of the AIO gRPC server.

This PR tries to fix this problem with following changes:
- Once starting to stop the grpc server with a grace time, we'll wait for this grace time explicitly such that the "stop" process will have enough time.
- Set grpc_server object to None to potentially trigger garbage collection on this object, which could potentially force the stop process.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
