### PR TITLE
[2.7] Add integration tests for examples (cherrypick from #4041)

### DIFF
--- a/examples/advanced/federated-statistics/image_stats/requirements.txt
+++ b/examples/advanced/federated-statistics/image_stats/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 numpy
 monai[itk]
 pandas

--- a/examples/advanced/psi/user_email_match/requirements.txt
+++ b/examples/advanced/psi/user_email_match/requirements.txt
@@ -1,2 +1,3 @@
+nvflare~=2.7.2rc
 openmined-psi>=2.0.5
 pandas

--- a/examples/advanced/sklearn-kmeans/requirements.txt
+++ b/examples/advanced/sklearn-kmeans/requirements.txt
@@ -1,3 +1,4 @@
+nvflare~=2.7.2rc
 pandas
 scikit-learn
 joblib

--- a/examples/advanced/sklearn-linear/prepare_data.sh
+++ b/examples/advanced/sklearn-linear/prepare_data.sh
@@ -6,10 +6,13 @@ DATASET_PATH="${DATASET_DIR}/HIGGS.csv"
 if [ -f "$DATASET_PATH" ]; then
     echo "${DATASET_PATH} exists."
 else
+    mkdir -p "${DATASET_DIR}"
     # Please note that the UCI's website may experience occasional downtime.
-    wget --directory-prefix ${DATASET_DIR} https://archive.ics.uci.edu/static/public/280/higgs.zip
-    unzip "${DATASET_DIR}/higgs.zip" -d "${DATASET_DIR}"
-    gzip -d "${DATASET_DIR}/HIGGS.csv.gz"
+    # overwrite the file if it exists so that corrupted downloads don't persist
+    wget -O "${DATASET_DIR}/higgs.zip" https://archive.ics.uci.edu/static/public/280/higgs.zip
+    unzip -o "${DATASET_DIR}/higgs.zip" -d "${DATASET_DIR}"
+    gzip -d -f "${DATASET_DIR}/HIGGS.csv.gz"
+    rm -f "${DATASET_DIR}/higgs.zip"
 
     echo "Data downloaded and saved in ${DATASET_PATH}"
 fi

--- a/examples/advanced/sklearn-linear/requirements.txt
+++ b/examples/advanced/sklearn-linear/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.5.0rc
+nvflare~=2.7.2rc
 pandas
 scikit-learn
 joblib

--- a/examples/advanced/sklearn-svm/requirements.txt
+++ b/examples/advanced/sklearn-svm/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.5.0rc
+nvflare~=2.7.2rc
 pandas
 scikit-learn
 joblib

--- a/examples/hello-world/hello-cyclic/requirements.txt
+++ b/examples/hello-world/hello-cyclic/requirements.txt
@@ -1,2 +1,2 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 tensorflow

--- a/examples/hello-world/hello-dp/requirements.txt
+++ b/examples/hello-world/hello-dp/requirements.txt
@@ -1,4 +1,4 @@
-nvflare[PT]~=2.7.0rc
+nvflare[PT]~=2.7.2rc
 torch
 tensorboard
 scikit-learn

--- a/examples/hello-world/hello-lightning-eval/generate_pretrain_models.py
+++ b/examples/hello-world/hello-lightning-eval/generate_pretrain_models.py
@@ -18,6 +18,7 @@ This trains a model on CIFAR-10 and saves it to a checkpoint file.
 """
 
 import argparse
+import os
 
 import torch
 from model import CIFAR10DataModule, LitNet
@@ -25,12 +26,19 @@ from pytorch_lightning import Trainer, seed_everything
 
 seed_everything(7)
 
+PRETRAIN_MODEL_DIR = "/tmp/nvflare/pretrain_models"
+
 
 def define_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch_size", type=int, default=32, help="Batch size for training")
     parser.add_argument("--epochs", type=int, default=5, help="Number of training epochs")
-    parser.add_argument("--output", type=str, default="pretrained_model.pt", help="Output checkpoint path")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=os.path.join(PRETRAIN_MODEL_DIR, "pretrained_model.pt"),
+        help="Output checkpoint path",
+    )
 
     return parser.parse_args()
 
@@ -50,11 +58,11 @@ def main():
     model = LitNet()
     cifar10_dm = CIFAR10DataModule(batch_size=args.batch_size)
 
-    # Setup trainer
+    # Setup trainer (save logs to /tmp to avoid cluttering repo)
     if torch.cuda.is_available():
-        trainer = Trainer(max_epochs=args.epochs, accelerator="gpu", devices=1)
+        trainer = Trainer(max_epochs=args.epochs, accelerator="gpu", devices=1, default_root_dir=PRETRAIN_MODEL_DIR)
     else:
-        trainer = Trainer(max_epochs=args.epochs, devices=None)
+        trainer = Trainer(max_epochs=args.epochs, accelerator="cpu", default_root_dir=PRETRAIN_MODEL_DIR)
 
     # Train the model
     print("\nStarting training...")
@@ -66,6 +74,7 @@ def main():
 
     # Save the full LitNet state dict (includes model + metrics)
     print(f"\nSaving model to {args.output}...")
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
     torch.save(model.state_dict(), args.output)
 
     print("\n" + "=" * 80)

--- a/examples/hello-world/hello-lightning-eval/job.py
+++ b/examples/hello-world/hello-lightning-eval/job.py
@@ -20,13 +20,18 @@ from model import LitNet
 from nvflare.app_opt.pt.recipes.fedeval import FedEvalRecipe
 from nvflare.recipe.sim_env import SimEnv
 
+PRETRAIN_MODEL_DIR = "/tmp/nvflare/pretrain_models"
+
 
 def define_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--n_clients", type=int, default=2)
     parser.add_argument("--batch_size", type=int, default=24)
     parser.add_argument(
-        "--checkpoint", type=str, default="pretrained_model.pt", help="Path to pre-trained model checkpoint"
+        "--checkpoint",
+        type=str,
+        default=os.path.join(PRETRAIN_MODEL_DIR, "pretrained_model.pt"),
+        help="Path to pre-trained model checkpoint",
     )
 
     return parser.parse_args()

--- a/examples/hello-world/hello-lightning-eval/requirements.txt
+++ b/examples/hello-world/hello-lightning-eval/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 torch
 torchvision
 jsonargparse[signatures]>=4.17.0

--- a/examples/hello-world/hello-lightning/requirements.txt
+++ b/examples/hello-world/hello-lightning/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 torch
 torchvision
 jsonargparse[signatures]>=4.17.0

--- a/examples/hello-world/hello-lr/requirements.txt
+++ b/examples/hello-world/hello-lr/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 flamby @ git+https://github.com/owkin/FLamby.git@main
 wget==3.2
 requests>=2.25.0

--- a/examples/hello-world/hello-numpy/requirements.txt
+++ b/examples/hello-world/hello-numpy/requirements.txt
@@ -1,2 +1,3 @@
-nvflare>=2.7.0rc
+nvflare~=2.7.2rc
 tensorboard
+torch

--- a/examples/hello-world/hello-pt/requirements.txt
+++ b/examples/hello-world/hello-pt/requirements.txt
@@ -1,4 +1,4 @@
-nvflare[PT]~=2.7.0rc
+nvflare[PT]~=2.7.2rc
 torch
 torchvision
 tensorboard

--- a/examples/hello-world/hello-tabular-stats/requirements.txt
+++ b/examples/hello-world/hello-tabular-stats/requirements.txt
@@ -1,6 +1,6 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 numpy
-pandas
+pandas~=2.3 
 matplotlib
 jupyterlab
 

--- a/examples/hello-world/hello-tf/requirements.txt
+++ b/examples/hello-world/hello-tf/requirements.txt
@@ -1,3 +1,4 @@
-nvflare~=2.7.0rc
+nvflare~=2.7.2rc
 tensorflow[and-cuda]
 tensorboard
+torch

--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -381,6 +381,10 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             self.fl_ctx.set_prop(AppConstants.CURRENT_ROUND, data.current_round, private=True, sticky=True)
         else:
             self.debug("The FLModel data does not contain the current_round information.")
+        if data and data.total_rounds is not None:
+            self.fl_ctx.set_prop(AppConstants.NUM_ROUNDS, data.total_rounds, private=True, sticky=True)
+        else:
+            self.debug("The FLModel data does not contain the total_rounds information.")
 
     def get_component(self, component_id: str):
         return self.engine.get_component(component_id)

--- a/nvflare/app_opt/pt/recipes/__init__.py
+++ b/nvflare/app_opt/pt/recipes/__init__.py
@@ -14,9 +14,18 @@
 
 from .cyclic import CyclicRecipe
 from .fedavg import FedAvgRecipe
-from .fedavg_he import FedAvgRecipeWithHE
 from .fedeval import FedEvalRecipe
 from .fedopt import FedOptRecipe
 from .scaffold import ScaffoldRecipe
+
+
+# Lazy import for HE recipe (requires optional tenseal dependency)
+def __getattr__(name):
+    if name == "FedAvgRecipeWithHE":
+        from .fedavg_he import FedAvgRecipeWithHE
+
+        return FedAvgRecipeWithHE
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["FedAvgRecipe", "CyclicRecipe", "FedOptRecipe", "ScaffoldRecipe", "FedAvgRecipeWithHE", "FedEvalRecipe"]


### PR DESCRIPTION
### Description
- Add hello-lightning-eval example improvements (generate_pretrain_models.py)
- Fix sklearn-svm recipe to use CollectAndAssembleModelAggregator
- Update requirements for hello-numpy, hello-tabular-stats, hello-tf
- Fix sklearn-linear prepare_data.sh script
- Update base_model_controller and pt recipes
- Auto process detection in runtest.sh

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
