### PR TITLE
[2.4] Fixed a LocalProcessor bug and a typo

### DIFF
--- a/integration/xgboost/processor/src/nvflare-plugin/local_processor.cc
+++ b/integration/xgboost/processor/src/nvflare-plugin/local_processor.cc
@@ -130,7 +130,7 @@ void *LocalProcessor::ProcessClearAggregation(std::size_t *size, std::map<int, s
     auto total_size = histo_size * nodes.size();
 
     histo_.clear();
-    histo_.reserve(total_size);
+    histo_.resize(total_size, 0.0);
     size_t start = 0;
     for (const auto &node : nodes) {
         auto rows = node.second;

--- a/nvflare/app_opt/xgboost/histogram_based_v2/runners/xgb_client_runner.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/runners/xgb_client_runner.py
@@ -130,7 +130,7 @@ class XGBClientRunner(AppRunner, FLComponent):
             self._xgb_params["device"] = f"cuda:{self._rank}"
 
         self.logger.info(
-            f"XGB trainging_mode: {self._training_mode} " f"params: {self._xgb_params} XGB options: {self._xgb_options}"
+            f"XGB training_mode: {self._training_mode} " f"params: {self._xgb_params} XGB options: {self._xgb_options}"
         )
         self.logger.info(f"server address is {self._server_addr}")
 


### PR DESCRIPTION
Fixes https://jirasw.nvidia.com/browse/FLARE-2047

### Description

Introduced a bug in LocalProcessor when fixing a memory leak. Used wrong function (reserve->resize).

Fixed a typo discovered by QA.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
