### PR TITLE
fix(test): migrate test_distributed_provisioning to FLARE API Session

### DIFF
--- a/tests/integration_test/src/utils.py
+++ b/tests/integration_test/src/utils.py
@@ -248,7 +248,11 @@ def check_job_done(job_id: str, admin_api: Session):
         print(f"Check client status failed: {client_statuses}")
         return False
 
-    job_run_status = admin_api.get_job_status(job_id)
+    try:
+        job_run_status = admin_api.get_job_status(job_id)
+    except Exception as e:
+        print(f"Get job status failed: {e}")
+        return False
     if job_run_status in (
         RunStatus.FINISHED_COMPLETED.value,
         RunStatus.FINISHED_ABORTED.value,

--- a/tests/integration_test/test_distributed_provisioning.py
+++ b/tests/integration_test/test_distributed_provisioning.py
@@ -313,7 +313,7 @@ class TestDistributedProvisioningE2E:
 
     @pytest.fixture()
     def admin_api(self, provisioned, tmp_path):
-        """Start server + 2 clients from packaged kits; yield a logged-in FLAdminAPI."""
+        """Start server + 2 clients from packaged kits; yield a logged-in Session."""
         env = os.environ.copy()
         python_path = ":".join(p for p in sys.path if p)
         env["PYTHONPATH"] = python_path
@@ -403,7 +403,7 @@ class TestDistributedProvisioningE2E:
 
         # Teardown
         try:
-            api.logout()
+            api.close()
         except Exception:
             pass
         for p in processes:
@@ -417,16 +417,12 @@ class TestDistributedProvisioningE2E:
     def test_hello_numpy_sag_completes(self, admin_api, tmp_path):
         """Submit hello-numpy-sag; verify it finishes with FINISHED_COMPLETED."""
         from nvflare.apis.job_def import RunStatus
-        from nvflare.fuel.hci.client.api_status import APIStatus
-        from nvflare.fuel.hci.client.fl_admin_api_spec import TargetType
         from tests.integration_test.src.utils import check_job_done, ensure_admin_api_logged_in, get_job_meta
 
         assert ensure_admin_api_logged_in(admin_api, timeout=60), "Admin API did not log in within 60 s"
 
         job_dir = os.path.join(os.path.dirname(__file__), "data", "jobs", "hello-numpy-sag")
-        response = admin_api.submit_job(job_dir)
-        assert response.get("status") == APIStatus.SUCCESS, f"Job submit failed: {response}"
-        job_id = response["details"]["job_id"]
+        job_id = admin_api.submit_job(job_dir)
 
         # Poll until done; log status every 30 s so a timeout is diagnosable.
         deadline = time.time() + _JOB_TIMEOUT
@@ -435,14 +431,20 @@ class TestDistributedProvisioningE2E:
             if check_job_done(job_id, admin_api):
                 break
             if time.time() - last_log >= 30:
-                srv = admin_api.check_status(target_type=TargetType.SERVER)
-                cli = admin_api.check_status(target_type=TargetType.CLIENT)
+                try:
+                    srv = admin_api.get_system_info()
+                    cli = admin_api.get_client_job_status()
+                except Exception as e:
+                    srv = cli = f"<error: {e}>"
                 print(f"\n[E2E poll] job={job_id}  server={srv}  clients={cli}")
                 last_log = time.time()
             time.sleep(5)
         else:
-            srv = admin_api.check_status(target_type=TargetType.SERVER)
-            cli = admin_api.check_status(target_type=TargetType.CLIENT)
+            try:
+                srv = admin_api.get_system_info()
+                cli = admin_api.get_client_job_status()
+            except Exception as e:
+                srv = cli = f"<error: {e}>"
             meta = get_job_meta(admin_api, job_id)
             pytest.fail(
                 f"Job {job_id} did not complete within {_JOB_TIMEOUT} s\n"


### PR DESCRIPTION
## Summary
- Migrate `test_distributed_provisioning.py` (added in #4380) from deleted `FLAdminAPI` to `Session` API, matching the migration done in #4400
- `submit_job` returns `str` job_id directly (not a dict with `status`/`details`)
- Replace `check_status(target_type=...)` with `get_system_info()` / `get_client_job_status()`
- Replace `logout()` with `close()` in fixture teardown
- Remove stale imports of `APIStatus` and `fl_admin_api_spec.TargetType`
- Wrap `get_job_status` in `check_job_done` defensively to match old bool-only return contract

Fixes breakage introduced by #4400 deleting the FLAdminAPI surface that #4380's test still referenced.