### PR TITLE
[2.4] Fix check resource auth

### DIFF
--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -760,6 +760,8 @@ class ServerEngine(ServerEngineInternalSpec):
     def _make_message_for_check_resource(self, job, resource_requirements, fl_ctx):
         request = Message(topic=TrainingTopic.CHECK_RESOURCE, body=resource_requirements)
         request.set_header(RequestHeader.JOB_ID, job.job_id)
+        request.set_header(RequestHeader.REQUIRE_AUTHZ, "true")
+        request.set_header(RequestHeader.ADMIN_COMMAND, AdminCommandNames.CHECK_RESOURCES)
 
         set_message_security_data(request, job, fl_ctx)
         return request


### PR DESCRIPTION
Fixes 4574333

These two lines were incorrectly removed in https://github.com/NVIDIA/NVFlare/pull/2048/

### Description

These two lines were incorrectly removed in https://github.com/NVIDIA/NVFlare/pull/2048/
We need both RequestHeader.REQUIRE_AUTHZ and RequestHeader.ADMIN_COMMAND to do authorization

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
