### PR TITLE
[2.6] Added error handling in file streaming tool

### DIFF
--- a/nvflare/fuel/f3/streaming/tools/README.md
+++ b/nvflare/fuel/f3/streaming/tools/README.md
@@ -1,15 +1,12 @@
 # Streaming API Testing Tools
 
-The following command line tools are provided to test the streaming API.
-
-There are 2 sets of tools:
-1. sender.py/receiver.py: Those can be used to send a memory buffer to the remote cell. The memory buffer size must
-   fit in the memory.
-2. file_sender.py/file_receiver.py: This uses StreamCell to send/receive files. This can be used to send 
-   files of any size, as long as receiving end has enough disk space.
-
+The following command line tools are not part of the F3 streaming library. 
+They are provided to test the streaming API.
 
 ## Sending a memory buffer
+
+sender.py/receiver.py can be used to send a memory buffer to the remote cell. 
+The memory buffer size must fit in the memory.
 
 Starting receiver side first:
 
@@ -18,6 +15,8 @@ Starting receiver side first:
 Starting sender on the same or different machine:
 
      python sender.py grpc://192.168.1.2:1234 -s 100000000
+
+where `-s` is the buffer size in bytes.
 
 ## Sending a file
 

--- a/nvflare/private/stream_runner.py
+++ b/nvflare/private/stream_runner.py
@@ -439,8 +439,10 @@ class ObjectStreamer(FLComponent):
                 # this is end of the streaming
                 if abort_signal and abort_signal.triggered:
                     rc = ReturnCode.TASK_ABORTED
-                else:
+                elif result:
                     rc = ReturnCode.OK
+                else:
+                    rc = ReturnCode.ERROR
                 self._notify_abort_streaming(targets, tx_id, secure, fl_ctx)
                 self.logger.debug(f"Done streaming: {rc}")
                 return rc, result

--- a/tests/tools/file_streaming/app/config/config_fed_client.json
+++ b/tests/tools/file_streaming/app/config/config_fed_client.json
@@ -18,7 +18,8 @@
       "id": "sender",
       "path": "file_streaming.FileSender",
       "args": {
-        "file_name": "/tmp/data/test.data"
+        "file_name": "/tmp/data/test.data",
+        "timeout": 10.0
       }
     }
   ]


### PR DESCRIPTION
### Description

1. Added timeout parameter to the file streaming testing job
2. Fixed some problem in error handling in streaming code.
3. Cleaned up README to remove reference to file_sender.py/file_receiver.py

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
