### PR TITLE
Added the current-round info the fl_ctx for BaseModelController

### DIFF
--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -224,9 +224,6 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         result_model.meta["props"] = client_task.task.props[AppConstants.META_DATA]
         result_model.meta["client_name"] = client_name
 
-        if result_model.current_round is not None:
-            self.fl_ctx.set_prop(AppConstants.CURRENT_ROUND, result_model.current_round, private=True, sticky=True)
-
         self.event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT)
         self._accept_train_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
         self.event(AppEventType.AFTER_CONTRIBUTION_ACCEPT)
@@ -378,6 +375,15 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         self.info(f"Sampled clients: {clients}")
 
         return clients
+
+    def set_fl_context(self, data: FLModel):
+        """Set up the fl_ctx information based on the passed in FLModel data.
+
+        """
+        if data and data.current_round is not None:
+            self.fl_ctx.set_prop(AppConstants.CURRENT_ROUND, data.current_round, private=True, sticky=True)
+        else:
+            self.warning(f"The FLModel data does not contain the current_round information.")
 
     def get_component(self, component_id: str):
         return self.engine.get_component(component_id)

--- a/nvflare/app_common/workflows/model_controller.py
+++ b/nvflare/app_common/workflows/model_controller.py
@@ -63,6 +63,7 @@ class ModelController(BaseModelController, ABC):
         Returns:
             List[FLModel]
         """
+        self.set_fl_context(data)
         return super().broadcast_model(
             task_name=task_name,
             data=data,
@@ -94,6 +95,7 @@ class ModelController(BaseModelController, ABC):
         Returns:
             None
         """
+        self.set_fl_context(data)
         super().broadcast_model(
             task_name=task_name,
             data=data,

--- a/research/fed-bpt/src/global_es.py
+++ b/research/fed-bpt/src/global_es.py
@@ -95,7 +95,7 @@ class GlobalES(FedAvg):
 
             clients = self.sample_clients(self.num_clients)
 
-            global_model = FLModel(params={"global_es": global_es})
+            global_model = FLModel(params={"global_es": global_es}, current_round=self.current_round)
             results = self.send_model_and_wait(targets=clients, data=global_model)
 
             # get solutions from clients


### PR DESCRIPTION
Fixes # .

### Description

Corrected the way how to add the current-round info the fl_ctx for BaseModelController. Fixed the missing current_round warning for cifar10 examples.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
