### PR TITLE
Stop running POC before force prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # NVIDIA FLARE
 
+
 [Website](https://nvidia.github.io/NVFlare) | [Paper](https://arxiv.org/abs/2210.13291) | [Blogs](https://developer.nvidia.com/blog/tag/federated-learning) | [Talks & Papers](https://nvflare.readthedocs.io/en/main/publications_and_talks.html) | [Webinars](https://nvidia.github.io/NVFlare/webinars) | [Research](./research/README.md) | [Documentation](https://nvflare.readthedocs.io/en/main)
 
 [![Blossom-CI](https://github.com/NVIDIA/nvflare/workflows/Blossom-CI/badge.svg?branch=main)](https://github.com/NVIDIA/nvflare/actions)

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -1123,7 +1123,25 @@ def is_poc_running(poc_workspace, service_config, project_config):
     prod_dir = get_prod_dir(poc_workspace, project_name)
     server_dir = os.path.join(prod_dir, service_config[SC.FLARE_SERVER])
     pid_file = os.path.join(server_dir, "pid.fl")
-    return os.path.exists(pid_file)
+    daemon_pid_file = os.path.join(server_dir, "daemon_pid.fl")
+    return _is_live_pid_file(pid_file) or _is_live_pid_file(daemon_pid_file)
+
+
+def _is_live_pid_file(pid_file: str) -> bool:
+    if not os.path.exists(pid_file):
+        return False
+
+    try:
+        with open(pid_file, "r") as f:
+            pid = int(f.read().strip())
+    except (OSError, ValueError):
+        return False
+
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
 
 
 def _clean_poc(poc_workspace: str, force: bool = False) -> bool:

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -627,7 +627,7 @@ def _stop_running_poc_before_prepare(workspace: str, timeout_in_sec: int = 30, p
     from nvflare.tool.cli_output import print_human
 
     print_human("Existing POC system is still running; stopping it before recreating the workspace.")
-    _stop_poc(workspace)
+    _stop_poc(workspace, project_config=project_config, service_config=service_config)
 
     deadline = time.time() + timeout_in_sec
     while time.time() < deadline:
@@ -912,8 +912,9 @@ def stop_poc(cmd_args):
     output_ok({"status": "stopped"})
 
 
-def _stop_poc(poc_workspace: str, excluded=None, services_list=None):
-    project_config, service_config = setup_service_config(poc_workspace)
+def _stop_poc(poc_workspace: str, excluded=None, services_list=None, project_config=None, service_config=None):
+    if project_config is None or service_config is None:
+        project_config, service_config = setup_service_config(poc_workspace)
 
     if services_list is None:
         services_list = []

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -597,7 +597,7 @@ def _prepare_poc(
                 f"Please copy {project_conf_path} to different location before running this command."
             )
 
-        _stop_running_poc_before_prepare(workspace)
+        _ensure_poc_stopped(workspace)
         shutil.rmtree(workspace, ignore_errors=True)
 
     project_config = prepare_poc_provision(
@@ -609,7 +609,7 @@ def _prepare_poc(
     return True
 
 
-def _stop_running_poc_before_prepare(workspace: str, timeout_in_sec: int = 30, poll_interval: float = 1.0):
+def _ensure_poc_stopped(workspace: str, timeout_in_sec: int = 30, poll_interval: float = 1.0):
     try:
         project_config, service_config = setup_service_config(workspace)
     except CLIException:

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import errno
 import json
 import os
 import random
@@ -1140,7 +1141,9 @@ def _is_live_pid_file(pid_file: str) -> bool:
     try:
         os.kill(pid, 0)
         return True
-    except OSError:
+    except OSError as e:
+        if e.errno == errno.EPERM:
+            return True
         return False
 
 

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -617,7 +617,8 @@ def _prepare_poc(
 def _get_running_poc_context(workspace: str):
     try:
         project_config, service_config = setup_service_config(workspace)
-    except CLIException:
+    except Exception:
+        # Best-effort detection only: unreadable workspace metadata should not block force recreation.
         return None
 
     if not project_config or not service_config:

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -580,8 +580,14 @@ def _prepare_poc(
     else:
         print_human(f"Preparing POC workspace at {workspace} using {project_conf_path}...")
 
-    project_config = None
     if os.path.exists(workspace):
+        running_poc = _get_running_poc_context(workspace)
+        if running_poc:
+            if force:
+                _ensure_poc_stopped(workspace, project_config=running_poc[0], service_config=running_poc[1])
+            else:
+                raise CLIException("system is still running, please stop the system first.")
+
         if not force:
             if not prompt_yn(
                 f"This will delete poc workspace directory: '{workspace}' and create a new one. Is it OK to proceed?"
@@ -597,7 +603,6 @@ def _prepare_poc(
                 f"Please copy {project_conf_path} to different location before running this command."
             )
 
-        _ensure_poc_stopped(workspace)
         shutil.rmtree(workspace, ignore_errors=True)
 
     project_config = prepare_poc_provision(
@@ -609,20 +614,32 @@ def _prepare_poc(
     return True
 
 
-def _ensure_poc_stopped(workspace: str, timeout_in_sec: int = 30, poll_interval: float = 1.0):
+def _get_running_poc_context(workspace: str):
     try:
         project_config, service_config = setup_service_config(workspace)
     except CLIException:
-        return
+        return None
 
     if not project_config or not service_config:
-        return
+        return None
 
     if not is_poc_ready(workspace, service_config, project_config):
-        return
+        return None
 
     if not is_poc_running(workspace, service_config, project_config):
-        return
+        return None
+
+    return project_config, service_config
+
+
+def _ensure_poc_stopped(
+    workspace: str, timeout_in_sec: int = 30, poll_interval: float = 1.0, project_config=None, service_config=None
+):
+    if project_config is None or service_config is None:
+        running_poc = _get_running_poc_context(workspace)
+        if not running_poc:
+            return
+        project_config, service_config = running_poc
 
     from nvflare.tool.cli_output import print_human
 

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -597,6 +597,7 @@ def _prepare_poc(
                 f"Please copy {project_conf_path} to different location before running this command."
             )
 
+        _stop_running_poc_before_prepare(workspace)
         shutil.rmtree(workspace, ignore_errors=True)
 
     project_config = prepare_poc_provision(
@@ -606,6 +607,35 @@ def _prepare_poc(
     project_name = project_config.get("name") if project_config else None
     save_startup_kit_dir_config(workspace, project_name)
     return True
+
+
+def _stop_running_poc_before_prepare(workspace: str, timeout_in_sec: int = 30, poll_interval: float = 1.0):
+    try:
+        project_config, service_config = setup_service_config(workspace)
+    except CLIException:
+        return
+
+    if not project_config or not service_config:
+        return
+
+    if not is_poc_ready(workspace, service_config, project_config):
+        return
+
+    if not is_poc_running(workspace, service_config, project_config):
+        return
+
+    from nvflare.tool.cli_output import print_human
+
+    print_human("Existing POC system is still running; stopping it before recreating the workspace.")
+    _stop_poc(workspace)
+
+    deadline = time.time() + timeout_in_sec
+    while time.time() < deadline:
+        if not is_poc_running(workspace, service_config, project_config):
+            return
+        time.sleep(poll_interval)
+
+    raise CLIException("system is still running after shutdown was requested; please run 'nvflare poc stop' first.")
 
 
 def prepare_poc_provision(

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -107,6 +107,33 @@ class TestPocForce:
         assert workspace.exists()
         assert sentinel.exists()
 
+    def test_prepare_without_force_raises_for_running_poc_before_prompt(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import _prepare_poc
+
+        workspace = str(tmp_path / "poc_ws_running_no_force")
+        os.makedirs(workspace)
+
+        with (
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                return_value=(
+                    {"name": "example_project"},
+                    {SC.FLARE_SERVER: "server", SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"},
+                ),
+            ),
+            patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
+            patch("nvflare.tool.poc.poc_commands.is_poc_running", return_value=True),
+            patch("nvflare.tool.cli_output.prompt_yn") as mock_prompt,
+            patch("nvflare.tool.poc.poc_commands._stop_poc") as mock_stop,
+            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prov,
+        ):
+            with pytest.raises(CLIException, match="system is still running, please stop the system first."):
+                _prepare_poc([], 2, workspace, force=False)
+
+        mock_prompt.assert_not_called()
+        mock_stop.assert_not_called()
+        mock_prov.assert_not_called()
+
     def test_no_force_non_interactive_exits_4(self, tmp_path):
         """Non-interactive mode without --force should output INVALID_ARGS exit 4."""
         from nvflare.tool.poc.poc_commands import prepare_poc

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -185,6 +185,38 @@ class TestPocForce:
         mock_rmtree.assert_called_once_with(workspace, ignore_errors=True)
         mock_prov.assert_called_once()
 
+    def test_is_poc_running_true_when_only_daemon_pid_is_alive(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import is_poc_running
+
+        workspace = tmp_path / "poc_ws_daemon_only"
+        server_dir = workspace / "example_project" / "prod_00" / "server"
+        server_dir.mkdir(parents=True)
+        (server_dir / "daemon_pid.fl").write_text("12345")
+
+        with patch("os.kill") as mock_kill:
+            assert is_poc_running(
+                str(workspace),
+                {SC.FLARE_SERVER: "server"},
+                {"name": "example_project"},
+            )
+
+        mock_kill.assert_called_once_with(12345, 0)
+
+    def test_is_poc_running_false_for_stale_daemon_pid(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import is_poc_running
+
+        workspace = tmp_path / "poc_ws_stale_daemon"
+        server_dir = workspace / "example_project" / "prod_00" / "server"
+        server_dir.mkdir(parents=True)
+        (server_dir / "daemon_pid.fl").write_text("12345")
+
+        with patch("os.kill", side_effect=OSError):
+            assert not is_poc_running(
+                str(workspace),
+                {SC.FLARE_SERVER: "server"},
+                {"name": "example_project"},
+            )
+
     def test_no_force_non_interactive_exits_4(self, tmp_path):
         """Non-interactive mode without --force should output INVALID_ARGS exit 4."""
         from nvflare.tool.poc.poc_commands import prepare_poc

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -70,6 +70,7 @@ class TestPocForce:
             patch("nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=fake_rmtree),
             patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", return_value={"name": "example_project"}),
             patch("nvflare.tool.poc.poc_commands.save_startup_kit_dir_config"),
+            patch("nvflare.tool.cli_output.print_human"),
         ):
             result = _prepare_poc([], 2, workspace, force=True)
 

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -61,14 +61,27 @@ class TestPocForce:
                 "nvflare.tool.poc.poc_commands.setup_service_config",
                 return_value=(
                     {"name": "example_project"},
-                    {SC.FLARE_SERVER: "server", SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"},
+                    {
+                        SC.FLARE_SERVER: "server",
+                        SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+                    },
                 ),
             ),
             patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
-            patch("nvflare.tool.poc.poc_commands.is_poc_running", side_effect=[True, False]),
-            patch("nvflare.tool.poc.poc_commands._stop_poc", side_effect=fake_stop) as mock_stop,
-            patch("nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=fake_rmtree),
-            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", return_value={"name": "example_project"}),
+            patch(
+                "nvflare.tool.poc.poc_commands.is_poc_running",
+                side_effect=[True, False],
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands._stop_poc", side_effect=fake_stop
+            ) as mock_stop,
+            patch(
+                "nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=fake_rmtree
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands.prepare_poc_provision",
+                return_value={"name": "example_project"},
+            ),
             patch("nvflare.tool.poc.poc_commands.save_startup_kit_dir_config"),
             patch("nvflare.tool.cli_output.print_human"),
         ):
@@ -78,7 +91,9 @@ class TestPocForce:
         assert mock_stop.call_count == 1
         assert calls == ["stop", "rmtree"]
 
-    def test_force_prepare_preserves_workspace_when_running_system_does_not_stop(self, tmp_path):
+    def test_force_prepare_preserves_workspace_when_running_system_does_not_stop(
+        self, tmp_path
+    ):
         from nvflare.tool.poc.poc_commands import _prepare_poc
 
         workspace = tmp_path / "poc_ws_stuck"
@@ -91,7 +106,10 @@ class TestPocForce:
                 "nvflare.tool.poc.poc_commands.setup_service_config",
                 return_value=(
                     {"name": "example_project"},
-                    {SC.FLARE_SERVER: "server", SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"},
+                    {
+                        SC.FLARE_SERVER: "server",
+                        SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+                    },
                 ),
             ),
             patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
@@ -100,7 +118,10 @@ class TestPocForce:
             patch("nvflare.tool.poc.poc_commands.time.time", side_effect=[0, 31]),
             patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prov,
         ):
-            with pytest.raises(CLIException, match="system is still running after shutdown was requested"):
+            with pytest.raises(
+                CLIException,
+                match="system is still running after shutdown was requested",
+            ):
                 _prepare_poc([], 2, str(workspace), force=True)
 
         mock_prov.assert_not_called()
@@ -118,7 +139,10 @@ class TestPocForce:
                 "nvflare.tool.poc.poc_commands.setup_service_config",
                 return_value=(
                     {"name": "example_project"},
-                    {SC.FLARE_SERVER: "server", SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"},
+                    {
+                        SC.FLARE_SERVER: "server",
+                        SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+                    },
                 ),
             ),
             patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
@@ -127,7 +151,10 @@ class TestPocForce:
             patch("nvflare.tool.poc.poc_commands._stop_poc") as mock_stop,
             patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prov,
         ):
-            with pytest.raises(CLIException, match="system is still running, please stop the system first."):
+            with pytest.raises(
+                CLIException,
+                match="system is still running, please stop the system first.",
+            ):
                 _prepare_poc([], 2, workspace, force=False)
 
         mock_prompt.assert_not_called()
@@ -141,9 +168,15 @@ class TestPocForce:
         os.makedirs(workspace)
 
         with (
-            patch("nvflare.tool.poc.poc_commands.setup_service_config", side_effect=Exception("bad yaml")),
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                side_effect=Exception("bad yaml"),
+            ),
             patch("nvflare.tool.poc.poc_commands.shutil.rmtree") as mock_rmtree,
-            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", return_value={"name": "example_project"}) as mock_prov,
+            patch(
+                "nvflare.tool.poc.poc_commands.prepare_poc_provision",
+                return_value={"name": "example_project"},
+            ) as mock_prov,
             patch("nvflare.tool.poc.poc_commands.save_startup_kit_dir_config"),
         ):
             result = _prepare_poc([], 2, workspace, force=True)
@@ -168,7 +201,9 @@ class TestPocForce:
         cmd_args.he = False
         cmd_args.project_input = ""
 
-        with patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=workspace):
+        with patch(
+            "nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=workspace
+        ):
             with patch("sys.stdin") as mock_stdin:
                 mock_stdin.isatty.return_value = False
                 with pytest.raises(SystemExit) as exc_info:
@@ -214,7 +249,10 @@ class TestPocForce:
         assert result is False
 
     def test_save_startup_kit_dir_config_uses_poc_admin_dir(self, tmp_path):
-        from nvflare.tool.poc.poc_commands import get_poc_workspace, save_startup_kit_dir_config
+        from nvflare.tool.poc.poc_commands import (
+            get_poc_workspace,
+            save_startup_kit_dir_config,
+        )
 
         workspace = str(tmp_path / "poc_ws")
         os.makedirs(workspace, exist_ok=True)
@@ -232,16 +270,30 @@ participants:
             )
 
         dst = str(tmp_path / "config.conf")
-        with patch("nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir", return_value=str(tmp_path)):
-            with patch("nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path", return_value=dst):
+        with patch(
+            "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
+            return_value=str(tmp_path),
+        ):
+            with patch(
+                "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
+                return_value=dst,
+            ):
                 save_startup_kit_dir_config(workspace, "example_project")
 
         config = CF.parse_file(dst)
-        assert config.get("poc.startup_kit").endswith("/example_project/prod_00/admin@nvidia.com")
+        assert config.get("poc.startup_kit").endswith(
+            "/example_project/prod_00/admin@nvidia.com"
+        )
         assert config.get("poc.workspace") == workspace
 
-        with patch("nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir", return_value=str(tmp_path)):
-            with patch("nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path", return_value=dst):
+        with patch(
+            "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
+            return_value=str(tmp_path),
+        ):
+            with patch(
+                "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
+                return_value=dst,
+            ):
                 with patch.dict(os.environ, {}, clear=True):
                     assert get_poc_workspace() == workspace
 
@@ -256,7 +308,9 @@ participants:
         with pytest.raises(CLIException, match="invalid or unreadable project config"):
             save_startup_kit_dir_config(workspace, "example_project")
 
-    def test_force_does_not_delete_workspace_before_rejecting_project_file_inside_workspace(self, tmp_path):
+    def test_force_does_not_delete_workspace_before_rejecting_project_file_inside_workspace(
+        self, tmp_path
+    ):
         from nvflare.tool.poc.poc_commands import prepare_poc
 
         workspace = tmp_path / "poc_ws"
@@ -275,7 +329,10 @@ participants:
         cmd_args.he = False
         cmd_args.project_input = str(project_file)
 
-        with patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=str(workspace)):
+        with patch(
+            "nvflare.tool.poc.poc_commands.get_poc_workspace",
+            return_value=str(workspace),
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 prepare_poc(cmd_args)
 
@@ -291,8 +348,14 @@ participants:
         args.force = False
 
         with (
-            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=str(tmp_path)),
-            patch("nvflare.tool.poc.poc_commands._prepare_jobs_dir", side_effect=Exception("boom")),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_poc_workspace",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands._prepare_jobs_dir",
+                side_effect=Exception("boom"),
+            ),
             patch("nvflare.tool.cli_output.output_error"),
         ):
             with pytest.raises(SystemExit) as exc_info:
@@ -320,16 +383,23 @@ participants:
         project_config = {"name": "proj"}
         service_config = {SC.FLARE_PROJ_ADMIN: admin_name}
 
-        with patch("nvflare.tool.poc.poc_commands.get_upload_dir", return_value=transfer_name):
+        with patch(
+            "nvflare.tool.poc.poc_commands.get_upload_dir", return_value=transfer_name
+        ):
             result = _prepare_jobs_dir(
-                str(jobs_src), str(workspace), config_packages=(project_config, service_config), force=True
+                str(jobs_src),
+                str(workspace),
+                config_packages=(project_config, service_config),
+                force=True,
             )
 
         assert result is True
         assert os.path.islink(dst)
         assert os.readlink(dst) == str(jobs_src)
 
-    def test_prepare_poc_raises_when_output_error_is_mocked_for_noninteractive_conflict(self, tmp_path):
+    def test_prepare_poc_raises_when_output_error_is_mocked_for_noninteractive_conflict(
+        self, tmp_path
+    ):
         from nvflare.tool.poc.poc_commands import prepare_poc
 
         workspace = str(tmp_path / "poc_ws")
@@ -345,7 +415,10 @@ participants:
         cmd_args.project_input = ""
 
         with (
-            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=workspace),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_poc_workspace",
+                return_value=workspace,
+            ),
             patch("sys.stdin") as mock_stdin,
             patch("nvflare.tool.cli_output.output_error"),
         ):
@@ -365,11 +438,17 @@ participants:
         args.study = None
 
         with (
-            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=str(tmp_path)),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_poc_workspace",
+                return_value=str(tmp_path),
+            ),
             patch("nvflare.tool.poc.poc_commands.get_service_list", return_value=[]),
             patch("nvflare.tool.poc.poc_commands.get_excluded", return_value=[]),
             patch("nvflare.tool.poc.poc_commands.get_gpis", return_value=[]),
-            patch("nvflare.tool.poc.poc_commands._start_poc", side_effect=Exception("boom")),
+            patch(
+                "nvflare.tool.poc.poc_commands._start_poc",
+                side_effect=Exception("boom"),
+            ),
             patch("nvflare.tool.cli_output.output_error"),
         ):
             with pytest.raises(SystemExit) as exc_info:
@@ -385,10 +464,15 @@ participants:
         args.ex = None
 
         with (
-            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=str(tmp_path)),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_poc_workspace",
+                return_value=str(tmp_path),
+            ),
             patch("nvflare.tool.poc.poc_commands.get_excluded", return_value=[]),
             patch("nvflare.tool.poc.poc_commands.get_service_list", return_value=[]),
-            patch("nvflare.tool.poc.poc_commands._stop_poc", side_effect=Exception("boom")),
+            patch(
+                "nvflare.tool.poc.poc_commands._stop_poc", side_effect=Exception("boom")
+            ),
             patch("nvflare.tool.cli_output.output_error"),
         ):
             with pytest.raises(SystemExit) as exc_info:
@@ -403,8 +487,14 @@ participants:
         args.force = True
 
         with (
-            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=str(tmp_path)),
-            patch("nvflare.tool.poc.poc_commands._clean_poc", side_effect=Exception("boom")),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_poc_workspace",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands._clean_poc",
+                side_effect=Exception("boom"),
+            ),
             patch("nvflare.tool.cli_output.output_error"),
         ):
             with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import os
 from unittest.mock import MagicMock, patch
 
@@ -210,6 +211,23 @@ class TestPocForce:
                 {SC.FLARE_SERVER: "server"},
                 {"name": "example_project"},
             )
+
+    def test_is_poc_running_true_for_eperm_pid(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import is_poc_running
+
+        workspace = tmp_path / "poc_ws_eperm_pid"
+        server_dir = workspace / "example_project" / "prod_00" / "server"
+        server_dir.mkdir(parents=True)
+        (server_dir / "daemon_pid.fl").write_text("12345")
+
+        with patch("os.kill", side_effect=OSError(errno.EPERM, "permission denied")) as mock_kill:
+            assert is_poc_running(
+                str(workspace),
+                {SC.FLARE_SERVER: "server"},
+                {"name": "example_project"},
+            )
+
+        mock_kill.assert_called_once_with(12345, 0)
 
     def test_no_force_non_interactive_exits_4(self, tmp_path):
         """Non-interactive mode without --force should output INVALID_ARGS exit 4."""

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -40,6 +40,72 @@ class TestPocForce:
         # force=True means no prompt; result should be True (not False)
         assert result is True
 
+    def test_force_prepare_stops_running_poc_before_delete(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import _prepare_poc
+
+        workspace = str(tmp_path / "poc_ws_running")
+        os.makedirs(workspace)
+
+        calls = []
+
+        def fake_stop(_workspace, *_args, **_kwargs):
+            calls.append("stop")
+
+        def fake_rmtree(path, ignore_errors=False):
+            assert path == workspace
+            assert ignore_errors is True
+            calls.append("rmtree")
+
+        with (
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                return_value=(
+                    {"name": "example_project"},
+                    {SC.FLARE_SERVER: "server", SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"},
+                ),
+            ),
+            patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
+            patch("nvflare.tool.poc.poc_commands.is_poc_running", side_effect=[True, False]),
+            patch("nvflare.tool.poc.poc_commands._stop_poc", side_effect=fake_stop) as mock_stop,
+            patch("nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=fake_rmtree),
+            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", return_value={"name": "example_project"}),
+            patch("nvflare.tool.poc.poc_commands.save_startup_kit_dir_config"),
+        ):
+            result = _prepare_poc([], 2, workspace, force=True)
+
+        assert result is True
+        assert mock_stop.call_count == 1
+        assert calls == ["stop", "rmtree"]
+
+    def test_force_prepare_preserves_workspace_when_running_system_does_not_stop(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import _prepare_poc
+
+        workspace = tmp_path / "poc_ws_stuck"
+        workspace.mkdir()
+        sentinel = workspace / "keep.txt"
+        sentinel.write_text("keep me")
+
+        with (
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                return_value=(
+                    {"name": "example_project"},
+                    {SC.FLARE_SERVER: "server", SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"},
+                ),
+            ),
+            patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
+            patch("nvflare.tool.poc.poc_commands.is_poc_running", return_value=True),
+            patch("nvflare.tool.poc.poc_commands._stop_poc"),
+            patch("nvflare.tool.poc.poc_commands.time.time", side_effect=[0, 31]),
+            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prov,
+        ):
+            with pytest.raises(CLIException, match="system is still running after shutdown was requested"):
+                _prepare_poc([], 2, str(workspace), force=True)
+
+        mock_prov.assert_not_called()
+        assert workspace.exists()
+        assert sentinel.exists()
+
     def test_no_force_non_interactive_exits_4(self, tmp_path):
         """Non-interactive mode without --force should output INVALID_ARGS exit 4."""
         from nvflare.tool.poc.poc_commands import prepare_poc

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -134,6 +134,24 @@ class TestPocForce:
         mock_stop.assert_not_called()
         mock_prov.assert_not_called()
 
+    def test_force_prepare_ignores_unreadable_workspace_config(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import _prepare_poc
+
+        workspace = str(tmp_path / "poc_ws_bad_yaml")
+        os.makedirs(workspace)
+
+        with (
+            patch("nvflare.tool.poc.poc_commands.setup_service_config", side_effect=Exception("bad yaml")),
+            patch("nvflare.tool.poc.poc_commands.shutil.rmtree") as mock_rmtree,
+            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", return_value={"name": "example_project"}) as mock_prov,
+            patch("nvflare.tool.poc.poc_commands.save_startup_kit_dir_config"),
+        ):
+            result = _prepare_poc([], 2, workspace, force=True)
+
+        assert result is True
+        mock_rmtree.assert_called_once_with(workspace, ignore_errors=True)
+        mock_prov.assert_called_once()
+
     def test_no_force_non_interactive_exits_4(self, tmp_path):
         """Non-interactive mode without --force should output INVALID_ARGS exit 4."""
         from nvflare.tool.poc.poc_commands import prepare_poc

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -72,12 +72,8 @@ class TestPocForce:
                 "nvflare.tool.poc.poc_commands.is_poc_running",
                 side_effect=[True, False],
             ),
-            patch(
-                "nvflare.tool.poc.poc_commands._stop_poc", side_effect=fake_stop
-            ) as mock_stop,
-            patch(
-                "nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=fake_rmtree
-            ),
+            patch("nvflare.tool.poc.poc_commands._stop_poc", side_effect=fake_stop) as mock_stop,
+            patch("nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=fake_rmtree),
             patch(
                 "nvflare.tool.poc.poc_commands.prepare_poc_provision",
                 return_value={"name": "example_project"},
@@ -91,9 +87,7 @@ class TestPocForce:
         assert mock_stop.call_count == 1
         assert calls == ["stop", "rmtree"]
 
-    def test_force_prepare_preserves_workspace_when_running_system_does_not_stop(
-        self, tmp_path
-    ):
+    def test_force_prepare_preserves_workspace_when_running_system_does_not_stop(self, tmp_path):
         from nvflare.tool.poc.poc_commands import _prepare_poc
 
         workspace = tmp_path / "poc_ws_stuck"
@@ -233,9 +227,7 @@ class TestPocForce:
         cmd_args.he = False
         cmd_args.project_input = ""
 
-        with patch(
-            "nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=workspace
-        ):
+        with patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=workspace):
             with patch("sys.stdin") as mock_stdin:
                 mock_stdin.isatty.return_value = False
                 with pytest.raises(SystemExit) as exc_info:
@@ -281,10 +273,7 @@ class TestPocForce:
         assert result is False
 
     def test_save_startup_kit_dir_config_uses_poc_admin_dir(self, tmp_path):
-        from nvflare.tool.poc.poc_commands import (
-            get_poc_workspace,
-            save_startup_kit_dir_config,
-        )
+        from nvflare.tool.poc.poc_commands import get_poc_workspace, save_startup_kit_dir_config
 
         workspace = str(tmp_path / "poc_ws")
         os.makedirs(workspace, exist_ok=True)
@@ -313,9 +302,7 @@ participants:
                 save_startup_kit_dir_config(workspace, "example_project")
 
         config = CF.parse_file(dst)
-        assert config.get("poc.startup_kit").endswith(
-            "/example_project/prod_00/admin@nvidia.com"
-        )
+        assert config.get("poc.startup_kit").endswith("/example_project/prod_00/admin@nvidia.com")
         assert config.get("poc.workspace") == workspace
 
         with patch(
@@ -340,9 +327,7 @@ participants:
         with pytest.raises(CLIException, match="invalid or unreadable project config"):
             save_startup_kit_dir_config(workspace, "example_project")
 
-    def test_force_does_not_delete_workspace_before_rejecting_project_file_inside_workspace(
-        self, tmp_path
-    ):
+    def test_force_does_not_delete_workspace_before_rejecting_project_file_inside_workspace(self, tmp_path):
         from nvflare.tool.poc.poc_commands import prepare_poc
 
         workspace = tmp_path / "poc_ws"
@@ -415,9 +400,7 @@ participants:
         project_config = {"name": "proj"}
         service_config = {SC.FLARE_PROJ_ADMIN: admin_name}
 
-        with patch(
-            "nvflare.tool.poc.poc_commands.get_upload_dir", return_value=transfer_name
-        ):
+        with patch("nvflare.tool.poc.poc_commands.get_upload_dir", return_value=transfer_name):
             result = _prepare_jobs_dir(
                 str(jobs_src),
                 str(workspace),
@@ -429,9 +412,7 @@ participants:
         assert os.path.islink(dst)
         assert os.readlink(dst) == str(jobs_src)
 
-    def test_prepare_poc_raises_when_output_error_is_mocked_for_noninteractive_conflict(
-        self, tmp_path
-    ):
+    def test_prepare_poc_raises_when_output_error_is_mocked_for_noninteractive_conflict(self, tmp_path):
         from nvflare.tool.poc.poc_commands import prepare_poc
 
         workspace = str(tmp_path / "poc_ws")
@@ -502,9 +483,7 @@ participants:
             ),
             patch("nvflare.tool.poc.poc_commands.get_excluded", return_value=[]),
             patch("nvflare.tool.poc.poc_commands.get_service_list", return_value=[]),
-            patch(
-                "nvflare.tool.poc.poc_commands._stop_poc", side_effect=Exception("boom")
-            ),
+            patch("nvflare.tool.poc.poc_commands._stop_poc", side_effect=Exception("boom")),
             patch("nvflare.tool.cli_output.output_error"),
         ):
             with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
## Summary
- stop an existing running POC system before Preparing POC workspace at /tmp/nvflare/poc for 2 clients...
provision at /tmp/nvflare/poc for 2 clients with /tmp/nvflare/poc/project.yml
INFO: Generated results can be found under /tmp/nvflare/poc/example_project/prod_00. 
link job directory from /Users/chesterc/projects/NVFlare/examples to /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com/transfer
workspace: /tmp/nvflare/poc
clients: ['site-1', 'site-2']

POC workspace ready at: /tmp/nvflare/poc
  Clients: site-1, site-2
  Next: place your jobs under the admin transfer folder, then run 'nvflare poc start'
  That starts the server and clients only; admin consoles must be started explicitly. deletes the workspace
- wait for the shutdown request to take effect and refuse deletion if the system is still running
- add targeted tests for the stop-first path and the failure path that preserves the workspace

## Testing
- python3 -m pytest tests/unit_test/tool/poc/poc_force_test.py tests/unit_test/tool/poc/poc_output_test.py tests/unit_test/lighter/poc_commands_test.py -q
- python3 -m py_compile nvflare/tool/poc/poc_commands.py tests/unit_test/tool/poc/poc_force_test.py