### PR TITLE
[2.5] Add exit code when nvflare provision encounter exception

### DIFF
--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -191,6 +191,7 @@ def run(prog_name):
                 print(traceback.format_exc())
         else:
             print_help(prog_parser, sub_cmd, sub_cmd_parsers)
+        sys.exit(1)
 
 
 def print_help(prog_parser, sub_cmd, sub_cmd_parsers):


### PR DESCRIPTION
Fixes #3296

### Description

nvflare cli doesn't exit with none-zero code when subcommands raises exceptions.  This fixes such issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
