### PR TITLE
[2.7] Add Server-Side Memory Management for Long-Running FL Jobs

### DIFF
--- a/docs/programming_guide/memory_management.rst
+++ b/docs/programming_guide/memory_management.rst
@@ -1,0 +1,206 @@
+.. _memory_management:
+
+#############################
+Memory Management Best Practices
+#############################
+
+This guide describes memory management techniques for long-running federated learning jobs
+using Python, PyTorch, and glibc.
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+Overview
+========
+
+Federated learning jobs can run for hours or days. Without proper memory management,
+RSS (Resident Set Size) can grow continuously due to:
+
+- Python garbage collection delays
+- glibc memory arena fragmentation
+- PyTorch CUDA cache retention
+
+NVFlare provides utilities and configuration options to manage memory effectively.
+
+Platform Compatibility
+======================
+
+Not all memory management features work on all platforms. The table below summarizes compatibility:
+
++---------------------------+-------------+-------------+-------------+
+| Feature                   | Linux/glibc | Linux/musl  | macOS       |
++===========================+=============+=============+=============+
+| ``gc.collect()``          | ✓           | ✓           | ✓           |
++---------------------------+-------------+-------------+-------------+
+| ``MALLOC_ARENA_MAX``      | ✓           | ✗           | ✗           |
++---------------------------+-------------+-------------+-------------+
+| ``malloc_trim()``         | ✓           | ✗           | ✗           |
++---------------------------+-------------+-------------+-------------+
+| ``torch.cuda.empty_cache``| ✓           | ✓           | ✓           |
++---------------------------+-------------+-------------+-------------+
+
+**Notes:**
+
+- **Linux/glibc**: Standard Linux distributions (Ubuntu, RHEL, Debian, etc.)
+- **Linux/musl**: Alpine Linux and other musl-based distributions
+- **macOS**: ``malloc_trim()`` is silently skipped (safe no-op)
+
+.. warning::
+
+   For maximum memory efficiency, use Linux with glibc. Alpine Linux (musl) and
+   macOS/Windows will still benefit from ``gc.collect()`` but cannot release
+   fragmented heap memory back to the OS.
+
+Environment Variables
+=====================
+
+Set these environment variables before starting NVFlare processes:
+
+Client (Training Nodes)
+-----------------------
+
+.. code-block:: bash
+
+    export MALLOC_ARENA_MAX=2
+
+**Why:** Clients typically have limited CPU memory. Setting ``MALLOC_ARENA_MAX=2``
+prevents arena explosion and reduces memory fragmentation.
+
+Server (Aggregation Node)
+-------------------------
+
+.. code-block:: bash
+
+    export MALLOC_ARENA_MAX=4
+
+**Why:** Servers are CPU memory heavy (4-7× model size) with multi-threaded networking.
+``MALLOC_ARENA_MAX=4`` balances throughput vs memory. Use ``8`` for high parallelism.
+
+Server-Side Memory Cleanup
+==========================
+
+The FedAvg controller supports automatic memory cleanup via the ``server_memory_gc_rounds`` parameter.
+
+Configuration
+-------------
+
+.. code-block:: python
+
+    from nvflare.recipe.fedavg import FedAvgRecipe
+
+    recipe = FedAvgRecipe(
+        name="my_job",
+        min_clients=4,
+        num_rounds=100,
+        train_script="client.py",
+        server_memory_gc_rounds=5,  # Cleanup every 5 rounds
+    )
+
+**Values:**
+
+- ``0`` = Disabled (default for BaseFedAvg-based controllers)
+- ``1`` = Cleanup every round (default for legacy controllers like ScatterAndGather)
+- ``5`` = Cleanup every 5 rounds (recommended for server)
+
+What It Does
+------------
+
+When enabled, at the end of every N rounds:
+
+1. Runs Python garbage collection (``gc.collect()``)
+2. Returns free heap pages to OS (``malloc_trim()``, Linux/glibc only)
+
+Performance Impact
+------------------
+
+Memory cleanup has minimal overhead in typical federated learning workloads:
+
++---------------------------+------------------+--------------------------------+
+| Operation                 | Typical Duration | Notes                          |
++===========================+==================+================================+
+| ``gc.collect()``          | 10-500 ms        | Depends on Python object count |
++---------------------------+------------------+--------------------------------+
+| ``malloc_trim()``         | < 1 ms           | Very fast (page table ops)     |
++---------------------------+------------------+--------------------------------+
+
+**Overhead analysis:**
+
+- **Training round duration**: Typically 30 seconds to 10+ minutes
+- **Cleanup duration**: 10-500 ms total
+- **Overhead per round**: Usually < 1%
+
+**With** ``server_memory_gc_rounds=5``:
+
+- Cleanup runs once every 5 rounds
+- Total overhead: < 0.2% of training time
+
+**Recommendation**: The default ``server_memory_gc_rounds=5`` provides good memory
+management with negligible performance impact. Only disable (``=0``) if you've
+measured and confirmed RSS is stable without cleanup.
+
+Recommended Settings
+====================
+
++--------+-----------------------------+--------------------+
+| Role   | ``server_memory_gc_rounds`` | ``MALLOC_ARENA_MAX`` |
++========+=============================+====================+
+| Server | 5                           | 4                  |
++--------+-----------------------------+--------------------+
+
+API Reference
+=============
+
+cleanup_memory
+--------------
+
+.. code-block:: python
+
+    from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+    cleanup_memory(torch_cuda_empty_cache=True)
+
+**Signature:** ``cleanup_memory(torch_cuda_empty_cache: bool = False) -> None``
+
+Performs memory cleanup:
+
+1. Runs ``gc.collect()``
+2. Calls ``malloc_trim(0)`` (Linux/glibc only, safe no-op elsewhere)
+3. Optionally calls ``torch.cuda.empty_cache()``
+
+try_malloc_trim
+---------------
+
+.. code-block:: python
+
+    from nvflare.fuel.utils.memory_utils import try_malloc_trim
+
+    result = try_malloc_trim()
+
+**Signature:** ``try_malloc_trim() -> Optional[int]``
+
+Low-level function to return free heap pages to OS.
+
+**Returns:**
+
+- ``1`` if memory was released
+- ``0`` if no memory to release
+- ``None`` if not available (non-Linux or non-glibc)
+
+Troubleshooting
+===============
+
+High RSS on Server
+------------------
+
+1. Check ``MALLOC_ARENA_MAX`` is set
+2. Enable ``server_memory_gc_rounds=5``
+3. Monitor with ``top`` or ``htop``
+
+OOM Errors
+----------
+
+1. Reduce batch size
+2. Enable memory cleanup every round (``server_memory_gc_rounds=1``)
+3. Check for memory leaks in training code
+

