### PR TITLE
[2.7] Recipe: support relative initial_ckpt and API enhancements

### DIFF
--- a/nvflare/app_common/np/recipes/cross_site_eval.py
+++ b/nvflare/app_common/np/recipes/cross_site_eval.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Optional
 
 from pydantic import BaseModel, field_validator
@@ -44,6 +45,11 @@ class _CrossSiteEvalValidator(BaseModel):
     @classmethod
     def validate_initial_ckpt(cls, v):
         if v is not None:
+            if not os.path.isabs(v):
+                raise ValueError(
+                    f"initial_ckpt must be an absolute path for NumpyCrossSiteEvalRecipe, got: {v}. "
+                    "Relative path support for this recipe is planned for a future release."
+                )
             validate_initial_ckpt(v)
         return v
 
@@ -133,6 +139,7 @@ class NumpyCrossSiteEvalRecipe(Recipe):
         # Determine model source
         if initial_ckpt is not None:
             # Use absolute path - pass directly to locator
+            # Note: Relative path support deferred to future release (locator path resolution needed)
             locator_model_name = {NPModelLocator.SERVER_MODEL_NAME: initial_ckpt}
             locator_model_dir = model_dir if model_dir is not None else "models"
         else:

--- a/nvflare/app_common/np/recipes/fedavg.py
+++ b/nvflare/app_common/np/recipes/fedavg.py
@@ -166,6 +166,8 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
     def _setup_model_and_persistor(self, job) -> str:
         """Override to handle NumPy-specific model setup."""
         if self._np_model is not None or self._np_initial_ckpt is not None:
+            from nvflare.recipe.utils import prepare_initial_ckpt
+
             # Convert numpy array to list for JSON serialization
             # NPModelPersistor expects a list, not a numpy array
             model_list = None
@@ -177,9 +179,10 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
                 else:
                     raise TypeError(f"model must be a numpy array or list, got {type(self._np_model).__name__}")
 
+            ckpt_path = prepare_initial_ckpt(self._np_initial_ckpt, job)
             persistor = NPModelPersistor(
                 model=model_list,
-                source_ckpt_file_full_name=self._np_initial_ckpt,
+                source_ckpt_file_full_name=ckpt_path,
             )
             return job.to_server(persistor, id="persistor")
         return ""

--- a/nvflare/app_common/np/recipes/lr/fedavg.py
+++ b/nvflare/app_common/np/recipes/lr/fedavg.py
@@ -125,9 +125,12 @@ class FedAvgLrRecipe(Recipe):
 
         # Create FedJob.
         job = FedJob(name=self.name, min_clients=self.min_clients)
+        from nvflare.recipe.utils import prepare_initial_ckpt
+
+        ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
         persistor = LRModelPersistor(
             n_features=self.num_features,
-            source_ckpt_file_full_name=self.initial_ckpt,
+            source_ckpt_file_full_name=ckpt_path,
         )
         persistor_id = job.to_server(persistor, id="lr_persistor")
 

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -161,13 +161,15 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         """Override to handle PyTorch-specific model setup."""
         if self.model is not None or self.initial_ckpt is not None:
             from nvflare.app_opt.pt.job_config.model import PTModel
+            from nvflare.recipe.utils import prepare_initial_ckpt
 
             # Disable numpy conversion when using tensor format to keep PyTorch tensors
             allow_numpy_conversion = self.server_expected_format != ExchangeFormat.PYTORCH
 
