### PR TITLE
[2.7] Add FOBS security section to decomposer_for_large_object.rst [skip ci]

### DIFF
--- a/docs/programming_guide/decomposer_for_large_object.rst
+++ b/docs/programming_guide/decomposer_for_large_object.rst
@@ -194,14 +194,14 @@ When the serialized data specifies a decomposer by name, FOBS checks whether it 
 Type Whitelist
 --------------
 
-Independently of the decomposer check, FOBS also enforces a type-name whitelist. For any type not already cached in the internal decomposer registry, the fully-qualified type name must appear in the whitelist before the class is loaded. This applies to all types — not just those handled by generic decomposers.
+Independently of the decomposer check, FOBS also enforces a type-name whitelist. The whitelist is consulted only when a type is *not* already in the internal decomposer registry (``_decomposers``). If the type is already registered (e.g., via ``fobs.register()``), the whitelist check is bypassed entirely.
 
-The whitelist is pre-populated with all builtin FLARE types (defined in ``BUILTIN_TYPES``). Types are also added automatically when registered via:
+The whitelist is relevant for types handled by generic builtin decomposers (``EnumTypeDecomposer``, ``DataClassDecomposer``) that have not been pre-registered via ``register_data_classes()`` or ``register_enum_types()``. The whitelist is pre-populated with all builtin FLARE types (defined in ``BUILTIN_TYPES``). Application types are added automatically when registered via:
 
 - ``fobs.register_data_classes(*classes)``
 - ``fobs.register_enum_types(*classes)``
 
-For application-specific types that use a custom non-builtin decomposer, the type must also be whitelisted explicitly:
+For application types that need lazy loading through a generic builtin decomposer without calling the above registration functions, types can be added to the whitelist explicitly:
 
 .. code-block:: python
 
@@ -209,7 +209,7 @@ For application-specific types that use a custom non-builtin decomposer, the typ
 
    fobs.add_type_name_whitelist("mypackage.mymodule.MyClass")
 
-If the type is not whitelisted, FOBS raises::
+If the type is not in the whitelist, FOBS raises::
 
    ValueError: Type '<name>' is not allowed. Use fobs.register_data_classes(),
    fobs.register_enum_types(), or fobs.add_type_name_whitelist() to allow this type.

