### PR TITLE
Cherry-pick #3402

### DIFF
--- a/docs/release_notes/flare_260.rst
+++ b/docs/release_notes/flare_260.rst
@@ -171,19 +171,34 @@ In NVIDIA FLARE 2.6, several changes have been made to the Dashboard:
 
 #. The ``FLARE_DASHBOARD_NAMESPACE`` constant has been added to the codebase. All API endpoints should now use this namespace prefix.
 
-PTClientAPILauncherExecutor and PTInProcessClientAPIExecutor Changes
-====================================================================
 
-FLARE 2.6.0 introduces significant changes to the "params_exchange_format" argument in PTClientAPILauncherExecutor and PTInProcessClientAPIExecutor. These changes impact how data is exchanged between the client script and NVFlare.
+ScriptRunner Changes in FLARE 2.6.0
+===================================
 
-Changes in params_exchange_format
----------------------------------
+Overview
+--------
 
-In previous versions, setting "params_exchange_format" to "pytorch" indicated that the client was using a PyTorch tensor on the third-party side. In this case, the tensor would be converted to a NumPy array before being sent back to NVFlare.
+FLARE 2.6.0 introduces a new `server_expected_format` parameter to enhance data exchange flexibility across the entire pipeline. This parameter is now available in:
+- `ScriptRunner`
+- `ClientAPILauncherExecutor`
+- `InProcessClientAPIExecutor`
 
-With the improvements introduced in FLARE 2.6.0, which now natively support PyTorch tensors during transmission, the meaning of "params_exchange_format" = "pytorch" has changed. Now, this setting directly sends PyTorch tensors to NVFlare without converting them to NumPy arrays.
+## Previous Implementation
+Previously, data format was controlled by:
+- `params_exchange_format` in executors
+- `framework` in `ScriptRunner`
 
-Action Required
----------------
+These parameters only defined the communication format between the NVFlare client and the user script. For example, setting `params_exchange_format` to "pytorch" meant the client communicated with the script using PyTorch tensors.
 
-To maintain the previous behavior (where PyTorch tensors are converted to NumPy arrays), you will need to explicitly set "params_exchange_format" to "numpy".
+However, the server-to-client communication was always restricted to NumPy arrays.
+
+New Implementation
+------------------
+
+With FLARE 2.6.0, we now support:
+1. End-to-end PyTorch tensor pipeline
+2. Flexible format specification at each communication boundary
+3. Native PyTorch tensor transmission
+
+The new `server_expected_format` parameter specifically controls the format used in server-client communication. When set to "pytorch", the entire pipeline - from server to client to script - can operate using PyTorch tensors without any format conversion.
+

--- a/examples/advanced/bionemo/downstream/sabdab/run_sim_sabdab.py
+++ b/examples/advanced/bionemo/downstream/sabdab/run_sim_sabdab.py
@@ -25,7 +25,7 @@ from nvflare.app_opt.pt.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import BaseScriptRunner
 
 sys.path.append(os.path.join(os.getcwd(), ".."))  # include parent folder in path
-from bionemo_filters import BioNeMoParamsFilter
+from bionemo_filters import BioNeMoParamsFilter, BioNeMoStateDictFilter
 
 
 def main(args):
@@ -76,13 +76,17 @@ def main(args):
             script=args.train_script,
             launch_external_process=True,
             framework="pytorch",
-            params_exchange_format="pytorch",
-            launcher=SubprocessLauncher(script=f"python3 custom/{args.train_script} {script_args}", launch_once=False),
+            server_expected_format="pytorch",
+            # bionemo script is launched new at every FL round. Adds a shutdown grace period to make sure bionemo can save the local model
+            launcher=SubprocessLauncher(
+                script=f"python3 custom/{args.train_script} {script_args}", launch_once=False, shutdown_timeout=100.0
+            ),
         )
         job.to(runner, client_name)
         job.to(
             BioNeMoParamsFilter(precision), client_name, tasks=["train", "validate"], filter_type=FilterType.TASK_DATA
         )
+        job.to(BioNeMoStateDictFilter(), client_name, tasks=["train", "validate"], filter_type=FilterType.TASK_RESULT)
 
     job.export_job("./exported_jobs")
     job.simulator_run(f"/tmp/nvflare/bionemo/sabdab/{job.name}", gpu=args.sim_gpus)

--- a/examples/advanced/bionemo/downstream/tap/run_sim_tap.py
+++ b/examples/advanced/bionemo/downstream/tap/run_sim_tap.py
@@ -25,7 +25,7 @@ from nvflare.app_opt.pt.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import BaseScriptRunner
 
 sys.path.append(os.path.join(os.getcwd(), ".."))  # include parent folder in path
