### PR TITLE
Fix var substitution in config parsing

### DIFF
--- a/nvflare/fuel/utils/wfconf.py
+++ b/nvflare/fuel/utils/wfconf.py
@@ -126,7 +126,15 @@ class _EnvUpdater(JsonObjectProcessor):
                 # this is a single var without params
                 element = self.vars.get(var_name, None)
         else:
-            element = element.format(**self.vars)
+            # Treat the element as a string that may contain var replacements expressed within {}:
+            # For example: "{ROOT_DIR}"
+            # Such vars will be replaced with values defined in self.vars.
+            try:
+                element = element.format(**self.vars)
+            except:
+                # If the substitution fails, return the original value
+                element = original_value
+
         if element != original_value:
             self.num_updated += 1
         return element


### PR DESCRIPTION
Fixes # .

### Description

Currently we do var substitution for all string type arg values. If the value happens to contain curly brackets but content within the brackets is not a valid var name (as reported in https://github.com/NVIDIA/NVFlare/issues/3229), the substitution will fail.

This PR adds protection to the substitution: if it fails, the original value will be returned.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