+            ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
             pt_model = PTModel(
                 model=self.model,
-                initial_ckpt=self.initial_ckpt,
+                initial_ckpt=ckpt_path,
                 persistor=self.model_persistor,
                 locator=self._pt_model_locator,
                 allow_numpy_conversion=allow_numpy_conversion,

--- a/nvflare/app_opt/pt/recipes/fedavg_he.py
+++ b/nvflare/app_opt/pt/recipes/fedavg_he.py
@@ -77,8 +77,9 @@ class FedAvgRecipeWithHE(Recipe):
             - nn.Module instance
             - Dict config: {"path": "module.ClassName", "args": {"param": value}}
             - None: no initial model
-        initial_ckpt: Absolute path to a pre-trained checkpoint file. The file may not
-            exist locally as it could be on the server. Used to load initial weights.
+        initial_ckpt: Path to a pre-trained checkpoint file. Can be:
+            - Relative path: file will be bundled into the job's custom/ directory.
+            - Absolute path: treated as a server-side path, used as-is at runtime.
             Note: PyTorch requires model when using initial_ckpt (for architecture).
         min_clients: Minimum number of clients required to start a training round.
         num_rounds: Number of federated training rounds to execute. Defaults to 2.
@@ -187,22 +188,25 @@ class FedAvgRecipeWithHE(Recipe):
         self.encrypt_layers: Optional[Union[List[str], str]] = v.encrypt_layers
         self.server_memory_gc_rounds = v.server_memory_gc_rounds
 
-        # Create a persistor with HE serialization filter if initial model or checkpoint is provided
-        model_persistor = None
-        if self.model is not None or self.initial_ckpt is not None:
-            model_persistor = PTFileModelPersistor(
-                model=self.model,
-                source_ckpt_file_full_name=self.initial_ckpt,
-                filter_id="model_serialize_filter",
-            )
-
-        # Create BaseFedJob with initial model and persistor
+        # Create BaseFedJob without model first (model setup done manually below for HE)
         job = BaseFedJob(
-            model=self.model,
             name=self.name,
             min_clients=self.min_clients,
-            model_persistor=model_persistor,
         )
+
+        # Create a persistor with HE serialization filter if initial model or checkpoint is provided
+        if self.model is not None or self.initial_ckpt is not None:
+            from nvflare.app_opt.pt.job_config.model import PTModel
+            from nvflare.recipe.utils import prepare_initial_ckpt
+
+            ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
+            model_persistor = PTFileModelPersistor(
+                model=self.model,
+                source_ckpt_file_full_name=ckpt_path,
+                filter_id="model_serialize_filter",
+            )
+            pt_model = PTModel(model=self.model, persistor=model_persistor)
+            job.comp_ids.update(job.to_server(pt_model))
 
         # Add HE model serialization filter (must be added before persistor uses it)
         if self.model is not None or self.initial_ckpt is not None:

--- a/nvflare/app_opt/pt/recipes/fedeval.py
+++ b/nvflare/app_opt/pt/recipes/fedeval.py
@@ -162,7 +162,10 @@ class FedEvalRecipe(Recipe):
             raise ValueError(f"model must be nn.Module or dict config, got {type(self.model)}")
 
         # PTModel handles both nn.Module and dict config uniformly
-        pt_model = PTModel(model=self.model, initial_ckpt=self.initial_ckpt)
+        from nvflare.recipe.utils import prepare_initial_ckpt
+
+        ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
+        pt_model = PTModel(model=self.model, initial_ckpt=ckpt_path)
 
         result = job.to_server(pt_model)
         job.comp_ids.update(result)

--- a/nvflare/app_opt/pt/recipes/fedopt.py
+++ b/nvflare/app_opt/pt/recipes/fedopt.py
@@ -221,9 +221,12 @@ class FedOptRecipe(Recipe):
         job.to_server(model_to_register, id=self.source_model)
 
         # Add the persisted model to the job with checkpoint support
+        from nvflare.recipe.utils import prepare_initial_ckpt
+
+        ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
         persistor = PTFileModelPersistor(
             model=self.source_model,
-            source_ckpt_file_full_name=self.initial_ckpt,
+            source_ckpt_file_full_name=ckpt_path,
         )
         persistor_id = job.to_server(persistor, id="persistor")
 

--- a/nvflare/app_opt/pt/recipes/scaffold.py
+++ b/nvflare/app_opt/pt/recipes/scaffold.py
@@ -142,7 +142,10 @@ class ScaffoldRecipe(Recipe):
         # Setup model persistor using PTModel
         persistor_id = ""
         if self.model is not None or self.initial_ckpt is not None:
-            pt_model = PTModel(model=self.model, initial_ckpt=self.initial_ckpt)
+            from nvflare.recipe.utils import prepare_initial_ckpt
+
+            ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
+            pt_model = PTModel(model=self.model, initial_ckpt=ckpt_path)
             result = job.to_server(pt_model, id="persistor")
             persistor_id = result["persistor_id"]
 

--- a/nvflare/app_opt/tf/job_config/base_fed_job.py
+++ b/nvflare/app_opt/tf/job_config/base_fed_job.py
@@ -99,6 +99,8 @@ class BaseFedJob(UnifiedBaseFedJob):
     ):
         """Setup TensorFlow model with persistor."""
         from nvflare.app_opt.tf.job_config.model import TFModel
+        from nvflare.recipe.utils import prepare_initial_ckpt
 
-        tf_model = TFModel(model=model, initial_ckpt=initial_ckpt, persistor=persistor)
+        ckpt_path = prepare_initial_ckpt(initial_ckpt, self)
+        tf_model = TFModel(model=model, initial_ckpt=ckpt_path, persistor=persistor)
         self.comp_ids["persistor_id"] = self.to_server(tf_model)

