### PR TITLE
[2.5] Support explicit message authentication

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -178,6 +178,9 @@ class FLContextKey(object):
     FILTER_DIRECTION = "__filter_dir__"
     ROOT_URL = "__root_url__"  # the URL for accessing the FL Server
     NOT_READY_TO_END_RUN = "not_ready_to_end_run__"  # component sets this to indicate it's not ready to end run yet
+    CLIENT_CONFIG = "__client_config__"
+    SERVER_CONFIG = "__server_config__"
+    SERVER_HOST_NAME = "__server_host_name__"
 
 
 class ReservedTopic(object):
@@ -479,6 +482,9 @@ class ConfigVarName:
 
     # client and server: max amount of time to wait for communication cell to be created
     CELL_WAIT_TIMEOUT = "cell_wait_timeout"
+
+    # these vars are set in Server's startup config (fed_server.json)
+    MAX_REG_DURATION = "max_reg_duration"
 
 
 class SystemVarName:

--- a/nvflare/fuel/f3/cellnet/defs.py
+++ b/nvflare/fuel/f3/cellnet/defs.py
@@ -160,7 +160,7 @@ class CellChannel:
 
 
 class CellChannelTopic:
-
+    Challenge = "challenge"
     Register = "register"
     Quit = "quit"
     GET_TASK = "get_task"
@@ -171,3 +171,11 @@ class CellChannelTopic:
     REPORT_JOB_FAILURE = "report_job_failure"
 
     SIMULATOR_WORKER_INIT = "simulator_worker_init"
+
+
+class IdentityChallengeKey:
+
+    NONCE = "nonce"
+    CERT = "cert"
+    SIGNATURE = "signature"
+    COMMON_NAME = "cn"

--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -198,7 +198,19 @@ def sh_replace(src, mapping_dict):
 
 def update_project_server_name_config(project_config: dict, old_server_name, server_name) -> dict:
     update_participant_server_name(project_config, old_server_name, server_name)
+    update_overseer_server_name(project_config, old_server_name, server_name)
     return project_config
+
+
+def update_overseer_server_name(project_config, old_server_name, server_name):
+    # update overseer_agent builder
+    builders = project_config.get("builders", [])
+    for b in builders:
+        if "args" in b:
+            if "overseer_agent" in b["args"]:
+                end_point = b["args"]["overseer_agent"]["args"]["sp_end_point"]
+                new_end_point = end_point.replace(old_server_name, server_name)
+                b["args"]["overseer_agent"]["args"]["sp_end_point"] = new_end_point
 
 
 def update_participant_server_name(project_config, old_server_name, new_server_name):

--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -40,7 +40,8 @@ def serialize_cert(cert):
 
 
 def load_crt(path):
-    return load_crt_bytes(open(path, "rb").read())
+    with open(path, "rb") as f:
+        return load_crt_bytes(f.read())
 
 
 def load_crt_bytes(data: bytes):
@@ -116,17 +117,19 @@ def sign_folders(folder, signing_pri_key, crt_path, max_depth=9999):
         for file in files:
             if file == NVFLARE_SIG_FILE or file == NVFLARE_SUBMITTER_CRT_FILE:
                 continue
-            signatures[file] = sign_content(
-                content=open(os.path.join(root, file), "rb").read(),
-                signing_pri_key=signing_pri_key,
-            )
+            with open(os.path.join(root, file), "rb") as f:
+                signatures[file] = sign_content(
+                    content=f.read(),
+                    signing_pri_key=signing_pri_key,
+                )
         for folder in folders:
             signatures[folder] = sign_content(
                 content=folder,
                 signing_pri_key=signing_pri_key,
             )
 
-        json.dump(signatures, open(os.path.join(root, NVFLARE_SIG_FILE), "wt"))
+        with open(os.path.join(root, NVFLARE_SIG_FILE), "wt") as f:
+            json.dump(signatures, f)
         shutil.copyfile(crt_path, os.path.join(root, NVFLARE_SUBMITTER_CRT_FILE))
         if depth >= max_depth:
             break
@@ -138,7 +141,8 @@ def verify_folder_signature(src_folder, root_ca_path):
         root_ca_public_key = root_ca_cert.public_key()
         for root, folders, files in os.walk(src_folder):
             try:
-                signatures = json.load(open(os.path.join(root, NVFLARE_SIG_FILE), "rt"))
+                with open(os.path.join(root, NVFLARE_SIG_FILE), "rt") as f:
+                    signatures = json.load(f)
                 cert = load_crt(os.path.join(root, NVFLARE_SUBMITTER_CRT_FILE))
                 public_key = cert.public_key()
             except:
@@ -150,11 +154,12 @@ def verify_folder_signature(src_folder, root_ca_path):
                     continue
                 signature = signatures.get(file)
                 if signature:
-                    verify_content(
-                        content=open(os.path.join(root, file), "rb").read(),
-                        signature=signature,
-                        public_key=public_key,
-                    )
+                    with open(os.path.join(root, file), "rb") as f:
+                        verify_content(
+                            content=f.read(),
+                            signature=signature,
+                            public_key=public_key,
+                        )
             for folder in folders:
                 signature = signatures.get(folder)
                 if signature:
@@ -173,16 +178,18 @@ def sign_all(content_folder, signing_pri_key):
     for f in os.listdir(content_folder):
         path = os.path.join(content_folder, f)
         if os.path.isfile(path):
-            signatures[f] = sign_content(
-                content=open(path, "rb").read(),
-                signing_pri_key=signing_pri_key,
-            )
+            with open(path, "rb") as file:
+                signatures[f] = sign_content(
+                    content=file.read(),
+                    signing_pri_key=signing_pri_key,
+                )
     return signatures
 
 
 def load_yaml(file):
     if isinstance(file, str):
-        return yaml.safe_load(open(file, "r"))
+        with open(file, "r") as f:
+            return yaml.safe_load(f)
     elif isinstance(file, bytes):
         return yaml.safe_load(file)
     else:

--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -19,12 +19,32 @@ import shutil
 from base64 import b64decode, b64encode
 
 import yaml
+from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
-from nvflare.lighter.impl.cert import load_crt
 from nvflare.lighter.tool_consts import NVFLARE_SIG_FILE, NVFLARE_SUBMITTER_CRT_FILE
+
+
+def serialize_pri_key(pri_key):
+    return pri_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def serialize_cert(cert):
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def load_crt(path):
+    return load_crt_bytes(open(path, "rb").read())
+
+
+def load_crt_bytes(data: bytes):
+    return x509.load_pem_x509_certificate(data, default_backend())
 
 
 def generate_password(passlen=16):
@@ -33,22 +53,59 @@ def generate_password(passlen=16):
     return p
 
 
