### PR TITLE
Enhance CLI command config

### DIFF
--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -31,6 +31,7 @@ from nvflare.utils.cli_utils import (
     create_poc_workspace_config,
     create_startup_kit_config,
     get_hidden_config,
+    print_hidden_config,
     save_config,
 )
 
@@ -116,14 +117,18 @@ def def_config_parser(sub_cmd):
 def handle_config_cmd(args):
     config_file_path, nvflare_config = get_hidden_config()
 
-    if not args.job_templates_dir or not os.path.isdir(args.job_templates_dir):
-        raise ValueError(f"job_templates_dir='{args.job_templates_dir}', it is not a directory")
+    if args.startup_kit_dir is None and args.poc_workspace_dir is None and args.job_templates_dir is None:
+        print(f"not specifying any directory. print existing config at {config_file_path}")
+        print_hidden_config(config_file_path, nvflare_config)
+        return
 
     nvflare_config = create_startup_kit_config(nvflare_config, args.startup_kit_dir)
     nvflare_config = create_poc_workspace_config(nvflare_config, args.poc_workspace_dir)
     nvflare_config = create_job_template_config(nvflare_config, args.job_templates_dir)
 
     save_config(nvflare_config, config_file_path)
+    print(f"new config at {config_file_path}")
+    print_hidden_config(config_file_path, nvflare_config)
 
 
 def parse_args(prog_name: str):

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import json
 import os
-import pathlib
 import random
 import shutil
 import socket
@@ -36,7 +35,7 @@ from nvflare.lighter.spec import Provisioner
 from nvflare.lighter.utils import load_yaml, update_project_server_name_config, update_storage_locations
 from nvflare.tool.api_utils import shutdown_system
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
-from nvflare.utils.cli_utils import hocon_to_string
+from nvflare.utils.cli_utils import get_hidden_nvflare_config_path, get_or_create_hidden_nvflare_dir, hocon_to_string
 
 DEFAULT_WORKSPACE = "/tmp/nvflare/poc"
 DEFAULT_PROJECT_NAME = "example_project"
@@ -396,7 +395,7 @@ def prepare_clients(clients, number_of_clients):
 
 
 def save_startup_kit_dir_config(workspace, project_name):
-    dst = get_hidden_nvflare_config_path()
+    dst = get_or_create_hidden_nvflare_config_path()
     config = None
     if os.path.isfile(dst):
         try:
@@ -485,27 +484,17 @@ def _prepare_poc(
     return True
 
 
-def get_home_dir():
-    return Path.home()
-
-
-def get_hidden_nvflare_config_path() -> str:
+def get_or_create_hidden_nvflare_config_path() -> str:
     """
     Get the path for the hidden nvflare configuration file.
 
     Returns:
         str: The path to the hidden nvflare configuration file.
     """
-    home_dir = get_home_dir()
-    hidden_nvflare_dir = pathlib.Path(home_dir) / ".nvflare"
+    hidden_nvflare_dir = get_or_create_hidden_nvflare_dir()
 
-    try:
-        hidden_nvflare_dir.mkdir(exist_ok=True)
-    except OSError as e:
-        raise RuntimeError(f"Error creating the hidden nvflare directory: {e}")
-
-    hidden_nvflare_config_file = hidden_nvflare_dir / "config.conf"
-    return str(hidden_nvflare_config_file)
+    hidden_nvflare_config_file = get_hidden_nvflare_config_path(str(hidden_nvflare_dir))
+    return hidden_nvflare_config_file
 
 
 def prepare_poc_provision(
@@ -1077,7 +1066,7 @@ def get_poc_workspace():
     poc_workspace = os.getenv("NVFLARE_POC_WORKSPACE")
 
     if not poc_workspace:
-        src_path = get_hidden_nvflare_config_path()
+        src_path = get_or_create_hidden_nvflare_config_path()
         if os.path.isfile(src_path):
             from pyhocon import ConfigFactory as CF
 


### PR DESCRIPTION
If users type "nvflare config" without entering any information, the old code will just raise an Exception and users see only:
```
"raise ValueError(f"job_templates_dir='{args.job_templates_dir}', it is not a directory")"
```

Add a new behavior so if specified nothing, users can check where the file is, and what is the current content of that hidden file.
If any directory is specified, the behavior is the same as before.

### Description

- Add print_hidden_config
- Reuse methods from nvflare/utils/cli_utils.py

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
