### PR TITLE
update PSI to support python 3.11

### DIFF
--- a/examples/advanced/psi/user_email_match/README.md
+++ b/examples/advanced/psi/user_email_match/README.md
@@ -113,18 +113,22 @@ copy NVFlare/examples/advanced/psi/user_email_match/data to /tmp/nvflare/psi dir
 
 **run job** 
 ```
-nvflare simulator -w /tmp/nvflare/psi -n 3 -t 3 user_email_match/jobs/user_email_match
+nvflare simulator -w /tmp/nvflare/psi/job -n 3 -t 3 user_email_match/jobs/user_email_match
 ```
 Once job completed and succeed, you should be able to find the intersection for different sites at
 
 ```
-/tmp/nvflare/psi/simulate_job/site-1/psi/intersection.txt 
-/tmp/nvflare/psi/simulate_job/site-2/psi/intersection.txt 
-/tmp/nvflare/psi/simulate_job/site-3/psi/intersection.txt  
+/tmp/nvflare/psi/job/simulate_job/site-1/psi/intersection.txt 
+/tmp/nvflare/psi/job/simulate_job/site-2/psi/intersection.txt 
+/tmp/nvflare/psi/job/simulate_job/site-3/psi/intersection.txt  
 ```
 to compare these intersections, you can check with the followings:
 
 ```bash
-diff <(sort /tmp/nvflare/psi/simulate_job/site-1/psi/intersection.txt) <(sort /tmp/nvflare/psi/simulate_job/site-2/psi/intersection.txt)
-diff <(sort /tmp/nvflare/psi/simulate_job/site-2/psi/intersection.txt) <(sort /tmp/nvflare/psi/simulate_job/site-3/psi/intersection.txt)
+diff <(sort /tmp/nvflare/psi/job/simulate_job/site-1/psi/intersection.txt) <(sort /tmp/nvflare/psi/job/simulate_job/site-2/psi/intersection.txt)
+diff <(sort /tmp/nvflare/psi/job/simulate_job/site-2/psi/intersection.txt) <(sort /tmp/nvflare/psi/job/simulate_job/site-3/psi/intersection.txt)
 ```
+
+**NOTE**
+>>The PSI operator depends on openmind-psi. It now supports up-to-python 3.11
+python 3.12 is still working in progress

--- a/examples/advanced/psi/user_email_match/requirements.txt
+++ b/examples/advanced/psi/user_email_match/requirements.txt
@@ -1,3 +1,2 @@
-nvflare~=2.5.0rc
-openmined.psi==1.1.1
+openmined-psi==2.0.4
 pandas

--- a/nvflare/app_common/psi/dh_psi/dh_psi_workflow.py
+++ b/nvflare/app_common/psi/dh_psi/dh_psi_workflow.py
@@ -261,6 +261,9 @@ class DhPSIWorkFlow(PSIWorkflow):
         other_sites = [site for site in ordered_clients if site.name != intersect_site.name]
         other_sites = self.get_updated_site_sizes(other_sites)
 
+        # todo: we might be able to skip these steps, simply broadcast the final intersection result directly
+        # todo: to all other sites, this avoid the backward pass of the intersection calculation
+
         s = intersect_site
         other_site_sizes = set([site.size for site in other_sites])
         setup_msgs: Dict[str, str] = self.prepare_setup_messages(s, other_site_sizes)


### PR DESCRIPTION
Update openmind-psi ==2.0.4 to support python 3.11


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
