### PR TITLE
Support app packages in job API

### DIFF
--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -203,6 +203,18 @@ class FedJob:
         self._deployed = False
         self._components = {}
 
+    def set_app_packages(self, app_packages: List[str]):
+        """Set app packages.
+        When generating job config, code from these packages will not be included into "custom" folder.
+
+        Args:
+            app_packages: app packages to be set
+
+        Returns: None
+
+        """
+        self.job.set_app_packages(app_packages)
+
     def set_up_client(self, target: str):
         """Setup routine called by FedJob when first sending object to a client target.
 

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 from enum import Enum
 from tempfile import TemporaryDirectory
-from typing import Dict
+from typing import Dict, List
 
 from nvflare.fuel.utils.class_utils import get_component_init_parameters
 from nvflare.fuel.utils.log_utils import get_obj_logger
@@ -61,6 +61,7 @@ class FedJobConfig:
         self.min_clients = min_clients
         self.mandatory_clients = mandatory_clients
         self.meta_props = meta_props
+        self.app_packages = []
 
         self.fed_apps: Dict[str, FedAppConfig] = {}
         self.deploy_map: Dict[str, str] = {}
@@ -68,6 +69,23 @@ class FedJobConfig:
 
         self.custom_modules = []
         self.logger = get_obj_logger(self)
+
+    def set_app_packages(self, app_packages: List[str]):
+        """Set app packages.
+        When generating job config, code from these packages will not be included into "custom" folder.
+
+        Args:
+            app_packages: app packages
+
+        Returns: None
+
+        """
+        if not app_packages:
+            app_packages = []
+        else:
+            check_object_type("app_packages", app_packages, list)
+
+        self.app_packages = app_packages
 
     def add_fed_app(self, app_name: str, fed_app: FedAppConfig):
         if not isinstance(fed_app, FedAppConfig):
@@ -268,7 +286,7 @@ class FedJobConfig:
     def _get_custom_file(self, custom_dir, module, source_file):
         package = module.split(".")[0]
         if os.path.exists(source_file):
-            if package not in FL_PACKAGES and module not in self.custom_modules:
+            if package not in FL_PACKAGES and package not in self.app_packages and module not in self.custom_modules:
                 module_path = module.replace(".", os.sep)
                 if module_path in source_file:
                     index = source_file.rindex(module_path)


### PR DESCRIPTION
Fixes # .

### Description

Currently, if a module is not in NVFLARE package, the Job API applies the magic of determining its class path and copying the source into the "custom" folder of generated job. When the module is in an app package that will be included in the final python env (e.g. docker container), then this magic is not desired. In fact, including the source code could cause confusion when resolving class path.

This PR implements a simple solution by letting the Job API user specify app packages to be excluded from this behavior.
If the package name of a module is in the specified app package list, then the magic won't be applied. 


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
