### PR TITLE
Enhance the client sync_runner process to timeout use max_timeout, in…

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -439,7 +439,7 @@ class FilterKey:
 class ConfigVarName:
     # These variables can be set in job config files (config_fed_server or config_fed_client)
     RUNNER_SYNC_TIMEOUT = "runner_sync_timeout"  # client: runner sync message timeout
-    MAX_RUNNER_SYNC_TRIES = "max_runner_sync_tries"  # client: max number of runner sync attempts
+    MAX_RUNNER_SYNC_TIMEOUT = "max_runner_sync_timeout"  # client: max timeout of runner sync attempts
     TASK_CHECK_TIMEOUT = "task_check_timeout"  # client: timeout for task_check message (before submitting task)
 
     # client: how long to wait before sending task_check again (if previous task_check fails)


### PR DESCRIPTION
Fixes # .

### Description

Enhance the client sync_runner process to timeout use MAX_RUNNER_SYNC_TIMEOUT, instead of using the MAX_RUNNER_SYNC_TRIES, because the server OK response will make the sync_runner call the return before the timeout.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
