### PR TITLE
[2.6] Fix SubprocessLauncher backward compatibility

### DIFF
--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -89,7 +89,7 @@ class SubprocessLauncher(Launcher):
         script: str,
         launch_once: Optional[bool] = True,
         clean_up_script: Optional[str] = None,
-        shutdown_timeout: Optional[float] = None,
+        shutdown_timeout: Optional[float] = 0.0,
     ):
         """Initializes the SubprocessLauncher.
 
@@ -98,7 +98,6 @@ class SubprocessLauncher(Launcher):
             launch_once (bool): Whether the external process will be launched only once at the beginning or on each task.
             clean_up_script (Optional[str]): Optional clean up script to be run after the main script execution.
             shutdown_timeout (float): If provided, will wait for this number of seconds before shutdown.
-                None means never times out.
         """
         super().__init__()
 

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -227,7 +227,6 @@ class BaseScriptRunner:
                 if self._launcher
                 else SubprocessLauncher(
                     script=self._command + " custom/" + self._script + " " + self._script_args,
-                    shutdown_timeout=0.0,
                 )
             )
             launcher_id = job.add_component("launcher", launcher, ctx)


### PR DESCRIPTION
Same as #3312
Default should be the same as previous behavior.
If users want to wait the external process to exit, they need to explicitly specify number of seconds to wait.
 
### Description
Change the default behavior back to the same as 2.5

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
