### PR TITLE
Fix poc command

### DIFF
--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -386,6 +386,13 @@ class StaticFileBuilder(Builder):
         agent_config = dict()
         self._prepare_overseer_agent(admin, agent_config, "admin", ctx)
         config["admin"].update(agent_config)
+
+        provision_mode = ctx.get("provision_mode")
+        if provision_mode == "poc":
+            # in poc mode, we change to use "local_cert" as the cred_type so that the user won't be
+            # prompted for username when starting the admin console
+            config["admin"]["username"] = admin.name
+            config["admin"]["cred_type"] = "local_cert"
         return config
 
     def build(self, project, ctx):

--- a/nvflare/lighter/spec.py
+++ b/nvflare/lighter/spec.py
@@ -246,12 +246,16 @@ class Provisioner(object):
         dirs = [workspace, resources_dir, wip_dir, state_dir]
         self._make_dir(dirs)
 
-    def provision(self, project: Project):
+    def provision(self, project: Project, mode=None):
         # ctx = {"workspace": os.path.join(self.root_dir, project.name), "project": project}
         workspace = os.path.join(self.root_dir, project.name)
         ctx = {"workspace": workspace}  # project is more static information while ctx is dynamic
         self._prepare_workspace(ctx)
         ctx["project"] = project
+
+        if mode:
+            ctx["provision_mode"] = mode
+
         try:
             for b in self.builders:
                 b.initialize(ctx)

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -306,8 +306,9 @@ def local_provision(
     service_config = get_service_config(project_config)
     project = prepare_project(project_config)
     builders = prepare_builders(project_config)
+
     provisioner = Provisioner(workspace, builders)
-    provisioner.provision(project)
+    provisioner.provision(project, mode="poc")
 
     return project_config, service_config
 


### PR DESCRIPTION
Fixes # .

### Description

Previous change to Provision broke the "poc start" command behavior: the user is prompted for username.  This PR fixes this.

The fix now allows a project to be provisioned in a specified "mode".  If the mode is not specified, then the project is provisioned in normal mode. If the mode is set to "poc", then when creating fed_admin.json (in StaticFileBuilder), the user's name will be added to the file, and the cred_type is set to "local_cert". 

The provision mode is set into the provision context (the "ctx"), which will allow any builder to do mode-specific processing.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
