### PR TITLE
simplify Pythonic job simulator_run with only workspace parameter

### DIFF
--- a/examples/advanced/job_config/hello-pt/hello_pt_job.py
+++ b/examples/advanced/job_config/hello-pt/hello_pt_job.py
@@ -109,12 +109,12 @@ class HelloPTJob:
     def export_job(self, job_root):
         self.job.generate_job_config(job_root)
 
-    def simulator_run(self, job_root, workspace):
-        self.job.simulator_run(job_root, workspace, threads=2)
+    def simulator_run(self, workspace):
+        self.job.simulator_run(workspace, threads=2)
 
 
 if __name__ == "__main__":
     job = HelloPTJob()
 
     # job.export_job("/tmp/nvflare/jobs")
-    job.simulator_run("/tmp/nvflare/jobs", "/tmp/nvflare/simulator_workspace")
+    job.simulator_run("/tmp/nvflare/simulator_workspace")

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -17,6 +17,7 @@ import json
 import os
 import shutil
 from enum import Enum
+from tempfile import TemporaryDirectory
 from typing import Dict
 
 from nvflare import SimulatorRunner
@@ -119,18 +120,19 @@ class FedJobConfig:
 
         self._generate_meta(job_dir)
 
-    def simulator_run(self, job_root, workspace, clients=None, n_clients=None, threads=None, gpu=None):
-        self.generate_job_config(job_root)
+    def simulator_run(self, workspace, clients=None, n_clients=None, threads=None, gpu=None):
+        with TemporaryDirectory() as job_root:
+            self.generate_job_config(job_root)
 
-        simulator = SimulatorRunner(
-            job_folder=os.path.join(job_root, self.job_name),
-            workspace=workspace,
-            clients=clients,
-            n_clients=n_clients,
-            threads=threads,
-            gpu=gpu,
-        )
-        simulator.run()
+            simulator = SimulatorRunner(
+                job_folder=os.path.join(job_root, self.job_name),
+                workspace=workspace,
+                clients=clients,
+                n_clients=n_clients,
+                threads=threads,
+                gpu=gpu,
+            )
+            simulator.run()
 
     def _get_server_app(self, config_dir, custom_dir, fed_app):
         server_app = {"format_version": 2, "workflows": []}


### PR DESCRIPTION
Fixes # .

### Description

simplify Pythonic job simulator_run to take only workspace parameter.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
