### PR TITLE
[2.7] clean up msg on flare agent

### DIFF
--- a/nvflare/client/flare_agent.py
+++ b/nvflare/client/flare_agent.py
@@ -26,6 +26,7 @@ from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.decomposers import common_decomposers
 from nvflare.fuel.utils.constants import PipeChannelName
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.fuel.utils.msg_root_utils import delete_msg_root
 from nvflare.fuel.utils.pipe.cell_pipe import CellPipe
 from nvflare.fuel.utils.pipe.pipe import Message, Mode, Pipe
 from nvflare.fuel.utils.pipe.pipe_handler import PipeHandler
@@ -341,7 +342,10 @@ class FlareAgent:
     def _do_submit_result(self, current_task: _TaskContext, result, rc):
         result = self.task_result_to_shareable(result, rc)
         reply = Message.new_reply(topic=current_task.task_name, req_msg_id=current_task.msg_id, data=result)
-        return self.pipe_handler.send_to_peer(reply, self.submit_result_timeout)
+        try:
+            return self.pipe_handler.send_to_peer(reply, self.submit_result_timeout)
+        finally:
+            delete_msg_root(reply.msg_id)
 
     def log(self, record: DXO) -> bool:
         """Logs a metric record.


### PR DESCRIPTION
### Fix download transaction leak in FlareAgent result submission

When the external process submits a task result via FlareAgent, the
ViaDownloaderDecomposer creates an ObjectDownloader (download transaction)
on the external process so CJ can pull large tensors. Without explicit
cleanup, these transactions are only released after the internal
ObjectDownloader timeout (60s).

On send retries each CellPipe.send() call triggers a new serialization
and a new ObjectDownloader instance, all holding references to the full
model tensors. For large models this can cause significant memory pressure
or OOM on long-running jobs where transient failures trigger retries.

### Fix: wrap send_to_peer() in try/finally and call delete_msg_root() after
all retries complete (success or failure), releasing the download
transaction immediately rather than waiting for the 60s timeout.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
