### PR TITLE
handle cases where quantile config is un-defined for certain features 

### DIFF
--- a/nvflare/app_common/statistics/statistics_config_utils.py
+++ b/nvflare/app_common/statistics/statistics_config_utils.py
@@ -30,12 +30,12 @@ def get_feature_bin_range(feature_name: str, hist_config: dict) -> Optional[List
     return bin_range
 
 
-def get_target_quantiles(percentile_config: dict, feature_name: str):
+def get_target_quantiles(percentile_config: dict, feature_name: str) -> list:
     if feature_name in percentile_config:
         percents = percentile_config.get(feature_name)
     elif "*" in percentile_config:
         percents = percentile_config.get("*")
     else:
-        raise ValueError(f"feature: {feature_name} target percents are not defined.")
+        percents = []
 
     return percents

--- a/nvflare/app_opt/statistics/quantile_stats.py
+++ b/nvflare/app_opt/statistics/quantile_stats.py
@@ -15,6 +15,7 @@
 from typing import Dict
 
 from nvflare.app_common.app_constant import StatisticsConstants as StC
+from nvflare.app_common.statistics.statistics_config_utils import get_target_quantiles
 from nvflare.fuel.utils.log_utils import get_module_logger
 
 try:
@@ -41,18 +42,6 @@ def get_quantiles(stats: Dict, statistic_configs: Dict, precision: int):
 
     quantile_config = statistic_configs.get(StC.STATS_QUANTILE)
     return compute_quantiles(global_digest, quantile_config, precision)
-
-
-def get_target_quantiles(quantile_config: dict, feature_name: str) -> list:
-    if feature_name in quantile_config:
-        percents = quantile_config.get(feature_name)
-    elif "*" in quantile_config:
-        percents = quantile_config.get("*")
-    else:
-        percents = []
-
-    return percents
-
 
 def merge_quantiles(metrics: Dict[str, Dict[str, Dict]], g_digest: dict) -> dict:
 

--- a/nvflare/app_opt/statistics/quantile_stats.py
+++ b/nvflare/app_opt/statistics/quantile_stats.py
@@ -43,13 +43,13 @@ def get_quantiles(stats: Dict, statistic_configs: Dict, precision: int):
     return compute_quantiles(global_digest, quantile_config, precision)
 
 
-def get_target_quantiles(quantile_config: dict, feature_name: str):
+def get_target_quantiles(quantile_config: dict, feature_name: str) -> list:
     if feature_name in quantile_config:
         percents = quantile_config.get(feature_name)
     elif "*" in quantile_config:
         percents = quantile_config.get("*")
     else:
-        raise ValueError(f"feature: {feature_name} target percents are not defined.")
+        percents = []
 
     return percents
 

--- a/nvflare/app_opt/statistics/quantile_stats.py
+++ b/nvflare/app_opt/statistics/quantile_stats.py
@@ -43,6 +43,7 @@ def get_quantiles(stats: Dict, statistic_configs: Dict, precision: int):
     quantile_config = statistic_configs.get(StC.STATS_QUANTILE)
     return compute_quantiles(global_digest, quantile_config, precision)
 
+
 def merge_quantiles(metrics: Dict[str, Dict[str, Dict]], g_digest: dict) -> dict:
 
     if not TDIGEST_AVAILABLE:


### PR DESCRIPTION
### Description
In some cases, the quantile is configured but only for selected features. We should be able to handle such cases

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
