### PR TITLE
Fix import error for TBAnalyticsReceiver

### DIFF
--- a/nvflare/app_opt/pt/job_config/base_fed_job.py
+++ b/nvflare/app_opt/pt/job_config/base_fed_job.py
@@ -22,7 +22,6 @@ from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
-from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
 from nvflare.job_config.base_fed_job import BaseFedJob as UnifiedBaseFedJob
 
 
@@ -73,6 +72,8 @@ class BaseFedJob(UnifiedBaseFedJob):
     ):
         # Add default TBAnalyticsReceiver if not provided (PyTorch-specific)
         if analytics_receiver is None:
+            from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
+
             analytics_receiver = TBAnalyticsReceiver()
 
         # Call the unified BaseFedJob

--- a/nvflare/app_opt/pt/job_config/base_fed_job.py
+++ b/nvflare/app_opt/pt/job_config/base_fed_job.py
@@ -50,8 +50,9 @@ class BaseFedJob(UnifiedBaseFedJob):
             If not provided, an IntimeModelSelector will be configured based on key_metric.
         convert_to_fed_event: (ConvertToFedEvent | None, optional): A component to convert certain events to fed events.
             if not provided, a ConvertToFedEvent object will be created.
-        analytics_receiver (bool | AnalyticsReceiver | None, optional): Receive analytics.
-            If not provided, a TBAnalyticsReceiver will be configured.
+        analytics_receiver (AnalyticsReceiver | None, optional): Component for receiving analytics data.
+            If not provided, no analytics tracking will be enabled. For experiment tracking (e.g., TensorBoard),
+            explicitly pass a TBAnalyticsReceiver instance.
         model_persistor (ModelPersistor | None, optional): how to persist the model.
         model_locator (ModelLocator | None, optional): how to locate the model.
     """
@@ -70,12 +71,6 @@ class BaseFedJob(UnifiedBaseFedJob):
         model_persistor: Optional[ModelPersistor] = None,
         model_locator: Optional[ModelLocator] = None,
     ):
-        # Add default TBAnalyticsReceiver if not provided (PyTorch-specific)
-        if analytics_receiver is None:
-            from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
-
-            analytics_receiver = TBAnalyticsReceiver()
-
         # Call the unified BaseFedJob
         super().__init__(
             name=name,

--- a/nvflare/app_opt/tf/job_config/base_fed_job.py
+++ b/nvflare/app_opt/tf/job_config/base_fed_job.py
@@ -21,7 +21,6 @@ from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
-from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
 from nvflare.job_config.base_fed_job import BaseFedJob as UnifiedBaseFedJob
 
 
@@ -72,6 +71,8 @@ class BaseFedJob(UnifiedBaseFedJob):
     ):
         # Add default TBAnalyticsReceiver if not provided (TensorFlow-specific)
         if analytics_receiver is None:
+            from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
+
             analytics_receiver = TBAnalyticsReceiver()
 
         # Call the unified BaseFedJob

--- a/nvflare/app_opt/tf/job_config/base_fed_job.py
+++ b/nvflare/app_opt/tf/job_config/base_fed_job.py
@@ -31,7 +31,7 @@ class BaseFedJob(UnifiedBaseFedJob):
     For new code, consider using nvflare.job_config.base_fed_job.BaseFedJob directly with
     framework=FrameworkType.TENSORFLOW.
 
-    Configures ValidationJsonGenerator, model selector, TBAnalyticsReceiver, ConvertToFedEvent.
+    Configures ValidationJsonGenerator, model selector, AnalyticsReceiver, ConvertToFedEvent.
 
     User must add controllers and executors.
 
@@ -51,8 +51,9 @@ class BaseFedJob(UnifiedBaseFedJob):
             If not provided, an IntimeModelSelector will be configured based on key_metric.
         convert_to_fed_event: (ConvertToFedEvent, optional): A component to convert certain events to fed events.
             if not provided, a ConvertToFedEvent object will be created.
-        analytics_receiver (AnalyticsReceiver, optional): Receive analytics.
-            If not provided, a TBAnalyticsReceiver will be configured.
+        analytics_receiver (AnalyticsReceiver | None, optional): Component for receiving analytics data.
+            If not provided, no analytics tracking will be enabled. For experiment tracking (e.g., TensorBoard),
+            explicitly pass a TBAnalyticsReceiver instance.
         model_persistor (optional, ModelPersistor): how to persist the model.
     """
 
