### PR TITLE
Edge - add hello_async and hello_sync schemes 

### DIFF
--- a/examples/advanced/edge/jobs/hello_async/app/config/config_fed_client.json
+++ b/examples/advanced/edge/jobs/hello_async/app/config/config_fed_client.json
@@ -1,0 +1,44 @@
+{
+  "format_version": 2,
+  "executors": [
+    {
+      "tasks": ["train"],
+      "executor": {
+        "path": "nvflare.edge.executors.edge_model_executor.EdgeModelExecutor",
+        "args": {
+          "aggr_factory_id": "aggr_factory",
+          "max_model_versions": 4,
+          "update_timeout": 5.0
+        }
+      }
+    }
+  ],
+  "task_result_filters": [
+  ],
+  "task_data_filters": [
+  ],
+  "components": [
+    {
+      "id": "aggr_factory",
+      "path": "nvflare.edge.aggregators.num_dxo_factory.NumDXOAggrFactory",
+      "args": {}
+    },
+    {
+      "id": "device_factory",
+      "path": "nvflare.edge.devices.num.NumDeviceFactory",
+      "args": {
+        "min_train_time": 0.2,
+        "max_train_time": 1.0
+      }
+    },
+    {
+      "id": "device_runner",
+      "path": "nvflare.edge.widgets.device_runner.DeviceRunner",
+      "args": {
+        "device_factory_id": "device_factory",
+        "num_devices": 100,
+        "num_workers": 30
+      }
+    }
+  ]
+}

--- a/examples/advanced/edge/jobs/hello_async/app/config/config_fed_server.json
+++ b/examples/advanced/edge/jobs/hello_async/app/config/config_fed_server.json
@@ -1,0 +1,31 @@
+{
+  "format_version": 2,
+  "min_clients": 2,
+  "task_data_filters": [],
+  "task_result_filters": [],
+  "components": [
+    {
+      "id": "assessor",
+      "path": "nvflare.edge.assessors.async_num.AsyncNumAssessor",
+      "args": {
+        "max_model_version": 15,
+        "max_model_history": 3,
+        "num_updates_for_model": 10,
+        "device_selection_size": 30,
+        "min_hole_to_fill": 1,
+        "device_reuse": false
+      }
+    }
+  ],
+  "workflows": [
+    {
+      "id": "scatter_and_gather",
+      "path": "nvflare.edge.controllers.sage.ScatterAndGatherForEdge",
+      "args": {
+        "num_rounds": 1,
+        "assessor_id": "assessor",
+        "task_name": "train"
+      }
+    }
+  ]
+}

--- a/examples/advanced/edge/jobs/hello_async/meta.json
+++ b/examples/advanced/edge/jobs/hello_async/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "hello-async",
+  "resource_spec": {},
+  "min_clients" : 2,
+  "deploy_map": {
+    "app": [
+      "@ALL"
+    ]
+  }
+}

--- a/examples/advanced/edge/jobs/hello_sync/app/config/config_fed_client.json
+++ b/examples/advanced/edge/jobs/hello_sync/app/config/config_fed_client.json
@@ -1,0 +1,44 @@
+{
+  "format_version": 2,
+  "executors": [
+    {
+      "tasks": ["train"],
+      "executor": {
+        "path": "nvflare.edge.executors.edge_model_executor.EdgeModelExecutor",
+        "args": {
+          "aggr_factory_id": "aggr_factory",
+          "max_model_versions": 4,
+          "update_timeout": 5.0
+        }
+      }
+    }
+  ],
+  "task_result_filters": [
+  ],
+  "task_data_filters": [
+  ],
+  "components": [
+    {
+      "id": "aggr_factory",
+      "path": "nvflare.edge.aggregators.num_dxo_factory.NumDXOAggrFactory",
+      "args": {}
+    },
+    {
+      "id": "device_factory",
+      "path": "nvflare.edge.devices.num.NumDeviceFactory",
+      "args": {
+        "min_train_time": 0.2,
+        "max_train_time": 1.0
+      }
+    },
+    {
+      "id": "device_runner",
+      "path": "nvflare.edge.widgets.device_runner.DeviceRunner",
+      "args": {
+        "device_factory_id": "device_factory",
+        "num_devices": 1,
+        "num_workers": 1
+      }
+    }
+  ]
+}

