### PR TITLE
[2.7]: Sign the root folders of startup kits

### DIFF
--- a/nvflare/lighter/impl/signature.py
+++ b/nvflare/lighter/impl/signature.py
@@ -30,7 +30,5 @@ class SignatureBuilder(Builder):
             raise RuntimeError(f"missing {CtxKey.ROOT_PRI_KEY} in ProvisionContext")
 
         for p in project.get_all_participants():
-            dest_dir = ctx.get_kit_dir(p)
-            sign_folders(dest_dir, root_pri_key, signature_file=ProvFileName.SIGNATURE_JSON)
-            dest_dir = ctx.get_local_dir(p)
+            dest_dir = ctx.get_ws_dir(p)
             sign_folders(dest_dir, root_pri_key, signature_file=ProvFileName.SIGNATURE_JSON)


### PR DESCRIPTION
Two folders, startup and local, of any startup kit were signed at provisioning time.  At the verification stage, nvflare checks the startup folder.  In CC environment, one more verification was done before nvflare started.  However, the verification checks from the root folder of a startup kit.  Therefore, there is a gap as the root folder and transfer folder are not signed.  This PR changed the signing process to apply to the root and all sub folders.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
