### PR TITLE
Add site runtime packaging

### DIFF
--- a/docs/design/site_runtime_packaging_design.md
+++ b/docs/design/site_runtime_packaging_design.md
@@ -1,0 +1,180 @@
+# Site Runtime Packaging Design
+
+## Goal
+
+Keep centralized provisioning unchanged for normal process-based deployments, while letting
+each site choose its own runtime packaging during the local `nvflare package` step.
+
+The site-local runtime choices are:
+
+- process
+- Docker
+- K8s
+
+## Chosen Approach
+
+Reuse the existing `nvflare package --project-file ...` path.
+
+- Central admin uses one central `project.yml` for `nvflare provision`.
+- Each site uses one local full project YAML for `nvflare package`.
+- The site-local YAML contains one participant and, optionally, one runtime builder.
+
+This keeps the design builder-driven and avoids adding a new package config concept.
+
+## Runtime Mapping
+
+- process: no runtime builder
+- Docker: `nvflare.lighter.impl.docker_launcher.DockerLauncherBuilder`
+- K8s: `nvflare.lighter.impl.k8s_runtime.K8sRuntimeBuilder`
+
+Runtime builders are for `server` and `client` kits only. Admin kits should remain
+process-based.
+
+## Why This Fits Current Code
+
+`nvflare package --project-file ...` already supports full project YAML and already reuses
+`builders:` from that YAML. Package also already swaps `CertBuilder` for
+`PrebuiltCertBuilder` and injects `WorkspaceBuilder` and `StaticFileBuilder` when needed.
+
+So the package CLI does not need a new runtime-specific option. The main work is in the
+runtime builders themselves.
+
+## Builder Responsibilities
+
+### DockerLauncherBuilder
+
+- generate `startup/start_docker.sh`
+- replace `process_launcher` with `docker_launcher`
+- allow site-local Docker settings such as `docker_image`, `network`,
+  `default_job_env`, and `default_job_container_kwargs`
+- replace `GPUResourceManager` with `PassthroughResourceManager`
+- remove `resource_consumer`
+
+### K8sRuntimeBuilder
+
+- reuse `HelmChartBuilder` to generate the Helm chart
+- replace `process_launcher` with `k8s_launcher`
+- write `local/study_data_pvc.yaml`
+- replace `GPUResourceManager` with `PassthroughResourceManager`
+- remove `resource_consumer`
+
+`HelmChartBuilder` alone is not enough because chart generation does not make the startup
+kit runtime-consistent for K8s.
+
+## Site YAML Examples
+
+### Process
+
+```yaml
+api_version: 3
+name: my_project
+
+participants:
+  - name: site-1
+    type: client
+    org: hospital
+```
+
+### Docker
+
+```yaml
+api_version: 3
+name: my_project
+
+participants:
+  - name: site-1
+    type: client
+    org: hospital
+
+builders:
+  - path: nvflare.lighter.impl.docker_launcher.DockerLauncherBuilder
+    args:
+      docker_image: nvflare-site:latest
+      network: nvflare-network
+      default_job_env:
+        NCCL_P2P_DISABLE: "1"
+      default_job_container_kwargs:
+        shm_size: 8g
+        ipc_mode: host
+```
+
+### K8s
+
+```yaml
+api_version: 3
+name: my_project
+
+participants:
+  - name: site-1
+    type: client
+    org: hospital
+
+builders:
+  - path: nvflare.lighter.impl.k8s_runtime.K8sRuntimeBuilder
+    args:
+      docker_image: nvflare-site:latest
+      namespace: default
+      parent_port: 8102
+      workspace_pvc: nvflws
+      workspace_mount_path: /var/tmp/nvflare/workspace
+      study_data_pvc:
+        default: nvfldata
+```
+
+## Workflow
+
+### Centralized Provisioning
+
+```bash
+nvflare provision -p project.yml
+```
+
+After centralized provisioning, a site that wants Docker or K8s local packaging must first
+stage a cert-material directory for `nvflare package`. Today, YAML mode expects:
+
+- `<participant>.crt`
+- `<participant>.key`
+- `rootCA.pem`
+
+So if the site starts from an existing startup kit containing files such as
+`startup/client.crt`, `startup/client.key`, and `startup/rootCA.pem`, there is currently an
+extra local step to copy or rename them into a raw cert directory such as:
+
+- `site-1.crt`
+- `site-1.key`
+- `rootCA.pem`
+
+The site then packages locally:
+
+```bash
+nvflare package \
+  --project-file ./site-1-project.yml \
+  --dir ./certs \
+  --endpoint grpc://server:8002
+```
+
+### Distributed Manual Provisioning
+
+```bash
+nvflare cert csr ...
+nvflare cert sign ...
+nvflare package \
+  --project-file ./site-1-project.yml \
+  --dir ./certs \
+  --endpoint grpc://server:8002
+```
+
+In both cases, the central side provides signed identity material and each site selects its
+runtime by choosing its local builder.
+
+## Remaining Workflow Gaps
+
+- In YAML mode, `--dir` currently expects raw cert material named
+  `<participant>.crt`, `<participant>.key`, and `rootCA.pem`.
+- The default output location can look odd when package is run from inside an existing
+  site folder.
+- Package still reports a generic next step such as `start.sh`, even when Docker or K8s
+  packaging changed the real runtime entrypoint.
+- The local site project YAML is not currently validated against the centrally provisioned
+  project. In practice, the site YAML should only change runtime packaging behavior, not
+  participant identity or topology, but the current package flow does not enforce that.

