### PR TITLE
TF scaffold rm numerics check

### DIFF
--- a/nvflare/app_opt/tf/scaffold.py
+++ b/nvflare/app_opt/tf/scaffold.py
@@ -22,8 +22,6 @@ gpu_devices = tf.config.experimental.list_physical_devices("GPU")
 for device in gpu_devices:
     tf.config.experimental.set_memory_growth(device, True)
 
-tf.debugging.enable_check_numerics()
-
 
 def optimize_weights(model, c_delta_para_value):
     """


### PR DESCRIPTION
Fixes #3232.

### Description

TF scaffold rm numerics check as it causes compatibility issues with CUDA training in the scaffold example. This option is only relevant for debugging and can be safely removed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
