### PR TITLE
Lower the log severity on timeout.  No change in logic.

### DIFF
--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -1383,7 +1383,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                 self.logger.debug(f"{self.my_info.fqcn}: set up waiter {waiter.id} to wait for {timeout} secs")
                 if not waiter.wait(timeout=timeout):
                     # timeout
-                    self.log_error(f"timeout on Request {waiter.id} for {topics} after {timeout} secs", for_msg)
+                    self.log_warning(f"timeout on Request {waiter.id} for {topics} after {timeout} secs", for_msg)
                     with self.stats_lock:
                         self.num_timeout_reqs += 1
         except Exception as ex:


### PR DESCRIPTION
### Description

When timeout happens, the log message is recorded at `ERROR` level.  However, later logic may recover from timeout.  Therefore, this log should be in `WARNING.`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