--- a/nvflare/lighter/impl/docker_launcher.py
+++ b/nvflare/lighter/impl/docker_launcher.py
@@ -21,6 +21,11 @@ from nvflare.lighter.constants import CommConfigArg, CtxKey, PropKey, ProvFileNa
 from nvflare.lighter.entity import Participant
 from nvflare.lighter.spec import Builder, Project, ProvisionContext
 
+_LAUNCHER_IDS = {"process_launcher", "docker_launcher", "k8s_launcher"}
+_PASSTHROUGH_RESOURCE_MANAGER_PATH = (
+    "nvflare.app_common.resource_managers.passthrough_resource_manager.PassthroughResourceManager"
+)
+
 
 class DockerLauncherBuilder(Builder):
     """Generates start_docker.sh per site and injects DockerJobLauncher into resources.json.
@@ -39,14 +44,33 @@ class DockerLauncherBuilder(Builder):
     (SJ/CJ) are then launched automatically by DockerJobLauncher when jobs are submitted.
     """
 
-    def __init__(self, docker_image: str = "nvflare:latest"):
+    def __init__(
+        self,
+        docker_image: str = "nvflare:latest",
+        network: str = "nvflare-network",
+        python_path: str = "/usr/local/bin/python",
+        default_job_container_kwargs: dict = None,
+        default_job_env: dict = None,
+        set_passthrough_resource_manager: bool = True,
+    ):
         """
         Args:
             docker_image: Docker image name for SP/CP containers. The site admin must
                           build and tag this image before running start_docker.sh.
                           Job images (SJ/CJ) are specified per job in meta.json.
+            network: Docker network name shared by the site container and per-job containers.
+            python_path: Python executable path inside the job containers.
+            default_job_container_kwargs: Default container kwargs passed to DockerJobLauncher.
+            default_job_env: Default environment variables passed to DockerJobLauncher.
+            set_passthrough_resource_manager: whether to replace process-mode resource
+                          scheduling components with PassthroughResourceManager.
         """
         self.docker_image = docker_image
+        self.network = network
+        self.python_path = python_path
+        self.default_job_container_kwargs = default_job_container_kwargs or {}
+        self.default_job_env = default_job_env or {}
+        self.set_passthrough_resource_manager = set_passthrough_resource_manager
 
     def _inject_launcher(self, dest_dir: str, path: str, args: dict):
         """Replace any existing job launcher component with DockerJobLauncher."""
@@ -54,10 +78,44 @@ class DockerLauncherBuilder(Builder):
         with open(resources_file, "rt") as f:
             resources = json.load(f)
 
