### PR TITLE
Add FLModel parameter checks

### DIFF
--- a/nvflare/app_common/abstract/fl_model.py
+++ b/nvflare/app_common/abstract/fl_model.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 from nvflare.apis.fl_constant import FLMetaKey
-from nvflare.fuel.utils.validation_utils import check_object_type
+from nvflare.fuel.utils.validation_utils import check_non_negative_int, check_object_type
 
 
 class ParamsType(str, Enum):
@@ -76,6 +76,15 @@ class FLModel:
         if params_type == ParamsType.FULL or params_type == ParamsType.DIFF:
             if params is None:
                 raise ValueError(f"params must be provided when params_type is {params_type}")
+
+        if metrics is not None:
+            check_object_type("metrics", metrics, dict)
+        if start_round is not None:
+            check_non_negative_int("start_round", start_round)
+        if current_round is not None:
+            check_non_negative_int("current_round", current_round)
+        if total_rounds is not None:
+            check_non_negative_int("total_rounds", total_rounds)
 
         self.params_type = params_type
         self.params = params


### PR DESCRIPTION
- Add check for FLModel metrics to be a dict to avoid unclear error in [4778901](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/4778901)
- Decorator was using float for metrics which was inconsistent with FLModel usage, however team decided decorator pattern will be deprecated

An alternative option is to instead check that the result.metrics are dicts before using WeightedAggregationHelper()

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
