### PR TITLE
[2.7] Increase link check timeout

### DIFF
--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -33,6 +33,7 @@ jobs:
         workingDirectory: .github/workflows
         args: >-
           --accept=200,403,429
+          --timeout=30
           --verbose
           --no-progress
           '${{ github.workspace }}/**/*.md'


### PR DESCRIPTION
Fixes # .

### Description

Increase the link check timeout to avoid CI failures on slow-responding websites.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
