### PR TITLE
User-defined aggregate_fn

### DIFF
--- a/nvflare/app_common/workflows/base_fedavg.py
+++ b/nvflare/app_common/workflows/base_fedavg.py
@@ -107,7 +107,7 @@ class BaseFedAvg(WFController):
             raise ValueError(f"Result from client(s) {empty_clients} is empty!")
 
     @staticmethod
-    def _aggregate_fn(results: List[FLModel]) -> FLModel:
+    def aggregate_fn(results: List[FLModel]) -> FLModel:
         aggregation_helper = WeightedAggregationHelper()
         for _result in results:
             aggregation_helper.add(
@@ -141,7 +141,7 @@ class BaseFedAvg(WFController):
         self._check_results(results)
 
         if not aggregate_fn:
-            aggregate_fn = self._aggregate_fn
+            aggregate_fn = self.aggregate_fn
 
         self.info(f"aggregating {len(results)} update(s) at round {self.current_round}")
         try:

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -57,8 +57,8 @@ class FedAvg(BaseFedAvg):
             results = self.send_model_and_wait(targets=clients, data=model)
 
             aggregate_results = self.aggregate(
-                results, aggregate_fn=None
-            )  # if no `aggregate_fn` provided, default `WeightedAggregationHelper` is used
+                results, aggregate_fn=self.aggregate_fn
+            )  # using default aggregate_fn with `WeightedAggregationHelper`. Can overwrite self.aggregrate_fn with signature Callable[List[FLModel], FLModel]
 
             model = self.update_model(model, aggregate_results)
 


### PR DESCRIPTION
Allow users to define `aggregate_fn` without needing to overwrite FedAvg's `run()` routine.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
