### PR TITLE
Enhance cyclic controller

### DIFF
--- a/nvflare/app_common/workflows/cyclic_ctl.py
+++ b/nvflare/app_common/workflows/cyclic_ctl.py
@@ -170,6 +170,19 @@ class CyclicController(Controller):
         self._is_done = True
 
     def _process_result(self, client_task: ClientTask, fl_ctx: FLContext):
+        result = client_task.result
+        rc = result.get_return_code()
+        client_name = client_task.client.name
+
+        # Raise errors if ReturnCode is not OK.
+        if rc and rc != ReturnCode.OK:
+            self.system_panic(
+                f"Result from {client_name} is bad, error code: {rc}. "
+                f"{self.__class__.__name__} exiting at round {self._current_round}.",
+                fl_ctx=fl_ctx,
+            )
+            return False
+
         # submitted shareable is stored in client_task.result
         # we need to update task.data with that shareable so the next target
         # will get the updated shareable

--- a/tests/unit_test/app_common/workflow/cyclic_ctl_test.py
+++ b/tests/unit_test/app_common/workflow/cyclic_ctl_test.py
@@ -55,16 +55,17 @@ ORDER_TEST_CASES = [
 ]
 
 
-def gen_shareable(is_early_termination: bool = False, is_not_shareable: bool = False):
-    if is_not_shareable:
-        return [1, 2, 3]
+def gen_shareable(return_code: ReturnCode):
     return_result = Shareable()
-    if is_early_termination:
-        return_result.set_return_code(ReturnCode.EARLY_TERMINATION)
+    return_result.set_return_code(return_code)
     return return_result
 
 
-PROCESS_RESULT_TEST_CASES = [gen_shareable(is_early_termination=True), gen_shareable(is_not_shareable=True)]
+PROCESS_RESULT_TEST_CASES = [
+    gen_shareable(return_code=ReturnCode.EARLY_TERMINATION),
+    gen_shareable(return_code=ReturnCode.EXECUTION_EXCEPTION),
+    [1, 2, 3],
+]
 
 
 class TestCyclicController:


### PR DESCRIPTION
### Description

Port changes from #2337 and enhance the logic of cyclic controller to check RC first before trying to call shareable_generator.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