-def sign_one(content, signing_pri_key):
+def sign_content(content, signing_pri_key, return_str=True):
+    if isinstance(content, str):
+        content = content.encode("utf-8")  # to bytes
     signature = signing_pri_key.sign(
         data=content,
-        padding=padding.PSS(
-            mgf=padding.MGF1(hashes.SHA256()),
-            salt_length=padding.PSS.MAX_LENGTH,
-        ),
-        algorithm=hashes.SHA256(),
+        padding=_content_padding(),
+        algorithm=_content_hash_algo(),
     )
-    return b64encode(signature).decode("utf-8")
+
+    # signature is bytes
+    if return_str:
+        return b64encode(signature).decode("utf-8")
+    else:
+        return signature
+
+
+def _content_padding():
+    return padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH)
+
+
+def _content_hash_algo():
+    return hashes.SHA256()
+
+
+def verify_content(content, signature, public_key):
+    if isinstance(content, str):
+        content = content.encode("utf-8")  # to bytes
+    if isinstance(signature, str):
+        signature = b64decode(signature.encode("utf-8"))  # decode to bytes
+    public_key.verify(
+        signature=signature,
+        data=content,
+        padding=_content_padding(),
+        algorithm=_content_hash_algo(),
+    )
+
+
+def verify_cert(cert_to_be_verified, root_ca_public_key):
+    root_ca_public_key.verify(
+        cert_to_be_verified.signature,
+        cert_to_be_verified.tbs_certificate_bytes,
+        padding.PKCS1v15(),
+        cert_to_be_verified.signature_hash_algorithm,
+    )
+
+
+def load_private_key(data: str):
+    return serialization.load_pem_private_key(data.encode("ascii"), password=None, backend=default_backend())
 
 
 def load_private_key_file(file_path):
     with open(file_path, "rt") as f:
-        pri_key = serialization.load_pem_private_key(f.read().encode("ascii"), password=None, backend=default_backend())
-    return pri_key
+        return load_private_key(f.read())
 
 
 def sign_folders(folder, signing_pri_key, crt_path, max_depth=9999):
@@ -59,25 +116,15 @@ def sign_folders(folder, signing_pri_key, crt_path, max_depth=9999):
         for file in files:
             if file == NVFLARE_SIG_FILE or file == NVFLARE_SUBMITTER_CRT_FILE:
                 continue
