### PR TITLE
Support decomposer registration in recipe

### DIFF
--- a/nvflare/app_common/widgets/decomposer_reg.py
+++ b/nvflare/app_common/widgets/decomposer_reg.py
@@ -22,6 +22,7 @@ from nvflare.widgets.widget import Widget
 class DecomposerRegister(Widget):
 
     def __init__(self, classes: List[str]):
+        self.classes = classes
         logger = get_obj_logger(self)
         Widget.__init__(self)
         for class_name in classes:


### PR DESCRIPTION
Fixes # .

### Description

Due to security concerns, we no longer support auto decomposer registration - required decomposers must be explicitly installed by the user.

This PR makes it possible for the user to easily decomposers needed by a recipe. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
