### PR TITLE
Optional import of tf or pt in tb receiver

### DIFF
--- a/nvflare/app_opt/tracking/tb/tb_receiver.py
+++ b/nvflare/app_opt/tracking/tb/tb_receiver.py
@@ -15,7 +15,15 @@
 import os
 from typing import List, Optional
 
-from torch.utils.tensorboard import SummaryWriter
+from nvflare.fuel.utils.import_utils import optional_import
+
+torch, torch_ok = optional_import(module="torch")
+if torch_ok:
+    from torch.utils.tensorboard import SummaryWriter
+
+tf, tf_ok = optional_import(module="tensorflow")
+if tf_ok and not torch_ok:
+    from tensorflow.summary import SummaryWriter
 
 from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
 from nvflare.apis.dxo import from_shareable

--- a/nvflare/app_opt/tracking/tb/tb_receiver.py
+++ b/nvflare/app_opt/tracking/tb/tb_receiver.py
@@ -23,6 +23,7 @@ if torch_ok:
 
 tf, tf_ok = optional_import(module="tensorflow")
 if tf_ok and not torch_ok:
+    # flake8: noqa: F811
     from tensorflow.summary import SummaryWriter
 
 from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType

--- a/nvflare/job_config/fed_job.py
+++ b/nvflare/job_config/fed_job.py
@@ -40,8 +40,6 @@ if tf_ok:
     from nvflare.app_opt.tf.model_persistor import TFModelPersistor
 
 tb, tb_ok = optional_import(module="tensorboard")
-if torch_ok and tb_ok:
-    from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
 
 
 class FilterType:
@@ -320,6 +318,8 @@ class ControllerApp(FedApp):
             self.app.add_component("model_selector", component)
 
         # TODO: make different tracking receivers configurable
-        if torch_ok and tb_ok:
+        if (torch_ok or tf_ok) and tb_ok:
+            from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
+
             component = TBAnalyticsReceiver(events=["fed.analytix_log_stats"])
             self.app.add_component("receiver", component)


### PR DESCRIPTION
Fixes # .

### Description

TBReceiver only works with tensorboard + torch. Make it available with Tensorflow as well using optional imports.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
