### PR TITLE
Warning for Mixed Plugin Use

### DIFF
--- a/docs/user_guide/federated_xgboost/secure_xgboost_user_guide.rst
+++ b/docs/user_guide/federated_xgboost/secure_xgboost_user_guide.rst
@@ -135,6 +135,10 @@ Two plugins are initially shipped with NVFlare,
 - **cuda_paillier**: The default plugin. This plugin uses GPU for cryptographic operations.
 - **nvflare**: This plugin forwards data locally to NVFlare process for encryption.
 
+.. note::
+   All clients must use the same plugin. When different plugins are used,
+   the XGBoost’s behavior is undetermined. It may cause the client to crash.
+
 The **cuda_paillier** plugin requires NVIDIA GPUs that support compute capability 7.0 or higher. Also, CUDA
 12.2 or 12.4 must be installed. Please refer to https://developer.nvidia.com/cuda-gpus for more information.
 


### PR DESCRIPTION
### Description

Added a warning that mixed plugin use may cause the client to crash in XGBoost doc.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
