### PR TITLE
[2.4] Fix sub_worker_process shutdown

### DIFF
--- a/nvflare/private/fed/app/client/sub_worker_process.py
+++ b/nvflare/private/fed/app/client/sub_worker_process.py
@@ -294,8 +294,6 @@ class SubWorkerExecutor(Runner):
 
     def _close(self, data):
         self.done = True
-        self.cell.stop()
-        # mpm.stop()
 
     def run(self):
         self.logger.info("SubWorkerExecutor process started.")


### PR DESCRIPTION
Fixes #2427 

### Description

The cell stop should just be run by the mpm callbacks. (in L174)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
