### PR TITLE
Fixed the SubprocessLauncher missing app_custom_folder in PYTHONPATH

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -494,6 +494,7 @@ class SystemVarName:
     ROOT_URL = "ROOT_URL"  # the URL of the Service Provider (server)
     SECURE_MODE = "SECURE_MODE"  # whether the system is running in secure mode
     JOB_CUSTOM_DIR = "JOB_CUSTOM_DIR"  # custom dir of the job
+    PYTHONPATH = "PYTHONPATH"
 
 
 class RunnerTask:

--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -19,10 +19,12 @@ import subprocess
 from threading import Thread
 from typing import Optional
 
+from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.launcher import Launcher, LauncherRunStatus
+from nvflare.private.fed.utils.fed_utils import add_custom_dir_to_path
 
 
 def log_subprocess_output(process, logger):
@@ -50,7 +52,7 @@ class SubprocessLauncher(Launcher):
     def initialize(self, fl_ctx: FLContext):
         self._app_dir = self.get_app_dir(fl_ctx)
         if self._launch_once:
-            self._start_external_process()
+            self._start_external_process(fl_ctx)
 
     def finalize(self, fl_ctx: FLContext) -> None:
         if self._launch_once and self._process:
@@ -58,18 +60,23 @@ class SubprocessLauncher(Launcher):
 
     def launch_task(self, task_name: str, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> bool:
         if not self._launch_once:
-            self._start_external_process()
+            self._start_external_process(fl_ctx)
         return True
 
     def stop_task(self, task_name: str, fl_ctx: FLContext, abort_signal: Signal) -> None:
         if not self._launch_once:
             self._stop_external_process()
 
-    def _start_external_process(self):
+    def _start_external_process(self, fl_ctx: FLContext):
         if self._process is None:
             command = self._script
             env = os.environ.copy()
             env["CLIENT_API_TYPE"] = "EX_PROCESS_API"
+
+            workspace = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
+            job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
+            app_custom_folder = workspace.get_app_custom_dir(job_id)
+            add_custom_dir_to_path(app_custom_folder, env)
 
             command_seq = shlex.split(command)
             self._process = subprocess.Popen(

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -62,6 +62,7 @@ from nvflare.private.fed.simulator.simulator_app_runner import SimulatorServerAp
 from nvflare.private.fed.simulator.simulator_audit import SimulatorAuditor
 from nvflare.private.fed.simulator.simulator_const import SimulatorConstants
 from nvflare.private.fed.utils.fed_utils import (
+    add_custom_dir_to_path,
     add_logfile_handler,
     custom_fobs_initialize,
     get_simulator_app_root,
@@ -702,7 +703,7 @@ class SimulatorClientRunner(FLComponent):
         if gpu:
             command += " --gpu " + str(gpu)
         new_env = os.environ.copy()
-        new_env["PYTHONPATH"] = os.pathsep.join(self._get_new_sys_path()) + os.pathsep + app_custom_folder
+        add_custom_dir_to_path(app_custom_folder, new_env)
 
         _ = subprocess.Popen(shlex.split(command, True), preexec_fn=os.setsid, env=new_env)
 

--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -28,7 +28,7 @@ from nvflare.fuel.f3.cellnet.core_cell import FQCN
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.private.defs import CellChannel, CellChannelTopic, JobFailureMsgKey, new_cell_message
-from nvflare.private.fed.utils.fed_utils import get_return_code
+from nvflare.private.fed.utils.fed_utils import add_custom_dir_to_path, get_return_code
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
 
 from .client_status import ClientStatus, get_status_message
@@ -172,7 +172,7 @@ class ProcessExecutor(ClientExecutor):
         """
         new_env = os.environ.copy()
         if app_custom_folder != "":
-            new_env["PYTHONPATH"] = new_env.get("PYTHONPATH", "") + os.pathsep + app_custom_folder
+            add_custom_dir_to_path(app_custom_folder, new_env)
 
         command_options = ""
         for t in args.set:

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -56,7 +56,12 @@ from nvflare.private.admin_defs import Message, MsgHeader
 from nvflare.private.defs import CellChannel, CellMessageHeaderKeys, RequestHeader, TrainingTopic, new_cell_message
 from nvflare.private.fed.server.server_json_config import ServerJsonConfigurator
 from nvflare.private.fed.server.server_state import ServerState
-from nvflare.private.fed.utils.fed_utils import get_return_code, security_close, set_message_security_data
+from nvflare.private.fed.utils.fed_utils import (
+    add_custom_dir_to_path,
+    get_return_code,
+    security_close,
+    set_message_security_data,
+)
 from nvflare.private.scheduler_constants import ShareableHeader
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import InfoCollector
@@ -237,7 +242,7 @@ class ServerEngine(ServerEngineInternalSpec):
     ):
         new_env = os.environ.copy()
         if app_custom_folder != "":
-            new_env["PYTHONPATH"] = new_env.get("PYTHONPATH", "") + os.pathsep + app_custom_folder
+            add_custom_dir_to_path(app_custom_folder, new_env)
 
         listen_port = open_ports[1]
         if snapshot:

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -26,7 +26,7 @@ from nvflare.apis.app_validation import AppValidator
 from nvflare.apis.client import Client
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLContext
-from nvflare.apis.fl_constant import ConfigVarName, FLContextKey, FLMetaKey, SiteType, WorkspaceConstants
+from nvflare.apis.fl_constant import ConfigVarName, FLContextKey, FLMetaKey, SiteType, SystemVarName, WorkspaceConstants
 from nvflare.apis.fl_exception import UnsafeComponentError
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.utils.decomposers import flare_decomposers
@@ -391,3 +391,11 @@ def get_return_code(process, job_id, workspace, logger):
 
 def get_simulator_app_root(simulator_root, site_name):
     return os.path.join(simulator_root, site_name, SimulatorConstants.JOB_NAME, "app_" + site_name)
+
+
+def add_custom_dir_to_path(app_custom_folder, new_env):
+    path = new_env.get(SystemVarName.PYTHONPATH, "")
+    if path:
+        new_env[SystemVarName.PYTHONPATH] = path + os.pathsep + app_custom_folder
+    else:
+        new_env[SystemVarName.PYTHONPATH] = app_custom_folder


### PR DESCRIPTION
…ath.

Fixes # .

### Description

Fixed the SubprocessLauncher missing app_custom_folder in the PYTHONPATH, which caused the ScriptRunner launch_external_process failure.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
