### PR TITLE
Add global round info for logging metrics global step

### DIFF
--- a/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
@@ -67,7 +67,7 @@ class PTLearner(Learner):
         # Epoch counter
         self.epoch_of_start_time = 0
         self.epoch_global = 0
-        
+
         self.data_path = data_path
         self.lr = lr
         self.epochs = epochs
@@ -137,9 +137,9 @@ class PTLearner(Learner):
         # local_train returns early if abort_signal is triggered.
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
-        
+
         self.epoch_of_start_time += self.epochs
-        
+
         # Save the local model after training.
         self.save_local_model(fl_ctx)
 

--- a/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
@@ -182,7 +182,7 @@ class PTLearner(Learner):
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.log_metric("validation_accuracy", metric, self.epochs * current_round + epoch)
+            self.writer.log_metric("validation_accuracy", metric, current_step)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())

--- a/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
@@ -149,9 +149,9 @@ class PTLearner(Learner):
 
     def local_train(self, fl_ctx, abort_signal):
         # Basic training
+        current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
         for epoch in range(self.epochs):
             self.model.train()
-            self.epoch_global = self.epoch_of_start_time + epoch
             running_loss = 0.0
             for i, batch in enumerate(self.train_loader):
                 if abort_signal.triggered:
@@ -177,7 +177,6 @@ class PTLearner(Learner):
                     )
 
                 # Stream training loss at each step
-                current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
                 current_step = self.n_iterations * self.epochs * current_round + self.n_iterations * epoch + i
                 self.writer.log_metrics({"train_loss": cost.item(), "running_loss": running_loss}, current_step)
 

--- a/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
@@ -44,6 +44,7 @@ class PTLearner(Learner):
         """Simple PyTorch Learner that trains and validates a simple network on the CIFAR10 dataset.
 
         Args:
+            data_path (str): Path that the data will be stored at. Defaults to "~/data".
             lr (float, optional): Learning rate. Defaults to 0.01
             epochs (int, optional): Epochs. Defaults to 5
             exclude_vars (list): List of variables to exclude during model loading.
@@ -63,6 +64,10 @@ class PTLearner(Learner):
         self.loss = None
         self.device = None
         self.model = None
+        # Epoch counter
+        self.epoch_of_start_time = 0
+        self.epoch_global = 0
+        
         self.data_path = data_path
         self.lr = lr
         self.epochs = epochs
@@ -132,7 +137,9 @@ class PTLearner(Learner):
         # local_train returns early if abort_signal is triggered.
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
-
+        
+        self.epoch_of_start_time += self.epochs
+        
         # Save the local model after training.
         self.save_local_model(fl_ctx)
 
@@ -149,6 +156,7 @@ class PTLearner(Learner):
         # Basic training
         for epoch in range(self.epochs):
             self.model.train()
+            self.epoch_global = self.epoch_of_start_time + epoch
             running_loss = 0.0
             for i, batch in enumerate(self.train_loader):
                 if abort_signal.triggered:
@@ -174,12 +182,12 @@ class PTLearner(Learner):
                     )
 
                 # Stream training loss at each step
-                current_step = len(self.train_loader) * epoch + i
+                current_step = self.n_iterations * self.epoch_global + i
                 self.writer.log_metrics({"train_loss": cost.item(), "running_loss": running_loss}, current_step)
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.log_metric("validation_accuracy", metric, epoch)
+            self.writer.log_metric("validation_accuracy", metric, self.epoch_global)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())

--- a/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_mlflow.py
@@ -24,7 +24,7 @@ from torchvision.datasets import CIFAR10
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from nvflare.apis.dxo import DXO, DataKind, MetaKey, from_shareable
-from nvflare.apis.fl_constant import ReservedKey, ReturnCode
+from nvflare.apis.fl_constant import FLContextKey, ReservedKey, ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.signal import Signal
@@ -64,9 +64,6 @@ class PTLearner(Learner):
         self.loss = None
         self.device = None
         self.model = None
-        # Epoch counter
-        self.epoch_of_start_time = 0
-        self.epoch_global = 0
 
         self.data_path = data_path
         self.lr = lr
@@ -138,8 +135,6 @@ class PTLearner(Learner):
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
 
-        self.epoch_of_start_time += self.epochs
-
         # Save the local model after training.
         self.save_local_model(fl_ctx)
 
@@ -182,12 +177,13 @@ class PTLearner(Learner):
                     )
 
                 # Stream training loss at each step
-                current_step = self.n_iterations * self.epoch_global + i
+                current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
+                current_step = self.n_iterations * self.epochs * current_round + self.n_iterations * epoch + i
                 self.writer.log_metrics({"train_loss": cost.item(), "running_loss": running_loss}, current_step)
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.log_metric("validation_accuracy", metric, self.epoch_global)
+            self.writer.log_metric("validation_accuracy", metric, self.epochs * current_round + epoch)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())

--- a/examples/advanced/experiment-tracking/pt/learner_with_tb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_tb.py
@@ -181,7 +181,7 @@ class PTLearner(Learner):
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.add_scalar("validation_accuracy", metric, self.epochs * current_round + epoch)
+            self.writer.add_scalar("validation_accuracy", metric, current_step)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())

--- a/examples/advanced/experiment-tracking/pt/learner_with_tb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_tb.py
@@ -43,7 +43,7 @@ from nvflare.app_opt.pt.model_persistence_format_manager import PTModelPersisten
 class PTLearner(Learner):
     def __init__(
         self,
-        data_path="/tmp/nvflare/tensorboard-streaming",
+        data_path="~/data",
         lr=0.01,
         epochs=5,
         exclude_vars=None,
@@ -52,6 +52,7 @@ class PTLearner(Learner):
         """Simple PyTorch Learner that trains and validates a simple network on the CIFAR10 dataset.
 
         Args:
