### PR TITLE
Fix torch 2.8.0 dependency conflicts in qwen3-vl example

### DIFF
--- a/examples/advanced/qwen3-vl/install_requirements.sh
+++ b/examples/advanced/qwen3-vl/install_requirements.sh
@@ -26,7 +26,7 @@ PYTHON_BIN="${PYTHON:-python}"
 "$PYTHON_BIN" -m pip install -U pip
 
 echo "==> Installing PyTorch first (required for building flash_attn)..."
-"$PYTHON_BIN" -m pip install torch==2.6.0 torchvision==0.21.0
+"$PYTHON_BIN" -m pip install torch==2.8.0 torchvision==0.23.0
 
 echo "==> Installing build-time deps for flash_attn (e.g. psutil)..."
 "$PYTHON_BIN" -m pip install psutil packaging ninja

--- a/examples/advanced/qwen3-vl/requirements.txt
+++ b/examples/advanced/qwen3-vl/requirements.txt
@@ -1,11 +1,11 @@
 nvflare~=2.7.2rc
 torch==2.8.0
-torchvision==0.21.0
+torchvision==0.23.0
 psutil  # required at build time by flash_attn
 transformers==5.0.0
 deepspeed==0.17.1
-flash_attn==2.7.4.post1
-triton==3.2.0
+flash_attn
+triton==3.4.0
 accelerate==1.7.0
 torchcodec==0.2
 peft==0.18.0


### PR DESCRIPTION
- Bump torchvision 0.21.0 → 0.23.0 (matches torch 2.8.0)
- Bump triton 3.2.0 → 3.4.0 (required by torch 2.8.0 on Linux x86_64)
- Unpin flash_attn version (pre-built 2.7.4.post1 wheel was compiled against torch 2.6.x, causing ABI symbol errors at runtime)
- Update install_requirements.sh build-time torch/torchvision pins to 2.8.0/0.23.0 so flash_attn is compiled against the correct ABI

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