-        launcher_ids = {"process_launcher", "docker_launcher", "k8s_launcher"}
         components = resources.get("components", [])
-        resources["components"] = [c for c in components if c.get("id") not in launcher_ids]
+        resources["components"] = [c for c in components if c.get("id") not in _LAUNCHER_IDS]
         resources["components"].append({"id": "docker_launcher", "path": path, "args": args})
+        utils.write(resources_file, json.dumps(resources, indent=4), "t")
+
+    def _set_resource_manager(self, dest_dir: str):
+        """Replace process-mode resource scheduling components for Docker runtime."""
+        resources_file = os.path.join(dest_dir, ProvFileName.RESOURCES_JSON_DEFAULT)
+        with open(resources_file, "rt") as f:
+            resources = json.load(f)
+
+        components = resources.get("components", [])
+        new_components = []
+        found_resource_manager = False
+        for component in components:
+            component_id = component.get("id")
+            if component_id == "resource_consumer":
+                continue
+            if component_id == "resource_manager":
+                component = {
+                    "id": "resource_manager",
+                    "path": _PASSTHROUGH_RESOURCE_MANAGER_PATH,
+                    "args": {},
+                }
+                found_resource_manager = True
+            new_components.append(component)
+
+        if not found_resource_manager:
+            new_components.insert(
+                0,
+                {
+                    "id": "resource_manager",
+                    "path": _PASSTHROUGH_RESOURCE_MANAGER_PATH,
+                    "args": {},
+                },
+            )
+
+        resources["components"] = new_components
         utils.write(resources_file, json.dumps(resources, indent=4), "t")
 
     def _set_internal_listener_host(self, participant: Participant):
@@ -71,12 +129,16 @@ class DockerLauncherBuilder(Builder):
 
         # Inject launcher config — workspace resolved at runtime from NVFL_DOCKER_WORKSPACE
         dest_dir = ctx.get_local_dir(server)
+        if self.set_passthrough_resource_manager:
+            self._set_resource_manager(dest_dir)
         self._inject_launcher(
             dest_dir,
             path=ServerDockerJobLauncher.__module__ + ".ServerDockerJobLauncher",
             args={
-                "network": "nvflare-network",
-                "python_path": "/usr/local/bin/python",
+                "network": self.network,
+                "python_path": self.python_path,
+                "default_job_container_kwargs": self.default_job_container_kwargs,
+                "default_job_env": self.default_job_env,
             },
         )
 
@@ -92,6 +154,7 @@ class DockerLauncherBuilder(Builder):
                 "fed_learn_port": fed_learn_port,
                 "server_name": server.name,
                 "docker_image": self.docker_image,
+                "network": self.network,
             },
             exe=True,
         )
@@ -101,12 +164,16 @@ class DockerLauncherBuilder(Builder):
 
         # Inject launcher config — workspace resolved at runtime from NVFL_DOCKER_WORKSPACE
         dest_dir = ctx.get_local_dir(client)
+        if self.set_passthrough_resource_manager:
+            self._set_resource_manager(dest_dir)
         self._inject_launcher(
             dest_dir,
             path=ClientDockerJobLauncher.__module__ + ".ClientDockerJobLauncher",
             args={
-                "network": "nvflare-network",
-                "python_path": "/usr/local/bin/python",
+                "network": self.network,
+                "python_path": self.python_path,
+                "default_job_container_kwargs": self.default_job_container_kwargs,
+                "default_job_env": self.default_job_env,
             },
         )
 
@@ -122,6 +189,7 @@ class DockerLauncherBuilder(Builder):
                 "fed_learn_port": fed_learn_port,
                 "docker_image": self.docker_image,
                 "client_name": client.name,
+                "network": self.network,
             },
             exe=True,
         )

