### PR TITLE
Fix the simulator without custom folder job run error

### DIFF
--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -707,9 +707,10 @@ class SimulatorClientRunner(FLComponent):
             command += " --gpu " + str(gpu)
         new_env = os.environ.copy()
         add_custom_dir_to_path(app_custom_folder, new_env)
-        if self.server_custom_folder:
+        if os.path.isdir(self.server_custom_folder):
             python_paths = new_env[SystemVarName.PYTHONPATH].split(os.pathsep)
-            python_paths.remove(self.server_custom_folder)
+            if self.server_custom_folder in python_paths:
+                python_paths.remove(self.server_custom_folder)
             new_env[SystemVarName.PYTHONPATH] = os.pathsep.join(python_paths)
 
         _ = subprocess.Popen(shlex.split(command, True), preexec_fn=os.setsid, env=new_env)


### PR DESCRIPTION
Fixes # .

### Description

Fixed the simulator without custom folder job run error. Add check for the job custom folder existence.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
