### PR TITLE
Cherry-pick of Address potential data corruption issue with Streamer (#4100)

### DIFF
--- a/nvflare/apis/wf_comm_spec.py
+++ b/nvflare/apis/wf_comm_spec.py
@@ -64,6 +64,10 @@ class WFCommSpec(ABC):
             wait_time_after_min_received: how long (secs) to wait after the min_responses is received.
               If == 0, end the task immediately after the min responses are received;
 
+        Note:
+            Server-side implementation creates immutable snapshot of task.data to prevent data corruption.
+            Raises RuntimeError if task.data contains non-serializable objects.
+
         """
         raise NotImplementedError
 

--- a/tests/unit_test/apis/impl/test_broadcast_snapshot.py
+++ b/tests/unit_test/apis/impl/test_broadcast_snapshot.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for broadcast snapshot protection in WFCommServer."""
+
+import numpy as np
+import torch
+
+from nvflare.apis.controller_spec import Task
+from nvflare.apis.dxo import DXO, DataKind, from_shareable
+from nvflare.apis.impl.wf_comm_server import WFCommServer
+from nvflare.apis.shareable import Shareable
+
+
+class TestBroadcastSnapshot:
+    """Test that broadcast creates snapshots to prevent in-place modification corruption."""
+
+    def test_snapshot_protects_numpy_arrays(self):
+        """Verify that broadcast snapshot protects numpy arrays from in-place modifications."""
+        server = WFCommServer()
+
+        # Create task with numpy data
+        original_data = {"weights": np.array([1.0, 2.0, 3.0])}
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data=original_data)
+        task = Task(name="train", data=dxo.to_shareable())
+
+        # Create snapshot
+        snapshot_task = server._create_broadcast_snapshot(task)
+
+        # Modify original data in-place
+        original_data["weights"][0] = 999.0
+
+        # Verify snapshot is NOT affected
+        snapshot_dxo = from_shareable(snapshot_task.data)
+        snapshot_weights = snapshot_dxo.data["weights"]
+
+        assert snapshot_weights[0] == 1.0, "Snapshot should not be affected by in-place modifications"
+        assert original_data["weights"][0] == 999.0, "Original data should be modified"
+
+    def test_snapshot_protects_torch_tensors(self):
+        """Verify that broadcast snapshot protects PyTorch tensors from in-place modifications."""
+        server = WFCommServer()
+
+        # Create task with PyTorch tensor data
+        original_tensor = torch.tensor([1.0, 2.0, 3.0])
+        original_data = {"weights": original_tensor}
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data=original_data)
+        task = Task(name="train", data=dxo.to_shareable())
+
+        # Create snapshot
+        snapshot_task = server._create_broadcast_snapshot(task)
+
+        # Modify original tensor in-place
+        original_tensor.add_(100.0)
+
+        # Verify snapshot is NOT affected
+        snapshot_dxo = from_shareable(snapshot_task.data)
+        snapshot_weights = snapshot_dxo.data["weights"]
+
+        assert snapshot_weights[0].item() == 1.0, "Snapshot should not be affected by in-place modifications"
+        assert original_tensor[0].item() == 101.0, "Original tensor should be modified"
+
+    def test_snapshot_creates_independent_memory(self):
+        """Verify that snapshot creates completely independent memory."""
+        server = WFCommServer()
+
+        # Create task with nested data
+        original_array = np.array([[1.0, 2.0], [3.0, 4.0]])
+        original_data = {"layer1": original_array, "layer2": np.array([5.0, 6.0])}
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data=original_data)
+        task = Task(name="train", data=dxo.to_shareable())
+
+        # Create snapshot
+        snapshot_task = server._create_broadcast_snapshot(task)
+
+        # Get snapshot data
+        snapshot_dxo = from_shareable(snapshot_task.data)
+        snapshot_data = snapshot_dxo.data
+
+        # Verify different memory addresses
+        assert id(original_data) != id(snapshot_data), "Data dicts should have different IDs"
+        assert id(original_data["layer1"]) != id(snapshot_data["layer1"]), "Arrays should have different IDs"
+        assert not np.shares_memory(original_data["layer1"], snapshot_data["layer1"]), "Arrays should not share memory"
+
+    def test_snapshot_protects_nested_structures(self):
+        """Verify that snapshot protects deeply nested data structures."""
+        server = WFCommServer()
+
+        # Create task with deeply nested data
+        nested_array = np.array([1.0, 2.0])
+        original_data = {"model": {"layers": {"conv1": nested_array, "conv2": np.array([3.0, 4.0])}}}
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data=original_data)
+        task = Task(name="train", data=dxo.to_shareable())
+
+        # Create snapshot
+        snapshot_task = server._create_broadcast_snapshot(task)
+
+        # Modify deeply nested original data
+        nested_array[0] = 999.0
+
+        # Verify snapshot is NOT affected
+        snapshot_dxo = from_shareable(snapshot_task.data)
+        snapshot_nested = snapshot_dxo.data["model"]["layers"]["conv1"]
+
+        assert snapshot_nested[0] == 1.0, "Deeply nested snapshot should not be affected"
+        assert nested_array[0] == 999.0, "Original nested data should be modified"
+
+    def test_snapshot_works_with_non_dxo_shareable(self):
+        """Verify snapshot works with Shareable that doesn't contain DXO."""
+        server = WFCommServer()
+
+        # Create task with plain Shareable (no DXO)
+        data = Shareable()
+        data["model_weights"] = np.array([1.0, 2.0, 3.0])
+        data["metadata"] = {"round": 1}
+        task = Task(name="train", data=data)
+
+        # Create snapshot
+        snapshot_task = server._create_broadcast_snapshot(task)
+
+        # Modify original
+        data["model_weights"][0] = 999.0
+
+        # Verify snapshot is NOT affected
+        assert snapshot_task.data["model_weights"][0] == 1.0, "Snapshot should not be affected"
+        assert data["model_weights"][0] == 999.0, "Original should be modified"
+
+    def test_snapshot_preserves_shareable_headers(self):
+        """Verify that snapshot preserves Shareable headers and cookies."""
+        server = WFCommServer()
+
+        # Create task with headers and cookies
+        original_data = {"weights": np.array([1.0, 2.0, 3.0])}
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data=original_data)
+        shareable = dxo.to_shareable()
+        shareable.set_header("round", 5)
+        shareable.add_cookie("client_id", "client_1")
+        task = Task(name="train", data=shareable)
+
+        # Create snapshot
+        snapshot_task = server._create_broadcast_snapshot(task)
+
+        # Verify headers and cookies are preserved
+        assert snapshot_task.data.get_header("round") == 5, "Headers should be preserved"
+        assert snapshot_task.data.get_cookie("client_id") == "client_1", "Cookies should be preserved"
+
+    def test_snapshot_handles_all_data_kinds(self):
+        """Verify snapshot works with all DataKind types."""
+        server = WFCommServer()
+
+        data_kinds = [DataKind.WEIGHTS, DataKind.WEIGHT_DIFF, DataKind.METRICS]
+
+        for kind in data_kinds:
+            # Create task
+            original_data = {"data": np.array([1.0, 2.0, 3.0])}
+            dxo = DXO(data_kind=kind, data=original_data)
+            task = Task(name="train", data=dxo.to_shareable())
+
+            # Create snapshot
+            snapshot_task = server._create_broadcast_snapshot(task)
+
+            # Modify original
+            original_data["data"][0] = 999.0
+
+            # Verify snapshot is NOT affected
+            snapshot_dxo = from_shareable(snapshot_task.data)
+            assert snapshot_dxo.data["data"][0] == 1.0, f"Snapshot should not be affected for {kind}"

