### PR TITLE
Remove broken link

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -25,12 +25,6 @@ Step-by-Step Walkthroughs
 - Covers FedAvg, Cyclic, Swarm Learning, Federated Statistics, Scikit-learn, XGBoost, and more.
 - `Step-by-step examples <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/step-by-step>`_
 
-ML-to-FL Conversion
--------------------
-
-- Learn to convert standalone or centralized training code to FL code with various deep learning frameworks.
-- `ML-to-FL walkthroughs <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/ml-to-fl>`_
-
 Feature Tutorials
 -----------------
 


### PR DESCRIPTION
Remove broken link caused by refactoring https://github.com/NVIDIA/NVFlare/pull/3882

### Description

Remove broken link caused by refactoring https://github.com/NVIDIA/NVFlare/pull/3882

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
