### PR TITLE
Fix admin login timeout default

### DIFF
--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -287,6 +287,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         self.uid_source = admin_config.get(AdminConfigKey.UID_SOURCE, UidSource.USER_INPUT)
         self.host = admin_config.get(AdminConfigKey.HOST, "localhost")
         self.port = admin_config.get(AdminConfigKey.PORT, 8002)
+        self.default_login_timeout = admin_config.get(AdminConfigKey.LOGIN_TIMEOUT, 10.0)
         self.file_download_progress_timeout = admin_config.get(AdminConfigKey.FILE_DOWNLOAD_PROGRESS_TIMEOUT, 5.0)
         self.authenticate_msg_timeout = admin_config.get(AdminConfigKey.AUTHENTICATE_MSG_TIMEOUT, 5.0)
         self.user_name = user_name
@@ -356,6 +357,17 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         return self.fl_ctx_mgr.new_context()
 
     def connect(self, timeout=None):
+        if timeout is not None:
+            # validate provided timeout value
+            if not isinstance(timeout, (int, float)):
+                raise ValueError(f"timeout must be a number but got {type(timeout)}")
+
+            if timeout <= 0:
+                raise ValueError(f"timeout must be a number > 0 but got {timeout}")
+        else:
+            # use value configured in admin config
+            timeout = self.default_login_timeout
+
         print("Connecting to FLARE ...")
         if self.cell:
             return


### PR DESCRIPTION
Fixes # .

### Description

This PR adds validation of login timeout value to the admin API's connect call.  If a value is not specified, it will use the default value defined in admin config.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
