### PR TITLE
[2.4] Fix NEMO links

### DIFF
--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -28,5 +28,6 @@ jobs:
       with:
         max-depth: -1
         use-verbose-mode: 'yes'
+        config-file: '.github/workflows/mlc_config.json'
         check-modified-files-only: 'yes'
-        base-branch: 'dev'
+        base-branch: 'main'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "catalog.ngc.nvidia.com"
+    }
+  ]
+}

--- a/integration/nemo/examples/README.md
+++ b/integration/nemo/examples/README.md
@@ -1,16 +1,16 @@
 # Examples of NeMo-NVFlare Integration
 
 ### [Parameter-Efficient Fine-Tuning (PEFT) with NeMo](./peft/README.md)
-In this example, we utilize NeMo's [PEFT](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/nlp/nemo_megatron/peft/landing_page.html) using NVFlare's new Client API (minimal code changes required to run a NeMo script in FL)
+In this example, we utilize NeMo's [PEFT](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/v1.22.0/nlp/nemo_megatron/peft/landing_page.html) using NVFlare's new Client API (minimal code changes required to run a NeMo script in FL)
 methods to showcase how to adapt a large language model (LLM) to 
 a downstream task, such as financial sentiment predictions. 
 
 ### [Supervised fine-tuning (SFT) with NeMo and NVFlare](./supervised_fine_tuning/README.md)
-An example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) 
+An example of using NVIDIA FLARE
 with NeMo for [supervised fine-tuning (SFT)](https://github.com/NVIDIA/NeMo-Megatron-Launcher#5152-sft-training) 
 to fine-tune all parameters of a large language model (LLM) on supervised data to teach the model how to follow user specified instructions. 
 
 ### [Prompt learning with NeMo and NVFlare](./prompt_learning/README.md)
-An example of using [NVIDIA FLARE](https://nvflare.readthedocs.io/en/main/index.html) 
-with NeMo for [prompt learning](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/prompt_learning.html) using NVFlare's Learner API
+An example of using NVIDIA FLARE
+with NeMo for [prompt learning](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/v1.17.0/nlp/nemo_megatron/prompt_learning.html) using NVFlare's Learner API
 to adapt a large language model (LLM) to a downstream task. 

--- a/integration/nemo/examples/peft/README.md
+++ b/integration/nemo/examples/peft/README.md
@@ -1,13 +1,13 @@
 ## Parameter-Efficient Fine-Tuning (PEFT) with NeMo
 
-In this example, we utilize NeMo's [PEFT](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/nlp/nemo_megatron/peft/landing_page.html)
+In this example, we utilize NeMo's [PEFT](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/v1.22.0/nlp/nemo_megatron/peft/landing_page.html)
 methods to showcase how to adapt a large language model (LLM) to 
 a downstream task, such as financial sentiment predictions. 
 
 With one line configuration change, you can try different PEFT techniques such as [p-tuning](https://arxiv.org/abs/2103.10385), [adapters](https://proceedings.mlr.press/v97/houlsby19a.html), or [LoRA](https://arxiv.org/abs/2106.09685), which add a small number of trainable parameters to the LLM
 that condition the model to produce the desired output for the downstream task.
 
-For more details, see the [PEFT script](https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/tuning/megatron_gpt_peft_tuning.py) in NeMo, which we adapt using NVFlare's Lightning client API to run in a federated scenario.
+For more details, see the [PEFT script](https://github.com/NVIDIA/NeMo/blob/v1.22.0/examples/nlp/language_modeling/tuning/megatron_gpt_peft_tuning.py) in NeMo, which we adapt using NVFlare's Lightning client API to run in a federated scenario.
 
 ## Dependencies
 The example was tested with the [NeMo 23.10 container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo).

--- a/integration/nemo/examples/prompt_learning/README.md
+++ b/integration/nemo/examples/prompt_learning/README.md
@@ -1,6 +1,6 @@
 ## Prompt Learning with NeMo
 
-In this example, we utilize NeMo's [prompt learning](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/prompt_learning.html)
+In this example, we utilize NeMo's [prompt learning](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/v1.17.0/nlp/nemo_megatron/prompt_learning.html)
 feature to showcase how to adapt a large language model (LLM) to 
 a downstream task such as financial sentiment predictions. 
 As the prompt learning technique shown in the example is p-tuning, which adds a small prompt encoder network to the LLM

--- a/integration/nemo/examples/prompt_learning/prompt_learning_20B.md
+++ b/integration/nemo/examples/prompt_learning/prompt_learning_20B.md
@@ -1,13 +1,13 @@
 ## Federated p-tuning using a 20 billion parameter GPT model
 
-In this example, we utilize NeMo's [prompt learning](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/prompt_learning.html)
+In this example, we utilize NeMo's [prompt learning](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/v1.17.0/nlp/nemo_megatron/prompt_learning.html)
 feature to showcase how to adapt a large language model (LLM) to 
 a downstream task such as financial sentiment predictions. 
 
 The prompt learning technique shown in the example is p-tuning which adds a small prompt encoder network to the LLM
 to produce virtual tokens that guide the model toward the desired output of the downstream task.
 
-For more details on how to change hyperparameters for prompt learning in NeMo, see this [tutorial](https://github.com/NVIDIA/NeMo/blob/main/tutorials/nlp/Multitask_Prompt_and_PTuning.ipynb) which is also the basis for this NVFlare tutorial.
+For more details on how to change hyperparameters for prompt learning in NeMo, see this [tutorial](https://github.com/NVIDIA/NeMo/blob/v1.17.0/tutorials/nlp/Multitask_Prompt_and_PTuning.ipynb) which is also the basis for this NVFlare tutorial.
 
 ## Dependencies
 This example running a 20B GPT model requires more computational resources.

--- a/integration/nemo/examples/supervised_fine_tuning/README.md
+++ b/integration/nemo/examples/supervised_fine_tuning/README.md
@@ -226,7 +226,7 @@ Below is the accuracy of the models on these tasks.
 As shown, FedAvg is able to generate a model with the best overall performance.    
 
 ## Inference
-We use NeMo's [inference script](https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/megatron_gpt_eval.py) for generation task with models after SFT. 
+We use NeMo's [inference script](https://github.com/NVIDIA/NeMo/blob/v1.20.0/examples/nlp/language_modeling/megatron_gpt_eval.py) for generation task with models after SFT. 
 Below, we define some test examples to feed to the SFT model to see its predictions.
 
 First, we ask the model to generate an answer to an open question: "Tell me an interesting fact about space travel." 


### PR DESCRIPTION
### Description

- Fix NEMO integration examples link.
- Ignore "catalog.ngc.nvidia.com" in link checks since it requires login

In the future we should make each example's NEMO version consistent.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
