### PR TITLE
Support ScriptRunner in ccwf_job

### DIFF
--- a/nvflare/app_common/ccwf/ccwf_job.py
+++ b/nvflare/app_common/ccwf/ccwf_job.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from typing import List, Optional
 
-from nvflare.apis.executor import Executor
 from nvflare.app_common.abstract.aggregator import Aggregator
 from nvflare.app_common.abstract.metric_comparator import MetricComparator
 from nvflare.app_common.abstract.model_persistor import ModelPersistor

--- a/nvflare/app_common/ccwf/ccwf_job.py
+++ b/nvflare/app_common/ccwf/ccwf_job.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional
+from typing import Any, List, Optional
 
+from nvflare.apis.executor import Executor
 from nvflare.app_common.abstract.aggregator import Aggregator
 from nvflare.app_common.abstract.metric_comparator import MetricComparator
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
@@ -20,7 +21,7 @@ from nvflare.app_common.abstract.shareable_generator import ShareableGenerator
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.ccwf.common import Constant, CyclicOrder
 from nvflare.fuel.utils.validation_utils import check_object_type
-from nvflare.job_config.api import FedJob
+from nvflare.job_config.api import FedJob, has_add_to_job_method
 from nvflare.widgets.widget import Widget
 
 from .cse_client_ctl import CrossSiteEvalClientController
@@ -64,12 +65,12 @@ class SwarmServerConfig:
 class SwarmClientConfig:
     def __init__(
         self,
-        executor,
-        persistor: ModelPersistor,
-        shareable_generator: ShareableGenerator,
-        aggregator: Aggregator,
-        metric_comparator: MetricComparator = None,
-        model_selector: Widget = None,
+        executor: Any,
+        persistor: Any,
+        shareable_generator: Any,
+        aggregator: Any,
+        metric_comparator: Any = None,
+        model_selector: Any = None,
         learn_task_check_interval=Constant.LEARN_TASK_CHECK_INTERVAL,
         learn_task_abort_timeout=Constant.LEARN_TASK_ABORT_TIMEOUT,
         learn_task_ack_timeout=Constant.LEARN_TASK_ACK_TIMEOUT,
@@ -79,16 +80,16 @@ class SwarmClientConfig:
         wait_time_after_min_resps_received: float = 10.0,
     ):
         # the executor could be a wrapper object that adds real Executor when added to job!
-        # check_object_type("executor", executor, Executor)
-        check_object_type("persistor", persistor, ModelPersistor)
-        check_object_type("shareable_generator", shareable_generator, ShareableGenerator)
-        check_object_type("aggregator", aggregator, Aggregator)
+        validate_object_for_job("executor", executor, Executor)
+        validate_object_for_job("persistor", persistor, ModelPersistor)
+        validate_object_for_job("shareable_generator", shareable_generator, ShareableGenerator)
+        validate_object_for_job("aggregator", aggregator, Aggregator)
 
         if model_selector:
-            check_object_type("model_selector", model_selector, Widget)
+            validate_object_for_job("model_selector", model_selector, Widget)
 
         if metric_comparator:
-            check_object_type("metric_comparator", metric_comparator, MetricComparator)
+            validate_object_for_job("metric_comparator", metric_comparator, MetricComparator)
 
         self.executor = executor
         self.persistor = persistor
@@ -134,17 +135,16 @@ class CyclicServerConfig:
 class CyclicClientConfig:
     def __init__(
         self,
-        executor,
-        persistor: ModelPersistor,
-        shareable_generator: ShareableGenerator,
+        executor: Any,
+        persistor: Any,
+        shareable_generator: Any,
         learn_task_abort_timeout=Constant.LEARN_TASK_ABORT_TIMEOUT,
         learn_task_ack_timeout=Constant.LEARN_TASK_ACK_TIMEOUT,
         final_result_ack_timeout=Constant.FINAL_RESULT_ACK_TIMEOUT,
     ):
-        # the executor could be a wrapper object that adds real Executor when added to job!
-        # check_object_type("executor", executor, Executor)
-        check_object_type("persistor", persistor, ModelPersistor)
-        check_object_type("shareable_generator", shareable_generator, ShareableGenerator)
+        validate_object_for_job("executor", executor, Executor)
+        validate_object_for_job("persistor", persistor, ModelPersistor)
+        validate_object_for_job("shareable_generator", shareable_generator, ShareableGenerator)
 
         self.executor = executor
         self.persistor = persistor
@@ -318,3 +318,21 @@ class CCWFJob(FedJob):
             get_model_timeout=cse_config.get_model_timeout,
         )
         self.to_clients(client_controller, tasks=["cse_*"])
+
+
+def validate_object_for_job(name, obj, obj_type):
+    """Check whether the specified object is valid for job.
+    The object must either have the add_to_fed_job method or is valid object type.
+
+    Args:
+        name: name of the object
+        obj: the object to be checked
+        obj_type: the object type that the object should be, if it doesn't have the add_to_fed_job method.
+
+    Returns: None
+
+    """
+    if has_add_to_job_method(obj):
+        return
+
+    check_object_type(name, obj, obj_type)

--- a/nvflare/app_common/ccwf/ccwf_job.py
+++ b/nvflare/app_common/ccwf/ccwf_job.py
@@ -65,7 +65,7 @@ class SwarmServerConfig:
 class SwarmClientConfig:
     def __init__(
         self,
-        executor: Executor,
+        executor,
         persistor: ModelPersistor,
         shareable_generator: ShareableGenerator,
         aggregator: Aggregator,
@@ -79,7 +79,8 @@ class SwarmClientConfig:
         min_responses_required: int = 1,
         wait_time_after_min_resps_received: float = 10.0,
     ):
