### PR TITLE
Fix job templates

### DIFF
--- a/docs/release_notes/flare_260.rst
+++ b/docs/release_notes/flare_260.rst
@@ -1,0 +1,21 @@
+**************************
+What's New in FLARE v2.6.0
+**************************
+
+
+**********************************
+Migration to 2.6.0: Notes and Tips
+**********************************
+
+
+For PTClientAPILauncherExecutor and PTInProcessClientAPIExecutor
+FLARE 2.6.0 introduces significant changes to the "params_exchange_format" argument in PTClientAPILauncherExecutor and PTInProcessClientAPIExecutor. These changes impact how data is exchanged between the client script and NVFlare.
+
+### Changes in params_exchange_format
+In previous versions, setting "params_exchange_format" to "pytorch" indicated that the client was using a PyTorch tensor on the third-party side. In this case, the tensor would be converted to a NumPy array before being sent back to NVFlare.
+
+With the improvements introduced in FLARE 2.6.0, which now natively support PyTorch tensors during transmission, the meaning of "params_exchange_format" = "pytorch" has changed. Now, this setting directly sends PyTorch tensors to NVFlare without converting them to NumPy arrays.
+
+### Action Required
+To maintain the previous behavior (where PyTorch tensors are converted to NumPy arrays), you will need to explicitly set "params_exchange_format" to "numpy".
+

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -4,7 +4,7 @@
 What's New
 ##########
 
-.. include:: release_notes/flare_250.rst
+.. include:: release_notes/flare_260.rst
 
 **************************
 Previous Releases of FLARE
@@ -13,6 +13,7 @@ Previous Releases of FLARE
 .. toctree::
    :maxdepth: 1
 
+   release_notes/flare_250
    release_notes/flare_240
    release_notes/flare_230
    release_notes/flare_220

--- a/job_templates/cyclic_cc_pt/config_fed_client.conf
+++ b/job_templates/cyclic_cc_pt/config_fed_client.conf
@@ -37,7 +37,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/cyclic_pt/config_fed_client.conf
+++ b/job_templates/cyclic_pt/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_cse_ccwf_pt/config_fed_client.conf
+++ b/job_templates/sag_cse_ccwf_pt/config_fed_client.conf
@@ -41,7 +41,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_gnn/app_1/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_1/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_gnn/app_2/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_2/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_nemo/app_1/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_1/config_fed_client.conf
@@ -35,7 +35,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_nemo/app_2/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_2/config_fed_client.conf
@@ -35,7 +35,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_nemo/app_3/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_3/config_fed_client.conf
@@ -35,7 +35,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt/config_fed_client.conf
+++ b/job_templates/sag_pt/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_deploy_map/app_1/config_fed_client.conf
+++ b/job_templates/sag_pt_deploy_map/app_1/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_deploy_map/app_2/config_fed_client.conf
+++ b/job_templates/sag_pt_deploy_map/app_2/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_he/config_fed_client.conf
+++ b/job_templates/sag_pt_he/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_mlflow/config_fed_client.conf
+++ b/job_templates/sag_pt_mlflow/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "pytorch"
+          params_exchange_format =  "numpy"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the


### PR DESCRIPTION
After https://github.com/NVIDIA/NVFlare/pull/3088 https://github.com/NVIDIA/NVFlare/pull/3115/
our params_exchange_format meaning changed a bit.
right now it means the exchange format between client script and NVFlare system.

### Description

Update the job_templates accordingly and add a migration doc

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
