### PR TITLE
Fix update client status

### DIFF
--- a/nvflare/app_common/ccwf/server_ctl.py
+++ b/nvflare/app_common/ccwf/server_ctl.py
@@ -345,7 +345,9 @@ class ServerSideController(Controller):
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if event_type == EventType.BEFORE_PROCESS_TASK_REQUEST:
-            self._update_client_status(fl_ctx)
+            peer_ctx = fl_ctx.get_peer_context()
+            if peer_ctx and self.workflow_id in peer_ctx.get_prop(Constant.STATUS_REPORTS, {}):
+                self._update_client_status(fl_ctx)
 
     def process_config_reply(self, client_name: str, reply: Shareable, fl_ctx: FLContext) -> bool:
         return True

--- a/nvflare/app_common/ccwf/server_ctl.py
+++ b/nvflare/app_common/ccwf/server_ctl.py
@@ -345,9 +345,7 @@ class ServerSideController(Controller):
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if event_type == EventType.BEFORE_PROCESS_TASK_REQUEST:
-            peer_ctx = fl_ctx.get_peer_context()
-            if peer_ctx and self.workflow_id in peer_ctx.get_prop(Constant.STATUS_REPORTS, {}):
-                self._update_client_status(fl_ctx)
+            self._update_client_status(fl_ctx)
 
     def process_config_reply(self, client_name: str, reply: Shareable, fl_ctx: FLContext) -> bool:
         return True
@@ -442,9 +440,6 @@ class ServerSideController(Controller):
         peer_ctx = fl_ctx.get_peer_context()
         assert isinstance(peer_ctx, FLContext)
         client_name = peer_ctx.get_identity_name()
-        if client_name not in self.client_statuses:
-            self.log_error(fl_ctx, f"received result from unknown client {client_name}!")
-            return
 
         # see whether status is available
         reports = peer_ctx.get_prop(Constant.STATUS_REPORTS)
@@ -454,6 +449,10 @@ class ServerSideController(Controller):
 
         my_report = reports.get(self.workflow_id)
         if not my_report:
+            return
+
+        if client_name not in self.client_statuses:
+            self.log_error(fl_ctx, f"received result from unknown client {client_name}!")
             return
 
         report = status_report_from_dict(my_report)


### PR DESCRIPTION
Check workflow id when handling event before calling `_update_client_status()` for the case of multiple workflows

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
