### PR TITLE
Fixed the wrong dh_psi_task_handler path

### DIFF
--- a/examples/advanced/vertical_federated_learning/cifar10-splitnn/jobs/cifar10_psi/site-1/config/config_fed_client.json
+++ b/examples/advanced/vertical_federated_learning/cifar10-splitnn/jobs/cifar10_psi/site-1/config/config_fed_client.json
@@ -17,7 +17,7 @@
   "components": [
     {
       "id": "dh_psi",
-      "path": "nvflare.app_common.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
+      "path": "nvflare.app_opt.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
       "args": {
         "local_psi_id": "local_psi"
       }

--- a/examples/advanced/vertical_federated_learning/cifar10-splitnn/jobs/cifar10_psi/site-2/config/config_fed_client.json
+++ b/examples/advanced/vertical_federated_learning/cifar10-splitnn/jobs/cifar10_psi/site-2/config/config_fed_client.json
@@ -17,7 +17,7 @@
   "components": [
     {
       "id": "dh_psi",
-      "path": "nvflare.app_common.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
+      "path": "nvflare.app_opt.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
       "args": {
         "local_psi_id": "local_psi"
       }

--- a/research/one-shot-vfl/jobs/cifar10_psi/site-1/config/config_fed_client.json
+++ b/research/one-shot-vfl/jobs/cifar10_psi/site-1/config/config_fed_client.json
@@ -17,7 +17,7 @@
   "components": [
     {
       "id": "dh_psi",
-      "path": "nvflare.app_common.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
+      "path": "nvflare.app_opt.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
       "args": {
         "local_psi_id": "local_psi"
       }

--- a/research/one-shot-vfl/jobs/cifar10_psi/site-2/config/config_fed_client.json
+++ b/research/one-shot-vfl/jobs/cifar10_psi/site-2/config/config_fed_client.json
@@ -17,7 +17,7 @@
   "components": [
     {
       "id": "dh_psi",
-      "path": "nvflare.app_common.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
+      "path": "nvflare.app_opt.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
       "args": {
         "local_psi_id": "local_psi"
       }


### PR DESCRIPTION
Fixes # .

### Description

Fixed the wrong dh_psi_task_handler path in the example and research folder.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
