### PR TITLE
[2.4] Fix Pipe and PipeHandler

### DIFF
--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -33,7 +33,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         external_execution_wait: float = 5.0,
         peer_read_timeout: Optional[float] = None,
         monitor_interval: float = 0.01,
-        read_interval: float = 0.001,
+        read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
         heartbeat_timeout: float = 30.0,
         workers: int = 4,

--- a/nvflare/app_common/executors/launcher_executor.py
+++ b/nvflare/app_common/executors/launcher_executor.py
@@ -45,7 +45,7 @@ class LauncherExecutor(TaskExchanger):
         external_execution_wait: float = 5.0,
         peer_read_timeout: Optional[float] = None,
         monitor_interval: float = 1.0,
-        read_interval: float = 0.1,
+        read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
         heartbeat_timeout: float = 30.0,
         workers: int = 1,

--- a/nvflare/app_common/executors/task_exchanger.py
+++ b/nvflare/app_common/executors/task_exchanger.py
@@ -33,7 +33,7 @@ class TaskExchanger(Executor):
     def __init__(
         self,
         pipe_id: str,
-        read_interval: float = 0.1,
+        read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
         heartbeat_timeout: Optional[float] = 30.0,
         resend_interval: float = 2.0,
@@ -48,7 +48,7 @@ class TaskExchanger(Executor):
         Args:
             pipe_id (str): component id of pipe.
             read_interval (float): how often to read from pipe.
-                Defaults to 0.1.
+                Defaults to 0.5.
             heartbeat_interval (float): how often to send heartbeat to peer.
                 Defaults to 5.0.
             heartbeat_timeout (float, optional): how long to wait for a
@@ -115,7 +115,7 @@ class TaskExchanger(Executor):
             self.pipe_handler.set_status_cb(self._pipe_status_cb)
             self.pipe.open(self.pipe_channel_name)
             self.pipe_handler.start()
-        elif event_type == EventType.END_RUN:
+        elif event_type == EventType.ABOUT_TO_END_RUN:
             self.log_info(fl_ctx, "Stopping pipe handler")
             if self.pipe_handler:
                 self.pipe_handler.notify_end("end_of_job")

--- a/nvflare/fuel/utils/pipe/cell_pipe.py
+++ b/nvflare/fuel/utils/pipe/cell_pipe.py
@@ -211,6 +211,16 @@ class CellPipe(Pipe):
         self.logger.info(f"registered CellPipe request CB for {self.channel}")
 
     def send(self, msg: Message, timeout=None) -> bool:
+        """Sends the specified message to the peer.
+
+        Args:
+            msg: the message to be sent
+            timeout: if specified, number of secs to wait for the peer to read the message.
+                If not specified, wait indefinitely.
+
+        Returns:
+            Whether the message is read by the peer.
+        """
         with self.pipe_lock:
             if self.closed:
                 raise BrokenPipeError("pipe closed")

--- a/nvflare/fuel/utils/pipe/file_pipe.py
+++ b/nvflare/fuel/utils/pipe/file_pipe.py
@@ -135,7 +135,7 @@ class FilePipe(Pipe):
         self._clear_dir(self.y_path)
         self._clear_dir(self.t_path)
 
-    def _monitor_file(self, file_path: str, timeout) -> bool:
+    def _monitor_file(self, file_path: str, timeout=None) -> bool:
         """Monitors the file until it's read-and-removed by peer, or timed out.
 
         If timeout, remove the file.
@@ -147,8 +147,6 @@ class FilePipe(Pipe):
         Returns:
             whether the file has been read and removed
         """
-        if not timeout:
-            return False
         start = time.time()
         while True:
             if not self.pipe_path:
@@ -156,7 +154,7 @@ class FilePipe(Pipe):
 
             if not os.path.exists(file_path):
                 return True
-            if time.time() - start > timeout:
+            if timeout and time.time() - start > timeout:
                 # timed out - try to delete the file
                 try:
                     os.remove(file_path)
@@ -247,13 +245,15 @@ class FilePipe(Pipe):
         return self._get_from_dir(self.y_path, timeout)
 
     def send(self, msg: Message, timeout=None) -> bool:
-        """
+        """Sends the specified message to the peer.
 
         Args:
-            msg:
-            timeout:
+            msg: the message to be sent
+            timeout: if specified, number of secs to wait for the peer to read the message.
+                If not specified, wait indefinitely.
 
-        Returns: whether the message is read by peer (if timeout is specified)
+        Returns:
+            Whether the message is read by the peer.
 
         """
         if not self.pipe_path:

--- a/nvflare/fuel/utils/pipe/pipe.py
+++ b/nvflare/fuel/utils/pipe/pipe.py
@@ -99,14 +99,15 @@ class Pipe(AttributesExportable, ABC):
 
     @abstractmethod
     def send(self, msg: Message, timeout=None) -> bool:
-        """Send the specified message to the peer.
+        """Sends the specified message to the peer.
 
         Args:
             msg: the message to be sent
             timeout: if specified, number of secs to wait for the peer to read the message.
+                If not specified, wait indefinitely.
 
-        Returns: whether the message is read by the peer.
-        If timeout is not specified, always return False.
+        Returns:
+            Whether the message is read by the peer.
 
         """
         pass
@@ -117,8 +118,10 @@ class Pipe(AttributesExportable, ABC):
 
         Args:
             timeout: how long (number of seconds) to try
+                If not specified, return right away.
 
-        Returns: the message received; or None if no message
+        Returns:
+            the message received; or None if no message
 
         """
         pass


### PR DESCRIPTION
### Description

Fix PipeHandler receive blocks "send_heartbeat"

### Issue

When sending heartbeats in PipeHandler (Line 323), we use timeout = None, which will be translated to use the default_request_timeout set to 5 seconds. This causes a problem where this send_to_peer(msg) can block the entire _try_read thread for up to 5 seconds. It is supposed to be a fast-checking loop.

When the loop is blocked, it also slows down the follow-up checking/sending heartbeat logic, making the system more prone to timeouts.

### Solution
- Separate the sending of heartbeats outside of reading thread.
- To ensure the PipeHandler code re-usability, we make the "send" assumption of FilePipe to match CellPipe: If timeout is None, then wait forever.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
