### PR TITLE
Add rank type check for client API

### DIFF
--- a/nvflare/client/api.py
+++ b/nvflare/client/api.py
@@ -14,7 +14,7 @@
 
 import logging
 from threading import Lock
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from nvflare.apis.analytix import AnalyticsDataType
 from nvflare.app_common.abstract.fl_model import FLModel


### PR DESCRIPTION
Fixes # .

### Description

The client API doesn't check if the user-provided rank is a string. Adding conversion or raising an error if a non-supported type is encountered.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
