### PR TITLE
[2.4] Remove cancel_futures args

### DIFF
--- a/nvflare/apis/utils/reliable_message.py
+++ b/nvflare/apis/utils/reliable_message.py
@@ -350,7 +350,7 @@ class ReliableMessage:
         """
         if not cls._shutdown_asked:
             cls._shutdown_asked = True
-            cls._executor.shutdown(cancel_futures=True, wait=False)
+            cls._executor.shutdown(wait=False)
             cls._logger.info("ReliableMessage is shutdown")
 
     @classmethod


### PR DESCRIPTION
### Description

Python 3.8 ThreadPoolExecutor does not have this argument: https://docs.python.org/3.8/library/concurrent.futures.html

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
