### PR TITLE
Fix job name in StatsJob

### DIFF
--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -559,7 +559,7 @@ class FedJob:
             self._deployed = True
 
     def export_job(self, job_root: str):
-        """Export job config to `job_root` directory with name `self.job_name`.
+        """Export job config to `job_root` directory with name `self.name`.
         For end users.
 
         Args:

--- a/nvflare/job_config/stats_job.py
+++ b/nvflare/job_config/stats_job.py
@@ -28,7 +28,7 @@ from nvflare.app_common.workflows.statistics_controller import StatisticsControl
 class StatsJob(FedJob):
     def __init__(
         self,
-        job_name: str,
+        name: str,
         statistic_configs: dict,
         stats_generator: Statistics,
         output_path: str,
@@ -37,10 +37,9 @@ class StatsJob(FedJob):
         max_noise_level=0.3,
         max_bins_percent=10,
     ):
-        super().__init__(name=job_name)
+        super().__init__(name=name)
         self.writer_id = "stats_writer"
         self.stats_generator_id_prefix = "stats_generator"
-        self.job_name = job_name
         self.stats_generator = stats_generator
         self.statistic_configs = statistic_configs
         self.output_path = output_path

--- a/nvflare/job_config/stats_job.py
+++ b/nvflare/job_config/stats_job.py
@@ -37,7 +37,7 @@ class StatsJob(FedJob):
         max_noise_level=0.3,
         max_bins_percent=10,
     ):
-        super().__init__()
+        super().__init__(name=job_name)
         self.writer_id = "stats_writer"
         self.stats_generator_id_prefix = "stats_generator"
         self.job_name = job_name

--- a/nvflare/recipe/fedstats.py
+++ b/nvflare/recipe/fedstats.py
@@ -81,7 +81,7 @@ class FedStatsRecipe(Recipe):
         max_bins_percent: float = 10,
     ):
         job = StatsJob(
-            job_name=name,
+            name=name,
             statistic_configs=statistic_configs,
             stats_generator=stats_generator,
             output_path=stats_output_path,


### PR DESCRIPTION
Fixes # .

### Description

Job name wasn't correctly propagated in StatsJob. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [ ] Documentation updated.
