### PR TITLE
Moved the simulator server logger init earlier

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -174,6 +174,10 @@ class SimulatorRunner(FLComponent):
         self._cleanup_workspace()
         init_security_content_service(self.args.workspace)
 
+        os.makedirs(os.path.join(self.simulator_root, "server"))
+        log_file = os.path.join(self.simulator_root, "server", WorkspaceConstants.LOG_FILE_NAME)
+        add_logfile_handler(log_file)
+
         try:
             data_bytes, job_name, meta = self.validate_job_data()
 
@@ -500,9 +504,6 @@ class SimulatorRunner(FLComponent):
         app_server_root = os.path.join(self.simulator_root, "server", SimulatorConstants.JOB_NAME, "app_server")
         args.workspace = os.path.join(self.simulator_root, "server")
         os.chdir(args.workspace)
-
-        log_file = os.path.join(self.simulator_root, "server", WorkspaceConstants.LOG_FILE_NAME)
-        add_logfile_handler(log_file)
 
         args.server_config = os.path.join("config", JobConstants.SERVER_JOB_CONFIG)
         app_custom_folder = os.path.join(app_server_root, "custom")


### PR DESCRIPTION
Fixes # .

### Description

Moved the simulator server logger init earlier to log more server start and app validation error messages. (Compatible with 2.4 release.)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
