### PR TITLE
Ingore -1 in slot numbers

### DIFF
--- a/nvflare/app_opt/xgboost/histogram_based_v2/aggr.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/aggr.py
@@ -22,6 +22,9 @@ class Aggregator:
 
     def _update_aggregation(self, gh_values, sample_bin_assignment, sample_id, aggr):
         bin_id = sample_bin_assignment[sample_id]
+        if bin_id < 0:
+            return
+        
         sample_value = gh_values[sample_id]
         current_value = aggr[bin_id]
         if current_value == 0:

--- a/nvflare/app_opt/xgboost/histogram_based_v2/sec/processor_data_converter.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/sec/processor_data_converter.py
@@ -124,7 +124,11 @@ class ProcessorDataConverter(DataConverter):
 
     @staticmethod
     def slot_to_bin(cuts: [int], slot: int) -> Tuple[int, int]:
-        if slot < 0 or slot >= cuts[-1]:
+
+        if slot < 0:
+            return 0, -1
+
+        if slot >= cuts[-1]:
             raise RuntimeError(f"Invalid slot {slot}, out of range [0-{cuts[-1] - 1}]")
 
         for i in range(len(cuts) - 1):


### PR DESCRIPTION
### Description

Ignore -1 slot number in the bin assignment returned from XGBoost during aggregation in Python.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
