### PR TITLE
Replace torch_dtype with dtype for latest transformers library

### DIFF
--- a/examples/advanced/llm_hf/src/hf_sft_peft_fl.py
+++ b/examples/advanced/llm_hf/src/hf_sft_peft_fl.py
@@ -158,7 +158,7 @@ def main():
         model_name_or_path,
         device_map=device_map,
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/advanced/llm_hf/utils/hf_sft_peft.py
+++ b/examples/advanced/llm_hf/utils/hf_sft_peft.py
@@ -95,7 +95,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/advanced/llm_hf/utils/hf_sft_peft_iter.py
+++ b/examples/advanced/llm_hf/utils/hf_sft_peft_iter.py
@@ -103,7 +103,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/advanced/llm_hf/utils/hf_sft_peft_iter_callback_multigpu.py
+++ b/examples/advanced/llm_hf/utils/hf_sft_peft_iter_callback_multigpu.py
@@ -151,7 +151,7 @@ def main():
         model_name_or_path,
         device_map=device_map,
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/advanced/streaming/src/streaming_controller.py
+++ b/examples/advanced/streaming/src/streaming_controller.py
@@ -113,7 +113,7 @@ class StreamingController(Controller):
         # load model to dict
         model = AutoModelForCausalLM.from_pretrained(
             model_name,
-            torch_dtype=torch.float32,
+            dtype=torch.float32,
             device_map="auto",
             use_cache=False,
         )

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/src/hf_sft_peft_fl.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/src/hf_sft_peft_fl.py
@@ -97,7 +97,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/utils/hf_sft_peft.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/utils/hf_sft_peft.py
@@ -85,7 +85,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/utils/hf_sft_peft_iter.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/utils/hf_sft_peft_iter.py
@@ -86,7 +86,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/src/hf_sft_peft_fl.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/src/hf_sft_peft_fl.py
@@ -97,7 +97,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/utils/hf_sft_peft.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/utils/hf_sft_peft.py
@@ -85,7 +85,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/src/hf_sft_peft_fl.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/src/hf_sft_peft_fl.py
@@ -97,7 +97,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/utils/hf_sft_peft.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/utils/hf_sft_peft.py
@@ -85,7 +85,7 @@ def main():
         model_name_or_path,
         device_map="auto",
         use_cache=False,
-        torch_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
     )
     torch.set_default_dtype(default_dtype)
 

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.5_llm_streaming/src/streaming_controller.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.5_llm_streaming/src/streaming_controller.py
@@ -111,7 +111,7 @@ class StreamingController(Controller):
         # load model to dict
         model = AutoModelForCausalLM.from_pretrained(
             model_name,
-            torch_dtype=torch.float32,
+            dtype=torch.float32,
             device_map="auto",
             use_cache=False,
         )


### PR DESCRIPTION
### Description

To avoid deprecation warnings when running on transformers>= 4.56.1.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
