### PR TITLE
[2.6] Fix docs for 2.6

### DIFF
--- a/docs/release_notes/flare_260.rst
+++ b/docs/release_notes/flare_260.rst
@@ -14,7 +14,7 @@ Key features:
   - Direct cropping and casting for fp32 to fp16 conversion
   - 8- and 4-bit quantization using bitsandbytes
 
-.. image:: ../resources/message_quantization.png
+.. image:: resources/message_quantization.png
     :height: 300px
 
 
@@ -42,7 +42,7 @@ The table below illustrates the message size in MB for a 1B parameter LLM under 
 
 By applying message quantization techniques, FL can achieve significant bandwidth savings, and for training LLM with Supervised Fine-Tuning (SFT) in our experiments. As shown in the Figure below, message quantization does not sacrifice model convergence quality with regard to the training loss.
 
-.. image:: ../resources/quantization_loss.png
+.. image:: resources/quantization_loss.png
     :height: 300px
 
 Native Tensor Transfer
@@ -103,7 +103,7 @@ System Monitoring
 =================
 FLARE Monitoring provides system metrics tracking for federated learning jobs, focusing on job and system lifecycle metrics. It leverages StatsD Exporter to monitor FLARE job and system events, which can be scraped by Prometheus and visualized with Grafana. This differs from machine learning experiment tracking by focusing on system-level metrics rather than training metrics. For more information, see :ref:`Monitoring <monitoring>`.
 
-.. image:: ../resources/system_monitoring.png
+.. image:: resources/system_monitoring.png
     :height: 450px
 
 Flower Integration v2

--- a/docs/user_guide/security/identity_security.rst
+++ b/docs/user_guide/security/identity_security.rst
@@ -91,7 +91,7 @@ Rights
 NVFLARE supports more accurate right definitions to be more flexible:
 
     - Each server-side admin command is a right! This makes it possible for an org to control each command explicitly;
-    - Admin commands are grouped into categories. For example, commands like abort_job, delete_job, start_app are in manage_job category; all shell commands are put into the shell_commands category. Each category is also a right.
+    - Admin commands are grouped into categories. For example, commands like abort_job and delete_job are in the manage_job category; all shell commands are put into the shell_commands category. Each category is also a right.
     - BYOC is now defined as a right so that some users are allowed to submit jobs with BYOC whereas some are not.
 
 This right system makes it easy to write simple policies that only use command categories. It also makes it possible to write policies to control individual commands. When both categories and commands are used, command-based control takes precedence over category-based control.
@@ -197,7 +197,6 @@ Command Categories
     COMMAND_CATEGORIES = {
         AC.ABORT: CommandCategory.MANAGE_JOB,
         AC.ABORT_JOB: CommandCategory.MANAGE_JOB,
-        AC.START_APP: CommandCategory.MANAGE_JOB,
         AC.DELETE_JOB: CommandCategory.MANAGE_JOB,
         AC.DELETE_WORKSPACE: CommandCategory.MANAGE_JOB,
         AC.CONFIGURE_JOB_LOG: CommandCategory.MANAGE_JOB,


### PR DESCRIPTION
Fixes pictures in release notes and remove start_app info in docs.

### Description

Fixes pictures in release notes and remove start_app info in docs.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
