### PR TITLE
Fix HelmChartBuilder mutating shared comm_config_args dictFix/helm chart shared dict mutation

### DIFF
--- a/nvflare/lighter/impl/helm_chart.py
+++ b/nvflare/lighter/impl/helm_chart.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import os
 import shutil
 
@@ -114,10 +115,12 @@ class HelmChartBuilder(Builder):
         fed_learn_port = ctx.get(CtxKey.FED_LEARN_PORT, 8002)
         admin_port = ctx.get(CtxKey.ADMIN_PORT, 8003)
 
-        # Align comm_config.json with the chart so that internal jobs can reach the
-        # parent at <nvflare-server>:<parent_port> within the cluster namespace.
+        # Build Helm-specific comm_config on a COPY so the shared dict is not mutated.
+        # Without deep-copy, the in-place update would corrupt comm_config for non-Helm
+        # deployments (Docker, subprocess) that share the same provisioned workspace.
         comm_config_args = server.get_prop(PropKey.COMM_CONFIG_ARGS)
         if comm_config_args is not None:
+            comm_config_args = copy.deepcopy(comm_config_args)
             comm_config_args.update(
                 {
                     CommConfigArg.HOST: "nvflare-server",
@@ -221,10 +224,10 @@ class HelmChartBuilder(Builder):
         templates_dir = os.path.join(chart_dir, "templates")
         os.makedirs(templates_dir, exist_ok=True)
 
-        # Align comm_config.json with the chart so that job pods can reach
-        # the client at <client.name>:<parent_port> within the cluster namespace.
+        # Build Helm-specific comm_config on a COPY so the shared dict is not mutated.
         comm_config_args = client.get_prop(PropKey.COMM_CONFIG_ARGS)
         if comm_config_args is not None:
+            comm_config_args = copy.deepcopy(comm_config_args)
             comm_config_args.update(
                 {
                     CommConfigArg.HOST: client.name,

--- a/tests/unit_test/lighter/helm_chart_builder_test.py
+++ b/tests/unit_test/lighter/helm_chart_builder_test.py
@@ -190,8 +190,12 @@ class TestClientChart:
 
             assert chart["appVersion"] == "2.7.0"
 
-    def test_comm_config_args_set_when_seeded(self):
-        """COMM_CONFIG_ARGS host/port must match the Helm Service name and containerPort."""
+    def test_comm_config_args_not_mutated_when_seeded(self):
+        """COMM_CONFIG_ARGS on the participant must NOT be mutated by HelmChartBuilder.
+
+        The builder must deep-copy the dict before updating it with Helm-specific values,
+        so the shared dict used by other builders (e.g. StaticFileBuilder) stays clean.
+        """
         project = _make_project(num_clients=1)
         _seed_comm_config_args(project)
         with tempfile.TemporaryDirectory() as root:
@@ -200,8 +204,7 @@ class TestClientChart:
 
         client = project.get_clients()[0]
         args = client.get_prop(PropKey.COMM_CONFIG_ARGS)
-        assert args[CommConfigArg.HOST] == "site-1", "host must equal client.name (= Kubernetes service name)"
-        assert args[CommConfigArg.PORT] == 18002, "port must equal parent_port (= containerPort / targetPort)"
+        assert args == {}, "shared COMM_CONFIG_ARGS must remain empty after HelmChartBuilder.build()"
 
     def test_comm_config_args_not_set_when_not_seeded(self):
         """When StaticFileBuilder has not run, COMM_CONFIG_ARGS is None; build() must not raise."""
@@ -405,8 +408,12 @@ class TestServerChart:
 
             assert values["parentPort"] == 9000
 
-    def test_server_comm_config_args_set_when_seeded(self):
-        """COMM_CONFIG_ARGS host must be 'server' and port must equal parent_port."""
+    def test_server_comm_config_args_not_mutated_when_seeded(self):
+        """COMM_CONFIG_ARGS on the server must NOT be mutated by HelmChartBuilder.
+
+        The builder must deep-copy the dict before updating it with Helm-specific values,
+        so the shared dict used by other builders (e.g. StaticFileBuilder) stays clean.
+        """
         project = _make_project()
         _seed_comm_config_args(project)
         with tempfile.TemporaryDirectory() as root:
@@ -415,8 +422,7 @@ class TestServerChart:
 
         server = project.get_server()
         args = server.get_prop(PropKey.COMM_CONFIG_ARGS)
-        assert args[CommConfigArg.HOST] == "nvflare-server"
-        assert args[CommConfigArg.PORT] == 18102, "port must equal parent_port"
+        assert args == {}, "shared COMM_CONFIG_ARGS must remain empty after HelmChartBuilder.build()"
 
     def test_server_comm_config_args_not_set_when_not_seeded(self):
         """When StaticFileBuilder has not run, COMM_CONFIG_ARGS is None; build() must not raise."""


### PR DESCRIPTION
● Summary

  - HelmChartBuilder.build() was calling comm_config_args.update() on the shared dict obtained via
  get_prop(PropKey.COMM_CONFIG_ARGS), overwriting the server hostname to "nvflare-server" (a K8s service name).
  Because dict.update() mutates in-place, all subsequent builders and the runtime comm_config saw the corrupted
  hostname, causing every FL job in non-Helm environments to fail with gaierror: [Errno -2] Name or service not
  known.
  - Fix: deep-copy comm_config_args before mutating, for both the server and client blocks.
  - 54 nightly regression test failures caused by this bug (introduced in PR #4427).
  - NVBugs: 6086130

● Changes

  - nvflare/lighter/impl/helm_chart.py: Add import copy and copy.deepcopy() before comm_config_args.update() in
  both _build_server_chart() and _build_one_client_chart()
  - tests/unit_test/lighter/helm_chart_builder_test.py: Update 2 unit tests to assert COMM_CONFIG_ARGS is NOT
  mutated after build()



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
