### PR TITLE
Fix edge project default

### DIFF
--- a/nvflare/lighter/edge_project.yml
+++ b/nvflare/lighter/edge_project.yml
@@ -45,3 +45,4 @@ builders:
       config_folder: config   # Configuration folder for setting up project details
   - path: nvflare.lighter.impl.cert.CertBuilder
   - path: nvflare.lighter.impl.signature.SignatureBuilder
+  - path: nvflare.lighter.impl.edge.EdgeBuilder


### PR DESCRIPTION
EdgeBuilder is required for the real deployment

### Description
EdgeBuilder is required for the real deployment



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
