### PR TITLE
Removed the no need client custom path.

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -331,9 +331,9 @@ class SimulatorRunner(FLComponent):
             client_name, self.args
         )
         self.federated_clients.append(client)
-        app_root = os.path.join(self.simulator_root, "app_" + client_name)
-        app_custom_folder = os.path.join(app_root, "custom")
-        sys.path.append(app_custom_folder)
+        # app_root = os.path.join(self.simulator_root, "app_" + client_name)
+        # app_custom_folder = os.path.join(app_root, "custom")
+        # sys.path.append(app_custom_folder)
 
     def _set_client_status(self):
         for client in self.federated_clients:

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -331,9 +331,6 @@ class SimulatorRunner(FLComponent):
             client_name, self.args
         )
         self.federated_clients.append(client)
-        # app_root = os.path.join(self.simulator_root, "app_" + client_name)
-        # app_custom_folder = os.path.join(app_root, "custom")
-        # sys.path.append(app_custom_folder)
 
     def _set_client_status(self):
         for client in self.federated_clients:


### PR DESCRIPTION
Fixes # .

### Description

Removed the no need client custom path when creating the simulator client. Which caused appending long system PATH.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
