### PR TITLE
[Main] Support object reuse

### DIFF
--- a/nvflare/app_common/ccwf/ccwf_job.py
+++ b/nvflare/app_common/ccwf/ccwf_job.py
@@ -20,8 +20,7 @@ from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.abstract.shareable_generator import ShareableGenerator
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.ccwf.common import Constant, CyclicOrder
-from nvflare.fuel.utils.validation_utils import check_object_type
-from nvflare.job_config.api import FedJob, has_add_to_job_method
+from nvflare.job_config.api import FedJob, validate_object_for_job
 from nvflare.widgets.widget import Widget
 
 from .cse_client_ctl import CrossSiteEvalClientController
@@ -318,21 +317,3 @@ class CCWFJob(FedJob):
             get_model_timeout=cse_config.get_model_timeout,
         )
         self.to_clients(client_controller, tasks=["cse_*"])
-
-
-def validate_object_for_job(name, obj, obj_type):
-    """Check whether the specified object is valid for job.
-    The object must either have the add_to_fed_job method or is valid object type.
-
-    Args:
-        name: name of the object
-        obj: the object to be checked
-        obj_type: the object type that the object should be, if it doesn't have the add_to_fed_job method.
-
-    Returns: None
-
-    """
-    if has_add_to_job_method(obj):
-        return
-
-    check_object_type(name, obj, obj_type)

--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -34,8 +34,7 @@ _ADD_TO_JOB_METHOD_NAME = "add_to_fed_job"
 
 class FedApp:
     def __init__(self, app_config: Union[ClientAppConfig, ServerAppConfig]):
-        """FedApp handles `ClientAppConfig` and `ServerAppConfig` and allows setting task result or task data filters.
-        """
+        """FedApp handles `ClientAppConfig` and `ServerAppConfig` and allows setting task result or task data filters."""
         self.app_config = app_config
         self._used_ids = []
 


### PR DESCRIPTION
Fixes # .

### Description

Currently when the same object is used in a job, duplicate config will be created, which will cause two object instances to be created during run time.

This PR makes it possible for the object to be reused multiple times without creating separate object instances.

This change is necessary in case that same object instance (e.g. model persistor) is used for different workflows in the same job.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