-from bionemo_filters import BioNeMoExcludeParamsFilter, BioNeMoParamsFilter
+from bionemo_filters import BioNeMoExcludeParamsFilter, BioNeMoParamsFilter, BioNeMoStateDictFilter
 
 
 def main(args):
@@ -66,7 +66,7 @@ def main(args):
         # define training script arguments
         # precision = "bf16-mixed"
         precision = "fp32"
-        script_args = f"--restore-from-checkpoint-path {checkpoint_path} --train-data-path {train_data_path} --valid-data-path {val_data_path} --config-class ESM2FineTuneSeqConfig --dataset-class InMemorySingleValueDataset --task-type regression --mlp-ft-dropout 0.1 --mlp-hidden-size 256 --mlp-target-size 1 --experiment-name {job.name} --num-steps {args.local_steps} --num-gpus 1 --val-check-interval {val_check_interval} --log-every-n-steps 10 --lr 1e-4 --lr-multiplier 5 --scale-lr-layer regression_head --result-dir bionemo --micro-batch-size 8 --precision {precision} --save-top-k 1 --limit-val-batches 1.0 --label-column {label_column}"
+        script_args = f"--restore-from-checkpoint-path {checkpoint_path} --train-data-path {train_data_path} --valid-data-path {val_data_path} --config-class ESM2FineTuneSeqConfig --dataset-class InMemorySingleValueDataset --task-type regression --mlp-ft-dropout 0.1 --mlp-hidden-size 256 --mlp-target-size 1 --experiment-name {job.name} --num-steps {args.local_steps} --num-gpus 1 --val-check-interval {val_check_interval} --log-every-n-steps 10 --lr 5e-4 --lr-multiplier 1e3 --scale-lr-layer regression_head --result-dir bionemo --micro-batch-size 8 --precision {precision} --save-top-k 1 --limit-val-batches 1.0 --label-column {label_column}"
         print(f"Running {args.train_script} with args: {script_args}")
 
         # Define training script runner
@@ -74,13 +74,17 @@ def main(args):
             script=args.train_script,
             launch_external_process=True,
             framework="pytorch",
-            params_exchange_format="pytorch",
-            launcher=SubprocessLauncher(script=f"python3 custom/{args.train_script} {script_args}", launch_once=False),
+            server_expected_format="pytorch",
+            # bionemo script is launched new at every FL round. Adds a shutdown grace period to make sure bionemo can save the local model
+            launcher=SubprocessLauncher(
+                script=f"python3 custom/{args.train_script} {script_args}", launch_once=False, shutdown_timeout=100.0
+            ),
         )
         job.to(runner, client_name)
         job.to(
             BioNeMoParamsFilter(precision), client_name, tasks=["train", "validate"], filter_type=FilterType.TASK_DATA
         )
+        job.to(BioNeMoStateDictFilter(), client_name, tasks=["train", "validate"], filter_type=FilterType.TASK_RESULT)
         job.to(
             BioNeMoExcludeParamsFilter(exclude_vars="regression_head"),
             client_name,

--- a/examples/advanced/llm_hf/sft_job.py
+++ b/examples/advanced/llm_hf/sft_job.py
@@ -77,7 +77,7 @@ def main():
     job.to("src/hf_sft_model.py", "server")
     # Then send the model persistor to the server
     model_args = {"path": "src.hf_sft_model.CausalLMModel", "args": {"model_name_or_path": model_name_or_path}}
-    job.to(PTFileModelPersistor(model=model_args), "server", id="persistor")
+    job.to(PTFileModelPersistor(model=model_args, allow_numpy_conversion=False), "server", id="persistor")
 
     # Add model selection widget and send to server
     job.to(IntimeModelSelector(key_metric="eval_loss", negate_key_metric=True), "server", id="model_selector")
@@ -91,16 +91,16 @@ def main():
 
         script_args = f"--model_name_or_path {model_name_or_path} --data_path_train {data_path_train} --data_path_valid {data_path_valid} --output_path {output_path} --train_mode {train_mode} --message_mode {message_mode} --clean_up {clean_up}"
         if message_mode == "tensor":
-            params_exchange_format = "pytorch"
+            server_expected_format = "pytorch"
         elif message_mode == "numpy":
-            params_exchange_format = "numpy"
+            server_expected_format = "numpy"
         else:
             raise ValueError(f"Invalid message_mode: {message_mode}, only numpy and tensor are supported.")
 
         runner = ScriptRunner(
             script=train_script,
             script_args=script_args,
-            params_exchange_format=params_exchange_format,
+            server_expected_format=server_expected_format,
             launch_external_process=False,
         )
         job.to(runner, site_name, tasks=["train"])

--- a/examples/advanced/sklearn-kmeans/kmeans_job_clientapi.py
+++ b/examples/advanced/sklearn-kmeans/kmeans_job_clientapi.py
@@ -135,7 +135,7 @@ def main():
             script_args=f"--data_path {data_path} "
             f"--train_start {train_start} --train_end {train_end} "
             f"--valid_start {valid_start} --valid_end {valid_end}",
-            params_exchange_format="raw",
+            framework="raw",
         )
         job.to(executor, f"site-{i}", tasks=["train"])
 

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.2_convert_kmeans_to_federated_learning/code/kmeans_job.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.2_convert_kmeans_to_federated_learning/code/kmeans_job.py
@@ -135,7 +135,7 @@ def main():
             script_args=f"--data_path {data_path} "
             f"--train_start {train_start} --train_end {train_end} "
             f"--valid_start {valid_start} --valid_end {valid_end}",
