### PR TITLE
Added Debug in ReliableMessage and Ignore XGB errors after shutdown

### DIFF
--- a/nvflare/apis/utils/reliable_message.py
+++ b/nvflare/apis/utils/reliable_message.py
@@ -53,7 +53,7 @@ TOPIC_RELIABLE_REPLY = "RM.RELIABLE_REPLY"
 PROP_KEY_TX_ID = "RM.TX_ID"
 PROP_KEY_TOPIC = "RM.TOPIC"
 PROP_KEY_OP = "RM.OP"
-PROP_KEY_DEBUG = "RM.DEBUG"
+PROP_KEY_DEBUG_INFO = "RM.DEBUG_INFO"
 
 
 def _extract_result(reply: dict, target: str):
@@ -422,7 +422,7 @@ class ReliableMessage:
         if topic:
             props.append(f"rm_topic={topic}")
 
-        debug_info = fl_ctx.get_prop(PROP_KEY_DEBUG)
+        debug_info = fl_ctx.get_prop(PROP_KEY_DEBUG_INFO)
         if debug_info:
             for k, v in debug_info.items():
                 props.append(f"{k}={v}")

--- a/nvflare/apis/utils/reliable_message.py
+++ b/nvflare/apis/utils/reliable_message.py
@@ -53,6 +53,7 @@ TOPIC_RELIABLE_REPLY = "RM.RELIABLE_REPLY"
 PROP_KEY_TX_ID = "RM.TX_ID"
 PROP_KEY_TOPIC = "RM.TOPIC"
 PROP_KEY_OP = "RM.OP"
+PROP_KEY_DEBUG = "RM.DEBUG"
 
 
 def _extract_result(reply: dict, target: str):
@@ -420,6 +421,11 @@ class ReliableMessage:
         topic = fl_ctx.get_prop(PROP_KEY_TOPIC)
         if topic:
             props.append(f"rm_topic={topic}")
+
+        debug_info = fl_ctx.get_prop(PROP_KEY_DEBUG)
+        if debug_info:
+            for k, v in debug_info.items():
+                props.append(f"{k}={v}")
 
         rm_ctx = ""
         if props:

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_server_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_server_adaptor.py
@@ -120,7 +120,7 @@ class GrpcServerAdaptor(XGBServerAdaptor):
             else:
                 raise RuntimeError(f"bad result from XGB server: expect AllgatherReply but got {type(result)}")
         except Exception as ex:
-            self._handle_error(ex, "all_gather", rank, seq, send_buf)
+            return self._handle_error(ex, "all_gather", rank, seq, send_buf)
 
     def all_gather_v(self, rank: int, seq: int, send_buf: bytes, fl_ctx: FLContext) -> bytes:
         try:
@@ -130,7 +130,7 @@ class GrpcServerAdaptor(XGBServerAdaptor):
             else:
                 raise RuntimeError(f"bad result from XGB server: expect AllgatherVReply but got {type(result)}")
         except Exception as ex:
