### PR TITLE
Fix the missing separators in nvflare cli

### DIFF
--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -141,7 +141,7 @@ def parse_args(prog_name: str):
     cmd = args.__dict__.get("sub_command")
     sub_cmd_parser = sub_cmd_parsers.get(cmd)
     if argv:
-        msg = f"{prog_name} {cmd}: unrecognized arguments: {''.join(argv)}\n"
+        msg = f"{prog_name} {cmd}: unrecognized arguments: {' '.join(argv)}\n"
         print(f"\nerror: {msg}")
         sub_cmd_parser.print_help()
         _parser.exit(2, "\n")


### PR DESCRIPTION
### Description

When nvflare.cli parses command line options, it asks subcommands to handle those options.  When subcommands encounter unknown options, they return error and the list of unknown options.  Then nvflare.cli prints the helper messages explaining the errors.  This PR add a separator when forming the message.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