--- a/nvflare/lighter/impl/k8s_runtime.py
+++ b/nvflare/lighter/impl/k8s_runtime.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import yaml
+
+from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher, ServerK8sJobLauncher
+from nvflare.lighter import utils
+from nvflare.lighter.constants import ProvFileName
+from nvflare.lighter.impl.helm_chart import HelmChartBuilder
+from nvflare.lighter.spec import Builder, Project, ProvisionContext
+
+_LAUNCHER_IDS = {"process_launcher", "docker_launcher", "k8s_launcher"}
+_PASSTHROUGH_RESOURCE_MANAGER_PATH = (
+    "nvflare.app_common.resource_managers.passthrough_resource_manager.PassthroughResourceManager"
+)
+_DEFAULT_STUDY_DATA_PVC = {"default": "nvfldata"}
+_STUDY_DATA_PVC_FILE_PATH = "/var/tmp/nvflare/workspace/local/study_data_pvc.yaml"
+
+
+class K8sRuntimeBuilder(Builder):
+    """Apply K8s runtime packaging to a site by reusing HelmChartBuilder and patching runtime config."""
+
+    def __init__(
+        self,
+        docker_image: str,
+        namespace: str = "default",
+        parent_port: int = 8102,
+        workspace_pvc: str = "nvflws",
+        workspace_mount_path: str = "/var/tmp/nvflare/workspace",
+        study_data_pvc: dict = None,
+        config_file_path: str = None,
+        pending_timeout: int = None,
+        python_path: str = "/usr/local/bin/python",
+        security_context: dict = None,
+        set_passthrough_resource_manager: bool = True,
+    ):
+        self.namespace = namespace
+        self.study_data_pvc = study_data_pvc or dict(_DEFAULT_STUDY_DATA_PVC)
+        self.config_file_path = config_file_path
+        self.pending_timeout = pending_timeout
+        self.python_path = python_path
+        self.security_context = security_context
+        self.set_passthrough_resource_manager = set_passthrough_resource_manager
+        self.helm_builder = HelmChartBuilder(
+            docker_image=docker_image,
+            parent_port=parent_port,
+            workspace_pvc=workspace_pvc,
+            workspace_mount_path=workspace_mount_path,
+        )
+
+    def _inject_launcher(self, dest_dir: str, path: str):
+        resources_file = os.path.join(dest_dir, ProvFileName.RESOURCES_JSON_DEFAULT)
+        with open(resources_file, "rt") as f:
+            resources = json.load(f)
+
+        components = resources.get("components", [])
+        resources["components"] = [c for c in components if c.get("id") not in _LAUNCHER_IDS]
+        args = {
+            "config_file_path": self.config_file_path,
+            "study_data_pvc_file_path": _STUDY_DATA_PVC_FILE_PATH,
+            "namespace": self.namespace,
+            "python_path": self.python_path,
+        }
+        if self.pending_timeout is not None:
+            args["pending_timeout"] = self.pending_timeout
+        if self.security_context:
+            args["security_context"] = self.security_context
+        resources["components"].append({"id": "k8s_launcher", "path": path, "args": args})
+        utils.write(resources_file, json.dumps(resources, indent=4), "t")
+
+    def _set_resource_manager(self, dest_dir: str):
+        resources_file = os.path.join(dest_dir, ProvFileName.RESOURCES_JSON_DEFAULT)
+        with open(resources_file, "rt") as f:
+            resources = json.load(f)
+
+        components = resources.get("components", [])
+        new_components = []
+        found_resource_manager = False
+        for component in components:
+            component_id = component.get("id")
+            if component_id == "resource_consumer":
+                continue
+            if component_id == "resource_manager":
+                component = {
+                    "id": "resource_manager",
+                    "path": _PASSTHROUGH_RESOURCE_MANAGER_PATH,
+                    "args": {},
+                }
+                found_resource_manager = True
+            new_components.append(component)
+
+        if not found_resource_manager:
+            new_components.insert(
+                0,
+                {
+                    "id": "resource_manager",
+                    "path": _PASSTHROUGH_RESOURCE_MANAGER_PATH,
+                    "args": {},
+                },
+            )
+
+        resources["components"] = new_components
+        utils.write(resources_file, json.dumps(resources, indent=4), "t")
+
+    def _write_study_data_pvc_file(self, dest_dir: str):
+        utils.write(
+            os.path.join(dest_dir, "study_data_pvc.yaml"), yaml.safe_dump(self.study_data_pvc, sort_keys=False), "t"
+        )
+
+    def _patch_server(self, ctx: ProvisionContext, server):
+        dest_dir = ctx.get_local_dir(server)
+        if self.set_passthrough_resource_manager:
+            self._set_resource_manager(dest_dir)
+        self._inject_launcher(dest_dir, ServerK8sJobLauncher.__module__ + ".ServerK8sJobLauncher")
+        self._write_study_data_pvc_file(dest_dir)
+
+    def _patch_client(self, ctx: ProvisionContext, client):
+        dest_dir = ctx.get_local_dir(client)
+        if self.set_passthrough_resource_manager:
+            self._set_resource_manager(dest_dir)
+        self._inject_launcher(dest_dir, ClientK8sJobLauncher.__module__ + ".ClientK8sJobLauncher")
+        self._write_study_data_pvc_file(dest_dir)
+
+    def build(self, project: Project, ctx: ProvisionContext):
+        self.helm_builder.build(project, ctx)
+
+        server = project.get_server()
+        if server:
+            self._patch_server(ctx, server)
+
+        for client in project.get_clients():
+            self._patch_client(ctx, client)

