### PR TITLE
BUGFIX: cloud deployment script issue with OSX 

### DIFF
--- a/nvflare/lighter/impl/aws_template.yml
+++ b/nvflare/lighter/impl/aws_template.yml
@@ -1,4 +1,5 @@
 aws_start_sh: |
+
   function find_ec2_gpu_instance_type() {
     local gpucnt=0
     local gpumem=0
@@ -98,10 +99,10 @@ aws_start_sh: |
   then
     while true
     do
-      read -e -i ${REGION} -p "* Cloud EC2 region, press ENTER to accept default: " REGION
+      prompt REGION "* Cloud EC2 region, press ENTER to accept default" "${REGION}"
       if [ ${container} = false ]
         then
-        read -e -i ${AMI_NAME} -p "* Cloud AMI image name, press ENTER to accept default (use amd64 or arm64): " AMI_NAME
+        prompt AMI_NAME "* Cloud AMI image name (use amd64 or arm64), press ENTER to accept default" "${AMI_NAME}"
         printf "    retrieving AMI ID for ${AMI_NAME} ... "
         IMAGES=$(aws ec2 describe-images --region ${REGION} --owners ${AMI_IMAGE_OWNER} --filters "Name=name,Values=*${AMI_NAME}*" --output json)
         if [ "${#IMAGES}" -lt 30 ]
@@ -118,9 +119,9 @@ aws_start_sh: |
         fi
         find_ec2_gpu_instance_type
       fi
-      prompt AMI_IMAGE "* Cloud AMI image, press ENTER to accept default ${AMI_IMAGE}: "
-      read -e -i ${EC2_TYPE} -p "* Cloud EC2 type, press ENTER to accept default: " EC2_TYPE
-      prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n) "
+      prompt AMI_IMAGE "* Cloud AMI image, press ENTER to accept default"
+      prompt EC2_TYPE  "* Cloud EC2 type, press ENTER to accept default" "${EC2_TYPE}"
+      prompt ans "region = ${REGION}, ami image = ${AMI_IMAGE}, EC2 type = ${EC2_TYPE}, OK? (Y/n)"
       if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]
       then
         break

--- a/nvflare/lighter/impl/azure_template.yml
+++ b/nvflare/lighter/impl/azure_template.yml
@@ -66,14 +66,14 @@ azure_start_svr_header_sh: |
   then
     while true
     do
-      prompt VM_IMAGE "Cloud VM image, press ENTER to accept default ${VM_IMAGE}: "
-      prompt VM_SIZE "Cloud VM size, press ENTER to accept default ${VM_SIZE}: "
+      prompt VM_IMAGE "Cloud VM image, press ENTER to accept default" "${VM_IMAGE}"
+      prompt VM_SIZE "Cloud VM size, press ENTER to accept default" "${VM_SIZE}"
       if [ $self_dns == true ]
       then
-        prompt LOCATION "Cloud location, press ENTER to accept default ${LOCATION}: "        
-        prompt ans "VM image = ${VM_IMAGE}, VM size = ${VM_SIZE}, location = ${LOCATION}, OK? (Y/n) "
+        prompt LOCATION "Cloud location, press ENTER to accept default" "${LOCATION}"
+        prompt ans "VM image = ${VM_IMAGE}, VM size = ${VM_SIZE}, location = ${LOCATION}, OK? (Y/n)"
       else
-        prompt ans "VM image = ${VM_IMAGE}, VM size = ${VM_SIZE}, OK? (Y/n) "
+        prompt ans "VM image = ${VM_IMAGE}, VM size = ${VM_SIZE}, OK? (Y/n)"
       fi
       if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]; then break; fi
     done
@@ -82,7 +82,7 @@ azure_start_svr_header_sh: |
   if [ $container == false ]
   then
     echo "If the client requires additional dependencies, please copy the requirements.txt to ${DIR}."
-    prompt ans "Press ENTER when it's done or no additional dependencies. "
+    prompt ans "Press ENTER when it's done or no additional dependencies."
   fi
 
   az login --use-device-code -o none
@@ -221,9 +221,9 @@ azure_start_cln_header_sh: |
   then
     while true
     do
-      prompt LOCATION "Cloud location, press ENTER to accept default ${LOCATION}: "
-      prompt VM_IMAGE "Cloud VM image, press ENTER to accept default ${VM_IMAGE}: "
-      prompt VM_SIZE "Cloud VM size, press ENTER to accept default ${VM_SIZE}: "
+      prompt LOCATION "Cloud location, press ENTER to accept default" "${LOCATION}"
+      prompt VM_IMAGE "Cloud VM image, press ENTER to accept default" "${VM_IMAGE}"
+      prompt VM_SIZE "Cloud VM size, press ENTER to accept default" "${VM_SIZE}"
       prompt ans "location = ${LOCATION}, VM image = ${VM_IMAGE}, VM size = ${VM_SIZE}, OK? (Y/n) "
       if [[ $ans = "" ]] || [[ $ans =~ ^(y|Y)$ ]]; then break; fi
     done
