### PR TITLE
[2.6] Use script path instead of relative path

### DIFF
--- a/examples/advanced/xgboost/fedxgb/prepare_data.sh
+++ b/examples/advanced/xgboost/fedxgb/prepare_data.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 DATASET_PATH="${1}/HIGGS.csv"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if [ ! -f "${DATASET_PATH}" ]
 then
     echo "Please check if you saved HIGGS dataset in ${DATASET_PATH}"
@@ -13,7 +15,7 @@ for site_num in 2 5 20;
 do
     for split_mode in uniform exponential square;
     do
-        python3 utils/prepare_data_horizontal.py \
+        python3 "${SCRIPT_DIR}/utils/prepare_data_horizontal.py" \
         --data_path "${DATASET_PATH}" \
         --site_num ${site_num} \
         --size_total 11000000 \
@@ -27,7 +29,7 @@ echo "Horizontal data splits are generated in ${OUTPUT_PATH}"
 OUTPUT_PATH="/tmp/nvflare/dataset/xgboost_higgs_vertical"
 OUTPUT_FILE="higgs.data.csv"
 # Note: HIGGS has 11 million preshuffled instances; using rows_total_percentage to reduce PSI time for example
-python3 utils/prepare_data_vertical.py \
+python3 "${SCRIPT_DIR}/utils/prepare_data_vertical.py" \
 --data_path "${DATASET_PATH}" \
 --site_num 2 \
 --rows_total_percentage 0.02 \

--- a/examples/advanced/xgboost/fedxgb_secure/prepare_data.sh
+++ b/examples/advanced/xgboost/fedxgb_secure/prepare_data.sh
@@ -1,5 +1,7 @@
+#!/usr/bin/env bash
 DATASET_PATH="/tmp/nvflare/dataset/creditcard.csv"
 SPLIT_PATH="/tmp/nvflare/dataset/xgb_dataset/"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ ! -f "${DATASET_PATH}" ]
 then
@@ -9,27 +11,27 @@ fi
 echo "Generating CreditCard data splits, reading from ${DATASET_PATH}"
 
 echo "Split data to training/validation v.s. testing"
-python3 utils/prepare_data_traintest_split.py \
+python3 "${SCRIPT_DIR}/utils/prepare_data_traintest_split.py" \
 --data_path "${DATASET_PATH}" \
 --test_ratio 0.2 \
 --out_folder "${SPLIT_PATH}"
 
 echo "Split training/validation data"
 OUTPUT_PATH="${SPLIT_PATH}/base_xgb_data"
-python3 utils/prepare_data_base.py \
+python3 "${SCRIPT_DIR}/utils/prepare_data_base.py" \
 --data_path "${SPLIT_PATH}/train.csv" \
 --out_path "${OUTPUT_PATH}"
 
 echo "Split training/validation data vertically"
 OUTPUT_PATH="${SPLIT_PATH}/vertical_xgb_data"
-python3 utils/prepare_data_vertical.py \
+python3 "${SCRIPT_DIR}/utils/prepare_data_vertical.py" \
 --data_path "${SPLIT_PATH}/train.csv" \
 --site_num 3 \
 --out_path "${OUTPUT_PATH}"
 
 echo "Split training/validation data horizontally"
 OUTPUT_PATH="${SPLIT_PATH}/horizontal_xgb_data"
-python3 utils/prepare_data_horizontal.py \
+python3 "${SCRIPT_DIR}/utils/prepare_data_horizontal.py" \
 --data_path "${SPLIT_PATH}/train.csv" \
 --site_num 3 \
 --out_path "${OUTPUT_PATH}"


### PR DESCRIPTION
Relative path does not work if we run the script from another folder.

### Description

Use script path instead of relative path

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