--- a/nvflare/lighter/templates/docker_launcher_template.yml
+++ b/nvflare/lighter/templates/docker_launcher_template.yml
@@ -18,7 +18,7 @@ docker_launcher_cln_sh: |
   echo "Starting NVFlare client {~~client_name~~} with image $DOCKER_IMAGE"
   echo "Host workspace: $HOST_WORKSPACE"
 
-  NETWORK_NAME="nvflare-network"
+  NETWORK_NAME="{~~network~~}"
   if ! docker network ls --filter name=$NETWORK_NAME --format "{{.Name}}" | grep -wq $NETWORK_NAME; then
       docker network create $NETWORK_NAME
       echo "Created Docker network: $NETWORK_NAME"
@@ -67,7 +67,7 @@ docker_launcher_svr_sh: |
   echo "Starting NVFlare server with image $DOCKER_IMAGE"
   echo "Host workspace: $HOST_WORKSPACE"
 
-  NETWORK_NAME="nvflare-network"
+  NETWORK_NAME="{~~network~~}"
   if ! docker network ls --filter name=$NETWORK_NAME --format "{{.Name}}" | grep -wq $NETWORK_NAME; then
       docker network create $NETWORK_NAME
       echo "Created Docker network: $NETWORK_NAME"

--- a/tests/unit_test/lighter/docker_launcher_builder_test.py
+++ b/tests/unit_test/lighter/docker_launcher_builder_test.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+from nvflare.lighter.constants import PropKey
+from nvflare.lighter.ctx import ProvisionContext
+from nvflare.lighter.entity import Project
+from nvflare.lighter.impl.docker_launcher import DockerLauncherBuilder
+
+
+def _make_project():
+    project = Project(name="test_project", description="test")
+    project.set_server("server-1", "nvidia", {"fed_learn_port": 8002, "admin_port": 8002})
+    project.add_client("site-1", "hospital", {})
+    return project
+
+
+def _seed_kit_dirs(ctx, project):
+    resources = {
+        "components": [
+            {
+                "id": "resource_manager",
+                "path": "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager",
+                "args": {"num_of_gpus": 2},
+            },
+            {
+                "id": "resource_consumer",
+                "path": "nvflare.app_common.resource_consumers.gpu_resource_consumer.GPUResourceConsumer",
+                "args": {},
+            },
+            {
+                "id": "process_launcher",
+                "path": "nvflare.app_common.job_launcher.client_process_launcher.ClientProcessJobLauncher",
+                "args": {},
+            },
+            {
+                "id": "keep_me",
+                "path": "example.Component",
+                "args": {"x": 1},
+            },
+        ]
+    }
+
+    for participant in project.get_all_participants():
+        participant.set_prop(PropKey.COMM_CONFIG_ARGS, {})
+        os.makedirs(ctx.get_local_dir(participant), exist_ok=True)
+        os.makedirs(ctx.get_kit_dir(participant), exist_ok=True)
+        with open(os.path.join(ctx.get_local_dir(participant), "resources.json.default"), "wt") as f:
+            json.dump(resources, f)
+
+
+def _load_resources(ctx, participant):
+    with open(os.path.join(ctx.get_local_dir(participant), "resources.json.default"), "rt") as f:
+        return json.load(f)
+
+
+def test_docker_launcher_builder_uses_custom_args_and_cleans_process_mode_components(tmp_path):
+    project = _make_project()
+    ctx = ProvisionContext(str(tmp_path), project)
+    _seed_kit_dirs(ctx, project)
+
+    builder = DockerLauncherBuilder(
+        docker_image="repo/nvflare:1.2.3",
+        network="my-overlay",
+        python_path="/opt/bin/python3",
+        default_job_container_kwargs={"shm_size": "8g", "ipc_mode": "host"},
+        default_job_env={"NCCL_P2P_DISABLE": "1"},
+    )
+    builder.initialize(project, ctx)
+    builder.build(project, ctx)
+
+    server = project.get_server()
+    client = project.get_clients()[0]
+
+    for participant in (server, client):
+        resources = _load_resources(ctx, participant)
+        components = resources["components"]
+        component_ids = {c["id"] for c in components}
+
+        assert "process_launcher" not in component_ids
+        assert "resource_consumer" not in component_ids
+        assert "keep_me" in component_ids
+
+        resource_manager = next(c for c in components if c["id"] == "resource_manager")
+        assert (
+            resource_manager["path"]
+            == "nvflare.app_common.resource_managers.passthrough_resource_manager.PassthroughResourceManager"
+        )
+
+        docker_launcher = next(c for c in components if c["id"] == "docker_launcher")
+        assert docker_launcher["args"]["network"] == "my-overlay"
+        assert docker_launcher["args"]["python_path"] == "/opt/bin/python3"
+        assert docker_launcher["args"]["default_job_env"] == {"NCCL_P2P_DISABLE": "1"}
+        assert docker_launcher["args"]["default_job_container_kwargs"] == {
+            "shm_size": "8g",
+            "ipc_mode": "host",
+        }
+
+        start_docker = os.path.join(ctx.get_kit_dir(participant), "start_docker.sh")
+        with open(start_docker, "rt") as f:
+            script = f.read()
+        assert 'NETWORK_NAME="my-overlay"' in script
+        assert "repo/nvflare:1.2.3" in script
+
+    assert server.get_prop(PropKey.COMM_CONFIG_ARGS)["host"] == "0.0.0.0"
+    assert client.get_prop(PropKey.COMM_CONFIG_ARGS)["host"] == "0.0.0.0"
+
+
+def test_docker_launcher_builder_can_preserve_existing_resource_manager_when_requested(tmp_path):
+    project = _make_project()
+    ctx = ProvisionContext(str(tmp_path), project)
+    _seed_kit_dirs(ctx, project)
+
+    builder = DockerLauncherBuilder(docker_image="repo/nvflare:1.2.3", set_passthrough_resource_manager=False)
+    builder.initialize(project, ctx)
+    builder.build(project, ctx)
+
+    client = project.get_clients()[0]
+    resources = _load_resources(ctx, client)
+    components = resources["components"]
+    component_ids = {c["id"] for c in components}
+
+    assert "process_launcher" not in component_ids
+    assert "resource_consumer" in component_ids
+    resource_manager = next(c for c in components if c["id"] == "resource_manager")
+    assert resource_manager["path"] == "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager"

