### PR TITLE
Fix an issue on property setting during creating admin startup kit.

### DIFF
--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -545,7 +545,7 @@ class StaticFileBuilder(Builder):
     def prepare_admin_config(self, admin: Participant, ctx: ProvisionContext):
         project = ctx.get_project()
         server = project.get_server()
-        conn_sec = server.get_prop_fb(PropKey.CONN_SECURITY)
+        conn_sec = admin.get_prop_fb(PropKey.CONN_SECURITY)
         if not conn_sec:
             conn_sec = ConnSecurity.MTLS
 


### PR DESCRIPTION
### Description

The provisioning tool set connection_security to each participant's startup kit.  This PR is to fix the incorrect setting of that property in admin startup kit.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
