### PR TITLE
Fix job process start commands

### DIFF
--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import json
 import threading
 import time
@@ -162,6 +163,8 @@ class JobExecutor(ClientExecutor):
             resource_manager: resource manager
             fl_ctx: FLContext
         """
+        # use a deep copy of the args for operation since its content will be changed!
+        args = copy.deepcopy(args)
 
         # update the job meta
         workspace = Workspace(args.workspace, site_name=client.client_name)

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -241,7 +241,9 @@ class ServerEngine(ServerEngineInternalSpec, StreamableEngine):
         # Each arg is a tuple of (arg_option, arg_value).
         # Note that the arg_option is fixed for each arg, and is not launcher specific!
         workspace_obj: Workspace = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
-        args = fl_ctx.get_prop(FLContextKey.ARGS)
+
+        # use a copy of args; otherwise the args will keep adding command options!
+        args = copy.deepcopy(fl_ctx.get_prop(FLContextKey.ARGS))
         server = fl_ctx.get_prop(FLContextKey.SITE_OBJ)
         job_id = job.job_id
         app_root = workspace_obj.get_app_dir(job_id)


### PR DESCRIPTION
Fixes # .

### Description

The commands for starting SJ and CJ need to adding extra options to the args. Currently it directly works on the globally saved args. Every time a new CJ/SJ is started, the args are added extra options, which cause the command to have more and more such options.

This PR changes to use a copy of the global args for the operation.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
