### PR TITLE
Add missing edge web model types to FOBS type whitelist

### DIFF
--- a/nvflare/fuel/utils/fobs/builtin_decomposers.py
+++ b/nvflare/fuel/utils/fobs/builtin_decomposers.py
@@ -104,4 +104,21 @@ BUILTIN_TYPES: set[str] = {
     # Found in integration test
     "nvflare.apis.job_def.JobMetaKey",
     "xgboost.core.DataSplitMode",
+    # --- Edge web model types (dict-based models for edge device communication) ---
+    # These types are serialized via FOBS when edge requests/responses flow through
+    # F3/cell message passing (e.g., SelectionRequest containing DeviceInfo).
+    # Without these entries, edge external-device tests fail with
+    # "Type 'nvflare.edge.web.models.device_info.DeviceInfo' is not allowed."
+    "nvflare.edge.web.models.device_info.DeviceInfo",
+    "nvflare.edge.web.models.user_info.UserInfo",
+    "nvflare.edge.web.models.capabilities.Capabilities",
+    "nvflare.edge.web.models.job_request.JobRequest",
+    "nvflare.edge.web.models.job_response.JobResponse",
+    "nvflare.edge.web.models.task_request.TaskRequest",
+    "nvflare.edge.web.models.task_response.TaskResponse",
+    "nvflare.edge.web.models.selection_request.SelectionRequest",
+    "nvflare.edge.web.models.selection_response.SelectionResponse",
+    "nvflare.edge.web.models.result_report.ResultReport",
+    "nvflare.edge.web.models.result_response.ResultResponse",
+    "nvflare.edge.web.models.error_response.ErrorResponse",
 }


### PR DESCRIPTION
## Summary

PR #4295 introduced a FOBS `type_name` whitelist to prevent RCE via deserialization, and PR #4298 added some missing types. However, **12 edge web model types** from `nvflare.edge.web.models.*` were not included in the whitelist.

When edge external-device workflows run, FOBS deserialization fails on child nodes with:
```
Type 'nvflare.edge.web.models.device_info.DeviceInfo' is not allowed.
Use fobs.register_data_classes(), fobs.register_enum_types(),
or fobs.add_type_name_whitelist() to allow this type.
```

This causes edge jobs to hang in `RUNNING` status indefinitely because child nodes cannot process edge messages.

## Root Cause

- **Worked in**: 2.7.2rc12 (before whitelist was introduced)
- **Broken since**: 2.7.2rc15 (first build containing PR #4295 and #4298)
- The `BUILTIN_TYPES` set in `builtin_decomposers.py` was missing all edge web model types that flow through F3/cell message passing

## Fix

Added all 12 edge web model types to `BUILTIN_TYPES`:
- `DeviceInfo`, `UserInfo`, `Capabilities`
- `JobRequest`, `JobResponse`
- `TaskRequest`, `TaskResponse`
- `SelectionRequest`, `SelectionResponse`
- `ResultReport`, `ResultResponse`
- `ErrorResponse`

## Test Plan

- [x] `L0_edge_num_async_job_ext` test passes (previously failed consistently since 2.7.2rc15)
- [x] Verified on both Python 3.10 and 3.12
- [x] All other L0 edge tests continue to pass