### PR TITLE
Gradient inversion: fix cross-validation path

### DIFF
--- a/research/quantifying-data-leakage/src/nvflare_gradinv/learners/cxr_learner.py
+++ b/research/quantifying-data-leakage/src/nvflare_gradinv/learners/cxr_learner.py
@@ -602,7 +602,7 @@ class CXRLearner(Learner):
         elif validate_type == ValidateType.MODEL_VALIDATE:
             if self.test_loader is None:
                 self.log_warning(fl_ctx, "No test data available. Skipping validation.")
-                val_results = {}
+                val_results = {"info": "Not validating on this client!"}
             else:
                 # perform valid
                 train_acc, train_auc = self.local_valid(self.train_loader, abort_signal)
@@ -639,7 +639,6 @@ class CXRLearner(Learner):
                     "val_auc": val_auc,
                     "test_auc": test_auc,
                 }
-
             metric_dxo = DXO(data_kind=DataKind.METRICS, data=val_results)
             return metric_dxo.to_shareable()
 

--- a/research/quantifying-data-leakage/start_fl_sim.sh
+++ b/research/quantifying-data-leakage/start_fl_sim.sh
@@ -44,6 +44,6 @@ echo "==========================================================================
 
 # Show cross-site validation results
 echo "Cross-site validation results:"
-cat "${workspace}/simulate_job/cross_site_val/cross_val_results.json"
+cat "${workspace}/server/simulate_job/cross_site_val/cross_val_results.json"
 echo
 echo "================================================================================================================="


### PR DESCRIPTION
Fixes # .

### Description

* Fixes the path when cross site validation result after training
* Add info for clients that don't validate. Validation only happens on "site-1" in this example.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
