### PR TITLE
[2.6] Handle None client in ClientRunManager

### DIFF
--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -101,9 +101,12 @@ class ClientRunManager(ClientEngineExecutorSpec, StreamableEngine):
         job_ctx_props = self.create_job_processing_context_properties(workspace, job_id)
         job_ctx_props.update({FLContextKey.PROCESS_TYPE: ProcessType.CLIENT_JOB})
 
-        client_config = client.client_args
-        fqsn = client_config.get("fqsn", client.client_name)
-        is_leaf = client_config.get("is_leaf", True)
+        is_leaf = True
+        fqsn = client.client_name
+        if client:
+            client_config = client.client_args
+            fqsn = client_config.get("fqsn", client.client_name)
+            is_leaf = client_config.get("is_leaf", True)
 
         self.fl_ctx_mgr = FLContextManager(
             engine=self,

--- a/nvflare/private/fed/client/client_run_manager.py
+++ b/nvflare/private/fed/client/client_run_manager.py
@@ -102,7 +102,7 @@ class ClientRunManager(ClientEngineExecutorSpec, StreamableEngine):
         job_ctx_props.update({FLContextKey.PROCESS_TYPE: ProcessType.CLIENT_JOB})
 
         is_leaf = True
-        fqsn = client.client_name
+        fqsn = client_name
         if client:
             client_config = client.client_args
             fqsn = client_config.get("fqsn", client.client_name)


### PR DESCRIPTION
Fixes # .

### Description

The "client" arg of ClientRunManager is set to None when used in Simulator. This PR handles this case and determines the FQSN and is_leaf by using default values.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
