### PR TITLE
Disable msg root processing

### DIFF
--- a/nvflare/fuel/utils/fobs/decomposers/via_file.py
+++ b/nvflare/fuel/utils/fobs/decomposers/via_file.py
@@ -255,6 +255,10 @@ class ViaFileDecomposer(fobs.Decomposer, ABC):
             # make sure the TTL is long enough
             msg_root_ttl = _MIN_MSG_ROOT_TTL
 
+        # disable msg root processing for now, until we find a better solution
+        # We need to detect that the msg object has mutated so that cached values cannot be used.
+        msg_root_id = None
+
         fobs_ctx[_CtxKey.MSG_ROOT_ID] = msg_root_id
         fobs_ctx[_CtxKey.MSG_ROOT_TTL] = msg_root_ttl
 


### PR DESCRIPTION
Fixes # .

### Description

Msg root based sharing of serialization results is flawed. The message payload could be changed within the life of a task. The changes could be caused by before_task_sent_cb, or by filters. Before we find a solution to automatically detect and handle payload changes, we will disable the msg root based sharing.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
