### PR TITLE
[2.6] Remove start_app command

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -230,7 +230,6 @@ class AdminCommandNames(object):
     DELETE_WORKSPACE = "delete_workspace"
     CHECK_RESOURCES = "check_resources"
     DEPLOY_APP = "deploy_app"
-    START_APP = "start_app"
     CHECK_STATUS = "check_status"
     ADMIN_CHECK_STATUS = "admin_check_status"
     ABORT = "abort"

--- a/nvflare/private/fed/client/client_req_processors.py
+++ b/nvflare/private/fed/client/client_req_processors.py
@@ -27,13 +27,11 @@ from .training_cmds import (  # StartClientMGpuProcessor,; SetRunNumberProcessor
     RestartClientProcessor,
     ScopeInfoProcessor,
     ShutdownClientProcessor,
-    StartAppProcessor,
 )
 
 
 class ClientRequestProcessors:
     request_processors = [
-        StartAppProcessor(),
         ClientStatusProcessor(),
         ScopeInfoProcessor(),
         AbortAppProcessor(),

--- a/nvflare/private/fed/client/training_cmds.py
+++ b/nvflare/private/fed/client/training_cmds.py
@@ -28,22 +28,6 @@ from nvflare.private.fed.client.client_engine_internal_spec import ClientEngineI
 from nvflare.private.fed.utils.fed_utils import get_scope_info
 
 
-class StartAppProcessor(RequestProcessor):
-    def get_topics(self) -> List[str]:
-        return [TrainingTopic.START]
-
-    def process(self, req: Message, app_ctx) -> Message:
-        engine = app_ctx
-        if not isinstance(engine, ClientEngineInternalSpec):
-            raise TypeError("engine must be ClientEngineInternalSpec, but got {}".format(type(engine)))
-
-        job_id = req.get_header(RequestHeader.JOB_ID)
-        result = engine.start_app(job_id)
-        if not result:
-            result = "OK"
-        return ok_reply(topic=f"reply_{req.topic}", body=result)
-
-
 class AbortAppProcessor(RequestProcessor):
     def get_topics(self) -> List[str]:
         return [TrainingTopic.ABORT]

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -19,9 +19,8 @@ import uuid
 from typing import Dict, List
 
 import nvflare.fuel.hci.file_transfer_defs as ftd
-from nvflare.apis.client import Client
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey, ReturnCode, RunProcessKey, ServerCommandKey
+from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey, ReturnCode, ServerCommandKey
 from nvflare.apis.job_def import Job, JobMetaKey, is_valid_job_id
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.shareable import Shareable

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -99,13 +99,6 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                     authz_func=self.authorize_configure_job_log,
                 ),
                 CommandSpec(
-                    name=AdminCommandNames.START_APP,
-                    description="start the FL app",
-                    usage=f"{AdminCommandNames.START_APP} job_id server|client|all",
-                    handler_func=self.start_app,
-                    authz_func=self.authorize_job,
-                ),
-                CommandSpec(
                     name=AdminCommandNames.LIST_JOBS,
                     description="list submitted jobs",
                     usage=f"{AdminCommandNames.LIST_JOBS} [-n name_prefix] [-d] [-u] [-r] [-m num_of_jobs] [job_id_prefix]",
@@ -255,71 +248,6 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             conn.append_error("syntax error: please provide job_id, target_type, and config")
             return PreAuthzReturnCode.ERROR
         return self.authorize_job(conn, args[:-1])
-
-    def _start_app_on_clients(self, conn: Connection, job_id: str) -> bool:
-        engine = conn.app_ctx
-        client_names = conn.get_prop(self.TARGET_CLIENT_NAMES, None)
-        run_process = engine.run_processes.get(job_id, {})
-        if not run_process:
-            conn.append_error(f"Job {job_id} is not running.")
-            return False
-
-        participants: Dict[str, Client] = run_process.get(RunProcessKey.PARTICIPANTS, {})
-        wrong_clients = []
-        for client in client_names:
-            client_valid = False
-            for _, p in participants.items():
-                if client == p.name:
-                    client_valid = True
-                    break
-            if not client_valid:
-                wrong_clients.append(client)
-
-        if wrong_clients:
-            display_clients = ",".join(wrong_clients)
-            conn.append_error(f"{display_clients} are not in the job running list.")
-            return False
-
-        err = engine.check_app_start_readiness(job_id)
-        if err:
-            conn.append_error(err)
-            return False
-
-        message = new_message(conn, topic=TrainingTopic.START, body="", require_authz=False)
-        message.set_header(RequestHeader.JOB_ID, job_id)
-        replies = self.send_request_to_clients(conn, message)
-        self.process_replies_to_table(conn, replies)
-        return True
-
-    def start_app(self, conn: Connection, args: List[str]):
-        engine = conn.app_ctx
-        if not isinstance(engine, ServerEngineInternalSpec):
-            raise TypeError("engine must be ServerEngineInternalSpec but got {}".format(type(engine)))
-
-        job_id = conn.get_prop(self.JOB_ID)
-        if len(args) < 3:
-            conn.append_error("Please provide the target name (client / all) for start_app command.")
-            return
-
-        target_type = args[2]
-        if target_type == self.TARGET_TYPE_SERVER:
-            # if not self._start_app_on_server(conn, job_id):
-            #     return
-            conn.append_error("start_app command only supports client app start.")
-            return
-        elif target_type == self.TARGET_TYPE_CLIENT:
-            if not self._start_app_on_clients(conn, job_id):
-                return
-        else:
-            # # all
-            # success = self._start_app_on_server(conn, job_id)
-            #
-            # if success:
-            client_names = conn.get_prop(self.TARGET_CLIENT_NAMES, None)
-            if client_names:
-                if not self._start_app_on_clients(conn, job_id):
-                    return
-        conn.append_success("")
 
     def delete_job_id(self, conn: Connection, args: List[str]):
         job_id = args[1]

--- a/nvflare/security/security.py
+++ b/nvflare/security/security.py
@@ -30,7 +30,6 @@ class CommandCategory(object):
 COMMAND_CATEGORIES = {
     AC.ABORT: CommandCategory.MANAGE_JOB,
     AC.ABORT_JOB: CommandCategory.MANAGE_JOB,
-    AC.START_APP: CommandCategory.MANAGE_JOB,
     AC.DELETE_JOB: CommandCategory.MANAGE_JOB,
     AC.DELETE_WORKSPACE: CommandCategory.MANAGE_JOB,
     AC.CONFIGURE_JOB_LOG: CommandCategory.MANAGE_JOB,


### PR DESCRIPTION
Fixes # .

### Description

This PR removes the obsolete start_app command. It is cherry-picked from commits of this PR: https://github.com/NVIDIA/NVFlare/pull/3313


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
