### PR TITLE
Add check on empty cc_info

### DIFF
--- a/nvflare/app_opt/confidential_computing/cc_manager.py
+++ b/nvflare/app_opt/confidential_computing/cc_manager.py
@@ -288,6 +288,9 @@ class CCManager(FLComponent):
             if k not in self.cc_enabled_sites:
                 result[k] = True
                 continue
+            if not cc_info:  # a cc-enabled site does not have any cc_info
+                invalid_participant_list.append(k + " namespace: {None} ")
+                continue
             for v in cc_info:
                 token = v.get(CC_TOKEN, "")
                 namespace = v.get(CC_NAMESPACE, "")


### PR DESCRIPTION
### Description

During cc_token verification, if the cc_info of a site is an empty list, current implementation will mark this site as invalid participant.

This PR increases security by marking such site as an invalid participant.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
