### PR TITLE
Added white-list for decomposers

### DIFF
--- a/nvflare/fuel/utils/fobs/builtin_decomposers.py
+++ b/nvflare/fuel/utils/fobs/builtin_decomposers.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This set holds the names of all the built-in decomposers
+BUILTIN_DECOMPOSERS: set[str] = {
+    "cma_decomposer.CMADataLoggerDecomposer",
+    "cma_decomposer.CMAOptionsDecomposer",
+    "cma_decomposer.GaussFullSamplerDecomposer",
+    "nvflare.apis.utils.decomposers.flare_decomposers.ContextDecomposer",
+    "nvflare.apis.utils.decomposers.flare_decomposers.DXODecomposer",
+    "nvflare.apis.utils.decomposers.flare_decomposers.WorkspaceDecomposer",
+    "nvflare.app_common.decomposers.common_decomposers.FLModelDecomposer",
+    "nvflare.app_common.decomposers.common_decomposers.FLModelDecomposer",
+    "nvflare.app_common.decomposers.numpy_decomposers.Float32ScalarDecomposer",
+    "nvflare.app_common.decomposers.numpy_decomposers.Float64ScalarDecomposer",
+    "nvflare.app_common.decomposers.numpy_decomposers.Int32ScalarDecomposer",
+    "nvflare.app_common.decomposers.numpy_decomposers.Int64ScalarDecomposer",
+    "nvflare.app_common.decomposers.numpy_decomposers.NumpyArrayDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.BinDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.BinRangeDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.DataTypeDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.FeatureDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.HistogramDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.HistogramTypeDecomposer",
+    "nvflare.app_common.statistics.statisitcs_objects_decomposer.StatisticConfigDecomposer",
+    "nvflare.app_opt.he.decomposers.CKKSVectorDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DataClassDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DictDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DictDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.DictDecomposer",
+    "nvflare.fuel.utils.fobs.decomposer.EnumTypeDecomposer",
+    "nvflare.fuel.utils.fobs.decomposers.core_decomposers.DatetimeDecomposer",
+    "nvflare.fuel.utils.fobs.decomposers.core_decomposers.OrderedDictDecomposer",
+    "nvflare.fuel.utils.fobs.decomposers.core_decomposers.SetDecomposer",
+    "nvflare.fuel.utils.fobs.decomposers.core_decomposers.TupleDecomposer",
+}

--- a/nvflare/fuel/utils/fobs/fobs.py
+++ b/nvflare/fuel/utils/fobs/fobs.py
@@ -23,6 +23,7 @@ from typing import Any, BinaryIO, Dict, Type, TypeVar, Union
 import msgpack
 
 from nvflare.fuel.utils.class_loader import get_class_name, load_class
+from nvflare.fuel.utils.fobs.builtin_decomposers import BUILTIN_DECOMPOSERS
 from nvflare.fuel.utils.fobs.datum import DatumManager
 from nvflare.fuel.utils.fobs.decomposer import (
     DataClassDecomposer,
@@ -155,6 +156,11 @@ class Packer:
         if type_name not in _decomposers:
             registered = False
             decomposer_name = obj.get(FOBS_DECOMPOSER)
+
+            # For security reason, only builtin decomposers are allowed without registration
+            if decomposer_name not in BUILTIN_DECOMPOSERS:
+                raise ValueError(f"Decomposer {decomposer_name} must be registered")
+
             cls = load_class(type_name)
             if not decomposer_name:
                 # Maintaining backward compatibility with auto enum registration

--- a/tests/unit_test/fuel/utils/fobs/fobs_test.py
+++ b/tests/unit_test/fuel/utils/fobs/fobs_test.py
@@ -68,10 +68,13 @@ class TestFobs:
         test_class = ExampleClass(TestFobs.NUMBER)
         fobs.register(ExampleClassDecomposer)
         buf = fobs.dumps(test_class)
-        # Clear registration before deserializing
+        # Unregister the decomposer
         fobs.reset()
-        new_class = fobs.loads(buf)
-        assert new_class.number == TestFobs.NUMBER
+
+        # ExampleClassDecomposer is not builtin, not allowed
+        with pytest.raises(ValueError):
+            new_class = fobs.loads(buf)
+            assert new_class.number == TestFobs.NUMBER
 
     def test_auto_registration(self):
         fobs.reset()


### PR DESCRIPTION
Fixes https://jirasw.nvidia.com/browse/FLARE-2551

### Description

When FOBS deserialize messages, it loads decomposer classes specified in the serialized data. This may pose a security risk if someone changes the name to an arbitrary decomposer class. 

This is fixed by checking a white-list of builtin decomposers.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
