### PR TITLE
[2.3] Changed exception log to error level for GRPC drivers

### DIFF
--- a/nvflare/fuel/f3/drivers/grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/grpc_driver.py
@@ -87,7 +87,7 @@ class StreamConnection(Connection):
             self.logger.debug(f"{self.side}: queued frame #{seq}")
             self.oq.append(Frame(seq=seq, data=bytes(frame)))
         except BaseException as ex:
-            raise CommError(CommError.ERROR, f"Error sending frame: {ex}")
+            raise CommError(CommError.ERROR, f"Error sending frame: {secure_format_exception(ex)}")
 
     def read_loop(self, msg_iter):
         ct = threading.current_thread()
@@ -151,7 +151,7 @@ class Servicer(StreamerServicer):
             t.start()
             yield from connection.generate_output()
         except BaseException as ex:
-            self.logger.error(f"Connection closed due to error: {ex}")
+            self.logger.error(f"Connection closed due to error: {secure_format_exception(ex)}")
         finally:
             if t is not None:
                 t.join()


### PR DESCRIPTION
### Description
Log all exceptions at error level for both AIO and sync GRPC drivers.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
