### PR TITLE
Update xgboost requirements

### DIFF
--- a/examples/advanced/finance-end-to-end/requirements.txt
+++ b/examples/advanced/finance-end-to-end/requirements.txt
@@ -1,8 +1,4 @@
 pandas
-# require xgboost 2.2 version, for now need to install a binary build
-# "xgboost>=2.2"
-
---extra-index-url https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/list.html?prefix=federated-secure/
-xgboost
-
+# require xgboost 2.2 version, for now need to install a nightly build
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl
 scikit-learn

--- a/examples/advanced/finance/requirements.txt
+++ b/examples/advanced/finance/requirements.txt
@@ -5,5 +5,4 @@ scikit-learn
 torch
 tensorboard
 # require xgboost 2.2 version, for now need to install a nightly build
---extra-index-url https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/list.html?prefix=federated-secure/
-xgboost
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl

--- a/examples/advanced/random_forest/requirements.txt
+++ b/examples/advanced/random_forest/requirements.txt
@@ -4,5 +4,4 @@ scikit-learn
 torch
 tensorboard
 # require xgboost 2.2 version, for now need to install a nightly build
---extra-index-url https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/list.html?prefix=federated-secure/
-xgboost
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl

--- a/examples/advanced/vertical_xgboost/requirements.txt
+++ b/examples/advanced/vertical_xgboost/requirements.txt
@@ -4,5 +4,4 @@ pandas
 torch
 tensorboard
 # require xgboost 2.2 version, for now need to install a nightly build
---extra-index-url https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/list.html?prefix=federated-secure/
-xgboost
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl

--- a/examples/advanced/xgboost/histogram-based/requirements.txt
+++ b/examples/advanced/xgboost/histogram-based/requirements.txt
@@ -4,5 +4,4 @@ scikit-learn
 torch
 tensorboard
 # require xgboost 2.2 version, for now need to install a nightly build
---extra-index-url https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/list.html?prefix=federated-secure/
-xgboost
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl

--- a/examples/advanced/xgboost/tree-based/requirements.txt
+++ b/examples/advanced/xgboost/tree-based/requirements.txt
@@ -4,5 +4,4 @@ scikit-learn
 torch
 tensorboard
 # require xgboost 2.2 version, for now need to install a nightly build
---extra-index-url https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/list.html?prefix=federated-secure/
-xgboost
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl

--- a/examples/hello-world/step-by-step/higgs/xgboost/requirements.txt
+++ b/examples/hello-world/step-by-step/higgs/xgboost/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 scikit-learn
-xgboost
+# require xgboost 2.2 version, for now need to install a nightly build
+https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl

--- a/integration/xgboost/encryption_plugins/README.md
+++ b/integration/xgboost/encryption_plugins/README.md
@@ -2,12 +2,12 @@
 
 
 ## Install required dependencies for building CUDA plugin
-If you want to build the CUDA plugin on your own, you need to install the following libraries:
-Require `libgmp3-dev`, CMake>=3.19, CUDA runtime >= 12.1, CUDA driver >= 12.1, NVIDIA GPU Driver >= 535
-Compute Compatibility >= 7.0
+If you want to build the CUDA plugin, you need to install the following libraries:
+Require `libgmp3-dev`, CMake>=3.19, CUDA Driver and runtime 12.2 or 12.4, NVIDIA GPU Driver >= 535
+Compute Compatibility >= 7.0.
 
 On the building site:
-1. Install GPU Driver >= 535, CUDA runtime >= 12.1, CUDA driver >= 12.1
+1. Install GPU Driver >= 535, CUDA Driver and runtime 12.2 or 12.4
 2. Install `libgmp3-dev`, gcc, CMake
 3. Clone the NVFlare main branch and update the submodule
     ```
@@ -39,7 +39,7 @@ The generated plugin files under build folder are,
 For each client site:
 
 1. Copy the pre-built ".so" files to each site
-2. Make sure you have installed required dependencies: GPU Driver >= 535, CUDA runtime >= 12.1, CUDA driver >= 12.1, `libgmp3-dev`
+2. Make sure you have installed required dependencies: GPU Driver >= 535, CUDA Driver and runtime 12.2 or 12.4, `libgmp3-dev`
 3. Update the site local resource.json to point to the appropriate ".so" file
 
 For handling these complex environment, we recommend you build a docker image so every


### PR DESCRIPTION

### Description

- Ping to a specific wheel: https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl
- CUDA support 12.2 and 12.4

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