@@ -69,12 +70,6 @@ class BaseFedJob(UnifiedBaseFedJob):
         analytics_receiver: Optional[AnalyticsReceiver] = None,
         model_persistor: Optional[ModelPersistor] = None,
     ):
-        # Add default TBAnalyticsReceiver if not provided (TensorFlow-specific)
-        if analytics_receiver is None:
-            from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
-
-            analytics_receiver = TBAnalyticsReceiver()
-
         # Call the unified BaseFedJob
         super().__init__(
             name=name,

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -55,10 +55,15 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         params_transfer_type (str): How to transfer the parameters. FULL means the whole model parameters are sent.
             DIFF means that only the difference is sent. Defaults to TransferType.FULL.
         model_persistor: Custom model persistor. If None, TFModelPersistor will be used.
-        analytics_receiver: Component for receiving analytics data. If not provided, defaults to TBAnalyticsReceiver
-            for TensorBoard experiment tracking.
+        analytics_receiver: Component for receiving analytics data (e.g., TBAnalyticsReceiver for TensorBoard).
+            If not provided, no experiment tracking will be enabled.
+            To enable experiment tracking, either:
+            - Pass an AnalyticsReceiver instance explicitly, OR
+            - Use add_experiment_tracking() from nvflare.recipe.utils after recipe creation
 
     Example:
+        Basic usage without experiment tracking:
+
         ```python
         recipe = FedAvgRecipe(
             name="my_fedavg_job",
@@ -70,10 +75,39 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         )
         ```
 
+        Enable TensorBoard experiment tracking (Option 1 - pass explicitly):
+
+        ```python
+        from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
+
+        recipe = FedAvgRecipe(
+            name="my_fedavg_job",
+            initial_model=pretrained_model,
+            min_clients=2,
+            num_rounds=10,
+            train_script="client.py",
+            train_args="--epochs 5 --batch_size 32",
+            analytics_receiver=TBAnalyticsReceiver()
+        )
+        ```
+
+        Enable experiment tracking (Option 2 - add after creation):
+
+        ```python
+        from nvflare.recipe.utils import add_experiment_tracking
+
+        recipe = FedAvgRecipe(...)  # Create recipe first
+        add_experiment_tracking(recipe, "tensorboard")  # Add tracking later
+        # Also supports: "mlflow", "wandb"
+        ```
+
     Note:
         By default, this recipe implements the standard FedAvg algorithm where model updates
         are aggregated using weighted averaging based on the number of training
         samples provided by each client.
+
+        Experiment tracking is opt-in. No tracking components are configured by default,
+        avoiding unnecessary dependencies.
 
         If you want to use a custom aggregator, you can pass it in the aggregator parameter.
         The custom aggregator must be a subclass of the Aggregator or ModelAggregator class.
@@ -98,12 +132,6 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         model_persistor: Optional[ModelPersistor] = None,
         analytics_receiver: Optional[AnalyticsReceiver] = None,
     ):
-        # Default to TBAnalyticsReceiver for TensorFlow if not provided
-        if analytics_receiver is None:
-            from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
-
-            analytics_receiver = TBAnalyticsReceiver()
-
         # Call the unified FedAvgRecipe with TensorFlow-specific settings
         super().__init__(
             name=name,


### PR DESCRIPTION
Fix import error for TBAnalyticsReceiver.

### Description

Fix import error for TBAnalyticsReceiver by removing the default.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
