### PR TITLE
Fix dashboard sqlite db location

### DIFF
--- a/nvflare/dashboard/application/cert.py
+++ b/nvflare/dashboard/application/cert.py
@@ -18,9 +18,11 @@ from dataclasses import dataclass
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
+from nvflare.dashboard.utils import EnvVar
 from nvflare.lighter.utils import Identity, generate_cert, generate_keys, serialize_cert, serialize_pri_key
 
-dashboard_pp = os.environ.get("NVFL_DASHBOARD_PP")
+dashboard_pp = os.environ.get(EnvVar.DASHBOARD_PP)
+
 if dashboard_pp is not None:
     dashboard_pp = dashboard_pp.encode("utf-8")
 

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -44,7 +44,7 @@ def start(args):
         environment[EnvVar.DASHBOARD_PP] = passphrase
     if args.cred:
         environment.update({EnvVar.CREDENTIAL: args.cred})
-    elif not os.path.exists(os.path.join(folder, ".db_init_done")):
+    elif EnvVar.CREDENTIAL not in environment and not os.path.exists(os.path.join(folder, ".db_init_done")):
         need_email = True
         while need_email:
             answer = input(


### PR DESCRIPTION
### Description

During dashboard launch time, it asks for the project admin credential.  However, if the sqlite db file exists, it causes conflicts as existing credential in sqlite will be used.  And the env var `NVFL_CREDENTIAL` is also considered during launch time.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