--- a/examples/advanced/edge/jobs/hello_sync/app/config/config_fed_server.json
+++ b/examples/advanced/edge/jobs/hello_sync/app/config/config_fed_server.json
@@ -1,0 +1,31 @@
+{
+  "format_version": 2,
+  "min_clients": 2,
+  "task_data_filters": [],
+  "task_result_filters": [],
+  "components": [
+    {
+      "id": "assessor",
+      "path": "nvflare.edge.assessors.async_num.AsyncNumAssessor",
+      "args": {
+        "max_model_version": 3,
+        "max_model_history": 1,
+        "num_updates_for_model": 4,
+        "device_selection_size": 4,
+        "min_hole_to_fill": 4,
+        "device_reuse": true
+      }
+    }
+  ],
+  "workflows": [
+    {
+      "id": "scatter_and_gather",
+      "path": "nvflare.edge.controllers.sage.ScatterAndGatherForEdge",
+      "args": {
+        "num_rounds": 1,
+        "assessor_id": "assessor",
+        "task_name": "train"
+      }
+    }
+  ]
+}

--- a/examples/advanced/edge/jobs/hello_sync/meta.json
+++ b/examples/advanced/edge/jobs/hello_sync/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "hello-sync",
+  "resource_spec": {},
+  "min_clients" : 2,
+  "deploy_map": {
+    "app": [
+      "@ALL"
+    ]
+  }
+}

--- a/nvflare/edge/assessors/async_num.py
+++ b/nvflare/edge/assessors/async_num.py
@@ -46,7 +46,7 @@ class AsyncNumAssessor(Assessor):
         max_model_history,
         device_selection_size,
         min_hole_to_fill=1,
-        device_reuse = True
+        device_reuse=True,
     ):
         Assessor.__init__(self)
         self.current_model_version = 0

--- a/nvflare/edge/assessors/async_num.py
+++ b/nvflare/edge/assessors/async_num.py
@@ -41,23 +41,27 @@ class AsyncNumAssessor(Assessor):
 
     def __init__(
         self,
-        num_updates_for_model=10,
-        max_model_versions=3,
-        device_selection_size=20,
-        train_time=60.0,
+        num_updates_for_model,
+        max_model_version,
+        max_model_history,
+        device_selection_size,
+        min_hole_to_fill=1,
+        device_reuse = True
     ):
         Assessor.__init__(self)
         self.current_model_version = 0
         self.current_model = None
         self.current_selection_version = 0
-        self.train_time = train_time
         self.current_selection = {}
         self.updates = {}  # model_version => _ModelState
         self.available_devices = {}
         self.used_devices = {}
         self.num_updates_for_model = num_updates_for_model
-        self.max_model_versions = max_model_versions
+        self.max_model_version = max_model_version
+        self.max_model_history = max_model_history
         self.device_selection_size = device_selection_size
+        self.min_hole_to_fill = min_hole_to_fill
+        self.device_reuse = device_reuse
         self.update_lock = threading.Lock()
         self.start_time = None
 
@@ -85,7 +89,7 @@ class AsyncNumAssessor(Assessor):
             aggr_info[v] = {"weight": weight, "value": aggr.value, "count": aggr.count, "score": score}
             total += weight * score
 
-            if self.current_model_version - v >= self.max_model_versions:
+            if self.current_model_version - v >= self.max_model_history:
                 old_model_versions.append(v)
 
         # create the ModelState for the new model version
@@ -109,7 +113,7 @@ class AsyncNumAssessor(Assessor):
         report = StateUpdateReport.from_shareable(update)
         if report.available_devices:
             self.available_devices.update(report.available_devices)
