### PR TITLE
Fix cert issue

### DIFF
--- a/nvflare/lighter/impl/cert.py
+++ b/nvflare/lighter/impl/cert.py
@@ -208,6 +208,8 @@ class CertBuilder(Builder):
                     if h != default_host:
                         sans.append(x509.DNSName(h))
             builder = builder.add_extension(x509.SubjectAlternativeName(sans), critical=False)
+        else:
+            builder = builder.add_extension(x509.SubjectAlternativeName([x509.DNSName(subject)]), critical=False)
         return builder.sign(signing_pri_key, hashes.SHA256(), default_backend())
 
     def _x509_name(self, cn_name, org_name=None, role=None):


### PR DESCRIPTION
SubjectAlternativeName needs to be added for non-server certificates as well, otherwise the integration tests failed.

### Description

- Add back SubjectAlternativeName after https://github.com/NVIDIA/NVFlare/pull/3018

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
