### PR TITLE
[2.6] Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ To install the [current release](https://pypi.org/project/nvflare/):
 ```
 $ python3 -m pip install nvflare
 ```
+
+For detailed installation please refer to [NVIDIA FLARE installation](https://nvflare.readthedocs.io/en/main/installation.html).
+
 ## Getting Started
 
 * To get started, visit our NVFLARE [website](https://nvidia.github.io/NVFlare/), which includes:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # NVIDIA FLARE
 
-[Website](https://nvidia.github.io/NVFlare) | [Paper](https://arxiv.org/abs/2210.13291) | [Blogs](https://developer.nvidia.com/blog/tag/federated-learning) | [Talks & Papers](https://nvflare.readthedocs.io/en/main/publications_and_talks.html) | [Research](./research/README.md) | [Documentation](https://nvflare.readthedocs.io/en/main)
+[Website](https://nvidia.github.io/NVFlare) | [Paper](https://arxiv.org/abs/2210.13291) | [Blogs](https://developer.nvidia.com/blog/tag/federated-learning) | [Talks & Papers](https://nvflare.readthedocs.io/en/2.6/publications_and_talks.html) | [Research](./research/README.md) | [Documentation](https://nvflare.readthedocs.io/en/2.6)
 
-[![Blossom-CI](https://github.com/NVIDIA/nvflare/workflows/Blossom-CI/badge.svg?branch=main)](https://github.com/NVIDIA/nvflare/actions)
-[![documentation](https://readthedocs.org/projects/nvflare/badge/?version=main)](https://nvflare.readthedocs.io/en/main/?badge=main)
+[![Blossom-CI](https://github.com/NVIDIA/nvflare/workflows/Blossom-CI/badge.svg?branch=2.6)](https://github.com/NVIDIA/nvflare/actions)
+[![documentation](https://readthedocs.org/projects/nvflare/badge/?version=2.6)](https://nvflare.readthedocs.io/en/2.6/?badge=2.6)
 [![license](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](./LICENSE)
 [![pypi](https://badge.fury.io/py/nvflare.svg)](https://badge.fury.io/py/nvflare)
 [![pyversion](https://img.shields.io/pypi/pyversions/nvflare.svg)](https://badge.fury.io/py/nvflare)
@@ -36,7 +36,7 @@ From Simulation to Real-World
 * Security enforcement through federated authorization and privacy policy
 * Built-in support for system resiliency and fault tolerance
 
-> _Take a look at [NVIDIA FLARE Overview](https://nvflare.readthedocs.io/en/main/flare_overview.html) for a complete overview, and [What's New](https://nvflare.readthedocs.io/en/main/whats_new.html) for the lastest changes._
+> _Take a look at [NVIDIA FLARE Overview](https://nvflare.readthedocs.io/en/2.6/flare_overview.html) for a complete overview, and [What's New](https://nvflare.readthedocs.io/en/2.6/whats_new.html) for the lastest changes._
 
 ## Installation
 To install the [current release](https://pypi.org/project/nvflare/):
@@ -44,7 +44,7 @@ To install the [current release](https://pypi.org/project/nvflare/):
 $ python3 -m pip install nvflare
 ```
 
-For detailed installation please refer to [NVIDIA FLARE installation](https://nvflare.readthedocs.io/en/main/installation.html).
+For detailed installation please refer to [NVIDIA FLARE installation](https://nvflare.readthedocs.io/en/2.6/installation.html).
 
 ## Getting Started
 
@@ -59,22 +59,22 @@ For detailed installation please refer to [NVIDIA FLARE installation](https://nv
   * DLI courses:
     * https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-FX-28+V1
     * https://learn.nvidia.com/courses/course-detail?course_id=course-v1:DLI+S-FX-29+V1
-  * follow the notebooks: https://github.com/NVIDIA/NVFlare/tree/main/examples/tutorials/self-paced-training
+  * follow the notebooks: https://github.com/NVIDIA/NVFlare/tree/2.6/examples/tutorials/self-paced-training
  
-* If you'd like to write your own NVIDIA FLARE components, a detailed programming guide can be found [here](https://nvflare.readthedocs.io/en/main/programming_guide.html).
+* If you'd like to write your own NVIDIA FLARE components, a detailed programming guide can be found [here](https://nvflare.readthedocs.io/en/2.6/programming_guide.html).
 * visit developer portal https://developer.nvidia.com/flare
 
 ## Community
 
-We welcome community contributions! Please refer to the [contributing guidelines](https://github.com/NVIDIA/NVFlare/blob/main/CONTRIBUTING.md) for more details.
+We welcome community contributions! Please refer to the [contributing guidelines](./CONTRIBUTING.md) for more details.
 
 Ask and answer questions, share ideas, and engage with other community members at [NVFlare Discussions](https://github.com/NVIDIA/NVFlare/discussions).
 
 ## Related Talks and Publications
 
-Take a look at our growing list of [talks and publications](https://nvflare.readthedocs.io/en/main/publications_and_talks.html), and [technical blogs](https://developer.nvidia.com/blog/tag/federated-learning) related to NVIDIA FLARE.
+Take a look at our growing list of [talks and publications](https://nvflare.readthedocs.io/en/2.6/publications_and_talks.html), and [technical blogs](https://developer.nvidia.com/blog/tag/federated-learning) related to NVIDIA FLARE.
 
 
 ## License
 
-NVIDIA FLARE is released under an [Apache 2.0 license](https://github.com/NVIDIA/NVFlare/blob/main/LICENSE).
+NVIDIA FLARE is released under an [Apache 2.0 license](./LICENSE).

--- a/docs/examples/hello_fedavg_numpy.rst
+++ b/docs/examples/hello_fedavg_numpy.rst
@@ -50,14 +50,14 @@ Ensure numpy is installed.
 
   (nvflare-env) $ python3 -m pip install numpy
 
-Now that you have all your dependencies installed, let's look into the ``fedavg_script_executor_hello-numpy.py`` script which
+Now that you have all your dependencies installed, let's look into the ``fedavg_script_runner_hello-numpy.py`` script which
 builds the job with the Job API.
 
 
 NVIDIA FLARE Job API
 --------------------
 
-The ``fedavg_script_executor_hello-numpy.py`` script builds the job with the Job API. The following sections are the key lines to focus on:
+The ``fedavg_script_runner_hello-numpy.py`` script builds the job with the Job API. The following sections are the key lines to focus on:
 
 Define a FedJob
 ^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ clients and rounds, then use the :func:`to<nvflare.job_config.api.FedJob.to>` ro
 
 Add Clients
 ^^^^^^^^^^^^
-Next, we can use the :class:`ScriptExecutor<nvflare.app_common.executors.script_executor.ScriptExecutor>` and send it to each of the
+Next, we can use the :class:`ScriptRunner<nvflare.job_config.script_runner.ScriptRunner>` and send it to each of the
 clients to run our training script. We will examine the training script ``hello-numpy_fl.py`` in the next main section.
 
 The :func:`to<nvflare.job_config.api.FedJob.to>` routine sends the component to the specified client for the job. Here, our clients
@@ -101,7 +101,7 @@ are named "site-0" and "site-1" and we are using the same training script for bo
    train_script = "src/hello-numpy_fl.py"
 
    for i in range(n_clients):
-      executor = ScriptExecutor(
+      executor = ScriptRunner(
          task_script_path=train_script, task_script_args="", params_exchange_format=ExchangeFormat.NUMPY
       )
       job.to(executor, f"site-{i}")
@@ -166,11 +166,11 @@ script ``hello-numpy_fl.py`` in the ``src`` directory of :github_nvflare_link:`e
 
 Running the Job API Script
 ---------------------------
-Now that you have a good understanding of the training script, you can run the job with the ``fedavg_script_executor_hello-numpy.py`` script:
+Now that you have a good understanding of the training script, you can run the job with the ``fedavg_script_runner_hello-numpy.py`` script:
 
 .. code-block:: shell
 
-   (nvflare-env) $ python3 fedavg_script_executor_hello-numpy.py
+   (nvflare-env) $ python3 fedavg_script_runner_hello-numpy.py
 
 This will run the job in a simulator environment and you should be able to see the output as the job proceeds to completion.
 

--- a/docs/examples/hello_pt_job_api.rst
+++ b/docs/examples/hello_pt_job_api.rst
@@ -3,6 +3,9 @@
 Hello PyTorch with Job API
 ==========================
 
+This example demonstrates how to use NVIDIA FLARE with PyTorch to train an image classifier using federated averaging (FedAvg).
+The complete example code can be found in the :github_nvflare_link:`hello-pt directory <examples/hello-world/hello-pt/>`.
+
 Before You Start
 ----------------
 
@@ -32,29 +35,36 @@ The following steps compose one cycle of weight updates, called a **round**:
  #. These updates are then sent to the server which will aggregate them to produce a model with new weights. 
  #. Finally, the server sends this updated version of the model back to each client.
 
-For this exercise, we will be working with the ``hello-pt`` application in the examples folder.
+Running the Example
+------------------
+To run this example:
 
-Let's get started. First clone the repo:
-
-.. code-block:: shell
-
-  $ git clone https://github.com/NVIDIA/NVFlare.git
-
-Remember to activate your NVIDIA FLARE Python virtual environment from the installation guide.
-
-Since you will use PyTorch and torchvision for this exercise, let's go ahead and install both libraries: 
+1. Clone the repository and navigate to the example directory:
 
 .. code-block:: shell
 
-  (nvflare-env) $ python3 -m pip install torch torchvision
+   $ git clone https://github.com/NVIDIA/NVFlare.git
+   $ cd NVFlare/examples/hello-world/hello-pt
 
-If you would like to go ahead and run the exercise now, you can run the ``fedavg_script_executor_hello-pt.py`` script which
-builds the job with the Job API and runs the job with the FLARE Simulator.
+2. Install the required dependencies:
+
+.. code-block:: shell
+
+   $ pip install -r requirements.txt
+
+3. Run the example:
+
+.. code-block:: shell
+
+   $ python fedavg_script_runner_pt.py
+
+The script will create an NVFlare job in /tmp/nvflare/jobs/job_config/hello-pt_cifar10_fedavg
+and run it using the FL Simulator.
 
 NVIDIA FLARE Job API
 --------------------
 
-The ``fedavg_script_executor_hello-pt.py`` script for this hello-pt example is very similar to the ``fedavg_script_executor_hello-numpy.py`` script
+The ``fedavg_script_runner_pt.py`` script for this hello-pt example is very similar to the ``fedavg_script_runner_hello-numpy.py`` script
 for the :doc:`Hello FedAvg with NumPy <hello_fedavg_numpy>` exercise. Other than changes to the names of the job and client script, the only difference
 is a line to define the initial global model for the server:
 
@@ -222,15 +232,15 @@ The client configuration is ``config_fed_client.json`` in the config folder of e
       "format_version": 2,
       "executors": [
          {
-               "tasks": [
-                  "*"
-               ],
-               "executor": {
-                  "path": "nvflare.app_common.executors.script_executor.ScriptExecutor",
-                  "args": {
-                     "task_script_path": "src/hello-pt_cifar10_fl.py"
-                  }
+            "tasks": [
+               "*"
+            ],
+            "executor": {
+               "path": "nvflare.app_opt.pt.in_process_client_api_executor.PTInProcessClientAPIExecutor",
+               "args": {
+                  "task_script_path": "src/hello-pt_cifar10_fl.py"
                }
+            }
          }
       ],
       "components": [
@@ -261,3 +271,4 @@ Previous Versions of Hello PyTorch
    - `hello-pt for 2.2 <https://github.com/NVIDIA/NVFlare/tree/2.2/examples/hello-pt>`_
    - `hello-pt for 2.3 <https://github.com/NVIDIA/NVFlare/tree/2.3/examples/hello-world/hello-pt>`_
    - `hello-pt for 2.4 <https://github.com/NVIDIA/NVFlare/tree/2.4/examples/hello-world/hello-pt>`_
+   - `hello-pt for 2.5 <https://github.com/NVIDIA/NVFlare/tree/2.5/examples/hello-world/hello-pt>`_

--- a/docs/examples/hello_tf_job_api.rst
+++ b/docs/examples/hello_tf_job_api.rst
@@ -45,12 +45,12 @@ Let's get started. Since this task is using TensorFlow, let's go ahead and insta
 
 With all the required dependencies installed, you are ready to run a Federated Learning system
 with two clients and one server. If you would like to go ahead and run the exercise now, you can run
-the ``fedavg_script_executor_hello-tf.py`` script which builds the job with the Job API and runs the
+the ``fedavg_script_runner_hello-tf.py`` script which builds the job with the Job API and runs the
 job with the FLARE Simulator.
 
 NVIDIA FLARE Job API
 --------------------
-The ``fedavg_script_executor_hello-tf.py`` script for this hello-tf example is very similar to the ``fedavg_script_executor_hello-numpy.py`` script
+The ``fedavg_script_runner_hello-tf.py`` script for this hello-tf example is very similar to the ``fedavg_script_runner_hello-numpy.py`` script
 for the :doc:`Hello FedAvg with NumPy <hello_fedavg_numpy>` example and also the script for the :doc:`Hello PyTorch <hello_pt_job_api>`
 example. Other than changes to the names of the job and client script, the only difference is the line to define the initial global model
 for the server:
@@ -182,15 +182,15 @@ The client configuration is ``config_fed_client.json`` in the config folder of e
       "format_version": 2,
       "executors": [
          {
-               "tasks": [
-                  "*"
-               ],
-               "executor": {
-                  "path": "nvflare.app_common.executors.script_executor.ScriptExecutor",
-                  "args": {
-                     "task_script_path": "src/hello-tf_fl.py"
-                  }
+            "tasks": [
+               "*"
+            ],
+            "executor": {
+               "path": "nvflare.app_opt.tf.in_process_client_api_executor.TFInProcessClientAPIExecutor",
+               "args": {
+                  "task_script_path": "src/hello-tf_fl.py"
                }
+            }
          }
       ],
       "components": [

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,9 +4,42 @@
 Getting Started
 ###############
 
-### To get started, take a look at the instructions and code examples on our [**website**](https://nvidia.github.io/NVFlare/).
+This guide will help you understand the different ways to run NVIDIA FLARE and get started with your federated learning journey.
+Before proceeding, make sure you have completed the :ref:`quickstart` guide to run your first example.
 
-* For more details, see our getting started `tutorials <https://github.com/NVIDIA/NVFlare/tree/main/examples/getting_started>`__.
-* For more advanced examples and `step-by-step <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/step-by-step>`__ walk-troughs, see our `examples <https://github.com/NVIDIA/NVFlare/tree/main/examples>`__.
-* There are also detailed instructions on how to convert your standalone/centralized training code to `federated learning code. <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/ml-to-fl>`__.
-* If you'd like to write your own NVIDIA FLARE components, a detailed programming guide can be found `here <https://nvflare.readthedocs.io/en/main/programming_guide.html>`__.
+Ways to Run NVFlare
+==================
+NVFlare supports different running modes to accommodate various use cases, from development to production:
+
+.. list-table:: NVIDIA FLARE Modes
+   :header-rows: 1
+
+   * - **Mode**
+     - **Documentation**
+     - **Description**
+   * - Simulator
+     - :ref:`fl_simulator`
+     - | The FL Simulator is a light weight simulation where the job run is automated on a 
+       | single system. Useful for quickly running a job or experimenting with research 
+       | or FL algorithms.
+   * - POC
+     - :ref:`poc_command`
+     - | POC mode establishes and connects distinct server and client "systems" which can 
+       | then be orchestrated using the FLARE Console all from a single machine. Users can 
+       | also experiment with various deployment options (project.yml), which can be used 
+       | in production modes.
+   * - Production
+     - :ref:`provisioned_setup`
+     - | Real world production mode involves a distributed deployment with generated startup 
+       | kits from the provisioning process. Provides provisioning tool, dashboard, and 
+       | various deployment options.
+
+Next Steps
+==========
+Now that you understand the different ways to run NVFlare:
+
+1. Try the getting started `tutorials <https://github.com/NVIDIA/NVFlare/tree/main/examples/getting_started>`__ to learn more about each mode
+2. Explore more advanced examples and `step-by-step <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/step-by-step>`__ walk-throughs
+3. Learn how to convert your standalone/centralized training code to `federated learning code <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/ml-to-fl>`__
+4. When ready for production, see :ref:`real_world_fl` for deployment guidance
+5. For development, see :ref:`programming_guide` for detailed programming instructions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,10 @@ NVIDIA FLARE
 
    fl_introduction
    flare_overview
+   Installation <installation>
+   Quickstart <quickstart>
+   getting_started
    whats_new
-   Getting Started <quickstart>
 
 .. toctree::
    :maxdepth: -1
@@ -52,9 +54,13 @@ Learn more about FLARE features in the :ref:`FLARE Overview <flare_overview>` an
 
 Getting Started
 ===============
+To get started with NVIDIA FLARE:
+
+1. Follow the :ref:`installation` guide to set up your environment
+2. Run through the :ref:`quickstart` guide to try your first example
+3. Explore more examples in the :ref:`Example Applications <example_applications>` section
+
 For first-time users and FL researchers, FLARE provides the :ref:`FL Simulator <fl_simulator>` that allows you to build, test, and deploy applications locally.
-The :ref:`Getting Started <getting_started>` guide covers installation and walks through an example application using the FL Simulator.
-Additional examples can be found at the :ref:`Examples Applications <example_applications>`, which showcase different federated learning workflows and algorithms on various machine learning and deep learning tasks.
 
 FLARE for Users
 ===============

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -78,12 +78,54 @@ Stable releases are available on `NVIDIA FLARE PyPI <https://pypi.org/project/nv
 
   $ python3 -m pip install nvflare
 
-.. note::
+Optional Dependencies
+^^^^^^^^^^^^^^^^^^^^
 
-    In addition to the dependencies included when installing nvflare, many of our example applications have additional packages that must be installed.
-    Make sure to install from any requirement.txt files before running the examples. If you already have a specific version of nvflare installed in your
-    environment, you may want to remove nvflare in the requirements to avoid reinstalling nvflare.
-    See :github_nvflare_link:`nvflare/app_opt <nvflare/app_opt>` for modules and components with optional dependencies.
+NVFlare provides several optional dependency groups that you can install based on your needs:
+
+* **HE** - Homomorphic Encryption support:
+  .. code-block:: shell
+     $ pip install nvflare[HE]
+
+* **PSI** - Private Set Intersection support:
+  .. code-block:: shell
+     $ pip install nvflare[PSI]
+
+* **PT** - PyTorch support:
+  .. code-block:: shell
+     $ pip install nvflare[PT]
+
+* **SKLEARN** - Scikit-learn support:
+  .. code-block:: shell
+     $ pip install nvflare[SKLEARN]
+
+* **TRACKING** - MLflow, Weights & Biases, and TensorBoard support:
+  .. code-block:: shell
+     $ pip install nvflare[TRACKING]
+
+* **MONITORING** - Datadog monitoring support:
+  .. code-block:: shell
+     $ pip install nvflare[MONITORING]
+
+* **CONFIG** - OmegaConf configuration support:
+  .. code-block:: shell
+     $ pip install nvflare[CONFIG]
+
+You can also install multiple optional dependencies at once:
+
+.. code-block:: shell
+
+  $ pip install nvflare[PT,SKLEARN,TRACKING]  # Install PyTorch, Scikit-learn, and tracking support
+
+For development, you can install all dependencies (except HE and PSI on macOS):
+
+.. code-block:: shell
+
+  # On Linux
+  $ pip install nvflare[dev]
+
+  # On macOS
+  $ pip install nvflare[dev_mac]
 
 Install from Source
 ------------------
@@ -94,7 +136,14 @@ Clone NVFlare repo and install from source (useful for accessing latest nightly 
 
   $ git clone https://github.com/NVIDIA/NVFlare.git
   $ cd NVFlare
-  $ pip install -e .
+  $ pip install -e .  # Install in editable mode
+
+You can also install with optional dependencies from source:
+
+.. code-block:: shell
+
+  $ pip install -e ".[dev]"  # Install all development dependencies
+  $ pip install -e ".[PT,SKLEARN]"  # Install specific optional dependencies
 
 Note on branches:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,161 @@
+.. _installation:
+
+#############
+Installation
+#############
+
+This guide covers the installation of NVIDIA FLARE and its dependencies.
+Before proceeding, make sure you understand the basics of federated learning
+from the :ref:`fl_introduction` and have reviewed the :ref:`flare_overview` to understand what you'll be installing.
+
+Prerequisites
+=============
+- Python 3.9+
+- pip
+- Git
+
+.. note::
+   The server and client versions of nvflare must match, we do not support cross-version compatibility.
+
+Supported Operating Systems
+---------------------------
+- Linux
+- OSX (Note: some optional dependencies are not compatible, such as tenseal and openmined.psi)
+
+Installation Methods
+===================
+
+Virtual Environment Setup
+------------------------
+
+It is highly recommended to install NVIDIA FLARE in a virtual environment if you are not using :ref:`containerized_deployment`.
+This guide briefly describes how to create a virtual environment with venv.
+
+Virtual Environments and Packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Python's official document explains the main idea about virtual environments.
+The module used to create and manage virtual environments is called `venv <https://docs.python.org/3.10/library/venv.html>`_.
+You can find more information there. We only describe a few necessary steps for a virtual environment for NVIDIA FLARE.
+
+Depending on your OS and the Python distribution, you may need to install the Python's venv package separately. For example, in Ubuntu
+20.04, you need to run the following commands to continue creating a virtual environment with venv.
+
+.. code-block:: shell
+
+   $ sudo apt update
+   $ sudo apt-get install python3-venv
+
+Once venv is installed, you can use it to create a virtual environment with:
+
+.. code-block:: shell
+
+    $ python3 -m venv nvflare-env
+
+This will create the ``nvflare-env`` directory in current working directory if it doesn't exist,
+and also create directories inside it containing a copy of the Python interpreter,
+the standard library, and various supporting files.
+
+Activate the virtualenv by running the following command:
+
+.. code-block:: shell
+
+    $ source nvflare-env/bin/activate
+
+You may find that the pip and setuptools versions in the venv need updating:
+
+.. code-block:: shell
+
+  (nvflare-env) $ python3 -m pip install -U pip
+  (nvflare-env) $ python3 -m pip install -U setuptools
+
+Install Stable Release
+---------------------
+
+Stable releases are available on `NVIDIA FLARE PyPI <https://pypi.org/project/nvflare>`_:
+
+.. code-block:: shell
+
+  $ python3 -m pip install nvflare
+
+.. note::
+
+    In addition to the dependencies included when installing nvflare, many of our example applications have additional packages that must be installed.
+    Make sure to install from any requirement.txt files before running the examples. If you already have a specific version of nvflare installed in your
+    environment, you may want to remove nvflare in the requirements to avoid reinstalling nvflare.
+    See :github_nvflare_link:`nvflare/app_opt <nvflare/app_opt>` for modules and components with optional dependencies.
+
+Install from Source
+------------------
+
+Clone NVFlare repo and install from source (useful for accessing latest nightly features or testing custom builds):
+
+.. code-block:: shell
+
+  $ git clone https://github.com/NVIDIA/NVFlare.git
+  $ cd NVFlare
+  $ pip install -e .
+
+Note on branches:
+
+* The `main <https://github.com/NVIDIA/NVFlare/tree/main>`_ branch is the default (unstable) development branch
+* The 2.1, 2.2, 2.3, 2.4, 2.5, etc. branches are the branches for each major release and there are tags based on these with a third digit for minor patches
+
+To switch to a specific branch:
+
+.. code-block:: shell
+
+  $ git switch 2.6  # Replace with desired version
+
+Building Wheels
+---------------
+
+You can build wheel packages for NVFlare using the following steps:
+
+1. Install build dependencies:
+
+.. code-block:: shell
+
+  $ pip install build wheel
+
+2. Build the wheel:
+
+.. code-block:: shell
+
+  $ python -m build
+
+This will create wheel files in the `dist/` directory. The wheel files can be installed using pip:
+
+.. code-block:: shell
+
+  $ pip install dist/nvflare-*.whl
+
+.. note::
+   Building wheels requires all build dependencies to be installed. If you encounter any issues,
+   make sure you have the latest version of pip, setuptools, and wheel installed.
+
+Building for Specific Platforms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To build wheels for specific platforms or Python versions, you can use the following environment variables:
+
+.. code-block:: shell
+
+  # For a specific Python version
+  $ PYTHON=python3.9 python -m build
+
+  # For a specific platform
+  $ PLATFORM=linux_x86_64 python -m build
+
+.. note::
+   The platform-specific builds are useful when you need to distribute wheels to systems
+   with different architectures or Python versions.
+
+Next Steps
+==========
+After completing the installation:
+
+1. Follow the :ref:`quickstart` guide to run your first federated learning example
+2. Learn more about different ways to use NVFlare in the :ref:`getting_started` guide
+3. Explore more examples in the :ref:`example_applications` section
+4. When ready for production, see :ref:`real_world_fl` for deployment guidance 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,426 +1,58 @@
+.. _quickstart:
+
 ##########
 Quickstart
 ##########
 
-.. _installation:
+This guide will get you running a simple federated learning example in minutes.
+Make sure you have completed the :ref:`installation` steps before proceeding.
 
-Installation
+Prerequisites
 =============
+- Python 3.9+
+- pip
+- Git
+- NVFlare installed (see :ref:`installation`)
 
-.. note::
-   The server and client versions of nvflare must match, we do not support cross-version compatibility.
-
-Supported Operating Systems
----------------------------
-- Linux
-- OSX (Note: some optional dependencies are not compatible, such as tenseal and openmined.psi)
-
-Python Version
---------------
-
-NVIDIA FLARE requires Python 3.9+.
-
-Install NVIDIA FLARE in a virtual environment
----------------------------------------------
-
-It is highly recommended to install NVIDIA FLARE in a virtual environment if you are not using :ref:`containerized_deployment`.
-This guide briefly describes how to create a virtual environment with venv.
-
-Virtual Environments and Packages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Python's official document explains the main idea about virtual environments.
-The module used to create and manage virtual environments is called `venv <https://docs.python.org/3.8/library/venv.html#module-venv>`_.
-You can find more information there.  We only describe a few necessary steps for a virtual environment for NVIDIA FLARE.
-
-
-Depending on your OS and the Python distribution, you may need to install the Python's venv package separately.  For example, in Ubuntu
-20.04, you need to run the following commands to continue creating a virtual environment with venv.
+Run Your First Example
+======================
+1. Clone the examples:
 
 .. code-block:: shell
 
-   $ sudo apt update
-   $ sudo apt-get install python3-venv
+   $ git clone https://github.com/NVIDIA/NVFlare.git
+   $ cd NVFlare/examples/hello-world/hello-pt
 
-
-Once venv is installed, you can use it to create a virtual environment with:
-
-.. code-block:: shell
-
-    $ python3 -m venv nvflare-env
-
-This will create the ``nvflare-env`` directory in current working directory if it doesn't exist,
-and also create directories inside it containing a copy of the Python interpreter,
-the standard library, and various supporting files.
-
-
-Activate the virtualenv by running the following command:
+2. Install example dependencies:
 
 .. code-block:: shell
 
-    $ source nvflare-env/bin/activate
+   $ pip install -r requirements.txt
 
-
-You may find that the pip and setuptools versions in the venv need updating:
-
-.. code-block:: shell
-
-  (nvflare-env) $ python3 -m pip install -U pip
-  (nvflare-env) $ python3 -m pip install -U setuptools
-
-Install Stable Release of NVFlare
----------------------------------
-
-Stable releases are available on `NVIDIA FLARE PyPI <https://pypi.org/project/nvflare>`_:
+3. Run the example:
 
 .. code-block:: shell
 
-  $ python3 -m pip install nvflare
+   $ python fedavg_script_runner_pt.py
 
-.. note::
+That's it! You should see the federated learning simulation running with two clients training a model together.
 
-    In addition to the dependencies included when installing nvflare, many of our example applications have additional packages that must be installed.
-    Make sure to install from any requirement.txt files before running the examples. If you already have a specific version of nvflare installed in your
-    environment, you may want to remove nvflare in the requirements to avoid reinstalling nvflare.
-    See :github_nvflare_link:`nvflare/app_opt <nvflare/app_opt>` for modules and components with optional dependencies.
-
-Cloning the NVFlare Repository and Checking Out a Branch
----------------------------------------------------------
-
-Clone NVFlare repo to get examples, and switch to either the main branch or the latest stable branch:
-
-.. code-block:: shell
-
-  $ git clone https://github.com/NVIDIA/NVFlare.git
-  $ cd NVFlare
-  $ git switch 2.5
-
-Note on branches:
-
-* The `main <https://github.com/NVIDIA/NVFlare/tree/main>`_ branch is the default (unstable) development branch
-
-* The 2.1, 2.2, 2.3, 2.4, 2.5, etc. branches are the branches for each major release and there are tags based on these with a third digit for minor patches
-
-Install NVFlare from source
-----------------------------
-
-Navigate to the NVFlare repository and use pip install with development mode (can be useful to access latest nightly features or test custom builds for example):
-
-.. code-block:: shell
-
-  $ git clone https://github.com/NVIDIA/NVFlare.git
-  $ cd NVFlare
-  $ pip install -e .
-
-
-.. _containerized_deployment:
-
-Containerized Deployment with Docker
-====================================
-
-Running NVIDIA FLARE in a Docker container is sometimes a convenient way to ensure a
-uniform OS and software environment across client and server systems.  This can be used
-as an alternative to the bare-metal Python virtual environment described above and will
-use a similar installation to simplify transitioning between a bare metal and containerized
-environment.
-
-To get started with a containerized deployment, you will first need to install a supported
-container runtime and the NVIDIA Container Toolkit to enable support for GPUs.  System requirements
-and instructions for this can be found in the `NVIDIA Container Toolkit Install Guide <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_.
-
-A simple Dockerfile is used to capture the base requirements and dependencies.  In
-this case, we're building an environment that will support PyTorch-based workflows,
-in particular the :github_nvflare_link:`Hello PyTorch <examples/hello-world/hello-pt>`
-example. The base for this build is the NGC PyTorch container.  On this base image,
-we will install the necessary dependencies and clone the NVIDIA FLARE GitHub
-source code into the root workspace directory.
-
-Let's first create a folder called ``build`` and then create a file inside named ``Dockerfile``:
-
-.. code-block:: shell
-
-  mkdir build
-  cd build
-  touch Dockerfile
-
-Using any text editor to edit the Dockerfile and paste the following:
-
-.. literalinclude:: resources/Dockerfile
-    :language: dockerfile
-
-.. note::
-
-    For nvflare version 2.5 set PYTORCH_IMAGE=nvcr.io/nvidia/pytorch:24.07-py3
-
-We can then build the new container by running docker build in the directory containing
-this Dockerfile, for example tagging it nvflare-pt:
-
-.. code-block:: shell
-
-  docker build -t nvflare-pt . -f Dockerfile
-
-This will result in a docker image, ``nvflare-pt:latest``.  You can run this container with Docker,
-in this example mounting a local ``my-workspace`` directory into the container for use as a persistent
-workspace:
-
-.. code-block:: shell
-
-  mkdir my-workspace
-  docker run --rm -it --gpus all \
-      --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
-      -w $(pwd -P)/my-workspace:/workspace/my-workspace \
-      nvflare-pt:latest
-
-Once the container is running, you can also exec into the container, for example if you need another
-terminal to start additional FLARE clients.  First find the ``CONTAINER ID`` using ``docker ps``, and then
-use that ID to exec into the container:
-
-.. code-block:: shell
-
-  docker ps  # use the CONTAINER ID in the output
-  docker exec -it <CONTAINER ID> /bin/bash
-
-This container can be used to run the FL Simulator or any FL server or client.  When using the
-FL Simulator (described in the next section), you can simply mount in any directories needed for
-your FLARE application code, and run the Simulator within the Docker container with
-all dependencies installed.
-
-For a notebook showcasing this example, see the :github_nvflare_link:`NVIDIA FLARE with Docker example <examples/advanced/docker>`.
-
-Ways to Run NVFlare
-===================
-NVFlare can currently support running with the FL Simulator, POC mode, or Production mode.
-
-FL Simulator is lightweight and uses threads to simulate different clients.
-The code used for the simulator can be directly used in production mode.
-
-Starting in 2.5, NVFlare supports running the FL Simulator with the Job API. The :ref:`Job API <fed_job_api>` allows
-you to build jobs programatically and then export them or directly run them with the simulator.
-
-POC mode is a quick way to get set up to run locally on one machine. The FL server and each client
-run on different processes or dockers.
-
-Production mode is secure with TLS certificates - depending the choice the deployment, you can further choose:
-
-  - HA or non-HA
-  - Local or remote
-  - On-premise or on cloud (See :ref:`cloud_deployment`)
-
-Using non-HA, secure, local mode (all clients and server running on the same host), production mode is very similar to POC mode except it is secure.
-
-Which mode should I choose for running NVFLARE? (Note: the same jobs can be run in any of the modes, and the same project.yml deployment options can be run in both POC mode and production.)
-
-.. list-table:: NVIDIA FLARE Modes
-   :header-rows: 1
-
-   * - **Mode**
-     - **Documentation**
-     - **Description**
-   * - Simulator
-     - :ref:`fl_simulator`
-     - | The FL Simulator is a light weight simulation where the job run is automated on a 
-       | single system. Useful for quickly running a job or experimenting with research 
-       | or FL algorithms.
-   * - POC
-     - :ref:`poc_command`
-     - | POC mode establishes and connects distinct server and client "systems" which can 
-       | then be orchestrated using the FLARE Console all from a single machine. Users can 
-       | also experiment with various deployment options (project.yml), which can be used 
-       | in production modes.
-   * - Production
-     - :ref:`provisioned_setup`
-     - | Real world production mode involves a distributed deployment with generated startup 
-       | kits from the provisioning process. Provides provisioning tool, dashboard, and 
-       | various deployment options.
-
-.. _starting_fl_simulator:
-
-The FL Simulator
+Understanding the Example
 =========================
+This example demonstrates a simple federated learning scenario using PyTorch. For a detailed explanation of:
 
-After installing the nvflare pip package, you have access to the NVFlare CLI including the FL Simulator.
-The Simulator allows you to start a FLARE server and any number of connected clients on your local
-workstation or laptop, and to quickly deploy an application for testing and debugging.
+- How the example works
+- The neural network architecture
+- The federated learning workflow
+- PyTorch integration details
 
-Basic usage for the :ref:`FL Simulator <fl_simulator>` is available with ``nvflare simulator -h``:
+See the :doc:`Hello PyTorch with Job API <examples/hello_pt_job_api>` guide and the :doc:`FedJob API <programming_guide/fed_job_api>` documentation.
 
-.. code-block:: shell
+Next Steps
+==========
+Now that you've run your first example:
 
-    $ nvflare simulator -h
-    usage: nvflare simulator [-h] [-w WORKSPACE] [-n N_CLIENTS] [-c CLIENTS] [-t THREADS] [-gpu GPU] [-l LOG_CONFIG] [-m MAX_CLIENTS] [--end_run_for_all] job_folder
-
-    positional arguments:
-        job_folder
-
-    options:
-        -h, --help            show this help message and exit
-        -w WORKSPACE, --workspace WORKSPACE
-                                WORKSPACE folder
-        -n N_CLIENTS, --n_clients N_CLIENTS
-                                number of clients
-        -c CLIENTS, --clients CLIENTS
-                                client names list
-        -t THREADS, --threads THREADS
-                                number of parallel running clients
-        -gpu GPU, --gpu GPU   list of GPU Device Ids, comma separated
-        -l LOG_CONFIG, --log_config LOG_CONFIG
-                                log config mode ('concise', 'full', 'verbose'), filepath, or level
-        -m MAX_CLIENTS, --max_clients MAX_CLIENTS
-                                max number of clients
-        --end_run_for_all     flag to indicate if running END_RUN event for all clients
-
-
-Before we get into the Simulator, we'll walk through a few additional setup steps in the next section required
-to run an example application.
-
-
-Running an example application
-================================
-
-Any of the :ref:`example_applications` can be used with the FL Simulator.  We'll demonstrate the steps here
-using the hello-pt example.
-
-First, we need to clone the NVFlare repo to get the source code for the examples:
-
-.. code-block:: shell
-
-  $ git clone https://github.com/NVIDIA/NVFlare.git
-
-
-Please make sure to switch to the correct branch that matches the NVFlare library version you installed.
-
-.. code-block:: shell
-
-  $ git switch [nvflare version]
-
-
-We can then copy the necessary files (the exercise code in the examples directory of the NVFlare repository)
-to a working directory:
-
-.. code-block:: shell
-
-  mkdir simulator-example
-  cp -rf NVFlare/examples/hello-world/hello-pt simulator-example/
-
-The hello-pt application requires a few dependencies to be installed.  As in the installation section,
-we can install these in the Python virtual environment by running:
-
-.. code-block:: shell
-
-  source nvflare-env/bin/activate
-  python3 -m pip install -r simulator-example/hello-pt/requirements.txt
-
-If using the Dockerfile above to run in a container, these dependencies have already been installed.
-
-Next, we can directly run the ``fedavg_script_runner_pt.py`` script which is configured to build a job
-with the Job API and then run it with the FL Simulator.
-
-.. code-block:: shell
-
-  cd simulator-example/hello-pt
-  python3 fedavg_script_runner_pt.py
-
-Now you will see output streaming from the server and client processes as they execute the federated
-application.  Once the run completes, your workspace directory (by default ``/tmp/nvflare/jobs/workdir``),
-will contain the input application configuration
-and codes, logs of the output, site and global models, cross-site validation results.
-
-.. code-block:: shell
-
-  $ tree -L 4 /tmp/nvflare/jobs/workdir
-  /tmp/nvflare/jobs/workdir
-  ├── server
-  │   ├── local
-  │   │   └── log_config.json
-  │   ├── log.txt
-  │   ├── pool_stats
-  │   │   └── simulator_cell_stats.json
-  │   ├── simulate_job
-  │   │   ├── app_server
-  │   │   │   ├── FL_global_model.pt
-  │   │   │   ├── config
-  │   │   │   └── custom
-  │   │   ├── cross_site_val
-  │   │   │   └── cross_val_results.json
-  │   │   ├── meta.json
-  │   │   └── tb_events
-  │   │       ├── site-1
-  │   │       └── site-2
-  │   └── startup
-  ├── site-1
-  │   ├── cifar_net.pth
-  │   ├── local
-  │   │   └── log_config.json
-  │   ├── log.txt
-  │   ├── simulate_job
-  │   │   ├── app_site-1
-  │   │   │   ├── config
-  │   │   │   └── custom
-  │   │   └── meta.json
-  │   └── startup
-  ├── site-2
-  │   ├── cifar_net.pth
-  │   ├── local
-  │   │   └── log_config.json
-  │   ├── log.txt
-  │   ├── simulate_job
-  │   │   ├── app_site-2
-  │   │   │   ├── config
-  │   │   │   └── custom
-  │   │   └── meta.json
-  │   └── startup
-  └── startup
-
-
-Now that we've explored an example application with the FL Simulator, we can look at what it takes to bring
-this type of application to a secure, distributed deployment in the :ref:`Real World Federated Learning <real_world_fl>`
-section.
-
-
-.. _setting_up_poc:
-
-Setting Up the Application Environment in POC Mode
-==================================================
-
-To get started with a proof of concept (POC) setup after :ref:`installation`, run this command to generate a poc folder
-with an overseer, server, two clients, and one admin client:
-
-.. code-block:: shell
-
-    $ nvflare poc prepare -n 2
-
-For more details, see :ref:`poc_command`.
-
-.. _starting_poc:
-
-Starting the Application Environment in POC Mode
-================================================
-
-Once you are ready to start the FL system, you can run the following command
-to start the server and client systems and an admin console:
-
-.. code-block::
-
-  nvflare poc start
-
-To start the server and client systems without an admin console:
-
-.. code-block::
-
-  nvflare poc start -ex admin@nvidia.com
-
-We can use the :ref:`job_cli` to easily submit a job to the POC system. (Note: We can run the same jobs we ran with the simulator in POC mode. If using the :ref:`fed_job_api`, simply export the job configuration with ``job.export_job()``.)
-
-.. code-block::
-
-  nvflare job submit -j NVFlare/examples/hello-world/hello-numpy-sag/jobs/hello-numpy-sag
-
-.. code-block::
-
-  nvflare poc stop
-
-.. code-block::
-
-  nvflare poc clean
-
-For more details, see :ref:`poc_command`.
+1. Learn more about different ways to run NVFlare in the :ref:`getting_started` guide
+2. Explore more examples in the :ref:`example_applications` section
+3. When ready for production, see :ref:`real_world_fl` for deployment guidance
+4. For development, see :ref:`programming_guide`

--- a/docs/real_world_fl.rst
+++ b/docs/real_world_fl.rst
@@ -30,6 +30,7 @@ to see the capabilities of the system and how it can be operated.
    real_world_fl/job
    real_world_fl/workspace
    real_world_fl/cloud_deployment
+   real_world_fl/containerized_deployment
    real_world_fl/kubernetes
    real_world_fl/notes_on_large_models
    user_guide/security/identity_security

--- a/docs/real_world_fl/cloud_deployment.rst
+++ b/docs/real_world_fl/cloud_deployment.rst
@@ -3,11 +3,15 @@
 ################
 Cloud Deployment
 ################
-In version 2.3.0 of NVFLARE, deploying to the cloud has become much easier than before. Previously, deploying to the cloud required someone to
-create the necessary virtual machine (VM) and infrastructure before attempting to deploy. However, with this release, users can simplify the
-cloud deployment process with a one-line command via the NVFLARE CLI tool. This command will create the necessary cloud infrastructure, such
-as resource groups, networking, DNS, and VM instances for Azure, or EC2 instances, security groups, and networks for AWS. The one-line command
-is applicable for NVFLARE Dashboard UI, FL Server, and FL clients.
+NVFlare provides cloud deployment tools that simplify the setup process. The CLI tool can automatically provision and configure cloud infrastructure, including:
+
+- Azure: resource groups, networking, DNS, and VM instances
+- AWS: EC2 instances, security groups, and networks
+
+These tools support deployment of:
+- NVFlare Dashboard UI
+- FL Server
+- FL Clients
 
 There are two ways to provision and deploy NVFLARE. The first way is to use the :ref:`NVFLARE CLI tool for provisioning <provision_command>`. However,
 the startup kits for different FL clients will need to be distributed manually via email, sftp, etc.
@@ -294,7 +298,7 @@ Checking FL System Status
 =========================
 With deployed FL server and clients, to make sure all systems are running correctly, you can check the server status.
 
-With 2.3.0, there are two ways to check server status, using the FLARE console (aka Admin console) or FLARE API.
+There are two ways to check server status, using the FLARE console (aka Admin console) or FLARE API.
 You can find more information on FLARE console commands on :ref:`this page <operating_nvflare>`, and the FLARE API :ref:`here <flare_api>`.
 
 Check Status with FLARE Console

--- a/docs/real_world_fl/containerized_deployment.rst
+++ b/docs/real_world_fl/containerized_deployment.rst
@@ -51,7 +51,7 @@ Using any text editor to edit the Dockerfile and paste the following:
 
 .. note::
     Feel free to substitute the base image with the latest version of the NGC PyTorch container.
-    See the `NGC PyTorch Container <https://catalog.ngc.nvidia.com/orgs/nvidia/collections/pytorch>`_
+    See the `NGC PyTorch Container <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch>`_
     for the latest versions.
 
 We can then build the new container by running docker build in the directory containing

--- a/docs/real_world_fl/containerized_deployment.rst
+++ b/docs/real_world_fl/containerized_deployment.rst
@@ -1,0 +1,129 @@
+.. _containerized_deployment:
+
+########################
+Containerized Deployment
+########################
+
+Containerized Deployment with Docker
+====================================
+
+Prerequisites
+-------------
+Before starting with containerized deployment, ensure you have:
+
+1. Docker installed on your system
+2. NVIDIA Container Toolkit installed for GPU support
+3. System requirements met as per the `NVIDIA Container Toolkit Install Guide <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
+
+Running NVIDIA FLARE in a Docker container provides several benefits:
+- Consistent environment across different systems
+- Easy dependency management
+- Simplified deployment process
+- Isolated execution environment
+- GPU support through NVIDIA Container Toolkit
+
+This can be used as an alternative to the bare-metal Python virtual environment and will
+use a similar installation to simplify transitioning between a bare metal and containerized
+environment.
+
+Building the Docker Image
+-------------------------
+
+A simple Dockerfile is used to capture the base requirements and dependencies.  In
+this case, we're building an environment that will support PyTorch-based workflows,
+in particular the :github_nvflare_link:`Hello PyTorch <examples/hello-world/hello-pt>`
+example. The base for this build is the NGC PyTorch container.  On this base image,
+we will install the necessary dependencies and clone the NVIDIA FLARE GitHub
+source code into the root workspace directory.
+
+Let's first create a folder called ``build`` and then create a file inside named ``Dockerfile``:
+
+.. code-block:: shell
+
+  mkdir build
+  cd build
+  touch Dockerfile
+
+Using any text editor to edit the Dockerfile and paste the following:
+
+.. literalinclude:: ../resources/Dockerfile
+    :language: dockerfile
+
+.. note::
+    Feel free to substitute the base image with the latest version of the NGC PyTorch container.
+    See the `NGC PyTorch Container <https://catalog.ngc.nvidia.com/orgs/nvidia/collections/pytorch>`_
+    for the latest versions.
+
+We can then build the new container by running docker build in the directory containing
+this Dockerfile, for example tagging it nvflare-pt:
+
+.. code-block:: shell
+
+  docker build -t nvflare-pt . -f Dockerfile
+
+This will result in a docker image, ``nvflare-pt:latest``.
+
+Running the Container
+---------------------
+
+To run the container with GPU support and a persistent workspace:
+
+.. code-block:: shell
+
+  mkdir my-workspace
+  docker run --rm -it --gpus all \
+      --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
+      -v $(pwd -P)/my-workspace:/workspace/my-workspace \
+      nvflare-pt:latest
+
+Once the container is running, you can also exec into the container, for example if you need another
+terminal to start additional FLARE clients.  First find the ``CONTAINER ID`` using ``docker ps``, and then
+use that ID to exec into the container:
+
+.. code-block:: shell
+
+  docker ps  # use the CONTAINER ID in the output
+  docker exec -it <CONTAINER ID> /bin/bash
+
+Deployment Scenarios
+--------------------
+
+The containerized environment can be used in several ways:
+
+1. FL Simulator
+   - Run the FL simulator inside the container
+   - Mount your application code directory
+   - All dependencies are pre-installed
+   - Useful for development and testing
+
+2. POC Mode
+   - Run multiple containers for server and clients
+   - Use Docker networking for communication
+   - Good for testing multi-party scenarios
+
+3. Production Mode
+   - Deploy containers across different machines
+   - Use proper networking and security configurations
+   - Suitable for real-world deployments
+
+When using the FL Simulator, you can simply mount in any directories needed for
+your FLARE application code, and run the Simulator within the Docker container with
+all dependencies installed.
+
+For a notebook showcasing this example, see the :github_nvflare_link:`NVIDIA FLARE with Docker example <examples/advanced/docker>`.
+
+Best Practices
+--------------
+
+1. Always use the latest compatible NVIDIA Container Toolkit version
+2. Mount volumes for persistent data storage
+3. Use appropriate resource limits (CPU, memory, GPU) based on your workload
+4. Consider using Docker Compose for multi-container deployments
+5. Keep your base images updated for security patches
+
+Common Issues and Solutions
+---------------------------
+
+1. GPU access issues: Ensure NVIDIA Container Toolkit is properly installed
+2. Memory issues: Adjust ulimit settings if needed
+3. Network connectivity: Configure proper network settings for multi-container deployments

--- a/docs/resources/Dockerfile
+++ b/docs/resources/Dockerfile
@@ -1,5 +1,5 @@
-ARG PYTORCH_IMAGE=nvcr.io/nvidia/pytorch:24.07-py3
-FROM ${PYTORCH_IMAGE}
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:25.04-py3
+FROM ${BASE_IMAGE}
 
 ARG NVF_VERSION=main
 ENV NVF_BRANCH=${NVF_VERSION}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ skip_glob = [ "*.pyi", "**/*_pb2*" ]
 
 [tool.black]
 line-length = 120
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312"]
 include = '\.pyi?$'
 exclude = '''
 (

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ long_description_content_type = text/markdown; charset=UTF-8
 license_files =
     LICENSE
 classifiers =
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -16,11 +15,11 @@ classifiers =
 
 [options]
 zip_safe = True
-python_requires = >= 3.8
+python_requires = >= 3.9
 install_requires =
     cryptography>=36.0.0
     Flask==3.0.2
-    Werkzeug==3.0.3
+    Werkzeug>=3.0.3
     Flask-JWT-Extended==4.6.0
     Flask-SQLAlchemy==3.1.1
     SQLAlchemy==2.0.16

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if versions["error"]:
     if base_version:
         version = f"{base_version}.dev{year:02d}{month:02d}{day:02d}"
     else:
-        version = f"2.5.0.dev{year:02d}{month:02d}{day:02d}"
+        version = f"2.6.0.dev{year:02d}{month:02d}{day:02d}"
 else:
     version = versions["version"]
 

--- a/tests/unit_test/app_common/workflow/cyclic_ctl_test.py
+++ b/tests/unit_test/app_common/workflow/cyclic_ctl_test.py
@@ -92,9 +92,10 @@ class TestCyclicController:
             abort_signal = Signal()
             fl_ctx = FLContext()
 
-            with patch.object(ctl.shareable_generator, "learnable_to_shareable") as mock_method1, patch.object(
-                ctl.shareable_generator, "shareable_to_learnable"
-            ) as mock_method2:
+            with (
+                patch.object(ctl.shareable_generator, "learnable_to_shareable") as mock_method1,
+                patch.object(ctl.shareable_generator, "shareable_to_learnable") as mock_method2,
+            ):
                 mock_method1.return_value = Shareable()
                 mock_method2.return_value = Learnable()
 
@@ -115,9 +116,11 @@ class TestCyclicController:
         ]
 
         fl_ctx = FLContext()
-        with patch.object(ctl, "cancel_task") as mock_method, patch.object(
-            ctl.shareable_generator, "learnable_to_shareable"
-        ) as mock_method1, patch.object(ctl.shareable_generator, "shareable_to_learnable") as mock_method2:
+        with (
+            patch.object(ctl, "cancel_task") as mock_method,
+            patch.object(ctl.shareable_generator, "learnable_to_shareable") as mock_method1,
+            patch.object(ctl.shareable_generator, "shareable_to_learnable") as mock_method2,
+        ):
             mock_method1.return_value = Shareable()
             mock_method2.return_value = Learnable()
 


### PR DESCRIPTION
1. Previous Quickstart contains Installation, Deployment, actual quickstart (the run of one example), introduction to simulator, introduction to POC, which is too much information
2. Typos in our documentation
3. python 3.8 is not supported anymore

### Description

- Split the previous Quickstart content into Installation, Getting Started, Containerized Deployment, and Quickstart
- Fix typos
- Remove python3.8

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
