### PR TITLE
[2.6] Added delay to shutdown controller

### DIFF
--- a/tests/tools/file_streaming/app/custom/controller.py
+++ b/tests/tools/file_streaming/app/custom/controller.py
@@ -32,6 +32,8 @@ class FileTransferController(Controller):
             while not receiver.is_done():
                 time.sleep(0.2)
 
+            # Wait for a while to make sure the reply is sent to client
+            time.sleep(5)
             self.log_info(fl_ctx, "Control flow ends")
         except Exception as ex:
             self.log_error(fl_ctx, f"Control flow error: {ex}")


### PR DESCRIPTION
### Description

Added a 5 seconds delay in the controller in file streaming testing job to avoid client timeout at the end.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