--- a/nvflare/app_opt/tf/recipes/cyclic.py
+++ b/nvflare/app_opt/tf/recipes/cyclic.py
@@ -30,8 +30,9 @@ class CyclicRecipe(BaseCyclicRecipe):
             - Dict config: {"path": "module.ClassName", "args": {"param": value}}
             - TFModel instance (already wrapped)
             - None: no initial model
-        initial_ckpt: Absolute path to a pre-trained checkpoint file (.h5, .keras, or SavedModel dir).
-            The file may not exist locally as it could be on the server.
+        initial_ckpt: Path to a pre-trained checkpoint file (.h5, .keras, or SavedModel dir). Can be:
+            - Relative path: file will be bundled into the job's custom/ directory.
+            - Absolute path: treated as a server-side path, used as-is at runtime.
             Note: TensorFlow can load full models from .h5/SavedModel without model.
         num_rounds: Number of complete training rounds to execute. Defaults to 2.
         min_clients: Minimum number of clients required to participate. Must be >= 2.
@@ -62,18 +63,26 @@ class CyclicRecipe(BaseCyclicRecipe):
         params_transfer_type: TransferType = TransferType.FULL,
         server_memory_gc_rounds: int = 1,
     ):
-        # Wrap model with TFModel if needed
+        # Validate initial_ckpt early (base class won't see it since we pass None)
+        from nvflare.recipe.utils import validate_initial_ckpt
+
+        validate_initial_ckpt(initial_ckpt)
+
+        # Store initial_ckpt for _setup_model_and_persistor; wrap model with TFModel there
+        self._tf_initial_ckpt = initial_ckpt
         if model is None and initial_ckpt is None:
             model_to_pass = None
         elif isinstance(model, TFModel):
             model_to_pass = model
+            self._tf_initial_ckpt = None  # Already handled by TFModel wrapper
         else:
-            model_to_pass = TFModel(model=model, initial_ckpt=initial_ckpt)
+            # Don't wrap yet — prepare_initial_ckpt needs the job which doesn't exist yet
+            model_to_pass = model
 
         super().__init__(
             name=name,
             model=model_to_pass,
-            initial_ckpt=None,  # Already handled by TFModel wrapper
+            initial_ckpt=None,  # Handled in _setup_model_and_persistor
             num_rounds=num_rounds,
             min_clients=min_clients,
             train_script=train_script,
@@ -85,3 +94,20 @@ class CyclicRecipe(BaseCyclicRecipe):
             params_transfer_type=params_transfer_type,
             server_memory_gc_rounds=server_memory_gc_rounds,
         )
+
+    def _setup_model_and_persistor(self, job) -> str:
+        """Override to handle TensorFlow-specific model setup with relative ckpt support."""
+        if self.model is None and self._tf_initial_ckpt is None:
+            return ""
+
+        # If model is already a TFModel wrapper (user passed TFModel directly), use as-is
+        if hasattr(self.model, "add_to_fed_job"):
+            result = job.to_server(self.model, id="persistor")
+            return result["persistor_id"]
+
+        from nvflare.recipe.utils import prepare_initial_ckpt
+
+        ckpt_path = prepare_initial_ckpt(self._tf_initial_ckpt, job)
+        tf_model = TFModel(model=self.model, initial_ckpt=ckpt_path)
+        result = job.to_server(tf_model, id="persistor")
+        return result["persistor_id"]

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -147,10 +147,12 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         """Override to handle TensorFlow-specific model setup."""
         if self.model is not None or self.initial_ckpt is not None:
             from nvflare.app_opt.tf.job_config.model import TFModel
+            from nvflare.recipe.utils import prepare_initial_ckpt
 
+            ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
             tf_model = TFModel(
                 model=self.model,
-                initial_ckpt=self.initial_ckpt,
+                initial_ckpt=ckpt_path,
                 persistor=self.model_persistor,
             )
             job.comp_ids["persistor_id"] = job.to_server(tf_model)

--- a/nvflare/edge/tools/edge_fed_buff_recipe.py
+++ b/nvflare/edge/tools/edge_fed_buff_recipe.py
@@ -326,8 +326,10 @@ class EdgeFedBuffRecipe(Recipe):
 
         # add persistor using PTModel (supports dict config and initial_ckpt)
         from nvflare.app_opt.pt.job_config.model import PTModel
+        from nvflare.recipe.utils import prepare_initial_ckpt
 
