### PR TITLE
Update edge examples to use prod environment

### DIFF
--- a/examples/advanced/edge/README.md
+++ b/examples/advanced/edge/README.md
@@ -15,7 +15,7 @@ This guide supports two distinct workflows:
 
 ## Setup the NVFlare System
 ### Install prerequisites
-After properly installing NVFlare, further install the required packages for this example:
+Install NVFlare and the required packages for this example:
 ```commandline
 pip install -r requirements.txt
 ```
@@ -172,34 +172,18 @@ cd /tmp/nvflare/workspaces/edge_example/prod_00/
 bash start_all.sh 
 ```  
 
-#### Step2: Generate Job Configs using the EdgeFedBuffRecipe API
+#### Step2: Generate Jobs and Submit Using the EdgeFedBuffRecipe API
 Next, let's generate job configs for cifar10 via EdgeFedBuffRecipe API.
+
+This will generate two job configurations and submit them to run on the FL system for basic synchronous and asynchronous training:
+- sync assumes ALL devices participate in each round
+- async assumes server updates the global model and immediately dispatch it after receiving ONE device's update.
 
 ```commandline
 python3 jobs/pt_job.py --fl_mode sync
 python3 jobs/pt_job.py --fl_mode async
 python3 jobs/pt_job.py --fl_mode sync --no_delay
 python3 jobs/pt_job.py --fl_mode async --no_delay
-```
-This will generate two job configurations for basic synchronous and asynchronous training:
-- sync assumes ALL devices participate in each round
-- async assumes server updates the global model and immediately dispatch it after receiving ONE device's update.
-
-#### Step3: Submit NVFlare Job
-Start a new console for admin to interact with the NVFlare system:
-```commandline
-/tmp/nvflare/workspaces/edge_example/prod_00/admin@nvidia.com/startup/fl_admin.sh
-```
-
-For simulations performed directly at leaf nodes, simply submit the job:
-```
-submit_job pt_job_sync
-```
-similarly for other jobs:
-```
-submit_job pt_job_async
-submit_job pt_job_sync_no_delay
-submit_job pt_job_async_no_delay
 ```
 
 You will then see the simulated devices start receiving the model from the server and complete local trainings.
@@ -265,11 +249,8 @@ The above experiments are performed in a controlled, consistent manner, where we
 In practice, we may have a large number of devices, and the devices may not always be available for training. In this case, we can use the EdgeFedBuffRecipe API to simulate a more realistic cross-device federated learning scenario, where devices are sampled from a large pool of devices, and only a subset of devices are selected for each round of training.
 
 To simulate this, rather than only specifying `sync`/`async`, we further specify multiple parameters which were automatically calculated based on the assumptions of the basic settings in previous experiment.
-```commandline
-python3 jobs/pt_job_adv.py 
-```
 
-This will generate a job configuration for cross-device federated learning with the following parameters:
+We can submit a job for cross-device federated learning with the following parameters:
 
 -   devices_per_leaf: 10000, so in total we have 40000 devices across all leaf nodes.
 -   device_selection_size: 200, every round we will randomly select 200 devices in total to execute local training.
@@ -281,9 +262,11 @@ This will generate a job configuration for cross-device federated learning with 
 -   local training parameters: local_batch_size 10, local_epochs 4, local_lr 0.1, and local_momentum 0.0. 
 These settings will simulate a realistic cross-device federated learning scenario, where devices are sampled from a large pool of devices, and only a subset of devices is selected for each round of training. As it is much more complex than the previous experiments, we call it advanced (`_adv`) recipe. Users can further customize the parameters to simulate different scenarios.
 In admin console, submit the job:
+
+```commandline
+python3 jobs/pt_job_adv.py 
 ```
-submit_job pt_job_adv
-```
+
 Upon finishing, we can visualize the results in TensorBoard as before:
 ```commandline
 tensorboard --logdir=/tmp/nvflare/

--- a/examples/advanced/edge/jobs/pt_job.py
+++ b/examples/advanced/edge/jobs/pt_job.py
@@ -24,6 +24,7 @@ from nvflare.edge.tools.edge_fed_buff_recipe import (
     ModelManagerConfig,
     SimulationConfig,
 )
+from nvflare.recipe.prod_env import ProdEnv
 
 
 def create_edge_recipe(fl_mode, devices_per_leaf, num_leaf_nodes, global_rounds, no_delay=False):
@@ -161,6 +162,23 @@ def main():
         action="store_true",
         help="If set, disable communication delay and device speed variations (set to 0.0)",
     )
+    parser.add_argument(
+        "--startup_kit_location",
+        type=str,
+        default="/tmp/nvflare/workspaces/edge_example/prod_00/admin@nvidia.com",
+        help="Admin startup kit location",
+    )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default="admin@nvidia.com",
+        help="Username",
+    )
+    parser.add_argument(
+        "--export_job",
+        action="store_true",
+        help="If set, export the recipe to the output directory",
+    )
 
     args = parser.parse_args()
 
@@ -175,15 +193,21 @@ def main():
             no_delay=args.no_delay,
         )
 
-        print("Exporting recipe...")
-        recipe.export(args.output_dir)
-        print("DONE")
-
     except Exception as e:
         print(f"Error creating recipe: {e}")
         return 1
 
-    return 0
+    if args.export_job:
+        print(f"Exporting recipe to {args.output_dir}")
+        recipe.export(args.output_dir)
+        print("DONE")
+    else:
+        env = ProdEnv(startup_kit_location=args.startup_kit_location, username=args.username)
+        run = recipe.execute(env)
+        print()
+        print("Result can be found in :", run.get_result())
+        print("Job Status is:", run.get_status())
+        print()
 
 
 if __name__ == "__main__":

--- a/examples/advanced/edge/jobs/pt_job_adv.py
+++ b/examples/advanced/edge/jobs/pt_job_adv.py
@@ -22,6 +22,7 @@ from nvflare.edge.tools.edge_fed_buff_recipe import (
     ModelManagerConfig,
     SimulationConfig,
 )
+from nvflare.recipe.prod_env import ProdEnv
 
 
 def main():
@@ -29,6 +30,8 @@ def main():
     devices_per_leaf = 10000
     device_selection_size = 200
     num_leaf_nodes = 4
+    startup_kit_location = "/tmp/nvflare/workspaces/edge_example/prod_00/admin@nvidia.com"
+    username = "admin@nvidia.com"
     output_dir = "/tmp/nvflare/workspaces/edge_example/prod_00/admin@nvidia.com/transfer"
     dataset_root = "/tmp/nvflare/datasets/cifar10"
     subset_size = 100
@@ -92,11 +95,16 @@ def main():
         custom_source_root=None,
     )
 
-    print("Exporting recipe...")
+    print(f"Exporting recipe to {output_dir}")
     recipe.export(output_dir)
     print("DONE")
 
-    return 0
+    env = ProdEnv(startup_kit_location=startup_kit_location, username=username)
+    run = recipe.execute(env)
+    print()
+    print("Result can be found in :", run.get_result())
+    print("Job Status is:", run.get_status())
+    print()
 
 
 if __name__ == "__main__":

--- a/examples/advanced/edge/requirements.txt
+++ b/examples/advanced/edge/requirements.txt
@@ -1,3 +1,4 @@
+nvflare~=2.7rc
 executorch
 torchvision
 torch


### PR DESCRIPTION
Fixes # .

### Description

Update job scripts to use ProdEnv directly, avoiding export.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
