### PR TITLE
fixed TaskScriptRunner which may locate the wrong script

### DIFF
--- a/nvflare/app_common/executors/in_process_client_api_executor.py
+++ b/nvflare/app_common/executors/in_process_client_api_executor.py
@@ -17,11 +17,12 @@ from typing import Optional
 
 from nvflare.apis.event_type import EventType
 from nvflare.apis.executor import Executor
-from nvflare.apis.fl_constant import FLMetaKey, ReturnCode
+from nvflare.apis.fl_constant import FLContextKey, FLMetaKey, ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.signal import Signal
 from nvflare.apis.utils.analytix_utils import create_analytic_dxo
+from nvflare.apis.workspace import Workspace
 from nvflare.app_common.abstract.params_converter import ParamsConverter
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.executors.task_script_runner import TaskScriptRunner
@@ -107,10 +108,11 @@ class InProcessClientAPIExecutor(Executor):
             self._fl_ctx = fl_ctx
             self._init_converter(fl_ctx)
 
+            workspace: Workspace = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
+            job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
+            custom_dir = workspace.get_app_custom_dir(job_id)
             self._task_fn_wrapper = TaskScriptRunner(
-                site_name=fl_ctx.get_identity_name(),
-                script_path=self._task_script_path,
-                script_args=self._task_script_args,
+                custom_dir=custom_dir, script_path=self._task_script_path, script_args=self._task_script_args
             )
 
             self._task_fn_thread = threading.Thread(target=self._task_fn_wrapper.run)

--- a/nvflare/app_common/executors/task_script_runner.py
+++ b/nvflare/app_common/executors/task_script_runner.py
@@ -28,11 +28,11 @@ print_fn = builtins.print
 class TaskScriptRunner:
     logger = logging.getLogger(__name__)
 
-    def __init__(self, site_name: str, script_path: str, script_args: str = None, redirect_print_to_log=True):
+    def __init__(self, custom_dir: str, script_path: str, script_args: str = None, redirect_print_to_log=True):
         """Wrapper for function given function path and args
 
         Args:
-            site_name (str): site name
+            custom_dir (str): site name
             script_path (str): script file name, such as train.py
             script_args (str, Optional): script arguments to pass in.
         """
@@ -40,10 +40,10 @@ class TaskScriptRunner:
         self.redirect_print_to_log = redirect_print_to_log
         self.event_manager = EventManager(DataBus())
         self.script_args = script_args
-        self.site_name = site_name
+        self.custom_dir = custom_dir
         self.logger = logging.getLogger(self.__class__.__name__)
         self.script_path = script_path
-        self.script_full_path = self.get_script_full_path(self.site_name, self.script_path)
+        self.script_full_path = self.get_script_full_path(self.custom_dir, self.script_path)
 
     def run(self):
         """Call the task_fn with any required arguments."""
@@ -77,7 +77,7 @@ class TaskScriptRunner:
         args_list = [] if not self.script_args else self.script_args.split()
         return [self.script_full_path] + args_list
 
-    def get_script_full_path(self, site_name, script_path) -> str:
+    def get_script_full_path(self, custom_dir, script_path) -> str:
         target_file = None
         script_filename = os.path.basename(script_path)
         script_dirs = os.path.dirname(script_path)
@@ -87,18 +87,14 @@ class TaskScriptRunner:
                 raise ValueError(f"script_path='{script_path}' not found")
             return script_path
 
-        for r, dirs, files in os.walk(os.getcwd()):
+        for r, dirs, files in os.walk(custom_dir):
             for f in files:
                 absolute_path = os.path.join(r, f)
-                if absolute_path.endswith(script_path):
-                    parent_dir = absolute_path[: absolute_path.find(script_path)].rstrip(os.sep)
-                    if os.path.isdir(parent_dir):
-                        path_components = parent_dir.split(os.path.sep)
-                        if site_name in path_components:
-                            target_file = absolute_path
-                            break
+                if absolute_path.endswith(os.sep + script_path):
+                    target_file = absolute_path
+                    break
 
