### PR TITLE
Enhanced the client job status

### DIFF
--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -62,11 +62,13 @@ class TrainingTopic(object):
     CANCEL_RESOURCE = "scheduler.cancel_resource"
     START_JOB = "train.start_job"
     GET_SCOPES = "train.get_scopes"
+    NOTIFY_JOB_STATUS = "train.notify_job_status"
 
 
 class RequestHeader(object):
 
     JOB_ID = "job_id"
+    JOB_STATUS = "job_status"
     TOPIC = "topic"
     JOB_META = "job_meta"
     APP_NAME = "app_name"

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -19,13 +19,7 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.private.admin_defs import Message
-from nvflare.private.defs import (
-    CellChannel,
-    EngineConstant,
-    RequestHeader,
-    TrainingTopic,
-    new_cell_message,
-)
+from nvflare.private.defs import CellChannel, EngineConstant, RequestHeader, TrainingTopic, new_cell_message
 from nvflare.private.fed.app.fl_conf import create_privacy_manager
 from nvflare.private.fed.client.client_json_config import ClientJsonConfigurator
 from nvflare.private.fed.client.client_run_manager import ClientRunManager

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -17,7 +17,6 @@ import os
 from nvflare.apis.fl_constant import FLContextKey, SystemConfigs
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.workspace import Workspace
-from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.private.admin_defs import Message
 from nvflare.private.defs import CellChannel, EngineConstant, RequestHeader, TrainingTopic, new_cell_message

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -168,6 +168,10 @@ class ClientEngine(ClientEngineInternalSpec):
 
         return "Start the client app..."
 
+    def notify_job_status(self, job_id: str, job_status):
+        self.client_executor.notify_job_status(job_id, job_status)
+        return f"Job {job_id} has started."
+
     def get_client_name(self):
         return self.client.client_name
 

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -170,7 +170,6 @@ class ClientEngine(ClientEngineInternalSpec):
 
     def notify_job_status(self, job_id: str, job_status):
         self.client_executor.notify_job_status(job_id, job_status)
-        return f"Job {job_id} has started."
 
     def get_client_name(self):
         return self.client.client_name

--- a/nvflare/private/fed/client/client_engine_internal_spec.py
+++ b/nvflare/private/fed/client/client_engine_internal_spec.py
@@ -71,6 +71,19 @@ class ClientEngineInternalSpec(ClientEngineSpec, ABC):
         pass
 
     @abstractmethod
+    def notify_job_status(self, job_id: str, job_status):
+        """Notify the engine what's the client job's new status.
+
+        Args:
+            job_id: job_id
+            job_status: Client job status
+
+        Returns:
+
+        """
+        pass
+
+    @abstractmethod
     def abort_app(self, job_id: str) -> str:
         """Aborts the app execution for the specified run.
 

--- a/nvflare/private/fed/client/client_req_processors.py
+++ b/nvflare/private/fed/client/client_req_processors.py
@@ -22,6 +22,7 @@ from .training_cmds import (  # StartClientMGpuProcessor,; SetRunNumberProcessor
     ClientStatusProcessor,
     DeleteRunNumberProcessor,
     DeployProcessor,
+    NotifyJobStatusProcessor,
     RestartClientProcessor,
     ScopeInfoProcessor,
     ShutdownClientProcessor,
@@ -50,6 +51,7 @@ class ClientRequestProcessors:
         CancelResourceProcessor(),
         ReportResourcesProcessor(),
         ReportEnvProcessor(),
+        NotifyJobStatusProcessor(),
     ]
 
     @staticmethod

--- a/nvflare/private/fed/client/training_cmds.py
+++ b/nvflare/private/fed/client/training_cmds.py
@@ -175,3 +175,17 @@ class ScopeInfoProcessor(RequestProcessor):
         result = {ScopeInfoKey.SCOPE_NAMES: scope_names, ScopeInfoKey.DEFAULT_SCOPE: default_scope_name}
         result = json.dumps(result)
         return ok_reply(topic=f"reply_{req.topic}", body=result)
+
+
+class NotifyJobStatusProcessor(RequestProcessor):
+    def get_topics(self) -> [str]:
+        return [TrainingTopic.NOTIFY_JOB_STATUS]
+
+    def process(self, req: Message, app_ctx) -> Message:
+        engine = app_ctx
+        if not isinstance(engine, ClientEngineInternalSpec):
+            raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
+        job_id = req.get_header(RequestHeader.JOB_ID)
+        job_status = req.get_header(RequestHeader.JOB_STATUS)
+        result = engine.notify_job_status(job_id, job_status)
+        return ok_reply(topic=f"reply_{req.topic}", body=result)

--- a/nvflare/private/fed/client/training_cmds.py
+++ b/nvflare/private/fed/client/training_cmds.py
@@ -187,5 +187,5 @@ class NotifyJobStatusProcessor(RequestProcessor):
             raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
         job_id = req.get_header(RequestHeader.JOB_ID)
         job_status = req.get_header(RequestHeader.JOB_STATUS)
-        result = engine.notify_job_status(job_id, job_status)
-        return ok_reply(topic=f"reply_{req.topic}", body=result)
+        engine.notify_job_status(job_id, job_status)
+        return ok_reply(topic=f"reply_{req.topic}", body=f"notify status: {job_status}")


### PR DESCRIPTION
Fixes # 

Enhance the client job status report.

### Description

Currently the client job status is directly checking with the client job process. However, when the client child cell has not been created when job starting, or the client child cell stopped after the job run, the parent process could not distinguish the difference. They were all marked as "not started".  The new approach will let the client job process to update the parent process what's the progress status of the job, The parent keeps an accurate client job status during the job run life cycle.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
