### PR TITLE
[2.7] Add retry mechanism for streaming download on TIMEOUT

### DIFF
--- a/nvflare/fuel/f3/streaming/download_service.py
+++ b/nvflare/fuel/f3/streaming/download_service.py
@@ -616,10 +616,13 @@ def download_object(
                         f"(ref={ref_id}, retry {consecutive_timeouts}/{max_retries}). "
                         f"Resending same state to re-request the chunk."
                     )
-                    time.sleep(2.0)
-                    # Check abort signal after sleep to avoid unnecessary retry
+                    # Check abort signal before sleeping to minimise delay
                     if abort_signal and abort_signal.triggered:
-                        consumer.download_failed(ref_id, "download aborted during retry")
+                        consumer.download_failed(ref_id, f"download aborted after {duration} secs")
+                        return
+                    time.sleep(2.0)
+                    if abort_signal and abort_signal.triggered:
+                        consumer.download_failed(ref_id, f"download aborted after {duration} secs")
                         return
                     continue
                 else:


### PR DESCRIPTION
Fixes swarming LLM streaming loss# .

### Description

Add retry mechanism for streaming download on TIMEOUT.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