-        pt_model = PTModel(model=self.model, initial_ckpt=self.initial_ckpt)
+        ckpt_path = prepare_initial_ckpt(self.initial_ckpt, job)
+        pt_model = PTModel(model=self.model, initial_ckpt=ckpt_path)
         result = job.to_server(pt_model, id="persistor")
         persistor_id = result["persistor_id"]
 

--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -509,6 +509,50 @@ class FedJob:
 
         return self.to(obj=obj, target=ALL_SITES, id=id, **kwargs)
 
+    def add_file_to(self, src_path: str, target: str, dest_dir=None, app_folder_type=None):
+        """Add a file to a specific target's app directory.
+
+        Args:
+            src_path: Local path to the file to be bundled into the job.
+            target: Target site name (e.g., "server", "site-1", or ALL_SITES for all clients).
+            dest_dir: Optional subdirectory within the target folder to place the file.
+            app_folder_type: Type of app folder to place the file. Valid values: "custom", "config".
+                If not specified, defaults to "custom".
+        """
+        self._validate_target(target)
+        target_type = JobTargetType.get_target_type(target)
+        app = self._deploy_map.get(target)
+        if not app:
+            if target_type == JobTargetType.SERVER:
+                app = ServerApp()
+                self._add_server_app(app, target)
+            else:
+                app = ClientApp()
+                self._add_client_app(app, target)
+        app.add_file_source(src_path, dest_dir, app_folder_type)
+
+    def add_file_to_server(self, src_path: str, dest_dir=None, app_folder_type=None):
+        """Add a file to the server app directory.
+
+        Args:
+            src_path: Local path to the file to be bundled into the job.
+            dest_dir: Optional subdirectory within the target folder to place the file.
+            app_folder_type: Type of app folder to place the file. Valid values: "custom", "config".
+                If not specified, defaults to "custom".
+        """
+        self.add_file_to(src_path, SERVER_SITE_NAME, dest_dir, app_folder_type)
+
+    def add_file_to_clients(self, src_path: str, dest_dir=None, app_folder_type=None):
+        """Add a file to all client apps' directory.
+
+        Args:
+            src_path: Local path to the file to be bundled into the job.
+            dest_dir: Optional subdirectory within the target folder to place the file.
+            app_folder_type: Type of app folder to place the file. Valid values: "custom", "config".
+                If not specified, defaults to "custom".
+        """
+        self.add_file_to(src_path, ALL_SITES, dest_dir, app_folder_type)
+
     def _validate_target(self, target):
         if not target:
             raise ValueError("Must provide a valid target name")

--- a/nvflare/recipe/cyclic.py
+++ b/nvflare/recipe/cyclic.py
@@ -64,8 +64,9 @@ class CyclicRecipe(Recipe):
             - Model instance (nn.Module, tf.keras.Model, np.ndarray, etc.)
             - Dict config: {"path": "module.ClassName", "args": {"param": value}}
             - None: no initial model
-        initial_ckpt: Absolute path to a pre-trained checkpoint file. The file may not
-            exist locally as it could be on the server. Used to load initial weights.
+        initial_ckpt: Path to a pre-trained checkpoint file. Can be:
+            - Relative path: file will be bundled into the job's custom/ directory.
+            - Absolute path: treated as a server-side path, used as-is at runtime.
         num_rounds: Number of complete training rounds to execute. Defaults to 2.
         min_clients: Minimum number of clients required to participate. Must be >= 2.
         train_script: Path to the client training script to execute.

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -241,6 +241,8 @@ class FedAvgRecipe(Recipe):
         self.server_memory_gc_rounds = v.server_memory_gc_rounds
 
         # Validate that we have at least one model source
