### PR TITLE
Add active garbage collection in CCWF

### DIFF
--- a/nvflare/app_common/ccwf/client_ctl.py
+++ b/nvflare/app_common/ccwf/client_ctl.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import gc
 import threading
 import time
 from abc import abstractmethod
@@ -461,6 +462,9 @@ class ClientSideController(Executor, TaskController):
                     self.do_learn_task(t.task_name, t.task_data, t.fl_ctx, t.abort_signal)
                 except:
                     self.logger.log(f"exception from do_learn_task: {secure_format_traceback()}")
+                finally:
+                    # force garbage collection
+                    gc.collect()
                 self.learn_task = None
             time.sleep(self.learn_task_check_interval)
 

--- a/nvflare/app_common/ccwf/cse_client_ctl.py
+++ b/nvflare/app_common/ccwf/cse_client_ctl.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import gc
 import time
 
 from nvflare.apis.controller_spec import Task
@@ -78,7 +79,9 @@ class CrossSiteEvalClientController(ClientSideController):
     def execute(self, task_name: str, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> Shareable:
         if task_name == self.eval_task_name:
             # server assigned task
-            return self._do_eval(shareable, fl_ctx, abort_signal)
+            result = self._do_eval(shareable, fl_ctx, abort_signal)
+            gc.collect()
+            return result
 
         elif task_name == self.prep_model_task_name:
             # server assigned task

--- a/nvflare/app_common/ccwf/swarm_client_ctl.py
+++ b/nvflare/app_common/ccwf/swarm_client_ctl.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import gc
 import random
 import threading
 import time
@@ -94,6 +95,9 @@ class Gatherer(FLComponent):
             except:
                 self.log_error(fl_ctx, f"exception gathering: {secure_format_traceback()}")
                 return make_reply(ReturnCode.EXECUTION_EXCEPTION)
+            finally:
+                # force garbage collection after each gather
+                gc.collect()
 
     def _do_gather(self, client_name: str, result: Shareable, fl_ctx: FLContext) -> Shareable:
         result_round = result.get_header(AppConstants.CURRENT_ROUND)


### PR DESCRIPTION
Fixes # .

### Description

In order to reduce peak memory usage, this PR adds garbage collection after heavy activities such as client training and aggregation.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