-            params_exchange_format="raw",
+            framework="raw",
         )
         job.to(executor, f"site-{i}", tasks=["train"])
 

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/km_job.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/km_job.py
@@ -63,7 +63,7 @@ def main():
     runner = ScriptRunner(
         script=train_script,
         script_args=script_args,
-        params_exchange_format="raw",
+        framework="raw",
         launch_external_process=False,
     )
     job.to_clients(runner, tasks=["train"])

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/km_job.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/km_job.py
@@ -64,7 +64,6 @@ def main():
         script=train_script,
         script_args=script_args,
         framework="raw",
-        params_exchange_format="raw",
         launch_external_process=False,
     )
     job.to_clients(runner, tasks=["train"])

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/sft_job.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/sft_job.py
@@ -91,16 +91,16 @@ def main():
 
         script_args = f"--model_name_or_path {model_name_or_path} --data_path_train {data_path_train} --data_path_valid {data_path_valid} --output_path {output_path} --train_mode {train_mode} --message_mode {message_mode} --clean_up {clean_up}"
         if message_mode == "tensor":
-            params_exchange_format = "pytorch"
+            server_expected_format = "pytorch"
         elif message_mode == "numpy":
-            params_exchange_format = "numpy"
+            server_expected_format = "numpy"
         else:
             raise ValueError(f"Invalid message_mode: {message_mode}, only numpy and tensor are supported.")
 
         runner = ScriptRunner(
             script=train_script,
             script_args=script_args,
-            params_exchange_format=params_exchange_format,
+            server_expected_format=server_expected_format,
             launch_external_process=False,
         )
         job.to(runner, site_name, tasks=["train"])

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/peft_job.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/peft_job.py
@@ -91,16 +91,16 @@ def main():
 
         script_args = f"--model_name_or_path {model_name_or_path} --data_path_train {data_path_train} --data_path_valid {data_path_valid} --output_path {output_path} --train_mode {train_mode} --message_mode {message_mode} --clean_up {clean_up}"
         if message_mode == "tensor":
-            params_exchange_format = "pytorch"
+            server_expected_format = "pytorch"
         elif message_mode == "numpy":
-            params_exchange_format = "numpy"
+            server_expected_format = "numpy"
         else:
             raise ValueError(f"Invalid message_mode: {message_mode}, only numpy and tensor are supported.")
 
         runner = ScriptRunner(
             script=train_script,
             script_args=script_args,
-            params_exchange_format=params_exchange_format,
+            server_expected_format=server_expected_format,
             launch_external_process=False,
         )
         job.to(runner, site_name, tasks=["train"])

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/sft_job.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/sft_job.py
@@ -91,16 +91,16 @@ def main():
 
         script_args = f"--model_name_or_path {model_name_or_path} --data_path_train {data_path_train} --data_path_valid {data_path_valid} --output_path {output_path} --train_mode {train_mode} --message_mode {message_mode} --clean_up {clean_up}"
         if message_mode == "tensor":
-            params_exchange_format = "pytorch"
+            server_expected_format = "pytorch"
         elif message_mode == "numpy":
-            params_exchange_format = "numpy"
+            server_expected_format = "numpy"
         else:
             raise ValueError(f"Invalid message_mode: {message_mode}, only numpy and tensor are supported.")
 
         runner = ScriptRunner(
             script=train_script,
             script_args=script_args,
-            params_exchange_format=params_exchange_format,
+            server_expected_format=server_expected_format,
             launch_external_process=False,
         )
         job.to(runner, site_name, tasks=["train"])

