### PR TITLE
[2.6] Refactor ScriptRunner and auto register TensorDecomposer

### DIFF
--- a/examples/hello-world/ml-to-fl/np/np_client_api_job.py
+++ b/examples/hello-world/ml-to-fl/np/np_client_api_job.py
@@ -18,7 +18,7 @@ from nvflare import FedJob
 from nvflare.app_common.np.np_model_persistor import NPModelPersistor
 from nvflare.app_common.workflows.fedavg import FedAvg
 from nvflare.app_opt.tracking.mlflow.mlflow_receiver import MLflowReceiver
-from nvflare.job_config.script_runner import ExchangeFormat, ScriptRunner
+from nvflare.job_config.script_runner import ScriptRunner
 
 
 def define_parser():
@@ -26,7 +26,7 @@ def define_parser():
     parser.add_argument("--n_clients", type=int, default=2)
     parser.add_argument("--num_rounds", type=int, default=5)
     parser.add_argument("--script", type=str, default="src/train_full.py")
-    parser.add_argument("--launch_process", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--launch_external_process", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--export_config", action=argparse.BooleanOptionalAction, default=False)
 
     return parser.parse_args()
@@ -39,7 +39,7 @@ def main():
     n_clients = args.n_clients
     num_rounds = args.num_rounds
     script = args.script
-    launch_process = args.launch_process
+    launch_external_process = args.launch_external_process
     export_config = args.export_config
 
     job = FedJob(name="np_client_api")
@@ -67,9 +67,7 @@ def main():
 
     executor = ScriptRunner(
         script=script,
-        launch_external_process=launch_process,
-        server_expected_format=ExchangeFormat.NUMPY,
-        script_expected_format=ExchangeFormat.NUMPY,
+        launch_external_process=launch_external_process,
     )
     job.to_clients(executor)
 

--- a/examples/hello-world/ml-to-fl/pt/pt_client_api_job.py
+++ b/examples/hello-world/ml-to-fl/pt/pt_client_api_job.py
@@ -18,7 +18,7 @@ from src.lit_net import LitNet
 from src.net import Net
 
 from nvflare.app_opt.pt.job_config.fed_avg import FedAvgJob
-from nvflare.job_config.script_runner import ExchangeFormat, ScriptRunner
+from nvflare.job_config.script_runner import ScriptRunner
 
 
 def define_parser():
@@ -61,8 +61,6 @@ def main():
             script=script,
             launch_external_process=launch_external_process,
             command=launch_command.replace("{PORT}", ports[i]),
-            server_expected_format=ExchangeFormat.NUMPY,
-            script_expected_format=ExchangeFormat.PYTORCH,
         )
         job.to(executor, f"site-{i + 1}")
 

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -590,7 +590,7 @@ class ConnectionSecurity:
     MTLS = "mtls"
 
 
-class ExchangeFormat:
+class ParamFormat:
     RAW = "raw"
     PYTORCH = "pytorch"
     NUMPY = "numpy"

--- a/nvflare/app_common/decomposers/common_decomposers.py
+++ b/nvflare/app_common/decomposers/common_decomposers.py
@@ -23,6 +23,7 @@ from nvflare.app_common.widgets.event_recorder import _CtxPropReq, _EventReq, _E
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.fobs.datum import DatumManager
 from nvflare.fuel.utils.fobs.decomposer import DictDecomposer, Externalizer, Internalizer
+from nvflare.fuel.utils.import_utils import optional_import
 
 
 class FLModelDecomposer(fobs.Decomposer):
@@ -61,6 +62,11 @@ class FLModelDecomposer(fobs.Decomposer):
 def register():
     if register.registered:
         return
+
+    # auto-register TensorDecomposer
+    tensor_decomposer, ok = optional_import(module="nvflare.app_opt.pt.decomposers", name="TensorDecomposer")
+    if ok:
+        fobs.register(tensor_decomposer)
 
     fobs.register(DictDecomposer(Learnable))
     fobs.register(DictDecomposer(ModelLearnable))

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -15,7 +15,6 @@
 import os
 from typing import Optional
 
-from nvflare.apis.fl_constant import ExchangeFormat
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.executors.launcher_executor import LauncherExecutor
@@ -44,7 +43,6 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         train_task_name: str = AppConstants.TASK_TRAIN,
         evaluate_task_name: str = AppConstants.TASK_VALIDATION,
         submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
