### PR TITLE
Fix an XGB Failure caused by len()

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/xgb_adaptor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/adaptors/xgb_adaptor.py
@@ -238,7 +238,6 @@ class XGBClientAdaptor(AppAdaptor, ABC):
                 "op": op,
                 "rank": req[Constant.PARAM_KEY_RANK],
                 "seq": req[Constant.PARAM_KEY_SEQ],
-                "size": len(req[Constant.PARAM_KEY_SEND_BUF]),
             }
             fl_ctx.set_prop(key=PROP_KEY_DEBUG_INFO, value=debug_info, private=True, sticky=False)
             reply = ReliableMessage.send_request(


### PR DESCRIPTION
### Description

Remove a debug statement that causes XGB training failures.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