--- a/job_templates/cyclic_cc_pt/config_fed_client.conf
+++ b/job_templates/cyclic_cc_pt/config_fed_client.conf
@@ -37,7 +37,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/cyclic_pt/config_fed_client.conf
+++ b/job_templates/cyclic_pt/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_cse_ccwf_pt/config_fed_client.conf
+++ b/job_templates/sag_cse_ccwf_pt/config_fed_client.conf
@@ -41,7 +41,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_gnn/app_1/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_1/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_gnn/app_2/config_fed_client.conf
+++ b/job_templates/sag_gnn/app_2/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_nemo/app_1/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_1/config_fed_client.conf
@@ -35,7 +35,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_nemo/app_2/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_2/config_fed_client.conf
@@ -35,7 +35,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_nemo/app_3/config_fed_client.conf
+++ b/job_templates/sag_nemo/app_3/config_fed_client.conf
@@ -35,7 +35,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt/config_fed_client.conf
+++ b/job_templates/sag_pt/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_deploy_map/app_1/config_fed_client.conf
+++ b/job_templates/sag_pt_deploy_map/app_1/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_deploy_map/app_2/config_fed_client.conf
+++ b/job_templates/sag_pt_deploy_map/app_2/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_he/config_fed_client.conf
+++ b/job_templates/sag_pt_he/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/job_templates/sag_pt_mlflow/config_fed_client.conf
+++ b/job_templates/sag_pt_mlflow/config_fed_client.conf
@@ -32,7 +32,7 @@
           heartbeat_timeout = 60
 
           # format of the exchange parameters
-          params_exchange_format =  "numpy"
+          params_exchange_format =  "pytorch"
 
           # if the transfer_type is FULL, then it will be sent directly
           # if the transfer_type is DIFF, then we will calculate the

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -48,6 +48,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         params_exchange_format: str = ExchangeFormat.NUMPY,
         params_transfer_type: str = TransferType.FULL,
         config_file_name: str = CLIENT_API_CONFIG,