-        check_object_type("executor", executor, Executor)
+        # the executor could be a wrapper object that adds real Executor when added to job!
+        # check_object_type("executor", executor, Executor)
         check_object_type("persistor", persistor, ModelPersistor)
         check_object_type("shareable_generator", shareable_generator, ShareableGenerator)
         check_object_type("aggregator", aggregator, Aggregator)
@@ -134,14 +135,15 @@ class CyclicServerConfig:
 class CyclicClientConfig:
     def __init__(
         self,
-        executor: Executor,
+        executor,
         persistor: ModelPersistor,
         shareable_generator: ShareableGenerator,
         learn_task_abort_timeout=Constant.LEARN_TASK_ABORT_TIMEOUT,
         learn_task_ack_timeout=Constant.LEARN_TASK_ACK_TIMEOUT,
         final_result_ack_timeout=Constant.FINAL_RESULT_ACK_TIMEOUT,
     ):
-        check_object_type("executor", executor, Executor)
+        # the executor could be a wrapper object that adds real Executor when added to job!
+        # check_object_type("executor", executor, Executor)
         check_object_type("persistor", persistor, ModelPersistor)
         check_object_type("shareable_generator", shareable_generator, ShareableGenerator)
 

--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -29,6 +29,8 @@ from .defs import FilterType, JobTargetType
 
 SPECIAL_CHARACTERS = '"!@#$%^&*()+?=,<>/'
 
+_ADD_TO_JOB_METHOD_NAME = "add_to_fed_job"
+
 
 class FedApp:
     def __init__(self):
@@ -252,7 +254,7 @@ class FedJob:
                 else:
                     raise ValueError(f"this object can only be assigned to client, but tried to assign to {target}")
 
-        add_to_job_method = getattr(obj, "add_to_fed_job", None)
+        add_to_job_method = getattr(obj, _ADD_TO_JOB_METHOD_NAME, None)
         if add_to_job_method is not None:
             ctx = JobCtx(obj, target, id)
             result = add_to_job_method(self, ctx, **kwargs)
@@ -564,3 +566,8 @@ class FedJob:
             for k in args_to_check.keys():
                 if k not in args_expected:
                     raise ValueError(f"Received unexpected arg '{k}'. " f"Supported args: {args_info}")
+
+
+def has_add_to_job_method(obj: Any) -> bool:
+    add_to_job_method = getattr(obj, _ADD_TO_JOB_METHOD_NAME, None)
+    return add_to_job_method is not None and callable(add_to_job_method)

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -141,7 +141,7 @@ class ScriptRunner:
             component = ExternalConfigurator(
                 component_ids=[metric_relay_id],
             )
-            job.add_component("config_preparer", component, ctx)
+            comp_ids["config_preparer_id"] = job.add_component("config_preparer", component, ctx)
         else:
             executor = self._get_in_process_executor_cls(self._framework)(
                 task_script_path=os.path.basename(self._script),

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -88,6 +88,7 @@ class ScriptRunner:
         """
         job.check_kwargs(args_to_check=kwargs, args_expected={"tasks": False})
         tasks = kwargs.get("tasks", ["*"])
+        comp_ids = {}
 
         if self._launch_external_process:
             from nvflare.app_common.launchers.subprocess_launcher import SubprocessLauncher
@@ -104,11 +105,13 @@ class ScriptRunner:
                 workspace_dir="{WORKSPACE}",
             )
             pipe_id = job.add_component("pipe", component, ctx)
+            comp_ids["pipe_id"] = pipe_id
 
             component = SubprocessLauncher(
                 script=self._command + " custom/" + os.path.basename(self._script) + " " + self._script_args,
             )
             launcher_id = job.add_component("launcher", component, ctx)
+            comp_ids["launcher_id"] = launcher_id
 
             executor = self._get_ex_process_executor_cls(self._framework)(
                 pipe_id=pipe_id,
@@ -126,12 +129,14 @@ class ScriptRunner:
                 workspace_dir="{WORKSPACE}",
             )
             metric_pipe_id = job.add_component("metrics_pipe", component, ctx)
+            comp_ids["metric_pipe_id"] = metric_pipe_id
 
             component = MetricRelay(
                 pipe_id=metric_pipe_id,
                 event_type="fed.analytix_log_stats",
             )
             metric_relay_id = job.add_component("metric_relay", component, ctx)
+            comp_ids["metric_relay_id"] = metric_relay_id
 
             component = ExternalConfigurator(
                 component_ids=[metric_relay_id],
@@ -146,6 +151,7 @@ class ScriptRunner:
             job.add_executor(executor, tasks=tasks, ctx=ctx)
 
         job.add_resources(resources=[self._script], ctx=ctx)
+        return comp_ids
 
     def _get_ex_process_executor_cls(self, framework: FrameworkType) -> Type[ClientAPILauncherExecutor]:
         if framework == FrameworkType.PYTORCH:


### PR DESCRIPTION
Fixes # .

### Description

The CCWFJob's SwarmClientConfig and CyclicClientConfig require the executor to be Executor. This will cause the type check to fail when using ScriptRunner as the executor, since ScriptRunner is not a true Executor.

Disabled the type check in CCWFJob.

Also improved ScriptRunner to return component IDs added to the job.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