+            data_path (str): Path that the data will be stored at. Defaults to "~/data".
             lr (float, optional): Learning rate. Defaults to 0.01
             epochs (int, optional): Epochs. Defaults to 5
             exclude_vars (list): List of variables to exclude during model loading.
@@ -71,6 +72,10 @@ class PTLearner(Learner):
         self.loss = None
         self.device = None
         self.model = None
+        # Epoch counter
+        self.epoch_of_start_time = 0
+        self.epoch_global = 0
+
         self.data_path = data_path
         self.lr = lr
         self.epochs = epochs
@@ -135,6 +140,8 @@ class PTLearner(Learner):
         # local_train returns early if abort_signal is triggered.
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
+        
+        self.epoch_of_start_time += self.epochs
 
         # Save the local model after training.
         self.save_local_model(fl_ctx)
@@ -152,6 +159,7 @@ class PTLearner(Learner):
         # Basic training
         for epoch in range(self.epochs):
             self.model.train()
+            self.epoch_global = self.epoch_of_start_time + epoch
             running_loss = 0.0
             for i, batch in enumerate(self.train_loader):
                 if abort_signal.triggered:
@@ -173,12 +181,12 @@ class PTLearner(Learner):
                     running_loss = 0.0
 
                 # Stream training loss at each step
-                current_step = len(self.train_loader) * epoch + i
+                current_step = self.n_iterations * self.epoch_global + i
                 self.writer.add_scalar("train_loss", cost.item(), current_step)
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.add_scalar("validation_accuracy", metric, epoch)
+            self.writer.add_scalar("validation_accuracy", metric, self.epoch_global)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())

--- a/examples/advanced/experiment-tracking/pt/learner_with_tb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_tb.py
@@ -152,9 +152,9 @@ class PTLearner(Learner):
 
     def local_train(self, fl_ctx, abort_signal):
         # Basic training
+        current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
         for epoch in range(self.epochs):
             self.model.train()
-            self.epoch_global = self.epoch_of_start_time + epoch
             running_loss = 0.0
             for i, batch in enumerate(self.train_loader):
                 if abort_signal.triggered:
@@ -176,7 +176,6 @@ class PTLearner(Learner):
                     running_loss = 0.0
 
                 # Stream training loss at each step
-                current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
                 current_step = self.n_iterations * self.epochs * current_round + self.n_iterations * epoch + i
                 self.writer.add_scalar("train_loss", cost.item(), current_step)
 

