### PR TITLE
Add feedback when users launch dashboard to cloud with editable version

### DIFF
--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -145,6 +145,11 @@ def cloud(args):
     dest = os.path.join(cwd, f"{csp}_start_dsb.sh")
     dsb_start = template[f"{csp}_start_dsb_sh"]
     version = nvflare.__version__
+    if "+" in version:
+        print(
+            f"Unable to launching dashboard on cloud with {version}.  Please install official NVFlare release from PyPi."
+        )
+        exit(0)
     replacement_dict = {"NVFLARE": f"nvflare=={version}", "START_OPT": f"-i {args.image}" if args.image else ""}
     _write(
         dest,


### PR DESCRIPTION
### Description

When users run nvflare dashboard --cloud azure or --cloud aws from non-released NVFlare (like pip install -e . with source codes), the cloud scripts fail install nvflare in the cloud VM instances because user's NVFlare version is not publicly available to those VM instances.

This PR detect if '+' is inside the NVFlare version string.  If it is, the version users use to launch dashboard on cloud is definitely not an official release and the dashboard launch command will display a message asking users installing official NVFlare version from PyPi.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
