### PR TITLE
Remove task_fn_args

### DIFF
--- a/nvflare/app_opt/pt/in_process_client_api_executor.py
+++ b/nvflare/app_opt/pt/in_process_client_api_executor.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, Optional
+from typing import Optional
 
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.executors.in_process_client_api_executor import InProcessClientAPIExecutor
@@ -26,7 +26,6 @@ class PTInProcessClientAPIExecutor(InProcessClientAPIExecutor):
         self,
         task_script_path: str,
         task_script_args: str = "",
-        task_fn_args: Dict = None,
         task_wait_time: Optional[float] = None,
         result_pull_interval: float = 0.5,
         log_pull_interval: Optional[float] = None,
@@ -41,7 +40,6 @@ class PTInProcessClientAPIExecutor(InProcessClientAPIExecutor):
         super(PTInProcessClientAPIExecutor, self).__init__(
             task_script_path=task_script_path,
             task_script_args=task_script_args,
-            task_fn_args=task_fn_args,
             task_wait_time=task_wait_time,
             result_pull_interval=result_pull_interval,
             train_with_evaluation=train_with_evaluation,


### PR DESCRIPTION
remove old `task_fn_args` from `PTInProcessClientAPIExecutor`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
