### PR TITLE
Fix a literalinclude link

### DIFF
--- a/docs/user_guide/confidential_computing/azure/confidential_azure_container_instances_deployment.rst
+++ b/docs/user_guide/confidential_computing/azure/confidential_azure_container_instances_deployment.rst
@@ -263,7 +263,7 @@ confidential ACI resources must be updated according to your own account and pre
 
 If you encounter permission issues or the script gets stuck, please check your role in the ACR.
 
-.. literalinclude:: ../../resources/ccprep.json
+.. literalinclude:: ../../../resources/ccprep.json
    :language: json
 
 


### PR DESCRIPTION
### Description

A recent PR moved one document to a different folder.  That document had literalinclude to one json file in the docs/resources folder.  However the relative path was not updated so that literalinclude failed finding the json file.  This PR fixes it.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
