### PR TITLE
Change the ScatterAndGather default persistor_id

### DIFF
--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -48,7 +48,7 @@ class ScatterAndGather(Controller):
         start_round: int = 0,
         wait_time_after_min_received: int = 10,
         aggregator_id=AppConstants.DEFAULT_AGGREGATOR_ID,
-        persistor_id="",
+        persistor_id=AppConstants.DEFAULT_PERSISTOR_ID,
         shareable_generator_id=AppConstants.DEFAULT_SHAREABLE_GENERATOR_ID,
         train_task_name=AppConstants.TASK_TRAIN,
         train_timeout: int = 0,

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -48,7 +48,7 @@ class ScatterAndGather(Controller):
         start_round: int = 0,
         wait_time_after_min_received: int = 10,
         aggregator_id=AppConstants.DEFAULT_AGGREGATOR_ID,
-        persistor_id=AppConstants.DEFAULT_PERSISTOR_ID,
+        persistor_id="",
         shareable_generator_id=AppConstants.DEFAULT_SHAREABLE_GENERATOR_ID,
         train_task_name=AppConstants.TASK_TRAIN,
         train_timeout: int = 0,
@@ -75,7 +75,7 @@ class ScatterAndGather(Controller):
             wait_time_after_min_received (int, optional): Time to wait before beginning aggregation after
                 minimum number of clients responses has been received. Defaults to 10.
             aggregator_id (str, optional): ID of the aggregator component. Defaults to "aggregator".
-            persistor_id (str, optional): ID of the persistor component. Defaults to "persistor".
+            persistor_id (str, optional): ID of the persistor component. Defaults to "".
             shareable_generator_id (str, optional): ID of the shareable generator. Defaults to "shareable_generator".
             train_task_name (str, optional): Name of the train task. Defaults to "train".
             train_timeout (int, optional): Time to wait for clients to do local training.


### PR DESCRIPTION
Fixes # .

### Description

Changed the ScatterAndGather default persistor_id value from "" to "persistor".

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
