### PR TITLE
[2.4] Support client custom code in simulator

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -601,10 +601,14 @@ class SimulatorClientRunner(FLComponent):
         if gpu:
             command += " --gpu " + str(gpu)
         new_env = os.environ.copy()
-        if not sys.path[0]:
-            new_env["PYTHONPATH"] = os.pathsep.join(sys.path[1:])
+        # append custom to path_to_pass so won't affect sys.path
+        app_custom_folder = os.path.join(client_workspace, "custom")
+        path_to_pass = [p for p in sys.path]
+        path_to_pass.append(app_custom_folder)
+        if not path_to_pass[0]:
+            new_env["PYTHONPATH"] = os.pathsep.join(path_to_pass[1:])
         else:
-            new_env["PYTHONPATH"] = os.pathsep.join(sys.path)
+            new_env["PYTHONPATH"] = os.pathsep.join(path_to_pass)
         _ = subprocess.Popen(shlex.split(command, True), preexec_fn=os.setsid, env=new_env)
 
         conn = self._create_connection(open_port, timeout=timeout)


### PR DESCRIPTION
After PR #2430 

When running a job with different apps for server and client, if the client custom folder has custom code ("data_loader.py",
and the config_fed_client goes like "
"path": "data_loader.DataLoader",

it will failed, for example in the finance example:
```
2024-03-25 17:01:32,688 - JsonScanner - ERROR - Traceback (most recent call last):
  File "/home/yuantingh/NVFlare/nvflare/fuel/utils/json_scanner.py", line 99, in _do_scan
    node.processor.process_element(node)
  File "/home/yuantingh/NVFlare/nvflare/private/json_configer.py", line 150, in process_element
    self.process_config_element(self.config_ctx, node)
  File "/home/yuantingh/NVFlare/nvflare/private/fed/client/client_json_config.py", line 90, in process_config_element
    FedJsonConfigurator.process_config_element(self, config_ctx, node)
  File "/home/yuantingh/NVFlare/nvflare/private/fed_json_config.py", line 91, in process_config_element
    c = self.authorize_and_build_component(element, config_ctx, node)
  File "/home/yuantingh/NVFlare/nvflare/private/json_configer.py", line 103, in authorize_and_build_component
    return self.build_component(config_dict)
  File "/home/yuantingh/NVFlare/nvflare/private/fed/client/client_json_config.py", line 122, in build_component
    t = super().build_component(config_dict)
  File "/home/yuantingh/NVFlare/nvflare/fuel/utils/component_builder.py", line 86, in build_component
    return instantiate_class(class_path, class_args)
  File "/home/yuantingh/NVFlare/nvflare/fuel/utils/class_utils.py", line 51, in instantiate_class
    c = get_class(class_path)
  File "/home/yuantingh/NVFlare/nvflare/fuel/utils/class_utils.py", line 30, in get_class
    module_ = importlib.import_module(module_name)
  File "/usr/lib/python3.8/importlib/{}init{}.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'data_loader'
```


### Description


Add custom path when running simulator client


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
