### PR TITLE
Cherry-pick job_recipe notebook updates from 2.7

### DIFF
--- a/examples/tutorials/job_recipe.ipynb
+++ b/examples/tutorials/job_recipe.ipynb
@@ -79,7 +79,10 @@
     "    name=\"hello-pt\",\n",
     "    min_clients=2,\n",
     "    num_rounds=3,\n",
-    "    initial_model=SimpleNetwork(),\n",
+    "    # Model can be specified as class instance or dict config:\n",
+    "    model=SimpleNetwork(),\n",
+    "    # Alternative: model={\"path\": \"model.SimpleNetwork\", \"args\": {}},\n",
+    "    # For pre-trained weights: initial_ckpt=\"/server/path/to/pretrained.pt\",\n",
     "    train_script=\"client.py\",\n",
     "    train_args=\"--batch_size 32\",\n",
     ")\n",
@@ -88,6 +91,97 @@
     "print(f\"Recipe name: {recipe.name}\")\n",
     "print(f\"Min clients: {recipe.min_clients}\")\n",
     "print(f\"Number of rounds: {recipe.num_rounds}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7b124e7",
+   "metadata": {},
+   "source": [
+    "## Model Input Options\n",
+    "\n",
+    "Recipes accept model input in two formats:\n",
+    "\n",
+    "### Option 1: Class Instance (Recommended for simplicity)\n",
+    "\n",
+    "```python\n",
+    "recipe = FedAvgRecipe(\n",
+    "    model=SimpleNetwork(),  # Instantiated model object\n",
+    "    ...\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "### Option 2: Dictionary Configuration (Recommended for large models)\n",
+    "\n",
+    "```python\n",
+    "recipe = FedAvgRecipe(\n",
+    "    model={\n",
+    "        \"path\": \"model.SimpleNetwork\",\n",
+    "        \"args\": {\"num_classes\": 10}\n",
+    "    },\n",
+    "    ...\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Important:</b> Understanding Model Serialization\n",
+    "\n",
+    "When you pass a class instance (e.g., `SimpleNetwork()`), NVFlare does <b>not</b> ship the Python object directly. Instead, the model is converted to a configuration file before job submission. The actual model is re-instantiated on the server/clients from this configuration.\n",
+    "\n",
+    "This means:\n",
+    "<ul>\n",
+    "<li><b>Large models:</b> Instantiating a large model (e.g., LLM with billions of parameters) just to create a recipe is inefficient. Use the dictionary format to avoid unnecessary instantiation time and memory usage.</li>\n",
+    "<li><b>Non-serializable state:</b> If your model carries state that cannot be reconstructed from JSON configuration (e.g., loaded data, open file handles), that state will be lost.</li>\n",
+    "<li><b>Trade-off:</b> Class instance is more Pythonic and catches errors early; dictionary format is more performant for large models.</li>\n",
+    "</ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b94e258c",
+   "metadata": {},
+   "source": [
+    "## Pre-trained Checkpoint Path\n",
+    "\n",
+    "Use `initial_ckpt` to specify a path to pre-trained model weights:\n",
+    "\n",
+    "```python\n",
+    "recipe = FedAvgRecipe(\n",
+    "    model=SimpleNetwork(),\n",
+    "    initial_ckpt=\"/data/models/pretrained_model.pt\",  # Absolute path\n",
+    "    ...\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Checkpoint Path Requirements:</b>\n",
+    "<ul>\n",
+    "<li><b>Absolute path required:</b> The path must be an absolute path (e.g., `/data/models/model.pt`), not relative.</li>\n",
+    "<li><b>May not exist locally:</b> The checkpoint file does <b>not</b> need to exist on the machine where you create the recipe. It only needs to exist on the <b>server</b> when the model is actually loaded during job execution.</li>\n",
+    "<li><b>PyTorch requires model architecture:</b> For PyTorch, you must provide `model` (class instance or dict config) along with `initial_ckpt`, because PyTorch checkpoints contain only weights, not architecture.</li>\n",
+    "<li><b>TensorFlow/Keras can use checkpoint alone:</b> Keras `.h5` or SavedModel formats contain both architecture and weights, so `initial_ckpt` can be used without `model`.</li>\n",
+    "</ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b9919b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Using dict config and pre-trained checkpoint\n",
+    "recipe_with_ckpt = FedAvgRecipe(\n",
+    "    name=\"hello-pt-pretrained\",\n",
+    "    min_clients=2,\n",
+    "    num_rounds=3,\n",
+    "    model={\"path\": \"model.SimpleNetwork\", \"args\": {}},  # Dict config\n",
+    "    initial_ckpt=\"/server/path/to/pretrained_model.pt\",  # Pre-trained weights (must exist on server)\n",
+    "    train_script=\"client.py\",\n",
+    ")\n",
+    "print(\"Recipe with pre-trained checkpoint created!\")"
    ]
   },
   {
@@ -226,7 +320,11 @@
    "id": "e8336793-fee0-46ff-84de-0456fa7fdab9",
    "metadata": {},
    "source": [
-    "The result are stored under the directory `/tmp/nvflare/poc`."
+    "The result are stored under the directory `/tmp/nvflare/poc`.\n",
+    "\n",
+    "**Note:** The POC environment is always started fresh at the beginning of each `recipe.execute(env)` call, and is automatically stopped when `run.get_result()` returns. This means every job run gets a clean environment.\n",
+    "\n",
+    "If you prefer to keep the POC environment running persistently and avoid the start/stop overhead on each job run, you can start a POC manually (`nvflare poc start -ex admin@nvidia.com`) and then use `ProdEnv` to connect to it, effectively treating the POC as a production environment."
    ]
   },
   {
@@ -307,9 +405,9 @@
      "slide_type": ""
     },
     "tags": [
-         "skip-execution",
-         "skip"
-        ]
+     "skip-execution",
+     "skip"
+    ]
    },
    "outputs": [],
    "source": [
@@ -326,13 +424,16 @@
     "    name=\"hello-pt\",\n",
     "    min_clients=2,\n",
     "    num_rounds=3,\n",
-    "    initial_model=SimpleNetwork(),\n",
+    "    # Model can be specified as class instance or dict config:\n",
+    "    model=SimpleNetwork(),\n",
+    "    # Alternative: model={\"path\": \"model.SimpleNetwork\", \"args\": {}},\n",
     "    train_script=\"client.py\",\n",
     "    train_args=\"--batch_size 32\",\n",
     ")\n",
     "# Create a Prod environment\n",
     "env = ProdEnv(\n",
-    "    startup_kit_location=\"/tmp/nvflare/prod_workspaces/example_project/prod_00/admin@nvidia.com\"\n",
+    "#    startup_kit_location=\"/tmp/nvflare/prod_workspaces/example_project/prod_00/admin@nvidia.com\"\n",
+    "    startup_kit_location=\"/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com\"\n",
     ")\n",
     "# Execute the recipe\n",
     "run = recipe.execute(env=env)\n",
@@ -411,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.12"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Summary
- Cherry-pick of #4147 from 2.7 branch
- Updates `examples/tutorials/job_recipe.ipynb`: `initial_model` → `model` param rename, adds Model Input Options and Pre-trained Checkpoint docs, POC environment note, ProdEnv example fix