### PR TITLE
Fix env variables used in vite build process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          PUBLIC_GH_BRANCH: ${{ github.ref_name }}
+          VITE_PUBLIC_GH_BRANCH: ${{ github.ref_name }}
         working-directory: ${{ env.site_path }}
 
       - name: Deploy

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 
-const branch = process.env.PUBLIC_GH_BRANCH;
+const branch = process.env.VITE_PUBLIC_GH_BRANCH;
 
 export default defineConfig({
   site: "https://nvidia.github.io",

--- a/web/src/components/code.astro
+++ b/web/src/components/code.astro
@@ -15,7 +15,7 @@ import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 import ClickTracker from './clickTracker.astro';
 import GoogleColab from '../images/google_colab.svg.png'
 
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 
 // PyTorch Code Sections --------------------------------------------------
 

--- a/web/src/components/gettingStarted.astro
+++ b/web/src/components/gettingStarted.astro
@@ -1,7 +1,7 @@
 ---
 import ClickTracker from './clickTracker.astro';
 
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 
 const walkthrough = [
   {

--- a/web/src/components/hero.astro
+++ b/web/src/components/hero.astro
@@ -3,7 +3,7 @@ import NvidiaLogo from '../images/nvidia_eye.png'
 import NvflareAnimation from '../images/nvflare_graphic_animation.mp4'
 import ClickTracker from './clickTracker.astro';
 
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 const base_url = import.meta.env.BASE_URL;
 ---
 <ClickTracker div_id="hero_div" eventLabel="Hero"/>

--- a/web/src/components/series.astro
+++ b/web/src/components/series.astro
@@ -1,7 +1,7 @@
 ---
 import ClickTracker from './clickTracker.astro';
 
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 
 const series_dli = {
   id: "DLI", // id must not have spaces

--- a/web/src/components/tutorials.astro
+++ b/web/src/components/tutorials.astro
@@ -2,7 +2,7 @@
 import GoogleColab from '../images/google_colab.svg.png'
 import ClickTracker from './clickTracker.astro';
 
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 const base_url = import.meta.env.BASE_URL;
 
 const tutorials = [

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -2,7 +2,7 @@
 import Layout from "@layouts/Layout.astro";
 
 const base_url = import.meta.env.BASE_URL;
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 ---
 
 <Layout title="404 Not Found">

--- a/web/src/pages/research.astro
+++ b/web/src/pages/research.astro
@@ -7,7 +7,7 @@ import MammographyGraphs from '../images/research/mammography_graphs.jpg'
 import Pancreas from '../images/research/pancreas.jpg'
 import Sun from '../images/research/sun.jpg'
 
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 const base_url = import.meta.env.BASE_URL;
 
 const case_studies = [

--- a/web/src/pages/security.astro
+++ b/web/src/pages/security.astro
@@ -4,7 +4,7 @@ import DataPrivacy from '../images/data_privacy_arch.png'
 import FedAuth from '../images/fed_auth_arch.png'
 
 const base_url = import.meta.env.BASE_URL;
-const gh_branch = import.meta.env.PUBLIC_GH_BRANCH;
+const gh_branch = import.meta.env.VITE_PUBLIC_GH_BRANCH;
 
 ---
 


### PR DESCRIPTION
### Description

In vite build process, the env var with VITE_ prefix are exposed (https://vite.dev/guide/env-and-mode#env-variables).  The BASE_URL is a built-in env var and no need to have VITE_.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