--- a/tests/unit_test/lighter/k8s_site_runtime_builder_test.py
+++ b/tests/unit_test/lighter/k8s_site_runtime_builder_test.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import yaml
+
+from nvflare.lighter.constants import PropKey
+from nvflare.lighter.ctx import ProvisionContext
+from nvflare.lighter.entity import Project
+from nvflare.lighter.impl.k8s_runtime import K8sRuntimeBuilder
+
+
+def _make_project():
+    project = Project(name="test_project", description="test")
+    project.set_server("server-1", "nvidia", {"fed_learn_port": 8002, "admin_port": 8002})
+    project.add_client("site-1", "hospital", {})
+    return project
+
+
+def _seed_local_resources(ctx, project):
+    common_components = [
+        {
+            "id": "resource_manager",
+            "path": "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager",
+            "args": {"num_of_gpus": 2},
+        },
+        {
+            "id": "resource_consumer",
+            "path": "nvflare.app_common.resource_consumers.gpu_resource_consumer.GPUResourceConsumer",
+            "args": {},
+        },
+        {
+            "id": "process_launcher",
+            "path": "nvflare.app_common.job_launcher.client_process_launcher.ClientProcessJobLauncher",
+            "args": {},
+        },
+        {
+            "id": "keep_me",
+            "path": "example.Component",
+            "args": {"x": 1},
+        },
+    ]
+    server_resources = {
+        "snapshot_persistor": {
+            "args": {
+                "storage": {
+                    "args": {
+                        "root_dir": "/tmp/nvflare/snapshot-storage",
+                    }
+                }
+            }
+        },
+        "components": [
+            {
+                "id": "job_manager",
+                "path": "nvflare.apis.impl.job_def_manager.SimpleJobDefManager",
+                "args": {"uri_root": "/tmp/nvflare/jobs-storage", "job_store_id": "job_store"},
+            },
+            *common_components,
+        ],
+    }
+
+    for participant in project.get_all_participants():
+        participant.set_prop(PropKey.COMM_CONFIG_ARGS, {})
+        os.makedirs(ctx.get_local_dir(participant), exist_ok=True)
+        os.makedirs(ctx.get_kit_dir(participant), exist_ok=True)
+        with open(os.path.join(ctx.get_local_dir(participant), "resources.json.default"), "wt") as f:
+            json.dump(server_resources if participant == project.get_server() else {"components": common_components}, f)
+
+
+def _load_resources(ctx, participant):
+    with open(os.path.join(ctx.get_local_dir(participant), "resources.json.default"), "rt") as f:
+        return json.load(f)
+
+
+def test_k8s_site_runtime_builder_generates_charts_and_patches_runtime(tmp_path):
+    project = _make_project()
+    ctx = ProvisionContext(str(tmp_path), project)
+    _seed_local_resources(ctx, project)
+
+    builder = K8sRuntimeBuilder(
+        docker_image="repo/nvflare:2.0.0",
+        namespace="nvflare",
+        parent_port=19002,
+        workspace_pvc="shared-ws",
+        workspace_mount_path="/workspace",
+        study_data_pvc={"default": "nvfldata", "study-a": "study-a-pvc"},
+    )
+    builder.build(project, ctx)
+
+    server = project.get_server()
+    client = project.get_clients()[0]
+
+    for participant, expected_launcher in [
+        (server, "nvflare.app_opt.job_launcher.k8s_launcher.ServerK8sJobLauncher"),
+        (client, "nvflare.app_opt.job_launcher.k8s_launcher.ClientK8sJobLauncher"),
+    ]:
+        resources = _load_resources(ctx, participant)
+        components = resources["components"]
+        component_ids = {c["id"] for c in components}
+
+        assert "process_launcher" not in component_ids
+        assert "resource_consumer" not in component_ids
+        assert "keep_me" in component_ids
+
+        resource_manager = next(c for c in components if c["id"] == "resource_manager")
+        assert (
+            resource_manager["path"]
+            == "nvflare.app_common.resource_managers.passthrough_resource_manager.PassthroughResourceManager"
+        )
+
+        k8s_launcher = next(c for c in components if c["id"] == "k8s_launcher")
+        assert k8s_launcher["path"] == expected_launcher
+        assert k8s_launcher["args"]["namespace"] == "nvflare"
+        assert (
+            k8s_launcher["args"]["study_data_pvc_file_path"] == "/var/tmp/nvflare/workspace/local/study_data_pvc.yaml"
+        )
+
+        with open(os.path.join(ctx.get_local_dir(participant), "study_data_pvc.yaml"), "rt") as f:
+            pvc_config = yaml.safe_load(f)
+        assert pvc_config == {"default": "nvfldata", "study-a": "study-a-pvc"}
+
+        chart_dir = os.path.join(ctx.get_ws_dir(participant), "helm_chart")
+        assert os.path.isdir(chart_dir)
+        assert os.path.isfile(os.path.join(chart_dir, "Chart.yaml"))
+        assert os.path.isfile(os.path.join(chart_dir, "values.yaml"))
+
+
+def test_k8s_site_runtime_builder_can_preserve_existing_resource_manager_when_requested(tmp_path):
+    project = _make_project()
+    ctx = ProvisionContext(str(tmp_path), project)
+    _seed_local_resources(ctx, project)
+
+    builder = K8sRuntimeBuilder(docker_image="repo/nvflare:2.0.0", set_passthrough_resource_manager=False)
+    builder.build(project, ctx)
+
+    client = project.get_clients()[0]
+    resources = _load_resources(ctx, client)
+    components = resources["components"]
+    component_ids = {c["id"] for c in components}
+
+    assert "process_launcher" not in component_ids
+    assert "resource_consumer" in component_ids
+    resource_manager = next(c for c in components if c["id"] == "resource_manager")
+    assert resource_manager["path"] == "nvflare.app_common.resource_managers.gpu_resource_manager.GPUResourceManager"


