### PR TITLE
Cherry-pick Update CIFAR10 to use TBWriter (#3449)

### DIFF
--- a/examples/advanced/cifar10/cifar10-real-world/jobs/cifar10_fedavg_stream_tb/cifar10_fedavg_stream_tb/config/config_fed_client.json
+++ b/examples/advanced/cifar10/cifar10-real-world/jobs/cifar10_fedavg_stream_tb/cifar10_fedavg_stream_tb/config/config_fed_client.json
@@ -31,8 +31,8 @@
             }
         },
         {
-            "id": "analytic_sender",
-            "path": "nvflare.app_common.widgets.streaming.AnalyticsSender",
+            "id": "tb_writer",
+            "path": "nvflare.app_opt.tracking.tb.tb_writer.TBWriter",
             "args": {
                 "event_type": "analytix_log_stats"
             }

--- a/examples/advanced/cifar10/pt/learners/cifar10_learner.py
+++ b/examples/advanced/cifar10/pt/learners/cifar10_learner.py
@@ -44,7 +44,7 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
         lr: float = 1e-2,
         fedproxloss_mu: float = 0.0,
         central: bool = False,
-        analytic_sender_id: str = "analytic_sender",
+        tb_writer_id: str = "tb_writer",
         batch_size: int = 64,
         num_workers: int = 0,
     ):
@@ -56,8 +56,8 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
             lr: local learning rate. Float number. Defaults to 1e-2.
             fedproxloss_mu: weight for FedProx loss. Float number. Defaults to 0.0 (no FedProx).
             central: Bool. Whether to simulate central training. Default False.
-            analytic_sender_id: id of `AnalyticsSender` if configured as a client component.
-                If configured, TensorBoard events will be fired. Defaults to "analytic_sender".
+            tb_writer_id: id of `TBWriter` if configured as a client component.
+                If configured, TensorBoard events will be fired. Defaults to "tb_writer".
             batch_size: batch size for training and validation.
             num_workers: number of workers for data loaders.
 
@@ -78,7 +78,7 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
         self.num_workers = num_workers
 
         self.writer = None
-        self.analytic_sender_id = analytic_sender_id
+        self.tb_writer_id = tb_writer_id
 
         # Epoch counter
         self.epoch_of_start_time = 0
@@ -124,7 +124,7 @@ class CIFAR10Learner(Learner):  # also supports CIFAR10ScaffoldLearner
         self.best_local_model_file = os.path.join(self.app_root, "best_local_model.pt")
 
         # Select local TensorBoard writer or event-based writer for streaming
-        self.writer = parts.get(self.analytic_sender_id)  # user configured config_fed_client.json for streaming
+        self.writer = parts.get(self.tb_writer_id)  # user configured config_fed_client.json for streaming
         if not self.writer:  # use local TensorBoard writer only
             self.writer = SummaryWriter(self.app_root)
 

--- a/examples/advanced/cifar10/pt/learners/cifar10_model_learner.py
+++ b/examples/advanced/cifar10/pt/learners/cifar10_model_learner.py
@@ -41,7 +41,7 @@ class CIFAR10ModelLearner(ModelLearner):  # does not support CIFAR10ScaffoldLear
         lr: float = 1e-2,
         fedproxloss_mu: float = 0.0,
         central: bool = False,
-        analytic_sender_id: str = "analytic_sender",
+        tb_writer_id: str = "tb_writer",
         batch_size: int = 64,
         num_workers: int = 0,
     ):
@@ -53,8 +53,8 @@ class CIFAR10ModelLearner(ModelLearner):  # does not support CIFAR10ScaffoldLear
             lr: local learning rate. Float number. Defaults to 1e-2.
             fedproxloss_mu: weight for FedProx loss. Float number. Defaults to 0.0 (no FedProx).
             central: Bool. Whether to simulate central training. Default False.
-            analytic_sender_id: id of `AnalyticsSender` if configured as a client component.
-                If configured, TensorBoard events will be fired. Defaults to "analytic_sender".
+            tb_writer_id: id of `TBWriter` if configured as a client component.
+                If configured, TensorBoard events will be fired. Defaults to "tb_writer".
             batch_size: batch size for training and validation.
             num_workers: number of workers for data loaders.
 
@@ -73,7 +73,7 @@ class CIFAR10ModelLearner(ModelLearner):  # does not support CIFAR10ScaffoldLear
         self.central = central
         self.batch_size = batch_size
         self.num_workers = num_workers