--- a/docs/programming_guide/decomposer_for_large_object.rst
+++ b/docs/programming_guide/decomposer_for_large_object.rst
@@ -173,8 +173,38 @@ If you need to send an object type that can potentially be very large, you shoul
          """
          pass
 
-All you need to do is to provide the four methods required by this base class. The methods are self-explanatory. The only thing is that the DOT values are in the range of 1 to 127 and must be globally unique. If your decomposer is part of Flare’s core, it should register its DOT values in ``nvflare.fuel.utils.fobs.dots.py``; otherwise, make sure its DOT values do not conflict with values defined there. Currently, only 4 DOT values are defined:
+All you need to do is to provide the four methods required by this base class. The methods are self-explanatory. The only thing is that the DOT values are in the range of 1 to 127 and must be globally unique. If your decomposer is part of Flare's core, it should register its DOT values in ``nvflare.fuel.utils.fobs.dots.py``; otherwise, make sure its DOT values do not conflict with values defined there. Currently, only 4 DOT values are defined:
 - NUMPY_BYTES = 1
 - NUMPY_FILE = 2
 - TENSOR_BYTES = 3
 - TENSOR_FILE = 4
+
+FOBS Security
+=============
+
+FOBS enforces two security rules during deserialization to prevent arbitrary class loading and remote code execution (RCE).
+
+Only Registered Decomposers Are Allowed
+----------------------------------------
+
+When FOBS deserializes an object, the decomposer embedded in the serialized data must have been explicitly registered. If an unrecognized decomposer is encountered, FOBS raises a ``ValueError`` and refuses to proceed. This ensures that only trusted, pre-registered decomposers can participate in deserialization.
+
+Type Whitelist for Generic Decomposers
+---------------------------------------
+
+Some decomposers are *generic* — they handle multiple types (e.g., ``EnumTypeDecomposer``, ``DataClassDecomposer``). Because these decomposers can reconstruct arbitrary classes by name, an additional type-name whitelist is enforced. A type must appear in the whitelist before FOBS will load it during deserialization.
+
+Types are automatically added to the whitelist when registered via:
+
+- ``fobs.register_data_classes(*classes)``
+- ``fobs.register_enum_types(*classes)``
+
+For other cases, types can be added explicitly:
+
+.. code-block:: python
+
+   import nvflare.fuel.utils.fobs as fobs
+
+   fobs.add_type_name_whitelist("mypackage.mymodule.MyClass")
+
+If a type is not in the whitelist and its decomposer has not been pre-registered, FOBS raises a ``ValueError`` with a message indicating which call to use to allow the type.

--- a/docs/programming_guide/decomposer_for_large_object.rst
+++ b/docs/programming_guide/decomposer_for_large_object.rst
@@ -182,24 +182,26 @@ All you need to do is to provide the four methods required by this base class. T
 FOBS Security
 =============
 
-FOBS enforces two security rules during deserialization to prevent arbitrary class loading and remote code execution (RCE).
+FOBS enforces two independent security checks during deserialization to prevent arbitrary class loading and remote code execution (RCE).
 
-Only Registered Decomposers Are Allowed
-----------------------------------------
+Non-Builtin Decomposers Must Be Registered
+-------------------------------------------
 
-When FOBS deserializes an object, the decomposer embedded in the serialized data must have been explicitly registered. If an unrecognized decomposer is encountered, FOBS raises a ``ValueError`` and refuses to proceed. This ensures that only trusted, pre-registered decomposers can participate in deserialization.
+When the serialized data specifies a decomposer by name, FOBS checks whether it is a builtin decomposer (i.e., listed in ``BUILTIN_DECOMPOSERS``). Builtin decomposers — such as ``NumpyArrayDecomposer``, ``DXODecomposer``, ``EnumTypeDecomposer``, ``DataClassDecomposer``, and others shipped with FLARE — are always trusted without explicit registration. Any decomposer *not* in ``BUILTIN_DECOMPOSERS`` must be explicitly registered before deserialization, otherwise FOBS raises::
 
-Type Whitelist for Generic Decomposers
----------------------------------------
+   ValueError: Decomposer <name> must be registered
 
-Some decomposers are *generic* — they handle multiple types (e.g., ``EnumTypeDecomposer``, ``DataClassDecomposer``). Because these decomposers can reconstruct arbitrary classes by name, an additional type-name whitelist is enforced. A type must appear in the whitelist before FOBS will load it during deserialization.
+Type Whitelist
+--------------
 
-Types are automatically added to the whitelist when registered via:
+Independently of the decomposer check, FOBS also enforces a type-name whitelist. For any type not already cached in the internal decomposer registry, the fully-qualified type name must appear in the whitelist before the class is loaded. This applies to all types — not just those handled by generic decomposers.
+
+The whitelist is pre-populated with all builtin FLARE types (defined in ``BUILTIN_TYPES``). Types are also added automatically when registered via:
 
 - ``fobs.register_data_classes(*classes)``
 - ``fobs.register_enum_types(*classes)``
 
-For other cases, types can be added explicitly:
+For application-specific types that use a custom non-builtin decomposer, the type must also be whitelisted explicitly:
 
 .. code-block:: python
 
@@ -207,4 +209,7 @@ For other cases, types can be added explicitly:
 
    fobs.add_type_name_whitelist("mypackage.mymodule.MyClass")
 
-If a type is not in the whitelist and its decomposer has not been pre-registered, FOBS raises a ``ValueError`` with a message indicating which call to use to allow the type.
+If the type is not whitelisted, FOBS raises::
+
+   ValueError: Type '<name>' is not allowed. Use fobs.register_data_classes(),
+   fobs.register_enum_types(), or fobs.add_type_name_whitelist() to allow this type.


### PR DESCRIPTION
## Summary

- Documents that only registered decomposers are allowed during FOBS deserialization
- Documents the type-name whitelist requirement for generic decomposers (e.g., `EnumTypeDecomposer`, `DataClassDecomposer`)
- Shows how to use `fobs.add_type_name_whitelist()` to explicitly allow types

## Test plan

- [ ] Verify RST renders correctly in the docs build (`./build_doc.sh --html --skip-api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)