### PR TITLE
[2.5] Fix dashboard server resource

### DIFF
--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -280,8 +280,10 @@ def _write_local(type, dest_dir, template, capacity=""):
         template["default_authz"],
         "t",
     )
-    resources = json.loads(template["local_client_resources"])
-    if type == "client":
+    if type == "server":
+        resources = json.loads(template["local_server_resources"])
+    elif type == "client":
+        resources = json.loads(template["local_client_resources"])
         for component in resources["components"]:
             if "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager" == component["path"]:
                 component["args"] = json.loads(capacity)


### PR DESCRIPTION
### Description

The local/resources.json.default was not generated correctly in dashboard.  This may cause jobs received by the server could not be dispatched/scheduled.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
