### PR TITLE
Fix cell encrypt

### DIFF
--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -942,6 +942,10 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
         if message.payload is None:
             message.payload = bytes(0)
+        elif isinstance(message.payload, memoryview) or isinstance(message.payload, bytearray):
+            message.payload = bytes(message.payload)
+        elif not isinstance(message.payload, bytes):
+            raise RuntimeError(f"Payload type of {type(message.payload)} is not supported.")
 
         payload_len = len(message.payload)
         message.add_headers(


### PR DESCRIPTION
### Issue

After 7/20/2024, our CI has been failing with the following error:

```
TypeError: unsupported operand type(s) for +: 'memoryview' and 'bytes'
```

### Cause

The old cryptography package (version 42.0.8) when it does the following code:

```
def _sym_enc(k: bytes, n: bytes, m: bytes) -> bytes:
    cipher = Cipher(algorithms.AES(k), modes.CBC(n), backend=default_backend())
    encryptor = cipher.encryptor()
    padder = padding.PKCS7(PADDING_LENGTH).padder()
    padded_data = padder.update(m) + padder.finalize()
    return encryptor.update(padded_data) + encryptor.finalize()
```

If the "m" is an object of type `memoryview`, the `padder.update(m)` will return an object of `bytes` type.

With the new cryptography package (version 43.0.0) released in 7/20/2024 when it does `padder.update(m)` with a `memoryview` type it will return an object of `memoryview` type.


So if we want to use this same method, we need to ensure the passed in "m" is indeed of type `bytes`.


### Description

- Convert message payload to bytes before feed into the encrypt method
- Remove unused CellCipher class

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
