### PR TITLE
[2.4] Use unbuffered python launch

### DIFF
--- a/job_templates/cyclic_cc_pt/config_fed_client.conf
+++ b/job_templates/cyclic_cc_pt/config_fed_client.conf
@@ -85,7 +85,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/cyclic_pt/config_fed_client.conf
+++ b/job_templates/cyclic_pt/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_cse_pt/config_fed_client.conf
+++ b/job_templates/sag_cse_pt/config_fed_client.conf
@@ -62,7 +62,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_gnn/app_1/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_1/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_gnn/app_2/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_2/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_np/config_fed_client.conf
+++ b/job_templates/sag_np/config_fed_client.conf
@@ -67,7 +67,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_np_cell_pipe/config_fed_client.conf
+++ b/job_templates/sag_np_cell_pipe/config_fed_client.conf
@@ -67,7 +67,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_np_metrics/config_fed_client.conf
+++ b/job_templates/sag_np_metrics/config_fed_client.conf
@@ -67,7 +67,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_pt/config_fed_client.conf
+++ b/job_templates/sag_pt/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_pt_deploy_map/app_1/config_fed_client.conf
+++ b/job_templates/sag_pt_deploy_map/app_1/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_pt_deploy_map/app_2/config_fed_client.conf
+++ b/job_templates/sag_pt_deploy_map/app_2/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_pt_he/config_fed_client.conf
+++ b/job_templates/sag_pt_he/config_fed_client.conf
@@ -84,7 +84,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_pt_mlflow/config_fed_client.conf
+++ b/job_templates/sag_pt_mlflow/config_fed_client.conf
@@ -64,7 +64,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sag_tf/config_fed_client.conf
+++ b/job_templates/sag_tf/config_fed_client.conf
@@ -55,7 +55,7 @@ components = [
 
     args {
       # the launcher will invoke the script
-      script = "python3 custom/{app_script}  {app_config} "
+      script = "python3 -u custom/{app_script}  {app_config} "
       # if launch_once is true, the SubprocessLauncher will launch once for the whole job
       # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
       launch_once = true

--- a/job_templates/sklearn_kmeans/config_fed_client.conf
+++ b/job_templates/sklearn_kmeans/config_fed_client.conf
@@ -65,7 +65,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sklearn_linear/config_fed_client.conf
+++ b/job_templates/sklearn_linear/config_fed_client.conf
@@ -65,7 +65,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/sklearn_svm/config_fed_client.conf
+++ b/job_templates/sklearn_svm/config_fed_client.conf
@@ -65,7 +65,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true

--- a/job_templates/swarm_cse_pt/config_fed_client.conf
+++ b/job_templates/swarm_cse_pt/config_fed_client.conf
@@ -89,7 +89,7 @@ components = [
 
     args {
       # the launcher will invoke the script
-      script = "python3 custom/{app_script}  {app_config} "
+      script = "python3 -u custom/{app_script}  {app_config} "
       # if launch_once is true, the SubprocessLauncher will launch once for the whole job
       # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
       launch_once = true

--- a/job_templates/xgboost_tree/config_fed_client.conf
+++ b/job_templates/xgboost_tree/config_fed_client.conf
@@ -65,7 +65,7 @@
 
       args {
         # the launcher will invoke the script
-        script = "python3 custom/{app_script}  {app_config} "
+        script = "python3 -u custom/{app_script}  {app_config} "
         # if launch_once is true, the SubprocessLauncher will launch once for the whole job
         # if launch_once is false, the SubprocessLauncher will launch a process for each task it receives from server
         launch_once = true


### PR DESCRIPTION
Fixes #2398 .

### Description

Let external process be un-buffered so users can see results right away.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
