### PR TITLE
Fix mock executors

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based_v2/mock/mock_executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/mock/mock_executor.py
@@ -21,13 +21,15 @@ class MockXGBExecutor(XGBExecutor):
     def __init__(
         self,
         int_server_grpc_options=None,
-        req_timeout=10.0,
+        per_msg_timeout=10.0,
+        tx_timeout=60.0,
         in_process=True,
     ):
         XGBExecutor.__init__(
             self,
             adaptor_component_id="",
-            req_timeout=req_timeout,
+            per_msg_timeout=per_msg_timeout,
+            tx_timeout=tx_timeout,
         )
         self.int_server_grpc_options = int_server_grpc_options
         self.in_process = in_process

--- a/nvflare/app_opt/xgboost/histogram_based_v2/mock/mock_secure_executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/mock/mock_secure_executor.py
@@ -21,13 +21,15 @@ class MockSecureXGBExecutor(XGBExecutor):
     def __init__(
         self,
         int_server_grpc_options=None,
-        req_timeout=10.0,
+        per_msg_timeout=10.0,
+        tx_timeout=100.0,
         in_process=True,
     ):
         XGBExecutor.__init__(
             self,
             adaptor_component_id="",
-            req_timeout=req_timeout,
+            per_msg_timeout=per_msg_timeout,
+            tx_timeout=tx_timeout,
         )
         self.int_server_grpc_options = int_server_grpc_options
         self.in_process = in_process


### PR DESCRIPTION
Fixes # .

### Description

The mock executors in XGboost is out of sync with the XGBExecutor base.  This PR fixes these problems.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
