### PR TITLE
Use externalizer in FOBS

### DIFF
--- a/nvflare/fuel/utils/fobs/datum.py
+++ b/nvflare/fuel/utils/fobs/datum.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Any, Dict, Union
 
 TEN_MEGA = 10 * 1024 * 1024
+MIN_THRESHOLD = 1024
 
 
 class DatumType(Enum):
@@ -91,8 +92,8 @@ class DatumManager:
         if not isinstance(threshold, int):
             raise TypeError(f"threshold must be int but got {type(threshold)}")
 
-        if threshold <= 0:
-            raise ValueError(f"threshold must > 0 but got {threshold}")
+        if threshold < MIN_THRESHOLD:
+            raise ValueError(f"threshold must be at least {MIN_THRESHOLD} but got {threshold}")
 
         self.threshold = threshold
         self.datums: Dict[str, Datum] = {}

--- a/nvflare/fuel/utils/fobs/fobs.py
+++ b/nvflare/fuel/utils/fobs/fobs.py
@@ -24,7 +24,13 @@ import msgpack
 
 from nvflare.fuel.utils.class_loader import get_class_name, load_class
 from nvflare.fuel.utils.fobs.datum import DatumManager
-from nvflare.fuel.utils.fobs.decomposer import DataClassDecomposer, Decomposer, EnumTypeDecomposer
+from nvflare.fuel.utils.fobs.decomposer import (
+    DataClassDecomposer,
+    Decomposer,
+    EnumTypeDecomposer,
+    Externalizer,
+    Internalizer,
+)
 
 __all__ = [
     "register",
@@ -115,7 +121,8 @@ class Packer:
 
         decomposed = decomposer.decompose(obj, self.manager)
         if self.manager:
-            decomposed = self.manager.externalize(decomposed)
+            externalizer = Externalizer(self.manager)
+            decomposed = externalizer.externalize(decomposed)
 
         return {FOBS_TYPE: type_name, FOBS_DATA: decomposed, FOBS_DECOMPOSER: get_class_name(type(decomposer))}
 
@@ -151,7 +158,8 @@ class Packer:
 
         data = obj[FOBS_DATA]
         if self.manager:
-            data = self.manager.internalize(data)
+            internalizer = Internalizer(self.manager)
+            data = internalizer.internalize(data)
 
         decomposer = _decomposers[type_name]
         return decomposer.recompose(data, self.manager)

--- a/tests/unit_test/apis/utils/decomposers/flare_decomposers_test.py
+++ b/tests/unit_test/apis/utils/decomposers/flare_decomposers_test.py
@@ -72,7 +72,7 @@ class TestFlareDecomposers:
             "zb": b"123456789012345678901234567890123456789012345678",
             "zc": "中文字母测试两岸猿声啼不住轻舟已过万重山:;.'[]{}`~<>!@#$%^&*()-_+=",
         }
-        ds = fobs.dumps(d, max_value_size=10)
+        ds = fobs.dumps(d, max_value_size=1024)
         dd = fobs.loads(ds)
         assert d == dd
 
@@ -91,7 +91,7 @@ class TestFlareDecomposers:
 
         with tempfile.TemporaryDirectory() as td:
             file_path = os.path.join(td, str(uuid.uuid4()))
-            fobs.dumpf(d, file_path, max_value_size=15)
+            fobs.dumpf(d, file_path, max_value_size=1024)
             df = fobs.loadf(file_path)
             assert df == d
 
@@ -136,7 +136,7 @@ class TestFlareDecomposers:
         d2 = DXO(data_kind=DataKind.WEIGHTS, data={"x": 3, "y": os.urandom(100)})
 
         d = DXO(data_kind=DataKind.COLLECTION, data={"x": d1, "y": d2})
-        ds = fobs.dumps(d, max_value_size=20)
+        ds = fobs.dumps(d, max_value_size=1024)
         dd = fobs.loads(ds)
         dd1 = dd.data["x"]
         dd2 = dd.data["y"]
@@ -150,7 +150,7 @@ class TestFlareDecomposers:
             data={"x": 1, "y": os.urandom(200), "z": "中文字母测试两岸猿声啼不住轻舟已过万重山"},
         )
         s1 = dxo.to_shareable()
-        ds = fobs.dumps(s1, max_value_size=15)
+        ds = fobs.dumps(s1, max_value_size=1024)
         s2 = fobs.loads(ds)
         dxo2 = from_shareable(s2)
         self._dxo_equal(dxo, dxo2)
@@ -228,5 +228,5 @@ class TestFlareDecomposers:
 
     @staticmethod
     def _run_fobs(data: Any) -> Any:
-        buf = fobs.dumps(data, max_value_size=15)
+        buf = fobs.dumps(data, max_value_size=1024)
         return fobs.loads(buf)

--- a/tests/unit_test/app_common/decomposers/common_decomposers_test.py
+++ b/tests/unit_test/app_common/decomposers/common_decomposers_test.py
@@ -65,7 +65,7 @@ class TestCommonDecomposers:
         model_learnable["B"] = 456
         s = Shareable()
         s["model"] = model_learnable
-        ds = fobs.dumps(s, max_value_size=20)
+        ds = fobs.dumps(s, max_value_size=1024)
         s2 = fobs.loads(ds)
         assert s == s2
 


### PR DESCRIPTION
### Description

Changed FOBS to use externalizer to handle larger than 4GB items in dict.

Cherry-picked from 2.6.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
