### PR TITLE
Add min_responses to send_model_and_wait()

### DIFF
--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -102,7 +102,7 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         task_name: str = AppConstants.TASK_TRAIN,
         data: FLModel = None,
         targets: Union[List[Client], List[str], None] = None,
-        min_responses: int = 0,
+        min_responses: int = None,
         timeout: int = 0,
         wait_time_after_min_received: int = 0,
         blocking: bool = True,
@@ -114,8 +114,8 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             task_name (str, optional): name of the task. Defaults to "train".
             data (FLModel, optional): FLModel to be sent to clients. If no data is given, send empty FLModel.
             targets (List[str], optional): the list of target client names or None (all clients). Defaults to None.
-            min_responses (int, optional): the minimum number of responses expected. If == 0, must receive responses from
-              all clients that the task has been sent to. Defaults to 0.
+            min_responses (int, optional): the minimum number of responses expected. If None, must receive responses from
+              all clients that the task has been sent to. Defaults to None.
             timeout (int, optional): time to wait for clients to perform task. Defaults to 0, i.e., never time out.
             wait_time_after_min_received (int, optional): time to wait after
                 minimum number of clients responses has been received. Defaults to 0.
@@ -130,6 +130,8 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             raise TypeError("task_name must be a string but got {}".format(type(task_name)))
         if data and not isinstance(data, FLModel):
             raise TypeError("data must be a FLModel or None but got {}".format(type(data)))
+        if min_responses is None:
+            min_responses = 0
         check_non_negative_int("min_responses", min_responses)
         check_non_negative_int("timeout", timeout)
         check_non_negative_int("wait_time_after_min_received", wait_time_after_min_received)

--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -131,7 +131,7 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         if data and not isinstance(data, FLModel):
             raise TypeError("data must be a FLModel or None but got {}".format(type(data)))
         if min_responses is None:
-            min_responses = 0
+            min_responses = 0  # this is internally used by controller's broadcast to represent all targets
         check_non_negative_int("min_responses", min_responses)
         check_non_negative_int("timeout", timeout)
         check_non_negative_int("wait_time_after_min_received", wait_time_after_min_received)

--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -102,8 +102,9 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         task_name: str = AppConstants.TASK_TRAIN,
         data: FLModel = None,
         targets: Union[List[Client], List[str], None] = None,
+        min_responses: int = 0,
         timeout: int = 0,
-        wait_time_after_min_received: int = 10,
+        wait_time_after_min_received: int = 0,
         blocking: bool = True,
         callback: Callable[[FLModel], None] = None,
     ) -> List:
@@ -113,9 +114,11 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             task_name (str, optional): name of the task. Defaults to "train".
             data (FLModel, optional): FLModel to be sent to clients. If no data is given, send empty FLModel.
             targets (List[str], optional): the list of target client names or None (all clients). Defaults to None.
+            min_responses (int, optional): the minimum number of responses expected. If == 0, must receive responses from
+              all clients that the task has been sent to. Defaults to 0.
             timeout (int, optional): time to wait for clients to perform task. Defaults to 0, i.e., never time out.
             wait_time_after_min_received (int, optional): time to wait after
-                minimum number of clients responses has been received. Defaults to 10.
+                minimum number of clients responses has been received. Defaults to 0.
             blocking (bool, optional): whether to block to wait for task result. Defaults to True.
             callback (Callable[[FLModel], None], optional): callback when a result is received, only called when blocking=False. Defaults to None.
 
@@ -127,6 +130,7 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             raise TypeError("task_name must be a string but got {}".format(type(task_name)))
         if data and not isinstance(data, FLModel):
             raise TypeError("data must be a FLModel or None but got {}".format(type(data)))
+        check_non_negative_int("min_responses", min_responses)
         check_non_negative_int("timeout", timeout)
         check_non_negative_int("wait_time_after_min_received", wait_time_after_min_received)
         if not blocking and not isinstance(callback, Callable):
@@ -140,10 +144,8 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
 
         if targets:
             targets = [client.name if isinstance(client, Client) else client for client in targets]
-            min_responses = len(targets)
             self.info(f"Sending task {task_name} to {targets}")
         else:
-            min_responses = len(self.engine.get_clients())
             self.info(f"Sending task {task_name} to all clients")
 
         if blocking:

--- a/nvflare/app_common/workflows/model_controller.py
+++ b/nvflare/app_common/workflows/model_controller.py
@@ -43,7 +43,7 @@ class ModelController(BaseModelController, ABC):
         task_name: str = "train",
         data: FLModel = None,
         targets: Union[List[str], None] = None,