--- a/tests/unit_test/app_common/np/test_np_downloader.py
+++ b/tests/unit_test/app_common/np/test_np_downloader.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ArrayDownloadable.
+
+Note: Deep copy protection is now handled at broadcast level in WFCommServer,
+not in ArrayDownloadable itself. These tests verify the Downloadable's basic behavior.
+"""
+
+import numpy as np
+
+from nvflare.app_common.np.np_downloader import ArrayDownloadable
+
+
+class TestArrayDownloadableBasic:
+    """Test basic ArrayDownloadable functionality."""
+
+    def test_basic_functionality(self):
+        """Verify basic Downloadable creation and data access."""
+        # Create arrays
+        arrays = {
+            "weights": np.array([[1.0, 2.0], [3.0, 4.0]]),
+            "bias": np.array([0.5, 1.5]),
+        }
+
+        # Create downloadable
+        downloadable = ArrayDownloadable(arrays=arrays, max_chunk_size=1024)
+
+        # Verify basic properties
+        assert downloadable.size == 2
+        assert set(downloadable.keys) == {"weights", "bias"}
+        assert np.allclose(downloadable.base_obj["weights"], arrays["weights"])
+        assert np.allclose(downloadable.base_obj["bias"], arrays["bias"])
+
+    def test_shares_memory_with_original(self):
+        """Verify that Downloadable references original arrays (no copy at this level)."""
+        original = {"layer": np.array([1.0, 2.0, 3.0])}
+
+        downloadable = ArrayDownloadable(arrays=original, max_chunk_size=1024)
+
+        # Should share memory (snapshot is done at broadcast level, not here)
+        assert np.shares_memory(
+            downloadable.base_obj["layer"], original["layer"]
+        ), "Downloadable should share memory with original (copy is done at broadcast level)"
+
+    def test_modification_affects_downloadable(self):
+        """Verify that modifications to original DO affect Downloadable (by design).
+
+        Note: Protection against this is now handled at broadcast level in WFCommServer.
+        """
+        arrays = {"model": np.array([1.0, 2.0])}
+
+        downloadable = ArrayDownloadable(arrays=arrays, max_chunk_size=1024)
+
+        # Modify original
+        arrays["model"][0] = 999.0
+
+        # Downloadable IS affected (this is expected - protection is at broadcast level)
+        assert downloadable.base_obj["model"][0] == 999.0

--- a/tests/unit_test/app_opt/pt/test_tensor_downloader.py
+++ b/tests/unit_test/app_opt/pt/test_tensor_downloader.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for TensorDownloadable.
+
+Note: Deep copy protection is now handled at broadcast level in WFCommServer,
+not in TensorDownloadable itself. These tests verify the Downloadable's basic behavior.
+"""
+
+import torch
+
+from nvflare.app_opt.pt.tensor_downloader import TensorDownloadable
+
+
+class TestTensorDownloadableBasic:
+    """Test basic TensorDownloadable functionality."""
+
+    def test_basic_functionality(self):
+        """Verify basic Downloadable creation and data access."""
+        # Create tensors
+        tensors = {
+            "weights": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            "bias": torch.tensor([0.5, 1.5]),
+        }
+
+        # Create downloadable
+        downloadable = TensorDownloadable(tensors=tensors, max_chunk_size=1024)
+
+        # Verify basic properties
+        assert downloadable.size == 2
+        assert set(downloadable.keys) == {"weights", "bias"}
+        assert torch.allclose(downloadable.base_obj["weights"], tensors["weights"])
+        assert torch.allclose(downloadable.base_obj["bias"], tensors["bias"])
+
+    def test_shares_memory_with_original(self):
+        """Verify that Downloadable references original tensors (no copy at this level)."""
+        original = {"layer": torch.tensor([1.0, 2.0, 3.0])}
+
+        downloadable = TensorDownloadable(tensors=original, max_chunk_size=1024)
+
+        # Should share memory (snapshot is done at broadcast level, not here)
+        assert (
+            downloadable.base_obj["layer"].data_ptr() == original["layer"].data_ptr()
+        ), "Downloadable should share memory with original (copy is done at broadcast level)"
+
+    def test_modification_affects_downloadable(self):
+        """Verify that modifications to original DO affect Downloadable (by design).
+
+        Note: Protection against this is now handled at broadcast level in WFCommServer.
+        """
+        tensors = {"model": torch.tensor([1.0, 2.0])}
+
+        downloadable = TensorDownloadable(tensors=tensors, max_chunk_size=1024)
+
+        # Modify original
+        tensors["model"][0] = 999.0
+
+        # Downloadable IS affected (this is expected - protection is at broadcast level)
+        assert downloadable.base_obj["model"][0].item() == 999.0


