### PR TITLE
[2.4] Fix pipe handler timeout in task exchanger and launcher executor

### DIFF
--- a/nvflare/app_common/executors/launcher_executor.py
+++ b/nvflare/app_common/executors/launcher_executor.py
@@ -44,7 +44,7 @@ class LauncherExecutor(TaskExchanger):
         last_result_transfer_timeout: float = 300.0,
         external_pre_init_timeout: float = 60.0,
         peer_read_timeout: Optional[float] = 60.0,
-        monitor_interval: float = 1.0,
+        monitor_interval: float = 0.1,
         read_interval: float = 0.5,
         heartbeat_interval: float = 5.0,
         heartbeat_timeout: float = 60.0,
@@ -373,8 +373,8 @@ class LauncherExecutor(TaskExchanger):
                 if self.launcher is None:
                     break
 
+                # no task is running
                 if self._current_task is None:
-                    self.pause_pipe_handler()
                     continue
 
                 task_name = self._current_task
@@ -390,16 +390,19 @@ class LauncherExecutor(TaskExchanger):
                     continue
 
                 elif run_status == LauncherRunStatus.NOT_RUNNING:
+                    # pause pipe handler because external process is not running
                     self.pause_pipe_handler()
                     continue
 
                 elif run_status == LauncherRunStatus.RUNNING:
+                    # resume pipe handler when external process is running
                     self.resume_pipe_handler()
                     continue
 
                 elif (
                     run_status == LauncherRunStatus.COMPLETE_FAILED or run_status == LauncherRunStatus.COMPLETE_SUCCESS
                 ):
+                    # pause pipe handler because external process is completed
                     self.pause_pipe_handler()
                     if not self._launcher_finish:
                         self._launcher_finish_time = time.time()

--- a/nvflare/app_common/executors/task_exchanger.py
+++ b/nvflare/app_common/executors/task_exchanger.py
@@ -111,7 +111,6 @@ class TaskExchanger(Executor):
             )
             self.pipe_handler.set_status_cb(self._pipe_status_cb)
             self.pipe.open(self.pipe_channel_name)
-        elif event_type == EventType.BEFORE_TASK_EXECUTION:
             self.pipe_handler.start()
         elif event_type == EventType.ABOUT_TO_END_RUN:
             self.log_info(fl_ctx, "Stopping pipe handler")


### PR DESCRIPTION
Fix 4593298

### Description

The pipe handler HB should start right away in START_RUN, then the monitor_launcher can check for external process's status to pause/resume.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
