### PR TITLE
Add async aggregator

### DIFF
--- a/nvflare/apis/fl_context.py
+++ b/nvflare/apis/fl_context.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import threading
 from typing import Any, Dict, List
 
@@ -271,6 +271,19 @@ class FLContext(object):
 
         """
         self.props[key] = {V: value, M: make_mask(private, sticky)}
+
+    def clone(self):
+        """Make a copy from self.
+
+        Returns: a new FLContext object
+
+        """
+        with _update_lock:
+            new_ctx = FLContext()
+            new_ctx.model = self.model
+            new_ctx.logger = self.logger
+            new_ctx.props = copy.copy(self.props)  # shallow copy
+            return new_ctx
 
     # implement Context Manager protocol
     def __enter__(self):

--- a/nvflare/app_common/aggregators/async.py
+++ b/nvflare/app_common/aggregators/async.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import queue
+import threading
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+from nvflare.app_common.abstract.aggregator import Aggregator
+from nvflare.fuel.utils.validation_utils import check_positive_number, check_str
+from nvflare.fuel.utils.waiter_utils import WaiterRC, conditional_wait
+from nvflare.security.logging import secure_format_exception
+
+_SHORT_WAIT = 0.1
+
+
+class _AcceptWaitRC(WaiterRC):
+    END_RUN = 10
+
+
+class _Contribution:
+
+    def __init__(self, data: Shareable, fl_ctx: FLContext):
+        self.data = data
+
+        # We need to make a copy of the fl_ctx since it could be used for multiple contributions and its
+        # content could be overwritten.
+        self.fl_ctx = fl_ctx.clone()
+
+
+class AsyncAggregator(Aggregator):
+
+    def __init__(self, aggregator_id: str, accept_timeout: float = 600.0):
+        """Constructor of AsyncAggregator.
+        AsyncAggregator is a wrapper for other aggregators to do accept processing in a separate thread.
+
+        During a typical SAG-based training, updates from clients are processed by the aggregator's "accept" method.
+        To ensure the integrity of training task, The SAG workflow processes client updates sequentially.
+        If the "accept" method is time-consuming and there are many clients, then the update processing will
+        become bottleneck.
+
+        Using the AsyncAggregator, the updates from clients are simply added to a queue quickly.
+        The actual "accept" processing is done in a separate thread that processes the queued updates sequentially.
+
+        Args:
+            aggregator_id: component ID of the real aggregator
+            accept_timeout: max amount of time to wait for accept to finish
+        """
+        Aggregator.__init__(self)
+        check_str("aggregator_id", aggregator_id)
+        check_positive_number("accept_timeout", accept_timeout)
+
+        self.aggregator_id = aggregator_id
+        self.accept_timeout = accept_timeout
+        self.aggregator = None
+        self.contributions = queue.Queue()
+        self.aggregating = False
+        self.run_ended = False
+        self.accept_done = threading.Event()
+        self.register_event_handler(EventType.START_RUN, self._async_aggr_start_run)
+        self.register_event_handler(EventType.END_RUN, self._async_aggr_end_run)
+
+    def _async_aggr_start_run(self, event_type: str, fl_ctx: FLContext):
+        engine = fl_ctx.get_engine()
+        aggr = engine.get_component(self.aggregator_id)
+        if not isinstance(aggr, Aggregator):
+            self.system_panic(f"component {self.aggregator_id} must be Aggregator but got {type(aggr)}", fl_ctx)
+            return
+
+        if isinstance(aggr, AsyncAggregator):
+            self.system_panic(f"component {self.aggregator_id} must not be AsyncAggregator", fl_ctx)
+            return
+
+        self.aggregator = aggr
+        accept_thread = threading.Thread(target=self._do_accept, daemon=True)
+        accept_thread.start()
+
+    def _async_aggr_end_run(self, event_type: str, fl_ctx: FLContext):
+        self.run_ended = True
+
+    def accept(self, shareable: Shareable, fl_ctx: FLContext) -> bool:
+        if not self.aggregating:
+            self.log_debug(fl_ctx, "adding contribution to queue")
+            self.contributions.put(_Contribution(shareable, fl_ctx))
+            self.log_debug(fl_ctx, "done adding contribution to queue")
+            return True
+        else:
+            # when the aggregation is started, we no longer accept new contributions
+            self.log_warning(fl_ctx, "dropped contribution while aggregating")
+            return False
+
+    def _do_accept(self):
+        self.logger.debug("Started accept thread")
+        while True:
+            if self.run_ended:
+                # the job is already done or aborted
+                self.logger.debug("run ended - exit")
+                break
+
+            try:
+                # we wait very shortly when trying to get a contribution, so we can check other conditions
+                contrib = self.contributions.get(timeout=_SHORT_WAIT)
+            except queue.Empty:
+                contrib = None
+
+            if contrib:
+                assert isinstance(contrib, _Contribution)
+                self.log_debug(contrib.fl_ctx, "Accepting contribution")
+                try:
+                    accepted = self.aggregator.accept(contrib.data, contrib.fl_ctx)
+                    self.log_debug(contrib.fl_ctx, f"{type(self.aggregator)} processed contribution: {accepted=}")
+                except Exception as ex:
+                    self.log_exception(
+                        contrib.fl_ctx,
+                        f"exception from {type(self.aggregator)} when accept: {secure_format_exception(ex)}",
+                    )
+
+            if self.aggregating and self.contributions.empty() and not self.accept_done.is_set():
+                # When self.aggregating is set, the "aggregate" process is started and waiting for all contributions
+                # to be accepted.
+                # We set "accept_done" when all pending contributions are done.
+                self.logger.debug("Finished accept for one round")
+                self.accept_done.set()
+
+        self.logger.debug("Finished accept thread")
+
+    def aggregate(self, fl_ctx: FLContext) -> Shareable:
+        self.log_debug(fl_ctx, "starting to aggregate")
+        # set self.aggregating to notify the "accept" thread that we are starting aggregation.
+        self.aggregating = True
+
+        # we wait until the "accept" thread is done with pending contributions
+        rc = conditional_wait(
+            waiter=self.accept_done,
+            timeout=self.accept_timeout,
+            abort_signal=fl_ctx.get_run_abort_signal(),
+            condition_cb=self._check_end_run,
+        )
+
+        if rc in [_AcceptWaitRC.ABORTED, _AcceptWaitRC.END_RUN]:
+            self.log_info(fl_ctx, "skipped aggregation since job is aborted")
+            return Shareable()
+
+        if rc != _AcceptWaitRC.IS_SET:
+            self.log_warning(fl_ctx, f"abnormal result {rc} waiting for accept thread")
+
+        # we then call the aggregator to perform actual aggregation
+        result = self.aggregator.aggregate(fl_ctx)
+
+        # reset state
+        self.aggregating = False
+        self.accept_done.clear()
+        self.log_debug(fl_ctx, "Finished aggregate for one round")
+        return result
+
+    def _check_end_run(self):
+        if self.run_ended:
+            return _AcceptWaitRC.END_RUN
+        else:
+            return _AcceptWaitRC.OK
+
+    def reset(self, fl_ctx: FLContext):
+        self.aggregating = False
+        self.accept_done.clear()
+        self.aggregator.reset(fl_ctx)


### PR DESCRIPTION
Fixes # .

### Description

This PR adds a wrapper aggregator that can be used to perform another aggregator's "accept" method in a separate thread. This can drastically reduce the block time of the SAG workflow when processing client submission if the "accept" processing is time-consuming.

To use this aggregator, the user simply puts the original aggregator as a component in this wrapper aggregator (AsyncAggregator):

"components": [
    {
      "id": "aggregator",
      "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
      "args": {
        "expected_data_kind": "WEIGHTS"
      }
    },
    {
      "id": "aggr_wrapper",
      "path": "nvflare.app_common.aggregators.async.AsyncAggregator",
      "args": {
        "aggregator_id": "aggregator"
      }
    },
    ...
  ],
  "workflows": [
    {
      "id": "scatter_and_gather",
      "path": "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather",
      "args": {
        "min_clients": "{min_clients}",
        "num_rounds": 2,
        "start_round": 0,
        "wait_time_after_min_received": "{wait_time}",
        "aggregator_id": "aggr_wrapper",
        "persistor_id": "persistor",
        "shareable_generator_id": "shareable_generator",
        "train_task_name": "train",
        "train_timeout": 6000,
        "ignore_result_error": true
      }
    }
  ]


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
