### PR TITLE
Support long server name

### DIFF
--- a/nvflare/lighter/impl/cert.py
+++ b/nvflare/lighter/impl/cert.py
@@ -26,7 +26,7 @@ from nvflare.lighter.entity import Participant, Project
 from nvflare.lighter.spec import Builder
 from nvflare.lighter.utils import Identity, generate_cert, generate_keys, serialize_cert, serialize_pri_key
 
-MAX_CN_LENGTH = 63
+MAX_CN_LENGTH = 64
 
 
 class _CertState:


### PR DESCRIPTION
Fixes # .

### Description

Server Name is used as CN of the cert. But the CN cannot exceed 63 chars. So we have to truncate it to make the cert.

Server Name also serves as the identity of the server for all clients to verify, and it must match the CN in the server's cert.

Server Name is also the default host name (unless default host is explicitly specified) for clients to connect to. Truncated name won't be a valid host name.

We have to accommodate all these factors:

- We truncate the server name and use it for both name and subject of the server. This will satisfy CN requirement of the cert, and will satisfy server identity validation by clients.

- We check whether the DEFAULT_HOST property is explicitly specified in the server. If not, we explicitly set it to the original name.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
