### PR TITLE
rolled back the job api custom_file copy destination change

### DIFF
--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -172,7 +172,7 @@ class FedJobConfig:
                     relative_script = self._get_relative_script(script)
                 else:
                     relative_script = script
-                dest_file = os.path.join(custom_dir, os.path.basename(relative_script))
+                dest_file = os.path.join(custom_dir, relative_script)
                 module = "".join(relative_script.rsplit(".py", 1)).replace(os.sep, ".")
                 self._copy_source_file(custom_dir, module, script, dest_file)
 
@@ -209,7 +209,7 @@ class FedJobConfig:
                     self.custom_modules.append(module)
                     os.makedirs(custom_dir, exist_ok=True)
                     # dest_file = os.path.join(custom_dir, module.replace(".", os.sep) + ".py")
-                    dest_file = os.path.join(custom_dir, os.path.basename(dest))
+                    dest_file = os.path.join(custom_dir, dest)
 
                     self._copy_source_file(custom_dir, module, source_file, dest_file)
 


### PR DESCRIPTION
Fixes # .

### Description

Rolled back the job api custom_file copy destination change, Keep the custom file sub-folder structure.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
