### PR TITLE
[2.6] Fix server start.sh arg replacement and add system_info.ipynb

### DIFF
--- a/nvflare/lighter/constants.py
+++ b/nvflare/lighter/constants.py
@@ -115,6 +115,7 @@ class OverseerRole:
 
 
 class TemplateSectionKey:
+    ADM_NOTEBOOK = "adm_notebook"
     START_SERVER_SH = "start_svr_sh"
     START_CLIENT_SH = "start_cln_sh"
     DOCKER_BUILD_SH = "docker_build_sh"
@@ -177,6 +178,7 @@ class ProvFileName:
     README_TXT = "readme.txt"
     FED_ADMIN_JSON = "fed_admin.json"
     FL_ADMIN_SH = "fl_admin.sh"
+    SYSTEM_INFO_IPYNB = "system_info.ipynb"
     SIGNATURE_JSON = "signature.json"
     COMPOSE_YAML = "compose.yaml"
     ENV = ".env"

--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -171,7 +171,13 @@ class StaticFileBuilder(Builder):
                 exe=True,
             )
 
-        ctx.build_from_template(dest_dir, TemplateSectionKey.START_SERVER_SH, ProvFileName.START_SH, exe=True)
+        ctx.build_from_template(
+            dest_dir,
+            TemplateSectionKey.START_SERVER_SH,
+            ProvFileName.START_SH,
+            replacement={"ha_mode": "false"},
+            exe=True,
+        )
 
         ctx.build_from_template(
             dest_dir,

--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -557,6 +557,7 @@ class StaticFileBuilder(Builder):
         server_name = ctx.get(CtxKey.SERVER_NAME)
 
         replacement_dict = {
+            "admin_name": admin.name,
             "cn": f"{server_name}",
             "admin_port": f"{admin_port}",
             "docker_image": self.docker_image,
@@ -577,6 +578,13 @@ class StaticFileBuilder(Builder):
             ProvFileName.FL_ADMIN_SH,
             replacement=replacement_dict,
             exe=True,
+        )
+
+        ctx.build_from_template(
+            dest_dir,
+            TemplateSectionKey.ADM_NOTEBOOK,
+            ProvFileName.SYSTEM_INFO_IPYNB,
+            replacement=replacement_dict,
         )
 
         ctx.build_from_template(dest_dir, TemplateSectionKey.ADMIN_README, ProvFileName.README_TXT)


### PR DESCRIPTION
Fixes # .

### Description

Fixed the missed "ha_mode" replacement when generating start.sh in server's startup kit.
Added the missing system_info.ipynb to the admin startup kit generation.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
