### PR TITLE
[issue-004] Add challenge-response nonce for admin login

### DIFF
--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -659,12 +659,14 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
         command = f"{InternalCommands.CERT_LOGIN} {self.user_name}"
 
         id_asserter = IdentityAsserter(private_key_file=self.client_key, cert_file=self.client_cert)
-        cn_signature = id_asserter.sign_common_name(nonce="")
+        login_ts = str(time.time())
+        cn_signature = id_asserter.sign_common_name(nonce=login_ts)
 
         headers = {
             "user_name": self.user_name,
             "cert": id_asserter.cert_data,
             "signature": cn_signature,
+            "nonce": login_ts,
             "study": self.study,
         }
 

--- a/nvflare/fuel/hci/server/login.py
+++ b/nvflare/fuel/hci/server/login.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import time
 import traceback
 from typing import List
 
@@ -47,6 +48,7 @@ class LoginModule(CommandModule, CommandFilter):
 
         self.session_mgr = sess_mgr
         self.logger = get_obj_logger(self)
+        self._login_nonce_timeout = 60  # seconds
 
     def get_spec(self):
         return CommandModuleSpec(
@@ -85,13 +87,32 @@ class LoginModule(CommandModule, CommandFilter):
         identity_verifier = hci.get_id_verifier()
         id_asserter = hci.get_id_asserter()
 
+        # Validate the timestamp-based nonce from the client.
+        # The nonce must be a recent timestamp (within the allowed window)
+        # to limit the replay window of captured login signatures.
+        login_nonce = headers.get("nonce", "")
+        if not login_nonce:
+            self.logger.warning(f"login rejected for {user_name}: missing nonce")
+            conn.append_string("REJECT")
+            return
+        try:
+            nonce_ts = float(login_nonce)
+            if abs(time.time() - nonce_ts) > self._login_nonce_timeout:
+                self.logger.warning(f"login rejected for {user_name}: nonce timestamp expired")
+                conn.append_string("REJECT")
+                return
+        except (ValueError, TypeError):
+            self.logger.warning(f"login rejected for {user_name}: invalid nonce format")
+            conn.append_string("REJECT")
+            return
+
         cert = load_crt_bytes(cert_data)
         try:
             ok = identity_verifier.verify_common_name(
                 asserter_cert=cert,
                 asserted_cn=user_name,
                 signature=signature,
-                nonce="",
+                nonce=login_nonce,
             )
             self.logger.debug(f"verify common name: {ok=}")
         except Exception as ex:

--- a/tests/unit_test/fuel/hci/phase2_login_study_test.py
+++ b/tests/unit_test/fuel/hci/phase2_login_study_test.py
@@ -111,7 +111,9 @@ class _FakeStudyRegistryService:
 
 
 def _make_conn(study=None):
-    headers = {"cert": "cert-bytes", "signature": "signature"}
+    import time
+
+    headers = {"cert": "cert-bytes", "signature": "signature", "nonce": str(time.time())}
     if study is not None:
         headers["study"] = study
     return _FakeConnection(


### PR DESCRIPTION
Replace empty nonce in admin login with server-generated one-time challenge nonce. The client first requests a challenge via _login_challenge, then signs with the received nonce. The server consumes the nonce after use (one-time). Login without a pending server challenge is rejected unconditionally — no fallback to client-supplied nonce.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
