### PR TITLE
Reduce timeout warnings during NeMo PEFT example

### DIFF
--- a/integration/nemo/examples/peft/README.md
+++ b/integration/nemo/examples/peft/README.md
@@ -24,10 +24,9 @@ docker run --runtime=nvidia -it --rm --shm-size=16g -p 8888:8888 -p 6006:6006 --
 -v ${PWD}/../../../../job_templates:/job_templates -v ${PWD}:/workspace -w /workspace ${DOCKER_IMAGE}
 ```
 
-For easy experimentation with NeMo, install NVFlare and mount the code inside the [nemo_nvflare](./nemo_nvflare) folder.
+Next, install NVFlare.
 ```
-pip install nvflare~=2.4.0rc7
-export PYTHONPATH=${PYTHONPATH}:/workspace
+pip install nvflare~=2.4.1
 ```
 
 ## Examples

--- a/integration/nemo/examples/peft/nemo_nvflare/peft_model.py
+++ b/integration/nemo/examples/peft/nemo_nvflare/peft_model.py
@@ -15,12 +15,7 @@
 
 import logging
 import os
-
 import torch
-from nemo.collections.nlp.models.language_modeling.megatron_gpt_sft_model import MegatronGPTSFTModel
-from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronLMPPTrainerBuilder
-from nemo.collections.nlp.parts.peft_config import PEFT_CONFIG_MAP
-from omegaconf import OmegaConf
 
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLComponent
@@ -56,6 +51,12 @@ class PEFTmodel(torch.nn.Module, FLComponent):
         FLComponent.__init__(self)
 
     def _initialize(self, fl_ctx: FLContext):
+        # importing nemo can take some time. Moving to initialize during START_RUN.
+        from nemo.collections.nlp.models.language_modeling.megatron_gpt_sft_model import MegatronGPTSFTModel
+        from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronLMPPTrainerBuilder
+        from nemo.collections.nlp.parts.peft_config import PEFT_CONFIG_MAP
+        from omegaconf import OmegaConf        
+        
         # get app root
         app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
 

--- a/job_templates/sag_nemo/app_server/config_fed_server.conf
+++ b/job_templates/sag_nemo/app_server/config_fed_server.conf
@@ -10,7 +10,7 @@
 
   # This assumes that there will be a "net.py" file with class name "Net".
   # If your model code is not in "net.py" and class name is not "Net", please modify here
-  model_class_path = "nemo_nvflare.peft_model.PEFTmodel"
+  model_class_path = "peft_model.PEFTmodel"
 
   # Location of pre-trained NeMo model file.
   restore_from_path = "/models/megatron_gpt_345m.nemo"


### PR DESCRIPTION
Fixes # .

### Description

Importing NeMo can take some time. Moving them to START_RUN event to avoid server sync timeouts.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
