### PR TITLE
[fix/ci] Handle run-state polling connection teardown

### DIFF
--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -275,12 +275,12 @@ class NVFTestDriver:
         if self.job_id and self.super_admin_api:
             try:
                 job_meta = get_job_meta(self.super_admin_api, job_id=self.job_id)
-            except JobNotFound:
+            except (JobNotFound, ConnectionError, SessionClosed):
                 return run_state
             job_run_status = job_meta.get("status")
             try:
                 stats = self._get_stats(target=TargetType.SERVER, job_id=self.job_id)
-            except (JobNotFound, JobNotRunning):
+            except (JobNotFound, JobNotRunning, ConnectionError, SessionClosed):
                 stats = None
             # update run_state
             changed, run_state = _update_run_state(stats=stats, run_state=run_state, job_run_status=job_run_status)


### PR DESCRIPTION
## Summary
- tolerate transient `ConnectionError` and `SessionClosed` while the integration harness polls run state
- keep `_get_run_state()` from failing the test during normal server/admin teardown

## Root Cause
PR #4400 migrated the integration harness from the deprecated `FLAdminAPI` surface to `flare_api.Session`.

With the new session path, `get_job_meta()` and `show_stats()` can raise real exceptions during teardown when the server side is already disconnecting. `_get_run_state()` already handled `JobNotFound` and `JobNotRunning`, but it did not handle the transient connection/session teardown exceptions, so the `np_app` integration case could fail sporadically with `ConnectionError: cannot connect to server: APIStatus.ERROR_SERVER_CONNECTION`.

## Why This Fix
The run-state polling loop should treat transient teardown disconnects like the already-handled end-of-run races: skip that poll iteration and continue. The change is intentionally narrow and only catches the connectivity/session exceptions that are expected during teardown.

## Validation
- reproduced the failure locally on a synthetic merge snapshot of PR #4415 into `main`
- validated that `np_job` passed on the same synthetic merge snapshot
- reran the reproduced `np_app` integration case locally 10 times on the same synthetic merge snapshot after the fix: 10/10 passed
