### PR TITLE
Fix missing job name in edge simulation feg_api

### DIFF
--- a/nvflare/edge/simulation/feg_api.py
+++ b/nvflare/edge/simulation/feg_api.py
@@ -52,7 +52,7 @@ class FegApi:
             clazz=JobResponse,
             url=urljoin(self.endpoint, "job"),
             params={},
-            body={EdgeProtoKey.CAPABILITIES: request.capabilities},
+            body={EdgeProtoKey.JOB_NAME: request.job_name, EdgeProtoKey.CAPABILITIES: request.capabilities},
         )
 
     def get_task(self, request: TaskRequest) -> TaskResponse:


### PR DESCRIPTION
Fixes # .

### Description

Added missing job_name in the getJob call. This is to fix bug https://nvbugspro.nvidia.com/bug/5433909.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
