### PR TITLE
Fix overseer test timing

### DIFF
--- a/tests/integration_test/overseer_test.py
+++ b/tests/integration_test/overseer_test.py
@@ -83,7 +83,7 @@ class TestOverseer:
             oa_launcher.stop_overseer()
             time.sleep(10)
             oa_launcher.start_overseer()
-            time.sleep(10)
+            time.sleep(20)
             for client_agent in client_agent_list:
                 psp = oa_launcher.get_primary_sp(client_agent)
                 assert psp.name == "server00"


### PR DESCRIPTION
10 second is not enough for the client agent to get the updated SP address.

### Description

Increase this test case to wait 20 seconds before checking.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
