### PR TITLE
[2.4] Add warning when the same admin in project.yml has different role

### DIFF
--- a/nvflare/lighter/impl/cert.py
+++ b/nvflare/lighter/impl/cert.py
@@ -87,6 +87,17 @@ class CertBuilder(Builder):
             pri_key = serialization.load_pem_private_key(
                 self.persistent_state[subject]["pri_key"].encode("ascii"), password=None, backend=default_backend()
             )
+            if participant.type == "admin":
+                cn_list = cert.subject.get_attributes_for_oid(NameOID.UNSTRUCTURED_NAME)
+                for cn in cn_list:
+                    role = cn.value
+                    new_role = participant.props.get("role")
+                    if role != new_role:
+                        err_msg = (
+                            f"{participant.name}'s previous role is {role} but is now {new_role}.\n"
+                            + "Please delete existing workspace and provision from scratch."
+                        )
+                        raise RuntimeError(err_msg)
         else:
             pri_key, cert = self.get_pri_key_cert(participant)
             self.persistent_state[subject] = dict(


### PR DESCRIPTION
### Description

By design, provisioners can add clients or admins in project.yml and do provision to get additional client/admin startup kits.  The certs and private keys of existing participants are kept the same so that there is no need to re-distribute those existing startup kits.

When the role of existing admin changes in project.yml, its cert/private key and thus the role in subject's unstructured_name, do not change.  This causes confusion as provisioners may think a new set of cert/private key is generated.

This PR adds a warning during provisioning time so that provisioners know what to do to generate the new startup kits.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