-        script_expected_format: str = ExchangeFormat.NUMPY,
         config_file_name: str = CLIENT_API_CONFIG,
     ) -> None:
         """Initializes the ClientAPILauncherExecutor.
@@ -67,7 +65,6 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             train_task_name (str): Task name of train mode.
             evaluate_task_name (str): Task name of evaluate mode.
             submit_model_task_name (str): Task name of submit_model mode.
-            script_expected_format (str): What format to exchange the parameters.
             config_file_name (str): The config file name to write attributes into, the client api will read in this file.
         """
         LauncherExecutor.__init__(
@@ -90,7 +87,6 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             submit_model_task_name=submit_model_task_name,
         )
 
-        self._script_expected_format = script_expected_format
         self._config_file_name = config_file_name
 
     def initialize(self, fl_ctx: FLContext) -> None:
@@ -101,7 +97,6 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         pipe_export_class, pipe_export_args = self.pipe.export(ExportMode.PEER)
         task_exchange_attributes = {
             ConfigKey.TRAIN_WITH_EVAL: self._train_with_evaluation,
-            ConfigKey.EXCHANGE_FORMAT: self._script_expected_format,
             ConfigKey.TRAIN_TASK_NAME: self._train_task_name,
             ConfigKey.EVAL_TASK_NAME: self._evaluate_task_name,
             ConfigKey.SUBMIT_MODEL_TASK_NAME: self._submit_model_task_name,

--- a/nvflare/app_common/executors/in_process_client_api_executor.py
+++ b/nvflare/app_common/executors/in_process_client_api_executor.py
@@ -19,7 +19,7 @@ from typing import Optional
 from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE
 from nvflare.apis.event_type import EventType
 from nvflare.apis.executor import Executor
-from nvflare.apis.fl_constant import ExchangeFormat, FLContextKey, FLMetaKey, ReturnCode
+from nvflare.apis.fl_constant import FLContextKey, FLMetaKey, ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.signal import Signal
@@ -50,7 +50,6 @@ class InProcessClientAPIExecutor(Executor):
         task_wait_time: Optional[float] = None,
         result_pull_interval: float = 0.5,
         log_pull_interval: Optional[float] = None,
-        script_expected_format: str = ExchangeFormat.NUMPY,
         train_with_evaluation: bool = False,
         train_task_name: str = AppConstants.TASK_TRAIN,
         evaluate_task_name: str = AppConstants.TASK_VALIDATION,
@@ -61,7 +60,6 @@ class InProcessClientAPIExecutor(Executor):
         self._client_api = None
         self._result_pull_interval = result_pull_interval
         self._log_pull_interval = log_pull_interval
-        self._script_expected_format = script_expected_format
 
         if not task_script_path or not task_script_path.endswith(".py"):
             raise ValueError(f"invalid task_script_path '{task_script_path}'")
@@ -170,7 +168,6 @@ class InProcessClientAPIExecutor(Executor):
             ConfigKey.TASK_NAME: task_name,
             ConfigKey.TASK_EXCHANGE: {
                 ConfigKey.TRAIN_WITH_EVAL: self._train_with_evaluation,
-                ConfigKey.EXCHANGE_FORMAT: self._script_expected_format,
                 ConfigKey.TRAIN_TASK_NAME: self._train_task_name,
                 ConfigKey.EVAL_TASK_NAME: self._evaluate_task_name,
                 ConfigKey.SUBMIT_MODEL_TASK_NAME: self._submit_model_task_name,

--- a/nvflare/client/api_context.py
+++ b/nvflare/client/api_context.py
@@ -17,10 +17,12 @@ import os
 from enum import Enum
 from typing import Optional
 
+from nvflare.apis.utils.decomposers import flare_decomposers
+from nvflare.app_common.decomposers import common_decomposers
+from nvflare.client.api_spec import CLIENT_API_KEY, CLIENT_API_TYPE_KEY, APISpec
 from nvflare.client.constants import CLIENT_API_CONFIG
 from nvflare.fuel.data_event.data_bus import DataBus
 
-from .api_spec import CLIENT_API_KEY, CLIENT_API_TYPE_KEY, APISpec
 from .ex_process.api import ExProcessClientAPI
 from .in_process.api import InProcessClientAPI
 
@@ -60,4 +62,6 @@ class APIContext:
                 raise RuntimeError(f"api {api} is not a valid InProcessClientAPI")
             return api
         else:
+            flare_decomposers.register()
+            common_decomposers.register()
             return ExProcessClientAPI(config_file=self.config_file)

--- a/nvflare/client/config.py
+++ b/nvflare/client/config.py
@@ -21,7 +21,6 @@ from nvflare.fuel.utils.config_factory import ConfigFactory
 
 
 class ConfigKey:
-    EXCHANGE_FORMAT = "exchange_format"
     TRAIN_WITH_EVAL = "train_with_eval"
     TRAIN_TASK_NAME = "train_task_name"
     EVAL_TASK_NAME = "eval_task_name"
@@ -44,7 +43,6 @@ class ClientConfig:
 
         .. code-block::
 
-            EXCHANGE_FORMAT: Format to exchange.
             TRAIN_WITH_EVAL: Whether train task needs to also do evaluation
             TRAIN_TASK_NAME: Name of the train task
             EVAL_TASK_NAME: Name of the evaluate task
@@ -82,7 +80,6 @@ class ClientConfig:
               "JOB_ID": "simulate_job",
               "TASK_EXCHANGE": {
                 "train_with_eval": true,
-                "exchange_format": "numpy",
                 "train_task_name": "train",
                 "eval_task_name": "validate",
                 "submit_model_task_name": "submit_model",
@@ -119,9 +116,6 @@ class ClientConfig:
 
     def get_pipe_class(self, section: str) -> str:
         return self.config[section][ConfigKey.PIPE][ConfigKey.CLASS_NAME]
-
-    def get_exchange_format(self) -> str:
-        return self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(ConfigKey.EXCHANGE_FORMAT, "")
 
     def get_train_task(self):
         return self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(ConfigKey.TRAIN_TASK_NAME, "")

--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -17,7 +17,7 @@ import os
 from typing import Any, Dict, Optional, Tuple
 
 from nvflare.apis.analytix import AnalyticsDataType
-from nvflare.apis.fl_constant import ConnPropKey, ExchangeFormat, FLMetaKey
+from nvflare.apis.fl_constant import ConnPropKey, FLMetaKey
 from nvflare.apis.utils.analytix_utils import create_analytic_dxo
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.client.api_spec import APISpec
@@ -26,8 +26,6 @@ from nvflare.client.flare_agent import FlareAgentException
 from nvflare.client.flare_agent_with_fl_model import FlareAgentWithFLModel
 from nvflare.client.model_registry import ModelRegistry
 from nvflare.fuel.data_event.utils import set_scope_property
-from nvflare.fuel.utils.fobs import fobs
-from nvflare.fuel.utils.import_utils import optional_import
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.fuel.utils.pipe.pipe import Pipe
 
@@ -73,14 +71,6 @@ def _create_pipe_using_config(client_config: ClientConfig, section: str) -> Tupl
     return pipe, pipe_channel_name
 
 
-def _register_tensor_decomposer():
-    tensor_decomposer, ok = optional_import(module="nvflare.app_opt.pt.decomposers", name="TensorDecomposer")
-    if ok:
-        fobs.register(tensor_decomposer)
-    else:
-        raise RuntimeError(f"Can't import TensorDecomposer for format: {ExchangeFormat.PYTORCH}")
-
-
 class ExProcessClientAPI(APISpec):
     def __init__(self, config_file: str):
         self.model_registry = None
@@ -115,9 +105,6 @@ class ExProcessClientAPI(APISpec):
         flare_agent = None
         try:
             if rank == "0":
-                if client_config.get_exchange_format() == ExchangeFormat.PYTORCH:
-                    _register_tensor_decomposer()
-
                 pipe, task_channel_name = None, ""
                 if ConfigKey.TASK_EXCHANGE in client_config.config:
                     pipe, task_channel_name = _create_pipe_using_config(

--- a/tests/unit_test/client/in_process/api_test.py
+++ b/tests/unit_test/client/in_process/api_test.py
@@ -36,7 +36,6 @@ class TestInProcessClientAPI(unittest.TestCase):
             "TASK_NAME": "train",
             ConfigKey.TASK_EXCHANGE: {
                 ConfigKey.TRAIN_WITH_EVAL: "train_with_eval",
-                ConfigKey.EXCHANGE_FORMAT: "pytorch",
                 ConfigKey.TRAIN_TASK_NAME: "train",
                 ConfigKey.EVAL_TASK_NAME: "evaluate",
                 ConfigKey.SUBMIT_MODEL_TASK_NAME: "submit_model",


### PR DESCRIPTION
(1) No need for "server_expected_format" and "script_expected_format" in ScriptRunner.
    The convienience of auto registering ParamsConverter is moved into ParamsConverterFilter
(2) No need for "script_expected_format" in ClientAPILauncherExecutor, the auto register of TensorDecomposer now happens in NVFlare level when we found PyTorch is installed
(3) Remove automatic magic PyTorch to NumPy conversion in nvflare/app_opt/pt/model_persistence_format_manager.py

### Description

- Remove "server_expected_format" and "script_expected_format" in ScriptRunner.
- Remove "script_expected_format" in ClientAPILauncherExecutor
- Update some examples to reflect changes

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
