### PR TITLE
Add job name to sample edge simulator config

### DIFF
--- a/nvflare/lighter/tree_prov.py
+++ b/nvflare/lighter/tree_prov.py
@@ -128,6 +128,7 @@ class _Packager(Packager):
         )
 
         sample_sim_config = {
+            "job_name": "edge_job",
             "endpoint": f"http://localhost:{self.rp_port}",
             "num_devices": 10000,
             "num_active_devices": 100,


### PR DESCRIPTION
Fixes QA issue FLARE-2619

### Description

Add job name to sample edge simulator config

We might need to remove the method <-> capability match since now we use pure job name to match.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
