### PR TITLE
BugFix: Hierarchical Fed Stats, prepare data: replace os.rename() function

### DIFF
--- a/examples/advanced/federated-statistics/hierarchical_stats/utils/prepare_data.py
+++ b/examples/advanced/federated-statistics/hierarchical_stats/utils/prepare_data.py
@@ -15,7 +15,6 @@ import argparse
 import csv
 import os
 import random
-import shutil
 
 
 def parse_args(prog_name: str):


### PR DESCRIPTION

Fixes # .replace os.rename() to shutil.move() to avoid os.error when destination and src are in different mnt or devices


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