-                if not site_name and not script_dirs and f == script_filename:
+                if not custom_dir and not script_dirs and f == script_filename:
                     target_file = absolute_path
                     break
 

--- a/tests/unit_test/app_common/executors/task_script_runner_test.py
+++ b/tests/unit_test/app_common/executors/task_script_runner_test.py
@@ -22,85 +22,102 @@ from nvflare.client.in_process.api import TOPIC_ABORT, TOPIC_STOP
 
 
 class TestTaskScriptRunner(unittest.TestCase):
+    def setUp(self) -> None:
+        file_dir = os.path.dirname(os.path.realpath(__file__))
+        splits = file_dir.split(os.sep)
+        self.nvflare_root = os.sep.join(splits[0:-4])
+
     def test_app_scripts_and_args(self):
-        curr_dir = os.getcwd()
         script_path = "nvflare/cli.py"
         script_args = "--batch_size 4"
-        wrapper = TaskScriptRunner(site_name="", script_path=script_path, script_args=script_args)
-
-        self.assertTrue(wrapper.script_full_path.endswith(script_path))
-        self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "cli.py"), "--batch_size", "4"])
-
-    def test_app_scripts_and_args2(self):
-        curr_dir = os.getcwd()
-        script_path = "cli.py"
-        script_args = "--batch_size 4"
-        wrapper = TaskScriptRunner(site_name="", script_path=script_path, script_args=script_args)
-
-        self.assertTrue(wrapper.script_full_path.endswith(script_path))
-        self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "cli.py"), "--batch_size", "4"])
-
-    def test_app_scripts_with_sub_dirs1(self):
-        curr_dir = os.getcwd()
-        script_path = "nvflare/__init__.py"
-        wrapper = TaskScriptRunner(site_name="", script_path=script_path)
-
-        self.assertTrue(wrapper.script_full_path.endswith(script_path))
-        self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "__init__.py")])
-
-    def test_app_scripts_with_sub_dirs2(self):
-        curr_dir = os.getcwd()
-        script_path = "nvflare/app_common/executors/__init__.py"
-        wrapper = TaskScriptRunner(site_name="", script_path=script_path)
+        wrapper = TaskScriptRunner(custom_dir=self.nvflare_root, script_path=script_path, script_args=script_args)
 
         self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(
-            wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "app_common", "executors", "__init__.py")]
+            wrapper.get_sys_argv(), [os.path.join(self.nvflare_root, "nvflare", "cli.py"), "--batch_size", "4"]
         )
 
-    def test_app_scripts_with_sub_dirs3(self):
-        curr_dir = os.getcwd()
-        script_path = "executors/task_script_runner.py"
-        wrapper = TaskScriptRunner(site_name="app_common", script_path=script_path)
+    def test_app_scripts_and_args2(self):
+        # curr_dir = os.getcwd()
+        script_path = "cli.py"
+        script_args = "--batch_size 4"
+        wrapper = TaskScriptRunner(custom_dir=self.nvflare_root, script_path=script_path, script_args=script_args)
+
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
+        self.assertEqual(
+            wrapper.get_sys_argv(), [os.path.join(self.nvflare_root, "nvflare", "cli.py"), "--batch_size", "4"]
+        )
+
+    def test_app_scripts_with_sub_dirs1(self):
+        # curr_dir = os.getcwd()
+        script_path = "nvflare/__init__.py"
+        wrapper = TaskScriptRunner(custom_dir=self.nvflare_root, script_path=script_path)
+
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
+        self.assertEqual(wrapper.get_sys_argv(), [os.path.join(self.nvflare_root, "nvflare", "__init__.py")])
+
+    def test_app_scripts_with_sub_dirs2(self):
+        # curr_dir = os.getcwd()
+        script_path = "nvflare/app_common/executors/__init__.py"
+        wrapper = TaskScriptRunner(custom_dir=self.nvflare_root, script_path=script_path)
 
         self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self.assertEqual(
             wrapper.get_sys_argv(),
-            [os.path.join(curr_dir, "nvflare", "app_common", "executors", "task_script_runner.py")],
+            [os.path.join(self.nvflare_root, "nvflare", "app_common", "executors", "__init__.py")],
+        )
+
+    def test_app_scripts_with_sub_dirs3(self):
+        # curr_dir = os.getcwd()
+        script_path = "executors/task_script_runner.py"
+        sub_dir = os.path.join(self.nvflare_root, "nvflare/app_common")
+        wrapper = TaskScriptRunner(custom_dir=sub_dir, script_path=script_path)
+
+        self.assertTrue(wrapper.script_full_path.endswith(script_path))
+        self.assertEqual(
+            wrapper.get_sys_argv(),
+            [os.path.join(self.nvflare_root, "nvflare", "app_common", "executors", "task_script_runner.py")],
         )
 
     def test_app_scripts_with_sub_dirs4(self):
