### PR TITLE
Fix p2p encrypt/decrypt

### DIFF
--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -943,7 +943,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         payload_len = len(message.payload)
         message.add_headers(
             {
-                MessageHeaderKey.PAYLOAD_LEN: payload_len,
+                MessageHeaderKey.CLEAR_PAYLOAD_LEN: payload_len,
                 MessageHeaderKey.ENCRYPTED: True,
             }
         )
@@ -968,7 +968,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         if not origin:
             raise RuntimeError("Message origin missing")
 
-        payload_len = message.get_header(MessageHeaderKey.PAYLOAD_LEN)
+        payload_len = message.get_header(MessageHeaderKey.CLEAR_PAYLOAD_LEN)
         origin_cert = self.cert_ex.get_certificate(origin)
         message.payload = self.credential_manager.decrypt(origin_cert, message.payload)
         if len(message.payload) != payload_len:

--- a/nvflare/fuel/f3/cellnet/defs.py
+++ b/nvflare/fuel/f3/cellnet/defs.py
@@ -42,6 +42,7 @@ class MessageHeaderKey:
     RETURN_REASON = CELLNET_PREFIX + "return_reason"
     SECURE = CELLNET_PREFIX + "secure"
     PAYLOAD_LEN = CELLNET_PREFIX + "payload_len"
+    CLEAR_PAYLOAD_LEN = CELLNET_PREFIX + "clear_payload_len"
     ENCRYPTED = CELLNET_PREFIX + "encrypted"
     OPTIONAL = CELLNET_PREFIX + "optional"
 


### PR DESCRIPTION
Fixes # .

### Description

The P2P message encryption is broken for CCWF.  This was caused by reuse of PAYLOAD_LEN msg header.
This PR fixes this by introducing a new message header CLEAR_PAYLOAD_LEN.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
