### PR TITLE
Fix keycloak docker image tag (bitnamilegacy)

### DIFF
--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_auth_system_integration/keycloak-setup/dockerfile
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_auth_system_integration/keycloak-setup/dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/keycloak:24
+FROM bitnamilegacy/keycloak:24
 
 USER root
 


### PR DESCRIPTION
Fixes keycloak tutorial docker compose by updating to bitnamilegacy image.

## Description

Bitnami moved their open-source images to `bitnamilegacy` registry as the new `bitnami/*` images are commercial-only. This was causing the keycloak tutorial docker compose to fail.

## Changes

- Updated dockerfile to use `bitnamilegacy/keycloak:24` instead of `bitnami/keycloak:24`

## Types of changes

- [x] Non-breaking change (fix that would not break existing functionality)
- [x] Quick tests passed locally

## Related

Cherry-picked from PR #4058 which was targeted at the 2.7 branch.