### PR TITLE
Simulator end run for all clients

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator.py
+++ b/nvflare/private/fed/app/simulator/simulator.py
@@ -30,6 +30,7 @@ def define_simulator_parser(simulator_parser):
     simulator_parser.add_argument("-t", "--threads", type=int, help="number of parallel running clients")
     simulator_parser.add_argument("-gpu", "--gpu", type=str, help="list of GPU Device Ids, comma separated")
     simulator_parser.add_argument("-m", "--max_clients", type=int, default=100, help="max number of clients")
+    parser.add_argument('--end_run_all', default=False, action=argparse.BooleanOptionalAction)
 
 
 def run_simulator(simulator_args):
@@ -41,6 +42,7 @@ def run_simulator(simulator_args):
         threads=simulator_args.threads,
         gpu=simulator_args.gpu,
         max_clients=simulator_args.max_clients,
+        end_run_all=simulator_args.end_run_all
     )
     run_status = simulator.run()
 

--- a/nvflare/private/fed/app/simulator/simulator.py
+++ b/nvflare/private/fed/app/simulator/simulator.py
@@ -30,7 +30,12 @@ def define_simulator_parser(simulator_parser):
     simulator_parser.add_argument("-t", "--threads", type=int, help="number of parallel running clients")
     simulator_parser.add_argument("-gpu", "--gpu", type=str, help="list of GPU Device Ids, comma separated")
     simulator_parser.add_argument("-m", "--max_clients", type=int, default=100, help="max number of clients")
-    parser.add_argument("--end_run_all", default=False, action=argparse.BooleanOptionalAction)
+    simulator_parser.add_argument(
+        "--end_run_for_all",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="flag to indicate if running END_RUN event for all clients",
+    )
 
 
 def run_simulator(simulator_args):
@@ -42,7 +47,7 @@ def run_simulator(simulator_args):
         threads=simulator_args.threads,
         gpu=simulator_args.gpu,
         max_clients=simulator_args.max_clients,
-        end_run_all=simulator_args.end_run_all,
+        end_run_for_all=simulator_args.end_run_for_all,
     )
     run_status = simulator.run()
 

--- a/nvflare/private/fed/app/simulator/simulator.py
+++ b/nvflare/private/fed/app/simulator/simulator.py
@@ -33,7 +33,7 @@ def define_simulator_parser(simulator_parser):
     simulator_parser.add_argument(
         "--end_run_for_all",
         default=False,
-        action='store_true',
+        action="store_true",
         help="flag to indicate if running END_RUN event for all clients",
     )
 

--- a/nvflare/private/fed/app/simulator/simulator.py
+++ b/nvflare/private/fed/app/simulator/simulator.py
@@ -33,7 +33,7 @@ def define_simulator_parser(simulator_parser):
     simulator_parser.add_argument(
         "--end_run_for_all",
         default=False,
-        action=argparse.BooleanOptionalAction,
+        action='store_true',
         help="flag to indicate if running END_RUN event for all clients",
     )
 

--- a/nvflare/private/fed/app/simulator/simulator.py
+++ b/nvflare/private/fed/app/simulator/simulator.py
@@ -30,7 +30,7 @@ def define_simulator_parser(simulator_parser):
     simulator_parser.add_argument("-t", "--threads", type=int, help="number of parallel running clients")
     simulator_parser.add_argument("-gpu", "--gpu", type=str, help="list of GPU Device Ids, comma separated")
     simulator_parser.add_argument("-m", "--max_clients", type=int, default=100, help="max number of clients")
-    parser.add_argument('--end_run_all', default=False, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--end_run_all", default=False, action=argparse.BooleanOptionalAction)
 
 
 def run_simulator(simulator_args):
@@ -42,7 +42,7 @@ def run_simulator(simulator_args):
         threads=simulator_args.threads,
         gpu=simulator_args.gpu,
         max_clients=simulator_args.max_clients,
-        end_run_all=simulator_args.end_run_all
+        end_run_all=simulator_args.end_run_all,
     )
     run_status = simulator.run()
 

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -519,7 +519,7 @@ class SimulatorClientRunner(FLComponent):
         self.kv_list = parse_vars(args.set)
         self.logging_config = os.path.join(self.args.workspace, "local", WorkspaceConstants.LOGGING_CONFIG)
 
