### PR TITLE
Separate STDERR from STDOUT in tie

### DIFF
--- a/nvflare/app_common/tie/process_mgr.py
+++ b/nvflare/app_common/tie/process_mgr.py
@@ -240,7 +240,7 @@ def run_command(cmd_desc: CommandDescriptor) -> str:
     command_seq = shlex.split(cmd_desc.cmd)
     p = subprocess.Popen(
         command_seq,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         cwd=cmd_desc.cwd,
         env=env,
         stdout=subprocess.PIPE,
@@ -249,10 +249,11 @@ def run_command(cmd_desc: CommandDescriptor) -> str:
     output = []
     while True:
         line = p.stdout.readline()
-        if not line:
+        # prevent blocking
+        stderr_line = p.stderr.readline()
+        if not line and not stderr_line:
             break
 
-        assert isinstance(line, bytes)
         line = line.decode("utf-8")
         output.append(line)
     return "".join(output)


### PR DESCRIPTION
### Issue

While testing the TIE + Flower job, I discovered that if the process outputs to STDERR, any attempt to use STDOUT for retrieving results fails when the two streams are mixed together.

For example: https://github.com/NVIDIA/NVFlare/blob/2.6/nvflare/app_opt/flower/applet.py#L225-L232


### Description

This PR separates STDERR from STDOUT to prevent mixing the two streams and ensure proper handling of the output.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