-        curr_dir = os.getcwd()
+        # curr_dir = os.getcwd()
         script_path = "in_process/api.py"
-        wrapper = TaskScriptRunner(site_name="client", script_path=script_path)
+        sub_dir = os.path.join(self.nvflare_root, "nvflare/client")
+        wrapper = TaskScriptRunner(custom_dir=sub_dir, script_path=script_path)
 
         self.assertTrue(wrapper.script_full_path.endswith(script_path))
-        self.assertEqual(wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "client", "in_process", "api.py")])
+        self.assertEqual(
+            wrapper.get_sys_argv(), [os.path.join(self.nvflare_root, "nvflare", "client", "in_process", "api.py")]
+        )
 
     def test_file_not_found_with_exception(self):
-        curr_dir = os.getcwd()
+        # curr_dir = os.getcwd()
         script_path = "in_process/api.py"
         with pytest.raises(ValueError, match="Can not find in_process/api.py"):
-            wrapper = TaskScriptRunner(site_name="site-1", script_path=script_path)
+            sub_dir = os.path.join(self.nvflare_root, "site-1")
+            wrapper = TaskScriptRunner(custom_dir=sub_dir, script_path=script_path)
             self.assertTrue(wrapper.script_full_path.endswith(script_path))
             self.assertEqual(
-                wrapper.get_sys_argv(), [os.path.join(curr_dir, "nvflare", "client", "in_process", "api.py")]
+                wrapper.get_sys_argv(), [os.path.join(self.nvflare_root, "nvflare", "client", "in_process", "api.py")]
             )
 
     def test_run_scripts_with_sub_dirs(self):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/server/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
             script_path = "train.py"
+            sub_dir = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1")
             wrapper = TaskScriptRunner(
-                site_name="site-1", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                custom_dir=sub_dir, script_path=script_path, script_args=script_args, redirect_print_to_log=False
             )
             self.assertTrue(wrapper.script_full_path.endswith(script_path))
-            expected_path = os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom/train.py")
+            expected_path = os.path.join(
+                self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom/train.py"
+            )
             self.assertEqual(wrapper.get_sys_argv(), [expected_path, "--batch_size", "4"])
             wrapper.run()
         finally:
@@ -109,17 +126,20 @@ class TestTaskScriptRunner(unittest.TestCase):
     def test_run_scripts_with_sub_dirs2(self):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/server/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
             script_path = "train.py"
+            sub_dir = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server")
             wrapper = TaskScriptRunner(
-                site_name="server", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                custom_dir=sub_dir, script_path=script_path, script_args=script_args, redirect_print_to_log=False
             )
             self.assertTrue(wrapper.script_full_path.endswith(script_path))
-            expected_path = os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/server/custom/train.py")
+            expected_path = os.path.join(
+                self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server/custom/train.py"
+            )
             self.assertEqual(wrapper.get_sys_argv(), [expected_path, "--batch_size", "4"])
             wrapper.run()
         finally:
