### PR TITLE
[2.4] Bump up monai nvflare

### DIFF
--- a/integration/monai/setup.py
+++ b/integration/monai/setup.py
@@ -24,14 +24,14 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 release = os.environ.get("MONAI_NVFL_RELEASE")
 if release == "1":
     package_name = "monai-nvflare"
-    version = "0.2.7"
+    version = "0.2.8"
 else:
     package_name = "monai-nvflare-nightly"
     today = datetime.date.today().timetuple()
     year = today[0] % 1000
     month = today[1]
     day = today[2]
-    version = f"0.2.6.{year:02d}{month:02d}{day:02d}"
+    version = f"0.2.9.{year:02d}{month:02d}{day:02d}"
 
 setup(
     name=package_name,
@@ -57,5 +57,5 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.8,<3.11",
-    install_requires=["monai>=1.3.0", "nvflare~=2.4.1rc3"],
+    install_requires=["monai>=1.3.0", "nvflare~=2.4.1rc8"],
 )


### PR DESCRIPTION
### Description

Update the monai_nvflare setup.py to 0.2.8 and its nvflare dependency to ~=2.4.1rc8

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
