### PR TITLE
Fix azure start script generation in azure provision builder

### DIFF
--- a/nvflare/lighter/impl/azure.py
+++ b/nvflare/lighter/impl/azure.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nvflare.lighter.constants import ProvFileName, TemplateSectionKey
+from nvflare.lighter.constants import CtxKey, ProvFileName, TemplateSectionKey
 from nvflare.lighter.spec import Builder, Project, ProvisionContext
 
 
@@ -26,6 +26,8 @@ class AzureBuilder(Builder):
         # build server
         server = project.get_server()
         dest_dir = ctx.get_kit_dir(server)
+        admin_port = ctx.get(CtxKey.ADMIN_PORT)
+        fl_port = ctx.get(CtxKey.FED_LEARN_PORT)
         ctx.build_from_template(
             dest_dir=dest_dir,
             file_name=ProvFileName.AZURE_START_SH,
@@ -34,6 +36,20 @@ class AzureBuilder(Builder):
                 TemplateSectionKey.AZURE_START_SVR_HEADER_SH,
                 TemplateSectionKey.AZURE_START_COMMON_SH,
             ],
+            # use the server org for project.
+            replacement={
+                "admin_port": admin_port,
+                "fed_learn_port": fl_port,
+                "config_folder": "config",
+                "ha_mode": "false",
+                "docker_image": "nvflare/nvflare",
+                "org_name": "",
+                "type": "server",
+                "cln_uid": "",
+                "docker_network": "--network host",
+                "server_name": server.name,
+                "ORG": server.org,
+            },
             exe=True,
         )
 
@@ -47,5 +63,15 @@ class AzureBuilder(Builder):
                     TemplateSectionKey.AZURE_START_CLN_HEADER_SH,
                     TemplateSectionKey.AZURE_START_COMMON_SH,
                 ],
+                replacement={
+                    "client_name": participant.name,
+                    "config_folder": "config",
+                    "docker_image": "nvflare/nvflare",
+                    "org_name": participant.org,
+                    "type": "client",
+                    "cln_uid": f"uid={participant.name}",
+                    "docker_network": "",
+                    "ORG": participant.org,
+                },
                 exe=True,
             )


### PR DESCRIPTION
Fixes # .

### Description

Added missing replacement dict when generating start script with templates.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
