### PR TITLE
Relax lightning logger get version

### DIFF
--- a/nvflare/app_opt/lightning/loggers/client_logger.py
+++ b/nvflare/app_opt/lightning/loggers/client_logger.py
@@ -84,7 +84,7 @@ class ClientLogger(Logger):
     @override
     def version(self) -> Optional[str]:
 
-        return nvflare.__version__
+        return getattr(nvflare, "__version__", "unknown")
 
     @override
     def after_save_checkpoint(self, checkpoint_callback: ModelCheckpoint) -> None:


### PR DESCRIPTION
During testing, I get "module 'nvflare' has no attribute '__version__'", relax this get version for "pip install -e ."

### Description

Relax lightning logger get version.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
