### PR TITLE
Update the token expiration time

### DIFF
--- a/examples/advanced/cc_provision/README.md
+++ b/examples/advanced/cc_provision/README.md
@@ -74,12 +74,12 @@ trustee_port: 8999
 cc_issuers:
   - id: snp_authorizer
     path: nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer
-    token_expiration: 3600 # in seconds
+    token_expiration: 150 # in seconds, needs to be less than check_frequency
   - id: gpu_authorizer
     path: nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer
-    token_expiration: 3600 # in seconds
+    token_expiration: 150 # in seconds, needs to be less than check_frequency
 
 cc_attestation:
-  check_frequency: 180 # in seconds
+  check_frequency: 300 # in seconds
 
 ```

--- a/examples/advanced/cc_provision/cc_server1.yml
+++ b/examples/advanced/cc_provision/cc_server1.yml
@@ -20,7 +20,7 @@ trustee_port: 8999
 cc_issuers:
   - id: snp_authorizer
     path: nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer
-    token_expiration: 3600
+    token_expiration: 150 # needs to be less than check_frequency
 
 cc_attestation:
-  check_frequency: 180
+  check_frequency: 300

--- a/examples/advanced/cc_provision/cc_site-1.yml
+++ b/examples/advanced/cc_provision/cc_site-1.yml
@@ -21,10 +21,10 @@ trustee_port: 8999
 cc_issuers:
   - id: snp_authorizer
     path: nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer
-    token_expiration: 3600
+    token_expiration: 150 # needs to be less than check_frequency
   - id: gpu_authorizer
     path: nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer
-    token_expiration: 3600
+    token_expiration: 150 # needs to be less than check_frequency
 
 cc_attestation:
-  check_frequency: 180
+  check_frequency: 300


### PR DESCRIPTION
The token expiration time needs to be less than the check_frequency so that we ensure the token is fresh (with nonce) everytime we verify it.

### Description

The token expiration time needs to be less than the check_frequency so that we ensure the token is fresh (with nonce) everytime we verify it.

Note that under the current code, we can only support 1 job at a time for CC.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
