### PR TITLE
Added delay to shutdown controller

### DIFF
--- a/tests/tools/file_streaming/app/custom/controller.py
+++ b/tests/tools/file_streaming/app/custom/controller.py
@@ -32,6 +32,8 @@ class FileTransferController(Controller):
             while not receiver.is_done():
                 time.sleep(0.2)
 
+            # Wait for a while to make sure the reply is sent to client
+            time.sleep(5)
             self.log_info(fl_ctx, "Control flow ends")
         except Exception as ex:
             self.log_error(fl_ctx, f"Control flow error: {ex}")

--- a/tests/tools/file_streaming/app/custom/file_streaming.py
+++ b/tests/tools/file_streaming/app/custom/file_streaming.py
@@ -26,6 +26,7 @@ CHANNEL = "_test_channel"
 TOPIC = "_test_topic"
 TIMESTAMP = "_timestamp"
 FILE_NAME = "_filename"
+SITE_NAME = "_site_name"
 
 
 class FileSender(FLComponent):
@@ -51,6 +52,7 @@ class FileSender(FLComponent):
             context = {
                 TIMESTAMP: time.time(),
                 FILE_NAME: os.path.basename(self.file_name),
+                SITE_NAME: fl_ctx.get_identity_name(),
             }
             rc, result = FileStreamer.stream_file(
                 targets=["server"],
@@ -99,7 +101,8 @@ class FileReceiver(FLComponent):
         self.done = True
 
         basename = stream_ctx.get(FILE_NAME, "No Name")
-        file_name = os.path.join(self.output_folder, basename)
+        site_name = stream_ctx.get(SITE_NAME, "unknown")
+        file_name = os.path.join(self.output_folder, site_name + "_" + basename)
         if rc != ReturnCode.OK:
             self.log_error(fl_ctx, f"File {file_name} receiving failed with RC: {rc})")
             return


### PR DESCRIPTION
### Description

1. Added a 5 seconds delay in the controller in file streaming testing job to avoid client timeout at the end.
2. Added support for multiple clients.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