-            signature = signing_pri_key.sign(
-                data=open(os.path.join(root, file), "rb").read(),
-                padding=padding.PSS(
-                    mgf=padding.MGF1(hashes.SHA256()),
-                    salt_length=padding.PSS.MAX_LENGTH,
-                ),
-                algorithm=hashes.SHA256(),
+            signatures[file] = sign_content(
+                content=open(os.path.join(root, file), "rb").read(),
+                signing_pri_key=signing_pri_key,
             )
-            signatures[file] = b64encode(signature).decode("utf-8")
         for folder in folders:
-            signature = signing_pri_key.sign(
-                data=folder.encode("utf-8"),
-                padding=padding.PSS(
-                    mgf=padding.MGF1(hashes.SHA256()),
-                    salt_length=padding.PSS.MAX_LENGTH,
-                ),
-                algorithm=hashes.SHA256(),
+            signatures[folder] = sign_content(
+                content=folder,
+                signing_pri_key=signing_pri_key,
             )
-            signatures[folder] = b64encode(signature).decode("utf-8")
 
         json.dump(signatures, open(os.path.join(root, NVFLARE_SIG_FILE), "wt"))
         shutil.copyfile(crt_path, os.path.join(root, NVFLARE_SUBMITTER_CRT_FILE))
@@ -96,30 +143,25 @@ def verify_folder_signature(src_folder, root_ca_path):
                 public_key = cert.public_key()
             except:
                 continue  # TODO: shall return False
-            root_ca_public_key.verify(
-                cert.signature, cert.tbs_certificate_bytes, padding.PKCS1v15(), cert.signature_hash_algorithm
-            )
-            for k in signatures:
-                signatures[k] = b64decode(signatures[k].encode("utf-8"))
+
+            verify_cert(cert_to_be_verified=cert, root_ca_public_key=root_ca_public_key)
             for file in files:
                 if file == NVFLARE_SIG_FILE or file == NVFLARE_SUBMITTER_CRT_FILE:
                     continue
                 signature = signatures.get(file)
                 if signature:
-                    public_key.verify(
+                    verify_content(
+                        content=open(os.path.join(root, file), "rb").read(),
                         signature=signature,
-                        data=open(os.path.join(root, file), "rb").read(),
-                        padding=padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
-                        algorithm=hashes.SHA256(),
+                        public_key=public_key,
                     )
             for folder in folders:
                 signature = signatures.get(folder)
                 if signature:
-                    public_key.verify(
+                    verify_content(
+                        content=folder,
                         signature=signature,
-                        data=folder.encode("utf-8"),
-                        padding=padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
-                        algorithm=hashes.SHA256(),
+                        public_key=public_key,
                     )
         return True
     except Exception as e:
@@ -131,15 +173,10 @@ def sign_all(content_folder, signing_pri_key):
     for f in os.listdir(content_folder):
         path = os.path.join(content_folder, f)
         if os.path.isfile(path):
-            signature = signing_pri_key.sign(
-                data=open(path, "rb").read(),
-                padding=padding.PSS(
-                    mgf=padding.MGF1(hashes.SHA256()),
-                    salt_length=padding.PSS.MAX_LENGTH,
-                ),
-                algorithm=hashes.SHA256(),
+            signatures[f] = sign_content(
+                content=open(path, "rb").read(),
+                signing_pri_key=signing_pri_key,
             )
-            signatures[f] = b64encode(signature).decode("utf-8")
     return signatures
 
 
@@ -161,19 +198,7 @@ def sh_replace(src, mapping_dict):
 
 def update_project_server_name_config(project_config: dict, old_server_name, server_name) -> dict:
     update_participant_server_name(project_config, old_server_name, server_name)
-    update_overseer_server_name(project_config, old_server_name, server_name)
     return project_config
-
-
-def update_overseer_server_name(project_config, old_server_name, server_name):
-    # update overseer_agent builder
-    builders = project_config.get("builders", [])
-    for b in builders:
-        if "args" in b:
-            if "overseer_agent" in b["args"]:
-                end_point = b["args"]["overseer_agent"]["args"]["sp_end_point"]
-                new_end_point = end_point.replace(old_server_name, server_name)
-                b["args"]["overseer_agent"]["args"]["sp_end_point"] = new_end_point
 
 
 def update_participant_server_name(project_config, old_server_name, new_server_name):
@@ -181,7 +206,28 @@ def update_participant_server_name(project_config, old_server_name, new_server_n
     for p in participants:
         if p["type"] == "server" and p["name"] == old_server_name:
             p["name"] = new_server_name
-            return
+            break
+    return project_config
+
+
+def update_server_default_host(project_config, default_host):
+    """Update the default_host property of the Server in the project config.
+    If a client does not explicitly specify "connect_to", it will use the default_host to connect to server.
+    This is mainly used for POC, where the default_host is set to localhost.
+
+    Args:
+        project_config: the project config dict
+        default_host: value of the default host
+
+    Returns: the updated project_config
+
+    """
+    participants = project_config["participants"]
+    for p in participants:
+        if p["type"] == "server":
+            p["default_host"] = default_host
+            break
+    return project_config
 
 
 def update_project_server_name(project_file: str, old_server_name, server_name):

--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -222,26 +222,6 @@ def update_participant_server_name(project_config, old_server_name, new_server_n
     return project_config
 
 
-def update_server_default_host(project_config, default_host):
-    """Update the default_host property of the Server in the project config.
-    If a client does not explicitly specify "connect_to", it will use the default_host to connect to server.
-    This is mainly used for POC, where the default_host is set to localhost.
-
-    Args:
-        project_config: the project config dict
-        default_host: value of the default host
-
-    Returns: the updated project_config
-
-    """
-    participants = project_config["participants"]
-    for p in participants:
-        if p["type"] == "server":
-            p["default_host"] = default_host
-            break
-    return project_config
-
-
 def update_project_server_name(project_file: str, old_server_name, server_name):
     with open(project_file, "r") as file:
         project_config = yaml.safe_load(file)

--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -33,8 +33,8 @@ class TaskConstant(object):
 class EngineConstant(object):
 
     FEDERATE_CLIENT = "federate_client"
-    FL_TOKEN = "fl_token"
-    CLIENT_TOKEN_FILE = "client_token.txt"
+    AUTH_TOKEN = "auth_token"
+    AUTH_TOKEN_SIGNATURE = "auth_token_signature"
     ENGINE_TASK_NAME = "engine_task_name"
 
 
@@ -140,13 +140,17 @@ class CellMessageHeaderKeys:
     CLIENT_NAME = "client_name"
     CLIENT_IP = "client_ip"
     PROJECT_NAME = "project_name"
-    TOKEN = "token"
+    TOKEN = "__token__"
+    TOKEN_SIGNATURE = "__token_signature__"
     SSID = "ssid"
     UNAUTHENTICATED = "unauthenticated"
     JOB_ID = "job_id"
     JOB_IDS = "job_ids"
     MESSAGE = "message"
     ABORT_JOBS = "abort_jobs"
+
+
+AUTH_CLIENT_NAME_FOR_SJ = "server_job"
 
 
 class JobFailureMsgKey:

--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import time
+import uuid
 
 # this import is to let existing scripts import from nvflare.private.defs
 from nvflare.fuel.f3.cellnet.defs import CellChannel, CellChannelTopic, SSLConstants  # noqa: F401
@@ -152,6 +154,18 @@ class JobFailureMsgKey:
     JOB_ID = "job_id"
     CODE = "code"
     REASON = "reason"
+
+
+class InternalFLContextKey:
+
+    CLIENT_REG_SESSION = "client_reg_session"
+
+
+class ClientRegSession:
+    def __init__(self, client_name: str):
+        self.client_name = client_name
+        self.nonce = str(uuid.uuid4())
+        self.reg_start_time = time.time()
 
 
 def new_cell_message(headers: dict, payload=None):

--- a/nvflare/private/fed/app/client/client_train.py
+++ b/nvflare/private/fed/app/client/client_train.py
@@ -108,6 +108,25 @@ def main(args):
             time.sleep(1.0)
 
         with client_engine.new_context() as fl_ctx:
+            fl_ctx.set_prop(
+                key=FLContextKey.CLIENT_CONFIG,
+                value=deployer.client_config,
+                private=True,
+                sticky=True,
+            )
+            fl_ctx.set_prop(
+                key=FLContextKey.SERVER_CONFIG,
+                value=deployer.server_config,
+                private=True,
+                sticky=True,
+            )
+            fl_ctx.set_prop(
+                key=FLContextKey.SECURE_MODE,
+                value=deployer.secure_train,
+                private=True,
+                sticky=True,
+            )
+
             fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, private=True)
             client_engine.fire_event(EventType.SYSTEM_BOOTSTRAP, fl_ctx)
 

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -28,7 +28,6 @@ from nvflare.fuel.sec.audit import AuditService
 from nvflare.fuel.sec.security_content_service import SecurityContentService
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
-from nvflare.private.defs import EngineConstant
 from nvflare.private.fed.app.fl_conf import FLClientStarterConfiger
 from nvflare.private.fed.app.utils import monitor_parent_process
 from nvflare.private.fed.client.client_app_runner import ClientAppRunner

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -111,11 +111,12 @@ def main(args):
         federated_client = deployer.create_fed_client(args)
         federated_client.status = ClientStatus.STARTING
 
+        federated_client.communicator.set_auth(args.client_name, args.token, args.token_signature, args.ssid)
         federated_client.token = args.token
+        federated_client.token_signature = args.token_signature
         federated_client.ssid = args.ssid
         federated_client.client_name = args.client_name
         federated_client.fl_ctx.set_prop(FLContextKey.CLIENT_NAME, args.client_name, private=False)
-        federated_client.fl_ctx.set_prop(EngineConstant.FL_TOKEN, args.token, private=False)
         federated_client.fl_ctx.set_prop(FLContextKey.WORKSPACE_ROOT, args.workspace, private=True)
 
         client_app_runner = ClientAppRunner(time_out=kv_list.get("app_runner_timeout", 60.0))
@@ -150,7 +151,8 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--workspace", "-m", type=str, help="WORKSPACE folder", required=True)
     parser.add_argument("--startup", "-w", type=str, help="startup folder", required=True)
-    parser.add_argument("--token", "-t", type=str, help="token", required=True)
+    parser.add_argument("--token", "-t", type=str, help="auth token", required=True)
+    parser.add_argument("--token_signature", "-ts", type=str, help="auth token signature", required=True)
     parser.add_argument("--ssid", "-d", type=str, help="ssid", required=True)
     parser.add_argument("--job_id", "-n", type=str, help="job_id", required=True)
     parser.add_argument("--client_name", "-c", type=str, help="client name", required=True)

--- a/nvflare/private/fed/app/deployer/simulator_deployer.py
+++ b/nvflare/private/fed/app/deployer/simulator_deployer.py
@@ -100,7 +100,7 @@ class SimulatorDeployer(ServerDeployer):
         )
         cell.start()
         federated_client.cell = cell
-        federated_client.communicator.cell = cell
+        federated_client.communicator.set_cell(cell)
         # if self.engine:
         #     self.engine.admin_agent.register_cell_cb()
 

--- a/nvflare/private/fed/app/server/server_train.py
+++ b/nvflare/private/fed/app/server/server_train.py
@@ -20,7 +20,7 @@ import os
 import sys
 import time
 
-from nvflare.apis.fl_constant import JobConstants, SiteType, WorkspaceConstants
+from nvflare.apis.fl_constant import FLContextKey, JobConstants, SiteType, WorkspaceConstants
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
@@ -120,6 +120,20 @@ def main(args):
             services.set_admin_server(admin_server)
 
             # mpm.add_cleanup_cb(admin_server.stop)
+            with services.engine.new_context() as fl_ctx:
+                fl_ctx.set_prop(
+                    key=FLContextKey.SERVER_CONFIG,
+                    value=deployer.server_config,
+                    private=True,
+                    sticky=True,
+                )
+
+                fl_ctx.set_prop(
+                    key=FLContextKey.SECURE_MODE,
+                    value=deployer.secure_train,
+                    private=True,
+                    sticky=True,
+                )
 
         finally:
             deployer.close()

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -215,6 +215,12 @@ class ClientTaskWorker(FLComponent):
         mpm.add_cleanup_cb(cell.stop)
         federated_client.cell = cell
         federated_client.communicator.set_cell(cell)
+        federated_client.communicator.set_auth(
+            client_name=federated_client.client_name,
+            token=federated_client.token,
+            token_signature="NA",
+            ssid="NA",
+        )
 
         start = time.time()
         while not cell.is_cell_connected(FQCN.ROOT_SERVER):

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -214,7 +214,7 @@ class ClientTaskWorker(FLComponent):
         cell.start()
         mpm.add_cleanup_cb(cell.stop)
         federated_client.cell = cell
-        federated_client.communicator.cell = cell
+        federated_client.communicator.set_cell(cell)
 
         start = time.time()
         while not cell.is_cell_connected(FQCN.ROOT_SERVER):

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -70,7 +70,6 @@ class ClientAppRunner(Runner):
     @staticmethod
     def _set_fl_context(fl_ctx: FLContext, app_root, args, workspace, secure_train):
         fl_ctx.set_prop(FLContextKey.CLIENT_NAME, args.client_name, private=False)
-        fl_ctx.set_prop(EngineConstant.FL_TOKEN, args.token, private=False)
         fl_ctx.set_prop(FLContextKey.WORKSPACE_ROOT, args.workspace, private=True)
         fl_ctx.set_prop(FLContextKey.ARGS, args, sticky=True)
         fl_ctx.set_prop(FLContextKey.APP_ROOT, app_root, private=True, sticky=True)

--- a/nvflare/private/fed/client/client_app_runner.py
+++ b/nvflare/private/fed/client/client_app_runner.py
@@ -19,7 +19,7 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.private.admin_defs import Message
-from nvflare.private.defs import CellChannel, EngineConstant, RequestHeader, TrainingTopic, new_cell_message
+from nvflare.private.defs import CellChannel, RequestHeader, TrainingTopic, new_cell_message
 from nvflare.private.fed.app.fl_conf import create_privacy_manager
 from nvflare.private.fed.client.client_json_config import ClientJsonConfigurator
 from nvflare.private.fed.client.client_run_manager import ClientRunManager

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -25,7 +25,7 @@ from nvflare.apis.fl_constant import FLContextKey, MachineStatus, SystemComponen
 from nvflare.apis.fl_context import FLContext, FLContextManager
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.utils.network_utils import get_open_ports
-from nvflare.private.defs import ERROR_MSG_PREFIX, ClientStatusKey, EngineConstant
+from nvflare.private.defs import ERROR_MSG_PREFIX, ClientStatusKey
 from nvflare.private.event import fire_event
 from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
 from nvflare.private.fed.utils.app_deployer import AppDeployer

--- a/nvflare/private/fed/client/client_engine.py
+++ b/nvflare/private/fed/client/client_engine.py
@@ -185,23 +185,6 @@ class ClientEngine(ClientEngineInternalSpec):
     def get_client_name(self):
         return self.client.client_name
 
-    def _write_token_file(self, job_id, open_port):
-        token_file = os.path.join(self.args.workspace, EngineConstant.CLIENT_TOKEN_FILE)
-        if os.path.exists(token_file):
-            os.remove(token_file)
-        with open(token_file, "wt") as f:
-            f.write(
-                "%s\n%s\n%s\n%s\n%s\n%s\n"
-                % (
-                    self.client.token,
-                    self.client.ssid,
-                    job_id,
-                    self.client.client_name,
-                    open_port,
-                    list(self.client.servers.values())[0]["target"],
-                )
-            )
-
     def abort_app(self, job_id: str) -> str:
         status = self.client_executor.get_status(job_id)
         if status == ClientStatus.STOPPED:

--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -184,6 +184,8 @@ class ProcessExecutor(ClientExecutor):
             + self.startup
             + " -t "
             + client.token
+            + " -ts "
+            + client.token_signature
             + " -d "
             + client.ssid
             + " -n "

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -31,6 +31,7 @@ from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
 from nvflare.fuel.f3.cellnet.core_cell import FQCN, CoreCell
 from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.utils import format_size
+from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.private.defs import CellChannel, CellChannelTopic, CellMessageHeaderKeys, SpecialTaskName, new_cell_message
 from nvflare.private.fed.client.client_engine_internal_spec import ClientEngineInternalSpec
 from nvflare.private.fed.utils.fed_utils import get_scope_prop
@@ -93,7 +94,39 @@ class Communicator:
         self.timeout = timeout
         self.maint_msg_timeout = maint_msg_timeout
 
+        # token and token_signature are issued by the Server after the client is authenticated
+        # they are added to every message going to the server as proof of authentication
+        self.token = None
+        self.token_signature = None
+        self.ssid = None
+        self.client_name = None
+
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.info(f"==== Communicator GOT CELL: {type(cell)}")
+
+    def set_auth(self, client_name, token, token_signature, ssid):
+        self.ssid = ssid
+        self.token_signature = token_signature
+        self.token = token
+        self.client_name = client_name
+
+    def set_cell(self, cell):
+        self.cell = cell
+
+        # set filter to add additional auth headers
+        cell.core_cell.add_outgoing_reply_filter(channel="*", topic="*", cb=self._add_auth_headers)
+        cell.core_cell.add_outgoing_request_filter(channel="*", topic="*", cb=self._add_auth_headers)
+
+    def _add_auth_headers(self, message: CellMessage):
+        if self.ssid:
+            message.set_header(CellMessageHeaderKeys.SSID, self.ssid)
+
+        if self.client_name:
+            message.set_header(CellMessageHeaderKeys.CLIENT_NAME, self.client_name)
+
+        if self.token:
+            message.set_header(CellMessageHeaderKeys.TOKEN, self.token)
+            message.set_header(CellMessageHeaderKeys.TOKEN_SIGNATURE, self.token_signature)
 
     def _challenge_server(self, client_name, expected_host, root_cert_file):
         # ask server for its info and make sure that it matches expected host
@@ -252,17 +285,19 @@ class Communicator:
                     raise FLCommunicationError("error:client_registration " + reason)
 
                 token = result.get_header(CellMessageHeaderKeys.TOKEN)
+                token_signature = result.get_header(CellMessageHeaderKeys.TOKEN_SIGNATURE, "NA")
                 ssid = result.get_header(CellMessageHeaderKeys.SSID)
                 if not token and not self.should_stop:
                     time.sleep(self.client_register_interval)
                 else:
+                    self.set_auth(client_name, token, token_signature, ssid)
                     break
 
             except Exception as ex:
                 traceback.print_exc()
                 raise FLCommunicationError("error:client_registration", ex)
 
-        return token, ssid
+        return token, token_signature, ssid
 
     def pull_task(self, project_name, token, ssid, fl_ctx: FLContext, timeout=None):
         """Get a task from server.
@@ -285,9 +320,6 @@ class Communicator:
         client_name = fl_ctx.get_identity_name()
         task_message = new_cell_message(
             {
-                CellMessageHeaderKeys.TOKEN: token,
-                CellMessageHeaderKeys.CLIENT_NAME: client_name,
-                CellMessageHeaderKeys.SSID: ssid,
                 CellMessageHeaderKeys.PROJECT_NAME: project_name,
             },
             shareable,
@@ -361,9 +393,6 @@ class Communicator:
 
         task_message = new_cell_message(
             {
-                CellMessageHeaderKeys.TOKEN: token,
-                CellMessageHeaderKeys.CLIENT_NAME: client_name,
-                CellMessageHeaderKeys.SSID: ssid,
                 CellMessageHeaderKeys.PROJECT_NAME: project_name,
             },
             shareable,
@@ -410,9 +439,6 @@ class Communicator:
         client_name = fl_ctx.get_identity_name()
         quit_message = new_cell_message(
             {
-                CellMessageHeaderKeys.TOKEN: token,
-                CellMessageHeaderKeys.CLIENT_NAME: client_name,
-                CellMessageHeaderKeys.SSID: ssid,
                 CellMessageHeaderKeys.PROJECT_NAME: task_name,
             },
             shareable,
@@ -452,9 +478,6 @@ class Communicator:
                 job_ids = engine.get_all_job_ids()
                 heartbeat_message = new_cell_message(
                     {
-                        CellMessageHeaderKeys.TOKEN: token,
-                        CellMessageHeaderKeys.SSID: ssid,
-                        CellMessageHeaderKeys.CLIENT_NAME: client_name,
                         CellMessageHeaderKeys.PROJECT_NAME: task_name,
                         CellMessageHeaderKeys.JOB_IDS: job_ids,
                     },

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -15,22 +15,26 @@
 import logging
 import socket
 import time
+import traceback
+import uuid
 from typing import List, Optional
 
 from nvflare.apis.event_type import EventType
 from nvflare.apis.filter import Filter
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_constant import ReturnCode as ShareableRC
-from nvflare.apis.fl_constant import ServerCommandKey, ServerCommandNames
+from nvflare.apis.fl_constant import SecureTrainConst, ServerCommandKey, ServerCommandNames
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import FLCommunicationError
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
 from nvflare.fuel.f3.cellnet.core_cell import FQCN, CoreCell
-from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.utils import format_size
 from nvflare.private.defs import CellChannel, CellChannelTopic, CellMessageHeaderKeys, SpecialTaskName, new_cell_message
 from nvflare.private.fed.client.client_engine_internal_spec import ClientEngineInternalSpec
+from nvflare.private.fed.utils.fed_utils import get_scope_prop
+from nvflare.private.fed.utils.identity_utils import IdentityAsserter, IdentityVerifier, load_crt_bytes
 from nvflare.security.logging import secure_format_exception
 
 
@@ -91,8 +95,75 @@ class Communicator:
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    def _challenge_server(self, client_name, expected_host, root_cert_file):
+        # ask server for its info and make sure that it matches expected host
+        my_nonce = str(uuid.uuid4())
+        headers = {IdentityChallengeKey.COMMON_NAME: client_name, IdentityChallengeKey.NONCE: my_nonce}
+        challenge = new_cell_message(headers, None)
+        result = self.cell.send_request(
+            target=FQCN.ROOT_SERVER,
+            channel=CellChannel.SERVER_MAIN,
+            topic=CellChannelTopic.Challenge,
+            request=challenge,
+            timeout=self.maint_msg_timeout,
+        )
+        return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
+        error = result.get_header(MessageHeaderKey.ERROR, "")
+        self.logger.info(f"challenge result: {return_code} {error}")
+        if return_code != ReturnCode.OK:
+            if return_code in [ReturnCode.TARGET_UNREACHABLE, ReturnCode.COMM_ERROR]:
+                # trigger retry
+                return None
+            err = result.get_header(MessageHeaderKey.ERROR, "")
+            raise FLCommunicationError(f"failed to challenge server: {return_code}: {err}")
+
+        reply = result.payload
+        assert isinstance(reply, Shareable)
+        server_nonce = reply.get(IdentityChallengeKey.NONCE)
+        cert_bytes = reply.get(IdentityChallengeKey.CERT)
+        server_cert = load_crt_bytes(cert_bytes)
+        server_signature = reply.get(IdentityChallengeKey.SIGNATURE)
+        server_cn = reply.get(IdentityChallengeKey.COMMON_NAME)
+
+        if server_cn != expected_host:
+            raise FLCommunicationError(f"expected server identity is '{expected_host}' but got '{server_cn}'")
+
+        # Use IdentityVerifier to validate:
+        # - the server cert can be validated with the root cert. Note that all sites have the same root cert!
+        # - the asserted CN matches the CN on the server cert
+        # - signature received from the server is valid
+        id_verifier = IdentityVerifier(root_cert_file=root_cert_file)
+        id_verifier.verify_common_name(
+            asserter_cert=server_cert, asserted_cn=server_cn, nonce=my_nonce, signature=server_signature
+        )
+
+        self.logger.info(f"verified server identity '{expected_host}'")
+        return server_nonce
+
     def client_registration(self, client_name, project_name, fl_ctx: FLContext):
-        """Client's metadata used to authenticate and communicate.
+        """Register the client with the FLARE Server.
+        Note that the client no longer needs to be directly connected with the Server!
+        Since the client may be connected with the Server indirectly (e.g. via bridge nodes or proxy), in the secure
+        mode, the client authentication cannot be based on the connection's TLS cert. Instead, the server and the
+        client will explicitly authenticate each other using their provisioned PKI credentials, as follows:
+        1. Make sure that the Server is authentic. The client sends a Challenge request with a random nonce.
+        The server is expected to return the following in its reply:
+            - its cert and common name (Server_CN)
+            - signature on the received client nonce + Server_CN
+            - a random Server Nonce. This will be used for the server to validate the client's identity in the
+            Registration request.
+        The client then validates to make sure:
+            - the Server_CN is the same as presented in the server cert
+            - the Server_CN is the same as configured in the client's config (fed_client.json)
+            - the signature is valid
+        2. Client sends Registration request that contains:
+            - client cert and common name (Client_CN)
+            - signature on the received Server Nonce + Client_CN
+        The Server then validates to make sure:
+            - the Client_CN is the same as presented in the client cert
+            - the signature is valid
+        NOTE: we do not explicitly validate certs' expiration time. This is because currently the same certs are
+        also used for SSL connections, which already validate expiration.
 
         Args:
             client_name: client name
@@ -103,10 +174,58 @@ class Communicator:
             The client's token
 
         """
+        start = time.time()
+        while not self.cell:
+            self.logger.info("Waiting for the client cell to be created.")
+            if time.time() - start > 15.0:
+                raise RuntimeError("Client cell could not be created. Failed to login the client.")
+            time.sleep(0.5)
+
         local_ip = _get_client_ip()
         shareable = Shareable()
         shared_fl_ctx = gen_new_peer_ctx(fl_ctx)
         shareable.set_header(ServerCommandKey.PEER_FL_CONTEXT, shared_fl_ctx)
+
+        secure_mode = fl_ctx.get_prop(FLContextKey.SECURE_MODE, False)
+        if secure_mode:
+            # explicitly authenticate with the Server
+            expected_host = None
+            server_config = fl_ctx.get_prop(FLContextKey.SERVER_CONFIG)
+            if server_config:
+                server0 = server_config[0]
+                expected_host = server0.get("identity")
+
+            if not expected_host:
+                # the provision was done with an old version
+                # to be backward compatible, we expect the host to be the server host we connected to
+                # we get the host name from DataBus!
+                expected_host = get_scope_prop(scope_name=client_name, key=FLContextKey.SERVER_HOST_NAME)
+
+            if not expected_host:
+                raise RuntimeError("cannot determine expected_host")
+
+            client_config = fl_ctx.get_prop(FLContextKey.CLIENT_CONFIG)
+            if not client_config:
+                raise RuntimeError(f"missing {FLContextKey.CLIENT_CONFIG} in FL Context")
+            private_key_file = client_config.get(SecureTrainConst.PRIVATE_KEY)
+            cert_file = client_config.get(SecureTrainConst.SSL_CERT)
+            root_cert_file = client_config.get(SecureTrainConst.SSL_ROOT_CERT)
+
+            while True:
+                server_nonce = self._challenge_server(client_name, expected_host, root_cert_file)
+                if server_nonce is None and not self.should_stop:
+                    # retry
+                    self.logger.info(f"re-challenge after {self.client_register_interval} seconds")
+                    time.sleep(self.client_register_interval)
+                else:
+                    break
+
+            id_asserter = IdentityAsserter(private_key_file=private_key_file, cert_file=cert_file)
+            cn_signature = id_asserter.sign_common_name(nonce=server_nonce)
+            shareable[IdentityChallengeKey.CERT] = id_asserter.cert_data
+            shareable[IdentityChallengeKey.SIGNATURE] = cn_signature
+            shareable[IdentityChallengeKey.COMMON_NAME] = id_asserter.cn
+            self.logger.info(f"sent identity info for client {client_name}")
 
         headers = {
             CellMessageHeaderKeys.CLIENT_NAME: client_name,
@@ -115,18 +234,7 @@ class Communicator:
         }
         login_message = new_cell_message(headers, shareable)
 
-        start = time.time()
-        while not self.cell:
-            self.logger.info("Waiting for the client cell to be created.")
-            if time.time() - start > 15.0:
-                raise RuntimeError("Client cell could not be created. Failed to login the client.")
-            time.sleep(0.5)
-
-        while not self.cell.is_cell_connected(FQCN.ROOT_SERVER):
-            time.sleep(0.1)
-            if time.time() - start > 30.0:
-                raise FLCommunicationError("error:Could not connect to the server for client_registration.")
-
+        self.logger.info("Trying to register with server ...")
         while True:
             try:
                 result = self.cell.send_request(
@@ -137,9 +245,11 @@ class Communicator:
                     timeout=self.maint_msg_timeout,
                 )
                 return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
+                self.logger.info(f"register RC: {return_code}")
                 if return_code == ReturnCode.UNAUTHENTICATED:
-                    unauthenticated = result.get_header(MessageHeaderKey.ERROR)
-                    raise FLCommunicationError("error:client_registration " + unauthenticated)
+                    reason = result.get_header(MessageHeaderKey.ERROR)
+                    self.logger.error(f"registration rejected: {reason}")
+                    raise FLCommunicationError("error:client_registration " + reason)
 
                 token = result.get_header(CellMessageHeaderKeys.TOKEN)
                 ssid = result.get_header(CellMessageHeaderKeys.SSID)
@@ -149,6 +259,7 @@ class Communicator:
                     break
 
             except Exception as ex:
+                traceback.print_exc()
                 raise FLCommunicationError("error:client_registration", ex)
 
         return token, ssid

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -31,7 +31,6 @@ from nvflare.fuel.f3.cellnet.net_agent import NetAgent
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.utils.argument_utils import parse_vars
-from nvflare.private.defs import EngineConstant
 from nvflare.private.fed.utils.fed_utils import set_scope_prop
 from nvflare.security.logging import secure_format_exception
 
@@ -77,6 +76,7 @@ class FederatedClientBase:
 
         self.client_name = client_name
         self.token = None
+        self.token_signature = None
         self.ssid = None
         self.client_args = client_args
         self.servers = server_args
@@ -207,7 +207,7 @@ class FederatedClientBase:
             parent_url=parent_url,
         )
         self.cell.start()
-        self.communicator.cell = self.cell
+        self.communicator.set_cell(self.cell)
         self.net_agent = NetAgent(self.cell)
         mpm.add_cleanup_cb(self.net_agent.close)
         mpm.add_cleanup_cb(self.cell.stop)
@@ -250,10 +250,11 @@ class FederatedClientBase:
         """
         if not self.token:
             try:
-                self.token, self.ssid = self.communicator.client_registration(self.client_name, project_name, fl_ctx)
+                self.token, self.token_signature, self.ssid = self.communicator.client_registration(
+                    self.client_name, project_name, fl_ctx
+                )
                 if self.token is not None:
                     self.fl_ctx.set_prop(FLContextKey.CLIENT_NAME, self.client_name, private=False)
-                    self.fl_ctx.set_prop(EngineConstant.FL_TOKEN, self.token, private=False)
                     self.logger.info(
                         "Successfully registered client:{} for project {}. Token:{} SSID:{}".format(
                             self.client_name, project_name, self.token, self.ssid

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -32,6 +32,7 @@ from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.private.defs import EngineConstant
+from nvflare.private.fed.utils.fed_utils import set_scope_prop
 from nvflare.security.logging import secure_format_exception
 
 from .client_status import ClientStatus
@@ -151,6 +152,10 @@ class FederatedClientBase:
             server = self.servers[project_name].get("target")
             location = sp.name + ":" + sp.fl_port
             if server != location:
+                # The SP name is the server host name that we will connect to.
+                # Save this name for this client so that it can be checked by others
+                set_scope_prop(scope_name=self.client_name, value=sp.name, key=FLContextKey.SERVER_HOST_NAME)
+
                 self.servers[project_name]["target"] = location
                 self.sp_established = True
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import threading
 import time
-import uuid
 from abc import ABC, abstractmethod
 from threading import Lock
 from typing import Dict, List, Optional

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -601,6 +601,9 @@ class FederatedServer(BaseServer):
             return return_message
 
     def _get_id_asserter(self):
+        if not self.secure_train:
+            return None
+
         if not self.id_asserter:
             with self.engine.new_context() as fl_ctx:
                 server_config = fl_ctx.get_prop(FLContextKey.SERVER_CONFIG)
@@ -629,10 +632,14 @@ class FederatedServer(BaseServer):
 
     def sign_auth_token(self, client_name: str, token: str):
         id_asserter = self._get_id_asserter()
+        if not id_asserter:
+            return "NA"
         return id_asserter.sign(client_name + token, return_str=True)
 
     def verify_auth_token(self, client_name: str, token: str, signature):
         id_asserter = self._get_id_asserter()
+        if not id_asserter:
+            return True
         return id_asserter.verify_signature(client_name + token, signature)
 
     def _ready_for_registration(self, fl_ctx: FLContext):

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -390,6 +390,15 @@ class FederatedServer(BaseServer):
         reg_checker.start()
 
     def _add_auth_headers(self, message: Message):
+        """Add auth headers to the messages sent by the server to itself.
+        This is such that no one can fake a message to pretend it's from the server to the server.
+
+        Args:
+            message: the message for which to add the headers
+
+        Returns: None
+
+        """
         origin = message.get_header(MessageHeaderKey.ORIGIN)
         dest = message.get_header(MessageHeaderKey.DESTINATION)
         if origin == FQCN.ROOT_SERVER and dest == origin:
@@ -401,8 +410,16 @@ class FederatedServer(BaseServer):
             message.set_header(CellMessageHeaderKeys.TOKEN_SIGNATURE, self.my_own_token_signature)
 
     def _validate_auth_headers(self, message: Message):
+        """Validate auth headers from messages that go through the server.
+
+        Args:
+            message: the message to validate
+
+        Returns:
+
+        """
         headers = message.headers
-        self.logger.info(f"**** _validate_auth_headers: {headers=}")
+        self.logger.debug(f"**** _validate_auth_headers: {headers=}")
         topic = message.get_header(MessageHeaderKey.TOPIC)
         channel = message.get_header(MessageHeaderKey.CHANNEL)
 
@@ -410,7 +427,7 @@ class FederatedServer(BaseServer):
 
         if topic in [CellChannelTopic.Register, CellChannelTopic.Challenge] and channel == CellChannel.SERVER_MAIN:
             # skip: client not registered yet
-            self.logger.info(f"skip special message {topic=} {channel=}")
+            self.logger.debug(f"skip special message {topic=} {channel=}")
             return None
 
         client_name = message.get_header(CellMessageHeaderKeys.CLIENT_NAME)
@@ -437,7 +454,7 @@ class FederatedServer(BaseServer):
             return make_cellnet_reply(rc=F3ReturnCode.UNAUTHENTICATED)
 
         # all good
-        self.logger.info(f"auth valid from {origin}: {topic=} {channel=}")
+        self.logger.debug(f"auth valid from {origin}: {topic=} {channel=}")
         return None
 
     def _check_regs(self):

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -53,7 +53,14 @@ from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.network_utils import get_open_ports
 from nvflare.fuel.utils.zip_utils import zip_directory_to_bytes
 from nvflare.private.admin_defs import Message, MsgHeader
-from nvflare.private.defs import CellChannel, CellMessageHeaderKeys, RequestHeader, TrainingTopic, new_cell_message
+from nvflare.private.defs import (
+    AUTH_CLIENT_NAME_FOR_SJ,
+    CellChannel,
+    CellMessageHeaderKeys,
+    RequestHeader,
+    TrainingTopic,
+    new_cell_message,
+)
 from nvflare.private.fed.server.server_json_config import ServerJsonConfigurator
 from nvflare.private.fed.server.server_state import ServerState
 from nvflare.private.fed.utils.fed_utils import (
@@ -253,6 +260,11 @@ class ServerEngine(ServerEngineInternalSpec):
         for t in args.set:
             command_options += " " + t
 
+        # create token and signature for SJ
+        token = run_number  # use the run_number as the auth token
+        client_name = AUTH_CLIENT_NAME_FOR_SJ
+        signature = self.server.sign_auth_token(client_name, token)
+
         command = (
             sys.executable
             + " -m nvflare.private.fed.app.server.runner_process -m "
@@ -261,6 +273,8 @@ class ServerEngine(ServerEngineInternalSpec):
             + app_root
             + " -n "
             + str(run_number)
+            + " -ts "
+            + signature
             + " -p "
             + str(cell.get_internal_listener_url())
             + " -u "

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -21,7 +21,7 @@ import pkgutil
 import sys
 import warnings
 from logging.handlers import RotatingFileHandler
-from typing import List, Union
+from typing import Any, List, Union
 
 from nvflare.apis.app_validation import AppValidator
 from nvflare.apis.client import Client
@@ -33,12 +33,14 @@ from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.utils.decomposers import flare_decomposers
 from nvflare.apis.workspace import Workspace
 from nvflare.app_common.decomposers import common_decomposers
+from nvflare.fuel.data_event.data_bus import DataBus
 from nvflare.fuel.f3.stats_pool import CsvRecordHandler, StatsPoolManager
 from nvflare.fuel.sec.audit import AuditService
 from nvflare.fuel.sec.authz import AuthorizationService
 from nvflare.fuel.sec.security_content_service import LoadResult, SecurityContentService
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.fobs.fobs import register_custom_folder
+from nvflare.fuel.utils.validation_utils import check_str
 from nvflare.private.defs import RequestHeader, SSLConstants
 from nvflare.private.event import fire_event
 from nvflare.private.fed.utils.decomposers import private_decomposers
@@ -399,3 +401,34 @@ def add_custom_dir_to_path(app_custom_folder, new_env):
     sys_path = copy.copy(sys.path)
     sys_path.append(app_custom_folder)
     new_env[SystemVarName.PYTHONPATH] = os.pathsep.join(sys_path)
+
+
+def _scope_prop_key(scope_name: str, key: str):
+    return f"{scope_name}::{key}"
+
+
+def set_scope_prop(scope_name: str, key: str, value: Any):
+    """Save the specified property of the specified scope (globally).
+    Args:
+        scope_name: name of the scope
+        key: key of the property to be saved
+        value: value of property
+    Returns: None
+    """
+    check_str("scope_name", scope_name)
+    check_str("key", key)
+    data_bus = DataBus()
+    data_bus.put_data(_scope_prop_key(scope_name, key), value)
+
+
+def get_scope_prop(scope_name: str, key: str) -> Any:
+    """Get the value of a specified property from the specified scope.
+    Args:
+        scope_name: name of the scope
+        key: key of the scope
+    Returns:
+    """
+    check_str("scope_name", scope_name)
+    check_str("key", key)
+    data_bus = DataBus()
+    return data_bus.get_data(_scope_prop_key(scope_name, key))

--- a/nvflare/private/fed/utils/identity_utils.py
+++ b/nvflare/private/fed/utils/identity_utils.py
@@ -67,8 +67,19 @@ class IdentityAsserter:
         self.cert = load_cert_bytes(self.cert_data)
         self.cn = get_cn_from_cert(self.cert)
 
-    def sign_common_name(self, nonce: str) -> str:
+    def sign_common_name(self, nonce: str):
         return sign_content(self.cn + nonce, self.pri_key, return_str=False)
+
+    def sign(self, content, return_str: bool) -> str:
+        return sign_content(content, self.pri_key, return_str=return_str)
+
+    def verify_signature(self, content, signature) -> bool:
+        pub_key = self.cert.public_key()
+        try:
+            verify_content(content=content, signature=signature, public_key=pub_key)
+            return True
+        except Exception:
+            return False
 
 
 class IdentityVerifier:

--- a/nvflare/private/fed/utils/identity_utils.py
+++ b/nvflare/private/fed/utils/identity_utils.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cryptography.x509.oid import NameOID
+
+from nvflare.lighter.utils import (
+    load_crt,
+    load_crt_bytes,
+    load_private_key_file,
+    sign_content,
+    verify_cert,
+    verify_content,
+)
+from nvflare.security.logging import secure_format_exception
+
+
+class CNMismatch(Exception):
+    pass
+
+
+class MissingCN(Exception):
+    pass
+
+
+class InvalidAsserterCert(Exception):
+    pass
+
+
+class InvalidCNSignature(Exception):
+    pass
+
+
+def get_cn_from_cert(cert):
+    subject = cert.subject
+    attr = subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    if not attr:
+        raise MissingCN()
+    return attr[0].value
+
+
+def load_cert_file(path: str):
+    return load_crt(path)
+
+
+def load_cert_bytes(data: bytes):
+    return load_crt_bytes(data)
+
+
+class IdentityAsserter:
+    def __init__(self, private_key_file: str, cert_file: str):
+        with open(cert_file, "rb") as f:
+            self.cert_data = f.read()
+        self.private_key_file = private_key_file
+        self.pri_key = load_private_key_file(private_key_file)
+        self.cert_file = cert_file
+        self.cert = load_cert_bytes(self.cert_data)
+        self.cn = get_cn_from_cert(self.cert)
+
+    def sign_common_name(self, nonce: str) -> str:
+        return sign_content(self.cn + nonce, self.pri_key, return_str=False)
+
+
+class IdentityVerifier:
+    def __init__(self, root_cert_file: str):
+        self.root_cert = load_cert_file(root_cert_file)
+        self.root_public_key = self.root_cert.public_key()
+
+    def verify_common_name(self, asserted_cn: str, nonce: str, asserter_cert, signature) -> bool:
+        # verify asserter_cert
+        try:
+            verify_cert(
+                cert_to_be_verified=asserter_cert,
+                root_ca_public_key=self.root_public_key,
+            )
+        except:
+            raise InvalidAsserterCert()
+
+        # verify signature provided by the asserter
+        asserter_public_key = asserter_cert.public_key()
+        cn = get_cn_from_cert(asserter_cert)
+
+        if cn != asserted_cn:
+            raise CNMismatch()
+
+        assert isinstance(cn, str)
+        try:
+            verify_content(content=cn + nonce, signature=signature, public_key=asserter_public_key)
+        except Exception as ex:
+            raise InvalidCNSignature(f"cannot verify common name signature: {secure_format_exception(ex)}")
+        return True


### PR DESCRIPTION
Fixes # .

### Description

Currently Flare's message security comes from mutual TLS: server and client authenticate each other when making connections. This means that only clients that have the right startup kits can make a connection to the server. 

The requirement of one-way SSL between the server and clients breaks this assumption: the server could be exposed to the internet and any one could write a client to connect to the server. To ensure message security, explicit message authentication is required.

This PR implements message authentication: messages received by the server must have an auth token, and the token must be validated successfully to prove that it was issued by the server!

Here is how it works:
- The client first tries to login to the server. The server/client authenticate each other explicitly with the credentials in their startup kits. This step is independent of how client/server is connected.
- If the client credential is validated correctly, the server issues a token and a signature that binds the client name and token together.  The signature is generated with the server's private key to prove that the signature can only be issued by the server.
- When sending a message to the server, the client adds the its client name, token and the signature as headers to the message.
- When the message is received, the server validates the token and the signature. Messages that are missing these headers or fail to validate will be rejected.

Note that this mechanism is based the security of the startup kits. All sites must protect their startup kits securely.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
