### PR TITLE
[2.4] Add flush=True to print in subprocess

### DIFF
--- a/examples/hello-world/ml-to-fl/np/code/train_loop.py
+++ b/examples/hello-world/ml-to-fl/np/code/train_loop.py
@@ -34,11 +34,11 @@ def main():
 
     # get system information
     sys_info = flare.system_info()
-    print(f"system info is: {sys_info}")
+    print(f"system info is: {sys_info}", flush=True)
 
     while flare.is_running():
         input_model = flare.receive()
-        print(f"received weights is: {input_model.params}")
+        print(f"received weights is: {input_model.params}", flush=True)
 
         input_numpy_array = input_model.params["numpy_key"]
 
@@ -49,11 +49,11 @@ def main():
         metrics = evaluate(input_numpy_array)
 
         sys_info = flare.system_info()
-        print(f"system info is: {sys_info}")
-        print(f"finish round: {input_model.current_round}")
+        print(f"system info is: {sys_info}", flush=True)
+        print(f"finish round: {input_model.current_round}", flush=True)
 
         # send back the model
-        print(f"send back: {output_numpy_array}")
+        print(f"send back: {output_numpy_array}", flush=True)
         flare.send(
             flare.FLModel(
                 params={"numpy_key": output_numpy_array},

--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -15,12 +15,23 @@
 import os
 import shlex
 import subprocess
+import sys
+from threading import Thread
 from typing import Optional
 
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.launcher import Launcher, LauncherRunStatus
+
+
+def log_subprocess_output(process, log_file):
+    with open(log_file, buffering=0, mode="ab") as f:
+        for c in iter(process.stdout.readline, b""):
+            sys.stdout.buffer.write(c)
+            sys.stdout.flush()
+            f.write(c)
+            f.flush()
 
 
 class SubprocessLauncher(Launcher):
@@ -62,18 +73,18 @@ class SubprocessLauncher(Launcher):
             command = self._script
             env = os.environ.copy()
             command_seq = shlex.split(command)
-
+            log_file = os.path.join(self._app_dir, "logfile")
             self._process = subprocess.Popen(
-                command_seq,
-                stderr=subprocess.STDOUT,
-                cwd=self._app_dir,
-                env=env,
+                command_seq, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self._app_dir, env=env
             )
+            self._log_thread = Thread(target=log_subprocess_output, args=(self._process, log_file))
+            self._log_thread.start()
 
     def _stop_external_process(self):
         if self._process:
             self._process.terminate()
             self._process.wait()
+            self._log_thread.join()
             if self._clean_up_script:
                 command_seq = shlex.split(self._clean_up_script)
                 process = subprocess.Popen(command_seq, cwd=self._app_dir)
@@ -81,11 +92,11 @@ class SubprocessLauncher(Launcher):
             self._process = None
 
     def check_run_status(self, task_name: str, fl_ctx: FLContext) -> str:
-        if self._process:
-            return_code = self._process.poll()
-            if return_code is None:
-                return LauncherRunStatus.RUNNING
-            elif return_code == 0:
-                return LauncherRunStatus.COMPLETE_SUCCESS
-            return LauncherRunStatus.COMPLETE_FAILED
-        return LauncherRunStatus.NOT_RUNNING
+        if self._process is None:
+            return LauncherRunStatus.NOT_RUNNING
+        return_code = self._process.poll()
+        if return_code is None:
+            return LauncherRunStatus.RUNNING
+        if return_code == 0:
+            return LauncherRunStatus.COMPLETE_SUCCESS
+        return LauncherRunStatus.COMPLETE_FAILED


### PR DESCRIPTION
### Description

Capture stdout and stderr from subprocess in a thread and write the captured result to both logfile and stdout.

Note that since the output from print inside child process is usually buffered and may not appear on PIPE soon enough, the example python code, train_loop.py, always flushes its print.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
