### PR TITLE
Update SimEnv get_status

### DIFF
--- a/nvflare/recipe/run.py
+++ b/nvflare/recipe/run.py
@@ -64,9 +64,6 @@ class Run:
     @contextmanager
     def _secure_session(self) -> Generator:
         """Context manager for secure session handling."""
-        if self._is_sim_env():
-            raise RuntimeError("Secure session not needed for simulation environment")
-
         sess = None
         try:
             sess = new_secure_session(**self._get_session_params())
@@ -77,7 +74,7 @@ class Run:
             if sess:
                 sess.close()
 
-    def get_status(self) -> str:
+    def get_status(self) -> Optional[str]:
         """Get the status of the run.
 
         Returns:
@@ -85,9 +82,9 @@ class Run:
         """
         if self._is_sim_env():
             print(
-                "get_status will always return completed in a simulation environment, please check the log inside the workspace returned by get_result()"
+                "get_status is not supported in a simulation environment, please check the log inside the workspace returned by get_result()"
             )
-            return "completed"
+            return None
 
         with self._secure_session() as sess:
             return sess.get_job_status(self.job_id)


### PR DESCRIPTION
Fix FLARE-2646

We currently don't have a clean way to get job completion status from simulator running, so change the message and return value to avoid confusion.

### Description

We currently don't have a clean way to get job completion status from simulator running, so change the message and return value to avoid confusion.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
