### PR TITLE
[2.7] Add missing server_memory_gc_rounds parameter to recipes

### DIFF
--- a/nvflare/app_opt/pt/recipes/cyclic.py
+++ b/nvflare/app_opt/pt/recipes/cyclic.py
@@ -35,6 +35,7 @@ class CyclicRecipe(BaseCyclicRecipe):
         framework: FrameworkType = FrameworkType.PYTORCH,
         server_expected_format: ExchangeFormat = ExchangeFormat.NUMPY,
         params_transfer_type: TransferType = TransferType.FULL,
+        server_memory_gc_rounds: int = 1,
     ):
         if initial_model is None or isinstance(initial_model, PTModel):
             model_to_pass = initial_model
@@ -52,4 +53,5 @@ class CyclicRecipe(BaseCyclicRecipe):
             framework=framework,
             server_expected_format=server_expected_format,
             params_transfer_type=params_transfer_type,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -117,6 +117,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         save_filename: str = "FL_global_model.pt",
         exclude_vars: Optional[str] = None,
         aggregation_weights: Optional[Dict[str, float]] = None,
+        server_memory_gc_rounds: int = 0,
     ):
         # Store PyTorch-specific model_locator before calling parent
         self._pt_model_locator = model_locator
@@ -146,6 +147,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             save_filename=save_filename,
             exclude_vars=exclude_vars,
             aggregation_weights=aggregation_weights,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )
 
     def _setup_model_and_persistor(self, job) -> str:

--- a/nvflare/app_opt/tf/recipes/cyclic.py
+++ b/nvflare/app_opt/tf/recipes/cyclic.py
@@ -35,6 +35,7 @@ class CyclicRecipe(BaseCyclicRecipe):
         framework: FrameworkType = FrameworkType.TENSORFLOW,
         server_expected_format: ExchangeFormat = ExchangeFormat.NUMPY,
         params_transfer_type: TransferType = TransferType.FULL,
+        server_memory_gc_rounds: int = 1,
     ):
         if initial_model is None or isinstance(initial_model, TFModel):
             model_to_pass = initial_model
@@ -52,4 +53,5 @@ class CyclicRecipe(BaseCyclicRecipe):
             framework=framework,
             server_expected_format=server_expected_format,
             params_transfer_type=params_transfer_type,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -111,6 +111,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        server_memory_gc_rounds: int = 0,
     ):
         # Call the unified FedAvgRecipe with TensorFlow-specific settings
         super().__init__(
@@ -132,6 +133,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )
 
     def _setup_model_and_persistor(self, job) -> str:

--- a/nvflare/app_opt/tf/recipes/fedopt.py
+++ b/nvflare/app_opt/tf/recipes/fedopt.py
@@ -39,6 +39,7 @@ class _FedOptValidator(BaseModel):
     params_transfer_type: TransferType = TransferType.FULL
     optimizer_args: dict = None
     lr_scheduler_args: dict = None
+    server_memory_gc_rounds: int = 0
 
 
 class FedOptRecipe(Recipe):
@@ -77,6 +78,8 @@ class FedOptRecipe(Recipe):
             Defaults to SGD with learning_rate=1.0 and momentum=0.6.
         lr_scheduler_args: Dictionary of server-side learning rate scheduler arguments with keys
             'path' and 'args'. Defaults to CosineDecay with initial_learning_rate=1.0 and alpha=0.9.
