### PR TITLE
Remove torch ping version

### DIFF
--- a/examples/advanced/distributed_optimization/requirements.txt
+++ b/examples/advanced/distributed_optimization/requirements.txt
@@ -1,8 +1,18 @@
-omegaconf==2.3.0
-rich==13.9.4
+# Tested with the following versions:
+# omegaconf==2.3.0
+# rich==13.9.4
+# torch==2.5.1
+# torchvision==0.20.1
+# matplotlib==3.10.0
+# scipy==1.15.0
+# scikit-learn==1.6.1
+# networkx==3.4.2
+
+omegaconf
+rich
 torch
 torchvision
-matplotlib==3.10.0
-scipy==1.15.0
-scikit-learn==1.6.1
-networkx==3.4.2
+matplotlib
+scipy
+scikit-learn
+networkx

--- a/examples/advanced/distributed_optimization/requirements.txt
+++ b/examples/advanced/distributed_optimization/requirements.txt
@@ -1,7 +1,7 @@
 omegaconf==2.3.0
 rich==13.9.4
-torch==2.5.1
-torchvision==0.20.1
+torch
+torchvision
 matplotlib==3.10.0
 scipy==1.15.0
 scikit-learn==1.6.1

--- a/examples/advanced/llm_hf/requirements.txt
+++ b/examples/advanced/llm_hf/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.5.1
+torch
 torchvision
 datasets
 tensorboard

--- a/examples/advanced/llm_hf/requirements.txt
+++ b/examples/advanced/llm_hf/requirements.txt
@@ -1,6 +1,6 @@
 # Tested with the following versions:
 # torch==2.5.1
-# transformers==4.48.0
+# transformers==4.50.0
 # peft==0.14.0
 # trl==0.13.0
 

--- a/examples/advanced/llm_hf/requirements.txt
+++ b/examples/advanced/llm_hf/requirements.txt
@@ -1,8 +1,14 @@
+# Tested with the following versions:
+# torch==2.5.1
+# transformers==4.48.0
+# peft==0.14.0
+# trl==0.13.0
+
 torch
 torchvision
 datasets
 tensorboard
-transformers==4.50.0
-peft==0.14.0
-trl==0.13.0
+transformers
+peft
+trl
 bitsandbytes

--- a/examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml
+++ b/examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml
@@ -2,6 +2,13 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# Tested with:
+#   flwr==1.16.0
+#   nvflare==2.6.0
+#   torch==2.7.0
+#   torchvision==0.22.0
+#   tensorboard==2.19.0
+
 [project]
 name = "flwr_pt_tb"
 version = "1.0.0"

--- a/examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml
+++ b/examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr>=1.16,<2.0",
     "nvflare~=2.6.0rc",
-    "torch==2.2.1",
-    "torchvision==0.17.1",
+    "torch",
+    "torchvision",
     "tensorboard"
 ]
 

--- a/examples/hello-world/hello-flower/flwr-pt/pyproject.toml
+++ b/examples/hello-world/hello-flower/flwr-pt/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr>=1.16,<2.0",
     "nvflare~=2.6.0rc",
-    "torch==2.2.1",
-    "torchvision==0.17.1",
+    "torch",
+    "torchvision",
     "tensorboard"
 ]
 

--- a/examples/hello-world/hello-flower/flwr-pt/pyproject.toml
+++ b/examples/hello-world/hello-flower/flwr-pt/pyproject.toml
@@ -2,6 +2,13 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# Tested with:
+#   flwr==1.16.0
+#   nvflare==2.6.0
+#   torch==2.7.0
+#   torchvision==0.22.0
+#   tensorboard==2.19.0
+
 [project]
 name = "flwr_pt"
 version = "1.0.0"

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/requirements.txt
@@ -1,7 +1,13 @@
+# Tested with the following versions:
+# torch==2.5.1
+# transformers==4.48.0
+# peft==0.14.0
+# trl==0.13.0
+
 torch
 datasets
 tensorboard
-transformers==4.48.0
-peft==0.14.0
-trl==0.13.0
+transformers
+peft
+trl
 bitsandbytes

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.5.1
+torch
 datasets
 tensorboard
 transformers==4.48.0

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/requirements.txt
@@ -1,7 +1,13 @@
+# Tested with the following versions:
+# torch==2.5.1
+# transformers==4.48.0
+# peft==0.14.0
+# trl==0.13.0
+
 torch
 datasets
 tensorboard
-transformers==4.48.0
-peft==0.14.0
-trl==0.13.0
+transformers
+peft
+trl
 bitsandbytes

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.5.1
+torch
 datasets
 tensorboard
 transformers==4.48.0


### PR DESCRIPTION
Our code should be able to work with any torch greater than 2.0 or something, so there's no need to ping to a specific version.

### Description

remove torch version pings

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
