### PR TITLE
[2.5] Remove hardcode heartbeat_timeout 0

### DIFF
--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -186,7 +186,6 @@ class BaseScriptRunner:
                     launcher_id=launcher_id,
                     params_exchange_format=self._params_exchange_format,
                     params_transfer_type=self._params_transfer_type,
-                    heartbeat_timeout=0,
                 )
             )
             job.add_executor(executor, tasks=tasks, ctx=ctx)


### PR DESCRIPTION

### Description

The original hardcode 0 has a problem, if the external user code has an exception and the program will never return.
Our FL client job process (running LauncherExecutor) will never ends.
By using the default heartbeat_timeout value, if the FL client job process does not receive the heartbeat from the user process for heartbeat_timeout seconds, then we will consider it dead.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
