### PR TITLE
[Website] add summer of code banner[skip ci]

### DIFF
--- a/web/src/components/hero.astro
+++ b/web/src/components/hero.astro
@@ -66,6 +66,24 @@ const base_url = import.meta.env.BASE_URL;
                   </svg>
                 </span>
               </a>
+              <a
+                href="https://developer.nvidia.com/flare-summer-of-code-2025"
+                class="inline-flex space-x-6">
+                <span
+                  class="rounded-full bg-nvidia/20 px-3 py-1 text-sm font-semibold leading-6 text-nvidia ring-1 ring-inset ring-nvidia/10 inline-flex items-center space-x-1">
+                  <span>SUMMER OF CODE 2025</span>
+                  <svg
+                    class="h-4 w-4 text-nvidia"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true">
+                    <path
+                      fill-rule="evenodd"
+                      d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                      clip-rule="evenodd"></path>
+                  </svg>
+                </span>
+              </a>
             </div>
             <img class="mt-6 flex items-center w-1/2" src={NvidiaLogo.src} alt="NVIDIA logo">
             <h1


### PR DESCRIPTION
Fixes # .

### Description

Adds link to [summer of code](https://developer.nvidia.com/flare-summer-of-code-2025) website. Preview looks like this
<img width="1325" height="660" alt="image" src="https://github.com/user-attachments/assets/f6774dbf-29d0-47c2-acd2-cebc31a3067b" />


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
