### PR TITLE
Enhance recipe and flare api abort job to return msg

### DIFF
--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -372,7 +372,8 @@ class Session(SessionSpec):
         Args:
             job_id (str): job to be aborted
 
-        Returns: dict of (status, info)
+        Returns:
+            str: the message from the server
 
         If the job is already done, no effect;
         If job is not started yet, it will be cancelled and won't be scheduled.
@@ -380,9 +381,13 @@ class Session(SessionSpec):
 
         """
         self._validate_job_id(job_id)
-        # result = self._do_command(AdminCommandNames.ABORT_JOB + " " + job_id)
-        # return result.get(ResultKey.META, None)
-        self._do_command(AdminCommandNames.ABORT_JOB + " " + job_id)
+        result = self._do_command(AdminCommandNames.ABORT_JOB + " " + job_id)
+        meta = result[ResultKey.META]
+        status = meta.get(MetaKey.STATUS)
+        info = meta.get(MetaKey.INFO)
+        if status != MetaStatusValue.OK:
+            raise InternalError(f"failed to abort job {job_id}: {status}, {info}")
+        return info
 
     def delete_job(self, job_id: str):
         """Delete the specified job completely from the system.
@@ -390,7 +395,8 @@ class Session(SessionSpec):
         Args:
             job_id (str): job to be deleted
 
-        Returns: None
+        Returns:
+            None
 
         The job will be deleted from the job store if the job is not currently running.
 

--- a/nvflare/recipe/run.py
+++ b/nvflare/recipe/run.py
@@ -14,10 +14,26 @@
 
 import os
 from contextlib import contextmanager
-from typing import Generator
+from typing import Generator, Optional
 
 from nvflare.fuel.flare_api.api_spec import MonitorReturnCode
-from nvflare.fuel.flare_api.flare_api import basic_cb_with_print, new_secure_session
+from nvflare.fuel.flare_api.flare_api import Session, new_secure_session
+
+
+def _cb_with_print(session: Session, job_id: str, job_meta, *cb_args, **cb_kwargs) -> bool:
+    """Callback to print job meta."""
+    # cb_run_counter is a dictionary that is passed to the callback and is used to keep track of the number of times the callback has been called
+    if cb_kwargs["cb_run_counter"]["count"] == 0:
+        print("Job ID: ", job_id)
+        print("Job Meta: ", job_meta)
+
+    if job_meta["status"] == "RUNNING":
+        print(".", end="")
+    else:
+        print("\n" + str(job_meta))
+
+    cb_kwargs["cb_run_counter"]["count"] += 1
+    return True
 
 
 class Run:
@@ -82,17 +98,29 @@ class Run:
             raise RuntimeError("Simulation workspace_root is None - SimEnv may not be properly initialized")
         return os.path.join(workspace_root, self.job_id)
 
-    def _get_prod_result(self, timeout: float = 0.0) -> str:
+    def _get_prod_result(self, timeout: float = 0.0) -> Optional[str]:
         with self._secure_session() as sess:
             cb_run_counter = {"count": 0}
-            rc = sess.monitor_job(self.job_id, timeout=timeout, cb=basic_cb_with_print, cb_run_counter=cb_run_counter)
+            rc = sess.monitor_job(self.job_id, timeout=timeout, cb=_cb_with_print, cb_run_counter=cb_run_counter)
             print(f"job monitor done: {rc=}")
             if rc == MonitorReturnCode.JOB_FINISHED:
                 return sess.download_job_result(self.job_id)
+            elif rc == MonitorReturnCode.TIMEOUT:
+                print(
+                    f"Job {self.job_id} did not complete within {timeout} seconds. "
+                    "Job is still running. Try calling get_result() again with a longer timeout."
+                )
+                return None
+            elif rc == MonitorReturnCode.ENDED_BY_CB:
+                print(
+                    "Job monitoring was stopped early by callback. "
+                    "Result may not be available yet. Check job status and try again."
+                )
+                return None
             else:
-                raise RuntimeError(f"Monitor job failed: {rc}")
+                raise RuntimeError(f"Unexpected monitor return code: {rc}")
 
-    def get_result(self, timeout: float = 0.0) -> str:
+    def get_result(self, timeout: float = 0.0) -> Optional[str]:
         """Get the result workspace of the run.
 
         Args:
@@ -100,7 +128,7 @@ class Run:
                 Defaults to 0.0, means never timeout.
 
         Returns:
-            str: The result workspace of the run.
+            Optional[str]: The result workspace path if job completed, None if still running or stopped early.
         """
         env_type = self.env_info.get("env_type")
         return self.handlers[env_type](timeout=timeout)
@@ -112,4 +140,5 @@ class Run:
             return
 
         with self._secure_session() as sess:
-            sess.abort_job(self.job_id)
+            msg = sess.abort_job(self.job_id)
+            print(f"Job {self.job_id} aborted successfully with message: {msg}")


### PR DESCRIPTION
Our previous "abort" command shows nothing for the users and does not report if errors happen.

### Description

- Change Flare API abort to return the info and raise Exception if abort failed
- Add a print inside run.abort to give users feedback

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
