### PR TITLE
Remove template builder in tests

### DIFF
--- a/tests/integration_test/data/projects/authz.yml
+++ b/tests/integration_test/data/projects/authz.yml
@@ -55,9 +55,6 @@ participants:
 # The same methods in all builders are called in their order defined in builders section
 builders:
   - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
-    args:
-      template_file: master_template.yml
-  - path: nvflare.lighter.impl.template.TemplateBuilder
   - path: nvflare.lighter.impl.static_file.StaticFileBuilder
     args:
       # config_folder can be set to inform NVIDIA FLARE where to get configuration

--- a/tests/integration_test/data/projects/dummy.yml
+++ b/tests/integration_test/data/projects/dummy.yml
@@ -21,9 +21,6 @@ participants:
 
 builders:
   - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
-    args:
-      template_file: master_template.yml
-  - path: nvflare.lighter.impl.template.TemplateBuilder
   - path: nvflare.lighter.impl.static_file.StaticFileBuilder
     args:
       # config_folder can be set to inform NVIDIA FLARE where to get configuration


### PR DESCRIPTION
Remove template builder in tests as they are deprecated.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
