### PR TITLE
Convert ET model once for each task

### DIFF
--- a/nvflare/edge/executors/edge_model_executor.py
+++ b/nvflare/edge/executors/edge_model_executor.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import threading
 import time
 from typing import Optional
 
@@ -37,6 +38,7 @@ class EdgeModelExecutor(EdgeTaskExecutor):
         EdgeTaskExecutor.__init__(self, "", update_timeout)
         self.aggr_factory_id = aggr_factory_id
         self.max_model_versions = max_model_versions
+        self.cvt_lock = threading.Lock()
 
     def get_updater(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
@@ -193,14 +195,22 @@ class EdgeModelExecutor(EdgeTaskExecutor):
         self.log_debug(
             fl_ctx, f"task for model V{task_state.model_version} sent to device {device_id}: {new_selection_id=}"
         )
-        task_data = self._convert_task(task_state, current_task, fl_ctx)
+
+        # all platforms use the same converted model for now!
+        with self.cvt_lock:
+            platform = "*"
+            converted_model = task_state.get_converted_model(platform)
+            if not converted_model:
+                converted_model = self._convert_task(task_state, current_task, fl_ctx)
+                task_state.set_converted_model(converted_model, platform)
+
         return TaskResponse(
             status=EdgeApiStatus.OK,
             job_id=job_id,
             retry_wait=0,
             task_id=current_task.id,
             task_name=current_task.name,
-            task_data=task_data,
+            task_data=converted_model,
             cookie=self._make_cookie(task_state.model_version, new_selection_id),
         )
 

--- a/nvflare/edge/mud.py
+++ b/nvflare/edge/mud.py
@@ -93,6 +93,30 @@ class BaseState:
         self.model = model
         self.device_selection_version = device_selection_version
         self.device_selection = device_selection
+        self.converted_models = {}  # platform => model
+
+    def set_converted_model(self, model, platform: str):
+        """Set the model that is converted from the original model for the specified platform.
+
+        Args:
+            model: the converted model
+            platform: the platform that the converted model will be used for
+
+        Returns: None
+
+        """
+        self.converted_models[platform] = model
+
+    def get_converted_model(self, platform: str):
+        """Get the model that is converted for the platform.
+
+        Args:
+            platform: the platform of the model
+
+        Returns: converted model if available; None otherwise.
+
+        """
+        return self.converted_models.get(platform)
 
     def is_device_selected(self, device_id: str, selection_id: int) -> (bool, int):
         """Determine whether the device should be selected for training.


### PR DESCRIPTION
Fixes # .

### Description

The PT model needs to be converted to ET format before sending to a device. There are two issues with current implementation:

- The model is converted every time a new request is received from the device, even though the conversion is the same for all devices.
- The conversion is not done within a lock. When multiple devices ask for the model at the same time, the multiple conversions happen concurrently, which could break the integrity of the converted result.

This PR fixes these issues:
- The model is converted only once. Converted result is cached for later reuse.
- The check-and-convert process is placed within a lock. 


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
