### PR TITLE
Fix config file name in doc

### DIFF
--- a/docs/examples/fl_experiment_tracking_mlflow.rst
+++ b/docs/examples/fl_experiment_tracking_mlflow.rst
@@ -51,7 +51,7 @@ with the appropriate path to the directory containing the "pt" directory with cu
 Adding MLflow Logging to Configurations
 ------------------------------------------------
 
-Inside the config folder there are two files, ``config_fed_client.json`` and ``config_fed_server.json``.
+Inside the config folder there are two files, ``config_fed_client.conf`` and ``config_fed_server.conf``.
 
 .. literalinclude:: ../../examples/advanced/experiment-tracking/mlflow/jobs/hello-pt-mlflow/app/config/config_fed_client.conf
    :language:


### PR DESCRIPTION
### Description

Should be updated to ".conf"

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
