### PR TITLE
Update flwr job object, client, server

### DIFF
--- a/examples/hello-world/hello-flower/README.md
+++ b/examples/hello-world/hello-flower/README.md
@@ -47,5 +47,5 @@ Next, we run 2 Flower clients and Flower Server in parallel using NVFlare while 
 the TensorBoard metrics to the server at each iteration using NVFlare's metric streaming.
 
 ```bash
-python job.py --job_name "flwr-pt-tb" --content_dir "./flwr-pt-tb" --stream_metrics --use_client_api
+python job.py --job_name "flwr-pt-tb" --content_dir "./flwr-pt-tb" --stream_metrics
 ```

--- a/examples/hello-world/hello-flower/flwr-pt-tb/flwr_pt_tb/client.py
+++ b/examples/hello-world/hello-flower/flwr-pt-tb/flwr_pt_tb/client.py
@@ -36,18 +36,16 @@ class FlowerClient(NumPyClient):
     def __init__(self, context: Context):
         super().__init__()
         self.writer = SummaryWriter()
-        self.set_context(context)
+        self.flwr_context = context
+
         if "step" not in context.state.metrics_records:
             self.set_step(0)
 
     def set_step(self, step: int):
-        context = self.get_context()
-        context.state = RecordSet(metrics_records={"step": MetricsRecord({"step": step})})
-        self.set_context(context)
+        self.flwr_context.state = RecordSet(metrics_records={"step": MetricsRecord({"step": step})})
 
     def get_step(self):
-        context = self.get_context()
-        return int(context.state.metrics_records["step"]["step"])
+        return int(self.flwr_context.state.metrics_records["step"]["step"])
 
     def fit(self, parameters, config):
         step = self.get_step()

--- a/examples/hello-world/hello-flower/flwr-pt-tb/flwr_pt_tb/server.py
+++ b/examples/hello-world/hello-flower/flwr-pt-tb/flwr_pt_tb/server.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 from typing import List, Tuple
 
-from flwr.common import Metrics, ndarrays_to_parameters
-from flwr.server import ServerApp, ServerConfig
+from flwr.common import Context, Metrics, ndarrays_to_parameters
+from flwr.server import ServerApp, ServerAppComponents, ServerConfig
 from flwr.server.strategy import FedAvg
 
 from .task import Net, get_weights
@@ -53,13 +53,16 @@ strategy = FedAvg(
     initial_parameters=parameters,
 )
 
-
 # Define config
 config = ServerConfig(num_rounds=3)
 
 
 # Flower ServerApp
-app = ServerApp(
-    config=config,
-    strategy=strategy,
-)
+def server_fn(context: Context):
+    return ServerAppComponents(
+        strategy=strategy,
+        config=config,
+    )
+
+
+app = ServerApp(server_fn=server_fn)

--- a/examples/hello-world/hello-flower/job.py
+++ b/examples/hello-world/hello-flower/job.py
@@ -14,7 +14,7 @@
 
 from argparse import ArgumentParser
 
-from nvflare.app_opt.flower.flower_job import FlowerJob
+from nvflare.app_opt.flower.flower_pt_job import FlowerPyTorchJob
 from nvflare.client.api import ClientAPIType
 from nvflare.client.api_spec import CLIENT_API_TYPE_KEY
 
@@ -30,10 +30,12 @@ def main():
     args = parser.parse_args()
 
     env = {}
-    if args.use_client_api:
+    if args.stream_metrics or args.use_client_api:
+        # needs to init client api to stream metrics
+        # only external client api works with the current flower integration
         env = {CLIENT_API_TYPE_KEY: ClientAPIType.EX_PROCESS_API.value}
 
