### PR TITLE
Fix CCWF cross-site-evaluation prep model task

### DIFF
--- a/nvflare/app_common/ccwf/cse_server_ctl.py
+++ b/nvflare/app_common/ccwf/cse_server_ctl.py
@@ -240,7 +240,7 @@ class CrossSiteEvalServerController(ServerSideController):
             task=task,
             fl_ctx=fl_ctx,
             targets=owners,
-            min_responses=1,
+            min_responses=len(owners),
             wait_time_after_min_received=0,
             abort_signal=abort_signal,
         )


### PR DESCRIPTION
Fixes # .

### Description

Fixed the prep-model task: the min_responses should be len(owners) instead of 1.
 
### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
