### PR TITLE
Fixed the subprocess read deadlock

### DIFF
--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -18,14 +18,13 @@ import subprocess
 from threading import Thread
 from typing import Optional
 
-from nvflare.utils.job_launcher_utils import add_custom_dir_to_path
-
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.launcher import Launcher, LauncherRunStatus
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.utils.job_launcher_utils import add_custom_dir_to_path
 
 
 def get_line(buffer: bytearray):


### PR DESCRIPTION
This fixes the subprocess launcher deadlock issue caused by readline.

It's cherry-picked from 2.5 branch.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