-        self.analytic_sender_id = analytic_sender_id
+        self.tb_writer_id = tb_writer_id
 
         # Epoch counter
         self.epoch_of_start_time = 0
@@ -111,9 +111,7 @@ class CIFAR10ModelLearner(ModelLearner):  # does not support CIFAR10ScaffoldLear
         self.best_local_model_file = os.path.join(self.app_root, "best_local_model.pt")
 
         # Select local TensorBoard writer or event-based writer for streaming
-        self.writer = self.get_component(
-            self.analytic_sender_id
-        )  # user configured config_fed_client.json for streaming
+        self.writer = self.get_component(self.tb_writer_id)  # user configured config_fed_client.json for streaming
         if not self.writer:  # use local TensorBoard writer only
             self.writer = SummaryWriter(self.app_root)
 

--- a/examples/advanced/cifar10/pt/learners/cifar10_scaffold_learner.py
+++ b/examples/advanced/cifar10/pt/learners/cifar10_scaffold_learner.py
@@ -34,7 +34,7 @@ class CIFAR10ScaffoldLearner(CIFAR10Learner):
         lr: float = 1e-2,
         fedproxloss_mu: float = 0.0,
         central: bool = False,
-        analytic_sender_id: str = "analytic_sender",
+        tb_writer_id: str = "tb_writer",
         batch_size: int = 64,
         num_workers: int = 0,
     ):
@@ -49,8 +49,8 @@ class CIFAR10ScaffoldLearner(CIFAR10Learner):
             lr: local learning rate. Float number. Defaults to 1e-2.
             fedproxloss_mu: weight for FedProx loss. Float number. Defaults to 0.0 (no FedProx).
             central: Bool. Whether to simulate central training. Default False.
-            analytic_sender_id: id of `AnalyticsSender` if configured as a client component.
-                If configured, TensorBoard events will be fired. Defaults to "analytic_sender".
+            tb_writer_id: id of `TBWriter` if configured as a client component.
+                If configured, TensorBoard events will be fired. Defaults to "tb_writer".
             batch_size: batch size for training and validation.
             num_workers: number of workers for data loaders.
 
@@ -66,7 +66,7 @@ class CIFAR10ScaffoldLearner(CIFAR10Learner):
             lr=lr,
             fedproxloss_mu=fedproxloss_mu,
             central=central,
-            analytic_sender_id=analytic_sender_id,
+            tb_writer_id=tb_writer_id,
             batch_size=batch_size,
             num_workers=num_workers,
         )

--- a/examples/advanced/cifar10/pt/learners/cifar10_scaffold_model_learner.py
+++ b/examples/advanced/cifar10/pt/learners/cifar10_scaffold_model_learner.py
@@ -31,7 +31,7 @@ class CIFAR10ScaffoldModelLearner(CIFAR10ModelLearner):
         lr: float = 1e-2,
         fedproxloss_mu: float = 0.0,
         central: bool = False,
-        analytic_sender_id: str = "analytic_sender",
+        tb_writer_id: str = "tb_writer",
         batch_size: int = 64,
         num_workers: int = 0,
     ):
@@ -46,8 +46,8 @@ class CIFAR10ScaffoldModelLearner(CIFAR10ModelLearner):
             lr: local learning rate. Float number. Defaults to 1e-2.
             fedproxloss_mu: weight for FedProx loss. Float number. Defaults to 0.0 (no FedProx).
             central: Bool. Whether to simulate central training. Default False.
-            analytic_sender_id: id of `AnalyticsSender` if configured as a client component.
-                If configured, TensorBoard events will be fired. Defaults to "analytic_sender".
+            tb_writer_id: id of `TBWriter` if configured as a client component.
+                If configured, TensorBoard events will be fired. Defaults to "tb_writer".
             batch_size: batch size for training and validation.
             num_workers: number of workers for data loaders.
 
@@ -62,7 +62,7 @@ class CIFAR10ScaffoldModelLearner(CIFAR10ModelLearner):
             lr=lr,
             fedproxloss_mu=fedproxloss_mu,
             central=central,
-            analytic_sender_id=analytic_sender_id,
+            tb_writer_id=tb_writer_id,
             batch_size=batch_size,
             num_workers=num_workers,
         )


### PR DESCRIPTION
The AnalyticsSender now is a lower level thing and does not have add_scalar.
The add_scalar functionality was moved already into TBWriter. So we should use TBWriter instead

- Update CIFAR10 example to use TBWriter

<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
