### PR TITLE
Allow the simulator to pass the End_Run aux message to clients

### DIFF
--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -508,24 +508,27 @@ class ServerEngine(ServerEngineInternalSpec):
         secure=False,
     ) -> dict:
         try:
-            if not targets:
-                targets = []
-                for t in self.get_clients():
-                    targets.append(t.name)
-            if targets:
-                return self.run_manager.aux_runner.send_aux_request(
-                    targets=targets,
-                    topic=topic,
-                    request=request,
-                    timeout=timeout,
-                    fl_ctx=fl_ctx,
-                    optional=optional,
-                    secure=secure,
-                )
-            else:
-                return {}
+            return self.send_aux_to_targets(targets, topic, request, timeout, fl_ctx, optional, secure)
         except Exception as e:
             self.logger.error(f"Failed to send the aux_message: {topic} with exception: {secure_format_exception(e)}.")
+
+    def send_aux_to_targets(self, targets, topic, request, timeout, fl_ctx, optional, secure):
+        if not targets:
+            targets = []
+            for t in self.get_clients():
+                targets.append(t.name)
+        if targets:
+            return self.run_manager.aux_runner.send_aux_request(
+                targets=targets,
+                topic=topic,
+                request=request,
+                timeout=timeout,
+                fl_ctx=fl_ctx,
+                optional=optional,
+                secure=secure,
+            )
+        else:
+            return {}
 
     def sync_clients_from_main_process(self):
         # repeatedly ask the parent process to get participating clients until we receive the result

--- a/nvflare/private/fed/simulator/simulator_server.py
+++ b/nvflare/private/fed/simulator/simulator_server.py
@@ -50,10 +50,11 @@ class SimulatorServerEngine(ServerEngine):
         optional=False,
         secure=False,
     ) -> dict:
-        if topic != ReservedTopic.END_RUN:
-            return super().send_aux_request(targets, topic, request, timeout, fl_ctx, optional, secure=secure)
-        else:
-            return {}
+        try:
+            return super().send_aux_to_targets(targets, topic, request, timeout, fl_ctx, optional, secure)
+        except Exception as e:
+            if topic != ReservedTopic.END_RUN:
+                self.logger.error(f"Failed to send the aux_message: {topic} with exception: {e}.")
 
 
 class SimulatorRunManager(RunManager):


### PR DESCRIPTION
Fixes # .

### Description

Allow the ServerRunner to pass END_RUN aux messages to the clients when running the simulator. Still keeps the behavior to avoid un-necessary error messages if client run finishes earlier when sending the messages.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
