### PR TITLE
[2.4] Fire and forget for pipe handler control messages

### DIFF
--- a/nvflare/fuel/utils/pipe/file_pipe.py
+++ b/nvflare/fuel/utils/pipe/file_pipe.py
@@ -22,7 +22,7 @@ from nvflare.fuel.utils.constants import Mode
 from nvflare.fuel.utils.pipe.file_accessor import FileAccessor
 from nvflare.fuel.utils.pipe.file_name_utils import file_name_to_message, message_to_file_name
 from nvflare.fuel.utils.pipe.fobs_file_accessor import FobsFileAccessor
-from nvflare.fuel.utils.pipe.pipe import Message, Pipe
+from nvflare.fuel.utils.pipe.pipe import Message, Pipe, Topic
 from nvflare.fuel.utils.validation_utils import check_object_type, check_positive_number, check_str
 
 
@@ -260,6 +260,10 @@ class FilePipe(Pipe):
         """
         if not self.pipe_path:
             raise BrokenPipeError("pipe is not open")
+
+        if not timeout and msg.topic in [Topic.END, Topic.ABORT, Topic.HEARTBEAT]:
+            timeout = 5.0
+
         return self.put_f(msg, timeout)
 
     def receive(self, timeout=None):


### PR DESCRIPTION
When one end of pipe is shutting down, the pipe handler on this side is trying to send the END or ABORT event to the other side, and it blocks there forever.

If the other end has already shutdown, then our system never end.


### Description

- PipeHandler send Abort or End needs to fire and forget, so we use small number 0.1 instead of waiting forever
- Add a default timeout for FilePipe so it will not wait forever for control signals


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
