### PR TITLE
Add option in dashboard cli for AWS vpc and subnet

### DIFF
--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -153,7 +153,11 @@ def cloud(args):
         "t",
         exe=True,
     )
-    print(f"Dashboard launch script for cloud is written at {dest}.  Now running the script.")
+    print(f"Dashboard launch script for cloud is written at {dest}.  Now running it.")
+    if args.vpc_id and args.subnet_id:
+        option = [f"--vpc-id={args.vpc_id}", f"--subnet-id={args.subnet_id}"]
+        print(f"Option of the script: {option}")
+        dest = [dest] + option
     _ = subprocess.run(dest)
     os.remove(dest)
 
@@ -192,6 +196,18 @@ def define_dashboard_parser(parser):
     parser.add_argument("--cred", help="set credential directly in the form of USER_EMAIL:PASSWORD")
     parser.add_argument("-i", "--image", help="set the container image name")
     parser.add_argument("--local", action="store_true", help="start dashboard locally without docker image")
+    parser.add_argument(
+        "--vpc-id",
+        type=str,
+        default="",
+        help="VPC id for AWS EC2 instance.  Applicable to AWS only.  Ignored if subnet-id is not specified.",
+    )
+    parser.add_argument(
+        "--subnet-id",
+        type=str,
+        default="",
+        help="Subnet id for AWS EC2 instance.  Applicable to AWS only.  Ignored if vpc-id is not specified.",
+    )
 
 
 def handle_dashboard(args):


### PR DESCRIPTION
### Description

This PR adds options in dashboard cli for cloud deployment.  Originally, those options were in server and client cloud deployment scripts.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
