### PR TITLE
Cifar10 fix plot

### DIFF
--- a/examples/advanced/cifar10/cifar10-sim/figs/plot_tensorboard_events.py
+++ b/examples/advanced/cifar10/cifar10-sim/figs/plot_tensorboard_events.py
@@ -93,7 +93,7 @@ def main():
     for config, exp in experiments.items():
         config_name = config.split(" ")[0]
         alpha = exp.get("alpha", None)
-        if alpha:
+        if alpha is not None:
             config_name = config_name + f"*alpha{alpha}"
         else:
             raise ValueError(f"Expected an alpha value to be provided but got alpha={alpha}")


### PR DESCRIPTION
Fixes # .

### Description

Fixes a parsing error in the plotting script as in #2345.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
