### PR TITLE
Add decomposer register

### DIFF
--- a/nvflare/app_common/widgets/decomposer_reg.py
+++ b/nvflare/app_common/widgets/decomposer_reg.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+
+from nvflare.fuel.utils.class_loader import load_class
+from nvflare.fuel.utils.fobs import register
+from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.widgets.widget import Widget
+
+
+class DecomposerRegister(Widget):
+
+    def __init__(self, classes: List[str]):
+        logger = get_obj_logger(self)
+        Widget.__init__(self)
+        for class_name in classes:
+            register(load_class(class_name))
+            logger.info(f"Registered decomposer {class_name}")


### PR DESCRIPTION
Fixes # .

### Description

Due to security concern raised by NVIDIA security team, we had to take out "auto decomposer registration" function from FOBS.  The application will have to explicitly register custom decomposers.

This PR adds a DecomposerRegister widget that can be used to configure and load any custom decomposers.
To use it, simply include it as a component in config_fed_server.json and/or config_fed_client.json.

"components": [
    {
      "id": "decomposer_reg",
      "path": "path.to.custom.decomposer",
      "args": {
        "classes": ["nvflare.app_opt.pt.decomposers.TensorDecomposer"]
      }
    }
  ]


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