### PR DESCRIPTION
# Fix Data Corruption in `min_responses < total_clients` Scenarios

## Problem

When using `min_responses < total_clients` with
`InTimeAccumulateWeightedAggregator`, the server can proceed to aggregate and modify the global model **while slow clients are still downloading it**, causing data corruption.

**Why this issue exists:**
- **Old framework**: Always sent full copies (FOBS serialization creates N copies per broadcast) → No corruption, but high memory usage
- **With TensorStreamer/NumpyDownloader**: Only passes REF_ID (reference to shared memory) → Memory efficient, but vulnerable to in-place modifications

**Race condition:**
1. Server broadcasts model to 5 clients (`min_responses=2`)
2. TensorStreamer creates `Downloadable` with REF_ID pointing to model data
3. Fast clients (1-2) respond immediately → server aggregates
4. Server updates model **in-place** (e.g., `model.params += updates`)
5. Slow clients (3-5) still downloading from same memory → **receive corrupted data** (mix of old + new)

**Real example of in-place modification**:
`nvflare/app_common/workflows/lr/fedavg.py:204`
```python
model.params[NPConstants.NUMPY_KEY] += model_update.params["newton_raphson_updates"]
```

---

## Solution

### 1. Broadcast Snapshot Protection (Core Fix)

**File**: `nvflare/apis/impl/wf_comm_server.py`

Added `_create_broadcast_snapshot()` to create **one immutable deep copy per broadcast**:

```python
def _create_broadcast_snapshot(self, task: Task) -> Task:
    """Snapshot task data to protect against in-place modifications."""
    import copy
    snapshot_task = copy.copy(task)
    snapshot_task.data = copy.deepcopy(task.data)  # Deep copy Shareable
    return snapshot_task
```

