### PR TITLE
[2.5] Fix flower app path

### DIFF
--- a/nvflare/app_opt/flower/applet.py
+++ b/nvflare/app_opt/flower/applet.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import time
 
 from nvflare.apis.fl_context import FLContext
@@ -57,6 +58,8 @@ class FlowerClientApplet(CLIApplet):
         job_id = fl_ctx.get_job_id()
         custom_dir = ws.get_app_custom_dir(job_id)
         app_dir = ws.get_app_dir(job_id)
+        if not os.path.isabs(custom_dir):
+            custom_dir = os.path.relpath(custom_dir, app_dir)
         cmd = f"flower-supernode --insecure --grpc-adapter --superlink {addr} {custom_dir}"
 
         # use app_dir as the cwd for flower's client app.


### PR DESCRIPTION
Fixes # .

### Description

Since the supernode is started with its current working directory set to the client app dir, if the custom directory is not an absolute path, it needs to be passed relative to the app dir.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
