### PR TITLE
Exclude non-training clients from cse

### DIFF
--- a/nvflare/app_common/ccwf/common.py
+++ b/nvflare/app_common/ccwf/common.py
@@ -88,6 +88,8 @@ class Constant:
     FINAL_RESULT_ACK_TIMEOUT = 10
     GET_MODEL_TIMEOUT = 10
 
+    PROP_KEY_TRAIN_CLIENTS = "cwf.train_clients"
+
 
 class ModelType:
 

--- a/nvflare/app_common/ccwf/cse_server_ctl.py
+++ b/nvflare/app_common/ccwf/cse_server_ctl.py
@@ -204,7 +204,13 @@ class CrossSiteEvalServerController(ServerSideController):
             self.current_round += 1
 
         # ask everyone to eval everyone else's local model
+        train_clients = fl_ctx.get_prop(Constant.PROP_KEY_TRAIN_CLIENTS)
         for c in self.evaluatees:
+            if train_clients and c not in train_clients:
+                # this client does not have local models
+                self.log_info(fl_ctx, f"ignore client {c} since it does not have local models")
+                continue
+
             self._ask_to_evaluate(
                 current_round=self.current_round,
                 model_name=ModelName.BEST_MODEL,

--- a/nvflare/app_common/ccwf/swarm_server_ctl.py
+++ b/nvflare/app_common/ccwf/swarm_server_ctl.py
@@ -92,5 +92,9 @@ class SwarmServerController(ServerSideController):
             if c not in self.train_clients and c not in self.aggr_clients:
                 raise RuntimeError(f"Config Error:  client {c} is neither train client nor aggr client")
 
+        # set train_clients as a sticky prop in fl_ctx
+        # in case CSE (cross site eval) workflow follows, it will know that only training clients have local models
+        fl_ctx.set_prop(key=Constant.PROP_KEY_TRAIN_CLIENTS, value=self.train_clients, private=True, sticky=True)
+
     def prepare_config(self):
         return {Constant.AGGR_CLIENTS: self.aggr_clients, Constant.TRAIN_CLIENTS: self.train_clients}


### PR DESCRIPTION
### Description

This is the same PR as https://github.com/NVIDIA/NVFlare/pull/2400, but applied to 2.5.

The CCWF's cross-site-eval workflow (CSE) assumes all evaluatees have local models. However, depending on the config of the Swarm Learning workflow (usually before CSE) of the job, some clients may only be aggregators and don't train. In this case, the client that is not a trainer won't be able to submit local model, which causes the CSE to fail.

This PR fixes this issue by checking the client against the training clients list of Swarm Learning workflow. Only training clients will be treated as evaluatees.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
