### PR TITLE
[2.4] Fix metric relay pipe handler timeout

### DIFF
--- a/nvflare/app_common/widgets/metric_relay.py
+++ b/nvflare/app_common/widgets/metric_relay.py
@@ -33,7 +33,6 @@ class MetricRelay(Widget, AttributesExportable):
         pipe_id: str,
         read_interval=0.1,
         heartbeat_interval=5.0,
-        heartbeat_timeout=30.0,
         pipe_channel_name=PipeChannelName.METRIC,
         event_type: str = ANALYTIC_EVENT_TYPE,
         fed_event: bool = True,
@@ -42,7 +41,6 @@ class MetricRelay(Widget, AttributesExportable):
         self.pipe_id = pipe_id
         self._read_interval = read_interval
         self._heartbeat_interval = heartbeat_interval
-        self._heartbeat_timeout = heartbeat_timeout
         self.pipe_channel_name = pipe_channel_name
         self.pipe = None
         self.pipe_handler = None
@@ -64,12 +62,11 @@ class MetricRelay(Widget, AttributesExportable):
                 pipe=self.pipe,
                 read_interval=self._read_interval,
                 heartbeat_interval=self._heartbeat_interval,
-                heartbeat_timeout=self._heartbeat_timeout,
+                heartbeat_timeout=0,
             )
             self.pipe_handler.set_status_cb(self._pipe_status_cb)
             self.pipe_handler.set_message_cb(self._pipe_msg_cb)
             self.pipe.open(self.pipe_channel_name)
-        elif event_type == EventType.BEFORE_TASK_EXECUTION:
             self.pipe_handler.start()
         elif event_type == EventType.ABOUT_TO_END_RUN:
             self.log_info(fl_ctx, "Stopping pipe handler")


### PR DESCRIPTION
### Description

Follow #2495, we should start heartbeat at START_RUN.

And we don't need to have heartbeat timeout at NVFlare client executor side, because LauncherExecutor will handle it.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
