### PR TITLE
[2.4] Move workspace setup inside constructor

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -94,6 +94,15 @@ class SimulatorRunner(FLComponent):
 
         self.clients_created = 0
 
+        running_dir = os.getcwd()
+        if self.workspace is None:
+            self.workspace = "simulator_workspace"
+            self.logger.warn(
+                f"Simulator workspace is not provided. Set it to the default location:"
+                f" {os.path.join(running_dir, self.workspace)}"
+            )
+        self.workspace = os.path.join(running_dir, self.workspace)
+
     def _generate_args(
         self, job_folder: str, workspace: str, clients=None, n_clients=None, threads=None, gpu=None, max_clients=100
     ):
@@ -110,15 +119,6 @@ class SimulatorRunner(FLComponent):
         return args
 
     def setup(self):
-        running_dir = os.getcwd()
-        if self.workspace is None:
-            self.workspace = "simulator_workspace"
-            self.logger.warn(
-                f"Simulator workspace is not provided. Set it to the default location:"
-                f" {os.path.join(running_dir, self.workspace)}"
-            )
-        self.workspace = os.path.join(running_dir, self.workspace)
-
         self.args = self._generate_args(
             self.job_folder, self.workspace, self.clients, self.n_clients, self.threads, self.gpu, self.max_clients
         )
@@ -348,7 +348,7 @@ class SimulatorRunner(FLComponent):
         try:
             manager = Manager()
             return_dict = manager.dict()
-            process = Process(target=self.run_processs, args=(return_dict,))
+            process = Process(target=self.run_process, args=(return_dict,))
             process.start()
             process.join()
             run_status = self._get_return_code(return_dict, process, self.workspace)
@@ -380,7 +380,7 @@ class SimulatorRunner(FLComponent):
                 self.logger.info(f"return_code from process.exitcode: {return_code}")
         return return_code
 
-    def run_processs(self, return_dict):
+    def run_process(self, return_dict):
         # run_status = self.simulator_run_main()
         try:
             run_status = mpm.run(


### PR DESCRIPTION
### Description

Line 354 `run_status = self._get_return_code(return_dict, process, self.workspace)` is running in the main process while 
the workspace was being setup in the forked process.

Then this workspace setup will not be reflected back into the main process.

We move the workspace setup code inside the class constructor to solve this problem.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
