### PR TITLE
Keep project_name shorter than the limit

### DIFF
--- a/nvflare/lighter/provision.py
+++ b/nvflare/lighter/provision.py
@@ -145,6 +145,7 @@ def prepare_project(project_dict, add_user_file_path=None, add_client_file_path=
     if len(project_name) > 63:
         print(f"Project name {project_name} is longer than 63.  Will truncate it to {project_name[:63]}.")
         project_name = project_name[:63]
+        project_dict[PropKey.NAME] = project_name
     project_description = project_dict.get(PropKey.DESCRIPTION, "")
     project = Project(name=project_name, description=project_description, props=project_dict)
     participant_defs = project_dict.get("participants")

--- a/nvflare/lighter/provision.py
+++ b/nvflare/lighter/provision.py
@@ -142,6 +142,9 @@ def prepare_project(project_dict, add_user_file_path=None, add_client_file_path=
     if api_version not in [3]:
         raise ValueError(f"API version expected 3 but found {api_version}")
     project_name = project_dict.get(PropKey.NAME)
+    if len(project_name) > 63:
+        print(f"Project name {project_name} is longer than 63.  Will truncate it to {project_name[:63]}.")
+        project_name = project_name[:63]
     project_description = project_dict.get(PropKey.DESCRIPTION, "")
     project = Project(name=project_name, description=project_description, props=project_dict)
     participant_defs = project_dict.get("participants")


### PR DESCRIPTION
Fixes #3093 .

### Description

When project_name in project.yml is longer than 64, generating the root CA cert fails due to CN field limit.  This PR truncates the project_name so it will not be longer than 64.  A friendly message is shown during provisioning if this happens. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
