### PR TITLE
Fix msg root creation in task

### DIFF
--- a/nvflare/apis/controller_spec.py
+++ b/nvflare/apis/controller_spec.py
@@ -155,13 +155,16 @@ class Task(object):
         self.task_done_cb = task_done_cb
 
         if self.before_task_sent_cb is None:
-            # msg data can only be modified in the before_task_sent_cb.
-            # if the cb is not specified, then the msg data won't be mutable!
+            # task data can only be modified in the before_task_sent_cb.
+            # if the cb is not specified, then the task data won't be mutable!
             task_data_mutable = False
 
         if task_data_mutable:
+            # since task data could change during the life of task, each msg must be serialized individually.
             self.msg_root_id = None
         else:
+            # since task data won't change during the life of task, messages originated from this task can share
+            # serialization results.
             self.msg_root_id = str(uuid.uuid4())
 
         self.targets = None

--- a/nvflare/apis/controller_spec.py
+++ b/nvflare/apis/controller_spec.py
@@ -78,6 +78,7 @@ class Task(object):
         task_done_cb=None,
         operator=None,
         secure=False,
+        task_data_mutable: bool = True,
     ):
         """Init the Task.
 
@@ -99,6 +100,7 @@ class Task(object):
                 It needs to follow the task_done_cb_signature.
             operator: task operator that describes the operation of the task
             secure: should this task be transmitted in a secure way
+            task_data_mutable: whether task data is mutable during the life of the task.
 
         """
         if not isinstance(name, str):
@@ -151,7 +153,16 @@ class Task(object):
         self.after_task_sent_cb = after_task_sent_cb
         self.result_received_cb = result_received_cb
         self.task_done_cb = task_done_cb
-        self.msg_root_id = str(uuid.uuid4())
+
+        if self.before_task_sent_cb is None:
+            # msg data can only be modified in the before_task_sent_cb.
+            # if the cb is not specified, then the msg data won't be mutable!
+            task_data_mutable = False
+
+        if task_data_mutable:
+            self.msg_root_id = None
+        else:
+            self.msg_root_id = str(uuid.uuid4())
 
         self.targets = None
         self.client_tasks = []  # list of ClientTasks sent

--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -204,6 +204,7 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             timeout=timeout,
             before_task_sent_cb=self._prepare_task_data,
             result_received_cb=self._process_result,
+            task_data_mutable=False,
         )
 
         return task

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import uuid
 from typing import Any
 
 from nvflare.apis.client import Client
@@ -248,6 +249,7 @@ class ScatterAndGather(Controller):
                     timeout=self._train_timeout,
                     before_task_sent_cb=self._prepare_train_task_data,
                     result_received_cb=self._process_train_result,
+                    task_data_mutable=False,
                 )
 
                 self.broadcast_and_wait(

--- a/nvflare/app_common/workflows/scatter_and_gather.py
+++ b/nvflare/app_common/workflows/scatter_and_gather.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import gc
-import uuid
 from typing import Any
 
 from nvflare.apis.client import Client

--- a/nvflare/app_common/workflows/scatter_and_gather_scaffold.py
+++ b/nvflare/app_common/workflows/scatter_and_gather_scaffold.py
@@ -155,6 +155,7 @@ class ScatterAndGatherScaffold(ScatterAndGather):
                     timeout=self._train_timeout,
                     before_task_sent_cb=self._prepare_train_task_data,
                     result_received_cb=self._process_train_result,
+                    task_data_mutable=False,
                 )
 
                 self.broadcast_and_wait(

--- a/nvflare/edge/controllers/sage.py
+++ b/nvflare/edge/controllers/sage.py
@@ -168,6 +168,7 @@ class ScatterAndGatherForEdge(Controller):
                     data=task_data,
                     before_task_sent_cb=self._prepare_train_task_data,
                     result_received_cb=self._process_train_result,
+                    task_data_mutable=False,
                 )
 
                 self.broadcast(

--- a/research/auto-fed-rl/src/autofedrl/autofedrl_scatter_and_gather.py
+++ b/research/auto-fed-rl/src/autofedrl/autofedrl_scatter_and_gather.py
@@ -168,6 +168,7 @@ class ScatterAndGatherAutoFedRL(ScatterAndGather):
                     timeout=self._train_timeout,
                     before_task_sent_cb=self._prepare_train_task_data,
                     result_received_cb=self._process_val_result,
+                    task_data_mutable=False,
                 )
 
                 self.broadcast_and_wait(
@@ -203,6 +204,7 @@ class ScatterAndGatherAutoFedRL(ScatterAndGather):
                     timeout=self._train_timeout,
                     before_task_sent_cb=self._prepare_train_task_data,
                     result_received_cb=self._process_train_result,
+                    task_data_mutable=False,
                 )
 
                 self.broadcast_and_wait(

--- a/research/fed-sm/jobs/fedsm_prostate/app/custom/workflows/scatter_and_gather_fedsm.py
+++ b/research/fed-sm/jobs/fedsm_prostate/app/custom/workflows/scatter_and_gather_fedsm.py
@@ -212,6 +212,7 @@ class ScatterAndGatherFedSM(ScatterAndGather):
                         timeout=self._train_timeout,
                         before_task_sent_cb=self._prepare_train_task_data,
                         result_received_cb=self._process_train_result,
+                        task_data_mutable=False,
                     )
 
                     # send only to the target client


### PR DESCRIPTION
Fixes # .

### Description

Previously, a msg root id is always created for a workflow task, assuming that the task data is never changed during the life of the task. This way, all messages originated from the same task can share the serialization result from the 1st message, hence saving time and memory usage.

Unfortunately, this assumption is not always true. For example, the cross-site validation controller reloads task data from disk every time it gets a request from a client for the same task).

This PR tries to fix this issue without losing the benefit of msg root sharing:

- Since task data modification always happens within the task's before_task_sent_cb, if this cb is not specified, then the task data is not mutable.
- If the cb is specified, then the app can further specify whether the task data is mutable explicitly when creating the task. For example, all variants of SAG specify the before_task_sent_cb, but they do not modify task data. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
