### PR TITLE
Fix FedOpt argument definitions (#4235)

### DIFF
--- a/docs/programming_guide/component_configuration.rst
+++ b/docs/programming_guide/component_configuration.rst
@@ -144,7 +144,7 @@ For example:
             "device": "cpu",
             "source_model": "model",
             "optimizer_args": {
-                "path": "torch.optim.SGD",
+                "class_path": "torch.optim.SGD",
                 "args": {
                     "lr": 1.0,
                     "momentum": 0.6
@@ -152,7 +152,7 @@ For example:
                 "config_type": "dict"
             },
             "lr_scheduler_args": {
-                "path": "torch.optim.lr_scheduler.CosineAnnealingLR",
+                "class_path": "torch.optim.lr_scheduler.CosineAnnealingLR",
                 "args": {
                     "T_max": "{num_rounds}",
                     "eta_min": 0.9
@@ -166,7 +166,7 @@ Notice the config:
 .. code-block:: json
 
     "optimizer_args": {
-        "path": "torch.optim.SGD",
+        "class_path": "torch.optim.SGD",
         "args": {
             "lr": 1.0,
             "momentum": 0.6

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -258,7 +258,7 @@ PyTorch FedOpt
         num_rounds=5,
         model=MyModel(),
         train_script="client.py",
-        optimizer_args={"path": "torch.optim.SGD", "args": {"lr": 1.0, "momentum": 0.6}},
+        optimizer_args={"class_path": "torch.optim.SGD", "args": {"lr": 1.0, "momentum": 0.6}},
     )
     env = SimEnv(num_clients=2)
     run = recipe.execute(env)
@@ -281,7 +281,7 @@ TensorFlow FedOpt
         num_rounds=5,
         model=MyTFModel(),
         train_script="client.py",
-        optimizer_args={"path": "tensorflow.keras.optimizers.SGD", "args": {"learning_rate": 1.0}},
+        optimizer_args={"class_path": "tensorflow.keras.optimizers.SGD", "args": {"learning_rate": 1.0}},
     )
     env = SimEnv(num_clients=2)
     run = recipe.execute(env)

--- a/examples/advanced/cifar10/pt/cifar10-sim/cifar10_fedopt/README.md
+++ b/examples/advanced/cifar10/pt/cifar10-sim/cifar10_fedopt/README.md
@@ -86,19 +86,19 @@ python job.py --n_clients 16 --num_rounds 100 --alpha 0.1 --aggregation_epochs 2
 
 ### Server-Side Optimization
 
-FedOpt is configured in `job.py` by specifying the server optimizer:
+FedOpt is configured in `job.py` using `FedOptRecipe` with `optimizer_args` and optional `lr_scheduler_args`:
 
 ```python
-from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.app_opt.pt.recipes.fedopt import FedOptRecipe
 
-recipe = FedAvgRecipe(
+recipe = FedOptRecipe(
     name="cifar10_fedopt",
     # ... other parameters ...
-    server_optimizer="sgd",           # Optimizer type
-    server_optimizer_args={
-        "lr": 1.0,                     # Server learning rate
-        "momentum": 0.9                # Momentum coefficient
-    }
+    optimizer_args={"class_path": "torch.optim.SGD", "args": {"lr": 1.0, "momentum": 0.6}},
+    lr_scheduler_args={
+        "class_path": "torch.optim.lr_scheduler.CosineAnnealingLR",
+        "args": {"T_max": num_rounds, "eta_min": 0.9},
+    },
 )
 ```
 
@@ -172,13 +172,12 @@ To try different server optimizers, modify `job.py`:
 
 ```python
 # Try Adam instead of SGD
-recipe = FedAvgRecipe(
+recipe = FedOptRecipe(
     # ... other parameters ...
-    server_optimizer="adam",
-    server_optimizer_args={
-        "lr": 0.01,
-        "betas": (0.9, 0.999)
-    }
+    optimizer_args={
+        "class_path": "torch.optim.Adam",
+        "args": {"lr": 0.01, "betas": (0.9, 0.999)},
+    },
 )
 ```
 
@@ -186,5 +185,5 @@ recipe = FedAvgRecipe(
 
 - [FedOpt Paper](https://arxiv.org/abs/2003.00295) - Reddi et al., 2020
 - [NVFlare Documentation](https://nvflare.readthedocs.io/)
-- [NVFlare FedAvgRecipe](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_opt.pt.recipes.fedavg.html)
+- [NVFlare FedOptRecipe](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_opt.pt.recipes.fedopt.html)
 

--- a/examples/advanced/cifar10/pt/cifar10-sim/cifar10_fedopt/job.py
+++ b/examples/advanced/cifar10/pt/cifar10-sim/cifar10_fedopt/job.py
@@ -80,11 +80,10 @@ def main():
         model=ModerateCNN(),
         train_script=os.path.join(os.path.dirname(__file__), "client.py"),
         train_args=f"--train_idx_root {train_idx_root} --num_workers {num_workers} --lr {lr} --batch_size {batch_size} --aggregation_epochs {aggregation_epochs}",
-        optimizer_args={"path": "torch.optim.SGD", "args": {"lr": 1.0, "momentum": 0.6}, "config_type": "dict"},
+        optimizer_args={"class_path": "torch.optim.SGD", "args": {"lr": 1.0, "momentum": 0.6}},
         lr_scheduler_args={
-            "path": "torch.optim.lr_scheduler.CosineAnnealingLR",
+            "class_path": "torch.optim.lr_scheduler.CosineAnnealingLR",
             "args": {"T_max": num_rounds, "eta_min": 0.9},
-            "config_type": "dict",
         },
     )
     add_experiment_tracking(recipe, tracking_type="tensorboard")

--- a/examples/advanced/cifar10/pt/src/data/cifar10_data_utils.py
+++ b/examples/advanced/cifar10/pt/src/data/cifar10_data_utils.py
@@ -38,6 +38,7 @@
 # SOFTWARE.
 
 import os
+import warnings
 
 import numpy as np
 import torch
@@ -46,12 +47,17 @@ import torchvision.datasets as datasets
 from data.cifar10_dataset import CIFAR10_Idx
 from torchvision import transforms
 
+# NumPy 2.4 deprecation when torchvision unpickles CIFAR batch files (align= in dtype)
+warnings.filterwarnings("ignore", message=".*align.*")
+
 CIFAR10_ROOT = "/tmp/cifar10"  # will be used for all CIFAR-10 experiments
 
 
 def load_cifar10_data():
-    # load data
-    train_dataset = datasets.CIFAR10(root=CIFAR10_ROOT, train=True, download=True)
+    # load data (suppress NumPy 2.4 dtype align deprecation from CIFAR pickle files)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*align.*")
+        train_dataset = datasets.CIFAR10(root=CIFAR10_ROOT, train=True, download=True)
 
     # only training label is needed for doing split
     train_label = np.array(train_dataset.targets)
@@ -105,20 +111,22 @@ def create_datasets(site_name, train_idx_root, central=False):
     else:
         site_idx = None  # use whole training dataset if central=True
 
-    train_dataset = CIFAR10_Idx(
-        root=CIFAR10_ROOT,
-        data_idx=site_idx,
-        train=True,
-        download=False,
-        transform=transform_train,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*align.*")
+        train_dataset = CIFAR10_Idx(
+            root=CIFAR10_ROOT,
+            data_idx=site_idx,
+            train=True,
+            download=False,
+            transform=transform_train,
+        )
 
-    valid_dataset = torchvision.datasets.CIFAR10(
-        root=CIFAR10_ROOT,
-        train=False,
-        download=False,
-        transform=transform_valid,
-    )
+        valid_dataset = torchvision.datasets.CIFAR10(
+            root=CIFAR10_ROOT,
+            train=False,
+            download=False,
+            transform=transform_valid,
+        )
 
     return train_dataset, valid_dataset
 

--- a/examples/advanced/cifar10/tf/cifar10_fedopt/job.py
+++ b/examples/advanced/cifar10/tf/cifar10_fedopt/job.py
@@ -58,23 +58,21 @@ def main():
 
     # Configure FedOpt optimizer arguments
     optimizer_args = {
-        "path": "tensorflow.keras.optimizers.SGD",
+        "class_path": "tensorflow.keras.optimizers.SGD",
         "args": {
             "learning_rate": args.server_lr,
             "momentum": args.server_momentum,
         },
-        "config_type": "dict",
     }
 
     # Configure FedOpt learning rate scheduler arguments
     lr_scheduler_args = {
-        "path": "tensorflow.keras.optimizers.schedules.CosineDecay",
+        "class_path": "tensorflow.keras.optimizers.schedules.CosineDecay",
         "args": {
             "initial_learning_rate": args.server_lr,
             "decay_steps": args.num_rounds,
             "alpha": args.server_lr_decay_alpha,
         },
-        "config_type": "dict",
     }
 
     # Create FedOpt recipe

--- a/examples/advanced/cifar10/tf/requirements.txt
+++ b/examples/advanced/cifar10/tf/requirements.txt
@@ -1,3 +1,3 @@
-nvflare~=2.7.2
+nvflare~=2.7.2rc
 tensorflow[and-cuda]
 filelock>=3.12.0

--- a/nvflare/app_opt/pt/fedopt.py
+++ b/nvflare/app_opt/pt/fedopt.py
@@ -45,9 +45,9 @@ class PTFedOptModelShareableGenerator(FullModelShareableGenerator):
 
         Args:
             optimizer_args: dictionary of optimizer arguments, e.g.
-                {'path': 'torch.optim.SGD', 'args': {'lr': 1.0}} (default).
+                {'class_path': 'torch.optim.SGD', 'args': {'lr': 1.0}} (default). 'path' is also accepted.
             lr_scheduler_args: dictionary of server-side learning rate scheduler arguments, e.g.
-                {'path': 'torch.optim.lr_scheduler.CosineAnnealingLR', 'args': {'T_max': 100}} (default: None).
+                {'class_path': 'torch.optim.lr_scheduler.CosineAnnealingLR', 'args': {'T_max': 100}} (default: None). 'path' is also accepted.
             source_model: either a valid torch model object or a component ID of a torch model object
             device: specify the device to run server-side optimization, e.g. "cpu" or "cuda:0"
                 (will default to cuda if available and no device is specified).
@@ -62,13 +62,13 @@ class PTFedOptModelShareableGenerator(FullModelShareableGenerator):
 
         if not isinstance(optimizer_args, dict):
             raise TypeError(
-                "optimizer_args must be a dict of format, e.g. {'path': 'torch.optim.SGD', 'args': {'lr': 1.0}}."
+                "optimizer_args must be a dict of format, e.g. {'class_path': 'torch.optim.SGD', 'args': {'lr': 1.0}}."
             )
         if lr_scheduler_args is not None:
             if not isinstance(lr_scheduler_args, dict):
                 raise TypeError(
-                    "optimizer_args must be a dict of format, e.g. "
-                    "{'path': 'torch.optim.lr_scheduler.CosineAnnealingLR', 'args': {'T_max': 100}}."
+                    "lr_scheduler_args must be a dict of format, e.g. "
+                    "{'class_path': 'torch.optim.lr_scheduler.CosineAnnealingLR', 'args': {'T_max': 100}}."
                 )
         self.source_model = source_model
         self.optimizer_args = optimizer_args
@@ -82,7 +82,7 @@ class PTFedOptModelShareableGenerator(FullModelShareableGenerator):
 
     def _get_component_name(self, component_args):
         if component_args is not None:
-            name = component_args.get("path", None)
+            name = component_args.get("path") or component_args.get("class_path")
             if name is None:
                 name = component_args.get("name", None)
             return name

--- a/nvflare/app_opt/pt/fedopt_ctl.py
+++ b/nvflare/app_opt/pt/fedopt_ctl.py
@@ -28,11 +28,11 @@ class FedOpt(FedAvg):
         *args,
         source_model: Union[str, torch.nn.Module],
         optimizer_args: dict = {
-            "path": "torch.optim.SGD",
+            "class_path": "torch.optim.SGD",
             "args": {"lr": 1.0, "momentum": 0.6},
         },
         lr_scheduler_args: dict = {
-            "path": "torch.optim.lr_scheduler.CosineAnnealingLR",
+            "class_path": "torch.optim.lr_scheduler.CosineAnnealingLR",
             "args": {"T_max": 3, "eta_min": 0.9},
         },
         device=None,

--- a/nvflare/app_opt/tf/recipes/fedopt.py
+++ b/nvflare/app_opt/tf/recipes/fedopt.py
@@ -81,10 +81,10 @@ class FedOptRecipe(Recipe):
         params_transfer_type: How to transfer the parameters between server and client.
             FULL means the whole model parameters are sent. DIFF means that only the difference is sent.
             Defaults to TransferType.FULL.
-        optimizer_args: Dictionary of server-side optimizer arguments with keys 'path' and 'args'.
+        optimizer_args: Dictionary of server-side optimizer arguments with keys 'class_path' (or 'path') and 'args'.
             Defaults to SGD with learning_rate=1.0 and momentum=0.6.
         lr_scheduler_args: Dictionary of server-side learning rate scheduler arguments with keys
-            'path' and 'args'. Defaults to CosineDecay with initial_learning_rate=1.0 and alpha=0.9.
+            'class_path' (or 'path') and 'args'. Defaults to CosineDecay with initial_learning_rate=1.0 and alpha=0.9.
         server_memory_gc_rounds: Run memory cleanup (gc.collect + malloc_trim) every N rounds on server.
             Set to 0 to disable. Defaults to 0.
 
@@ -154,7 +154,7 @@ class FedOptRecipe(Recipe):
         self.initial_ckpt = v.initial_ckpt
 
         # Validate inputs using shared utilities
-        from nvflare.recipe.utils import recipe_model_to_job_model, validate_ckpt
+        from nvflare.recipe.utils import ensure_config_type_dict, recipe_model_to_job_model, validate_ckpt
 
         validate_ckpt(self.initial_ckpt)
         if isinstance(self.model, dict):
@@ -168,8 +168,8 @@ class FedOptRecipe(Recipe):
         self.command = v.command
         self.server_expected_format: ExchangeFormat = v.server_expected_format
         self.params_transfer_type: TransferType = v.params_transfer_type
-        self.optimizer_args = v.optimizer_args
-        self.lr_scheduler_args = v.lr_scheduler_args
+        self.optimizer_args = ensure_config_type_dict(v.optimizer_args)
+        self.lr_scheduler_args = ensure_config_type_dict(v.lr_scheduler_args)
         self.server_memory_gc_rounds = v.server_memory_gc_rounds
 
         # Create BaseFedJob


### PR DESCRIPTION
Fixes # .

### Description

## FedOpt: default config_type for optimizer/scheduler, support class_path

Cherry-pick #4235

### Why
FedOptRecipe failed at config load when `optimizer_args` / `lr_scheduler_args` omitted `config_type`: the component builder tried to instantiate the optimizer (e.g. `torch.optim.SGD`) before the model existed, so `params` were missing. Users had to remember to set `config_type: "dict"`. Optimizer/scheduler configs also didn't support `class_path`, unlike model_config.

### What
- **Recipe utils:** Added `ensure_config_type_dict()` — sets `config_type: "dict"` when missing and, if only `class_path` is set, copies it to `path` so the config layer keeps working.
- **FedOptRecipe (PT & TF):** Run optimizer_args and lr_scheduler_args through `ensure_config_type_dict()` so `config_type` is no longer required; accept both `path` and `class_path`.
- **PT shareable generator:** Resolve display name from `path` or `class_path`.
- **Examples/docs:** Use `class_path` for optimizer/scheduler; remove explicit `config_type` from FedOpt examples; fix cifar10_fedopt README to use FedOptRecipe and the correct API.
- **Tests:** Cover both `path` and `class_path` for PT and TF; skip PT tests when PyTorch is missing and TF tests when TensorFlow is missing or fails to load, so either venv can run the suite without failures.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [x] Documentation updated.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
