### PR TITLE
[2.7] Check full Apache license header and normalize inconsistent headers

### DIFF
--- a/ci/check_license_header.py
+++ b/ci/check_license_header.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+from pathlib import Path
+
+DEFAULT_FOLDERS = ("nvflare", "examples", "tests", "integration", "research")
+PUBLIC_DOMAIN_MARKER = "This file is released into the public domain."
+EXCLUDED_FILE_NAMES = {"modeling_roberta.py"}
+
+LICENSE_HEADER_PATTERN = re.compile(
+    r"\A"
+    r"(?:#!.*\n)?"
+    r"(?:#.*coding[:=].*\n)?"
+    r"(?:\n)*"
+    r"# Copyright \(c\) \d{4}(?:-\d{4})?, NVIDIA CORPORATION\.  All rights reserved\.\n"
+    r"#\n"
+    r"# Licensed under the Apache License, Version 2\.0 \(the \"License\"\);\n"
+    r"# you may not use this file except in compliance with the License\.\n"
+    r"# You may obtain a copy of the License at\n"
+    r"#\n"
+    r"#     http://www\.apache\.org/licenses/LICENSE-2\.0\n"
+    r"#\n"
+    r"# Unless required by applicable law or agreed to in writing, software\n"
+    r"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+    r"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n"
+    r"# See the License for the specific language governing permissions and\n"
+    r"# limitations under the License\.\n"
+)
+
+
+def iter_python_files(folders: list[str]) -> list[Path]:
+    files = []
+    for folder in folders:
+        root = Path(folder)
+        if not root.exists():
+            continue
+
+        for file_path in root.rglob("*.py"):
+            if any("protos" in part for part in file_path.parts):
+                continue
+            if file_path.name in EXCLUDED_FILE_NAMES:
+                continue
+            files.append(file_path)
+    return sorted(files)
+
+
+def has_valid_license_header(file_text: str) -> bool:
+    if PUBLIC_DOMAIN_MARKER in file_text[:512]:
+        return True
+    return bool(LICENSE_HEADER_PATTERN.match(file_text))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate canonical license headers for Python files.")
+    parser.add_argument("folders", nargs="*", default=list(DEFAULT_FOLDERS), help="Folders to recursively scan.")
+    args = parser.parse_args()
+
+    files_with_bad_headers = []
+    for file_path in iter_python_files(args.folders):
+        file_text = file_path.read_text(encoding="utf-8", errors="ignore")
+        if not has_valid_license_header(file_text):
+            files_with_bad_headers.append(file_path)
+
+    if files_with_bad_headers:
+        for file_path in files_with_bad_headers:
+            print(file_path)
+        print("License text not found or inconsistent on the above files.")
+        print("Please fix them.")
+        return 1
+
+    print(f"All Python files in folder {' '.join(args.folders)} have consistent license headers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/advanced/bionemo/downstream/model.py
+++ b/examples/advanced/bionemo/downstream/model.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS FOR ANY KIND, either express or implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ESM2 server module: loads checkpoint state_dict for NVFlare FedAvg (no Megatron/Lightning init)."""

--- a/nvflare/app_opt/tf/scaffold.py
+++ b/nvflare/app_opt/tf/scaffold.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/runtest.sh
+++ b/runtest.sh
@@ -89,22 +89,11 @@ function dry_run() {
 }
 
 function check_license() {
-    folders_to_check_license="nvflare examples tests integration research"
-    echo "checking license header in folder: $folders_to_check_license"
-    (grep -r --include "*.py" --exclude-dir "*protos*" --exclude "modeling_roberta.py" -L \
-    "\(# Copyright (c) \(2021\|2022\|2023\|2024\|2025\|2026\), NVIDIA CORPORATION.  All rights reserved.\)\|\(This file is released into the public domain.\)" \
-    ${folders_to_check_license} || true) > no_license.lst
-    if [ -s no_license.lst ]; then
-        # The file is not-empty.
-        cat no_license.lst
-        echo "License text not found on the above files."
-        echo "Please fix them."
-        rm -f no_license.lst
-        exit 1
-    else
-        echo "All Python files in folder ${folders_to_check_license} have license header"
-        rm -f no_license.lst
-    fi
+    folders_to_check_license=("nvflare" "examples" "tests" "integration" "research")
+    echo "checking license header in folder: ${folders_to_check_license[*]}"
+    status=0
+    python3 ci/check_license_header.py "${folders_to_check_license[@]}" || status="$?"
+    report_status "${status}"
     echo "finished checking license header"
 }
 

--- a/tests/integration_test/data/jobs/big_model_4g/app/custom/train.py
+++ b/tests/integration_test/data/jobs/big_model_4g/app/custom/train.py
@@ -1,4 +1,17 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import random
 import re

--- a/tests/integration_test/data/jobs/pt_client_api_basic/app/custom/poc_executor.py
+++ b/tests/integration_test/data/jobs/pt_client_api_basic/app/custom/poc_executor.py
@@ -1,4 +1,17 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import random
 import re

--- a/tests/integration_test/data/jobs/pt_lightning/app/custom/pl_net.py
+++ b/tests/integration_test/data/jobs/pt_lightning/app/custom/pl_net.py
@@ -1,4 +1,17 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import random
 import re
 import time

--- a/tests/integration_test/data/jobs/pt_lightning/app/custom/poc_executor.py
+++ b/tests/integration_test/data/jobs/pt_lightning/app/custom/poc_executor.py
@@ -1,4 +1,16 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import pl_net
 import pytorch_lightning as L


### PR DESCRIPTION
Fixes # .

### Description

Cherry-pick https://github.com/NVIDIA/NVFlare/pull/4241

## Summary
- replace the line-based license grep in runtest.sh with ci/check_license_header.py to validate the full Apache 2.0 header (year-flexible)
- keep the intended exception for public-domain files and keep existing exclusions for protos and modeling_roberta.py
- normalize inconsistent license headers in affected files (missing full block and minor text typos)

## Testing
- python3 ci/check_license_header.py nvflare examples tests integration research

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
