### PR TITLE
Update monai nvflare setup.py file

### DIFF
--- a/integration/monai/setup.py
+++ b/integration/monai/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 release = os.environ.get("MONAI_NVFL_RELEASE")
 if release == "1":
     package_name = "monai-nvflare"
-    version = "0.2.3"
+    version = "0.2.4"
 else:
     package_name = "monai-nvflare-nightly"
     today = datetime.date.today().timetuple()
@@ -57,5 +57,5 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.8,<3.11",
-    install_requires=["monai>=1.2.0rc5", "nvflare>=2.3.0"],
+    install_requires=["monai>=1.3.0", "nvflare==2.4.0rc6"],
 )


### PR DESCRIPTION
### Description

This PR bumps up the setup.py of monai-nvflare package.  Once the nvflare 2.4.0 is available, another PR will bump up monai-nvflare version and set install_requires nvflare>=2.4.0.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
