### PR TITLE
Fix FLModelUtil

### DIFF
--- a/nvflare/app_common/utils/fl_model_utils.py
+++ b/nvflare/app_common/utils/fl_model_utils.py
@@ -97,7 +97,11 @@ class FLModelUtils:
         params = None
         meta = {}
 
-        try:
+        submit_model_name = shareable.get_header(AppConstants.SUBMIT_MODEL_NAME)
+        if submit_model_name:
+            # this only happens in cross-site eval right now
+            meta[MetaKey.SUBMIT_MODEL_NAME] = submit_model_name
+        else:
             dxo = from_shareable(shareable)
             meta = dict(dxo.meta)
             if dxo.data_kind == DataKind.METRICS:
@@ -115,10 +119,6 @@ class FLModelUtils:
 
                 if MetaKey.INITIAL_METRICS in meta:
                     metrics = meta[MetaKey.INITIAL_METRICS]
-        except:
-            # this only happens in cross-site eval right now
-            submit_model_name = shareable.get_header(AppConstants.SUBMIT_MODEL_NAME)
-            meta[MetaKey.SUBMIT_MODEL_NAME] = submit_model_name
 
         current_round = shareable.get_header(AppConstants.CURRENT_ROUND, None)
         total_rounds = shareable.get_header(AppConstants.NUM_ROUNDS, None)


### PR DESCRIPTION
### Description

The old logic was assuming that if any Exceptions happens in the try block we consider it as cross-val.
That is wrong, we should NOT make that assumption, in addition it will swallow any exceptions happen in between.

We change it to use the header `AppConstants.SUBMIT_MODEL_NAME` in the shareable to decide if this is coming from cross-site eval.
If it is coming from cross-site eval then we don't convert it to DXO, just put the `submit_model_name` in the meta.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
