### PR TITLE
Add functionality of adding individual args to JobAPI

### DIFF
--- a/examples/advanced/llm_hf/llm_hf_fl_job.py
+++ b/examples/advanced/llm_hf/llm_hf_fl_job.py
@@ -115,6 +115,10 @@ def main():
             job.to(quantizer, site_name, tasks=["train"], filter_type=FilterType.TASK_RESULT)
             job.to(dequantizer, site_name, tasks=["train"], filter_type=FilterType.TASK_DATA)
 
+        # Add additional arguments to clients
+        client_args = {"submit_task_result_timeout": 300}
+        job.to(client_args, site_name, tasks=["train"])
+
     # Export the job
     print("job_dir=", job_dir)
     job.export_job(job_dir)

--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -106,6 +106,14 @@ class FedApp:
     def add_file_source(self, src_path: str, dest_dir=None, app_folder_type=None):
         self.app_config.add_file_source(src_path, dest_dir, app_folder_type)
 
+    def add_args(self, args: Dict[str, any]):
+        """Add additional configuration arguments to be included in the generated JSON configs.
+        
+        Args:
+            args: Dictionary of configuration arguments (e.g., {"timeout": 600, "max_retries": 3})
+        """
+        self.app_config.add_args(args)
+
     def _add_resource(self, resource: str):
         if not isinstance(resource, str):
             raise ValueError(f"cannot add resource: resource must be a str but got {type(resource)}")
@@ -271,6 +279,10 @@ class FedJob:
                 app.add_external_script(obj)
             return None
 
+        if isinstance(obj, dict):  # treat dict type object as additional arguments
+            app.add_args(obj)
+            return None
+
         get_target_type_method = getattr(obj, "get_job_target_type", None)
         if get_target_type_method is not None:
             expected_target_type = get_target_type_method()
@@ -423,6 +435,19 @@ class FedJob:
         """
         app = self._get_app(ctx)
         app.add_file_source(src_path, dest_dir, app_folder_type)
+
+    def add_args(self, args: Dict[str, any], ctx: JobCtx):
+        """Add additional configuration arguments to the job. To be used by job component programmer.
+
+        Args:
+            args: Dictionary of configuration arguments (e.g., {"timeout": 600, "max_retries": 3})
+            ctx: JobCtx for contextual information.
+
+        Returns:
+
+        """
+        app = self._get_app(ctx)
+        app.add_args(args)
 
     def to_server(
         self,

--- a/nvflare/job_config/base_app_config.py
+++ b/nvflare/job_config/base_app_config.py
@@ -35,6 +35,7 @@ class BaseAppConfig(ABC):
         self.ext_dirs = []
         self.file_sources = []
         self.handlers: [FLComponent] = []
+        self.additional_args: Dict[str, any] = {}  # additional configuration arguments
 
     def add_component(self, cid: str, component):
         if cid in self.components.keys():
@@ -65,6 +66,17 @@ class BaseAppConfig(ABC):
             raise RuntimeError(f"external resource dir: {ext_dir} does not exist")
 
         self.ext_dirs.append(ext_dir)
+
+    def add_args(self, args: Dict[str, any]):
+        """Add additional configuration arguments to be included in the generated JSON configs.
+        
+        Args:
+            args: Dictionary of configuration arguments (e.g., {"timeout": 600, "max_retries": 3})
+        """
+        if not isinstance(args, dict):
+            raise RuntimeError(f"args must be type of dict, but got {args.__class__}")
+        
+        self.additional_args.update(args)
 
     @staticmethod
     def _add_task_filter(tasks, filter, taskset_filters: list):

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -194,6 +194,11 @@ class FedJobConfig:
                 }
             )
         self._get_base_app(custom_dir, fed_app.server_app, server_app)
+        
+        # Add additional arguments to the server app config
+        if fed_app.server_app.additional_args:
+            server_app.update(fed_app.server_app.additional_args)
+            
         server_config = os.path.join(config_dir, FED_SERVER_JSON)
         with open(server_config, "w") as outfile:
             json_dump = json.dumps(server_app, indent=4)
@@ -316,6 +321,11 @@ class FedJobConfig:
                 }
             )
         self._get_base_app(custom_dir, fed_app.client_app, client_app)
+        
+        # Add additional arguments to the client app config
+        if fed_app.client_app.additional_args:
+            client_app.update(fed_app.client_app.additional_args)
+            
         client_config = os.path.join(config_dir, FED_CLIENT_JSON)
         with open(client_config, "w") as outfile:
             json_dump = json.dumps(client_app, indent=4)


### PR DESCRIPTION
### Description

Current JobAPI does not have the functionality to add individual configs (e.g. "submit_task_result_timeout = 300") to job config jsons at top level. But it is in some cases needed - e.g. llm model transmission. So adding this function by considering additional args as a dict input to ".to" function.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
