### PR TITLE
Fix financial phrase bank dataset links

### DIFF
--- a/integration/nemo/examples/peft/peft.ipynb
+++ b/integration/nemo/examples/peft/peft.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "source": [
     "## Data preprocessing\n",
-    "As our downstream task, we will use the [Financial PhraseBank dataset](https://huggingface.co/datasets/financial_phrasebank) for sentiment analysis.\n",
+    "As our downstream task, we will use the [Financial PhraseBank dataset](https://www.researchgate.net/publication/251231364_FinancialPhraseBank-v10) for sentiment analysis.\n",
     "\n",
     "The Financial PhraseBank dataset contains the sentiments for financial news headlines from a retail investor's perspective. Further details about the dataset can be found in Malo et al.'s [\"Good Debt or Bad Debt: Detecting Semantic Orientations in Economic Texts\"](https://arxiv.org/abs/1307.5336).\n",
     "\n",

--- a/integration/nemo/examples/prompt_learning/prompt_learning.ipynb
+++ b/integration/nemo/examples/prompt_learning/prompt_learning.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "source": [
     "## Data preprocessing\n",
-    "As our downstream task, we will use the [Financial PhraseBank dataset](https://huggingface.co/datasets/financial_phrasebank) for sentiment analysis.\n",
+    "As our downstream task, we will use the [Financial PhraseBank dataset](https://www.researchgate.net/publication/251231364_FinancialPhraseBank-v10) for sentiment analysis.\n",
     "\n",
     "The Financial PhraseBank dataset contains the sentiments for financial news headlines from a retail investor's perspective. Further details about the dataset can be found in Malo et al.'s [\"Good Debt or Bad Debt: Detecting Semantic Orientations in Economic Texts\"](https://arxiv.org/abs/1307.5336).\n"
    ]

--- a/integration/nemo/examples/prompt_learning/prompt_learning_20B.md
+++ b/integration/nemo/examples/prompt_learning/prompt_learning_20B.md
@@ -58,7 +58,7 @@ python3 megatron_change_num_partitions.py --model_file ${source_ckpt} --target_f
 ```
 
 ## Data preprocessing
-As our downstream task, we will use the [Financial PhraseBank dataset](https://huggingface.co/datasets/financial_phrasebank) for sentiment analysis.
+As our downstream task, we will use the [Financial PhraseBank dataset](https://www.researchgate.net/publication/251231364_FinancialPhraseBank-v10) for sentiment analysis.
 
 The Financial PhraseBank dataset contains the sentiments for financial news headlines from a retail investor's perspective. 
 Further details about the dataset can be found in Malo et al.'s ["Good Debt or Bad Debt: Detecting Semantic Orientations in Economic Texts"](https://arxiv.org/abs/1307.5336).


### PR DESCRIPTION
Fixes # .

### Description

Huggingface links are broken. Found the original data link.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
