### PR TITLE
Add ignore_errors=True when trying to remove the build dir

### DIFF
--- a/tests/unit_test/app_common/executors/task_script_runner_test.py
+++ b/tests/unit_test/app_common/executors/task_script_runner_test.py
@@ -32,7 +32,7 @@ class TestTaskScriptRunner(unittest.TestCase):
         # to ensure test correctness
         build_dir = os.path.join(self.nvflare_root, "build")
         if os.path.exists(build_dir):
-            shutil.rmtree(build_dir)
+            shutil.rmtree(build_dir, ignore_errors=True)
 
     def test_app_scripts_and_args(self):
         script_path = "nvflare/cli.py"


### PR DESCRIPTION
### Description

The build directory sometimes is removed during the test is running,
right after the check "if os.path.exists(build_dir)", so we add "ignore_errors=True"

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