**Integrated into broadcast methods only:**
- `broadcast()` - creates deep copy snapshot before scheduling
- `broadcast_forever()` - same protection
- `broadcast_and_wait()` - waits on snapshot (not original task)
- ℹ️ `send()`/`relay()` intentionally NOT protected - see rationale below

**Impact:**
- ✅ Protects concurrent broadcasts from in-place modifications
- ✅ One snapshot per broadcast (shared by all clients) - memory efficient
- ⚠️ Adds ~10-50ms latency per broadcast (deepcopy overhead, model size dependent)

**Why only broadcast?**
- **Primary issue**: Broadcast sends to multiple clients concurrently → race condition when `min_responses` allows early aggregation
- **Send/relay**: Sequential dispatch (one client at a time), and in practice all controllers use `*_and_wait()` (blocking)
- **Theoretical risk**: Non-blocking `send()`/`relay()` could corrupt if controller modifies data immediately, but no known controllers do this
- **Cyclic constraint**: Cyclic workflow intentionally modifies `task.data` between clients (see `cyclic_ctl.py:233`) - centralized snapshot would interfere
- **Fallback protection**: Without TensorStreamer, FOBS creates full copies automatically → no corruption regardless

**Trade-off**: Fix known real bug (broadcast) vs theoretical edge case (non-blocking send/relay). Phase 2 will provide comprehensive lifecycle management.

---

### 2. Fixed Cleanup Bug

**Original bug**: Cleanup only ran when `task_done_cb` existed:
```python
if exit_task.task_done_cb is not None:
    delete_msg_root(msg_root_id)  # ❌ Cleanup missed when no callback!
```

**Fix**: Cleanup now **always runs**:
```python
# Cleanup download transactions (always, regardless of callback)
msg_root_id = exit_task.msg_root_id
if msg_root_id:
    delete_msg_root(msg_root_id)  # ✅ Always cleanup

if exit_task.task_done_cb is not None:
    exit_task.task_done_cb(...)
```

---

## Testing

### Unit Tests
- `tests/unit_test/apis/impl/test_broadcast_snapshot.py` - Broadcast snapshot protection (NEW)
- `tests/unit_test/app_opt/pt/test_tensor_downloader.py` - TensorDownloadable basic tests (NEW)
- `tests/unit_test/app_common/np/test_np_downloader.py` - ArrayDownloadable basic tests (NEW)

### Integration Test
**`examples/hello-world/hello-numpy-cleanup-test/`**

Validates the fix end-to-end:
- 5 clients, `min_clients=2`, `wait_time=10s`
- Clients 3-5 delay 15s (miss aggregation window)
- ✅ Fast clients (1-2) aggregated successfully
- ✅ Slow clients (3-5) marked "TOO LATE" but rejoin next round
- ✅ No data corruption despite in-place aggregation
- ✅ Cleanup happens automatically

---

## Compatibility

✅ **No breaking changes** - all existing code works unchanged   ✅ **Transparent** - automatic protection for all controllers   ✅ **Safe** - tested with PyTorch, NumPy, and HE tensors

### Known Limitation
**Callbacks must not modify `task.data` during concurrent downloads:**
- **Design flaw**: Current callback API has no lifecycle contract for when `task.data` is mutable
- If a broadcast `result_received_cb` modifies `task.data` while other clients are downloading → **data corruption**
- This limitation exists regardless of snapshot (it's a fundamental API design issue)
- **In practice this is safe**: Standard workflows (ScatterAndGather, FedAvg) don't modify `task.data` in callbacks
- Sequential workflows (send/relay) can modify between clients (e.g., cyclic at `cyclic_ctl.py:233`)
- Without TensorStreamer, FOBS creates full copies (automatic protection)

**Phase 2** will fix this design flaw with explicit `commit_model()` lifecycle.

---

## Future Work (Phase 2)

This PR implements **Phase 1: Broadcast-level snapshot**. 

**Phase 2** (future PR) will add a formal `commit_model()` API for broader architectural benefits:
```python
# After aggregation, create official immutable snapshot
snapshot = self.commit_model(aggregated_model, round_num, fl_ctx)
```

**Phase 2 Benefits:**
- ✅ **Persistence integration**: Official snapshot for S3, model registry, cloud storage
- ✅ **Versioning**: Clear checkpoint of "official round N model"
- ✅ **Rollback capability**: Revert to committed snapshot if needed
- ✅ **Event handler contract**: Handlers can't modify committed models
- ✅ **Memory management**: Explicit lifecycle for model snapshots

See `MODEL_COMMIT_DESIGN.md` for full Phase 2 design.

**Why Phase 1 first?**
- ✅ Solves immediate corruption issue
- ✅ Low risk (5 files modified)
- ✅ Phase 2 requires design discussion (persistor integration, storage backends, API contract)
- ✅ Phase 2 requires 20-25 file changes across all controllers




### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

---------

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