-            self._handle_error(ex, "all_gather_v", rank, seq, send_buf)
+            return self._handle_error(ex, "all_gather_v", rank, seq, send_buf)
 
     def all_reduce(
         self,
@@ -154,7 +154,7 @@ class GrpcServerAdaptor(XGBServerAdaptor):
             else:
                 raise RuntimeError(f"bad result from XGB server: expect AllreduceReply but got {type(result)}")
         except Exception as ex:
-            self._handle_error(ex, "all_reduce", rank, seq, send_buf)
+            return self._handle_error(ex, "all_reduce", rank, seq, send_buf)
 
     def broadcast(self, rank: int, seq: int, root: int, send_buf: bytes, fl_ctx: FLContext) -> bytes:
         self.logger.debug(f"Sending broadcast: {rank=} {seq=} {root=} {len(send_buf)=}")
@@ -165,9 +165,9 @@ class GrpcServerAdaptor(XGBServerAdaptor):
             else:
                 raise RuntimeError(f"bad result from XGB server: expect BroadcastReply but got {type(result)}")
         except Exception as ex:
-            self._handle_error(ex, "broadcast", rank, seq, send_buf)
+            return self._handle_error(ex, "broadcast", rank, seq, send_buf)
 
-    def _handle_error(self, ex: Exception, op: str, rank: int, seq: int, send_buf: bytes):
+    def _handle_error(self, ex: Exception, op: str, rank: int, seq: int, send_buf: bytes) -> bytes:
         if self._stopping:
             self.logger.warning(f"Error while stopping ignored, " f"op={op} {rank=} {seq=} {len(send_buf)=}: {ex}")
             return bytes(0)

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_server_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/grpc_server_adaptor.py
@@ -65,6 +65,7 @@ class GrpcServerAdaptor(XGBServerAdaptor):
         self.internal_xgb_client = None
         self._server_stopped = False
         self._exit_code = 0
+        self._stopping = False
 
     def _start_server(self, addr: str, port: int, world_size: int, fl_ctx: FLContext):
         runner_ctx = {
@@ -103,6 +104,7 @@ class GrpcServerAdaptor(XGBServerAdaptor):
         self.internal_xgb_client.start(ready_timeout=self.xgb_server_ready_timeout)
 
     def stop(self, fl_ctx: FLContext):
+        _stopping = True
         client = self.internal_xgb_client
         self.internal_xgb_client = None
         if client:
@@ -111,18 +113,36 @@ class GrpcServerAdaptor(XGBServerAdaptor):
         self._stop_server()
 
     def all_gather(self, rank: int, seq: int, send_buf: bytes, fl_ctx: FLContext) -> bytes:
-        result = self.internal_xgb_client.send_allgather(seq_num=seq, rank=rank, data=send_buf)
-        if isinstance(result, pb2.AllgatherReply):
-            return result.receive_buffer
-        else:
-            raise RuntimeError(f"bad result from XGB server: expect AllgatherReply but got {type(result)}")
+        try:
+            result = self.internal_xgb_client.send_allgather(seq_num=seq, rank=rank, data=send_buf)
+            if isinstance(result, pb2.AllgatherReply):
+                return result.receive_buffer
+            else:
+                raise RuntimeError(f"bad result from XGB server: expect AllgatherReply but got {type(result)}")
+        except Exception as ex:
+            if self._stopping:
+                self.logger.warning(
+                    f"Error while stopping ignored, " f"op=all_gather {rank=} {seq=} {len(send_buf)=}: {ex}"
+                )
+                return bytes(0)
+            else:
+                raise ex
 
     def all_gather_v(self, rank: int, seq: int, send_buf: bytes, fl_ctx: FLContext) -> bytes:
-        result = self.internal_xgb_client.send_allgatherv(seq_num=seq, rank=rank, data=send_buf)
-        if isinstance(result, pb2.AllgatherVReply):
-            return result.receive_buffer
-        else:
-            raise RuntimeError(f"bad result from XGB server: expect AllgatherVReply but got {type(result)}")
+        try:
+            result = self.internal_xgb_client.send_allgatherv(seq_num=seq, rank=rank, data=send_buf)
+            if isinstance(result, pb2.AllgatherVReply):
+                return result.receive_buffer
+            else:
+                raise RuntimeError(f"bad result from XGB server: expect AllgatherVReply but got {type(result)}")
+        except Exception as ex:
+            if self._stopping:
+                self.logger.warning(
+                    f"Error while stopping ignored, " f"op=all_gather_v {rank=} {seq=} {len(send_buf)=}: {ex}"
+                )
+                return bytes(0)
+            else:
+                raise ex
 
     def all_reduce(
         self,
@@ -133,22 +153,40 @@ class GrpcServerAdaptor(XGBServerAdaptor):
         send_buf: bytes,
         fl_ctx: FLContext,
     ) -> bytes:
-        result = self.internal_xgb_client.send_allreduce(
-            seq_num=seq,
-            rank=rank,
-            data=send_buf,
-            data_type=data_type,
-            reduce_op=reduce_op,
-        )
-        if isinstance(result, pb2.AllreduceReply):
-            return result.receive_buffer
-        else:
-            raise RuntimeError(f"bad result from XGB server: expect AllreduceReply but got {type(result)}")
+        try:
+            result = self.internal_xgb_client.send_allreduce(
+                seq_num=seq,
+                rank=rank,
+                data=send_buf,
+                data_type=data_type,
+                reduce_op=reduce_op,
+            )
+            if isinstance(result, pb2.AllreduceReply):
+                return result.receive_buffer
+            else:
+                raise RuntimeError(f"bad result from XGB server: expect AllreduceReply but got {type(result)}")
+        except Exception as ex:
+            if self._stopping:
+                self.logger.warning(
+                    f"Error while stopping ignored, " f"op=all_reduce {rank=} {seq=} {len(send_buf)=}: {ex}"
+                )
+                return bytes(0)
+            else:
+                raise ex
 
     def broadcast(self, rank: int, seq: int, root: int, send_buf: bytes, fl_ctx: FLContext) -> bytes:
         self.logger.debug(f"Sending broadcast: {rank=} {seq=} {root=} {len(send_buf)=}")
-        result = self.internal_xgb_client.send_broadcast(seq_num=seq, rank=rank, data=send_buf, root=root)
-        if isinstance(result, pb2.BroadcastReply):
-            return result.receive_buffer
-        else:
-            raise RuntimeError(f"bad result from XGB server: expect BroadcastReply but got {type(result)}")
+        try:
+            result = self.internal_xgb_client.send_broadcast(seq_num=seq, rank=rank, data=send_buf, root=root)
+            if isinstance(result, pb2.BroadcastReply):
+                return result.receive_buffer
+            else:
+                raise RuntimeError(f"bad result from XGB server: expect BroadcastReply but got {type(result)}")
+        except Exception as ex:
+            if self._stopping:
+                self.logger.warning(
+                    f"Error while stopping ignored, " f"op=broadcast {rank=} {seq=} {len(send_buf)=}: {ex}"
+                )
+                return bytes(0)
+            else:
+                raise ex

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/xgb_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/xgb_adaptor.py
@@ -18,7 +18,7 @@ from typing import Tuple
 from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.apis.utils.reliable_message import PROP_KEY_DEBUG, ReliableMessage
+from nvflare.apis.utils.reliable_message import PROP_KEY_DEBUG_INFO, ReliableMessage
 from nvflare.app_opt.xgboost.histogram_based_v2.defs import Constant
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.utils.validation_utils import check_non_negative_int, check_positive_int
@@ -240,7 +240,7 @@ class XGBClientAdaptor(AppAdaptor, ABC):
                 "seq": req[Constant.PARAM_KEY_SEQ],
                 "size": len(req[Constant.PARAM_KEY_SEND_BUF]),
             }
-            fl_ctx.set_prop(key=PROP_KEY_DEBUG, value=debug_info, private=True, sticky=False)
+            fl_ctx.set_prop(key=PROP_KEY_DEBUG_INFO, value=debug_info, private=True, sticky=False)
             reply = ReliableMessage.send_request(
                 target=FQCN.ROOT_SERVER,
                 topic=Constant.TOPIC_XGB_REQUEST,

--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/xgb_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/xgb_adaptor.py
@@ -18,7 +18,7 @@ from typing import Tuple
 from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.apis.utils.reliable_message import ReliableMessage
+from nvflare.apis.utils.reliable_message import PROP_KEY_DEBUG, ReliableMessage
 from nvflare.app_opt.xgboost.histogram_based_v2.defs import Constant
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.utils.validation_utils import check_non_negative_int, check_positive_int
@@ -234,6 +234,13 @@ class XGBClientAdaptor(AppAdaptor, ABC):
         req.set_header(Constant.MSG_KEY_XGB_OP, op)
 
         with self.engine.new_context() as fl_ctx:
+            debug_info = {
+                "op": op,
+                "rank": req[Constant.PARAM_KEY_RANK],
+                "seq": req[Constant.PARAM_KEY_SEQ],
+                "size": len(req[Constant.PARAM_KEY_SEND_BUF]),
+            }
+            fl_ctx.set_prop(key=PROP_KEY_DEBUG, value=debug_info, private=True, sticky=False)
             reply = ReliableMessage.send_request(
                 target=FQCN.ROOT_SERVER,
                 topic=Constant.TOPIC_XGB_REQUEST,


### PR DESCRIPTION
### Description

1. Added XGB debug info in reliable message log. This will try to nail down a problem reported by QA.
2. Ignore GRPC errors after XGB shutdown. This will alleviate the issues caused by unknown GRPC failures at the end of training.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
