### PR TITLE
Fixed the filter bug that changes task data

### DIFF
--- a/nvflare/apis/impl/wf_comm_server.py
+++ b/nvflare/apis/impl/wf_comm_server.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import threading
 import time
 from threading import Lock
@@ -196,7 +197,10 @@ class WFCommServer(FLComponent, WFCommSpec):
         client_task_to_send = None
         with self._task_lock:
             self.logger.debug("self._tasks: {}".format(self._tasks))
-            for task in self._tasks:
+            for t in self._tasks:
+                task = copy.copy(t)
+                task.data = copy.deepcopy(t.data)
+
                 if task.completion_status is not None:
                     # this task is finished (and waiting for the monitor to exit it)
                     continue

--- a/nvflare/apis/impl/wf_comm_server.py
+++ b/nvflare/apis/impl/wf_comm_server.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import threading
 import time
 from threading import Lock
@@ -197,10 +196,7 @@ class WFCommServer(FLComponent, WFCommSpec):
         client_task_to_send = None
         with self._task_lock:
             self.logger.debug("self._tasks: {}".format(self._tasks))
-            for t in self._tasks:
-                task = copy.copy(t)
-                task.data = copy.deepcopy(t.data)
-
+            for task in self._tasks:
                 if task.completion_status is not None:
                     # this task is finished (and waiting for the monitor to exit it)
                     continue

--- a/nvflare/apis/utils/task_utils.py
+++ b/nvflare/apis/utils/task_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 
 from nvflare.apis.fl_constant import FilterKey, FLContextKey
 
@@ -29,6 +30,8 @@ def apply_filters(filters_name, filter_data, fl_ctx, config_filters, task_name, 
         filter_list.extend(task_filter_list)
 
     if filter_list:
+        # A deep copy is needed here to prevent filter from changing task data
+        filter_data = copy.deepcopy(filter_data)
         for f in filter_list:
             filter_data = f.process(filter_data, fl_ctx)
     return filter_data


### PR DESCRIPTION
When server filters are applied, it changes the task data on server. This causes the client get a different data on every GET_TASK.

Fixed the problem in wf_comm_server.py with a deep copy of the data.

The same problem may exist in other controllers.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
