### PR TITLE
Support aborting messages

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -16,7 +16,6 @@ import concurrent.futures
 import copy
 import logging
 import threading
-import time
 import uuid
 from typing import Dict, List, Union
 

--- a/nvflare/fuel/f3/cellnet/utils.py
+++ b/nvflare/fuel/f3/cellnet/utils.py
@@ -83,7 +83,22 @@ def format_log_message(fqcn: str, message: Message, log: str) -> str:
     return " ".join(context) + f"] {log}"
 
 
-def encode_payload(message: Message, encoding_key=MessageHeaderKey.PAYLOAD_ENCODING):
+def encode_payload(message: Message, encoding_key=MessageHeaderKey.PAYLOAD_ENCODING) -> int:
+    """Encode the payload of the specified message.
+
+    Args:
+        message: the message to be encoded
+        encoding_key: the key name of the encoding property in the message header. If the encoding property is not
+        set in the message header, then it means that the message payload has not been encoded. If the property is
+        already set, then the message payload is already encoded, and no processing is done.
+        If encoding is needed, we will determine the encoding scheme based on the data type of the payload:
+        - If the payload is None, encoding scheme is NONE
+        - If the payload data type is like bytes, encoding scheme is BYTES
+        - Otherwise, encoding scheme is FOBS, and the payload is serialized with FOBS.
+
+    Returns: the encoded payload size.
+
+    """
     encoding = message.get_header(encoding_key)
     if not encoding:
         if message.payload is None:
@@ -97,6 +112,7 @@ def encode_payload(message: Message, encoding_key=MessageHeaderKey.PAYLOAD_ENCOD
 
     size = buffer_len(message.payload)
     message.set_header(MessageHeaderKey.PAYLOAD_LEN, size)
+    return size
 
 
 def decode_payload(message: Message, encoding_key=MessageHeaderKey.PAYLOAD_ENCODING):

--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -27,7 +27,7 @@ from nvflare.fuel.f3.streaming.stream_const import (
     StreamDataType,
     StreamHeaderKey,
 )
-from nvflare.fuel.f3.streaming.stream_types import Stream, StreamCancelled, StreamError, StreamFuture, StreamTaskSpec
+from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError, StreamFuture, StreamTaskSpec
 from nvflare.fuel.f3.streaming.stream_utils import (
     ONE_MB,
     gen_stream_id,

--- a/nvflare/fuel/utils/waiter_utils.py
+++ b/nvflare/fuel/utils/waiter_utils.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import threading
+import time
+
+from nvflare.apis.signal import Signal
+
+_SMALL_WAIT = 0.01
+
+
+class WaiterRC:
+    OK = 0
+    IS_SET = 1
+    TIMEOUT = 2
+    ABORTED = 3
+    ERROR = 4
+
+
+def conditional_wait(waiter: threading.Event, timeout: float, abort_signal: Signal, condition_cb=None, **cb_kwargs):
+    wait_time = min(_SMALL_WAIT, timeout)
+    start = time.time()
+    while True:
+        if waiter.wait(wait_time):
+            # triggered
+            return WaiterRC.IS_SET
+
+        if time.time() - start >= timeout:
+            return WaiterRC.TIMEOUT
+
+        # check conditions
+        if abort_signal and abort_signal.triggered:
+            return WaiterRC.ABORTED
+
+        if condition_cb:
+            try:
+                rc = condition_cb(**cb_kwargs)
+                if rc != WaiterRC.OK:
+                    return rc
+            except:
+                return WaiterRC.ERROR

--- a/nvflare/private/aux_runner.py
+++ b/nvflare/private/aux_runner.py
@@ -280,7 +280,9 @@ class AuxRunner(FLComponent):
             )
 
         if timeout > 0:
-            cell_replies = cell.broadcast_multi_requests(target_messages, timeout, optional=optional, secure=secure)
+            cell_replies = cell.broadcast_multi_requests(
+                target_messages, timeout, optional=optional, secure=secure, abort_signal=fl_ctx.get_run_abort_signal()
+            )
             return self._process_cell_replies(cell_replies, topic, channel, fqcn_to_name)
         else:
             cell.fire_multi_requests_and_forget(
@@ -395,6 +397,7 @@ class AuxRunner(FLComponent):
                 timeout=timeout,
                 optional=optional,
                 secure=secure,
+                abort_signal=fl_ctx.get_run_abort_signal(),
             )
             return self._process_cell_replies(cell_replies, topic, channel, fqcn_to_name)
         else:

--- a/nvflare/private/fed/client/client_engine_executor_spec.py
+++ b/nvflare/private/fed/client/client_engine_executor_spec.py
@@ -149,10 +149,11 @@ class ClientEngineExecutorSpec(ClientEngineSpec, EngineSpec, ABC):
         """Send an async request to Server via the aux channel.
 
         Args:
-            topic: topic of the request
+            topic: topic of the request.
             request: request to be sent
             fl_ctx: FL context
             optional: whether the request is optional
+            secure: whether to send the message in P2P secure mode
 
         Returns:
 

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -244,7 +244,13 @@ class ClientRunManager(ClientEngineExecutorSpec):
 
         if msg_targets:
             return self.aux_runner.send_aux_request(
-                msg_targets, topic, request, timeout, fl_ctx, optional=optional, secure=secure
+                msg_targets,
+                topic,
+                request,
+                timeout,
+                fl_ctx,
+                optional=optional,
+                secure=secure,
             )
         else:
             return {}

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -28,8 +28,9 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import FLCommunicationError
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
-from nvflare.fuel.f3.cellnet.core_cell import FQCN, CoreCell
+from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.utils import format_size
 from nvflare.private.defs import CellChannel, CellChannelTopic, CellMessageHeaderKeys, SpecialTaskName, new_cell_message
 from nvflare.private.fed.client.client_engine_internal_spec import ClientEngineInternalSpec
@@ -67,7 +68,7 @@ class Communicator:
         secure_train=False,
         client_state_processors: Optional[List[Filter]] = None,
         compression=None,
-        cell: CoreCell = None,
+        cell: Cell = None,
         client_register_interval=2,
         timeout=5.0,
         maint_msg_timeout=5.0,
@@ -312,6 +313,7 @@ class Communicator:
             request=task_message,
             timeout=timeout,
             optional=True,
+            abort_signal=fl_ctx.get_run_abort_signal(),
         )
         end_time = time.time()
         return_code = task.get_header(MessageHeaderKey.RETURN_CODE)
@@ -388,6 +390,7 @@ class Communicator:
             request=task_message,
             timeout=timeout,
             optional=optional,
+            abort_signal=fl_ctx.get_run_abort_signal(),
         )
         end_time = time.time()
         return_code = result.get_header(MessageHeaderKey.RETURN_CODE)

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -144,7 +144,7 @@ class GetTaskCommand(CommandProcessor, ServerStateCheck):
         return ServerCommandNames.GET_TASK
 
     def process(self, data: Shareable, fl_ctx: FLContext):
-        """Called to process the abort command.
+        """Called to process the GetTask command.
 
         Args:
             data: process data


### PR DESCRIPTION
Fixes # .

### Description

This PR adds the capability to abort/cancel the sending of a message. Without this, the system cannot be quickly aborted if the message is big.  This function is more important when streaming large messages or large number of objects, which can take long time.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
