### PR TITLE
Add phase 1 study plumbing

### DIFF
--- a/docs/design/multistudy_phase1.md
+++ b/docs/design/multistudy_phase1.md
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-Flare currently operates as a single-tenant system. All jobs share a flat store (`jobs/<uuid>/`), and every authorized admin can see and act on every job. There is no data segregation between different collaborations running on the same infrastructure.
+Flare currently operates as a single-tenant system. Every authorized admin can see and act on every job. There is no data segregation between different collaborations running on the same infrastructure.
 
 Phase 1 introduces a **study** concept as lightweight metadata plumbing. Every job carries a `study` name (defaulting to `"default"`). The study flows from user-facing APIs into job metadata and runtime launchers so that K8s deployments can mount study-specific workspace volumes immediately — without any access-control, provisioning, or job-store changes.
 

--- a/docs/design/multistudy_phase1.md
+++ b/docs/design/multistudy_phase1.md
@@ -1,0 +1,116 @@
+# Multi-Study Support — Phase 1: Study Plumbing
+
+## Revision History
+
+| Version | Notes |
+|---------|-------|
+| 1 | Initial version |
+| 2 | Incorporate feedback and Mayo discussion |
+| 3 | Rename `project` → `study`; split Phase 1 / Phase 2 docs |
+
+## Introduction
+
+Flare currently operates as a single-tenant system. All jobs share a flat store (`jobs/<uuid>/`), and every authorized admin can see and act on every job. There is no data segregation between different collaborations running on the same infrastructure.
+
+Phase 1 introduces a **study** concept as lightweight metadata plumbing. Every job carries a `study` name (defaulting to `"default"`). The study flows from user-facing APIs into job metadata and runtime launchers so that K8s deployments can mount study-specific workspace volumes immediately — without any access-control, provisioning, or job-store changes.
+
+See [multistudy_phase2.md](multistudy_phase2.md) for the full multi-tenancy design (access control, study registry, job-store partitioning, etc.).
+
+### Design Principles
+
+1. **Backward compatible** — a `default` study preserves current single-tenant behavior; legacy jobs missing a `study` field are treated as `default` on read
+2. **Phased rollout** — Phase 1 delivers plumbing only; access-control enforcement is deferred to Phase 2
+3. **Minimal footprint** — no authorization, no provisioning, no job-store layout changes
+
+---
+
+## Scope
+
+1. `study: str = "default"` parameter on `ProdEnv`, `Session`, `new_session`, `new_secure_session`, `new_insecure_session`.
+2. `Session` carries the active study context; `list_jobs` inherits it and returns only jobs in that study.
+3. Study is passed through to job metadata at submission time, with syntax validation before persistence.
+4. Clone preserves the source job's study (not the session's study).
+5. `K8sJobLauncher` reads `study` from job metadata and selects the corresponding study workspace volume (TODO in code).
+6. `DockerJobLauncher` unchanged; TODO marker for future study-aware settings resolution.
+7. Admin console (`fl_admin.sh`) accepts `--study` at launch time; the study applies to `submit_job` and `list_jobs` commands.
+8. No changes to authorization, job store paths, `project.yml` schema, scheduler, or provisioning.
+
+---
+
+## User Experience
+
+### Data Scientist (Recipe API)
+
+The recipe is unchanged. The study is specified via `ProdEnv`:
+
+```python
+env = ProdEnv(
+    startup_kit_location=args.startup_kit_location,
+    study="cancer-research",
+)
+run = recipe.execute(env)
+```
+
+If `study` is omitted, it defaults to `"default"`.
+
+### Admin (FLARE API)
+
+The `Session` gains a study context:
+
+```python
+sess = new_secure_session(
+    username="admin@org_a.com",
+    startup_kit_location="./startup",
+    study="cancer-research",
+)
+jobs = sess.list_jobs()        # only jobs in cancer-research
+sess.submit_job("./my_job")   # tagged to cancer-research
+```
+
+The study is session-scoped, not a per-command filter.
+
+### Admin Console
+
+```
+$ ./startup/fl_admin.sh --study cancer-research
+
+> list_jobs
+... only shows jobs in cancer-research ...
+```
+
+If `--study` is omitted, the admin terminal uses `default`.
+
+---
+
+## Data Model
+
+### Job Metadata
+
+`study` is a first-class field on every job (`JobMetaKey.STUDY`). Set at submission time from the session's active study. Immutable after creation.
+
+The study value is syntactically validated at the API layer (client-side) and again on the server before persistence. The regex pattern is `^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$` — lowercase alphanumeric with hyphens, 1–63 characters.
+
+### Legacy Jobs
+
+Jobs created before Phase 1 have no `study` field. `get_job_meta_study()` returns `"default"` for these jobs, so they appear in the `default` study transparently.
+
+### Default Study Constant
+
+`DEFAULT_JOB_STUDY = "default"` in `nvflare.apis.job_def` — single source of truth for the default value.
+
+---
+
+## What This Enables
+
+- Data scientists tag jobs with a study and get physical data isolation on K8s immediately (once K8s launcher TODO is implemented).
+- Admin/API sessions operate inside one active study context, so Phase 2 authz can validate study access when sessions enter a study.
+- Legacy single-tenant deployments are unaffected — everything defaults to `"default"`.
+
+## What This Does NOT Do
+
+- No access control — any user can submit to any valid study name
+- No job store partitioning (`jobs/<uuid>/` path unchanged)
+- No `project.yml` parsing or `StudyRegistry`
+- No Docker launcher behavior change yet
+- No `set_study` / `list_studies` admin commands
+- Subprocess launcher unchanged (single-tenant/trusted only)

--- a/docs/design/multistudy_phase1.md
+++ b/docs/design/multistudy_phase1.md
@@ -32,7 +32,7 @@ See [multistudy_phase2.md](multistudy_phase2.md) for the full multi-tenancy desi
 4. Clone preserves the source job's study (not the session's study).
 5. `K8sJobLauncher` reads `study` from job metadata and selects the corresponding study workspace volume (TODO in code).
 6. `DockerJobLauncher` unchanged; TODO marker for future study-aware settings resolution.
-7. Admin console (`fl_admin.sh`) accepts `--study` at launch time; the study applies to `submit_job` and `list_jobs` commands.
+7. Admin console (`fl_admin.sh`) accepts `--study` at launch time; the study is established when the admin session logs in and then inherited by `submit_job` and `list_jobs`.
 8. No changes to authorization, job store paths, `project.yml` schema, scheduler, or provisioning.
 
 ---
