### PR TITLE
[2.4] Fixed the wrong workspace object in the simulator worker

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -505,6 +505,7 @@ class SimulatorClientRunner(FLComponent):
         self.deploy_args = deploy_args
         self.build_ctx = build_ctx
         self.kv_list = parse_vars(args.set)
+        self.logging_config = os.path.join(self.args.workspace, "local", WorkspaceConstants.LOGGING_CONFIG)
 
         self.end_run_clients = []
 
@@ -573,10 +574,13 @@ class SimulatorClientRunner(FLComponent):
 
     def do_one_task(self, client, num_of_threads, gpu, lock, timeout=60.0, task_name=RunnerTask.TASK_EXEC):
         open_port = get_open_ports(1)[0]
+        client_workspace = os.path.join(self.args.workspace, SimulatorConstants.JOB_NAME, "app_" + client.client_name)
         command = (
             sys.executable
             + " -m nvflare.private.fed.app.simulator.simulator_worker -o "
-            + self.args.workspace
+            + client_workspace
+            + " --logging_config "
+            + self.logging_config
             + " --client "
             + client.client_name
             + " --token "

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -231,15 +231,11 @@ def main(args):
     thread = threading.Thread(target=check_parent_alive, args=(parent_pid, stop_event))
     thread.start()
 
-    log_config_file_path = os.path.join(args.workspace, "startup", WorkspaceConstants.LOGGING_CONFIG)
-    if not os.path.isfile(log_config_file_path):
-        log_config_file_path = os.path.join(os.path.dirname(__file__), WorkspaceConstants.LOGGING_CONFIG)
-    logging.config.fileConfig(fname=log_config_file_path, disable_existing_loggers=False)
-    workspace = os.path.join(args.workspace, SimulatorConstants.JOB_NAME, "app_" + args.client)
-    log_file = os.path.join(workspace, WorkspaceConstants.LOG_FILE_NAME)
+    logging.config.fileConfig(fname=args.logging_config, disable_existing_loggers=False)
+    log_file = os.path.join(args.workspace, WorkspaceConstants.LOG_FILE_NAME)
     add_logfile_handler(log_file)
 
-    os.chdir(workspace)
+    os.chdir(args.workspace)
     fobs_initialize()
     AuthorizationService.initialize(EmptyAuthorizer())
     # AuditService.initialize(audit_file_name=WorkspaceConstants.AUDIT_LOG)
@@ -263,6 +259,7 @@ def main(args):
 def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--workspace", "-o", type=str, help="WORKSPACE folder", required=True)
+    parser.add_argument("--logging_config", type=str, help="logging config file", required=True)
     parser.add_argument("--client", type=str, help="Client name", required=True)
     parser.add_argument("--token", type=str, help="Client token", required=True)
     parser.add_argument("--port", type=str, help="Listen port", required=True)


### PR DESCRIPTION
Fixes # .

### Description

Fixed the wrong path of workspace object in the simulator worker.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
