### PR TITLE
trim the whitespace of the clients and gpu from the job simulator_run

### DIFF
--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -148,12 +148,14 @@ class FedJobConfig:
                     + workspace
                 )
                 if clients:
+                    clients = self._trim_whitespace(clients)
                     command += " -c " + str(clients)
                 if n_clients:
                     command += " -n " + str(n_clients)
                 if threads:
                     command += " -t " + str(threads)
                 if gpu:
+                    gpu = self._trim_whitespace(gpu)
                     command += " -gpu " + str(gpu)
 
                 new_env = os.environ.copy()
@@ -385,3 +387,9 @@ class FedJobConfig:
             deploy_map[app_name] = deploy_map.get(app_name, [])
             deploy_map[app_name].append(site)
         return deploy_map
+
+    def _trim_whitespace(self, string: str):
+        strings = string.split(",")
+        for i in range(len(strings)):
+            strings[i] = strings[i].strip()
+        return ",".join(strings)

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -32,3 +32,11 @@ class TestFedJobConfig:
             with tempfile.NamedTemporaryFile(dir=cwd, suffix=".py") as dest_file:
                 imports = list(job_config.locate_imports(sf, dest_file=dest_file.name))
         assert imports == expected
+
+    def test_trim_whitespace(self):
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        expected = "site-0,site-1"
+        assert expected == job_config._trim_whitespace("site-0,site-1")
+        assert expected == job_config._trim_whitespace("site-0, site-1")
+        assert expected == job_config._trim_whitespace(" site-0,site-1 ")
+        assert expected == job_config._trim_whitespace(" site-0, site-1 ")


### PR DESCRIPTION
Fixes # .

### Description

trim the whitespace of the clients and gpu from the job simulator_run.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
