### PR TITLE
Fix the streaming test conflict

### DIFF
--- a/nvflare/fuel/f3/streaming/tools/utils.py
+++ b/nvflare/fuel/f3/streaming/tools/utils.py
@@ -19,7 +19,7 @@ BUF_SIZE = 64 * 1024 * 1024 + 1
 TEST_CHANNEL = "stream"
 TEST_TOPIC = "test"
 TX_CELL = "sender"
-RX_CELL = "server"
+RX_CELL = "receiver"
 
 
 def make_buffer(size: int) -> bytearray:


### PR DESCRIPTION
### Description

Renamed RX_CELL from server to receiver to avoid cell name conflicts with other tests.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
