### PR TITLE
Modify log config to write errors to a separate log file

### DIFF
--- a/docs/resources/log.config
+++ b/docs/resources/log.config
@@ -1,27 +1,27 @@
 [loggers]
-keys=root,modelLogger
+keys=root
 
 [handlers]
-keys=consoleHandler
+keys=consoleHandler,errorFileHandler
 
 [formatters]
 keys=fullFormatter
 
 [logger_root]
 level=INFO
-handlers=consoleHandler
-
-[logger_modelLogger]
-level=DEBUG
-handlers=consoleHandler
-qualname=modelLogger
-propagate=0
+handlers=consoleHandler,errorFileHandler
 
 [handler_consoleHandler]
 class=StreamHandler
 level=DEBUG
 formatter=fullFormatter
 args=(sys.stdout,)
+
+[handler_errorFileHandler]
+class=FileHandler
+level=ERROR
+formatter=fullFormatter
+args=('error.log', 'a')
 
 [formatter_fullFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/nvflare/lighter/impl/master_template.yml
+++ b/nvflare/lighter/impl/master_template.yml
@@ -297,20 +297,26 @@ log_config: |
   keys=root
 
   [handlers]
-  keys=consoleHandler
+  keys=consoleHandler,errorFileHandler
 
   [formatters]
   keys=fullFormatter
 
   [logger_root]
   level=INFO
-  handlers=consoleHandler
+  handlers=consoleHandler,errorFileHandler
 
   [handler_consoleHandler]
   class=StreamHandler
   level=DEBUG
   formatter=fullFormatter
   args=(sys.stdout,)
+
+  [handler_errorFileHandler]
+  class=FileHandler
+  level=ERROR
+  formatter=fullFormatter
+  args=('error.log', 'a')
 
   [formatter_fullFormatter]
   format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/nvflare/private/fed/app/simulator/log.config
+++ b/nvflare/private/fed/app/simulator/log.config
@@ -2,20 +2,26 @@
 keys=root
 
 [handlers]
-keys=consoleHandler
+keys=consoleHandler,errorFileHandler
 
 [formatters]
 keys=fullFormatter
 
 [logger_root]
 level=INFO
-handlers=consoleHandler
+handlers=consoleHandler,errorFileHandler
 
 [handler_consoleHandler]
 class=StreamHandler
 level=DEBUG
 formatter=fullFormatter
 args=(sys.stdout,)
+
+[handler_errorFileHandler]
+class=FileHandler
+level=ERROR
+formatter=fullFormatter
+args=('error.log', 'a')
 
 [formatter_fullFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -54,9 +54,9 @@ from .app_authz import AppAuthzService
 
 def add_logfile_handler(log_file: str):
     """Adds a log file handler to the root logger.
-    
+
     The purpose for this is to handle dynamic log file locations.
-    
+
     If a handler named errorFileHandler is found, it will be used as a template to
     create a new handler for writing to the error.log file at the same directory as log_file.
     The original errorFileHandler will be removed and replaced by the new handler.

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -17,6 +17,7 @@ import logging
 import logging.config
 import os
 import pkgutil
+import re
 import sys
 import warnings
 from logging.handlers import RotatingFileHandler
@@ -53,11 +54,23 @@ from .app_authz import AppAuthzService
 
 def add_logfile_handler(log_file):
     root_logger = logging.getLogger()
+    configured_handlers = root_logger.handlers
     main_handler = root_logger.handlers[0]
     file_handler = RotatingFileHandler(log_file, maxBytes=20 * 1024 * 1024, backupCount=10)
     file_handler.setLevel(main_handler.level)
     file_handler.setFormatter(main_handler.formatter)
     root_logger.addHandler(file_handler)
+
+    if len(configured_handlers) < 2:
+        return
+    
+    config_error_handler = configured_handlers[1]
+    error_log_file = os.path.join(os.path.dirname(log_file), "error.log")
+    error_file_handler = RotatingFileHandler(error_log_file, maxBytes=20 * 1024 * 1024, backupCount=10)
+    error_file_handler.setLevel(config_error_handler.level)
+    error_file_handler.setFormatter(config_error_handler.formatter)
+    root_logger.addHandler(error_file_handler)
+    root_logger.removeHandler(config_error_handler)
 
 
 def _check_secure_content(site_type: str) -> List[str]:

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -52,7 +52,20 @@ from ..simulator.simulator_const import SimulatorConstants
 from .app_authz import AppAuthzService
 
 
-def add_logfile_handler(log_file):
+def add_logfile_handler(log_file: str):
+    """Adds a log file handler to the root logger.
+    
+    The purpose for this is to handle dynamic log file locations.
+    
+    If a handler named errorFileHandler is found, it will be used as a template to
+    create a new handler for writing to the error.log file at the same directory as log_file.
+    The original errorFileHandler will be removed and replaced by the new handler.
+
+    Each log file will be rotated when it reaches 20MB.
+
+    Args:
+        log_file (str): log file path
+    """
     root_logger = logging.getLogger()
     configured_handlers = root_logger.handlers
     main_handler = root_logger.handlers[0]
@@ -61,16 +74,22 @@ def add_logfile_handler(log_file):
     file_handler.setFormatter(main_handler.formatter)
     root_logger.addHandler(file_handler)
 
-    if len(configured_handlers) < 2:
+    configured_error_handler = None
+    for handler in configured_handlers:
+        if handler.get_name() == "errorFileHandler":
+            configured_error_handler = handler
+            break
+
+    if not configured_error_handler:
         return
-    
-    config_error_handler = configured_handlers[1]
+
     error_log_file = os.path.join(os.path.dirname(log_file), "error.log")
     error_file_handler = RotatingFileHandler(error_log_file, maxBytes=20 * 1024 * 1024, backupCount=10)
-    error_file_handler.setLevel(config_error_handler.level)
-    error_file_handler.setFormatter(config_error_handler.formatter)
+    error_file_handler.setLevel(configured_error_handler.level)
+    error_file_handler.setFormatter(configured_error_handler.formatter)
+
     root_logger.addHandler(error_file_handler)
-    root_logger.removeHandler(config_error_handler)
+    root_logger.removeHandler(configured_error_handler)
 
 
 def _check_secure_content(site_type: str) -> List[str]:

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -17,7 +17,6 @@ import logging
 import logging.config
 import os
 import pkgutil
-import re
 import sys
 import warnings
 from logging.handlers import RotatingFileHandler


### PR DESCRIPTION
Modify log config to write errors to a separate log file in addition to log.txt.

### Description

Modify log config to write errors to a separate log file in addition to log.txt. I think this covers all the places we provide a default log config and this will enable future work for the error logs to be aggregated for reporting and downloading.

Updated nvflare/private/fed/utils/fed_utils.py to add an error log file to write errors to using the configuration of the error file handler based on the errorFileHandler in log.config.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