### PR DESCRIPTION

### Description

This PR enables site-local runtime selection during `nvflare package` by reusing the existing full-YAML `--project-file` flow.

Instead of introducing a new package config concept, each site can now provide its own local project YAML with one participant and, optionally, one runtime builder:

- no builder: process
- `DockerLauncherBuilder`: Docker
- `K8sRuntimeBuilder`: K8s

## What changed

- Enhanced `DockerLauncherBuilder` to support site-local Docker runtime settings:
  - `docker_image`
  - `network`
  - `python_path`
  - `default_job_env`
  - `default_job_container_kwargs`
- Updated Docker packaging behavior to:
  - generate `startup/start_docker.sh`
  - replace `process_launcher` with `docker_launcher`
  - switch to `PassthroughResourceManager`
  - remove `resource_consumer`
- Added `K8sRuntimeBuilder` for site-local K8s packaging:
  - reuses `HelmChartBuilder`
  - replaces `process_launcher` with `k8s_launcher`
  - writes `local/study_data_pvc.yaml`
  - switches to `PassthroughResourceManager`
  - removes `resource_consumer`
- Updated the Docker launcher template to use the configured Docker network
- Added focused unit tests for both Docker and K8s runtime builders
- Added a design doc describing the site-local packaging model and current workflow gaps

## Why

The goal is to keep centralized provisioning unchanged for normal process-based deployments while letting each site decide its own runtime packaging during the local `nvflare package` step.

This keeps runtime choice local to the site and builds on package behavior that already supports full project YAML with `builders:`.

## Current workflow

Central admin:

- runs `nvflare provision -p project.yml`

Site admin:

- prepares a local full project YAML for the site
- chooses Docker or K8s by specifying the runtime builder
- runs `nvflare package --project-file <site-project.yml> ...`

## Testing

Ran:

```bash
./venv/bin/python -m pytest tests/unit_test/lighter/docker_launcher_builder_test.py tests/unit_test/lighter/k8s_site_runtime_builder_test.py -q
```

## Known gaps

This PR does not yet address some existing package workflow gaps:

- YAML-mode `--dir` still expects raw cert material named `<participant>.crt`, `<participant>.key`, and `rootCA.pem`
- package output reporting is still generic and may print `start.sh` even for Docker/K8s packaging
- local site project YAML is not yet validated against the centrally provisioned project for identity/topology consistency


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
