### PR TITLE
[2.4] Add support to large object in LauncherExecutor using CellPipe

### DIFF
--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -31,11 +31,11 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         task_wait_timeout: Optional[float] = None,
         last_result_transfer_timeout: float = 300.0,
         external_execution_wait: float = 5.0,
-        peer_read_timeout: Optional[float] = None,
+        peer_read_timeout: Optional[float] = 60.0,
         monitor_interval: float = 0.01,
         read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
-        heartbeat_timeout: float = 30.0,
+        heartbeat_timeout: float = 60.0,
         workers: int = 4,
         train_with_evaluation: bool = True,
         train_task_name: str = "train",
@@ -50,22 +50,23 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         """Initializes the ClientAPILauncherExecutor.
 
         Args:
-            pipe_id (Optional[str]): Identifier for obtaining the Pipe from NVFlare components.
+            pipe_id (str): Identifier for obtaining the Pipe from NVFlare components.
             launcher_id (Optional[str]): Identifier for obtaining the Launcher from NVFlare components.
             launch_timeout (Optional[float]): Timeout for the Launcher's "launch_task" method to complete (None for no timeout).
             task_wait_timeout (Optional[float]): Timeout for retrieving the task result (None for no timeout).
-            last_result_transfer_timeout (float): Timeout for transmitting the last result from an external process (default: 5.0).
+            last_result_transfer_timeout (float): Timeout for transmitting the last result from an external process.
                 This value should be greater than the time needed for sending the whole result.
-            peer_read_timeout (Optional[float]): Timeout for waiting the task to be read by the peer from the pipe (None for no timeout).
-            monitor_interval (float): Interval for monitoring the launcher (default: 0.01).
-            read_interval (float): Interval for reading from the pipe (default: 0.5).
-            heartbeat_interval (float): Interval for sending heartbeat to the peer (default: 5.0).
-            heartbeat_timeout (float): Timeout for waiting for a heartbeat from the peer (default: 30.0).
-            workers (int): Number of worker threads needed (default: 4).
-            train_with_evaluation (bool): Whether to run training with global model evaluation (default: True).
-            train_task_name (str): Task name of train mode (default: train).
-            evaluate_task_name (str): Task name of evaluate mode (default: evaluate).
-            submit_model_task_name (str): Task name of submit_model mode (default: submit_model).
+            external_execution_wait (float): Time to wait for external process to start.
+            peer_read_timeout (float, optional): time to wait for peer to accept sent message.
+            monitor_interval (float): Interval for monitoring the launcher.
+            read_interval (float): Interval for reading from the pipe.
+            heartbeat_interval (float): Interval for sending heartbeat to the peer.
+            heartbeat_timeout (float): Timeout for waiting for a heartbeat from the peer.
+            workers (int): Number of worker threads needed.
+            train_with_evaluation (bool): Whether to run training with global model evaluation.
+            train_task_name (str): Task name of train mode.
+            evaluate_task_name (str): Task name of evaluate mode.
+            submit_model_task_name (str): Task name of submit_model mode.
             from_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.
                 This ParamsConverter will be called when model is sent from nvflare controller side to executor side.
             to_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.

--- a/nvflare/app_common/executors/launcher_executor.py
+++ b/nvflare/app_common/executors/launcher_executor.py
@@ -43,12 +43,12 @@ class LauncherExecutor(TaskExchanger):
         task_wait_timeout: Optional[float] = None,
         last_result_transfer_timeout: float = 300.0,
         external_execution_wait: float = 5.0,
-        peer_read_timeout: Optional[float] = None,
+        peer_read_timeout: Optional[float] = 60.0,
         monitor_interval: float = 1.0,
         read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
-        heartbeat_timeout: float = 30.0,
-        workers: int = 1,
+        heartbeat_timeout: float = 60.0,
+        workers: int = 4,
         train_with_evaluation: bool = True,
         train_task_name: str = "train",
         evaluate_task_name: str = "evaluate",
@@ -63,18 +63,19 @@ class LauncherExecutor(TaskExchanger):
             launcher_id (Optional[str]): Identifier for obtaining the Launcher from NVFlare components.
             launch_timeout (Optional[float]): Timeout for the Launcher's "launch_task" method to complete (None for no timeout).
             task_wait_timeout (Optional[float]): Timeout for retrieving the task result (None for no timeout).
-            last_result_transfer_timeout (float): Timeout for transmitting the last result from an external process (default: 5.0).
+            last_result_transfer_timeout (float): Timeout for transmitting the last result from an external process.
                 This value should be greater than the time needed for sending the whole result.
-            peer_read_timeout (Optional[float]): Timeout for waiting the task to be read by the peer from the pipe (None for no timeout).
-            monitor_interval (float): Interval for monitoring the launcher (default: 0.01).
-            read_interval (float): Interval for reading from the pipe (default: 0.5).
-            heartbeat_interval (float): Interval for sending heartbeat to the peer (default: 5.0).
-            heartbeat_timeout (float): Timeout for waiting for a heartbeat from the peer (default: 30.0).
-            workers (int): Number of worker threads needed (default: 1).
-            train_with_evaluation (bool): Whether to run training with global model evaluation (default: True).
-            train_task_name (str): Task name of train mode (default: train).
-            evaluate_task_name (str): Task name of evaluate mode (default: evaluate).
-            submit_model_task_name (str): Task name of submit_model mode (default: submit_model).
+            external_execution_wait (float): Time to wait for external process to start.
+            peer_read_timeout (float, optional): time to wait for peer to accept sent message.
+            monitor_interval (float): Interval for monitoring the launcher.
+            read_interval (float): Interval for reading from the pipe.
+            heartbeat_interval (float): Interval for sending heartbeat to the peer.
+            heartbeat_timeout (float): Timeout for waiting for a heartbeat from the peer.
+            workers (int): Number of worker threads needed.
+            train_with_evaluation (bool): Whether to run training with global model evaluation.
+            train_task_name (str): Task name of train mode.
+            evaluate_task_name (str): Task name of evaluate mode.
+            submit_model_task_name (str): Task name of submit_model mode.
             from_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.
                 This ParamsConverter will be called when model is sent from nvflare controller side to executor side.
             to_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.
@@ -142,6 +143,8 @@ class LauncherExecutor(TaskExchanger):
                 self._abort_signal.trigger(f"{EventType.END_RUN} event received - telling external to stop")
             self.finalize(fl_ctx)
             self.log_info(fl_ctx, f"{EventType.END_RUN} event received - telling external to stop")
+            super().handle_event(event_type, fl_ctx)
+        else:
             super().handle_event(event_type, fl_ctx)
 
     def execute(self, task_name: str, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> Shareable:
@@ -280,12 +283,15 @@ class LauncherExecutor(TaskExchanger):
                 return False
 
             if abort_signal.triggered:
+                self.log_info(fl_ctx, "External execution is not set up but abort signal is triggered.")
                 return False
 
             if self.peer_is_up_or_dead():
                 return True
 
-            if self.launcher.check_run_status(task_name, fl_ctx) != LauncherRunStatus.RUNNING:
+            run_status = self.launcher.check_run_status(task_name, fl_ctx)
+            if run_status != LauncherRunStatus.RUNNING:
+                self.log_info(fl_ctx, f"External execution is not set up and run status becomes {run_status}.")
                 return False
 
             time.sleep(0.1)
@@ -293,18 +299,17 @@ class LauncherExecutor(TaskExchanger):
     def _finalize_external_execution(
         self, task_name: str, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal
     ) -> bool:
-        with self._lock:
-            if self._job_end:
-                ask_peer_end_success = self.ask_peer_to_end(fl_ctx)
-                if not ask_peer_end_success:
-                    return False
+        if self._job_end:
+            ask_peer_end_success = self.ask_peer_to_end(fl_ctx)
+            if not ask_peer_end_success:
+                return False
 
         check_run_status = self._execute_launcher_method_in_thread_executor(
             method_name="check_run_status",
             task_name=task_name,
             fl_ctx=fl_ctx,
         )
-        if check_run_status != LauncherRunStatus.COMPLETE_SUCCESS:
+        if not self._received_result.is_set() and check_run_status != LauncherRunStatus.COMPLETE_SUCCESS:
             self.log_warning(fl_ctx, f"Try to stop task ({task_name}) when launcher run status is {check_run_status}")
 
         self.log_info(fl_ctx, f"Calling stop task ({task_name}).")
@@ -365,6 +370,7 @@ class LauncherExecutor(TaskExchanger):
                     break
 
                 if self._current_task is None:
+                    self.pause_pipe_handler()
                     continue
 
                 task_name = self._current_task

--- a/nvflare/app_common/executors/task_exchanger.py
+++ b/nvflare/app_common/executors/task_exchanger.py
@@ -35,10 +35,10 @@ class TaskExchanger(Executor):
         pipe_id: str,
         read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
-        heartbeat_timeout: Optional[float] = 30.0,
+        heartbeat_timeout: Optional[float] = 60.0,
         resend_interval: float = 2.0,
         max_resends: Optional[int] = None,
-        peer_read_timeout: Optional[float] = 5.0,
+        peer_read_timeout: Optional[float] = 60.0,
         task_wait_time: Optional[float] = None,
         result_poll_interval: float = 0.5,
         pipe_channel_name=PipeChannelName.TASK,
@@ -48,19 +48,16 @@ class TaskExchanger(Executor):
         Args:
             pipe_id (str): component id of pipe.
             read_interval (float): how often to read from pipe.
-                Defaults to 0.5.
             heartbeat_interval (float): how often to send heartbeat to peer.
-                Defaults to 5.0.
             heartbeat_timeout (float, optional): how long to wait for a
                 heartbeat from the peer before treating the peer as dead,
-                0 means DO NOT check for heartbeat. Defaults to 30.0.
+                0 means DO NOT check for heartbeat.
             resend_interval (float): how often to resend a message if failing to send.
                 None means no resend. Note that if the pipe does not support resending,
-                then no resend. Defaults to 2.0.
+                then no resend.
             max_resends (int, optional): max number of resend. None means no limit.
                 Defaults to None.
             peer_read_timeout (float, optional): time to wait for peer to accept sent message.
-                Defaults to 5.0.
             task_wait_time (float, optional): how long to wait for a task to complete.
                 None means waiting forever. Defaults to None.
             result_poll_interval (float): how often to poll task result.
@@ -114,6 +111,7 @@ class TaskExchanger(Executor):
             )
             self.pipe_handler.set_status_cb(self._pipe_status_cb)
             self.pipe.open(self.pipe_channel_name)
+        elif event_type == EventType.BEFORE_TASK_EXECUTION:
             self.pipe_handler.start()
         elif event_type == EventType.ABOUT_TO_END_RUN:
             self.log_info(fl_ctx, "Stopping pipe handler")

--- a/nvflare/app_common/widgets/metric_relay.py
+++ b/nvflare/app_common/widgets/metric_relay.py
@@ -32,8 +32,6 @@ class MetricRelay(Widget, AttributesExportable):
         self,
         pipe_id: str,
         read_interval=0.1,
-        heartbeat_interval=5.0,
-        heartbeat_timeout=30.0,
         pipe_channel_name=PipeChannelName.METRIC,
         event_type: str = ANALYTIC_EVENT_TYPE,
         fed_event: bool = True,
@@ -41,8 +39,6 @@ class MetricRelay(Widget, AttributesExportable):
         super().__init__()
         self.pipe_id = pipe_id
         self._read_interval = read_interval
-        self._heartbeat_interval = heartbeat_interval
-        self._heartbeat_timeout = heartbeat_timeout
         self.pipe_channel_name = pipe_channel_name
         self.pipe = None
         self.pipe_handler = None
@@ -63,12 +59,12 @@ class MetricRelay(Widget, AttributesExportable):
             self.pipe_handler = PipeHandler(
                 pipe=self.pipe,
                 read_interval=self._read_interval,
-                heartbeat_interval=self._heartbeat_interval,
-                heartbeat_timeout=self._heartbeat_timeout,
+                enable_heartbeat=False,
             )
             self.pipe_handler.set_status_cb(self._pipe_status_cb)
             self.pipe_handler.set_message_cb(self._pipe_msg_cb)
             self.pipe.open(self.pipe_channel_name)
+        elif event_type == EventType.BEFORE_TASK_EXECUTION:
             self.pipe_handler.start()
         elif event_type == EventType.ABOUT_TO_END_RUN:
             self.log_info(fl_ctx, "Stopping pipe handler")

--- a/nvflare/client/flare_agent.py
+++ b/nvflare/client/flare_agent.py
@@ -66,10 +66,10 @@ class FlareAgent:
         pipe: Pipe,
         read_interval=0.1,
         heartbeat_interval=5.0,
-        heartbeat_timeout=30.0,
+        heartbeat_timeout=60.0,
         resend_interval=2.0,
         max_resends=None,
-        submit_result_timeout=30.0,
+        submit_result_timeout=60.0,
         metric_pipe=None,
         task_channel_name: str = PipeChannelName.TASK,
         metric_channel_name: str = PipeChannelName.METRIC,
@@ -83,15 +83,15 @@ class FlareAgent:
 
         Args:
             pipe (Pipe): pipe for task communication.
-            read_interval (float): how often to read from the pipe. Defaults to 0.1.
-            heartbeat_interval (float): how often to send a heartbeat to the peer. Defaults to 5.0.
+            read_interval (float): how often to read from the pipe.
+            heartbeat_interval (float): how often to send a heartbeat to the peer.
             heartbeat_timeout (float): how long to wait for a heartbeat from the peer before treating the peer as dead,
-                0 means DO NOT check for heartbeat. Defaults to 30.0.
+                0 means DO NOT check for heartbeat.
             resend_interval (float): how often to resend a message if failing to send. None means no resend.
-                Note that if the pipe does not support resending, then no resend. Defaults to 2.0.
+                Note that if the pipe does not support resending, then no resend.
             max_resends (int, optional): max number of resend. None means no limit. Defaults to None.
             submit_result_timeout (float): when submitting task result,
-                how long to wait for response from the CJ. Defaults to 30.0.
+                how long to wait for response from the CJ.
             metric_pipe (Pipe, optional): pipe for metric communication. Defaults to None.
             task_channel_name (str): channel name for task. Defaults to ``task``.
             metric_channel_name (str): channel name for metric. Defaults to ``metric``.
@@ -123,10 +123,9 @@ class FlareAgent:
             self.metric_pipe_handler = PipeHandler(
                 pipe=self.metric_pipe,
                 read_interval=read_interval,
-                heartbeat_interval=heartbeat_interval,
-                heartbeat_timeout=heartbeat_timeout,
                 resend_interval=resend_interval,
                 max_resends=max_resends,
+                enable_heartbeat=False,
             )
 
         self.current_task = None
@@ -346,10 +345,10 @@ class FlareAgentWithCellPipe(FlareAgent):
         workspace_dir: str,
         read_interval=0.1,
         heartbeat_interval=5.0,
-        heartbeat_timeout=30.0,
+        heartbeat_timeout=60.0,
         resend_interval=2.0,
         max_resends=None,
-        submit_result_timeout=30.0,
+        submit_result_timeout=60.0,
         has_metrics=False,
     ):
         """Constructor of Flare Agent with Cell Pipe. This is a convenient class.


### PR DESCRIPTION
### Issue

We need https://github.com/NVIDIA/NVFlare/pull/2406 to enable streaming capabilities to CellPipe as well

1. When the object/model is large, the pull_task from client side will takes a lot of time, so we don't want to start the PipeHandler heartbeat at "START_RUN" event

2. Metric relay component does not need separate timeout itself, so adding an option in PipeHandler to disable the heartbeat

3. Since we always will have task pipe for flare_agent, we just need it to do heartbeats so even if metric pipe is provided, it does not need to send heartbeats 

4. When peer_read_timeout is None, it is not waiting forever, instead the underlying PipeHandler will just use a default request timeout of 5 seconds which is not enough for the model weights/weight diff, so change to a larger default value 

5. PipeHandler send Abort or End signal does not need to wait forever, so provide a timeout there

6. Same as https://github.com/NVIDIA/NVFlare/pull/2370 we need to invoke TaskExchanger's handle_event in LauncherExecutor 

### Description

Add support to large object to LauncherExecutor/ClientAPI utilizing CellPipe


- Update timeout values for larger objects
- Should start the pipe_handler's heartbeat / checking for heartbeat mechanism after the task is pulled and ready to be executed
- MetricRelay component does not need its own heartbeat mechanism

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
