### PR TITLE
Fix for last index of module path

### DIFF
--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -203,7 +203,7 @@ class FedJobConfig:
             if package not in FL_PACKAGES and module not in self.custom_modules:
                 module_path = module.replace(".", os.sep)
                 if module_path in source_file:
-                    index = source_file.index(module_path)
+                    index = source_file.rindex(module_path)
                     dest = source_file[index:]
 
                     self.custom_modules.append(module)


### PR DESCRIPTION
Fixes # .

### Description

Change to match the last index of module_path from source_file.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