@@ -232,7 +232,7 @@ azure_start_cln_header_sh: |
   if [ $container == false ]
   then
     echo "If the client requires additional dependencies, please copy the requirements.txt to ${DIR}."
-    prompt ans "Press ENTER when it's done or no additional dependencies. "
+    prompt ans "Press ENTER when it's done or no additional dependencies."
   fi
 
   az login --use-device-code -o none

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -798,12 +798,29 @@ cloud_script_header: |
   }
 
   function prompt() {
-    local __default="$1"
-    read -p "$2" ans
-    if [[ ! -z "$ans" ]]
-    then
-      eval $__default="'$ans'"
+    # usage:  prompt NEW_VAR "Prompt message" ["${PROMPT_VALUE}"]
+    local __resultvar=$1
+    local __prompt=$2
+    local __default=${3:-}
+    local __result
+    if [[ ${BASH_VERSINFO[0]} -ge 4 && -n "$__default" ]]
+      then
+      read -e -i "$__default" -p "$__prompt: " __result
+    else
+      __default=${3:-${!__resultvar:-}}
+      if [[ -n $__default ]]
+        then
+        printf "%s [%s]: " "$__prompt" "$__default"
+      else
+        printf "%s: " "$__prompt"
+      fi
+      IFS= read -r __result
+      if [[ -z "$__result" && -n "$__default" ]]
+        then
+        __result="$__default"
+      fi
     fi
+    eval $__resultvar="'$__result'"
   }
 
   function get_resources_file() {


### PR DESCRIPTION
Sorry about this folks, should have known better but there was an OSX compatibility issue with my recent pull request 2650

This new PR addresses a bug with MacOS introduced with c73f6149a92d0b1c3d909381e33c4cf2e718e964 because "read -i" requires Bash >= 4 (newer than 2009 !) as OSX only comes with Bash 3.2 by default (you can use brew to install a newer version)

Refactor of prompt function has:

  - editable prompts with read -i ONLY if Bash >= 4
  - in cases where you do not want or need an editable prompt (e.g. AMI ID) you leave out the 3rd argument
  - fully compatible with previous prompt function (only cosmetic changes in azure template)


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.


so if you are on Bash >= 4 you can edit the default values in place (except the AMI id)

```
* Cloud EC2 region, press ENTER to accept default: us-west-2
* Cloud AMI image name (use amd64 or arm64), press ENTER to accept default: ubuntu-*-22.04-amd64-pro-server
    retrieving AMI ID for ubuntu-*-22.04-amd64-pro-server ... ami-0812a6811f8b12a3f found
    finding smallest instance type with 1 GPUs and 15360 MiB VRAM ... g4dn.xlarge found
* Cloud AMI image, press ENTER to accept default [ami-0812a6811f8b12a3f]:
* Cloud EC2 type, press ENTER to accept default: g4dn.xlarge
region = us-west-2, ami image = ami-0812a6811f8b12a3f, EC2 type = g4dn.xlarge, OK? (Y/n):
If the client requires additional Python packages, please add them to:
    /home/dp/NVFlare/dirk/Test/AWS-T4.Y/startup/requirements.txt
Press ENTER when it's done or no additional dependencies. :
```

and if you are on older Bash, the default values will simply be shown in square brackets:

```
* Cloud EC2 region, press ENTER to accept default [us-west-2]:
* Cloud AMI image name (use amd64 or arm64), press ENTER to accept default [ubuntu-*-22.04-amd64-pro-server]:
    retrieving AMI ID for ubuntu-*-22.04-amd64-pro-server ... ami-0812a6811f8b12a3f found
    finding smallest instance type with 1 GPUs and 15360 MiB VRAM ... g4dn.xlarge found
* Cloud AMI image, press ENTER to accept default [ami-0812a6811f8b12a3f]:
* Cloud EC2 type, press ENTER to accept default [g4dn.xlarge]:
region = us-west-2, ami image = ami-0812a6811f8b12a3f, EC2 type = g4dn.xlarge, OK? (Y/n):
If the client requires additional Python packages, please add them to:
    /home/dp/NVFlare/dirk/Test/AWS-T4.Y/startup/requirements.txt
Press ENTER when it's done or no additional dependencies. :
```