-            self.log_info(
+            self.log_debug(
                 fl_ctx,
                 f"assessor got reported {len(report.available_devices)} available devices from child. "
                 f"total num available devices: {len(self.available_devices)}",
@@ -126,7 +130,7 @@ class AsyncNumAssessor(Assessor):
                     self.log_error(fl_ctx, f"bad child update version {model_version}: no update data")
                     continue
 
-                if self.current_model_version - model_version > self.max_model_versions:
+                if self.current_model_version - model_version > self.max_model_history:
                     # this version is too old
                     self.log_info(
                         fl_ctx,
@@ -166,9 +170,11 @@ class AsyncNumAssessor(Assessor):
                     self._generate_new_model(fl_ctx)
 
             # recompute selection
-            self._fill_selection(fl_ctx)
+            num_holes = self.device_selection_size - len(self.current_selection)
+            if num_holes >= self.min_hole_to_fill:
+                self._fill_selection(fl_ctx)
         else:
-            self.log_info(fl_ctx, "no model updates")
+            self.log_debug(fl_ctx, "no model updates")
 
         # reply
         if self.current_model_version == 0:
@@ -195,25 +201,32 @@ class AsyncNumAssessor(Assessor):
         self.log_info(fl_ctx, f"filling {num_holes} holes in selection list")
         if num_holes > 0:
             self.current_selection_version += 1
-            usable_devices = set(self.available_devices.keys()) - set(self.used_devices.keys())
+            if not self.device_reuse:
+                # remove all used devices from available devices
+                usable_devices = set(self.available_devices.keys()) - set(self.used_devices.keys())
+            else:
+                # remove only the devices that are associated with the current model version
+                usable_devices = set(self.available_devices.keys()) - set(
+                    k for k, v in self.used_devices.items() if v == self.current_model_version
+                )
+
             if usable_devices:
                 for _ in range(num_holes):
                     device_id = random.choice(list(usable_devices))
                     usable_devices.remove(device_id)
                     self.current_selection[device_id] = self.current_selection_version
-                    self.used_devices[device_id] = self.current_selection_version
+                    self.used_devices[device_id] = self.current_model_version
                     if not usable_devices:
                         break
         self.log_info(fl_ctx, f"current selection: V{self.current_selection_version}; {self.current_selection}")
 
     def assess(self, fl_ctx: FLContext) -> Assessment:
-        duration = time.time() - self.start_time
-        if duration > self.train_time:
+        if self.current_model_version >= self.max_model_version:
             model_version = self.current_model_version
             selection_version = self.current_selection_version
             self.log_info(
                 fl_ctx,
-                f"training finished in {duration} secs: {model_version=} {selection_version=} "
+                f"Max model version {self.max_model_version} reached: {model_version=} {selection_version=} "
                 f"num of devices used: {len(self.used_devices)}",
             )
             return Assessment.WORKFLOW_DONE

--- a/nvflare/edge/executors/edge_model_executor.py
+++ b/nvflare/edge/executors/edge_model_executor.py
@@ -149,7 +149,7 @@ class EdgeModelExecutor(EdgeTaskExecutor):
         if not selected:
             return self._make_retry(job_id, "Device not selected")
 
-        self.log_info(
+        self.log_debug(
             fl_ctx, f"task for model V{task_state.model_version} sent to device {device_id}: {new_selection_id=}"
         )
         task_data = self._convert_task(task_state, current_task, fl_ctx)
@@ -196,7 +196,7 @@ class EdgeModelExecutor(EdgeTaskExecutor):
         self.log_info(fl_ctx, f"Got task_ended: {task.id} (seq {task.seq})")
 
     def process_edge_request(self, request: Any, current_task: TaskInfo, fl_ctx: FLContext) -> Any:
-        self.log_info(fl_ctx, f"Received edge request from device: {request['device_info']}")
+        self.log_debug(fl_ctx, f"Received edge request from device: {request['device_info']}")
 
         try:
             if isinstance(request, TaskRequest):

--- a/nvflare/edge/updaters/emd.py
+++ b/nvflare/edge/updaters/emd.py
@@ -106,7 +106,7 @@ class EdgeModelUpdater(Updater):
                 model_updates[k] = v.to_model_update(fl_ctx)
 
             if model_updates:
-                self.log_info(fl_ctx, f"prepared {len(model_updates)} model updates for parent")
+                self.log_debug(fl_ctx, f"prepared {len(model_updates)} model updates for parent")
 
             report = StateUpdateReport(
                 current_model_version=state.model_version,
@@ -115,7 +115,7 @@ class EdgeModelUpdater(Updater):
                 available_devices=self.available_devices,
             )
 
-            self.log_info(
+            self.log_debug(
                 fl_ctx,
                 f"prepared parent update report: {report.current_model_version=} "
                 f"model_updates={report.model_updates.keys()}"
@@ -211,7 +211,7 @@ class EdgeModelUpdater(Updater):
                 device_selection=dev_selection,
             )
 
-            self.log_info(
+            self.log_debug(
                 fl_ctx,
                 f"accepted {len(report.available_devices)} available devices from child "
                 f"total available devices is now {len(self.available_devices)}",


### PR DESCRIPTION
Fixes # .

### Description

Sync (without sampling) is a special case to async scheme under the following settings:
Assuming we have 4 leaf nodes, and the total device is 4N, then to have a synchronized scheme with all devices participating in a synchronized manner, we set

- Client-side, num_devices = N 
- Server-side, num_updates_for_model = device_selection_size = min_hole_to_fill = 4N
- Server-side, set device_reuse to True

In this way, server will have to wait for all devices to report (num_updates_for_model) to cast a new model, and have to wait for the entire list become empty (min_hole_to_fill) to fill, and the same device will get new model (device_reuse) for local training

To further simulate sync with over-sampling, we can set
- Server-side, num_updates_for_model = min_hole_to_fill = 4N, device_selection_size > 4N
- Server-side, set device_reuse to True, (and set clear_list when min_hole_to_fill reached to true - to implement)
- Client-side, num_devices >= device_selection_size / 4

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
