### PR TITLE
[#3021] Fixed broken doc ref to 'helm_chart'

### DIFF
--- a/docs/real_world_fl/overview.rst
+++ b/docs/real_world_fl/overview.rst
@@ -68,7 +68,7 @@ For advanced users, you can customize your provision with additional behavior th
     - **Zip**: To create password protected zip archives for the startup kits, see :ref:`distribution_builder`
     - **Docker-compose**: Provision to launch NVIDIA FLARE system via docker containers. You can customize the provisioning process and ask the provisioner to generate a docker-compose file. This can be found in :ref:`docker_compose`.
     - **Docker**: Provision to launch NVIDIA FLARE system via docker containers. If you just want to use docker files, see :ref:`containerized_deployment`.
-    - **Helm**: To change the provisioning tool to generate an NVIDIA FLARE Helm chart for Kubernetes deployment, see :ref:` helm_chart`.
+    - **Helm**: To change the provisioning tool to generate an NVIDIA FLARE Helm chart for Kubernetes deployment, see :ref:`helm_chart`.
     - **CUSTOM**: you can build custom builders specific to your needs like in :ref:`distribution_builder`.
 
 Package distribution


### PR DESCRIPTION
Fixes #3021 .

### Description

Removed leading space, which was causing the link to brake.

### Types of changes
- [x] Documentation updated.
