### PR TITLE
[2.4] Improve xgb runner status check

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptor_controller.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptor_controller.py
@@ -295,7 +295,7 @@ class XGBController(Controller):
         if exit_code == 0:
             self.log_info(fl_ctx, f"XGB client is done with exit code {exit_code}")
         elif exit_code == Constant.EXIT_CODE_CANT_START_XGB:
-            self.log_error(fl_ctx, f"XGB client failed to start")
+            self.log_error(fl_ctx, "XGB client failed to start")
             self.system_panic("XGB client failed to start", fl_ctx)
         else:
             self.log_warning(fl_ctx, f"XGB client is done with exit code {exit_code}")

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptor_controller.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptor_controller.py
@@ -294,6 +294,9 @@ class XGBController(Controller):
         # Problem is that even if the exit_code is not 0, we can't say the job failed.
         if exit_code == 0:
             self.log_info(fl_ctx, f"XGB client is done with exit code {exit_code}")
+        elif exit_code == Constant.EXIT_CODE_CANT_START_XGB:
+            self.log_error(fl_ctx, f"XGB client failed to start")
+            self.system_panic("XGB client failed to start", fl_ctx)
         else:
             self.log_warning(fl_ctx, f"XGB client is done with exit code {exit_code}")
 

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_client_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_client_adaptor.py
@@ -38,6 +38,7 @@ class _ClientStarter:
         self.error = None
         self.started = True
         self.stopped = False
+        self.exit_code = 0
 
     def start(self, ctx: dict):
         """Start the runner and wait for it to finish.
@@ -55,6 +56,8 @@ class _ClientStarter:
             secure_log_traceback()
             self.error = f"Exception happens when running xgb train: {secure_format_exception(e)}"
             self.started = False
+            self.stopped = True
+            self.exit_code = Constant.EXIT_CODE_CANT_START_XGB
 
 
 class GrpcClientAdaptor(XGBClientAdaptor, FederatedServicer):
@@ -171,7 +174,7 @@ class GrpcClientAdaptor(XGBClientAdaptor, FederatedServicer):
         if self.in_process:
             if self._starter:
                 if self._starter.stopped:
-                    return True, 0
+                    return True, self._starter.exit_code
 
             if self._training_stopped:
                 return True, 0

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_client_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_client_adaptor.py
@@ -58,8 +58,8 @@ class _ClientStarter:
             secure_log_traceback()
             self.error = f"Exception happens when running xgb train: {secure_format_exception(e)}"
             self.started = False
-            self.stopped = True
             self.exit_code = Constant.EXIT_CODE_CANT_START_XGB
+            self.stopped = True
             if not self.in_process:
                 # running in separate process - exit with error code for the monitor to report to server
                 sys.exit(self.exit_code)

--- a/nvflare/app_opt/xgboost/histogram_based_v2/defs.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/defs.py
@@ -85,4 +85,4 @@ class Constant:
     RUNNER_CTX_RANK = "rank"
     RUNNER_CTX_MODEL_DIR = "model_dir"
 
-    EXIT_CODE_CANT_START_XGB = -101
+    EXIT_CODE_CANT_START_XGB = 101

--- a/nvflare/app_opt/xgboost/histogram_based_v2/defs.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/defs.py
@@ -29,7 +29,7 @@ class Constant:
     # default component config values
     CONFIG_TASK_TIMEOUT = 10
     START_TASK_TIMEOUT = 10
-    XGB_SERVER_READY_TIMEOUT = 10.0
+    XGB_SERVER_READY_TIMEOUT = 5.0
 
     TASK_CHECK_INTERVAL = 0.5
     JOB_STATUS_CHECK_INTERVAL = 2.0
@@ -84,3 +84,5 @@ class Constant:
     RUNNER_CTX_WORLD_SIZE = "world_size"
     RUNNER_CTX_RANK = "rank"
     RUNNER_CTX_MODEL_DIR = "model_dir"
+
+    EXIT_CODE_CANT_START_XGB = -101


### PR DESCRIPTION
Fixes #4572122.

### Description

When XGB client fails to start, the status and exit code were not set properly. So even though the XGB client already stopped , the server won't get notified properly.

This PR fixes this issue by setting the correct status code and exit code. When server receives the notification, it will terminate the job immediately.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
