### PR TITLE
Moved the get_component_init_parameters to class_utils

### DIFF
--- a/nvflare/fuel/utils/class_utils.py
+++ b/nvflare/fuel/utils/class_utils.py
@@ -149,6 +149,14 @@ def _retrieve_parameters(class__, parameters):
 
 
 def get_component_init_parameters(component):
+    """To retrieve the initialize parameters of an object from the class constructor.
+
+    Args:
+        component: a class instance
+
+    Returns:
+
+    """
     class__ = component.__class__
     parameters = {}
     _retrieve_parameters(class__, parameters)

--- a/nvflare/fuel/utils/class_utils.py
+++ b/nvflare/fuel/utils/class_utils.py
@@ -136,3 +136,20 @@ class ModuleScanner:
             The module name if found.
         """
         return self._class_table.get(class_name, None)
+
+
+def _retrieve_parameters(class__, parameters):
+    constructor = class__.__init__
+    constructor__parameters = inspect.signature(constructor).parameters
+    parameters.update(constructor__parameters)
+    if "args" in constructor__parameters.keys() and "kwargs" in constructor__parameters.keys():
+        for item in class__.__bases__:
+            parameters.update(_retrieve_parameters(item, parameters))
+    return parameters
+
+
+def get_component_init_parameters(component):
+    class__ = component.__class__
+    parameters = {}
+    _retrieve_parameters(class__, parameters)
+    return parameters

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -21,6 +21,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict
 
 from nvflare import SimulatorRunner
+from nvflare.fuel.utils.class_utils import get_component_init_parameters
 from nvflare.job_config.fed_app_config import FedAppConfig
 from nvflare.private.fed.app.fl_conf import FL_PACKAGES
 
@@ -260,7 +261,7 @@ class FedJobConfig:
             )
 
     def _get_args(self, component, custom_dir):
-        parameters = self._get_init_parameters(component)
+        parameters = get_component_init_parameters(component)
         attrs = component.__dict__
         args = {}
 
@@ -282,21 +283,6 @@ class FedJobConfig:
                     }
 
         return args
-
-    def _get_init_parameters(self, component):
-        class__ = component.__class__
-        parameters = {}
-        self._retrieve_parameters(class__, parameters)
-        return parameters
-
-    def _retrieve_parameters(self, class__, parameters):
-        constructor = class__.__init__
-        constructor__parameters = inspect.signature(constructor).parameters
-        parameters.update(constructor__parameters)
-        if "args" in constructor__parameters.keys() and "kwargs" in constructor__parameters.keys():
-            for item in class__.__bases__:
-                parameters.update(self._retrieve_parameters(item, parameters))
-        return parameters
 
     def _get_filters(self, filters, custom_dir):
         r = []

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -261,26 +261,27 @@ class FedJobConfig:
             )
 
     def _get_args(self, component, custom_dir):
-        parameters = get_component_init_parameters(component)
-        attrs = component.__dict__
         args = {}
+        if hasattr(component, "__dict__"):
+            parameters = get_component_init_parameters(component)
+            attrs = component.__dict__
 
-        for param in parameters:
-            attr_key = param if param in attrs.keys() else "_" + param
+            for param in parameters:
+                attr_key = param if param in attrs.keys() else "_" + param
 
-            if attr_key in ["args", "kwargs"]:
-                continue
+                if attr_key in ["args", "kwargs"]:
+                    continue
 
-            if attr_key in attrs.keys() and parameters[param].default != attrs[attr_key]:
-                if type(attrs[attr_key]).__name__ in dir(builtins):
-                    args[param] = attrs[attr_key]
-                elif issubclass(attrs[attr_key].__class__, Enum):
-                    args[param] = attrs[attr_key].value
-                else:
-                    args[param] = {
-                        "path": self._get_class_path(attrs[attr_key], custom_dir),
-                        "args": self._get_args(attrs[attr_key], custom_dir),
-                    }
+                if attr_key in attrs.keys() and parameters[param].default != attrs[attr_key]:
+                    if type(attrs[attr_key]).__name__ in dir(builtins):
+                        args[param] = attrs[attr_key]
+                    elif issubclass(attrs[attr_key].__class__, Enum):
+                        args[param] = attrs[attr_key].value
+                    else:
+                        args[param] = {
+                            "path": self._get_class_path(attrs[attr_key], custom_dir),
+                            "args": self._get_args(attrs[attr_key], custom_dir),
+                        }
 
         return args
 

--- a/tests/unit_test/fuel/utils/class_utils_test.py
+++ b/tests/unit_test/fuel/utils/class_utils_test.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import inspect
+
+from nvflare.fuel.utils.class_utils import get_component_init_parameters
+from nvflare.private.fed.server.client_manager import ClientManager
+
+
+class A:
+    def __init__(self, name: str = None):
+        self.name = name
+
+
+class B(A):
+    def __init__(self, type: str = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.type = type
+
+
+class TestClassUtils:
+    def test_get_component_init_parameters(self):
+        manager = ClientManager(project_name="Sample project", min_num_clients=1)
+        constructor = ClientManager.__init__
+        expected_parameters = inspect.signature(constructor).parameters
+        parameters = get_component_init_parameters(manager)
+
+        assert parameters == expected_parameters
+
+    def test_nested_init_parameters(self):
+        expected_parameters = {}
+        constructor = B.__init__
+        b = B(name="name", type="type")
+        expected_parameters.update(inspect.signature(constructor).parameters)
+        constructor = A.__init__
+        expected_parameters.update(inspect.signature(constructor).parameters)
+        parameters = get_component_init_parameters(b)
+
+        assert parameters == expected_parameters


### PR DESCRIPTION
Fixes # .

### Description

Moved the get_component_init_parameters to class_utils for sharing function.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
