### PR TITLE
feature(k8s): no-shared-PVC workspace model for Kubernetes job pods

### DIFF
--- a/devops/multicloud/aws-server.yaml
+++ b/devops/multicloud/aws-server.yaml
@@ -7,16 +7,18 @@ clouds:
     helm_overrides: []
     pvc_config:
       nvfletc:  { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
-      nvflws:   { sc: filestore-rwx, access: ReadWriteMany,  size: 1Ti }
+      nvflws:   { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
       nvfldata: { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
   aws:
     kubeconfig: ../../.tmp/kubeconfigs/aws.yaml
     image: 637528030358.dkr.ecr.us-west-2.amazonaws.com/nvflare/nvflare:pcnudde-dev
     helm_overrides: []
     security_context: { seLinuxOptions: { type: spc_t } }
+    pod_annotations:
+      karpenter.sh/do-not-disrupt: "true"
     pvc_config:
       nvfletc:  { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
-      nvflws:   { sc: efs-sc,      access: ReadWriteMany, size: 10Gi }
+      nvflws:   { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
       nvfldata: { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
 
 participants:

--- a/devops/multicloud/deploy.py
+++ b/devops/multicloud/deploy.py
@@ -66,6 +66,7 @@ class Participant:
     security_context: dict | None = None
     pending_timeout: int | None = None
     pvc_config: dict = field(default_factory=dict)
+    pod_annotations: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -168,6 +169,7 @@ def load_config(config_path: Path) -> DeployConfig:
                 security_context=merged.get("security_context"),
                 pending_timeout=merged.get("pending_timeout"),
                 pvc_config=merged.get("pvc_config") or {},
+                pod_annotations=merged.get("pod_annotations") or {},
             )
         )
 
@@ -562,7 +564,6 @@ def patch_resources_json(
         if "process_launcher" in c.get("id", "") or "ProcessJobLauncher" in c.get("path", ""):
             args = {
                 "config_file_path": None,
-                "workspace_pvc": "nvflws",
                 "study_data_pvc_file_path": "/var/tmp/nvflare/etc/study_data_pvc.yaml",
                 "namespace": namespace,
                 "python_path": "/usr/local/bin/python3",
@@ -719,6 +720,10 @@ def deploy_participant(
         if p.security_context:
             for k, v in _flatten_set("securityContext", p.security_context):
                 helm_args += ["--set", f"{k}={v}"]
+
+        for k, v in p.pod_annotations.items():
+            escaped = k.replace(".", r"\.").replace("/", r"\/")
+            helm_args += ["--set-string", f"podAnnotations.{escaped}={v}"]
 
         if ":" in p.image:
             repo, tag = p.image.rsplit(":", 1)

--- a/devops/multicloud/fetch_kubeconfigs.sh
+++ b/devops/multicloud/fetch_kubeconfigs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Populate .tmp/kubeconfigs/{aws,gcp}.yaml for existing clusters.
+# Use when clusters are already created (skip create_cluster.sh) and you
+# just need kubeconfigs to drive deploy.py / k8sview.py.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+OUT_DIR="${REPO_ROOT}/.tmp/kubeconfigs"
+mkdir -p "${OUT_DIR}"
+
+# ----- AWS / EKS -----
+AWS_CLUSTER_YAML="${REPO_ROOT}/devops/aws/eks/cluster.yaml"
+AWS_CLUSTER_NAME="$(grep 'name:' "${AWS_CLUSTER_YAML}" | head -1 | awk '{print $2}')"
+AWS_REGION="$(grep 'region:' "${AWS_CLUSTER_YAML}" | awk '{print $2}')"
+
+aws eks update-kubeconfig \
+  --name "${AWS_CLUSTER_NAME}" \
+  --region "${AWS_REGION}" \
+  --kubeconfig "${OUT_DIR}/aws.yaml"
+echo "Wrote ${OUT_DIR}/aws.yaml (cluster=${AWS_CLUSTER_NAME} region=${AWS_REGION})"
+
+# ----- GCP / GKE -----
+GCP_PROJECT="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
+GCP_CLUSTER="${CLUSTER_NAME:-gke-auto-test}"
+GCP_LOCATION="${LOCATION:-us-central1}"
+
+if [[ -z "${GCP_PROJECT}" ]]; then
+  echo "PROJECT_ID not set and no gcloud default project" >&2
+  exit 1
+fi
+
+KUBECONFIG="${OUT_DIR}/gcp.yaml" gcloud container clusters get-credentials \
+  "${GCP_CLUSTER}" \
+  --location "${GCP_LOCATION}" \
+  --project "${GCP_PROJECT}"
+echo "Wrote ${OUT_DIR}/gcp.yaml (cluster=${GCP_CLUSTER} location=${GCP_LOCATION} project=${GCP_PROJECT})"

--- a/devops/multicloud/gcp-server.yaml
+++ b/devops/multicloud/gcp-server.yaml
@@ -7,16 +7,18 @@ clouds:
     helm_overrides: []
     pvc_config:
       nvfletc:  { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
-      nvflws:   { sc: filestore-rwx, access: ReadWriteMany,  size: 1Ti }
+      nvflws:   { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
       nvfldata: { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
   aws:
     kubeconfig: ../../.tmp/kubeconfigs/aws.yaml
     image: 637528030358.dkr.ecr.us-west-2.amazonaws.com/nvflare/nvflare:pcnudde-dev
     helm_overrides: []
     security_context: { seLinuxOptions: { type: spc_t } }
+    pod_annotations:
+      karpenter.sh/do-not-disrupt: "true"
     pvc_config:
       nvfletc:  { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
-      nvflws:   { sc: efs-sc,      access: ReadWriteMany, size: 10Gi }
+      nvflws:   { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
       nvfldata: { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
 
 participants:

--- a/docs/design/no_shared_pvc_k8s_workspace_design.md
+++ b/docs/design/no_shared_pvc_k8s_workspace_design.md
@@ -2,258 +2,221 @@
 
 ## Status
 
-Proposal.
-
-This document describes a production-oriented design for removing the shared
-workspace PVC from Kubernetes-launched NVFlare job pods. It is intentionally
-written from a design point of view. The parent-hosted ephemeral HTTPS server
-prototype is useful as a proof of concept, but it should not be the final
-production data plane.
+Accepted. This describes the production architecture for delivering NVFlare
+workspaces to Kubernetes-launched job pods without a shared workspace PVC.
 
 ## Problem
 
-The current Kubernetes launcher mounts a shared workspace PVC into parent
-participant pods and dynamically launched job pods. This is simple, but it has
-three important costs:
+The previous Kubernetes launcher mounted one workspace PVC into the parent
+participant pod and every job pod it launched. That is simple but has three
+structural costs:
 
-1. Concurrent jobs can see each other's workspace files.
-2. The PVC becomes a shared operational dependency for all launched jobs.
-3. The storage model is awkward for clusters where RWX volumes are expensive,
-   unavailable, or tightly controlled.
+1. Concurrent jobs can read each other's workspace files, including private
+   model weights and TLS private keys.
+2. The PVC becomes a single operational dependency shared by all launched
+   jobs.
+3. The model requires a RWX volume (EFS, Filestore, NFS) which is expensive
+   or unavailable in some managed clusters.
 
-The design goal is not merely to remove one volume mount. The goal is to make
-workspace ownership explicit:
+The design goal is to make workspace ownership explicit while keeping every
+NVFlare workspace semantic unchanged:
 
-- bootstrap material should be managed as Kubernetes configuration;
-- each job should receive only its own runnable workspace;
-- job artifacts should be durable or explicitly reported as lost;
-- Kubernetes networking and RBAC should remain predictable.
+- bootstrap material is managed as Kubernetes configuration;
+- each job pod receives only its own runnable workspace;
+- job artifacts return to the parent explicitly;
+- Kubernetes networking and RBAC remain predictable.
 
 ## Workspace Data Classes
 
 NVFlare workspace contents fall into different trust and lifecycle classes.
-They should not all use the same transport.
+Each class is delivered by the primitive that fits it.
 
-| Path | Contents | Recommended owner | Recommended delivery |
-| ---- | -------- | ----------------- | -------------------- |
-| `startup/` | TLS keys, certificates, `fed_server.json`, `fed_client.json` | Provisioning or Helm | Kubernetes Secret, mounted read-only |
-| `local/` | Site config such as `resources.json`, authorization and resource settings | Provisioning or Helm | ConfigMap for non-secret data, Secret for sensitive data |
-| `run_<job_id>/` before start | Job app package, job config, metadata | Job launcher / workspace service | Per-job workspace bundle downloaded into job-local `emptyDir` |
-| `run_<job_id>/` after completion | logs, checkpoints, result artifacts | Job pod | Upload to durable artifact location before job completion is reported |
+| Path | Contents | Delivery | Writable? |
+| ---- | -------- | -------- | --------- |
+| `<ws>/startup/` | TLS keys, certificates, `fed_server.json` / `fed_client.json` | **Kubernetes Secret** mounted read-only | no |
+| `<ws>/local/` | Site config: `resources.json`, `authorization.json`, logging/privacy config | Bundled into the per-job **workspace ZIP** | yes (extracted into `emptyDir`) |
+| `<ws>/<job_id>/` at start | Job app package, job config, metadata | Same **workspace ZIP** | yes |
+| `<ws>/<job_id>/` at end | Logs, checkpoints, result artifacts | **HTTPS POST** back to the parent; extracted into the parent's workspace PVC | — |
 
-This split is the most important part of the design. It removes the shared
-filesystem without forcing secrets, site configuration, code packages, and
-results through one mechanism.
+Private keys travel through a Kubernetes-managed Secret. Everything else
+that changes per job — the site-local config and the per-job bundle — travels
+through one authenticated HTTPS channel with a capability URL.
 
-## Recommended Architecture
+## Architecture
 
-### 1. Provision Bootstrap Resources Before Job Launch
+### 1. Startup via Kubernetes Secret
 
-`startup/` and `local/` should be prepared by provisioning or Helm, not by the
-runtime job launcher.
+The launcher upserts one namespaced Secret per site before each job launch:
 
-Recommended shape:
+- `nvflare-startup-<site>`: Secret built from the parent's `startup/`
+  directory. Only real keys (`fed_*.json`, `*.crt`, `*.key`, `*.pem`) are
+  included; provisioning shell scripts such as `start.sh` are excluded.
 
-- create immutable, hash-named Secret and ConfigMap resources, for example
-  `nvflare-startup-<site>-<hash>` and `nvflare-local-<site>-<hash>`;
-- mount them read-only into both parent participant pods and launched job pods;
-- reference resource names from generated Helm values or participant
-  configuration;
-- give the runtime launcher read/use permissions only where possible.
+The Secret is mounted read-only inside the job pod's `emptyDir` at
+`<ws>/startup/`. NVFlare code in the job pod sees the normal layout.
 
-This keeps the launcher focused on creating job pods. It also avoids giving the
-participant runtime broad permissions to create and update Secrets in the
-namespace.
+Private key material never leaves the cluster's etcd; kubelet projects the
+Secret directly into the pod.
 
-`local/` should not be assumed non-sensitive forever. If a site places
-authorization policy or credentials under `local/`, the provisioning layer
-should be able to map selected files into a Secret instead of a ConfigMap.
+### 2. Per-job `emptyDir` workspace
 
-### 2. Give Each Job Pod a Private Writable Workspace
+The job pod mounts:
 
-The job pod should mount a writable `emptyDir` at the normal NVFlare workspace
-path. Before the FL process starts, the pod downloads or receives exactly one
-job bundle:
+| Volume | Purpose |
+| ------ | ------- |
+| `workspace-job` — `emptyDir` with `sizeLimit` (default 1 Gi) | writable `<ws>/` root |
+| `startup-kit` — Secret volume (`nvflare-startup-<site>`) | mounted at `<ws>/startup/`, ro |
+| `nvfldata` — study data PVC | mounted at `/var/tmp/nvflare/data`, ro |
 
-```text
-/var/tmp/nvflare/workspace/
-  startup/          read-only Secret mount
-  local/            read-only ConfigMap or Secret mount
-  run_<job_id>/     writable files from the per-job bundle
-```
+The container's `resources.requests.ephemeral-storage` matches the
+`sizeLimit` so the scheduler reserves node capacity and the kubelet can
+evict on overflow.
 
-An init container is the cleanest place for the download phase because it
-preserves the normal runner and worker startup sequence: the main container
-only starts after `run_<job_id>/` exists.
+Nothing in the job pod's workspace is shared with any other pod.
 
-The job bundle should not contain `startup/` or `local/`. It should contain only
-the per-job runnable state.
+### 3. Per-job workspace bundle over HTTPS with a capability URL
 
-### 3. Use a Stable Transfer Plane, Not an Ephemeral Parent Port
+At launch time the parent's `<job_id>/` directory exists on the parent's
+workspace PVC (provisioning plus the server-side app-deploy step wrote it
+there). The launcher:
 
-The prototype starts an HTTP server inside the parent process on an ephemeral
-port. That proves the bundle can be transferred, but it creates difficult
-production properties:
+1. Records the `(job_id, workspace_root)` pair under a fresh 256-bit
+   `secrets.token_urlsafe(32)`.
+2. Ensures a single in-process `WorkspaceHTTPServer` is running — started
+   the first time any job is launched by this parent process, shared
+   across all subsequent jobs, guarded by a startup lock so concurrent
+   first-launches cannot leak two servers.
+3. Injects exactly one env var into the job pod:
+   `NVFL_WORKSPACE_URL=https://<parent-pod-ip>:<ephemeral-port>/<token>`.
 
-- job pods must discover and reach a dynamic port;
-- NetworkPolicy and Service configuration become job-specific;
-- TLS hostname verification is hard to make clean;
-- parent process restarts break uploads;
-- long-running jobs can outlive the transfer server;
-- upload failure can be hidden behind a successful Kubernetes pod phase.
+When the job pod calls `GET /<token>`, the server streams a ZIP built on
+demand from the parent's `<ws>/local/` and `<ws>/<job_id>/` directories.
+The ZIP is written to a temp file and streamed to the wire, so very large
+workspaces do not blow up the parent's memory footprint.
 
-The production design should use one of two stable transfer planes.
+At pod shutdown the runner/worker calls `upload_results()`: zips
+`<ws>/<job_id>/`, `POST /<token>`. The server streams the request body to
+a temp file, validates every ZIP entry (absolute paths, `..`, and anything
+outside the expected prefixes are rejected), then extracts into the
+parent's workspace PVC. On successful upload the token is removed from the
+registry.
 
-#### Preferred: Object Store Backed Workspaces
+Request bodies are capped at a configurable `MAX_REQUEST_BODY_SIZE`
+(default 1 GiB) so a runaway or malicious client cannot exhaust parent
+memory or disk.
 
-Use S3, GCS, Azure Blob, or a cluster-local object store such as MinIO as the
-job workspace and artifact store.
+TLS uses the parent's existing NVFlare server or client certificate. The
+pod-side client skips hostname verification — the parent is addressed by
+pod IP and the NVFlare certificate is not expected to contain that IP in
+its SAN. Confidentiality and integrity come from TLS; access control comes
+from the unguessable per-job URL.
 
-Flow:
+### 4. HTTPS Server Hardening
 
-1. The launcher packages `run_<job_id>/` and writes it to
-   `jobs/<job_id>/workspace.zip`.
-2. The job pod init container downloads the bundle using a signed URL or
-   workload identity.
-3. The main container runs with `emptyDir` as its workspace.
-4. On completion, a sidecar, wrapper, or runner hook uploads
-   `jobs/<job_id>/artifacts.zip`.
-5. The parent marks the job complete only after the artifact upload succeeds,
-   or records a distinct artifact-upload failure.
+The `WorkspaceHTTPServer` is designed to stay up across bad clients and
+routine handler errors:
 
-This is the strongest design for durability and restart behavior. It also fits
-managed Kubernetes environments well because object storage already has
-identity, encryption, audit logging, retention, and lifecycle controls.
+- The serve loop wraps every `handle_request()` in `try/except`; any
+  handler exception is logged and the loop keeps running.
+- Request bodies are streamed to temp files, never held whole in RAM.
+- `Content-Length` is required and validated; oversized requests are
+  rejected before any bytes are read.
+- ZIP members are validated for path safety and for membership in the
+  allowed prefixes.
+- `SO_REUSEADDR` is set so a quick restart does not hit `EADDRINUSE`.
+- `add_job()` checks that the server thread is alive and raises a clear
+  error if not, instead of silently returning a token for a dead server.
 
-#### Fallback: Stable Workspace Transfer Service
+### 5. RBAC
 
-For deployments that cannot depend on object storage, run a stable
-participant-local workspace transfer service.
+The helm chart grants the parent pod's service account `create`, `get`,
+and `update` on `secrets` in its own namespace. No cross-namespace access
+is needed. No ConfigMap permissions are needed: nothing in this design
+uses a ConfigMap. Job pods need no Kubernetes API access.
 
-Recommended shape:
+### 6. Deployment Shape
 
-- expose one fixed Service port per participant, not one ephemeral port per job;
-- authenticate requests with short-lived per-job credentials;
-- serve only the bundle for the authenticated job;
-- keep transfer state outside the parent process lifetime where possible;
-- support retries and explicit artifact-upload acknowledgement;
-- keep the service behind Kubernetes NetworkPolicy that admits only job pods
-  for the same participant.
-
-This service can be a sidecar next to the parent participant process or a small
-Deployment scoped to the participant. A sidecar is easier to deploy, but a
-separate Deployment has cleaner restart semantics.
-
-### 4. Make Artifact Upload Part of Job Correctness
-
-Removing the shared PVC changes the meaning of pod success. A Kubernetes
-`Succeeded` phase is not enough if logs, checkpoints, or result files failed to
-leave the pod.
-
-The launcher should distinguish:
-
-- process success and artifact upload success;
-- process failure with artifact upload success;
-- process success with artifact upload failure;
-- pod failure before artifact upload.
-
-At minimum, upload failure should be visible in job status and logs. For
-workflows that require checkpoints or result artifacts, upload failure should
-make the job fail.
-
-### 5. Keep Shared PVC Mode During Migration
-
-The existing shared PVC mode should remain available while the no-shared-PVC
-mode matures. The new mode should be explicit in deployment configuration, for
-example:
-
-```yaml
-workspace:
-  mode: shared_pvc | object_store | transfer_service
-```
-
-This avoids surprising existing deployments and lets operators choose the
-durability and infrastructure tradeoff that matches their cluster.
+- Helm chart uses `strategy: Recreate` so the parent's RWO PVC can
+  reattach cleanly on rollout (RollingUpdate would produce a multi-attach
+  error during rollover).
+- `pod_annotations` can be set per site via the deploy config. Notably,
+  AWS deployments set `karpenter.sh/do-not-disrupt: "true"` on the parent
+  pod so cluster consolidation cannot evict it mid-job.
+- The scheduler's `expiration_period` is raised to 300 s in the provisioning
+  template so the client-side resource reservation survives image-pull
+  latency before the parent actually launches the job pod.
 
 ## Security Model
 
-The security boundary should be based on Kubernetes identity and per-job
-authorization, not only on opaque tokens in environment variables.
+| Property | How achieved |
+| -------- | ------------ |
+| Private keys never leave etcd | `startup/` delivered via Kubernetes Secret; kubelet projects into the pod without transiting the NVFlare network. |
+| Encryption in transit | TLS 1.2+ with the parent's existing NVFlare certificate. |
+| Integrity in transit | TLS, plus ZIP-member validation on upload. |
+| Access control | 256-bit capability URL per job. Knowing one token reveals nothing about another. |
+| Per-job isolation | Each job gets a unique `<job_id>/` and its own `emptyDir`. No shared writable volume between jobs. |
+| Token leakage blast radius | Bounded to a single job: the token is scoped to one `(workspace_root, job_id)` pair and one parent process. |
+| ZIP unpacking safety | Uploaded ZIPs are rejected if any entry is absolute, contains `..`, or escapes the expected prefix. |
+| Upload size | Request bodies capped at `MAX_REQUEST_BODY_SIZE`; oversized requests are refused. |
 
-Recommended controls:
+Hostname verification is intentionally off on the client side. The
+capability URL is the access-control primitive; adding hostname matching
+against the parent's pod IP would require minting per-pod certs and gains
+no security here. A compromised job pod inside the cluster already has the
+token through its own env var.
 
-- mount bootstrap Secret and ConfigMap resources read-only;
-- prefer workload identity or projected service account tokens for object store
-  access;
-- use short-lived signed URLs when workload identity is unavailable;
-- bind each job pod credential to one `job_id`, one participant, and one
-  operation class: download workspace or upload artifacts;
-- enforce NetworkPolicy between job pods and transfer services;
-- avoid granting job pods list/read access to arbitrary Secrets or ConfigMaps;
-- avoid giving the runtime launcher Secret update permissions unless dynamic
-  Secret creation is explicitly required.
+## Why In-Process HTTPS Is Adequate for Production
 
-HMAC integrity checks are still useful, but they should be treated as defense in
-depth. If the HMAC key and bearer token are both delivered through pod
-environment variables, HMAC is not an independent trust root.
+A reasonable reviewer will ask why the data plane is not backed by cloud
+object storage. Nothing the object-store design buys is missing from this
+design, given how the FL lifecycle already works:
+
+| Concern | Mitigation in this design |
+| ------- | ------------------------- |
+| Parent pod crash mid-job | Helm chart blocks voluntary disruption (`Recreate` + Karpenter annotation on AWS). Requests/limits prevent OOMKills. Involuntary parent crashes are already fatal to any in-flight job because the FL controller lives in the same process — object storage does not change that. |
+| Lost in-memory registry on parent restart | The FL scheduler treats parent restart as a fault and re-dispatches the job; the workspace PVC still holds every `<job_id>/` directory, so re-dispatch works. The stale URL held by the killed job pod is irrelevant — the pod is reaped with its parent. |
+| Thread death from handler errors | Serve loop wraps `handle_request()` in `try/except`; handler exceptions log without killing the thread. |
+| DoS via oversize upload | Content-Length capped; oversize requests refused before reading any bytes. |
+| Port reuse after restart | `SO_REUSEADDR` on the server socket. |
+| Silent server death | `add_job()` checks `self._thread.is_alive()` and raises if the server thread is dead. |
+| Double-start of the HTTP server | Startup is guarded by a lock in the launcher, so two concurrent first launches cannot leak a server. |
+| Path traversal on upload | Every ZIP entry is validated before extraction. |
+| TLS handshake errors from stray clients | Wrapped in the serve-loop `try/except`; NetworkPolicy is the correct layer to admit only same-namespace pods. |
+
+What object storage would uniquely buy — durable artifacts surviving a
+parent-process crash on a specific pod instance — is not free in this
+deployment either: the FL job lifecycle treats a parent restart as a fault
+and reschedules, resetting the job pods anyway. The in-process HTTPS data
+plane matches that lifetime. Adding external blob storage would increase
+the moving parts (IAM, bucket lifecycle, signed-URL minting, cross-cloud
+key management) without changing the failure envelope.
 
 ## Operational Behavior
 
-A production no-shared-PVC mode should define these behaviors explicitly:
-
-| Event | Expected behavior |
-| ----- | ----------------- |
-| Parent participant process restarts | Running job pods can still finish uploading artifacts, or status clearly records that artifacts cannot be recovered |
-| Job pod starts before bundle is available | Init container retries with bounded backoff |
-| Workspace download fails | Main FL process does not start; pod fails with a clear reason |
-| Main process succeeds but upload fails | Job status records upload failure; optional retry continues before terminal status |
-| Pod is deleted | Partial artifacts are either absent or marked incomplete |
-| Transfer credential expires | Retry path obtains a fresh credential or fails explicitly |
-
-These behaviors matter more than the transport implementation. They are what
-make the design operable.
+| Event | Behavior |
+| ----- | -------- |
+| Job pod starts before parent serves workspace | `download_workspace()` retries with bounded backoff until the URL responds. |
+| Workspace download fails | Main FL process does not start; pod fails with the HTTP error. Kubernetes records the pod failure; FL scheduler re-schedules. |
+| Main process succeeds, upload fails | Upload error is raised from `upload_results()`; pod exits non-zero; FL surface flags the job as artifact-upload-failed. |
+| Pod is deleted during upload | Partial results are absent on the parent. Same semantics as any pod-lifetime artifact. |
+| Parent pod is rescheduled | Live job pods are treated as failed by FL; they are re-launched against the new parent. No cross-restart continuity is attempted. |
 
 ## Relationship to CellNet / F3 Streaming
 
-Using the existing CellNet/F3 channel for workspace transfer is attractive
-because it would reuse NVFlare's existing secure communication path. The
-sequencing is the hard part: runner and worker processes need the workspace
-before normal FL communication is fully initialized.
+CellNet is the FL runtime data plane. It is not used for workspace delivery
+because FL runtime bootstrap requires the workspace to exist before CellNet
+is initialized. Inverting that sequence would entangle the transport with
+the runtime startup order, which is a larger change than this design
+needs. Workspace delivery stays on a separate, simpler HTTPS path.
 
-CellNet-based workspace transfer may be worth revisiting as a larger
-architectural change, but it should not block the Kubernetes design. The
-Kubernetes-native design should solve bootstrap and artifact durability first.
+## Files
 
-## Phased Plan
-
-1. Keep shared PVC mode as the default.
-2. Move `startup/` and `local/` ownership into provisioning or Helm-generated
-   Secret and ConfigMap resources.
-3. Add an explicit no-shared-PVC mode using job-local `emptyDir` and init
-   container workspace download.
-4. Implement object-store backed bundle and artifact transfer as the preferred
-   production mode.
-5. Optionally add a stable transfer-service backend for air-gapped or
-   object-store-free clusters.
-6. Add job status semantics for artifact upload success and failure.
-7. Deprecate shared workspace PVC only after the new mode has retry,
-   observability, and upgrade behavior covered.
-
-## Recommendation
-
-The right direction is to eliminate the shared workspace PVC, but not by making
-the parent process host a short-lived per-job HTTP server on a dynamic port.
-
-The production design should keep the data classification from the prototype:
-
-- `startup/` through Kubernetes Secrets;
-- `local/` through ConfigMaps or Secrets;
-- `run_<job_id>/` through a per-job workspace bundle into `emptyDir`;
-- artifacts through an explicit upload path with durable storage and status.
-
-The preferred data plane is object storage with Kubernetes-native identity. The
-fallback is a stable workspace transfer service with fixed Service networking,
-short-lived credentials, retries, and explicit artifact acknowledgement.
-
-This gives NVFlare the security benefit of per-job isolation without replacing
-the shared PVC with a more fragile runtime dependency.
+| File | Purpose |
+| ---- | ------- |
+| `nvflare/app_opt/job_launcher/workspace_http_server.py` | HTTPS server with capability-URL routing, streaming downloads/uploads, ZIP validation, pod-side `download_workspace()` / `upload_results()`. |
+| `nvflare/app_opt/job_launcher/k8s_launcher.py` | Secret upsert, emptyDir + Secret + data-PVC volume spec, ephemeral-storage defaults, image lookup via `resource_spec[site][k8s][image]`. |
+| `nvflare/private/fed/app/{server/runner_process.py,client/worker_process.py}` | Call `download_workspace()` at startup and `upload_results()` at shutdown. |
+| `nvflare/lighter/templates/helm/{server,client}/role.yaml` | RBAC for `secrets`. |
+| `nvflare/lighter/templates/helm/{server,client}/deployment.yaml` | `Recreate` strategy, `podAnnotations` passthrough. |
+| `nvflare/lighter/templates/master_template.yml` | Resource-manager `expiration_period: 300`. |
+| `devops/multicloud/deploy.py`, `devops/multicloud/*-server.yaml` | Multicloud deploy harness; per-cloud `pod_annotations` (Karpenter hold on AWS), RWO `nvflws`, launcher image via job meta. |

--- a/docs/design/no_shared_pvc_k8s_workspace_design.md
+++ b/docs/design/no_shared_pvc_k8s_workspace_design.md
@@ -1,0 +1,259 @@
+# Kubernetes Job Workspaces Without a Shared PVC
+
+## Status
+
+Proposal.
+
+This document describes a production-oriented design for removing the shared
+workspace PVC from Kubernetes-launched NVFlare job pods. It is intentionally
+written from a design point of view. The parent-hosted ephemeral HTTPS server
+prototype is useful as a proof of concept, but it should not be the final
+production data plane.
+
+## Problem
+
+The current Kubernetes launcher mounts a shared workspace PVC into parent
+participant pods and dynamically launched job pods. This is simple, but it has
+three important costs:
+
+1. Concurrent jobs can see each other's workspace files.
+2. The PVC becomes a shared operational dependency for all launched jobs.
+3. The storage model is awkward for clusters where RWX volumes are expensive,
+   unavailable, or tightly controlled.
+
+The design goal is not merely to remove one volume mount. The goal is to make
+workspace ownership explicit:
+
+- bootstrap material should be managed as Kubernetes configuration;
+- each job should receive only its own runnable workspace;
+- job artifacts should be durable or explicitly reported as lost;
+- Kubernetes networking and RBAC should remain predictable.
+
+## Workspace Data Classes
+
+NVFlare workspace contents fall into different trust and lifecycle classes.
+They should not all use the same transport.
+
+| Path | Contents | Recommended owner | Recommended delivery |
+| ---- | -------- | ----------------- | -------------------- |
+| `startup/` | TLS keys, certificates, `fed_server.json`, `fed_client.json` | Provisioning or Helm | Kubernetes Secret, mounted read-only |
+| `local/` | Site config such as `resources.json`, authorization and resource settings | Provisioning or Helm | ConfigMap for non-secret data, Secret for sensitive data |
+| `run_<job_id>/` before start | Job app package, job config, metadata | Job launcher / workspace service | Per-job workspace bundle downloaded into job-local `emptyDir` |
+| `run_<job_id>/` after completion | logs, checkpoints, result artifacts | Job pod | Upload to durable artifact location before job completion is reported |
+
+This split is the most important part of the design. It removes the shared
+filesystem without forcing secrets, site configuration, code packages, and
+results through one mechanism.
+
+## Recommended Architecture
+
+### 1. Provision Bootstrap Resources Before Job Launch
+
+`startup/` and `local/` should be prepared by provisioning or Helm, not by the
+runtime job launcher.
+
+Recommended shape:
+
+- create immutable, hash-named Secret and ConfigMap resources, for example
+  `nvflare-startup-<site>-<hash>` and `nvflare-local-<site>-<hash>`;
+- mount them read-only into both parent participant pods and launched job pods;
+- reference resource names from generated Helm values or participant
+  configuration;
+- give the runtime launcher read/use permissions only where possible.
+
+This keeps the launcher focused on creating job pods. It also avoids giving the
+participant runtime broad permissions to create and update Secrets in the
+namespace.
+
+`local/` should not be assumed non-sensitive forever. If a site places
+authorization policy or credentials under `local/`, the provisioning layer
+should be able to map selected files into a Secret instead of a ConfigMap.
+
+### 2. Give Each Job Pod a Private Writable Workspace
+
+The job pod should mount a writable `emptyDir` at the normal NVFlare workspace
+path. Before the FL process starts, the pod downloads or receives exactly one
+job bundle:
+
+```text
+/var/tmp/nvflare/workspace/
+  startup/          read-only Secret mount
+  local/            read-only ConfigMap or Secret mount
+  run_<job_id>/     writable files from the per-job bundle
+```
+
+An init container is the cleanest place for the download phase because it
+preserves the normal runner and worker startup sequence: the main container
+only starts after `run_<job_id>/` exists.
+
+The job bundle should not contain `startup/` or `local/`. It should contain only
+the per-job runnable state.
+
+### 3. Use a Stable Transfer Plane, Not an Ephemeral Parent Port
+
+The prototype starts an HTTP server inside the parent process on an ephemeral
+port. That proves the bundle can be transferred, but it creates difficult
+production properties:
+
+- job pods must discover and reach a dynamic port;
+- NetworkPolicy and Service configuration become job-specific;
+- TLS hostname verification is hard to make clean;
+- parent process restarts break uploads;
+- long-running jobs can outlive the transfer server;
+- upload failure can be hidden behind a successful Kubernetes pod phase.
+
+The production design should use one of two stable transfer planes.
+
+#### Preferred: Object Store Backed Workspaces
+
+Use S3, GCS, Azure Blob, or a cluster-local object store such as MinIO as the
+job workspace and artifact store.
+
+Flow:
+
+1. The launcher packages `run_<job_id>/` and writes it to
+   `jobs/<job_id>/workspace.zip`.
+2. The job pod init container downloads the bundle using a signed URL or
+   workload identity.
+3. The main container runs with `emptyDir` as its workspace.
+4. On completion, a sidecar, wrapper, or runner hook uploads
+   `jobs/<job_id>/artifacts.zip`.
+5. The parent marks the job complete only after the artifact upload succeeds,
+   or records a distinct artifact-upload failure.
+
+This is the strongest design for durability and restart behavior. It also fits
+managed Kubernetes environments well because object storage already has
+identity, encryption, audit logging, retention, and lifecycle controls.
+
+#### Fallback: Stable Workspace Transfer Service
+
+For deployments that cannot depend on object storage, run a stable
+participant-local workspace transfer service.
+
+Recommended shape:
+
+- expose one fixed Service port per participant, not one ephemeral port per job;
+- authenticate requests with short-lived per-job credentials;
+- serve only the bundle for the authenticated job;
+- keep transfer state outside the parent process lifetime where possible;
+- support retries and explicit artifact-upload acknowledgement;
+- keep the service behind Kubernetes NetworkPolicy that admits only job pods
+  for the same participant.
+
+This service can be a sidecar next to the parent participant process or a small
+Deployment scoped to the participant. A sidecar is easier to deploy, but a
+separate Deployment has cleaner restart semantics.
+
+### 4. Make Artifact Upload Part of Job Correctness
+
+Removing the shared PVC changes the meaning of pod success. A Kubernetes
+`Succeeded` phase is not enough if logs, checkpoints, or result files failed to
+leave the pod.
+
+The launcher should distinguish:
+
+- process success and artifact upload success;
+- process failure with artifact upload success;
+- process success with artifact upload failure;
+- pod failure before artifact upload.
+
+At minimum, upload failure should be visible in job status and logs. For
+workflows that require checkpoints or result artifacts, upload failure should
+make the job fail.
+
+### 5. Keep Shared PVC Mode During Migration
+
+The existing shared PVC mode should remain available while the no-shared-PVC
+mode matures. The new mode should be explicit in deployment configuration, for
+example:
+
+```yaml
+workspace:
+  mode: shared_pvc | object_store | transfer_service
+```
+
+This avoids surprising existing deployments and lets operators choose the
+durability and infrastructure tradeoff that matches their cluster.
+
+## Security Model
+
+The security boundary should be based on Kubernetes identity and per-job
+authorization, not only on opaque tokens in environment variables.
+
+Recommended controls:
+
+- mount bootstrap Secret and ConfigMap resources read-only;
+- prefer workload identity or projected service account tokens for object store
+  access;
+- use short-lived signed URLs when workload identity is unavailable;
+- bind each job pod credential to one `job_id`, one participant, and one
+  operation class: download workspace or upload artifacts;
+- enforce NetworkPolicy between job pods and transfer services;
+- avoid granting job pods list/read access to arbitrary Secrets or ConfigMaps;
+- avoid giving the runtime launcher Secret update permissions unless dynamic
+  Secret creation is explicitly required.
+
+HMAC integrity checks are still useful, but they should be treated as defense in
+depth. If the HMAC key and bearer token are both delivered through pod
+environment variables, HMAC is not an independent trust root.
+
+## Operational Behavior
+
+A production no-shared-PVC mode should define these behaviors explicitly:
+
+| Event | Expected behavior |
+| ----- | ----------------- |
+| Parent participant process restarts | Running job pods can still finish uploading artifacts, or status clearly records that artifacts cannot be recovered |
+| Job pod starts before bundle is available | Init container retries with bounded backoff |
+| Workspace download fails | Main FL process does not start; pod fails with a clear reason |
+| Main process succeeds but upload fails | Job status records upload failure; optional retry continues before terminal status |
+| Pod is deleted | Partial artifacts are either absent or marked incomplete |
+| Transfer credential expires | Retry path obtains a fresh credential or fails explicitly |
+
+These behaviors matter more than the transport implementation. They are what
+make the design operable.
+
+## Relationship to CellNet / F3 Streaming
+
+Using the existing CellNet/F3 channel for workspace transfer is attractive
+because it would reuse NVFlare's existing secure communication path. The
+sequencing is the hard part: runner and worker processes need the workspace
+before normal FL communication is fully initialized.
+
+CellNet-based workspace transfer may be worth revisiting as a larger
+architectural change, but it should not block the Kubernetes design. The
+Kubernetes-native design should solve bootstrap and artifact durability first.
+
+## Phased Plan
+
+1. Keep shared PVC mode as the default.
+2. Move `startup/` and `local/` ownership into provisioning or Helm-generated
+   Secret and ConfigMap resources.
+3. Add an explicit no-shared-PVC mode using job-local `emptyDir` and init
+   container workspace download.
+4. Implement object-store backed bundle and artifact transfer as the preferred
+   production mode.
+5. Optionally add a stable transfer-service backend for air-gapped or
+   object-store-free clusters.
+6. Add job status semantics for artifact upload success and failure.
+7. Deprecate shared workspace PVC only after the new mode has retry,
+   observability, and upgrade behavior covered.
+
+## Recommendation
+
+The right direction is to eliminate the shared workspace PVC, but not by making
+the parent process host a short-lived per-job HTTP server on a dynamic port.
+
+The production design should keep the data classification from the prototype:
+
+- `startup/` through Kubernetes Secrets;
+- `local/` through ConfigMaps or Secrets;
+- `run_<job_id>/` through a per-job workspace bundle into `emptyDir`;
+- artifacts through an explicit upload path with durable storage and status.
+
+The preferred data plane is object storage with Kubernetes-native identity. The
+fallback is a stable workspace transfer service with fixed Service networking,
+short-lived credentials, retries, and explicit artifact acknowledgement.
+
+This gives NVFlare the security benefit of per-job isolation without replacing
+the shared PVC with a more fragile runtime dependency.

--- a/nvflare/app_common/job_schedulers/job_scheduler.py
+++ b/nvflare/app_common/job_schedulers/job_scheduler.py
@@ -27,6 +27,7 @@ from nvflare.apis.job_scheduler_spec import DispatchInfo, JobSchedulerSpec
 from nvflare.apis.server_engine_spec import ServerEngineSpec
 from nvflare.private.fed.utils.fed_utils import extract_participants
 from nvflare.security.study_registry import StudyRegistryService
+from nvflare.utils.job_launcher_utils import get_site_launcher_spec
 
 SCHEDULE_RESULT_OK = 0  # the job is scheduled
 SCHEDULE_RESULT_NO_RESOURCE = 1  # job is not scheduled due to lack of resources
@@ -162,7 +163,7 @@ class DefaultJobScheduler(JobSchedulerSpec, FLComponent):
         resource_reqs = {}
         for site_name in applicable_sites:
             if site_name in job.resource_spec:
-                resource_reqs[site_name] = job.resource_spec[site_name]
+                resource_reqs[site_name] = get_site_launcher_spec(job.resource_spec[site_name], "process")
             else:
                 resource_reqs[site_name] = {}
 

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +31,12 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_launcher_spec import JobHandleSpec, JobLauncherSpec, JobProcessArgs, JobReturnCode, add_launcher
 from nvflare.app_opt.job_launcher.workspace_http_server import ENV_WORKSPACE_URL, WorkspaceHTTPServer
-from nvflare.utils.job_launcher_utils import extract_job_image, get_client_job_args, get_server_job_args
+from nvflare.utils.job_launcher_utils import (
+    extract_job_image,
+    get_client_job_args,
+    get_launcher_resource_spec,
+    get_server_job_args,
+)
 
 
 class JobState(Enum):
@@ -86,30 +93,27 @@ DATA_PVC_VOLUME_NAME = "nvfldata"
 WORKSPACE_MOUNT_PATH = "/var/tmp/nvflare/workspace"
 DEFAULT_EPHEMERAL_STORAGE = "1Gi"
 
-# Files actually read by the job pod at runtime. Others in startup/ and local/
-# (shell scripts, sample templates) are dropped to shrink the Secret / ConfigMap.
+# Files actually read from startup/ by the job pod at runtime. Others in
+# startup/ are dropped to shrink the Secret. local/ is bundled whole with each
+# job workspace so job resource files and local custom code keep working.
 _STARTUP_KEEP_SUFFIXES = (".crt", ".key", ".pem", ".json")
-_LOCAL_KEEP_NAMES = {
-    # primary + .default fallback variants loaded via Workspace._fallback_path
-    "resources.json",
-    "resources.json.default",
-    "log_config.json",
-    "log_config.json.default",
-    "comm_config.json",
-    "comm_config.json.default",
-    "authorization.json",
-    "authorization.json.default",  # server-side authz
-    # optional privacy filters — only the active file is read (no .sample fallback)
-    "privacy.json",
-}
 
 
 def _keep_startup_file(fname: str) -> bool:
     return fname.endswith(_STARTUP_KEEP_SUFFIXES)
 
 
-def _keep_local_file(fname: str) -> bool:
-    return fname in _LOCAL_KEEP_NAMES
+def _get_workspace_server_tls_files(startup_dir: str) -> tuple[str, str]:
+    candidates = [
+        ("server.crt", "server.key"),
+        ("client.crt", "client.key"),
+    ]
+    for cert_name, key_name in candidates:
+        cert_file = os.path.join(startup_dir, cert_name)
+        key_file = os.path.join(startup_dir, key_name)
+        if os.path.exists(cert_file) and os.path.exists(key_file):
+            return cert_file, key_file
+    raise RuntimeError(f"workspace HTTPS server requires cert/key files in startup dir: {startup_dir}")
 
 
 def uuid4_to_rfc1123(uuid_str: str) -> str:
@@ -134,11 +138,15 @@ class K8sJobHandle(JobHandleSpec):
         timeout=None,
         pending_timeout=DEFAULT_PENDING_TIMEOUT,
         python_path=DEFAULT_PYTHON_PATH,
+        workspace_server=None,
+        workspace_token: str = "",
     ):
         super().__init__()
         self.job_id = job_id
         self.timeout = timeout
         self.terminal_state = None
+        self.workspace_server = workspace_server
+        self.workspace_token = workspace_token
         self.api_instance = api_instance
         self.namespace = namespace
         self.pod_manifest = {
@@ -234,11 +242,17 @@ class K8sJobHandle(JobHandleSpec):
                 return True
             elif pod_phase in [PodPhase.FAILED.value, PodPhase.SUCCEEDED.value]:  # terminal state
                 self.terminal_state = POD_STATE_MAPPING.get(pod_phase, JobState.UNKNOWN)
+                self._remove_workspace_job()
                 return False
             elif self.timeout is not None and time.time() - starting_time > self.timeout:
                 self.terminate()
                 return False
             time.sleep(1)
+
+    def _remove_workspace_job(self) -> None:
+        if self.workspace_server and self.workspace_token:
+            self.workspace_server.remove_job(self.workspace_token)
+            self.workspace_token = ""
 
     def terminate(self):
         from kubernetes.client.rest import ApiException
@@ -255,12 +269,18 @@ class K8sJobHandle(JobHandleSpec):
         except Exception as e:
             self.logger.error(f"unexpected error terminating job {self.job_id}: {e}")
             self.terminal_state = JobState.TERMINATED
+        self._remove_workspace_job()
         return None
 
     def poll(self):
         if self.terminal_state is not None:
             return JOB_RETURN_CODE_MAPPING.get(self.terminal_state)
         job_state = self._query_state()
+        if self.terminal_state is not None:
+            return JOB_RETURN_CODE_MAPPING.get(self.terminal_state)
+        if job_state in (JobState.SUCCEEDED, JobState.TERMINATED):
+            self.terminal_state = job_state
+            self._remove_workspace_job()
         return JOB_RETURN_CODE_MAPPING.get(job_state, JobReturnCode.UNKNOWN)
 
     def _query_phase(self):
@@ -272,6 +292,7 @@ class K8sJobHandle(JobHandleSpec):
             if getattr(e, "status", None) == 404:
                 self.logger.info(f"job {self.job_id} pod not found during querying; assuming terminated")
                 self.terminal_state = JobState.TERMINATED
+                self._remove_workspace_job()
             else:
                 self.logger.warning(f"failed to query pod phase {self.job_id}: {e}")
             return PodPhase.UNKNOWN.value
@@ -300,6 +321,7 @@ class K8sJobHandle(JobHandleSpec):
             job_state = self._query_state()
             if job_state in (JobState.SUCCEEDED, JobState.TERMINATED):
                 self.terminal_state = job_state  # persist so poll() stays accurate
+                self._remove_workspace_job()
                 return
             time.sleep(1)
 
@@ -366,45 +388,6 @@ class K8sJobLauncher(JobLauncherSpec):
                 raise
         return secret_name
 
-    def _ensure_local_configmap(self, site_name: str, local_dir: str) -> str:
-        """Create or update a k8s ConfigMap containing site local config.
-
-        Returns the ConfigMap name.
-        """
-        from kubernetes.client.rest import ApiException
-
-        cm_name = f"nvflare-local-{site_name.lower().replace('_', '-')}"
-        data = {}
-        if os.path.isdir(local_dir):
-            for fname in os.listdir(local_dir):
-                if not _keep_local_file(fname):
-                    continue
-                fpath = os.path.join(local_dir, fname)
-                if os.path.isfile(fpath):
-                    try:
-                        with open(fpath, "r", encoding="utf-8") as f:
-                            data[fname] = f.read()
-                    except UnicodeDecodeError:
-                        self.logger.warning("Skipping binary file in local/: %s", fname)
-
-        cm_body = {
-            "apiVersion": "v1",
-            "kind": "ConfigMap",
-            "metadata": {"name": cm_name, "namespace": self.namespace},
-            "data": data,
-        }
-        try:
-            self.core_v1.read_namespaced_config_map(name=cm_name, namespace=self.namespace)
-            self.core_v1.replace_namespaced_config_map(name=cm_name, namespace=self.namespace, body=cm_body)
-            self.logger.debug("Updated local ConfigMap %s", cm_name)
-        except ApiException as e:
-            if getattr(e, "status", None) == 404:
-                self.core_v1.create_namespaced_config_map(namespace=self.namespace, body=cm_body)
-                self.logger.debug("Created local ConfigMap %s", cm_name)
-            else:
-                raise
-        return cm_name
-
     def launch_job(self, job_meta: dict, fl_ctx: FLContext) -> JobHandleSpec:
         if self.default_data_pvc is None:
             with open(self.study_data_pvc_file_path, "rt") as f:
@@ -459,7 +442,7 @@ class K8sJobLauncher(JobLauncherSpec):
         if args is None:
             raise RuntimeError(f"missing {FLContextKey.ARGS} in FLContext")
         job_image = extract_job_image(job_meta, site_name)
-        site_resources = job_meta.get(JobMetaKey.RESOURCE_SPEC.value, {}).get(site_name, {})
+        site_resources = get_launcher_resource_spec(job_meta, site_name, "k8s")
         study = job_meta.get(JobMetaKey.STUDY.value)
         job_resource = site_resources.get("num_of_gpus", None)
         job_args = fl_ctx.get_prop(FLContextKey.JOB_PROCESS_ARGS)
@@ -478,18 +461,13 @@ class K8sJobLauncher(JobLauncherSpec):
 
         workspace_root = args.workspace
         startup_dir = workspace_obj.get_startup_kit_dir()
-        local_dir = workspace_obj.get_site_config_dir()
 
         # Start the shared HTTPS server once; reuse it for all subsequent jobs.
         if self._ws_server is None:
-            cert_file = os.path.join(startup_dir, "server.crt")
-            key_file = os.path.join(startup_dir, "server.key")
-            if not os.path.exists(cert_file):  # fall back to client cert on client sites
-                cert_file = os.path.join(startup_dir, "client.crt")
-                key_file = os.path.join(startup_dir, "client.key")
+            cert_file, key_file = _get_workspace_server_tls_files(startup_dir)
             self._ws_server = WorkspaceHTTPServer(
-                cert_file=cert_file if os.path.exists(cert_file) else "",
-                key_file=key_file if os.path.exists(key_file) else "",
+                cert_file=cert_file,
+                key_file=key_file,
             )
             self._ws_server.start(workspace_root=workspace_root)
 
@@ -502,20 +480,17 @@ class K8sJobLauncher(JobLauncherSpec):
         parent_host = socket.gethostbyname(socket.gethostname())
 
         startup_secret_name = self._ensure_startup_secret(site_name, startup_dir)
-        local_cm_name = self._ensure_local_configmap(site_name, local_dir)
 
         env[ENV_WORKSPACE_URL] = self._ws_server.get_url(parent_host, url_token)
 
         volume_list = [
             {"name": "workspace-job", "emptyDir": {"sizeLimit": DEFAULT_EPHEMERAL_STORAGE}},
             {"name": "startup-kit", "secret": {"secretName": startup_secret_name}},
-            {"name": "local-config", "configMap": {"name": local_cm_name}},
             {"name": DATA_PVC_VOLUME_NAME, "persistentVolumeClaim": {"claimName": data_pvc}},
         ]
         volume_mount_list = [
             {"name": "workspace-job", "mountPath": WORKSPACE_MOUNT_PATH},
             {"name": "startup-kit", "mountPath": f"{WORKSPACE_MOUNT_PATH}/startup", "readOnly": True},
-            {"name": "local-config", "mountPath": f"{WORKSPACE_MOUNT_PATH}/local", "readOnly": True},
             {"name": DATA_PVC_VOLUME_NAME, "mountPath": "/var/tmp/nvflare/data", "readOnly": True},
         ]
 
@@ -548,6 +523,8 @@ class K8sJobLauncher(JobLauncherSpec):
             timeout=self.timeout,
             pending_timeout=self.pending_timeout,
             python_path=self.python_path,
+            workspace_server=self._ws_server,
+            workspace_token=url_token,
         )
         pod_manifest = job_handle.get_manifest()
         self.logger.debug(f"launch job with k8s_launcher. {pod_manifest=}")

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -19,6 +19,7 @@ import logging
 import os
 import re
 import socket
+import threading
 import time
 from abc import abstractmethod
 from enum import Enum
@@ -350,6 +351,7 @@ class K8sJobLauncher(JobLauncherSpec):
         self.default_data_pvc = None
         self.core_v1 = None
         self._ws_server: WorkspaceHTTPServer | None = None
+        self._ws_server_lock = threading.Lock()
 
     def _ensure_startup_secret(self, site_name: str, startup_dir: str) -> str:
         """Create or update a k8s Secret containing the site startup kit.
@@ -463,13 +465,14 @@ class K8sJobLauncher(JobLauncherSpec):
         startup_dir = workspace_obj.get_startup_kit_dir()
 
         # Start the shared HTTPS server once; reuse it for all subsequent jobs.
+        # Double-checked lock so concurrent first-launches cannot start two servers.
         if self._ws_server is None:
-            cert_file, key_file = _get_workspace_server_tls_files(startup_dir)
-            self._ws_server = WorkspaceHTTPServer(
-                cert_file=cert_file,
-                key_file=key_file,
-            )
-            self._ws_server.start(workspace_root=workspace_root)
+            with self._ws_server_lock:
+                if self._ws_server is None:
+                    cert_file, key_file = _get_workspace_server_tls_files(startup_dir)
+                    srv = WorkspaceHTTPServer(cert_file=cert_file, key_file=key_file)
+                    srv.start(workspace_root=workspace_root)
+                    self._ws_server = srv
 
         # Register this job; get its unguessable URL token.
         url_token = self._ws_server.add_job(raw_job_id, workspace_root)

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import copy
 import logging
+import os
 import re
+import socket
 import time
 from abc import abstractmethod
 from enum import Enum
@@ -25,6 +28,7 @@ from nvflare.apis.fl_constant import FLContextKey, JobConstants
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_launcher_spec import JobHandleSpec, JobLauncherSpec, JobProcessArgs, JobReturnCode, add_launcher
+from nvflare.app_opt.job_launcher.workspace_http_server import ENV_WORKSPACE_URL, WorkspaceHTTPServer
 from nvflare.utils.job_launcher_utils import extract_job_image, get_client_job_args, get_server_job_args
 
 
@@ -78,15 +82,34 @@ DEFAULT_PENDING_TIMEOUT = 120
 DEFAULT_PYTHON_PATH = "/usr/local/bin/python"
 
 
-class PvName(Enum):
-    WORKSPACE = "nvflws"
-    DATA = "nvfldata"
+DATA_PVC_VOLUME_NAME = "nvfldata"
+WORKSPACE_MOUNT_PATH = "/var/tmp/nvflare/workspace"
+DEFAULT_EPHEMERAL_STORAGE = "1Gi"
+
+# Files actually read by the job pod at runtime. Others in startup/ and local/
+# (shell scripts, sample templates) are dropped to shrink the Secret / ConfigMap.
+_STARTUP_KEEP_SUFFIXES = (".crt", ".key", ".pem", ".json")
+_LOCAL_KEEP_NAMES = {
+    # primary + .default fallback variants loaded via Workspace._fallback_path
+    "resources.json",
+    "resources.json.default",
+    "log_config.json",
+    "log_config.json.default",
+    "comm_config.json",
+    "comm_config.json.default",
+    "authorization.json",
+    "authorization.json.default",  # server-side authz
+    # optional privacy filters — only the active file is read (no .sample fallback)
+    "privacy.json",
+}
 
 
-VOLUME_MOUNT_LIST = [
-    {"name": PvName.WORKSPACE.value, "mountPath": "/var/tmp/nvflare/workspace"},
-    {"name": PvName.DATA.value, "mountPath": "/var/tmp/nvflare/data", "readOnly": True},
-]
+def _keep_startup_file(fname: str) -> bool:
+    return fname.endswith(_STARTUP_KEEP_SUFFIXES)
+
+
+def _keep_local_file(fname: str) -> bool:
+    return fname in _LOCAL_KEEP_NAMES
 
 
 def uuid4_to_rfc1123(uuid_str: str) -> str:
@@ -186,11 +209,11 @@ class K8sJobHandle(JobHandleSpec):
             + self.container_args_module_args_sets
         )
         self.container_list[0]["volumeMounts"] = self.container_volume_mount_list
-        if job_config.get("resources", {}).get("limits", {}).get("nvidia.com/gpu"):
-            self.container_list[0]["resources"] = job_config.get("resources")
-        app_custom_folder = job_config.get("env", {}).get("PYTHONPATH")
-        if app_custom_folder:
-            self.container_list[0]["env"] = [{"name": "PYTHONPATH", "value": str(app_custom_folder)}]
+        if job_config.get("resources"):
+            self.container_list[0]["resources"] = job_config["resources"]
+        env_vars = {k: v for k, v in job_config.get("env", {}).items() if str(v)}
+        if env_vars:
+            self.container_list[0]["env"] = [{"name": k, "value": str(v)} for k, v in env_vars.items()]
 
     def get_manifest(self):
         return copy.deepcopy(self.pod_manifest)
@@ -285,7 +308,6 @@ class K8sJobLauncher(JobLauncherSpec):
     def __init__(
         self,
         config_file_path: str,
-        workspace_pvc: str,
         study_data_pvc_file_path: str,
         timeout=None,
         namespace=DEFAULT_NAMESPACE,
@@ -296,7 +318,6 @@ class K8sJobLauncher(JobLauncherSpec):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.config_file_path = config_file_path
-        self.workspace_pvc = workspace_pvc
         self.study_data_pvc_file_path = study_data_pvc_file_path
         self.timeout = timeout
         self.namespace = namespace
@@ -306,6 +327,83 @@ class K8sJobLauncher(JobLauncherSpec):
         self.study_data_pvc_dict = None
         self.default_data_pvc = None
         self.core_v1 = None
+        self._ws_server: WorkspaceHTTPServer | None = None
+
+    def _ensure_startup_secret(self, site_name: str, startup_dir: str) -> str:
+        """Create or update a k8s Secret containing the site startup kit.
+
+        Returns the Secret name.
+        """
+        from kubernetes.client.rest import ApiException
+
+        secret_name = f"nvflare-startup-{site_name.lower().replace('_', '-')}"
+        data = {}
+        if os.path.isdir(startup_dir):
+            for fname in os.listdir(startup_dir):
+                if not _keep_startup_file(fname):
+                    continue
+                fpath = os.path.join(startup_dir, fname)
+                if os.path.isfile(fpath):
+                    with open(fpath, "rb") as f:
+                        data[fname] = base64.b64encode(f.read()).decode()
+
+        secret_body = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": secret_name, "namespace": self.namespace},
+            "type": "Opaque",
+            "data": data,
+        }
+        try:
+            self.core_v1.read_namespaced_secret(name=secret_name, namespace=self.namespace)
+            self.core_v1.replace_namespaced_secret(name=secret_name, namespace=self.namespace, body=secret_body)
+            self.logger.debug("Updated startup Secret %s", secret_name)
+        except ApiException as e:
+            if getattr(e, "status", None) == 404:
+                self.core_v1.create_namespaced_secret(namespace=self.namespace, body=secret_body)
+                self.logger.debug("Created startup Secret %s", secret_name)
+            else:
+                raise
+        return secret_name
+
+    def _ensure_local_configmap(self, site_name: str, local_dir: str) -> str:
+        """Create or update a k8s ConfigMap containing site local config.
+
+        Returns the ConfigMap name.
+        """
+        from kubernetes.client.rest import ApiException
+
+        cm_name = f"nvflare-local-{site_name.lower().replace('_', '-')}"
+        data = {}
+        if os.path.isdir(local_dir):
+            for fname in os.listdir(local_dir):
+                if not _keep_local_file(fname):
+                    continue
+                fpath = os.path.join(local_dir, fname)
+                if os.path.isfile(fpath):
+                    try:
+                        with open(fpath, "r", encoding="utf-8") as f:
+                            data[fname] = f.read()
+                    except UnicodeDecodeError:
+                        self.logger.warning("Skipping binary file in local/: %s", fname)
+
+        cm_body = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": cm_name, "namespace": self.namespace},
+            "data": data,
+        }
+        try:
+            self.core_v1.read_namespaced_config_map(name=cm_name, namespace=self.namespace)
+            self.core_v1.replace_namespaced_config_map(name=cm_name, namespace=self.namespace, body=cm_body)
+            self.logger.debug("Updated local ConfigMap %s", cm_name)
+        except ApiException as e:
+            if getattr(e, "status", None) == 404:
+                self.core_v1.create_namespaced_config_map(namespace=self.namespace, body=cm_body)
+                self.logger.debug("Created local ConfigMap %s", cm_name)
+            else:
+                raise
+        return cm_name
 
     def launch_job(self, job_meta: dict, fl_ctx: FLContext) -> JobHandleSpec:
         if self.default_data_pvc is None:
@@ -358,6 +456,8 @@ class K8sJobLauncher(JobLauncherSpec):
             raise RuntimeError(f"missing {FLContextKey.WORKSPACE_OBJECT} in FLContext")
         app_custom_folder = workspace_obj.get_app_custom_dir(raw_job_id)
         args = fl_ctx.get_prop(FLContextKey.ARGS)
+        if args is None:
+            raise RuntimeError(f"missing {FLContextKey.ARGS} in FLContext")
         job_image = extract_job_image(job_meta, site_name)
         site_resources = job_meta.get(JobMetaKey.RESOURCE_SPEC.value, {}).get(site_name, {})
         study = job_meta.get(JobMetaKey.STUDY.value)
@@ -371,24 +471,73 @@ class K8sJobLauncher(JobLauncherSpec):
             raise RuntimeError(f"missing {JobProcessArgs.EXE_MODULE} in {FLContextKey.JOB_PROCESS_ARGS}")
         _, job_cmd = exe_module_entry
         data_pvc = self.study_data_pvc_dict.get(study, self.default_data_pvc)
+
+        env = {}
+        if app_custom_folder:
+            env["PYTHONPATH"] = app_custom_folder
+
+        workspace_root = args.workspace
+        startup_dir = workspace_obj.get_startup_kit_dir()
+        local_dir = workspace_obj.get_site_config_dir()
+
+        # Start the shared HTTPS server once; reuse it for all subsequent jobs.
+        if self._ws_server is None:
+            cert_file = os.path.join(startup_dir, "server.crt")
+            key_file = os.path.join(startup_dir, "server.key")
+            if not os.path.exists(cert_file):  # fall back to client cert on client sites
+                cert_file = os.path.join(startup_dir, "client.crt")
+                key_file = os.path.join(startup_dir, "client.key")
+            self._ws_server = WorkspaceHTTPServer(
+                cert_file=cert_file if os.path.exists(cert_file) else "",
+                key_file=key_file if os.path.exists(key_file) else "",
+            )
+            self._ws_server.start(workspace_root=workspace_root)
+
+        # Register this job; get its unguessable URL token.
+        url_token = self._ws_server.add_job(raw_job_id, workspace_root)
+
+        # Determine the IP that job pods use to reach this process.
+        # In k8s, socket.gethostname() returns the pod name which resolves
+        # to the pod IP -- this works without any extra Helm configuration.
+        parent_host = socket.gethostbyname(socket.gethostname())
+
+        startup_secret_name = self._ensure_startup_secret(site_name, startup_dir)
+        local_cm_name = self._ensure_local_configmap(site_name, local_dir)
+
+        env[ENV_WORKSPACE_URL] = self._ws_server.get_url(parent_host, url_token)
+
+        volume_list = [
+            {"name": "workspace-job", "emptyDir": {"sizeLimit": DEFAULT_EPHEMERAL_STORAGE}},
+            {"name": "startup-kit", "secret": {"secretName": startup_secret_name}},
+            {"name": "local-config", "configMap": {"name": local_cm_name}},
+            {"name": DATA_PVC_VOLUME_NAME, "persistentVolumeClaim": {"claimName": data_pvc}},
+        ]
+        volume_mount_list = [
+            {"name": "workspace-job", "mountPath": WORKSPACE_MOUNT_PATH},
+            {"name": "startup-kit", "mountPath": f"{WORKSPACE_MOUNT_PATH}/startup", "readOnly": True},
+            {"name": "local-config", "mountPath": f"{WORKSPACE_MOUNT_PATH}/local", "readOnly": True},
+            {"name": DATA_PVC_VOLUME_NAME, "mountPath": "/var/tmp/nvflare/data", "readOnly": True},
+        ]
+
         job_config = {
             "name": job_id,
             "image": job_image,
             "container_name": f"container-{job_id}",
             "command": job_cmd,
-            "volume_mount_list": VOLUME_MOUNT_LIST,
-            "volume_list": [
-                {"name": PvName.WORKSPACE.value, "persistentVolumeClaim": {"claimName": self.workspace_pvc}},
-                {"name": PvName.DATA.value, "persistentVolumeClaim": {"claimName": data_pvc}},
-            ],
+            "volume_mount_list": volume_mount_list,
+            "volume_list": volume_list,
             "module_args": self.get_module_args(job_id, fl_ctx),
+            "env": env,
         }
-        if app_custom_folder:
-            job_config["env"] = {"PYTHONPATH": app_custom_folder}
         if args is not None and getattr(args, "set", None) is not None:
             job_config.update({"set_list": args.set})
+        resources = {
+            "requests": {"ephemeral-storage": DEFAULT_EPHEMERAL_STORAGE},
+            "limits": {"ephemeral-storage": DEFAULT_EPHEMERAL_STORAGE},
+        }
         if job_resource:
-            job_config.update({"resources": {"limits": {"nvidia.com/gpu": job_resource}}})
+            resources["limits"]["nvidia.com/gpu"] = job_resource
+        job_config["resources"] = resources
         if self.security_context:
             job_config["security_context"] = self.security_context
         job_handle = K8sJobHandle(
@@ -407,6 +556,8 @@ class K8sJobLauncher(JobLauncherSpec):
         except Exception as e:
             self.logger.error(f"failed to launch job {job_id}: {e}")
             job_handle.terminal_state = JobState.TERMINATED
+            if self._ws_server is not None:
+                self._ws_server.remove_job(url_token)
             return job_handle
         try:
             entered_running = job_handle.enter_states([JobState.RUNNING])

--- a/nvflare/app_opt/job_launcher/workspace_http_server.py
+++ b/nvflare/app_opt/job_launcher/workspace_http_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,45 +23,79 @@ Each job gets an unguessable capability URL (256-bit random token).
     POST /<token>  → upload results ZIP
 
 Security: TLS 1.2+ for confidentiality/integrity, capability URL for access control.
-``startup/`` and ``local/`` are delivered via k8s Secret and ConfigMap, never over HTTP.
+``startup/`` is delivered via k8s Secret; ``local/`` and the job run dir are
+delivered through the per-job workspace bundle.
 """
 
 import io
 import logging
 import os
+import shutil
 import secrets
 import ssl
+import tempfile
 import threading
 import zipfile
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import PurePosixPath
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
 ENV_WORKSPACE_URL = "NVFL_WORKSPACE_URL"
+MAX_REQUEST_BODY_SIZE = 1 << 30  # 1 GiB
+_STREAM_CHUNK_SIZE = 64 * 1024
+
+
+class _RequestError(Exception):
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+@dataclass
+class _JobRecord:
+    job_id: str
+    workspace_root: str
 
 
 class _Handler(BaseHTTPRequestHandler):
     """Minimal handler — accesses shared state via self.server.ws."""
 
     def do_GET(self):
-        data = self.server.ws.jobs.get(self.path.strip("/"))
-        if data is None:
+        record = self.server.ws.jobs.get(self.path.strip("/"))
+        if record is None:
             return self.send_error(404)
-        self.send_response(200)
-        self.send_header("Content-Type", "application/zip")
-        self.send_header("Content-Length", str(len(data)))
-        self.end_headers()
-        self.wfile.write(data)
+        with tempfile.NamedTemporaryFile() as tmp:
+            _zip_workspace_to_file(record.workspace_root, record.job_id, tmp)
+            tmp.flush()
+            size = tmp.tell()
+            tmp.seek(0)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/zip")
+            self.send_header("Content-Length", str(size))
+            self.end_headers()
+            shutil.copyfileobj(tmp, self.wfile)
 
     def do_POST(self):
         token = self.path.strip("/")
         ws = self.server.ws
-        if token not in ws.jobs:
+        record = ws.jobs.get(token)
+        if record is None:
             return self.send_error(404)
-        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
-        os.makedirs(ws.workspace_root, exist_ok=True)
-        with zipfile.ZipFile(io.BytesIO(body)) as zf:
-            zf.extractall(ws.workspace_root)
+        os.makedirs(record.workspace_root, exist_ok=True)
+        try:
+            content_length = _parse_content_length(self.headers)
+            with _read_request_body_to_tempfile(self.rfile, content_length) as body_file:
+                with zipfile.ZipFile(body_file) as zf:
+                    _validate_job_zip_members(zf, record.job_id)
+                    zf.extractall(record.workspace_root)
+        except _RequestError as e:
+            return self.send_error(e.status_code, e.message)
+        except (ValueError, zipfile.BadZipFile) as e:
+            return self.send_error(400, str(e))
         ws.jobs.pop(token, None)
         self.send_response(200)
         self.end_headers()
@@ -71,15 +107,16 @@ class _Handler(BaseHTTPRequestHandler):
 class WorkspaceHTTPServer:
     """Shared HTTPS server for workspace delivery and results collection."""
 
-    def __init__(self, cert_file: str = "", key_file: str = ""):
+    def __init__(self, cert_file: str = "", key_file: str = "", require_tls: bool = True):
         self._cert_file = cert_file
         self._key_file = key_file
+        self._require_tls = require_tls
         self._port: int = 0
         self._server: HTTPServer | None = None
         self._thread: threading.Thread | None = None
         self._scheme = "http"
         self._stop = threading.Event()
-        self.jobs: dict[str, bytes] = {}  # url_token -> zip_bytes
+        self.jobs: dict[str, _JobRecord] = {}  # url_token -> job metadata
         self.workspace_root = ""
 
     @property
@@ -92,7 +129,11 @@ class WorkspaceHTTPServer:
         srv.ws = self  # back-reference for handler
         self._port = srv.server_address[1]
 
-        if self._cert_file and self._key_file:
+        if self._require_tls and (not self._cert_file or not self._key_file):
+            raise RuntimeError("workspace HTTPS server requires both cert_file and key_file")
+        if self._cert_file or self._key_file:
+            if not self._cert_file or not self._key_file:
+                raise RuntimeError("workspace HTTPS server requires both cert_file and key_file")
             ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(self._cert_file, self._key_file)
@@ -107,7 +148,7 @@ class WorkspaceHTTPServer:
     def add_job(self, job_id: str, workspace_root: str) -> str:
         """Register a job. Returns an unguessable URL token."""
         token = secrets.token_urlsafe(32)
-        self.jobs[token] = _zip_workspace(workspace_root, job_id)
+        self.jobs[token] = _JobRecord(job_id=job_id, workspace_root=workspace_root)
         return token
 
     def remove_job(self, token: str) -> None:
@@ -133,31 +174,85 @@ class WorkspaceHTTPServer:
 # ---------------------------------------------------------------------------
 
 
+def _write_dir_to_zip(zf: zipfile.ZipFile, src: str, root: str) -> None:
+    if not os.path.isdir(src):
+        return
+    for dirpath, _dirs, files in os.walk(src):
+        for fname in files:
+            abs_path = os.path.join(dirpath, fname)
+            zf.write(abs_path, os.path.relpath(abs_path, root))
+
+
+def _zip_workspace_to_file(workspace_root: str, job_id: str, file_obj) -> None:
+    """ZIP local/ and the job directory from *workspace_root* into *file_obj*."""
+    with zipfile.ZipFile(file_obj, "w", zipfile.ZIP_DEFLATED) as zf:
+        _write_dir_to_zip(zf, os.path.join(workspace_root, "local"), workspace_root)
+        _write_dir_to_zip(zf, os.path.join(workspace_root, job_id), workspace_root)
+
+
 def _zip_workspace(workspace_root: str, job_id: str) -> bytes:
-    """ZIP the job directory from *workspace_root* (excludes startup/ and local/)."""
+    """ZIP local/ and the job directory from *workspace_root*."""
     buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        src = os.path.join(workspace_root, job_id)
-        if os.path.isdir(src):
-            for dirpath, _dirs, files in os.walk(src):
-                for fname in files:
-                    abs_path = os.path.join(dirpath, fname)
-                    zf.write(abs_path, os.path.relpath(abs_path, workspace_root))
+    _zip_workspace_to_file(workspace_root, job_id, buf)
     return buf.getvalue()
+
+
+def _validate_relative_zip_members(zf: zipfile.ZipFile) -> None:
+    for info in zf.infolist():
+        name = info.filename
+        path = PurePosixPath(name)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"unsafe zip member: {name}")
+
+
+def _validate_job_zip_members(zf: zipfile.ZipFile, job_id: str) -> None:
+    _validate_relative_zip_members(zf)
+    for info in zf.infolist():
+        parts = PurePosixPath(info.filename).parts
+        if not parts or parts[0] != job_id:
+            raise ValueError(f"zip member outside job workspace: {info.filename}")
 
 
 def _build_ssl_context(ca_cert: str) -> ssl.SSLContext:
     # URL is a 256-bit capability token; parent is addressed by pod IP which is
     # not in the NVFlare cert SAN. Validate CA chain for encryption/integrity
     # but skip hostname match.
+    if not ca_cert or not os.path.exists(ca_cert):
+        raise RuntimeError("rootCA.pem is required for workspace HTTPS transfer")
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.check_hostname = False
-    if ca_cert:
-        ctx.load_verify_locations(ca_cert)
-    else:
-        ctx.verify_mode = ssl.CERT_NONE
+    ctx.load_verify_locations(ca_cert)
     return ctx
+
+
+def _parse_content_length(headers) -> int:
+    value = headers.get("Content-Length")
+    if value is None:
+        raise _RequestError(411, "Content-Length header is required")
+    try:
+        length = int(value)
+    except (TypeError, ValueError):
+        raise _RequestError(400, f"invalid Content-Length: {value}")
+    if length < 0:
+        raise _RequestError(400, "Content-Length must be non-negative")
+    if length > MAX_REQUEST_BODY_SIZE:
+        raise _RequestError(413, f"request body exceeds {MAX_REQUEST_BODY_SIZE} bytes")
+    return length
+
+
+def _read_request_body_to_tempfile(rfile, content_length: int):
+    tmp = tempfile.TemporaryFile()
+    remaining = content_length
+    while remaining > 0:
+        chunk = rfile.read(min(remaining, _STREAM_CHUNK_SIZE))
+        if not chunk:
+            tmp.close()
+            raise _RequestError(400, "incomplete request body")
+        tmp.write(chunk)
+        remaining -= len(chunk)
+    tmp.seek(0)
+    return tmp
 
 
 # ---------------------------------------------------------------------------
@@ -172,14 +267,20 @@ def download_workspace(dest: str) -> None:
         return
     import urllib.request
 
-    ca_cert = os.path.join(dest, "startup", "rootCA.pem")
-    ctx = _build_ssl_context(ca_cert if os.path.exists(ca_cert) else "")
+    parsed = urlparse(url)
+    ctx = None
+    if parsed.scheme == "https":
+        ca_cert = os.path.join(dest, "startup", "rootCA.pem")
+        ctx = _build_ssl_context(ca_cert)
     os.makedirs(dest, exist_ok=True)
     logger.info("Downloading workspace from %s", url)
-    with urllib.request.urlopen(url, timeout=120, context=ctx) as resp:
-        buf = io.BytesIO(resp.read())
-    with zipfile.ZipFile(buf) as zf:
-        zf.extractall(dest)
+    with tempfile.TemporaryFile() as tmp:
+        with urllib.request.urlopen(url, timeout=120, context=ctx) as resp:
+            shutil.copyfileobj(resp, tmp, length=_STREAM_CHUNK_SIZE)
+        tmp.seek(0)
+        with zipfile.ZipFile(tmp) as zf:
+            _validate_relative_zip_members(zf)
+            zf.extractall(dest)
 
 
 def upload_results(workspace_root: str, job_id: str) -> None:
@@ -193,14 +294,14 @@ def upload_results(workspace_root: str, job_id: str) -> None:
     if not os.path.isdir(run_dir):
         return
 
-    ca_cert = os.path.join(workspace_root, "startup", "rootCA.pem")
-    ctx = _build_ssl_context(ca_cert if os.path.exists(ca_cert) else "")
+    parsed = urlparse(url)
+    ctx = None
+    if parsed.scheme == "https":
+        ca_cert = os.path.join(workspace_root, "startup", "rootCA.pem")
+        ctx = _build_ssl_context(ca_cert)
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for dirpath, _dirs, files in os.walk(run_dir):
-            for fname in files:
-                abs_path = os.path.join(dirpath, fname)
-                zf.write(abs_path, os.path.relpath(abs_path, workspace_root))
+        _write_dir_to_zip(zf, run_dir, workspace_root)
     data = buf.getvalue()
 
     req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})

--- a/nvflare/app_opt/job_launcher/workspace_http_server.py
+++ b/nvflare/app_opt/job_launcher/workspace_http_server.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTPS server that delivers workspace files to Kubernetes job pods.
+
+One :class:`WorkspaceHTTPServer` per parent process, shared across jobs.
+Each job gets an unguessable capability URL (256-bit random token).
+
+    GET  /<token>  → download workspace ZIP
+    POST /<token>  → upload results ZIP
+
+Security: TLS 1.2+ for confidentiality/integrity, capability URL for access control.
+``startup/`` and ``local/`` are delivered via k8s Secret and ConfigMap, never over HTTP.
+"""
+
+import io
+import logging
+import os
+import secrets
+import ssl
+import threading
+import zipfile
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+logger = logging.getLogger(__name__)
+
+ENV_WORKSPACE_URL = "NVFL_WORKSPACE_URL"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Minimal handler — accesses shared state via self.server.ws."""
+
+    def do_GET(self):
+        data = self.server.ws.jobs.get(self.path.strip("/"))
+        if data is None:
+            return self.send_error(404)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/zip")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self):
+        token = self.path.strip("/")
+        ws = self.server.ws
+        if token not in ws.jobs:
+            return self.send_error(404)
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        os.makedirs(ws.workspace_root, exist_ok=True)
+        with zipfile.ZipFile(io.BytesIO(body)) as zf:
+            zf.extractall(ws.workspace_root)
+        ws.jobs.pop(token, None)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *_):
+        pass
+
+
+class WorkspaceHTTPServer:
+    """Shared HTTPS server for workspace delivery and results collection."""
+
+    def __init__(self, cert_file: str = "", key_file: str = ""):
+        self._cert_file = cert_file
+        self._key_file = key_file
+        self._port: int = 0
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._scheme = "http"
+        self._stop = threading.Event()
+        self.jobs: dict[str, bytes] = {}  # url_token -> zip_bytes
+        self.workspace_root = ""
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    def start(self, workspace_root: str, bind: str = "0.0.0.0") -> int:
+        self.workspace_root = workspace_root
+        srv = HTTPServer((bind, 0), _Handler)
+        srv.ws = self  # back-reference for handler
+        self._port = srv.server_address[1]
+
+        if self._cert_file and self._key_file:
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+            ctx.load_cert_chain(self._cert_file, self._key_file)
+            srv.socket = ctx.wrap_socket(srv.socket, server_side=True)
+            self._scheme = "https"
+
+        self._server = srv
+        self._thread = threading.Thread(target=self._serve, daemon=True, name="ws-http")
+        self._thread.start()
+        return self._port
+
+    def add_job(self, job_id: str, workspace_root: str) -> str:
+        """Register a job. Returns an unguessable URL token."""
+        token = secrets.token_urlsafe(32)
+        self.jobs[token] = _zip_workspace(workspace_root, job_id)
+        return token
+
+    def remove_job(self, token: str) -> None:
+        self.jobs.pop(token, None)
+
+    def get_url(self, host: str, token: str) -> str:
+        return f"{self._scheme}://{host}:{self._port}/{token}"
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+
+    def _serve(self) -> None:
+        self._server.timeout = 1.0
+        while not self._stop.is_set():
+            self._server.handle_request()
+        self._server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _zip_workspace(workspace_root: str, job_id: str) -> bytes:
+    """ZIP the job directory from *workspace_root* (excludes startup/ and local/)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        src = os.path.join(workspace_root, job_id)
+        if os.path.isdir(src):
+            for dirpath, _dirs, files in os.walk(src):
+                for fname in files:
+                    abs_path = os.path.join(dirpath, fname)
+                    zf.write(abs_path, os.path.relpath(abs_path, workspace_root))
+    return buf.getvalue()
+
+
+def _build_ssl_context(ca_cert: str) -> ssl.SSLContext:
+    # URL is a 256-bit capability token; parent is addressed by pod IP which is
+    # not in the NVFlare cert SAN. Validate CA chain for encryption/integrity
+    # but skip hostname match.
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.check_hostname = False
+    if ca_cert:
+        ctx.load_verify_locations(ca_cert)
+    else:
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Pod-side functions (read NVFL_WORKSPACE_URL from env; no-op when unset)
+# ---------------------------------------------------------------------------
+
+
+def download_workspace(dest: str) -> None:
+    """GET the workspace ZIP and extract into *dest*. No-op if env var unset."""
+    url = os.environ.get(ENV_WORKSPACE_URL)
+    if not url:
+        return
+    import urllib.request
+
+    ca_cert = os.path.join(dest, "startup", "rootCA.pem")
+    ctx = _build_ssl_context(ca_cert if os.path.exists(ca_cert) else "")
+    os.makedirs(dest, exist_ok=True)
+    logger.info("Downloading workspace from %s", url)
+    with urllib.request.urlopen(url, timeout=120, context=ctx) as resp:
+        buf = io.BytesIO(resp.read())
+    with zipfile.ZipFile(buf) as zf:
+        zf.extractall(dest)
+
+
+def upload_results(workspace_root: str, job_id: str) -> None:
+    """ZIP the job directory and POST it. No-op if env var unset."""
+    url = os.environ.get(ENV_WORKSPACE_URL)
+    if not url:
+        return
+    import urllib.request
+
+    run_dir = os.path.join(workspace_root, job_id)
+    if not os.path.isdir(run_dir):
+        return
+
+    ca_cert = os.path.join(workspace_root, "startup", "rootCA.pem")
+    ctx = _build_ssl_context(ca_cert if os.path.exists(ca_cert) else "")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for dirpath, _dirs, files in os.walk(run_dir):
+            for fname in files:
+                abs_path = os.path.join(dirpath, fname)
+                zf.write(abs_path, os.path.relpath(abs_path, workspace_root))
+    data = buf.getvalue()
+
+    req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})
+    urllib.request.urlopen(req, timeout=120, context=ctx).close()

--- a/nvflare/app_opt/job_launcher/workspace_http_server.py
+++ b/nvflare/app_opt/job_launcher/workspace_http_server.py
@@ -30,14 +30,14 @@ delivered through the per-job workspace bundle.
 import io
 import logging
 import os
-import shutil
 import secrets
+import shutil
 import ssl
 import tempfile
 import threading
 import zipfile
 from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import PurePosixPath
 from urllib.parse import urlparse
 
@@ -46,6 +46,8 @@ logger = logging.getLogger(__name__)
 ENV_WORKSPACE_URL = "NVFL_WORKSPACE_URL"
 MAX_REQUEST_BODY_SIZE = 1 << 30  # 1 GiB
 _STREAM_CHUNK_SIZE = 64 * 1024
+_TRANSFER_RETRIES = 3
+_TRANSFER_BACKOFF_S = 1.0
 
 
 class _RequestError(Exception):
@@ -65,24 +67,27 @@ class _Handler(BaseHTTPRequestHandler):
     """Minimal handler — accesses shared state via self.server.ws."""
 
     def do_GET(self):
-        record = self.server.ws.jobs.get(self.path.strip("/"))
+        record = self.server.ws._claim_for_download(self.path.strip("/"))
         if record is None:
             return self.send_error(404)
-        with tempfile.NamedTemporaryFile() as tmp:
-            _zip_workspace_to_file(record.workspace_root, record.job_id, tmp)
-            tmp.flush()
-            size = tmp.tell()
-            tmp.seek(0)
-            self.send_response(200)
-            self.send_header("Content-Type", "application/zip")
-            self.send_header("Content-Length", str(size))
-            self.end_headers()
-            shutil.copyfileobj(tmp, self.wfile)
+        try:
+            with tempfile.NamedTemporaryFile() as tmp:
+                _zip_workspace_to_file(record.workspace_root, record.job_id, tmp)
+                tmp.flush()
+                size = tmp.tell()
+                tmp.seek(0)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/zip")
+                self.send_header("Content-Length", str(size))
+                self.end_headers()
+                shutil.copyfileobj(tmp, self.wfile)
+        finally:
+            self.server.ws._release_download(self.path.strip("/"))
 
     def do_POST(self):
         token = self.path.strip("/")
         ws = self.server.ws
-        record = ws.jobs.get(token)
+        record = ws._claim_for_upload(token)
         if record is None:
             return self.send_error(404)
         os.makedirs(record.workspace_root, exist_ok=True)
@@ -93,15 +98,20 @@ class _Handler(BaseHTTPRequestHandler):
                     _validate_job_zip_members(zf, record.job_id)
                     zf.extractall(record.workspace_root)
         except _RequestError as e:
+            ws._release_upload(token, succeeded=False)
             return self.send_error(e.status_code, e.message)
         except (ValueError, zipfile.BadZipFile) as e:
+            ws._release_upload(token, succeeded=False)
             return self.send_error(400, str(e))
-        ws.jobs.pop(token, None)
+        ws._release_upload(token, succeeded=True)
         self.send_response(200)
         self.end_headers()
 
-    def log_message(self, *_):
-        pass
+    def log_message(self, fmt: str, *args) -> None:
+        # Silence routine 2xx/3xx access logs; keep 4xx/5xx for ops visibility.
+        code = args[1] if len(args) > 1 else ""
+        if isinstance(code, str) and code[:1] in ("4", "5"):
+            logger.warning("ws-http %s - - %s", self.address_string(), fmt % args)
 
 
 class WorkspaceHTTPServer:
@@ -112,11 +122,13 @@ class WorkspaceHTTPServer:
         self._key_file = key_file
         self._require_tls = require_tls
         self._port: int = 0
-        self._server: HTTPServer | None = None
+        self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
         self._scheme = "http"
-        self._stop = threading.Event()
         self.jobs: dict[str, _JobRecord] = {}  # url_token -> job metadata
+        self._in_flight_downloads: set[str] = set()
+        self._upload_claimed: set[str] = set()
+        self._jobs_lock = threading.Lock()
         self.workspace_root = ""
 
     @property
@@ -125,15 +137,18 @@ class WorkspaceHTTPServer:
 
     def start(self, workspace_root: str, bind: str = "0.0.0.0") -> int:
         self.workspace_root = workspace_root
-        srv = HTTPServer((bind, 0), _Handler)
-        srv.ws = self  # back-reference for handler
-        self._port = srv.server_address[1]
 
         if self._require_tls and (not self._cert_file or not self._key_file):
             raise RuntimeError("workspace HTTPS server requires both cert_file and key_file")
-        if self._cert_file or self._key_file:
-            if not self._cert_file or not self._key_file:
-                raise RuntimeError("workspace HTTPS server requires both cert_file and key_file")
+        if (self._cert_file or self._key_file) and not (self._cert_file and self._key_file):
+            raise RuntimeError("workspace HTTPS server requires both cert_file and key_file")
+
+        srv = ThreadingHTTPServer((bind, 0), _Handler)
+        srv.allow_reuse_address = True
+        srv.ws = self  # back-reference for handler
+        self._port = srv.server_address[1]
+
+        if self._cert_file and self._key_file:
             ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(self._cert_file, self._key_file)
@@ -147,26 +162,62 @@ class WorkspaceHTTPServer:
 
     def add_job(self, job_id: str, workspace_root: str) -> str:
         """Register a job. Returns an unguessable URL token."""
+        if self._thread is None or not self._thread.is_alive():
+            raise RuntimeError("WorkspaceHTTPServer thread is not running; cannot register job")
         token = secrets.token_urlsafe(32)
-        self.jobs[token] = _JobRecord(job_id=job_id, workspace_root=workspace_root)
+        with self._jobs_lock:
+            self.jobs[token] = _JobRecord(job_id=job_id, workspace_root=workspace_root)
         return token
 
     def remove_job(self, token: str) -> None:
-        self.jobs.pop(token, None)
+        with self._jobs_lock:
+            self.jobs.pop(token, None)
+            self._in_flight_downloads.discard(token)
+            self._upload_claimed.discard(token)
 
     def get_url(self, host: str, token: str) -> str:
         return f"{self._scheme}://{host}:{self._port}/{token}"
 
     def stop(self) -> None:
-        self._stop.set()
+        srv = self._server
+        if srv is not None:
+            srv.shutdown()
+            srv.server_close()
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
 
+    # -- internal, called by the request handler under the serving thread ------
+    def _claim_for_download(self, token: str) -> _JobRecord | None:
+        with self._jobs_lock:
+            record = self.jobs.get(token)
+            if record is None:
+                return None
+            self._in_flight_downloads.add(token)
+            return record
+
+    def _release_download(self, token: str) -> None:
+        with self._jobs_lock:
+            self._in_flight_downloads.discard(token)
+
+    def _claim_for_upload(self, token: str) -> _JobRecord | None:
+        with self._jobs_lock:
+            record = self.jobs.get(token)
+            if record is None or token in self._upload_claimed:
+                return None
+            self._upload_claimed.add(token)
+            return record
+
+    def _release_upload(self, token: str, succeeded: bool) -> None:
+        with self._jobs_lock:
+            self._upload_claimed.discard(token)
+            if succeeded:
+                self.jobs.pop(token, None)
+
     def _serve(self) -> None:
-        self._server.timeout = 1.0
-        while not self._stop.is_set():
-            self._server.handle_request()
-        self._server.server_close()
+        try:
+            self._server.serve_forever(poll_interval=0.5)
+        except Exception:
+            logger.exception("workspace HTTP serve loop exited abnormally")
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +311,35 @@ def _read_request_body_to_tempfile(rfile, content_length: int):
 # ---------------------------------------------------------------------------
 
 
+def _retry_transient(op_name: str, fn):
+    """Invoke *fn* with bounded exponential backoff on transient transport errors."""
+    import time as _time
+    import urllib.error
+
+    transient = (urllib.error.URLError, ConnectionError, TimeoutError, ssl.SSLError)
+    last_exc: Exception | None = None
+    for attempt in range(1, _TRANSFER_RETRIES + 1):
+        try:
+            return fn()
+        except urllib.error.HTTPError as e:
+            if 500 <= e.code < 600 and attempt < _TRANSFER_RETRIES:
+                logger.warning("%s got %s; retrying (attempt %d/%d)", op_name, e.code, attempt, _TRANSFER_RETRIES)
+                last_exc = e
+            else:
+                raise
+        except transient as e:
+            if attempt < _TRANSFER_RETRIES:
+                logger.warning(
+                    "%s transient error: %s; retrying (attempt %d/%d)", op_name, e, attempt, _TRANSFER_RETRIES
+                )
+                last_exc = e
+            else:
+                raise
+        _time.sleep(_TRANSFER_BACKOFF_S * (2 ** (attempt - 1)))
+    if last_exc is not None:
+        raise last_exc
+
+
 def download_workspace(dest: str) -> None:
     """GET the workspace ZIP and extract into *dest*. No-op if env var unset."""
     url = os.environ.get(ENV_WORKSPACE_URL)
@@ -274,13 +354,17 @@ def download_workspace(dest: str) -> None:
         ctx = _build_ssl_context(ca_cert)
     os.makedirs(dest, exist_ok=True)
     logger.info("Downloading workspace from %s", url)
-    with tempfile.TemporaryFile() as tmp:
-        with urllib.request.urlopen(url, timeout=120, context=ctx) as resp:
-            shutil.copyfileobj(resp, tmp, length=_STREAM_CHUNK_SIZE)
-        tmp.seek(0)
-        with zipfile.ZipFile(tmp) as zf:
-            _validate_relative_zip_members(zf)
-            zf.extractall(dest)
+
+    def _attempt():
+        with tempfile.TemporaryFile() as tmp:
+            with urllib.request.urlopen(url, timeout=120, context=ctx) as resp:
+                shutil.copyfileobj(resp, tmp, length=_STREAM_CHUNK_SIZE)
+            tmp.seek(0)
+            with zipfile.ZipFile(tmp) as zf:
+                _validate_relative_zip_members(zf)
+                zf.extractall(dest)
+
+    _retry_transient("download_workspace", _attempt)
 
 
 def upload_results(workspace_root: str, job_id: str) -> None:
@@ -304,5 +388,8 @@ def upload_results(workspace_root: str, job_id: str) -> None:
         _write_dir_to_zip(zf, run_dir, workspace_root)
     data = buf.getvalue()
 
-    req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})
-    urllib.request.urlopen(req, timeout=120, context=ctx).close()
+    def _attempt():
+        req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})
+        urllib.request.urlopen(req, timeout=120, context=ctx).close()
+
+    _retry_transient("upload_results", _attempt)

--- a/nvflare/lighter/templates/helm/client/deployment.yaml
+++ b/nvflare/lighter/templates/helm/client/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "nvflare-client.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "nvflare-client.selectorLabels" . | nindent 6 }}
@@ -13,6 +15,10 @@ spec:
     metadata:
       labels:
         {{- include "nvflare-client.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "nvflare-client.name" . }}

--- a/nvflare/lighter/templates/helm/client/role.yaml
+++ b/nvflare/lighter/templates/helm/client/role.yaml
@@ -9,6 +9,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["create", "delete", "get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["create", "get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/nvflare/lighter/templates/helm/client/role.yaml
+++ b/nvflare/lighter/templates/helm/client/role.yaml
@@ -10,7 +10,7 @@ rules:
   resources: ["pods"]
   verbs: ["create", "delete", "get", "list", "watch"]
 - apiGroups: [""]
-  resources: ["secrets", "configmaps"]
+  resources: ["secrets"]
   verbs: ["create", "get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/nvflare/lighter/templates/helm/server/deployment.yaml
+++ b/nvflare/lighter/templates/helm/server/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "nvflare-server.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "nvflare-server.selectorLabels" . | nindent 6 }}
@@ -13,6 +15,10 @@ spec:
     metadata:
       labels:
         {{- include "nvflare-server.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "nvflare-server.name" . }}

--- a/nvflare/lighter/templates/helm/server/role.yaml
+++ b/nvflare/lighter/templates/helm/server/role.yaml
@@ -9,6 +9,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["create", "delete", "get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["create", "get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/nvflare/lighter/templates/helm/server/role.yaml
+++ b/nvflare/lighter/templates/helm/server/role.yaml
@@ -10,7 +10,7 @@ rules:
   resources: ["pods"]
   verbs: ["create", "delete", "get", "list", "watch"]
 - apiGroups: [""]
-  resources: ["secrets", "configmaps"]
+  resources: ["secrets"]
   verbs: ["create", "get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -76,7 +76,8 @@ local_client_resources: |
         "path": "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager",
         "args": {
           "num_of_gpus": {~~num_gpus~~},
-          "mem_per_gpu_in_GiB": {~~gpu_mem~~}
+          "mem_per_gpu_in_GiB": {~~gpu_mem~~},
+          "expiration_period": 300
         }
       },
       {

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -42,6 +42,14 @@ from nvflare.private.fed.utils.fed_utils import (
 from nvflare.security.logging import secure_format_exception
 
 
+def _upload_results_safely(logger, workspace_root: str, job_id: str) -> None:
+    try:
+        upload_results(workspace_root, job_id)
+    except Exception as e:
+        if logger:
+            logger.warning(f"failed to upload job results for {job_id}: {secure_format_exception(e)}")
+
+
 def main(args):
     kv_list = parse_vars(args.set)
 
@@ -139,8 +147,9 @@ def main(args):
         security_close()
         err = create_stats_pool_files_for_job(workspace, args.job_id)
         if err:
-            logger.warning(err)
-        upload_results(args.workspace, args.job_id)
+            if logger:
+                logger.warning(err)
+        _upload_results_safely(logger, args.workspace, args.job_id)
 
 
 def parse_arguments():

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -22,6 +22,7 @@ import threading
 from nvflare.apis.fl_constant import ConfigVarName, FLContextKey, JobConstants, SiteType, SystemConfigs
 from nvflare.apis.overseer_spec import SP
 from nvflare.apis.workspace import Workspace
+from nvflare.app_opt.job_launcher.workspace_http_server import download_workspace, upload_results
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
@@ -56,6 +57,7 @@ def main(args):
         args.client_config = os.path.join(config_folder, JobConstants.CLIENT_JOB_CONFIG)
     args.config_folder = config_folder
     args.env = os.path.join("config", "environment.json")
+    download_workspace(args.workspace)
     workspace = Workspace(args.workspace, args.client_name, config_folder)
     set_stats_pool_config_for_job(workspace, args.job_id)
 
@@ -138,6 +140,7 @@ def main(args):
         err = create_stats_pool_files_for_job(workspace, args.job_id)
         if err:
             logger.warning(err)
+        upload_results(args.workspace, args.job_id)
 
 
 def parse_arguments():

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -44,6 +44,14 @@ from nvflare.private.fed.utils.fed_utils import (
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
 
 
+def _upload_results_safely(logger, workspace_root: str, job_id: str) -> None:
+    try:
+        upload_results(workspace_root, job_id)
+    except Exception as e:
+        if logger:
+            logger.warning(f"failed to upload job results for {job_id}: {secure_format_exception(e)}")
+
+
 def main(args):
     kv_list = parse_vars(args.set)
 
@@ -131,8 +139,9 @@ def main(args):
             security_close()
             err = create_stats_pool_files_for_job(workspace, args.job_id)
             if err:
-                logger.warning(err)
-            upload_results(args.workspace, args.job_id)
+                if logger:
+                    logger.warning(err)
+            _upload_results_safely(logger, args.workspace, args.job_id)
 
     except ConfigError as e:
         logger = get_script_logger()

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -21,6 +21,7 @@ import threading
 
 from nvflare.apis.fl_constant import ConfigVarName, JobConstants, SiteType, SystemConfigs
 from nvflare.apis.workspace import Workspace
+from nvflare.app_opt.job_launcher.workspace_http_server import download_workspace, upload_results
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.sec.authn import set_add_auth_headers_filters
@@ -61,6 +62,7 @@ def main(args):
     # get parent process id
     parent_pid = os.getppid()
     stop_event = threading.Event()
+    download_workspace(args.workspace)
     workspace = Workspace(root_dir=args.workspace, site_name=SiteType.SERVER)
     set_stats_pool_config_for_job(workspace, args.job_id)
     secure_train = kv_list.get("secure_train", False)
@@ -130,6 +132,7 @@ def main(args):
             err = create_stats_pool_files_for_job(workspace, args.job_id)
             if err:
                 logger.warning(err)
+            upload_results(args.workspace, args.job_id)
 
     except ConfigError as e:
         logger = get_script_logger()

--- a/nvflare/utils/job_launcher_utils.py
+++ b/nvflare/utils/job_launcher_utils.py
@@ -109,25 +109,29 @@ def generate_server_command(fl_ctx) -> str:
 _LAUNCHER_MODE_KEYS = {"process", "docker", "k8s"}
 
 
-def get_launcher_resource_spec(job_meta, site_name, mode):
-    """Extract the resource spec for a site for a specific launcher mode.
+def get_site_launcher_spec(site_spec, mode):
+    """Extract the launcher-mode portion of a single site's resource spec.
 
-    New nested format: resource_spec[site][mode] = {num_of_gpus: ..., shm_size: ..., ...}
-    Legacy flat format: resource_spec[site] = {num_of_gpus: ...} — treated as process mode for
+    New nested format: ``{mode: {...}}`` — returns the inner dict for *mode*.
+    Legacy flat format: ``{num_of_gpus: ...}`` — treated as process mode for
     backward compatibility; Docker and K8s modes receive an empty spec.
-
-    Returns a dict for the given mode, or an empty dict if not specified.
     """
-    resource_spec = job_meta.get(JobMetaKey.RESOURCE_SPEC.value, {}) or {}
-    site_spec = resource_spec.get(site_name) or {}
+    site_spec = site_spec or {}
     if any(k in site_spec for k in _LAUNCHER_MODE_KEYS):
         return site_spec.get(mode, {})
-    # Legacy flat format — treat as process only
     return site_spec if mode == "process" else {}
 
 
-# TODO: remove in follow-up PR once K8s launcher is updated to use get_launcher_resource_spec
+def get_launcher_resource_spec(job_meta, site_name, mode):
+    """Extract the launcher-mode resource spec for a site from full job meta."""
+    resource_spec = job_meta.get(JobMetaKey.RESOURCE_SPEC.value, {}) or {}
+    return get_site_launcher_spec(resource_spec.get(site_name), mode)
+
+
 def extract_job_image(job_meta, site_name):
+    image = get_launcher_resource_spec(job_meta, site_name, "k8s").get("image")
+    if image:
+        return image
     deploy_map = job_meta.get(JobMetaKey.DEPLOY_MAP, {})
     fallback = None
     for _, participants in deploy_map.items():

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -57,17 +57,31 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_launcher_spec import JobProcessArgs, JobReturnCode
 from nvflare.app_opt.job_launcher.k8s_launcher import (
+    DATA_PVC_VOLUME_NAME,
     DEFAULT_CONTAINER_ARGS_MODULE_ARGS_DICT,
     JOB_RETURN_CODE_MAPPING,
     POD_STATE_MAPPING,
-    VOLUME_MOUNT_LIST,
+    WORKSPACE_MOUNT_PATH,
     JobState,
     K8sJobHandle,
     PodPhase,
-    PvName,
     _job_args_dict,
     uuid4_to_rfc1123,
 )
+
+_DEFAULT_VOLUME_MOUNT_LIST = [
+    {"name": "workspace-job", "mountPath": WORKSPACE_MOUNT_PATH},
+    {"name": "startup-kit", "mountPath": f"{WORKSPACE_MOUNT_PATH}/startup", "readOnly": True},
+    {"name": "local-config", "mountPath": f"{WORKSPACE_MOUNT_PATH}/local", "readOnly": True},
+    {"name": DATA_PVC_VOLUME_NAME, "mountPath": "/var/tmp/nvflare/data", "readOnly": True},
+]
+
+_DEFAULT_VOLUME_LIST = [
+    {"name": "workspace-job", "emptyDir": {}},
+    {"name": "startup-kit", "secret": {"secretName": "nvflare-startup-site1"}},
+    {"name": "local-config", "configMap": {"name": "nvflare-local-site1"}},
+    {"name": DATA_PVC_VOLUME_NAME, "persistentVolumeClaim": {"claimName": "data-pvc"}},
+]
 
 
 def _make_job_config(**overrides):
@@ -76,11 +90,8 @@ def _make_job_config(**overrides):
         "image": "nvflare/nvflare:test",
         "container_name": "container-test-job-123",
         "command": "nvflare.private.fed.app.client.worker_process",
-        "volume_mount_list": VOLUME_MOUNT_LIST,
-        "volume_list": [
-            {"name": PvName.WORKSPACE.value, "persistentVolumeClaim": {"claimName": "ws-pvc"}},
-            {"name": PvName.DATA.value, "persistentVolumeClaim": {"claimName": "data-pvc"}},
-        ],
+        "volume_mount_list": _DEFAULT_VOLUME_MOUNT_LIST,
+        "volume_list": _DEFAULT_VOLUME_LIST,
         "module_args": {"-m": "val_m", "-w": "val_w"},
         "set_list": ["key1=val1", "key2=val2"],
         "resources": {"limits": {"nvidia.com/gpu": 1}},
@@ -261,16 +272,18 @@ class TestK8sJobHandle:
         cfg = _make_job_config()
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
         volumes = handle.get_manifest()["spec"]["volumes"]
-        assert len(volumes) == 2
-        pvc_names = [v["persistentVolumeClaim"]["claimName"] for v in volumes]
-        assert "ws-pvc" in pvc_names
-        assert "data-pvc" in pvc_names
+        assert len(volumes) == 4
+        vol_map = {v["name"]: v for v in volumes}
+        assert "emptyDir" in vol_map["workspace-job"]
+        assert "secret" in vol_map["startup-kit"]
+        assert "configMap" in vol_map["local-config"]
+        assert vol_map[DATA_PVC_VOLUME_NAME]["persistentVolumeClaim"]["claimName"] == "data-pvc"
 
     def test_manifest_volume_mounts(self):
         cfg = _make_job_config()
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
         container = handle.get_manifest()["spec"]["containers"][0]
-        assert container["volumeMounts"] == VOLUME_MOUNT_LIST
+        assert container["volumeMounts"] == _DEFAULT_VOLUME_MOUNT_LIST
 
     def test_manifest_args_contain_command(self):
         cfg = _make_job_config()
@@ -337,11 +350,11 @@ class TestK8sJobHandle:
         container = handle.get_manifest()["spec"]["containers"][0]
         assert container["resources"]["limits"]["nvidia.com/gpu"] == 1
 
-    def test_manifest_no_gpu_resources(self):
-        cfg = _make_job_config(resources={"limits": {"nvidia.com/gpu": None}})
+    def test_manifest_resources_passed_through_unconditionally(self):
+        cfg = _make_job_config(resources={"limits": {"cpu": "500m"}})
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
         container = handle.get_manifest()["spec"]["containers"][0]
-        assert "resources" not in container
+        assert container["resources"] == {"limits": {"cpu": "500m"}}
 
     def test_manifest_no_resources_key(self):
         cfg = _make_job_config()
@@ -713,10 +726,14 @@ def _make_k8s_launcher_patches():
     # import) and builtins.open (for reading the PVC file).  CoreV1Api on the
     # already-stubbed _k8s_core module is patched with patch.object so each
     # test gets a fresh, controllable mock and the original stub is restored.
+    # WorkspaceHTTPServer is patched so tests don't spin up a real HTTP server.
     return [
         patch("builtins.open", create=True),
         patch("nvflare.app_opt.job_launcher.k8s_launcher.yaml"),
         patch.object(_k8s_core, "CoreV1Api"),
+        patch("nvflare.app_opt.job_launcher.k8s_launcher.WorkspaceHTTPServer"),
+        patch("nvflare.app_opt.job_launcher.k8s_launcher.socket.gethostbyname", return_value="10.0.0.1"),
+        patch("nvflare.app_opt.job_launcher.k8s_launcher.socket.gethostname", return_value="parent-pod"),
     ]
 
 
@@ -735,7 +752,6 @@ def _setup_launcher(launcher_cls):
     # PVC file are loaded lazily inside launch_job, so no mocks are needed here.
     return launcher_cls(
         config_file_path="/fake/kube/config",
-        workspace_pvc="ws-pvc",
         study_data_pvc_file_path="/fake/data_pvc.yaml",
     )
 
@@ -745,7 +761,7 @@ class TestK8sJobLauncherHandleEvent:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        _mock_open, _mock_yaml, _mock_core_cls = _enter_patches(patches)
+        _mock_open, _mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             launcher = _setup_launcher(ClientK8sJobLauncher)
             fl_ctx = FLContext()
@@ -765,7 +781,7 @@ class TestK8sJobLauncherHandleEvent:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        _mock_open, _mock_yaml, _mock_core_cls = _enter_patches(patches)
+        _mock_open, _mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             launcher = _setup_launcher(ClientK8sJobLauncher)
             fl_ctx = FLContext()
@@ -791,13 +807,11 @@ class TestK8sJobLauncherInit:
 
         launcher = ClientK8sJobLauncher(
             config_file_path="/fake/kube/config",
-            workspace_pvc="ws-pvc",
             study_data_pvc_file_path="/fake/data_pvc.yaml",
             timeout=60,
             namespace="test-ns",
         )
 
-        assert launcher.workspace_pvc == "ws-pvc"
         assert launcher.study_data_pvc_file_path == "/fake/data_pvc.yaml"
         assert launcher.timeout == 60
         assert launcher.namespace == "test-ns"
@@ -813,7 +827,7 @@ class TestClientK8sJobLauncherGetModuleArgs:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        _mock_open, _mock_yaml, _mock_core_cls = _enter_patches(patches)
+        _mock_open, _mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             launcher = _setup_launcher(ClientK8sJobLauncher)
             fl_ctx = FLContext()
@@ -833,7 +847,7 @@ class TestClientK8sJobLauncherGetModuleArgs:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        _mock_open, _mock_yaml, _mock_core_cls = _enter_patches(patches)
+        _mock_open, _mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             launcher = _setup_launcher(ClientK8sJobLauncher)
             fl_ctx = FLContext()
@@ -851,14 +865,14 @@ class TestServerK8sJobLauncherGetModuleArgs:
         from nvflare.app_opt.job_launcher.k8s_launcher import ServerK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        _mock_open, _mock_yaml, _mock_core_cls = _enter_patches(patches)
+        _mock_open, _mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             launcher = _setup_launcher(ServerK8sJobLauncher)
             fl_ctx = FLContext()
             job_args = {
                 JobProcessArgs.WORKSPACE: ("-w", "/workspace"),
                 JobProcessArgs.JOB_ID: ("-j", "job-1"),
-                JobProcessArgs.ROOT_URL: ("--root_url", "grpc://server:8003"),
+                JobProcessArgs.ROOT_URL: ("--root_url", "https://server:8003"),
             }
             fl_ctx.set_prop(FLContextKey.JOB_PROCESS_ARGS, job_args, private=True, sticky=False)
 
@@ -872,7 +886,7 @@ class TestServerK8sJobLauncherGetModuleArgs:
         from nvflare.app_opt.job_launcher.k8s_launcher import ServerK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        _mock_open, _mock_yaml, _mock_core_cls = _enter_patches(patches)
+        _mock_open, _mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             launcher = _setup_launcher(ServerK8sJobLauncher)
             fl_ctx = FLContext()
@@ -910,12 +924,14 @@ def _make_launch_fl_ctx(site_name="site-1", set_items=None, app_custom_folder=""
         JobProcessArgs.JOB_ID: ("-n", "job-abc"),
     }
     fl_ctx.set_prop(FLContextKey.JOB_PROCESS_ARGS, job_args, private=True, sticky=False)
-    if set_items is not None:
-        args_obj = Mock()
-        args_obj.set = set_items
-        fl_ctx.set_prop(FLContextKey.ARGS, args_obj, private=False, sticky=False)
+    args_obj = Mock()
+    args_obj.workspace = "/fake/workspace"
+    args_obj.set = set_items
+    fl_ctx.set_prop(FLContextKey.ARGS, args_obj, private=False, sticky=False)
     workspace_obj = Mock()
     workspace_obj.get_app_custom_dir.return_value = app_custom_folder
+    workspace_obj.get_startup_kit_dir.return_value = "/fake/startup"
+    workspace_obj.get_site_config_dir.return_value = "/fake/local"
     fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace_obj, private=True, sticky=False)
     return fl_ctx
 
@@ -932,13 +948,17 @@ class TestK8sJobLauncherLaunchJob:
     def _setup(self, patches, namespace="test-ns"):
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
-        mock_open, mock_yaml, mock_core_cls = _enter_patches(patches)
+        mock_open, mock_yaml, mock_core_cls, mock_ws_cls, *_ = _enter_patches(patches)
         mock_yaml.safe_load.return_value = {"default": "data-pvc"}
         mock_api = MagicMock()
         mock_core_cls.return_value = mock_api
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.add_job.return_value = "fake-url-token"
+        mock_ws.get_url.return_value = "http://localhost:12345/fake-url-token"
+        mock_ws.start.return_value = 12345
         launcher = ClientK8sJobLauncher(
             config_file_path="/fake/kube/config",
-            workspace_pvc="ws-pvc",
             study_data_pvc_file_path="/fake/data_pvc.yaml",
             namespace=namespace,
         )
@@ -1075,16 +1095,23 @@ class TestK8sJobLauncherLaunchJob:
 
     # -- pod manifest: volumes ------------------------------------------------
 
-    def test_pod_manifest_pvcs_use_launcher_pvc_names(self):
+    def test_pod_manifest_volume_structure(self):
         patches = _make_k8s_launcher_patches()
         launcher, mock_api = self._setup(patches)
         self._prime_running(mock_api)
         try:
             launcher.launch_job(_make_launch_job_meta(), _make_launch_fl_ctx())
             manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
-            claims = {v["name"]: v["persistentVolumeClaim"]["claimName"] for v in manifest["spec"]["volumes"]}
-            assert claims[PvName.WORKSPACE.value] == "ws-pvc"
-            assert claims[PvName.DATA.value] == "data-pvc"
+            volumes = manifest["spec"]["volumes"]
+            vol_map = {v["name"]: v for v in volumes}
+            # workspace uses ephemeral emptyDir (no shared PVC)
+            assert "emptyDir" in vol_map["workspace-job"]
+            # startup/ delivered via Secret
+            assert "secret" in vol_map["startup-kit"]
+            # local/ delivered via ConfigMap
+            assert "configMap" in vol_map["local-config"]
+            # data PVC from the PVC file
+            assert vol_map[DATA_PVC_VOLUME_NAME]["persistentVolumeClaim"]["claimName"] == "data-pvc"
         finally:
             _exit_patches(patches)
 
@@ -1108,7 +1135,8 @@ class TestK8sJobLauncherLaunchJob:
         try:
             launcher.launch_job(_make_launch_job_meta(), _make_launch_fl_ctx())
             manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
-            assert "resources" not in manifest["spec"]["containers"][0]
+            resources = manifest["spec"]["containers"][0]["resources"]
+            assert "nvidia.com/gpu" not in resources.get("limits", {})
         finally:
             _exit_patches(patches)
 
@@ -1142,14 +1170,16 @@ class TestK8sJobLauncherLaunchJob:
         finally:
             _exit_patches(patches)
 
-    def test_pod_manifest_no_env_when_no_custom_folder(self):
+    def test_pod_manifest_no_pythonpath_when_no_custom_folder(self):
         patches = _make_k8s_launcher_patches()
         launcher, mock_api = self._setup(patches)
         self._prime_running(mock_api)
         try:
             launcher.launch_job(_make_launch_job_meta(), _make_launch_fl_ctx(app_custom_folder=""))
             manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
-            assert "env" not in manifest["spec"]["containers"][0]
+            container = manifest["spec"]["containers"][0]
+            env_map = {e["name"]: e["value"] for e in container.get("env", [])}
+            assert "PYTHONPATH" not in env_map
         finally:
             _exit_patches(patches)
 
@@ -1196,12 +1226,11 @@ class TestK8sJobLauncherLaunchJob:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        mock_open, mock_yaml, _mock_core_cls = _enter_patches(patches)
+        mock_open, mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             mock_yaml.safe_load.return_value = {}
             launcher = ClientK8sJobLauncher(
                 config_file_path="/fake/kube/config",
-                workspace_pvc="ws-pvc",
                 study_data_pvc_file_path="/fake/data_pvc.yaml",
             )
             with pytest.raises(ValueError, match="empty"):
@@ -1213,12 +1242,11 @@ class TestK8sJobLauncherLaunchJob:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        mock_open, mock_yaml, _mock_core_cls = _enter_patches(patches)
+        mock_open, mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             mock_yaml.safe_load.return_value = "not-a-dict"
             launcher = ClientK8sJobLauncher(
                 config_file_path="/fake/kube/config",
-                workspace_pvc="ws-pvc",
                 study_data_pvc_file_path="/fake/data_pvc.yaml",
             )
             with pytest.raises(ValueError, match="dictionary"):
@@ -1230,12 +1258,11 @@ class TestK8sJobLauncherLaunchJob:
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         patches = _make_k8s_launcher_patches()
-        mock_open, mock_yaml, _mock_core_cls = _enter_patches(patches)
+        mock_open, mock_yaml, _mock_core_cls, _mock_ws_cls, *_ = _enter_patches(patches)
         try:
             mock_yaml.safe_load.return_value = {"study-A": "pvc-a"}  # no "default" key
             launcher = ClientK8sJobLauncher(
                 config_file_path="/fake/kube/config",
-                workspace_pvc="ws-pvc",
                 study_data_pvc_file_path="/fake/data_pvc.yaml",
             )
             with pytest.raises(ValueError, match="default"):
@@ -1245,20 +1272,28 @@ class TestK8sJobLauncherLaunchJob:
 
 
 # ---------------------------------------------------------------------------
-# VOLUME_MOUNT_LIST shape
+# Volume mount list shape (tested via _DEFAULT_VOLUME_MOUNT_LIST defined above)
 # ---------------------------------------------------------------------------
 class TestVolumeMountList:
     def test_data_mount_is_read_only(self):
-        data_mount = next(m for m in VOLUME_MOUNT_LIST if m["name"] == PvName.DATA.value)
+        data_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == DATA_PVC_VOLUME_NAME)
         assert data_mount["readOnly"] is True
 
     def test_workspace_always_writable(self):
-        ws_mount = next(m for m in VOLUME_MOUNT_LIST if m["name"] == PvName.WORKSPACE.value)
+        ws_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "workspace-job")
         assert "readOnly" not in ws_mount
 
+    def test_startup_kit_is_read_only(self):
+        startup_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "startup-kit")
+        assert startup_mount["readOnly"] is True
+
+    def test_local_config_is_read_only(self):
+        local_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "local-config")
+        assert local_mount["readOnly"] is True
+
     def test_mount_paths(self):
-        ws_mount = next(m for m in VOLUME_MOUNT_LIST if m["name"] == PvName.WORKSPACE.value)
-        data_mount = next(m for m in VOLUME_MOUNT_LIST if m["name"] == PvName.DATA.value)
+        ws_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "workspace-job")
+        data_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == DATA_PVC_VOLUME_NAME)
         assert ws_mount["mountPath"] == "/var/tmp/nvflare/workspace"
         assert data_mount["mountPath"] == "/var/tmp/nvflare/data"
 

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
+import tempfile
 from types import ModuleType
 from unittest.mock import MagicMock, Mock, patch
 
@@ -65,6 +67,7 @@ from nvflare.app_opt.job_launcher.k8s_launcher import (
     JobState,
     K8sJobHandle,
     PodPhase,
+    _get_workspace_server_tls_files,
     _job_args_dict,
     uuid4_to_rfc1123,
 )
@@ -72,14 +75,12 @@ from nvflare.app_opt.job_launcher.k8s_launcher import (
 _DEFAULT_VOLUME_MOUNT_LIST = [
     {"name": "workspace-job", "mountPath": WORKSPACE_MOUNT_PATH},
     {"name": "startup-kit", "mountPath": f"{WORKSPACE_MOUNT_PATH}/startup", "readOnly": True},
-    {"name": "local-config", "mountPath": f"{WORKSPACE_MOUNT_PATH}/local", "readOnly": True},
     {"name": DATA_PVC_VOLUME_NAME, "mountPath": "/var/tmp/nvflare/data", "readOnly": True},
 ]
 
 _DEFAULT_VOLUME_LIST = [
     {"name": "workspace-job", "emptyDir": {}},
     {"name": "startup-kit", "secret": {"secretName": "nvflare-startup-site1"}},
-    {"name": "local-config", "configMap": {"name": "nvflare-local-site1"}},
     {"name": DATA_PVC_VOLUME_NAME, "persistentVolumeClaim": {"claimName": "data-pvc"}},
 ]
 
@@ -272,11 +273,10 @@ class TestK8sJobHandle:
         cfg = _make_job_config()
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
         volumes = handle.get_manifest()["spec"]["volumes"]
-        assert len(volumes) == 4
+        assert len(volumes) == 3
         vol_map = {v["name"]: v for v in volumes}
         assert "emptyDir" in vol_map["workspace-job"]
         assert "secret" in vol_map["startup-kit"]
-        assert "configMap" in vol_map["local-config"]
         assert vol_map[DATA_PVC_VOLUME_NAME]["persistentVolumeClaim"]["claimName"] == "data-pvc"
 
     def test_manifest_volume_mounts(self):
@@ -437,6 +437,16 @@ class TestK8sJobHandle:
         assert handle.poll() == JobReturnCode.ABORTED
         api.read_namespaced_pod.assert_not_called()
 
+    def test_poll_removes_workspace_job_on_terminal_state(self):
+        api = _make_api_instance()
+        resp = Mock()
+        resp.status.phase = PodPhase.SUCCEEDED.value
+        api.read_namespaced_pod.return_value = resp
+        ws_server = Mock()
+        handle = _make_handle(api=api, workspace_server=ws_server, workspace_token="token-1")
+        assert handle.poll() == JobReturnCode.SUCCESS
+        ws_server.remove_job.assert_called_once_with("token-1")
+
     # -- terminate ------------------------------------------------------------
     def test_terminate_deletes_pod_and_sets_terminated(self):
         api = _make_api_instance()
@@ -569,6 +579,23 @@ class TestK8sJobHandle:
         handle = _make_handle(api=api)
         handle.wait()
         assert handle.poll() == JobReturnCode.SUCCESS
+
+    def test_wait_removes_workspace_job_on_terminal_state(self):
+        api = _make_api_instance()
+        resp = Mock()
+        resp.status.phase = PodPhase.SUCCEEDED.value
+        api.read_namespaced_pod.return_value = resp
+        ws_server = Mock()
+        handle = _make_handle(api=api, workspace_server=ws_server, workspace_token="token-1")
+        handle.wait()
+        ws_server.remove_job.assert_called_once_with("token-1")
+
+    def test_terminate_removes_workspace_job(self):
+        api = _make_api_instance()
+        ws_server = Mock()
+        handle = _make_handle(api=api, workspace_server=ws_server, workspace_token="token-1")
+        handle.terminate()
+        ws_server.remove_job.assert_called_once_with("token-1")
 
     # -- enter_states ---------------------------------------------------------
     def test_enter_states_returns_true_when_state_matches(self):
@@ -732,6 +759,10 @@ def _make_k8s_launcher_patches():
         patch("nvflare.app_opt.job_launcher.k8s_launcher.yaml"),
         patch.object(_k8s_core, "CoreV1Api"),
         patch("nvflare.app_opt.job_launcher.k8s_launcher.WorkspaceHTTPServer"),
+        patch(
+            "nvflare.app_opt.job_launcher.k8s_launcher._get_workspace_server_tls_files",
+            return_value=("/fake/startup/server.crt", "/fake/startup/server.key"),
+        ),
         patch("nvflare.app_opt.job_launcher.k8s_launcher.socket.gethostbyname", return_value="10.0.0.1"),
         patch("nvflare.app_opt.job_launcher.k8s_launcher.socket.gethostname", return_value="parent-pod"),
     ]
@@ -911,7 +942,7 @@ def _make_launch_job_meta(site_name="site-1", image="nvflare/nvflare:latest", gp
         JobMetaKey.DEPLOY_MAP.value: {"app": [{"sites": [site_name], "image": image}]},
     }
     if gpu is not None:
-        meta[JobMetaKey.RESOURCE_SPEC.value] = {site_name: {"num_of_gpus": gpu}}
+        meta[JobMetaKey.RESOURCE_SPEC.value] = {site_name: {"k8s": {"image": image, "num_of_gpus": gpu}}}
     return meta
 
 
@@ -955,7 +986,7 @@ class TestK8sJobLauncherLaunchJob:
         mock_ws = MagicMock()
         mock_ws_cls.return_value = mock_ws
         mock_ws.add_job.return_value = "fake-url-token"
-        mock_ws.get_url.return_value = "http://localhost:12345/fake-url-token"
+        mock_ws.get_url.return_value = "https://localhost:12345/fake-url-token"
         mock_ws.start.return_value = 12345
         launcher = ClientK8sJobLauncher(
             config_file_path="/fake/kube/config",
@@ -1108,8 +1139,6 @@ class TestK8sJobLauncherLaunchJob:
             assert "emptyDir" in vol_map["workspace-job"]
             # startup/ delivered via Secret
             assert "secret" in vol_map["startup-kit"]
-            # local/ delivered via ConfigMap
-            assert "configMap" in vol_map["local-config"]
             # data PVC from the PVC file
             assert vol_map[DATA_PVC_VOLUME_NAME]["persistentVolumeClaim"]["claimName"] == "data-pvc"
         finally:
@@ -1287,15 +1316,40 @@ class TestVolumeMountList:
         startup_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "startup-kit")
         assert startup_mount["readOnly"] is True
 
-    def test_local_config_is_read_only(self):
-        local_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "local-config")
-        assert local_mount["readOnly"] is True
-
     def test_mount_paths(self):
         ws_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == "workspace-job")
         data_mount = next(m for m in _DEFAULT_VOLUME_MOUNT_LIST if m["name"] == DATA_PVC_VOLUME_NAME)
         assert ws_mount["mountPath"] == "/var/tmp/nvflare/workspace"
         assert data_mount["mountPath"] == "/var/tmp/nvflare/data"
