### PR TITLE
Fix loading cli history in admin console

### DIFF
--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -399,7 +399,11 @@ class AdminClient(cmd.Cmd, EventHandler):
 
     def preloop(self):
         if readline and os.path.exists(self.cli_history_file):
-            readline.read_history_file(self.cli_history_file)
+            try:
+                readline.read_history_file(self.cli_history_file)
+            except OSError:
+                self.stdout.write("Unable to read history file.  No command history loaded\n")
+                readline.clear_history()
 
     def postcmd(self, stop, line):
         if readline:


### PR DESCRIPTION
### Description

When users copy admin console startup kits between different OS, the cli history file could not be loaded.  This PR catches the exception and shows a message to users.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
