### PR TITLE
[2.7] Fix CURRENT_ROUND context in ModelController contribution events

### DIFF
--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -240,7 +240,21 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         if task_round is None and result:
             task_round = result.get_header(AppConstants.CURRENT_ROUND, None)
         if task_round is not None:
-            fl_ctx.set_prop(AppConstants.CURRENT_ROUND, task_round, private=True, sticky=True)
+            detail = fl_ctx.get_prop_detail(AppConstants.CURRENT_ROUND)
+            if detail is not None:
+                fl_ctx.set_prop(
+                    AppConstants.CURRENT_ROUND,
+                    task_round,
+                    private=detail["private"],
+                    sticky=detail["sticky"],
+                )
+            else:
+                fl_ctx.set_prop(
+                    AppConstants.CURRENT_ROUND,
+                    task_round,
+                    private=True,
+                    sticky=False,
+                )
 
         # Check return code and handle errors first
         self.event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT)


### PR DESCRIPTION
## Summary
This PR fixes CURRENT_ROUND context propagation for BaseModelController result callbacks so BEFORE_CONTRIBUTION_ACCEPT handlers (notably IntimeModelSelector) receive the correct round in the callback FLContext.

## Problem
On latest 2.7, recipe-based FedAvg (ModelController path) could log warnings like:

- discarding shareable from <site> for round: X. Current round is: None

This happened because _process_result() fired BEFORE_CONTRIBUTION_ACCEPT before CURRENT_ROUND was populated on the callback fl_ctx.

## Changes
1. In nvflare/app_common/workflows/base_model_controller.py:
   - Populate CURRENT_ROUND in callback fl_ctx before BEFORE_CONTRIBUTION_ACCEPT.
   - Round source priority: task data header first, result header fallback.
2. Align property attributes with existing set_fl_context() semantics:
   - Preserve existing private/sticky attributes when prop already exists.
   - Default to private=True, sticky=False when first setting the prop.
3. Add focused unit tests in tests/unit_test/app_common/workflow/base_model_controller_test.py for:
   - task-header round path
   - result-header fallback path
   - default non-sticky behavior
   - preservation of existing prop attributes

## Validation
- tests/unit_test/app_common/workflow/base_model_controller_test.py -> 4 passed
- tests/unit_test/app_common/workflow/fedavg_test.py -> 48 passed
- Reproduced CIFAR-10 sim (2 clients, 2 rounds) and confirmed warning is gone:
  - no matches for discarding shareable from / Current round is: None
  - model selector now logs validation metrics from clients as expected

## Notes
This is intentionally minimal and scoped to callback context propagation; no aggregation math or task acceptance logic was changed.