@@ -128,17 +148,20 @@ class TestTaskScriptRunner(unittest.TestCase):
     def test_run_scripts_with_sub_dirs3(self):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/server/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
             script_path = "src/train.py"
             wrapper = TaskScriptRunner(
-                site_name="", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                custom_dir=self.nvflare_root,
+                script_path=script_path,
+                script_args=script_args,
+                redirect_print_to_log=False,
             )
             self.assertTrue(wrapper.script_full_path.endswith(script_path))
-            expected_path = os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/custom/src/train.py")
+            expected_path = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/custom/src/train.py")
             self.assertEqual(wrapper.get_sys_argv(), [expected_path, "--batch_size", "4"])
             wrapper.run()
         finally:
@@ -147,14 +170,15 @@ class TestTaskScriptRunner(unittest.TestCase):
     def test_run_failed_scripts(self):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/server/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
             script_path = "failed_train.py"
+            sub_dir = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1")
             wrapper = TaskScriptRunner(
-                site_name="site-1", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                custom_dir=sub_dir, script_path=script_path, script_args=script_args, redirect_print_to_log=False
             )
             wrapper.event_manager.data_bus.subscribe([TOPIC_ABORT, TOPIC_STOP], self.abort_callback)
 
@@ -175,17 +199,18 @@ class TestTaskScriptRunner(unittest.TestCase):
     def test_run_relative_import_scripts(self):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/server/custom"))
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/server/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
             script_path = "relative_import_train.py"
+            sub_dir = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1")
             wrapper = TaskScriptRunner(
-                site_name="site-1", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                custom_dir=sub_dir, script_path=script_path, script_args=script_args, redirect_print_to_log=False
             )
             self.assertTrue(wrapper.script_full_path.endswith(script_path))
-            path = os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom")
+            path = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom")
             msg = f"attempted relative import with no known parent package, the relative import is not support. python import is based off the sys.path: {path}"
             with pytest.raises(ImportError, match=msg):
                 # check the ImportError
@@ -197,14 +222,15 @@ class TestTaskScriptRunner(unittest.TestCase):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
 
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
             # path doesn't exist
             script_path = "/foo/dummy/train.py"
             with pytest.raises(ValueError, match="script_path='/foo/dummy/train.py' not found"):
+                sub_dir = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1")
                 wrapper = TaskScriptRunner(
-                    site_name="site-1", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                    custom_dir=sub_dir, script_path=script_path, script_args=script_args, redirect_print_to_log=False
                 )
         finally:
             sys.path = old_sys_path
@@ -212,12 +238,15 @@ class TestTaskScriptRunner(unittest.TestCase):
     def test_run_abs_path_scripts2(self):
         old_sys_path = sys.path
         script_args = "--batch_size 4"
-        sys.path.append(os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
+        sys.path.append(os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom"))
 
         try:
-            script_path = os.path.join(os.getcwd(), "tests/unit_test/data/jobs/in_proc_job/site-1/custom/train.py")
+            script_path = os.path.join(
+                self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1/custom/train.py"
+            )
+            sub_dir = os.path.join(self.nvflare_root, "tests/unit_test/data/jobs/in_proc_job/site-1")
             wrapper = TaskScriptRunner(
-                site_name="site-1", script_path=script_path, script_args=script_args, redirect_print_to_log=False
+                custom_dir=sub_dir, script_path=script_path, script_args=script_args, redirect_print_to_log=False
             )
             wrapper.run()
         finally:


### PR DESCRIPTION
Fixes # .

### Description

Fixed several issues with the TaskScriptRunner:

- Instead of using the site_name for searching the script on the site, change to use the custom_dir from the site workspace.
- searching the script under the custom_dir, instead of the os.getcwd(), otherwise it may locate the script from a different job;
- Change the unit tests to enable running the unit tests from different sub-folders, otherwise the unit tests can only be run from the NVFlare root folder.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