+        server_memory_gc_rounds: Run memory cleanup (gc.collect + malloc_trim) every N rounds on server.
+            Set to 0 to disable. Defaults to 0.
 
     Example:
         ```python
@@ -118,6 +121,7 @@ class FedOptRecipe(Recipe):
         params_transfer_type: TransferType = TransferType.FULL,
         optimizer_args: dict = None,
         lr_scheduler_args: dict = None,
+        server_memory_gc_rounds: int = 0,
     ):
         # Validate inputs internally
         v = _FedOptValidator(
@@ -133,6 +137,7 @@ class FedOptRecipe(Recipe):
             params_transfer_type=params_transfer_type,
             optimizer_args=optimizer_args,
             lr_scheduler_args=lr_scheduler_args,
+            server_memory_gc_rounds=server_memory_gc_rounds,
         )
 
         self.name = v.name
@@ -147,6 +152,7 @@ class FedOptRecipe(Recipe):
         self.params_transfer_type: TransferType = v.params_transfer_type
         self.optimizer_args = v.optimizer_args
         self.lr_scheduler_args = v.lr_scheduler_args
+        self.server_memory_gc_rounds = v.server_memory_gc_rounds
 
         # Create BaseFedJob with initial model
         job = BaseFedJob(
@@ -161,6 +167,7 @@ class FedOptRecipe(Recipe):
             num_rounds=self.num_rounds,
             optimizer_args=self.optimizer_args,
             lr_scheduler_args=self.lr_scheduler_args,
+            memory_gc_rounds=self.server_memory_gc_rounds,
         )
 
         # Send the controller to the server

--- a/tests/unit_test/recipe/server_memory_gc_rounds_test.py
+++ b/tests/unit_test/recipe/server_memory_gc_rounds_test.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for server_memory_gc_rounds parameter in recipes."""
+
+from unittest.mock import patch
+
+import pytest
+import torch.nn as nn
+
+from nvflare.apis.job_def import SERVER_SITE_NAME
+
+
+class SimpleTestModel(nn.Module):
+    """A simple PyTorch model for testing purposes."""
+
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(10, 10)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+@pytest.fixture
+def mock_file_system():
+    """Mock file system operations for all tests."""
+    with patch("os.path.isfile", return_value=True), patch("os.path.exists", return_value=True):
+        yield
+
+
+@pytest.fixture
+def simple_model():
+    """Create a simple test model."""
+    return SimpleTestModel()
+
+
+@pytest.fixture
+def base_recipe_params():
+    """Base parameters for creating recipe instances."""
+    return {
+        "train_script": "mock_train_script.py",
+        "train_args": "--epochs 10",
+        "min_clients": 2,
+        "num_rounds": 5,
+    }
+
+
+def get_controller(recipe):
+    """Extract controller from recipe's job."""
+    server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
+    # Controller is usually the workflow component
+    for comp_id, comp in server_app.app_config.components.items():
+        if hasattr(comp, "_memory_gc_rounds") or hasattr(comp, "memory_gc_rounds"):
+            return comp
+    return None
+
+
+class TestCyclicRecipeServerMemoryGcRounds:
+    """Test server_memory_gc_rounds for CyclicRecipe."""
+
+    def test_cyclic_default_server_memory_gc_rounds(self, mock_file_system, simple_model):
+        """Test CyclicRecipe has default server_memory_gc_rounds=1."""
+        from nvflare.app_opt.pt.recipes.cyclic import CyclicRecipe
+
+        recipe = CyclicRecipe(
+            name="test_cyclic",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+        )
+
+        assert recipe.server_memory_gc_rounds == 1
+
+    def test_cyclic_custom_server_memory_gc_rounds(self, mock_file_system, simple_model):
+        """Test CyclicRecipe accepts custom server_memory_gc_rounds."""
+        from nvflare.app_opt.pt.recipes.cyclic import CyclicRecipe
+
+        recipe = CyclicRecipe(
+            name="test_cyclic",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+            server_memory_gc_rounds=5,
+        )
+
+        assert recipe.server_memory_gc_rounds == 5
+
+    def test_cyclic_disable_server_memory_gc(self, mock_file_system, simple_model):
+        """Test CyclicRecipe can disable server memory GC with 0."""
+        from nvflare.app_opt.pt.recipes.cyclic import CyclicRecipe
+
+        recipe = CyclicRecipe(
+            name="test_cyclic",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+            server_memory_gc_rounds=0,
+        )
+
+        assert recipe.server_memory_gc_rounds == 0
+
+
+class TestFedAvgRecipeServerMemoryGcRounds:
+    """Test server_memory_gc_rounds for FedAvgRecipe."""
+
+    def test_fedavg_default_server_memory_gc_rounds(self, mock_file_system, base_recipe_params):
+        """Test FedAvgRecipe has default server_memory_gc_rounds=0."""
+        from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+
+        recipe = FedAvgRecipe(name="test_fedavg", **base_recipe_params)
+
+        assert recipe.server_memory_gc_rounds == 0
+
+    def test_fedavg_custom_server_memory_gc_rounds(self, mock_file_system, base_recipe_params):
+        """Test FedAvgRecipe accepts custom server_memory_gc_rounds."""
+        from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+
+        recipe = FedAvgRecipe(
+            name="test_fedavg",
+            server_memory_gc_rounds=3,
+            **base_recipe_params,
+        )
+
+        assert recipe.server_memory_gc_rounds == 3
+
+
+class TestFedOptRecipeServerMemoryGcRounds:
+    """Test server_memory_gc_rounds for FedOptRecipe."""
+
+    def test_pt_fedopt_default_server_memory_gc_rounds(self, mock_file_system, simple_model):
+        """Test PT FedOptRecipe has default server_memory_gc_rounds=1."""
+        from nvflare.app_opt.pt.recipes.fedopt import FedOptRecipe
+
+        recipe = FedOptRecipe(
+            name="test_fedopt",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+        )
+
+        assert recipe.server_memory_gc_rounds == 1
+
+    def test_pt_fedopt_custom_server_memory_gc_rounds(self, mock_file_system, simple_model):
+        """Test PT FedOptRecipe accepts custom server_memory_gc_rounds."""
+        from nvflare.app_opt.pt.recipes.fedopt import FedOptRecipe
+
+        recipe = FedOptRecipe(
+            name="test_fedopt",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+            server_memory_gc_rounds=10,
+        )
+
+        assert recipe.server_memory_gc_rounds == 10
+
+
+class TestFedAvgHERecipeServerMemoryGcRounds:
+    """Test server_memory_gc_rounds for FedAvgRecipeWithHE."""
+
+    def test_fedavg_he_default_server_memory_gc_rounds(self, mock_file_system, simple_model):
+        """Test FedAvgRecipeWithHE has default server_memory_gc_rounds=1."""
+        from nvflare.app_opt.pt.recipes.fedavg_he import FedAvgRecipeWithHE
+
+        recipe = FedAvgRecipeWithHE(
+            name="test_fedavg_he",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+        )
+
+        assert recipe.server_memory_gc_rounds == 1
+
+    def test_fedavg_he_custom_server_memory_gc_rounds(self, mock_file_system, simple_model):
+        """Test FedAvgRecipeWithHE accepts custom server_memory_gc_rounds."""
+        from nvflare.app_opt.pt.recipes.fedavg_he import FedAvgRecipeWithHE
+
+        recipe = FedAvgRecipeWithHE(
+            name="test_fedavg_he",
+            initial_model=simple_model,
+            train_script="client.py",
+            min_clients=2,
+            num_rounds=3,
+            server_memory_gc_rounds=2,
+        )
+
+        assert recipe.server_memory_gc_rounds == 2


### PR DESCRIPTION
## Summary

Several recipes were missing the `server_memory_gc_rounds` parameter, which controls server-side memory cleanup (gc.collect + malloc_trim) during federated learning rounds.

This PR adds the parameter to all training recipes that were missing it:

| Recipe | Controller | Default |
|--------|------------|---------|
| `nvflare/recipe/cyclic.py` | CyclicController | 1 |
| `nvflare/app_opt/pt/recipes/cyclic.py` | (inherits) | 1 |
| `nvflare/app_opt/tf/recipes/cyclic.py` | (inherits) | 1 |
| `nvflare/app_opt/pt/recipes/fedopt.py` | ScatterAndGather | 1 |
| `nvflare/app_opt/tf/recipes/fedopt.py` | FedOpt (extends FedAvg) | 0 |
| `nvflare/app_opt/pt/recipes/fedavg.py` | (inherits from base) | 0 |
| `nvflare/app_opt/tf/recipes/fedavg.py` | (inherits from base) | 0 |
| `nvflare/app_opt/pt/recipes/fedavg_he.py` | ScatterAndGather | 1 |

**Note:** Default values match the corresponding controller defaults to maintain backward compatibility.

## Changes

- Added `server_memory_gc_rounds` parameter to validator, constructor, and controller instantiation in each recipe
- Added docstring documentation for the new parameter
- Created unit tests to verify default values and custom value passthrough

## Test Plan

- [x] Added 9 unit tests in `tests/unit_test/recipe/server_memory_gc_rounds_test.py`
- [x] Tests verify default values match controller defaults
- [x] Tests verify custom values are accepted and stored correctly
- [x] All existing tests continue to pass