### PR TITLE
[2.4] Fix ParamsConverter signature

### DIFF
--- a/nvflare/app_common/abstract/params_converter.py
+++ b/nvflare/app_common/abstract/params_converter.py
@@ -16,12 +16,11 @@ from abc import ABC, abstractmethod
 from typing import Any, List
 
 from nvflare.apis.dxo import from_shareable
-from nvflare.apis.filter import Filter
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 
 
-class ParamsConverter(Filter, ABC):
+class ParamsConverter(ABC):
     def __init__(self, supported_tasks: List[str] = None):
         self.supported_tasks = supported_tasks
 


### PR DESCRIPTION
### Description

PR https://github.com/NVIDIA/NVFlare/pull/2260 add required functionalities but it breaks the "Filter" base class signature.
This PR removes the "Filter" base class inheritance

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
