### PR TITLE
Reduce CellPipe heartbeat error log

### DIFF
--- a/nvflare/fuel/utils/pipe/pipe.py
+++ b/nvflare/fuel/utils/pipe/pipe.py
@@ -22,6 +22,14 @@ from nvflare.fuel.utils.constants import Mode
 from nvflare.fuel.utils.validation_utils import check_str
 
 
+class Topic(object):
+
+    ABORT = "_ABORT_"
+    END = "_END_"
+    HEARTBEAT = "_HEARTBEAT_"
+    PEER_GONE = "_PEER_GONE_"
+
+
 class Message:
 
     REQUEST = "REQ"

--- a/nvflare/fuel/utils/pipe/pipe_handler.py
+++ b/nvflare/fuel/utils/pipe/pipe_handler.py
@@ -19,7 +19,7 @@ from collections import deque
 from typing import Optional
 
 from nvflare.apis.signal import Signal
-from nvflare.fuel.utils.pipe.pipe import Message, Pipe
+from nvflare.fuel.utils.pipe.pipe import Message, Pipe, Topic
 from nvflare.fuel.utils.validation_utils import (
     check_callable,
     check_non_negative_number,
@@ -27,14 +27,6 @@ from nvflare.fuel.utils.validation_utils import (
     check_positive_number,
 )
 from nvflare.security.logging import secure_format_exception
-
-
-class Topic(object):
-
-    ABORT = "_ABORT_"
-    END = "_END_"
-    HEARTBEAT = "_HEARTBEAT_"
-    PEER_GONE = "_PEER_GONE_"
 
 
 class PipeHandler(object):

--- a/nvflare/fuel/utils/pipe/pipe_handler.py
+++ b/nvflare/fuel/utils/pipe/pipe_handler.py
@@ -62,6 +62,7 @@ class PipeHandler(object):
         heartbeat_timeout=30.0,
         resend_interval=2.0,
         max_resends=None,
+        default_request_timeout=5.0,
     ):
         """
         Constructor of the PipeHandler.
@@ -75,6 +76,7 @@ class PipeHandler(object):
             resend_interval: how often to resend a message if failing to send. None means no resend.
                 Note that if the pipe does not support resending, then no resend.
             max_resends: max number of resends. None means no limit.
+            default_request_timeout: default timeout for request if timeout not specified
         """
         check_positive_number("read_interval", read_interval)
         check_positive_number("heartbeat_interval", heartbeat_interval)
@@ -89,6 +91,7 @@ class PipeHandler(object):
         self.read_interval = read_interval
         self.heartbeat_interval = heartbeat_interval
         self.heartbeat_timeout = heartbeat_timeout
+        self.default_request_timeout = default_request_timeout
         self.resend_interval = resend_interval
         self.max_resends = max_resends
         self.messages = deque([])
@@ -164,6 +167,8 @@ class PipeHandler(object):
             return False
 
         if not timeout or not pipe.can_resend() or not self.resend_interval:
+            if not timeout:
+                timeout = self.default_request_timeout
             return pipe.send(msg, timeout)
 
         num_sends = 0
@@ -186,6 +191,12 @@ class PipeHandler(object):
             self.logger.info(f"will resend '{msg.topic}' in {self.resend_interval} secs")
             start_wait = time.time()
             while True:
+                if self.asked_to_stop:
+                    return False
+
+                if abort_signal and abort_signal.triggered:
+                    return False
+
                 if time.time() - start_wait > self.resend_interval:
                     break
                 time.sleep(0.1)


### PR DESCRIPTION
Fixes NVBug https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=4431630

### Description

Currently when CellPipe heartbeat messages fail, many error messages are logged. This is unnecessary since HB messages are repeated, especially at the beginning of the job when the two peers of the pipe are not started up at the same time.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
