### PR TITLE
[2.7] Fix duplicate subprocess log lines in ExProcessClientAPI

### DIFF
--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -122,7 +122,10 @@ class ExProcessClientAPI(APISpec):
             root_level = dict_config.get("loggers", {}).get("root", {}).get("level", "INFO")
             formatters = dict_config.get("formatters", {})
             if "baseFormatter" not in formatters:
-                formatters = {**formatters, "baseFormatter": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"}}
+                formatters = {
+                    **formatters,
+                    "baseFormatter": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"},
+                }
             stdout_only_config = {
                 "version": 1,
                 "disable_existing_loggers": False,


### PR DESCRIPTION
## Problem

When `NVFLARE_CLIENT_MEMORY_PROFILE=1` (or any subprocess logging) was enabled, every log record appeared **twice** in the site log files:

```
2026-02-24 19:38:00,853 - mem_utils - INFO - [RSS] round=8 after_send: 1268.6 MB
2026-02-24 19:38:00,853 - SubprocessLauncher - INFO - 2026-02-24 19:38:00,853 - mem_utils - INFO - [RSS] round=8 after_send: 1268.6 MB
```

**Root cause:** `_configure_subprocess_logging()` applied the full `log_config.json` to the subprocess, which includes both file handlers (direct writes to `log.txt`, `log.json`, etc.) and a `consoleHandler` writing to `sys.stdout`. `SubprocessLauncher` captures subprocess stdout and re-logs every line through the parent process — which also has file handlers attached — so each log record took two paths to the same log files.

## Fix

- **Strip file handlers** from the subprocess log config before applying it. The single path for subprocess logs becomes: `subprocess logger → consoleHandler → stdout → SubprocessLauncher → parent file handlers → log.txt`.
- **Switch stream handler to `baseFormatter`** (plain text) instead of `consoleFormatter` (`ColorFormatter`). Since subprocess stdout is a pipe rather than a TTY, `ColorFormatter` would embed ANSI escape codes in the log files.

## Test plan

- [ ] Run simulation with `NVFLARE_CLIENT_MEMORY_PROFILE=1` and confirm each `[RSS]` line appears exactly once in `log.txt`
- [ ] Confirm no ANSI color codes appear in `log.txt` for subprocess log lines
- [ ] Confirm normal (non-RSS) subprocess log lines still appear in site log files via `SubprocessLauncher`

🤖 Generated with [Claude Code](https://claude.com/claude-code)