### PR TITLE
Fix heartbeat timeout config

### DIFF
--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -103,6 +103,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         self._params_exchange_format = params_exchange_format
         self._params_transfer_type = params_transfer_type
         self._config_file_name = config_file_name
+        self._heartbeat_timeout = heartbeat_timeout
 
     def initialize(self, fl_ctx: FLContext) -> None:
         self.prepare_config_for_launch(fl_ctx)
@@ -122,6 +123,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 ConfigKey.CLASS_NAME: pipe_export_class,
                 ConfigKey.ARG: pipe_export_args,
             },
+            ConfigKey.HEARTBEAT_TIMEOUT: self._heartbeat_timeout,
         }
 
         config_data = {

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -103,7 +103,6 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         self._params_exchange_format = params_exchange_format
         self._params_transfer_type = params_transfer_type
         self._config_file_name = config_file_name
-        self._heartbeat_timeout = heartbeat_timeout
 
     def initialize(self, fl_ctx: FLContext) -> None:
         self.prepare_config_for_launch(fl_ctx)
@@ -123,7 +122,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 ConfigKey.CLASS_NAME: pipe_export_class,
                 ConfigKey.ARG: pipe_export_args,
             },
-            ConfigKey.HEARTBEAT_TIMEOUT: self._heartbeat_timeout,
+            ConfigKey.HEARTBEAT_TIMEOUT: self.heartbeat_timeout,
         }
 
         config_data = {

--- a/nvflare/app_common/executors/task_exchanger.py
+++ b/nvflare/app_common/executors/task_exchanger.py
@@ -25,7 +25,12 @@ from nvflare.app_common.app_constant import AppConstants
 from nvflare.fuel.utils.constants import PipeChannelName
 from nvflare.fuel.utils.pipe.pipe import Message, Pipe
 from nvflare.fuel.utils.pipe.pipe_handler import PipeHandler, Topic
-from nvflare.fuel.utils.validation_utils import check_non_negative_int, check_positive_number, check_str
+from nvflare.fuel.utils.validation_utils import (
+    check_non_negative_int,
+    check_non_negative_number,
+    check_positive_number,
+    check_str,
+)
 from nvflare.security.logging import secure_format_exception
 
 
@@ -70,7 +75,7 @@ class TaskExchanger(Executor):
         check_positive_number("read_interval", read_interval)
         check_positive_number("heartbeat_interval", heartbeat_interval)
         if heartbeat_timeout is not None:
-            check_positive_number("heartbeat_timeout", heartbeat_timeout)
+            check_non_negative_number("heartbeat_timeout", heartbeat_timeout)
         check_positive_number("resend_interval", resend_interval)
         if max_resends is not None:
             check_non_negative_int("max_resends", max_resends)

--- a/nvflare/app_common/widgets/metric_relay.py
+++ b/nvflare/app_common/widgets/metric_relay.py
@@ -94,5 +94,6 @@ class MetricRelay(Widget, AttributesExportable):
                 ConfigKey.CLASS_NAME: pipe_export_class,
                 ConfigKey.ARG: pipe_export_args,
             },
+            ConfigKey.HEARTBEAT_TIMEOUT: self._heartbeat_timeout,
         }
         return ConfigKey.METRICS_EXCHANGE, config_dict

--- a/nvflare/client/config.py
+++ b/nvflare/client/config.py
@@ -148,6 +148,13 @@ class ClientConfig:
     def get_submit_model_task(self):
         return self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(ConfigKey.SUBMIT_MODEL_TASK_NAME, "")
 
+    def get_heartbeat_timeout(self):
+        # TODO decouple task and metric heartbeat timeouts
+        return self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(
+            ConfigKey.HEARTBEAT_TIMEOUT,
+            self.config.get(ConfigKey.METRICS_EXCHANGE, {}).get(ConfigKey.HEARTBEAT_TIMEOUT, 60),
+        )
+
     def to_json(self, config_file: str):
         with open(config_file, "w") as f:
             json.dump(self.config, f, indent=2)

--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -111,7 +111,7 @@ class ExProcessClientAPI(APISpec):
                     task_channel_name=task_channel_name,
                     metric_pipe=metric_pipe,
                     metric_channel_name=metric_channel_name,
-                    heartbeat_timeout=client_config.config.get(ConfigKey.HEARTBEAT_TIMEOUT, 60),
+                    heartbeat_timeout=client_config.get_heartbeat_timeout(),
                 )
                 flare_agent.start()
 

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -33,7 +33,7 @@ class ScriptRunner:
         script: str,
         script_args: str = "",
         launch_external_process: bool = False,
-        command: str = "python3",
+        command: str = "python3 -u",
         framework: FrameworkType = FrameworkType.PYTORCH,
     ):
         """ScriptRunner is used with FedJob API to run or launch a script.
@@ -116,6 +116,7 @@ class ScriptRunner:
                 pipe_id=pipe_id,
                 launcher_id=launcher_id,
                 params_exchange_format=self._params_exchange_format,
+                heartbeat_timeout=0,
             )
             job.add_executor(executor, tasks=tasks, ctx=ctx)
 
@@ -133,6 +134,7 @@ class ScriptRunner:
             component = MetricRelay(
                 pipe_id=metric_pipe_id,
                 event_type="fed.analytix_log_stats",
+                heartbeat_timeout=0,
             )
             metric_relay_id = job.add_component("metric_relay", component, ctx)
             comp_ids["metric_relay_id"] = metric_relay_id


### PR DESCRIPTION
Fixes [4820226](https://nvbugspro.nvidia.com/bug/4820226).

- Using the LauncherExecutor with Cyclic failed due to the FlareAgent timing out while the first site trains
- Add heartbeat_timeout to config for FlareAgent and set heartbeat_timeout=0 to not timeout in ScriptRunner ex-process mode
 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