-        self.end_run_clients = []
+        self.clients_finished_end_run = []
 
     def run(self, gpu):
         try:
@@ -575,7 +575,7 @@ class SimulatorClientRunner(FLComponent):
                 )
                 if end_run_client:
                     with lock:
-                        self.end_run_clients.append(end_run_client)
+                        self.clients_finished_end_run.append(end_run_client)
 
                 client.simulate_running = False
 
@@ -593,7 +593,7 @@ class SimulatorClientRunner(FLComponent):
 
         """
         # Each thread only stop picking up the NOT-DONE client until all clients have run the END_RUN event.
-        while len(self.end_run_clients) != len(self.federated_clients):
+        while len(self.clients_finished_end_run) != len(self.federated_clients):
             with lock:
                 end_run_client = self._pick_next_client()
             if end_run_client:
@@ -606,9 +606,9 @@ class SimulatorClientRunner(FLComponent):
     def _pick_next_client(self):
         for client in self.federated_clients:
             # Ensure the client has not run the END_RUN event
-            if client.client_name not in self.end_run_clients and not client.simulate_running:
+            if client.client_name not in self.clients_finished_end_run and not client.simulate_running:
                 client.simulate_running = True
-                self.end_run_clients.append(client.client_name)
+                self.clients_finished_end_run.append(client.client_name)
                 return client
         return None
 

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -596,7 +596,6 @@ class SimulatorClientRunner(FLComponent):
         while len(self.end_run_clients) != len(self.federated_clients):
             with lock:
                 end_run_client = self._pick_next_client()
-                self.end_run_clients.append(end_run_client.client_name)
             if end_run_client:
                 self.do_one_task(
                     end_run_client, num_of_threads, gpu, lock, timeout=timeout, task_name=RunnerTask.END_RUN
@@ -609,6 +608,7 @@ class SimulatorClientRunner(FLComponent):
             # Ensure the client has not run the END_RUN event
             if client.client_name not in self.end_run_clients and not client.simulate_running:
                 client.simulate_running = True
+                self.end_run_clients.append(client.client_name)
                 return client
         return None
 

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -77,7 +77,7 @@ class SimulatorRunner(FLComponent):
         threads=None,
         gpu=None,
         max_clients=100,
-        end_run_all=False,
+        end_run_for_all=False,
     ):
         super().__init__()
 
@@ -88,7 +88,7 @@ class SimulatorRunner(FLComponent):
         self.threads = threads
         self.gpu = gpu
         self.max_clients = max_clients
-        self.end_run_all = end_run_all
+        self.end_run_for_all = end_run_for_all
 
         self.ask_to_stop = False
 
@@ -154,7 +154,7 @@ class SimulatorRunner(FLComponent):
         self.args.env = os.path.join("config", AppFolderConstants.CONFIG_ENV)
         cwd = os.getcwd()
         self.args.job_folder = os.path.join(cwd, self.args.job_folder)
-        self.args.end_run_all = self.end_run_all
+        self.args.end_run_for_all = self.end_run_for_all
 
         if not os.path.exists(self.args.workspace):
             os.makedirs(self.args.workspace)
@@ -530,7 +530,8 @@ class SimulatorClientRunner(FLComponent):
             timeout = self.kv_list.get("simulator_worker_timeout", 60.0)
             for i in range(self.args.threads):
                 executor.submit(
-                    lambda p: self.run_client_thread(*p), [self.args.threads, gpu, lock, self.args.end_run_all, timeout]
+                    lambda p: self.run_client_thread(*p),
+                    [self.args.threads, gpu, lock, self.args.end_run_for_all, timeout],
                 )
 
             # wait for the server and client running thread to finish.
@@ -554,7 +555,7 @@ class SimulatorClientRunner(FLComponent):
             # Ignore the exception for the simulator client shutdown
             self.logger.warn(f"Exception happened to client{client.name} during shutdown ")
 
-    def run_client_thread(self, num_of_threads, gpu, lock, end_run_all, timeout=60):
+    def run_client_thread(self, num_of_threads, gpu, lock, end_run_for_all, timeout=60):
         stop_run = False
         interval = 1
         client_to_run = None  # indicates the next client to run
@@ -578,7 +579,7 @@ class SimulatorClientRunner(FLComponent):
 
                 client.simulate_running = False
 
-            if end_run_all:
+            if end_run_for_all:
                 self._end_run_clients(client, gpu, lock, num_of_threads, timeout)
         except Exception as e:
             self.logger.error(f"run_client_thread error: {secure_format_exception(e)}")

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -69,8 +69,15 @@ SIMULATOR_POOL_STATS = "simulator_cell_stats.json"
 
 class SimulatorRunner(FLComponent):
     def __init__(
-        self, job_folder: str, workspace: str, clients=None, n_clients=None, threads=None, gpu=None, max_clients=100,
-            end_run_all=False
+        self,
+        job_folder: str,
+        workspace: str,
+        clients=None,
+        n_clients=None,
+        threads=None,
+        gpu=None,
+        max_clients=100,
+        end_run_all=False,
     ):
         super().__init__()
 
@@ -522,16 +529,12 @@ class SimulatorClientRunner(FLComponent):
             lock = threading.Lock()
             timeout = self.kv_list.get("simulator_worker_timeout", 60.0)
             for i in range(self.args.threads):
-                executor.submit(lambda p: self.run_client_thread(*p), [self.args.threads, gpu, lock, self.args.end_run_all, timeout])
+                executor.submit(
+                    lambda p: self.run_client_thread(*p), [self.args.threads, gpu, lock, self.args.end_run_all, timeout]
+                )
 
             # wait for the server and client running thread to finish.
             executor.shutdown()
-
-            # for client in self.federated_clients:
-            #     if client.client_name not in self.end_run_clients:
-            #         self.do_one_task(
-            #             client, self.args.threads, gpu, lock, timeout=timeout, task_name=RunnerTask.END_RUN
-            #         )
 
         except Exception as e:
             self.logger.error(f"SimulatorClientRunner run error: {secure_format_exception(e)}")

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -598,16 +598,17 @@ class SimulatorClientRunner(FLComponent):
                 end_run_client = self._pick_next_client()
                 self.end_run_clients.append(end_run_client.client_name)
             if end_run_client:
-                end_run_client.simulate_running = True
                 self.do_one_task(
                     end_run_client, num_of_threads, gpu, lock, timeout=timeout, task_name=RunnerTask.END_RUN
                 )
-                end_run_client.simulate_running = False
+                with lock:
+                    end_run_client.simulate_running = False
 
     def _pick_next_client(self):
         for client in self.federated_clients:
             # Ensure the client has not run the END_RUN event
             if client.client_name not in self.end_run_clients and not client.simulate_running:
+                client.simulate_running = True
                 return client
         return None
 

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -599,7 +599,9 @@ class SimulatorClientRunner(FLComponent):
                 self.end_run_clients.append(end_run_client.client_name)
             if end_run_client:
                 end_run_client.simulate_running = True
-                self.do_one_task(end_run_client, num_of_threads, gpu, lock, timeout=timeout, task_name=RunnerTask.END_RUN)
+                self.do_one_task(
+                    end_run_client, num_of_threads, gpu, lock, timeout=timeout, task_name=RunnerTask.END_RUN
+                )
                 end_run_client.simulate_running = False
 
     def _pick_next_client(self):


### PR DESCRIPTION
Fixes # 

Address the simulator run large number of clients performance issue.

### Description

Simulator only runs the END_RUN events for those active running clients when the workflow finishes the run. All those swapped out clients need to be swapped in and re-created to run the END_RUN event handling. Most of the applications the END_RUN event handling are not needed when the client processes are not active. Change the simulator to provide an "end_run_for_all" option. The default is false. Only set it to run END_RUN event handling for all clients when explicitly set.

Also change to use multi-threads to run the END_RUN event handling if needed.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
