### PR TITLE
[2.7] Removed references to ws

### DIFF
--- a/nvflare/fuel/f3/drivers/aio_http_driver.py
+++ b/nvflare/fuel/f3/drivers/aio_http_driver.py
@@ -101,7 +101,7 @@ class AioHttpDriver(BaseDriver):
 
     @staticmethod
     def supported_transports() -> List[str]:
-        return ["http", "https", "ws", "wss"]
+        return ["http", "https"]
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:

--- a/nvflare/fuel/f3/drivers/driver.py
+++ b/nvflare/fuel/f3/drivers/driver.py
@@ -56,7 +56,7 @@ class Driver(ABC):
     @abstractmethod
     def supported_transports() -> List[str]:
         """Return a list of transports supported by this driver, for example
-        ["http", "https", "ws", "wss"]
+        ["http", "https", "grpc", "grpcs"]
         """
         pass
 

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -33,7 +33,7 @@ HI_PORT = 65535
 MAX_ITER_SIZE = 10
 RANDOM_TRIES = 20
 BIND_TIME_OUT = 5
-SECURE_SCHEMES = {"https", "wss", "grpcs", "agrpcs", "ngrpcs", "stcp", "satcp"}
+SECURE_SCHEMES = {"https", "grpcs", "agrpcs", "ngrpcs", "stcp", "satcp"}
 
 # GRPC can't handle frame size over 2G. So the limit is set to (2G-2M)
 MAX_FRAME_SIZE = 2 * 1024 * 1024 * 1024 - (2 * 1024 * 1024)

--- a/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
+++ b/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
@@ -15,7 +15,7 @@ import json
 import threading
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Tuple
+from typing import Any
 
 import nvflare.fuel.utils.app_config_utils as acu
 from nvflare.apis.fl_constant import ConfigVarName
@@ -110,7 +110,7 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
         secure=False,
         optional=False,
         abort_signal=None,
-    ) -> Tuple[str, dict]:
+    ) -> tuple[str, dict]:
         pass
 
     def supported_dots(self):
@@ -399,7 +399,7 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
         req_timeout = fobs_ctx.get(fobs.FOBSContextKey.DOWNLOAD_REQ_TIMEOUT, None)
         if not req_timeout:
             req_timeout = acu.get_positive_float_var(
-                self._config_var_name(ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT), 10.0
+                self._config_var_name(ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT), 60.0
             )
         self.logger.debug(f"DOWNLOAD_REQ_TIMEOUT={req_timeout}")
 

--- a/tests/unit_test/fuel/f3/drivers/driver_manager_test.py
+++ b/tests/unit_test/fuel/f3/drivers/driver_manager_test.py
@@ -36,8 +36,6 @@ class TestDriverManager:
             ("stcp", TcpDriver),
             ("http", AioHttpDriver),
             ("https", AioHttpDriver),
-            ("ws", AioHttpDriver),
-            ("wss", AioHttpDriver),
             ("atcp", AioTcpDriver),
             ("satcp", AioTcpDriver),
         ],


### PR DESCRIPTION
### Description

1. Removed references to wss as a scheme/protocol. It's only used internally by aiohttp library.
2. Increased the downloader timeout in decomposers to 60s. It was causing download failures for large models.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
