### PR TITLE
Enhance snp with retry

### DIFF
--- a/nvflare/lighter/cc_provision/impl/onprem_packager.py
+++ b/nvflare/lighter/cc_provision/impl/onprem_packager.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 import yaml
@@ -171,5 +172,7 @@ class OnPremPackager(Packager):
 
         participants = project.get_all_participants()
 
-        for participant in participants:
+        for i, participant in enumerate(participants):
             self._package_for_participant(participant, ctx)
+            if i != len(participants) - 1:
+                time.sleep(100.0)


### PR DESCRIPTION
Sometimes the AMD server attestation failed because of network instability or rate limiting some transient errors.
We added retry in this PR.

### Description
We added retry in this PR.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
