### PR TITLE
Enable delayed model build

### DIFF
--- a/examples/hello-world/job_api/tf/requirements.txt
+++ b/examples/hello-world/job_api/tf/requirements.txt
@@ -1,2 +1,2 @@
 nvflare~=2.5.0rc
-tensorflow==2.15.0
+tensorflow[and-cuda]

--- a/examples/hello-world/job_api/tf/src/cifar10_tf_fl.py
+++ b/examples/hello-world/job_api/tf/src/cifar10_tf_fl.py
@@ -29,6 +29,7 @@ def main():
     train_images, test_images = train_images / 255.0, test_images / 255.0
 
     model = TFNet()
+    model.build(input_shape=(None, 32, 32, 3))
     model.compile(
         optimizer="adam", loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True), metrics=["accuracy"]
     )

--- a/examples/hello-world/job_api/tf/src/tf_net.py
+++ b/examples/hello-world/job_api/tf/src/tf_net.py
@@ -16,9 +16,11 @@ from tensorflow.keras import layers, models
 
 
 class TFNet(models.Sequential):
-    def __init__(self):
+    def __init__(self, input_shape=(None, 32, 32, 3)):
         super().__init__()
-        self.add(layers.Input(shape=(32, 32, 3)))
+        self._input_shape = input_shape
+        # Do not specify input as we will use delayed built only during runtime of the model
+        # self.add(layers.Input(shape=(32, 32, 3)))
         self.add(layers.Conv2D(32, (3, 3), activation="relu"))
         self.add(layers.MaxPooling2D((2, 2)))
         self.add(layers.Conv2D(64, (3, 3), activation="relu"))

--- a/examples/hello-world/job_api/tf/tf_fedavg_script_executor_cifar10.py
+++ b/examples/hello-world/job_api/tf/tf_fedavg_script_executor_cifar10.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     job.to(controller, "server")
 
     # Define the initial global model and send to server
-    job.to(TFNet(), "server")
+    job.to(TFNet(input_shape=(None, 32, 32, 3)), "server")
 
     # Add clients
     for i in range(n_clients):

--- a/nvflare/app_opt/tf/model_persistor.py
+++ b/nvflare/app_opt/tf/model_persistor.py
@@ -48,6 +48,13 @@ class TFModelPersistor(ModelPersistor):
             self.logger.info("Loading server model and weights")
             self.model.load_weights(self._model_save_path)
 
+        # build model if not built yet
+        if not self.model.built:
+            if hasattr(self.model, "_input_shape"):
+                self.model.build(input_shape=self.model._input_shape)
+            else:
+                raise AttributeError("To use delayed model build, you need to set model._input_shape")
+
         # get flat model parameters
         layer_weights_dict = {layer.name: layer.get_weights() for layer in self.model.layers}
         result = flat_layer_weights_dict(layer_weights_dict)


### PR DESCRIPTION
Fixes # .

### Description

Enable delayed Keras model build for job API. Otherwise, the model would be built twice (once during job creation and once during simulation), which causes the code to hang.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
