### PR TITLE
update for flwr=1.16.0

### DIFF
--- a/examples/hello-world/hello-flower/flwr-pt-tb/flwr_pt_tb/client.py
+++ b/examples/hello-world/hello-flower/flwr-pt-tb/flwr_pt_tb/client.py
@@ -40,7 +40,9 @@ class FlowerClient(NumPyClient):
             self.set_step(0)
 
     def set_step(self, step: int):
-        self.flwr_context.state = RecordSet(metrics_records={"step": MetricsRecord({"step": step})})
+        record = RecordSet()
+        record["step"] = MetricsRecord({"step": step})
+        self.flwr_context.state = record
 
     def get_step(self):
         return int(self.flwr_context.state.metrics_records["step"]["step"])
@@ -81,13 +83,12 @@ app = ClientApp(
 )
 
 
-@app.enter()
-def enter(ctxt: Context) -> None:
+@app.lifespan()
+def lifespan(ctxt: Context) -> None:
     flare.init()
     print("ClientApp entering. Flare initialized.")
 
+    yield
 
-@app.exit()
-def exit(ctxt: Context) -> None:
     flare.shutdown()
     print("ClientApp exiting. Flare shutdown.")

--- a/examples/hello-world/hello-flower/job.py
+++ b/examples/hello-world/hello-flower/job.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from argparse import ArgumentParser
 
 from nvflare.app_opt.flower.flower_pt_job import FlowerPyTorchJob
@@ -43,7 +44,7 @@ def main():
     )
 
     job.export_job(args.export_dir)
-    job.simulator_run(args.workdir, gpu="0", n_clients=2)
+    job.simulator_run(os.path.join(args.workdir, job.name), gpu="0", n_clients=2)
 
 
 if __name__ == "__main__":

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -586,7 +586,7 @@ class SimulatorRunner(FLComponent):
     def dump_stats(self, workspace: Workspace):
         stats_dict = StatsPoolManager.to_dict()
         json_object = json.dumps(stats_dict, indent=4)
-        os.makedirs(os.path.join(workspace.get_root_dir(), POOL_STATS_DIR))
+        os.makedirs(os.path.join(workspace.get_root_dir(), POOL_STATS_DIR), exist_ok=True)
         file = os.path.join(workspace.get_root_dir(), POOL_STATS_DIR, SIMULATOR_POOL_STATS)
         with open(file, "w") as outfile:
             outfile.write(json_object)


### PR DESCRIPTION
Fixes # .

### Description

- Update examples for  flwr=1.16.0, use lifespan decorator and new record set.
- Fix simulator when stats pool dir exists.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
