### PR TITLE
Change job simulator run to use Popen

### DIFF
--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -145,7 +145,8 @@ class FedJobConfig:
                 command = (
                     f"{sys.executable} -m nvflare.private.fed.app.simulator.simulator "
                     + os.path.join(job_root, self.job_name)
-                    + " -w " + workspace
+                    + " -w "
+                    + workspace
                 )
                 if clients:
                     command += " -c " + str(clients)


### PR DESCRIPTION
Fixes # .

### Description

Change job simulator run to use Popen, instead of directly using the SimulatorRunner class. This is to solve the TF job API simulator_run got stuck issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