+        # Note: Subclasses (e.g., sklearn) that manage models differently should pass
+        # a model or model_persistor to satisfy this check.
         if self.model is None and self.model_persistor is None and self.initial_ckpt is None:
             raise ValueError(
                 "Must provide either model, initial_ckpt, or model_persistor. "

--- a/tests/unit_test/recipe/cyclic_recipe_test.py
+++ b/tests/unit_test/recipe/cyclic_recipe_test.py
@@ -64,19 +64,18 @@ class TestBaseCyclicRecipe:
     Use framework-specific recipes (PTCyclicRecipe, TFCyclicRecipe) for those.
     """
 
-    def test_initial_ckpt_must_be_absolute(self):
-        """Test that relative paths are rejected (no mock - validation must run)."""
-        # Don't use mock_file_system fixture - we need real os.path.isabs check
-        with patch("os.path.isfile", return_value=True), patch("os.path.exists", return_value=True):
-            with pytest.raises(ValueError, match="must be an absolute path"):
-                BaseCyclicRecipe(
-                    name="test_relative",
-                    model=None,
-                    initial_ckpt="relative/path/model.pt",
-                    train_script="/abs/train.py",
-                    min_clients=2,
-                    num_rounds=2,
-                )
+    def test_initial_ckpt_must_exist_for_relative_path(self):
+        """Test that non-existent relative paths are rejected (no mock - validation must run)."""
+        # Don't use mock_file_system fixture - we need real validation
+        with pytest.raises(ValueError, match="does not exist locally"):
+            BaseCyclicRecipe(
+                name="test_relative",
+                model=None,
+                initial_ckpt="relative/path/model.pt",
+                train_script="/abs/train.py",
+                min_clients=2,
+                num_rounds=2,
+            )
 
     def test_requires_model_or_checkpoint(self, base_recipe_params):
         """Test that at least model or initial_ckpt must be provided."""

--- a/tests/unit_test/recipe/edge_recipe_test.py
+++ b/tests/unit_test/recipe/edge_recipe_test.py
@@ -129,17 +129,18 @@ class TestEdgeFedBuffRecipe:
         assert isinstance(recipe.model, dict)
         assert recipe.model["path"] == "torch.nn.Linear"
 
-    def test_relative_path_rejected(
+    def test_relative_path_accepted_if_exists(
         self, mock_file_system, simple_pt_model, model_manager_config, device_manager_config
     ):
-        """Test that relative paths are rejected."""
+        """Test that existing relative paths are accepted and bundled."""
         from nvflare.edge.tools.edge_fed_buff_recipe import EdgeFedBuffRecipe
 
-        with pytest.raises(ValueError, match="must be an absolute path"):
-            EdgeFedBuffRecipe(
-                job_name="test_edge",
-                model=simple_pt_model,
-                model_manager_config=model_manager_config,
-                device_manager_config=device_manager_config,
-                initial_ckpt="relative/path/model.pt",
-            )
+        # This should not raise since relative paths are now supported
+        recipe = EdgeFedBuffRecipe(
+            job_name="test_edge",
+            model=simple_pt_model,
+            model_manager_config=model_manager_config,
+            device_manager_config=device_manager_config,
+            initial_ckpt="relative/path/model.pt",
+        )
+        assert recipe is not None

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -460,9 +460,9 @@ class TestFedAvgRecipeInitialCkpt:
                 **base_recipe_params,
             )
 
-    def test_initial_ckpt_must_be_absolute_path(self, base_recipe_params, simple_model):
-        """Test that relative paths are rejected (without mock to allow validation)."""
-        with pytest.raises(ValueError, match="must be an absolute path"):
+    def test_initial_ckpt_must_exist_for_relative_path(self, base_recipe_params, simple_model):
+        """Test that non-existent relative paths are rejected."""
+        with pytest.raises(ValueError, match="does not exist locally"):
             FedAvgRecipe(
                 name="test_relative_path",
                 model=simple_model,

--- a/tests/unit_test/recipe/fedopt_recipe_test.py
+++ b/tests/unit_test/recipe/fedopt_recipe_test.py
@@ -125,11 +125,11 @@ class TestPTFedOptRecipe:
 
         assert recipe.optimizer_args == optimizer_args
 
-    def test_initial_ckpt_must_be_absolute_path(self, base_recipe_params, simple_model):
-        """Test that relative paths are rejected."""
+    def test_initial_ckpt_must_exist_for_relative_path(self, base_recipe_params, simple_model):
+        """Test that non-existent relative paths are rejected."""
         from nvflare.app_opt.pt.recipes.fedopt import FedOptRecipe
 
-        with pytest.raises(ValueError, match="must be an absolute path"):
+        with pytest.raises(ValueError, match="does not exist locally"):
             FedOptRecipe(
                 name="test_relative_path",
                 model=simple_model,

--- a/tests/unit_test/recipe/numpy_lr_recipe_test.py
+++ b/tests/unit_test/recipe/numpy_lr_recipe_test.py
@@ -62,19 +62,20 @@ class TestFedAvgLrRecipe:
 
         assert recipe.job is not None
 
-    def test_relative_path_rejected(self, mock_file_system):
-        """Test that relative paths are rejected."""
+    def test_relative_path_accepted_if_exists(self, mock_file_system):
+        """Test that existing relative paths are accepted and bundled."""
         from nvflare.app_common.np.recipes.lr.fedavg import FedAvgLrRecipe
 
-        with pytest.raises(ValueError, match="must be an absolute path"):
-            FedAvgLrRecipe(
-                name="test_lr",
-                train_script="train.py",
-                min_clients=2,
-                num_rounds=5,
-                num_features=13,
-                initial_ckpt="relative/path/model.npy",
-            )
+        # This should not raise since relative paths are now supported
+        recipe = FedAvgLrRecipe(
+            name="test_lr",
+            train_script="train.py",
+            min_clients=2,
+            num_rounds=5,
+            num_features=13,
+            initial_ckpt="relative/path/model.npy",
+        )
+        assert recipe is not None
 
     def test_custom_damping_factor(self, mock_file_system):
         """Test that custom damping_factor is accepted."""

--- a/tests/unit_test/recipe/scaffold_recipe_test.py
+++ b/tests/unit_test/recipe/scaffold_recipe_test.py
@@ -101,11 +101,11 @@ class TestPTScaffoldRecipe:
 
         assert recipe.model == model_config
 
-    def test_initial_ckpt_must_be_absolute_path(self, base_recipe_params, simple_model):
-        """Test that relative paths are rejected."""
+    def test_initial_ckpt_must_exist_for_relative_path(self, base_recipe_params, simple_model):
+        """Test that non-existent relative paths are rejected."""
         from nvflare.app_opt.pt.recipes.scaffold import ScaffoldRecipe
 
-        with pytest.raises(ValueError, match="must be an absolute path"):
+        with pytest.raises(ValueError, match="does not exist locally"):
             ScaffoldRecipe(
                 name="test_relative_path",
                 model=simple_model,

--- a/tests/unit_test/recipe/sklearn_recipe_test.py
+++ b/tests/unit_test/recipe/sklearn_recipe_test.py
@@ -137,20 +137,6 @@ class TestKMeansFedAvgRecipe:
 
         assert recipe.job is not None
 
-    def test_relative_path_rejected(self, mock_file_system):
-        """Test that relative paths are rejected."""
-        from nvflare.app_opt.sklearn.recipes.kmeans import KMeansFedAvgRecipe
-
-        with pytest.raises(ValueError, match="must be an absolute path"):
-            KMeansFedAvgRecipe(
-                name="test_kmeans",
-                n_clusters=3,
-                train_script="train.py",
-                min_clients=2,
-                num_rounds=5,
-                initial_ckpt="relative/path/model.joblib",
-            )
-
 
 class TestSVMFedAvgRecipe:
     """Test cases for SVMFedAvgRecipe with initial_ckpt support."""

--- a/tests/unit_test/recipe/swarm_recipe_test.py
+++ b/tests/unit_test/recipe/swarm_recipe_test.py
@@ -83,18 +83,19 @@ class TestSimpleSwarmLearningRecipe:
 
         assert recipe.job is not None
 
-    def test_relative_path_rejected(self, mock_file_system, simple_pt_model):
-        """Test that relative paths are rejected."""
+    def test_relative_path_accepted_if_exists(self, mock_file_system, simple_pt_model):
+        """Test that existing relative paths are accepted and bundled."""
         from nvflare.app_opt.pt.recipes.swarm import SimpleSwarmLearningRecipe
 
-        with pytest.raises(ValueError, match="must be an absolute path"):
-            SimpleSwarmLearningRecipe(
-                name="test_swarm",
-                model=simple_pt_model,
-                num_rounds=5,
-                train_script="train.py",
-                initial_ckpt="relative/path/model.pt",
-            )
+        # This should not raise since relative paths are now supported
+        recipe = SimpleSwarmLearningRecipe(
+            name="test_swarm",
+            model=simple_pt_model,
+            num_rounds=5,
+            train_script="train.py",
+            initial_ckpt="relative/path/model.pt",
+        )
+        assert recipe is not None
 
     def test_cross_site_eval_option(self, mock_file_system, simple_pt_model):
         """Test with cross-site evaluation enabled."""

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvflare.recipe.utils import prepare_initial_ckpt, validate_initial_ckpt
+
+
+@pytest.fixture
+def temp_workdir():
+    """Fixture that creates a temp directory and changes into it, restoring cwd after."""
+    original_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        yield tmpdir
+        os.chdir(original_cwd)
+
+
+class TestValidateInitialCkpt:
+    """Tests for validate_initial_ckpt function."""
+
+    def test_none_ckpt(self):
+        """None should pass validation."""
+        validate_initial_ckpt(None)  # Should not raise
+
+    def test_absolute_path_not_exists(self):
+        """Absolute path that doesn't exist should pass (server-side path)."""
+        validate_initial_ckpt("/server/path/to/checkpoint.pt")  # Should not raise
+
+    def test_absolute_path_exists(self):
+        """Absolute path that exists locally should pass."""
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            ckpt_path = f.name
+        try:
+            validate_initial_ckpt(ckpt_path)  # Should not raise
+        finally:
+            os.unlink(ckpt_path)
+
+    def test_relative_path_exists(self, temp_workdir):
+        """Relative path that exists locally should pass."""
+        ckpt_file = "checkpoint.pt"
+        open(ckpt_file, "w").close()
+        validate_initial_ckpt(ckpt_file)  # Should not raise
+
+    def test_relative_path_not_exists(self):
+        """Relative path that doesn't exist should raise ValueError."""
+        with pytest.raises(ValueError, match="does not exist locally"):
+            validate_initial_ckpt("non_existent_checkpoint.pt")
+
+    def test_relative_path_subdirectory_exists(self, temp_workdir):
+        """Relative path in subdirectory that exists should pass."""
+        os.makedirs("checkpoints", exist_ok=True)
+        ckpt_file = "checkpoints/model.pt"
+        open(ckpt_file, "w").close()
+        validate_initial_ckpt(ckpt_file)  # Should not raise
+
+    def test_relative_path_subdirectory_not_exists(self):
+        """Relative path in subdirectory that doesn't exist should raise."""
+        with pytest.raises(ValueError, match="does not exist locally"):
+            validate_initial_ckpt("checkpoints/non_existent.pt")
+
+
+class TestPrepareInitialCkpt:
+    """Tests for prepare_initial_ckpt function."""
+
+    def test_none_ckpt(self):
+        """None should return None."""
+        job = MagicMock()
+        result = prepare_initial_ckpt(None, job)
+        assert result is None
+        job.add_file_to_server.assert_not_called()
+
+    def test_absolute_path_server_side(self):
+        """Absolute path should be returned as-is (server-side path)."""
+        job = MagicMock()
+        abs_path = "/workspace/models/checkpoint.pt"
+        result = prepare_initial_ckpt(abs_path, job)
+        assert result == abs_path
+        job.add_file_to_server.assert_not_called()
+
+    def test_absolute_path_local_file(self):
+        """Absolute path to local file should still be returned as-is (user intent)."""
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            ckpt_path = f.name
+        try:
+            job = MagicMock()
+            result = prepare_initial_ckpt(ckpt_path, job)
+            # Absolute paths are treated as server-side, not bundled
+            assert result == ckpt_path
+            job.add_file_to_server.assert_not_called()
+        finally:
+            os.unlink(ckpt_path)
+
+    def test_relative_path_bundled(self, temp_workdir):
+        """Relative path should be bundled and basename returned."""
+        ckpt_file = "checkpoint.pt"
+        open(ckpt_file, "w").close()
+
+        job = MagicMock()
+        result = prepare_initial_ckpt(ckpt_file, job)
+
+        # Should bundle the file
+        job.add_file_to_server.assert_called_once_with(ckpt_file)
+        # Should return basename
+        assert result == "checkpoint.pt"
+
+    def test_relative_path_subdirectory_bundled(self, temp_workdir):
+        """Relative path in subdirectory should be bundled and basename returned."""
+        os.makedirs("checkpoints", exist_ok=True)
+        ckpt_file = "checkpoints/model.pt"
+        open(ckpt_file, "w").close()
+
+        job = MagicMock()
+        result = prepare_initial_ckpt(ckpt_file, job)
+
+        # Should bundle the full relative path
+        job.add_file_to_server.assert_called_once_with(ckpt_file)
+        # Should return basename only
+        assert result == "model.pt"
+
+    def test_multiple_calls_different_files(self, temp_workdir):
+        """Multiple calls with different files should bundle each."""
+        ckpt1 = "ckpt1.pt"
+        ckpt2 = "ckpt2.pt"
+        open(ckpt1, "w").close()
+        open(ckpt2, "w").close()
+
+        job = MagicMock()
+
+        result1 = prepare_initial_ckpt(ckpt1, job)
+        assert result1 == "ckpt1.pt"
+
+        result2 = prepare_initial_ckpt(ckpt2, job)
+        assert result2 == "ckpt2.pt"
+
+        assert job.add_file_to_server.call_count == 2


### PR DESCRIPTION
## Summary

This PR enhances the Recipe interface to support **relative `initial_ckpt` paths** across all applicable recipes, with unified validation, file bundling utilities, and new job API enhancements.

### Problem
- `initial_ckpt` only supported absolute paths, requiring users to know the exact server-side file location
- No convenient API to bundle local files into job packages
- Checkpoint validation was inconsistent across recipes (each used different validation logic)
- Cyclic PT/TF recipes bypassed validation for `initial_ckpt` due to passing `None` to the base class

### Solution
- **Unified checkpoint utilities**: `validate_initial_ckpt()` and `prepare_initial_ckpt()` in `nvflare/recipe/utils.py`
  - Relative paths: validated locally, bundled into server app custom/ directory, basename stored in config
  - Absolute paths: treated as server-side paths, passed through as-is
- **Runtime path resolution**: `PTFileModelPersistor` and NumPy `load_numpy_model()` resolve relative checkpoint paths using `APP_ROOT + custom/` at runtime
- **New BaseFedJob APIs**: `add_file_to()`, `add_file_to_server()`, `add_file_to_clients()` with `app_folder_type` parameter

### Files Changed (30 files, +553/-124)

**Core utilities (2 files)**
- `nvflare/recipe/utils.py` - Added `validate_initial_ckpt()`, `prepare_initial_ckpt()`
- `nvflare/job_config/api.py` - Added `add_file_to`, `add_file_to_server`, `add_file_to_clients` APIs

**Persistors / model loading (2 files)**
- `nvflare/app_opt/pt/file_model_persistor.py` - Relative path resolution via APP_ROOT
- `nvflare/app_common/np/utils.py` - Relative path resolution via APP_ROOT

**Recipe files (17 files)**
- `nvflare/recipe/fedavg.py` - Fixed misleading comment on model source validation
- `nvflare/recipe/cyclic.py` - Updated initial_ckpt docstring
- `nvflare/app_opt/pt/recipes/fedavg.py` - Use validate_initial_ckpt
- `nvflare/app_opt/pt/recipes/fedopt.py` - Use validate_initial_ckpt
- `nvflare/app_opt/pt/recipes/scaffold.py` - Use validate_initial_ckpt
- `nvflare/app_opt/pt/recipes/cyclic.py` - Early validation + docstring update
- `nvflare/app_opt/pt/recipes/fedeval.py` - Fix: use initial_ckpt for PTModel
- `nvflare/app_opt/pt/recipes/fedavg_he.py` - Use validate_initial_ckpt + docstring
- `nvflare/app_opt/pt/recipes/swarm.py` - Refactored for proper relative path bundling
- `nvflare/app_opt/tf/recipes/fedavg.py` - Use validate_initial_ckpt
- `nvflare/app_opt/tf/recipes/cyclic.py` - Early validation + docstring update
- `nvflare/app_opt/tf/job_config/base_fed_job.py` - Use validate_initial_ckpt
- `nvflare/app_common/np/recipes/fedavg.py` - Use validate_initial_ckpt
- `nvflare/app_common/np/recipes/lr/fedavg.py` - Use validate_initial_ckpt + min_clients
- `nvflare/app_common/np/recipes/cross_site_eval.py` - Absolute-only restriction
- `nvflare/edge/tools/edge_fed_buff_recipe.py` - Use validate_initial_ckpt

**Tests (9 files)**
- `tests/unit_test/recipe/utils_test.py` - **NEW**: 13 tests for validate/prepare utilities
- `tests/unit_test/job_config/fed_job_test.py` - 6 new tests for add_file_to_* APIs
- 7 updated recipe test files to match new validation behavior and remove unused FrameworkType imports

### Intentional Design Decisions
1. **NumpyCrossSiteEvalRecipe**: Explicitly restricted to absolute `initial_ckpt` paths only. Relative path support requires a different approach for `NPModelLocator` and is deferred to a future release.
2. **Sklearn recipes** (KMeans, SVM): Do not support `initial_ckpt` as they lack model persistors that accept checkpoint paths.
3. **FedAvgRecipeWithHE**: Passes both `model` and `persistor` to `PTModel` — this is correct because `PTModel` uses the persistor directly when provided, avoiding double registration.
4. **Cyclic PT/TF recipes**: Added explicit `validate_initial_ckpt()` calls in `__init__` because the base class receives `None` for `initial_ckpt`, bypassing its own validation.

## Test Plan
- [x] All 13 `utils_test.py` tests pass (validate_initial_ckpt, prepare_initial_ckpt)
- [x] All 6 `fed_job_test.py` add_file_to_* tests pass
- [x] All recipe unit tests pass (179 passed, 13 skipped)
- [x] No regressions in existing tests
- [x] isort and flake8 checks clean