### PR TITLE
Fix ProdEnv

### DIFF
--- a/nvflare/recipe/prod_env.py
+++ b/nvflare/recipe/prod_env.py
@@ -20,7 +20,7 @@ from nvflare.job_config.api import FedJob
 from .spec import ExecEnv
 
 
-class ProdExecEnv(ExecEnv):
+class ProdEnv(ExecEnv):
 
     def __init__(
         self,


### PR DESCRIPTION
temp_dir is already a string

### Description

temp_dir is already a string

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
