### PR TITLE
[2.4] Add info for custom data/class

### DIFF
--- a/docs/programming_guide/execution_api_type/client_api.rst
+++ b/docs/programming_guide/execution_api_type/client_api.rst
@@ -248,7 +248,10 @@ Client API configuration.  You can further nail down the selection by choice of 
 in-process or not, type of models ( GNN, NeMo LLM), workflow patterns ( Swarm learning or standard fedavg with scatter and gather (sag)) etc.
 
 
+Sending custom type/class data
+==============================
 
+Users will need to write custom Decomposer following :ref:`serialization`.
 
-
-
+Then use ```fobs.register()``` to register this Decomposer on client code side,
+NVFlare client side and NVFlare server side.


### PR DESCRIPTION
### Description

Add information point users to read serialization page for sending/receiving custom data/class.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