@@ -67,7 +67,7 @@ jobs = sess.list_jobs()        # only jobs in cancer-research
 sess.submit_job("./my_job")   # tagged to cancer-research
 ```
 
-The study is session-scoped, not a per-command filter.
+The study is session-scoped, not a per-command filter. For HCI/admin sessions, the study is sent during login, stored in the authenticated server session, and preserved in the session token so later commands inherit the same active study.
 
 ### Admin Console
 
@@ -90,13 +90,17 @@ If `--study` is omitted, the admin terminal uses `default`.
 
 The study value is syntactically validated at the API layer (client-side) and again on the server before persistence. The regex pattern is `^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$` — lowercase alphanumeric with hyphens, 1–63 characters.
 
+### Session Transport
+
+For `flare_api.Session` and the admin terminal, `study` is not passed on each command. It is established at session creation/login time, stored on the server-side authenticated session, and carried in the signed session token so recreated sessions keep the same active study.
+
 ### Legacy Jobs
 
 Jobs created before Phase 1 have no `study` field. `get_job_meta_study()` returns `"default"` for these jobs, so they appear in the `default` study transparently.
 
 ### Default Study Constant
 
-`DEFAULT_JOB_STUDY = "default"` in `nvflare.apis.job_def` — single source of truth for the default value.
+`DEFAULT_STUDY = "default"` in `nvflare.apis.job_def` — single source of truth for the default value.
 
 ---
 

--- a/docs/design/multistudy_phase1.md
+++ b/docs/design/multistudy_phase1.md
@@ -16,6 +16,11 @@ Phase 1 introduces a **study** concept as lightweight metadata plumbing. Every j
 
 See [multistudy_phase2.md](multistudy_phase2.md) for the full multi-tenancy design (access control, study registry, job-store partitioning, etc.).
 
+> **Note:** Multi-study is an operational enhancement for shared-trust environments.
+> It does not provide the same isolation guarantees as separate deployments.
+> See [When to Use Multi-Study vs. Separate Deployments](multistudy_phase2.md#when-to-use-multi-study-vs-separate-deployments)
+> in [multistudy_phase2.md](multistudy_phase2.md).
+
 ### Design Principles
 
 1. **Backward compatible** — a `default` study preserves current single-tenant behavior; legacy jobs missing a `study` field are treated as `default` on read

--- a/docs/design/multistudy_phase1.md
+++ b/docs/design/multistudy_phase1.md
@@ -1,13 +1,5 @@
 # Multi-Study Support — Phase 1: Study Plumbing
 
-## Revision History
-
-| Version | Notes |
-|---------|-------|
-| 1 | Initial version |
-| 2 | Incorporate feedback and Mayo discussion |
-| 3 | Rename `project` → `study`; split Phase 1 / Phase 2 docs |
-
 ## Introduction
 
 Flare currently operates as a single-tenant system. Every authorized admin can see and act on every job. There is no data segregation between different collaborations running on the same infrastructure.

--- a/docs/design/multistudy_phase2.md
+++ b/docs/design/multistudy_phase2.md
@@ -1,0 +1,208 @@
+# Multi-Study Support — Phase 2: Per-Study Access Control
+
+## Revision History
+
+| Version | Notes |
+|---------|-------|
+| 1 | Initial version |
+| 2 | Incorporate feedback and Mayo discussion |
+| 3 | Rename `project` → `study`; split Phase 1 / Phase 2 docs |
+| 4 | Simplify: reuse existing roles, no new role types, minimal changes |
+
+## Prerequisites
+
+Phase 1 ([multistudy_phase1.md](multistudy_phase1.md)) must be complete: `study` metadata flows from user-facing APIs through to job metadata and launcher plumbing.
+
+## Introduction
+
+Phase 2 adds per-study access control on top of Phase 1's plumbing. The existing role model (`project_admin`, `org_admin`, `lead`, `member`) is unchanged — the only difference is that roles become per-study instead of global. No new roles are introduced.
+
+---
+
+## Core Idea
+
+Today, a user's role is global (baked into the X.509 cert). Phase 2 makes the same role **per-study**: a user can be `lead` in one study and `member` in another.
+
+The existing authorization rules (`authorization.json`) stay exactly as they are. The only new layer is a **study filter**: before evaluating existing RBAC, the server checks whether the resource belongs to the user's active study. If not, the resource is invisible.
+
+---
+
+## How Authorization Works Today
+
+### `authorization.json`
+
+Each deployment ships an `authorization.json` that maps roles to permissions. The default policy:
+
+```json
+{
+  "format_version": "1.0",
+  "permissions": {
+    "project_admin": "any",
+    "org_admin": {
+      "submit_job": "none",
+      "clone_job": "none",
+      "manage_job": "o:submitter",
+      "download_job": "o:submitter",
+      "view": "any",
+      "operate": "o:site",
+      "shell_commands": "o:site",
+      "byoc": "none"
+    },
+    "lead": {
+      "submit_job": "any",
+      "clone_job": "n:submitter",
+      "manage_job": "n:submitter",
+      "download_job": "n:submitter",
+      "view": "any",
+      "operate": "o:site",
+      "shell_commands": "o:site",
+      "byoc": "any"
+    },
+    "member": {
+      "view": "any"
+    }
+  }
+}
+```
+
+Permission conditions: `"any"` = unrestricted, `"none"` = denied, `"n:submitter"` = only if user is the submitter, `"o:submitter"` = only if user is in the same org as the submitter, `"o:site"` = only if user is in the same org as the target site.
+
+### Authorization Flow
+
+1. A `Person(name, org, role)` is constructed from the user's X.509 cert
+2. An `AuthzContext(right, user, submitter)` wraps the request
+3. The `Authorizer` evaluates the policy: look up `permissions[person.role][right]` and check the condition against the context
+
+**Phase 2 changes only step 1**: the `role` used to construct `Person` can come from the per-study mapping instead of the cert. Steps 2 and 3 are untouched. `authorization.json` is unchanged.
+
+---
+
+## Role Resolution
+
+No new roles. The existing four roles are reused:
+
+| Role | Capabilities (per `authorization.json`, unchanged) |
+|------|-----|
+| `project_admin` | All operations (`"any"`) |
+| `org_admin` | Manage/download own-org jobs, view all, operate own-org sites |
+| `lead` | Submit/manage/download own jobs, view all, operate own-org sites |
+| `member` | View only |
+
+**Resolution order:**
+1. If `project.yml` has a `studies:` section AND the user has a mapping for the active study → use that role
+2. Else if active study is `default` → fall back to cert-embedded role (legacy compatibility)
+3. Otherwise → deny
+
+### What the participant `role` means
+
+The `role` field on admin participants in `project.yml` serves two purposes:
+- It is baked into the X.509 cert at provisioning time (identity + authentication)
+- It is the **effective role for the `default` study** and for deployments without a `studies:` section
+
+When a `studies:` section is present, the per-study role overrides the cert role for that study. The cert role still applies to the `default` study as a fallback.
+
+Example: a user with `role: lead` in their participant entry and `member` in the `cancer-research` study mapping is `lead` when operating in the `default` study but `member` when operating in `cancer-research`.
+
+---
+
+## Provisioning: `project.yml`
+
+Minimal addition: a `studies:` section that maps study names to enrolled sites and per-user role overrides. Everything else stays as-is.
+
+```yaml
+# Existing sections unchanged
+participants:
+  - name: server1.example.com
+    type: server
+    org: nvidia
+  - name: hospital-a
+    type: client
+    org: org_a
+  - name: hospital-b
+    type: client
+    org: org_b
+  - name: admin@nvidia.com
+    type: admin
+    org: nvidia
+    role: project_admin    # cert role; effective role for "default" study
+  - name: trainer@org_a.com
+    type: admin
+    org: org_a
+    role: lead             # cert role; effective role for "default" study
+
+# New section — per-study role overrides
+studies:
+  cancer-research:
+    sites: [hospital-a, hospital-b]
+    admins:
+      trainer@org_a.com: lead        # same as cert role here, but explicit
+
+  multiple-sclerosis:
+    sites: [hospital-a]
+    admins:
+      trainer@org_a.com: member      # overrides cert role for this study
+```
+
+- If `studies:` is absent, the system behaves exactly as today (single-tenant, cert roles only).
+- Sites listed under a study must reference existing client-type participants.
+- Admins listed under a study must reference existing admin-type participants.
+- A user not listed under a study has no access to that study (except `default`, which falls back to cert role).
+
+---
+
+## Authorization Enforcement
+
+Two layers, evaluated in order for every command:
+
+1. **Study filter** (new): Does the target resource (job, client) belong to the user's active study? If no → invisible.
+2. **RBAC policy** (existing, unchanged): Construct `Person` with the resolved per-study role, evaluate `authorization.json` as today.
+
+The session's active study (set at session start via `--study` or the `study` API parameter) determines which study filter applies.
+
+---
+
+## Job Scheduler
+
+When a `studies:` section is present in `project.yml`:
+
+1. **Site filtering**: Only schedule jobs to sites enrolled in the job's study
+2. **Validation**: `deploy_map` sites must be a subset of the study's enrolled sites
+
+No quota or priority changes.
+
+---
+
+## Runtime Isolation
+
+### Kubernetes
+
+The K8s launcher reads `study` from job metadata and resolves study-specific workspace volumes:
+- Workspace volume resolved by `(study, client)` tuple
+- Each job pod mounts only its study's data volume
+
+### Docker
+
+The Docker launcher reads `study` from job metadata and mounts the corresponding host directory (e.g., `/data/<study>/`) as the workspace volume.
+
+---
+
+## Migration / Backward Compatibility
+
+1. **No `studies:` section** → system behaves as today, single-tenant, cert roles only.
+2. **`studies:` section present** → per-study role enforcement enabled; the `default` study falls back to cert roles for compatibility.
+3. **Legacy jobs** (no `study` field) → treated as `default` study (Phase 1 behavior, unchanged).
+4. **No data migration** — job store layout is unchanged (`jobs/<uuid>/`).
+
+---
+
+## Design Decisions
+
+| # | Question | Decision |
+|---|----------|----------|
+| D1 | Can clients participate in multiple studies? | **Yes.** Listed under multiple studies in `project.yml`. Data isolation via launcher (K8s PVs / Docker mounts). |
+| D2 | New roles needed? | **No.** Existing `project_admin` / `org_admin` / `lead` / `member` reused per-study. |
+| D3 | Study lifecycle management? | **Deferred.** Studies defined at provisioning time in `project.yml`. |
+| D4 | Per-study quotas? | **Deferred.** Rely on K8s-level resource controls. |
+| D5 | How do launchers know which volume to mount? | Job metadata carries the study; the launcher resolves the volume from that. |
+| D6 | What does the participant `role` mean when `studies:` exists? | It is baked into the cert and serves as the effective role for the `default` study. Per-study mappings override it for non-default studies. |
+

--- a/docs/design/multistudy_phase2.md
+++ b/docs/design/multistudy_phase2.md
@@ -157,7 +157,7 @@ Two layers, evaluated in order for every command:
 1. **Study filter** (new): Does the target resource (job, client) belong to the user's active study? If no → invisible.
 2. **RBAC policy** (existing, unchanged): Construct `Person` with the resolved per-study role, evaluate `authorization.json` as today.
 
-The session's active study (set at session start via `--study` or the `study` API parameter) determines which study filter applies.
+The session's active study (set at session start via `--study` or the `study` API parameter) determines which study filter applies. The study is carried by the authenticated server session and preserved in the session token, so subsequent commands do not need to resend it.
 
 ---
 
@@ -205,4 +205,3 @@ The Docker launcher reads `study` from job metadata and mounts the corresponding
 | D4 | Per-study quotas? | **Deferred.** Rely on K8s-level resource controls. |
 | D5 | How do launchers know which volume to mount? | Job metadata carries the study; the launcher resolves the volume from that. |
 | D6 | What does the participant `role` mean when `studies:` exists? | It is baked into the cert and serves as the effective role for the `default` study. Per-study mappings override it for non-default studies. |
-

--- a/docs/design/multistudy_phase2.md
+++ b/docs/design/multistudy_phase2.md
@@ -1,14 +1,5 @@
 # Multi-Study Support — Phase 2: Per-Study Access Control
 
-## Revision History
-
-| Version | Notes |
-|---------|-------|
-| 1 | Initial version |
-| 2 | Incorporate feedback and Mayo discussion |
-| 3 | Rename `project` → `study`; split Phase 1 / Phase 2 docs |
-| 4 | Simplify: reuse existing roles, no new role types, minimal changes |
-
 ## Prerequisites
 
 Phase 1 ([multistudy_phase1.md](multistudy_phase1.md)) must be complete: `study` metadata flows from user-facing APIs through to job metadata and launcher plumbing.

--- a/docs/design/multistudy_phase2.md
+++ b/docs/design/multistudy_phase2.md
@@ -186,6 +186,42 @@ The Docker launcher reads `study` from job metadata and mounts the corresponding
 
 ---
 
+## When to Use Multi-Study vs. Separate Deployments
+
+Multi-study is an operational convenience feature for shared-trust environments. If you need stronger isolation, use separate deployments on separate hardware or VMs.
+
+### Use multi-study when
+
+- One or more client sites participate in multiple studies and re-provisioning them for each study is operationally costly
+- All studies operate within the same operational trust boundary
+- You accept software-enforced isolation: study separation relies on correct authorization logic, session management, and launcher volume configuration
+
+### Use separate deployments when
+
+- You need stronger isolation than a shared multi-study deployment can provide
+- A problem in one study must not be able to affect another study
+- Studies have non-overlapping participants (no shared client sites), so separate deployments add little operational cost
+
+### Security Assumptions That Change
+
+With a single multi-study deployment, the following are shared across all studies:
+
+| Resource | Separate deployments | Multi-study |
+|----------|----------------------|-------------|
+| Server runtime | Separate per deployment | Shared |
+| Client runtime at each site | Separate per deployment | Shared |
+| PKI / cert root | Independent | Shared |
+| `project_admin` blast radius | One deployment | All studies in that deployment |
+| Isolation mechanism | Separate hardware/VM deployment boundary | Shared software authz and launcher configuration |
+
+A bug in authorization, session handling, or launcher volume configuration can affect multiple studies in the same deployment.
+
+### Summary
+
+Use multi-study to reduce operational overhead when client sites participate in multiple studies under a shared trust boundary. Use separate deployments when you need stronger isolation.
+
+---
+
 ## Migration / Backward Compatibility
 
 1. **No `studies:` section** → system behaves as today, single-tenant, cert roles only.

--- a/docs/user_guide/admin_guide/deployment/operation.rst
+++ b/docs/user_guide/admin_guide/deployment/operation.rst
@@ -13,6 +13,9 @@ Admin command prompt
 After running ``fl_admin.sh``, log in by following the prompt and entering the name of the participant that the admin
 package was provisioned for (or for poc mode, "admin" as the name and password).
 
+To scope the terminal to a study, launch it with ``fl_admin.sh --study cancer-research``. If ``--study`` is omitted,
+the admin terminal uses the ``default`` study for that terminal session.
+
 Typing "help" or "?" will display a list of the commands and a brief description for each. Typing "? " before a command
 like "? check_status" or "?ls" will provide additional details for the usage of a command. Provided below is a list of
 commands shown as examples of how they may be run with a description.

--- a/nvflare/apis/job_def.py
+++ b/nvflare/apis/job_def.py
@@ -21,6 +21,7 @@ from nvflare.apis.fl_context import FLContext
 # this is treated as all online sites in job deploy_map
 ALL_SITES = "@ALL"
 SERVER_SITE_NAME = "server"
+DEFAULT_JOB_STUDY = "default"
 
 
 class RunStatus(str, Enum):
@@ -76,6 +77,7 @@ class JobMetaKey(str, Enum):
     CUSTOM_PROPS = "custom_props"
     EDGE_METHOD = "edge_method"
     JOB_CLIENTS = "job_clients"  # clients that participated the job
+    STUDY = "study"
 
     def __repr__(self):
         return self.value
@@ -212,6 +214,15 @@ def is_valid_job_id(jid: str) -> bool:
     # If the jid string is a valid hex code, but an invalid uuid4,the UUID.__init__ will convert it to a
     # valid uuid4. This is bad for validation purposes.
     return val.hex == jid.replace("-", "")
+
+
+def get_job_meta_study(meta: dict) -> str:
+    if not isinstance(meta, dict):
+        return DEFAULT_JOB_STUDY
+    study = meta.get(JobMetaKey.STUDY.value)
+    if isinstance(study, str) and study:
+        return study
+    return DEFAULT_JOB_STUDY
 
 
 def get_custom_prop(meta: dict, prop_key: str, default=None):

--- a/nvflare/apis/job_def.py
+++ b/nvflare/apis/job_def.py
@@ -21,7 +21,7 @@ from nvflare.apis.fl_context import FLContext
 # this is treated as all online sites in job deploy_map
 ALL_SITES = "@ALL"
 SERVER_SITE_NAME = "server"
-DEFAULT_JOB_STUDY = "default"
+DEFAULT_STUDY = "default"
 
 
 class RunStatus(str, Enum):
@@ -218,11 +218,11 @@ def is_valid_job_id(jid: str) -> bool:
 
 def get_job_meta_study(meta: dict) -> str:
     if not isinstance(meta, dict):
-        return DEFAULT_JOB_STUDY
+        return DEFAULT_STUDY
     study = meta.get(JobMetaKey.STUDY.value)
     if isinstance(study, str) and study:
         return study
-    return DEFAULT_JOB_STUDY
+    return DEFAULT_STUDY
 
 
 def get_custom_prop(meta: dict, prop_key: str, default=None):

--- a/nvflare/apis/utils/format_check.py
+++ b/nvflare/apis/utils/format_check.py
@@ -28,6 +28,7 @@ type_pattern_mapping = {
     "email": r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}$",
     "org": r"^[A-Za-z0-9_]+$",
     "simple_name": r"^[A-Za-z0-9_]+$",
+    "study": r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$",
 }
 
 

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -117,6 +117,9 @@ class DockerJobLauncher(JobLauncherSpec):
         command = f' /bin/bash -c "export PYTHONPATH={python_path};{cmd}"'
         self.logger.info(f"Launch image:{job_image}, run command: {command}")
 
+        # TODO: Keep Docker launch behavior unchanged for now. The final Docker
+        # implementation should add study-aware workspace/network resolution in
+        # one place, similar to the planned K8s settings lookup.
         docker_workspace = os.environ.get("NVFL_DOCKER_WORKSPACE")
         self.logger.info(f"launch_job {job_id} in docker_workspace: {docker_workspace}")
         docker_client = docker.from_env()

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -228,6 +228,13 @@ class K8sJobLauncher(JobLauncherSpec):
             raise RuntimeError(f"missing {FLContextKey.JOB_PROCESS_ARGS} in FLContext")
 
         _, job_cmd = job_args[JobProcessArgs.EXE_MODULE]
+        # TODO: Make the K8s launcher study-aware with minimal code churn.
+        # The intended change is only to read the optional job_meta["study"]
+        # and use it to resolve study-specific Kubernetes settings before pod
+        # launch. That settings lookup may include workspace volume/path plus
+        # any other K8s deployment settings required for the selected study.
+        # Keep the existing launch flow unchanged; only the settings resolution
+        # should become study-aware.
         job_config = {
             "name": job_id,
             "image": job_image,

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -209,6 +209,9 @@ class Session(SessionSpec):
         if not isinstance(job_id, str):
             raise JobNotFound(f"invalid job_id {job_id}")
 
+    def _get_active_study(self) -> str:
+        return getattr(self, "_study", DEFAULT_JOB_STUDY)
+
     def clone_job(self, job_id: str) -> str:
         """Create a new job by cloning a specified job.
 
@@ -258,7 +261,8 @@ class Session(SessionSpec):
                 "Use only letters, numbers, dots, underscores, and hyphens, with no spaces."
             )
         result = self._do_command(
-            AdminCommandNames.SUBMIT_JOB + " " + job_definition_path, props={JobMetaKey.STUDY.value: self._study}
+            AdminCommandNames.SUBMIT_JOB + " " + job_definition_path,
+            props={JobMetaKey.STUDY.value: self._get_active_study()},
         )
         meta = result[ResultKey.META]
         job_id = meta.get(MetaKey.JOB_ID, None)
@@ -333,7 +337,7 @@ class Session(SessionSpec):
                 raise InvalidArgumentError("id_prefix must be str but got {}.".format(type(id_prefix)))
             else:
                 command = command + " " + id_prefix
-        result = self._do_command(command, props={JobMetaKey.STUDY.value: self._study})
+        result = self._do_command(command, props={JobMetaKey.STUDY.value: self._get_active_study()})
         meta = result[ResultKey.META]
         jobs_list = meta.get(MetaKey.JOBS, [])
         return jobs_list

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -18,7 +18,7 @@ import time
 from typing import List, Optional
 
 from nvflare.apis.fl_constant import AdminCommandNames
-from nvflare.apis.job_def import JobMetaKey
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY, JobMetaKey
 from nvflare.apis.utils.format_check import name_check
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
@@ -70,6 +70,7 @@ class Session(SessionSpec):
         startup_path: str,
         secure_mode: bool = True,
         debug: bool = False,
+        study: str = DEFAULT_JOB_STUDY,
     ):
         """Initializes a session with the NVFLARE system.
 
@@ -78,9 +79,12 @@ class Session(SessionSpec):
             startup_path (str): path to the provisioned startup kit, which contains endpoint of the system
             secure_mode (bool): whether to log in with secure mode
             debug (bool): turn on debug or not
+            study (str): active study context for submitted jobs and session-scoped job listing; defaults to
+                "default"
         """
         assert isinstance(username, str), "username must be str"
         assert isinstance(startup_path, str), "startup_path must be str"
+        assert isinstance(study, str), "study must be str"
         assert os.path.isdir(startup_path), f"startup kit does not exist at {startup_path}"
 
         workspace = Workspace(root_dir=startup_path)
@@ -106,6 +110,11 @@ class Session(SessionSpec):
         )
         self.upload_dir = upload_dir
         self.download_dir = download_dir
+        self._study = study
+        if name_check(self._study, "study")[0]:
+            raise ValueError(
+                f"study name '{self._study}' contains unsupported characters. Use only lowercase letters, numbers, and hyphens."
+            )
 
     def close(self):
         """Close the session."""
@@ -248,7 +257,9 @@ class Session(SessionSpec):
                 f"job folder name '{job_folder_name}' contains unsupported characters. "
                 "Use only letters, numbers, dots, underscores, and hyphens, with no spaces."
             )
-        result = self._do_command(AdminCommandNames.SUBMIT_JOB + " " + job_definition_path)
+        result = self._do_command(
+            AdminCommandNames.SUBMIT_JOB + " " + job_definition_path, props={JobMetaKey.STUDY.value: self._study}
+        )
         meta = result[ResultKey.META]
         job_id = meta.get(MetaKey.JOB_ID, None)
         if not job_id:
@@ -322,7 +333,7 @@ class Session(SessionSpec):
                 raise InvalidArgumentError("id_prefix must be str but got {}.".format(type(id_prefix)))
             else:
                 command = command + " " + id_prefix
-        result = self._do_command(command)
+        result = self._do_command(command, props={JobMetaKey.STUDY.value: self._study})
         meta = result[ResultKey.META]
         jobs_list = meta.get(MetaKey.JOBS, [])
         return jobs_list
@@ -942,13 +953,26 @@ def new_session(
     secure_mode: bool = True,
     debug: bool = False,
     timeout: float = 10.0,
+    study: str = DEFAULT_JOB_STUDY,
 ) -> Session:
-    session = Session(username=username, startup_path=startup_kit_location, debug=debug, secure_mode=secure_mode)
+    session = Session(
+        username=username,
+        startup_path=startup_kit_location,
+        debug=debug,
+        secure_mode=secure_mode,
+        study=study,
+    )
     session.try_connect(timeout)
     return session
 
 
-def new_secure_session(username: str, startup_kit_location: str, debug: bool = False, timeout: float = 10.0) -> Session:
+def new_secure_session(
+    username: str,
+    startup_kit_location: str,
+    debug: bool = False,
+    timeout: float = 10.0,
+    study: str = DEFAULT_JOB_STUDY,
+) -> Session:
     """Create a new secure FLARE API session with the NVFLARE system.
 
     Args:
@@ -956,20 +980,27 @@ def new_secure_session(username: str, startup_kit_location: str, debug: bool = F
         startup_kit_location (str): path to the provisioned startup folder, the root admin dir containing the startup folder
         debug (bool): enable debug mode
         timeout (float): how long to try to establish the session, in seconds
+        study (str): active study context for submitted jobs and session-scoped job listing; defaults to "default"
 
     Returns: a Session object
 
     """
-    return new_session(username, startup_kit_location, True, debug, timeout)
+    return new_session(username, startup_kit_location, True, debug, timeout, study=study)
 
 
-def new_insecure_session(startup_kit_location: str, debug: bool = False, timeout: float = 10.0) -> Session:
+def new_insecure_session(
+    startup_kit_location: str,
+    debug: bool = False,
+    timeout: float = 10.0,
+    study: str = DEFAULT_JOB_STUDY,
+) -> Session:
     """Create a new insecure FLARE API session with the NVFLARE system.
 
     Args:
         startup_kit_location (str): path to the provisioned startup folder
         debug (bool): enable debug mode
         timeout (float): how long to try to establish the session, in seconds
+        study (str): active study context for submitted jobs and session-scoped job listing; defaults to "default"
 
     Returns: a Session object
 
@@ -977,5 +1008,10 @@ def new_insecure_session(startup_kit_location: str, debug: bool = False, timeout
 
     """
     return new_session(
-        username="", startup_kit_location=startup_kit_location, secure_mode=False, debug=debug, timeout=timeout
+        username="",
+        startup_kit_location=startup_kit_location,
+        secure_mode=False,
+        debug=debug,
+        timeout=timeout,
+        study=study,
     )

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -18,7 +18,7 @@ import time
 from typing import List, Optional
 
 from nvflare.apis.fl_constant import AdminCommandNames
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY, JobMetaKey
+from nvflare.apis.job_def import DEFAULT_STUDY, JobMetaKey
 from nvflare.apis.utils.format_check import name_check
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
@@ -70,7 +70,7 @@ class Session(SessionSpec):
         startup_path: str,
         secure_mode: bool = True,
         debug: bool = False,
-        study: str = DEFAULT_JOB_STUDY,
+        study: str = DEFAULT_STUDY,
     ):
         """Initializes a session with the NVFLARE system.
 
@@ -107,6 +107,7 @@ class Session(SessionSpec):
             user_name=username,
             debug=debug,
             event_handlers=conf.handlers,
+            study=study,
         )
         self.upload_dir = upload_dir
         self.download_dir = download_dir
@@ -209,9 +210,6 @@ class Session(SessionSpec):
         if not isinstance(job_id, str):
             raise JobNotFound(f"invalid job_id {job_id}")
 
-    def _get_active_study(self) -> str:
-        return getattr(self, "_study", DEFAULT_JOB_STUDY)
-
     def clone_job(self, job_id: str) -> str:
         """Create a new job by cloning a specified job.
 
@@ -260,10 +258,7 @@ class Session(SessionSpec):
                 f"job folder name '{job_folder_name}' contains unsupported characters. "
                 "Use only letters, numbers, dots, underscores, and hyphens, with no spaces."
             )
-        result = self._do_command(
-            AdminCommandNames.SUBMIT_JOB + " " + job_definition_path,
-            props={JobMetaKey.STUDY.value: self._get_active_study()},
-        )
+        result = self._do_command(AdminCommandNames.SUBMIT_JOB + " " + job_definition_path)
         meta = result[ResultKey.META]
         job_id = meta.get(MetaKey.JOB_ID, None)
         if not job_id:
@@ -337,7 +332,7 @@ class Session(SessionSpec):
                 raise InvalidArgumentError("id_prefix must be str but got {}.".format(type(id_prefix)))
             else:
                 command = command + " " + id_prefix
-        result = self._do_command(command, props={JobMetaKey.STUDY.value: self._get_active_study()})
+        result = self._do_command(command)
         meta = result[ResultKey.META]
         jobs_list = meta.get(MetaKey.JOBS, [])
         return jobs_list
@@ -957,7 +952,7 @@ def new_session(
     secure_mode: bool = True,
     debug: bool = False,
     timeout: float = 10.0,
-    study: str = DEFAULT_JOB_STUDY,
+    study: str = DEFAULT_STUDY,
 ) -> Session:
     session = Session(
         username=username,
@@ -975,7 +970,7 @@ def new_secure_session(
     startup_kit_location: str,
     debug: bool = False,
     timeout: float = 10.0,
-    study: str = DEFAULT_JOB_STUDY,
+    study: str = DEFAULT_STUDY,
 ) -> Session:
     """Create a new secure FLARE API session with the NVFLARE system.
 
@@ -996,7 +991,7 @@ def new_insecure_session(
     startup_kit_location: str,
     debug: bool = False,
     timeout: float = 10.0,
-    study: str = DEFAULT_JOB_STUDY,
+    study: str = DEFAULT_STUDY,
 ) -> Session:
     """Create a new insecure FLARE API session with the NVFLARE system.
 

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -827,8 +827,10 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         ctx.set_command_entry(ent)
         return ctx
 
-    def _do_client_command(self, command, args, ent: CommandEntry):
+    def _do_client_command(self, command, args, ent: CommandEntry, props=None):
         ctx = self._new_command_context(command, args, ent)
+        if props:
+            ctx.set_command_props(props)
         return_result = ent.handler(args, ctx)
         result = ctx.get_command_result()
         if return_result:
@@ -881,7 +883,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
 
         ent = entries[0]
         if cmd_type == _CMD_TYPE_CLIENT:
-            return self._do_client_command(command=command, args=args, ent=ent)
+            return self._do_client_command(command=command, args=args, ent=ent, props=props)
 
         # server command
         if not self.server_sess_active:

--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -26,6 +26,7 @@ from typing import List, Optional
 import nvflare.fuel.f3.streaming.file_downloader as downloader
 from nvflare.apis.fl_constant import ConnectionSecurity, FLContextKey, ProcessType, ReservedKey, ReturnCode
 from nvflare.apis.fl_context import FLContext, FLContextManager
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.apis.streaming import ConsumerFactory, ObjectProducer, StreamableEngine, StreamContext
@@ -237,6 +238,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         debug: bool = False,
         auto_login_max_tries: int = 15,
         event_handlers=None,
+        study: str = DEFAULT_STUDY,
     ):
         """API to keep certs, keys and connection information and to execute admin commands through do_command.
 
@@ -291,6 +293,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         self.file_download_progress_timeout = admin_config.get(AdminConfigKey.FILE_DOWNLOAD_PROGRESS_TIMEOUT, 5.0)
         self.authenticate_msg_timeout = admin_config.get(AdminConfigKey.AUTHENTICATE_MSG_TIMEOUT, 5.0)
         self.user_name = user_name
+        self.study = study
         self.event_handlers = event_handlers
 
         if not self.ca_cert:
@@ -662,6 +665,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
             "user_name": self.user_name,
             "cert": id_asserter.cert_data,
             "signature": cn_signature,
+            "study": self.study,
         }
 
         self.login_result = None

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -23,6 +23,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+from nvflare.apis.fl_constant import AdminCommandNames
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY, JobMetaKey
+
 try:
     import readline
 except ImportError:
@@ -61,6 +64,13 @@ class _BuiltInCmdModule(CommandModule):
         )
 
 
+# Only commands whose behavior is defined by the active session study inherit it
+# from the admin terminal. submit_job writes the job's study, and list_jobs scopes
+# visibility by the session study. clone_job intentionally does not use the
+# session study because it preserves the source job's study.
+_SESSION_STUDY_COMMANDS = frozenset({AdminCommandNames.SUBMIT_JOB, AdminCommandNames.LIST_JOBS})
+
+
 class AdminClient(cmd.Cmd, EventHandler):
     """Admin command prompt for submitting admin commands to the server through the CLI.
 
@@ -79,11 +89,13 @@ class AdminClient(cmd.Cmd, EventHandler):
         handlers=None,
         cli_history_dir: str = str(Path.home() / ".nvflare"),
         cli_history_size: int = 1000,
+        study: str = DEFAULT_JOB_STUDY,
     ):
         super().__init__()
         self.intro = "Type help or ? to list commands.\n"
         self.prompt = admin_config.get(AdminConfigKey.PROMPT, "> ")
         self.user_name = username
+        self._study = study
         self.debug = debug
         self.out_file = None
         self.no_stdout = False
@@ -360,6 +372,8 @@ class AdminClient(cmd.Cmd, EventHandler):
 
         # execute the command!
         start = time.time()
+        if cmd_name in _SESSION_STUDY_COMMANDS:
+            props = {JobMetaKey.STUDY.value: self._study}
         resp = self.api.do_command(line, props=props)
         secs = time.time() - start
         usecs = int(secs * 1000000)

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -373,7 +373,8 @@ class AdminClient(cmd.Cmd, EventHandler):
         # execute the command!
         start = time.time()
         if cmd_name in _SESSION_STUDY_COMMANDS:
-            props = {JobMetaKey.STUDY.value: self._study}
+            props = dict(props) if isinstance(props, dict) else {}
+            props[JobMetaKey.STUDY.value] = self._study
         resp = self.api.do_command(line, props=props)
         secs = time.time() - start
         usecs = int(secs * 1000000)

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -23,8 +23,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from nvflare.apis.fl_constant import AdminCommandNames
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY, JobMetaKey
+from nvflare.apis.job_def import DEFAULT_STUDY
 
 try:
     import readline
@@ -64,13 +63,6 @@ class _BuiltInCmdModule(CommandModule):
         )
 
 
-# Only commands whose behavior is defined by the active session study inherit it
-# from the admin terminal. submit_job writes the job's study, and list_jobs scopes
-# visibility by the session study. clone_job intentionally does not use the
-# session study because it preserves the source job's study.
-_SESSION_STUDY_COMMANDS = frozenset({AdminCommandNames.SUBMIT_JOB, AdminCommandNames.LIST_JOBS})
-
-
 class AdminClient(cmd.Cmd, EventHandler):
     """Admin command prompt for submitting admin commands to the server through the CLI.
 
@@ -89,7 +81,7 @@ class AdminClient(cmd.Cmd, EventHandler):
         handlers=None,
         cli_history_dir: str = str(Path.home() / ".nvflare"),
         cli_history_size: int = 1000,
-        study: str = DEFAULT_JOB_STUDY,
+        study: str = DEFAULT_STUDY,
     ):
         super().__init__()
         self.intro = "Type help or ? to list commands.\n"
@@ -130,6 +122,7 @@ class AdminClient(cmd.Cmd, EventHandler):
             user_name=self.user_name,
             debug=self.debug,
             event_handlers=event_handlers,
+            study=study,
         )
 
         if not os.path.isdir(cli_history_dir):
@@ -372,9 +365,6 @@ class AdminClient(cmd.Cmd, EventHandler):
 
         # execute the command!
         start = time.time()
-        if cmd_name in _SESSION_STUDY_COMMANDS:
-            props = dict(props) if isinstance(props, dict) else {}
-            props[JobMetaKey.STUDY.value] = self._study
         resp = self.api.do_command(line, props=props)
         secs = time.time() - start
         usecs = int(secs * 1000000)

--- a/nvflare/fuel/hci/server/constants.py
+++ b/nvflare/fuel/hci/server/constants.py
@@ -24,6 +24,7 @@ class ConnProps(object):
     USER_NAME = "_userName"
     USER_ORG = "_userOrg"
     USER_ROLE = "_userRole"
+    ACTIVE_STUDY = "_activeStudy"
     SUBMITTER_NAME = "_submitterName"
     SUBMITTER_ORG = "_submitterOrg"
     SUBMITTER_ROLE = "_submitterRole"

--- a/nvflare/fuel/hci/server/login.py
+++ b/nvflare/fuel/hci/server/login.py
@@ -14,6 +14,8 @@
 import traceback
 from typing import List
 
+from nvflare.apis.job_def import DEFAULT_STUDY
+from nvflare.apis.utils.format_check import name_check
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.hci.conn import Connection
@@ -75,6 +77,7 @@ class LoginModule(CommandModule, CommandFilter):
         headers = conn.get_prop(ConnProps.CMD_HEADERS)
         cert_data = headers.get("cert")
         signature = headers.get("signature")
+        study = headers.get("study", DEFAULT_STUDY)
 
         self.logger.debug(f"got cert login headers: {headers=}")
         hci = conn.get_prop(ConnProps.HCI_SERVER)
@@ -99,6 +102,15 @@ class LoginModule(CommandModule, CommandFilter):
             conn.append_string("REJECT")
             return
 
+        if not isinstance(study, str):
+            conn.append_string("REJECT")
+            return
+
+        invalid, _ = name_check(study, "study")
+        if invalid:
+            conn.append_string("REJECT")
+            return
+
         cert_dict = cert_to_dict(cert)
         self.logger.debug(f"got cert dict: {cert_dict}")
         identity = get_identity_info(cert_dict)
@@ -112,6 +124,7 @@ class LoginModule(CommandModule, CommandFilter):
             user_org=identity.get(IdentityKey.ORG, ""),
             user_role=identity.get(IdentityKey.ROLE, ""),
             origin_fqcn=origin,
+            active_study=study,
         )
         token = session.make_token(id_asserter)
         self.logger.info(f"Created user session for {user_name}")
@@ -165,6 +178,7 @@ class LoginModule(CommandModule, CommandFilter):
         conn.set_prop(ConnProps.USER_NAME, sess.user_name)
         conn.set_prop(ConnProps.USER_ORG, sess.user_org)
         conn.set_prop(ConnProps.USER_ROLE, sess.user_role)
+        conn.set_prop(ConnProps.ACTIVE_STUDY, sess.active_study)
         conn.set_prop(ConnProps.TOKEN, token)
         return True
 

--- a/nvflare/fuel/hci/server/sess.py
+++ b/nvflare/fuel/hci/server/sess.py
@@ -17,6 +17,7 @@ import time
 import uuid
 from typing import List
 
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.fuel.f3.cellnet.defs import CellChannel
 from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.hci.base64_utils import b64str_to_str, str_to_b64str
@@ -31,12 +32,13 @@ CHECK_SESSION_CMD_NAME = InternalCommands.CHECK_SESSION
 
 
 class Session(object):
-    def __init__(self, sess_id, user_name, org, role, origin_fqcn):
+    def __init__(self, sess_id, user_name, org, role, origin_fqcn, active_study=DEFAULT_STUDY):
         """Object keeping track of an admin client session with token and time data."""
         self.sess_id = sess_id
         self.user_name = user_name
         self.user_org = org
         self.user_role = role
+        self.active_study = active_study
         self.origin_fqcn = origin_fqcn
         self.start_time = time.time()
         self.last_active_time = time.time()
@@ -50,6 +52,7 @@ class Session(object):
             "r": self.user_role,
             "o": self.user_org,
             "s": self.sess_id,
+            "t": self.active_study,
         }
         ds = json.dumps(user)
         bds = str_to_b64str(ds)
@@ -83,6 +86,7 @@ class Session(object):
             org=user.get("o"),
             sess_id=user.get("s"),
             origin_fqcn="",
+            active_study=user.get("t", DEFAULT_STUDY),
         )
 
 
@@ -134,7 +138,7 @@ class SessionManager(CommandModule):
     def shutdown(self):
         self.asked_to_stop = True
 
-    def create_session(self, user_name, user_org, user_role, origin_fqcn):
+    def create_session(self, user_name, user_org, user_role, origin_fqcn, active_study=DEFAULT_STUDY):
         """Creates new session with a new session token.
 
         Args:
@@ -154,6 +158,7 @@ class SessionManager(CommandModule):
             org=user_org,
             role=user_role,
             origin_fqcn=origin_fqcn,
+            active_study=active_study,
         )
         with self.sess_update_lock:
             self.sessions[sess_id] = sess

--- a/nvflare/fuel/hci/tools/admin.py
+++ b/nvflare/fuel/hci/tools/admin.py
@@ -15,6 +15,8 @@
 import argparse
 import os
 
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.apis.utils.format_check import name_check
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.hci.client.api_spec import AdminConfigKey
@@ -36,10 +38,16 @@ def main():
     parser.add_argument(
         "--fed_admin", "-s", type=str, help="json file with configurations for launching admin client", required=True
     )
+    parser.add_argument("--study", type=str, default=DEFAULT_JOB_STUDY, help="study context for this admin session")
     parser.add_argument("--cli_history_size", type=int, default=DEFAULT_CLI_HIST_SIZE)
     parser.add_argument("--with_debug", action="store_true")
 
     args = parser.parse_args()
+
+    invalid, reason = name_check(args.study, "study")
+    if invalid:
+        print(reason)
+        return
 
     try:
         os.chdir(args.workspace)
@@ -92,6 +100,7 @@ def main():
         handlers=conf.handlers,
         cli_history_dir=args.workspace,
         cli_history_size=cli_history_size,
+        study=args.study,
     )
 
     client.run()

--- a/nvflare/fuel/hci/tools/admin.py
+++ b/nvflare/fuel/hci/tools/admin.py
@@ -14,6 +14,7 @@
 
 import argparse
 import os
+import sys
 
 from nvflare.apis.job_def import DEFAULT_JOB_STUDY
 from nvflare.apis.utils.format_check import name_check
@@ -47,7 +48,7 @@ def main():
     invalid, reason = name_check(args.study, "study")
     if invalid:
         print(reason)
-        return
+        sys.exit(1)
 
     try:
         os.chdir(args.workspace)

--- a/nvflare/fuel/hci/tools/admin.py
+++ b/nvflare/fuel/hci/tools/admin.py
@@ -16,7 +16,7 @@ import argparse
 import os
 import sys
 
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.apis.utils.format_check import name_check
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.excepts import ConfigError
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         "--fed_admin", "-s", type=str, help="json file with configurations for launching admin client", required=True
     )
-    parser.add_argument("--study", type=str, default=DEFAULT_JOB_STUDY, help="study context for this admin session")
+    parser.add_argument("--study", type=str, default=DEFAULT_STUDY, help="study context for this admin session")
     parser.add_argument("--cli_history_size", type=int, default=DEFAULT_CLI_HIST_SIZE)
     parser.add_argument("--with_debug", action="store_true")
 

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -381,7 +381,7 @@ fl_admin_sh: |
   #!/usr/bin/env bash
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   mkdir -p $DIR/../transfer
-  python3 -m nvflare.fuel.hci.tools.admin -m $DIR/.. -s fed_admin.json
+  python3 -m nvflare.fuel.hci.tools.admin -m $DIR/.. -s fed_admin.json "$@"
 
 log_config: |
   {

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -21,13 +21,7 @@ from typing import Dict, List
 import nvflare.fuel.hci.file_transfer_defs as ftd
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey, ReturnCode, ServerCommandKey
-from nvflare.apis.job_def import (
-    DEFAULT_JOB_STUDY,
-    Job,
-    JobMetaKey,
-    get_job_meta_study,
-    is_valid_job_id,
-)
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY, Job, JobMetaKey, get_job_meta_study, is_valid_job_id
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.storage import DATA, JOB_ZIP, META, META_JSON, WORKSPACE, WORKSPACE_ZIP, StorageSpec

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -21,7 +21,13 @@ from typing import Dict, List
 import nvflare.fuel.hci.file_transfer_defs as ftd
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey, ReturnCode, ServerCommandKey
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY, Job, JobMetaKey, get_job_meta_study, is_valid_job_id
+from nvflare.apis.job_def import (
+    DEFAULT_JOB_STUDY,
+    Job,
+    JobMetaKey,
+    get_job_meta_study,
+    is_valid_job_id,
+)
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.storage import DATA, JOB_ZIP, META, META_JSON, WORKSPACE, WORKSPACE_ZIP, StorageSpec
@@ -536,7 +542,9 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         conn.append_success("", meta=make_meta(status=MetaStatusValue.OK, extra={MetaKey.JOB_ID: new_job_id}))
 
     @staticmethod
-    def _job_match(job_meta: Dict, id_prefix: str, name_prefix: str, user_name: str, requested_study: str = None) -> bool:
+    def _job_match(
+        job_meta: Dict, id_prefix: str, name_prefix: str, user_name: str, requested_study: str = None
+    ) -> bool:
         return (
             ((not id_prefix) or job_meta.get("job_id").lower().startswith(id_prefix.lower()))
             and ((not name_prefix) or job_meta.get("name").lower().startswith(name_prefix.lower()))

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -21,10 +21,11 @@ from typing import Dict, List
 import nvflare.fuel.hci.file_transfer_defs as ftd
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey, ReturnCode, ServerCommandKey
-from nvflare.apis.job_def import Job, JobMetaKey, is_valid_job_id
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY, Job, JobMetaKey, get_job_meta_study, is_valid_job_id
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.storage import DATA, JOB_ZIP, META, META_JSON, WORKSPACE, WORKSPACE_ZIP, StorageSpec
+from nvflare.apis.utils.format_check import name_check
 from nvflare.fuel.hci.conn import Connection
 from nvflare.fuel.hci.proto import ConfirmMethod, MetaKey, MetaStatusValue, make_meta
 from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandSpec
@@ -53,7 +54,10 @@ CLONED_META_KEYS = {
     JobMetaKey.MIN_CLIENTS.value,
     JobMetaKey.MANDATORY_CLIENTS.value,
     JobMetaKey.DATA_STORAGE_FORMAT.value,
+    JobMetaKey.STUDY.value,
 }
+
+STUDY_CMD_PROP_KEY = JobMetaKey.STUDY.value
 
 
 def _create_list_job_cmd_parser():
@@ -77,6 +81,15 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
     def __init__(self):
         super().__init__()
         self.logger = get_obj_logger(self)
+
+    @staticmethod
+    def _get_requested_study(conn: Connection):
+        """Return the study carried in command props by the client session, if any."""
+        cmd_props = conn.get_prop(ConnProps.CMD_PROPS)
+        if not isinstance(cmd_props, dict):
+            return None
+
+        return cmd_props.get(STUDY_CMD_PROP_KEY)
 
     def get_spec(self):
         return CommandModuleSpec(
@@ -317,6 +330,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         try:
             parser = _create_list_job_cmd_parser()
             parsed_args = parser.parse_args(args[1:])
+            requested_study = self._get_requested_study(conn)
 
             engine = conn.app_ctx
             job_def_manager = engine.job_def_manager
@@ -333,7 +347,9 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                 max_jobs_listed = parsed_args.m
                 user_name = conn.get_prop(ConnProps.USER_NAME, "") if parsed_args.u else None
 
-                filtered_jobs = [job for job in jobs if self._job_match(job.meta, id_prefix, name_prefix, user_name)]
+                filtered_jobs = [
+                    job for job in jobs if self._job_match(job.meta, id_prefix, name_prefix, user_name, requested_study)
+                ]
                 if not filtered_jobs:
                     conn.append_string(
                         "No jobs matching the specified criteria.",
@@ -408,7 +424,11 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         with engine.new_context() as fl_ctx:
             job = job_def_manager.get_job(jid=job_id, fl_ctx=fl_ctx)
             if job:
-                conn.append_dict(job.meta, meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_META: job.meta}))
+                normalized_meta = dict(job.meta)
+                normalized_meta[JobMetaKey.STUDY.value] = get_job_meta_study(job.meta)
+                conn.append_dict(
+                    normalized_meta, meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_META: normalized_meta})
+                )
             else:
                 conn.append_error(
                     f"job {job_id} does not exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
@@ -502,6 +522,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                 job_meta[JobMetaKey.SUBMITTER_ORG.value] = conn.get_prop(ConnProps.USER_ORG)
                 job_meta[JobMetaKey.SUBMITTER_ROLE.value] = conn.get_prop(ConnProps.USER_ROLE)
                 job_meta[JobMetaKey.CLONED_FROM.value] = job_id
+                job_meta[JobMetaKey.STUDY.value] = get_job_meta_study(job.meta)
 
                 meta = job_def_manager.clone(from_jid=job_id, meta=job_meta, fl_ctx=fl_ctx)
                 new_job_id = meta.get(JobMetaKey.JOB_ID)
@@ -515,11 +536,12 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         conn.append_success("", meta=make_meta(status=MetaStatusValue.OK, extra={MetaKey.JOB_ID: new_job_id}))
 
     @staticmethod
-    def _job_match(job_meta: Dict, id_prefix: str, name_prefix: str, user_name: str) -> bool:
+    def _job_match(job_meta: Dict, id_prefix: str, name_prefix: str, user_name: str, requested_study: str = None) -> bool:
         return (
             ((not id_prefix) or job_meta.get("job_id").lower().startswith(id_prefix.lower()))
             and ((not name_prefix) or job_meta.get("name").lower().startswith(name_prefix.lower()))
             and ((not user_name) or job_meta.get("submitter_name") == user_name)
+            and ((not requested_study) or get_job_meta_study(job_meta) == requested_study)
         )
 
     @staticmethod
@@ -527,8 +549,10 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         list_of_jobs = []
         for job in jobs:
             JobCommandModule._set_duration(job)
-            conn.append_string(json.dumps(job.meta, indent=4))
-            list_of_jobs.append(job.meta)
+            normalized_meta = dict(job.meta)
+            normalized_meta[JobMetaKey.STUDY.value] = get_job_meta_study(job.meta)
+            conn.append_string(json.dumps(normalized_meta, indent=4))
+            list_of_jobs.append(normalized_meta)
         conn.append_string("", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOBS: list_of_jobs}))
 
     @staticmethod
@@ -551,6 +575,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                     MetaKey.STATUS: job.meta.get(JobMetaKey.STATUS.value, ""),
                     MetaKey.SUBMIT_TIME: job.meta.get(JobMetaKey.SUBMIT_TIME_ISO.value, ""),
                     MetaKey.DURATION: str(job.meta.get(JobMetaKey.DURATION.value, "N/A")),
+                    JobMetaKey.STUDY.value: get_job_meta_study(job.meta),
                 },
             )
 
@@ -582,6 +607,26 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                     raise TypeError(
                         f"job_def_manager in engine is not of type JobDefManagerSpec, but got {type(job_def_manager)}"
                     )
+
+                requested_study = self._get_requested_study(conn)
+                if requested_study is None:
+                    # Older/raw admin command paths do not send a study prop, so
+                    # keep single-tenant behavior by defaulting to the default study.
+                    requested_study = DEFAULT_JOB_STUDY
+                else:
+                    if not isinstance(requested_study, str):
+                        error = f"study must be str but got {type(requested_study)}"
+                    else:
+                        invalid, reason = name_check(requested_study, "study")
+                        if not invalid:
+                            error = None
+                        else:
+                            error = reason
+
+                    if error:
+                        conn.append_error(error, meta=make_meta(MetaStatusValue.INVALID_JOB_DEFINITION, error))
+                        return
+                meta[JobMetaKey.STUDY.value] = requested_study
 
                 fl_ctx.set_prop(FLContextKey.JOB_META, meta, private=True, sticky=False)
                 engine.fire_event(EventType.SUBMIT_JOB, fl_ctx)

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -21,11 +21,10 @@ from typing import Dict, List
 import nvflare.fuel.hci.file_transfer_defs as ftd
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey, ReturnCode, ServerCommandKey
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY, Job, JobMetaKey, get_job_meta_study, is_valid_job_id
+from nvflare.apis.job_def import DEFAULT_STUDY, Job, JobMetaKey, get_job_meta_study, is_valid_job_id
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.storage import DATA, JOB_ZIP, META, META_JSON, WORKSPACE, WORKSPACE_ZIP, StorageSpec
-from nvflare.apis.utils.format_check import name_check
 from nvflare.fuel.hci.conn import Connection
 from nvflare.fuel.hci.proto import ConfirmMethod, MetaKey, MetaStatusValue, make_meta
 from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandSpec
@@ -57,8 +56,6 @@ CLONED_META_KEYS = {
     JobMetaKey.STUDY.value,
 }
 
-STUDY_CMD_PROP_KEY = JobMetaKey.STUDY.value
-
 
 def _create_list_job_cmd_parser():
     parser = SafeArgumentParser(prog=AdminCommandNames.LIST_JOBS)
@@ -81,15 +78,6 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
     def __init__(self):
         super().__init__()
         self.logger = get_obj_logger(self)
-
-    @staticmethod
-    def _get_requested_study(conn: Connection):
-        """Return the study carried in command props by the client session, if any."""
-        cmd_props = conn.get_prop(ConnProps.CMD_PROPS)
-        if not isinstance(cmd_props, dict):
-            return None
-
-        return cmd_props.get(STUDY_CMD_PROP_KEY)
 
     def get_spec(self):
         return CommandModuleSpec(
@@ -330,7 +318,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         try:
             parser = _create_list_job_cmd_parser()
             parsed_args = parser.parse_args(args[1:])
-            requested_study = self._get_requested_study(conn)
+            requested_study = conn.get_prop(ConnProps.ACTIVE_STUDY, DEFAULT_STUDY)
 
             engine = conn.app_ctx
             job_def_manager = engine.job_def_manager
@@ -536,9 +524,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         conn.append_success("", meta=make_meta(status=MetaStatusValue.OK, extra={MetaKey.JOB_ID: new_job_id}))
 
     @staticmethod
-    def _job_match(
-        job_meta: Dict, id_prefix: str, name_prefix: str, user_name: str, requested_study: str = None
-    ) -> bool:
+    def _job_match(job_meta: Dict, id_prefix: str, name_prefix: str, user_name: str, requested_study: str) -> bool:
         return (
             ((not id_prefix) or job_meta.get("job_id").lower().startswith(id_prefix.lower()))
             and ((not name_prefix) or job_meta.get("name").lower().startswith(name_prefix.lower()))
@@ -610,25 +596,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                         f"job_def_manager in engine is not of type JobDefManagerSpec, but got {type(job_def_manager)}"
                     )
 
-                requested_study = self._get_requested_study(conn)
-                if requested_study is None:
-                    # Older/raw admin command paths do not send a study prop, so
-                    # keep single-tenant behavior by defaulting to the default study.
-                    requested_study = DEFAULT_JOB_STUDY
-                else:
-                    if not isinstance(requested_study, str):
-                        error = f"study must be str but got {type(requested_study)}"
-                    else:
-                        invalid, reason = name_check(requested_study, "study")
-                        if not invalid:
-                            error = None
-                        else:
-                            error = reason
-
-                    if error:
-                        conn.append_error(error, meta=make_meta(MetaStatusValue.INVALID_JOB_DEFINITION, error))
-                        return
-                meta[JobMetaKey.STUDY.value] = requested_study
+                meta[JobMetaKey.STUDY.value] = conn.get_prop(ConnProps.ACTIVE_STUDY, DEFAULT_STUDY)
 
                 fl_ctx.set_prop(FLContextKey.JOB_META, meta, private=True, sticky=False)
                 engine.fire_event(EventType.SUBMIT_JOB, fl_ctx)

--- a/nvflare/recipe/prod_env.py
+++ b/nvflare/recipe/prod_env.py
@@ -18,6 +18,8 @@ from typing import Optional
 
 from pydantic import BaseModel, PositiveFloat, model_validator
 
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.apis.utils.format_check import name_check
 from nvflare.job_config.api import FedJob
 from nvflare.recipe.spec import ExecEnv
 from nvflare.recipe.utils import collect_non_local_scripts
@@ -34,11 +36,16 @@ class _ProdEnvValidator(BaseModel):
     startup_kit_location: str
     login_timeout: PositiveFloat = 5.0
     username: str = DEFAULT_ADMIN_USER
+    study: str = DEFAULT_JOB_STUDY
 
     @model_validator(mode="after")
     def check_startup_kit_location_exists(self) -> "_ProdEnvValidator":
         if not os.path.exists(self.startup_kit_location):
             raise ValueError(f"startup_kit_location path does not exist: {self.startup_kit_location}")
+        if name_check(self.study, "study")[0]:
+            raise ValueError(
+                f"study name '{self.study}' contains unsupported characters. Use only lowercase letters, numbers, and hyphens."
+            )
         return self
 
 
@@ -48,6 +55,7 @@ class ProdEnv(ExecEnv):
         startup_kit_location: str,
         login_timeout: float = 5.0,
         username: str = DEFAULT_ADMIN_USER,
+        study: str = DEFAULT_JOB_STUDY,
         extra: Optional[dict] = None,
     ):
         """Production execution environment for submitting and monitoring NVFlare jobs.
@@ -58,6 +66,7 @@ class ProdEnv(ExecEnv):
             startup_kit_location (str): Path to the admin's startup kit directory.
             login_timeout (float): Timeout (in seconds) for logging into the Flare API session. Must be > 0.
             username (str): Username to log in with.
+            study (str): Study name to tag submitted jobs. Defaults to "default".
             extra: extra env info.
         """
         super().__init__(extra)
@@ -66,11 +75,13 @@ class ProdEnv(ExecEnv):
             startup_kit_location=startup_kit_location,
             login_timeout=login_timeout,
             username=username,
+            study=study,
         )
 
         self.startup_kit_location = v.startup_kit_location
         self.login_timeout = v.login_timeout
         self.username = v.username
+        self.study = v.study
         self._session_manager = None  # Lazy initialization
 
     def get_job_status(self, job_id: str) -> Optional[str]:
@@ -103,6 +114,7 @@ class ProdEnv(ExecEnv):
                 "username": self.username,
                 "startup_kit_location": self.startup_kit_location,
                 "timeout": self.login_timeout,
+                "study": self.study,
             }
             self._session_manager = SessionManager(session_params)
         return self._session_manager

--- a/nvflare/recipe/prod_env.py
+++ b/nvflare/recipe/prod_env.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from pydantic import BaseModel, PositiveFloat, model_validator
 
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.apis.utils.format_check import name_check
 from nvflare.job_config.api import FedJob
 from nvflare.recipe.spec import ExecEnv
@@ -36,7 +36,7 @@ class _ProdEnvValidator(BaseModel):
     startup_kit_location: str
     login_timeout: PositiveFloat = 5.0
     username: str = DEFAULT_ADMIN_USER
-    study: str = DEFAULT_JOB_STUDY
+    study: str = DEFAULT_STUDY
 
     @model_validator(mode="after")
     def check_startup_kit_location_exists(self) -> "_ProdEnvValidator":
@@ -55,7 +55,7 @@ class ProdEnv(ExecEnv):
         startup_kit_location: str,
         login_timeout: float = 5.0,
         username: str = DEFAULT_ADMIN_USER,
-        study: str = DEFAULT_JOB_STUDY,
+        study: str = DEFAULT_STUDY,
         extra: Optional[dict] = None,
     ):
         """Production execution environment for submitting and monitoring NVFlare jobs.

--- a/tests/integration_test/study_session_test.py
+++ b/tests/integration_test/study_session_test.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import pty
+import re
+import select
+import shutil
+import subprocess
+import sys
+import time
+from contextlib import contextmanager, suppress
+
+import pytest
+
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY, JobMetaKey
+from nvflare.apis.workspace import Workspace
+from nvflare.fuel.flare_api.flare_api import new_secure_session
+from nvflare.fuel.hci.client.api_spec import AdminConfigKey
+from nvflare.fuel.hci.client.config import secure_load_admin_config
+from tests.integration_test.src import NVFTestDriver, POCSiteLauncher
+from tests.integration_test.src.utils import _get_job_store_path_from_workspace, get_job_meta
+
+JOBS_ROOT_DIR = os.path.join(os.path.dirname(__file__), "data", "jobs")
+JOB_NAME = "hello-numpy-sag"
+JOB_DIR = os.path.join(JOBS_ROOT_DIR, JOB_NAME)
+ADMIN_NAME = "admin@nvidia.com"
+POC_CLIENTS = 2
+
+
+def _wait_for_job_meta(admin_api, job_id: str, timeout: float = 30.0) -> dict:
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        meta = get_job_meta(admin_api, job_id)
+        if meta.get(JobMetaKey.JOB_ID.value) == job_id:
+            return meta
+        time.sleep(0.5)
+    raise AssertionError(f"Timed out waiting for job meta for {job_id}")
+
+
+def _find_job(jobs: list[dict], job_id: str) -> dict:
+    for job in jobs:
+        if job.get("job_id") == job_id:
+            return job
+    raise AssertionError(f"job_id {job_id} not found in job list: {jobs}")
+
+
+def _remove_study_from_persisted_job_meta(workspace_root: str, job_id: str):
+    job_store_path = _get_job_store_path_from_workspace(workspace_root, "server")
+    meta_path = os.path.join(job_store_path, job_id, "meta")
+    with open(meta_path, "r", encoding="utf-8") as f:
+        meta = json.load(f)
+    meta.pop(JobMetaKey.STUDY.value, None)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+
+
+def _read_until(master_fd: int, patterns: list[str], timeout: float = 30.0) -> str:
+    end_time = time.time() + timeout
+    output = ""
+    while time.time() < end_time:
+        remaining = max(0.1, end_time - time.time())
+        ready, _, _ = select.select([master_fd], [], [], remaining)
+        if not ready:
+            continue
+        chunk = os.read(master_fd, 4096).decode("utf-8", errors="replace")
+        output += chunk
+        if any(pattern in output for pattern in patterns):
+            return output
+    raise AssertionError(f"Timed out waiting for patterns {patterns!r}. Output so far:\n{output}")
+
+
+def _send_line(master_fd: int, text: str):
+    os.write(master_fd, f"{text}\n".encode("utf-8"))
+
+
+def _login_to_admin_shell(master_fd: int, admin_name: str) -> str:
+    output = _read_until(master_fd, ["User Name:", "> "], timeout=30.0)
+    if "User Name:" in output:
+        _send_line(master_fd, admin_name)
+        output += _read_until(master_fd, ["> "], timeout=30.0)
+    return output
+
+
+def _run_admin_shell_command(master_fd: int, command: str) -> str:
+    _send_line(master_fd, command)
+    return _read_until(master_fd, ["> "], timeout=60.0)
+
+
+def _get_admin_upload_dir(admin_root: str) -> str:
+    conf = secure_load_admin_config(Workspace(root_dir=admin_root))
+    admin_config = conf.get_admin_config()
+    return admin_config[AdminConfigKey.UPLOAD_DIR]
+
+
+@contextmanager
+def _admin_shell(admin_root: str, study: str):
+    startup_dir = os.path.join(admin_root, "startup")
+    script_path = os.path.join(startup_dir, "fl_admin.sh")
+    master_fd, slave_fd = pty.openpty()
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join([os.path.dirname(sys.executable), env.get("PATH", "")])
+    process = subprocess.Popen(
+        ["bash", script_path, "--study", study],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        cwd=startup_dir,
+        env=env,
+    )
+    os.close(slave_fd)
+    try:
+        yield process, master_fd
+    finally:
+        with suppress(Exception):
+            _send_line(master_fd, "bye")
+        with suppress(Exception):
+            process.terminate()
+        with suppress(Exception):
+            process.wait(timeout=10)
+        with suppress(Exception):
+            os.close(master_fd)
+
+
+@pytest.fixture
+def running_poc_system(tmp_path):
+    site_launcher = POCSiteLauncher(n_servers=1, n_clients=POC_CLIENTS)
+    workspace_root = site_launcher.prepare_workspace()
+    site_launcher.start_servers()
+    site_launcher.start_clients()
+
+    download_root_dir = tmp_path / "download_result"
+    download_root_dir.mkdir()
+    test_driver = NVFTestDriver(download_root_dir=str(download_root_dir), site_launcher=site_launcher, poll_period=1)
+
+    sessions = []
+    try:
+        test_driver.initialize_super_user(
+            workspace_root_dir=workspace_root,
+            upload_root_dir=JOBS_ROOT_DIR,
+            super_user_name=ADMIN_NAME,
+        )
+        test_driver.ensure_clients_started(num_clients=POC_CLIENTS, timeout=300)
+        yield {
+            "workspace_root": workspace_root,
+            "admin_root": os.path.join(workspace_root, ADMIN_NAME),
+            "old_admin_api": test_driver.super_admin_api,
+            "sessions": sessions,
+        }
+    finally:
+        for session in sessions:
+            with suppress(Exception):
+                session.close()
+        test_driver.finalize()
+        site_launcher.stop_all_sites()
+        site_launcher.cleanup()
+
+
+@pytest.mark.xdist_group(name="system_tests_group")
+class TestStudySessionIntegration:
+    def test_fladminapi_submit_defaults_study_and_list_jobs_exposes_it(self, running_poc_system):
+        admin_api = running_poc_system["old_admin_api"]
+
+        response = admin_api.submit_job(JOB_NAME)
+        assert response["status"] == "SUCCESS"
+        job_id = response["details"]["job_id"]
+
+        meta = _wait_for_job_meta(admin_api, job_id)
+        assert meta[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+
+        jobs = admin_api.list_jobs()["details"]
+        listed_job = _find_job(jobs, job_id)
+        assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+
+    def test_legacy_job_without_study_is_normalized_to_default(self, running_poc_system):
+        admin_api = running_poc_system["old_admin_api"]
+
+        response = admin_api.submit_job(JOB_NAME)
+        assert response["status"] == "SUCCESS"
+        job_id = response["details"]["job_id"]
+
+        _wait_for_job_meta(admin_api, job_id)
+        _remove_study_from_persisted_job_meta(running_poc_system["workspace_root"], job_id)
+
+        normalized_meta = _wait_for_job_meta(admin_api, job_id)
+        assert normalized_meta[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+
+        jobs = admin_api.list_jobs()["details"]
+        listed_job = _find_job(jobs, job_id)
+        assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+
+    def test_session_scopes_list_jobs_and_clone_preserves_source_study(self, running_poc_system):
+        admin_root = running_poc_system["admin_root"]
+
+        session_a = new_secure_session(ADMIN_NAME, admin_root, study="study-a")
+        session_b = new_secure_session(ADMIN_NAME, admin_root, study="study-b")
+        running_poc_system["sessions"].extend([session_a, session_b])
+
+        job_a = session_a.submit_job(JOB_DIR)
+        job_b = session_b.submit_job(JOB_DIR)
+
+        meta_a = session_a.get_job_meta(job_a)
+        meta_b = session_b.get_job_meta(job_b)
+        assert meta_a[JobMetaKey.STUDY.value] == "study-a"
+        assert meta_b[JobMetaKey.STUDY.value] == "study-b"
+
+        jobs_a = session_a.list_jobs()
+        jobs_b = session_b.list_jobs()
+
+        assert {job["job_id"] for job in jobs_a} == {job_a}
+        assert {job["job_id"] for job in jobs_b} == {job_b}
+
+        cloned_job_id = session_b.clone_job(job_a)
+        cloned_meta = session_a.get_job_meta(cloned_job_id)
+        assert cloned_meta[JobMetaKey.STUDY.value] == "study-a"
+
+        jobs_a_after_clone = session_a.list_jobs()
+        jobs_b_after_clone = session_b.list_jobs()
+        assert {job["job_id"] for job in jobs_a_after_clone} == {job_a, cloned_job_id}
+        assert {job["job_id"] for job in jobs_b_after_clone} == {job_b}
+
+    def test_fl_admin_shell_study_flag_scopes_terminal_session(self, running_poc_system):
+        admin_root = running_poc_system["admin_root"]
+        upload_dir = _get_admin_upload_dir(admin_root)
+        shell_job_dir = os.path.join(upload_dir, JOB_NAME)
+        shutil.copytree(JOB_DIR, shell_job_dir, dirs_exist_ok=True)
+
+        try:
+            with _admin_shell(admin_root, "study-a") as (_process_a, master_fd_a):
+                _login_to_admin_shell(master_fd_a, ADMIN_NAME)
+
+                submit_output = _run_admin_shell_command(master_fd_a, f"submit_job {JOB_NAME}")
+                match = re.search(r"Submitted job:\s*([0-9a-fA-F-]+)", submit_output)
+                assert match, f"failed to parse job id from output:\n{submit_output}"
+                job_id = match.group(1)
+
+                detailed_output = _run_admin_shell_command(master_fd_a, "list_jobs -d")
+                assert job_id in detailed_output
+                assert '"study": "study-a"' in detailed_output
+
+                meta = _wait_for_job_meta(running_poc_system["old_admin_api"], job_id)
+                assert meta[JobMetaKey.STUDY.value] == "study-a"
+
+            with _admin_shell(admin_root, "study-b") as (_process_b, master_fd_b):
+                _login_to_admin_shell(master_fd_b, ADMIN_NAME)
+                other_study_output = _run_admin_shell_command(master_fd_b, "list_jobs")
+                assert job_id not in other_study_output
+                assert "No jobs matching the specified criteria." in other_study_output
+        finally:
+            shutil.rmtree(shell_job_dir, ignore_errors=True)

--- a/tests/integration_test/study_session_test.py
+++ b/tests/integration_test/study_session_test.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager, suppress
 
 import pytest
 
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY, JobMetaKey
+from nvflare.apis.job_def import DEFAULT_STUDY, JobMetaKey
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.flare_api.flare_api import new_secure_session
 from nvflare.fuel.hci.client.api_spec import AdminConfigKey
@@ -178,11 +178,11 @@ class TestStudySessionIntegration:
         job_id = response["details"]["job_id"]
 
         meta = _wait_for_job_meta(admin_api, job_id)
-        assert meta[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+        assert meta[JobMetaKey.STUDY.value] == DEFAULT_STUDY
 
         jobs = admin_api.list_jobs()["details"]
         listed_job = _find_job(jobs, job_id)
-        assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+        assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_STUDY
 
     def test_legacy_job_without_study_is_normalized_to_default(self, running_poc_system):
         admin_api = running_poc_system["old_admin_api"]
@@ -195,11 +195,11 @@ class TestStudySessionIntegration:
         _remove_study_from_persisted_job_meta(running_poc_system["workspace_root"], job_id)
 
         normalized_meta = _wait_for_job_meta(admin_api, job_id)
-        assert normalized_meta[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+        assert normalized_meta[JobMetaKey.STUDY.value] == DEFAULT_STUDY
 
         jobs = admin_api.list_jobs()["details"]
         listed_job = _find_job(jobs, job_id)
-        assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_JOB_STUDY
+        assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_STUDY
 
     def test_session_scopes_list_jobs_and_clone_preserves_source_study(self, running_poc_system):
         admin_root = running_poc_system["admin_root"]

--- a/tests/integration_test/study_session_test.py
+++ b/tests/integration_test/study_session_test.py
@@ -23,13 +23,16 @@ import sys
 import time
 from contextlib import contextmanager, suppress
 
+import numpy as np
 import pytest
 
 from nvflare.apis.job_def import DEFAULT_STUDY, JobMetaKey
 from nvflare.apis.workspace import Workspace
+from nvflare.app_common.np.recipes import NumpyFedAvgRecipe
 from nvflare.fuel.flare_api.flare_api import new_secure_session
 from nvflare.fuel.hci.client.api_spec import AdminConfigKey
 from nvflare.fuel.hci.client.config import secure_load_admin_config
+from nvflare.recipe import ProdEnv
 from tests.integration_test.src import NVFTestDriver, POCSiteLauncher
 from tests.integration_test.src.utils import _get_job_store_path_from_workspace, get_job_meta
 
@@ -55,6 +58,32 @@ def _find_job(jobs: list[dict], job_id: str) -> dict:
         if job.get("job_id") == job_id:
             return job
     raise AssertionError(f"job_id {job_id} not found in job list: {jobs}")
+
+
+def _wait_for_runtime_job_meta(workspace_root: str, site_name: str, job_id: str, timeout: float = 30.0) -> dict:
+    site_root = os.path.join(workspace_root, site_name)
+    workspace = Workspace(root_dir=site_root, site_name=site_name)
+    meta_path = workspace.get_job_meta_path(job_id)
+
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        if os.path.exists(meta_path):
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+            if meta.get(JobMetaKey.JOB_ID.value) == job_id:
+                return meta
+        time.sleep(0.5)
+    raise AssertionError(f"Timed out waiting for runtime job meta for {job_id} at site {site_name}")
+
+
+def _make_numpy_recipe(name: str) -> NumpyFedAvgRecipe:
+    return NumpyFedAvgRecipe(
+        name=name,
+        min_clients=POC_CLIENTS,
+        num_rounds=1,
+        model=np.array([0.0] * 10),
+        train_script=os.path.join(os.path.dirname(__file__), "client.py"),
+    )
 
 
 def _remove_study_from_persisted_job_meta(workspace_root: str, job_id: str):
@@ -260,3 +289,54 @@ class TestStudySessionIntegration:
                 assert "No jobs matching the specified criteria." in other_study_output
         finally:
             shutil.rmtree(shell_job_dir, ignore_errors=True)
+
+    def test_prod_env_defaults_study_and_propagates_runtime_meta(self, running_poc_system):
+        admin_root = running_poc_system["admin_root"]
+        admin_api = running_poc_system["old_admin_api"]
+        workspace_root = running_poc_system["workspace_root"]
+
+        env = ProdEnv(startup_kit_location=admin_root, username=ADMIN_NAME)
+        run = _make_numpy_recipe("prod-env-default-study").execute(env)
+        job_id = run.get_job_id()
+
+        meta = _wait_for_job_meta(admin_api, job_id)
+        assert meta[JobMetaKey.STUDY.value] == DEFAULT_STUDY
+
+        default_session = new_secure_session(ADMIN_NAME, admin_root)
+        running_poc_system["sessions"].append(default_session)
+        assert {job["job_id"] for job in default_session.list_jobs()} >= {job_id}
+
+        for site_name in ["server", "site-1", "site-2"]:
+            runtime_meta = _wait_for_runtime_job_meta(workspace_root, site_name, job_id)
+            assert runtime_meta[JobMetaKey.STUDY.value] == DEFAULT_STUDY
+
+        result = run.get_result(timeout=120)
+        assert result is not None
+        assert os.path.exists(result)
+
+    def test_prod_env_explicit_study_scopes_session_and_runtime_meta(self, running_poc_system):
+        admin_root = running_poc_system["admin_root"]
+        admin_api = running_poc_system["old_admin_api"]
+        workspace_root = running_poc_system["workspace_root"]
+
+        env = ProdEnv(startup_kit_location=admin_root, username=ADMIN_NAME, study="study-a")
+        run = _make_numpy_recipe("prod-env-study-a").execute(env)
+        job_id = run.get_job_id()
+
+        meta = _wait_for_job_meta(admin_api, job_id)
+        assert meta[JobMetaKey.STUDY.value] == "study-a"
+
+        session_a = new_secure_session(ADMIN_NAME, admin_root, study="study-a")
+        session_b = new_secure_session(ADMIN_NAME, admin_root, study="study-b")
+        running_poc_system["sessions"].extend([session_a, session_b])
+
+        assert {job["job_id"] for job in session_a.list_jobs()} >= {job_id}
+        assert job_id not in {job["job_id"] for job in session_b.list_jobs()}
+
+        for site_name in ["server", "site-1", "site-2"]:
+            runtime_meta = _wait_for_runtime_job_meta(workspace_root, site_name, job_id)
+            assert runtime_meta[JobMetaKey.STUDY.value] == "study-a"
+
+        result = run.get_result(timeout=120)
+        assert result is not None
+        assert os.path.exists(result)

--- a/tests/integration_test/study_session_test.py
+++ b/tests/integration_test/study_session_test.py
@@ -135,14 +135,17 @@ def _get_admin_upload_dir(admin_root: str) -> str:
 
 
 @contextmanager
-def _admin_shell(admin_root: str, study: str):
+def _admin_shell(admin_root: str, study: str | None = None):
     startup_dir = os.path.join(admin_root, "startup")
     script_path = os.path.join(startup_dir, "fl_admin.sh")
     master_fd, slave_fd = pty.openpty()
     env = os.environ.copy()
     env["PATH"] = os.pathsep.join([os.path.dirname(sys.executable), env.get("PATH", "")])
+    command = ["bash", script_path]
+    if study is not None:
+        command.extend(["--study", study])
     process = subprocess.Popen(
-        ["bash", script_path, "--study", study],
+        command,
         stdin=slave_fd,
         stdout=slave_fd,
         stderr=slave_fd,
@@ -230,6 +233,21 @@ class TestStudySessionIntegration:
         listed_job = _find_job(jobs, job_id)
         assert listed_job[JobMetaKey.STUDY.value] == DEFAULT_STUDY
 
+    def test_session_defaults_study_without_argument(self, running_poc_system):
+        admin_root = running_poc_system["admin_root"]
+
+        default_session = new_secure_session(ADMIN_NAME, admin_root)
+        other_study_session = new_secure_session(ADMIN_NAME, admin_root, study="study-a")
+        running_poc_system["sessions"].extend([default_session, other_study_session])
+
+        job_id = default_session.submit_job(JOB_DIR)
+
+        meta = default_session.get_job_meta(job_id)
+        assert meta[JobMetaKey.STUDY.value] == DEFAULT_STUDY
+
+        assert {job["job_id"] for job in default_session.list_jobs()} >= {job_id}
+        assert job_id not in {job["job_id"] for job in other_study_session.list_jobs()}
+
     def test_session_scopes_list_jobs_and_clone_preserves_source_study(self, running_poc_system):
         admin_root = running_poc_system["admin_root"]
 
@@ -259,6 +277,36 @@ class TestStudySessionIntegration:
         jobs_b_after_clone = session_b.list_jobs()
         assert {job["job_id"] for job in jobs_a_after_clone} == {job_a, cloned_job_id}
         assert {job["job_id"] for job in jobs_b_after_clone} == {job_b}
+
+    def test_fl_admin_shell_defaults_to_default_study_without_flag(self, running_poc_system):
+        admin_root = running_poc_system["admin_root"]
+        upload_dir = _get_admin_upload_dir(admin_root)
+        shell_job_dir = os.path.join(upload_dir, JOB_NAME)
+        shutil.copytree(JOB_DIR, shell_job_dir, dirs_exist_ok=True)
+
+        try:
+            with _admin_shell(admin_root) as (_process_default, master_fd_default):
+                _login_to_admin_shell(master_fd_default, ADMIN_NAME)
+
+                submit_output = _run_admin_shell_command(master_fd_default, f"submit_job {JOB_NAME}")
+                match = re.search(r"Submitted job:\s*([0-9a-fA-F-]+)", submit_output)
+                assert match, f"failed to parse job id from output:\n{submit_output}"
+                job_id = match.group(1)
+
+                detailed_output = _run_admin_shell_command(master_fd_default, "list_jobs -d")
+                assert job_id in detailed_output
+                assert f'"study": "{DEFAULT_STUDY}"' in detailed_output
+
+                meta = _wait_for_job_meta(running_poc_system["old_admin_api"], job_id)
+                assert meta[JobMetaKey.STUDY.value] == DEFAULT_STUDY
+
+            with _admin_shell(admin_root, "study-a") as (_process_other, master_fd_other):
+                _login_to_admin_shell(master_fd_other, ADMIN_NAME)
+                other_study_output = _run_admin_shell_command(master_fd_other, "list_jobs")
+                assert job_id not in other_study_output
+                assert "No jobs matching the specified criteria." in other_study_output
+        finally:
+            shutil.rmtree(shell_job_dir, ignore_errors=True)
 
     def test_fl_admin_shell_study_flag_scopes_terminal_session(self, running_poc_system):
         admin_root = running_poc_system["admin_root"]

--- a/tests/unit_test/apis/job_def_test.py
+++ b/tests/unit_test/apis/job_def_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvflare.apis.job_def import is_valid_job_id
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY, get_job_meta_study, is_valid_job_id
 
 
 class TestJobDef:
@@ -22,3 +22,6 @@ class TestJobDef:
         assert is_valid_job_id("c2564481536a45488dfacf183a3652a1")
         assert not is_valid_job_id("c2564481536a45488dfacf183a3652a1ddd")
         assert not is_valid_job_id("c2564481-536a-4548-fdff-df183a3652a1")
+
+    def test_get_job_meta_study_defaults_legacy_jobs(self):
+        assert get_job_meta_study({}) == DEFAULT_JOB_STUDY

--- a/tests/unit_test/apis/job_def_test.py
+++ b/tests/unit_test/apis/job_def_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY, get_job_meta_study, is_valid_job_id
+from nvflare.apis.job_def import DEFAULT_STUDY, get_job_meta_study, is_valid_job_id
 
 
 class TestJobDef:
@@ -24,4 +24,4 @@ class TestJobDef:
         assert not is_valid_job_id("c2564481-536a-4548-fdff-df183a3652a1")
 
     def test_get_job_meta_study_defaults_legacy_jobs(self):
-        assert get_job_meta_study({}) == DEFAULT_JOB_STUDY
+        assert get_job_meta_study({}) == DEFAULT_STUDY

--- a/tests/unit_test/apis/utils/format_check_test.py
+++ b/tests/unit_test/apis/utils/format_check_test.py
@@ -55,3 +55,23 @@ class TestNameCheck:
         assert err == err_value
         err, reason = name_check(name, "email")
         assert err == err_value
+
+    @pytest.mark.parametrize(
+        "name, err_value",
+        [
+            ["default", False],
+            ["cancer-research", False],
+            ["a", False],
+            ["a" * 63, False],
+            ["", True],
+            ["A", True],
+            ["abc_", True],
+            ["-abc", True],
+            ["abc-", True],
+            ["a" * 64, True],
+            ["with space", True],
+        ],
+    )
+    def test_study(self, name, err_value):
+        err, reason = name_check(name, "study")
+        assert err == err_value

--- a/tests/unit_test/fuel/flare_api/flare_api_study_test.py
+++ b/tests/unit_test/fuel/flare_api/flare_api_study_test.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.fuel.flare_api.flare_api import Session, new_secure_session
+from nvflare.fuel.hci.client.api import ResultKey
+from nvflare.fuel.hci.proto import MetaKey
+
+
+def _make_session_for_study(study):
+    session = Session.__new__(Session)
+    session.upload_dir = "/tmp"
+    session._study = study
+    return session
+
+
+def test_submit_job_sends_study_cmd_props():
+    session = _make_session_for_study("cancer-research")
+    captured = {}
+
+    def _fake_do_command(command, enforce_meta=True, props=None):
+        captured["props"] = props
+        return {ResultKey.META: {MetaKey.JOB_ID: "job-1"}}
+
+    session._do_command = _fake_do_command
+    with patch("os.path.isdir", return_value=True):
+        session.submit_job("/tmp/job")
+
+    assert captured["props"] == {"study": "cancer-research"}
+
+
+def test_clone_job_does_not_send_study_cmd_props():
+    session = _make_session_for_study("multiple-sclerosis")
+    captured = {}
+
+    def _fake_do_command(command, enforce_meta=True, props=None):
+        captured["props"] = props
+        return {ResultKey.META: {MetaKey.JOB_ID: "job-2"}}
+
+    session._do_command = _fake_do_command
+    session.clone_job("source-job")
+
+    assert captured["props"] is None
+
+
+def test_submit_job_sends_default_study_cmd_props():
+    session = _make_session_for_study(DEFAULT_JOB_STUDY)
+    captured = {}
+
+    def _fake_do_command(command, enforce_meta=True, props=None):
+        captured["props"] = props
+        return {ResultKey.META: {MetaKey.JOB_ID: "job-3"}}
+
+    session._do_command = _fake_do_command
+    with patch("os.path.isdir", return_value=True):
+        session.submit_job("/tmp/job")
+
+    assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
+
+
+def test_list_jobs_sends_default_study_cmd_props():
+    session = _make_session_for_study(DEFAULT_JOB_STUDY)
+    captured = {}
+
+    def _fake_do_command(command, enforce_meta=True, props=None):
+        captured["props"] = props
+        return {ResultKey.META: {MetaKey.JOBS: []}}
+
+    session._do_command = _fake_do_command
+    session.list_jobs()
+
+    assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
+
+
+def test_session_rejects_none_study():
+    fake_conf = SimpleNamespace(
+        get_admin_config=lambda: {"upload_dir": "/tmp", "download_dir": "/tmp"},
+        handlers=[],
+    )
+    with (
+        patch("os.path.isdir", return_value=True),
+        patch("nvflare.fuel.flare_api.flare_api.secure_load_admin_config", return_value=fake_conf),
+        patch("nvflare.fuel.flare_api.flare_api.AdminAPI"),
+        pytest.raises(AssertionError, match="study must be str"),
+    ):
+        Session("admin@nvidia.com", "/tmp/kit", study=None)
+
+
+def test_new_secure_session_forwards_study():
+    with patch("nvflare.fuel.flare_api.flare_api.new_session") as mock_new_session:
+        new_secure_session("admin@nvidia.com", "/tmp/kit", study="cancer-research")
+        _, kwargs = mock_new_session.call_args
+        assert kwargs["study"] == "cancer-research"
+
+
+def test_new_secure_session_defaults_study():
+    with patch("nvflare.fuel.flare_api.flare_api.new_session") as mock_new_session:
+        new_secure_session("admin@nvidia.com", "/tmp/kit")
+        _, kwargs = mock_new_session.call_args
+        assert kwargs["study"] == DEFAULT_JOB_STUDY

--- a/tests/unit_test/fuel/flare_api/flare_api_study_test.py
+++ b/tests/unit_test/fuel/flare_api/flare_api_study_test.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.fuel.flare_api.flare_api import Session, new_secure_session
 from nvflare.fuel.hci.client.api import ResultKey
 from nvflare.fuel.hci.proto import MetaKey
@@ -30,7 +30,7 @@ def _make_session_for_study(study):
     return session
 
 
-def test_submit_job_sends_study_cmd_props():
+def test_submit_job_relies_on_session_study():
     session = _make_session_for_study("cancer-research")
     captured = {}
 
@@ -42,7 +42,7 @@ def test_submit_job_sends_study_cmd_props():
     with patch("os.path.isdir", return_value=True):
         session.submit_job("/tmp/job")
 
-    assert captured["props"] == {"study": "cancer-research"}
+    assert captured["props"] is None
 
 
 def test_clone_job_does_not_send_study_cmd_props():
@@ -59,8 +59,8 @@ def test_clone_job_does_not_send_study_cmd_props():
     assert captured["props"] is None
 
 
-def test_submit_job_sends_default_study_cmd_props():
-    session = _make_session_for_study(DEFAULT_JOB_STUDY)
+def test_submit_job_with_default_study_uses_session_context_only():
+    session = _make_session_for_study(DEFAULT_STUDY)
     captured = {}
 
     def _fake_do_command(command, enforce_meta=True, props=None):
@@ -71,11 +71,11 @@ def test_submit_job_sends_default_study_cmd_props():
     with patch("os.path.isdir", return_value=True):
         session.submit_job("/tmp/job")
 
-    assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
+    assert captured["props"] is None
 
 
-def test_list_jobs_sends_default_study_cmd_props():
-    session = _make_session_for_study(DEFAULT_JOB_STUDY)
+def test_list_jobs_relies_on_session_study():
+    session = _make_session_for_study(DEFAULT_STUDY)
     captured = {}
 
     def _fake_do_command(command, enforce_meta=True, props=None):
@@ -85,7 +85,7 @@ def test_list_jobs_sends_default_study_cmd_props():
     session._do_command = _fake_do_command
     session.list_jobs()
 
-    assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
+    assert captured["props"] is None
 
 
 def test_session_rejects_none_study():
@@ -102,6 +102,27 @@ def test_session_rejects_none_study():
         Session("admin@nvidia.com", "/tmp/kit", study=None)
 
 
+def test_session_passes_study_to_admin_api():
+    fake_conf = SimpleNamespace(
+        get_admin_config=lambda: {"upload_dir": "/tmp", "download_dir": "/tmp"},
+        handlers=[],
+    )
+    captured = {}
+
+    class _FakeAdminAPI:
+        def __init__(self, **kwargs):
+            captured["study"] = kwargs["study"]
+
+    with (
+        patch("os.path.isdir", return_value=True),
+        patch("nvflare.fuel.flare_api.flare_api.secure_load_admin_config", return_value=fake_conf),
+        patch("nvflare.fuel.flare_api.flare_api.AdminAPI", _FakeAdminAPI),
+    ):
+        Session("admin@nvidia.com", "/tmp/kit", study="cancer-research")
+
+    assert captured["study"] == "cancer-research"
+
+
 def test_new_secure_session_forwards_study():
     with patch("nvflare.fuel.flare_api.flare_api.new_session") as mock_new_session:
         new_secure_session("admin@nvidia.com", "/tmp/kit", study="cancer-research")
@@ -113,4 +134,4 @@ def test_new_secure_session_defaults_study():
     with patch("nvflare.fuel.flare_api.flare_api.new_session") as mock_new_session:
         new_secure_session("admin@nvidia.com", "/tmp/kit")
         _, kwargs = mock_new_session.call_args
-        assert kwargs["study"] == DEFAULT_JOB_STUDY
+        assert kwargs["study"] == DEFAULT_STUDY

--- a/tests/unit_test/fuel/hci/admin_cli_study_test.py
+++ b/tests/unit_test/fuel/hci/admin_cli_study_test.py
@@ -15,6 +15,8 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from nvflare.apis.job_def import DEFAULT_JOB_STUDY
 from nvflare.fuel.hci.client.api_spec import AdminConfigKey
 from nvflare.fuel.hci.client.api import CommandInfo
@@ -72,6 +74,18 @@ def test_list_jobs_sends_default_session_study_cmd_props():
     assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
 
 
+def test_list_jobs_merges_existing_cmd_props():
+    client, captured = _make_admin_client_for_study("cancer-research")
+
+    with patch(
+        "nvflare.fuel.hci.client.cli.parse_command_line",
+        return_value=("list_jobs", ["list_jobs"], {"foo": "bar"}),
+    ):
+        client._do_default("list_jobs")
+
+    assert captured["props"] == {"foo": "bar", "study": "cancer-research"}
+
+
 def test_clone_job_does_not_send_session_study_cmd_props():
     client, captured = _make_admin_client_for_study("multiple-sclerosis")
 
@@ -108,3 +122,13 @@ def test_admin_main_passes_launch_study_to_admin_client():
         admin.main()
 
     assert captured == {"study": "cancer-research", "ran": True}
+
+
+def test_admin_main_exits_non_zero_for_invalid_study():
+    with (
+        patch("sys.argv", ["admin.py", "-m", "/tmp/admin", "-s", "fed_admin.json", "--study", "Bad Study"]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        admin.main()
+
+    assert exc_info.value.code == 1

--- a/tests/unit_test/fuel/hci/admin_cli_study_test.py
+++ b/tests/unit_test/fuel/hci/admin_cli_study_test.py
@@ -18,8 +18,8 @@ from unittest.mock import patch
 import pytest
 
 from nvflare.apis.job_def import DEFAULT_JOB_STUDY
-from nvflare.fuel.hci.client.api_spec import AdminConfigKey
 from nvflare.fuel.hci.client.api import CommandInfo
+from nvflare.fuel.hci.client.api_spec import AdminConfigKey
 from nvflare.fuel.hci.client.api_status import APIStatus
 from nvflare.fuel.hci.client.cli import AdminClient
 from nvflare.fuel.hci.tools import admin

--- a/tests/unit_test/fuel/hci/admin_cli_study_test.py
+++ b/tests/unit_test/fuel/hci/admin_cli_study_test.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.fuel.hci.client.api_spec import AdminConfigKey
+from nvflare.fuel.hci.client.api import CommandInfo
+from nvflare.fuel.hci.client.api_status import APIStatus
+from nvflare.fuel.hci.client.cli import AdminClient
+from nvflare.fuel.hci.tools import admin
+
+
+def _make_admin_client_for_study(study):
+    client = AdminClient.__new__(AdminClient)
+    captured = {}
+
+    class _FakeAPI:
+        shutdown_received = False
+        shutdown_msg = ""
+
+        @staticmethod
+        def check_command(line):
+            captured["checked_line"] = line
+            return CommandInfo.OK
+
+        @staticmethod
+        def do_command(line, props=None):
+            captured["line"] = line
+            captured["props"] = props
+            return {"status": APIStatus.SUCCESS, "details": ""}
+
+    client.api = _FakeAPI()
+    client._study = study
+    client.user_name = ""
+    client.debug = False
+    client.out_file = None
+    client.no_stdout = False
+    client.write_string = lambda *_args, **_kwargs: None
+    client.write_stdout = lambda *_args, **_kwargs: None
+    client.write_error = lambda *_args, **_kwargs: None
+    client.print_resp = lambda *_args, **_kwargs: None
+    client._set_output_file = lambda *_args, **_kwargs: None
+    return client, captured
+
+
+def test_submit_job_sends_session_study_cmd_props():
+    client, captured = _make_admin_client_for_study("cancer-research")
+
+    client._do_default("submit_job hello")
+
+    assert captured["props"] == {"study": "cancer-research"}
+
+
+def test_list_jobs_sends_default_session_study_cmd_props():
+    client, captured = _make_admin_client_for_study(DEFAULT_JOB_STUDY)
+
+    client._do_default("list_jobs")
+
+    assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
+
+
+def test_clone_job_does_not_send_session_study_cmd_props():
+    client, captured = _make_admin_client_for_study("multiple-sclerosis")
+
+    client._do_default("clone_job job-1")
+
+    assert captured["props"] is None
+
+
+def test_admin_main_passes_launch_study_to_admin_client():
+    captured = {}
+    fake_conf = SimpleNamespace(
+        get_admin_config=lambda: {AdminConfigKey.USERNAME: "admin@nvidia.com"},
+        handlers=[],
+    )
+
+    class _FakeAdminClient:
+        def __init__(self, **kwargs):
+            captured["study"] = kwargs["study"]
+
+        @staticmethod
+        def run():
+            captured["ran"] = True
+
+    with (
+        patch(
+            "sys.argv",
+            ["admin.py", "-m", "/tmp/admin", "-s", "fed_admin.json", "--study", "cancer-research"],
+        ),
+        patch("os.chdir"),
+        patch("nvflare.fuel.hci.tools.admin.Workspace"),
+        patch("nvflare.fuel.hci.tools.admin.secure_load_admin_config", return_value=fake_conf),
+        patch("nvflare.fuel.hci.tools.admin.AdminClient", _FakeAdminClient),
+    ):
+        admin.main()
+
+    assert captured == {"study": "cancer-research", "ran": True}

--- a/tests/unit_test/fuel/hci/admin_cli_study_test.py
+++ b/tests/unit_test/fuel/hci/admin_cli_study_test.py
@@ -17,9 +17,10 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.apis.job_def import DEFAULT_JOB_STUDY
+from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.fuel.hci.client.api import CommandInfo
-from nvflare.fuel.hci.client.api_spec import AdminConfigKey
+from nvflare.fuel.hci.client.api_spec import AdminConfigKey, UidSource
 from nvflare.fuel.hci.client.api_status import APIStatus
 from nvflare.fuel.hci.client.cli import AdminClient
 from nvflare.fuel.hci.tools import admin
@@ -58,23 +59,23 @@ def _make_admin_client_for_study(study):
     return client, captured
 
 
-def test_submit_job_sends_session_study_cmd_props():
+def test_submit_job_relies_on_session_study():
     client, captured = _make_admin_client_for_study("cancer-research")
 
     client._do_default("submit_job hello")
 
-    assert captured["props"] == {"study": "cancer-research"}
+    assert captured["props"] is None
 
 
-def test_list_jobs_sends_default_session_study_cmd_props():
-    client, captured = _make_admin_client_for_study(DEFAULT_JOB_STUDY)
+def test_list_jobs_relies_on_session_study():
+    client, captured = _make_admin_client_for_study(DEFAULT_STUDY)
 
     client._do_default("list_jobs")
 
-    assert captured["props"] == {"study": DEFAULT_JOB_STUDY}
+    assert captured["props"] is None
 
 
-def test_list_jobs_merges_existing_cmd_props():
+def test_list_jobs_preserves_existing_cmd_props():
     client, captured = _make_admin_client_for_study("cancer-research")
 
     with patch(
@@ -83,7 +84,7 @@ def test_list_jobs_merges_existing_cmd_props():
     ):
         client._do_default("list_jobs")
 
-    assert captured["props"] == {"foo": "bar", "study": "cancer-research"}
+    assert captured["props"] == {"foo": "bar"}
 
 
 def test_clone_job_does_not_send_session_study_cmd_props():
@@ -132,3 +133,29 @@ def test_admin_main_exits_non_zero_for_invalid_study():
         admin.main()
 
     assert exc_info.value.code == 1
+
+
+def test_admin_client_passes_study_to_admin_api(tmp_path):
+    captured = {}
+    admin_config = {
+        AdminConfigKey.CONNECTION_SECURITY: ConnectionSecurity.MTLS,
+        AdminConfigKey.CA_CERT: "ca.crt",
+        AdminConfigKey.CLIENT_CERT: "client.crt",
+        AdminConfigKey.CLIENT_KEY: "client.key",
+        AdminConfigKey.UID_SOURCE: UidSource.CERT,
+    }
+
+    class _FakeAdminAPI:
+        def __init__(self, **kwargs):
+            captured["study"] = kwargs["study"]
+
+    with patch("nvflare.fuel.hci.client.cli.AdminAPI", _FakeAdminAPI):
+        AdminClient(
+            admin_config=admin_config,
+            username="admin@nvidia.com",
+            handlers=[],
+            cli_history_dir=str(tmp_path),
+            study="cancer-research",
+        )
+
+    assert captured["study"] == "cancer-research"

--- a/tests/unit_test/fuel/hci/client_api_props_test.py
+++ b/tests/unit_test/fuel/hci/client_api_props_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from nvflare.fuel.hci.client.api import AdminAPI
+from nvflare.fuel.hci.client.api_spec import CommandContext
+
+
+def test_do_client_command_preserves_command_props():
+    api = AdminAPI.__new__(AdminAPI)
+    captured = {}
+
+    def _new_command_context(command, args, ent):
+        ctx = CommandContext()
+        ctx.set_command(command)
+        ctx.set_command_args(args)
+        ctx.set_command_entry(ent)
+        return ctx
+
+    def _handler(args, ctx):
+        captured["props"] = ctx.get_command_props()
+        ctx.set_command_result({"status": "ok"})
+
+    api._new_command_context = _new_command_context
+    ent = SimpleNamespace(handler=_handler)
+
+    result = api._do_client_command("submit_job hello", ["submit_job", "hello"], ent, props={"study": "study-a"})
+
+    assert result == {"status": "ok"}
+    assert captured["props"] == {"study": "study-a"}

--- a/tests/unit_test/fuel/hci/client_api_props_test.py
+++ b/tests/unit_test/fuel/hci/client_api_props_test.py
@@ -14,6 +14,7 @@
 
 from types import SimpleNamespace
 
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.fuel.hci.client.api import AdminAPI
 from nvflare.fuel.hci.client.api_spec import CommandContext
 
@@ -40,3 +41,73 @@ def test_do_client_command_preserves_command_props():
 
     assert result == {"status": "ok"}
     assert captured["props"] == {"study": "study-a"}
+
+
+def test_user_login_sends_study_header(monkeypatch):
+    api = AdminAPI.__new__(AdminAPI)
+    api.client_key = "client.key"
+    api.client_cert = "client.crt"
+    api.user_name = "admin@nvidia.com"
+    api.study = "cancer-research"
+    api.login_result = None
+    captured = {}
+
+    class _FakeIdentityAsserter:
+        cert_data = "cert-data"
+
+        def __init__(self, private_key_file, cert_file):
+            assert private_key_file == "client.key"
+            assert cert_file == "client.crt"
+
+        @staticmethod
+        def sign_common_name(nonce=""):
+            return "signature"
+
+    monkeypatch.setattr("nvflare.fuel.hci.client.api.IdentityAsserter", _FakeIdentityAsserter)
+
+    def _fake_server_execute(command, reply_processor, headers=None):
+        captured["command"] = command
+        captured["headers"] = headers
+        api.login_result = "OK"
+
+    api.server_execute = _fake_server_execute
+    api._after_login = lambda: {"status": "ok"}
+
+    result = api._user_login()
+
+    assert result == {"status": "ok"}
+    assert captured["command"] == "_cert_login admin@nvidia.com"
+    assert captured["headers"]["study"] == "cancer-research"
+
+
+def test_user_login_defaults_study_header(monkeypatch):
+    api = AdminAPI.__new__(AdminAPI)
+    api.client_key = "client.key"
+    api.client_cert = "client.crt"
+    api.user_name = "admin@nvidia.com"
+    api.study = DEFAULT_STUDY
+    api.login_result = None
+    captured = {}
+
+    class _FakeIdentityAsserter:
+        cert_data = "cert-data"
+
+        def __init__(self, private_key_file, cert_file):
+            pass
+
+        @staticmethod
+        def sign_common_name(nonce=""):
+            return "signature"
+
+    monkeypatch.setattr("nvflare.fuel.hci.client.api.IdentityAsserter", _FakeIdentityAsserter)
+
+    def _fake_server_execute(command, reply_processor, headers=None):
+        captured["headers"] = headers
+        api.login_result = "OK"
+
+    api.server_execute = _fake_server_execute
+    api._after_login = lambda: {"status": "ok"}
+
+    api._user_login()
+
+    assert captured["headers"]["study"] == DEFAULT_STUDY

--- a/tests/unit_test/fuel/hci/session_study_test.py
+++ b/tests/unit_test/fuel/hci/session_study_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.apis.job_def import DEFAULT_STUDY
+from nvflare.fuel.hci.base64_utils import str_to_b64str
+from nvflare.fuel.hci.server.sess import Session
+
+
+class _FakeIdAsserter:
+    cert = "server-cert"
+
+    @staticmethod
+    def sign(data, return_str=True):
+        assert return_str
+        return "signature"
+
+
+def test_session_token_round_trip_preserves_study():
+    session = Session(
+        sess_id="session-id",
+        user_name="admin@nvidia.com",
+        org="nvidia",
+        role="lead",
+        origin_fqcn="origin",
+        active_study="cancer-research",
+    )
+
+    token = session.make_token(_FakeIdAsserter())
+    restored = Session.decode_token(token)
+
+    assert restored.active_study == "cancer-research"
+    assert restored.user_name == "admin@nvidia.com"
+    assert restored.user_org == "nvidia"
+    assert restored.user_role == "lead"
+
+
+def test_decode_token_defaults_legacy_session_study():
+    legacy_payload = json.dumps({"n": "admin@nvidia.com", "r": "lead", "o": "nvidia", "s": "session-id"})
+    token = f"{str_to_b64str(legacy_payload)}:signature"
+
+    restored = Session.decode_token(token)
+
+    assert restored.active_study == DEFAULT_STUDY

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -16,7 +16,13 @@ from argparse import Namespace
 
 import pytest
 
-from nvflare.private.fed.server.job_cmds import _create_list_job_cmd_parser
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.job_def import JobMetaKey
+from nvflare.fuel.hci.server.constants import ConnProps
+from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
+from nvflare.private.fed.server import job_cmds as job_cmds_module
+from nvflare.private.fed.server.job_cmds import JobCommandModule, _create_list_job_cmd_parser
 
 TEST_CASES = [
     (
@@ -41,3 +47,278 @@ class TestListJobCmdParser:
         parser = _create_list_job_cmd_parser()
         parsed_args = parser.parse_args(args)
         assert parsed_args == expected_args
+
+
+class _MockConnection:
+    def __init__(self, cmd_props=None, app_ctx=None, props=None):
+        self._props = dict(props or {})
+        self._props.setdefault(ConnProps.CMD_PROPS, cmd_props)
+        self.app_ctx = app_ctx
+        self.errors = []
+        self.strings = []
+        self.successes = []
+        self.dicts = []
+        self.tables = []
+
+    def get_prop(self, key, default=None):
+        return self._props.get(key, default)
+
+    def append_error(self, msg, meta=None):
+        self.errors.append((msg, meta))
+
+    def append_string(self, msg, meta=None):
+        self.strings.append((msg, meta))
+
+    def append_success(self, msg, meta=None):
+        self.successes.append((msg, meta))
+
+    def append_dict(self, data, meta=None):
+        self.dicts.append((data, meta))
+
+    def append_table(self, headers, name=None):
+        table = _MockTable(headers=headers, name=name)
+        self.tables.append(table)
+        return table
+
+
+class _MockTable:
+    def __init__(self, headers, name=None):
+        self.headers = headers
+        self.name = name
+        self.rows = []
+
+    def add_row(self, row, meta=None):
+        self.rows.append((row, meta))
+
+
+class TestStudyCmdProps:
+    @pytest.mark.parametrize(
+        "cmd_props, expected_study",
+        [
+            (None, None),
+            ("not-a-dict", None),
+            ({}, None),
+            ({"study": ""}, ""),
+            ({"study": "cancer-research"}, "cancer-research"),
+            ({"study": "default"}, "default"),
+        ],
+    )
+    def test_get_requested_study(self, cmd_props, expected_study):
+        conn = _MockConnection(cmd_props=cmd_props)
+
+        assert JobCommandModule._get_requested_study(conn) == expected_study
+        assert conn.errors == []
+
+
+class _FakeJobMetaValidator:
+    def validate(self, folder_name, zip_file_name):
+        assert folder_name == "job_folder"
+        assert zip_file_name == "job.zip"
+        return True, "", {}
+
+
+class _FakeJobDefManager:
+    def __init__(self):
+        self.created_meta = None
+        self.cloned_meta = None
+
+    def create(self, meta, uploaded_content, fl_ctx):
+        self.created_meta = dict(meta)
+        result = dict(meta)
+        result[JobMetaKey.JOB_ID.value] = "new-job-id"
+        return result
+
+    def clone(self, from_jid, meta, fl_ctx):
+        self.cloned_meta = dict(meta)
+        result = dict(meta)
+        result[JobMetaKey.JOB_ID.value] = "cloned-job-id"
+        return result
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.job_def_manager = _FakeJobDefManager()
+        self.submit_event_meta = None
+
+    def new_context(self):
+        from nvflare.apis.fl_context import FLContext
+
+        return FLContext()
+
+    def fire_event(self, event_type, fl_ctx):
+        assert event_type == EventType.SUBMIT_JOB
+        self.submit_event_meta = dict(fl_ctx.get_prop(FLContextKey.JOB_META, {}))
+
+
+class _FakeListedJob:
+    def __init__(self, meta):
+        self.meta = meta
+
+
+class _FakeListJobDefManager:
+    def __init__(self, jobs):
+        self.jobs = jobs
+
+    def get_all_jobs(self, fl_ctx):
+        return self.jobs
+
+    def get_job(self, jid, fl_ctx):
+        for job in self.jobs:
+            if job.meta.get(JobMetaKey.JOB_ID.value) == jid:
+                return job
+        return None
+
+
+class _FakeListEngine:
+    def __init__(self, jobs):
+        self.job_def_manager = _FakeListJobDefManager(jobs)
+
+    def new_context(self):
+        from nvflare.apis.fl_context import FLContext
+
+        return FLContext()
+
+
+def test_submit_job_exposes_study_in_submit_event(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobMetaValidator", _FakeJobMetaValidator)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+
+    engine = _FakeEngine()
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={
+            ConnProps.FILE_LOCATION: "job.zip",
+            ConnProps.CMD_PROPS: {"study": "cancer-research"},
+            ConnProps.USER_NAME: "submitter",
+            ConnProps.USER_ORG: "org",
+            ConnProps.USER_ROLE: "role",
+        },
+    )
+
+    JobCommandModule().submit_job(conn, ["submit_job", "job_folder"])
+
+    assert conn.errors == []
+    assert len(conn.successes) == 1
+    assert engine.submit_event_meta == {JobMetaKey.STUDY.value: "cancer-research"}
+    assert engine.job_def_manager.created_meta[JobMetaKey.STUDY.value] == "cancer-research"
+
+
+def test_submit_job_defaults_study_when_cmd_props_missing(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobMetaValidator", _FakeJobMetaValidator)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+
+    engine = _FakeEngine()
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={
+            ConnProps.FILE_LOCATION: "job.zip",
+            ConnProps.USER_NAME: "submitter",
+            ConnProps.USER_ORG: "org",
+            ConnProps.USER_ROLE: "role",
+        },
+    )
+
+    JobCommandModule().submit_job(conn, ["submit_job", "job_folder"])
+
+    assert conn.errors == []
+    assert engine.submit_event_meta == {JobMetaKey.STUDY.value: "default"}
+    assert engine.job_def_manager.created_meta[JobMetaKey.STUDY.value] == "default"
+
+
+def test_clone_job_preserves_source_study(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", object)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+
+    source_job = _FakeListedJob(
+        {
+            JobMetaKey.JOB_ID.value: "source-job",
+            JobMetaKey.JOB_NAME.value: "source",
+            JobMetaKey.STUDY.value: "cancer-research",
+        }
+    )
+    engine = _FakeEngine()
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={
+            JobCommandModule.JOB: source_job,
+            JobCommandModule.JOB_ID: "source-job",
+            ConnProps.CMD_PROPS: {"study": "multiple-sclerosis"},
+            ConnProps.USER_NAME: "submitter",
+            ConnProps.USER_ORG: "org",
+            ConnProps.USER_ROLE: "role",
+        },
+    )
+
+    JobCommandModule().clone_job(conn, ["clone_job", "source-job"])
+
+    assert conn.errors == []
+    assert engine.job_def_manager.cloned_meta[JobMetaKey.STUDY.value] == "cancer-research"
+
+
+def test_list_jobs_filters_legacy_jobs_into_default_study(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    jobs = [
+        _FakeListedJob({JobMetaKey.JOB_ID.value: "legacy-job", JobMetaKey.JOB_NAME.value: "legacy"}),
+        _FakeListedJob(
+            {
+                JobMetaKey.JOB_ID.value: "study-job",
+                JobMetaKey.JOB_NAME.value: "study",
+                JobMetaKey.STUDY.value: "cancer-research",
+            }
+        ),
+    ]
+    conn = _MockConnection(app_ctx=_FakeListEngine(jobs), cmd_props={"study": "default"})
+
+    JobCommandModule().list_jobs(conn, ["list_jobs"])
+
+    assert conn.errors == []
+    assert len(conn.tables) == 1
+    assert len(conn.tables[0].rows) == 1
+    assert conn.tables[0].rows[0][1][JobMetaKey.STUDY.value] == "default"
+    assert conn.tables[0].rows[0][1][MetaKey.JOB_ID] == "legacy-job"
+
+
+def test_list_jobs_rejects_invalid_study(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    conn = _MockConnection(app_ctx=_FakeListEngine([]), cmd_props={"study": "Bad Study"})
+
+    JobCommandModule().list_jobs(conn, ["list_jobs"])
+
+    assert conn.errors == []
+    assert len(conn.strings) == 1
+    assert conn.strings[0][0] == "No jobs found."
+
+
+def test_submit_job_rejects_invalid_study_when_persisting(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobMetaValidator", _FakeJobMetaValidator)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+
+    engine = _FakeEngine()
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={
+            ConnProps.FILE_LOCATION: "job.zip",
+            ConnProps.CMD_PROPS: {"study": "Bad Study"},
+            ConnProps.USER_NAME: "submitter",
+            ConnProps.USER_ORG: "org",
+            ConnProps.USER_ROLE: "role",
+        },
+    )
+
+    JobCommandModule().submit_job(conn, ["submit_job", "job_folder"])
+
+    assert len(conn.errors) == 1
+    assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_DEFINITION
+    assert conn.successes == []
+
+
+def test_get_job_meta_normalizes_legacy_job_study(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    jobs = [_FakeListedJob({JobMetaKey.JOB_ID.value: "legacy-job", JobMetaKey.JOB_NAME.value: "legacy"})]
+    conn = _MockConnection(app_ctx=_FakeListEngine(jobs), props={JobCommandModule.JOB_ID: "legacy-job"})
+
+    JobCommandModule().get_job_meta(conn, ["get_job_meta", "legacy-job"])
+
+    assert conn.errors == []
+    assert len(conn.dicts) == 1
+    assert conn.dicts[0][0][JobMetaKey.STUDY.value] == "default"

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -19,8 +19,8 @@ import pytest
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.job_def import JobMetaKey
-from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
+from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.private.fed.server import job_cmds as job_cmds_module
 from nvflare.private.fed.server.job_cmds import JobCommandModule, _create_list_job_cmd_parser
 

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -91,25 +91,6 @@ class _MockTable:
         self.rows.append((row, meta))
 
 
-class TestStudyCmdProps:
-    @pytest.mark.parametrize(
-        "cmd_props, expected_study",
-        [
-            (None, None),
-            ("not-a-dict", None),
-            ({}, None),
-            ({"study": ""}, ""),
-            ({"study": "cancer-research"}, "cancer-research"),
-            ({"study": "default"}, "default"),
-        ],
-    )
-    def test_get_requested_study(self, cmd_props, expected_study):
-        conn = _MockConnection(cmd_props=cmd_props)
-
-        assert JobCommandModule._get_requested_study(conn) == expected_study
-        assert conn.errors == []
-
-
 class _FakeJobMetaValidator:
     def validate(self, folder_name, zip_file_name):
         assert folder_name == "job_folder"
@@ -188,7 +169,7 @@ def test_submit_job_exposes_study_in_submit_event(monkeypatch):
         app_ctx=engine,
         props={
             ConnProps.FILE_LOCATION: "job.zip",
-            ConnProps.CMD_PROPS: {"study": "cancer-research"},
+            ConnProps.ACTIVE_STUDY: "cancer-research",
             ConnProps.USER_NAME: "submitter",
             ConnProps.USER_ORG: "org",
             ConnProps.USER_ROLE: "role",
@@ -242,7 +223,7 @@ def test_clone_job_preserves_source_study(monkeypatch):
         props={
             JobCommandModule.JOB: source_job,
             JobCommandModule.JOB_ID: "source-job",
-            ConnProps.CMD_PROPS: {"study": "multiple-sclerosis"},
+            ConnProps.ACTIVE_STUDY: "multiple-sclerosis",
             ConnProps.USER_NAME: "submitter",
             ConnProps.USER_ORG: "org",
             ConnProps.USER_ROLE: "role",
@@ -267,7 +248,7 @@ def test_list_jobs_filters_legacy_jobs_into_default_study(monkeypatch):
             }
         ),
     ]
-    conn = _MockConnection(app_ctx=_FakeListEngine(jobs), cmd_props={"study": "default"})
+    conn = _MockConnection(app_ctx=_FakeListEngine(jobs), props={ConnProps.ACTIVE_STUDY: "default"})
 
     JobCommandModule().list_jobs(conn, ["list_jobs"])
 
@@ -278,38 +259,28 @@ def test_list_jobs_filters_legacy_jobs_into_default_study(monkeypatch):
     assert conn.tables[0].rows[0][1][MetaKey.JOB_ID] == "legacy-job"
 
 
-def test_list_jobs_rejects_invalid_study(monkeypatch):
+def test_list_jobs_defaults_to_default_study_when_session_study_missing(monkeypatch):
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
-    conn = _MockConnection(app_ctx=_FakeListEngine([]), cmd_props={"study": "Bad Study"})
+    jobs = [
+        _FakeListedJob({JobMetaKey.JOB_ID.value: "legacy-job", JobMetaKey.JOB_NAME.value: "legacy"}),
+        _FakeListedJob(
+            {
+                JobMetaKey.JOB_ID.value: "study-job",
+                JobMetaKey.JOB_NAME.value: "study",
+                JobMetaKey.STUDY.value: "cancer-research",
+            }
+        ),
+    ]
+    conn = _MockConnection(app_ctx=_FakeListEngine(jobs))
 
     JobCommandModule().list_jobs(conn, ["list_jobs"])
 
     assert conn.errors == []
-    assert len(conn.strings) == 1
-    assert conn.strings[0][0] == "No jobs found."
-
-
-def test_submit_job_rejects_invalid_study_when_persisting(monkeypatch):
-    monkeypatch.setattr(job_cmds_module, "JobMetaValidator", _FakeJobMetaValidator)
-    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
-
-    engine = _FakeEngine()
-    conn = _MockConnection(
-        app_ctx=engine,
-        props={
-            ConnProps.FILE_LOCATION: "job.zip",
-            ConnProps.CMD_PROPS: {"study": "Bad Study"},
-            ConnProps.USER_NAME: "submitter",
-            ConnProps.USER_ORG: "org",
-            ConnProps.USER_ROLE: "role",
-        },
-    )
-
-    JobCommandModule().submit_job(conn, ["submit_job", "job_folder"])
-
-    assert len(conn.errors) == 1
-    assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_DEFINITION
-    assert conn.successes == []
+    assert conn.strings == []
+    assert len(conn.tables) == 1
+    assert len(conn.tables[0].rows) == 1
+    assert conn.tables[0].rows[0][1][JobMetaKey.STUDY.value] == "default"
+    assert len(conn.successes) == 1
 
 
 def test_get_job_meta_normalizes_legacy_job_study(monkeypatch):

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -19,7 +19,7 @@ import pytest
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.job_def import JobMetaKey
-from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
+from nvflare.fuel.hci.proto import MetaKey
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.private.fed.server import job_cmds as job_cmds_module
 from nvflare.private.fed.server.job_cmds import JobCommandModule, _create_list_job_cmd_parser

--- a/tests/unit_test/recipe/prod_env_test.py
+++ b/tests/unit_test/recipe/prod_env_test.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.recipe.prod_env import ProdEnv
+
+
+def test_prod_env_session_manager_passes_study():
+    with tempfile.TemporaryDirectory() as startup_kit_location:
+        env = ProdEnv(startup_kit_location=startup_kit_location, study="cancer-research")
+        with patch("nvflare.recipe.prod_env.SessionManager") as mock_session_manager:
+            env._get_session_manager()
+            session_params = mock_session_manager.call_args[0][0]
+            assert session_params["study"] == "cancer-research"
+
+
+def test_prod_env_rejects_invalid_study_name():
+    with tempfile.TemporaryDirectory() as startup_kit_location:
+        with pytest.raises(ValueError):
+            ProdEnv(startup_kit_location=startup_kit_location, study="Bad Study")
+
+
+def test_prod_env_defaults_study():
+    with tempfile.TemporaryDirectory() as startup_kit_location:
+        env = ProdEnv(startup_kit_location=startup_kit_location)
+        with patch("nvflare.recipe.prod_env.SessionManager") as mock_session_manager:
+            env._get_session_manager()
+            session_params = mock_session_manager.call_args[0][0]
+            assert session_params["study"] == "default"


### PR DESCRIPTION
## Summary
- add phase 1 study session plumbing across Flare API, ProdEnv, server job handling, and the admin CLI launch path
- scope `list_jobs` by session study, persist study on submit, preserve the source study on clone, and normalize legacy jobs without study metadata to `default`
- split the design docs into phase 1 and phase 2 documents and add focused unit/integration coverage, including admin terminal and legacy-client compatibility paths
