### PR TITLE
Improve the kill children processes

### DIFF
--- a/nvflare/private/fed/app/utils.py
+++ b/nvflare/private/fed/app/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import signal
 import sys
 import threading
 import time

--- a/nvflare/private/fed/app/utils.py
+++ b/nvflare/private/fed/app/utils.py
@@ -49,7 +49,7 @@ def check_parent_alive(parent_pid, stop_event: threading.Event):
         time.sleep(1)
 
 
-def kill_child_processes(parent_pid, sig=signal.SIGTERM):
+def kill_child_processes(parent_pid):
     try:
         parent = psutil.Process(parent_pid)
     except psutil.NoSuchProcess:

--- a/nvflare/private/fed/app/utils.py
+++ b/nvflare/private/fed/app/utils.py
@@ -56,7 +56,7 @@ def kill_child_processes(parent_pid, sig=signal.SIGTERM):
         return
     children = parent.children(recursive=True)
     for process in children:
-        process.send_signal(sig)
+        process.kill()
 
 
 def create_admin_server(fl_server: FederatedServer, server_conf=None, args=None, secure_train=False):


### PR DESCRIPTION
Fixes # .

### Description

Change to use process.kill() to kill the children processes. This force kill the example like flow child process.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
