### PR TITLE
[2.4] always use default grpc opts

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based_v2/controller.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/controller.py
@@ -16,7 +16,6 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.app_opt.xgboost.histogram_based_v2.adaptor_controller import XGBController
 from nvflare.app_opt.xgboost.histogram_based_v2.adaptors.grpc_server_adaptor import GrpcServerAdaptor
 from nvflare.app_opt.xgboost.histogram_based_v2.defs import Constant
-from nvflare.app_opt.xgboost.histogram_based_v2.grpc.defs import GRPC_DEFAULT_OPTIONS
 from nvflare.app_opt.xgboost.histogram_based_v2.runners.server_runner import XGBServerRunner
 
 
@@ -32,7 +31,6 @@ class XGBFedController(XGBController):
         max_client_op_interval: float = Constant.MAX_CLIENT_OP_INTERVAL,
         progress_timeout: float = Constant.WORKFLOW_PROGRESS_TIMEOUT,
         client_ranks=None,
-        int_client_grpc_options=None,
         in_process=True,
     ):
         XGBController.__init__(
@@ -48,9 +46,8 @@ class XGBFedController(XGBController):
             progress_timeout=progress_timeout,
             client_ranks=client_ranks,
         )
-        self.int_client_grpc_options = (
-            GRPC_DEFAULT_OPTIONS if int_client_grpc_options is None else int_client_grpc_options
-        )
+        # do not let user specify int_client_grpc_options in this version - always use default.
+        self.int_client_grpc_options = None
         self.in_process = in_process
 
     def get_adaptor(self, fl_ctx: FLContext):

--- a/nvflare/app_opt/xgboost/histogram_based_v2/executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/executor.py
@@ -27,7 +27,6 @@ class FedXGBHistogramExecutor(XGBExecutor):
         sender_id: str = None,
         verbose_eval=False,
         use_gpus=False,
-        int_server_grpc_options=None,
         req_timeout=100.0,
         model_file_name="model.json",
         metrics_writer_id: str = None,
@@ -44,10 +43,12 @@ class FedXGBHistogramExecutor(XGBExecutor):
         self.data_loader_id = data_loader_id
         self.verbose_eval = verbose_eval
         self.use_gpus = use_gpus
-        self.int_server_grpc_options = int_server_grpc_options
         self.model_file_name = model_file_name
         self.in_process = in_process
         self.metrics_writer_id = metrics_writer_id
+
+        # do not let use specify int_server_grpc_options in this version - always use default
+        self.int_server_grpc_options = None
 
     def get_adaptor(self, fl_ctx: FLContext):
         runner = XGBClientRunner(


### PR DESCRIPTION
Fixes 4570002 .

### Description

The current version of XGB integration only supports local XGB GRPC server and clients, there is no need for user to specify grpc options - default setting is sufficient.  This PR removes the grpc options arg from controller and executor.

We can add these args back when/if we need to support remote XGB GRPC server/clients in the future.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
