### PR TITLE
Latest cryptography breaks poc prepare

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 zip_safe = True
 python_requires = >= 3.8
 install_requires =
-    cryptography>=36.0.0
+    cryptography>=36.0.0,<43
     Flask==3.0.2
     Werkzeug==3.0.1
     Flask-JWT-Extended==4.6.0


### PR DESCRIPTION
Fixes #2760 

### Description

The latest release of cryptography @ 43.0.0 breaks some nvflare commands like `nvflare poc prepare` with the following error:
```
# pip install nvflare
# nvflare poc prepare
prepare poc at /tmp/nvflare/poc for 2 clients
provision at /tmp/nvflare/poc for 2 clients with /tmp/nvflare/poc/project.yml
Exception raised during provision.  Incomplete prod_n folder removed.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/nvflare/lighter/spec.py", line 174, in provision
    b.build(project, ctx)
  File "/usr/local/lib/python3.10/site-packages/nvflare/lighter/impl/cert.py", line 137, in build
    self._build_write_cert_pair(server, "server", ctx)
  File "/usr/local/lib/python3.10/site-packages/nvflare/lighter/impl/cert.py", line 119, in _build_write_cert_pair
    pkcs12 = serialization.pkcs12.serialize_key_and_certificates(
AttributeError: module 'cryptography.hazmat.primitives.serialization' has no attribute 'pkcs12'
```

This PR modifies setup.cfg to specify a maximum version `<43`, the last working version of cryptography is 42.0.8 https://pypi.org/project/cryptography/#history.

Unsure which branches this change needs to be merged into so that the latest 2.4.1 release on PyPI is fixed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
