### PR TITLE
Fix max client limit to exclude admin clients

### DIFF
--- a/nvflare/fuel/f3/cellnet/net_agent.py
+++ b/nvflare/fuel/f3/cellnet/net_agent.py
@@ -29,6 +29,7 @@ from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.utils import make_reply
 from nvflare.fuel.f3.stats_pool import StatsPoolManager
+from nvflare.fuel.utils.admin_name_utils import is_valid_admin_client_name
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.log_utils import get_obj_logger
 
@@ -931,8 +932,14 @@ class NetAgent:
 
         children, clients = self.cell.get_sub_cell_names()
         targets = []
-        targets.extend(children)
-        targets.extend(clients)
+
+        for c in children:
+            if not is_valid_admin_client_name(c):
+                targets.append(c)
+
+        for c in clients:
+            if not is_valid_admin_client_name(c):
+                targets.append(c)
 
         if targets:
             if timeout > 0.0:

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -287,6 +287,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         self.host = admin_config.get(AdminConfigKey.HOST, "localhost")
         self.port = admin_config.get(AdminConfigKey.PORT, 8002)
         self.file_download_progress_timeout = admin_config.get(AdminConfigKey.FILE_DOWNLOAD_PROGRESS_TIMEOUT, 5.0)
+        self.authenticate_msg_timeout = admin_config.get(AdminConfigKey.AUTHENTICATE_MSG_TIMEOUT, 5.0)
         self.user_name = user_name
         self.event_handlers = event_handlers
 
@@ -402,7 +403,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
             root_cert_file=self.ca_cert,
             private_key_file=self.client_key,
             cert_file=self.client_cert,
-            msg_timeout=2.0,
+            msg_timeout=self.authenticate_msg_timeout,
             retry_interval=1.0,
             timeout=timeout,
         )

--- a/nvflare/fuel/hci/client/api_spec.py
+++ b/nvflare/fuel/hci/client/api_spec.py
@@ -230,6 +230,7 @@ class AdminConfigKey:
     DOWNLOAD_DIR = "download_dir"
     USERNAME = "username"
     FILE_DOWNLOAD_PROGRESS_TIMEOUT = "file_download_progress_timeout"
+    AUTHENTICATE_MSG_TIMEOUT = "authenticate_msg_timeout"
 
 
 class UidSource:

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -316,6 +316,7 @@ default_admin_resources: |
       "idle_timeout": 900.0,
       "login_timeout": 10.0,
       "with_debug": false,
+      "authenticate_msg_timeout": 2.0,
       "prompt": "> "
     }
   }

--- a/nvflare/private/fed/server/client_manager.py
+++ b/nvflare/private/fed/server/client_manager.py
@@ -57,7 +57,8 @@ class ClientManager:
             self.name_to_clients[c.name] = c
 
     def authenticate(self, request, fl_ctx: FLContext) -> Optional[Client]:
-        client = self.login_client(request, fl_ctx)
+        client_type = request.get_header(CellMessageHeaderKeys.CLIENT_TYPE)
+        client = self.login_client(request, fl_ctx, client_type)
         if not client:
             return None
 
@@ -66,7 +67,6 @@ class ClientManager:
 
         # new client join
         with self.lock:
-            client_type = request.get_header(CellMessageHeaderKeys.CLIENT_TYPE)
             if client_type == ClientType.REGULAR:
                 self.name_to_clients[client.name] = client
                 self.clients.update({client.token: client})
@@ -100,7 +100,7 @@ class ClientManager:
             )
             return client
 
-    def login_client(self, client_login, fl_ctx: FLContext):
+    def login_client(self, client_login, fl_ctx: FLContext, client_type):
         proj_name = client_login.get_header(CellMessageHeaderKeys.PROJECT_NAME)
         if not self.is_valid_task(proj_name):
             fl_ctx.set_prop(
@@ -108,7 +108,7 @@ class ClientManager:
             )
             self.logger.error(f"login_client failed: {proj_name}")
             return None
-        return self.authenticated_client(client_login, fl_ctx)
+        return self.authenticated_client(client_login, fl_ctx, client_type)
 
     def validate_client(self, request, fl_ctx: FLContext, allow_new=False):
         """Validate the client state message.
@@ -141,7 +141,7 @@ class ClientManager:
     def _get_id_verifier(self, fl_ctx: FLContext):
         return self.cred_keeper.get_id_verifier(fl_ctx)
 
-    def authenticated_client(self, request, fl_ctx: FLContext) -> Optional[Client]:
+    def authenticated_client(self, request, fl_ctx: FLContext, client_type) -> Optional[Client]:
         """Use SSL certificate for authenticate the client.
 
         Args:
@@ -207,7 +207,8 @@ class ClientManager:
         self._set_client_props(client, client_fqcn, fl_ctx)
         self.logger.debug(f"authenticated client {client_name}: {client_fqcn=}")
 
-        if len(self.clients) >= self.max_num_clients:
+        if client_type == ClientType.REGULAR and len(self.clients) >= self.max_num_clients:
+            # only impose the limit to REGULAR clients
             fl_ctx.set_prop(FLContextKey.UNAUTHENTICATED, "Maximum number of clients reached", sticky=False)
             self.logger.info(f"Maximum number of clients reached. Reject client: {client_name} login.")
             return None


### PR DESCRIPTION
Fixes # .

### Description

This PR fixes the bug 4 (reported in https://nvbugspro.nvidia.com/bug/5390831) that failed to allow admin clients once max number of FL clients are connected.  Admin clients will not be counted as FL clients.

This PR also attempts to fix bug 5 in the report. Though we couldn't reproduce the issue following QA instructions, we found and fixed a place that could potentially cause this.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
