### PR TITLE
Increase the grace period so error msg won't show up

### DIFF
--- a/nvflare/fuel/f3/mpm.py
+++ b/nvflare/fuel/f3/mpm.py
@@ -129,7 +129,7 @@ class MainProcessMonitor:
         waiter.set()
 
     @classmethod
-    def run(cls, main_func, run_dir=None, shutdown_grace_time=1.5, cleanup_grace_time=1.5, **kwargs):
+    def run(cls, main_func, run_dir=None, shutdown_grace_time=3, cleanup_grace_time=3, **kwargs):
         if not callable(main_func):
             raise ValueError("main_func must be runnable")
 


### PR DESCRIPTION
Fixes QA bug FLARE-2599

### Description

Increases the grace period so the shutdown error msg won't show up easily, as suggested by QA

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
