### PR TITLE
Add example for mulitparty kaplan-meier analysis with HE

### DIFF
--- a/examples/advanced/kaplan-meier-he/baseline_kaplan_meier_multi_party.py
+++ b/examples/advanced/kaplan-meier-he/baseline_kaplan_meier_multi_party.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import copy
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tenseal as ts
+from lifelines import KaplanMeierFitter
+from lifelines.utils import survival_table_from_events
+from sksurv.datasets import load_veterans_lung_cancer
+
+
+def args_parser():
+    parser = argparse.ArgumentParser(description="Kaplan Meier Survival Analysis")
+    parser.add_argument("--num_of_clients", type=int, default=5, help="number of clients")
+    parser.add_argument("--he", action="store_true", help="use homomorphic encryption")
+    parser.add_argument(
+        "--output_curve_path",
+        type=str,
+        default="./km_curve_multi_party.png",
+        help="save path for the output curve",
+    )
+    return parser
+
+
+def prepare_data(num_of_clients: int, bin_days: int = 7):
+    # Load data
+    data_x, data_y = load_veterans_lung_cancer()
+    # Get total data count
+    total_data_num = data_x.shape[0]
+    print(f"Total data count: {total_data_num}")
+    # Get event and time
+    event = data_y["Status"]
+    time = data_y["Survival_in_days"]
+    # Categorize data to a bin, default is a week (7 days)
+    time = np.ceil(time / bin_days).astype(int)
+    # Shuffle data
+    idx = np.random.permutation(total_data_num)
+    # Split data to clients
+    event_clients = {}
+    time_clients = {}
+    for i in range(num_of_clients):
+        start = int(i * total_data_num / num_of_clients)
+        end = int((i + 1) * total_data_num / num_of_clients)
+        event_i = event[idx[start:end]]
+        time_i = time[idx[start:end]]
+        event_clients[i] = event_i
+        time_clients[i] = time_i
+    return event, time, event_clients, time_clients
+
+
+def main():
+    parser = args_parser()
+    args = parser.parse_args()
+
+    # Set parameters
+    num_of_clients = args.num_of_clients
+    he = args.he
+    output_curve_path = args.output_curve_path
+
+    # Generate data
+    event, time, event_clients, time_clients = prepare_data(num_of_clients)
+
+    # Setup Plot
+    plt.figure()
+    if he:
+        total_subplot = 3
+    else:
+        total_subplot = 2
+
+    # Setup tenseal context
+    # using BFV scheme since observations are integers
+    if he:
+        context = ts.context(ts.SCHEME_TYPE.BFV, poly_modulus_degree=4096, plain_modulus=1032193)
+
+    # Fit and plot Kaplan Meier curve with lifelines
+    kmf = KaplanMeierFitter()
+    kmf.fit(time, event)
+    # Plot the Kaplan-Meier survival curve
+    plt.subplot(1, total_subplot, 1)
+    plt.title("Centralized")
+    kmf.plot_survival_function()
+    plt.ylim(0, 1)
+    plt.ylabel("prob")
+    plt.xlabel("time")
+    plt.legend("", frameon=False)
+
+    # Distributed
+    # Stage 1 local: collect info and set histogram dict
+    event_table = {}
+    max_week_idx = []
+    for client in range(num_of_clients):
+        # condense date to histogram
+        event_table[client] = survival_table_from_events(time_clients[client], event_clients[client])
+        week_idx = event_table[client].index.values.astype(int)
+        # get the max week index
+        max_week_idx.append(max(week_idx))
+    # Stage 1 global: get global histogram dict
+    hist_obs_global = {}
+    hist_sen_global = {}
+    # actual week as index, so plus 1
+    max_week = max(max_week_idx) + 1
+    for week in range(max_week):
+        hist_obs_global[week] = 0
+        hist_sen_global[week] = 0
+    if he:
+        # encrypt with tenseal
+        hist_obs_global_he = ts.bfv_vector(context, list(hist_obs_global.values()))
+        hist_sen_global_he = ts.bfv_vector(context, list(hist_sen_global.values()))
+    # Stage 2 local: convert local table to uniform histogram
+    hist_obs_local = {}
+    hist_sen_local = {}
+    hist_obs_local_he = {}
+    hist_sen_local_he = {}
+    for client in range(num_of_clients):
+        hist_obs_local[client] = copy.deepcopy(hist_obs_global)
+        hist_sen_local[client] = copy.deepcopy(hist_sen_global)
+        # assign values
+        week_idx = event_table[client].index.values.astype(int)
+        observed = event_table[client]["observed"].to_numpy()
+        sensored = event_table[client]["censored"].to_numpy()
+        for i in range(len(week_idx)):
+            hist_obs_local[client][week_idx[i]] = observed[i]
+            hist_sen_local[client][week_idx[i]] = sensored[i]
+        if he:
+            # encrypt with tenseal using BFV scheme since observations are integers
+            hist_obs_local_he[client] = ts.bfv_vector(context, list(hist_obs_local[client].values()))
+            hist_sen_local_he[client] = ts.bfv_vector(context, list(hist_sen_local[client].values()))
+    # Stage 2 global: sum up local histogram
+    for client in range(num_of_clients):
+        for week in range(max_week):
+            hist_obs_global[week] += hist_obs_local[client][week]
+            hist_sen_global[week] += hist_sen_local[client][week]
+        if he:
+            hist_obs_global_he += hist_obs_local_he[client]
+            hist_sen_global_he += hist_sen_local_he[client]
+
+    # Stage 3 local: convert histogram to event list and fit K-M curve
+    # unfold histogram to event list
+    time_unfold = []
+    event_unfold = []
+    for i in range(max_week):
+        for j in range(hist_obs_global[i]):
+            time_unfold.append(i)
+            event_unfold.append(True)
+        for k in range(hist_sen_global[i]):
+            time_unfold.append(i)
+            event_unfold.append(False)
+    time_unfold = np.array(time_unfold)
+    event_unfold = np.array(event_unfold)
+    # Fit the survival data with lifelines
+    kmf.fit(time_unfold, event_unfold)
+    # Plot the Kaplan-Meier survival curve
+    plt.subplot(1, total_subplot, 2)
+    plt.title("Federated")
+    kmf.plot_survival_function()
+    plt.ylim(0, 1)
+    plt.ylabel("prob")
+    plt.xlabel("time")
+    plt.legend("", frameon=False)
+
+    if he:
+        # decrypt with tenseal
+        hist_obs_global_he = hist_obs_global_he.decrypt()
+        hist_sen_global_he = hist_sen_global_he.decrypt()
+        # unfold histogram to event list
+        time_unfold = []
+        event_unfold = []
+        for i in range(max_week):
+            for j in range(hist_obs_global_he[i]):
+                time_unfold.append(i)
+                event_unfold.append(True)
+            for k in range(hist_sen_global_he[i]):
+                time_unfold.append(i)
+                event_unfold.append(False)
+        time_unfold = np.array(time_unfold)
+        event_unfold = np.array(event_unfold)
+        # Fit the survival data with lifelines
+        kmf.fit(time_unfold, event_unfold)
+        # Plot the Kaplan-Meier survival curve
+        plt.subplot(1, total_subplot, 3)
+        plt.title("Federated HE")
+        kmf.plot_survival_function()
+        plt.ylim(0, 1)
+        plt.ylabel("prob")
+        plt.xlabel("time")
+        plt.legend("", frameon=False)
+
+    # Save curve
+    plt.tight_layout()
+    plt.savefig(output_curve_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/kaplan-meier-he/jobs/km_he/app/config/config_fed_client.conf
+++ b/examples/advanced/kaplan-meier-he/jobs/km_he/app/config/config_fed_client.conf
@@ -1,0 +1,116 @@
+{
+  # version of the configuration
+  format_version = 2
+
+  # This is the application script which will be invoked. Client can replace this script with user's own training script.
+  app_script = "km_train.py"
+
+  # Additional arguments needed by the training code. For example, in lightning, these can be --trainer.batch_size=xxx.
+  app_config = ""
+
+  # Client Computing Executors.
+  executors = [
+    {
+      # tasks the executors are defined to handle
+      tasks = ["train"]
+
+      # This particular executor
+      executor {
+
+        # This is an executor for Client API. The underline data exchange is using Pipe.
+        path = "nvflare.app_opt.pt.client_api_launcher_executor.ClientAPILauncherExecutor"
+
+        args {
+          # launcher_id is used to locate the Launcher object in "components"
+          launcher_id = "launcher"
+
+          # pipe_id is used to locate the Pipe object in "components"
+          pipe_id = "pipe"
+
+          # Timeout in seconds for waiting for a heartbeat from the training script. Defaults to 30 seconds.
+          # Please refer to the class docstring for all available arguments
+          heartbeat_timeout = 60
+
+          # format of the exchange parameters
+          params_exchange_format =  "raw"
+
+          # if the transfer_type is FULL, then it will be sent directly
+          # if the transfer_type is DIFF, then we will calculate the
+          # difference VS received parameters and send the difference
+          params_transfer_type = "FULL"
+
+          # if train_with_evaluation is true, the executor will expect
+          # the custom code need to send back both the trained parameters and the evaluation metric
+          # otherwise only trained parameters are expected
+          train_with_evaluation = false
+        }
+      }
+    }
+  ],
+
+  # this defined an array of task data filters. If provided, it will control the data from server controller to client executor
+  task_data_filters =  []
+
+  # this defined an array of task result filters. If provided, it will control the result from client executor to server controller
+  task_result_filters = []
+
+  components =  [
+    {
+      # component id is "launcher"
+      id = "launcher"
+
+      # the class path of this component
+      path = "nvflare.app_common.launchers.subprocess_launcher.SubprocessLauncher"
+
+      args {
+        # the launcher will invoke the script
+        script = "python3 custom/{app_script}  {app_config} "
+        # if launch_once is true, the SubprocessLauncher will launch once for the whole job
+        # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
+        launch_once = true
+      }
+    }
+    {
+      id = "pipe"
+      path = "nvflare.fuel.utils.pipe.cell_pipe.CellPipe"
+      args {
+        mode = "PASSIVE"
+        site_name = "{SITE_NAME}"
+        token = "{JOB_ID}"
+        root_url = "{ROOT_URL}"
+        secure_mode = "{SECURE_MODE}"
+        workspace_dir = "{WORKSPACE}"
+      }
+    }
+    {
+      id = "metrics_pipe"
+      path = "nvflare.fuel.utils.pipe.cell_pipe.CellPipe"
+      args {
+        mode = "PASSIVE"
+        site_name = "{SITE_NAME}"
+        token = "{JOB_ID}"
+        root_url = "{ROOT_URL}"
+        secure_mode = "{SECURE_MODE}"
+        workspace_dir = "{WORKSPACE}"
+      }
+    },
+    {
+      id = "metric_relay"
+      path = "nvflare.app_common.widgets.metric_relay.MetricRelay"
+      args {
+        pipe_id = "metrics_pipe"
+        event_type = "fed.analytix_log_stats"
+        # how fast should it read from the peer
+        read_interval = 0.1
+      }
+    },
+    {
+      # we use this component so the client api `flare.init()` can get required information
+      id = "config_preparer"
+      path = "nvflare.app_common.widgets.external_configurator.ExternalConfigurator"
+      args {
+        component_ids = ["metric_relay"]
+      }
+    }
+  ]
+}

--- a/examples/advanced/kaplan-meier-he/jobs/km_he/app/config/config_fed_server.conf
+++ b/examples/advanced/kaplan-meier-he/jobs/km_he/app/config/config_fed_server.conf
@@ -1,0 +1,23 @@
+{
+  # version of the configuration
+  format_version = 2
+  task_data_filters =[]
+  task_result_filters = []
+
+  workflows = [
+      {
+        id = "km"
+        path = "nvflare.app_common.workflows.wf_controller.WFController"
+        args {
+            task_name = "train"
+            wf_class_path = "kaplan_meier_wf.KM",
+            wf_args {
+                min_clients = 2
+            }
+        }
+      }
+  ]
+
+  components = []
+
+}

--- a/examples/advanced/kaplan-meier-he/jobs/km_he/app/custom/kaplan_meier_wf.py
+++ b/examples/advanced/kaplan-meier-he/jobs/km_he/app/custom/kaplan_meier_wf.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Dict
+
+import tenseal as ts
+
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+from nvflare.app_common.workflows.wf_comm.wf_comm_api_spec import (
+    CURRENT_ROUND,
+    DATA,
+    MIN_RESPONSES,
+    NUM_ROUNDS,
+    START_ROUND,
+)
+from nvflare.app_common.workflows.wf_comm.wf_spec import WF
+
+# Controller Workflow
+
+
+class KM(WF):
+    def __init__(self, min_clients: int):
+        super(KM, self).__init__()
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.min_clients = min_clients
+        self.num_rounds = 3
+
+    def run(self):
+        he_context, max_idx_results = self.distribute_he_context_collect_max_idx()
+        global_res = self.aggr_max_idx(max_idx_results)
+        enc_hist_results = self.distribute_max_idx_collect_enc_stats(global_res)
+        hist_obs_global, hist_cen_global = self.aggr_he_hist(he_context, enc_hist_results)
+        _ = self.distribute_global_hist(hist_obs_global, hist_cen_global)
+
+    def distribute_he_context_collect_max_idx(self):
+        self.logger.info("send kaplan-meier analysis command to all sites with HE context \n")
+
+        context = ts.context(ts.SCHEME_TYPE.BFV, poly_modulus_degree=4096, plain_modulus=1032193)
+        context_serial = context.serialize(save_secret_key=True)
+        # drop private key for server
+        context.make_context_public()
+        # payload data always needs to be wrapped into an FLModel
+        model = FLModel(params={"he_context": context_serial}, params_type=ParamsType.FULL)
+
+        msg_payload = {
+            MIN_RESPONSES: self.min_clients,
+            CURRENT_ROUND: 1,
+            NUM_ROUNDS: self.num_rounds,
+            START_ROUND: 1,
+            DATA: model,
+        }
+
+        results = self.flare_comm.broadcast_and_wait(msg_payload)
+        return context, results
+
+    def aggr_max_idx(self, sag_result: Dict[str, Dict[str, FLModel]]):
+        self.logger.info("aggregate max histogram index \n")
+
+        if not sag_result:
+            raise RuntimeError("input is None or empty")
+
+        task_name, task_result = next(iter(sag_result.items()))
+
+        if not task_result:
+            raise RuntimeError("task_result None or empty ")
+
+        max_idx_global = []
+        for site, fl_model in task_result.items():
+            max_idx = fl_model.params["max_idx"]
+            print(max_idx)
+            max_idx_global.append(max_idx)
+        # actual time point as index, so plus 1 for storage
+        return max(max_idx_global) + 1
+
+    def distribute_max_idx_collect_enc_stats(self, result: int):
+        self.logger.info("send global max_index to all sites \n")
+
+        model = FLModel(params={"max_idx_global": result}, params_type=ParamsType.FULL)
+
+        msg_payload = {
+            MIN_RESPONSES: self.min_clients,
+            CURRENT_ROUND: 2,
+            NUM_ROUNDS: self.num_rounds,
+            START_ROUND: 1,
+            DATA: model,
+        }
+
+        results = self.flare_comm.broadcast_and_wait(msg_payload)
+        return results
+
+    def aggr_he_hist(self, he_context, sag_result: Dict[str, Dict[str, FLModel]]):
+        self.logger.info("aggregate histogram within HE \n")
+
+        if not sag_result:
+            raise RuntimeError("input is None or empty")
+
+        task_name, task_result = next(iter(sag_result.items()))
+
+        if not task_result:
+            raise RuntimeError("task_result None or empty ")
+
+        hist_obs_global = None
+        hist_cen_global = None
+        for site, fl_model in task_result.items():
+            hist_obs_he_serial = fl_model.params["hist_obs"]
+            hist_obs_he = ts.bfv_vector_from(he_context, hist_obs_he_serial)
+            hist_cen_he_serial = fl_model.params["hist_cen"]
+            hist_cen_he = ts.bfv_vector_from(he_context, hist_cen_he_serial)
+
+            if not hist_obs_global:
+                print(f"assign global hist with result from {site}")
+                hist_obs_global = hist_obs_he
+            else:
+                print(f"add to global hist with result from {site}")
+                hist_obs_global += hist_obs_he
+
+            if not hist_cen_global:
+                print(f"assign global hist with result from {site}")
+                hist_cen_global = hist_cen_he
+            else:
+                print(f"add to global hist with result from {site}")
+                hist_cen_global += hist_cen_he
+
+        # return the two accumulated vectors, serialized for transmission
+        hist_obs_global_serial = hist_obs_global.serialize()
+        hist_cen_global_serial = hist_cen_global.serialize()
+        return hist_obs_global_serial, hist_cen_global_serial
+
+    def distribute_global_hist(self, hist_obs_global_serial, hist_cen_global_serial):
+        self.logger.info("send global accumulated histograms within HE to all sites \n")
+
+        model = FLModel(
+            params={"hist_obs_global": hist_obs_global_serial, "hist_cen_global": hist_cen_global_serial},
+            params_type=ParamsType.FULL,
+        )
+
+        msg_payload = {
+            MIN_RESPONSES: self.min_clients,
+            CURRENT_ROUND: 3,
+            NUM_ROUNDS: self.num_rounds,
+            START_ROUND: 1,
+            DATA: model,
+        }
+
+        results = self.flare_comm.broadcast_and_wait(msg_payload)
+        return results

--- a/examples/advanced/kaplan-meier-he/jobs/km_he/app/custom/km_train.py
+++ b/examples/advanced/kaplan-meier-he/jobs/km_he/app/custom/km_train.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tenseal as ts
+from lifelines import KaplanMeierFitter
+from lifelines.utils import survival_table_from_events
+from sksurv.datasets import load_veterans_lung_cancer
+
+# (1) import nvflare client API
+import nvflare.client as flare
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+
+# Client training code
+
+np.random.seed(77)
+
+
+def prepare_data(num_of_clients: int = 2, bin_days: int = 7):
+    # Load data
+    data_x, data_y = load_veterans_lung_cancer()
+    # Get total data count
+    total_data_num = data_x.shape[0]
+    print(f"Total data count: {total_data_num}")
+    # Get event and time
+    event = data_y["Status"]
+    time = data_y["Survival_in_days"]
+    # Categorize data to a bin, default is a week (7 days)
+    time = np.ceil(time / bin_days).astype(int)
+    # Shuffle data
+    idx = np.random.permutation(total_data_num)
+    # Split data to clients
+    event_clients = {}
+    time_clients = {}
+    for i in range(num_of_clients):
+        start = int(i * total_data_num / num_of_clients)
+        end = int((i + 1) * total_data_num / num_of_clients)
+        event_i = event[idx[start:end]]
+        time_i = time[idx[start:end]]
+        event_clients["site-" + str(i + 1)] = event_i
+        time_clients["site-" + str(i + 1)] = time_i
+    return event_clients, time_clients
+
+
+def save(result: dict):
+    file_path = os.path.join(os.getcwd(), "km_global.json")
+    print(f"save the result to {file_path} \n")
+    with open(file_path, "w") as json_file:
+        json.dump(result, json_file, indent=4)
+
+
+def main():
+    flare.init()
+
+    site_name = flare.get_site_name()
+    print(f"Kaplan-meier analysis for {site_name}")
+
+    # get local data
+    event_clients, time_clients = prepare_data()
+    event_local = event_clients[site_name]
+    time_local = time_clients[site_name]
+
+    while flare.is_running():
+        # receives global message from NVFlare
+        global_msg = flare.receive()
+        curr_round = global_msg.current_round
+        print(f"current_round={curr_round}")
+
+        if curr_round == 1:
+            # First round:
+            # Get HE context from server
+            # Send max index back
+
+            # In real-life application, HE setup is done by secure provisioning
+            he_context_serial = global_msg.params["he_context"]
+            # bytes back to context object
+            he_context = ts.context_from(he_context_serial)
+
+            # Condense local data to histogram
+            event_table = survival_table_from_events(time_local, event_local)
+            hist_idx = event_table.index.values.astype(int)
+            # Get the max index to be synced globally
+            max_hist_idx = max(hist_idx)
+
+            # Send max to server
+            print(f"send max hist index for site = {flare.get_site_name()}")
+            # Send the results to server
+            model = FLModel(params={"max_idx": max_hist_idx}, params_type=ParamsType.FULL)
+            flare.send(model)
+
+        elif curr_round == 2:
+            # Second round, get global max index
+            # Organize local histogram and encrypt
+            max_idx_global = global_msg.params["max_idx_global"]
+            print("Global Max Idx")
+            print(max_idx_global)
+            # Convert local table to uniform histogram
+            hist_obs = {}
+            hist_cen = {}
+            for idx in range(max_idx_global):
+                hist_obs[idx] = 0
+                hist_cen[idx] = 0
+            # assign values
+            idx = event_table.index.values.astype(int)
+            observed = event_table["observed"].to_numpy()
+            censored = event_table["censored"].to_numpy()
+            for i in range(len(idx)):
+                hist_obs[idx[i]] = observed[i]
+                hist_cen[idx[i]] = censored[i]
+            # Encrypt with tenseal using BFV scheme since observations are integers
+            hist_obs_he = ts.bfv_vector(he_context, list(hist_obs.values()))
+            hist_cen_he = ts.bfv_vector(he_context, list(hist_cen.values()))
+            # Serialize for transmission
+            hist_obs_he_serial = hist_obs_he.serialize()
+            hist_cen_he_serial = hist_cen_he.serialize()
+            # Send encrypted histograms to server
+            response = FLModel(
+                params={"hist_obs": hist_obs_he_serial, "hist_cen": hist_cen_he_serial}, params_type=ParamsType.FULL
+            )
+            flare.send(response)
+
+        elif curr_round == 3:
+            # Get global histograms
+            hist_obs_global_serial = global_msg.params["hist_obs_global"]
+            hist_cen_global_serial = global_msg.params["hist_cen_global"]
+            # Deserialize
+            hist_obs_global = ts.bfv_vector_from(he_context, hist_obs_global_serial)
+            hist_cen_global = ts.bfv_vector_from(he_context, hist_cen_global_serial)
+            # Decrypt
+            hist_obs_global = hist_obs_global.decrypt()
+            hist_cen_global = hist_cen_global.decrypt()
+            # Unfold histogram to event list
+            time_unfold = []
+            event_unfold = []
+            for i in range(max_idx_global):
+                for j in range(hist_obs_global[i]):
+                    time_unfold.append(i)
+                    event_unfold.append(True)
+                for k in range(hist_cen_global[i]):
+                    time_unfold.append(i)
+                    event_unfold.append(False)
+            time_unfold = np.array(time_unfold)
+            event_unfold = np.array(event_unfold)
+
+            # Perform Kaplan-Meier analysis on global aggregated information
+            # Create a Kaplan-Meier estimator
+            kmf = KaplanMeierFitter()
+
+            # Fit the model
+            kmf.fit(durations=time_unfold, event_observed=event_unfold)
+
+            # Plot and save KM curve
+            plt.figure()
+            plt.title("Federated HE")
+            kmf.plot_survival_function()
+            plt.ylim(0, 1)
+            plt.ylabel("prob")
+            plt.xlabel("time")
+            plt.legend("", frameon=False)
+            plt.tight_layout()
+            plt.savefig(os.path.join(os.getcwd(), "km_curve.png"))
+
+            # Save global result to a json file
+            # Get the survival function at all observed time points
+            survival_function_at_all_times = kmf.survival_function_
+            # Get the timeline (time points)
+            timeline = survival_function_at_all_times.index.values
+            # Get the KM estimate
+            km_estimate = survival_function_at_all_times["KM_estimate"].values
+            # Get the event count at each time point
+            event_count = kmf.event_table.iloc[:, 0].values  # Assuming the first column is the observed events
+            # Get the survival rate at each time point (using the 1st column of the survival function)
+            survival_rate = 1 - survival_function_at_all_times.iloc[:, 0].values
+            # Return the results
+            results = {
+                "timeline": timeline.tolist(),
+                "km_estimate": km_estimate.tolist(),
+                "event_count": event_count.tolist(),
+                "survival_rate": survival_rate.tolist(),
+            }
+            save(results)
+
+            # Send a simple response to server
+            response = FLModel(params={}, params_type=ParamsType.FULL)
+            flare.send(response)
+
+    print(f"finish send for {site_name}, complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/kaplan-meier-he/jobs/km_he/meta.conf
+++ b/examples/advanced/kaplan-meier-he/jobs/km_he/meta.conf
@@ -1,0 +1,7 @@
+{
+  name = "fl_km"
+  deploy_map {
+    app = ["@ALL"]
+  }
+  min_clients = 2
+}

--- a/examples/advanced/kaplan-meier-he/requirements.txt
+++ b/examples/advanced/kaplan-meier-he/requirements.txt
@@ -1,0 +1,12 @@
+lifelines
+
+
+
+git clone --recursive https://github.com/OpenMined/TenSEAL.git
+cd TenSEAL/
+git submodule init
+git submodule update
+pip install .
+
+
+scikit-survival


### PR DESCRIPTION
Fixes # .

### Description

Under HE setting, server should not be able to parse any statistics from client's submissions, this example:
- make use of WF API to add HE functionality, so that it can run with simulator
- convert KM native event-time data to histogram, so that they can be securely aggregated on server-end, encrypted

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
