### PR TITLE
[2.3] Fix 2.3 unit tests

### DIFF
--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -328,6 +328,9 @@ class AioGrpcDriver(BaseDriver):
             msg_iter = stub.Stream(connection.generate_output())
             conn_ctx.conn = connection
             await connection.read_loop(msg_iter)
+        except asyncio.CancelledError:
+            self.logger.error("CLIENT: RPC cancelled")
+            self.logger.error(secure_format_traceback())
         except grpc.FutureCancelledError:
             self.logger.info("CLIENT: Future cancelled")
         except Exception as ex:

--- a/nvflare/fuel/f3/drivers/aio_grpc_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_grpc_driver.py
@@ -102,6 +102,9 @@ class AioStreamSession(Connection):
             seq = AioStreamSession.seq_num
             f = Frame(seq=seq, data=bytes(frame))
             self.aio_ctx.run_coro(self.oq.put(f))
+        except asyncio.CancelledError:
+            self.logger.error("RPC cancelled")
+            self.logger.error(secure_format_traceback())
         except Exception as ex:
             self.logger.error(f"exception send_frame: {self}: {secure_format_exception(ex)}")
             if not self.closing:
@@ -181,7 +184,8 @@ class Servicer(StreamerServicer):
                 item = await connection.oq.get()
                 yield item
         except asyncio.CancelledError:
-            self.logger.info("SERVER: RPC cancelled")
+            self.logger.error("SERVER: RPC cancelled")
+            self.logger.error(secure_format_traceback())
         except Exception as ex:
             self.logger.error(f"{connection}: connection exception: {secure_format_exception(ex)}")
             self.logger.error(secure_format_traceback())
@@ -274,6 +278,9 @@ class AioGrpcDriver(BaseDriver):
             try:
                 conn_ctx.conn = True
                 await self.server.start(conn_ctx)
+            except asyncio.CancelledError:
+                self.logger.error("RPC cancelled")
+                self.logger.error(secure_format_traceback())
             except Exception as ex:
                 conn_ctx.error = f"failed to start server: {type(ex)}: {secure_format_exception(ex)}"
                 self.logger.error(conn_ctx.error)


### PR DESCRIPTION
AioGrpcDriver exception handling bug: in python 3.8, `asyncio.CancelledError` was changed to subclass `BaseException` instead of `Exception`, so it will not be caught with `except Exception as ex:`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
