### PR TITLE
[2.4] Support log file rotation in admin commands

### DIFF
--- a/nvflare/fuel/hci/client/fl_admin_api.py
+++ b/nvflare/fuel/hci/client/fl_admin_api.py
@@ -25,6 +25,7 @@ from nvflare.fuel.hci.client.api import AdminAPI
 from nvflare.fuel.hci.client.api_status import APIStatus
 from nvflare.fuel.hci.client.fl_admin_api_constants import FLDetailKey
 from nvflare.fuel.hci.client.fl_admin_api_spec import APISyntaxError, FLAdminAPIResponse, FLAdminAPISpec, TargetType
+from nvflare.fuel.hci.cmd_arg_utils import get_file_extension
 from nvflare.security.logging import secure_format_exception
 
 from .overseer_service_finder import ServiceFinderByOverseer
@@ -209,7 +210,7 @@ class FLAdminAPI(AdminAPI, FLAdminAPISpec):
         for p in paths:
             if p == "..":
                 raise APISyntaxError(".. in file path is not allowed")
-        basename, file_extension = os.path.splitext(file)
+        file_extension = get_file_extension(file)
         if file_extension not in [".txt", ".log", ".json", ".csv", ".sh", ".config", ".py"]:
             raise APISyntaxError(
                 "this command cannot be applied to file {}. Only files with the following extensions are "

--- a/nvflare/fuel/hci/cmd_arg_utils.py
+++ b/nvflare/fuel/hci/cmd_arg_utils.py
@@ -121,10 +121,26 @@ def validate_path_string(path: str) -> str:
     return path
 
 
+def get_file_extension(file: str) -> str:
+    """Get extension part of the specified file name.
+    If the file's name is ended with number, then the extension is before it.
+    Args:
+        file: the file name
+    Returns: extension part of the file name
+    """
+    parts = file.split(".")
+    last_part = parts[-1]
+    if last_part.isnumeric():
+        parts.pop(-1)
+        file = ".".join(parts)
+    _, ex = os.path.splitext(file)
+    return ex
+
+
 def validate_file_string(file: str) -> str:
     """Returns the file string if it is valid."""
     validate_path_string(file)
-    basename, file_extension = os.path.splitext(file)
+    file_extension = get_file_extension(file)
     if file_extension not in [".txt", ".log", ".json", ".csv", ".sh", ".config", ".py"]:
         raise SyntaxError(
             "this command cannot be applied to file {}. Only files with the following extensions are "

--- a/nvflare/private/fed/server/shell_cmd.py
+++ b/nvflare/private/fed/server/shell_cmd.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 import subprocess
 from typing import List
 
-from nvflare.fuel.hci.cmd_arg_utils import join_args
+from nvflare.fuel.hci.cmd_arg_utils import get_file_extension, join_args
 from nvflare.fuel.hci.conn import Connection
 from nvflare.fuel.hci.proto import MetaStatusValue, make_meta
 from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandSpec
@@ -186,15 +185,7 @@ class _FileCmdExecutor(_CommandExecutor):
                         return ".. in path name is not allowed"
 
                 if self.text_file_only:
-                    # check whether the file name is ended with numbers. If so, the actual file extension is before it.
-                    # this is the case that when the log file (log.txt) is rotated, the previous file becomes log.txt.1.
-                    parts = f.split(".")
-                    last_part = parts[-1]
-                    if last_part.isnumeric():
-                        parts.pop(-1)
-                        f = ".".join(parts)
-
-                    basename, file_extension = os.path.splitext(f)
+                    file_extension = get_file_extension(f)
                     if file_extension not in [".txt", ".log", ".json", ".csv", ".sh", ".config", ".py"]:
                         return (
                             "this command cannot be applied to file {}. Only files with the following extensions "

--- a/nvflare/private/fed/server/shell_cmd.py
+++ b/nvflare/private/fed/server/shell_cmd.py
@@ -186,6 +186,14 @@ class _FileCmdExecutor(_CommandExecutor):
                         return ".. in path name is not allowed"
 
                 if self.text_file_only:
+                    # check whether the file name is ended with numbers. If so, the actual file extension is before it.
+                    # this is the case that when the log file (log.txt) is rotated, the previous file becomes log.txt.1.
+                    parts = f.split(".")
+                    last_part = parts[-1]
+                    if last_part.isnumeric():
+                        parts.pop(-1)
+                        f = ".".join(parts)
+
                     basename, file_extension = os.path.splitext(f)
                     if file_extension not in [".txt", ".log", ".json", ".csv", ".sh", ".config", ".py"]:
                         return (


### PR DESCRIPTION
Fixes # .

### Description

This PR fixes bug https://nvbugspro.nvidia.com/bug/4686492

When a log file (log.txt) is rotated, the previous file name becomes "log.txt.1". and file extension becomes "1". Admin commands like "cat" won't work from this file.

This PR fixes this problem for version 2.4.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