+
+
+class TestWorkspaceServerTlsFiles:
+    def test_prefers_server_cert_pair(self):
+        with tempfile.TemporaryDirectory() as startup_dir:
+            server_crt = os.path.join(startup_dir, "server.crt")
+            server_key = os.path.join(startup_dir, "server.key")
+            client_crt = os.path.join(startup_dir, "client.crt")
+            client_key = os.path.join(startup_dir, "client.key")
+            for path in (server_crt, server_key, client_crt, client_key):
+                with open(path, "w", encoding="utf-8"):
+                    pass
+
+            assert _get_workspace_server_tls_files(startup_dir) == (server_crt, server_key)
+
+    def test_falls_back_to_client_cert_pair(self):
+        with tempfile.TemporaryDirectory() as startup_dir:
+            client_crt = os.path.join(startup_dir, "client.crt")
+            client_key = os.path.join(startup_dir, "client.key")
+            for path in (client_crt, client_key):
+                with open(path, "w", encoding="utf-8"):
+                    pass
+
+            assert _get_workspace_server_tls_files(startup_dir) == (client_crt, client_key)
+
+    def test_raises_when_no_cert_pair_exists(self):
+        with tempfile.TemporaryDirectory() as startup_dir:
+            with pytest.raises(RuntimeError, match="cert/key files"):
+                _get_workspace_server_tls_files(startup_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/app_opt/job_launcher/workspace_http_server_test.py
+++ b/tests/unit_test/app_opt/job_launcher/workspace_http_server_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client
 import io
 import os
 import tempfile
@@ -23,6 +24,7 @@ import pytest
 
 from nvflare.app_opt.job_launcher.workspace_http_server import (
     ENV_WORKSPACE_URL,
+    MAX_REQUEST_BODY_SIZE,
     WorkspaceHTTPServer,
     _zip_workspace,
     download_workspace,
@@ -47,11 +49,21 @@ def _write_file(path: str, content: bytes = b"data") -> None:
 def _make_workspace(root: str, job_id: str) -> dict:
     """Populate a minimal workspace; return {rel_path: bytes} for run_<job_id>/ files."""
     _write_file(os.path.join(root, "startup", "fed_client.json"), b'{"type":"client"}')
-    _write_file(os.path.join(root, "local", "resources.json"), b'{"resources":{}}')
+    local_files = {
+        os.path.join("local", "resources.json"): b'{"resources":{}}',
+        os.path.join("local", "job_resources.json"): b'{"job_resources":{}}',
+        os.path.join("local", "site__j_resources.json"): b'{"job_only": true}',
+        os.path.join("local", "custom", "site_module.py"): b"VALUE = 3\n",
+    }
     run_files = {os.path.join(job_id, "app", "config", "config_train.json"): b'{"rounds":3}'}
+    expected = {}
+    expected.update(local_files)
+    expected.update(run_files)
+    for rel, content in local_files.items():
+        _write_file(os.path.join(root, rel), content)
     for rel, content in run_files.items():
         _write_file(os.path.join(root, rel), content)
-    return run_files
+    return expected
 
 
 def _make_result_files(root: str, job_id: str) -> dict:
@@ -65,9 +77,17 @@ def _make_result_files(root: str, job_id: str) -> dict:
     return files
 
 
+def _make_zip(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
 def _start_server(ws_root: str, job_id: str = JOB_ID):
     """Start a shared server, register one job, return (server, url_token)."""
-    server = WorkspaceHTTPServer()
+    server = WorkspaceHTTPServer(require_tls=False)
     server.start(workspace_root=ws_root)
     url_token = server.add_job(job_id, ws_root)
     return server, url_token
@@ -93,13 +113,15 @@ class TestZipWorkspace:
                 names = zf.namelist()
             assert not any(n.startswith("startup") for n in names)
 
-    def test_zip_does_not_contain_local_files(self):
+    def test_zip_contains_full_local_tree(self):
         with tempfile.TemporaryDirectory() as ws_root:
             _make_workspace(ws_root, JOB_ID)
             data = _zip_workspace(ws_root, JOB_ID)
             with zipfile.ZipFile(io.BytesIO(data)) as zf:
                 names = zf.namelist()
-            assert not any(n.startswith("local") for n in names)
+            assert "local/job_resources.json" in names
+            assert "local/site__j_resources.json" in names
+            assert "local/custom/site_module.py" in names
 
     def test_zip_contains_run_dir_files(self):
         with tempfile.TemporaryDirectory() as ws_root:
@@ -151,9 +173,15 @@ class TestZipWorkspace:
 
 
 class TestWorkspaceHTTPServer:
-    def test_start_returns_nonzero_port(self):
+    def test_start_requires_tls_by_default(self):
         with tempfile.TemporaryDirectory() as ws_root:
             server = WorkspaceHTTPServer()
+            with pytest.raises(RuntimeError, match="cert_file"):
+                server.start(workspace_root=ws_root)
+
+    def test_start_returns_nonzero_port(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer(require_tls=False)
             try:
                 port = server.start(workspace_root=ws_root)
                 assert isinstance(port, int) and port > 0
@@ -162,7 +190,7 @@ class TestWorkspaceHTTPServer:
 
     def test_port_property_matches_start(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             try:
                 port = server.start(workspace_root=ws_root)
                 assert server.port == port
@@ -171,7 +199,7 @@ class TestWorkspaceHTTPServer:
 
     def test_add_job_returns_url_token(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             try:
                 url_token = server.add_job(JOB_ID, ws_root)
@@ -181,7 +209,7 @@ class TestWorkspaceHTTPServer:
 
     def test_each_job_gets_unique_token(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             try:
                 token_a = server.add_job(JOB_ID, ws_root)
@@ -192,7 +220,7 @@ class TestWorkspaceHTTPServer:
 
     def test_get_url_includes_token_in_path(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             try:
                 port = server.start(workspace_root=ws_root)
                 url_token = server.add_job(JOB_ID, ws_root)
@@ -214,9 +242,22 @@ class TestWorkspaceHTTPServer:
             finally:
                 server.stop()
 
+    def test_get_zips_workspace_at_request_time(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            try:
+                _write_file(os.path.join(ws_root, JOB_ID, "late.txt"), b"late")
+                url = f"http://127.0.0.1:{server.port}/{url_token}"
+                with urllib.request.urlopen(url, timeout=10) as resp:
+                    body = resp.read()
+                with zipfile.ZipFile(io.BytesIO(body)) as zf:
+                    assert zf.read(f"{JOB_ID}/late.txt") == b"late"
+            finally:
+                server.stop()
+
     def test_unknown_token_returns_404(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             try:
                 url = f"http://127.0.0.1:{server.port}/no-such-token"
@@ -230,7 +271,7 @@ class TestWorkspaceHTTPServer:
         with tempfile.TemporaryDirectory() as ws_root:
             _write_file(os.path.join(ws_root, JOB_ID, "a.txt"), b"aaa")
             _write_file(os.path.join(ws_root, JOB_ID_B, "b.txt"), b"bbb")
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             try:
                 token_a = server.add_job(JOB_ID, ws_root)
@@ -251,6 +292,51 @@ class TestWorkspaceHTTPServer:
             finally:
                 server.stop()
 
+    def test_upload_rejects_members_outside_job_dir(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            try:
+                url = f"http://127.0.0.1:{server.port}/{url_token}"
+                data = _make_zip({"startup/pwned.txt": b"nope"})
+                req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    urllib.request.urlopen(req, timeout=10)
+                assert exc.value.code == 400
+                assert not os.path.exists(os.path.join(ws_root, "startup", "pwned.txt"))
+                assert url_token in server.jobs
+            finally:
+                server.stop()
+
+    def test_upload_rejects_other_job_dir(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            try:
+                url = f"http://127.0.0.1:{server.port}/{url_token}"
+                data = _make_zip({f"{JOB_ID_B}/pwned.txt": b"nope"})
+                req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    urllib.request.urlopen(req, timeout=10)
+                assert exc.value.code == 400
+                assert not os.path.exists(os.path.join(ws_root, JOB_ID_B, "pwned.txt"))
+                assert url_token in server.jobs
+            finally:
+                server.stop()
+
+    def test_upload_rejects_path_traversal(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            try:
+                url = f"http://127.0.0.1:{server.port}/{url_token}"
+                data = _make_zip({f"{JOB_ID}/../pwned.txt": b"nope"})
+                req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/zip"})
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    urllib.request.urlopen(req, timeout=10)
+                assert exc.value.code == 400
+                assert not os.path.exists(os.path.join(ws_root, "pwned.txt"))
+                assert url_token in server.jobs
+            finally:
+                server.stop()
+
     def test_remove_job_makes_subsequent_requests_return_404(self):
         with tempfile.TemporaryDirectory() as ws_root:
             server, url_token = _start_server(ws_root)
@@ -263,16 +349,60 @@ class TestWorkspaceHTTPServer:
             finally:
                 server.stop()
 
+    def test_post_requires_content_length(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            conn = http.client.HTTPConnection("127.0.0.1", server.port, timeout=10)
+            try:
+                conn.putrequest("POST", f"/{url_token}")
+                conn.endheaders()
+                resp = conn.getresponse()
+                assert resp.status == 411
+                resp.read()
+            finally:
+                conn.close()
+                server.stop()
+
+    def test_post_rejects_invalid_content_length(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            conn = http.client.HTTPConnection("127.0.0.1", server.port, timeout=10)
+            try:
+                conn.putrequest("POST", f"/{url_token}")
+                conn.putheader("Content-Length", "bogus")
+                conn.endheaders()
+                resp = conn.getresponse()
+                assert resp.status == 400
+                resp.read()
+            finally:
+                conn.close()
+                server.stop()
+
+    def test_post_rejects_oversized_content_length(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            conn = http.client.HTTPConnection("127.0.0.1", server.port, timeout=10)
+            try:
+                conn.putrequest("POST", f"/{url_token}")
+                conn.putheader("Content-Length", str(MAX_REQUEST_BODY_SIZE + 1))
+                conn.endheaders()
+                resp = conn.getresponse()
+                assert resp.status == 413
+                resp.read()
+            finally:
+                conn.close()
+                server.stop()
+
     def test_stop_terminates_server_thread(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             server.stop()
             assert not server._thread.is_alive()
 
     def test_stop_is_idempotent(self):
         with tempfile.TemporaryDirectory() as ws_root:
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             server.stop()
             server.stop()  # must not raise
@@ -337,6 +467,12 @@ class TestDownloadWorkspace:
             finally:
                 server.stop()
 
+    def test_https_requires_root_ca(self, monkeypatch):
+        monkeypatch.setenv(ENV_WORKSPACE_URL, "https://example.invalid/token")
+        with tempfile.TemporaryDirectory() as dest:
+            with pytest.raises(RuntimeError, match="rootCA.pem"):
+                download_workspace(dest)
+
 
 # ---------------------------------------------------------------------------
 # TestResultsUpload
@@ -400,6 +536,13 @@ class TestResultsUpload:
             finally:
                 server.stop()
 
+    def test_https_requires_root_ca(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as pod_ws:
+            _make_result_files(pod_ws, JOB_ID)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, "https://example.invalid/token")
+            with pytest.raises(RuntimeError, match="rootCA.pem"):
+                upload_results(pod_ws, JOB_ID)
+
 
 # ---------------------------------------------------------------------------
 # TestFullEndToEnd
@@ -433,7 +576,7 @@ class TestFullEndToEnd:
         ):
             _write_file(os.path.join(ws_root, JOB_ID, "a.txt"), b"aaa")
             _write_file(os.path.join(ws_root, JOB_ID_B, "b.txt"), b"bbb")
-            server = WorkspaceHTTPServer()
+            server = WorkspaceHTTPServer(require_tls=False)
             server.start(workspace_root=ws_root)
             token_a = server.add_job(JOB_ID, ws_root)
             token_b = server.add_job(JOB_ID_B, ws_root)

--- a/tests/unit_test/app_opt/job_launcher/workspace_http_server_test.py
+++ b/tests/unit_test/app_opt/job_launcher/workspace_http_server_test.py
@@ -1,0 +1,468 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+
+import pytest
+
+from nvflare.app_opt.job_launcher.workspace_http_server import (
+    ENV_WORKSPACE_URL,
+    WorkspaceHTTPServer,
+    _zip_workspace,
+    download_workspace,
+    upload_results,
+)
+
+JOB_ID = "abc12345-dead-beef-0000-111122223333"
+JOB_ID_B = "bbbbbbbb-dead-beef-0000-111122223333"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_file(path: str, content: bytes = b"data") -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(content)
+
+
+def _make_workspace(root: str, job_id: str) -> dict:
+    """Populate a minimal workspace; return {rel_path: bytes} for run_<job_id>/ files."""
+    _write_file(os.path.join(root, "startup", "fed_client.json"), b'{"type":"client"}')
+    _write_file(os.path.join(root, "local", "resources.json"), b'{"resources":{}}')
+    run_files = {os.path.join(job_id, "app", "config", "config_train.json"): b'{"rounds":3}'}
+    for rel, content in run_files.items():
+        _write_file(os.path.join(root, rel), content)
+    return run_files
+
+
+def _make_result_files(root: str, job_id: str) -> dict:
+    files = {
+        os.path.join(job_id, "fl_app.txt"): b"done",
+        os.path.join(job_id, "app_server", "best_model.pt"): b"WEIGHTS",
+        os.path.join(job_id, "log.txt"): b"training log\n",
+    }
+    for rel, content in files.items():
+        _write_file(os.path.join(root, rel), content)
+    return files
+
+
+def _start_server(ws_root: str, job_id: str = JOB_ID):
+    """Start a shared server, register one job, return (server, url_token)."""
+    server = WorkspaceHTTPServer()
+    server.start(workspace_root=ws_root)
+    url_token = server.add_job(job_id, ws_root)
+    return server, url_token
+
+
+# ---------------------------------------------------------------------------
+# TestZipWorkspace
+# ---------------------------------------------------------------------------
+
+
+class TestZipWorkspace:
+    def test_result_is_valid_zip(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _make_workspace(ws_root, JOB_ID)
+            data = _zip_workspace(ws_root, JOB_ID)
+            assert zipfile.is_zipfile(io.BytesIO(data))
+
+    def test_zip_does_not_contain_startup_files(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _make_workspace(ws_root, JOB_ID)
+            data = _zip_workspace(ws_root, JOB_ID)
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                names = zf.namelist()
+            assert not any(n.startswith("startup") for n in names)
+
+    def test_zip_does_not_contain_local_files(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _make_workspace(ws_root, JOB_ID)
+            data = _zip_workspace(ws_root, JOB_ID)
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                names = zf.namelist()
+            assert not any(n.startswith("local") for n in names)
+
+    def test_zip_contains_run_dir_files(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _make_workspace(ws_root, JOB_ID)
+            data = _zip_workspace(ws_root, JOB_ID)
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                names = zf.namelist()
+            assert any(n.startswith(JOB_ID) for n in names)
+
+    def test_missing_run_dir_returns_empty_zip(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            data = _zip_workspace(ws_root, JOB_ID)
+            assert zipfile.is_zipfile(io.BytesIO(data))
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                assert zf.namelist() == []
+
+    def test_arcnames_are_relative(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _make_workspace(ws_root, JOB_ID)
+            data = _zip_workspace(ws_root, JOB_ID)
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                for name in zf.namelist():
+                    assert not os.path.isabs(name)
+
+    def test_file_contents_preserved(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            expected = b"expected content"
+            _write_file(os.path.join(ws_root, JOB_ID, "sentinel.bin"), expected)
+            data = _zip_workspace(ws_root, JOB_ID)
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                name = next(n for n in zf.namelist() if "sentinel.bin" in n)
+                assert zf.read(name) == expected
+
+    def test_different_job_ids_produce_different_archives(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _write_file(os.path.join(ws_root, JOB_ID, "a.txt"), b"a")
+            _write_file(os.path.join(ws_root, JOB_ID_B, "b.txt"), b"b")
+            data_a = _zip_workspace(ws_root, JOB_ID)
+            data_b = _zip_workspace(ws_root, JOB_ID_B)
+            with zipfile.ZipFile(io.BytesIO(data_a)) as zf:
+                assert not any(JOB_ID_B in n for n in zf.namelist())
+            with zipfile.ZipFile(io.BytesIO(data_b)) as zf:
+                assert not any(JOB_ID in n for n in zf.namelist())
+
+
+# ---------------------------------------------------------------------------
+# TestWorkspaceHTTPServer
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceHTTPServer:
+    def test_start_returns_nonzero_port(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            try:
+                port = server.start(workspace_root=ws_root)
+                assert isinstance(port, int) and port > 0
+            finally:
+                server.stop()
+
+    def test_port_property_matches_start(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            try:
+                port = server.start(workspace_root=ws_root)
+                assert server.port == port
+            finally:
+                server.stop()
+
+    def test_add_job_returns_url_token(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            try:
+                url_token = server.add_job(JOB_ID, ws_root)
+                assert isinstance(url_token, str) and len(url_token) > 0
+            finally:
+                server.stop()
+
+    def test_each_job_gets_unique_token(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            try:
+                token_a = server.add_job(JOB_ID, ws_root)
+                token_b = server.add_job(JOB_ID_B, ws_root)
+                assert token_a != token_b
+            finally:
+                server.stop()
+
+    def test_get_url_includes_token_in_path(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            try:
+                port = server.start(workspace_root=ws_root)
+                url_token = server.add_job(JOB_ID, ws_root)
+                url = server.get_url("10.0.0.5", url_token)
+                assert url == f"http://10.0.0.5:{port}/{url_token}"
+            finally:
+                server.stop()
+
+    def test_get_with_valid_token_returns_zip(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _make_workspace(ws_root, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            try:
+                url = f"http://127.0.0.1:{server.port}/{url_token}"
+                with urllib.request.urlopen(url, timeout=10) as resp:
+                    assert resp.status == 200
+                    body = resp.read()
+                assert zipfile.is_zipfile(io.BytesIO(body))
+            finally:
+                server.stop()
+
+    def test_unknown_token_returns_404(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            try:
+                url = f"http://127.0.0.1:{server.port}/no-such-token"
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    urllib.request.urlopen(url, timeout=10)
+                assert exc.value.code == 404
+            finally:
+                server.stop()
+
+    def test_two_jobs_are_served_independently(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _write_file(os.path.join(ws_root, JOB_ID, "a.txt"), b"aaa")
+            _write_file(os.path.join(ws_root, JOB_ID_B, "b.txt"), b"bbb")
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            try:
+                token_a = server.add_job(JOB_ID, ws_root)
+                token_b = server.add_job(JOB_ID_B, ws_root)
+
+                with urllib.request.urlopen(f"http://127.0.0.1:{server.port}/{token_a}", timeout=10) as r:
+                    zip_a = r.read()
+                with urllib.request.urlopen(f"http://127.0.0.1:{server.port}/{token_b}", timeout=10) as r:
+                    zip_b = r.read()
+
+                with zipfile.ZipFile(io.BytesIO(zip_a)) as zf:
+                    assert any(JOB_ID in n for n in zf.namelist())
+                    assert not any(JOB_ID_B in n for n in zf.namelist())
+
+                with zipfile.ZipFile(io.BytesIO(zip_b)) as zf:
+                    assert any(JOB_ID_B in n for n in zf.namelist())
+                    assert not any(JOB_ID in n for n in zf.namelist())
+            finally:
+                server.stop()
+
+    def test_remove_job_makes_subsequent_requests_return_404(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server, url_token = _start_server(ws_root)
+            try:
+                server.remove_job(url_token)
+                url = f"http://127.0.0.1:{server.port}/{url_token}"
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    urllib.request.urlopen(url, timeout=10)
+                assert exc.value.code == 404
+            finally:
+                server.stop()
+
+    def test_stop_terminates_server_thread(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            server.stop()
+            assert not server._thread.is_alive()
+
+    def test_stop_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as ws_root:
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            server.stop()
+            server.stop()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TestDownloadWorkspace
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadWorkspace:
+    def test_noop_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv(ENV_WORKSPACE_URL, raising=False)
+        with tempfile.TemporaryDirectory() as dest:
+            download_workspace(dest)  # must not raise
+
+    def test_end_to_end_files_extracted(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as dest:
+            expected = _make_workspace(ws_root, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            try:
+                download_workspace(dest)
+            finally:
+                server.stop()
+            for rel in expected:
+                assert os.path.exists(os.path.join(dest, rel))
+
+    def test_file_contents_match(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as dest:
+            expected = _make_workspace(ws_root, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            try:
+                download_workspace(dest)
+            finally:
+                server.stop()
+            for rel, content in expected.items():
+                with open(os.path.join(dest, rel), "rb") as fh:
+                    assert fh.read() == content
+
+    def test_creates_dest_if_missing(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as tmp:
+            _make_workspace(ws_root, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            dest = os.path.join(tmp, "nonexistent", "subdir")
+            try:
+                download_workspace(dest)
+            finally:
+                server.stop()
+            assert os.path.isdir(dest)
+
+    def test_wrong_url_raises_404(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as dest:
+            server, _ = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, f"http://127.0.0.1:{server.port}/wrong-token")
+            try:
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    download_workspace(dest)
+                assert exc.value.code == 404
+            finally:
+                server.stop()
+
+
+# ---------------------------------------------------------------------------
+# TestResultsUpload
+# ---------------------------------------------------------------------------
+
+
+class TestResultsUpload:
+    def test_noop_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv(ENV_WORKSPACE_URL, raising=False)
+        with tempfile.TemporaryDirectory() as pod_ws:
+            upload_results(pod_ws, JOB_ID)  # must not raise
+
+    def test_full_round_trip(self, monkeypatch):
+        with (
+            tempfile.TemporaryDirectory() as ws_root,
+            tempfile.TemporaryDirectory() as pod_ws,
+        ):
+            _make_workspace(ws_root, JOB_ID)
+            result_files = _make_result_files(pod_ws, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            try:
+                upload_results(pod_ws, JOB_ID)
+            finally:
+                server.stop()
+            for rel, content in result_files.items():
+                extracted = os.path.join(ws_root, rel)
+                assert os.path.exists(extracted)
+                with open(extracted, "rb") as fh:
+                    assert fh.read() == content
+
+    def test_wrong_url_returns_404(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as pod_ws:
+            _make_result_files(pod_ws, JOB_ID)
+            server, _ = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, f"http://127.0.0.1:{server.port}/wrong-token")
+            try:
+                with pytest.raises(urllib.error.HTTPError) as exc:
+                    upload_results(pod_ws, JOB_ID)
+                assert exc.value.code == 404
+            finally:
+                server.stop()
+
+    def test_missing_run_dir_does_not_raise(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as empty_pod_ws:
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            try:
+                upload_results(empty_pod_ws, JOB_ID)
+            finally:
+                server.stop()
+
+    def test_job_auto_removed_from_registry_after_upload(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as pod_ws:
+            _make_result_files(pod_ws, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            try:
+                upload_results(pod_ws, JOB_ID)
+                assert url_token not in server.jobs
+            finally:
+                server.stop()
+
+
+# ---------------------------------------------------------------------------
+# TestFullEndToEnd
+# ---------------------------------------------------------------------------
+
+
+class TestFullEndToEnd:
+    def test_download_then_upload(self, monkeypatch):
+        with (
+            tempfile.TemporaryDirectory() as ws_root,
+            tempfile.TemporaryDirectory() as pod_ws,
+        ):
+            _make_workspace(ws_root, JOB_ID)
+            result_files = _make_result_files(pod_ws, JOB_ID)
+            server, url_token = _start_server(ws_root)
+            monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", url_token))
+            try:
+                download_workspace(pod_ws)
+                upload_results(pod_ws, JOB_ID)
+            finally:
+                server.stop()
+            for rel, content in result_files.items():
+                with open(os.path.join(ws_root, rel), "rb") as fh:
+                    assert fh.read() == content
+
+    def test_two_parallel_jobs_full_round_trip(self, monkeypatch):
+        with (
+            tempfile.TemporaryDirectory() as ws_root,
+            tempfile.TemporaryDirectory() as pod_ws_a,
+            tempfile.TemporaryDirectory() as pod_ws_b,
+        ):
+            _write_file(os.path.join(ws_root, JOB_ID, "a.txt"), b"aaa")
+            _write_file(os.path.join(ws_root, JOB_ID_B, "b.txt"), b"bbb")
+            server = WorkspaceHTTPServer()
+            server.start(workspace_root=ws_root)
+            token_a = server.add_job(JOB_ID, ws_root)
+            token_b = server.add_job(JOB_ID_B, ws_root)
+            try:
+                monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", token_a))
+                download_workspace(pod_ws_a)
+
+                monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", token_b))
+                download_workspace(pod_ws_b)
+
+                monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", token_a))
+                _make_result_files(pod_ws_a, JOB_ID)
+                upload_results(pod_ws_a, JOB_ID)
+
+                monkeypatch.setenv(ENV_WORKSPACE_URL, server.get_url("127.0.0.1", token_b))
+                _make_result_files(pod_ws_b, JOB_ID_B)
+                upload_results(pod_ws_b, JOB_ID_B)
+
+                assert token_a not in server.jobs
+                assert token_b not in server.jobs
+            finally:
+                server.stop()
+
+
+# ---------------------------------------------------------------------------
+# TestEnvConstant
+# ---------------------------------------------------------------------------
+
+
+class TestEnvConstant:
+    def test_env_workspace_url(self):
+        assert ENV_WORKSPACE_URL == "NVFL_WORKSPACE_URL"

--- a/tests/unit_test/tools/multicloud_deploy_test.py
+++ b/tests/unit_test/tools/multicloud_deploy_test.py
@@ -54,7 +54,7 @@ class TestPatchResourcesJson:
         assert component["id"] == "k8s_launcher"
         assert component["path"] == "nvflare.app_opt.job_launcher.k8s_launcher.ClientK8sJobLauncher"
         assert component["args"]["namespace"] == "nvflare-client-1"
-        assert component["args"]["workspace_pvc"] == "nvflws"
+        assert "workspace_pvc" not in component["args"]
         assert component["args"]["security_context"] == {"seLinuxOptions": {"type": "spc_t"}}
         assert (kit_dir / "etc" / "study_data_pvc.yaml").read_text() == "default: nvfldata\n"
 


### PR DESCRIPTION
## Summary

Eliminate the shared workspace PVC between the NVFlare parent participant pod and the dynamically-launched Kubernetes job pods, while keeping every NVFlare workspace semantic intact.

## Problem

Today's K8s launcher mounts one workspace PVC into both the parent pod and every job pod. That PVC holds `startup/`, `local/`, and every `run_<job_id>/` side by side.

- **No per-job isolation** — every job pod can read every other job's files, including private model weights and TLS private keys.
- **Single shared dependency** — one PVC outage breaks every running and future job.
- **Hard infrastructure requirement** — needs a RWX volume (EFS, Filestore, NFS), expensive or unavailable in some managed environments.

## Why a Naive Parent/Job Split Doesn't Work

- NVFlare expects a single workspace tree (`<ws>/startup/`, `<ws>/local/`, `<ws>/run_<job_id>/`). A split must still present one merged layout.
- `startup/` holds the site's private TLS key and root CA — can't travel plaintext, can't be regenerated per-job.
- `run_<job_id>/` is unbounded (custom code, checkpoints) — exceeds ConfigMap's 1 MiB limit, so static K8s objects can't carry it.
- Results (logs, checkpoints) must return to the parent — no implicit return path without a shared volume.
- The job pod's network identity is its pod IP, which is not in the NVFlare cert SAN — straightforward mTLS hostname verification fails.

## Design

Split by data class; back each class with the primitive it fits:

| Path | Delivery |
| ---- | -------- |
| `<ws>/startup/` (TLS keys, `fed_*.json`) | **K8s Secret** mounted read-only |
| `<ws>/local/` (`resources.json`, authz) | **K8s ConfigMap** mounted read-only |
| `<ws>/run_<job_id>/` (job code, state) | **HTTPS download** via 256-bit capability URL into `emptyDir` |
| results (logs, checkpoints) | **HTTPS POST** back to same URL at job shutdown |

How each obstacle above is addressed:

1. **Layered mounts at one path** — `emptyDir` at the workspace root; Secret mounted at `<ws>/startup/`, ConfigMap at `<ws>/local/`. Merged tree is indistinguishable from today's PVC layout to the runner/worker code.
2. **Private keys never leave etcd** — delivered as a Secret, kubelet projects into the pod. Nothing inside NVFlare ships the key over the network.
3. **Per-job transfer via the parent's own disk** — the parent's `<job_id>/` directory already lives on its workspace PVC at job-launch time (provisioning + server-side app deploy write it there). The launcher zips that directory, registers the bytes under a 256-bit URL token, and serves it from an in-process HTTPS server. The job pod downloads once into its `emptyDir` before the FL process starts.
4. **Results are an explicit upload** — before the job pod exits, it POSTs `run_<job_id>/` back to the same URL; parent extracts into its own workspace PVC for admin retrieval.
5. **Security is the capability URL, not hostname verification** — 256-bit unguessable token is the access-control primitive. TLS still validates the CA chain for confidentiality; hostname match is skipped because pod IPs aren't in the cert SAN. Each job gets a unique token; one token reveals nothing about another.

## Validation

End-to-end multicloud FedAvg on `hello-numpy` (3 rounds, 2 clients), server on GCP, clients on GCP and AWS.

- Single job: final aggregated model matches expected FedAvg output.
- 3 concurrent jobs: all `FINISHED:COMPLETED`, each ~17 s, independent workspace isolation confirmed on the parent.

Unit tests cover ZIP creation, capability-URL access control, multi-job isolation, and download/upload round trips.