### PR TITLE
Fixed the FOBS lazy loading issue

### DIFF
--- a/nvflare/fuel/utils/fobs/fobs.py
+++ b/nvflare/fuel/utils/fobs/fobs.py
@@ -66,15 +66,10 @@ def _get_type_name(cls: Type) -> str:
 
 def _load_class(type_name: str):
     try:
-        parts = type_name.split(".")
-        if len(parts) == 1:
-            parts = ["builtins", type_name]
+        module_name, class_name = type_name.rsplit('.', 1)
+        module = importlib.import_module(module_name)
 
-        mod = __import__(parts[0])
-        for comp in parts[1:]:
-            mod = getattr(mod, comp)
-
-        return mod
+        return getattr(module, class_name)
     except Exception as ex:
         raise TypeError(f"Can't load class {type_name}: {ex}")
 


### PR DESCRIPTION
### Description

FOBS class loader didn't handle lazy-loaded class correctly. So some class can't be found.
It's fixed by using importlib.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
