### PR TITLE
Adjust get task timeout for proper LLM execution

### DIFF
--- a/examples/advanced/llm_hf/llm_hf_fl_job.py
+++ b/examples/advanced/llm_hf/llm_hf_fl_job.py
@@ -132,10 +132,7 @@ def main():
             job.to(dequantizer, site_name, tasks=["train"], filter_type=FilterType.TASK_DATA)
 
         # Add additional parameters to clients
-        client_params = {
-            "get_task_timeout": 300,
-            "submit_task_result_timeout": 300
-        }
+        client_params = {"get_task_timeout": 300, "submit_task_result_timeout": 300}
         job.to(client_params, site_name)
 
     # Export the job


### PR DESCRIPTION
Fixes # FLARE-2661.

### Description

Get task timeout will cause error when using quantization filter, this PR add a large timeout for llm example to ensure that timeout won't happen to avoid the error.

Still, further updates may be needed to update filter behavior, as the current issue indicates that the filter process has some coupling and interference with get_task, while it should not and should block the task dispatch - timeout should be fine as long as it is sufficient for the task transmission

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
