### PR TITLE
Fix the entry for getting started in the TOC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ NVIDIA FLARE
    fl_introduction
    flare_overview
    whats_new
-   getting_started <quickstart>
+   Getting Started <quickstart>
 
 .. toctree::
    :maxdepth: -1


### PR DESCRIPTION
Fix the entry for getting started in the TOC.

### Description

Minor fix for formatting and capitalization for how the Getting Started link in the TOC looks.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
