### PR TITLE
[2.4] Fix Auto login "communication error"

### DIFF
--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -46,7 +46,7 @@ _CMD_TYPE_CLIENT = 1
 _CMD_TYPE_SERVER = 2
 
 MAX_AUTO_LOGIN_TRIES = 300
-AUTO_LOGIN_INTERVAL = 1.0
+AUTO_LOGIN_INTERVAL = 1.5
 
 
 class ResultKey(object):
@@ -313,7 +313,7 @@ class AdminAPI(AdminAPISpec):
         session_timeout_interval=None,
         session_status_check_interval=None,
         auto_login_delay: int = 5,
-        auto_login_max_tries: int = 5,
+        auto_login_max_tries: int = 15,
         event_handlers=None,
     ):
         """API to keep certs, keys and connection information and to execute admin commands through do_command.


### PR DESCRIPTION
# Fix

increase max_login_tries from 5 to 15 and increase the sleep interval from 1 to 1.5 sec

Description
auto login try to login with 5 login attempts and 1 second sleep in between. But recent startup seems take longer time.
the login will take a longer time especially in a new env. and python cache is not created.
The start time increased to around 15 seconds instead of 5 seconds.

Change the number of max login retries to 15 and the sleep interval to 1.5 second
A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
