### PR TITLE
Clarify default persistor_id

### DIFF
--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -38,7 +38,7 @@ from nvflare.security.logging import secure_format_exception
 class BaseModelController(Controller, FLComponentWrapper, ABC):
     def __init__(
         self,
-        persistor_id="persistor",
+        persistor_id: str = AppConstants.DEFAULT_PERSISTOR_ID,
         ignore_result_error: bool = False,
         allow_empty_global_weights: bool = False,
         task_check_period: float = 0.5,
@@ -46,7 +46,7 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         """FLModel based controller.
 
         Args:
-            persistor_id (str, optional): ID of the persistor component. Defaults to "persistor".
+            persistor_id (str, optional): ID of the persistor component. Defaults to AppConstants.DEFAULT_PERSISTOR_ID ("persistor").
             ignore_result_error (bool, optional): whether this controller can proceed if client result has errors.
                 Defaults to False.
             allow_empty_global_weights (bool, optional): whether to allow empty global weights. Some pipelines can have

--- a/nvflare/app_common/workflows/model_controller.py
+++ b/nvflare/app_common/workflows/model_controller.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Callable, List, Union
 
 from nvflare.app_common.abstract.fl_model import FLModel
+from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.workflows.base_model_controller import BaseModelController
 
 
@@ -23,13 +24,13 @@ class ModelController(BaseModelController, ABC):
     def __init__(
         self,
         *args,
-        persistor_id: str = "persistor",
+        persistor_id: str = AppConstants.DEFAULT_PERSISTOR_ID,
         **kwargs,
     ):
         """Model Controller API for FLModel-based Controller.
 
         Args:
-            persistor_id (str, optional): ID of the persistor component. Defaults to "".
+            persistor_id (str, optional): ID of the persistor component. Defaults to AppConstants.DEFAULT_PERSISTOR_ID ("persistor").
         """
         super().__init__(*args, persistor_id, **kwargs)
 


### PR DESCRIPTION
Address [4822385](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/4822385) to use AppConstants.DEFAULT_PERSISTOR_ID

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