+        server_expected_format: str = ExchangeFormat.NUMPY,
     ) -> None:
         """Initializes the ClientAPILauncherExecutor.
 
@@ -73,7 +74,8 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 This ParamsConverter will be called when model is sent from nvflare controller side to executor side.
             to_nvflare_converter_id (Optional[str]): Identifier used to get the ParamsConverter from NVFlare components.
                 This ParamsConverter will be called when model is sent from nvflare executor side to controller side.
-            params_exchange_format (str): What format to exchange the parameters.
+            server_expected_format (str): What format to exchange the parameters between server and client.
+            params_exchange_format (str): What format to exchange the parameters between client and script.
             params_transfer_type (str): How to transfer the parameters. FULL means the whole model parameters are sent.
                 DIFF means that only the difference is sent.
             config_file_name (str): The config file name to write attributes into, the client api will read in this file.
@@ -100,6 +102,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             to_nvflare_converter_id=to_nvflare_converter_id,
         )
 
+        self._server_expected_format = server_expected_format
         self._params_exchange_format = params_exchange_format
         self._params_transfer_type = params_transfer_type
         self._config_file_name = config_file_name

--- a/nvflare/app_common/executors/in_process_client_api_executor.py
+++ b/nvflare/app_common/executors/in_process_client_api_executor.py
@@ -60,6 +60,7 @@ class InProcessClientAPIExecutor(Executor):
         train_task_name: str = AppConstants.TASK_TRAIN,
         evaluate_task_name: str = AppConstants.TASK_VALIDATION,
         submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
+        server_expected_format: str = ExchangeFormat.NUMPY,
     ):
         super(InProcessClientAPIExecutor, self).__init__()
         self._abort = False
@@ -67,6 +68,7 @@ class InProcessClientAPIExecutor(Executor):
         self._result_pull_interval = result_pull_interval
         self._log_pull_interval = log_pull_interval
         self._params_exchange_format = params_exchange_format
+        self._server_expected_format = server_expected_format
         self._params_transfer_type = params_transfer_type
 
         if not task_script_path or not task_script_path.endswith(".py"):

--- a/nvflare/app_opt/pt/client_api_launcher_executor.py
+++ b/nvflare/app_opt/pt/client_api_launcher_executor.py
@@ -12,48 +12,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.executors.client_api_launcher_executor import ClientAPILauncherExecutor
 from nvflare.app_opt.pt.decomposers import TensorDecomposer
 from nvflare.app_opt.pt.numpy_params_converter import NumpyToPTParamsConverter, PTToNumpyParamsConverter
-from nvflare.app_opt.pt.tensor_params_converter import PTReceiveParamsConverter, PTSendParamsConverter
-from nvflare.client.config import ExchangeFormat
+from nvflare.client.config import ExchangeFormat, TransferType
+from nvflare.client.constants import CLIENT_API_CONFIG
 from nvflare.fuel.utils import fobs
-from nvflare.fuel.utils.log_utils import get_obj_logger
 
 
 class PTClientAPILauncherExecutor(ClientAPILauncherExecutor):
+    def __init__(
+        self,
+        pipe_id: str,
+        launcher_id: Optional[str] = None,
+        launch_timeout: Optional[float] = None,
+        task_wait_timeout: Optional[float] = None,
+        last_result_transfer_timeout: float = 300.0,
+        external_pre_init_timeout: float = 60.0,
+        peer_read_timeout: Optional[float] = 60.0,
+        monitor_interval: float = 0.01,
+        read_interval: float = 0.5,
+        heartbeat_interval: float = 5.0,
+        heartbeat_timeout: float = 60.0,
+        workers: int = 4,
+        train_with_evaluation: bool = False,
+        train_task_name: str = AppConstants.TASK_TRAIN,
+        evaluate_task_name: str = AppConstants.TASK_VALIDATION,
+        submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
+        from_nvflare_converter_id: Optional[str] = None,
+        to_nvflare_converter_id: Optional[str] = None,
+        server_expected_format: str = ExchangeFormat.NUMPY,
+        params_exchange_format: str = ExchangeFormat.PYTORCH,
+        params_transfer_type: str = TransferType.FULL,
+        config_file_name: str = CLIENT_API_CONFIG,
+    ) -> None:
+        ClientAPILauncherExecutor.__init__(
+            self,
+            pipe_id=pipe_id,
+            launcher_id=launcher_id,
+            launch_timeout=launch_timeout,
+            task_wait_timeout=task_wait_timeout,
+            last_result_transfer_timeout=last_result_transfer_timeout,
+            external_pre_init_timeout=external_pre_init_timeout,
+            peer_read_timeout=peer_read_timeout,
+            monitor_interval=monitor_interval,
+            read_interval=read_interval,
+            heartbeat_interval=heartbeat_interval,
+            heartbeat_timeout=heartbeat_timeout,
+            workers=workers,
+            train_with_evaluation=train_with_evaluation,
+            train_task_name=train_task_name,
+            evaluate_task_name=evaluate_task_name,
+            submit_model_task_name=submit_model_task_name,
+            from_nvflare_converter_id=from_nvflare_converter_id,
+            to_nvflare_converter_id=to_nvflare_converter_id,
+            server_expected_format=server_expected_format,
+            params_exchange_format=params_exchange_format,
+            params_transfer_type=params_transfer_type,
+            config_file_name=config_file_name,
+        )
+
     def initialize(self, fl_ctx: FLContext) -> None:
         fobs.register(TensorDecomposer)
         super().initialize(fl_ctx)
-        self.logger = get_obj_logger(self)
-        if self._from_nvflare_converter is None:
-            # if not specified, assign defaults
-            if self._params_exchange_format == ExchangeFormat.NUMPY:
-                self.logger.debug("Numpy from_nvflare_converter initialized")
+
+        if (
+            self._server_expected_format == ExchangeFormat.NUMPY
+            and self._params_exchange_format == ExchangeFormat.PYTORCH
+        ):
+            if self._from_nvflare_converter is None:
                 self._from_nvflare_converter = NumpyToPTParamsConverter(
                     [AppConstants.TASK_TRAIN, AppConstants.TASK_VALIDATION]
                 )
-            elif self._params_exchange_format == ExchangeFormat.PYTORCH:
-                self.logger.debug("Pytorch from_nvflare_converter initialized")
-                self._from_nvflare_converter = PTReceiveParamsConverter(
-                    [AppConstants.TASK_TRAIN, AppConstants.TASK_VALIDATION]
-                )
-            else:
-                self._from_nvflare_converter = None
 
-        if self._to_nvflare_converter is None:
-            # if not specified, assign defaults
-            if self._params_exchange_format == ExchangeFormat.NUMPY:
-                self.logger.debug("Numpy to_nvflare_converter initialized")
+            if self._to_nvflare_converter is None:
                 self._to_nvflare_converter = PTToNumpyParamsConverter(
                     [AppConstants.TASK_TRAIN, AppConstants.TASK_SUBMIT_MODEL]
                 )
-            elif self._params_exchange_format == ExchangeFormat.PYTORCH:
-                self.logger.debug("Pytorch to_nvflare_converter initialized")
-                self._to_nvflare_converter = PTSendParamsConverter(
-                    [AppConstants.TASK_TRAIN, AppConstants.TASK_SUBMIT_MODEL]
-                )
-            else:
-                self._to_nvflare_converter = None

--- a/nvflare/app_opt/pt/file_model_persistor.py
+++ b/nvflare/app_opt/pt/file_model_persistor.py
@@ -43,6 +43,7 @@ class PTFileModelPersistor(ModelPersistor):
         source_ckpt_file_full_name=None,
         filter_id: str = None,
         load_weights_only: bool = False,
+        allow_numpy_conversion: bool = True,
     ):
         """Persist pytorch-based model to/from file system.
 