-        min_responses: int = 0,
+        min_responses: int = None,
         timeout: int = 0,
     ) -> List[FLModel]:
         """Send a task with data to targets and wait for results.
@@ -52,8 +52,8 @@ class ModelController(BaseModelController, ABC):
             task_name (str, optional): name of the task. Defaults to "train".
             data (FLModel, optional): FLModel to be sent to clients. Defaults to None.
             targets (List[str], optional): the list of target client names or None (all clients). Defaults to None.
-            min_responses (int, optional): the minimum number of responses expected. If == 0, must receive responses from
-              all clients that the task has been sent to. Defaults to 0.
+            min_responses (int, optional): the minimum number of responses expected. If None, must receive responses from
+              all clients that the task has been sent to. Defaults to None.
             timeout (int, optional): time to wait for clients to perform task. Defaults to 0 (never time out).
 
         Returns:
@@ -63,8 +63,8 @@ class ModelController(BaseModelController, ABC):
             task_name=task_name,
             data=data,
             targets=targets,
-            timeout=timeout,
             min_responses=min_responses,
+            timeout=timeout,
         )
 
     def send_model(
@@ -72,6 +72,7 @@ class ModelController(BaseModelController, ABC):
         task_name: str = "train",
         data: FLModel = None,
         targets: Union[List[str], None] = None,
+        min_responses: int = None,
         timeout: int = 0,
         callback: Callable[[FLModel], None] = None,
     ) -> None:
@@ -81,6 +82,8 @@ class ModelController(BaseModelController, ABC):
             task_name (str, optional): name of the task. Defaults to "train".
             data (FLModel, optional): FLModel to be sent to clients. Defaults to None.
             targets (List[str], optional): the list of target client names or None (all clients). Defaults to None.
+            min_responses (int, optional): the minimum number of responses expected. If None, must receive responses from
+              all clients that the task has been sent to. Defaults to None.
             timeout (int, optional): time to wait for clients to perform task. Defaults to 0 (never time out).
             callback (Callable[[FLModel], None], optional): callback when a result is received. Defaults to None.
 
@@ -91,6 +94,7 @@ class ModelController(BaseModelController, ABC):
             task_name=task_name,
             data=data,
             targets=targets,
+            min_responses=min_responses,
             timeout=timeout,
             blocking=False,
             callback=callback,

--- a/nvflare/app_common/workflows/model_controller.py
+++ b/nvflare/app_common/workflows/model_controller.py
@@ -43,8 +43,8 @@ class ModelController(BaseModelController, ABC):
         task_name: str = "train",
         data: FLModel = None,
         targets: Union[List[str], None] = None,
+        min_responses: int = 0,
         timeout: int = 0,
-        wait_time_after_min_received: int = 10,
     ) -> List[FLModel]:
         """Send a task with data to targets and wait for results.
 
@@ -52,8 +52,9 @@ class ModelController(BaseModelController, ABC):
             task_name (str, optional): name of the task. Defaults to "train".
             data (FLModel, optional): FLModel to be sent to clients. Defaults to None.
             targets (List[str], optional): the list of target client names or None (all clients). Defaults to None.
+            min_responses (int, optional): the minimum number of responses expected. If == 0, must receive responses from
+              all clients that the task has been sent to. Defaults to 0.
             timeout (int, optional): time to wait for clients to perform task. Defaults to 0 (never time out).
-            wait_time_after_min_received (int, optional): time to wait after minimum number of client responses have been received. Defaults to 10.
 
         Returns:
             List[FLModel]
@@ -63,7 +64,7 @@ class ModelController(BaseModelController, ABC):
             data=data,
             targets=targets,
             timeout=timeout,
-            wait_time_after_min_received=wait_time_after_min_received,
+            min_responses=min_responses,
         )
 
     def send_model(
@@ -72,7 +73,6 @@ class ModelController(BaseModelController, ABC):
         data: FLModel = None,
         targets: Union[List[str], None] = None,
         timeout: int = 0,
-        wait_time_after_min_received: int = 10,
         callback: Callable[[FLModel], None] = None,
     ) -> None:
         """Send a task with data to targets (non-blocking). Callback is called when a result is received.
@@ -82,7 +82,6 @@ class ModelController(BaseModelController, ABC):
             data (FLModel, optional): FLModel to be sent to clients. Defaults to None.
             targets (List[str], optional): the list of target client names or None (all clients). Defaults to None.
             timeout (int, optional): time to wait for clients to perform task. Defaults to 0 (never time out).
-            wait_time_after_min_received (int, optional): time to wait after minimum number of client responses have been received. Defaults to 10.
             callback (Callable[[FLModel], None], optional): callback when a result is received. Defaults to None.
 
         Returns:
@@ -93,7 +92,6 @@ class ModelController(BaseModelController, ABC):
             data=data,
             targets=targets,
             timeout=timeout,
-            wait_time_after_min_received=wait_time_after_min_received,
             blocking=False,
             callback=callback,
         )


### PR DESCRIPTION
#[4717625](https://nvbugspro.nvidia.com/bug/4717625)

- expose `min_responses` argument in ModelController's `send_model_and_wait()`
- hide `wait_time_after_min_received` argument, set default to 0

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
