### PR TITLE
[2.6] Add preserve_path to job api

### DIFF
--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -208,6 +208,7 @@ class FedJob:
         obj: Any,
         target: str,
         id=None,
+        preserve_path: bool = True,
         **kwargs,
     ) -> Any:
         """Assign an object to the target. For end users.
@@ -216,6 +217,10 @@ class FedJob:
             obj: the object to be assigned
             target: the target that the object is assigned to
             id: the id of the object
+            preserve_path: if True, maintains the original directory structure when copying files
+                          (e.g., 'src/custom_enum.py' -> 'custom/src/custom_enum.py').
+                          if False, copies only the file without its path
+                          (e.g., 'src/custom_enum.py' -> 'custom/custom_enum.py').
             **kwargs: additional args to be passed to the object's add_to_fed_job method.
 
         If the obj provides the add_to_fed_job method, it will be called with the kwargs.
@@ -257,7 +262,10 @@ class FedJob:
             if os.path.isdir(obj):
                 app.add_external_dir(obj)
             else:
-                app.add_external_script(obj)
+                if preserve_path:
+                    app.add_external_script(obj)
+                else:
+                    app.add_file_source(obj)
             return None
 
         get_target_type_method = getattr(obj, "get_job_target_type", None)


### PR DESCRIPTION
When adding the custom_enums or custom_fobs, we want to add them directly inside the custom folder.
Previously, when user call 
```
job.to("src/custom_enum.py", "server")
```

The file will be put under "server/custom/src/custom_enum.py"

We want to enable a new way for them to put things directly inside "server/custom" so it will be picked up automatically.

### Description

Add a new argument "preserve_path" to control whether to add files directly under "custom" or not

New Usage:

```
    job.to("src/custom_enum.py", "server", preserve_path=False)
    job.to("src/custom_fobs.py", "server", preserve_path=False)
```

It will be put under "server/custom/custom_enum.py"

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
