### PR TITLE
Fix `project.yml` master templates

### DIFF
--- a/nvflare/lighter/dummy_project.yml
+++ b/nvflare/lighter/dummy_project.yml
@@ -3,7 +3,9 @@ name: example_project
 description: NVIDIA FLARE sample project yaml file
 
 participants:
-  # change example.com to the FQDN of the server
+  # Change the name of the server (server1) to the Fully Qualified Domain Name
+  # (FQDN) of the server, for example: server1.example.com.
+  # Ensure that the FQDN is correctly mapped in the /etc/hosts file.
   - name: server1
     type: server
     org: nvidia

--- a/nvflare/lighter/ha_project.yml
+++ b/nvflare/lighter/ha_project.yml
@@ -3,19 +3,26 @@ name: example_project
 description: NVIDIA FLARE sample project yaml file
 
 participants:
-  # change overseer.example.com to the FQDN of the overseer
+  # Change the name of the overseer to the Fully Qualified Domain Name (FQDN)
+  # of the overseer, for example: overseer.example.com.
+  # Ensure that the FQDN is correctly mapped in the /etc/hosts file.
   - name: overseer
     type: overseer
     org: nvidia
     protocol: https
     api_root: /api/v1
     port: 8443
-  # change example.com to the FQDN of the server
+  # Change the name of the server (server1) to the Fully Qualified Domain Name
+  # (FQDN) of the first server, for example: server1.example.com.
+  # Ensure that the FQDN is correctly mapped in the /etc/hosts file.
   - name: server1
     type: server
     org: nvidia
     fed_learn_port: 8002
     admin_port: 8003
+  # Change the name of the server (server2) to the Fully Qualified Domain Name
+  # (FQDN) of the second server, for example: server2.example.com.
+  # Ensure that the FQDN is correctly mapped in the /etc/hosts file.
   - name: server2
     type: server
     org: nvidia


### PR DESCRIPTION
Fixes # .
This change just fixes comments in `project.yml` templates to make it more clear.

### Description
The `project.yml` generated by `nvflare provision` command has comments `change overseer.example.com to the FQDN of the overseer` and `change example.com to the FQDN of the server` but the actual values nowhere has `example.com` mentioned and it is confusing.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Quick tests passed locally by running `./runtest.sh`.