### PR TITLE
[2.4] Rely on launcher check_run_status to pause/resume heartbeat

### DIFF
--- a/nvflare/app_common/executors/launcher_executor.py
+++ b/nvflare/app_common/executors/launcher_executor.py
@@ -373,10 +373,6 @@ class LauncherExecutor(TaskExchanger):
                 if self.launcher is None:
                     break
 
-                # no task is running
-                if self._current_task is None:
-                    continue
-
                 task_name = self._current_task
                 run_status = self._execute_launcher_method_in_thread_executor(
                     method_name="check_run_status",

--- a/nvflare/app_common/executors/task_exchanger.py
+++ b/nvflare/app_common/executors/task_exchanger.py
@@ -142,7 +142,7 @@ class TaskExchanger(Executor):
         task_id = shareable.get_header(key=FLContextKey.TASK_ID)
 
         # send to peer
-        self.log_debug(fl_ctx, f"sending task to peer {self.peer_read_timeout=}")
+        self.log_info(fl_ctx, f"sending task to peer {self.peer_read_timeout=}")
         req = Message.new_request(topic=task_name, data=shareable, msg_id=task_id)
         start_time = time.time()
         has_been_read = self.pipe_handler.send_to_peer(req, timeout=self.peer_read_timeout, abort_signal=abort_signal)


### PR DESCRIPTION
### Issue

To address both scenarios where launch_once is set to False or True, we remove the skip condition ``if self._current_task is None: continue``. This skip condition is inaccurate.
The LauncherExecutor should not use this skip; instead, it should verify whether the external process is running to determine whether to pause or resume the PipeHandler heartbeat.

For instance, consider a scenario where the TASK is very large (4GB or more).
When launch_once is set to False, the PipeHandler heartbeat begins at the "START_RUN" event, while the NVFlare client process attempts to pull the task from the server. This process can take a significant amount of time (up to 300 seconds or more). The external process is only started after the task is pulled (in the execute method). Since the PipeHandler heartbeat checking/sending begins at the start, it may timeout (default 60 seconds) before the external process has a chance to launch (because 60 < 300).

To prevent users from needing to adjust the heartbeat timeout in proportion to the time taken to pull the task, we propose the following change in this PR.

### Description
The revised logic is as follows:

1. When launch_once is True, the `TaskExchanger` calls the `pipe_handler.start` at the "START_RUN" event, and the SubprocessLauncher launches the external process at the same event. Since the external process continues running throughout, it will not be paused or resumed.

2. When launch_once is False, the `TaskExchanger` still calls the `pipe_handler.start` at the "START_RUN" event. In `_monitor_launcher`, it detects that the SubprocessLauncher has not launched the external process, so it calls `pause_pipe_handler`. After the task is pulled, the SubprocessLauncher launches the external process. Subsequently, in `_monitor_launcher`, it detects that the SubprocessLauncher has launched the external process, so it calls `resume_pipe_handler`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
