### PR TITLE
Fix docs typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,13 @@ python3 -m pip install nvflare[dev]
 To build the docs, please run. 
 
 ```bash
-./build_docs.sh --html
+./build_doc.sh --html
 ```
 
 Once built, you can view the docs in `docs/_build folder`. To clean the docs, please run
 
 ```bash
-./build_docs.sh --clean
+./build_doc.sh --clean
 ```
 
 #### Signing your work

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -97,14 +97,14 @@ To build the docs, please run.
 
 .. code:: bash
 
-   ./build_docs --html
+   ./build_doc.sh --html
 
 Once built, you can view the docs in ``docs/_build folder``. To clean
 the docs, please run
 
 .. code:: bash
 
-   ./build_docs --clean
+   ./build_doc.sh --clean
 
 Signing your work
 ^^^^^^^^^^^^^^^^^

--- a/docs/real_world_fl/flare_api.rst
+++ b/docs/real_world_fl/flare_api.rst
@@ -42,7 +42,7 @@ Like with FLAdminAPI previously, :class:`AdminAPI<nvflare.fuel.hci.client.api.Ad
 
 There is no more ``logout()``, instead, use ``close()`` to end the session. One common pattern of usage may be to have the code using the session
 to execute commands inside a try block and then close
-the session in a finally clause::
+the session in a finally clause:
 
 .. code-block:: python
 
@@ -64,7 +64,7 @@ the session in a finally clause::
 Additional and Complex Commands
 -------------------------------
 With a ``job_id`` for example after submit_job in the code block above, here are some examples of other commands that
-can be run::
+can be run:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixes # .

This change fixes:

- Typos in the `build_doc.sh` references.
- Incorrect rendering of python code blocks on Flare API page.

### Description

Came across few typos while going through the provisioning documentation. The python code blocks were getting rendered incorrectly on FLARE API page as can be seen below:
![image](https://github.com/NVIDIA/NVFlare/assets/8667981/beceb892-f983-457c-b6b8-ceb837ad85ab)

This change fixes it to:
![image](https://github.com/NVIDIA/NVFlare/assets/8667981/569520c5-bb15-4186-8d17-2fa9781d1acb)

And fixes few typos where `build_doc.sh` was referenced as `build_docs.sh`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Quick tests passed locally by running `./runtest.sh`.
- [x] Documentation updated.
