### PR TITLE
Due to credential env var format change, the user prompt requires one

### DIFF
--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -54,10 +54,20 @@ def start(args):
                 print(f"Expecting an email address, but got one in an invalid format.  Reason: {reason}")
             else:
                 need_email = False
+        email = answer
+        need_org = True
+        while need_org:
+            answer = input("Please provide project admin organization name.\n")
+            error, reason = name_check(answer, "org")
+            if error:
+                print(f"Expecting an organization name, but got one in an invalid format.  Reason: {reason}")
+            else:
+                need_org = False
+        org_name = answer
         print("generating random password")
         pwd = utils.generate_password(8)
         print(f"Project admin credential is {answer} and the password is {pwd}")
-        environment.update({"NVFL_CREDENTIAL": f"{answer}:{pwd}"})
+        environment.update({"NVFL_CREDENTIAL": f"{email}:{pwd}:{org_name}"})
     if args.local:
         return start_local(environment)
     try:

--- a/nvflare/lighter/templates/aws_template.yml
+++ b/nvflare/lighter/templates/aws_template.yml
@@ -305,7 +305,9 @@ aws_start_dsb_sh: |
   echo "One initial user will be created when starting dashboard."
   echo "Please enter the email address for this user."
   read email
-  credential="${email}:$RANDOM"
+  echo "Please enter the organization name of this person."
+  read org_name
+  credential="${email}:$RANDOM:${org_name}"
 
   # Generate key pair
 

--- a/nvflare/lighter/templates/azure_template.yml
+++ b/nvflare/lighter/templates/azure_template.yml
@@ -374,7 +374,9 @@ azure_start_dsb_sh: |
   echo "One initial user will be created when starting dashboard."
   echo "Please enter the email address for this user."
   read email
-  credential="${email}:$RANDOM"
+  echo "Please enter the organization name of this person."
+  read org_name
+  credential="${email}:$RANDOM:${org_name}"
 
   az login --use-device-code -o none
   report_status "$?" "login"


### PR DESCRIPTION
more information during dashboard launch.  This PR fixes the issue with updated UI and logic.

### Description

Dashboard initial user (project admin) now requires organization name.  The env var `NVFL_CREDENTIAL` now has format as 'email:passowrd:org_name.'  All user facing operations requires to update to support this new format.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