-    job = FlowerJob(
+    job = FlowerPyTorchJob(
         name=args.job_name,
         flower_content=args.content_dir,
         stream_metrics=args.stream_metrics,

--- a/nvflare/app_opt/flower/flower_pt_job.py
+++ b/nvflare/app_opt/flower/flower_pt_job.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path
 from typing import List, Optional
 
 from nvflare.app_common.tie.defs import Constant
-from nvflare.app_common.widgets.external_configurator import ExternalConfigurator
-from nvflare.app_common.widgets.metric_relay import MetricRelay
-from nvflare.app_common.widgets.streaming import AnalyticsReceiver
-from nvflare.fuel.utils.pipe.cell_pipe import CellPipe
-from nvflare.fuel.utils.validation_utils import check_object_type
-from nvflare.job_config.api import FedJob
+from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
 
-from .controller import FlowerController
-from .executor import FlowerExecutor
+from .flower_job import FlowerJob
 
 
-class FlowerJob(FedJob):
+class FlowerPyTorchJob(FlowerJob):
     def __init__(
         self,
         name: str,
@@ -70,12 +63,15 @@ class FlowerJob(FedJob):
             analytics_receiver (AnalyticsReceiver, optional): the AnalyticsReceiver to use to process received metrics.
             extra_env (dict, optional): optional extra env variables to be passed to Flower client
         """
-        if not os.path.isdir(flower_content):
-            raise ValueError(f"{flower_content} is not a valid directory")
+        analytics_receiver = (
+            analytics_receiver if analytics_receiver else TBAnalyticsReceiver(events=["fed.analytix_log_stats"])
+        )
 
-        super().__init__(name=name, min_clients=min_clients, mandatory_clients=mandatory_clients)
-
-        controller = FlowerController(
+        super().__init__(
+            name=name,
+            flower_content=flower_content,
+            min_clients=min_clients,
+            mandatory_clients=mandatory_clients,
             database=database,
             server_app_args=server_app_args,
             superlink_ready_timeout=superlink_ready_timeout,
@@ -83,50 +79,10 @@ class FlowerJob(FedJob):
             start_task_timeout=start_task_timeout,
             max_client_op_interval=max_client_op_interval,
             progress_timeout=progress_timeout,
-        )
-        self.to_server(controller)
-        self.to_server(obj=flower_content)
-
-        executor = FlowerExecutor(
             per_msg_timeout=per_msg_timeout,
             tx_timeout=tx_timeout,
             client_shutdown_timeout=client_shutdown_timeout,
+            stream_metrics=stream_metrics,
+            analytics_receiver=analytics_receiver,
             extra_env=extra_env,
         )
-        self.to_clients(executor)
-        self.to_clients(obj=flower_content)
-
-        if not stream_metrics:
-            return
-
-        # add required components for metrics streaming
-        # server side - need analytics_receiver
-        if analytics_receiver:
-            check_object_type("analytics_receiver", analytics_receiver, AnalyticsReceiver)
-            self.to_server(analytics_receiver, "analytics_receiver")
-        else:
-            raise ValueError("Missing analytics receiver on the server side.")
-
-        # client side
-        # cell pipe
-        cell_pipe = CellPipe(
-            mode="PASSIVE",
-            site_name="{SITE_NAME}",
-            token="{JOB_ID}",
-            root_url="{ROOT_URL}",
-            secure_mode="{SECURE_MODE}",
-            workspace_dir="{WORKSPACE}",
-        )
-        pipe_id = self.to_clients(cell_pipe, "metrics_pipe")
-
-        metric_relay = MetricRelay(
-            pipe_id=pipe_id,
-            event_type="fed.analytix_log_stats",
-            read_interval=0.1,
-            heartbeat_timeout=0,
-            fed_event=True,
-        )
-
-        relay_id = self.to_clients(metric_relay, "metric_relay")
-        conf = ExternalConfigurator(component_ids=[relay_id])
-        self.to_clients(conf, "client_api_config_preparer")


### PR DESCRIPTION
Fixes #2962 .

### Description
- Get rid of set_context, get_context as that is deprecated by Flower
- Separate FlowerJob and FlowerPytorchJob
- Change to new style of Flower server code

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
