### PR TITLE
[2.7] Add end-to-end download starvation test for stream pool fix

### DIFF
--- a/tests/unit_test/fuel/f3/streaming/download_starvation_test.py
+++ b/tests/unit_test/fuel/f3/streaming/download_starvation_test.py
@@ -97,7 +97,8 @@ class ChunkedConsumer(Consumer):
 
 
 def _make_test_data() -> bytes:
-    return bytes(range(256)) * (TOTAL_SIZE // 256)
+    pattern = bytes(range(256))
+    return (pattern * (TOTAL_SIZE // len(pattern) + 1))[:TOTAL_SIZE]
 
 
 def _run_parallel_downloads(
@@ -325,8 +326,9 @@ class TestDownloadPreFixStarvation:
         )
         print(f"\n[PRE-FIX SIM] {succeeded} ok, {failed} failed, {timed_out} timed out / {NUM_PARALLEL}")
 
-        assert succeeded < NUM_PARALLEL, (
-            f"[PRE-FIX SIM] Unexpectedly all {succeeded}/{NUM_PARALLEL} succeeded. "
-            f"The synchronous blob_cb + slow _read_stream should cause deadlock."
+        assert succeeded == 0, (
+            f"[PRE-FIX SIM] Expected 0 succeeded but got {succeeded}/{NUM_PARALLEL} "
+            f"({failed} failed, {timed_out} timed out). "
+            f"The synchronous blob_cb + slow _read_stream should cause complete deadlock."
         )
-        print(f"[PRE-FIX SIM] Confirmed starvation: only {succeeded}/{NUM_PARALLEL} succeeded")
+        print(f"[PRE-FIX SIM] Confirmed starvation: 0/{NUM_PARALLEL} succeeded")


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test that validates the P0 stream thread pool starvation fix introduced in #4171. Unlike the existing unit test (`pool_starvation_test.py`) which uses mocks, this test exercises the **full `download_object()` code path** through real TCP-connected `Cell` objects and blob streaming.

### What the test does

Creates two real `Cell` objects connected via TCP (server + client) and runs **8 concurrent `download_object()` calls**, each producing ~200 chunks (256 bytes each, 50KB total) through the complete flow:

```
download_object()
  -> Cell.send_request()
    -> Cell.__getattr__() routes to _send_request() (stream channel)
      -> _send_one_request()
        -> send_blob() [request]
          -> BlobStreamer -> ByteStreamer -> TxTask._transmit_task (stream_thread_pool)
          -> ByteReceiver._callback_wrapper (stream_thread_pool)
            -> BlobHandler.handle_blob_cb
              -> _read_stream (stream_thread_pool)
              -> _run_blob_cb (callback_thread_pool) <-- THE FIX
                -> Adapter.call()
                  -> future.result() [waits for _read_stream]
                  -> DownloadService._handle_download()
                    -> Downloadable.produce()
                  -> send_blob() [reply]
        -> _process_reply()
          -> Consumer.consume()
```

### Two test variants

| Test class | Behavior | Expected result |
|---|---|---|
| **TestDownloadWithFix** | Uses real production code: blob_cb dispatched to separate callback_thread_pool | All 8/8 downloads succeed |
| **TestDownloadPreFixStarvation** | Patches BlobHandler.handle_blob_cb to call blob_cb **synchronously** on pool worker (pre-fix behavior) + wraps _read_stream with 2s delay (simulating large blob transfer) + uses 4-worker shared pool | 0/8 succeed -- **deadlock confirmed** |

### How the pre-fix starvation is reproduced

The pre-fix test creates cells **after** patching so the registered callbacks capture the patched behavior:

1. `BlobHandler.handle_blob_cb` is monkeypatched to call blob_cb synchronously (instead of submitting to callback_thread_pool)
2. `_read_stream` is wrapped with a 2s `time.sleep()` to simulate the time a real multi-MB model tensor takes to transfer via many transport chunks
3. All streaming modules (blob_streamer, byte_receiver, byte_streamer) use a tiny 4-worker shared pool

**Deadlock mechanism:**
- `ByteReceiver._callback_wrapper` runs on pool worker, calls `handle_blob_cb`
- `handle_blob_cb` submits slow `_read_stream` to pool, then calls blob_cb **synchronously**
- blob_cb (`Adapter.call`) blocks on `future.result()`, waiting for `_read_stream` to complete
- With 4+ concurrent requests, all 4 workers are stuck in blob_cb, `_read_stream` tasks queued but cannot execute -- **permanent deadlock**

### Test results

```
TestDownloadWithFix::test_parallel_downloads_with_fix
  [WITH FIX] 8 ok, 0 failed, 0 timed out / 8    PASSED

TestDownloadPreFixStarvation::test_parallel_downloads_simulating_pre_fix_starvation
  [PRE-FIX SIM] 0 ok, 8 failed, 0 timed out / 8
  [PRE-FIX SIM] Confirmed starvation: only 0/8 succeeded    PASSED
```

## Test plan

- [x] `pytest tests/unit_test/fuel/f3/streaming/download_starvation_test.py -v -s` -- both tests pass
- [x] Test 1 confirms fix works: 8/8 parallel downloads succeed
- [x] Test 2 confirms pre-fix bug: 0/8 succeed due to deadlock
- [x] No changes to production code -- test-only PR
- [ ] CI premerge passes
