### PR TITLE
Add min_clients to CyclicRecipe

### DIFF
--- a/nvflare/recipe/cyclic_recipe.py
+++ b/nvflare/recipe/cyclic_recipe.py
@@ -14,7 +14,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, conint
 
 from nvflare import FedJob
 from nvflare.app_common.shareablegenerators import FullModelShareableGenerator
@@ -31,6 +31,7 @@ class _CyclicValidator(BaseModel):
     name: str
     initial_model: Any
     num_rounds: int
+    min_clients: conint(ge=2)
     train_script: str
     train_args: str
     launch_external_process: bool = False
@@ -47,6 +48,7 @@ class CyclicRecipe(Recipe):
         name: str = "cyclic",
         initial_model: Any = None,
         num_rounds: int = 2,
+        min_clients: int = 2,
         train_script: str,
         train_args: str = "",
         launch_external_process: bool = False,
@@ -60,6 +62,7 @@ class CyclicRecipe(Recipe):
             name=name,
             initial_model=initial_model,
             num_rounds=num_rounds,
+            min_clients=min_clients,
             train_script=train_script,
             train_args=train_args,
             launch_external_process=launch_external_process,
@@ -81,7 +84,7 @@ class CyclicRecipe(Recipe):
         self.server_expected_format: ExchangeFormat = v.server_expected_format
         self.params_transfer_type: TransferType = v.params_transfer_type
 
-        job = FedJob(name=name)
+        job = FedJob(name=name, min_clients=v.min_clients)
         # Define the controller workflow and send to server
         controller = CyclicController(
             num_rounds=num_rounds,


### PR DESCRIPTION
Cyclic Controller needs at least 2 clients to work:

https://github.com/NVIDIA/NVFlare/blob/main/nvflare/app_common/workflows/cyclic_ctl.py#L142

But in our CyclicRecipe we are not mandating that, will leads to cryptic error and confusion as reported by QA FLARE-2648

### Description

- Add min_clients arg to CyclicRecipe

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
