### PR TITLE
Fix external lib issue when used for pytorch with numpy exchange

### DIFF
--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -26,7 +26,6 @@ from nvflare.client.constants import CLIENT_API_CONFIG
 from nvflare.client.flare_agent import FlareAgentException
 from nvflare.client.flare_agent_with_fl_model import FlareAgentWithFLModel
 from nvflare.client.model_registry import ModelRegistry
-from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.import_utils import optional_import
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.fuel.utils.pipe.pipe import Pipe
@@ -90,7 +89,7 @@ class ExProcessClientAPI(APISpec):
                     # import here, and register later when needed
                     _, ok = optional_import(module="nvflare.app_opt.pt.decomposers", name="TensorDecomposer")
                     if not ok:
-                        raise RuntimeError(f"Can't import TensorDecomposer")
+                        raise RuntimeError("Can't import TensorDecomposer")
 
                 pipe, task_channel_name = None, ""
                 if ConfigKey.TASK_EXCHANGE in client_config.config:

--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -93,7 +93,8 @@ class ExProcessClientAPI(APISpec):
         flare_agent = None
         try:
             if rank == "0":
-                if client_config.get_exchange_format() == ExchangeFormat.PYTORCH:
+                if client_config.get_exchange_format() in [ExchangeFormat.PYTORCH, ExchangeFormat.NUMPY]:
+                    # both numpy and pytorch exchange format can need tensor decomposer
                     _register_tensor_decomposer()
 
                 pipe, task_channel_name = None, ""


### PR DESCRIPTION
Fixes # .

### Description

One line code update to fix the `module 'nvflare' has no attribute 'app_opt'` error when using external process with numpy exchange format for pytorch

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
