### PR TITLE
Fix Brats18 readme typo [skip ci]

### DIFF
--- a/examples/advanced/brats18/README.md
+++ b/examples/advanced/brats18/README.md
@@ -30,8 +30,8 @@ First, we add the image and datalist directory roots to `config_train.json` file
 ```
 for alg in brats_central brats_fedavg brats_fedavg_dp
 do
-  sed -i "s|DATASET_ROOT|${PWD}/dataset_brats18/dataset|g" configs/${alg}/config/config_train.json
-  sed -i "s|DATALIST_ROOT|${PWD}/dataset_brats18/datalist|g" configs/${alg}/config/config_train.json
+  sed -i "s|DATASET_ROOT|${PWD}/dataset_brats18/dataset|g" configs/${alg}/app/config/config_train.json
+  sed -i "s|DATALIST_ROOT|${PWD}/dataset_brats18/datalist|g" configs/${alg}/app/config/config_train.json
 done
 ```
 


### PR DESCRIPTION
Fixes #3141 .

### Description
Typo in README

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
