### PR TITLE
AWS cloud deployments: Adding multi-region capability and auto-detection of GPU instance types and AMI images 

### DIFF
--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -33,6 +33,10 @@ aws_start_sh: |
   DEST_FOLDER=/var/tmp/cloud
   KEY_PAIR=NVFlare{~~type~~}KeyPair
   KEY_FILE=${KEY_PAIR}.pem
+  AMI_IMAGE_OWNER="099720109477" # Owner account id=Amazon
+  AMI_NAME="ubuntu-*-22.04-amd64-pro-server"
+  ARCH=x86_64
+  EC2_TYPE_ARM=t4g.small
 
   echo "This script requires aws (AWS CLI), sshpass, dig and jq.  Now checking if they are installed."
 
@@ -75,14 +79,32 @@ aws_start_sh: |
       report_status "$?" "Loading config file"
   fi
 
-
   if [ $useDefault == true ]
   then
     while true
     do
-      prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
-      prompt EC2_TYPE "Cloud EC2 type, use g4dn.xlarge for GPU or press ENTER to accept default ${EC2_TYPE}: "
       prompt REGION "Cloud EC2 region, press ENTER to accept default ${REGION}: "
+      if [ ${container} = false ]
+        then
+        read -e -i ${AMI_NAME} -p "Cloud AMI image name, press ENTER to accept default (use amd64 or arm64): " AMI_NAME
+        printf "    retrieving AMI ID for ${AMI_NAME} ... "
+        IMAGES=$(aws ec2 describe-images --region ${REGION} --owners ${AMI_IMAGE_OWNER} --filters "Name=name,Values=*${AMI_NAME}*" --output json)
+        if [ "${#IMAGES}" -lt 30 ]
+          then
+          echo -e "\nNo images found, starting over\n"
+          continue
+        fi
+        AMI_IMAGE=$(echo $IMAGES | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')
+        echo "${AMI_IMAGE} found"
+        if [[ "$AMI_NAME" == *"arm64"* ]]
+          then
+          ARCH="arm64"
+          EC2_TYPE=${EC2_TYPE_ARM}
+        fi
+        find_ec2_gpu_instance_type
+      fi
+      prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
+      prompt EC2_TYPE "Cloud EC2 type, press ENTER to accept default ${EC2_TYPE}: "
       prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
       if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
       then

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -51,6 +51,13 @@ aws_start_sh: |
   : "${AWS_REGION:=$AWS_DEFAULT_REGION}"
   REGION=${AWS_REGION}
 
+  echo -e "\nChecking AWS identity ... \n"
+  aws_identity=$(aws sts get-caller-identity)
+  if [[ $? -ne 0 ]]; then
+    echo ""
+    exit 1
+  fi
+
   if [ -z ${vpc_id+x} ]
   then
       using_default_vpc=true

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -45,6 +45,12 @@ aws_start_sh: |
   check_binary dig "Please install it first."
   check_binary jq "Please install it first."
 
+  REGION=$(aws configure get region 2>/dev/null)
+  : "${REGION:=us-west-2}"
+  : "${AWS_DEFAULT_REGION:=$REGION}"
+  : "${AWS_REGION:=$AWS_DEFAULT_REGION}"
+  REGION=${AWS_REGION}
+
   if [ -z ${vpc_id+x} ]
   then
       using_default_vpc=true

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -213,22 +213,34 @@ aws_start_sh: |
     -s fed_{~~type~~}.json --set {~~cln_uid~~} secure_train=true config_folder=config org={~~ORG~~} \" " > /tmp/nvflare.log 2>&1 
     report_status "$?" "launching container"
   else
-    echo "Installing packages in $VM_NAME, may take a few minutes."
-    ssh -f -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
-    " sudo apt update && \
-    if lspci | grep -i nvidia; then sudo DEBIAN_FRONTEND=noninteractive apt install -y nvidia-driver-535-server; fi && \
-    if lspci | grep -i nvidia; then sudo modprobe nvidia; fi && \
-    echo 'export PATH=~/.local/bin:\$PATH' >> ~/.bashrc && \
-    export PATH=/home/ubuntu/.local/bin:\$PATH && \
+    echo "Installing os packages as root in $VM_NAME, may take a few minutes ... "
+    ssh -f -i ${KEY_FILE} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    ' NVIDIA_OS_PKG="nvidia-driver-550-server" && sudo apt update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt install -y python3-dev gcc && \
+    . /etc/os-release && if [ "${VERSION_ID}" \< "22.04" ]; then NVIDIA_OS_PKG="nvidia-driver-535-server"; fi && \
+    if lspci | grep -i nvidia; then sudo DEBIAN_FRONTEND=noninteractive apt install -y ${NVIDIA_OS_PKG}; fi && \
+    if lspci | grep -i nvidia; then sudo modprobe nvidia; fi && sleep 10 && \
+    exit' >> ${LOGFILE}.log 2>&1
+    report_status "$?" "installing os packages"
+    sleep 10
+    echo "Installing user space packages in $VM_NAME, may take a few minutes ... "
+    ssh -f -i ${KEY_FILE} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    ' echo "export PATH=~/.local/bin:$PATH" >> ~/.bashrc && \
+    export PATH=/home/ubuntu/.local/bin:$PATH && \
     pwd && wget -q https://bootstrap.pypa.io/get-pip.py && \
+    timeout 300 sh -c """until [ -f /usr/bin/gcc ]; do sleep 3; done""" && \
     python3 get-pip.py --break-system-packages && python3 -m pip install --break-system-packages nvflare && \
-    touch ${DEST_FOLDER}/startup/requirements.txt && \
-    python3 -m pip install -r ${DEST_FOLDER}/startup/requirements.txt && \
-    python3 -m pip install --break-system-packages --no-cache-dir -r ${DEST_FOLDER}/startup/requirements.txt && \
-    (crontab -l 2>/dev/null; echo '@reboot  /var/tmp/cloud/startup/start.sh >> /var/tmp/nvflare-start.log 2>&1') | crontab && \
-    nohup ${DEST_FOLDER}/startup/start.sh && sleep 20 && \
-    exit" > /tmp/nvflare.log 2>&1
-    report_status "$?" "installing packages"
+    touch /var/tmp/cloud/startup/requirements.txt && \
+    printf "installing from requirements.txt: " && \
+    cat /var/tmp/cloud/startup/requirements.txt | tr "\n" " " && \
+    python3 -m pip install --break-system-packages --no-cache-dir -r /var/tmp/cloud/startup/requirements.txt && \
+    (crontab -l 2>/dev/null; echo "@reboot  /var/tmp/cloud/startup/start.sh >> /var/tmp/nvflare-start.log 2>&1") | crontab && \
+    NVIDIAMOD="nvidia.ko.zst" && . /etc/os-release && if [ "${VERSION_ID}" \< "24.04" -a "${VERSION_ID}" \> "16.04" ]; then NVIDIAMOD="nvidia.ko"; fi && \
+    if lspci | grep -i nvidia; then timeout 900 sh -c """until [ -f /lib/modules/$(uname -r)/updates/dkms/${NVIDIAMOD} ]; do sleep 3; done"""; fi && \
+    sleep 60 && nohup /var/tmp/cloud/startup/start.sh && sleep 20 && \
+    exit' >> ${LOGFILE}.log 2>&1
+    report_status "$?" "installing user space packages"
+    sleep 10
   fi
 
   echo "System was provisioned"

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -98,10 +98,10 @@ aws_start_sh: |
   then
     while true
     do
-      prompt REGION "Cloud EC2 region, press ENTER to accept default ${REGION}: "
+      read -e -i ${REGION} -p "* Cloud EC2 region, press ENTER to accept default: " REGION
       if [ ${container} = false ]
         then
-        read -e -i ${AMI_NAME} -p "Cloud AMI image name, press ENTER to accept default (use amd64 or arm64): " AMI_NAME
+        read -e -i ${AMI_NAME} -p "* Cloud AMI image name, press ENTER to accept default (use amd64 or arm64): " AMI_NAME
         printf "    retrieving AMI ID for ${AMI_NAME} ... "
         IMAGES=$(aws ec2 describe-images --region ${REGION} --owners ${AMI_IMAGE_OWNER} --filters "Name=name,Values=*${AMI_NAME}*" --output json)
         if [ "${#IMAGES}" -lt 30 ]
@@ -118,8 +118,8 @@ aws_start_sh: |
         fi
         find_ec2_gpu_instance_type
       fi
-      prompt AMI_IMAGE "Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
-      prompt EC2_TYPE "Cloud EC2 type, press ENTER to accept default ${EC2_TYPE}: "
+      prompt AMI_IMAGE "* Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
+      read -e -i ${EC2_TYPE} -p "* Cloud EC2 type, press ENTER to accept default: " EC2_TYPE
       prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
       if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
       then

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -36,6 +36,8 @@ aws_start_sh: |
   AMI_IMAGE_OWNER="099720109477" # Owner account id=Amazon
   AMI_NAME="ubuntu-*-22.04-amd64-pro-server"
   ARCH=x86_64
+  AMI_IMAGE=ami-03c983f9003cb9cd1  # 22.04  20.04:ami-04bad3c587fe60d89 24.04:ami-0406d1fdd021121cd
+  EC2_TYPE=t2.small
   EC2_TYPE_ARM=t4g.small
   TMPDIR="${TMPDIR:-/tmp}"
   LOGFILE=$(mktemp "${TMPDIR}/nvflare-aws-XXX")
@@ -52,6 +54,9 @@ aws_start_sh: |
   : "${AWS_DEFAULT_REGION:=$REGION}"
   : "${AWS_REGION:=$AWS_DEFAULT_REGION}"
   REGION=${AWS_REGION}
+
+  echo "Note: run this command first for a different AWS profile:"
+  echo "  export AWS_PROFILE=your-profile-name."
 
   echo -e "\nChecking AWS identity ... \n"
   aws_identity=$(aws sts get-caller-identity)
@@ -78,11 +83,6 @@ aws_start_sh: |
   then
     AMI_IMAGE=ami-06b8d5099f3a8d79d
     EC2_TYPE=t2.xlarge
-    REGION=us-west-2
-  else
-    AMI_IMAGE=ami-03c983f9003cb9cd1  # 22.04  20.04:ami-04bad3c587fe60d89 24.04:ami-0406d1fdd021121cd
-    EC2_TYPE=t2.small
-    REGION=us-west-2
   fi
 
   if [ -z ${config_file+x} ]
@@ -130,7 +130,8 @@ aws_start_sh: |
 
   if [ $container == false ]
   then
-    echo "If the {~~type~~} requires additional dependencies, please copy the requirements.txt to ${DIR}."
+    echo "If the {~~type~~} requires additional Python packages, please add them to: "
+    echo "    ${DIR}/requirements.txt"
     prompt ans "Press ENTER when it's done or no additional dependencies. "
   fi
 
@@ -264,12 +265,16 @@ aws_start_sh: |
     sleep 10
   fi
 
-  echo "System was provisioned"
-  echo "To terminate the EC2 instance, run the following command."
-  echo "aws ec2 terminate-instances --region {REGION} --instance-ids ${instance_id}"
+  echo "System was provisioned, packages may continue to install in the background."
+  echo "To terminate the EC2 instance, run the following command:"
+  echo "  aws ec2 terminate-instances --region ${REGION} --instance-ids ${instance_id}"
   echo "Other resources provisioned"
   echo "security group: ${SECURITY_GROUP}"
   echo "key pair: ${KEY_PAIR}"
+  echo "review install progress:"
+  echo "  tail -f ${LOGFILE}.log"
+  echo "login to instance:"
+  echo "  ssh -i \"${KEY_FILE}\" ubuntu@${IP_ADDRESS}"
 
 aws_start_dsb_sh: |
   VM_NAME=nvflare_dashboard

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -1,4 +1,33 @@
 aws_start_sh: |
+  function find_ec2_gpu_instance_type() {
+    local gpucnt=0
+    local gpumem=0
+    if rfile=$(get_resources_file)
+      then
+      # Parse the number of GPUs and memory per GPU from the resource_manager component in local/resources.json
+      gpucnt=$(jq -r '.components[] | select(.id == "resource_manager") | .args.num_of_gpus' "${rfile}")
+      if [ ${gpucnt} -gt 0 ]
+        then
+        gpumem=$(jq -r '.components[] | select(.id == "resource_manager") | .args.mem_per_gpu_in_GiB' "${rfile}")
+        if [ ${gpumem} -gt 0 ]
+          then
+          gpumem=$(( ${gpumem}*1024 ))
+          printf "    finding smallest instance type with ${gpucnt} GPUs and ${gpumem} MiB VRAM ... "
+          gpu_types=$(aws ec2 describe-instance-types --region ${REGION} --query 'InstanceTypes[?GpuInfo.Gpus[?Manufacturer==`NVIDIA`]].{InstanceType: InstanceType, GPU: GpuInfo.Gpus[*].{Name: Name, GpuMemoryMiB: MemoryInfo.SizeInMiB, GpuCount: Count}, Architecture: ProcessorInfo.SupportedArchitectures, VCpuCount: VCpuInfo.DefaultVCpus, MemoryMiB: MemoryInfo.SizeInMiB}' --output json)
+          filtered_gpu_types=$(echo ${gpu_types} | jq "[.[] | select(.GPU | any(.GpuCount == ${gpucnt} and .GpuMemoryMiB >= ${gpumem})) | select(.Architecture | index(\"${ARCH}\"))]")
+          smallest_gpu_type=$(echo ${filtered_gpu_types} | jq -r 'min_by(.VCpuCount).InstanceType')
+          if [ ${smallest_gpu_type} = null ]
+            then
+            echo "failed finding a GPU instance, EC2_TYPE unchanged."
+          else
+            echo "${smallest_gpu_type} found"
+            EC2_TYPE=${smallest_gpu_type}
+          fi
+        fi
+      fi
+    fi
+  }
+
   VM_NAME=nvflare_{~~type~~}
   SECURITY_GROUP=nvflare_{~~type~~}_sg_$RANDOM
   DEST_FOLDER=/var/tmp/cloud

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -37,6 +37,8 @@ aws_start_sh: |
   AMI_NAME="ubuntu-*-22.04-amd64-pro-server"
   ARCH=x86_64
   EC2_TYPE_ARM=t4g.small
+  TMPDIR="${TMPDIR:-/tmp}"
+  LOGFILE=$(mktemp "${TMPDIR}/nvflare-aws-XXX")
 
   echo "This script requires aws (AWS CLI), sshpass, dig and jq.  Now checking if they are installed."
 
@@ -174,10 +176,10 @@ aws_start_sh: |
   my_public_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
   if [ "$?" -eq 0 ] && [[ "$my_public_ip" =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]
   then
-    aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+    aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > ${LOGFILE}.sec_grp.log
   else
     echo "getting my public IP failed, please manually configure the inbound rule to limit SSH access"
-    aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+    aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > ${LOGFILE}.sec_grp.log
   fi
   {~~inbound_rule~~}
   report_status "$?" "creating security group rules"
@@ -203,6 +205,11 @@ aws_start_sh: |
   report_status "$?" "creating VM"
   instance_id=$(jq -r .Instances[0].InstanceId vm_create.json)
 
+  longkeyfile="$(pwd)/${KEY_PAIR}_${instance_id}.pem"
+  cp -f ${KEY_FILE} "${longkeyfile}"
+  chmod 400 "${longkeyfile}"
+  KEY_FILE="${longkeyfile}"
+  
   aws ec2 wait instance-status-ok --region ${REGION} --instance-ids $instance_id
   aws ec2 describe-instances --region ${REGION} --instance-ids $instance_id > vm_result.json
 
@@ -214,20 +221,21 @@ aws_start_sh: |
   DEST_SITE=ubuntu@${IP_ADDRESS}
   DEST=${DEST_SITE}:${DEST_FOLDER}
   echo "Destination folder is ${DEST}"
-  scp -q -i $KEY_FILE -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $PWD $DEST
+  scp -q -i "${KEY_FILE}" -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $PWD $DEST
   report_status "$?" "copying startup kits to VM"
 
+  rm -f ${LOGFILE}.log
   if [ $container == true ]
   then
     echo "Launching container with docker option ${DOCKER_OPTION}."
-    ssh -f -i $KEY_FILE -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    ssh -f -i "${KEY_FILE}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
     "docker run -d -v ${DEST_FOLDER}:${DEST_FOLDER} --network host ${DOCKER_OPTION} ${image_name} \
     /bin/bash -c \"python -u -m nvflare.private.fed.app.{~~type~~}.{~~type~~}_train -m ${DEST_FOLDER} \
     -s fed_{~~type~~}.json --set {~~cln_uid~~} secure_train=true config_folder=config org={~~ORG~~} \" " > /tmp/nvflare.log 2>&1 
     report_status "$?" "launching container"
   else
     echo "Installing os packages as root in $VM_NAME, may take a few minutes ... "
-    ssh -f -i ${KEY_FILE} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    ssh -f -i "${KEY_FILE}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
     ' NVIDIA_OS_PKG="nvidia-driver-550-server" && sudo apt update && \
     sudo DEBIAN_FRONTEND=noninteractive apt install -y python3-dev gcc && \
     . /etc/os-release && if [ "${VERSION_ID}" \< "22.04" ]; then NVIDIA_OS_PKG="nvidia-driver-535-server"; fi && \
@@ -237,7 +245,7 @@ aws_start_sh: |
     report_status "$?" "installing os packages"
     sleep 10
     echo "Installing user space packages in $VM_NAME, may take a few minutes ... "
-    ssh -f -i ${KEY_FILE} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
+    ssh -f -i "${KEY_FILE}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${DEST_SITE} \
     ' echo "export PATH=~/.local/bin:$PATH" >> ~/.bashrc && \
     export PATH=/home/ubuntu/.local/bin:$PATH && \
     pwd && wget -q https://bootstrap.pypa.io/get-pip.py && \
@@ -258,7 +266,7 @@ aws_start_sh: |
 
   echo "System was provisioned"
   echo "To terminate the EC2 instance, run the following command."
-  echo "aws ec2 terminate-instances --instance-ids ${instance_id}"
+  echo "aws ec2 terminate-instances --region {REGION} --instance-ids ${instance_id}"
   echo "Other resources provisioned"
   echo "security group: ${SECURITY_GROUP}"
   echo "key pair: ${KEY_PAIR}"

--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -129,11 +129,11 @@ aws_start_sh: |
   if [ $using_default_vpc == true ]
   then
     echo "Checking if default VPC exists"
-    found_default_vpc=$(aws ec2 describe-vpcs | jq '.Vpcs[] | select(.IsDefault == true)')
+    found_default_vpc=$(aws ec2 describe-vpcs --region ${REGION} | jq '.Vpcs[] | select(.IsDefault == true)')
     if [ -z "${found_default_vpc}" ]
     then
       echo "No default VPC found.  Please create one before running this script with the following command."
-      echo "aws ec2 create-default-vpc"
+      echo "aws ec2 create-default-vpc --region ${REGION}"
       echo "or specify your own vpc and subnet with --vpc-id and --subnet-id"
       exit
     else
@@ -149,9 +149,9 @@ aws_start_sh: |
 
   echo "Generating key pair for VM"
 
-  aws ec2 delete-key-pair --key-name $KEY_PAIR > /dev/null 2>&1
+  aws ec2 delete-key-pair --region ${REGION} --key-name $KEY_PAIR > /dev/null 2>&1
   rm -rf $KEY_FILE
-  aws ec2 create-key-pair --key-name $KEY_PAIR --query 'KeyMaterial' --output text > $KEY_FILE
+  aws ec2 create-key-pair  --region ${REGION} --key-name $KEY_PAIR --query 'KeyMaterial' --output text > $KEY_FILE
   report_status "$?" "creating key pair"
   chmod 400 $KEY_FILE
 
@@ -159,27 +159,27 @@ aws_start_sh: |
   # Try not reusing existing security group because we have to modify it for our own need.
   if [ $using_default_vpc == true ]
   then
-    sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
+    sg_id=$(aws ec2 create-security-group --region ${REGION} --group-name $SECURITY_GROUP --description "NVFlare security group" | jq -r .GroupId)
   else
-    sg_id=$(aws ec2 create-security-group --group-name $SECURITY_GROUP --description "NVFlare security group" --vpc-id $vpc_id | jq -r .GroupId)    
+    sg_id=$(aws ec2 create-security-group --region ${REGION} --group-name $SECURITY_GROUP --description "NVFlare security group" --vpc-id $vpc_id | jq -r .GroupId)    
   fi
   report_status "$?" "creating security group"
   my_public_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
   if [ "$?" -eq 0 ] && [[ "$my_public_ip" =~ ^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$ ]]
   then
-    aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
+    aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 22 --cidr ${my_public_ip}/32 > /tmp/sec_grp.log
   else
     echo "getting my public IP failed, please manually configure the inbound rule to limit SSH access"
-    aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
+    aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 22 --cidr 0.0.0.0/0 > /tmp/sec_grp.log
   fi
   {~~inbound_rule~~}
   report_status "$?" "creating security group rules"
 
   # Start provisioning
 
-  echo "Creating VM at region $REGION, may take a few minutes."
+  echo "Creating VM at region ${REGION}, may take a few minutes."
 
-  ami_info=$(aws ec2 describe-images --image-ids $AMI_IMAGE --output json)
+  ami_info=$(aws ec2 describe-images --region ${REGION} --image-ids $AMI_IMAGE --output json)
   amidevice=$(echo $ami_info | jq -r '.Images[0].BlockDeviceMappings[0].DeviceName')
   block_device_mappings=$(echo $ami_info | jq -r '.Images[0].BlockDeviceMappings')
   original_size=$(echo $block_device_mappings | jq -r '.[0].Ebs.VolumeSize')
@@ -189,15 +189,15 @@ aws_start_sh: |
 
   if [ $using_default_vpc == true ]
   then
-    aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --block-device-mappings $bdmap --security-group-ids $sg_id > vm_create.json
+    aws ec2 run-instances --region ${REGION} --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --block-device-mappings $bdmap --security-group-ids $sg_id > vm_create.json
   else
-    aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --block-device-mappings $bdmap --security-group-ids $sg_id --subnet-id $subnet_id  > vm_create.json
+    aws ec2 run-instances --region ${REGION} --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --block-device-mappings $bdmap --security-group-ids $sg_id --subnet-id $subnet_id  > vm_create.json
   fi
   report_status "$?" "creating VM"
   instance_id=$(jq -r .Instances[0].InstanceId vm_create.json)
 
-  aws ec2 wait instance-status-ok --instance-ids $instance_id
-  aws ec2 describe-instances --instance-ids $instance_id > vm_result.json
+  aws ec2 wait instance-status-ok --region ${REGION} --instance-ids $instance_id
+  aws ec2 describe-instances --region ${REGION} --instance-ids $instance_id > vm_result.json
 
   IP_ADDRESS=$(jq -r .Reservations[0].Instances[0].PublicIpAddress vm_result.json)
 
@@ -338,12 +338,12 @@ aws_start_dsb_sh: |
 
   # Start provisioning
 
-  echo "Creating VM at region $REGION, may take a few minutes."
+  echo "Creating VM at region ${REGION}, may take a few minutes."
   if [ $using_default_vpc == true ]
   then
-    aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id > vm_create.json
+    aws ec2 run-instances --region ${REGION} --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id > vm_create.json
   else
-    aws ec2 run-instances --region $REGION --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id --subnet-id $subnet_id > vm_create.json
+    aws ec2 run-instances --region ${REGION} --image-id $AMI_IMAGE --count 1 --instance-type $EC2_TYPE --key-name $KEY_PAIR --security-group-ids $sg_id --subnet-id $subnet_id > vm_create.json
   fi
   report_status "$?" "creating VM"
   instance_id=$(jq -r .Instances[0].InstanceId vm_create.json)

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -806,6 +806,20 @@ cloud_script_header: |
     fi
   }
 
+  function get_resources_file() {
+    local rfile="${DIR}/../local/resources.json"
+    if [ -f "${rfile}" ]
+      then
+      echo "${rfile}"
+    elif [ -f "${rfile}.default" ]
+      then
+      echo "${rfile}.default"
+    else
+      echo ""
+      exit 1
+    fi
+  }
+
   # parse arguments
   while [[ $# -gt 0 ]]
   do

--- a/nvflare/lighter/tplt_utils.py
+++ b/nvflare/lighter/tplt_utils.py
@@ -44,7 +44,7 @@ class Template:
             tmp,
             {
                 "type": "server",
-                "inbound_rule": "aws ec2 authorize-security-group-ingress --group-id $sg_id --protocol tcp --port 8002-8003 --cidr 0.0.0.0/0 >> /tmp/sec_grp.log",
+                "inbound_rule": "aws ec2 authorize-security-group-ingress --region ${REGION} --group-id $sg_id --protocol tcp --port 8002-8003 --cidr 0.0.0.0/0 >> ${LOGFILE}.sec_grp.log",
                 "cln_uid": "",
                 "server_name": entity.name,
                 "ORG": "",


### PR DESCRIPTION
### Description

Deploying cloud infrastructure across multiple AWS regions can be challenging due to each region having unique AMI image IDs. With these proposed changes, the user will be prompted to select their region first, followed by their desired image name (default: ubuntu-*-22.04-amd64-pro-server). After confirming an amd64 or arm64 image name pattern, NVFlare will look up the appropriate AMI image ID, identify a compatible GPU instance type based on resources.json, and present the user with these new defaults. Dynamically obtaining the AMI ID also ensures that the user always has the latest image with all security updates already installed. 

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

I tested the following combinations over the last few days but only the 24.04 ARM option seems to fail with NVidia drivers 535 and 550. The instances just freeze after installation of the driver. This is unrelated to NVFlare

![image](https://github.com/NVIDIA/NVFlare/assets/1427719/cdea2c67-c614-4737-8fb1-55811912422c)

The new UI would look like this 

```
startup/start.sh --cloud aws
This script requires aws (AWS CLI), sshpass, dig and jq.  Now checking if they are installed.
Checking if aws exists. => found
Checking if sshpass exists. => found
Checking if dig exists. => found
Checking if jq exists. => found
Note: run this command first for a different AWS profile:
  export AWS_PROFILE=your-profile-name.

Checking AWS identity ...

* Cloud EC2 region, press ENTER to accept default: us-east-2
* Cloud AMI image name, press ENTER to accept default (use amd64 or arm64): ubuntu-*-22.04-amd64-pro-server
    retrieving AMI ID for ubuntu-*-22.04-amd64-pro-server ... ami-0a7e9bed072bb379b found
    finding smallest instance type with 1 GPUs and 15360 MiB VRAM ... g6.xlarge found
* Cloud EC2 type, press ENTER to accept default: g6.xlarge
* Cloud AMI image id, press ENTER to accept default: ami-0a7e9bed072bb379b
region = us-east-2, EC2 type = g6.xlarge, ami image = ami-0a7e9bed072bb379b , OK? (Y/n)
If the client requires additional Python packages, please add them to:
    /home/dp/NVFlare/dirk/Test/AWS-T4.X/startup/requirements.txt
Press ENTER when it's done or no additional dependencies.

Checking if default VPC exists
Default VPC found
Generating key pair for VM
Creating VM at region us-east-2, this may take a few minutes ...
VM created with IP address: 52.14.44.113
Copying files to nvflare_client
Destination folder is ubuntu@52.14.44.113:/var/tmp/cloud
Installing os packages as root in the background, this may take a few minutes ...
Installing user space packages in the background, this may take a few minutes ...
System was provisioned, packages may continue to install in the background.
To terminate the EC2 instance, run the following command:
  aws ec2 terminate-instances --region us-east-2 --instance-ids i-0837e105f2661a4e3
Other resources provisioned
security group: nvflare_client_sg_2036
key pair: NVFlareClientKeyPair
review install progress:
  tail -f /tmp/nvflare-aws-YGR.log
login to instance:
  ssh -i "/home/dirk/AWS-T4.X/NVFlareClientKeyPair_i-0837e105f2661a4e3.pem" ubuntu@52.14.44.113
```

Note that commit 2c035cd was updated via force-push to ccd3bc3 because of a wrong port (22 instead of 8002-8003)
