### PR TITLE
added back the API auto login after server restart

### DIFF
--- a/nvflare/ha/overseer/overseer.py
+++ b/nvflare/ha/overseer/overseer.py
@@ -97,4 +97,4 @@ def refresh():
 
 
 if __name__ == "__main__":
-    app.run()
+    app.run(host="localhost", port=6000)

--- a/nvflare/ha/overseer/overseer.py
+++ b/nvflare/ha/overseer/overseer.py
@@ -97,4 +97,4 @@ def refresh():
 
 
 if __name__ == "__main__":
-    app.run(host="localhost", port=6000)
+    app.run()

--- a/nvflare/private/fed/server/training_cmds.py
+++ b/nvflare/private/fed/server/training_cmds.py
@@ -222,7 +222,7 @@ class TrainingCommandModule(CommandModule, CommandUtil):
 
                 # ask the admin client to shut down since its current session will become invalid after
                 # the server is restarted.
-                conn.append_shutdown("Goodbye!")
+                # conn.append_shutdown("Goodbye!")
         elif target_type == self.TARGET_TYPE_CLIENT:
             clients = conn.get_prop(self.TARGET_CLIENT_TOKENS)
             if not clients:


### PR DESCRIPTION
Fixes # .

Fix restarting the server breaks the current FlareAPI session issue.

### Description

When issuing the "restart" command, the CLI and FLARE API issued a shutdown command to the server and terminate the current FlareAPI session. Added back the auto-login to re-login the API for continuous operations. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
