### PR TITLE
[2.5] Support connection security for cell pipe

### DIFF
--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -15,7 +15,7 @@
 import os
 from typing import Optional
 
-from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.fl_constant import FLMetaKey, SecureTrainConst
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.executors.launcher_executor import LauncherExecutor
@@ -137,6 +137,10 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             FLMetaKey.AUTH_TOKEN: auth_token,
             FLMetaKey.AUTH_TOKEN_SIGNATURE: signature,
         }
+
+        conn_sec = get_scope_property(site_name, SecureTrainConst.CONNECTION_SECURITY)
+        if conn_sec:
+            config_data[SecureTrainConst.CONNECTION_SECURITY] = conn_sec
 
         config_file_path = self._get_external_config_file_path(fl_ctx)
         write_config_to_file(config_data=config_data, config_file_path=config_file_path)

--- a/nvflare/client/config.py
+++ b/nvflare/client/config.py
@@ -16,7 +16,7 @@ import json
 import os
 from typing import Dict, Optional
 
-from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.fl_constant import FLMetaKey, SecureTrainConst
 from nvflare.fuel.utils.config_factory import ConfigFactory
 
 
@@ -164,6 +164,9 @@ class ClientConfig:
 
     def get_auth_token_signature(self):
         return self.config.get(FLMetaKey.AUTH_TOKEN_SIGNATURE)
+
+    def get_connection_security(self):
+        return self.config.get(SecureTrainConst.CONNECTION_SECURITY)
 
     def to_json(self, config_file: str):
         with open(config_file, "w") as f:

--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -17,7 +17,7 @@ import os
 from typing import Any, Dict, Optional, Tuple
 
 from nvflare.apis.analytix import AnalyticsDataType
-from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.fl_constant import FLMetaKey, SecureTrainConst
 from nvflare.apis.utils.analytix_utils import create_analytic_dxo
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.client.api_spec import APISpec
@@ -45,6 +45,11 @@ def _create_client_config(config: str) -> ClientConfig:
     site_name = client_config.get_site_name()
     set_scope_property(scope_name=site_name, key=FLMetaKey.AUTH_TOKEN, value=auth_token)
     set_scope_property(scope_name=site_name, key=FLMetaKey.AUTH_TOKEN_SIGNATURE, value=signature)
+
+    conn_sec = client_config.get_connection_security()
+    if conn_sec:
+        set_scope_property(site_name, SecureTrainConst.CONNECTION_SECURITY, conn_sec)
+
     return client_config
 
 

--- a/nvflare/fuel/utils/pipe/cell_pipe.py
+++ b/nvflare/fuel/utils/pipe/cell_pipe.py
@@ -18,7 +18,7 @@ import threading
 import time
 from typing import Tuple, Union
 
-from nvflare.apis.fl_constant import CellMessageAuthHeaderKey, FLMetaKey, SystemVarName
+from nvflare.apis.fl_constant import CellMessageAuthHeaderKey, FLMetaKey, SecureTrainConst, SystemVarName
 from nvflare.fuel.data_event.utils import get_scope_property
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.cell import Message as CellMessage
@@ -148,6 +148,10 @@ class CellPipe(Pipe):
                     credentials = {
                         DriverParams.CA_CERT.value: root_cert_path,
                     }
+
+                    conn_sec = get_scope_property(site_name, SecureTrainConst.CONNECTION_SECURITY)
+                    if conn_sec:
+                        credentials[DriverParams.CONNECTION_SECURITY.value] = conn_sec
 
                 cell = Cell(
                     fqcn=_cell_fqcn(mode, site_name, token),

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -196,6 +196,7 @@ class FederatedClientBase:
             conn_security = self.client_args.get(SecureTrainConst.CONNECTION_SECURITY)
             if conn_security:
                 credentials[DriverParams.CONNECTION_SECURITY.value] = conn_security
+                set_scope_prop(self.client_name, SecureTrainConst.CONNECTION_SECURITY, conn_security)
         else:
             credentials = {}
         self.cell = Cell(


### PR DESCRIPTION
Fixes # .

### Description

This PR adds support of Connection Security (TLS, mTLS, Clear) to Cell Pipe. This is necessary to ensure that client API based cells can connect to the server properly.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
