### PR TITLE
[2.7] Skip unsupported metrics for aggregation

### DIFF
--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -41,6 +41,7 @@ def _is_aggregatable_metric_value(v: Any) -> bool:
         return True
     try:
         _ = v * 1.0
+        _ = v + v
         return True
     except (TypeError, ValueError):
         return False


### PR DESCRIPTION
Fixes # .

### Description

Skip non-aggregatable metrics during aggregation. Print a warning in that case, e.g.

```
Metric 'shap_metrics' (dict) skipped for aggregation.
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