@@ -94,8 +95,11 @@ class PTFileModelPersistor(ModelPersistor):
             source_ckpt_file_full_name (str, optional): full file name for source model checkpoint file. Defaults to None.
             filter_id: Optional string that defines a filter component that is applied to prepare the model to be saved,
                 e.g. for serialization of custom Python objects.
-            load_weights_only:  Indicates whether torch's unpickler should be restricted to loading only tensors, primitive types, dictionaries
+            load_weights_only: Indicates whether torch's unpickler should be restricted to loading only tensors, primitive types, dictionaries
                 and any types added via :func:`torch.serialization.add_safe_globals`. Defaults to False (<=PyTorch 2.6 behavior).
+            allow_numpy_conversion (bool): If set to True, enables conversion between PyTorch tensors and NumPy arrays.
+                PyTorch tensors will be converted to NumPy arrays during 'load_model',
+                and NumPy arrays will be converted to PyTorch tensors during 'save_model'. Defaults to True.
         Raises:
             ValueError: when source_ckpt_file_full_name does not exist
         """
@@ -113,6 +117,7 @@ class PTFileModelPersistor(ModelPersistor):
         self.best_global_model_file_name = best_global_model_file_name
         self.source_ckpt_file_full_name = source_ckpt_file_full_name
         self.load_weights_only = load_weights_only
+        self._allow_numpy_conversion = allow_numpy_conversion
 
         self.default_train_conf = None
 
@@ -226,7 +231,9 @@ class PTFileModelPersistor(ModelPersistor):
         if self.model:
             self.default_train_conf = {"train": {"model": type(self.model).__name__}}
 
-        self.persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
+        self.persistence_manager = PTModelPersistenceFormatManager(
+            data, default_train_conf=self.default_train_conf, allow_numpy_conversion=self._allow_numpy_conversion
+        )
         return self.persistence_manager.to_model_learnable(self.exclude_vars)
 
     def _get_persistence_manager(self, fl_ctx: FLContext):
@@ -270,7 +277,9 @@ class PTFileModelPersistor(ModelPersistor):
             # Use the "cpu" to load the global model weights, avoid GPU out of memory
             device = "cpu"
             data = torch.load(location, map_location=device, weights_only=self.load_weights_only)
-            persistence_manager = PTModelPersistenceFormatManager(data, default_train_conf=self.default_train_conf)
+            persistence_manager = PTModelPersistenceFormatManager(
+                data, default_train_conf=self.default_train_conf, allow_numpy_conversion=self._allow_numpy_conversion
+            )
             return persistence_manager.to_model_learnable(self.exclude_vars)
         except Exception:
             self.log_exception(fl_ctx, "error loading checkpoint from {}".format(location))

--- a/nvflare/app_opt/tf/in_process_client_api_executor.py
+++ b/nvflare/app_opt/tf/in_process_client_api_executor.py
@@ -35,7 +35,8 @@ class TFInProcessClientAPIExecutor(InProcessClientAPIExecutor):
         train_task_name: str = AppConstants.TASK_TRAIN,
         evaluate_task_name: str = AppConstants.TASK_VALIDATION,
         submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
-        params_exchange_format=ExchangeFormat.NUMPY,
+        params_exchange_format=ExchangeFormat.KERAS_LAYER_WEIGHTS,
+        server_expected_format=ExchangeFormat.NUMPY,
     ):
         super(TFInProcessClientAPIExecutor, self).__init__(
             task_script_path=task_script_path,
@@ -51,13 +52,18 @@ class TFInProcessClientAPIExecutor(InProcessClientAPIExecutor):
             params_exchange_format=params_exchange_format,
             params_transfer_type=params_transfer_type,
             log_pull_interval=log_pull_interval,
+            server_expected_format=server_expected_format,
         )
 
-        if self._from_nvflare_converter is None:
-            self._from_nvflare_converter = NumpyToKerasModelParamsConverter(
-                [AppConstants.TASK_TRAIN, AppConstants.TASK_VALIDATION]
-            )
-        if self._to_nvflare_converter is None:
-            self._to_nvflare_converter = KerasModelToNumpyParamsConverter(
-                [AppConstants.TASK_TRAIN, AppConstants.TASK_SUBMIT_MODEL]
-            )
+        if (
+            self._server_expected_format == ExchangeFormat.NUMPY
+            and self._params_exchange_format == ExchangeFormat.KERAS_LAYER_WEIGHTS
+        ):
+            if self._from_nvflare_converter is None:
+                self._from_nvflare_converter = NumpyToKerasModelParamsConverter(
+                    [AppConstants.TASK_TRAIN, AppConstants.TASK_VALIDATION]
+                )
+            if self._to_nvflare_converter is None:
+                self._to_nvflare_converter = KerasModelToNumpyParamsConverter(
+                    [AppConstants.TASK_TRAIN, AppConstants.TASK_SUBMIT_MODEL]
+                )

--- a/nvflare/client/config.py
+++ b/nvflare/client/config.py
@@ -24,6 +24,7 @@ class ExchangeFormat:
     RAW = "raw"
     PYTORCH = "pytorch"
     NUMPY = "numpy"
+    KERAS_LAYER_WEIGHTS = "keras_layer_weights"
 
 
 class TransferType:

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -57,12 +57,10 @@ class BaseScriptRunner:
         script_args: str = "",
         launch_external_process: bool = False,
         command: str = "python3 -u",
-        framework: FrameworkType = FrameworkType.PYTORCH,
+        server_expected_format: str = ExchangeFormat.NUMPY,
+        framework: str = FrameworkType.PYTORCH,
         params_transfer_type: str = TransferType.FULL,
         executor: Union[ClientAPILauncherExecutor, InProcessClientAPIExecutor, None] = None,
-        params_exchange_format: Optional[str] = None,
-        from_nvflare_converter_id: Optional[str] = None,
-        to_nvflare_converter_id: Optional[str] = None,
         task_pipe: Optional[Pipe] = None,
         launcher: Optional[Launcher] = None,
         metric_relay: Optional[MetricRelay] = None,
@@ -85,24 +83,14 @@ class BaseScriptRunner:
             script_args (str): Optional arguments for script (appended to script).
             launch_external_process (bool): Whether to launch the script in external process. Defaults to False.
             command (str): If launch_external_process=True, command to run script (preprended to script). Defaults to "python3".
-            framework (str): Framework type to connfigure converter and params exchange formats. Defaults to FrameworkType.PYTORCH.
+            framework (str): Framework is used to determine the `params_exchange_format`. Defaults to FrameworkType.PYTORCH.
+            server_expected_format (str): What format to exchange the parameters between server and client.
             params_transfer_type (str): How to transfer the parameters. FULL means the whole model parameters are sent.
                 DIFF means that only the difference is sent. Defaults to TransferType.FULL.
             executor (Union[ClientAPILauncherExecutor, InProcessClientAPIExecutor, None], optional):
                 The executor to use in client process. Can be an instance of
                 `ClientAPILauncherExecutor`, `InProcessClientAPIExecutor`, or `None`. Defaults to `None`.
-                If specified, the script and script_args and command will be ignored.
-            params_exchange_format (Optional[str], optional):
-                The format to exchange the parameters. Defaults to `None`.
-                This specifies the format in which the parameters are exchanged between the client and the server.
-                For example, if the framework is pytorch, the exchange format can be pytorch or numpy;
-                if the framework is numpy, the exchange format can only be numpy.
-            from_nvflare_converter_id (Optional[str], optional):
-                The id of the converter to use to convert parameters from exchange format to the client format.
-                Defaults to `None`.
-            to_nvflare_converter_id (Optional[str], optional):
-                The id of the converter to use to convert parameters from the client format to exchange format.
-                Defaults to `None`.
+                If specified, the `script`, `script_args`, `command`, `server_expected_format`, `params_transfer_type` will be ignored.
             task_pipe (Optional[Pipe], optional):
                 An optional Pipe instance for passing task between ClientAPILauncherExecutor
                 and client api, this is only used if `launch_external_process` is True.
@@ -129,33 +117,28 @@ class BaseScriptRunner:
         self._script_args = script_args
         self._command = command
         self._launch_external_process = launch_external_process
+        self._server_expected_format = server_expected_format
         self._framework = framework
         self._params_transfer_type = params_transfer_type
-        self._params_exchange_format = params_exchange_format
-        self._from_nvflare_converter_id = from_nvflare_converter_id
-        self._to_nvflare_converter_id = to_nvflare_converter_id
         self._pipe_connect_type = pipe_connect_type
+
+        self._params_exchange_format = None
 
         if self._framework == FrameworkType.PYTORCH:
             _, torch_ok = optional_import(module="torch")
             if torch_ok:
-                # If exchange format is not set, default to numpy
-                if self._params_exchange_format is None:
-                    self._params_exchange_format = ExchangeFormat.NUMPY
+                self._params_exchange_format = ExchangeFormat.PYTORCH
             else:
                 raise ValueError("Using FrameworkType.PYTORCH, but unable to import torch")
         elif self._framework == FrameworkType.TENSORFLOW:
             _, tf_ok = optional_import(module="tensorflow")
             if tf_ok:
-                # tf can only use numpy exchange format
-                self._params_exchange_format = ExchangeFormat.NUMPY
+                self._params_exchange_format = ExchangeFormat.KERAS_LAYER_WEIGHTS
             else:
                 raise ValueError("Using FrameworkType.TENSORFLOW, but unable to import tensorflow")
         elif self._framework == FrameworkType.NUMPY:
-            # numpy can only use numpy exchange format
             self._params_exchange_format = ExchangeFormat.NUMPY
         elif self._framework == FrameworkType.RAW:
-            # raw can only use raw exchange format
             self._params_exchange_format = ExchangeFormat.RAW
         else:
             raise ValueError(f"Framework {self._framework} unsupported")
@@ -240,8 +223,7 @@ class BaseScriptRunner:
                     launcher_id=launcher_id,
                     params_exchange_format=self._params_exchange_format,
                     params_transfer_type=self._params_transfer_type,
-                    from_nvflare_converter_id=self._from_nvflare_converter_id,
-                    to_nvflare_converter_id=self._to_nvflare_converter_id,
+                    server_expected_format=self._server_expected_format,
                 )
             )
             job.add_executor(executor, tasks=tasks, ctx=ctx)
@@ -275,8 +257,7 @@ class BaseScriptRunner:
                     task_script_args=self._script_args,
                     params_exchange_format=self._params_exchange_format,
                     params_transfer_type=self._params_transfer_type,
-                    from_nvflare_converter_id=self._from_nvflare_converter_id,
-                    to_nvflare_converter_id=self._to_nvflare_converter_id,
+                    server_expected_format=self._server_expected_format,
                 )
             )
             job.add_executor(executor, tasks=tasks, ctx=ctx)
@@ -317,7 +298,7 @@ class ScriptRunner(BaseScriptRunner):
         launch_external_process: bool = False,
         command: str = "python3 -u",
         framework: FrameworkType = FrameworkType.PYTORCH,
-        params_exchange_format: ExchangeFormat = ExchangeFormat.NUMPY,
+        server_expected_format: str = ExchangeFormat.NUMPY,
         params_transfer_type: str = TransferType.FULL,
         pipe_connect_type: str = PipeConnectType.VIA_CP,
     ):
@@ -331,8 +312,8 @@ class ScriptRunner(BaseScriptRunner):
             script_args (str): Optional arguments for script (appended to script).
             launch_external_process (bool): Whether to launch the script in external process. Defaults to False.
             command (str): If launch_external_process=True, command to run script (preprended to script). Defaults to "python3".
-            framework (str): Framework type to connfigure converter and params exchange formats. Defaults to FrameworkType.PYTORCH.
-            params_exchange_format (str): The format to exchange the parameters. Defaults to ExchangeFormat.NUMPY.
+            framework (str): Framework is used to determine the `params_exchange_format`. Defaults to FrameworkType.PYTORCH.
+            server_expected_format (str): What format to exchange the parameters between server and client.
             params_transfer_type (str): How to transfer the parameters. FULL means the whole model parameters are sent.
                 DIFF means that only the difference is sent. Defaults to TransferType.FULL.
             pipe_connect_type (str): how pipe peers are to be connected
@@ -342,8 +323,8 @@ class ScriptRunner(BaseScriptRunner):
             script_args=script_args,
             launch_external_process=launch_external_process,
             command=command,
+            server_expected_format=server_expected_format,
             framework=framework,
-            params_exchange_format=params_exchange_format,
             params_transfer_type=params_transfer_type,
             pipe_connect_type=pipe_connect_type,
         )


### PR DESCRIPTION
Cherry-pick (#3402) to be consistent for now.

Make "params_exchange_format" has the same meaning as in previous release (2.5.2).
Introduce a new parameter "server_expected_format" to let user define the format between server <-> client.

"framework" in ScriptRunner and "params_exchange_format" in executors mean the same thing now.

We will enhance these in the next release.

- Make "params_exchange_format" has the same meaning as in previous release.
- Introduce a new parameter "server_expected_format" to let user define the format between server <-> client.
- Update examples/tutorials/release notes
- Revert changes of https://github.com/NVIDIA/NVFlare/pull/3319 so we are consistent with 2.5.2

with the changes, ScriptRunner can be used:

```
BaseScriptRunner(
            script=args.train_script,
            launch_external_process=True,
            framework="pytorch",
            server_expected_format="pytorch",
)
```

By passing both the framework and server_expected_format as "pytorch", we ensure the ParamsConverter will NOT be installed, which means direct PyTorch tensor communications

<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