--- a/nvflare/app_common/workflows/cyclic.py
+++ b/nvflare/app_common/workflows/cyclic.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nvflare.fuel.utils.memory_utils import cleanup_memory
+from nvflare.fuel.utils.validation_utils import check_non_negative_int
+
 from .model_controller import ModelController
 
 
@@ -22,6 +25,7 @@ class Cyclic(ModelController):
         num_clients: int = 2,
         num_rounds: int = 5,
         start_round: int = 0,
+        memory_gc_rounds: int = 0,
         **kwargs,
     ):
         """The Cyclic ModelController to implement the Cyclic Weight Transfer (CWT) algorithm.
@@ -29,14 +33,26 @@ class Cyclic(ModelController):
         Args:
             num_clients (int, optional): The number of clients. Defaults to 2.
             num_rounds (int, optional): The total number of training rounds. Defaults to 5.
-            start_round (int, optional): The starting round number. Defaults to 0
+            start_round (int, optional): The starting round number. Defaults to 0.
+            memory_gc_rounds (int, optional): Run memory cleanup (gc.collect + malloc_trim)
+                every N rounds. Set to 0 to disable. Defaults to 0 (disabled).
         """
         super().__init__(*args, **kwargs)
+
+        check_non_negative_int("memory_gc_rounds", memory_gc_rounds)
 
         self.num_clients = num_clients
         self.num_rounds = num_rounds
         self.start_round = start_round
