### PR TITLE
Task Script Runner for In-process Client API executor: replace run_path with run_module

### DIFF
--- a/tests/unit_test/app_common/executors/custom/__init__.py
+++ b/tests/unit_test/app_common/executors/custom/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/app_common/executors/custom/src/__init__.py
+++ b/tests/unit_test/app_common/executors/custom/src/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/app_common/executors/custom/src/code.py
+++ b/tests/unit_test/app_common/executors/custom/src/code.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+from .model import Model
+
+
+class Code:
+    # code to test relative import
+    def run(self, dataset_path, batch_size):
+        model = Model()
+        model.train(dataset_path, batch_size)
+
+    def define_parser(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--dataset_path", type=str, default="/data", nargs="?")
+        parser.add_argument("--batch_size", type=int, default=4, nargs="?")
+        return parser.parse_args()
+
+    def main(self):
+        args = self.define_parser()
+        dataset_path = args.dataset_path
+        batch_size = args.batch_size
+        self.run(dataset_path, batch_size)
+
+
+if __name__ == "__main__":
+    code = Code()
+    code.main()

--- a/tests/unit_test/app_common/executors/custom/src/model.py
+++ b/tests/unit_test/app_common/executors/custom/src/model.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Model:
+    def train(self, dataset_path, batch_size):
+        pass

--- a/tests/unit_test/app_common/executors/task_script_runner_test.py
+++ b/tests/unit_test/app_common/executors/task_script_runner_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sys
 import unittest
 
 from nvflare.app_common.executors.task_script_runner import TaskScriptRunner
@@ -24,7 +25,7 @@ class TestTaskScriptRunner(unittest.TestCase):
         script_args = "--batch_size 4"
         wrapper = TaskScriptRunner(script_path=script_path, script_args=script_args)
 
-        self.assertTrue(wrapper.script_path.endswith(script_path))
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "cli.py"), "--batch_size", "4"])
 
     def test_app_scripts_and_args2(self):
@@ -33,7 +34,7 @@ class TestTaskScriptRunner(unittest.TestCase):
         script_args = "--batch_size 4"
         wrapper = TaskScriptRunner(script_path=script_path, script_args=script_args)
 
-        self.assertTrue(wrapper.script_path.endswith(script_path))
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "cli.py"), "--batch_size", "4"])
 
     def test_app_scripts_with_sub_dirs1(self):
@@ -41,7 +42,7 @@ class TestTaskScriptRunner(unittest.TestCase):
         script_path = "nvflare/__init__.py"
         wrapper = TaskScriptRunner(script_path=script_path)
 
-        self.assertTrue(wrapper.script_path.endswith(script_path))
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "__init__.py")])
 
     def test_app_scripts_with_sub_dirs2(self):
@@ -49,7 +50,7 @@ class TestTaskScriptRunner(unittest.TestCase):
         script_path = "nvflare/app_common/executors/__init__.py"
         wrapper = TaskScriptRunner(script_path=script_path)
 
-        self.assertTrue(wrapper.script_path.endswith(script_path))
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(
             wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "app_common", "executors", "__init__.py")]
         )
@@ -59,7 +60,7 @@ class TestTaskScriptRunner(unittest.TestCase):
         script_path = "executors/task_script_runner.py"
         wrapper = TaskScriptRunner(script_path=script_path)
 
-        self.assertTrue(wrapper.script_path.endswith(script_path))
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(
             wrapper.get_sys_argv(),
             [os.path.join(curr_dir, "nvflare", "app_common", "executors", "task_script_runner.py")],
@@ -70,5 +71,18 @@ class TestTaskScriptRunner(unittest.TestCase):
         script_path = "in_process/api.py"
         wrapper = TaskScriptRunner(script_path=script_path)
 
-        self.assertTrue(wrapper.script_path.endswith(script_path))
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "client", "in_process", "api.py")])
+
+    def test_run_module_scripts_with_sub_dirs(self):
+        old_sys_path = sys.path
+        try:
+            # test the run should not throw exception for the relative path import.
+            script_args = "--batch_size 4"
+            sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/app_common/executors/custom"))
+            script_path = "src/code.py"
+            wrapper = TaskScriptRunner(script_path=script_path, script_args=script_args)
+            wrapper.run()
+
+        finally:
+            sys.path = old_sys_path


### PR DESCRIPTION
### Description
runpy.run_path() seems not able to cope with relative import. we replaced with runpy.run_module() call and add relative import test case


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
