### PR TITLE
Use absolute path for nvidia logo [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="docs/resources/nvidia_eye.wwPt122j.png" alt="NVIDIA Logo" width="200">
+<img src="https://raw.githubusercontent.com/NVIDIA/NVFlare/main/docs/resources/nvidia_eye.wwPt122j.png" alt="NVIDIA Logo" width="200">
 
 # NVIDIA FLARE
 


### PR DESCRIPTION
### Description

The current long description in pypi has an incorrect link to a png file.  This PR fixes it with one absolute https path.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