+        self.memory_gc_rounds = memory_gc_rounds
         self.current_round = None
+
+    def _maybe_cleanup_memory(self):
+        """Perform memory cleanup if configured (every N rounds based on memory_gc_rounds)."""
+        if self.current_round is None:
+            return
+        if self.memory_gc_rounds > 0 and (self.current_round + 1) % self.memory_gc_rounds == 0:
+            cleanup_memory()
 
     def run(self) -> None:
         self.info("Start Cyclic.")
@@ -56,5 +72,8 @@ class Cyclic(ModelController):
                 model.params, model.meta = result.params, result.meta
 
             self.save_model(model)
+
+            # Memory cleanup at end of round (if configured)
+            self._maybe_cleanup_memory()
 
         self.info("Finished Cyclic.")

--- a/nvflare/app_common/workflows/cyclic_ctl.py
+++ b/nvflare/app_common/workflows/cyclic_ctl.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import random
 from typing import List, Union
 
@@ -27,6 +26,8 @@ from nvflare.app_common.abstract.learnable_persistor import LearnablePersistor
 from nvflare.app_common.abstract.shareable_generator import ShareableGenerator
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.fuel.utils.memory_utils import cleanup_memory
+from nvflare.fuel.utils.validation_utils import check_non_negative_int
 from nvflare.security.logging import secure_format_exception
 
 
@@ -52,6 +53,7 @@ class CyclicController(Controller):
         snapshot_every_n_rounds: int = 1,
         order: Union[str, List[str]] = RelayOrder.FIXED,
         allow_early_termination=False,
+        memory_gc_rounds: int = 1,
     ):
         """A sample implementation to demonstrate how to use relay method for Cyclic Federated Learning.
 
@@ -79,6 +81,8 @@ class CyclicController(Controller):
                 - If a list of strings is provided, it represents a custom order for relay.
 
             allow_early_termination: whether to allow early workflow termination from clients
+            memory_gc_rounds (int, optional): Run memory cleanup (gc.collect + malloc_trim) every N rounds.
+                Set to 0 to disable. Defaults to 1 (every round).
 
         Raises:
             TypeError: when any of input arguments does not have correct type
@@ -114,10 +118,19 @@ class CyclicController(Controller):
         self.shareable_generator = None
         self._persist_every_n_rounds = persist_every_n_rounds
         self._snapshot_every_n_rounds = snapshot_every_n_rounds
+        check_non_negative_int("memory_gc_rounds", memory_gc_rounds)
+        self._memory_gc_rounds = memory_gc_rounds
         self._participating_clients = None
         self._last_client = None
         self._order = order
         self._allow_early_termination = allow_early_termination
+
+    def _maybe_cleanup_memory(self):
+        """Perform memory cleanup if configured (every N rounds based on memory_gc_rounds)."""
+        if self._current_round is None:
+            return
+        if self._memory_gc_rounds > 0 and (self._current_round + 1) % self._memory_gc_rounds == 0:
+            cleanup_memory()
 
     def start_controller(self, fl_ctx: FLContext):
         self.log_debug(fl_ctx, "starting controller")
@@ -222,8 +235,6 @@ class CyclicController(Controller):
         task.data.set_header(AppConstants.NUM_ROUNDS, self._num_rounds)
         task.data.add_cookie(AppConstants.CONTRIBUTION_ROUND, self._current_round)
 
-        gc.collect()
-
     def control_flow(self, abort_signal: Signal, fl_ctx: FLContext):
         try:
             self.log_debug(fl_ctx, "Cyclic starting.")
@@ -280,7 +291,9 @@ class CyclicController(Controller):
                     self._engine.persist_components(fl_ctx, completed=False)
 
                 self.log_debug(fl_ctx, "Ending current round={}.".format(self._current_round))
-                gc.collect()
+
+                # Memory cleanup at end of round (if configured)
+                self._maybe_cleanup_memory()
 
             self.log_debug(fl_ctx, "Cyclic ended.")
         except Exception as e:

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -205,6 +205,9 @@ class FedAvg(BaseFedAvg):
                 # No early stopping: save model every round
                 self.save_model(model)
 
+            # Memory cleanup at end of round (if configured)
+            self._maybe_cleanup_memory()
+
         self.info(center_message("Finished FedAvg."))
 
     def _aggregate_one_result(self, result: FLModel) -> None:

--- a/nvflare/app_common/workflows/scaffold.py
+++ b/nvflare/app_common/workflows/scaffold.py
@@ -43,6 +43,8 @@ class Scaffold(BaseFedAvg):
         allow_empty_global_weights (bool, optional): whether to allow empty global weights. Some pipelines can have
             empty global weights at first round, such that clients start training from scratch without any global info.
             Defaults to False.
+        memory_gc_rounds (int, optional): Run memory cleanup (gc.collect + malloc_trim) every N rounds.
+            Set to 0 to disable. Defaults to 0 (inherited from BaseFedAvg).
     """
 
     def initialize(self, fl_ctx):