--- a/examples/advanced/experiment-tracking/pt/learner_with_tb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_tb.py
@@ -140,7 +140,7 @@ class PTLearner(Learner):
         # local_train returns early if abort_signal is triggered.
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
-        
+
         self.epoch_of_start_time += self.epochs
 
         # Save the local model after training.

--- a/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
@@ -143,9 +143,9 @@ class PTLearner(Learner):
 
     def local_train(self, fl_ctx, abort_signal):
         # Basic training
+        current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
         for epoch in range(self.epochs):
             self.model.train()
-            self.epoch_global = self.epoch_of_start_time + epoch
             running_loss = 0.0
             for i, batch in enumerate(self.train_loader):
                 if abort_signal.triggered:
@@ -167,7 +167,6 @@ class PTLearner(Learner):
                     running_loss = 0.0
 
                 # Stream training loss at each step
-                current_round = fl_ctx.get_prop(FLContextKey.TASK_DATA).get_header("current_round")
                 current_step = self.n_iterations * self.epochs * current_round + self.n_iterations * epoch + i
                 self.writer.log({"train_loss": cost.item()}, current_step)
 

--- a/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
@@ -131,7 +131,7 @@ class PTLearner(Learner):
         # local_train returns early if abort_signal is triggered.
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
-        
+
         self.epoch_of_start_time += self.epochs
 
         # Save the local model after training.

--- a/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
@@ -44,6 +44,7 @@ class PTLearner(Learner):
         """Simple PyTorch Learner that trains and validates a simple network on the CIFAR10 dataset.
 
         Args:
+            data_path (str): Path that the data will be stored at. Defaults to "~/data".
             lr (float, optional): Learning rate. Defaults to 0.01
             epochs (int, optional): Epochs. Defaults to 5
             exclude_vars (list): List of variables to exclude during model loading.
@@ -63,6 +64,10 @@ class PTLearner(Learner):
         self.loss = None
         self.device = None
         self.model = None
+        # Epoch counter
+        self.epoch_of_start_time = 0
+        self.epoch_global = 0
+
         self.data_path = data_path
         self.lr = lr
         self.epochs = epochs
@@ -126,6 +131,8 @@ class PTLearner(Learner):
         # local_train returns early if abort_signal is triggered.
         if abort_signal.triggered:
             return make_reply(ReturnCode.TASK_ABORTED)
+        
+        self.epoch_of_start_time += self.epochs
 
         # Save the local model after training.
         self.save_local_model(fl_ctx)
@@ -143,6 +150,7 @@ class PTLearner(Learner):
         # Basic training
         for epoch in range(self.epochs):
             self.model.train()
+            self.epoch_global = self.epoch_of_start_time + epoch
             running_loss = 0.0
             for i, batch in enumerate(self.train_loader):
                 if abort_signal.triggered:
@@ -164,12 +172,12 @@ class PTLearner(Learner):
                     running_loss = 0.0
 
                 # Stream training loss at each step
-                current_step = len(self.train_loader) * epoch + i
+                current_step = self.n_iterations * self.epoch_global + i
                 self.writer.log({"train_loss": cost.item()}, current_step)
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.log({"validation_accuracy": metric}, epoch)
+            self.writer.log({"validation_accuracy": metric}, self.epoch_global)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())

--- a/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
+++ b/examples/advanced/experiment-tracking/pt/learner_with_wandb.py
@@ -172,7 +172,7 @@ class PTLearner(Learner):
 
             # Stream validation accuracy at the end of each epoch
             metric = self.local_validate(abort_signal)
-            self.writer.log({"validation_accuracy": metric}, self.epochs * current_round + epoch)
+            self.writer.log({"validation_accuracy": metric}, current_step)
 
     def get_model_for_validation(self, model_name: str, fl_ctx: FLContext) -> Shareable:
         run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())


### PR DESCRIPTION
Adds global round info for logging metrics global step.

### Description

Previously when logging metrics in MLFlow, TB, and W&B, calculations were missing global round info. This adds the global epoch.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
