### PR TITLE
Fix DockerBuilder to add `build` section

### DIFF
--- a/nvflare/lighter/impl/docker.py
+++ b/nvflare/lighter/impl/docker.py
@@ -45,6 +45,7 @@ class DockerBuilder(Builder):
         info_dict = copy.deepcopy(self.services["__flserver__"])
         info_dict["volumes"][0] = f"./{server.name}:" + "${WORKSPACE}"
         info_dict["ports"] = [f"{fed_learn_port}:{fed_learn_port}", f"{admin_port}:{admin_port}"]
+        info_dict["build"] = "nvflare_compose"
         for i in range(len(info_dict["command"])):
             if info_dict["command"][i] == "flserver":
                 info_dict["command"][i] = server.name
@@ -56,6 +57,7 @@ class DockerBuilder(Builder):
     def _build_client(self, client, ctx):
         info_dict = copy.deepcopy(self.services["__flclient__"])
         info_dict["volumes"] = [f"./{client.name}:" + "${WORKSPACE}"]
+        info_dict["build"] = "nvflare_compose"
         for i in range(len(info_dict["command"])):
             if info_dict["command"][i] == "flclient":
                 info_dict["command"][i] = client.name


### PR DESCRIPTION
Fixes # .

The `compose.yml` generated by the `DockerBuilder` class adds a build section only for the overseer. As a result, when we have non-HA mode `project.yml`, generated `compose.yml` won't have the build section and so `docker compose build` won't build the required NVFlare docker image.

This change adds a build section in the generated `compose.yml` even for clients and servers. It fixes the above issue and also with this change, same `compose.yml` can be used to build/run individual servers and clients using the `docker compose` method.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).