@@ -81,6 +83,9 @@ class Scaffold(BaseFedAvg):
                 self._global_ctrl_weights[v_name] += v_value
 
             self.save_model(self.model)
+
+            # Memory cleanup at end of round (if configured)
+            self._maybe_cleanup_memory()
 
         self.info("Finished FedAvg.")
 

--- a/nvflare/app_opt/tf/recipes/scaffold.py
+++ b/nvflare/app_opt/tf/recipes/scaffold.py
@@ -37,6 +37,7 @@ class _ScaffoldValidator(BaseModel):
     command: str = "python3 -u"
     server_expected_format: ExchangeFormat = ExchangeFormat.NUMPY
     params_transfer_type: TransferType = TransferType.FULL
+    server_memory_gc_rounds: int = 0
 
 
 class ScaffoldRecipe(Recipe):
@@ -71,6 +72,8 @@ class ScaffoldRecipe(Recipe):
         params_transfer_type: How to transfer the parameters between server and client.
             FULL means the whole model parameters are sent. DIFF means that only the difference is sent.
             Defaults to TransferType.FULL.
+        server_memory_gc_rounds: Run memory cleanup (gc.collect + malloc_trim) every N rounds on server.
+            Set to 0 to disable. Defaults to 0.
 
     Example:
         ```python
@@ -110,6 +113,7 @@ class ScaffoldRecipe(Recipe):
         command: str = "python3 -u",
         server_expected_format: ExchangeFormat = ExchangeFormat.NUMPY,
         params_transfer_type: TransferType = TransferType.FULL,
+        server_memory_gc_rounds: int = 0,
     ):
         # Validate inputs internally
         v = _ScaffoldValidator(
@@ -123,6 +127,7 @@ class ScaffoldRecipe(Recipe):
             command=command,
             server_expected_format=server_expected_format,
             params_transfer_type=params_transfer_type,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )
 
         self.name = v.name
@@ -135,6 +140,7 @@ class ScaffoldRecipe(Recipe):
         self.command = v.command
         self.server_expected_format: ExchangeFormat = v.server_expected_format
         self.params_transfer_type: TransferType = v.params_transfer_type
+        self.server_memory_gc_rounds = v.server_memory_gc_rounds
 
         # Create BaseFedJob with initial model
         job = BaseFedJob(
@@ -147,6 +153,7 @@ class ScaffoldRecipe(Recipe):
         controller = Scaffold(
             num_clients=self.min_clients,
             num_rounds=self.num_rounds,
+            memory_gc_rounds=self.server_memory_gc_rounds,
         )
         # Send the controller to the server
         job.to(controller, "server")

--- a/nvflare/fuel/utils/memory_utils.py
+++ b/nvflare/fuel/utils/memory_utils.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Memory management utilities for federated learning.
+
+This module provides memory cleanup utilities to help manage RSS (Resident Set Size)
+in long-running FL jobs using Python + PyTorch + glibc.
+
+Best Practices:
+- Client: Set MALLOC_ARENA_MAX=2, cleanup every round
+- Server: Set MALLOC_ARENA_MAX=4, cleanup every 5 rounds
+
+Usage:
+    from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+    # At end of each round (client) or every N rounds (server)
+    cleanup_memory(torch_cuda_empty_cache=True)  # True for PyTorch GPU clients
+"""
+
+import gc
+import logging
+from ctypes import CDLL, c_size_t
+from functools import lru_cache
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _get_glibc() -> Optional[CDLL]:
+    """Get glibc library handle if available (Linux only).
+
+    Returns:
+        CDLL handle to glibc with malloc_trim configured, or None if not available.
+    """
+    try:
+        libc = CDLL("libc.so.6")
+        if not hasattr(libc, "malloc_trim"):
+            return None
+        libc.malloc_trim.argtypes = [c_size_t]
+        libc.malloc_trim.restype = int
+        return libc
+    except (OSError, AttributeError):
+        # Not Linux, or glibc not available (e.g., Alpine/musl)
+        return None
+
+
+def try_malloc_trim() -> Optional[int]:
+    """Attempt to release free memory back to the OS (glibc only).
+
+    This calls glibc's malloc_trim(0) to return free heap pages to the OS,
+    which helps reduce RSS (Resident Set Size) after memory-intensive operations.
+
+    Returns:
+        1 if memory was released, 0 if not, None if malloc_trim is not available.
+
+    Note:
+        - Only works on Linux with glibc (not musl/Alpine)
+        - Safe no-op on other platforms
+        - Very low overhead, safe to call frequently
+    """
+    libc = _get_glibc()
+    if libc is None:
+        return None
+    try:
+        return int(libc.malloc_trim(0))
+    except Exception as e:
+        logger.debug(f"malloc_trim failed: {e}")
+        return None
+
+
+def cleanup_memory(torch_cuda_empty_cache: bool = False) -> None:
+    """Perform memory cleanup to reduce RSS.
+
+    This function:
+    1. Runs Python garbage collection (gc.collect)
+    2. Releases free heap pages to OS (malloc_trim, Linux/glibc only)
+    3. Optionally clears PyTorch CUDA cache
+
+    Args:
+        torch_cuda_empty_cache: If True, also call torch.cuda.empty_cache().
+            Only applicable to PyTorch GPU clients.
+
+    Note:
+        Call this at the end of each FL round (client) or every N rounds (server).
+    """
+    # Step 1: Python garbage collection
+    gc.collect()
+
+    # Step 2: Return free heap pages to OS (glibc only)
+    result = try_malloc_trim()
+    if result is not None:
+        logger.debug(f"malloc_trim returned {result}")
+
+    # Step 3: Clear PyTorch CUDA cache if requested
+    if torch_cuda_empty_cache:
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                logger.debug("torch.cuda.empty_cache() called")
+        except ImportError:
+            pass  # PyTorch not installed
+        except Exception as e:
+            logger.debug(f"cuda.empty_cache failed: {e}")

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -566,6 +566,10 @@ sub_start_sh: |
   mkdir -p $DIR/../transfer
   export PYTHONPATH=/local/custom:$PYTHONPATH
   echo "PYTHONPATH is $PYTHONPATH"
+  
+  # Memory management: limit glibc memory arenas to reduce RSS fragmentation
+  # Recommended: MALLOC_ARENA_MAX=2 for clients, MALLOC_ARENA_MAX=4 for servers
+  export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-4}
 
   while [[ $# -gt 0 ]]
   do

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -56,6 +56,8 @@ class _FedAvgValidator(BaseModel):
     save_filename: str = "FL_global_model.pt"
     exclude_vars: Optional[str] = None
     aggregation_weights: Optional[Dict[str, float]] = None
+    # Memory management
+    server_memory_gc_rounds: int = 0
 
 
 class FedAvgRecipe(Recipe):
@@ -127,6 +129,8 @@ class FedAvgRecipe(Recipe):
         save_filename: Filename for saving the best model. Defaults to "FL_global_model.pt".
         exclude_vars: Regex pattern for variables to exclude from aggregation.
         aggregation_weights: Per-client aggregation weights dict. Defaults to equal weights.
+        server_memory_gc_rounds: Run memory cleanup (gc.collect + malloc_trim) every N rounds on server.
+            Set to 0 to disable. Defaults to 0.
 
     Note:
         This recipe uses InTime (streaming) aggregation for memory efficiency - each client
@@ -166,6 +170,7 @@ class FedAvgRecipe(Recipe):
         save_filename: str = "FL_global_model.pt",
         exclude_vars: Optional[str] = None,
         aggregation_weights: Optional[Dict[str, float]] = None,
+        server_memory_gc_rounds: int = 0,
     ):
         # Validate inputs internally
         v = _FedAvgValidator(
@@ -192,6 +197,7 @@ class FedAvgRecipe(Recipe):
             save_filename=save_filename,
             exclude_vars=exclude_vars,
             aggregation_weights=aggregation_weights,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )
 
         self.name = v.name
@@ -217,6 +223,7 @@ class FedAvgRecipe(Recipe):
         self.save_filename = v.save_filename
         self.exclude_vars = v.exclude_vars
         self.aggregation_weights = v.aggregation_weights
+        self.server_memory_gc_rounds = v.server_memory_gc_rounds
 
         # Validate RAW framework requirements
         if self.framework == FrameworkType.RAW:
@@ -260,6 +267,7 @@ class FedAvgRecipe(Recipe):
             task_name="train",
             exclude_vars=self.exclude_vars,
             aggregation_weights=self.aggregation_weights,
+            memory_gc_rounds=self.server_memory_gc_rounds,
         )
         job.to_server(controller)
 

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -734,3 +734,111 @@ class TestPTFedAvgModelPersistence:
         assert hasattr(controller, "run")
         # The actual registration happens when run() is called, which requires
         # a full FL context. We just verify the method exists.
+
+
+class TestBaseFedAvgMemoryManagement:
+    """Test memory management in BaseFedAvg."""
+
+    def test_memory_gc_rounds_default(self):
+        """Test memory_gc_rounds defaults to 0 (disabled)."""
+        controller = FedAvg()
+        assert controller.memory_gc_rounds == 0
+
+    def test_memory_gc_rounds_custom(self):
+        """Test memory_gc_rounds can be set to custom value."""
+        controller = FedAvg(memory_gc_rounds=5)
+        assert controller.memory_gc_rounds == 5
+
+    def test_maybe_cleanup_memory_disabled(self):
+        """Test _maybe_cleanup_memory does nothing when memory_gc_rounds=0."""
+        from unittest.mock import patch
+
+        controller = FedAvg(memory_gc_rounds=0)
+        controller.current_round = 0
+
+        with patch("nvflare.app_common.workflows.base_fedavg.cleanup_memory") as mock_cleanup:
+            controller._maybe_cleanup_memory()
+            mock_cleanup.assert_not_called()
+
+    def test_maybe_cleanup_memory_called_on_interval(self):
+        """Test _maybe_cleanup_memory calls cleanup at correct intervals."""
+        from unittest.mock import patch
+
+        controller = FedAvg(memory_gc_rounds=5)
+
+        with patch("nvflare.app_common.workflows.base_fedavg.cleanup_memory") as mock_cleanup:
+            # Round 0-3: should not trigger (round+1 not divisible by 5)
+            for r in range(4):
+                controller.current_round = r
+                controller._maybe_cleanup_memory()
+            assert mock_cleanup.call_count == 0
+
+            # Round 4: (4+1) % 5 == 0, should trigger
+            controller.current_round = 4
+            controller._maybe_cleanup_memory()
+            assert mock_cleanup.call_count == 1
+
+            # Round 5-8: should not trigger
+            for r in range(5, 9):
+                controller.current_round = r
+                controller._maybe_cleanup_memory()
+            assert mock_cleanup.call_count == 1
+
+            # Round 9: (9+1) % 5 == 0, should trigger again
+            controller.current_round = 9
+            controller._maybe_cleanup_memory()
+            assert mock_cleanup.call_count == 2
+
+    def test_maybe_cleanup_memory_every_round(self):
+        """Test _maybe_cleanup_memory with memory_gc_rounds=1 (every round)."""
+        from unittest.mock import patch
+
+        controller = FedAvg(memory_gc_rounds=1)
+
+        with patch("nvflare.app_common.workflows.base_fedavg.cleanup_memory") as mock_cleanup:
+            for r in range(5):
+                controller.current_round = r
+                controller._maybe_cleanup_memory()
+            assert mock_cleanup.call_count == 5
+
+    def test_memory_gc_rounds_inherited_by_scaffold(self):
+        """Test Scaffold inherits memory_gc_rounds from BaseFedAvg."""
+        from nvflare.app_common.workflows.scaffold import Scaffold
+
+        controller = Scaffold(memory_gc_rounds=3)
+        assert controller.memory_gc_rounds == 3
+
+    def test_memory_gc_rounds_in_cyclic(self):
+        """Test Cyclic has memory_gc_rounds parameter."""
+        from nvflare.app_common.workflows.cyclic import Cyclic
+
+        controller = Cyclic(memory_gc_rounds=2)
+        assert controller.memory_gc_rounds == 2
+
+    def test_memory_gc_rounds_in_scatter_and_gather(self):
+        """Test ScatterAndGather has memory_gc_rounds parameter with default=1."""
+        from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
+
+        # Default is 1 (every round) for backward compatibility
+        controller = ScatterAndGather()
+        assert controller._memory_gc_rounds == 1
+
+        # Can be customized
+        controller2 = ScatterAndGather(memory_gc_rounds=5)
+        assert controller2._memory_gc_rounds == 5
+
+        # Can be disabled
+        controller3 = ScatterAndGather(memory_gc_rounds=0)
+        assert controller3._memory_gc_rounds == 0
+
+    def test_memory_gc_rounds_in_cyclic_controller(self):
+        """Test CyclicController has memory_gc_rounds parameter with default=1."""
+        from nvflare.app_common.workflows.cyclic_ctl import CyclicController
+
+        # Default is 1 (every round) for backward compatibility
+        controller = CyclicController()
+        assert controller._memory_gc_rounds == 1
+
+        # Can be customized
+        controller2 = CyclicController(memory_gc_rounds=3)
+        assert controller2._memory_gc_rounds == 3

--- a/tests/unit_test/fuel/utils/memory_utils_test.py
+++ b/tests/unit_test/fuel/utils/memory_utils_test.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+from unittest.mock import patch
+
+
+class TestMemoryUtils:
+    """Tests for nvflare.fuel.utils.memory_utils module."""
+
+    def test_try_malloc_trim_returns_int_or_none(self):
+        """Test that try_malloc_trim returns int on Linux/glibc or None otherwise."""
+        from nvflare.fuel.utils.memory_utils import try_malloc_trim
+
+        result = try_malloc_trim()
+        # On Linux with glibc, returns 0 or 1; on other systems, returns None
+        assert result is None or isinstance(result, int)
+
+    def test_cleanup_memory_calls_gc_collect(self):
+        """Test that cleanup_memory calls gc.collect."""
+        from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+        with patch.object(gc, "collect") as mock_gc:
+            with patch("nvflare.fuel.utils.memory_utils.try_malloc_trim"):
+                cleanup_memory()
+                mock_gc.assert_called_once()
+
+    def test_cleanup_memory_calls_try_malloc_trim(self):
+        """Test that cleanup_memory calls try_malloc_trim."""
+        from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+        with patch("nvflare.fuel.utils.memory_utils.try_malloc_trim") as mock_trim:
+            cleanup_memory()
+            mock_trim.assert_called_once()
+
+    def test_cleanup_memory_torch_cuda_empty_cache_false(self):
+        """Test that cleanup_memory with torch_cuda_empty_cache=False does not call torch."""
+        from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+        # This should not raise and should not try to import torch
+        cleanup_memory(torch_cuda_empty_cache=False)
+
+    def test_cleanup_memory_torch_cuda_empty_cache_true(self):
+        """Test that cleanup_memory handles torch_cuda_empty_cache=True gracefully."""
+        from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+        # This should not raise even if torch is not installed or CUDA unavailable
+        cleanup_memory(torch_cuda_empty_cache=True)
+
+    def test_get_glibc_caching(self):
+        """Test that _get_glibc is cached (only loads once)."""
+        from nvflare.fuel.utils.memory_utils import _get_glibc
+
+        # Clear the cache first
+        _get_glibc.cache_clear()
+
+        result1 = _get_glibc()
+        result2 = _get_glibc()
+
+        # Should return the same object (cached)
+        assert result1 is result2
+
+        # Check cache info
+        cache_info = _get_glibc.cache_info()
+        assert cache_info.hits >= 1  # Second call should be a cache hit


### PR DESCRIPTION
# Description
Cherry picks from Main branch

## Overview
This PR adds server-side memory management capabilities to reduce RSS (Resident Set Size) growth during long-running federated learning jobs. Without proper memory management, Python/PyTorch/glibc can cause continuous memory growth due to garbage collection delays and memory arena fragmentation.
## Problem
Federated learning jobs can run for hours or days. During this time:
Python garbage collection may not run frequently enough
glibc malloc arenas can fragment and hold onto freed memory
RSS grows continuously, potentially causing OOM errors
## Solution
Introduces a memory_gc_rounds parameter for server-side controllers that performs periodic memory cleanup:
Runs gc.collect() to free Python objects
Calls malloc_trim() (Linux/glibc) to return freed heap pages to OS
Configurable interval (e.g., every 5 rounds) to balance cleanup overhead vs memory savings
## Key Features
New memory_utils module: cleanup_memory() and try_malloc_trim() utilities
Controller support: FedAvg, Scaffold, Cyclic, ScatterAndGather, CyclicController
Recipe integration: server_memory_gc_rounds parameter in FedAvgRecipe, ScaffoldRecipe
Startup templates: Sets MALLOC_ARENA_MAX=4 by default for new deployments
Documentation: Comprehensive guide in memory_management.rst
## Usage
from nvflare.recipe.fedavg import FedAvgReciperecipe = FedAvgRecipe(    name="my_job",    min_clients=4,    num_rounds=100,    train_script="client.py",    server_memory_gc_rounds=5,  # Cleanup every 5 rounds)
## Expected Results
Based on testing with 5GB models and 4 clients, this can reduce server RSS by 20-50% during long training runs. Results may vary depending on model size, number of clients, and FL algorithm.
## Backward Compatibility
Default memory_gc_rounds=0 (disabled) for BaseFedAvg-based controllers
Default memory_gc_rounds=1 for legacy controllers (ScatterAndGather, CyclicController) to maintain existing behavior

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
