### PR TITLE
Remove the build folder for unit test to ensure correctness

### DIFF
--- a/tests/unit_test/app_common/executors/task_script_runner_test.py
+++ b/tests/unit_test/app_common/executors/task_script_runner_test.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
+import shutil
 import sys
 import unittest
 
@@ -26,6 +28,11 @@ class TestTaskScriptRunner(unittest.TestCase):
         file_dir = os.path.dirname(os.path.realpath(__file__))
         splits = file_dir.split(os.sep)
         self.nvflare_root = os.sep.join(splits[0:-4])
+        # sometimes a build dir is generated, we need to remove
+        # to ensure test correctness
+        build_dir = os.path.join(self.nvflare_root, "build")
+        if os.path.exists(build_dir):
+            shutil.rmtree(build_dir)
 
     def test_app_scripts_and_args(self):
         script_path = "nvflare/cli.py"


### PR DESCRIPTION
Fix the occasionally issue in TestTaskScriptRunner

### Description

Sometimes the unit test failed because there is a "build" dir, this will lead to test failure:
```
AssertionError: Lists differ: ['/ho[28 chars]VFlare-premerge/build/lib/nvflare/cli.py', '--batch_size', '4'] != ['/ho[28 chars]VFlare-premerge/nvflare/cli.py', '--batch_size', '4']
```

That build dir is generated by pip install and can be removed during the unit test phase to ensure correctness

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
