### PR TITLE
Enhance NVFlare CLI startup kit workflows

### DIFF
--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -1,7 +1,7 @@
 # NVFLARE CLI Design: Enhance NVFLARE CLI Commands
 
 Created Date: 2026-03-26
-Updated Date: 2026-04-14
+Updated Date: 2026-04-24
 
 
 ## Problem Statement
@@ -11,6 +11,10 @@ NVFlare's admin operations are currently accessible only through an interactive 
 - Not scriptable: automating FL workflows (submit job, wait, download results) requires fragile stdin piping or the deprecated FLAdminAPI.
 - Not CI/CD friendly: pipeline systems (GitHub Actions, Airflow, Kubernetes Jobs) cannot drive an interactive console.
 - Incomplete `nvflare job`: submit exists but list, abort, delete, download, clone do not.
+- Startup kit selection is too visible in normal workflows: repeated `--startup-target`,
+  `--startup-kit`, and environment-only state force users to think about local
+  implementation details instead of running commands such as `nvflare job list`,
+  `nvflare study list`, and `nvflare system status`.
 
 Goal: make the full NVFlare admin command surface accessible non-interactively — scriptable from CI/CD pipelines, automation tools, and AI agents. This covers:
 
@@ -20,6 +24,8 @@ Goal: make the full NVFlare admin command surface accessible non-interactively �
 - `nvflare network` — cellnet diagnostics for advanced troubleshooting
 - `nvflare agent` — bootstrap and context management for agentic workflows
 - `nvflare install-skills` — installs skill files into agent framework discovery paths
+- `nvflare kit` — local startup kit registry and active-kit selection for all
+  server-connected commands
 
 
 ## Design Principles
@@ -127,7 +133,9 @@ The JSON output shape and error codes defined here become the MCP tool schemas i
 | Command | Subcommands | Agent Readiness Status |
 | --- | --- | --- |
 | `nvflare simulator` | — | Deprecated — retain with stderr warning; use Job Recipe SimEnv directly (`python job.py`) |
-| `nvflare poc` | `prepare`, `start`, `stop`, `clean` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass |
+| `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass; register generated user and site kits in the shared startup kit registry |
+| `nvflare kit` | `add`, `use`, `show`, `list`, `remove` | New local startup kit registry; no server connection |
+| `nvflare study` | `register`, `show`, `list`, `remove`, `add-site`, `remove-site`, `add-user`, `remove-user` | Add multi-study lifecycle CLI using the active startup kit |
 | `nvflare provision` | — | Add JSON output, `--schema`, `--force` for Y/N prompts; restore pre-2.7.0 default: no args = generate `project.yml` |
 | `nvflare preflight-check` | — | Add JSON output, `--schema`; exit 0=pass, 1=fail. Underscore alias `preflight_check` accepted for backward compatibility. |
 | `nvflare config` | — | Add JSON output, `--schema` |
@@ -186,15 +194,42 @@ Only commands that serve common end-user or admin tasks are exposed. Diagnostic,
 - `job logs` (plural) = read log content
 - `job log-config` = write logging configuration
 
-Current state: there is no proper API to retrieve or parse job logs. Users have been using interactive console shell commands (`cat`, `tail`, `grep` via `tail_target_log` / `grep_target` on `Session`) to find errors. These commands are unstructured, security-sensitive, and not agent-usable. The commands below replace this with a proper log API.
+Current state: users have been using interactive console shell commands (`cat`, `tail`, `grep` via `tail_target_log` / `grep_target` on `Session`) to find errors. These commands are unstructured, security-sensitive, and not agent-usable. The commands below replace this with a proper log API.
+
+When client-side log streaming to the server is enabled, client logs are treated as server-side stored job logs. `nvflare job logs` does not connect to client sites directly and does not execute shell commands on client machines. It asks the server for the job log content that the server has locally for the requested site target.
+
+Client log streaming is enabled by the job, not by `nvflare job logs`. The portable job-level pattern is:
+
+```python
+from nvflare.app_common.logging.job_log_receiver import JobLogReceiver
+from nvflare.app_common.logging.job_log_streamer import JobLogStreamer
+
+recipe.job.to_clients(JobLogStreamer())
+recipe.job.to_server(JobLogReceiver())
+```
+
+`JobLogStreamer` runs in each client job process, tails the job `log.txt`, and streams bytes to the server. `JobLogReceiver` runs on the server side for that job, writes incoming chunks into the server job workspace as `<client_name>/log.txt`, and hands the file to the job manager so it is included in the archived job `workspace` artifact. Server-side resource configuration may also provide a global `JobLogReceiver`, but jobs that include both components are self-contained across POC and production deployments.
 
 ### `nvflare job logs`
 
 ```text
-nvflare job logs <job_id> [--site server|<client_name>|all] [--tail N] [--grep PATTERN]
+nvflare job logs <job_id> [--site server|<client_name>|all]
 ```
 
-`--site` defaults to `all`. `--tail N` limits to last N lines per site. `--grep PATTERN` filters lines server-side before returning.
+`--site` defaults to `server` for bounded output and backward-compatible behavior.
+
+Site target behavior:
+
+- `--site server`: return the server-side job log.
+- `--site <client_name>`: return that client's job log as streamed to and stored by the server.
+- `--site all`: return the server log plus all client logs available in the server-side job log store.
+
+The command never applies local filtering such as `tail` or `grep`; users can pipe or post-process the returned log content if needed.
+
+Human output prints log text directly. For a single `--site server` or
+`--site <client_name>` target, no JSON envelope or dict wrapper is printed. For
+`--site all`, each site is separated by a short header. `--format json` keeps the
+structured response shown below.
 
 Example:
 
@@ -204,7 +239,7 @@ Example:
   "status": "ok",
   "data": {
     "job_id": "abc123",
-    "log_source": "workspace",
+    "target": "all",
     "logs": {
       "server": "2026-03-27 10:01:00 INFO ...\n...",
       "site-1": "2026-03-27 10:01:05 ERROR ...\n...",
@@ -214,9 +249,37 @@ Example:
 }
 ```
 
-Server-side change needed: add a new admin command that returns job log content as structured data. `tail_target_log` / `grep_target` are insufficient.
+If `--site all` is requested and some known job sites do not have stored log content, the command should still return the logs that are available and report missing sites separately. A zero-byte log file is still returned as an available empty string; a missing log file is reported under `unavailable`.
 
-Session API change needed: add `get_job_logs(job_id, target, tail_lines, grep_pattern)` to `Session` in `flare_api.py`.
+```json
+{
+  "schema_version": "1",
+  "status": "ok",
+  "data": {
+    "job_id": "abc123",
+    "target": "all",
+    "logs": {
+      "server": "2026-03-27 10:01:00 INFO ...\n...",
+      "site-1": "2026-03-27 10:01:05 ERROR ...\n..."
+    },
+    "unavailable": {
+      "site-2": "client log stream not available for this job"
+    }
+  }
+}
+```
+
+For a specific requested site, missing log content is an error instead of a partial success:
+
+```text
+Error: job logs are not available for site 'site-2'
+Hint: Verify that client log streaming is enabled and that the site has run this job.
+Code: LOG_NOT_FOUND (exit 1)
+```
+
+Server-side behavior: `get_job_log <job_id> [server|all|client_name]` returns structured data from server-side stored artifacts. Server logs are read from the live server workspace when available, then from the saved job-store `workspace` component after the run workspace has been archived. Client logs are read from the server's live job workspace at `<job_id>/<client_name>/log.txt` when available, then from the saved job-store `workspace` component member `<client_name>/log.txt`. For compatibility with existing stored receiver outputs, the command can also fall back to client-data components such as `LOG_log.txt_<client_name>`. `tail_target_log` / `grep_target` are insufficient and are not used for this command.
+
+Session API: `Session.get_job_logs(job_id, target)` sends the structured server command and returns `logs` plus optional `unavailable`.
 
 ### `nvflare job log-config`
 
@@ -260,10 +323,10 @@ Session API change needed: add `configure_job_log(job_id, config, target)` and `
 
 | Command | Description |
 | --- | --- |
-| `nvflare job logs <job_id>` | Download job log content from server store |
+| `nvflare job logs <job_id>` | Download job log content from the server-side log store, including streamed client logs when available |
 
 ```text
-nvflare job logs     <job_id> [--site server|<client_name>|all] [--tail N] [--grep PATTERN]
+nvflare job logs     <job_id> [--site server|<client_name>|all]
 ```
 
 
@@ -316,7 +379,7 @@ Exit code 0 on `FINISHED_OK`, exit code 1 on `FAILED` / `ABORTED`.
 
 ## Shell Commands
 
-Commands like `pwd`, `ls`, `cat`, `head`, `tail`, and `grep` are not exposed in the CLI. Client targets were removed per FLARE-2808; server targets remain in the interactive console only for controlled debug use.
+Commands like `pwd`, `ls`, `cat`, `head`, `tail`, and `grep` are not exposed in the CLI. Direct client shell targets were removed per FLARE-2808; `nvflare job logs --site <client_name>` is not a shell target and only reads client logs already streamed to the server-side log store. Server shell targets remain in the interactive console only for controlled debug use.
 
 
 ## Hidden Admin Console Commands
@@ -334,6 +397,495 @@ These do not appear in help and should not be exposed in the CLI.
 | `_commands` | `builtin.py` | Return full command registry | No |
 | `pull_binary_file` | `file_transfer.py` | Internal binary file pull | No |
 | `push_folder` | `file_transfer.py` | Internal folder push | No |
+
+
+## Startup Kit Registry and Active Kit
+
+Normal server-connected commands use one active local startup kit. Users should not need
+to pass `--startup-target`, `--startup-kit`, or a startup-kit path on every command.
+
+Common POC flow:
+
+```bash
+nvflare poc prepare
+nvflare poc start
+nvflare job list
+nvflare job submit -j ./job
+```
+
+`poc prepare` registers the generated Project Admin startup kit and makes it active.
+
+Production flow:
+
+```bash
+nvflare kit add alice_example_project /secure/startup_kits/example_project/alice@nvidia.com
+nvflare kit use alice_example_project
+nvflare job list
+```
+
+Multiple local identities are handled by activating a different registered ID:
+
+```bash
+nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
+nvflare kit add fraud_org_admin /secure/startup_kits/fraud/org_admin@nvidia.com
+nvflare kit use cancer_lead
+nvflare kit show
+```
+
+Activation is local config mutation only. It does not contact the server.
+
+### Config Model
+
+`~/.nvflare/config.conf` stores a startup kit ID-to-path registry plus one active ID:
+
+```hocon
+version = 2
+
+startup_kits {
+  active = "admin@nvidia.com"
+
+  entries {
+    "admin@nvidia.com" = "/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com"
+    "lead@nvidia.com" = "/tmp/nvflare/poc/example_project/prod_00/lead@nvidia.com"
+    "org-admin@nvidia.com" = "/tmp/nvflare/poc/example_project/prod_00/org-admin@nvidia.com"
+    "site-1" = "/tmp/nvflare/poc/example_project/prod_00/site-1"
+    cancer_lead = "/secure/startup_kits/cancer/lead@nvidia.com"
+    fraud_org_admin = "/secure/startup_kits/fraud/org_admin@nvidia.com"
+  }
+}
+
+poc {
+  workspace = "/tmp/nvflare/poc"
+}
+
+job_template {
+  path = "/path/to/job_templates"
+}
+
+agent {
+  poll_interval = 10
+  job_timeout = 3600
+}
+```
+
+The registry key is a local ID. It is not a server-side object, not a certificate role,
+and not a study role. For POC-generated user startup kits, the default ID is the user
+identity, such as `admin@nvidia.com` or `lead@nvidia.com`. For POC-generated site
+startup kits, the default ID is the site name, such as `site-1`. For production kits,
+users choose meaningful local IDs such as `cancer_lead`.
+
+The entry value is only the startup kit path. Metadata such as identity and certificate
+role is inspected from the startup kit when needed by commands such as `nvflare kit show`;
+it is not duplicated in `config.conf`. Fields that are not reliably derivable from the
+startup kit are omitted from normal output.
+
+`poc.workspace` is retained because POC service management needs a workspace root. POC
+startup kit locations are not duplicated under `poc`.
+
+### `nvflare kit`
+
+`nvflare kit` manages local startup kit registrations. It is not a server-side resource.
+Running `nvflare kit` without a subcommand should print help and exit without an
+`INVALID_ARGS` error.
+
+#### `nvflare kit add <id> <path>`
+
+Registers a startup kit location under a local ID.
+
+Behavior:
+
+1. Read `~/.nvflare/config.conf`.
+2. Validate that `<path>` is a valid participant startup kit directory. A valid admin/user
+   startup kit must contain all three of:
+   - `startup/fed_admin.json`
+   - `startup/client.crt`
+   - `startup/rootCA.pem`
+   A valid site startup kit must contain `startup/fed_client.json`.
+3. Fail if `<id>` already exists unless `--force` is provided.
+4. Create or replace `startup_kits.entries.<id> = "<path>"`.
+5. Do not change `startup_kits.active`. Registration and activation are separate.
+6. Write config atomically.
+
+Example output:
+
+```text
+registered startup kit: alice_example_project
+path: /secure/startup_kits/example_project/alice@nvidia.com
+next_step: nvflare kit use alice_example_project
+```
+
+#### `nvflare kit use <id>`
+
+Makes a registered startup kit active.
+
+Behavior:
+
+1. Read `~/.nvflare/config.conf`.
+2. Resolve `<id>` to a path from `startup_kits.entries`.
+3. Validate that the path still passes the admin/user startup kit check.
+4. Set `startup_kits.active = "<id>"`.
+5. Write config atomically.
+6. Print the active ID and path. Identity and role can be displayed when they can be
+   inspected from the startup kit.
+
+No server call is made. The next server-connected command creates a session using the
+selected startup kit.
+
+#### `nvflare kit show`
+
+Shows the configured active startup kit:
+
+```text
+active: cancer_lead
+identity: lead@nvidia.com
+cert_role: lead
+path: /secure/startup_kits/cancer/lead@nvidia.com
+```
+
+`kit show` reports `startup_kits.active`. It does not replace that value with
+`NVFLARE_STARTUP_KIT_DIR`, but it should warn when the environment variable is set:
+
+```text
+warning: NVFLARE_STARTUP_KIT_DIR is set (/secure/startup_kits/cancer/lead@nvidia.com)
+         normal commands will use this path instead of the active kit above
+```
+
+If the active path is missing or invalid, show the stale registration and suggest
+`nvflare kit use <id>` or `nvflare kit remove <id>`.
+
+#### `nvflare kit list`
+
+Lists registered startup kits. The command checks each registered path locally and flags
+stale entries without contacting the server:
+
+```text
+* cancer_lead       ok       lead@nvidia.com        lead          /secure/startup_kits/cancer/lead@nvidia.com
+  site-1            ok       site-1                 -             /tmp/nvflare/poc/example_project/prod_00/site-1
+  fraud_org_admin   missing  -                      -             /secure/startup_kits/fraud/org_admin@nvidia.com
+  old_lab_admin     invalid  -                      -             /archive/old_lab/admin@nvidia.com
+```
+
+The active startup kit is marked with `*`. Missing or invalid paths are shown as
+`missing` or `invalid`. Site kits can be registered and listed, but they cannot be
+activated for server-connected admin commands.
+
+#### `nvflare kit remove <id>`
+
+Removes a local config registration. It does not delete the startup kit directory. If the
+removed ID is active, clear `startup_kits.active` and print:
+
+```text
+removed startup kit: cancer_lead
+warning: no active startup kit is configured
+next_step: nvflare kit use <id>
+```
+
+### Resolution Model
+
+All server-connected commands, including `nvflare job`, `nvflare study`, `nvflare system`,
+and `nvflare network`, resolve the startup kit using this ordered lookup:
+
+1. If `NVFLARE_STARTUP_KIT_DIR` is set, validate it with the same three-file admin startup
+   kit check and use it.
+2. Otherwise, use `startup_kits.active` from `~/.nvflare/config.conf`.
+3. If neither source resolves to a valid admin/user startup kit, fail before any server
+   connection attempt.
+
+The common user documentation should teach the active startup kit model. The environment
+variable is an automation override, not the primary user workflow.
+
+### POC Integration
+
+`poc prepare` continues to create the default POC workspace and provision the POC project.
+It also registers generated admin/user and site startup kits in the shared registry.
+
+Behavior:
+
+1. Provision the POC project as today.
+2. Find generated admin/user and site startup kits in the POC prod directory, normally
+   `prod_00` after the first `poc prepare`.
+3. Keep generated site startup kits in the POC workspace for local service management and
+   register their local paths for discovery and cleanup.
+4. Read participant identity, org, type, and role from the POC project metadata.
+5. Register the Project Admin kit by identity, such as `admin@nvidia.com`.
+6. Register each additional admin/user kit by identity, such as `lead@nvidia.com`.
+7. Register each site kit by site name, such as `site-1`; site kits are never made active.
+8. Set `startup_kits.active` to the identity of the first `project_admin` participant
+   found in the project metadata.
+9. If no `project_admin` participant exists, do not set `startup_kits.active`; print a
+   hint to create or register an admin startup kit before running admin CLI commands.
+
+`poc prepare --force` keeps its existing meaning: recreate the local POC workspace and
+rerun provisioning. It does not mean "override any startup kit registration with the same
+ID." During registration, `poc prepare` may replace entries whose paths are under the POC
+workspace being recreated. If an ID already points outside the POC workspace, fail with a
+hint to remove or replace that kit explicitly.
+
+On the `cli_enhancement2` branch, `dummy_project.yml` includes these local POC user
+identities:
+
+```text
+admin@nvidia.com     role=project_admin
+org-admin@nvidia.com role=org_admin
+lead@nvidia.com      role=lead
+```
+
+Example result:
+
+```text
+startup_kits.active                         -> admin@nvidia.com
+startup_kits.entries."admin@nvidia.com"     -> .../prod_00/admin@nvidia.com
+startup_kits.entries."org-admin@nvidia.com" -> .../prod_00/org-admin@nvidia.com
+startup_kits.entries."lead@nvidia.com"      -> .../prod_00/lead@nvidia.com
+startup_kits.entries."site-1"               -> .../prod_00/site-1
+```
+
+#### `nvflare poc add user <cert-role> <email> --org <org>`
+
+Creates a new local POC user startup kit and registers it in the shared registry. Valid
+`<cert-role>` values are `project_admin`, `org_admin`, `lead`, and `member`. These are
+certificate roles, not study-specific roles.
+
+Behavior:
+
+1. Resolve the default POC workspace the same way existing POC commands do.
+2. Resolve the active startup kit and require its certificate role to be `project_admin`.
+   If `NVFLARE_STARTUP_KIT_DIR` is set, it participates in normal startup-kit resolution
+   and must also point to a `project_admin` kit. Otherwise fail with `NOT_AUTHORIZED`
+   before mutating project metadata.
+3. Read the persisted POC `project.yml` from that workspace. This file is originally
+   generated from the default POC `dummy_project.yml` baseline, then becomes the local
+   source of truth for later POC additions.
+4. If the identity does not exist, append one admin participant with the requested
+   identity, organization, and certificate role. With `--force`, update an existing
+   participant entry in place instead of appending a duplicate.
+5. Persist the updated project YAML on disk before provisioning.
+6. Invoke the existing POC provisioning/build pipeline with the updated project YAML, the
+   same as a full-project provision. This is the local POC form of dynamic provisioning:
+   the existing provision state is reused, so the root CA is not changed, and generated
+   startup kits from the new `prod_NN` output are used.
+7. Register the generated admin/user kit under startup kit ID `<email>`.
+8. If there is no active startup kit, make the new kit active.
+9. In the normal POC flow, leave the current active kit unchanged and print the activation
+   command.
+
+Example output when an active kit already exists:
+
+```text
+startup_kit: /tmp/nvflare/poc/example_project/prod_01/bob@nvidia.com
+id: bob@nvidia.com
+identity: bob@nvidia.com
+cert_role: lead
+next_step: nvflare kit use bob@nvidia.com
+```
+
+Example output when no active kit exists:
+
+```text
+startup_kit: /tmp/nvflare/poc/example_project/prod_01/bob@nvidia.com
+id: bob@nvidia.com
+identity: bob@nvidia.com
+cert_role: lead
+active: bob@nvidia.com
+```
+
+After the first `poc prepare`, the initial output is normally `prod_00`. A later
+`poc add user` runs the provisioning pipeline again and normally creates the next output
+directory, such as `prod_01`. Existing participant certificates are loaded from the POC
+provision state and reused. The CLI should point registrations at the latest generated
+startup kits.
+
+If the user identity already exists, the command fails unless `--force` is provided. With
+`--force`, update the existing project metadata entry in place, create a new startup kit,
+and replace only the config registration for that ID. If that ID is active, the active ID
+remains the same and now points to the new path.
+
+#### `nvflare poc add site <name> --org <org>`
+
+Creates a new local POC site startup kit and records it in the POC workspace and startup
+kit registry.
+
+Behavior:
+
+1. Resolve the default POC workspace the same way existing POC commands do.
+2. Resolve the active startup kit and require its certificate role to be `project_admin`.
+   If `NVFLARE_STARTUP_KIT_DIR` is set, it participates in normal startup-kit resolution
+   and must also point to a `project_admin` kit. Otherwise fail with `NOT_AUTHORIZED`
+   before mutating project metadata.
+3. Read the persisted POC `project.yml` from that workspace.
+4. Read the service metadata from that POC workspace.
+5. If the site does not exist, append one client participant with the requested site name
+   and organization. With `--force`, update an existing site participant entry in place
+   instead of appending a duplicate.
+6. Persist the updated project YAML on disk before provisioning.
+7. Invoke the existing POC provisioning/build pipeline with the updated project YAML, the
+   same as a full-project provision. The existing provision state is reused, so the root CA
+   is not changed, and generated startup kits from the new `prod_NN` output are used.
+8. Register the generated site kit under startup kit ID `<name>`.
+9. Update the POC service config so commands such as `nvflare poc start -p site-3` know the
+   new site exists.
+10. Print the generated startup kit path and start instructions.
+
+`poc add site` does not take a separate workspace argument. It is scoped to the active
+local POC workspace. Adding a site does not switch the active startup kit because site
+kits are service identities, not interactive admin identities.
+
+If the POC system is running, `poc add site` should still be allowed. Existing running
+services are not stopped; the new startup kit is used when the site is started or
+restarted.
+
+#### `nvflare poc clean`
+
+`poc clean` removes the local POC workspace and clears POC-generated config entries.
+
+Behavior:
+
+1. Stop if the POC system is still running, as today.
+2. Remove the POC workspace.
+3. Remove startup kit entries whose canonical paths are under the canonical POC workspace
+   path.
+4. Remove the `poc.workspace` key from `~/.nvflare/config.conf`.
+5. If the active startup kit was removed, clear `startup_kits.active`.
+6. Leave manually registered production startup kits untouched.
+
+The "under the POC workspace" check must use canonical path comparison, such as
+`Path.resolve()` plus `Path.is_relative_to()` or `os.path.commonpath()`. It must not use a
+raw string prefix check because `/tmp/nvflare/poc-backup` is not under `/tmp/nvflare/poc`.
+
+### Startup Kit and POC Error Handling
+
+General rules:
+
+- Validate before mutating `~/.nvflare/config.conf`.
+- Write config atomically so a failed command does not leave a partially written config.
+- Do not contact the server for `nvflare kit` registration, activation, listing, or
+  removal errors.
+- Treat identity, role, org, and project inspection as best effort. Failure to inspect
+  metadata should not break `kit add` or `kit use` when the startup kit path itself is
+  valid.
+
+If `~/.nvflare/config.conf` does not exist:
+
+- `nvflare kit list` prints an empty list.
+- `nvflare kit show` reports that no active startup kit is configured.
+- Normal server-connected commands fail before connecting:
+
+```text
+Error: no active startup kit is configured
+Hint: Run nvflare poc prepare, or run nvflare kit add <id> <startup-kit-dir> then nvflare kit use <id>.
+```
+
+If config parsing fails, commands stop without modifying the file:
+
+```text
+Error: cannot parse ~/.nvflare/config.conf
+Hint: Fix the config file, or move it aside and run nvflare poc prepare.
+```
+
+If `startup_kits.active` points to an ID that is not in `startup_kits.entries`:
+
+```text
+Error: active startup kit 'cancer_lead' is not registered
+Hint: Run nvflare kit list, then nvflare kit use <id>.
+```
+
+`kit add` error cases:
+
+```text
+Error: startup kit path does not exist: /secure/startup_kits/cancer/lead@nvidia.com
+```
+
+```text
+Error: path is not a valid startup kit: /secure/startup_kits/cancer/lead@nvidia.com
+Hint: Use the participant startup directory produced by provisioning.
+```
+
+```text
+Error: startup kit id 'cancer_lead' already exists
+Hint: Use --force to replace this local registration.
+```
+
+IDs may contain characters such as `@`, `.`, and `-`. Empty IDs are invalid. If the same
+path is registered under more than one ID, allow it; that is local aliasing and does not
+affect server behavior.
+
+`kit use` error cases:
+
+```text
+Error: startup kit id 'cancer_lead' is not registered
+Hint: Run nvflare kit list.
+```
+
+```text
+Error: startup kit path for 'cancer_lead' does not exist: /secure/startup_kits/cancer/lead@nvidia.com
+Hint: Restore the startup kit, remove the registration, or activate another kit.
+```
+
+```text
+Error: registered path for 'cancer_lead' is not a valid startup kit
+Hint: Run nvflare kit remove cancer_lead, or replace it with nvflare kit add cancer_lead <startup-kit-dir> --force.
+```
+
+`kit use` must not change `startup_kits.active` until the selected ID resolves to a valid
+startup kit path.
+
+`kit list` should not fail just because one registered path is stale. It marks each entry
+independently as `ok`, `missing`, or `invalid`. If the active entry is stale, keep the `*`
+marker and show the stale status.
+
+`poc prepare` registers POC-generated user kits by identity. `--force` is reserved for
+recreating the POC workspace and rerunning provisioning; it is not a general startup kit
+registry override. If a target ID already exists:
+
+- If the existing path is under the current POC workspace, replace it.
+- If the existing path is outside the current POC workspace, fail and require an explicit
+  registry action such as `nvflare kit remove <id>` or
+  `nvflare kit add <id> <path> --force`.
+
+```text
+Error: startup kit id 'lead@nvidia.com' already points outside the POC workspace
+Hint: Run nvflare kit remove lead@nvidia.com, or replace it explicitly with nvflare kit add lead@nvidia.com <startup-kit-dir> --force.
+```
+
+`poc add user` fails before creating or registering a new kit when the requested identity
+already exists in the POC project, unless `--force` is provided. With `--force`, update
+the existing participant metadata in place and persist it to disk; do not append a
+duplicate participant.
+
+`poc add site` follows the same duplicate rule for sites. If services are running, the
+command may add the new site kit but must not restart existing services automatically.
+
+Both `poc add user` and `poc add site` require the active startup kit to have the
+`project_admin` certificate role. A lead, org admin, member, missing role, or stale kit
+must fail before project metadata is changed.
+
+`poc clean` removes only startup kit entries whose canonical paths are under the canonical
+`poc.workspace` path. If the active startup kit is removed, clear `startup_kits.active`.
+Manual production registrations remain untouched.
+
+### Startup Kit Behavior Guarantees
+
+- `poc prepare` activates the default POC Project Admin startup kit automatically.
+- `poc prepare` writes POC admin/user and site startup kits into `startup_kits.entries`.
+- `poc.startup_kit` and `prod.startup_kit` are not read or written.
+- Normal server-connected commands do not expose `--startup-target` or `--startup-kit`.
+- Commands resolve the startup kit through `NVFLARE_STARTUP_KIT_DIR` first, then
+  `startup_kits.active`.
+- `nvflare kit` is the user-facing startup kit management interface.
+- `nvflare config` keeps non-startup-kit settings such as `poc.workspace` and job template
+  config, but it does not manage startup kit locations.
+- `poc add user` registers generated user kits in `startup_kits.entries`.
+- `poc add site` registers generated site kits in `startup_kits.entries` and updates POC
+  workspace metadata.
+- `poc add user` and `poc add site` do not switch away from the active kit in the normal
+  POC flow.
+- `poc add site` is allowed while POC services are running and does not stop existing
+  services.
+- For `nvflare kit add` and `nvflare poc add user`, `--force` replaces the config
+  registration for an existing ID without deleting old startup kit directories.
+- For `nvflare poc prepare`, `--force` means recreate the POC workspace; it does not
+  override unrelated startup kit registrations outside `poc.workspace`.
+- Persona commands are not needed. The common switching command is `nvflare kit use <id>`.
 
 
 ## Existing Command Reference
@@ -355,6 +907,8 @@ All commands need `--schema` and always emit a JSON envelope unless marked other
 | `--schema` | flag | No | — | Print command schema and exit |
 
 On success, auto-invoke `install_skills()`; exit 0 on failure because skills are optional.
+It also registers generated admin/user and site startup kits in `startup_kits.entries` and
+activates the first Project Admin kit.
 
 #### `nvflare poc start`
 
@@ -384,6 +938,27 @@ Must emit `server_url` in the JSON data field when server accepts connections.
 | `-debug`, `--debug` | flag | No | — | Debug mode |
 | `--schema` | flag | No | — | Print command schema and exit |
 
+#### `nvflare poc add user`
+
+```text
+nvflare poc add user <cert-role> <email> --org <org> [--force] [--schema]
+```
+
+Creates or refreshes a local POC admin/user participant from the default POC project YAML,
+generates the corresponding startup kit through the existing POC provisioning pipeline,
+and registers that user kit under startup kit ID `<email>`.
+
+#### `nvflare poc add site`
+
+```text
+nvflare poc add site <name> --org <org> [--force] [--schema]
+```
+
+Creates or refreshes a local POC client participant from the default POC project YAML,
+generates the site startup kit through the existing POC provisioning pipeline, registers
+the site kit under startup kit ID `<name>`, and updates POC service metadata so
+`nvflare poc start -p <name>` can manage the new site.
+
 ### `nvflare job`
 
 #### `nvflare job create` — deprecated
@@ -402,13 +977,14 @@ Retain with stderr deprecation warning. Migrate to `python job.py --export --exp
 
 #### `nvflare job submit`
 
-Submits a pre-built job config folder to a running server. Returns `job_id` immediately — no waiting. The job artifact is unchanged at submit time; `--startup-target` only selects which startup kit to use for server connection. If neither `--startup-target` nor `--startup-kit` is supplied, submit defaults to the POC startup kit from `~/.nvflare/config.conf`. Use `nvflare job monitor` to wait for results.
+Submits a pre-built job config folder to a running server. Returns `job_id` immediately
+with no waiting. The job artifact is unchanged at submit time. Server connection uses the
+active startup kit described in §Resolution Model. Use `nvflare job monitor` to wait
+for results.
 
 | Argument | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `-j`, `--job-folder` | str | No | `"./current_job"` | Pre-built job config folder |
-| `--startup-target` | `poc|prod` | No | `poc` | Select startup kit from config; mutually exclusive with `--startup-kit` |
-| `--startup-kit` | str | No | — | Explicit admin startup kit directory, or its `startup/` subdirectory; mutually exclusive with `--startup-target` |
 | `-debug`, `--debug` | flag | No | — | Debug mode |
 | `--study` | str | No | `"default"` | Study to submit the job to |
 | `--schema` | flag | No | — | Print command schema and exit |
@@ -428,8 +1004,6 @@ Polls a running job until it reaches a terminal state. Prints status updates to 
 | `job_id` | str | Yes | — | Job ID to monitor |
 | `--timeout` | int | No | 0 | Max seconds to wait |
 | `--interval` | int | No | 2 | Poll interval in seconds |
-| `--startup-target` | `poc\|prod` | No | `poc` | Select startup kit from config; mutually exclusive with `--startup-kit` |
-| `--startup-kit` | str | No | — | Explicit admin startup kit directory; mutually exclusive with `--startup-target` |
 | `--schema` | flag | No | — | Print command schema and exit |
 
 Exit code 0 on `FINISHED_OK`, exit code 1 on `FAILED` / `ABORTED`.
@@ -472,63 +1046,39 @@ Exit code must be 0 on all checks pass, 1 on any failure.
 
 ### `nvflare config`
 
-Manages `~/.nvflare/config.conf`.
-
-Config file keys use underscores (`startup_kit`, `poll_interval`, `job_timeout`) — this is the HOCON file convention and is distinct from CLI flag naming. CLI flags use dashes (`--startup-kit`, `--startup-target`); the config file is not a CLI surface.
-
-Config file format:
-
-```hocon
-version = 2
-
-poc {
-    startup_kit = "/tmp/nvflare/poc/workspace/example_project/prod_00/admin@nvidia.com"
-    workspace   = "/tmp/nvflare/poc/workspace"
-}
-prod {
-    startup_kit = "/path/to/prod/admin_startup_kit"
-}
-job_template {
-    path = "/path/to/job_templates"
-}
-agent {
-    poll_interval = 10
-    job_timeout   = 3600
-}
-claude {
-    skills_dir = "~/.claude/skills/nvflare"
-}
-openclaw {
-    skills_dir = "~/.openclaw/plugins/nvflare"
-}
-```
+Manages non-startup-kit settings in `~/.nvflare/config.conf`, such as `poc.workspace`,
+job template paths, and agent defaults. Startup kit locations are managed by `nvflare kit`
+and stored in `startup_kits.entries`; `nvflare config` should not expose or write
+`poc.startup_kit` or `prod.startup_kit`.
 
 Persistence rules:
 
 1. `version = 2` is always the first line in the saved config.
-2. Once a config is loaded and re-saved by the CLI, it is normalized to the v2 layout above.
-3. Legacy v1 keys such as `startup_kit.path` and `poc_workspace.path` are still read for backward compatibility, but they must not be written back alongside the v2 sections.
-4. The compatibility alias `nvflare config --startup_kit_dir <path>` updates `poc.startup_kit` only. It does not populate `prod.startup_kit`.
+2. Once a config is loaded and re-saved by the CLI, it is normalized to the v2 layout in
+   §Config Model.
+3. Startup kit entries are preserved when unrelated config fields are updated.
+4. `poc.workspace` is preserved unless `nvflare poc clean` removes the POC workspace.
 
 ### Admin username and `@` in directory names
 
-Admin startup kit directories are named after the admin user, typically an email address such as `admin@nvidia.com`. Two issues arise from the `@` character:
+Admin startup kit directories and startup kit IDs are often email addresses such as
+`admin@nvidia.com`. Two issues arise from the `@` character:
 
 1. **Cert name validation** — `_validate_safe_cert_name` currently uses the regex `[A-Za-z0-9][A-Za-z0-9._-]*`, which rejects `@`. The regex must be updated to `[A-Za-z0-9][A-Za-z0-9._@-]*` to allow email-format admin names. Both call sites must be updated: the `--name` argument handler in `cert_commands.py` and the CSR subject CN validator.
 
-2. **Path argument with `@`** — When an admin startup kit path containing `@` is passed on the command line (e.g. `--startup-kit /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com`), most shells pass it through unchanged. Some shell configurations (notably zsh with certain glob options) may attempt expansion on `@`. NVFlare cannot control shell parsing — if a shell expands `@` in the path, the user must quote the argument: `--startup-kit '/path/to/admin@nvidia.com'`. The NVFlare-side fix is limited to the cert name validator: once `@` is permitted there, the extracted directory basename passes NVFlare's own validation. Shell quoting is the user's responsibility for shells that treat `@` specially.
+2. **Startup kit IDs and paths with `@`** — When an ID or path containing `@` is passed
+   on the command line, most shells pass it through unchanged. Some shell configurations
+   may attempt expansion on `@`. NVFlare cannot control shell parsing; if a shell expands
+   `@`, the user must quote the argument. The config writer must quote IDs when HOCON
+   requires quoting.
 
 **Implementation requirement:** update `_SAFE_CERT_NAME_PATTERN` in `nvflare/tool/cert/cert_commands.py` from `[A-Za-z0-9][A-Za-z0-9._-]*` to `[A-Za-z0-9][A-Za-z0-9._@-]*`. No change is needed in argparse or path resolution — `@` is valid at the filesystem level and passes through argparse unchanged.
 
 ---
 
-For startup kit resolution order, see §Startup Kit Resolution under Implementation.
-
 | Argument | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `--poc.startup_kit` | str | No | — | POC startup kit path |
 | `--poc.workspace` | str | No | — | POC workspace path |
-| `--prod.startup_kit` | str | No | — | Production startup kit path |
 | `-jt`, `--job_templates_dir` | str | No | — | Job templates path |
 | `--agent.poll_interval` | int | No | — | Job monitor poll interval |
 | `--agent.job_timeout` | int | No | — | Job monitor timeout |
@@ -552,15 +1102,19 @@ Retain with stderr warning. Underscore alias `authz_preview` accepted for backwa
 | Command | JSON default | `--schema` | Exit Codes | Other |
 | --- | --- | --- | --- | --- |
 | `poc prepare` | Add | Add | Add | Add `--force`; auto-invoke `install_skills()` on success |
+| `poc add user` | Add | Add | Add | Add POC user startup kit and register it in `startup_kits.entries` |
+| `poc add site` | Add | Add | Add | Add POC site startup kit, register it in `startup_kits.entries`, and update POC service metadata |
 | `poc start` | Add | Add | Add | `server_url` in JSON data field when ready |
 | `poc stop` | Add | Add | Add | — |
 | `poc clean` | Add | Add | Add | — |
+| `kit add/use/show/list/remove` | Add | Add | Add | Manage local startup kit registry; no server connection |
 | `job create` | — | — | — | Deprecated |
 | `job submit` | Add | Add | Add | Returns `job_id` immediately |
 | `job monitor` | Add | Add | Add | Standalone wait/poll |
+| `study register/show/list/remove/add-site/remove-site/add-user/remove-user` | Add | Add | Add | Manage multi-study lifecycle through active startup kit |
 | `provision` | Add | Add | Add | Restore pre-2.7.0 default; add `--force` |
 | `preflight-check` | Add | Add | Fix | 0=pass, 1=fail; alias `preflight_check` kept |
-| `config` | Add | Add | Add | — |
+| `config` | Add | Add | Add | Manage non-startup-kit config; startup kits are managed by `nvflare kit` |
 | `job list-templates` | — | — | — | Deprecated; alias `list_templates` kept |
 | `job show-variables` | — | — | — | Deprecated; alias `show_variables` kept |
 | `simulator` | — | — | — | Deprecated |
@@ -574,24 +1128,48 @@ Retain with stderr warning. Underscore alias `authz_preview` accepted for backwa
 
 Add missing operations to the existing `nvflare job` subcommand:
 
-All server-connected `nvflare job` commands require a startup kit to be resolvable. They accept `--startup-target poc|prod` and `--startup-kit <dir>` as mutually exclusive explicit selectors; see §Startup Kit Resolution for the full lookup order, including env/config fallback.
+All server-connected `nvflare job` commands require a startup kit to be resolvable through
+the active-kit registry or `NVFLARE_STARTUP_KIT_DIR`.
 
 ```text
 # Job lifecycle (server must be running)
-nvflare job submit    -j <job_folder> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job monitor   <job_id> [--timeout N] [--interval N] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job list      [-n prefix] [-i id_prefix] [-r] [-m num] [--study name|all] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job meta      <job_id> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job abort     <job_id> [--force] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job clone     <job_id> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job download  <job_id> [-o destination] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job delete    <job_id> [--force] [--startup-target poc|prod | --startup-kit <dir>]
+nvflare job submit    -j <job_folder>
+nvflare job monitor   <job_id> [--timeout N] [--interval N]
+nvflare job list      [-n prefix] [-i id_prefix] [-r] [-m num] [--study name|all]
+nvflare job meta      <job_id>
+nvflare job abort     <job_id> [--force]
+nvflare job clone     <job_id>
+nvflare job download  <job_id> [-o destination]
+nvflare job delete    <job_id> [--force]
 
 # Observability (server must be running)
-nvflare job stats     <job_id> [--site server|<name>|all] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job logs      <job_id> [--site server|<name>|all] [--tail N] [--grep PATTERN] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare job log-config <job_id> [--site server|<name>|all] <level> [--startup-target poc|prod | --startup-kit <dir>]
+nvflare job stats     <job_id> [--site server|<name>|all]
+nvflare job logs      <job_id> [--site server|<name>|all]
+nvflare job log-config <job_id> [--site server|<name>|all] <level>
 ```
+
+### Add `nvflare study`
+
+All `nvflare study` commands connect to the server and require a startup kit to be
+resolvable through the active-kit registry or `NVFLARE_STARTUP_KIT_DIR`.
+
+```text
+nvflare study register    <name> [--sites <site> [<site> ...] | --site-org <org>:<site>[,<site>...]]
+nvflare study show        <name>
+nvflare study list
+nvflare study remove      <name>
+nvflare study add-site    <name> [--sites <site> [<site> ...] | --site-org <org>:<site>[,<site>...]]
+nvflare study remove-site <name> [--sites <site> [<site> ...] | --site-org <org>:<site>[,<site>...]]
+nvflare study add-user    <name> <user>
+nvflare study remove-user <name> <user>
+```
+
+Site enrollment is role-sensitive:
+
+- `project_admin` uses `--site-org <org>:<site>[,<site>...]`.
+- `org_admin` uses `--sites <site> [<site> ...]`.
+- `--sites` accepts either space-delimited or comma-delimited input.
+- `--sites` and `--site-org` are mutually exclusive.
 
 ### Add `nvflare recipe`
 
@@ -601,19 +1179,21 @@ nvflare recipe list [--framework <framework>]
 
 ### Add `nvflare network`
 
-All `nvflare network` commands query the server's cell network topology over an admin session and require a startup kit to be resolvable. They accept `--startup-target poc|prod` and `--startup-kit <dir>` as mutually exclusive explicit selectors; see §Startup Kit Resolution for the full lookup order, including env/config fallback.
+All `nvflare network` commands query the server's cell network topology over an admin
+session and require a startup kit to be resolvable through the active-kit registry or
+`NVFLARE_STARTUP_KIT_DIR`.
 
 ```text
-nvflare network cells        [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network peers        <target_cell> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network conns        <target_cell> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network route        <to_cell> [--from <from_cell>] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network msg-stats    <target> [--mode mode] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network list-pools   <target> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network show-pool    <target> <pool_name> [--mode mode] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network comm-config  <target> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network config-vars  <target> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare network process-info <target> [--startup-target poc|prod | --startup-kit <dir>]
+nvflare network cells
+nvflare network peers        <target_cell>
+nvflare network conns        <target_cell>
+nvflare network route        <to_cell> [--from <from_cell>]
+nvflare network msg-stats    <target> [--mode mode]
+nvflare network list-pools   <target>
+nvflare network show-pool    <target> <pool_name> [--mode mode]
+nvflare network comm-config  <target>
+nvflare network config-vars  <target>
+nvflare network process-info <target>
 ```
 
 All `nvflare network` commands support `--schema`. User-supplied arguments are validated against strict patterns before interpolation into `do_command()` strings.
@@ -649,16 +1229,17 @@ All `nvflare network` commands support `--schema`. User-supplied arguments are v
 
 ## Add `nvflare system`
 
-All `nvflare system` commands connect to the server and require a startup kit to be resolvable. They accept `--startup-target poc|prod` and `--startup-kit <dir>` as mutually exclusive explicit selectors; see §Startup Kit Resolution for the full lookup order, including env/config fallback.
+All `nvflare system` commands connect to the server and require a startup kit to be
+resolvable through the active-kit registry or `NVFLARE_STARTUP_KIT_DIR`.
 
 ```text
-nvflare system status        [server|client] [client_names...] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare system resources     [server|client] [clients...] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare system shutdown      <server|client|all> [client_names...] [--force] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare system restart       <server|client|all> [client_names...] [--force] [--startup-target poc|prod | --startup-kit <dir>]
-nvflare system remove-client <client_name> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare system log-config    [--site server|<client_name>|all] <level> [--startup-target poc|prod | --startup-kit <dir>]
-nvflare system version       [--site server|<name>|all] [--startup-target poc|prod | --startup-kit <dir>]
+nvflare system status        [server|client] [client_names...]
+nvflare system resources     [server|client] [clients...]
+nvflare system shutdown      <server|client|all> [client_names...] [--force]
+nvflare system restart       <server|client|all> [client_names...] [--force]
+nvflare system remove-client <client_name>
+nvflare system log-config    [--site server|<client_name>|all] <level>
+nvflare system version       [--site server|<name>|all]
 ```
 
 
@@ -702,21 +1283,48 @@ Example:
 
 ## Implementation
 
-### Startup Kit Resolution
+### Startup Kit Resolution Implementation
 
-All server-connected commands (`nvflare job`, `nvflare system`, `nvflare network`) resolve the startup kit using the same ordered lookup:
+All server-connected commands (`nvflare job`, `nvflare study`, `nvflare system`,
+`nvflare network`) resolve the startup kit using the same ordered lookup:
 
-1. `--startup-kit <dir>` — explicit path on the command line
-2. `NVFLARE_STARTUP_KIT_DIR` — environment variable
-3. `--startup-target poc|prod` — config v2 key lookup (`poc.startup_kit` or `prod.startup_kit`)
-4. default target `poc` — uses `poc.startup_kit` from config when `--startup-target` is absent
-5. config v1 fallback — legacy keys read for backward compatibility; normalized to v2 on save
+1. `NVFLARE_STARTUP_KIT_DIR` — automation override. If set, validate it with the
+   three-file admin startup kit check and use it.
+2. `startup_kits.active` — resolve the active ID from `~/.nvflare/config.conf`, then
+   validate the registered path.
+3. If neither source resolves to a valid admin/user startup kit, fail before any server
+   connection attempt.
 
 This resolution order applies uniformly. Command-level descriptions that say "same resolution order as `nvflare job`" refer to this list.
 
+Normal commands do not expose `--startup-target` or `--startup-kit`. Users switch local
+identity with `nvflare kit use <id>`. Automation can use `NVFLARE_STARTUP_KIT_DIR` when
+mutating local config is undesirable.
+
+Resolution error examples:
+
+```text
+Error: no active startup kit is configured
+Hint: Run nvflare kit use <id>.
+```
+
+```text
+Error: NVFLARE_STARTUP_KIT_DIR does not point to a valid startup kit for admin use
+Path: /secure/startup_kits/cancer/lead@nvidia.com
+Hint: Unset NVFLARE_STARTUP_KIT_DIR, or set it to a valid admin startup kit directory.
+```
+
+```text
+Error: active startup kit 'cancer_lead' points to a missing path
+Path: /secure/startup_kits/cancer/lead@nvidia.com
+Hint: Run nvflare kit use <id> or nvflare kit remove cancer_lead.
+```
+
 ### Session Reuse
 
-`nvflare job submit` already uses `new_secure_session()` with startup kit discovery. All new server-connected commands follow the same session pattern once the startup kit location is resolved.
+`nvflare job submit` already uses `new_secure_session()` with startup kit discovery. All
+server-connected commands follow the same session pattern once the startup kit location is
+resolved.
 
 ### Session API Coverage
 
@@ -741,7 +1349,7 @@ Needs adding:
 - `list_jobs`
 - `get_job_meta`
 - `delete_job`
-- `get_job_logs(job_id, target, tail_lines, grep_pattern)`
+- `get_job_logs(job_id, target)`
 - `configure_job_log(job_id, config, target)`
 
 New methods are thin wrappers over `AdminAPI.do_command()`.
@@ -756,6 +1364,9 @@ New methods are thin wrappers over `AdminAPI.do_command()`.
 | `nvflare/tool/recipe/recipe_cli.py` | `nvflare recipe list` |
 | `nvflare/tool/network/__init__.py` | Package |
 | `nvflare/tool/network/network_cli.py` | All `nvflare network` handlers |
+| `nvflare/tool/kit/__init__.py` | Package |
+| `nvflare/tool/kit/kit_cli.py` | `nvflare kit` command handlers |
+| `nvflare/tool/kit/kit_config.py` | Startup kit registry config and metadata helpers |
 | `nvflare/tool/agent/__init__.py` | Package |
 | `nvflare/tool/agent/agent_cli.py` | `nvflare agent` subcommands |
 | `nvflare/agent/__init__.py` | Agent package |
@@ -773,9 +1384,11 @@ New methods are thin wrappers over `AdminAPI.do_command()`.
 | File | Change |
 | --- | --- |
 | `nvflare/tool/job/job_cli.py` | Add job lifecycle and observability subcommands |
+| `nvflare/tool/study/study_cli.py` | Add multi-study lifecycle commands and active startup kit resolution |
 | `nvflare/fuel/flare_api/flare_api.py` | Add missing session methods |
 | `nvflare/cli.py` | Register new top-level commands |
-| `nvflare/tool/poc/poc_commands.py` | Call `install_skills()` on successful `poc prepare` |
+| `nvflare/tool/cli_session.py` | Resolve `NVFLARE_STARTUP_KIT_DIR` or the active startup kit registry entry |
+| `nvflare/tool/poc/poc_commands.py` | Call `install_skills()` on successful `poc prepare`; register generated POC user kits; support `poc add user/site` |
 | `nvflare/lighter/provision.py` | Call `install_skills()` on successful `provision` |
 
 

--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -24,7 +24,7 @@ Goal: make the full NVFlare admin command surface accessible non-interactively �
 - `nvflare network` — cellnet diagnostics for advanced troubleshooting
 - `nvflare agent` — bootstrap and context management for agentic workflows
 - `nvflare install-skills` — installs skill files into agent framework discovery paths
-- `nvflare kit` — local startup kit registry and active-kit selection for all
+- `nvflare config kit` — local startup kit registry and active-kit selection for all
   server-connected commands
 
 
@@ -134,7 +134,7 @@ The JSON output shape and error codes defined here become the MCP tool schemas i
 | --- | --- | --- |
 | `nvflare simulator` | — | Deprecated — retain with stderr warning; use Job Recipe SimEnv directly (`python job.py`) |
 | `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass and to `clean` for stop-before-cleanup; register generated user and site kits in the shared startup kit registry |
-| `nvflare kit` | `add`, `use`, `show`, `list`, `remove` | New local startup kit registry; no server connection |
+| `nvflare config kit` | `add`, `use`, `show`, `list`, `remove` | New local startup kit registry; no server connection |
 | `nvflare study` | `register`, `show`, `list`, `remove`, `add-site`, `remove-site`, `add-user`, `remove-user` | Add multi-study lifecycle CLI using the active startup kit |
 | `nvflare provision` | — | Add JSON output, `--schema`, `--force` for Y/N prompts; restore pre-2.7.0 default: no args = generate `project.yml` |
 | `nvflare preflight-check` | — | Add JSON output, `--schema`; exit 0=pass, 1=fail. Underscore alias `preflight_check` accepted for backward compatibility. |
@@ -418,18 +418,18 @@ nvflare job submit -j ./job
 Production flow:
 
 ```bash
-nvflare kit add alice_example_project /secure/startup_kits/example_project/alice@nvidia.com
-nvflare kit use alice_example_project
+nvflare config kit add alice_example_project /secure/startup_kits/example_project/alice@nvidia.com
+nvflare config kit use alice_example_project
 nvflare job list
 ```
 
 Multiple local identities are handled by activating a different registered ID:
 
 ```bash
-nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
-nvflare kit add fraud_org_admin /secure/startup_kits/fraud/org_admin@nvidia.com
-nvflare kit use cancer_lead
-nvflare kit show
+nvflare config kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
+nvflare config kit add fraud_org_admin /secure/startup_kits/fraud/org_admin@nvidia.com
+nvflare config kit use cancer_lead
+nvflare config kit show
 ```
 
 Activation is local config mutation only. It does not contact the server.
@@ -458,14 +458,6 @@ poc {
   workspace = "/tmp/nvflare/poc"
 }
 
-job_template {
-  path = "/path/to/job_templates"
-}
-
-agent {
-  poll_interval = 10
-  job_timeout = 3600
-}
 ```
 
 The registry key is a local ID. It is not a server-side object, not a certificate role,
@@ -475,20 +467,20 @@ startup kits, the default ID is the site name, such as `site-1`. For production 
 users choose meaningful local IDs such as `cancer_lead`.
 
 The entry value is only the startup kit path. Metadata such as identity and certificate
-role is inspected from the startup kit when needed by commands such as `nvflare kit show`;
+role is inspected from the startup kit when needed by commands such as `nvflare config kit show`;
 it is not duplicated in `config.conf`. Fields that are not reliably derivable from the
 startup kit are omitted from normal output.
 
 `poc.workspace` is retained because POC service management needs a workspace root. POC
 startup kit locations are not duplicated under `poc`.
 
-### `nvflare kit`
+### `nvflare config kit`
 
-`nvflare kit` manages local startup kit registrations. It is not a server-side resource.
-Running `nvflare kit` without a subcommand should print help and exit without an
+`nvflare config kit` manages local startup kit registrations. It is not a server-side resource.
+Running `nvflare config kit` without a subcommand should print help and exit without an
 `INVALID_ARGS` error.
 
-#### `nvflare kit add <id> <path>`
+#### `nvflare config kit add <id> <path>`
 
 Registers a startup kit location under a local ID.
 
@@ -511,10 +503,10 @@ Example output:
 ```text
 registered startup kit: alice_example_project
 path: /secure/startup_kits/example_project/alice@nvidia.com
-next_step: nvflare kit use alice_example_project
+next_step: nvflare config kit use alice_example_project
 ```
 
-#### `nvflare kit use <id>`
+#### `nvflare config kit use <id>`
 
 Makes a registered startup kit active.
 
@@ -531,7 +523,7 @@ Behavior:
 No server call is made. The next server-connected command creates a session using the
 selected startup kit.
 
-#### `nvflare kit show`
+#### `nvflare config kit show`
 
 Shows the configured active startup kit:
 
@@ -551,9 +543,9 @@ warning: NVFLARE_STARTUP_KIT_DIR is set (/secure/startup_kits/cancer/lead@nvidia
 ```
 
 If the active path is missing or invalid, show the stale registration and suggest
-`nvflare kit use <id>` or `nvflare kit remove <id>`.
+`nvflare config kit use <id>` or `nvflare config kit remove <id>`.
 
-#### `nvflare kit list`
+#### `nvflare config kit list`
 
 Lists registered startup kits. The command checks each registered path locally and flags
 stale entries without contacting the server:
@@ -569,7 +561,7 @@ The active startup kit is marked with `*`. Missing or invalid paths are shown as
 `missing` or `invalid`. Site kits can be registered and listed, but they cannot be
 activated for server-connected admin commands.
 
-#### `nvflare kit remove <id>`
+#### `nvflare config kit remove <id>`
 
 Removes a local config registration. It does not delete the startup kit directory. If the
 removed ID is active, clear `startup_kits.active` and print:
@@ -577,7 +569,7 @@ removed ID is active, clear `startup_kits.active` and print:
 ```text
 removed startup kit: cancer_lead
 warning: no active startup kit is configured
-next_step: nvflare kit use <id>
+next_step: nvflare config kit use <id>
 ```
 
 ### Resolution Model
@@ -676,7 +668,7 @@ startup_kit: /tmp/nvflare/poc/example_project/prod_01/bob@nvidia.com
 id: bob@nvidia.com
 identity: bob@nvidia.com
 cert_role: lead
-next_step: nvflare kit use bob@nvidia.com
+next_step: nvflare config kit use bob@nvidia.com
 ```
 
 Example output when no active kit exists:
@@ -759,7 +751,7 @@ General rules:
 
 - Validate before mutating `~/.nvflare/config.conf`.
 - Write config atomically so a failed command does not leave a partially written config.
-- Do not contact the server for `nvflare kit` registration, activation, listing, or
+- Do not contact the server for `nvflare config kit` registration, activation, listing, or
   removal errors.
 - Treat identity, role, org, and project inspection as best effort. Failure to inspect
   metadata should not break `kit add` or `kit use` when the startup kit path itself is
@@ -767,13 +759,13 @@ General rules:
 
 If `~/.nvflare/config.conf` does not exist:
 
-- `nvflare kit list` prints an empty list.
-- `nvflare kit show` reports that no active startup kit is configured.
+- `nvflare config kit list` prints an empty list.
+- `nvflare config kit show` reports that no active startup kit is configured.
 - Normal server-connected commands fail before connecting:
 
 ```text
 Error: no active startup kit is configured
-Hint: Run nvflare poc prepare, or run nvflare kit add <id> <startup-kit-dir> then nvflare kit use <id>.
+Hint: Run nvflare poc prepare, or run nvflare config kit add <id> <startup-kit-dir> then nvflare config kit use <id>.
 ```
 
 If config parsing fails, commands stop without modifying the file:
@@ -787,7 +779,7 @@ If `startup_kits.active` points to an ID that is not in `startup_kits.entries`:
 
 ```text
 Error: active startup kit 'cancer_lead' is not registered
-Hint: Run nvflare kit list, then nvflare kit use <id>.
+Hint: Run nvflare config kit list, then nvflare config kit use <id>.
 ```
 
 `kit add` error cases:
@@ -814,7 +806,7 @@ affect server behavior.
 
 ```text
 Error: startup kit id 'cancer_lead' is not registered
-Hint: Run nvflare kit list.
+Hint: Run nvflare config kit list.
 ```
 
 ```text
@@ -824,7 +816,7 @@ Hint: Restore the startup kit, remove the registration, or activate another kit.
 
 ```text
 Error: registered path for 'cancer_lead' is not a valid startup kit
-Hint: Run nvflare kit remove cancer_lead, or replace it with nvflare kit add cancer_lead <startup-kit-dir> --force.
+Hint: Run nvflare config kit remove cancer_lead, or replace it with nvflare config kit add cancer_lead <startup-kit-dir> --force.
 ```
 
 `kit use` must not change `startup_kits.active` until the selected ID resolves to a valid
@@ -840,12 +832,12 @@ registry override. If a target ID already exists:
 
 - If the existing path is under the current POC workspace, replace it.
 - If the existing path is outside the current POC workspace, fail and require an explicit
-  registry action such as `nvflare kit remove <id>` or
-  `nvflare kit add <id> <path> --force`.
+  registry action such as `nvflare config kit remove <id>` or
+  `nvflare config kit add <id> <path> --force`.
 
 ```text
 Error: startup kit id 'lead@nvidia.com' already points outside the POC workspace
-Hint: Run nvflare kit remove lead@nvidia.com, or replace it explicitly with nvflare kit add lead@nvidia.com <startup-kit-dir> --force.
+Hint: Run nvflare config kit remove lead@nvidia.com, or replace it explicitly with nvflare config kit add lead@nvidia.com <startup-kit-dir> --force.
 ```
 
 `poc add user` fails before creating or registering a new kit when the requested identity
@@ -872,9 +864,9 @@ Manual production registrations remain untouched.
 - Normal server-connected commands do not expose `--startup-target` or `--startup-kit`.
 - Commands resolve the startup kit through `NVFLARE_STARTUP_KIT_DIR` first, then
   `startup_kits.active`.
-- `nvflare kit` is the user-facing startup kit management interface.
-- `nvflare config` keeps non-startup-kit settings such as `poc.workspace` and job template
-  config, but it does not manage startup kit locations.
+- `nvflare config kit` is the user-facing startup kit management interface.
+- `nvflare config` manages local CLI configuration. The root command manages
+  `poc.workspace`; `nvflare config kit` manages startup kit locations.
 - `poc add user` registers generated user kits in `startup_kits.entries`.
 - `poc add site` registers generated site kits in `startup_kits.entries` and updates POC
   workspace metadata.
@@ -882,11 +874,11 @@ Manual production registrations remain untouched.
   POC flow.
 - `poc add site` is allowed while POC services are running and does not stop existing
   services.
-- For `nvflare kit add` and `nvflare poc add user`, `--force` replaces the config
+- For `nvflare config kit add` and `nvflare poc add user`, `--force` replaces the config
   registration for an existing ID without deleting old startup kit directories.
 - For `nvflare poc prepare`, `--force` means recreate the POC workspace; it does not
   override unrelated startup kit registrations outside `poc.workspace`.
-- Persona commands are not needed. The common switching command is `nvflare kit use <id>`.
+- Persona commands are not needed. The common switching command is `nvflare config kit use <id>`.
 
 
 ## Existing Command Reference
@@ -1048,10 +1040,10 @@ Exit code must be 0 on all checks pass, 1 on any failure.
 
 ### `nvflare config`
 
-Manages non-startup-kit settings in `~/.nvflare/config.conf`, such as `poc.workspace`,
-job template paths, and agent defaults. Startup kit locations are managed by `nvflare kit`
-and stored in `startup_kits.entries`; `nvflare config` should not expose or write
-`poc.startup_kit` or `prod.startup_kit`.
+Manages local CLI settings in `~/.nvflare/config.conf`. The root `nvflare config`
+command manages `poc.workspace`; startup kit locations are managed by
+`nvflare config kit` and stored in `startup_kits.entries`. `nvflare config` should
+not expose or write `poc.startup_kit` or `prod.startup_kit`.
 
 Persistence rules:
 
@@ -1081,11 +1073,6 @@ Admin startup kit directories and startup kit IDs are often email addresses such
 | Argument | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `--poc.workspace` | str | No | — | POC workspace path |
-| `-jt`, `--job_templates_dir` | str | No | — | Job templates path |
-| `--agent.poll_interval` | int | No | — | Job monitor poll interval |
-| `--agent.job_timeout` | int | No | — | Job monitor timeout |
-| `--claude.skills_dir` | str | No | — | Claude Code skill discovery path |
-| `--openclaw.skills_dir` | str | No | — | OpenClaw plugin discovery path |
 | `-debug`, `--debug` | flag | No | — | Debug mode |
 | `--describe` | flag | No | — | Print config file path, current contents, and format description |
 | `--schema` | flag | No | — | Print command schema and exit |
@@ -1109,14 +1096,14 @@ Retain with stderr warning. Underscore alias `authz_preview` accepted for backwa
 | `poc start` | Add | Add | Add | `server_url` in JSON data field when ready |
 | `poc stop` | Add | Add | Add | — |
 | `poc clean` | Add | Add | Add | Add `--force` to stop a running local POC system before cleanup |
-| `kit add/use/show/list/remove` | Add | Add | Add | Manage local startup kit registry; no server connection |
+| `config kit add/use/show/list/remove` | Add | Add | Add | Manage local startup kit registry; no server connection |
 | `job create` | — | — | — | Deprecated |
 | `job submit` | Add | Add | Add | Returns `job_id` immediately |
 | `job monitor` | Add | Add | Add | Standalone wait/poll |
 | `study register/show/list/remove/add-site/remove-site/add-user/remove-user` | Add | Add | Add | Manage multi-study lifecycle through active startup kit |
 | `provision` | Add | Add | Add | Restore pre-2.7.0 default; add `--force` |
 | `preflight-check` | Add | Add | Fix | 0=pass, 1=fail; alias `preflight_check` kept |
-| `config` | Add | Add | Add | Manage non-startup-kit config; startup kits are managed by `nvflare kit` |
+| `config` | Add | Add | Add | Manage POC workspace and nested startup kit registry commands |
 | `job list-templates` | — | — | — | Deprecated; alias `list_templates` kept |
 | `job show-variables` | — | — | — | Deprecated; alias `show_variables` kept |
 | `simulator` | — | — | — | Deprecated |
@@ -1300,14 +1287,14 @@ All server-connected commands (`nvflare job`, `nvflare study`, `nvflare system`,
 This resolution order applies uniformly. Command-level descriptions that say "same resolution order as `nvflare job`" refer to this list.
 
 Normal commands do not expose `--startup-target` or `--startup-kit`. Users switch local
-identity with `nvflare kit use <id>`. Automation can use `NVFLARE_STARTUP_KIT_DIR` when
+identity with `nvflare config kit use <id>`. Automation can use `NVFLARE_STARTUP_KIT_DIR` when
 mutating local config is undesirable.
 
 Resolution error examples:
 
 ```text
 Error: no active startup kit is configured
-Hint: Run nvflare kit use <id>.
+Hint: Run nvflare config kit use <id>.
 ```
 
 ```text
@@ -1319,7 +1306,7 @@ Hint: Unset NVFLARE_STARTUP_KIT_DIR, or set it to a valid admin startup kit dire
 ```text
 Error: active startup kit 'cancer_lead' points to a missing path
 Path: /secure/startup_kits/cancer/lead@nvidia.com
-Hint: Run nvflare kit use <id> or nvflare kit remove cancer_lead.
+Hint: Run nvflare config kit use <id> or nvflare config kit remove cancer_lead.
 ```
 
 ### Session Reuse
@@ -1367,7 +1354,7 @@ New methods are thin wrappers over `AdminAPI.do_command()`.
 | `nvflare/tool/network/__init__.py` | Package |
 | `nvflare/tool/network/network_cli.py` | All `nvflare network` handlers |
 | `nvflare/tool/kit/__init__.py` | Package |
-| `nvflare/tool/kit/kit_cli.py` | `nvflare kit` command handlers |
+| `nvflare/tool/kit/kit_cli.py` | `nvflare config kit` command handlers |
 | `nvflare/tool/kit/kit_config.py` | Startup kit registry config and metadata helpers |
 | `nvflare/tool/agent/__init__.py` | Package |
 | `nvflare/tool/agent/agent_cli.py` | `nvflare agent` subcommands |

--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -279,7 +279,7 @@ Code: LOG_NOT_FOUND (exit 1)
 
 Server-side behavior: `get_job_log <job_id> [server|all|client_name]` returns structured data from server-side stored artifacts. Server logs are read from the live server workspace when available, then from the saved job-store `workspace` component after the run workspace has been archived. Client logs are read from the server's live job workspace at `<job_id>/<client_name>/log.txt` when available, then from the saved job-store `workspace` component member `<client_name>/log.txt`. For compatibility with existing stored receiver outputs, the command can also fall back to client-data components such as `LOG_log.txt_<client_name>`. `tail_target_log` / `grep_target` are insufficient and are not used for this command.
 
-Session API: `Session.get_job_logs(job_id, target)` sends the structured server command and returns `logs` plus optional `unavailable`.
+Session API: `Session.get_job_logs(job_id, target, tail_lines=None, grep_pattern=None)` sends the structured server command and returns `logs` plus optional `unavailable`. `tail_lines` and `grep_pattern` are retained as deprecated compatibility arguments for existing Python callers; the CLI no longer exposes these options, and any filtering is applied locally by the session wrapper after retrieving the server-side stored logs.
 
 ### `nvflare job log-config`
 
@@ -1349,7 +1349,7 @@ Needs adding:
 - `list_jobs`
 - `get_job_meta`
 - `delete_job`
-- `get_job_logs(job_id, target)`
+- `get_job_logs(job_id, target, tail_lines=None, grep_pattern=None)`
 - `configure_job_log(job_id, config, target)`
 
 New methods are thin wrappers over `AdminAPI.do_command()`.

--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -133,7 +133,7 @@ The JSON output shape and error codes defined here become the MCP tool schemas i
 | Command | Subcommands | Agent Readiness Status |
 | --- | --- | --- |
 | `nvflare simulator` | — | Deprecated — retain with stderr warning; use Job Recipe SimEnv directly (`python job.py`) |
-| `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass and to `clean` for stop-before-cleanup; register generated user and site kits in the shared startup kit registry |
+| `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass and to `clean` for stop-before-cleanup; register generated user/admin kits in the shared startup kit registry |
 | `nvflare config kit` | `add`, `use`, `show`, `list`, `remove` | New local startup kit registry; no server connection |
 | `nvflare study` | `register`, `show`, `list`, `remove`, `add-site`, `remove-site`, `add-user`, `remove-user` | Add multi-study lifecycle CLI using the active startup kit |
 | `nvflare provision` | — | Add JSON output, `--schema`, `--force` for Y/N prompts; restore pre-2.7.0 default: no args = generate `project.yml` |
@@ -448,7 +448,6 @@ startup_kits {
     "admin@nvidia.com" = "/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com"
     "lead@nvidia.com" = "/tmp/nvflare/poc/example_project/prod_00/lead@nvidia.com"
     "org-admin@nvidia.com" = "/tmp/nvflare/poc/example_project/prod_00/org-admin@nvidia.com"
-    "site-1" = "/tmp/nvflare/poc/example_project/prod_00/site-1"
     cancer_lead = "/secure/startup_kits/cancer/lead@nvidia.com"
     fraud_org_admin = "/secure/startup_kits/fraud/org_admin@nvidia.com"
   }
@@ -462,9 +461,9 @@ poc {
 
 The registry key is a local ID. It is not a server-side object, not a certificate role,
 and not a study role. For POC-generated user startup kits, the default ID is the user
-identity, such as `admin@nvidia.com` or `lead@nvidia.com`. For POC-generated site
-startup kits, the default ID is the site name, such as `site-1`. For production kits,
-users choose meaningful local IDs such as `cancer_lead`.
+identity, such as `admin@nvidia.com` or `lead@nvidia.com`. Site startup kits are service
+identities and are not registered in this CLI identity registry. For production kits, users
+choose meaningful local IDs such as `cancer_lead`.
 
 The entry value is only the startup kit path. Metadata such as identity and certificate
 role is inspected from the startup kit when needed by commands such as `nvflare config kit show`;
@@ -487,12 +486,13 @@ Registers a startup kit location under a local ID.
 Behavior:
 
 1. Read `~/.nvflare/config.conf`.
-2. Validate that `<path>` is a valid participant startup kit directory. A valid admin/user
+2. Validate that `<path>` is a valid admin/user startup kit directory. A valid admin/user
    startup kit must contain all three of:
    - `startup/fed_admin.json`
    - `startup/client.crt`
    - `startup/rootCA.pem`
-   A valid site startup kit must contain `startup/fed_client.json`.
+   Site startup kits are not accepted because they cannot be used for server-connected
+   admin CLI sessions.
 3. Fail if `<id>` already exists unless `--force` is provided.
 4. Create or replace `startup_kits.entries.<id> = "<path>"`.
 5. Do not change `startup_kits.active`. Registration and activation are separate.
@@ -552,14 +552,12 @@ stale entries without contacting the server:
 
 ```text
 * cancer_lead       ok       lead@nvidia.com        lead          /secure/startup_kits/cancer/lead@nvidia.com
-  site-1            ok       site-1                 -             /tmp/nvflare/poc/example_project/prod_00/site-1
   fraud_org_admin   missing  -                      -             /secure/startup_kits/fraud/org_admin@nvidia.com
   old_lab_admin     invalid  -                      -             /archive/old_lab/admin@nvidia.com
 ```
 
 The active startup kit is marked with `*`. Missing or invalid paths are shown as
-`missing` or `invalid`. Site kits can be registered and listed, but they cannot be
-activated for server-connected admin commands.
+`missing` or `invalid`. Valid site kits are not shown because they are not CLI identities.
 
 #### `nvflare config kit remove <id>`
 
@@ -589,22 +587,21 @@ variable is an automation override, not the primary user workflow.
 ### POC Integration
 
 `poc prepare` continues to create the default POC workspace and provision the POC project.
-It also registers generated admin/user and site startup kits in the shared registry.
+It also registers generated admin/user startup kits in the shared registry.
 
 Behavior:
 
 1. Provision the POC project as today.
-2. Find generated admin/user and site startup kits in the POC prod directory, normally
+2. Find generated admin/user startup kits in the POC prod directory, normally
    `prod_00` after the first `poc prepare`.
-3. Keep generated site startup kits in the POC workspace for local service management and
-   register their local paths for discovery and cleanup.
+3. Keep generated site startup kits in the POC workspace for local service management, but
+   do not register them as CLI identities.
 4. Read participant identity, org, type, and role from the POC project metadata.
 5. Register the Project Admin kit by identity, such as `admin@nvidia.com`.
 6. Register each additional admin/user kit by identity, such as `lead@nvidia.com`.
-7. Register each site kit by site name, such as `site-1`; site kits are never made active.
-8. Set `startup_kits.active` to the identity of the first `project_admin` participant
+7. Set `startup_kits.active` to the identity of the first `project_admin` participant
    found in the project metadata.
-9. If no `project_admin` participant exists, do not set `startup_kits.active`; print a
+8. If no `project_admin` participant exists, do not set `startup_kits.active`; print a
    hint to create or register an admin startup kit before running admin CLI commands.
 
 `poc prepare --force` keeps its existing meaning: recreate the local POC workspace and
@@ -629,7 +626,6 @@ startup_kits.active                         -> admin@nvidia.com
 startup_kits.entries."admin@nvidia.com"     -> .../prod_00/admin@nvidia.com
 startup_kits.entries."org-admin@nvidia.com" -> .../prod_00/org-admin@nvidia.com
 startup_kits.entries."lead@nvidia.com"      -> .../prod_00/lead@nvidia.com
-startup_kits.entries."site-1"               -> .../prod_00/site-1
 ```
 
 #### `nvflare poc add user <cert-role> <email> --org <org>`
@@ -694,8 +690,9 @@ remains the same and now points to the new path.
 
 #### `nvflare poc add site <name> --org <org>`
 
-Creates a new local POC site startup kit and records it in the POC workspace and startup
-kit registry.
+Creates a new local POC site startup kit and records it in the POC workspace. Site kits
+are not registered in the startup kit registry because they are service identities, not
+interactive CLI user identities.
 
 Behavior:
 
@@ -713,10 +710,9 @@ Behavior:
 7. Invoke the existing POC provisioning/build pipeline with the updated project YAML, the
    same as a full-project provision. The existing provision state is reused, so the root CA
    is not changed, and generated startup kits from the new `prod_NN` output are used.
-8. Register the generated site kit under startup kit ID `<name>`.
-9. Update the POC service config so commands such as `nvflare poc start -p site-3` know the
+8. Update the POC service config so commands such as `nvflare poc start -p site-3` know the
    new site exists.
-10. Print the generated startup kit path and start instructions.
+9. Print the generated startup kit path and start instructions.
 
 `poc add site` does not take a separate workspace argument. It is scoped to the active
 local POC workspace. Adding a site does not switch the active startup kit because site
@@ -859,7 +855,7 @@ Manual production registrations remain untouched.
 ### Startup Kit Behavior Guarantees
 
 - `poc prepare` activates the default POC Project Admin startup kit automatically.
-- `poc prepare` writes POC admin/user and site startup kits into `startup_kits.entries`.
+- `poc prepare` writes POC admin/user startup kits into `startup_kits.entries`.
 - `poc.startup_kit` and `prod.startup_kit` are not read or written.
 - Normal server-connected commands do not expose `--startup-target` or `--startup-kit`.
 - Commands resolve the startup kit through `NVFLARE_STARTUP_KIT_DIR` first, then
@@ -868,8 +864,8 @@ Manual production registrations remain untouched.
 - `nvflare config` manages local CLI configuration. The root command manages
   `poc.workspace`; `nvflare config kit` manages startup kit locations.
 - `poc add user` registers generated user kits in `startup_kits.entries`.
-- `poc add site` registers generated site kits in `startup_kits.entries` and updates POC
-  workspace metadata.
+- `poc add site` generates site kits and updates POC workspace metadata, but it does not
+  register site kits in `startup_kits.entries`.
 - `poc add user` and `poc add site` do not switch away from the active kit in the normal
   POC flow.
 - `poc add site` is allowed while POC services are running and does not stop existing
@@ -900,7 +896,7 @@ All commands need `--schema` and always emit a JSON envelope unless marked other
 | `--schema` | flag | No | — | Print command schema and exit |
 
 On success, auto-invoke `install_skills()`; exit 0 on failure because skills are optional.
-It also registers generated admin/user and site startup kits in `startup_kits.entries` and
+It also registers generated admin/user startup kits in `startup_kits.entries` and
 activates the first Project Admin kit.
 
 #### `nvflare poc start`
@@ -949,8 +945,7 @@ nvflare poc add site <name> --org <org> [--force] [--schema]
 ```
 
 Creates or refreshes a local POC client participant from the default POC project YAML,
-generates the site startup kit through the existing POC provisioning pipeline, registers
-the site kit under startup kit ID `<name>`, and updates POC service metadata so
+generates the site startup kit through the existing POC provisioning pipeline, and updates POC service metadata so
 `nvflare poc start -p <name>` can manage the new site.
 
 ### `nvflare job`
@@ -1092,7 +1087,7 @@ Retain with stderr warning. Underscore alias `authz_preview` accepted for backwa
 | --- | --- | --- | --- | --- |
 | `poc prepare` | Add | Add | Add | Add `--force`; auto-invoke `install_skills()` on success |
 | `poc add user` | Add | Add | Add | Add POC user startup kit and register it in `startup_kits.entries` |
-| `poc add site` | Add | Add | Add | Add POC site startup kit, register it in `startup_kits.entries`, and update POC service metadata |
+| `poc add site` | Add | Add | Add | Add POC site startup kit and update POC service metadata; site kits are not CLI identities |
 | `poc start` | Add | Add | Add | `server_url` in JSON data field when ready |
 | `poc stop` | Add | Add | Add | — |
 | `poc clean` | Add | Add | Add | Add `--force` to stop a running local POC system before cleanup |

--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -134,11 +134,11 @@ The JSON output shape and error codes defined here become the MCP tool schemas i
 | --- | --- | --- |
 | `nvflare simulator` | — | Deprecated — retain with stderr warning; use Job Recipe SimEnv directly (`python job.py`) |
 | `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass and to `clean` for stop-before-cleanup; register generated user/admin kits in the shared startup kit registry |
-| `nvflare config kit` | `add`, `use`, `show`, `list`, `remove` | New local startup kit registry; no server connection |
+| `nvflare config kit` | `add`, `use`, `show`, `list`, `remove` | User-facing startup kit registry commands; no server connection |
 | `nvflare study` | `register`, `show`, `list`, `remove`, `add-site`, `remove-site`, `add-user`, `remove-user` | Add multi-study lifecycle CLI using the active startup kit |
 | `nvflare provision` | — | Add JSON output, `--schema`, `--force` for Y/N prompts; restore pre-2.7.0 default: no args = generate `project.yml` |
 | `nvflare preflight-check` | — | Add JSON output, `--schema`; exit 0=pass, 1=fail. Underscore alias `preflight_check` accepted for backward compatibility. |
-| `nvflare config` | — | Add JSON output, `--schema` |
+| `nvflare config` | `kit` | Parent command namespace for local CLI settings. The user-facing workflow in this design is `nvflare config kit`. |
 | `nvflare dashboard` | — | No changes; excluded from this plan |
 | `nvflare authz-preview` | — | Deprecated — retain with stderr warning. Underscore alias `authz_preview` accepted for backward compatibility. |
 
@@ -434,9 +434,11 @@ nvflare config kit show
 
 Activation is local config mutation only. It does not contact the server.
 
-### Config Model
+### Startup Kit Registry Storage
 
-`~/.nvflare/config.conf` stores a startup kit ID-to-path registry plus one active ID:
+`~/.nvflare/config.conf` is the local storage file for the startup kit registry. The
+user-facing command is `nvflare config kit`; the stored `startup_kits` data is an
+implementation detail, not a separate customer-facing concept.
 
 ```hocon
 version = 2
@@ -452,11 +454,6 @@ startup_kits {
     fraud_org_admin = "/secure/startup_kits/fraud/org_admin@nvidia.com"
   }
 }
-
-poc {
-  workspace = "/tmp/nvflare/poc"
-}
-
 ```
 
 The registry key is a local ID. It is not a server-side object, not a certificate role,
@@ -470,8 +467,8 @@ role is inspected from the startup kit when needed by commands such as `nvflare 
 it is not duplicated in `config.conf`. Fields that are not reliably derivable from the
 startup kit are omitted from normal output.
 
-`poc.workspace` is retained because POC service management needs a workspace root. POC
-startup kit locations are not duplicated under `poc`.
+Other CLI state may also be stored in `~/.nvflare/config.conf`, but it is outside the
+startup kit registry and should not be part of the normal user workflow.
 
 ### `nvflare config kit`
 
@@ -647,20 +644,26 @@ Behavior:
 4. If the identity does not exist, append one admin participant with the requested
    identity, organization, and certificate role. With `--force`, update an existing
    participant entry in place instead of appending a duplicate.
-5. Persist the updated project YAML on disk before provisioning.
-6. Invoke the existing POC provisioning/build pipeline with the updated project YAML, the
-   same as a full-project provision. This is the local POC form of dynamic provisioning:
-   the existing provision state is reused, so the root CA is not changed, and generated
-   startup kits from the new `prod_NN` output are used.
-7. Register the generated admin/user kit under startup kit ID `<email>`.
-8. If there is no active startup kit, make the new kit active.
-9. In the normal POC flow, leave the current active kit unchanged and print the activation
+5. Locate the current POC output directory, normally `prod_00`, and the existing POC CA
+   state/rootCA created by `poc prepare`.
+6. Build a reduced dynamic provisioning project from the persisted POC project metadata.
+   The reduced project contains the existing server and only the new admin participant.
+   Existing clients, admins, and their startup kits are not regenerated.
+7. Run the existing POC provisioning/build pipeline on that reduced project, using the
+   existing CA state so the root CA is unchanged.
+8. Move only the new participant startup kit into the current POC output directory and
+   remove the temporary provisioning output. Existing participant directories in `prod_00`
+   must remain untouched.
+9. Persist the updated project YAML on disk.
+10. Register the generated admin/user kit under startup kit ID `<email>`.
+11. If there is no active startup kit, make the new kit active.
+12. In the normal POC flow, leave the current active kit unchanged and print the activation
    command.
 
 Example output when an active kit already exists:
 
 ```text
-startup_kit: /tmp/nvflare/poc/example_project/prod_01/bob@nvidia.com
+startup_kit: /tmp/nvflare/poc/example_project/prod_00/bob@nvidia.com
 id: bob@nvidia.com
 identity: bob@nvidia.com
 cert_role: lead
@@ -670,7 +673,7 @@ next_step: nvflare config kit use bob@nvidia.com
 Example output when no active kit exists:
 
 ```text
-startup_kit: /tmp/nvflare/poc/example_project/prod_01/bob@nvidia.com
+startup_kit: /tmp/nvflare/poc/example_project/prod_00/bob@nvidia.com
 id: bob@nvidia.com
 identity: bob@nvidia.com
 cert_role: lead
@@ -678,10 +681,9 @@ active: bob@nvidia.com
 ```
 
 After the first `poc prepare`, the initial output is normally `prod_00`. A later
-`poc add user` runs the provisioning pipeline again and normally creates the next output
-directory, such as `prod_01`. Existing participant certificates are loaded from the POC
-provision state and reused. The CLI should point registrations at the latest generated
-startup kits.
+`poc add user` is dynamic provisioning: it uses a temporary reduced build to generate only
+the new user kit, then places that kit under the existing `prod_00`. The command must not
+replace existing participant startup kits or repoint their registry entries.
 
 If the user identity already exists, the command fails unless `--force` is provided. With
 `--force`, update the existing project metadata entry in place, create a new startup kit,
@@ -706,13 +708,20 @@ Behavior:
 5. If the site does not exist, append one client participant with the requested site name
    and organization. With `--force`, update an existing site participant entry in place
    instead of appending a duplicate.
-6. Persist the updated project YAML on disk before provisioning.
-7. Invoke the existing POC provisioning/build pipeline with the updated project YAML, the
-   same as a full-project provision. The existing provision state is reused, so the root CA
-   is not changed, and generated startup kits from the new `prod_NN` output are used.
-8. Update the POC service config so commands such as `nvflare poc start -p site-3` know the
+6. Locate the current POC output directory, normally `prod_00`, and the existing POC CA
+   state/rootCA created by `poc prepare`.
+7. Build a reduced dynamic provisioning project from the persisted POC project metadata.
+   The reduced project contains the existing server and only the new client participant.
+   Existing participants are not regenerated.
+8. Run the existing POC provisioning/build pipeline on that reduced project, using the
+   existing CA state so the root CA is unchanged.
+9. Move only the new site startup kit into the current POC output directory and remove the
+   temporary provisioning output. Existing participant directories in `prod_00` must remain
+   untouched.
+10. Persist the updated project YAML on disk.
+11. Update the POC service config so commands such as `nvflare poc start -p site-3` know the
    new site exists.
-9. Print the generated startup kit path and start instructions.
+12. Print the generated startup kit path and start instructions.
 
 `poc add site` does not take a separate workspace argument. It is scoped to the active
 local POC workspace. Adding a site does not switch the active startup kit because site
@@ -733,7 +742,7 @@ Behavior:
 2. Remove the POC workspace.
 3. Remove startup kit entries whose canonical paths are under the canonical POC workspace
    path.
-4. Remove the `poc.workspace` key from `~/.nvflare/config.conf`.
+4. Remove local POC workspace state from `~/.nvflare/config.conf`.
 5. If the active startup kit was removed, clear `startup_kits.active`.
 6. Leave manually registered production startup kits untouched.
 
@@ -849,20 +858,19 @@ Both `poc add user` and `poc add site` require the active startup kit to have th
 must fail before project metadata is changed.
 
 `poc clean` removes only startup kit entries whose canonical paths are under the canonical
-`poc.workspace` path. If the active startup kit is removed, clear `startup_kits.active`.
+POC workspace path. If the active startup kit is removed, clear `startup_kits.active`.
 Manual production registrations remain untouched.
 
 ### Startup Kit Behavior Guarantees
 
 - `poc prepare` activates the default POC Project Admin startup kit automatically.
 - `poc prepare` writes POC admin/user startup kits into `startup_kits.entries`.
-- `poc.startup_kit` and `prod.startup_kit` are not read or written.
 - Normal server-connected commands do not expose `--startup-target` or `--startup-kit`.
 - Commands resolve the startup kit through `NVFLARE_STARTUP_KIT_DIR` first, then
   `startup_kits.active`.
 - `nvflare config kit` is the user-facing startup kit management interface.
-- `nvflare config` manages local CLI configuration. The root command manages
-  `poc.workspace`; `nvflare config kit` manages startup kit locations.
+- `nvflare config` is the parent command namespace; the normal user workflow in this
+  design is `nvflare config kit`.
 - `poc add user` registers generated user kits in `startup_kits.entries`.
 - `poc add site` generates site kits and updates POC workspace metadata, but it does not
   register site kits in `startup_kits.entries`.
@@ -873,7 +881,7 @@ Manual production registrations remain untouched.
 - For `nvflare config kit add` and `nvflare poc add user`, `--force` replaces the config
   registration for an existing ID without deleting old startup kit directories.
 - For `nvflare poc prepare`, `--force` means recreate the POC workspace; it does not
-  override unrelated startup kit registrations outside `poc.workspace`.
+  override unrelated startup kit registrations outside the POC workspace.
 - Persona commands are not needed. The common switching command is `nvflare config kit use <id>`.
 
 
@@ -935,8 +943,8 @@ nvflare poc add user <cert-role> <email> --org <org> [--force] [--schema]
 ```
 
 Creates or refreshes a local POC admin/user participant from the default POC project YAML,
-generates the corresponding startup kit through the existing POC provisioning pipeline,
-and registers that user kit under startup kit ID `<email>`.
+dynamically generates only that participant's startup kit with the existing POC CA, and
+registers that user kit under startup kit ID `<email>`.
 
 #### `nvflare poc add site`
 
@@ -945,8 +953,8 @@ nvflare poc add site <name> --org <org> [--force] [--schema]
 ```
 
 Creates or refreshes a local POC client participant from the default POC project YAML,
-generates the site startup kit through the existing POC provisioning pipeline, and updates POC service metadata so
-`nvflare poc start -p <name>` can manage the new site.
+dynamically generates only that participant's startup kit with the existing POC CA, and
+updates POC service metadata so `nvflare poc start -p <name>` can manage the new site.
 
 ### `nvflare job`
 
@@ -1035,18 +1043,16 @@ Exit code must be 0 on all checks pass, 1 on any failure.
 
 ### `nvflare config`
 
-Manages local CLI settings in `~/.nvflare/config.conf`. The root `nvflare config`
-command manages `poc.workspace`; startup kit locations are managed by
-`nvflare config kit` and stored in `startup_kits.entries`. `nvflare config` should
-not expose or write `poc.startup_kit` or `prod.startup_kit`.
+`nvflare config` is the parent command namespace for local CLI settings. The startup kit
+workflow is exposed through `nvflare config kit`; users should not need to edit or reason
+about the underlying storage layout.
 
 Persistence rules:
 
 1. `version = 2` is always the first line in the saved config.
 2. Once a config is loaded and re-saved by the CLI, it is normalized to the v2 layout in
-   §Config Model.
+   §Startup Kit Registry Storage.
 3. Startup kit entries are preserved when unrelated config fields are updated.
-4. `poc.workspace` is preserved unless `nvflare poc clean` removes the POC workspace.
 
 ### Admin username and `@` in directory names
 
@@ -1065,12 +1071,9 @@ Admin startup kit directories and startup kit IDs are often email addresses such
 
 ---
 
-| Argument | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| `--poc.workspace` | str | No | — | POC workspace path |
-| `-debug`, `--debug` | flag | No | — | Debug mode |
-| `--describe` | flag | No | — | Print config file path, current contents, and format description |
-| `--schema` | flag | No | — | Print command schema and exit |
+The root `nvflare config` command is a parent namespace in this design. The documented
+user-facing workflow is `nvflare config kit`; other local config storage is implementation
+state and should not be part of normal user workflows.
 
 ### `nvflare dashboard` — deprecated (under review)
 
@@ -1098,7 +1101,7 @@ Retain with stderr warning. Underscore alias `authz_preview` accepted for backwa
 | `study register/show/list/remove/add-site/remove-site/add-user/remove-user` | Add | Add | Add | Manage multi-study lifecycle through active startup kit |
 | `provision` | Add | Add | Add | Restore pre-2.7.0 default; add `--force` |
 | `preflight-check` | Add | Add | Fix | 0=pass, 1=fail; alias `preflight_check` kept |
-| `config` | Add | Add | Add | Manage POC workspace and nested startup kit registry commands |
+| `config` | Add | Add | Add | Parent namespace for `config kit`; no normal server connection |
 | `job list-templates` | — | — | — | Deprecated; alias `list_templates` kept |
 | `job show-variables` | — | — | — | Deprecated; alias `show_variables` kept |
 | `simulator` | — | — | — | Deprecated |

--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -133,7 +133,7 @@ The JSON output shape and error codes defined here become the MCP tool schemas i
 | Command | Subcommands | Agent Readiness Status |
 | --- | --- | --- |
 | `nvflare simulator` | — | Deprecated — retain with stderr warning; use Job Recipe SimEnv directly (`python job.py`) |
-| `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass; register generated user and site kits in the shared startup kit registry |
+| `nvflare poc` | `prepare`, `start`, `stop`, `clean`, `add user`, `add site` | Add JSON output, exit codes, `--schema`; add `--force` to `prepare` for workspace deletion prompt bypass and to `clean` for stop-before-cleanup; register generated user and site kits in the shared startup kit registry |
 | `nvflare kit` | `add`, `use`, `show`, `list`, `remove` | New local startup kit registry; no server connection |
 | `nvflare study` | `register`, `show`, `list`, `remove`, `add-site`, `remove-site`, `add-user`, `remove-user` | Add multi-study lifecycle CLI using the active startup kit |
 | `nvflare provision` | — | Add JSON output, `--schema`, `--force` for Y/N prompts; restore pre-2.7.0 default: no args = generate `project.yml` |
@@ -740,7 +740,8 @@ restarted.
 
 Behavior:
 
-1. Stop if the POC system is still running, as today.
+1. If the POC system is still running, fail unless `--force` is provided. With `--force`,
+   stop the local POC system before cleanup.
 2. Remove the POC workspace.
 3. Remove startup kit entries whose canonical paths are under the canonical POC workspace
    path.
@@ -936,6 +937,7 @@ Must emit `server_url` in the JSON data field when server accepts connections.
 | Argument | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `-debug`, `--debug` | flag | No | — | Debug mode |
+| `--force` | flag | No | — | Stop a running POC system before cleanup |
 | `--schema` | flag | No | — | Print command schema and exit |
 
 #### `nvflare poc add user`
@@ -1106,7 +1108,7 @@ Retain with stderr warning. Underscore alias `authz_preview` accepted for backwa
 | `poc add site` | Add | Add | Add | Add POC site startup kit, register it in `startup_kits.entries`, and update POC service metadata |
 | `poc start` | Add | Add | Add | `server_url` in JSON data field when ready |
 | `poc stop` | Add | Add | Add | — |
-| `poc clean` | Add | Add | Add | — |
+| `poc clean` | Add | Add | Add | Add `--force` to stop a running local POC system before cleanup |
 | `kit add/use/show/list/remove` | Add | Add | Add | Manage local startup kit registry; no server connection |
 | `job create` | — | — | — | Deprecated |
 | `job submit` | Add | Add | Add | Returns `job_id` immediately |

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -46,19 +46,19 @@ the general system admin API.
 CLI Startup Kit Resolution Change
 ---------------------------------
 
-On the current ``main`` branch, the ``NVFLARE_STARTUP_KIT_DIR`` environment
-variable now takes precedence over the persisted CLI config when resolving the
-startup kit for server-connected CLI commands.
+On the current ``main`` branch, server-connected CLI commands use a shared
+active startup kit registry in ``~/.nvflare/config.conf``.
 
 Impact:
 
-- If both ``NVFLARE_STARTUP_KIT_DIR`` and the CLI config specify startup kit
-  paths, the environment variable wins.
-- Shell profiles that export ``NVFLARE_STARTUP_KIT_DIR`` may override
-  ``poc.startup_kit`` or ``prod.startup_kit`` from ``~/.nvflare/config.conf``.
+- Use ``nvflare kit add <id> <startup-kit-dir>`` and ``nvflare kit use <id>``
+  to register and activate a startup kit.
+- ``NVFLARE_STARTUP_KIT_DIR`` remains an automation override and takes
+  precedence over the active registry entry when set.
+- ``nvflare config`` no longer manages startup kit paths.
 
-If you rely on the persisted CLI config, review your shell environment before
-upgrading to the next release built from ``main``.
+If you use shell profiles or CI settings that export ``NVFLARE_STARTUP_KIT_DIR``,
+review them before upgrading because they override the active registry entry.
 
 CLI Config Flag Clarification
 -----------------------------

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -51,11 +51,13 @@ active startup kit registry in ``~/.nvflare/config.conf``.
 
 Impact:
 
-- Use ``nvflare kit add <id> <startup-kit-dir>`` and ``nvflare kit use <id>``
-  to register and activate a startup kit.
+- Use ``nvflare config kit add <id> <startup-kit-dir>`` and
+  ``nvflare config kit use <id>`` to register and activate a startup kit.
 - ``NVFLARE_STARTUP_KIT_DIR`` remains an automation override and takes
   precedence over the active registry entry when set.
-- ``nvflare config`` no longer manages startup kit paths.
+- Root ``nvflare config`` continues to manage local settings such as the POC
+  workspace. Startup kit paths are managed by the ``nvflare config kit``
+  subcommands.
 
 If you use shell profiles or CI settings that export ``NVFLARE_STARTUP_KIT_DIR``,
 review them before upgrading because they override the active registry entry.

--- a/docs/user_guide/nvflare_cli/config_command.rst
+++ b/docs/user_guide/nvflare_cli/config_command.rst
@@ -13,10 +13,7 @@ Command Usage
 
 .. code-block:: none
 
-   usage: nvflare config [-h] [-d [STARTUP_KIT_DIR]]
-                         [--poc.startup_kit [POC_STARTUP_KIT_DIR]]
-                         [--prod.startup_kit [PROD_STARTUP_KIT_DIR]]
-                         [--poc.workspace [POC_WORKSPACE_DIR]]
+   usage: nvflare config [-h] [--poc.workspace [POC_WORKSPACE_DIR]]
                          [-jt [JOB_TEMPLATES_DIR]]
                          [--job_templates_dir [JOB_TEMPLATES_DIR]] [-debug] [--schema]
 
@@ -24,18 +21,12 @@ Command Usage
 Common Examples
 *****************
 
-Set the default POC admin startup kit directory used by ``nvflare job`` and
-``nvflare system``:
+Startup kit paths are managed by :ref:`kit_command`, not ``nvflare config``:
 
 .. code-block:: shell
 
-   nvflare config --poc.startup_kit /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com
-
-Set the production admin startup kit directory:
-
-.. code-block:: shell
-
-   nvflare config --prod.startup_kit /path/to/prod/admin_startup_kit
+   nvflare kit add project_admin /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com
+   nvflare kit use project_admin
 
 Set the default POC workspace:
 
@@ -57,10 +48,9 @@ Set the job template directory for deprecated ``nvflare job list_templates``:
 Configuration notes:
 
 - The saved config format is normalized to v2 with ``version = 2`` as the first line.
-- ``poc.startup_kit`` and ``prod.startup_kit`` should point to admin startup kit
-  directories such as ``.../admin@nvidia.com``.
-- The legacy compatibility alias ``--startup_kit_dir`` updates ``poc.startup_kit``
-  only. It does not set ``prod.startup_kit``. Note: this flag is hidden from
-  ``--help`` because it is a legacy compatibility alias.
+- ``startup_kits.active`` and ``startup_kits.entries`` are managed by ``nvflare kit``.
+- ``poc.startup_kit`` and ``prod.startup_kit`` are not read or written.
 - The legacy compatibility alias ``-pw`` is still accepted for ``--poc.workspace``,
   but it is hidden from help and docs.
+
+For startup kit registration and switching, see :ref:`kit_command`.

--- a/docs/user_guide/nvflare_cli/config_command.rst
+++ b/docs/user_guide/nvflare_cli/config_command.rst
@@ -4,9 +4,10 @@
 Config Command
 #########################
 
-Use ``nvflare config`` to manage local CLI settings stored in
-``~/.nvflare/config.conf``. The root command manages the POC workspace, and
-``nvflare config kit`` manages startup kit registration and activation.
+Use ``nvflare config kit`` to manage local startup kit registration and
+activation. ``nvflare config`` is the parent command namespace for local CLI
+settings; normal users should not need to edit or reason about the underlying
+``~/.nvflare/config.conf`` storage layout.
 
 ***********************
 Command Usage
@@ -14,18 +15,11 @@ Command Usage
 
 .. code-block:: none
 
-   usage: nvflare config [-h] [--poc.workspace [POC_WORKSPACE_DIR]]
-                         [-debug] [--schema] {kit} ...
+   usage: nvflare config [-h] [--schema] {kit} ...
 
 *****************
 Common Examples
 *****************
-
-Set the default POC workspace:
-
-.. code-block:: shell
-
-   nvflare config --poc.workspace /tmp/nvflare/poc
 
 Register and activate a startup kit:
 
@@ -38,7 +32,5 @@ Configuration notes:
 
 - The saved config format is normalized to v2 with ``version = 2`` as the first line.
 - ``startup_kits.active`` and ``startup_kits.entries`` are managed by ``nvflare config kit``.
-- ``poc.startup_kit`` and ``prod.startup_kit`` are not read or written.
-- The compatibility alias ``-pw`` is still accepted for ``--poc.workspace``.
 
 For startup kit registration and switching details, see :ref:`kit_command`.

--- a/docs/user_guide/nvflare_cli/config_command.rst
+++ b/docs/user_guide/nvflare_cli/config_command.rst
@@ -5,7 +5,8 @@ Config Command
 #########################
 
 Use ``nvflare config`` to manage local CLI settings stored in
-``~/.nvflare/config.conf``.
+``~/.nvflare/config.conf``. The root command manages the POC workspace, and
+``nvflare config kit`` manages startup kit registration and activation.
 
 ***********************
 Command Usage
@@ -14,19 +15,11 @@ Command Usage
 .. code-block:: none
 
    usage: nvflare config [-h] [--poc.workspace [POC_WORKSPACE_DIR]]
-                         [-jt [JOB_TEMPLATES_DIR]]
-                         [--job_templates_dir [JOB_TEMPLATES_DIR]] [-debug] [--schema]
+                         [-debug] [--schema] {kit} ...
 
 *****************
 Common Examples
 *****************
-
-Startup kit paths are managed by :ref:`kit_command`, not ``nvflare config``:
-
-.. code-block:: shell
-
-   nvflare kit add project_admin /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com
-   nvflare kit use project_admin
 
 Set the default POC workspace:
 
@@ -34,23 +27,18 @@ Set the default POC workspace:
 
    nvflare config --poc.workspace /tmp/nvflare/poc
 
-Set the job template directory for deprecated ``nvflare job list_templates``:
+Register and activate a startup kit:
 
 .. code-block:: shell
 
-   nvflare config --job_templates_dir /path/to/job_templates
-
-.. note::
-
-   Most new job creation workflows use exported job folders or ``nvflare recipe``
-   instead of the legacy template commands.
+   nvflare config kit add project_admin /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com
+   nvflare config kit use project_admin
 
 Configuration notes:
 
 - The saved config format is normalized to v2 with ``version = 2`` as the first line.
-- ``startup_kits.active`` and ``startup_kits.entries`` are managed by ``nvflare kit``.
+- ``startup_kits.active`` and ``startup_kits.entries`` are managed by ``nvflare config kit``.
 - ``poc.startup_kit`` and ``prod.startup_kit`` are not read or written.
-- The legacy compatibility alias ``-pw`` is still accepted for ``--poc.workspace``,
-  but it is hidden from help and docs.
+- The compatibility alias ``-pw`` is still accepted for ``--poc.workspace``.
 
-For startup kit registration and switching, see :ref:`kit_command`.
+For startup kit registration and switching details, see :ref:`kit_command`.

--- a/docs/user_guide/nvflare_cli/job_cli.rst
+++ b/docs/user_guide/nvflare_cli/job_cli.rst
@@ -5,11 +5,15 @@ NVIDIA FLARE Job CLI
 #########################
 
 The ``nvflare job`` command family is used to submit, inspect, monitor, and
-manage federated learning jobs from a configured admin startup kit.
+manage federated learning jobs from the active local admin startup kit.
 
-Before using these commands, configure the startup kit location with
-``nvflare config --poc.startup_kit <path>`` or prepare a local POC workspace
-with ``nvflare poc prepare``.
+Before using server-connected job commands, either run ``nvflare poc prepare``
+or activate a registered startup kit with :ref:`kit_command`:
+
+.. code-block:: shell
+
+   nvflare kit add project_admin /path/to/admin@nvidia.com
+   nvflare kit use project_admin
 
 ***********************
 Command Usage
@@ -27,7 +31,7 @@ Command Usage
      list            list jobs on the server
      abort           abort a running job
      meta            get metadata for a job
-     logs            retrieve job logs from server workspace
+     logs            retrieve job logs from the server-side log store
      log-config      change logging configuration for a running job
      stats           show running job statistics
      download        download job result
@@ -47,15 +51,6 @@ Common Workflow
 4. Inspect metadata, stats, or logs as needed.
 5. Download, clone, abort, or delete the job when appropriate.
 
-.. note::
-
-   ``--startup-target`` and ``--startup-kit`` are accepted by all
-   server-connected ``nvflare job`` commands, including ``submit``,
-   ``monitor``, ``list``, ``meta``, ``abort``, ``clone``, ``download``,
-   ``delete``, ``stats``, ``logs``, and ``log-config``. They are mutually
-   exclusive explicit selectors; startup kit resolution also supports
-   ``NVFLARE_STARTUP_KIT_DIR`` and config fallback as described below.
-
 ****************
 Submit a Job
 ****************
@@ -69,8 +64,6 @@ Use ``nvflare job submit`` to submit a pre-built NVFlare job folder:
 Submit options:
 
 - ``-j, --job_folder``: job folder path. Defaults to ``./current_job``.
-- ``--startup-target {poc,prod}``: choose the configured startup target from ``~/.nvflare/config.conf``. Mutually exclusive with ``--startup-kit``. See the startup kit resolution order below.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--study``: submit into a named study when the server is configured for multi-study access. If omitted, the literal study name ``default`` is submitted.
 - ``-debug, --debug``: keep the temporary copied job folder for inspection.
 - ``--schema``: print the command schema as JSON and exit.
@@ -81,26 +74,21 @@ job status.
 To change job configuration values, edit the exported job files before
 submission. Submit-time ``-f/--config_file`` overrides are not supported.
 
-Startup kit resolution order:
+Startup kit resolution order for server-connected job commands:
 
-1. ``--startup-kit``
-2. ``NVFLARE_STARTUP_KIT_DIR``
-3. resolved target via config (explicit ``--startup-target`` value, otherwise default ``poc``):
-   - ``poc`` -> ``poc.startup_kit``
-   - ``prod`` -> ``prod.startup_kit``
+1. ``NVFLARE_STARTUP_KIT_DIR`` when set.
+2. ``startup_kits.active`` from ``~/.nvflare/config.conf``.
+3. If neither resolves to a valid admin startup kit, the command fails before connecting.
 
 Examples:
 
 .. code-block:: shell
 
-   nvflare job submit -j /tmp/nvflare/hello-pt --startup-target poc
-   nvflare job submit -j /tmp/nvflare/hello-pt --startup-target prod
-   nvflare job submit -j /tmp/nvflare/hello-pt --startup-kit /tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com
+   nvflare kit use project_admin
+   nvflare job submit -j /tmp/nvflare/hello-pt
 
-``--startup-kit`` must point to the admin startup kit directory itself, not the
-broader ``prod_00`` root. For example, use
-``/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com`` rather than
-``/tmp/nvflare/poc/example_project/prod_00``.
+Registered startup kit paths must point to the admin startup kit directory
+itself, not the broader ``prod_00`` root.
 
 Example JSON success response:
 
@@ -225,19 +213,60 @@ Notes:
 Observability
 **************
 
-Retrieve job logs from the server workspace:
+Retrieve job logs from the server-side log store:
 
 .. code-block:: shell
 
    nvflare job logs <job_id>
-   nvflare job logs <job_id> --tail 200
-   nvflare job logs <job_id> --grep ERROR
+   nvflare job logs <job_id> --site site-1
+   nvflare job logs <job_id> --site all
 
-Current implementation note:
+``job logs`` accepts:
 
-- ``job logs --site`` accepts only ``server``. Default: ``server``. Any other
-  value is rejected during argument parsing.
-- ``job logs`` also supports ``--tail``, ``--grep``, and ``--schema``.
+- ``--site server``: return the server job log. This is the default.
+- ``--site <client_name>``: return that client's job log after it has been
+  streamed to and stored by the server.
+- ``--site all``: return the server log and all client logs currently available
+  in the server-side log store. If a known job site does not have stored log
+  content, the JSON response includes it under ``unavailable``.
+- ``--sites`` is accepted as an alias for ``--site`` but still selects one
+  target value.
+- ``job logs`` also supports ``--schema``.
+
+In normal human output mode, ``job logs`` prints the log text directly. With
+``--site all``, each site is separated by a short header. Use ``--format json``
+when a structured ``logs`` dictionary is needed for automation.
+
+``job logs`` does not provide built-in ``tail`` or ``grep`` options. Pipe or
+post-process the returned content when filtering is needed.
+
+Client logs are not fetched from client machines at command time. The command
+asks the server for logs that were already streamed to the server during the
+job. The current implementation reads client logs from the server job
+workspace, where streamed client logs are stored as ``<client_name>/log.txt``;
+after the job workspace is archived, the same files are read from the stored
+job ``workspace`` artifact.
+
+To enable client job log streaming in a portable job, add the job-level log
+streamer and receiver components to the job definition:
+
+.. code-block:: python
+
+   from nvflare.app_common.logging.job_log_receiver import JobLogReceiver
+   from nvflare.app_common.logging.job_log_streamer import JobLogStreamer
+
+   # Tails each client's job log.txt and streams it to the server.
+   recipe.job.to_clients(JobLogStreamer())
+
+   # Receives streamed log chunks on the server and stores them with the job.
+   recipe.job.to_server(JobLogReceiver())
+
+System-level logging configuration in ``resources.json.default`` is separate
+from this job-level opt-in. Some deployments may configure a server-side
+``JobLogReceiver`` globally, but including both components in the job makes the
+job self-contained across POC and production deployments.
+
+The ``examples/hello-world/hello-log-streaming`` example shows this pattern.
 
 Change logging configuration for a running job:
 

--- a/docs/user_guide/nvflare_cli/job_cli.rst
+++ b/docs/user_guide/nvflare_cli/job_cli.rst
@@ -12,8 +12,8 @@ or activate a registered startup kit with :ref:`kit_command`:
 
 .. code-block:: shell
 
-   nvflare kit add project_admin /path/to/admin@nvidia.com
-   nvflare kit use project_admin
+   nvflare config kit add project_admin /path/to/admin@nvidia.com
+   nvflare config kit use project_admin
 
 ***********************
 Command Usage
@@ -84,7 +84,7 @@ Examples:
 
 .. code-block:: shell
 
-   nvflare kit use project_admin
+   nvflare config kit use project_admin
    nvflare job submit -j /tmp/nvflare/hello-pt
 
 Registered startup kit paths must point to the admin startup kit directory

--- a/docs/user_guide/nvflare_cli/kit_command.rst
+++ b/docs/user_guide/nvflare_cli/kit_command.rst
@@ -33,8 +33,8 @@ Running ``nvflare config kit`` without a subcommand prints this help text.
 Common Workflow
 *****************
 
-For POC, ``nvflare poc prepare`` registers generated admin/user and site
-startup kits and activates the default Project Admin kit automatically:
+For POC, ``nvflare poc prepare`` registers generated admin/user startup kits
+and activates the default Project Admin kit automatically:
 
 .. code-block:: shell
 
@@ -84,8 +84,8 @@ Arguments and options:
 
 - ``<id>``: local ID used to refer to the startup kit. IDs can be meaningful
   names such as ``cancer_lead`` or identities such as ``lead@nvidia.com``.
-- ``<startup-kit-dir>``: participant startup kit directory, such as
-  ``.../prod_00/admin@nvidia.com`` or ``.../prod_00/site-1``. Passing the
+- ``<startup-kit-dir>``: admin/user startup kit directory, such as
+  ``.../prod_00/admin@nvidia.com``. Passing the
   ``startup`` subdirectory is also accepted and normalized to the participant
   startup kit directory.
 - ``--force``: replace an existing local registration for the same ID.
@@ -97,9 +97,8 @@ For an admin/user startup kit, the path must contain:
 - ``startup/client.crt``
 - ``startup/rootCA.pem``
 
-For a site startup kit, ``startup/fed_client.json`` is enough for local
-registration. Site kits can be listed and removed from the registry, but they
-cannot be activated for server-connected admin commands.
+Site startup kits are not valid here because they are service identities, not
+interactive admin/user identities for CLI sessions.
 
 Example:
 
@@ -181,7 +180,6 @@ Example output:
    active  id               status   identity         cert_role  path
    -------------------------------------------------------------------------------
    *       cancer_lead      ok       lead@nvidia.com  lead       /secure/startup_kits/cancer/lead@nvidia.com
-           site-1           ok       site-1           -          /tmp/nvflare/poc/example_project/prod_00/site-1
            fraud_org_admin  missing  -                -          /secure/startup_kits/fraud/org_admin@nvidia.com
            old_lab_admin    invalid  -                -          /archive/old_lab/admin@nvidia.com
 
@@ -226,7 +224,6 @@ Config File
      entries {
        cancer_lead = "/secure/startup_kits/cancer/lead@nvidia.com"
        fraud_org_admin = "/secure/startup_kits/fraud/org_admin@nvidia.com"
-       "site-1" = "/tmp/nvflare/poc/example_project/prod_00/site-1"
      }
    }
 

--- a/docs/user_guide/nvflare_cli/kit_command.rst
+++ b/docs/user_guide/nvflare_cli/kit_command.rst
@@ -228,5 +228,5 @@ Config File
    }
 
 Startup kit paths are managed by the ``kit`` subcommands under
-``nvflare config``. The root ``nvflare config`` command remains responsible for
-the POC workspace path.
+``nvflare config``. Other local CLI state in ``~/.nvflare/config.conf`` is an
+implementation detail and is not part of the normal startup kit workflow.

--- a/docs/user_guide/nvflare_cli/kit_command.rst
+++ b/docs/user_guide/nvflare_cli/kit_command.rst
@@ -1,13 +1,13 @@
 .. _kit_command:
 
-#########################
-Startup Kit Command
-#########################
+################################
+Startup Kit Config Subcommands
+################################
 
-Use ``nvflare kit`` to register local startup kit paths and choose the active
+Use ``nvflare config kit`` to register local startup kit paths and choose the active
 admin startup kit used by server-connected CLI commands.
 
-The registry is local to the current machine. ``nvflare kit`` does not contact
+The registry is local to the current machine. ``nvflare config kit`` does not contact
 the server. It updates ``~/.nvflare/config.conf`` so commands such as
 ``nvflare job list``, ``nvflare study list``, and ``nvflare system status`` can
 connect without repeated startup-kit arguments.
@@ -18,7 +18,7 @@ Command Usage
 
 .. code-block:: none
 
-   usage: nvflare kit [-h]  ...
+   usage: nvflare config kit [-h]  ...
 
    kit subcommands:
      add       register a startup kit path
@@ -27,7 +27,7 @@ Command Usage
      list      list registered startup kits
      remove    remove a local startup kit registration
 
-Running ``nvflare kit`` without a subcommand prints this help text.
+Running ``nvflare config kit`` without a subcommand prints this help text.
 
 *****************
 Common Workflow
@@ -45,16 +45,16 @@ For a production or manually copied startup kit, register and activate it once:
 
 .. code-block:: shell
 
-   nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
-   nvflare kit use cancer_lead
+   nvflare config kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
+   nvflare config kit use cancer_lead
    nvflare job list
 
 To switch local identity, activate another registered ID:
 
 .. code-block:: shell
 
-   nvflare kit add fraud_org_admin /secure/startup_kits/fraud/org_admin@nvidia.com
-   nvflare kit use fraud_org_admin
+   nvflare config kit add fraud_org_admin /secure/startup_kits/fraud/org_admin@nvidia.com
+   nvflare config kit use fraud_org_admin
    nvflare system status
 
 ************************
@@ -69,8 +69,8 @@ Server-connected commands resolve the startup kit in this order:
    connecting.
 
 The environment variable is intended for automation. For normal interactive
-use, register startup kits with ``nvflare kit add`` and switch with
-``nvflare kit use``.
+use, register startup kits with ``nvflare config kit add`` and switch with
+``nvflare config kit use``.
 
 *********************
 Register a Startup Kit
@@ -78,7 +78,7 @@ Register a Startup Kit
 
 .. code-block:: shell
 
-   nvflare kit add <id> <startup-kit-dir>
+   nvflare config kit add <id> <startup-kit-dir>
 
 Arguments and options:
 
@@ -105,7 +105,7 @@ Example:
 
 .. code-block:: shell
 
-   nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
+   nvflare config kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
 
 Example output:
 
@@ -113,7 +113,7 @@ Example output:
 
    registered_startup_kit: cancer_lead
    path: /secure/startup_kits/cancer/lead@nvidia.com
-   next_step: nvflare kit use cancer_lead
+   next_step: nvflare config kit use cancer_lead
 
 ``kit add`` registers the path only. It does not make the kit active.
 
@@ -123,7 +123,7 @@ Activate a Startup Kit
 
 .. code-block:: shell
 
-   nvflare kit use <id>
+   nvflare config kit use <id>
 
 ``kit use`` validates that the registered path is an admin/user startup kit and
 then sets ``startup_kits.active``.
@@ -132,7 +132,7 @@ Example:
 
 .. code-block:: shell
 
-   nvflare kit use cancer_lead
+   nvflare config kit use cancer_lead
 
 Example output:
 
@@ -149,7 +149,7 @@ Show Active Startup Kit
 
 .. code-block:: shell
 
-   nvflare kit show
+   nvflare config kit show
 
 Example output:
 
@@ -172,7 +172,7 @@ List Registered Kits
 
 .. code-block:: shell
 
-   nvflare kit list
+   nvflare config kit list
 
 Example output:
 
@@ -201,7 +201,7 @@ Remove a Registration
 
 .. code-block:: shell
 
-   nvflare kit remove <id>
+   nvflare config kit remove <id>
 
 This removes the local registry entry only. It does not delete the startup kit
 directory.
@@ -213,7 +213,7 @@ activate another kit before running server-connected commands.
 Config File
 *********************
 
-``nvflare kit`` stores startup kit registrations in
+``nvflare config kit`` stores startup kit registrations in
 ``~/.nvflare/config.conf``:
 
 .. code-block:: none
@@ -230,6 +230,6 @@ Config File
      }
    }
 
-Startup kit paths are managed by ``nvflare kit``, not ``nvflare config``.
-``nvflare config`` remains responsible for other local settings such as
-``poc.workspace`` and job template paths.
+Startup kit paths are managed by the ``kit`` subcommands under
+``nvflare config``. The root ``nvflare config`` command remains responsible for
+the POC workspace path.

--- a/docs/user_guide/nvflare_cli/kit_command.rst
+++ b/docs/user_guide/nvflare_cli/kit_command.rst
@@ -1,0 +1,235 @@
+.. _kit_command:
+
+#########################
+Startup Kit Command
+#########################
+
+Use ``nvflare kit`` to register local startup kit paths and choose the active
+admin startup kit used by server-connected CLI commands.
+
+The registry is local to the current machine. ``nvflare kit`` does not contact
+the server. It updates ``~/.nvflare/config.conf`` so commands such as
+``nvflare job list``, ``nvflare study list``, and ``nvflare system status`` can
+connect without repeated startup-kit arguments.
+
+***********************
+Command Usage
+***********************
+
+.. code-block:: none
+
+   usage: nvflare kit [-h]  ...
+
+   kit subcommands:
+     add       register a startup kit path
+     use       activate a registered startup kit
+     show      show the configured active startup kit
+     list      list registered startup kits
+     remove    remove a local startup kit registration
+
+Running ``nvflare kit`` without a subcommand prints this help text.
+
+*****************
+Common Workflow
+*****************
+
+For POC, ``nvflare poc prepare`` registers generated admin/user and site
+startup kits and activates the default Project Admin kit automatically:
+
+.. code-block:: shell
+
+   nvflare poc prepare
+   nvflare job list
+
+For a production or manually copied startup kit, register and activate it once:
+
+.. code-block:: shell
+
+   nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
+   nvflare kit use cancer_lead
+   nvflare job list
+
+To switch local identity, activate another registered ID:
+
+.. code-block:: shell
+
+   nvflare kit add fraud_org_admin /secure/startup_kits/fraud/org_admin@nvidia.com
+   nvflare kit use fraud_org_admin
+   nvflare system status
+
+************************
+Startup Kit Resolution
+************************
+
+Server-connected commands resolve the startup kit in this order:
+
+1. ``NVFLARE_STARTUP_KIT_DIR`` environment variable, when set.
+2. ``startup_kits.active`` from ``~/.nvflare/config.conf``.
+3. If neither resolves to a valid admin startup kit, the command fails before
+   connecting.
+
+The environment variable is intended for automation. For normal interactive
+use, register startup kits with ``nvflare kit add`` and switch with
+``nvflare kit use``.
+
+*********************
+Register a Startup Kit
+*********************
+
+.. code-block:: shell
+
+   nvflare kit add <id> <startup-kit-dir>
+
+Arguments and options:
+
+- ``<id>``: local ID used to refer to the startup kit. IDs can be meaningful
+  names such as ``cancer_lead`` or identities such as ``lead@nvidia.com``.
+- ``<startup-kit-dir>``: participant startup kit directory, such as
+  ``.../prod_00/admin@nvidia.com`` or ``.../prod_00/site-1``. Passing the
+  ``startup`` subdirectory is also accepted and normalized to the participant
+  startup kit directory.
+- ``--force``: replace an existing local registration for the same ID.
+- ``--schema``: print the command schema as JSON and exit.
+
+For an admin/user startup kit, the path must contain:
+
+- ``startup/fed_admin.json``
+- ``startup/client.crt``
+- ``startup/rootCA.pem``
+
+For a site startup kit, ``startup/fed_client.json`` is enough for local
+registration. Site kits can be listed and removed from the registry, but they
+cannot be activated for server-connected admin commands.
+
+Example:
+
+.. code-block:: shell
+
+   nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com
+
+Example output:
+
+.. code-block:: none
+
+   registered_startup_kit: cancer_lead
+   path: /secure/startup_kits/cancer/lead@nvidia.com
+   next_step: nvflare kit use cancer_lead
+
+``kit add`` registers the path only. It does not make the kit active.
+
+************************
+Activate a Startup Kit
+************************
+
+.. code-block:: shell
+
+   nvflare kit use <id>
+
+``kit use`` validates that the registered path is an admin/user startup kit and
+then sets ``startup_kits.active``.
+
+Example:
+
+.. code-block:: shell
+
+   nvflare kit use cancer_lead
+
+Example output:
+
+.. code-block:: none
+
+   active_startup_kit: cancer_lead
+   identity: lead@nvidia.com
+   cert_role: lead
+   path: /secure/startup_kits/cancer/lead@nvidia.com
+
+**********************
+Show Active Startup Kit
+**********************
+
+.. code-block:: shell
+
+   nvflare kit show
+
+Example output:
+
+.. code-block:: none
+
+   active: cancer_lead
+   path: /secure/startup_kits/cancer/lead@nvidia.com
+   config_file: /home/user/.nvflare/config.conf
+   status: ok
+   identity: lead@nvidia.com
+   cert_role: lead
+
+If ``NVFLARE_STARTUP_KIT_DIR`` is set, ``kit show`` still shows the configured
+active kit and prints a warning that normal commands will use the environment
+path instead.
+
+**********************
+List Registered Kits
+**********************
+
+.. code-block:: shell
+
+   nvflare kit list
+
+Example output:
+
+.. code-block:: none
+
+   active  id               status   identity         cert_role  path
+   -------------------------------------------------------------------------------
+   *       cancer_lead      ok       lead@nvidia.com  lead       /secure/startup_kits/cancer/lead@nvidia.com
+           site-1           ok       site-1           -          /tmp/nvflare/poc/example_project/prod_00/site-1
+           fraud_org_admin  missing  -                -          /secure/startup_kits/fraud/org_admin@nvidia.com
+           old_lab_admin    invalid  -                -          /archive/old_lab/admin@nvidia.com
+
+The active startup kit is marked with ``*``. Status values:
+
+- ``ok``: the path exists and contains a valid startup kit.
+- ``missing``: the registered path no longer exists.
+- ``invalid``: the path exists but does not contain the required startup kit
+  files.
+
+``kit list`` does not contact the server and does not fail just because one
+registered path is stale.
+
+*********************
+Remove a Registration
+*********************
+
+.. code-block:: shell
+
+   nvflare kit remove <id>
+
+This removes the local registry entry only. It does not delete the startup kit
+directory.
+
+If the removed ID was active, ``startup_kits.active`` is cleared and you must
+activate another kit before running server-connected commands.
+
+*********************
+Config File
+*********************
+
+``nvflare kit`` stores startup kit registrations in
+``~/.nvflare/config.conf``:
+
+.. code-block:: none
+
+   version = 2
+
+   startup_kits {
+     active = "cancer_lead"
+
+     entries {
+       cancer_lead = "/secure/startup_kits/cancer/lead@nvidia.com"
+       fraud_org_admin = "/secure/startup_kits/fraud/org_admin@nvidia.com"
+       "site-1" = "/tmp/nvflare/poc/example_project/prod_00/site-1"
+     }
+   }
+
+Startup kit paths are managed by ``nvflare kit``, not ``nvflare config``.
+``nvflare config`` remains responsible for other local settings such as
+``poc.workspace`` and job template paths.

--- a/docs/user_guide/nvflare_cli/nvflare_cli.rst
+++ b/docs/user_guide/nvflare_cli/nvflare_cli.rst
@@ -31,11 +31,11 @@ Command groups
 - ``poc``: manage a local proof-of-concept deployment
 - ``provision``: centralized provisioning workflow
 - ``cert`` / ``package``: distributed (manual) provisioning workflow
-- ``kit``: register local admin startup kits and choose the active startup kit
 - ``job``: submit and manage jobs
 - ``study``: manage multi-study lifecycle (register, enroll sites, manage users)
 - ``system``: inspect and operate a running FL system
-- ``config``: store non-startup-kit local CLI settings
+- ``config``: manage local CLI settings, including ``config kit`` startup-kit
+  registration and active-kit selection
 - ``recipe``: list built-in recipe families for exported jobs
 - ``preflight_check`` / ``preflight``: validate a provisioned startup kit
   before deployment (``preflight`` is the preferred alias)
@@ -50,13 +50,13 @@ workflows unless you are maintaining an older setup.
 
    fl_simulator
    poc_command
+   config_command
    kit_command
    provision_command
    distributed_provisioning
    job_cli
    study_command
    system_command
-   config_command
    cert_command
    package_command
    recipe_command

--- a/docs/user_guide/nvflare_cli/nvflare_cli.rst
+++ b/docs/user_guide/nvflare_cli/nvflare_cli.rst
@@ -31,10 +31,11 @@ Command groups
 - ``poc``: manage a local proof-of-concept deployment
 - ``provision``: centralized provisioning workflow
 - ``cert`` / ``package``: distributed (manual) provisioning workflow
+- ``kit``: register local admin startup kits and choose the active startup kit
 - ``job``: submit and manage jobs
 - ``study``: manage multi-study lifecycle (register, enroll sites, manage users)
 - ``system``: inspect and operate a running FL system
-- ``config``: store local CLI settings such as the startup kit path
+- ``config``: store non-startup-kit local CLI settings
 - ``recipe``: list built-in recipe families for exported jobs
 - ``preflight_check`` / ``preflight``: validate a provisioned startup kit
   before deployment (``preflight`` is the preferred alias)
@@ -49,6 +50,7 @@ workflows unless you are maintaining an older setup.
 
    fl_simulator
    poc_command
+   kit_command
    provision_command
    distributed_provisioning
    job_cli

--- a/docs/user_guide/nvflare_cli/poc_command.rst
+++ b/docs/user_guide/nvflare_cli/poc_command.rst
@@ -125,7 +125,7 @@ user or site:
 Behavior notes:
 
 - ``poc add user`` and ``poc add site`` require the active startup kit to have
-  the ``project_admin`` certificate role. Use ``nvflare kit use <id>`` to switch
+  the ``project_admin`` certificate role. Use ``nvflare config kit use <id>`` to switch
   back to the POC Project Admin kit before adding users or sites.
 - ``poc add user`` adds an admin participant to the persisted POC
   ``project.yml``, runs the existing POC provisioning pipeline, and registers
@@ -145,10 +145,10 @@ Examples:
 .. code-block:: shell
 
    nvflare poc add user lead bob@nvidia.com --org nvidia
-   nvflare kit use bob@nvidia.com
+   nvflare config kit use bob@nvidia.com
 
    nvflare poc add site site-3 --org nvidia
-   nvflare kit list
+   nvflare config kit list
    nvflare poc start -p site-3
 
 **************

--- a/docs/user_guide/nvflare_cli/poc_command.rst
+++ b/docs/user_guide/nvflare_cli/poc_command.rst
@@ -129,14 +129,16 @@ Behavior notes:
   the ``project_admin`` certificate role. Use ``nvflare config kit use <id>`` to switch
   back to the POC Project Admin kit before adding users or sites.
 - ``poc add user`` adds an admin participant to the persisted POC
-  ``project.yml``, runs the existing POC provisioning pipeline, and registers
-  the generated user startup kit in the shared startup kit registry.
+  ``project.yml``, dynamically provisions only that new user with the existing
+  POC CA, and registers the generated user startup kit in the shared startup
+  kit registry.
 - ``poc add site`` adds a client participant to the persisted POC
-  ``project.yml`` and generates the site startup kit in the latest POC output
-  directory. The generated site kit is not registered in ``~/.nvflare/config.conf``
-  because only admin/user kits are CLI identities.
-- POC add uses the existing provision state, so the root CA is reused across
-  provision runs.
+  ``project.yml`` and dynamically provisions only that new site with the
+  existing POC CA. The generated site kit is placed in the current POC output
+  directory, normally ``prod_00``, and is not registered in
+  ``~/.nvflare/config.conf`` because only admin/user kits are CLI identities.
+- POC add uses the existing provision state/rootCA and does not regenerate
+  existing participant startup kits.
 - Use ``--force`` only to replace an existing participant entry in the local
   POC project metadata.
 

--- a/docs/user_guide/nvflare_cli/poc_command.rst
+++ b/docs/user_guide/nvflare_cli/poc_command.rst
@@ -67,8 +67,9 @@ Behavior notes:
 - If the workspace already exists and stdin is non-interactive, ``--force`` is
   required.
 - ``nvflare poc prepare`` updates ``~/.nvflare/config.conf`` with the POC
-  workspace, registers generated admin/user and site startup kits, and activates the
-  default Project Admin kit.
+  workspace, registers generated admin/user startup kits, and activates the
+  default Project Admin kit. Site startup kits stay in the POC workspace and are
+  not registered as CLI identities.
 - On success, the command prints a JSON result containing the workspace path and
   discovered client list.
 
@@ -132,9 +133,8 @@ Behavior notes:
   the generated user startup kit in the shared startup kit registry.
 - ``poc add site`` adds a client participant to the persisted POC
   ``project.yml`` and generates the site startup kit in the latest POC output
-  directory. The generated site kit is registered in ``~/.nvflare/config.conf``
-  for local discovery and cleanup, but it is not made active because only
-  admin/user kits can be active CLI startup kits.
+  directory. The generated site kit is not registered in ``~/.nvflare/config.conf``
+  because only admin/user kits are CLI identities.
 - POC add uses the existing provision state, so the root CA is reused across
   provision runs.
 - Use ``--force`` only to replace an existing participant entry in the local
@@ -256,8 +256,9 @@ The workspace can also be controlled by:
 - ``~/.nvflare/config.conf`` via ``nvflare config --poc.workspace <poc_workspace>``
 
 ``nvflare poc prepare`` writes the POC workspace into the local NVFlare config
-and registers generated admin/user and site startup kits in the shared startup kit
-registry automatically.
+and registers generated admin/user startup kits in the shared startup kit
+registry automatically. Site startup kits remain in the POC workspace for local
+service management.
 
 The default Project Admin startup kit becomes active, so server-connected
 commands such as ``nvflare job list`` and ``nvflare system status`` work

--- a/docs/user_guide/nvflare_cli/poc_command.rst
+++ b/docs/user_guide/nvflare_cli/poc_command.rst
@@ -14,13 +14,13 @@ Command Usage
 ***********************
 
 The POC command provides the subcommands ``prepare``, ``prepare-jobs-dir``,
-``start``, ``stop``, and ``clean``.
+``add``, ``start``, ``stop``, and ``clean``.
 
 .. code-block:: none
 
    nvflare poc -h
 
-   usage: nvflare poc [-h] {prepare,prepare-jobs-dir,start,stop,clean} ...
+   usage: nvflare poc [-h] {prepare,prepare-jobs-dir,add,start,stop,clean} ...
 
 *****************
 Common Workflow
@@ -29,10 +29,12 @@ Common Workflow
 1. Run ``nvflare poc prepare`` to create the local workspace and startup kits.
 2. Optionally run ``nvflare poc prepare-jobs-dir`` to link a jobs folder into
    the admin transfer area.
-3. Run ``nvflare poc start`` to start the server and clients.
-4. Start an admin console explicitly only when you need one.
-5. Run ``nvflare poc stop`` to stop the system.
-6. Run ``nvflare poc clean`` after the system is stopped.
+3. Optionally run ``nvflare poc add user`` or ``nvflare poc add site`` to add a
+   local participant startup kit.
+4. Run ``nvflare poc start`` to start the server and clients.
+5. Start an admin console explicitly only when you need one.
+6. Run ``nvflare poc stop`` to stop the system.
+7. Run ``nvflare poc clean`` after the system is stopped.
 
 *******************
 Prepare Workspace
@@ -65,7 +67,8 @@ Behavior notes:
 - If the workspace already exists and stdin is non-interactive, ``--force`` is
   required.
 - ``nvflare poc prepare`` updates ``~/.nvflare/config.conf`` with the POC
-  workspace and startup kit locations.
+  workspace, registers generated admin/user and site startup kits, and activates the
+  default Project Admin kit.
 - On success, the command prints a JSON result containing the workspace path and
   discovered client list.
 
@@ -104,6 +107,49 @@ Example:
 .. code-block:: shell
 
    nvflare poc prepare-jobs-dir -j /path/to/jobs --force
+
+***************
+Add Participant
+***************
+
+Use ``nvflare poc add`` to extend the prepared local POC workspace with another
+user or site:
+
+.. code-block:: none
+
+   nvflare poc add user [-h] [--org ORG] [--force] [--schema]
+                        {project_admin,org_admin,lead,member} email
+
+   nvflare poc add site [-h] [--org ORG] [--force] [--schema] name
+
+Behavior notes:
+
+- ``poc add user`` and ``poc add site`` require the active startup kit to have
+  the ``project_admin`` certificate role. Use ``nvflare kit use <id>`` to switch
+  back to the POC Project Admin kit before adding users or sites.
+- ``poc add user`` adds an admin participant to the persisted POC
+  ``project.yml``, runs the existing POC provisioning pipeline, and registers
+  the generated user startup kit in the shared startup kit registry.
+- ``poc add site`` adds a client participant to the persisted POC
+  ``project.yml`` and generates the site startup kit in the latest POC output
+  directory. The generated site kit is registered in ``~/.nvflare/config.conf``
+  for local discovery and cleanup, but it is not made active because only
+  admin/user kits can be active CLI startup kits.
+- POC add uses the existing provision state, so the root CA is reused across
+  provision runs.
+- Use ``--force`` only to replace an existing participant entry in the local
+  POC project metadata.
+
+Examples:
+
+.. code-block:: shell
+
+   nvflare poc add user lead bob@nvidia.com --org nvidia
+   nvflare kit use bob@nvidia.com
+
+   nvflare poc add site site-3 --org nvidia
+   nvflare kit list
+   nvflare poc start -p site-3
 
 **************
 Start Services
@@ -208,11 +254,16 @@ The workspace can also be controlled by:
 - ``NVFLARE_POC_WORKSPACE``
 - ``~/.nvflare/config.conf`` via ``nvflare config --poc.workspace <poc_workspace>``
 
-``nvflare poc prepare`` writes the POC workspace and startup kit location into
-the local NVFlare config automatically.
+``nvflare poc prepare`` writes the POC workspace into the local NVFlare config
+and registers generated admin/user and site startup kits in the shared startup kit
+registry automatically.
 
-The saved ``poc.startup_kit`` value is the POC admin startup kit directory,
-for example ``.../prod_00/admin@nvidia.com``, not the broader ``prod_00`` root.
+The default Project Admin startup kit becomes active, so server-connected
+commands such as ``nvflare job list`` and ``nvflare system status`` work
+without extra startup-kit flags.
+
+Use :ref:`kit_command` to inspect generated POC startup kit registrations or
+switch between POC-generated user startup kits.
 
 *********************
 JSON Output and Help

--- a/docs/user_guide/nvflare_cli/poc_command.rst
+++ b/docs/user_guide/nvflare_cli/poc_command.rst
@@ -234,14 +234,15 @@ Use ``nvflare poc clean`` to remove the POC workspace:
 Options:
 
 - ``-debug, --debug``: debug mode.
-- ``--force``: remove the workspace without an interactive confirmation prompt.
+- ``--force``: stop a running local POC system before removing the workspace.
 - ``--schema``: print command schema as JSON and exit.
 
 Behavior notes:
 
-- The workspace is removed only when it is a valid POC directory and the system
-  is not still running.
-- If the POC system is still running, stop it first with ``nvflare poc stop``.
+- The workspace is removed only when it is a valid POC directory.
+- If the POC system is still running, ``nvflare poc clean`` fails with a hint to
+  stop it first. Use ``nvflare poc clean --force`` to stop the local POC system
+  and then remove the workspace in one command.
 
 *********************
 Workspace Configuration

--- a/docs/user_guide/nvflare_cli/study_command.rst
+++ b/docs/user_guide/nvflare_cli/study_command.rst
@@ -42,8 +42,8 @@ A user can register and activate a startup kit once with :ref:`kit_command`:
 
 .. code-block:: shell
 
-   nvflare kit add project_admin /path/to/admin@nvidia.com
-   nvflare kit use project_admin
+   nvflare config kit add project_admin /path/to/admin@nvidia.com
+   nvflare config kit use project_admin
 
 If no source resolves, the command exits with error code 4 and ``"error_code": "STARTUP_KIT_MISSING"``.
 

--- a/docs/user_guide/nvflare_cli/study_command.rst
+++ b/docs/user_guide/nvflare_cli/study_command.rst
@@ -34,14 +34,16 @@ Startup Kit Resolution
 All ``nvflare study`` commands connect to the server through an admin startup kit. Resolution
 is identical to all other server-connected ``nvflare`` commands (``job``, ``system``, etc.):
 
-1. ``--startup-kit <path>`` — explicit path to the startup kit directory or its ``startup/``
-   subdirectory.
-2. ``NVFLARE_STARTUP_KIT_DIR`` environment variable.
-3. ``~/.nvflare/config.conf`` — reads the ``poc`` target by default; reads ``prod`` when
-   ``--startup-target prod`` is given. Written by ``nvflare config``.
+1. ``NVFLARE_STARTUP_KIT_DIR`` environment variable.
+2. ``startup_kits.active`` from ``~/.nvflare/config.conf``.
+3. If neither resolves to a valid admin startup kit, the command fails before connecting.
 
-A user who has run ``nvflare config`` once does not need to pass any flag — the config file
-is consulted automatically. ``--startup-kit`` and ``--startup-target`` are mutually exclusive.
+A user can register and activate a startup kit once with :ref:`kit_command`:
+
+.. code-block:: shell
+
+   nvflare kit add project_admin /path/to/admin@nvidia.com
+   nvflare kit use project_admin
 
 If no source resolves, the command exits with error code 4 and ``"error_code": "STARTUP_KIT_MISSING"``.
 
@@ -74,16 +76,16 @@ Register a new study and enroll its initial set of sites.
        --site-org org_b:clinic-1
 
    # org_admin: register and enroll own org's sites
-   nvflare study register cancer-research --sites hospital-1,hospital-2
+   nvflare study register cancer-research --sites hospital-1 hospital-2
 
 Options:
 
 - ``<name>`` (required positional): name of the study to create.
 - ``--site-org <org>:<site>`` (project_admin): one or more ``org:site`` pairs; repeat the flag
   for multiple entries.
-- ``--sites <site>[,<site>...]`` (org_admin): comma-separated list of sites in the caller's
-  organisation.
-- ``--startup-target``, ``--startup-kit``: startup kit resolution (see above).
+- ``--sites <site> [<site> ...]`` (org_admin): one or more sites in the caller's
+  organisation. Comma-separated input such as ``--sites hospital-1,hospital-2`` is also
+  accepted.
 
 *********************
 Show a Study

--- a/docs/user_guide/nvflare_cli/system_command.rst
+++ b/docs/user_guide/nvflare_cli/system_command.rst
@@ -96,10 +96,9 @@ Change runtime logging:
 .. note::
 
    All server-connected ``nvflare system`` commands resolve the startup kit in
-   this order: ``--startup-kit``, ``NVFLARE_STARTUP_KIT_DIR``, then the
-   configured target selected by ``--startup-target`` (or the default config
-   target when no explicit selector is given). ``--startup-kit`` and
-   ``--startup-target`` are mutually exclusive explicit selectors.
+   this order: ``NVFLARE_STARTUP_KIT_DIR``, then ``startup_kits.active`` from
+   ``~/.nvflare/config.conf``. Use ``nvflare kit add`` and ``nvflare kit use``
+   to manage the active startup kit. See :ref:`kit_command`.
 
 ****************
 Status and Resources
@@ -107,17 +106,13 @@ Status and Resources
 
 ``nvflare system status`` reports server and client connectivity.
 
-This command uses the word ``target`` in two different places:
-
-- positional ``target``: ``server`` or ``client``. This tells NVFlare what to query.
-- ``--startup-target {poc,prod}``: this tells the CLI which startup kit to use.
+The positional ``target`` argument means ``server`` or ``client``. It tells
+NVFlare what to query.
 
 Status arguments:
 
 - positional ``target``: optional. ``server`` or ``client``.
 - positional ``client_names``: optional list of client names when targeting clients.
-- ``--startup-target {poc,prod}``: choose the configured admin startup target. Mutually exclusive with ``--startup-kit``.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--schema``: print the command schema as JSON and exit.
 
 Examples:
@@ -127,26 +122,19 @@ Examples:
    nvflare system status
    nvflare system status server
    nvflare system status client site-1 site-2
-   nvflare system status client site-1 --startup-target prod
 
-In ``nvflare system status client site-1 --startup-target prod``:
-
-- ``client site-1`` means query client ``site-1``.
-- ``--startup-target prod`` means use the ``prod`` startup kit.
+In ``nvflare system status client site-1``, ``client site-1`` means query
+client ``site-1``.
 
 ``nvflare system resources`` reports server and client resource usage.
 
-This command uses the word ``target`` in two different places:
-
-- positional ``target``: ``server`` or ``client``. This tells NVFlare what to query.
-- ``--startup-target {poc,prod}``: this tells the CLI which startup kit to use.
+The positional ``target`` argument means ``server`` or ``client``. It tells
+NVFlare what to query.
 
 Resource arguments:
 
 - positional ``target``: optional. ``server`` or ``client``.
 - positional ``client_names``: optional list of client names when targeting clients.
-- ``--startup-target {poc,prod}``: choose the configured admin startup target. Mutually exclusive with ``--startup-kit``.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--schema``: print the command schema as JSON and exit.
 
 Examples:
@@ -155,12 +143,10 @@ Examples:
 
    nvflare system resources
    nvflare system resources client
-   nvflare system resources client site-1 --startup-target prod
+   nvflare system resources client site-1
 
-In ``nvflare system resources client site-1 --startup-target prod``:
-
-- ``client site-1`` means query client ``site-1``.
-- ``--startup-target prod`` means use the ``prod`` startup kit.
+In ``nvflare system resources client site-1``, ``client site-1`` means query
+client ``site-1``.
 
 **********************
 Shutdown and Restart
@@ -179,8 +165,6 @@ Control arguments:
 
 - positional ``target``: required. One of ``server``, ``client``, or ``all``.
 - positional ``client_names``: optional. One or more client names. Only meaningful when ``target`` is ``client``.
-- ``--startup-target {poc,prod}``: choose the configured admin startup target. Mutually exclusive with ``--startup-kit``.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--force``: skip the confirmation prompt.
 - ``--schema``: print the command schema as JSON and exit.
 
@@ -211,8 +195,6 @@ federation (equivalent to the admin console ``remove_client`` command).
 Remove-client arguments:
 
 - positional ``client_name``: required. The name of the client to remove.
-- ``--startup-target {poc,prod}``: choose the configured admin startup target. Mutually exclusive with ``--startup-kit``.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--force``: skip the confirmation prompt.
 - ``--schema``: print the command schema as JSON and exit.
 
@@ -232,8 +214,6 @@ sites.
 Version arguments:
 
 - ``--site``: ``server``, a client name, or ``all``. Default: ``all``.
-- ``--startup-target {poc,prod}``: choose the configured admin startup target. Mutually exclusive with ``--startup-kit``.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--schema``: print the command schema as JSON and exit.
 
 Examples:
@@ -263,8 +243,6 @@ Logging arguments:
 
 - positional ``level``: runtime-required log level or built-in log mode; omitting it returns a CLI error
 - ``--site``: ``server``, a client name, or ``all``. Default: ``all``.
-- ``--startup-target {poc,prod}``: choose the configured admin startup target. Mutually exclusive with ``--startup-kit``.
-- ``--startup-kit``: explicit admin startup kit directory, or its ``startup/`` subdirectory. Mutually exclusive with ``--startup-target``.
 - ``--schema``: print the command schema as JSON and exit.
 
 Supported built-in values for positional ``level``:

--- a/docs/user_guide/nvflare_cli/system_command.rst
+++ b/docs/user_guide/nvflare_cli/system_command.rst
@@ -97,7 +97,7 @@ Change runtime logging:
 
    All server-connected ``nvflare system`` commands resolve the startup kit in
    this order: ``NVFLARE_STARTUP_KIT_DIR``, then ``startup_kits.active`` from
-   ``~/.nvflare/config.conf``. Use ``nvflare kit add`` and ``nvflare kit use``
+   ``~/.nvflare/config.conf``. Use ``nvflare config kit add`` and ``nvflare config kit use``
    to manage the active startup kit. See :ref:`kit_command`.
 
 ****************

--- a/nvflare/app_common/hub/hub_app_deployer.py
+++ b/nvflare/app_common/hub/hub_app_deployer.py
@@ -74,6 +74,17 @@ class HubAppDeployer(AppDeployerSpec, FLComponent):
         t2_run_dir = workspace.get_run_dir(t2_job_id)
         shutil.copytree(t1_run_dir, t2_run_dir)
 
+        # Verify the original T1 app before HUB rewrites any job files.
+        # FROM_HUB_SITE=True later signals that the hub verified the job, so we must actually do so here.
+        app_path = workspace.get_app_dir(job_id)
+        root_ca_path = os.path.join(workspace.get_startup_kit_dir(), "rootCA.pem")
+        sig_file = os.path.join(app_path, NVFLARE_SIG_FILE)
+        if os.path.exists(sig_file):
+            if not verify_folder_signature(app_path, root_ca_path):
+                return "hub: job signature verification failed before forwarding", None, None
+        elif require_signed_jobs(workspace):
+            return "hub: unsigned job rejected — require_signed_jobs is enabled", None, None
+
         # step 3: modify the T1 client's config_fed_client.json to use HubExecutor
         # simply use t1_config_fed_client.json in the site folder
         site_config_dir = workspace.get_site_config_dir()
@@ -145,17 +156,6 @@ class HubAppDeployer(AppDeployerSpec, FLComponent):
         submitter_role = t1_meta.get(JobMetaKey.SUBMITTER_ROLE.value, "")
         scope = t1_meta.get(JobMetaKey.SCOPE.value, "")
 
-        # Verify the job app folder signature before setting FROM_HUB_SITE.
-        # FROM_HUB_SITE=True signals that the hub verified the job, so we must actually do so here.
-        app_path = workspace.get_app_dir(job_id)
-        root_ca_path = os.path.join(workspace.get_startup_kit_dir(), "rootCA.pem")
-        sig_file = os.path.join(app_path, NVFLARE_SIG_FILE)
-        if os.path.exists(sig_file):
-            if not verify_folder_signature(app_path, root_ca_path):
-                return "hub: job signature verification failed before forwarding", None, None
-        elif require_signed_jobs(workspace):
-            return "hub: unsigned job rejected — require_signed_jobs is enabled", None, None
-
         # Note: the app_name is already created like "app_"+site_name, which is also the directory that contains
         # app config files (config_fed_server.json and config_fed_client.json).
         # We need to make sure that the deploy-map uses this app name!
@@ -176,6 +176,11 @@ class HubAppDeployer(AppDeployerSpec, FLComponent):
         t2_meta_path = workspace.get_job_meta_path(t2_job_id)
         with open(t2_meta_path, "w") as f:
             json.dump(t2_meta, f, indent=4)
+
+        # The copied T2 app has been rewritten, so the originator signature no longer describes its contents.
+        t2_sig_file = os.path.join(workspace.get_app_dir(t2_job_id), NVFLARE_SIG_FILE)
+        if os.path.exists(t2_sig_file):
+            os.remove(t2_sig_file)
 
         # step 5: submit T2 app (as a job) to T1's job store
         t2_job_def = load_job_def_bytes(from_path=workspace.root_dir, def_name=t2_job_id)

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -41,7 +41,6 @@ from nvflare.utils.cli_utils import (
     CONFIG_VERSION,
     CURRENT_CONFIG_VERSION,
     backup_hidden_config_file,
-    create_job_template_config,
     create_poc_workspace_config,
     find_startup_kit_config_keys,
     load_hidden_config_state,
@@ -58,7 +57,6 @@ CMD_AUTHZ_PREVIEW = "authz-preview"
 CMD_JOB = "job"
 CMD_RECIPE = "recipe"
 CMD_CONFIG = "config"
-CMD_KIT = "kit"
 CMD_CERT = "cert"
 CMD_PACKAGE = "package"
 CMD_SYSTEM = "system"
@@ -151,7 +149,7 @@ _config_parser = None
 def def_config_parser(sub_cmd):
     global _config_parser
     cmd = "config"
-    config_parser = sub_cmd.add_parser(cmd, help="configure local NVFlare settings (POC workspace, job templates)")
+    config_parser = sub_cmd.add_parser(cmd, help="configure local NVFlare settings")
     _config_parser = config_parser
     config_parser.add_argument(
         "-pw",
@@ -162,11 +160,10 @@ def def_config_parser(sub_cmd):
         default=None,
         help="POC workspace location",
     )
-    config_parser.add_argument(
-        "-jt", "--job_templates_dir", type=str, nargs="?", default=None, help="job templates location"
-    )
     config_parser.add_argument("-debug", "--debug", action="store_true", help="debug is on")
     config_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    config_subparser = config_parser.add_subparsers(title="config subcommands", metavar="", dest="config_sub_cmd")
+    def_kit_cli_parser(config_subparser)
     return {cmd: config_parser}
 
 
@@ -174,14 +171,17 @@ def handle_config_cmd(args):
     from nvflare.tool.cli_output import output_error, output_ok, print_human
     from nvflare.tool.cli_schema import handle_schema_flag
 
+    if getattr(args, "config_sub_cmd", None) == "kit":
+        handle_kit_cmd(args)
+        return
+
     handle_schema_flag(
         _config_parser,
         "nvflare config",
         [
             "nvflare config --poc.workspace /path/to/poc_workspace",
-            "nvflare config --job_templates_dir /path/to/job_templates",
-            "nvflare kit add project_admin /path/to/startup-kit",
-            "nvflare kit use project_admin",
+            "nvflare config kit add project_admin /path/to/startup-kit",
+            "nvflare config kit use project_admin",
         ],
         sys.argv[1:],
     )
@@ -190,22 +190,21 @@ def handle_config_cmd(args):
     nvflare_config = loaded_config or CF.parse_string("{}")
     requested_poc_workspace = args.poc_workspace_dir
 
-    if requested_poc_workspace is None and args.job_templates_dir is None:
+    if requested_poc_workspace is None:
         # Read-only: print existing config
         poc_workspace_dir = nvflare_config.get("poc.workspace", None) if nvflare_config else None
-        job_templates_dir = nvflare_config.get("job_template.path", None) if nvflare_config else None
+        active_startup_kit = nvflare_config.get("startup_kits.active", None) if nvflare_config else None
         output_ok(
             {
                 "config_file": config_file_path,
                 "poc_workspace_dir": poc_workspace_dir,
-                "job_templates_dir": job_templates_dir,
+                "active_startup_kit": active_startup_kit,
             }
         )
         return
 
     try:
         nvflare_config = create_poc_workspace_config(nvflare_config, requested_poc_workspace)
-        nvflare_config = create_job_template_config(nvflare_config, args.job_templates_dir)
         removed_startup_kit_keys = find_startup_kit_config_keys(nvflare_config)
         nvflare_config = remove_startup_kit_config_keys(nvflare_config)
     except ValueError as e:
@@ -216,7 +215,7 @@ def handle_config_cmd(args):
     backup_path = backup_hidden_config_file(config_file_path) if removed_startup_kit_keys else None
     save_config(nvflare_config, config_file_path)
     if removed_startup_kit_keys:
-        message = "Warning: removed startup kit config keys now managed by 'nvflare kit': " + ", ".join(
+        message = "Warning: removed startup kit config keys now managed by 'nvflare config kit': " + ", ".join(
             removed_startup_kit_keys
         )
         if backup_path:
@@ -224,13 +223,13 @@ def handle_config_cmd(args):
         print_human(message)
 
     poc_workspace_dir = nvflare_config.get("poc.workspace", None) if nvflare_config else requested_poc_workspace
-    job_templates_dir = nvflare_config.get("job_template.path", None) if nvflare_config else args.job_templates_dir
+    active_startup_kit = nvflare_config.get("startup_kits.active", None) if nvflare_config else None
 
     output_ok(
         {
             "config_file": config_file_path,
             "poc_workspace_dir": poc_workspace_dir,
-            "job_templates_dir": job_templates_dir,
+            "active_startup_kit": active_startup_kit,
         }
     )
 
@@ -357,7 +356,6 @@ def parse_args(prog_name: str):
     sub_cmd_parsers.update(def_dashboard_parser(sub_cmd))
     sub_cmd_parsers.update(def_authz_preview_parser(sub_cmd))
     sub_cmd_parsers.update(def_job_cli_parser(sub_cmd))
-    sub_cmd_parsers.update(def_kit_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_recipe_parser(sub_cmd))
     sub_cmd_parsers.update(def_config_parser(sub_cmd))
     sub_cmd_parsers.update(def_cert_cli_parser(sub_cmd))
@@ -391,7 +389,11 @@ def parse_args(prog_name: str):
         ns.poc_sub_cmd = sub_sub
         ns.system_sub_cmd = sub_sub
         ns.study_sub_cmd = sub_sub
-        ns.kit_sub_cmd = sub_sub
+        ns.config_sub_cmd = sub_sub
+        if raw_cmd == CMD_CONFIG and sub_sub == "kit":
+            ns.kit_sub_cmd = positionals[2] if len(positionals) > 2 else None
+        else:
+            ns.kit_sub_cmd = sub_sub
         ns.cert_sub_command = sub_sub
         ns.recipe_sub_cmd = sub_sub or "list"
         ns.format = global_args.format
@@ -425,7 +427,6 @@ handlers = {
     CMD_DASHBOARD: handle_dashboard,
     CMD_AUTHZ_PREVIEW: handle_authz_preview,
     CMD_JOB: handle_job_cli_cmd,
-    CMD_KIT: handle_kit_cmd,
     CMD_RECIPE: handle_recipe_cmd,
     CMD_CONFIG: handle_config_cmd,
     CMD_CERT: handle_cert_cmd,

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -30,6 +30,7 @@ from nvflare.private.fed.app.simulator.simulator import define_simulator_parser,
 from nvflare.private.fed.app.utils import version_check
 from nvflare.tool.cert.cert_cli import def_cert_cli_parser, handle_cert_cmd
 from nvflare.tool.job.job_cli import def_job_cli_parser, handle_job_cli_cmd
+from nvflare.tool.kit.kit_cli import def_kit_cli_parser, handle_kit_cmd
 from nvflare.tool.package.package_cli import def_package_cli_parser, handle_package_cmd
 from nvflare.tool.poc.poc_commands import def_poc_parser, handle_poc_cmd
 from nvflare.tool.preflight_check import check_packages, define_preflight_check_parser
@@ -37,15 +38,14 @@ from nvflare.tool.recipe.recipe_cli import def_recipe_parser, handle_recipe_cmd
 from nvflare.tool.study.study_cli import def_study_cli_parser, handle_study_cmd
 from nvflare.tool.system.system_cli import def_system_cli_parser, handle_system_cmd
 from nvflare.utils.cli_utils import (
-    TARGET_POC,
-    TARGET_PROD,
+    CONFIG_VERSION,
+    CURRENT_CONFIG_VERSION,
     backup_hidden_config_file,
     create_job_template_config,
     create_poc_workspace_config,
-    create_startup_kit_config,
-    ensure_hidden_config_migrated,
+    find_startup_kit_config_keys,
     load_hidden_config_state,
-    print_hidden_config_migration_notice,
+    remove_startup_kit_config_keys,
     save_config,
 )
 
@@ -58,6 +58,7 @@ CMD_AUTHZ_PREVIEW = "authz-preview"
 CMD_JOB = "job"
 CMD_RECIPE = "recipe"
 CMD_CONFIG = "config"
+CMD_KIT = "kit"
 CMD_CERT = "cert"
 CMD_PACKAGE = "package"
 CMD_SYSTEM = "system"
@@ -150,33 +151,8 @@ _config_parser = None
 def def_config_parser(sub_cmd):
     global _config_parser
     cmd = "config"
-    config_parser = sub_cmd.add_parser(cmd, help="configure local NVFlare settings (startup kit path, POC workspace)")
+    config_parser = sub_cmd.add_parser(cmd, help="configure local NVFlare settings (POC workspace, job templates)")
     _config_parser = config_parser
-    config_parser.add_argument(
-        "--poc.startup_kit",
-        dest="poc_startup_kit_dir",
-        type=str,
-        nargs="?",
-        default=None,
-        help="POC startup kit location",
-    )
-    config_parser.add_argument(
-        "--prod.startup_kit",
-        dest="prod_startup_kit_dir",
-        type=str,
-        nargs="?",
-        default=None,
-        help="production startup kit location",
-    )
-    config_parser.add_argument(
-        "-d",
-        "--startup_kit_dir",
-        dest="legacy_startup_kit_dir",
-        type=str,
-        nargs="?",
-        default=None,
-        help=argparse.SUPPRESS,
-    )
     config_parser.add_argument(
         "-pw",
         "--poc.workspace",
@@ -202,52 +178,25 @@ def handle_config_cmd(args):
         _config_parser,
         "nvflare config",
         [
-            "nvflare config --poc.startup_kit /path/to/poc_startup",
-            "nvflare config --prod.startup_kit /path/to/prod_startup",
             "nvflare config --poc.workspace /path/to/poc_workspace",
+            "nvflare config --job_templates_dir /path/to/job_templates",
+            "nvflare kit add project_admin /path/to/startup-kit",
+            "nvflare kit use project_admin",
         ],
         sys.argv[1:],
     )
 
-    config_file_path, loaded_config, migration_needed = load_hidden_config_state()
+    config_file_path, loaded_config, _migration_needed = load_hidden_config_state()
     nvflare_config = loaded_config or CF.parse_string("{}")
-    requested_poc_startup = args.poc_startup_kit_dir
-    requested_prod_startup = args.prod_startup_kit_dir
     requested_poc_workspace = args.poc_workspace_dir
-    legacy_startup_kit_dir = getattr(args, "legacy_startup_kit_dir", None)
 
-    if legacy_startup_kit_dir is not None:
-        if requested_poc_startup is not None or requested_prod_startup is not None:
-            output_error(
-                "INVALID_ARGS",
-                exit_code=4,
-                detail="--startup_kit_dir cannot be used together with --poc.startup_kit or --prod.startup_kit",
-            )
-            raise SystemExit(4)
-        requested_poc_startup = legacy_startup_kit_dir
-        print_human(
-            "WARNING: 'nvflare config -d/--startup_kit_dir' is deprecated. "
-            "Use '--poc.startup_kit' for the same setting."
-        )
-
-    if (
-        requested_poc_startup is None
-        and requested_prod_startup is None
-        and requested_poc_workspace is None
-        and args.job_templates_dir is None
-    ):
+    if requested_poc_workspace is None and args.job_templates_dir is None:
         # Read-only: print existing config
-        poc_startup_kit_dir = nvflare_config.get("poc.startup_kit", None) if nvflare_config else None
-        prod_startup_kit_dir = nvflare_config.get("prod.startup_kit", None) if nvflare_config else None
-        startup_kit_dir = poc_startup_kit_dir or prod_startup_kit_dir
         poc_workspace_dir = nvflare_config.get("poc.workspace", None) if nvflare_config else None
         job_templates_dir = nvflare_config.get("job_template.path", None) if nvflare_config else None
         output_ok(
             {
                 "config_file": config_file_path,
-                "startup_kit_dir": startup_kit_dir,
-                "poc_startup_kit_dir": poc_startup_kit_dir,
-                "prod_startup_kit_dir": prod_startup_kit_dir,
                 "poc_workspace_dir": poc_workspace_dir,
                 "job_templates_dir": job_templates_dir,
             }
@@ -255,31 +204,31 @@ def handle_config_cmd(args):
         return
 
     try:
-        nvflare_config = create_startup_kit_config(nvflare_config, TARGET_POC, requested_poc_startup)
-        nvflare_config = create_startup_kit_config(nvflare_config, TARGET_PROD, requested_prod_startup)
         nvflare_config = create_poc_workspace_config(nvflare_config, requested_poc_workspace)
         nvflare_config = create_job_template_config(nvflare_config, args.job_templates_dir)
+        removed_startup_kit_keys = find_startup_kit_config_keys(nvflare_config)
+        nvflare_config = remove_startup_kit_config_keys(nvflare_config)
     except ValueError as e:
         output_error("INVALID_ARGS", exit_code=4, detail=str(e))
         raise SystemExit(4)
 
-    backup_path = backup_hidden_config_file(config_file_path) if migration_needed else None
+    nvflare_config.put(CONFIG_VERSION, CURRENT_CONFIG_VERSION)
+    backup_path = backup_hidden_config_file(config_file_path) if removed_startup_kit_keys else None
     save_config(nvflare_config, config_file_path)
-    if backup_path:
-        print_hidden_config_migration_notice(config_file_path, backup_path)
+    if removed_startup_kit_keys:
+        message = "Warning: removed startup kit config keys now managed by 'nvflare kit': " + ", ".join(
+            removed_startup_kit_keys
+        )
+        if backup_path:
+            message += f"; backup saved to {backup_path}"
+        print_human(message)
 
-    poc_startup_kit_dir = nvflare_config.get("poc.startup_kit", None) if nvflare_config else requested_poc_startup
-    prod_startup_kit_dir = nvflare_config.get("prod.startup_kit", None) if nvflare_config else requested_prod_startup
-    startup_kit_dir = poc_startup_kit_dir or prod_startup_kit_dir
     poc_workspace_dir = nvflare_config.get("poc.workspace", None) if nvflare_config else requested_poc_workspace
     job_templates_dir = nvflare_config.get("job_template.path", None) if nvflare_config else args.job_templates_dir
 
     output_ok(
         {
             "config_file": config_file_path,
-            "startup_kit_dir": startup_kit_dir,
-            "poc_startup_kit_dir": poc_startup_kit_dir,
-            "prod_startup_kit_dir": prod_startup_kit_dir,
             "poc_workspace_dir": poc_workspace_dir,
             "job_templates_dir": job_templates_dir,
         }
@@ -408,6 +357,7 @@ def parse_args(prog_name: str):
     sub_cmd_parsers.update(def_dashboard_parser(sub_cmd))
     sub_cmd_parsers.update(def_authz_preview_parser(sub_cmd))
     sub_cmd_parsers.update(def_job_cli_parser(sub_cmd))
+    sub_cmd_parsers.update(def_kit_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_recipe_parser(sub_cmd))
     sub_cmd_parsers.update(def_config_parser(sub_cmd))
     sub_cmd_parsers.update(def_cert_cli_parser(sub_cmd))
@@ -441,6 +391,7 @@ def parse_args(prog_name: str):
         ns.poc_sub_cmd = sub_sub
         ns.system_sub_cmd = sub_sub
         ns.study_sub_cmd = sub_sub
+        ns.kit_sub_cmd = sub_sub
         ns.cert_sub_command = sub_sub
         ns.recipe_sub_cmd = sub_sub or "list"
         ns.format = global_args.format
@@ -474,6 +425,7 @@ handlers = {
     CMD_DASHBOARD: handle_dashboard,
     CMD_AUTHZ_PREVIEW: handle_authz_preview,
     CMD_JOB: handle_job_cli_cmd,
+    CMD_KIT: handle_kit_cmd,
     CMD_RECIPE: handle_recipe_cmd,
     CMD_CONFIG: handle_config_cmd,
     CMD_CERT: handle_cert_cmd,
@@ -594,7 +546,6 @@ def print_nvflare_version():
 def main():
     if "--schema" not in sys.argv:
         version_check()
-        ensure_hidden_config_migrated()
     run("nvflare")
 
 

--- a/nvflare/fuel/flare_api/api_spec.py
+++ b/nvflare/fuel/flare_api/api_spec.py
@@ -286,18 +286,15 @@ class SessionSpec(ABC):
         pass
 
     @abstractmethod
-    def get_job_logs(
-        self, job_id: str, target: str = "server", tail_lines: int = None, grep_pattern: str = None
-    ) -> dict:
+    def get_job_logs(self, job_id: str, target: str = "server") -> dict:
         """Retrieve logs for the specified job.
 
         Args:
             job_id: ID of the job
-            target: target site name. Only ``server`` is currently supported
-            tail_lines: optional number of tail lines to retrieve
-            grep_pattern: optional substring filter
+            target: ``server``, ``all``, or a client site name
 
-        Returns: dict with ``logs`` mapping site names to log content.
+        Returns: dict with ``logs`` mapping site names to log content, and
+            optional ``unavailable`` mapping site names to reasons.
 
         """
         pass

--- a/nvflare/fuel/flare_api/api_spec.py
+++ b/nvflare/fuel/flare_api/api_spec.py
@@ -286,12 +286,20 @@ class SessionSpec(ABC):
         pass
 
     @abstractmethod
-    def get_job_logs(self, job_id: str, target: str = "server") -> dict:
+    def get_job_logs(
+        self,
+        job_id: str,
+        target: str = "server",
+        tail_lines: Optional[int] = None,
+        grep_pattern: Optional[str] = None,
+    ) -> dict:
         """Retrieve logs for the specified job.
 
         Args:
             job_id: ID of the job
             target: ``server``, ``all``, or a client site name
+            tail_lines: deprecated compatibility option to return the last N lines
+            grep_pattern: deprecated compatibility option to return matching lines
 
         Returns: dict with ``logs`` mapping site names to log content, and
             optional ``unavailable`` mapping site names to reasons.

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -1083,40 +1083,30 @@ class Session(SessionSpec):
 
         self._do_command(join_args([AdminCommandNames.REMOVE_CLIENT, client_name]))
 
-    def get_job_logs(
-        self, job_id: str, target: str = "server", tail_lines: int = None, grep_pattern: str = None
-    ) -> dict:
-        """Retrieve job logs from server workspace.
+    def get_job_logs(self, job_id: str, target: str = "server") -> dict:
+        """Retrieve job logs from the server-side log store.
 
         Args:
             job_id (str): ID of the job
-            target (str): target site name. Only "server" is currently supported.
-            tail_lines (int): optional number of tail lines to retrieve
-            grep_pattern (str): optional grep pattern to filter log lines
+            target (str): "server", "all", or a client site name
 
-        Returns: dict with "logs" keys mapping site name to log text.
+        Returns: dict with "logs" mapping site name to log text, and optional
+            "unavailable" mapping site names to reasons.
 
         """
         self._validate_job_id(job_id)
-        if target != "server":
-            raise ValueError("get_job_logs currently only supports target='server'")
-        if tail_lines is not None:
-            if not isinstance(tail_lines, int):
-                raise ValueError(f"tail_lines must be int but got {type(tail_lines)}")
-            if tail_lines <= 0:
-                raise ValueError("tail_lines must be greater than 0")
+        if not isinstance(target, str) or not target:
+            raise ValueError("target must be a non-empty str")
 
-        parts = [AdminCommandNames.GET_JOB_LOG, job_id]
-        if tail_lines is not None:
-            parts.extend(["-n", str(tail_lines)])
-        if grep_pattern:
-            parts.extend(["-g", grep_pattern])
-
+        parts = [AdminCommandNames.GET_JOB_LOG, job_id, target]
         command = join_args(parts)
         reply = self._do_command(command, enforce_meta=False)
         payload = self._get_dict_data(reply)
         if isinstance(payload, dict) and "logs" in payload:
-            return {"logs": payload.get("logs", {})}
+            result = {"logs": payload.get("logs", {})}
+            if "unavailable" in payload:
+                result["unavailable"] = payload.get("unavailable", {})
+            return result
         return {"logs": payload}
 
     def configure_job_log(self, job_id: str, config, target: str = "all") -> None:

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -1083,12 +1083,56 @@ class Session(SessionSpec):
 
         self._do_command(join_args([AdminCommandNames.REMOVE_CLIENT, client_name]))
 
-    def get_job_logs(self, job_id: str, target: str = "server") -> dict:
+    @staticmethod
+    def _filter_job_log_text(log_text: str, tail_lines: Optional[int], grep_pattern: Optional[str]) -> str:
+        lines = log_text.splitlines(keepends=True)
+        if tail_lines is not None:
+            try:
+                line_count = int(tail_lines)
+            except (TypeError, ValueError) as e:
+                raise ValueError("tail_lines must be an integer") from e
+            if line_count < 0:
+                raise ValueError("tail_lines must be greater than or equal to 0")
+            lines = lines[-line_count:] if line_count else []
+        if grep_pattern:
+            pattern = str(grep_pattern)
+            lines = [line for line in lines if pattern in line]
+        return "".join(lines)
+
+    @classmethod
+    def _filter_job_logs_payload(cls, result: dict, tail_lines: Optional[int], grep_pattern: Optional[str]) -> dict:
+        if tail_lines is None and not grep_pattern:
+            return result
+
+        logs = result.get("logs")
+        if not isinstance(logs, dict):
+            return result
+
+        filtered_logs = {}
+        for site_name, log_text in logs.items():
+            if isinstance(log_text, str):
+                filtered_logs[site_name] = cls._filter_job_log_text(log_text, tail_lines, grep_pattern)
+            else:
+                filtered_logs[site_name] = log_text
+
+        filtered_result = dict(result)
+        filtered_result["logs"] = filtered_logs
+        return filtered_result
+
+    def get_job_logs(
+        self,
+        job_id: str,
+        target: str = "server",
+        tail_lines: Optional[int] = None,
+        grep_pattern: Optional[str] = None,
+    ) -> dict:
         """Retrieve job logs from the server-side log store.
 
         Args:
             job_id (str): ID of the job
             target (str): "server", "all", or a client site name
+            tail_lines (int, optional): deprecated compatibility filter that returns only the last N lines
+            grep_pattern (str, optional): deprecated compatibility filter that returns matching lines
 
         Returns: dict with "logs" mapping site name to log text, and optional
             "unavailable" mapping site names to reasons.
@@ -1106,8 +1150,8 @@ class Session(SessionSpec):
             result = {"logs": payload.get("logs", {})}
             if "unavailable" in payload:
                 result["unavailable"] = payload.get("unavailable", {})
-            return result
-        return {"logs": payload}
+            return self._filter_job_logs_payload(result, tail_lines, grep_pattern)
+        return self._filter_job_logs_payload({"logs": payload}, tail_lines, grep_pattern)
 
     def configure_job_log(self, job_id: str, config, target: str = "all") -> None:
         """Configure logging for a running job.

--- a/nvflare/lighter/dummy_project.yml
+++ b/nvflare/lighter/dummy_project.yml
@@ -28,6 +28,14 @@ participants:
     type: admin
     org: nvidia
     role: project_admin
+  - name: org-admin@nvidia.com
+    type: admin
+    org: nvidia
+    role: org_admin
+  - name: lead@nvidia.com
+    type: admin
+    org: nvidia
+    role: lead
 
 # The same methods in all builders are called in their order defined in builders section
 builders:

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -504,8 +504,16 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
 
         # Accept the protocol token "@ALL" and the CLI/API spelling "all".
         all_targets = {ALL_SITES.lower(), "all"}
+        workspace_zip = None
+        workspace_zip_loaded = False
+        if target_lower in all_targets:
+            workspace_zip = self._read_stored_workspace_zip(conn, job_id)
+            workspace_zip_loaded = True
+
         if target_lower in {SERVER_SITE_NAME, *all_targets}:
-            server_log = self._read_server_job_log(conn, job_id)
+            server_log = self._read_server_job_log(
+                conn, job_id, workspace_zip=workspace_zip, workspace_zip_loaded=workspace_zip_loaded
+            )
             if server_log is not None or target_lower == SERVER_SITE_NAME:
                 payload["logs"][SERVER_SITE_NAME] = server_log or ""
             else:
@@ -515,7 +523,9 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             if target_lower not in {SERVER_SITE_NAME, *all_targets}:
                 self._add_client_job_log(conn, payload, job_id, target)
             elif target_lower in all_targets:
-                self._add_all_client_job_logs(conn, payload, job_id)
+                self._add_all_client_job_logs(
+                    conn, payload, job_id, workspace_zip=workspace_zip, workspace_zip_loaded=workspace_zip_loaded
+                )
         except TypeError as e:
             error = secure_format_exception(e)
             conn.append_error(error, meta=make_meta(MetaStatusValue.INTERNAL_ERROR, error))
@@ -523,11 +533,15 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
 
         conn.append_dict(payload, meta=make_meta(MetaStatusValue.OK))
 
-    def _read_server_job_log(self, conn: Connection, job_id: str) -> Optional[str]:
+    def _read_server_job_log(
+        self, conn: Connection, job_id: str, workspace_zip: bytes = None, workspace_zip_loaded: bool = False
+    ) -> Optional[str]:
         engine = conn.app_ctx
         log_text = self._read_live_server_job_log(engine, job_id)
         if log_text is not None:
             return log_text
+        if workspace_zip_loaded:
+            return self._extract_server_log_from_workspace_zip(workspace_zip)
         return self._read_stored_server_job_log(conn, job_id)
 
     def _read_live_server_job_log(self, engine, job_id: str) -> Optional[str]:
@@ -544,6 +558,10 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         return None
 
     def _read_stored_server_job_log(self, conn: Connection, job_id: str) -> Optional[str]:
+        workspace_zip = self._read_stored_workspace_zip(conn, job_id)
+        return self._extract_server_log_from_workspace_zip(workspace_zip)
+
+    def _read_stored_workspace_zip(self, conn: Connection, job_id: str) -> Optional[bytes]:
         engine = conn.app_ctx
         job_def_manager = engine.job_def_manager
         if not isinstance(job_def_manager, JobDefManagerSpec):
@@ -555,7 +573,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             except StorageException:
                 return None
 
-        return self._extract_server_log_from_workspace_zip(workspace_zip)
+        return workspace_zip
 
     def _extract_server_log_from_workspace_zip(self, workspace_zip: bytes) -> Optional[str]:
         if not workspace_zip:
@@ -594,7 +612,14 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         else:
             payload["logs"][client_name] = text
 
-    def _add_all_client_job_logs(self, conn: Connection, payload: dict, job_id: str):
+    def _add_all_client_job_logs(
+        self,
+        conn: Connection,
+        payload: dict,
+        job_id: str,
+        workspace_zip: bytes = None,
+        workspace_zip_loaded: bool = False,
+    ):
         engine = conn.app_ctx
         job_def_manager = engine.job_def_manager
         if not isinstance(job_def_manager, JobDefManagerSpec):
@@ -604,11 +629,28 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
 
         with engine.new_context() as fl_ctx:
             available_sites = self._get_available_client_log_sites(job_def_manager, job_id, fl_ctx)
-            available_sites.update(self._get_available_workspace_client_log_sites(job_def_manager, job_id, fl_ctx))
+            if workspace_zip_loaded:
+                workspace_client_logs = self._extract_client_logs_from_workspace_zip(workspace_zip)
+            else:
+                # Defensive path for direct helper calls. get_job_log preloads the workspace
+                # ZIP before calling this for --site all.
+                workspace_client_logs = self._read_workspace_client_job_logs(job_def_manager, job_id, fl_ctx)
+            available_sites.update(workspace_client_logs.keys())
 
         known_sites = self._get_job_client_targets(conn.get_prop(self.JOB))
         for client_name in sorted(known_sites | available_sites):
-            text = self._read_client_job_log(conn, job_id, client_name)
+            text = self._read_live_client_job_log(engine, job_id, client_name)
+            if text is None:
+                text = workspace_client_logs.get(client_name)
+            if text is None:
+                with engine.new_context() as fl_ctx:
+                    data = job_def_manager.get_client_data(
+                        jid=job_id,
+                        client_name=client_name,
+                        data_type=self._client_log_data_type(),
+                        fl_ctx=fl_ctx,
+                    )
+                text = self._decode_job_log_data(data)
             if text is not None:
                 payload["logs"][client_name] = text
 
@@ -708,32 +750,57 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             if component.startswith(component_prefix) and component[len(component_prefix) :]
         }
 
-    def _get_available_workspace_client_log_sites(self, job_def_manager, job_id: str, fl_ctx) -> Set[str]:
+    def _read_workspace_client_job_logs(self, job_def_manager, job_id: str, fl_ctx) -> Dict[str, str]:
         try:
             workspace_zip = job_def_manager.get_storage_component(jid=job_id, component=WORKSPACE, fl_ctx=fl_ctx)
         except StorageException:
-            return set()
+            return {}
 
+        return self._extract_client_logs_from_workspace_zip(workspace_zip)
+
+    def _extract_client_logs_from_workspace_zip(self, workspace_zip: bytes) -> Dict[str, str]:
         if not workspace_zip:
-            return set()
+            return {}
 
         try:
             with ZipFile(io.BytesIO(workspace_zip), "r") as zip_file:
-                return self._find_workspace_client_log_sites(zip_file.namelist())
+                log_members = self._find_workspace_client_log_members(zip_file.namelist())
+                logs = {}
+                for client_name, log_name in log_members.items():
+                    try:
+                        with zip_file.open(log_name, "r") as log_file:
+                            data = log_file.read(self.MAX_RETURNED_JOB_LOG_BYTES + 1)
+                    except (KeyError, OSError):
+                        continue
+                    text = self._decode_job_log_data(data)
+                    if text is not None:
+                        logs[client_name] = text
+                return logs
         except (BadZipFile, OSError, TypeError):
-            return set()
+            return {}
 
     @staticmethod
     def _find_workspace_client_log_sites(member_names: List[str]) -> Set[str]:
-        sites = set()
+        return set(JobCommandModule._find_workspace_client_log_members(member_names))
+
+    @staticmethod
+    def _find_workspace_client_log_members(member_names: List[str]) -> Dict[str, str]:
+        members = {}
+        exact_members = {}
         log_file_name = WorkspaceConstants.LOG_FILE_NAME
         for member_name in member_names:
             if member_name.endswith("/") or not member_name.endswith(f"/{log_file_name}"):
                 continue
             parts = member_name.split("/")
             if len(parts) >= 2 and parts[-2] and parts[-2] != SERVER_SITE_NAME:
-                sites.add(parts[-2])
-        return sites
+                if len(parts) == 2:
+                    exact_members[parts[-2]] = member_name
+                elif parts[-2] not in members:
+                    members[parts[-2]] = member_name
+        # Prefer exact two-part paths (client_name/fl.log) over deeper paths
+        # (run_1/client_name/fl.log) by letting exact_members overwrite members.
+        members.update(exact_members)
+        return members
 
     @staticmethod
     def _get_job_client_targets(job) -> Set[str]:

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -511,10 +511,15 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             else:
                 payload.setdefault("unavailable", {})[SERVER_SITE_NAME] = "server log not available for this job"
 
-        if target_lower not in {SERVER_SITE_NAME, *all_targets}:
-            self._add_client_job_log(conn, payload, job_id, target)
-        elif target_lower in all_targets:
-            self._add_all_client_job_logs(conn, payload, job_id)
+        try:
+            if target_lower not in {SERVER_SITE_NAME, *all_targets}:
+                self._add_client_job_log(conn, payload, job_id, target)
+            elif target_lower in all_targets:
+                self._add_all_client_job_logs(conn, payload, job_id)
+        except TypeError as e:
+            error = secure_format_exception(e)
+            conn.append_error(error, meta=make_meta(MetaStatusValue.INTERNAL_ERROR, error))
+            return
 
         conn.append_dict(payload, meta=make_meta(MetaStatusValue.OK))
 
@@ -573,6 +578,13 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         log_file_name = WorkspaceConstants.LOG_FILE_NAME
         if log_file_name in member_names:
             return log_file_name
+        server_log_name = f"{SERVER_SITE_NAME}/{log_file_name}"
+        if server_log_name in member_names:
+            return server_log_name
+        suffix = f"/{server_log_name}"
+        for member_name in member_names:
+            if not member_name.endswith("/") and member_name.endswith(suffix):
+                return member_name
         return None
 
     def _add_client_job_log(self, conn: Connection, payload: dict, job_id: str, client_name: str):
@@ -719,7 +731,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             if member_name.endswith("/") or not member_name.endswith(f"/{log_file_name}"):
                 continue
             parts = member_name.split("/")
-            if len(parts) >= 2 and parts[-2]:
+            if len(parts) >= 2 and parts[-2] and parts[-2] != SERVER_SITE_NAME:
                 sites.add(parts[-2])
         return sites
 

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import datetime
+import io
 import json
 import os
 import shutil
 import uuid
-from collections import deque
-from typing import Dict, List
+from typing import Dict, List, Optional, Set
+from zipfile import BadZipFile, ZipFile
 
 import nvflare.fuel.hci.file_transfer_defs as ftd
 from nvflare.apis.event_type import EventType
@@ -34,7 +35,17 @@ from nvflare.apis.job_def import (
 )
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.shareable import Shareable
-from nvflare.apis.storage import DATA, JOB_ZIP, META, META_JSON, WORKSPACE, WORKSPACE_ZIP, StorageSpec
+from nvflare.apis.storage import (
+    DATA,
+    JOB_ZIP,
+    META,
+    META_JSON,
+    WORKSPACE,
+    WORKSPACE_ZIP,
+    DataTypes,
+    StorageException,
+    StorageSpec,
+)
 from nvflare.fuel.hci.conn import Connection
 from nvflare.fuel.hci.proto import ConfirmMethod, MetaKey, MetaStatusValue, make_meta
 from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandSpec
@@ -87,8 +98,7 @@ def _create_list_job_cmd_parser():
 def _create_get_job_log_cmd_parser():
     parser = SafeArgumentParser(prog=AdminCommandNames.GET_JOB_LOG)
     parser.add_argument("job_id", help="Job ID")
-    parser.add_argument("-n", dest="tail_lines", type=int, help="Tail line count")
-    parser.add_argument("-g", dest="grep_pattern", help="Filter log lines containing the substring pattern")
+    parser.add_argument("target", nargs="?", default=SERVER_SITE_NAME, help="server, all, or a client site name")
     return parser
 
 
@@ -96,7 +106,6 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
     """Command module with commands for job management."""
 
     MAX_RETURNED_JOB_LOG_BYTES = 5 * 1024 * 1024
-    MAX_RETURNED_JOB_LOG_LINES = 10000
 
     def __init__(self):
         super().__init__()
@@ -131,8 +140,8 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                 ),
                 CommandSpec(
                     name=AdminCommandNames.GET_JOB_LOG,
-                    description="get server log text for a job",
-                    usage=f"{AdminCommandNames.GET_JOB_LOG} job_id [-n tail_lines] [-g grep_pattern]",
+                    description="get job log text from the server-side log store",
+                    usage=f"{AdminCommandNames.GET_JOB_LOG} job_id [server|all|client_name]",
                     handler_func=self.get_job_log,
                     authz_func=self.authorize_job_id,
                 ),
@@ -489,92 +498,281 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         if not isinstance(engine, ServerEngine):
             raise TypeError("engine must be ServerEngine but got {}".format(type(engine)))
 
+        target = parsed_args.target
+        target_lower = target.lower() if isinstance(target, str) else target
+        payload = {"logs": {}}
+
+        # Accept the protocol token "@ALL" and the CLI/API spelling "all".
+        all_targets = {ALL_SITES.lower(), "all"}
+        if target_lower in {SERVER_SITE_NAME, *all_targets}:
+            server_log = self._read_server_job_log(conn, job_id)
+            if server_log is not None or target_lower == SERVER_SITE_NAME:
+                payload["logs"][SERVER_SITE_NAME] = server_log or ""
+            else:
+                payload.setdefault("unavailable", {})[SERVER_SITE_NAME] = "server log not available for this job"
+
+        if target_lower not in {SERVER_SITE_NAME, *all_targets}:
+            self._add_client_job_log(conn, payload, job_id, target)
+        elif target_lower in all_targets:
+            self._add_all_client_job_logs(conn, payload, job_id)
+
+        conn.append_dict(payload, meta=make_meta(MetaStatusValue.OK))
+
+    def _read_server_job_log(self, conn: Connection, job_id: str) -> Optional[str]:
+        engine = conn.app_ctx
+        log_text = self._read_live_server_job_log(engine, job_id)
+        if log_text is not None:
+            return log_text
+        return self._read_stored_server_job_log(conn, job_id)
+
+    def _read_live_server_job_log(self, engine, job_id: str) -> Optional[str]:
         workspace = engine.get_workspace()
         log_file = os.path.join(workspace.get_log_root(job_id), WorkspaceConstants.LOG_FILE_NAME)
-        log_lines = []
         try:
             if os.path.exists(log_file):
-                if parsed_args.tail_lines is not None and parsed_args.tail_lines <= 0:
-                    conn.append_error(
-                        "tail_lines must be greater than 0",
-                        meta=make_meta(MetaStatusValue.SYNTAX_ERROR, "tail_lines must be greater than 0"),
-                    )
-                    return
-
-                log_lines = self._collect_job_log_lines(
-                    log_file, tail_lines=parsed_args.tail_lines, grep_pattern=parsed_args.grep_pattern
-                )
+                return "".join(self._collect_job_log_lines(log_file))
         except FileNotFoundError:
             # The log file can disappear between the existence check and the open() if the
-            # active run rotates or cleans up the workspace. Treat that as an empty live-log
-            # read rather than surfacing an internal error to the admin client.
-            log_lines = []
+            # active run rotates or cleans up the workspace. Treat that as unavailable
+            # rather than surfacing an internal error to the admin client.
+            return None
+        return None
 
-        conn.append_dict({"logs": {SERVER_SITE_NAME: "".join(log_lines)}}, meta=make_meta(MetaStatusValue.OK))
+    def _read_stored_server_job_log(self, conn: Connection, job_id: str) -> Optional[str]:
+        engine = conn.app_ctx
+        job_def_manager = engine.job_def_manager
+        if not isinstance(job_def_manager, JobDefManagerSpec):
+            return None
 
-    def _collect_job_log_lines(self, log_file: str, tail_lines=None, grep_pattern=None):
-        if tail_lines is not None:
-            # Bound tail mode by both requested lines and an internal safety cap so an
-            # extreme `-n` on a file with very short lines cannot grow server memory
-            # without limit before the byte cap has a chance to kick in.
-            max_tail_lines = min(tail_lines, self.MAX_RETURNED_JOB_LOG_LINES)
-            capped_by_line_limit = tail_lines > self.MAX_RETURNED_JOB_LOG_LINES
-            lines = deque()
+        with engine.new_context() as fl_ctx:
+            try:
+                workspace_zip = job_def_manager.get_storage_component(jid=job_id, component=WORKSPACE, fl_ctx=fl_ctx)
+            except StorageException:
+                return None
+
+        return self._extract_server_log_from_workspace_zip(workspace_zip)
+
+    def _extract_server_log_from_workspace_zip(self, workspace_zip: bytes) -> Optional[str]:
+        if not workspace_zip:
+            return None
+
+        try:
+            with ZipFile(io.BytesIO(workspace_zip), "r") as zip_file:
+                log_name = self._find_server_log_member(zip_file.namelist())
+                if not log_name:
+                    return None
+                with zip_file.open(log_name, "r") as log_file:
+                    data = log_file.read(self.MAX_RETURNED_JOB_LOG_BYTES + 1)
+        except (BadZipFile, KeyError, OSError, TypeError):
+            return None
+
+        return self._decode_job_log_data(data)
+
+    @staticmethod
+    def _find_server_log_member(member_names: List[str]) -> Optional[str]:
+        log_file_name = WorkspaceConstants.LOG_FILE_NAME
+        if log_file_name in member_names:
+            return log_file_name
+        return None
+
+    def _add_client_job_log(self, conn: Connection, payload: dict, job_id: str, client_name: str):
+        text = self._read_client_job_log(conn, job_id, client_name)
+        if text is None:
+            payload.setdefault("unavailable", {})[client_name] = "client log stream not available for this job"
         else:
-            capped_by_line_limit = False
-            lines = []
+            payload["logs"][client_name] = text
+
+    def _add_all_client_job_logs(self, conn: Connection, payload: dict, job_id: str):
+        engine = conn.app_ctx
+        job_def_manager = engine.job_def_manager
+        if not isinstance(job_def_manager, JobDefManagerSpec):
+            raise TypeError(
+                f"job_def_manager in engine is not of type JobDefManagerSpec, but got {type(job_def_manager)}"
+            )
+
+        with engine.new_context() as fl_ctx:
+            available_sites = self._get_available_client_log_sites(job_def_manager, job_id, fl_ctx)
+            available_sites.update(self._get_available_workspace_client_log_sites(job_def_manager, job_id, fl_ctx))
+
+        known_sites = self._get_job_client_targets(conn.get_prop(self.JOB))
+        for client_name in sorted(known_sites | available_sites):
+            text = self._read_client_job_log(conn, job_id, client_name)
+            if text is not None:
+                payload["logs"][client_name] = text
+
+        missing_sites = known_sites - set(payload["logs"].keys()) - {SERVER_SITE_NAME}
+        if missing_sites:
+            unavailable = payload.setdefault("unavailable", {})
+            for client_name in sorted(missing_sites):
+                unavailable[client_name] = "client log stream not available for this job"
+
+    def _read_client_job_log(self, conn: Connection, job_id: str, client_name: str) -> Optional[str]:
+        engine = conn.app_ctx
+        job_def_manager = engine.job_def_manager
+        if not isinstance(job_def_manager, JobDefManagerSpec):
+            raise TypeError(
+                f"job_def_manager in engine is not of type JobDefManagerSpec, but got {type(job_def_manager)}"
+            )
+
+        text = self._read_live_client_job_log(engine, job_id, client_name)
+        if text is not None:
+            return text
+
+        text = self._read_stored_client_job_log(conn, job_id, client_name)
+        if text is not None:
+            return text
+
+        with engine.new_context() as fl_ctx:
+            data = job_def_manager.get_client_data(
+                jid=job_id,
+                client_name=client_name,
+                data_type=self._client_log_data_type(),
+                fl_ctx=fl_ctx,
+            )
+        return self._decode_job_log_data(data)
+
+    def _read_live_client_job_log(self, engine, job_id: str, client_name: str) -> Optional[str]:
+        workspace = engine.get_workspace()
+        log_file = os.path.join(workspace.get_log_root(job_id), client_name, WorkspaceConstants.LOG_FILE_NAME)
+        try:
+            if os.path.exists(log_file):
+                return "".join(self._collect_job_log_lines(log_file))
+        except FileNotFoundError:
+            return None
+        return None
+
+    def _read_stored_client_job_log(self, conn: Connection, job_id: str, client_name: str) -> Optional[str]:
+        engine = conn.app_ctx
+        job_def_manager = engine.job_def_manager
+        if not isinstance(job_def_manager, JobDefManagerSpec):
+            return None
+
+        with engine.new_context() as fl_ctx:
+            try:
+                workspace_zip = job_def_manager.get_storage_component(jid=job_id, component=WORKSPACE, fl_ctx=fl_ctx)
+            except StorageException:
+                return None
+
+        return self._extract_client_log_from_workspace_zip(workspace_zip, client_name)
+
+    def _extract_client_log_from_workspace_zip(self, workspace_zip: bytes, client_name: str) -> Optional[str]:
+        if not workspace_zip:
+            return None
+
+        try:
+            with ZipFile(io.BytesIO(workspace_zip), "r") as zip_file:
+                log_name = self._find_client_log_member(zip_file.namelist(), client_name)
+                if not log_name:
+                    return None
+                with zip_file.open(log_name, "r") as log_file:
+                    data = log_file.read(self.MAX_RETURNED_JOB_LOG_BYTES + 1)
+        except (BadZipFile, KeyError, OSError, TypeError):
+            return None
+
+        return self._decode_job_log_data(data)
+
+    @staticmethod
+    def _find_client_log_member(member_names: List[str], client_name: str) -> Optional[str]:
+        log_file_name = WorkspaceConstants.LOG_FILE_NAME
+        client_log_name = f"{client_name}/{log_file_name}"
+        if client_log_name in member_names:
+            return client_log_name
+        suffix = f"/{client_log_name}"
+        for member_name in member_names:
+            if not member_name.endswith("/") and member_name.endswith(suffix):
+                return member_name
+        return None
+
+    @staticmethod
+    def _client_log_data_type() -> str:
+        return f"{DataTypes.LOG.value}_{WorkspaceConstants.LOG_FILE_NAME}"
+
+    def _get_available_client_log_sites(self, job_def_manager, job_id: str, fl_ctx) -> Set[str]:
+        component_prefix = f"{self._client_log_data_type()}_"
+        components = job_def_manager.list_components(jid=job_id, fl_ctx=fl_ctx) or []
+        return {
+            component[len(component_prefix) :]
+            for component in components
+            if component.startswith(component_prefix) and component[len(component_prefix) :]
+        }
+
+    def _get_available_workspace_client_log_sites(self, job_def_manager, job_id: str, fl_ctx) -> Set[str]:
+        try:
+            workspace_zip = job_def_manager.get_storage_component(jid=job_id, component=WORKSPACE, fl_ctx=fl_ctx)
+        except StorageException:
+            return set()
+
+        if not workspace_zip:
+            return set()
+
+        try:
+            with ZipFile(io.BytesIO(workspace_zip), "r") as zip_file:
+                return self._find_workspace_client_log_sites(zip_file.namelist())
+        except (BadZipFile, OSError, TypeError):
+            return set()
+
+    @staticmethod
+    def _find_workspace_client_log_sites(member_names: List[str]) -> Set[str]:
+        sites = set()
+        log_file_name = WorkspaceConstants.LOG_FILE_NAME
+        for member_name in member_names:
+            if member_name.endswith("/") or not member_name.endswith(f"/{log_file_name}"):
+                continue
+            parts = member_name.split("/")
+            if len(parts) >= 2 and parts[-2]:
+                sites.add(parts[-2])
+        return sites
+
+    @staticmethod
+    def _get_job_client_targets(job) -> Set[str]:
+        if not job or not getattr(job, "meta", None):
+            return set()
+
+        deploy_map = job.meta.get(JobMetaKey.DEPLOY_MAP.value, {})
+        if not isinstance(deploy_map, dict):
+            return set()
+
+        targets = set()
+        for deployments in deploy_map.values():
+            for site_name in extract_participants(deployments):
+                if not site_name or site_name == SERVER_SITE_NAME or site_name.upper() == ALL_SITES:
+                    continue
+                targets.add(site_name)
+        return targets
+
+    def _decode_job_log_data(self, data) -> Optional[str]:
+        if data is None:
+            return None
+        if isinstance(data, str):
+            raw_data = data.encode("utf-8", errors="replace")
+        else:
+            raw_data = bytes(data)
+
+        truncated = len(raw_data) > self.MAX_RETURNED_JOB_LOG_BYTES
+        if truncated:
+            raw_data = raw_data[: self.MAX_RETURNED_JOB_LOG_BYTES]
+        text = raw_data.decode("utf-8", errors="replace")
+        if truncated:
+            text += f"\n... output truncated after {self.MAX_RETURNED_JOB_LOG_BYTES} bytes ...\n"
+        return text
+
+    def _collect_job_log_lines(self, log_file: str):
+        lines = []
         collected_bytes = 0
         truncated_by_bytes = False
-        truncated_by_lines = False
 
         with open(log_file, "r", encoding="utf-8", errors="replace") as f:
             for line in f:
-                if grep_pattern and grep_pattern not in line:
-                    continue
-
                 line_len = len(line.encode("utf-8", errors="replace"))
-                if tail_lines is None:
-                    if collected_bytes + line_len > self.MAX_RETURNED_JOB_LOG_BYTES:
-                        truncated_by_bytes = True
-                        break
-                    collected_bytes += line_len
-                    lines.append(line)
-                else:
-                    if line_len > self.MAX_RETURNED_JOB_LOG_BYTES:
-                        truncated_by_bytes = True
-                        continue
+                if collected_bytes + line_len > self.MAX_RETURNED_JOB_LOG_BYTES:
+                    truncated_by_bytes = True
+                    break
+                collected_bytes += line_len
+                lines.append(line)
 
-                    while lines and len(lines) >= max_tail_lines:
-                        _removed_line, removed_len = lines.popleft()
-                        collected_bytes -= removed_len
-                        if capped_by_line_limit:
-                            truncated_by_lines = True
-
-                    while lines and collected_bytes + line_len > self.MAX_RETURNED_JOB_LOG_BYTES:
-                        _removed_line, removed_len = lines.popleft()
-                        collected_bytes -= removed_len
-                        truncated_by_bytes = True
-
-                    # If a single retained line would still exceed the byte budget after
-                    # eviction, drop it and report truncation rather than returning a
-                    # response that exceeds the server-side safety limit.
-                    if collected_bytes + line_len > self.MAX_RETURNED_JOB_LOG_BYTES:
-                        truncated_by_bytes = True
-                        continue
-
-                    lines.append((line, line_len))
-                    collected_bytes += line_len
-
-        result = [line for line, _ in lines] if tail_lines is not None else list(lines)
-        if truncated_by_bytes or truncated_by_lines:
-            if truncated_by_bytes and truncated_by_lines:
-                limit_text = f"{self.MAX_RETURNED_JOB_LOG_BYTES} bytes and {self.MAX_RETURNED_JOB_LOG_LINES} lines"
-            elif truncated_by_bytes:
-                limit_text = f"{self.MAX_RETURNED_JOB_LOG_BYTES} bytes"
-            else:
-                limit_text = f"{self.MAX_RETURNED_JOB_LOG_LINES} lines"
-            result.append(f"... output truncated after {limit_text}; use -n/-g to narrow results ...\n")
-        return result
+        if truncated_by_bytes:
+            lines.append(f"... output truncated after {self.MAX_RETURNED_JOB_LOG_BYTES} bytes ...\n")
+        return lines
 
     def list_job_components(self, conn: Connection, args: List[str]):
         if len(args) < 2:

--- a/nvflare/tool/cli_errors.py
+++ b/nvflare/tool/cli_errors.py
@@ -40,7 +40,7 @@ _ERROR_REGISTRY: Dict[str, Dict[str, str]] = {
     },
     "STARTUP_KIT_MISSING": {
         "message": "Startup kit not found.",
-        "hint": "Use --startup-kit, set NVFLARE_STARTUP_KIT_DIR, or configure a startup kit with 'nvflare config'.",
+        "hint": "Run 'nvflare kit list' and 'nvflare kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation.",
     },
     "SITE_NOT_FOUND": {
         "message": "Site '{site}' is not connected.",
@@ -91,8 +91,8 @@ _ERROR_REGISTRY: Dict[str, Dict[str, str]] = {
         "hint": "Use 'nvflare study add-user' to add the user first.",
     },
     "STARTUP_KIT_NOT_CONFIGURED": {
-        "message": "Startup kit is not configured for target '{target}'.",
-        "hint": "Run 'nvflare config --{target}.startup_kit <dir>' or use --startup-kit.",
+        "message": "No active startup kit is configured.",
+        "hint": "Run 'nvflare kit list' and 'nvflare kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation.",
     },
     "LOCK_TIMEOUT": {
         "message": "Study registry is busy.",
@@ -114,6 +114,10 @@ _ERROR_REGISTRY: Dict[str, Dict[str, str]] = {
     "JOB_INVALID": {
         "message": "Job folder is not a valid NVFlare job.",
         "hint": "Check meta.json and config_fed_server.json.",
+    },
+    "LOG_NOT_FOUND": {
+        "message": "Job logs are not available for site '{site}'.",
+        "hint": "Verify that client log streaming is enabled and that the site has run this job.",
     },
     # --- Cert commands ---
     "OUTPUT_DIR_NOT_WRITABLE": {

--- a/nvflare/tool/cli_errors.py
+++ b/nvflare/tool/cli_errors.py
@@ -40,7 +40,7 @@ _ERROR_REGISTRY: Dict[str, Dict[str, str]] = {
     },
     "STARTUP_KIT_MISSING": {
         "message": "Startup kit not found.",
-        "hint": "Run 'nvflare kit list' and 'nvflare kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation.",
+        "hint": "Run 'nvflare config kit list' and 'nvflare config kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation.",
     },
     "SITE_NOT_FOUND": {
         "message": "Site '{site}' is not connected.",
@@ -92,7 +92,7 @@ _ERROR_REGISTRY: Dict[str, Dict[str, str]] = {
     },
     "STARTUP_KIT_NOT_CONFIGURED": {
         "message": "No active startup kit is configured.",
-        "hint": "Run 'nvflare kit list' and 'nvflare kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation.",
+        "hint": "Run 'nvflare config kit list' and 'nvflare config kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation.",
     },
     "LOCK_TIMEOUT": {
         "message": "Study registry is busy.",

--- a/nvflare/tool/cli_session.py
+++ b/nvflare/tool/cli_session.py
@@ -14,6 +14,7 @@
 """CLI-scoped session helpers."""
 
 from nvflare.fuel.flare_api.flare_api import Session, new_secure_session
+from nvflare.tool.kit.kit_config import resolve_admin_user_and_dir_from_startup_kit, resolve_startup_kit_dir
 
 
 def new_cli_session(
@@ -32,4 +33,17 @@ def new_cli_session(
         study=study,
         timeout=timeout,
         auto_login_max_tries=1,
+    )
+
+
+def new_active_cli_session(timeout: float, study: str = "default", debug: bool = False) -> Session:
+    """Create a CLI session using NVFLARE_STARTUP_KIT_DIR or the active registered startup kit."""
+    startup_dir = resolve_startup_kit_dir()
+    username, admin_user_dir = resolve_admin_user_and_dir_from_startup_kit(startup_dir)
+    return new_cli_session(
+        username=username,
+        startup_kit_location=admin_user_dir,
+        timeout=timeout,
+        study=study,
+        debug=debug,
     )

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -992,7 +992,9 @@ def _get_arg_value(args, name, default=None):
 
 
 def _job_session_for_args(cmd_args=None, study="default"):
-    return _session(args=cmd_args, study=study)
+    if study != "default":
+        return _session(study=study)
+    return _session()
 
 
 def cmd_job_list(cmd_args):

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -89,7 +89,7 @@ CMD_JOB_LOG_ALIAS = "log"
 
 _JOB_HELP_FORMATTER = partial(argparse.HelpFormatter, max_help_position=24, width=120)
 _ACTIVE_STARTUP_KIT_HINT = (
-    "Run 'nvflare kit list' and 'nvflare kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation."
+    "Run 'nvflare config kit list' and 'nvflare config kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation."
 )
 
 
@@ -434,7 +434,7 @@ def submit_job(cmd_args):
     handle_schema_flag(
         job_sub_cmd_parser[CMD_SUBMIT_JOB],
         "nvflare job submit",
-        ["nvflare kit use admin@nvidia.com", "nvflare job submit -j ./my_job"],
+        ["nvflare config kit use admin@nvidia.com", "nvflare job submit -j ./my_job"],
         sys.argv[1:],
     )
 

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -30,7 +30,7 @@ from pyhocon import ConfigTree
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
 from nvflare.fuel.utils.config import ConfigFormat
 from nvflare.fuel.utils.config_factory import ConfigFactory
-from nvflare.tool.cli_session import new_cli_session
+from nvflare.tool.cli_session import new_active_cli_session, new_cli_session
 from nvflare.tool.job.config.configer import (
     build_config_file_indices,
     filter_indices,
@@ -60,14 +60,10 @@ from nvflare.tool.job.job_client_const import (
     TEMPLATES_KEY,
 )
 from nvflare.utils.cli_utils import (
-    TARGET_POC,
-    backup_hidden_config_file,
     create_job_template_config,
     find_job_templates_location,
     get_curr_dir,
-    get_startup_kit_dir_for_target,
     load_hidden_config_state,
-    print_hidden_config_migration_notice,
     save_config,
 )
 
@@ -92,6 +88,9 @@ CMD_JOB_LOG_CONFIG = "log-config"
 CMD_JOB_LOG_ALIAS = "log"
 
 _JOB_HELP_FORMATTER = partial(argparse.HelpFormatter, max_help_position=24, width=120)
+_ACTIVE_STARTUP_KIT_HINT = (
+    "Run 'nvflare kit list' and 'nvflare kit use <id>', or set NVFLARE_STARTUP_KIT_DIR for automation."
+)
 
 
 def find_filename_basename(f: str):
@@ -377,17 +376,14 @@ def list_templates(cmd_args):
 
 
 def update_job_templates_dir(job_templates_dir: str):
-    config_file_path, nvflare_config, migration_needed = load_hidden_config_state()
+    config_file_path, nvflare_config, _migration_needed = load_hidden_config_state()
     if nvflare_config is None:
         from pyhocon import ConfigFactory as CF
 
         nvflare_config = CF.parse_string("{}")
 
     config = create_job_template_config(nvflare_config, job_templates_dir)
-    backup_path = backup_hidden_config_file(config_file_path) if migration_needed else None
     save_config(config, config_file_path)
-    if backup_path:
-        print_hidden_config_migration_notice(config_file_path, backup_path)
 
 
 def display_available_templates(template_index_conf):
@@ -438,7 +434,7 @@ def submit_job(cmd_args):
     handle_schema_flag(
         job_sub_cmd_parser[CMD_SUBMIT_JOB],
         "nvflare job submit",
-        ["nvflare job submit -j ./my_job"],
+        ["nvflare kit use admin@nvidia.com", "nvflare job submit -j ./my_job"],
         sys.argv[1:],
     )
 
@@ -493,11 +489,7 @@ def submit_job(cmd_args):
         app_names = app_names if app_names else [DEFAULT_APP_NAME]
 
         prepare_job_config(cmd_args, app_names, temp_job_dir)
-        admin_username, admin_user_dir = find_admin_user_and_dir(
-            startup_kit_dir=getattr(cmd_args, "startup_kit", None),
-            target=getattr(cmd_args, "startup_target", None),
-        )
-        internal_submit_job(admin_user_dir, admin_username, temp_job_dir, cmd_args)
+        internal_submit_job(None, None, temp_job_dir, cmd_args)
 
     except ValueError as e:
         from nvflare.tool.cli_output import output_usage_error, print_human
@@ -516,33 +508,9 @@ def submit_job(cmd_args):
 
 
 def _resolve_admin_user_and_dir_from_startup_kit(startup_kit_dir: str) -> Tuple[str, str]:
-    if os.path.basename(startup_kit_dir) == "startup":
-        admin_user_dir = os.path.dirname(startup_kit_dir)
-        startup_dir = startup_kit_dir
-    else:
-        admin_user_dir = startup_kit_dir
-        startup_dir = os.path.join(admin_user_dir, "startup")
+    from nvflare.tool.kit.kit_config import resolve_admin_user_and_dir_from_startup_kit
 
-    if not os.path.isdir(startup_dir):
-        raise ValueError(
-            f"startup kit directory '{startup_kit_dir}' must be an admin startup kit directory "
-            f"or its 'startup' subdirectory"
-        )
-
-    fed_admin_config = ConfigFactory.load_config("fed_admin.json", [startup_dir])
-
-    if fed_admin_config:
-        config_dict = fed_admin_config.to_dict()
-        admin_username = config_dict["admin"].get("username", None)
-    else:
-        raise ValueError(f"Unable to locate fed_admin configuration from startup kit location {startup_kit_dir}")
-
-    return admin_username, admin_user_dir
-
-
-def find_admin_user_and_dir(startup_kit_dir: Optional[str] = None, target: Optional[str] = None) -> Tuple[str, str]:
-    startup_kit_dir = get_startup_kit_dir_for_target(startup_kit_dir=startup_kit_dir, target=target)
-    return _resolve_admin_user_and_dir_from_startup_kit(startup_kit_dir)
+    return resolve_admin_user_and_dir_from_startup_kit(startup_kit_dir)
 
 
 def internal_submit_job(admin_user_dir, username, temp_job_dir, cmd_args=None):
@@ -552,15 +520,8 @@ def internal_submit_job(admin_user_dir, username, temp_job_dir, cmd_args=None):
     if not is_json_mode():
         print_human("trying to connect to the server")
     study = getattr(cmd_args, "study", "default") if cmd_args else "default"
-    from nvflare.tool.cli_output import get_connect_timeout
 
-    timeout = get_connect_timeout()
-    sess = new_cli_session(
-        username=username,
-        startup_kit_location=admin_user_dir,
-        timeout=timeout,
-        study=study,
-    )
+    sess = _get_session(args=cmd_args, admin_user_dir=admin_user_dir, username=username, study=study)
     try:
         try:
             job_id = sess.submit_job(temp_job_dir)
@@ -653,26 +614,6 @@ def def_job_cli_parser(sub_cmd):
     return {cmd: parser}
 
 
-def _add_job_connection_args(parser):
-    startup_target_group = parser.add_mutually_exclusive_group()
-    startup_target_group.add_argument(
-        "--startup-target",
-        "--startup_target",  # backward compat
-        choices=["poc", "prod"],
-        default=None,
-        dest="startup_target",
-        help=f"startup kit target from ~/.nvflare/config.conf, default to {TARGET_POC}",
-    )
-    startup_target_group.add_argument(
-        "--startup-kit",
-        "--startup_kit",  # backward compat
-        dest="startup_kit",
-        type=str,
-        default=None,
-        help="explicit startup kit location; mutually exclusive with --startup-target",
-    )
-
-
 def define_submit_job_parser(job_subparser):
     submit_parser = job_subparser.add_parser("submit", help="submit job")
     submit_parser.add_argument(
@@ -685,7 +626,6 @@ def define_submit_job_parser(job_subparser):
         default=os.path.join(get_curr_dir(), "current_job"),
         help="job folder path, default to ./current_job directory",
     )
-    _add_job_connection_args(submit_parser)
     submit_parser.add_argument("-debug", "--debug", action="store_true", help="debug is on")
     submit_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     submit_parser.add_argument("--study", type=str, default="default", help="study to submit the job to")
@@ -985,24 +925,45 @@ def create_app_dir(job_folder, app_name: str = "app"):
 
 
 def _get_session(args=None, admin_user_dir=None, username=None, study="default"):
-    """Create a secure session using the startup kit."""
+    """Create a secure session using the active startup kit."""
     from nvflare.tool.cli_output import get_connect_timeout, output_error
+
+    timeout = get_connect_timeout()
+
+    if admin_user_dir is None and username is None:
+        try:
+            return new_active_cli_session(
+                timeout=timeout,
+                study=study,
+                debug=_get_arg_value(args, "debug", False),
+            )
+        except ValueError as e:
+            output_error(
+                "STARTUP_KIT_MISSING",
+                exit_code=2,
+                detail=str(e),
+                hint=getattr(e, "hint", None) or _ACTIVE_STARTUP_KIT_HINT,
+            )
+            raise SystemExit(2)
 
     if admin_user_dir is None or username is None:
         try:
-            u, d = find_admin_user_and_dir(
-                startup_kit_dir=_get_arg_value(args, "startup_kit"),
-                target=_get_arg_value(args, "startup_target"),
-            )
+            from nvflare.tool.kit.kit_config import resolve_admin_user_and_dir_from_startup_kit, resolve_startup_kit_dir
+
+            u, d = resolve_admin_user_and_dir_from_startup_kit(resolve_startup_kit_dir())
         except ValueError as e:
-            output_error("STARTUP_KIT_MISSING", exit_code=2, detail=str(e))
+            output_error(
+                "STARTUP_KIT_MISSING",
+                exit_code=2,
+                detail=str(e),
+                hint=getattr(e, "hint", None) or _ACTIVE_STARTUP_KIT_HINT,
+            )
             raise SystemExit(2)
         if username is None:
             username = u
         if admin_user_dir is None:
             admin_user_dir = d
 
-    timeout = get_connect_timeout()
     return new_cli_session(
         username=username,
         startup_kit_location=admin_user_dir,
@@ -1031,13 +992,7 @@ def _get_arg_value(args, name, default=None):
 
 
 def _job_session_for_args(cmd_args=None, study="default"):
-    if cmd_args is not None and (
-        _get_arg_value(cmd_args, "startup_kit") is not None or _get_arg_value(cmd_args, "startup_target") is not None
-    ):
-        return _session(args=cmd_args, study=study)
-    if study != "default":
-        return _session(study=study)
-    return _session()
+    return _session(args=cmd_args, study=study)
 
 
 def cmd_job_list(cmd_args):
@@ -1257,7 +1212,6 @@ def define_list_jobs_parser(job_subparser):
     p.add_argument("-r", "--reverse", action="store_true", default=False, help="reverse sort order")
     p.add_argument("-m", "--max", type=int, default=None, help="max results to return")
     p.add_argument("--study", type=str, default="default", help="study to list jobs from")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_LIST] = p
     job_sub_cmd_handlers[CMD_JOB_LIST] = cmd_job_list
@@ -1266,7 +1220,6 @@ def define_list_jobs_parser(job_subparser):
 def define_job_meta_parser(job_subparser):
     p = job_subparser.add_parser(CMD_JOB_META, help="get metadata for a job")
     p.add_argument("job_id", type=str, help="job ID")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_META] = p
     job_sub_cmd_handlers[CMD_JOB_META] = cmd_job_meta
@@ -1276,7 +1229,6 @@ def define_abort_job_parser(job_subparser):
     p = job_subparser.add_parser(CMD_JOB_ABORT, help="abort a running job")
     p.add_argument("job_id", type=str, help="job ID")
     p.add_argument("--force", action="store_true", help="skip confirmation prompt")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_ABORT] = p
     job_sub_cmd_handlers[CMD_JOB_ABORT] = cmd_job_abort
@@ -1285,7 +1237,6 @@ def define_abort_job_parser(job_subparser):
 def define_clone_job_parser(job_subparser):
     p = job_subparser.add_parser(CMD_JOB_CLONE, help="clone an existing job")
     p.add_argument("job_id", type=str, help="job ID to clone")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_CLONE] = p
     job_sub_cmd_handlers[CMD_JOB_CLONE] = cmd_job_clone
@@ -1295,7 +1246,6 @@ def define_download_job_parser(job_subparser):
     p = job_subparser.add_parser(CMD_JOB_DOWNLOAD, help="download job result")
     p.add_argument("job_id", type=str, help="job ID")
     p.add_argument("-o", "--output-dir", dest="output_dir", type=str, default="./", help="destination directory")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_DOWNLOAD] = p
     job_sub_cmd_handlers[CMD_JOB_DOWNLOAD] = cmd_job_download
@@ -1305,7 +1255,6 @@ def define_delete_job_parser(job_subparser):
     p = job_subparser.add_parser(CMD_JOB_DELETE, help="delete a job")
     p.add_argument("job_id", type=str, help="job ID")
     p.add_argument("--force", action="store_true", help="skip confirmation prompt")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_DELETE] = p
     job_sub_cmd_handlers[CMD_JOB_DELETE] = cmd_job_delete
@@ -1354,33 +1303,25 @@ def cmd_job_stats(cmd_args):
 
 def cmd_job_logs(cmd_args):
     from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotFound, NoConnection
-    from nvflare.tool.cli_output import output_error, output_ok
+    from nvflare.tool.cli_output import is_json_mode, output_error, output_ok, print_human
     from nvflare.tool.cli_schema import handle_schema_flag
 
     handle_schema_flag(
         job_sub_cmd_parser[CMD_JOB_LOGS],
         "nvflare job logs",
-        ["nvflare job logs abc123", "nvflare job logs abc123 --tail 100 --site server"],
+        [
+            "nvflare job logs abc123",
+            "nvflare job logs abc123 --site site-1",
+            "nvflare job logs abc123 --site all",
+        ],
         sys.argv[1:],
     )
 
     site = getattr(cmd_args, "site", "server")
-    if site != "server":
-        output_error(
-            "INVALID_ARGS",
-            exit_code=4,
-            detail="only --site server is currently supported; client log streaming is not yet available",
-        )
-        raise SystemExit(4)
 
     try:
         with _job_session_for_args(cmd_args) as sess:
-            result = sess.get_job_logs(
-                cmd_args.job_id,
-                target=site,
-                tail_lines=cmd_args.tail,
-                grep_pattern=cmd_args.grep,
-            )
+            result = sess.get_job_logs(cmd_args.job_id, target=site)
     except JobNotFound:
         output_error("JOB_NOT_FOUND", job_id=cmd_args.job_id)
         return
@@ -1393,31 +1334,75 @@ def cmd_job_logs(cmd_args):
         output_error("INTERNAL_ERROR", exit_code=5, detail=str(e))
         return
 
-    output_ok({"job_id": cmd_args.job_id, "logs": result.get("logs", {})})
+    logs = result.get("logs", {})
+    unavailable = result.get("unavailable", {})
+    if site != "all" and site != "server" and site in unavailable and site not in logs:
+        output_error(
+            "LOG_NOT_FOUND",
+            exit_code=1,
+            site=site,
+            detail=unavailable.get(site),
+        )
+        return
+
+    payload = {"job_id": cmd_args.job_id, "target": site, "logs": logs}
+    if unavailable:
+        payload["unavailable"] = unavailable
+    if not is_json_mode():
+        _print_job_logs_human(site, logs, unavailable, print_human)
+        return
+    output_ok(payload)
+
+
+def _print_job_logs_human(target: str, logs: dict, unavailable: dict, print_func):
+    def _print_log_text(text):
+        if text:
+            print_func(text, end="" if text.endswith("\n") else "\n")
+        else:
+            print_func("(no log content)")
+
+    if target != "all" and target in logs and len(logs) == 1 and not unavailable:
+        _print_log_text(logs[target])
+        return
+
+    site_names = list(logs.keys())
+    if "server" in site_names:
+        site_names.remove("server")
+        site_names.insert(0, "server")
+
+    for index, site_name in enumerate(site_names):
+        if index:
+            print_func()
+        print_func(f"===== {site_name} =====")
+        _print_log_text(logs[site_name])
+
+    if unavailable:
+        if logs:
+            print_func()
+        print_func("Unavailable logs:", file=sys.stderr)
+        for site_name in sorted(unavailable):
+            print_func(f"{site_name}: {unavailable[site_name]}", file=sys.stderr)
 
 
 def define_job_stats_parser(job_subparser):
     p = job_subparser.add_parser(CMD_JOB_STATS, help="show running job statistics")
     p.add_argument("job_id", type=str, help="job ID")
     p.add_argument("--site", default="all", help="target site name or all")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_STATS] = p
     job_sub_cmd_handlers[CMD_JOB_STATS] = cmd_job_stats
 
 
 def define_job_logs_parser(job_subparser):
-    p = job_subparser.add_parser(CMD_JOB_LOGS, help="retrieve job logs from server workspace")
+    p = job_subparser.add_parser(CMD_JOB_LOGS, help="retrieve job logs from the server-side log store")
     p.add_argument("job_id", type=str, help="job ID")
     p.add_argument(
+        "--sites",
         "--site",
+        dest="site",
         default="server",
-        choices=["server"],
-        help="target site: only 'server' is currently supported (client log streaming not yet available)",
+        help="target site name, server, or all. Client logs must have been streamed to the server.",
     )
-    p.add_argument("--tail", type=int, default=None, help="number of tail lines to retrieve")
-    p.add_argument("--grep", default=None, help="grep pattern to filter log lines")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_LOGS] = p
     job_sub_cmd_handlers[CMD_JOB_LOGS] = cmd_job_logs
@@ -1821,7 +1806,6 @@ def define_job_monitor_parser(job_subparser):
         default=None,
         help="extra metric key to surface from stats (repeatable)",
     )
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_MONITOR] = p
     job_sub_cmd_handlers[CMD_JOB_MONITOR] = cmd_job_monitor
@@ -1841,7 +1825,6 @@ def define_job_log_parser(job_subparser):
         help="log level or mode: DEBUG, INFO, WARNING, ERROR, CRITICAL, concise, msg_only, full, verbose, reload",
     )
     p.add_argument("--site", default="all", help="target site name or all")
-    _add_job_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     job_sub_cmd_parser[CMD_JOB_LOG_CONFIG] = p
     job_sub_cmd_parser[CMD_JOB_LOG_ALIAS] = p

--- a/nvflare/tool/kit/__init__.py
+++ b/nvflare/tool/kit/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Startup kit registry CLI support."""

--- a/nvflare/tool/kit/kit_cli.py
+++ b/nvflare/tool/kit/kit_cli.py
@@ -23,6 +23,7 @@ from nvflare.tool.cli_output import is_json_mode, output_error_message, output_o
 from nvflare.tool.cli_schema import handle_schema_flag
 from nvflare.tool.kit.kit_config import (
     NVFLARE_STARTUP_KIT_DIR,
+    STARTUP_KIT_KIND_ADMIN,
     StartupKitConfigError,
     add_startup_kit_entry,
     get_active_startup_kit_id,
@@ -184,6 +185,10 @@ def cmd_kit_list(args):
     rows = []
     for kit_id, path in sorted(entries.items()):
         status, normalized_path, metadata = get_startup_kit_status(path)
+        # Valid site/server kits are service identities, not CLI user identities.
+        # Keep missing/invalid rows visible so users can clean stale registrations.
+        if metadata.get("kind") != STARTUP_KIT_KIND_ADMIN and status == "ok":
+            continue
         rows.append(
             {
                 "active": "*" if kit_id == active else "",

--- a/nvflare/tool/kit/kit_cli.py
+++ b/nvflare/tool/kit/kit_cli.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""nvflare kit command parser and handlers."""
+"""nvflare config kit command parser and handlers."""
 
 import os
 import sys
@@ -41,6 +41,7 @@ CMD_KIT_USE = "use"
 CMD_KIT_SHOW = "show"
 CMD_KIT_LIST = "list"
 CMD_KIT_REMOVE = "remove"
+KIT_COMMAND = "nvflare config kit"
 
 _kit_root_parser = None
 _kit_sub_cmd_parsers = {}
@@ -61,8 +62,8 @@ def _metadata_for_output(path: str) -> Dict[str, str]:
 def cmd_kit_add(args):
     handle_schema_flag(
         _kit_sub_cmd_parsers[CMD_KIT_ADD],
-        "nvflare kit add",
-        ["nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com"],
+        f"{KIT_COMMAND} add",
+        [f"{KIT_COMMAND} add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com"],
         sys.argv[1:],
     )
 
@@ -78,7 +79,7 @@ def cmd_kit_add(args):
         {
             "registered_startup_kit": kit_id,
             "path": get_startup_kit_entries(config)[kit_id],
-            "next_step": f"nvflare kit use {kit_id}",
+            "next_step": f"{KIT_COMMAND} use {kit_id}",
         }
     )
 
@@ -86,8 +87,8 @@ def cmd_kit_add(args):
 def cmd_kit_use(args):
     handle_schema_flag(
         _kit_sub_cmd_parsers[CMD_KIT_USE],
-        "nvflare kit use",
-        ["nvflare kit use cancer_lead"],
+        f"{KIT_COMMAND} use",
+        [f"{KIT_COMMAND} use cancer_lead"],
         sys.argv[1:],
     )
 
@@ -122,8 +123,8 @@ def _print_env_warning():
 def cmd_kit_show(args):
     handle_schema_flag(
         _kit_sub_cmd_parsers[CMD_KIT_SHOW],
-        "nvflare kit show",
-        ["nvflare kit show"],
+        f"{KIT_COMMAND} show",
+        [f"{KIT_COMMAND} show"],
         sys.argv[1:],
     )
 
@@ -141,13 +142,13 @@ def cmd_kit_show(args):
             output_ok({"active": None, "config_file": str(get_cli_config_path())})
         else:
             print_human("No active startup kit.")
-            print_human("Hint: Run nvflare kit use <id>.")
+            print_human(f"Hint: Run {KIT_COMMAND} use <id>.")
         return
 
     path = entries.get(active)
     data = {"active": active, "path": path or "-", "config_file": str(get_cli_config_path())}
     if path is None:
-        data.update({"status": "unregistered", "hint": "run nvflare kit list, then nvflare kit use <id>"})
+        data.update({"status": "unregistered", "hint": f"run {KIT_COMMAND} list, then {KIT_COMMAND} use <id>"})
     else:
         status, normalized_path, metadata = get_startup_kit_status(path)
         data["status"] = status
@@ -159,7 +160,7 @@ def cmd_kit_show(args):
         else:
             data["identity"] = "-"
             data["cert_role"] = "-"
-            data["hint"] = f"run nvflare kit use <id> or nvflare kit remove {active}"
+            data["hint"] = f"run {KIT_COMMAND} use <id> or {KIT_COMMAND} remove {active}"
 
     _print_env_warning()
     output_ok(data)
@@ -168,8 +169,8 @@ def cmd_kit_show(args):
 def cmd_kit_list(args):
     handle_schema_flag(
         _kit_sub_cmd_parsers[CMD_KIT_LIST],
-        "nvflare kit list",
-        ["nvflare kit list"],
+        f"{KIT_COMMAND} list",
+        [f"{KIT_COMMAND} list"],
         sys.argv[1:],
     )
 
@@ -202,8 +203,8 @@ def cmd_kit_list(args):
 def cmd_kit_remove(args):
     handle_schema_flag(
         _kit_sub_cmd_parsers[CMD_KIT_REMOVE],
-        "nvflare kit remove",
-        ["nvflare kit remove cancer_lead"],
+        f"{KIT_COMMAND} remove",
+        [f"{KIT_COMMAND} remove cancer_lead"],
         sys.argv[1:],
     )
 
@@ -219,7 +220,7 @@ def cmd_kit_remove(args):
     data = {"removed_startup_kit": kit_id}
     if was_active:
         data["warning"] = "no active startup kit is configured"
-        data["next_step"] = "nvflare kit use <id>"
+        data["next_step"] = f"{KIT_COMMAND} use <id>"
     output_ok(data)
 
 
@@ -271,11 +272,11 @@ def handle_kit_cmd(args):
     if "--schema" in getattr(args, "_argv", []) and sub_cmd is None:
         handle_schema_flag(
             _kit_root_parser,
-            "nvflare kit",
+            KIT_COMMAND,
             [
-                "nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com",
-                "nvflare kit use cancer_lead",
-                "nvflare kit list",
+                f"{KIT_COMMAND} add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com",
+                f"{KIT_COMMAND} use cancer_lead",
+                f"{KIT_COMMAND} list",
             ],
             sys.argv[1:],
         )

--- a/nvflare/tool/kit/kit_cli.py
+++ b/nvflare/tool/kit/kit_cli.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""nvflare kit command parser and handlers."""
+
+import os
+import sys
+from typing import Callable, Dict
+
+from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
+from nvflare.tool.cli_output import is_json_mode, output_error_message, output_ok, print_human
+from nvflare.tool.cli_schema import handle_schema_flag
+from nvflare.tool.kit.kit_config import (
+    NVFLARE_STARTUP_KIT_DIR,
+    StartupKitConfigError,
+    add_startup_kit_entry,
+    get_active_startup_kit_id,
+    get_cli_config_path,
+    get_startup_kit_entries,
+    get_startup_kit_status,
+    inspect_startup_kit_metadata,
+    load_cli_config,
+    remove_startup_kit_entry,
+    save_cli_config,
+    set_active_startup_kit,
+)
+
+CMD_KIT_ADD = "add"
+CMD_KIT_USE = "use"
+CMD_KIT_SHOW = "show"
+CMD_KIT_LIST = "list"
+CMD_KIT_REMOVE = "remove"
+
+_kit_root_parser = None
+_kit_sub_cmd_parsers = {}
+
+
+def _emit_kit_error(e: StartupKitConfigError, exit_code: int = 4):
+    output_error_message("INVALID_ARGS", str(e), hint=e.hint, exit_code=exit_code)
+
+
+def _metadata_for_output(path: str) -> Dict[str, str]:
+    metadata = inspect_startup_kit_metadata(path)
+    return {
+        "identity": metadata.get("identity") or "-",
+        "cert_role": metadata.get("cert_role") or "-",
+    }
+
+
+def cmd_kit_add(args):
+    handle_schema_flag(
+        _kit_sub_cmd_parsers[CMD_KIT_ADD],
+        "nvflare kit add",
+        ["nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com"],
+        sys.argv[1:],
+    )
+
+    kit_id = args.kit_id.strip()
+    try:
+        config = load_cli_config()
+        config = add_startup_kit_entry(config, kit_id, args.startup_kit_dir, force=args.force)
+        save_cli_config(config)
+    except StartupKitConfigError as e:
+        _emit_kit_error(e)
+
+    output_ok(
+        {
+            "registered_startup_kit": kit_id,
+            "path": get_startup_kit_entries(config)[kit_id],
+            "next_step": f"nvflare kit use {kit_id}",
+        }
+    )
+
+
+def cmd_kit_use(args):
+    handle_schema_flag(
+        _kit_sub_cmd_parsers[CMD_KIT_USE],
+        "nvflare kit use",
+        ["nvflare kit use cancer_lead"],
+        sys.argv[1:],
+    )
+
+    kit_id = args.kit_id.strip()
+    try:
+        config = load_cli_config()
+        entries = get_startup_kit_entries(config)
+        config = set_active_startup_kit(config, kit_id)
+        save_cli_config(config)
+    except StartupKitConfigError as e:
+        _emit_kit_error(e)
+
+    path = entries[kit_id]
+    metadata = _metadata_for_output(path)
+    output_ok(
+        {
+            "active_startup_kit": kit_id,
+            "identity": metadata["identity"],
+            "cert_role": metadata["cert_role"],
+            "path": path,
+        }
+    )
+
+
+def _print_env_warning():
+    env_path = os.getenv(NVFLARE_STARTUP_KIT_DIR)
+    if env_path:
+        print_human(f"warning: {NVFLARE_STARTUP_KIT_DIR} is set ({env_path})")
+        print_human("         normal commands will use this path instead of the active kit above")
+
+
+def cmd_kit_show(args):
+    handle_schema_flag(
+        _kit_sub_cmd_parsers[CMD_KIT_SHOW],
+        "nvflare kit show",
+        ["nvflare kit show"],
+        sys.argv[1:],
+    )
+
+    try:
+        config = load_cli_config()
+    except StartupKitConfigError as e:
+        _emit_kit_error(e)
+
+    active = get_active_startup_kit_id(config)
+    entries = get_startup_kit_entries(config)
+
+    if not active:
+        _print_env_warning()
+        if is_json_mode():
+            output_ok({"active": None, "config_file": str(get_cli_config_path())})
+        else:
+            print_human("No active startup kit.")
+            print_human("Hint: Run nvflare kit use <id>.")
+        return
+
+    path = entries.get(active)
+    data = {"active": active, "path": path or "-", "config_file": str(get_cli_config_path())}
+    if path is None:
+        data.update({"status": "unregistered", "hint": "run nvflare kit list, then nvflare kit use <id>"})
+    else:
+        status, normalized_path, metadata = get_startup_kit_status(path)
+        data["status"] = status
+        if normalized_path:
+            data["path"] = normalized_path
+        if status == "ok":
+            data["identity"] = metadata.get("identity") or "-"
+            data["cert_role"] = metadata.get("cert_role") or "-"
+        else:
+            data["identity"] = "-"
+            data["cert_role"] = "-"
+            data["hint"] = f"run nvflare kit use <id> or nvflare kit remove {active}"
+
+    _print_env_warning()
+    output_ok(data)
+
+
+def cmd_kit_list(args):
+    handle_schema_flag(
+        _kit_sub_cmd_parsers[CMD_KIT_LIST],
+        "nvflare kit list",
+        ["nvflare kit list"],
+        sys.argv[1:],
+    )
+
+    try:
+        config = load_cli_config()
+    except StartupKitConfigError as e:
+        _emit_kit_error(e)
+
+    active = get_active_startup_kit_id(config)
+    entries = get_startup_kit_entries(config)
+    rows = []
+    for kit_id, path in sorted(entries.items()):
+        status, normalized_path, metadata = get_startup_kit_status(path)
+        rows.append(
+            {
+                "active": "*" if kit_id == active else "",
+                "id": kit_id,
+                "status": status,
+                "identity": metadata.get("identity") or "-",
+                "cert_role": metadata.get("cert_role") or "-",
+                "path": normalized_path or path,
+            }
+        )
+
+    if not rows and not is_json_mode():
+        print_human("No startup kits registered.")
+    output_ok(rows)
+
+
+def cmd_kit_remove(args):
+    handle_schema_flag(
+        _kit_sub_cmd_parsers[CMD_KIT_REMOVE],
+        "nvflare kit remove",
+        ["nvflare kit remove cancer_lead"],
+        sys.argv[1:],
+    )
+
+    kit_id = args.kit_id.strip()
+    try:
+        config = load_cli_config()
+        was_active = get_active_startup_kit_id(config) == kit_id
+        config = remove_startup_kit_entry(config, kit_id)
+        save_cli_config(config)
+    except StartupKitConfigError as e:
+        _emit_kit_error(e)
+
+    data = {"removed_startup_kit": kit_id}
+    if was_active:
+        data["warning"] = "no active startup kit is configured"
+        data["next_step"] = "nvflare kit use <id>"
+    output_ok(data)
+
+
+_KIT_HANDLERS: Dict[str, Callable] = {
+    CMD_KIT_ADD: cmd_kit_add,
+    CMD_KIT_USE: cmd_kit_use,
+    CMD_KIT_SHOW: cmd_kit_show,
+    CMD_KIT_LIST: cmd_kit_list,
+    CMD_KIT_REMOVE: cmd_kit_remove,
+}
+
+
+def def_kit_cli_parser(sub_cmd):
+    global _kit_root_parser
+    parser = sub_cmd.add_parser("kit", help="manage local startup kit registrations")
+    _kit_root_parser = parser
+    kit_subparser = parser.add_subparsers(title="kit subcommands", metavar="", dest="kit_sub_cmd")
+
+    add_parser = kit_subparser.add_parser(CMD_KIT_ADD, help="register a startup kit path")
+    add_parser.add_argument("kit_id", help="local startup kit ID")
+    add_parser.add_argument("startup_kit_dir", help="admin startup kit directory")
+    add_parser.add_argument("--force", action="store_true", help="replace an existing local registration")
+    add_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _kit_sub_cmd_parsers[CMD_KIT_ADD] = add_parser
+
+    use_parser = kit_subparser.add_parser(CMD_KIT_USE, help="activate a registered startup kit")
+    use_parser.add_argument("kit_id", help="local startup kit ID")
+    use_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _kit_sub_cmd_parsers[CMD_KIT_USE] = use_parser
+
+    show_parser = kit_subparser.add_parser(CMD_KIT_SHOW, help="show the configured active startup kit")
+    show_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _kit_sub_cmd_parsers[CMD_KIT_SHOW] = show_parser
+
+    list_parser = kit_subparser.add_parser(CMD_KIT_LIST, help="list registered startup kits")
+    list_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _kit_sub_cmd_parsers[CMD_KIT_LIST] = list_parser
+
+    remove_parser = kit_subparser.add_parser(CMD_KIT_REMOVE, help="remove a local startup kit registration")
+    remove_parser.add_argument("kit_id", help="local startup kit ID")
+    remove_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _kit_sub_cmd_parsers[CMD_KIT_REMOVE] = remove_parser
+
+    return {"kit": parser}
+
+
+def handle_kit_cmd(args):
+    sub_cmd = getattr(args, "kit_sub_cmd", None)
+    if "--schema" in getattr(args, "_argv", []) and sub_cmd is None:
+        handle_schema_flag(
+            _kit_root_parser,
+            "nvflare kit",
+            [
+                "nvflare kit add cancer_lead /secure/startup_kits/cancer/lead@nvidia.com",
+                "nvflare kit use cancer_lead",
+                "nvflare kit list",
+            ],
+            sys.argv[1:],
+        )
+
+    handler = _KIT_HANDLERS.get(sub_cmd)
+    if handler:
+        handler(args)
+    elif sub_cmd is None:
+        _kit_root_parser.print_help()
+    else:
+        raise CLIUnknownCmdException("invalid kit command")

--- a/nvflare/tool/kit/kit_cli.py
+++ b/nvflare/tool/kit/kit_cli.py
@@ -23,7 +23,6 @@ from nvflare.tool.cli_output import is_json_mode, output_error_message, output_o
 from nvflare.tool.cli_schema import handle_schema_flag
 from nvflare.tool.kit.kit_config import (
     NVFLARE_STARTUP_KIT_DIR,
-    STARTUP_KIT_KIND_ADMIN,
     StartupKitConfigError,
     add_startup_kit_entry,
     get_active_startup_kit_id,
@@ -42,6 +41,7 @@ CMD_KIT_USE = "use"
 CMD_KIT_SHOW = "show"
 CMD_KIT_LIST = "list"
 CMD_KIT_REMOVE = "remove"
+# The kit parser is registered under the config subparser in nvflare/cli.py.
 KIT_COMMAND = "nvflare config kit"
 
 _kit_root_parser = None
@@ -75,6 +75,7 @@ def cmd_kit_add(args):
         save_cli_config(config)
     except StartupKitConfigError as e:
         _emit_kit_error(e)
+        return
 
     output_ok(
         {
@@ -101,6 +102,7 @@ def cmd_kit_use(args):
         save_cli_config(config)
     except StartupKitConfigError as e:
         _emit_kit_error(e)
+        return
 
     path = entries[kit_id]
     metadata = _metadata_for_output(path)
@@ -133,6 +135,7 @@ def cmd_kit_show(args):
         config = load_cli_config()
     except StartupKitConfigError as e:
         _emit_kit_error(e)
+        return
 
     active = get_active_startup_kit_id(config)
     entries = get_startup_kit_entries(config)
@@ -179,16 +182,13 @@ def cmd_kit_list(args):
         config = load_cli_config()
     except StartupKitConfigError as e:
         _emit_kit_error(e)
+        return
 
     active = get_active_startup_kit_id(config)
     entries = get_startup_kit_entries(config)
     rows = []
     for kit_id, path in sorted(entries.items()):
         status, normalized_path, metadata = get_startup_kit_status(path)
-        # Valid site/server kits are service identities, not CLI user identities.
-        # Keep missing/invalid rows visible so users can clean stale registrations.
-        if metadata.get("kind") != STARTUP_KIT_KIND_ADMIN and status == "ok":
-            continue
         rows.append(
             {
                 "active": "*" if kit_id == active else "",
@@ -221,6 +221,7 @@ def cmd_kit_remove(args):
         save_cli_config(config)
     except StartupKitConfigError as e:
         _emit_kit_error(e)
+        return
 
     data = {"removed_startup_kit": kit_id}
     if was_active:
@@ -246,7 +247,7 @@ def def_kit_cli_parser(sub_cmd):
 
     add_parser = kit_subparser.add_parser(CMD_KIT_ADD, help="register a startup kit path")
     add_parser.add_argument("kit_id", help="local startup kit ID")
-    add_parser.add_argument("startup_kit_dir", help="admin startup kit directory")
+    add_parser.add_argument("startup_kit_dir", help="admin/user startup kit directory")
     add_parser.add_argument("--force", action="store_true", help="replace an existing local registration")
     add_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _kit_sub_cmd_parsers[CMD_KIT_ADD] = add_parser

--- a/nvflare/tool/kit/kit_config.py
+++ b/nvflare/tool/kit/kit_config.py
@@ -16,6 +16,7 @@
 
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Dict, Optional, Set, Tuple
@@ -25,6 +26,15 @@ from pyhocon import ConfigTree, HOCONConverter
 
 from nvflare.fuel.utils.config_factory import ConfigFactory
 from nvflare.tool.job.job_client_const import CONFIG_CONF
+
+try:
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.x509.oid import NameOID
+except ImportError:
+    x509 = None
+    default_backend = None
+    NameOID = None
 
 CONFIG_VERSION = "version"
 CURRENT_CONFIG_VERSION = 2
@@ -42,6 +52,7 @@ SERVER_STARTUP_KIT_REQUIRED_FILES = (os.path.join("startup", "fed_server.json"),
 STARTUP_KIT_KIND_ADMIN = "admin"
 STARTUP_KIT_KIND_SITE = "site"
 STARTUP_KIT_KIND_SERVER = "server"
+_HOCON_SIMPLE_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class StartupKitConfigError(ValueError):
@@ -100,7 +111,7 @@ def save_cli_config(config: ConfigTree) -> None:
     """Atomically write ~/.nvflare/config.conf as config schema version 2."""
     config_path = get_cli_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    _remove_legacy_startup_kit_keys(_ensure_v2_config(config))
+    config = _remove_legacy_startup_kit_keys(_ensure_v2_config(config))
 
     config_text = HOCONConverter.to_hocon(config=config, level=1)
     temp_path = None
@@ -116,7 +127,12 @@ def save_cli_config(config: ConfigTree) -> None:
             os.remove(temp_path)
 
 
-def _quote_hocon_key(key: str) -> str:
+def _hocon_path_key(key: str) -> str:
+    """Return a ConfigTree.put path segment that preserves the registry ID literally."""
+    if _HOCON_SIMPLE_KEY_PATTERN.match(key):
+        return key
+    # ConfigTree.put treats dots as path separators. Quote emails and other complex IDs so
+    # values like lead@nvidia.com remain one registry key instead of nested HOCON paths.
     return json.dumps(key)
 
 
@@ -262,7 +278,7 @@ def add_startup_kit_entry(config: ConfigTree, kit_id: str, path: str, force: boo
     if raw_existing_key is not None:
         entries.pop(raw_existing_key, None)
 
-    config.put(f"{STARTUP_KITS_ENTRIES_KEY}.{_quote_hocon_key(kit_id)}", normalized_path)
+    config.put(f"{STARTUP_KITS_ENTRIES_KEY}.{_hocon_path_key(kit_id)}", normalized_path)
     return _ensure_v2_config(config)
 
 
@@ -304,26 +320,38 @@ def _canonical_path(path: str) -> Path:
     return Path(path).expanduser().resolve(strict=False)
 
 
+def _absolute_path(path: str) -> Path:
+    return Path(path).expanduser().absolute()
+
+
+def _path_match_candidates(path: str) -> Tuple[Path, ...]:
+    """Return real-path and spelling-preserving variants for workspace containment checks."""
+    canonical_path = _canonical_path(path)
+    absolute_path = _absolute_path(path)
+    if canonical_path == absolute_path:
+        return (canonical_path,)
+    return canonical_path, absolute_path
+
+
 def _is_relative_to(path: Path, base: Path) -> bool:
-    try:
-        return path == base or path.is_relative_to(base)
-    except AttributeError:
-        try:
-            return os.path.commonpath([str(path), str(base)]) == str(base)
-        except ValueError:
-            return False
+    return path == base or path.is_relative_to(base)
 
 
 def remove_entries_under_workspace(config: ConfigTree, workspace: str) -> Tuple[ConfigTree, Set[str]]:
-    """Remove entries whose canonical paths are under canonical workspace path."""
-    workspace_path = _canonical_path(workspace)
+    """Remove entries whose canonical or lexical paths are under the workspace path."""
+    workspace_paths = _path_match_candidates(workspace)
     entries = _get_entries_tree(config)
     removed = set()
 
     for raw_key, path in list(entries.items()):
         if not isinstance(path, str):
             continue
-        if _is_relative_to(_canonical_path(path), workspace_path):
+        path_candidates = _path_match_candidates(path)
+        if any(
+            _is_relative_to(path_candidate, workspace_path)
+            for path_candidate in path_candidates
+            for workspace_path in workspace_paths
+        ):
             removed.add(_decode_hocon_key(raw_key))
             entries.pop(raw_key, None)
 
@@ -350,22 +378,19 @@ def inspect_startup_kit_metadata(path: str) -> Dict[str, Optional[str]]:
         except Exception:
             pass
 
-        try:
-            from cryptography import x509
-            from cryptography.hazmat.backends import default_backend
-            from cryptography.x509.oid import NameOID
-
-            cert_path = os.path.join(startup_dir, "client.crt")
-            with open(cert_path, "rb") as f:
-                cert = x509.load_pem_x509_certificate(f.read(), default_backend())
-            role_attrs = cert.subject.get_attributes_for_oid(NameOID.UNSTRUCTURED_NAME)
-            if role_attrs:
-                metadata["cert_role"] = role_attrs[0].value
-            cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
-            if cn_attrs and not metadata["identity"]:
-                metadata["identity"] = cn_attrs[0].value
-        except Exception:
-            pass
+        if x509 and default_backend and NameOID:
+            try:
+                cert_path = os.path.join(startup_dir, "client.crt")
+                with open(cert_path, "rb") as f:
+                    cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+                role_attrs = cert.subject.get_attributes_for_oid(NameOID.UNSTRUCTURED_NAME)
+                if role_attrs:
+                    metadata["cert_role"] = role_attrs[0].value
+                cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+                if cn_attrs and not metadata["identity"]:
+                    metadata["identity"] = cn_attrs[0].value
+            except Exception:
+                pass
 
     if not metadata["identity"]:
         metadata["identity"] = os.path.basename(startup_kit_dir)

--- a/nvflare/tool/kit/kit_config.py
+++ b/nvflare/tool/kit/kit_config.py
@@ -1,0 +1,456 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared startup kit registry helpers for the NVFlare CLI."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict, Optional, Set, Tuple
+
+from pyhocon import ConfigFactory as CF
+from pyhocon import ConfigTree, HOCONConverter
+
+from nvflare.fuel.utils.config_factory import ConfigFactory
+from nvflare.tool.job.job_client_const import CONFIG_CONF
+
+CONFIG_VERSION = "version"
+CURRENT_CONFIG_VERSION = 2
+STARTUP_KITS_ACTIVE_KEY = "startup_kits.active"
+STARTUP_KITS_ENTRIES_KEY = "startup_kits.entries"
+NVFLARE_STARTUP_KIT_DIR = "NVFLARE_STARTUP_KIT_DIR"
+
+ADMIN_STARTUP_KIT_REQUIRED_FILES = (
+    os.path.join("startup", "fed_admin.json"),
+    os.path.join("startup", "client.crt"),
+    os.path.join("startup", "rootCA.pem"),
+)
+SITE_STARTUP_KIT_REQUIRED_FILES = (os.path.join("startup", "fed_client.json"),)
+SERVER_STARTUP_KIT_REQUIRED_FILES = (os.path.join("startup", "fed_server.json"),)
+STARTUP_KIT_KIND_ADMIN = "admin"
+STARTUP_KIT_KIND_SITE = "site"
+STARTUP_KIT_KIND_SERVER = "server"
+
+
+class StartupKitConfigError(ValueError):
+    """Configuration or validation error for startup kit resolution."""
+
+    def __init__(self, message: str, hint: str = None):
+        super().__init__(message)
+        self.hint = hint
+
+
+def get_cli_config_path() -> Path:
+    return Path.home() / ".nvflare" / CONFIG_CONF
+
+
+def _empty_v2_config() -> ConfigTree:
+    config = CF.parse_string("{}")
+    config.put(CONFIG_VERSION, CURRENT_CONFIG_VERSION)
+    config.put(STARTUP_KITS_ENTRIES_KEY, ConfigTree())
+    return config
+
+
+def _ensure_v2_config(config: ConfigTree) -> ConfigTree:
+    config.put(CONFIG_VERSION, CURRENT_CONFIG_VERSION)
+    if not isinstance(config.get(STARTUP_KITS_ENTRIES_KEY, None), ConfigTree):
+        config.put(STARTUP_KITS_ENTRIES_KEY, ConfigTree())
+    return config
+
+
+def _remove_legacy_startup_kit_keys(config: ConfigTree) -> ConfigTree:
+    for key in ("startup_kit.path", "startup_kit", "poc.startup_kit", "prod.startup_kit"):
+        try:
+            config.pop(key, None)
+        except Exception:
+            pass
+    return config
+
+
+def load_cli_config() -> ConfigTree:
+    """Load ~/.nvflare/config.conf or return an empty version-2 config."""
+    config_path = get_cli_config_path()
+    if not config_path.is_file():
+        return _empty_v2_config()
+
+    try:
+        config = CF.parse_file(str(config_path))
+    except Exception as e:
+        raise StartupKitConfigError(
+            f"cannot parse {config_path}",
+            hint="Fix the config file, or move it aside and run nvflare poc prepare.",
+        ) from e
+
+    return _ensure_v2_config(config)
+
+
+def save_cli_config(config: ConfigTree) -> None:
+    """Atomically write ~/.nvflare/config.conf as config schema version 2."""
+    config_path = get_cli_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    _remove_legacy_startup_kit_keys(_ensure_v2_config(config))
+
+    config_text = HOCONConverter.to_hocon(config=config, level=1)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=str(config_path.parent), delete=False) as outfile:
+            temp_path = outfile.name
+            outfile.write(f"{config_text}\n")
+            outfile.flush()
+            os.fsync(outfile.fileno())
+        os.replace(temp_path, config_path)
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+def _quote_hocon_key(key: str) -> str:
+    return json.dumps(key)
+
+
+def _decode_hocon_key(key: str) -> str:
+    if len(key) >= 2 and key[0] == '"' and key[-1] == '"':
+        try:
+            return json.loads(key)
+        except Exception:
+            return key[1:-1]
+    return key
+
+
+def _find_raw_entry_key(entries: ConfigTree, kit_id: str) -> Optional[str]:
+    for raw_key in entries.keys():
+        if _decode_hocon_key(raw_key) == kit_id:
+            return raw_key
+    return None
+
+
+def _get_entries_tree(config: ConfigTree) -> ConfigTree:
+    _ensure_v2_config(config)
+    entries = config.get(STARTUP_KITS_ENTRIES_KEY, None)
+    if isinstance(entries, ConfigTree):
+        return entries
+    config.put(STARTUP_KITS_ENTRIES_KEY, ConfigTree())
+    return config.get(STARTUP_KITS_ENTRIES_KEY)
+
+
+def _normalize_kit_id(kit_id: str) -> str:
+    kit_id = kit_id.strip() if kit_id is not None else ""
+    if not kit_id:
+        raise StartupKitConfigError("startup kit id cannot be empty", hint="Choose a non-empty local ID.")
+    return kit_id
+
+
+def get_startup_kit_entries(config: ConfigTree) -> Dict[str, str]:
+    """Return the startup kit registry as an ID-to-path mapping."""
+    entries = config.get(STARTUP_KITS_ENTRIES_KEY, None)
+    if not isinstance(entries, ConfigTree):
+        return {}
+
+    result = {}
+    for raw_key, value in entries.items():
+        if isinstance(value, str):
+            result[_decode_hocon_key(raw_key)] = value
+    return result
+
+
+def get_active_startup_kit_id(config: ConfigTree) -> Optional[str]:
+    active = config.get_string(STARTUP_KITS_ACTIVE_KEY, None) if config else None
+    return active.strip() if active and active.strip() else None
+
+
+def _as_existing_dir(path: str) -> Path:
+    if not path or not str(path).strip():
+        raise StartupKitConfigError("startup kit directory is not specified")
+
+    expanded = Path(path).expanduser()
+    if not expanded.exists():
+        raise StartupKitConfigError(f"startup kit path does not exist: {path}")
+    if not expanded.is_dir():
+        raise StartupKitConfigError(
+            f"path is not a valid startup kit: {path}",
+            hint="Use the participant startup directory produced by provisioning.",
+        )
+    return expanded
+
+
+def validate_admin_startup_kit(path: str) -> str:
+    """Return normalized admin user dir. Raise StartupKitConfigError on invalid kit."""
+    kind, normalized_path = classify_startup_kit(path)
+    if kind != STARTUP_KIT_KIND_ADMIN:
+        raise StartupKitConfigError(
+            f"path is not an admin startup kit: {path}",
+            hint="Use an admin/user startup directory for commands that connect to FLARE.",
+        )
+    return normalized_path
+
+
+def _has_required_files(startup_kit_dir: Path, required_files) -> bool:
+    return all((startup_kit_dir / rel_path).is_file() for rel_path in required_files)
+
+
+def classify_startup_kit(path: str) -> Tuple[str, str]:
+    """Return (kind, normalized participant dir) for a generated startup kit."""
+    startup_path = _as_existing_dir(path)
+    startup_kit_dir = startup_path.parent if startup_path.name == "startup" else startup_path
+
+    for kind, required_files in (
+        (STARTUP_KIT_KIND_ADMIN, ADMIN_STARTUP_KIT_REQUIRED_FILES),
+        (STARTUP_KIT_KIND_SITE, SITE_STARTUP_KIT_REQUIRED_FILES),
+        (STARTUP_KIT_KIND_SERVER, SERVER_STARTUP_KIT_REQUIRED_FILES),
+    ):
+        if _has_required_files(startup_kit_dir, required_files):
+            return kind, str(startup_kit_dir.resolve())
+
+    raise StartupKitConfigError(
+        f"path is not a valid startup kit: {path}",
+        hint="Use the participant startup directory produced by provisioning.",
+    )
+
+
+def validate_startup_kit(path: str) -> str:
+    """Return normalized participant dir for any generated startup kit."""
+    _, normalized_path = classify_startup_kit(path)
+    return normalized_path
+
+
+def _validate_registered_path(kit_id: str, path: str) -> str:
+    if not path:
+        raise StartupKitConfigError(
+            f"startup kit id '{kit_id}' is not registered",
+            hint="Run nvflare kit list.",
+        )
+
+    try:
+        return validate_admin_startup_kit(path)
+    except StartupKitConfigError as e:
+        path_obj = Path(path).expanduser()
+        if not path_obj.exists():
+            raise StartupKitConfigError(
+                f"startup kit path for '{kit_id}' does not exist: {path}",
+                hint="Restore the startup kit, remove the registration, or activate another kit.",
+            ) from e
+        raise StartupKitConfigError(
+            f"registered path for '{kit_id}' is not a valid startup kit for admin use",
+            hint=f"Run nvflare kit use <admin-id>, or replace it with nvflare kit add {kit_id} <startup-kit-dir> --force.",
+        ) from e
+
+
+def add_startup_kit_entry(config: ConfigTree, kit_id: str, path: str, force: bool = False) -> ConfigTree:
+    """Register ID -> path for any startup kit. Never changes active."""
+    kit_id = _normalize_kit_id(kit_id)
+    normalized_path = validate_startup_kit(path)
+    entries = _get_entries_tree(config)
+
+    raw_existing_key = _find_raw_entry_key(entries, kit_id)
+    if raw_existing_key is not None and not force:
+        raise StartupKitConfigError(
+            f"startup kit id '{kit_id}' already exists",
+            hint="Use --force to replace this local registration.",
+        )
+    if raw_existing_key is not None:
+        entries.pop(raw_existing_key, None)
+
+    config.put(f"{STARTUP_KITS_ENTRIES_KEY}.{_quote_hocon_key(kit_id)}", normalized_path)
+    return _ensure_v2_config(config)
+
+
+def set_active_startup_kit(config: ConfigTree, kit_id: str) -> ConfigTree:
+    """Validate ID and path, then set startup_kits.active."""
+    kit_id = _normalize_kit_id(kit_id)
+    entries = get_startup_kit_entries(config)
+    if kit_id not in entries:
+        raise StartupKitConfigError(f"startup kit id '{kit_id}' is not registered", hint="Run nvflare kit list.")
+
+    _validate_registered_path(kit_id, entries[kit_id])
+    config.put(STARTUP_KITS_ACTIVE_KEY, kit_id)
+    return _ensure_v2_config(config)
+
+
+def remove_startup_kit_entry(config: ConfigTree, kit_id: str) -> ConfigTree:
+    kit_id = _normalize_kit_id(kit_id)
+    entries = _get_entries_tree(config)
+    raw_key = _find_raw_entry_key(entries, kit_id)
+    if raw_key is None:
+        raise StartupKitConfigError(f"startup kit id '{kit_id}' is not registered")
+
+    entries.pop(raw_key, None)
+    return clear_active_if(config, {kit_id})
+
+
+def clear_active_if(config: ConfigTree, removed_ids: Set[str]) -> ConfigTree:
+    """Clear startup_kits.active when it points to a removed ID."""
+    active = get_active_startup_kit_id(config)
+    if active in removed_ids:
+        try:
+            config.pop(STARTUP_KITS_ACTIVE_KEY, None)
+        except Exception:
+            pass
+    return _ensure_v2_config(config)
+
+
+def _canonical_path(path: str) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        return path == base or path.is_relative_to(base)
+    except AttributeError:
+        try:
+            return os.path.commonpath([str(path), str(base)]) == str(base)
+        except ValueError:
+            return False
+
+
+def remove_entries_under_workspace(config: ConfigTree, workspace: str) -> Tuple[ConfigTree, Set[str]]:
+    """Remove entries whose canonical paths are under canonical workspace path."""
+    workspace_path = _canonical_path(workspace)
+    entries = _get_entries_tree(config)
+    removed = set()
+
+    for raw_key, path in list(entries.items()):
+        if not isinstance(path, str):
+            continue
+        if _is_relative_to(_canonical_path(path), workspace_path):
+            removed.add(_decode_hocon_key(raw_key))
+            entries.pop(raw_key, None)
+
+    clear_active_if(config, removed)
+    return config, removed
+
+
+def inspect_startup_kit_metadata(path: str) -> Dict[str, Optional[str]]:
+    """Best-effort metadata inspection for display."""
+    metadata = {"identity": None, "cert_role": None, "kind": None}
+    try:
+        kind, startup_kit_dir = classify_startup_kit(path)
+        metadata["kind"] = kind
+    except StartupKitConfigError:
+        return metadata
+
+    startup_dir = os.path.join(startup_kit_dir, "startup")
+    if kind == STARTUP_KIT_KIND_ADMIN:
+        try:
+            fed_admin_config = ConfigFactory.load_config("fed_admin.json", [startup_dir])
+            if fed_admin_config:
+                config_dict = fed_admin_config.to_dict()
+                metadata["identity"] = config_dict.get("admin", {}).get("username")
+        except Exception:
+            pass
+
+        try:
+            from cryptography import x509
+            from cryptography.hazmat.backends import default_backend
+            from cryptography.x509.oid import NameOID
+
+            cert_path = os.path.join(startup_dir, "client.crt")
+            with open(cert_path, "rb") as f:
+                cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+            role_attrs = cert.subject.get_attributes_for_oid(NameOID.UNSTRUCTURED_NAME)
+            if role_attrs:
+                metadata["cert_role"] = role_attrs[0].value
+            cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+            if cn_attrs and not metadata["identity"]:
+                metadata["identity"] = cn_attrs[0].value
+        except Exception:
+            pass
+
+    if not metadata["identity"]:
+        metadata["identity"] = os.path.basename(startup_kit_dir)
+
+    return metadata
+
+
+def get_startup_kit_status(path: str) -> Tuple[str, Optional[str], Dict[str, Optional[str]]]:
+    """Return (status, normalized_path, metadata) without raising for stale entries."""
+    path_obj = Path(path).expanduser() if path else Path("")
+    if not path or not path_obj.exists():
+        return "missing", None, {"identity": None, "cert_role": None}
+
+    try:
+        _, normalized_path = classify_startup_kit(path)
+    except StartupKitConfigError:
+        return "invalid", None, {"identity": None, "cert_role": None}
+
+    return "ok", normalized_path, inspect_startup_kit_metadata(normalized_path)
+
+
+def resolve_startup_kit_dir() -> str:
+    """Resolve env var or active config to a validated admin user dir."""
+    env_startup_kit_dir = os.getenv(NVFLARE_STARTUP_KIT_DIR)
+    if env_startup_kit_dir is not None and env_startup_kit_dir.strip():
+        try:
+            return validate_admin_startup_kit(env_startup_kit_dir)
+        except StartupKitConfigError as e:
+            env_path = Path(env_startup_kit_dir).expanduser()
+            if not env_path.exists():
+                raise StartupKitConfigError(
+                    f"{NVFLARE_STARTUP_KIT_DIR} points to a missing path\nPath: {env_startup_kit_dir}",
+                    hint=f"Unset {NVFLARE_STARTUP_KIT_DIR}, or set it to a valid startup kit directory.",
+                ) from e
+            raise StartupKitConfigError(
+                f"{NVFLARE_STARTUP_KIT_DIR} does not point to a valid startup kit for admin use\nPath: {env_startup_kit_dir}",
+                hint=f"Unset {NVFLARE_STARTUP_KIT_DIR}, or set it to a valid admin startup kit directory.",
+            ) from e
+
+    config = load_cli_config()
+    active = get_active_startup_kit_id(config)
+    if not active:
+        raise StartupKitConfigError(
+            "no active startup kit is configured",
+            hint="Run nvflare poc prepare, or run nvflare kit add <id> <startup-kit-dir> then nvflare kit use <id>.",
+        )
+
+    entries = get_startup_kit_entries(config)
+    if active not in entries:
+        raise StartupKitConfigError(
+            f"active startup kit '{active}' is not registered",
+            hint="Run nvflare kit list, then nvflare kit use <id>.",
+        )
+
+    path = entries[active]
+    try:
+        return validate_admin_startup_kit(path)
+    except StartupKitConfigError as e:
+        path_obj = Path(path).expanduser()
+        if not path_obj.exists():
+            raise StartupKitConfigError(
+                f"active startup kit '{active}' points to a missing path\nPath: {path}",
+                hint=f"Run nvflare kit use <id> or nvflare kit remove {active}.",
+            ) from e
+        raise StartupKitConfigError(
+            f"active startup kit '{active}' is not a valid startup kit for admin use\nPath: {path}",
+            hint=f"Run nvflare kit use <id> or nvflare kit remove {active}.",
+        ) from e
+
+
+def resolve_admin_user_and_dir_from_startup_kit(startup_kit_dir: str) -> Tuple[str, str]:
+    """Resolve admin username and normalized admin user dir from a startup kit path."""
+    admin_user_dir = validate_admin_startup_kit(startup_kit_dir)
+    startup_dir = os.path.join(admin_user_dir, "startup")
+    fed_admin_config = ConfigFactory.load_config("fed_admin.json", [startup_dir])
+    if not fed_admin_config:
+        raise StartupKitConfigError(
+            f"Unable to locate fed_admin configuration from startup kit location {startup_kit_dir}"
+        )
+
+    config_dict = fed_admin_config.to_dict()
+    username = config_dict.get("admin", {}).get("username")
+    if not username:
+        metadata = inspect_startup_kit_metadata(admin_user_dir)
+        username = metadata.get("identity")
+    if not username:
+        raise StartupKitConfigError(f"Unable to resolve admin username from startup kit location {startup_kit_dir}")
+    return username, admin_user_dir

--- a/nvflare/tool/kit/kit_config.py
+++ b/nvflare/tool/kit/kit_config.py
@@ -248,9 +248,9 @@ def _validate_registered_path(kit_id: str, path: str) -> str:
 
 
 def add_startup_kit_entry(config: ConfigTree, kit_id: str, path: str, force: bool = False) -> ConfigTree:
-    """Register ID -> path for any startup kit. Never changes active."""
+    """Register ID -> path for an admin/user startup kit. Never changes active."""
     kit_id = _normalize_kit_id(kit_id)
-    normalized_path = validate_startup_kit(path)
+    normalized_path = validate_admin_startup_kit(path)
     entries = _get_entries_tree(config)
 
     raw_existing_key = _find_raw_entry_key(entries, kit_id)

--- a/nvflare/tool/kit/kit_config.py
+++ b/nvflare/tool/kit/kit_config.py
@@ -229,7 +229,7 @@ def _validate_registered_path(kit_id: str, path: str) -> str:
     if not path:
         raise StartupKitConfigError(
             f"startup kit id '{kit_id}' is not registered",
-            hint="Run nvflare kit list.",
+            hint="Run nvflare config kit list.",
         )
 
     try:
@@ -243,7 +243,7 @@ def _validate_registered_path(kit_id: str, path: str) -> str:
             ) from e
         raise StartupKitConfigError(
             f"registered path for '{kit_id}' is not a valid startup kit for admin use",
-            hint=f"Run nvflare kit use <admin-id>, or replace it with nvflare kit add {kit_id} <startup-kit-dir> --force.",
+            hint=f"Run nvflare config kit use <admin-id>, or replace it with nvflare config kit add {kit_id} <startup-kit-dir> --force.",
         ) from e
 
 
@@ -271,7 +271,7 @@ def set_active_startup_kit(config: ConfigTree, kit_id: str) -> ConfigTree:
     kit_id = _normalize_kit_id(kit_id)
     entries = get_startup_kit_entries(config)
     if kit_id not in entries:
-        raise StartupKitConfigError(f"startup kit id '{kit_id}' is not registered", hint="Run nvflare kit list.")
+        raise StartupKitConfigError(f"startup kit id '{kit_id}' is not registered", hint="Run nvflare config kit list.")
 
     _validate_registered_path(kit_id, entries[kit_id])
     config.put(STARTUP_KITS_ACTIVE_KEY, kit_id)
@@ -410,14 +410,14 @@ def resolve_startup_kit_dir() -> str:
     if not active:
         raise StartupKitConfigError(
             "no active startup kit is configured",
-            hint="Run nvflare poc prepare, or run nvflare kit add <id> <startup-kit-dir> then nvflare kit use <id>.",
+            hint="Run nvflare poc prepare, or run nvflare config kit add <id> <startup-kit-dir> then nvflare config kit use <id>.",
         )
 
     entries = get_startup_kit_entries(config)
     if active not in entries:
         raise StartupKitConfigError(
             f"active startup kit '{active}' is not registered",
-            hint="Run nvflare kit list, then nvflare kit use <id>.",
+            hint="Run nvflare config kit list, then nvflare config kit use <id>.",
         )
 
     path = entries[active]
@@ -428,11 +428,11 @@ def resolve_startup_kit_dir() -> str:
         if not path_obj.exists():
             raise StartupKitConfigError(
                 f"active startup kit '{active}' points to a missing path\nPath: {path}",
-                hint=f"Run nvflare kit use <id> or nvflare kit remove {active}.",
+                hint=f"Run nvflare config kit use <id> or nvflare config kit remove {active}.",
             ) from e
         raise StartupKitConfigError(
             f"active startup kit '{active}' is not a valid startup kit for admin use\nPath: {path}",
-            hint=f"Run nvflare kit use <id> or nvflare kit remove {active}.",
+            hint=f"Run nvflare config kit use <id> or nvflare config kit remove {active}.",
         ) from e
 
 

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -989,7 +989,12 @@ def _get_running_poc_context(workspace: str):
 
 
 def _ensure_poc_stopped(
-    workspace: str, timeout_in_sec: int = 30, poll_interval: float = 1.0, project_config=None, service_config=None
+    workspace: str,
+    timeout_in_sec: int = 30,
+    poll_interval: float = 1.0,
+    project_config=None,
+    service_config=None,
+    reason: str = "recreating the workspace",
 ):
     if project_config is None or service_config is None:
         running_poc = _get_running_poc_context(workspace)
@@ -999,7 +1004,7 @@ def _ensure_poc_stopped(
 
     from nvflare.tool.cli_output import print_human
 
-    print_human("Existing POC system is still running; stopping it before recreating the workspace.")
+    print_human(f"Existing POC system is still running; stopping it before {reason}.")
     _stop_poc(workspace, project_config=project_config, service_config=service_config)
 
     deadline = time.time() + timeout_in_sec
@@ -1447,8 +1452,16 @@ def _run_poc(
 
 
 def clean_poc(cmd_args):
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    handle_schema_flag(
+        _poc_sub_cmd_parsers.get(CMD_CLEAN_POC),
+        "nvflare poc clean",
+        ["nvflare poc clean", "nvflare poc clean --force"],
+        sys.argv[1:],
+    )
     poc_workspace = get_poc_workspace()
-    _clean_poc(poc_workspace)
+    _clean_poc(poc_workspace, force=getattr(cmd_args, "force", False))
 
 
 def _clean_poc_config(poc_workspace: str):
@@ -1495,24 +1508,35 @@ def _is_live_pid_file(pid_file: str) -> bool:
         return False
 
 
-def _clean_poc(poc_workspace: str):
+def _clean_poc(poc_workspace: str, force: bool = False):
     if os.path.isdir(poc_workspace):
         project_config, service_config = setup_service_config(poc_workspace)
         if project_config is None:
             raise CLIException(f"{poc_workspace} is not valid poc directory")
         if is_poc_ready(poc_workspace, service_config, project_config):
-            if not is_poc_running(poc_workspace, service_config, project_config):
-                from nvflare.tool.cli_output import print_human
+            if is_poc_running(poc_workspace, service_config, project_config):
+                if force:
+                    _ensure_poc_stopped(
+                        poc_workspace,
+                        project_config=project_config,
+                        service_config=service_config,
+                        reason="cleaning the workspace",
+                    )
+                else:
+                    raise CLIException("system is still running, please stop the system first.")
 
-                try:
-                    shutil.rmtree(poc_workspace)
-                finally:
-                    _clean_poc_config(poc_workspace)
-
-                print_human(f"{poc_workspace} is removed")
-                return True
-            else:
+            if is_poc_running(poc_workspace, service_config, project_config):
                 raise CLIException("system is still running, please stop the system first.")
+
+            from nvflare.tool.cli_output import print_human
+
+            try:
+                shutil.rmtree(poc_workspace)
+            finally:
+                _clean_poc_config(poc_workspace)
+
+            print_human(f"{poc_workspace} is removed")
+            return True
         else:
             raise CLIException(f"{poc_workspace} is not valid poc directory")
     else:
@@ -1657,7 +1681,10 @@ def define_add_parser(poc_parser):
 
 def define_clean_parser(poc_parser):
     clean_parser = poc_parser.add_parser(CMD_CLEAN_POC, help="clean up poc workspace")
+    _poc_sub_cmd_parsers[CMD_CLEAN_POC] = clean_parser
     clean_parser.add_argument("-debug", "--debug", action="store_true", help="debug is on")
+    clean_parser.add_argument("--force", action="store_true", help="stop a running POC system before cleanup")
+    clean_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
 
 
 def define_start_parser(poc_parser):

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -521,7 +521,7 @@ def _register_poc_startup_kits(config: Dict[str, Any], workspace: str, kit_entri
         if existing_path:
             raise CLIException(
                 f"startup kit id '{kit_id}' already exists outside POC workspace; "
-                f"run 'nvflare kit remove {kit_id}' or replace it explicitly"
+                f"run 'nvflare config kit remove {kit_id}' or replace it explicitly"
             )
         add_startup_kit_entry(config, kit_id, kit_path, force=True)
 
@@ -541,7 +541,7 @@ def _write_poc_startup_kit_registry(workspace: str, project_name: str, project_c
 
         print_human(
             "No generated Project Admin startup kit was found; "
-            "run 'nvflare kit use <id>' after registering an admin startup kit."
+            "run 'nvflare config kit use <id>' after registering an admin startup kit."
         )
 
     config.put(f"{POC_KEY}.{WORKSPACE_KEY}", workspace)
@@ -683,7 +683,7 @@ def _add_poc_user(poc_workspace: str, cert_role: str, email: str, org: str, forc
     if preferred_active:
         result["active"] = email
     else:
-        result["next_step"] = f"nvflare kit use {email}"
+        result["next_step"] = f"nvflare config kit use {email}"
     return result
 
 

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -515,7 +515,9 @@ def _get_generated_poc_startup_kits(project_config: Dict, prod_dir: str) -> Tupl
     return entries, active_id
 
 
-def _register_poc_startup_kits(config: Dict[str, Any], workspace: str, kit_entries: Dict[str, str]) -> set:
+def _register_poc_startup_kits(
+    config: Dict[str, Any], workspace: str, kit_entries: Dict[str, str]
+) -> Tuple[Dict[str, Any], set]:
     config, removed_ids = remove_entries_under_workspace(config, workspace)
     entries = get_startup_kit_entries(config)
 
@@ -528,14 +530,14 @@ def _register_poc_startup_kits(config: Dict[str, Any], workspace: str, kit_entri
             )
         config = add_startup_kit_entry(config, kit_id, kit_path, force=True)
 
-    return removed_ids
+    return config, removed_ids
 
 
 def _write_poc_startup_kit_registry(workspace: str, project_name: str, project_config: Dict):
     config = load_cli_config()
     prod_dir = get_prod_dir(workspace, project_name)
     kit_entries, active_id = _get_generated_poc_startup_kits(project_config, prod_dir)
-    _register_poc_startup_kits(config, workspace, kit_entries)
+    config, _removed_ids = _register_poc_startup_kits(config, workspace, kit_entries)
 
     if active_id:
         config.put("startup_kits.active", active_id)
@@ -834,10 +836,15 @@ def _require_poc_project_admin():
     metadata = inspect_startup_kit_metadata(startup_kit_dir)
     cert_role = metadata.get("cert_role")
     identity = metadata.get("identity") or "<unknown>"
+    if not cert_role:
+        raise AuthorizationError(
+            f"nvflare poc add requires an active startup kit with role '{POC_ADD_REQUIRED_CERT_ROLE}'; "
+            f"could not determine the certificate role for active identity '{identity}'"
+        )
     if cert_role != POC_ADD_REQUIRED_CERT_ROLE:
         raise AuthorizationError(
             f"nvflare poc add requires an active startup kit with role '{POC_ADD_REQUIRED_CERT_ROLE}'; "
-            f"active identity '{identity}' has role '{cert_role or 'unknown'}'"
+            f"active identity '{identity}' has role '{cert_role}'"
         )
 
 

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -1653,8 +1653,8 @@ def _clean_poc(poc_workspace: str, force: bool = False):
 
             from nvflare.tool.cli_output import print_human
 
-            _clean_poc_config(poc_workspace)
             shutil.rmtree(poc_workspace)
+            _clean_poc_config(poc_workspace)
 
             print_human(f"{poc_workspace} is removed")
             return True

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import errno
 import json
 import os
@@ -28,7 +29,7 @@ import yaml
 from nvflare.cli_exception import CLIException
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
 from nvflare.fuel.utils.gpu_utils import get_host_gpu_ids
-from nvflare.lighter.constants import PropKey, ProvisionMode
+from nvflare.lighter.constants import CtxKey, PropKey, ProvisionMode
 from nvflare.lighter.prov_utils import prepare_builders, prepare_packager
 from nvflare.lighter.provision import gen_default_project_config, prepare_project
 from nvflare.lighter.provisioner import Provisioner
@@ -40,8 +41,11 @@ from nvflare.lighter.utils import (
 )
 from nvflare.tool.api_utils import shutdown_system
 from nvflare.tool.kit.kit_config import (
+    STARTUP_KIT_KIND_ADMIN,
+    STARTUP_KIT_KIND_SITE,
     StartupKitConfigError,
     add_startup_kit_entry,
+    classify_startup_kit,
     get_active_startup_kit_id,
     get_startup_kit_entries,
     inspect_startup_kit_metadata,
@@ -71,6 +75,10 @@ POC_ADD_REQUIRED_CERT_ROLE = "project_admin"
 POC_KEY = "poc"
 STARTUP_KIT_KEY = "startup_kit"
 WORKSPACE_KEY = "workspace"
+
+
+class AuthorizationError(PermissionError):
+    """The current CLI identity is not authorized for the command."""
 
 
 def client_gpu_assignments(clients: List[str], gpu_ids: List[int]) -> Dict[str, List[int]]:
@@ -475,15 +483,12 @@ def prepare_clients(clients, number_of_clients):
     return clients
 
 
-def _is_admin_startup_kit_dir(kit_dir: str) -> bool:
-    return all(
-        os.path.isfile(os.path.join(kit_dir, SC.STARTUP, required_file))
-        for required_file in ("fed_admin.json", "client.crt", "rootCA.pem")
-    )
-
-
-def _is_site_startup_kit_dir(kit_dir: str) -> bool:
-    return os.path.isfile(os.path.join(kit_dir, SC.STARTUP, "fed_client.json"))
+def _is_startup_kit_kind(kit_dir: str, expected_kind: str) -> bool:
+    try:
+        kind, _ = classify_startup_kit(kit_dir)
+    except StartupKitConfigError:
+        return False
+    return kind == expected_kind
 
 
 def _get_generated_poc_startup_kits(project_config: Dict, prod_dir: str) -> Tuple[Dict[str, str], Optional[str]]:
@@ -502,7 +507,7 @@ def _get_generated_poc_startup_kits(project_config: Dict, prod_dir: str) -> Tupl
 
         kit_dir = os.path.abspath(os.path.join(prod_dir, identity))
         participant_type = participant.get("type")
-        if participant_type == "admin" and _is_admin_startup_kit_dir(kit_dir):
+        if participant_type == "admin" and _is_startup_kit_kind(kit_dir, STARTUP_KIT_KIND_ADMIN):
             entries[identity] = kit_dir
             if active_id is None and participant.get("role") == "project_admin":
                 active_id = identity
@@ -521,7 +526,7 @@ def _register_poc_startup_kits(config: Dict[str, Any], workspace: str, kit_entri
                 f"startup kit id '{kit_id}' already exists outside POC workspace; "
                 f"run 'nvflare config kit remove {kit_id}' or replace it explicitly"
             )
-        add_startup_kit_entry(config, kit_id, kit_path, force=True)
+        config = add_startup_kit_entry(config, kit_id, kit_path, force=True)
 
     return removed_ids
 
@@ -628,27 +633,134 @@ def _restore_poc_active_kit(previous_active: Optional[str], preferred_active: Op
         save_cli_config(config)
 
 
+def _get_existing_poc_prod_dir(poc_workspace: str, project_name: str) -> str:
+    prod_dirs = _get_prod_dirs(poc_workspace, project_name)
+    if not prod_dirs:
+        raise CLIException("POC workspace has no existing provisioned output; run 'nvflare poc prepare' first")
+    return prod_dirs[-1]
+
+
+def _remove_path(path: str):
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    elif os.path.exists(path):
+        os.remove(path)
+
+
+class _PocDynamicProvisionLogger:
+    def debug(self, msg: str):
+        pass
+
+    def info(self, msg: str):
+        pass
+
+    def warning(self, msg: str):
+        pass
+
+    def error(self, msg: str):
+        pass
+
+
+def _dynamic_poc_project_config(project_config: Dict, participant: Dict) -> Dict:
+    dynamic_config = copy.deepcopy(project_config)
+    participants = project_config.get("participants", [])
+    servers = [p for p in participants if isinstance(p, dict) and p.get("type") == "server"]
+    if len(servers) != 1:
+        raise CLIException(f"project should only have one server, but {len(servers)} are provided")
+
+    dynamic_config["participants"] = [copy.deepcopy(servers[0]), copy.deepcopy(participant)]
+    # Dynamic POC provisioning only builds the new participant kit. Study registry updates
+    # belong to the running server metadata, not to this short-lived reduced project.
+    dynamic_config.pop("studies", None)
+    return dynamic_config
+
+
+def _ensure_dynamic_poc_ca_available(poc_workspace: str, project_name: str, prod_dir: str, project_config: Dict) -> str:
+    state_file = os.path.join(poc_workspace, project_name, "state", "cert.json")
+    if not os.path.isfile(state_file):
+        raise CLIException(
+            "existing POC CA state was not found; run 'nvflare poc prepare' before using 'nvflare poc add'"
+        )
+
+    server_name = get_fl_server_name(project_config)
+    root_ca_path = os.path.join(prod_dir, server_name, SC.STARTUP, "rootCA.pem")
+    if not os.path.isfile(root_ca_path):
+        raise CLIException(
+            "existing POC rootCA.pem was not found; run 'nvflare poc prepare' before using 'nvflare poc add'"
+        )
+    return root_ca_path
+
+
+def _provision_poc_participant_only(
+    poc_workspace: str,
+    project_config: Dict,
+    participant: Dict,
+    target_prod_dir: str,
+    force: bool = False,
+) -> str:
+    project_name = project_config.get("name") or DEFAULT_PROJECT_NAME
+    _ensure_dynamic_poc_ca_available(poc_workspace, project_name, target_prod_dir, project_config)
+    dynamic_config = _dynamic_poc_project_config(project_config, participant)
+
+    project = prepare_project(dynamic_config)
+    builders = prepare_builders(dynamic_config)
+    packager = prepare_packager(dynamic_config)
+    provisioner = Provisioner(poc_workspace, builders, packager)
+
+    temp_prod_dir = None
+    try:
+        ctx = provisioner.provision(project, mode=ProvisionMode.POC, logger=_PocDynamicProvisionLogger())
+        if ctx.get(CtxKey.BUILD_ERROR):
+            raise CLIException("dynamic POC provisioning failed; see provisioning output for details")
+
+        temp_prod_dir = ctx.get(CtxKey.CURRENT_PROD_DIR)
+        if not temp_prod_dir:
+            raise CLIException("dynamic POC provisioning did not produce an output directory")
+
+        participant_name = participant["name"]
+        generated_kit = os.path.join(temp_prod_dir, participant_name)
+        if not os.path.isdir(generated_kit):
+            raise CLIException(f"startup kit was not generated for participant '{participant_name}'")
+
+        target_kit = os.path.join(target_prod_dir, participant_name)
+        if os.path.exists(target_kit):
+            if not force:
+                raise CLIException(f"startup kit already exists for participant '{participant_name}'")
+            _remove_path(target_kit)
+
+        shutil.move(generated_kit, target_kit)
+        return target_kit
+    finally:
+        if temp_prod_dir and os.path.isdir(temp_prod_dir):
+            shutil.rmtree(temp_prod_dir, ignore_errors=True)
+
+
 def _dynamic_poc_provision(
     poc_workspace: str,
     project_file: str,
     project_config: Dict,
+    participant: Dict,
+    expected_kit_kind: str,
     previous_active: Optional[str],
     preferred_active: Optional[str] = None,
+    force: bool = False,
 ) -> Tuple[Dict, str]:
-    save_project_config(project_config, project_file)
-    project_config = prepare_poc_provision(
-        [],
-        0,
-        poc_workspace,
-        docker_image=None,
-        use_he=False,
-        project_conf_path=project_file,
-        examples_dir=None,
-    )
     project_name = project_config.get("name") if project_config else DEFAULT_PROJECT_NAME
+    prod_dir = _get_existing_poc_prod_dir(poc_workspace, project_name)
+    startup_kit = _provision_poc_participant_only(
+        poc_workspace,
+        project_config,
+        participant,
+        prod_dir,
+        force=force,
+    )
+    if not _is_startup_kit_kind(startup_kit, expected_kit_kind):
+        raise CLIException(f"startup kit was not generated for participant '{participant['name']}'")
+
+    save_project_config(project_config, project_file)
     save_startup_kit_dir_config(poc_workspace, project_name)
     _restore_poc_active_kit(previous_active, preferred_active)
-    return project_config, get_prod_dir(poc_workspace, project_name)
+    return project_config, prod_dir
 
 
 def _add_poc_user(poc_workspace: str, cert_role: str, email: str, org: str, force: bool = False) -> Dict:
@@ -661,11 +773,14 @@ def _add_poc_user(poc_workspace: str, cert_role: str, email: str, org: str, forc
         poc_workspace,
         project_file,
         project_config,
+        participant,
+        STARTUP_KIT_KIND_ADMIN,
         previous_active,
         preferred_active=preferred_active,
+        force=force,
     )
     startup_kit = os.path.join(prod_dir, email)
-    if not _is_admin_startup_kit_dir(startup_kit):
+    if not _is_startup_kit_kind(startup_kit, STARTUP_KIT_KIND_ADMIN):
         raise CLIException(f"startup kit was not generated for user '{email}'")
 
     result = {
@@ -694,10 +809,13 @@ def _add_poc_site(poc_workspace: str, name: str, org: str, force: bool = False) 
         poc_workspace,
         project_file,
         project_config,
+        participant,
+        STARTUP_KIT_KIND_SITE,
         previous_active,
+        force=force,
     )
     startup_kit = os.path.join(prod_dir, name)
-    if not _is_site_startup_kit_dir(startup_kit):
+    if not _is_startup_kit_kind(startup_kit, STARTUP_KIT_KIND_SITE):
         raise CLIException(f"startup kit was not generated for site '{name}'")
 
     return {
@@ -717,7 +835,7 @@ def _require_poc_project_admin():
     cert_role = metadata.get("cert_role")
     identity = metadata.get("identity") or "<unknown>"
     if cert_role != POC_ADD_REQUIRED_CERT_ROLE:
-        raise PermissionError(
+        raise AuthorizationError(
             f"nvflare poc add requires an active startup kit with role '{POC_ADD_REQUIRED_CERT_ROLE}'; "
             f"active identity '{identity}' has role '{cert_role or 'unknown'}'"
         )
@@ -766,7 +884,7 @@ def add_poc_user(cmd_args):
     except ValueError as e:
         output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
         raise SystemExit(4)
-    except PermissionError as e:
+    except AuthorizationError as e:
         output_error("NOT_AUTHORIZED", exit_code=1, detail=str(e))
         raise SystemExit(1)
     except CLIException as e:
@@ -810,7 +928,7 @@ def add_poc_site(cmd_args):
     except ValueError as e:
         output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
         raise SystemExit(4)
-    except PermissionError as e:
+    except AuthorizationError as e:
         output_error("NOT_AUTHORIZED", exit_code=1, detail=str(e))
         raise SystemExit(1)
     except CLIException as e:
@@ -1528,10 +1646,8 @@ def _clean_poc(poc_workspace: str, force: bool = False):
 
             from nvflare.tool.cli_output import print_human
 
-            try:
-                shutil.rmtree(poc_workspace)
-            finally:
-                _clean_poc_config(poc_workspace)
+            _clean_poc_config(poc_workspace)
+            shutil.rmtree(poc_workspace)
 
             print_human(f"{poc_workspace} is removed")
             return True

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -515,10 +515,23 @@ def _get_generated_poc_startup_kits(project_config: Dict, prod_dir: str) -> Tupl
     return entries, active_id
 
 
+def _get_configured_poc_workspace(config: Dict[str, Any]) -> Optional[str]:
+    try:
+        workspace = config.get(f"{POC_KEY}.{WORKSPACE_KEY}", None)
+    except Exception:
+        return None
+    return workspace.strip() if isinstance(workspace, str) and workspace.strip() else None
+
+
 def _register_poc_startup_kits(
     config: Dict[str, Any], workspace: str, kit_entries: Dict[str, str]
 ) -> Tuple[Dict[str, Any], set]:
-    config, removed_ids = remove_entries_under_workspace(config, workspace)
+    removed_ids = set()
+    previous_workspace = _get_configured_poc_workspace(config)
+    if previous_workspace:
+        config, removed_ids = remove_entries_under_workspace(config, previous_workspace)
+    config, current_removed_ids = remove_entries_under_workspace(config, workspace)
+    removed_ids.update(current_removed_ids)
     entries = get_startup_kit_entries(config)
 
     for kit_id, kit_path in kit_entries.items():

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -506,8 +506,6 @@ def _get_generated_poc_startup_kits(project_config: Dict, prod_dir: str) -> Tupl
             entries[identity] = kit_dir
             if active_id is None and participant.get("role") == "project_admin":
                 active_id = identity
-        elif participant_type == "client" and _is_site_startup_kit_dir(kit_dir):
-            entries[identity] = kit_dir
 
     return entries, active_id
 

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -21,14 +21,12 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, OrderedDict, Tuple
+from typing import Any, Dict, List, Optional, OrderedDict, Tuple
 
 import yaml
-from pyhocon import ConfigFactory as CF
 
 from nvflare.cli_exception import CLIException
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
-from nvflare.fuel.utils.config import ConfigFormat
 from nvflare.fuel.utils.gpu_utils import get_host_gpu_ids
 from nvflare.lighter.constants import PropKey, ProvisionMode
 from nvflare.lighter.prov_utils import prepare_builders, prepare_packager
@@ -41,8 +39,18 @@ from nvflare.lighter.utils import (
     update_storage_locations,
 )
 from nvflare.tool.api_utils import shutdown_system
+from nvflare.tool.kit.kit_config import (
+    add_startup_kit_entry,
+    get_active_startup_kit_id,
+    get_startup_kit_entries,
+    inspect_startup_kit_metadata,
+    load_cli_config,
+    remove_entries_under_workspace,
+    resolve_startup_kit_dir,
+    save_cli_config,
+)
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
-from nvflare.utils.cli_utils import get_hidden_nvflare_config_path, get_or_create_hidden_nvflare_dir, hocon_to_string
+from nvflare.utils.cli_utils import get_hidden_nvflare_config_path, get_or_create_hidden_nvflare_dir
 
 DEFAULT_WORKSPACE = "/tmp/nvflare/poc"
 DEFAULT_PROJECT_NAME = "example_project"
@@ -52,6 +60,16 @@ CMD_PREPARE_JOBS_DIR = "prepare-jobs-dir"
 CMD_START_POC = "start"
 CMD_STOP_POC = "stop"
 CMD_CLEAN_POC = "clean"
+CMD_ADD_POC = "add"
+CMD_ADD_USER = "user"
+CMD_ADD_SITE = "site"
+
+POC_USER_CERT_ROLES = ("project_admin", "org_admin", "lead", "member")
+POC_ADD_REQUIRED_CERT_ROLE = "project_admin"
+
+POC_KEY = "poc"
+STARTUP_KIT_KEY = "startup_kit"
+WORKSPACE_KEY = "workspace"
 
 
 def client_gpu_assignments(clients: List[str], gpu_ids: List[int]) -> Dict[str, List[int]]:
@@ -231,10 +249,29 @@ def _prepare_jobs_dir(
     return True
 
 
+def _get_prod_dirs(workspace, project_name: str = DEFAULT_PROJECT_NAME) -> List[str]:
+    project_name = project_name if project_name else DEFAULT_PROJECT_NAME
+    project_dir = os.path.join(workspace, project_name)
+    prod_dirs = []
+    if os.path.isdir(project_dir):
+        for name in os.listdir(project_dir):
+            if not name.startswith("prod_"):
+                continue
+            try:
+                stage = int(name.split("_")[-1])
+            except ValueError:
+                continue
+            prod_dirs.append((stage, os.path.join(project_dir, name)))
+
+    return [path for _, path in sorted(prod_dirs)]
+
+
 def get_prod_dir(workspace, project_name: str = DEFAULT_PROJECT_NAME):
     project_name = project_name if project_name else DEFAULT_PROJECT_NAME
-    prod_dir = os.path.join(workspace, project_name, "prod_00")
-    return prod_dir
+    prod_dirs = _get_prod_dirs(workspace, project_name)
+    if prod_dirs:
+        return prod_dirs[-1]
+    return os.path.join(workspace, project_name, "prod_00")
 
 
 def gen_project_config_file(workspace: str) -> str:
@@ -437,15 +474,85 @@ def prepare_clients(clients, number_of_clients):
     return clients
 
 
-def save_startup_kit_dir_config(workspace, project_name):
-    dst = get_hidden_nvflare_config_path(str(get_or_create_hidden_nvflare_dir()))
-    config = None
-    if os.path.isfile(dst):
-        try:
-            config = CF.parse_file(dst)
-        except Exception:
-            config = None
+def _is_admin_startup_kit_dir(kit_dir: str) -> bool:
+    return all(
+        os.path.isfile(os.path.join(kit_dir, SC.STARTUP, required_file))
+        for required_file in ("fed_admin.json", "client.crt", "rootCA.pem")
+    )
 
+
+def _is_site_startup_kit_dir(kit_dir: str) -> bool:
+    return os.path.isfile(os.path.join(kit_dir, SC.STARTUP, "fed_client.json"))
+
+
+def _get_generated_poc_startup_kits(project_config: Dict, prod_dir: str) -> Tuple[Dict[str, str], Optional[str]]:
+    participants = project_config.get("participants", [])
+    if not isinstance(participants, list):
+        raise CLIException("project.yml participants must be a list")
+
+    entries = {}
+    active_id = None
+    for participant in participants:
+        if not isinstance(participant, dict):
+            raise CLIException("participant entry must be a mapping")
+        identity = participant.get("name")
+        if not identity:
+            raise CLIException("participant missing name")
+
+        kit_dir = os.path.abspath(os.path.join(prod_dir, identity))
+        participant_type = participant.get("type")
+        if participant_type == "admin" and _is_admin_startup_kit_dir(kit_dir):
+            entries[identity] = kit_dir
+            if active_id is None and participant.get("role") == "project_admin":
+                active_id = identity
+        elif participant_type == "client" and _is_site_startup_kit_dir(kit_dir):
+            entries[identity] = kit_dir
+
+    return entries, active_id
+
+
+def _register_poc_startup_kits(config: Dict[str, Any], workspace: str, kit_entries: Dict[str, str]) -> set:
+    config, removed_ids = remove_entries_under_workspace(config, workspace)
+    entries = get_startup_kit_entries(config)
+
+    for kit_id, kit_path in kit_entries.items():
+        existing_path = entries.get(kit_id)
+        if existing_path:
+            raise CLIException(
+                f"startup kit id '{kit_id}' already exists outside POC workspace; "
+                f"run 'nvflare kit remove {kit_id}' or replace it explicitly"
+            )
+        add_startup_kit_entry(config, kit_id, kit_path, force=True)
+
+    return removed_ids
+
+
+def _write_poc_startup_kit_registry(workspace: str, project_name: str, project_config: Dict):
+    config = load_cli_config()
+    prod_dir = get_prod_dir(workspace, project_name)
+    kit_entries, active_id = _get_generated_poc_startup_kits(project_config, prod_dir)
+    _register_poc_startup_kits(config, workspace, kit_entries)
+
+    if active_id:
+        config.put("startup_kits.active", active_id)
+    else:
+        from nvflare.tool.cli_output import print_human
+
+        print_human(
+            "No generated Project Admin startup kit was found; "
+            "run 'nvflare kit use <id>' after registering an admin startup kit."
+        )
+
+    config.put(f"{POC_KEY}.{WORKSPACE_KEY}", workspace)
+    try:
+        config.pop(f"{POC_KEY}.{STARTUP_KIT_KEY}", None)
+        config.pop("prod.startup_kit", None)
+    except Exception:
+        pass
+    save_cli_config(config)
+
+
+def save_startup_kit_dir_config(workspace, project_name):
     project_file = os.path.join(workspace, "project.yml")
     try:
         project_config = load_yaml(project_file) if os.path.isfile(project_file) else None
@@ -453,25 +560,265 @@ def save_startup_kit_dir_config(workspace, project_name):
         project_config = None
     if not project_config or not isinstance(project_config, dict):
         raise CLIException(f"invalid or unreadable project config: {project_file}")
-    project_admin = get_proj_admin(project_config)
-    prod_dir = get_prod_dir(workspace, project_name)
-    poc_admin_dir = os.path.join(prod_dir, project_admin)
-    conf = f"""
-        version = 2
-        poc {{
-            startup_kit = "{poc_admin_dir}"
-            workspace = "{workspace}"
-        }}
-    """
-    if config:
-        new_config = CF.parse_string(conf)
-        config = new_config.with_fallback(config)
-        config_str = hocon_to_string(ConfigFormat.PYHOCON, config)
-    else:
-        config_str = conf
+    _write_poc_startup_kit_registry(workspace, project_name, project_config)
 
-    with open(dst, "w") as file:
-        file.write(f"{config_str}\n")
+
+def _load_poc_project_config(poc_workspace: str) -> Tuple[str, Dict]:
+    project_file = os.path.join(poc_workspace, "project.yml")
+    if not os.path.isfile(project_file):
+        raise CLIException("please use nvflare poc prepare to create workspace first")
+
+    project_config = load_yaml(project_file)
+    if not isinstance(project_config, dict):
+        raise CLIException(f"invalid or unreadable project config: {project_file}")
+
+    participants = project_config.get("participants")
+    if not isinstance(participants, list):
+        raise CLIException("project.yml participants must be a list")
+
+    return project_file, project_config
+
+
+def _find_participant_index(participants: List[Dict], name: str) -> Optional[int]:
+    for index, participant in enumerate(participants):
+        if isinstance(participant, dict) and participant.get("name") == name:
+            return index
+    return None
+
+
+def _upsert_poc_participant(project_config: Dict, participant: Dict, force: bool) -> str:
+    participants = project_config.get("participants")
+    index = _find_participant_index(participants, participant["name"])
+    if index is None:
+        participants.append(participant)
+        return "added"
+
+    existing = participants[index]
+    if existing.get("type") != participant.get("type"):
+        raise CLIException(
+            f"participant '{participant['name']}' already exists as type '{existing.get('type')}', "
+            f"not '{participant.get('type')}'"
+        )
+
+    if not force:
+        raise CLIException(f"participant '{participant['name']}' already exists; use --force to replace it")
+
+    if existing.get("type") == "admin" and existing.get("role") != participant.get("role"):
+        raise CLIException(
+            f"participant '{participant['name']}' already exists with role '{existing.get('role')}'; "
+            "changing a POC user's certificate role requires nvflare poc clean and a fresh prepare"
+        )
+
+    updated = dict(existing)
+    updated.update(participant)
+    participants[index] = updated
+    return "updated"
+
+
+def _restore_poc_active_kit(previous_active: Optional[str], preferred_active: Optional[str] = None):
+    config = load_cli_config()
+    entries = get_startup_kit_entries(config)
+    active_id = None
+    if previous_active and previous_active in entries:
+        active_id = previous_active
+    elif preferred_active and preferred_active in entries:
+        active_id = preferred_active
+
+    if active_id:
+        config.put("startup_kits.active", active_id)
+        save_cli_config(config)
+
+
+def _dynamic_poc_provision(
+    poc_workspace: str,
+    project_file: str,
+    project_config: Dict,
+    previous_active: Optional[str],
+    preferred_active: Optional[str] = None,
+) -> Tuple[Dict, str]:
+    save_project_config(project_config, project_file)
+    project_config = prepare_poc_provision(
+        [],
+        0,
+        poc_workspace,
+        docker_image=None,
+        use_he=False,
+        project_conf_path=project_file,
+        examples_dir=None,
+    )
+    project_name = project_config.get("name") if project_config else DEFAULT_PROJECT_NAME
+    save_startup_kit_dir_config(poc_workspace, project_name)
+    _restore_poc_active_kit(previous_active, preferred_active)
+    return project_config, get_prod_dir(poc_workspace, project_name)
+
+
+def _add_poc_user(poc_workspace: str, cert_role: str, email: str, org: str, force: bool = False) -> Dict:
+    project_file, project_config = _load_poc_project_config(poc_workspace)
+    previous_active = get_active_startup_kit_id(load_cli_config())
+    participant = {"name": email, "type": "admin", "org": org, "role": cert_role}
+    action = _upsert_poc_participant(project_config, participant, force)
+    preferred_active = email if not previous_active else None
+    project_config, prod_dir = _dynamic_poc_provision(
+        poc_workspace,
+        project_file,
+        project_config,
+        previous_active,
+        preferred_active=preferred_active,
+    )
+    startup_kit = os.path.join(prod_dir, email)
+    if not _is_admin_startup_kit_dir(startup_kit):
+        raise CLIException(f"startup kit was not generated for user '{email}'")
+
+    result = {
+        "status": action,
+        "type": "user",
+        "id": email,
+        "identity": email,
+        "org": org,
+        "cert_role": cert_role,
+        "startup_kit": startup_kit,
+        "prod_dir": prod_dir,
+    }
+    if preferred_active:
+        result["active"] = email
+    else:
+        result["next_step"] = f"nvflare kit use {email}"
+    return result
+
+
+def _add_poc_site(poc_workspace: str, name: str, org: str, force: bool = False) -> Dict:
+    project_file, project_config = _load_poc_project_config(poc_workspace)
+    previous_active = get_active_startup_kit_id(load_cli_config())
+    participant = {"name": name, "type": "client", "org": org}
+    action = _upsert_poc_participant(project_config, participant, force)
+    project_config, prod_dir = _dynamic_poc_provision(
+        poc_workspace,
+        project_file,
+        project_config,
+        previous_active,
+    )
+    startup_kit = os.path.join(prod_dir, name)
+    if not _is_site_startup_kit_dir(startup_kit):
+        raise CLIException(f"startup kit was not generated for site '{name}'")
+
+    return {
+        "status": action,
+        "type": "site",
+        "id": name,
+        "name": name,
+        "org": org,
+        "startup_kit": startup_kit,
+        "prod_dir": prod_dir,
+    }
+
+
+def _require_poc_project_admin():
+    startup_kit_dir = resolve_startup_kit_dir()
+    metadata = inspect_startup_kit_metadata(startup_kit_dir)
+    cert_role = metadata.get("cert_role")
+    identity = metadata.get("identity") or "<unknown>"
+    if cert_role != POC_ADD_REQUIRED_CERT_ROLE:
+        raise PermissionError(
+            f"nvflare poc add requires an active startup kit with role '{POC_ADD_REQUIRED_CERT_ROLE}'; "
+            f"active identity '{identity}' has role '{cert_role or 'unknown'}'"
+        )
+
+
+def add_poc(cmd_args):
+    sub_cmd = getattr(cmd_args, "poc_add_sub_cmd", None)
+    if sub_cmd == CMD_ADD_USER:
+        return add_poc_user(cmd_args)
+    if sub_cmd == CMD_ADD_SITE:
+        return add_poc_site(cmd_args)
+    from nvflare.tool.cli_output import output_error
+
+    output_error(
+        "INVALID_ARGS",
+        exit_code=4,
+        detail="poc add subcommand required",
+        hint="Run with -h for usage.",
+    )
+    raise SystemExit(4)
+
+
+def add_poc_user(cmd_args):
+    from nvflare.tool.cli_output import output_error, output_ok, print_human
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    handle_schema_flag(
+        _poc_add_sub_cmd_parsers.get(CMD_ADD_USER),
+        "nvflare poc add user",
+        ["nvflare poc add user lead bob@nvidia.com --org nvidia"],
+        sys.argv[1:],
+    )
+    poc_workspace = get_poc_workspace()
+    try:
+        _require_poc_project_admin()
+        result = _add_poc_user(
+            poc_workspace,
+            cmd_args.cert_role,
+            cmd_args.email,
+            cmd_args.org,
+            force=getattr(cmd_args, "force", False),
+        )
+    except ValueError as e:
+        output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
+        raise SystemExit(4)
+    except PermissionError as e:
+        output_error("NOT_AUTHORIZED", exit_code=1, detail=str(e))
+        raise SystemExit(1)
+    except CLIException as e:
+        output_error("INVALID_ARGS", exit_code=4, detail=str(e))
+        raise SystemExit(4)
+    except Exception as e:
+        output_error("INTERNAL_ERROR", exit_code=5, detail=str(e))
+        raise SystemExit(5)
+
+    output_ok(result)
+    print_human(f"\nPOC user {result['status']}: {result['identity']}")
+    print_human(f"  Startup kit: {result['startup_kit']}")
+    if result.get("active"):
+        print_human(f"  Active startup kit: {result['active']}")
+    else:
+        print_human(f"  Activate with: {result['next_step']}")
+
+
+def add_poc_site(cmd_args):
+    from nvflare.tool.cli_output import output_error, output_ok, print_human
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    handle_schema_flag(
+        _poc_add_sub_cmd_parsers.get(CMD_ADD_SITE),
+        "nvflare poc add site",
+        ["nvflare poc add site site-3 --org nvidia"],
+        sys.argv[1:],
+    )
+    poc_workspace = get_poc_workspace()
+    try:
+        _require_poc_project_admin()
+        result = _add_poc_site(
+            poc_workspace,
+            cmd_args.name,
+            cmd_args.org,
+            force=getattr(cmd_args, "force", False),
+        )
+    except ValueError as e:
+        output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
+        raise SystemExit(4)
+    except PermissionError as e:
+        output_error("NOT_AUTHORIZED", exit_code=1, detail=str(e))
+        raise SystemExit(1)
+    except CLIException as e:
+        output_error("INVALID_ARGS", exit_code=4, detail=str(e))
+        raise SystemExit(4)
+    except Exception as e:
+        output_error("INTERNAL_ERROR", exit_code=5, detail=str(e))
+        raise SystemExit(5)
+
+    output_ok(result)
+    print_human(f"\nPOC site {result['status']}: {result['name']}")
+    print_human(f"  Startup kit: {result['startup_kit']}")
+    print_human(f"  Start with: nvflare poc start -p {result['name']}")
 
 
 def prepare_poc(cmd_args):
@@ -1097,13 +1444,29 @@ def clean_poc(cmd_args):
     _clean_poc(poc_workspace)
 
 
+def _clean_poc_config(poc_workspace: str):
+    config = load_cli_config()
+    config, _removed_ids = remove_entries_under_workspace(config, poc_workspace)
+    for key in (f"{POC_KEY}.{WORKSPACE_KEY}", f"{POC_KEY}.{STARTUP_KIT_KEY}", "prod.startup_kit"):
+        try:
+            config.pop(key, None)
+        except Exception:
+            pass
+    save_cli_config(config)
+
+
 def is_poc_running(poc_workspace, service_config, project_config):
     project_name = project_config.get("name") if project_config else DEFAULT_PROJECT_NAME
-    prod_dir = get_prod_dir(poc_workspace, project_name)
-    server_dir = os.path.join(prod_dir, service_config[SC.FLARE_SERVER])
-    pid_file = os.path.join(server_dir, "pid.fl")
-    daemon_pid_file = os.path.join(server_dir, "daemon_pid.fl")
-    return _is_live_pid_file(pid_file) or _is_live_pid_file(daemon_pid_file)
+    prod_dirs = _get_prod_dirs(poc_workspace, project_name)
+    if not prod_dirs:
+        prod_dirs = [get_prod_dir(poc_workspace, project_name)]
+    for prod_dir in prod_dirs:
+        server_dir = os.path.join(prod_dir, service_config[SC.FLARE_SERVER])
+        pid_file = os.path.join(server_dir, "pid.fl")
+        daemon_pid_file = os.path.join(server_dir, "daemon_pid.fl")
+        if _is_live_pid_file(pid_file) or _is_live_pid_file(daemon_pid_file):
+            return True
+    return False
 
 
 def _is_live_pid_file(pid_file: str) -> bool:
@@ -1134,7 +1497,8 @@ def _clean_poc(poc_workspace: str):
             if not is_poc_running(poc_workspace, service_config, project_config):
                 from nvflare.tool.cli_output import print_human
 
-                shutil.rmtree(poc_workspace, ignore_errors=True)
+                shutil.rmtree(poc_workspace)
+                _clean_poc_config(poc_workspace)
 
                 print_human(f"{poc_workspace} is removed")
                 return True
@@ -1149,6 +1513,7 @@ def _clean_poc(poc_workspace: str):
 poc_sub_cmd_handlers = {
     CMD_PREPARE_POC: prepare_poc,
     CMD_PREPARE_JOBS_DIR: prepare_jobs_dir,
+    CMD_ADD_POC: add_poc,
     CMD_START_POC: start_poc,
     CMD_STOP_POC: stop_poc,
     CMD_CLEAN_POC: clean_poc,
@@ -1156,6 +1521,7 @@ poc_sub_cmd_handlers = {
 
 # Populated by define_*_parser functions; used by handlers for --schema support
 _poc_sub_cmd_parsers = {}
+_poc_add_sub_cmd_parsers = {}
 _poc_root_parser = None
 
 
@@ -1168,6 +1534,7 @@ def def_poc_parser(sub_cmd):
     poc_parser = parser.add_subparsers(title=cmd, dest="poc_sub_cmd", help="poc subcommand")
     define_prepare_parser(poc_parser)
     define_prepare_jobs_parser(poc_parser)
+    define_add_parser(poc_parser)
     define_start_parser(poc_parser)
     define_stop_parser(poc_parser)
     define_clean_parser(poc_parser)
@@ -1251,6 +1618,32 @@ def define_prepare_jobs_parser(poc_parser):
         "--force", action="store_true", help="overwrite existing jobs directory without prompting"
     )
     prepare_jobs_dir_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+
+def define_add_parser(poc_parser):
+    add_parser = poc_parser.add_parser(CMD_ADD_POC, help="add a participant to the local POC project")
+    _poc_sub_cmd_parsers[CMD_ADD_POC] = add_parser
+
+    add_sub_parser = add_parser.add_subparsers(
+        title=CMD_ADD_POC,
+        dest="poc_add_sub_cmd",
+        help="poc add subcommand",
+    )
+
+    user_parser = add_sub_parser.add_parser(CMD_ADD_USER, help="add a POC user startup kit")
+    _poc_add_sub_cmd_parsers[CMD_ADD_USER] = user_parser
+    user_parser.add_argument("cert_role", choices=POC_USER_CERT_ROLES, help="certificate role for the user")
+    user_parser.add_argument("email", help="user identity, usually an email address")
+    user_parser.add_argument("--org", default="nvidia", help="organization name, default nvidia")
+    user_parser.add_argument("--force", action="store_true", help="replace an existing user participant")
+    user_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    site_parser = add_sub_parser.add_parser(CMD_ADD_SITE, help="add a POC site startup kit")
+    _poc_add_sub_cmd_parsers[CMD_ADD_SITE] = site_parser
+    site_parser.add_argument("name", help="site name")
+    site_parser.add_argument("--org", default="nvidia", help="organization name, default nvidia")
+    site_parser.add_argument("--force", action="store_true", help="replace an existing site participant")
+    site_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
 
 
 def define_clean_parser(poc_parser):

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -40,6 +40,7 @@ from nvflare.lighter.utils import (
 )
 from nvflare.tool.api_utils import shutdown_system
 from nvflare.tool.kit.kit_config import (
+    StartupKitConfigError,
     add_startup_kit_entry,
     get_active_startup_kit_id,
     get_startup_kit_entries,
@@ -761,6 +762,9 @@ def add_poc_user(cmd_args):
             cmd_args.org,
             force=getattr(cmd_args, "force", False),
         )
+    except StartupKitConfigError as e:
+        output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e), hint=getattr(e, "hint", ""))
+        raise SystemExit(4)
     except ValueError as e:
         output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
         raise SystemExit(4)
@@ -802,6 +806,9 @@ def add_poc_site(cmd_args):
             cmd_args.org,
             force=getattr(cmd_args, "force", False),
         )
+    except StartupKitConfigError as e:
+        output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e), hint=getattr(e, "hint", ""))
+        raise SystemExit(4)
     except ValueError as e:
         output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
         raise SystemExit(4)
@@ -1497,8 +1504,10 @@ def _clean_poc(poc_workspace: str):
             if not is_poc_running(poc_workspace, service_config, project_config):
                 from nvflare.tool.cli_output import print_human
 
-                shutil.rmtree(poc_workspace)
-                _clean_poc_config(poc_workspace)
+                try:
+                    shutil.rmtree(poc_workspace)
+                finally:
+                    _clean_poc_config(poc_workspace)
 
                 print_human(f"{poc_workspace} is removed")
                 return True

--- a/nvflare/tool/study/study_cli.py
+++ b/nvflare/tool/study/study_cli.py
@@ -17,6 +17,7 @@ import os
 import sys
 from contextlib import contextmanager
 
+from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
 from nvflare.fuel.flare_api.api_spec import (
     AuthenticationError,
@@ -27,8 +28,6 @@ from nvflare.fuel.flare_api.api_spec import (
     NoConnection,
 )
 from nvflare.tool.cli_output import output_error, output_error_message, output_ok, output_usage_error
-from nvflare.tool.job.job_cli import _resolve_admin_user_and_dir_from_startup_kit
-from nvflare.utils.cli_utils import get_startup_kit_dir_for_target
 
 CMD_STUDY_REGISTER = "register"
 CMD_STUDY_ADD_SITE = "add-site"
@@ -67,51 +66,22 @@ def _ensure_study_parsers():
     _study_root_parser = root
 
 
-def _add_connection_args(parser):
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "--startup-target",
-        choices=["poc", "prod"],
-        default=None,
-        dest="startup_target",
-        help="startup kit target from ~/.nvflare/config.conf",
-    )
-    group.add_argument(
-        "--startup-kit",
-        dest="startup_kit",
-        default=None,
-        help="explicit startup kit location; mutually exclusive with --startup-target",
-    )
+def _resolve_active_startup_kit_dir() -> str:
+    from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
 
-
-def _resolve_session_inputs(args):
-    startup = get_startup_kit_dir_for_target(
-        startup_kit_dir=getattr(args, "startup_kit", None),
-        target=getattr(args, "startup_target", None),
-    )
-    return _resolve_admin_user_and_dir_from_startup_kit(startup)
+    return resolve_startup_kit_dir()
 
 
 @contextmanager
 def _study_session(args):
     from nvflare.tool.cli_output import get_connect_timeout
-    from nvflare.tool.cli_session import new_cli_session
+    from nvflare.tool.cli_session import new_active_cli_session
 
     try:
-        username, startup_dir = _resolve_session_inputs(args)
+        sess = new_active_cli_session(timeout=get_connect_timeout(), study=DEFAULT_STUDY)
     except ValueError as e:
-        detail = str(e)
-        if "config.conf" in detail or "config file" in detail or "not configured" in detail:
-            target = getattr(args, "startup_target", None) or "poc"
-            output_error("STARTUP_KIT_NOT_CONFIGURED", exit_code=4, detail=detail, target=target)
-        output_error("STARTUP_KIT_MISSING", exit_code=4, detail=detail)
+        output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
         raise SystemExit(4)
-
-    sess = new_cli_session(
-        username=username,
-        startup_kit_location=startup_dir,
-        timeout=get_connect_timeout(),
-    )
     try:
         yield sess
     finally:
@@ -161,16 +131,19 @@ def _get_caller_role_from_startup_kit(admin_user_dir: str) -> str:
 
 def _try_get_caller_role(args) -> str:
     try:
-        _, admin_user_dir = _resolve_session_inputs(args)
+        admin_user_dir = _resolve_active_startup_kit_dir()
         return _get_caller_role_from_startup_kit(admin_user_dir)
     except Exception:
         return ""
 
 
-def _parse_sites_arg(sites_arg: str):
+def _parse_sites_arg(sites_arg):
     if sites_arg is None:
         raise ValueError("--sites is required")
-    sites = [s.strip() for s in sites_arg.split(",") if s.strip()]
+    raw_items = sites_arg if isinstance(sites_arg, list) else [sites_arg]
+    sites = []
+    for raw_item in raw_items:
+        sites.extend(s.strip() for s in str(raw_item).split(",") if s.strip())
     if not sites:
         raise ValueError("--sites must contain at least one site")
     return sites
@@ -210,14 +183,14 @@ def _resolve_lifecycle_inputs(args, command_label: str):
         if args.site_org:
             _output_invalid_lifecycle_args(
                 "org_admin must use --sites, not --site-org",
-                hint=f"Use: nvflare study {command_label} {args.name} --sites site-1,site-2",
+                hint=f"Use: nvflare study {command_label} {args.name} --sites site-1 site-2",
             )
         try:
             sites = _parse_sites_arg(args.sites)
         except ValueError:
             _output_invalid_lifecycle_args(
                 "org_admin must provide --sites",
-                hint=f"Use: nvflare study {command_label} {args.name} --sites site-1,site-2",
+                hint=f"Use: nvflare study {command_label} {args.name} --sites site-1 site-2",
             )
         return sites, None
 
@@ -265,7 +238,7 @@ def cmd_register(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_REGISTER],
         "nvflare study register",
-        ["nvflare study register cancer-research --sites hospital-a --startup-target prod"],
+        ["nvflare study register cancer-research --site-org nvidia:site-1,site-2"],
         sys.argv[1:],
     )
     parser = _study_sub_cmd_parsers[CMD_STUDY_REGISTER]
@@ -287,7 +260,7 @@ def cmd_add_site(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_ADD_SITE],
         "nvflare study add-site",
-        ["nvflare study add-site cancer-research --sites hospital-b --startup-target prod"],
+        ["nvflare study add-site cancer-research --sites hospital-b"],
         sys.argv[1:],
     )
     parser = _study_sub_cmd_parsers[CMD_STUDY_ADD_SITE]
@@ -309,7 +282,7 @@ def cmd_remove_site(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_REMOVE_SITE],
         "nvflare study remove-site",
-        ["nvflare study remove-site cancer-research --sites hospital-b --startup-target prod"],
+        ["nvflare study remove-site cancer-research --sites hospital-b"],
         sys.argv[1:],
     )
     parser = _study_sub_cmd_parsers[CMD_STUDY_REMOVE_SITE]
@@ -331,7 +304,7 @@ def cmd_remove(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_REMOVE],
         "nvflare study remove",
-        ["nvflare study remove cancer-research --startup-target prod"],
+        ["nvflare study remove cancer-research"],
         sys.argv[1:],
     )
     _run_with_payload(
@@ -346,7 +319,7 @@ def cmd_list(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_LIST],
         "nvflare study list",
-        ["nvflare study list --startup-target prod"],
+        ["nvflare study list"],
         sys.argv[1:],
     )
     _run_with_payload(args, lambda s: s.list_studies(), parser=_study_sub_cmd_parsers[CMD_STUDY_LIST])
@@ -359,7 +332,7 @@ def cmd_show(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_SHOW],
         "nvflare study show",
-        ["nvflare study show cancer-research --startup-target prod"],
+        ["nvflare study show cancer-research"],
         sys.argv[1:],
     )
     _run_with_payload(
@@ -374,7 +347,7 @@ def cmd_add_user(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_ADD_USER],
         "nvflare study add-user",
-        ["nvflare study add-user cancer-research trainer@org_a.com --startup-target prod"],
+        ["nvflare study add-user cancer-research trainer@org_a.com"],
         sys.argv[1:],
     )
     _run_with_payload(
@@ -393,7 +366,7 @@ def cmd_remove_user(args):
     handle_schema_flag(
         _study_sub_cmd_parsers[CMD_STUDY_REMOVE_USER],
         "nvflare study remove-user",
-        ["nvflare study remove-user cancer-research trainer@org_a.com --startup-target prod"],
+        ["nvflare study remove-user cancer-research trainer@org_a.com"],
         sys.argv[1:],
     )
     _run_with_payload(
@@ -409,54 +382,47 @@ def _define_study_subcommands(parser):
     sub = parser.add_subparsers(title="study subcommands", metavar="", dest="study_sub_cmd")
 
     p = sub.add_parser(CMD_STUDY_REGISTER, help="create or merge a study")
-    _add_connection_args(p)
     p.add_argument("name")
-    p.add_argument("--sites", required=False)
+    p.add_argument("--sites", nargs="+", required=False)
     p.add_argument("--site-org", action="append", default=[])
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _study_sub_cmd_parsers[CMD_STUDY_REGISTER] = p
     _study_handlers[CMD_STUDY_REGISTER] = cmd_register
 
     p = sub.add_parser(CMD_STUDY_ADD_SITE, help="add sites to a study")
-    _add_connection_args(p)
     p.add_argument("name")
-    p.add_argument("--sites", required=False)
+    p.add_argument("--sites", nargs="+", required=False)
     p.add_argument("--site-org", action="append", default=[])
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _study_sub_cmd_parsers[CMD_STUDY_ADD_SITE] = p
     _study_handlers[CMD_STUDY_ADD_SITE] = cmd_add_site
 
     p = sub.add_parser(CMD_STUDY_REMOVE_SITE, help="remove sites from a study")
-    _add_connection_args(p)
     p.add_argument("name")
-    p.add_argument("--sites", required=False)
+    p.add_argument("--sites", nargs="+", required=False)
     p.add_argument("--site-org", action="append", default=[])
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _study_sub_cmd_parsers[CMD_STUDY_REMOVE_SITE] = p
     _study_handlers[CMD_STUDY_REMOVE_SITE] = cmd_remove_site
 
     p = sub.add_parser(CMD_STUDY_REMOVE, help="remove a study")
-    _add_connection_args(p)
     p.add_argument("name")
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _study_sub_cmd_parsers[CMD_STUDY_REMOVE] = p
     _study_handlers[CMD_STUDY_REMOVE] = cmd_remove
 
     p = sub.add_parser(CMD_STUDY_LIST, help="list visible studies")
-    _add_connection_args(p)
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _study_sub_cmd_parsers[CMD_STUDY_LIST] = p
     _study_handlers[CMD_STUDY_LIST] = cmd_list
 
     p = sub.add_parser(CMD_STUDY_SHOW, help="show a study")
-    _add_connection_args(p)
     p.add_argument("name")
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _study_sub_cmd_parsers[CMD_STUDY_SHOW] = p
     _study_handlers[CMD_STUDY_SHOW] = cmd_show
 
     p = sub.add_parser(CMD_STUDY_ADD_USER, help="add a study user")
-    _add_connection_args(p)
     p.add_argument("study")
     p.add_argument("user")
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
@@ -464,7 +430,6 @@ def _define_study_subcommands(parser):
     _study_handlers[CMD_STUDY_ADD_USER] = cmd_add_user
 
     p = sub.add_parser(CMD_STUDY_REMOVE_USER, help="remove a study user")
-    _add_connection_args(p)
     p.add_argument("study")
     p.add_argument("user")
     p.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")

--- a/nvflare/tool/system/system_cli.py
+++ b/nvflare/tool/system/system_cli.py
@@ -30,30 +30,12 @@ CMD_SYSTEM_LOG_CONFIG = "log-config"
 _system_sub_cmd_parsers = {}
 
 
-def _add_system_connection_args(parser):
-    parser.add_argument(
-        "--startup-kit",
-        dest="startup_kit",
-        default=None,
-        help="path to the admin startup kit directory (overrides target-based config lookup)",
-    )
-    parser.add_argument(
-        "--startup-target",
-        choices=["poc", "prod"],
-        default=None,
-        dest="startup_target",
-        help="startup kit target to use from config.conf when --startup-kit is not supplied",
-    )
-
-
 def def_system_cli_parser(system_parser):
     """system_parser is already created in cli.py — add subcommands here."""
-    _add_system_connection_args(system_parser)
     sub = system_parser.add_subparsers(title="system subcommands", metavar="", dest="system_sub_cmd")
 
     # status
     p = sub.add_parser(CMD_SYSTEM_STATUS, help="show server and client status")
-    _add_system_connection_args(p)
     p.add_argument("target", nargs="?", choices=["server", "client"], default=None)
     p.add_argument("client_names", nargs="*", default=[])
     p.add_argument("--schema", action="store_true")
@@ -61,7 +43,6 @@ def def_system_cli_parser(system_parser):
 
     # resources
     p = sub.add_parser(CMD_SYSTEM_RESOURCES, help="show server and client resource usage")
-    _add_system_connection_args(p)
     p.add_argument("target", nargs="?", choices=["server", "client"], default=None)
     p.add_argument("client_names", nargs="*", default=[])
     p.add_argument("--schema", action="store_true")
@@ -69,7 +50,6 @@ def def_system_cli_parser(system_parser):
 
     # shutdown
     p = sub.add_parser(CMD_SYSTEM_SHUTDOWN, help="shut down server, clients, or all")
-    _add_system_connection_args(p)
     p.add_argument("target", choices=["server", "client", "all"])
     p.add_argument("client_names", nargs="*", default=[])
     p.add_argument("--force", action="store_true")
@@ -78,7 +58,6 @@ def def_system_cli_parser(system_parser):
 
     # restart
     p = sub.add_parser(CMD_SYSTEM_RESTART, help="restart server, clients, or all")
-    _add_system_connection_args(p)
     p.add_argument("target", choices=["server", "client", "all"])
     p.add_argument("client_names", nargs="*", default=[])
     p.add_argument("--force", action="store_true")
@@ -87,7 +66,6 @@ def def_system_cli_parser(system_parser):
 
     # remove-client
     p = sub.add_parser(CMD_SYSTEM_REMOVE_CLIENT, help="remove a client from the federation")
-    _add_system_connection_args(p)
     p.add_argument("client_name", help="name of the client to remove")
     p.add_argument("--force", action="store_true")
     p.add_argument("--schema", action="store_true")
@@ -95,14 +73,12 @@ def def_system_cli_parser(system_parser):
 
     # version
     p = sub.add_parser(CMD_SYSTEM_VERSION, help="show NVFlare version on each remote site")
-    _add_system_connection_args(p)
     p.add_argument("--site", default="all", help="server, a client name, or all")
     p.add_argument("--schema", action="store_true")
     _system_sub_cmd_parsers[CMD_SYSTEM_VERSION] = p
 
     # log-config
     p = sub.add_parser(CMD_SYSTEM_LOG_CONFIG, help="change logging level on server or client sites")
-    _add_system_connection_args(p)
     p.add_argument(
         "level",
         nargs="?",
@@ -136,32 +112,13 @@ def _confirm_or_force(prompt, args):
 def _get_system_session(args=None):
     """Create a secure session using the startup kit."""
     from nvflare.tool.cli_output import get_connect_timeout
-    from nvflare.tool.cli_session import new_cli_session
-    from nvflare.utils.cli_utils import get_startup_kit_dir_for_target
-
-    username = None
-    startup = None
+    from nvflare.tool.cli_session import new_active_cli_session
 
     try:
-        from nvflare.tool.job.job_cli import _resolve_admin_user_and_dir_from_startup_kit
-
-        startup_target = getattr(args, "startup_target", None) or "poc"
-        startup_override = getattr(args, "startup_kit", None)
-        startup = get_startup_kit_dir_for_target(startup_kit_dir=startup_override, target=startup_target)
-        username, startup = _resolve_admin_user_and_dir_from_startup_kit(startup)
+        return new_active_cli_session(timeout=get_connect_timeout())
     except ValueError as e:
         output_error("STARTUP_KIT_MISSING", exit_code=4, detail=str(e))
         raise SystemExit(4)
-    except Exception:
-        output_error(
-            "STARTUP_KIT_MISSING",
-            exit_code=4,
-            detail="admin username could not be resolved from the startup kit",
-        )
-        raise SystemExit(4)
-
-    timeout = get_connect_timeout()
-    return new_cli_session(username=username, startup_kit_location=startup, timeout=timeout)
 
 
 @contextmanager

--- a/nvflare/utils/cli_utils.py
+++ b/nvflare/utils/cli_utils.py
@@ -14,9 +14,7 @@
 import os
 import pathlib
 import shutil
-import sys
 import tempfile
-from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -24,13 +22,10 @@ from pyhocon import ConfigFactory as CF
 from pyhocon import ConfigTree, HOCONConverter
 
 from nvflare.fuel.utils.config import ConfigFormat
-from nvflare.fuel_opt.utils.pyhocon_loader import PyhoconConfig
 from nvflare.tool.job.job_client_const import CONFIG_CONF, JOB_TEMPLATES
 
 CONFIG_VERSION = "version"
 CURRENT_CONFIG_VERSION = 2
-TARGET_POC = "poc"
-TARGET_PROD = "prod"
 
 
 def get_home_dir() -> Path:
@@ -81,170 +76,59 @@ def load_config(config_file_path) -> Optional[ConfigTree]:
         return None
 
 
-def _get_optional_config_value(nvflare_config: Optional[ConfigTree], *keys: str):
+def find_startup_kit_config_keys(nvflare_config: ConfigTree) -> List[str]:
+    """Return old startup-kit config keys that should no longer be persisted."""
     if not nvflare_config:
-        return None
+        return []
 
-    for key in keys:
+    keys = []
+    for key in ("startup_kit.path", "startup_kit", "poc.startup_kit", "prod.startup_kit"):
         try:
-            value = nvflare_config.get(key)
+            if nvflare_config.get(key, None) is not None:
+                keys.append(key)
         except Exception:
-            value = None
-        if value is not None:
-            return value
-
-    return None
+            pass
+    return keys
 
 
-def _config_to_plain_dict(nvflare_config: Optional[ConfigTree]) -> dict:
+def remove_startup_kit_config_keys(nvflare_config: ConfigTree) -> ConfigTree:
+    """Remove obsolete startup kit config keys without touching the startup_kits registry."""
     if not nvflare_config:
-        return {}
-    return PyhoconConfig(nvflare_config).to_dict()
-
-
-def _has_legacy_config_keys(nvflare_config: Optional[ConfigTree]) -> bool:
-    if not nvflare_config:
-        return False
-    return (
-        _get_optional_config_value(
-            nvflare_config,
-            "config_version",
-            "startup_kit.path",
-            "startup_kit",
-            "poc_workspace.path",
-            "poc_workspace",
-        )
-        is not None
-    )
-
-
-def migrate_config_to_v2(nvflare_config: Optional[ConfigTree]) -> ConfigTree:
-    if not nvflare_config:
-        return CF.parse_string("{}")
-
-    try:
-        current_version = nvflare_config.get_int(CONFIG_VERSION)
-    except Exception:
-        current_version = None
-
-    if current_version == CURRENT_CONFIG_VERSION and not _has_legacy_config_keys(nvflare_config):
         return nvflare_config
 
-    old_startup_kit = _get_optional_config_value(nvflare_config, "startup_kit.path", "startup_kit")
-    old_poc_workspace = _get_optional_config_value(nvflare_config, "poc_workspace.path", "poc_workspace")
-    config_dict = _config_to_plain_dict(nvflare_config)
-    config_dict.pop("config_version", None)
-    config_dict.pop("version", None)
-    config_dict.pop("startup_kit", None)
-    config_dict.pop("poc_workspace", None)
-
-    if old_startup_kit:
-        poc_cfg = config_dict.setdefault(TARGET_POC, {})
-        poc_cfg.setdefault("startup_kit", old_startup_kit)
-    if old_poc_workspace:
-        poc_cfg = config_dict.setdefault(TARGET_POC, {})
-        poc_cfg.setdefault("workspace", old_poc_workspace)
-
-    if not config_dict:
-        return CF.parse_string("{}")
-
-    ordered = OrderedDict()
-    ordered[CONFIG_VERSION] = CURRENT_CONFIG_VERSION
-    for key, value in config_dict.items():
-        if key != CONFIG_VERSION:
-            ordered[key] = value
-
-    return CF.from_dict(ordered)
-
-
-def find_startup_kit_location(target: Optional[str] = None) -> str:
-    nvflare_config = load_hidden_config()
-    target = target or TARGET_POC
-    if target == TARGET_PROD:
-        return _get_optional_config_value(nvflare_config, "prod.startup_kit", "startup_kit.path", "startup_kit")
-    return _get_optional_config_value(nvflare_config, "poc.startup_kit", "startup_kit.path", "startup_kit")
+    for key in ("startup_kit.path", "startup_kit", "poc.startup_kit", "prod.startup_kit"):
+        try:
+            nvflare_config.pop(key, None)
+        except Exception:
+            pass
+    return nvflare_config
 
 
 def load_hidden_config_state() -> Tuple[str, Optional[ConfigTree], bool]:
     hidden_dir = get_or_create_hidden_nvflare_dir()
     hidden_nvflare_config_file = get_hidden_nvflare_config_path(str(hidden_dir))
     nvflare_config = load_config(hidden_nvflare_config_file)
-    if nvflare_config is None:
-        return hidden_nvflare_config_file, None, False
-
-    try:
-        current_version = nvflare_config.get_int(CONFIG_VERSION)
-    except Exception:
-        current_version = None
-
-    if current_version == CURRENT_CONFIG_VERSION and not _has_legacy_config_keys(nvflare_config):
-        return hidden_nvflare_config_file, nvflare_config, False
-
-    migrated = migrate_config_to_v2(nvflare_config)
-    return hidden_nvflare_config_file, migrated, True
-
-
-def persist_hidden_config_migration(hidden_nvflare_config_file: str, migrated_config: ConfigTree):
-    backup_path = backup_hidden_config_file(hidden_nvflare_config_file)
-    save_config(migrated_config, hidden_nvflare_config_file)
-    print_hidden_config_migration_notice(hidden_nvflare_config_file, backup_path)
-
-
-def ensure_hidden_config_migrated():
-    hidden_nvflare_config_file, migrated_config, migration_needed = load_hidden_config_state()
-    if migration_needed and migrated_config is not None:
-        persist_hidden_config_migration(hidden_nvflare_config_file, migrated_config)
+    return hidden_nvflare_config_file, nvflare_config, False
 
 
 def backup_hidden_config_file(hidden_nvflare_config_file: str) -> Optional[str]:
-    backup_path = f"{hidden_nvflare_config_file}.bak"
-    if os.path.exists(hidden_nvflare_config_file):
-        shutil.copy2(hidden_nvflare_config_file, backup_path)
-        return backup_path
-    return None
+    if not os.path.exists(hidden_nvflare_config_file):
+        return None
 
+    backup_base = f"{hidden_nvflare_config_file}.bak"
+    backup_path = backup_base
+    suffix = 1
+    while os.path.exists(backup_path):
+        backup_path = f"{backup_base}{suffix}"
+        suffix += 1
 
-def print_hidden_config_migration_notice(hidden_nvflare_config_file: str, backup_path: Optional[str]):
-    message = f"Migrated {hidden_nvflare_config_file} to config version {CURRENT_CONFIG_VERSION}."
-    if backup_path:
-        message += f" Backup saved to {backup_path}."
-    print(message, file=sys.stderr)
+    shutil.copy2(hidden_nvflare_config_file, backup_path)
+    return backup_path
 
 
 def load_hidden_config() -> ConfigTree:
     _, nvflare_config, _ = load_hidden_config_state()
     return nvflare_config
-
-
-def create_startup_kit_config(
-    nvflare_config: ConfigTree,
-    target: str,
-    startup_kit_dir: Optional[str] = None,
-) -> ConfigTree:
-    """
-    Args:
-        startup_kit_dir: specified startup kit location
-        nvflare_config (ConfigTree): The existing nvflare configuration.
-
-    Returns:
-        ConfigTree: The merged configuration tree.
-    """
-    old_startup_kit_dir = _get_optional_config_value(nvflare_config, "startup_kit", "startup_kit.path")
-    if old_startup_kit_dir is None and (startup_kit_dir is not None and not os.path.isdir(startup_kit_dir)):
-        raise ValueError(f"invalid startup kit location '{startup_kit_dir}'")
-    if startup_kit_dir:
-        startup_kit_dir = get_startup_kit_dir(startup_kit_dir)
-        conf_str = f"""
-            {CONFIG_VERSION} = {CURRENT_CONFIG_VERSION}
-            {target} {{
-                startup_kit = "{startup_kit_dir}"
-            }}
-        """
-        conf: ConfigTree = CF.parse_string(conf_str)
-
-        return conf.with_fallback(nvflare_config)
-    else:
-        return nvflare_config
 
 
 def create_poc_workspace_config(nvflare_config: ConfigTree, poc_workspace_dir: Optional[str] = None) -> ConfigTree:
@@ -299,35 +183,6 @@ def create_job_template_config(nvflare_config: ConfigTree, job_templates_dir: Op
 def check_dir(dir_path: str):
     if not dir_path or not os.path.isdir(dir_path):
         raise ValueError(f"directory {dir_path} doesn't exists")
-
-
-def get_startup_kit_dir(startup_kit_dir: Optional[str] = None) -> str:
-    # Compatibility wrapper for legacy callers: no explicit target means "use the POC kit".
-    return get_startup_kit_dir_for_target(startup_kit_dir=startup_kit_dir)
-
-
-def get_startup_kit_dir_for_target(startup_kit_dir: Optional[str] = None, target: Optional[str] = None) -> str:
-    if not startup_kit_dir:
-        # Explicit env var takes priority over persisted config so CI/CD can override without editing files.
-        startup_kit_dir = os.getenv("NVFLARE_STARTUP_KIT_DIR")
-        if startup_kit_dir is None:
-            startup_kit_dir = find_startup_kit_location(target=target)
-
-        if startup_kit_dir is None or len(startup_kit_dir.strip()) == 0:
-            raise ValueError("startup kit directory is not specified")
-
-    check_startup_dir(startup_kit_dir)
-    startup_kit_dir = os.path.abspath(startup_kit_dir)
-    return startup_kit_dir
-
-
-def check_startup_dir(startup_kit_dir):
-    if not startup_kit_dir or not os.path.isdir(startup_kit_dir):
-        raise ValueError(
-            f"startup_kit_dir '{startup_kit_dir}' must be a valid and non-empty path. "
-            f"use 'nvflare poc' command to 'prepare' if you are using POC mode. Or use"
-            f" 'nvflare config' to setup startup_kit_dir location if you are in production"
-        )
 
 
 def find_job_templates_location(job_templates_dir: Optional[str] = None):

--- a/tests/unit_test/app_common/hub/hub_app_deployer_test.py
+++ b/tests/unit_test/app_common/hub/hub_app_deployer_test.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from nvflare.apis.fl_constant import SystemComponents, SystemVarName
+from nvflare.apis.job_def import JobMetaKey
+from nvflare.apis.workspace import Workspace
+from nvflare.app_common.hub.hub_app_deployer import HubAppDeployer
+from nvflare.lighter.tool_consts import NVFLARE_SIG_FILE
+
+SITE_NAME = "site-1"
+JOB_ID = "job-1"
+T2_JOB_ID = f"{JOB_ID}_t2"
+
+
+def _write_json(path: str, data: dict):
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data))
+
+
+def _read_json(path: str) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def _make_workspace(tmp_path) -> Workspace:
+    root = tmp_path / "workspace"
+    (root / "startup").mkdir(parents=True)
+    (root / "local").mkdir()
+    (root / "startup" / "rootCA.pem").write_text("root ca")
+
+    workspace = Workspace(str(root), site_name=SITE_NAME)
+
+    _write_json(workspace.get_client_app_config_file_path(JOB_ID), {"client": "original"})
+    _write_json(workspace.get_server_app_config_file_path(JOB_ID), {"server": "original"})
+    _write_json(
+        workspace.get_job_meta_path(JOB_ID),
+        {
+            JobMetaKey.SUBMITTER_NAME.value: "admin@nvidia.com",
+            JobMetaKey.SUBMITTER_ORG.value: "nvidia",
+            JobMetaKey.SUBMITTER_ROLE.value: "lead",
+            JobMetaKey.SCOPE.value: "global",
+        },
+    )
+    Path(workspace.get_app_dir(JOB_ID), NVFLARE_SIG_FILE).write_text('{"sig": "originator"}')
+
+    _write_json(
+        workspace.get_file_path_in_site_config(HubAppDeployer.HUB_CLIENT_CONFIG_TEMPLATE_NAME),
+        {"client": "hub"},
+    )
+    _write_json(
+        workspace.get_file_path_in_site_config(HubAppDeployer.HUB_SERVER_CONFIG_TEMPLATE_NAME),
+        {"workflows": [{"id": "hub-controller"}]},
+    )
+    return workspace
+
+
+def _make_fl_ctx(workspace: Workspace):
+    fed_client = MagicMock()
+    fed_client.cell.get_root_url_for_child.return_value = "grpc://t1-root:8002"
+    fed_client.cell.is_secure.return_value = True
+
+    validator = MagicMock()
+    validator.validate.return_value = (True, "", {JobMetaKey.JOB_ID.value: JOB_ID})
+
+    props = {
+        SystemVarName.WORKSPACE: workspace.root_dir,
+        SystemComponents.FED_CLIENT: fed_client,
+        SystemComponents.JOB_META_VALIDATOR: validator,
+    }
+
+    fl_ctx = MagicMock()
+    fl_ctx.get_prop.side_effect = lambda key: props.get(key)
+    return fl_ctx
+
+
+class TestHubAppDeployerSignatureHandling:
+    def test_prepare_verifies_before_rewrite_and_strips_t2_signature(self, tmp_path):
+        workspace = _make_workspace(tmp_path)
+        fl_ctx = _make_fl_ctx(workspace)
+
+        def _verify_before_rewrite(app_path, root_ca_path):
+            assert app_path == workspace.get_app_dir(JOB_ID)
+            assert root_ca_path == str(Path(workspace.get_startup_kit_dir(), "rootCA.pem"))
+            assert _read_json(workspace.get_client_app_config_file_path(JOB_ID)) == {"client": "original"}
+            assert _read_json(workspace.get_server_app_config_file_path(T2_JOB_ID)) == {"server": "original"}
+            return True
+
+        def _load_after_t2_signature_removed(from_path, def_name):
+            assert from_path == workspace.root_dir
+            assert def_name == T2_JOB_ID
+            assert not Path(workspace.get_app_dir(T2_JOB_ID), NVFLARE_SIG_FILE).exists()
+            return b"t2-job"
+
+        with (
+            patch(
+                "nvflare.app_common.hub.hub_app_deployer.verify_folder_signature", side_effect=_verify_before_rewrite
+            ),
+            patch(
+                "nvflare.app_common.hub.hub_app_deployer.load_job_def_bytes",
+                side_effect=_load_after_t2_signature_removed,
+            ),
+        ):
+            err, meta, job_def = HubAppDeployer().prepare(fl_ctx, workspace, JOB_ID, remove_tmp_t2_dir=False)
+
+        assert err == ""
+        assert meta[JobMetaKey.JOB_ID.value] == JOB_ID
+        assert job_def == b"t2-job"
+        assert _read_json(workspace.get_client_app_config_file_path(JOB_ID)) == {"client": "hub"}
+        assert _read_json(workspace.get_server_app_config_file_path(T2_JOB_ID))["workflows"] == [
+            {"id": "hub-controller"}
+        ]
+        assert Path(workspace.get_app_dir(JOB_ID), NVFLARE_SIG_FILE).exists()
+
+    def test_prepare_rejects_invalid_signature_before_rewrite(self, tmp_path):
+        workspace = _make_workspace(tmp_path)
+        fl_ctx = _make_fl_ctx(workspace)
+
+        def _verify_before_rewrite(app_path, root_ca_path):
+            assert _read_json(workspace.get_client_app_config_file_path(JOB_ID)) == {"client": "original"}
+            assert _read_json(workspace.get_server_app_config_file_path(T2_JOB_ID)) == {"server": "original"}
+            return False
+
+        with (
+            patch(
+                "nvflare.app_common.hub.hub_app_deployer.verify_folder_signature", side_effect=_verify_before_rewrite
+            ),
+            patch("nvflare.app_common.hub.hub_app_deployer.load_job_def_bytes") as load_job_def_bytes,
+        ):
+            err, meta, job_def = HubAppDeployer().prepare(fl_ctx, workspace, JOB_ID, remove_tmp_t2_dir=False)
+
+        assert err == "hub: job signature verification failed before forwarding"
+        assert meta is None
+        assert job_def is None
+        load_job_def_bytes.assert_not_called()
+        assert _read_json(workspace.get_client_app_config_file_path(JOB_ID)) == {"client": "original"}
+        assert _read_json(workspace.get_server_app_config_file_path(T2_JOB_ID)) == {"server": "original"}

--- a/tests/unit_test/fuel/flare_api/session_new_methods_test.py
+++ b/tests/unit_test/fuel/flare_api/session_new_methods_test.py
@@ -532,6 +532,62 @@ class TestGetJobLogs:
         cmd = mock_cmd.call_args[0][0]
         assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1", "all"]
 
+    def test_accepts_legacy_tail_and_grep_keywords_without_changing_command(self):
+        session = _make_session()
+        from nvflare.fuel.hci.client.api import APIStatus
+
+        reply = {
+            ResultKey.STATUS: APIStatus.SUCCESS,
+            ResultKey.META: None,
+            "data": [
+                {
+                    "type": "dict",
+                    "data": {
+                        "logs": {
+                            "server": "INFO first\nERROR second\nINFO third\nERROR fourth\n",
+                            "site-1": "INFO site\nERROR site\n",
+                        }
+                    },
+                }
+            ],
+        }
+        with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
+            result = session.get_job_logs("job1", tail_lines=1, grep_pattern="ERROR")
+
+        cmd = mock_cmd.call_args[0][0]
+        assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1", "server"]
+        assert result == {
+            "logs": {
+                "server": "ERROR fourth\n",
+                "site-1": "ERROR site\n",
+            }
+        }
+
+    def test_accepts_legacy_positional_tail_and_grep_arguments(self):
+        session = _make_session()
+        from nvflare.fuel.hci.client.api import APIStatus
+
+        reply = {
+            ResultKey.STATUS: APIStatus.SUCCESS,
+            ResultKey.META: None,
+            "data": [
+                {
+                    "type": "dict",
+                    "data": {
+                        "logs": {
+                            "site-1": "ERROR first\nINFO second\nERROR third\n",
+                        }
+                    },
+                }
+            ],
+        }
+        with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
+            result = session.get_job_logs("job1", "site-1", 2, "ERROR")
+
+        cmd = mock_cmd.call_args[0][0]
+        assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1", "site-1"]
+        assert result == {"logs": {"site-1": "ERROR third\n"}}
+
     def test_rejects_empty_target(self):
         session = _make_session()
 

--- a/tests/unit_test/fuel/flare_api/session_new_methods_test.py
+++ b/tests/unit_test/fuel/flare_api/session_new_methods_test.py
@@ -510,83 +510,33 @@ class TestGetJobLogs:
         with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
             session.get_job_logs("job1")
         cmd = mock_cmd.call_args[0][0]
-        assert "get_job_log" in cmd
-        assert "job1" in cmd
+        assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1", "server"]
 
-    def test_includes_tail_lines_flag(self):
+    def test_sends_client_target(self):
         session = _make_session()
         from nvflare.fuel.hci.client.api import APIStatus
 
         reply = {ResultKey.STATUS: APIStatus.SUCCESS, ResultKey.META: None, "data": []}
         with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
-            session.get_job_logs("job1", tail_lines=50)
+            session.get_job_logs("job1", target="site-1")
         cmd = mock_cmd.call_args[0][0]
-        assert "-n" in cmd
-        assert "50" in cmd
+        assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1", "site-1"]
 
-    @pytest.mark.parametrize("tail_lines", [0, -1])
-    def test_rejects_non_positive_tail_lines(self, tail_lines):
-        session = _make_session()
-
-        with pytest.raises(ValueError, match="greater than 0"):
-            session.get_job_logs("job1", tail_lines=tail_lines)
-
-    def test_rejects_non_integer_tail_lines(self):
-        session = _make_session()
-
-        with pytest.raises(ValueError, match="tail_lines must be int"):
-            session.get_job_logs("job1", tail_lines=2.5)
-
-    def test_includes_grep_pattern_flag(self):
+    def test_sends_all_target(self):
         session = _make_session()
         from nvflare.fuel.hci.client.api import APIStatus
 
         reply = {ResultKey.STATUS: APIStatus.SUCCESS, ResultKey.META: None, "data": []}
         with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
-            session.get_job_logs("job1", grep_pattern="ERROR")
+            session.get_job_logs("job1", target="all")
         cmd = mock_cmd.call_args[0][0]
-        assert "-g" in cmd
-        assert "ERROR" in cmd
+        assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1", "all"]
 
-    def test_quotes_multi_word_grep_pattern(self):
+    def test_rejects_empty_target(self):
         session = _make_session()
-        from nvflare.fuel.hci.client.api import APIStatus
 
-        reply = {ResultKey.STATUS: APIStatus.SUCCESS, ResultKey.META: None, "data": []}
-        with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
-            session.get_job_logs("job1", grep_pattern="CUDA out of memory")
-        cmd = mock_cmd.call_args[0][0]
-        assert split_to_args(cmd) == [
-            AdminCommandNames.GET_JOB_LOG,
-            "job1",
-            "-g",
-            "CUDA out of memory",
-        ]
-
-    def test_quotes_grep_pattern_with_embedded_double_quote(self):
-        session = _make_session()
-        from nvflare.fuel.hci.client.api import APIStatus
-
-        reply = {ResultKey.STATUS: APIStatus.SUCCESS, ResultKey.META: None, "data": []}
-        with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
-            session.get_job_logs("job1", grep_pattern='foo"bar')
-        cmd = mock_cmd.call_args[0][0]
-        assert split_to_args(cmd) == [
-            AdminCommandNames.GET_JOB_LOG,
-            "job1",
-            "-g",
-            'foo"bar',
-        ]
-
-    def test_ignores_empty_grep_pattern(self):
-        session = _make_session()
-        from nvflare.fuel.hci.client.api import APIStatus
-
-        reply = {ResultKey.STATUS: APIStatus.SUCCESS, ResultKey.META: None, "data": []}
-        with patch.object(session, "_do_command", return_value=reply) as mock_cmd:
-            session.get_job_logs("job1", grep_pattern="")
-        cmd = mock_cmd.call_args[0][0]
-        assert split_to_args(cmd) == [AdminCommandNames.GET_JOB_LOG, "job1"]
+        with pytest.raises(ValueError, match="target must be a non-empty str"):
+            session.get_job_logs("job1", target="")
 
     def test_grep_target_quotes_pattern_with_embedded_double_quote(self):
         session = _make_session()
@@ -604,20 +554,29 @@ class TestGetJobLogs:
         cmd = mock_cmd.call_args[0][0]
         assert split_to_args(cmd) == ["grep", "server", 'foo"bar', "log.txt"]
 
-    def test_returns_logs_dict(self):
+    def test_returns_logs_dict_and_unavailable(self):
         session = _make_session()
         from nvflare.fuel.hci.client.api import APIStatus
 
-        reply = {ResultKey.STATUS: APIStatus.SUCCESS, ResultKey.META: None, "data": []}
+        reply = {
+            ResultKey.STATUS: APIStatus.SUCCESS,
+            ResultKey.META: None,
+            "data": [
+                {
+                    "type": "dict",
+                    "data": {
+                        "logs": {"server": "server log\n"},
+                        "unavailable": {"site-1": "client log stream not available for this job"},
+                    },
+                }
+            ],
+        }
         with patch.object(session, "_do_command", return_value=reply):
             result = session.get_job_logs("job1")
-        assert "logs" in result
-
-    def test_rejects_non_server_target(self):
-        session = _make_session()
-
-        with pytest.raises(ValueError, match="only supports target='server'"):
-            session.get_job_logs("job1", target="all")
+        assert result == {
+            "logs": {"server": "server log\n"},
+            "unavailable": {"site-1": "client log stream not available for this job"},
+        }
 
 
 class TestConfigureJobLog:

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 from argparse import Namespace
 from pathlib import Path
 from unittest.mock import MagicMock
+from zipfile import ZipFile
 
 import pytest
 
@@ -59,10 +61,15 @@ class TestListJobCmdParser:
 
 
 class TestGetJobLogCmdParser:
-    def test_parse_args(self):
+    def test_parse_args_defaults_to_server(self):
         parser = _create_get_job_log_cmd_parser()
-        parsed_args = parser.parse_args(["job-123", "-n", "10", "-g", "ERROR"])
-        assert parsed_args == Namespace(job_id="job-123", tail_lines=10, grep_pattern="ERROR")
+        parsed_args = parser.parse_args(["job-123"])
+        assert parsed_args == Namespace(job_id="job-123", target="server")
+
+    def test_parse_args_accepts_target(self):
+        parser = _create_get_job_log_cmd_parser()
+        parsed_args = parser.parse_args(["job-123", "site-1"])
+        assert parsed_args == Namespace(job_id="job-123", target="site-1")
 
 
 class _MockConnection:
@@ -255,6 +262,14 @@ class _FakeJobMetaValidatorWithMeta:
         return True, "", dict(self.meta)
 
 
+def _zip_bytes(files):
+    output = io.BytesIO()
+    with ZipFile(output, "w") as zip_file:
+        for name, content in files.items():
+            zip_file.writestr(name, content)
+    return output.getvalue()
+
+
 def test_submit_job_exposes_study_in_submit_event(monkeypatch):
     monkeypatch.setattr(job_cmds_module, "JobMetaValidator", _FakeJobMetaValidator)
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
@@ -442,18 +457,52 @@ def test_get_job_meta_normalizes_legacy_job_study(monkeypatch):
     assert conn.dicts[0][0][JobMetaKey.STUDY.value] == "default"
 
 
-def test_get_job_log_tail_uses_bounded_lines(tmp_path, monkeypatch):
+def test_get_job_log_client_target_returns_persisted_log(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
     workspace = _FakeWorkspace(tmp_path)
     engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_client_data.return_value = b"client line1\nclient line2\n"
     conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
-    log_file = Path(workspace.get_log_root("job-1")) / WorkspaceConstants.LOG_FILE_NAME
-    log_file.write_text("line1\nline2\nline3\n", encoding="utf-8")
 
-    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "-n", "2"])
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "site-1"])
 
     payload, _meta = conn.dicts[0]
-    assert payload["logs"]["server"] == "line2\nline3\n"
+    assert payload == {"logs": {"site-1": "client line1\nclient line2\n"}}
+    engine.job_def_manager.get_client_data.assert_called_once()
+
+
+def test_get_job_log_client_target_reads_live_workspace_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    client_log = Path(workspace.get_log_root("job-1")) / "site-1" / WorkspaceConstants.LOG_FILE_NAME
+    client_log.parent.mkdir(parents=True, exist_ok=True)
+    client_log.write_text("live client log\n", encoding="utf-8")
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "site-1"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {"logs": {"site-1": "live client log\n"}}
+    engine.job_def_manager.get_storage_component.assert_not_called()
+    engine.job_def_manager.get_client_data.assert_not_called()
+
+
+def test_get_job_log_client_target_reads_stored_workspace_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes({"site-1/log.txt": "stored client log\n"})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "site-1"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {"logs": {"site-1": "stored client log\n"}}
+    engine.job_def_manager.get_client_data.assert_not_called()
 
 
 def test_get_job_log_truncates_large_output(tmp_path, monkeypatch):
@@ -472,38 +521,124 @@ def test_get_job_log_truncates_large_output(tmp_path, monkeypatch):
     assert "truncated after 16 bytes" in payload["logs"]["server"]
 
 
-def test_get_job_log_tail_still_respects_byte_cap(tmp_path, monkeypatch):
+def test_get_job_log_reads_server_log_from_stored_workspace_when_live_log_is_gone(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
     workspace = _FakeWorkspace(tmp_path)
     engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes(
+        {WorkspaceConstants.LOG_FILE_NAME: "stored server log\n"}
+    )
     conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
-    log_file = Path(workspace.get_log_root("job-1")) / WorkspaceConstants.LOG_FILE_NAME
-    log_file.write_text("a" * 12 + "\n" + "b" * 12 + "\n" + "c" * 12 + "\n", encoding="utf-8")
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "server"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload["logs"]["server"] == "stored server log\n"
+    engine.job_def_manager.get_storage_component.assert_called_once()
+
+
+def test_get_job_log_client_target_truncates_large_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_client_data.return_value = b"a" * 20
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
 
     monkeypatch.setattr(JobCommandModule, "MAX_RETURNED_JOB_LOG_BYTES", 16)
 
-    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "-n", "10"])
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "site-1"])
 
     payload, _meta = conn.dicts[0]
-    assert "truncated after 16 bytes" in payload["logs"]["server"]
-    assert "aaaaaaaaaaaa" not in payload["logs"]["server"]
+    assert payload["logs"]["site-1"].startswith("a" * 16)
+    assert "truncated after 16 bytes" in payload["logs"]["site-1"]
 
 
-def test_get_job_log_tail_caps_buffered_line_count(tmp_path, monkeypatch):
+def test_get_job_log_all_returns_available_client_logs_and_unavailable_sites(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
     workspace = _FakeWorkspace(tmp_path)
     engine = _FakeServerEngine(workspace)
-    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
     log_file = Path(workspace.get_log_root("job-1")) / WorkspaceConstants.LOG_FILE_NAME
-    log_file.write_text("".join(f"line{i}\n" for i in range(6)), encoding="utf-8")
+    log_file.write_text("server line\n", encoding="utf-8")
+    engine.job_def_manager.list_components.return_value = ["LOG_log.txt_site-1", "meta", "workspace"]
+    engine.job_def_manager.get_client_data.side_effect = lambda jid, client_name, data_type, fl_ctx: (
+        b"client line\n" if client_name == "site-1" else None
+    )
+    job = _FakeListedJob({JobMetaKey.DEPLOY_MAP.value: {"app": ["server", "site-1", "site-2"]}})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1", JobCommandModule.JOB: job})
 
-    monkeypatch.setattr(JobCommandModule, "MAX_RETURNED_JOB_LOG_LINES", 3)
-
-    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "-n", "1000"])
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
 
     payload, _meta = conn.dicts[0]
-    assert payload["logs"]["server"].startswith("line3\nline4\nline5\n")
-    assert "truncated after 3 lines" in payload["logs"]["server"]
+    assert payload["logs"] == {"server": "server line\n", "site-1": "client line\n"}
+    assert payload["unavailable"] == {"site-2": "client log stream not available for this job"}
+
+
+def test_get_job_log_all_returns_workspace_client_logs(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.list_components.return_value = []
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes(
+        {
+            "log.txt": "server line\n",
+            "site-1/log.txt": "site-1 line\n",
+            "site-2/log.txt": "site-2 line\n",
+        }
+    )
+    job = _FakeListedJob({JobMetaKey.DEPLOY_MAP.value: {"app": ["server", "site-1", "site-2"]}})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1", JobCommandModule.JOB: job})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {
+        "logs": {
+            "server": "server line\n",
+            "site-1": "site-1 line\n",
+            "site-2": "site-2 line\n",
+        }
+    }
+
+
+def test_get_job_log_all_marks_missing_server_log_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.list_components.return_value = []
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes({"site-1/log.txt": "site-1 line\n"})
+    job = _FakeListedJob({JobMetaKey.DEPLOY_MAP.value: {"app": ["server", "site-1"]}})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1", JobCommandModule.JOB: job})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {
+        "logs": {"site-1": "site-1 line\n"},
+        "unavailable": {"server": "server log not available for this job"},
+    }
+
+
+def test_get_job_log_all_includes_empty_server_log_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    server_log = Path(workspace.get_log_root("job-1")) / WorkspaceConstants.LOG_FILE_NAME
+    server_log.write_text("", encoding="utf-8")
+    engine.job_def_manager.list_components.return_value = []
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes({"site-1/log.txt": "site-1 line\n"})
+    job = _FakeListedJob({JobMetaKey.DEPLOY_MAP.value: {"app": ["server", "site-1"]}})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1", JobCommandModule.JOB: job})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {"logs": {"server": "", "site-1": "site-1 line\n"}}
 
 
 def test_configure_job_log_all_targets_server_and_clients(tmp_path, monkeypatch):
@@ -799,22 +934,26 @@ def test_get_job_log_returns_server_log(monkeypatch, tmp_path):
     assert conn.dicts[0][1][MetaKey.STATUS].lower() == "ok"
 
 
-def test_get_job_log_applies_grep_and_tail(monkeypatch, tmp_path):
+def test_get_job_log_specific_missing_client_returns_unavailable(monkeypatch, tmp_path):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", object)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
 
     workspace = _FakeWorkspace(tmp_path)
-    log_file = Path(workspace.get_log_root("job-123")) / WorkspaceConstants.LOG_FILE_NAME
-    log_file.write_text("INFO line1\nERROR line2\nERROR line3\n", encoding="utf-8")
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_client_data.return_value = None
 
     conn = _MockConnection(
-        app_ctx=_FakeServerEngine(workspace),
+        app_ctx=engine,
         props={JobCommandModule.JOB_ID: "job-123"},
     )
 
-    JobCommandModule().get_job_log(conn, ["get_job_log", "job-123", "-g", "ERROR", "-n", "1"])
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-123", "site-2"])
 
     assert conn.errors == []
-    assert conn.dicts[0][0] == {"logs": {"server": "ERROR line3\n"}}
+    assert conn.dicts[0][0] == {
+        "logs": {},
+        "unavailable": {"site-2": "client log stream not available for this job"},
+    }
 
 
 def test_get_job_log_missing_file_returns_empty(monkeypatch, tmp_path):
@@ -928,7 +1067,7 @@ def test_submit_job_reports_all_deploy_map_sites_outside_study(monkeypatch):
     assert conn.successes == []
 
 
-def test_get_job_log_tail_zero_returns_syntax_error(tmp_path, monkeypatch):
+def test_get_job_log_rejects_removed_tail_flag(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", object)
     job_id = "job-123"
     log_root = tmp_path / job_id
@@ -953,7 +1092,7 @@ def test_get_job_log_tail_zero_returns_syntax_error(tmp_path, monkeypatch):
 
     assert len(conn.errors) == 1
     msg, meta = conn.errors[0]
-    assert msg == "tail_lines must be greater than 0"
+    assert "unrecognized arguments" in msg
     assert meta[MetaKey.STATUS] == "syntax_error"
 
 

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -24,7 +24,7 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey, ReturnCode, ServerCommandKey, WorkspaceConstants
 from nvflare.apis.job_def import JobMetaKey, RunStatus
 from nvflare.apis.shareable import Shareable
-from nvflare.fuel.hci.proto import MetaKey
+from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
 from nvflare.fuel.hci.server.authz import PreAuthzReturnCode
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.private.fed.server import cmd_utils as cmd_utils_module
@@ -538,6 +538,27 @@ def test_get_job_log_reads_server_log_from_stored_workspace_when_live_log_is_gon
     engine.job_def_manager.get_storage_component.assert_called_once()
 
 
+def test_get_job_log_reads_nested_server_log_from_stored_workspace(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes(
+        {"server/log.txt": "stored server log\n", "site-1/log.txt": "stored client log\n"}
+    )
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "server"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload["logs"]["server"] == "stored server log\n"
+
+
+def test_find_server_log_member_does_not_use_client_log():
+    assert JobCommandModule._find_server_log_member(["site-1/log.txt"]) is None
+    assert JobCommandModule._find_server_log_member(["workspace/server/log.txt"]) == "workspace/server/log.txt"
+
+
 def test_get_job_log_client_target_truncates_large_log(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
@@ -553,6 +574,38 @@ def test_get_job_log_client_target_truncates_large_log(tmp_path, monkeypatch):
     payload, _meta = conn.dicts[0]
     assert payload["logs"]["site-1"].startswith("a" * 16)
     assert "truncated after 16 bytes" in payload["logs"]["site-1"]
+
+
+def test_get_job_log_client_target_returns_structured_error_for_invalid_job_def_manager(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", type("ExpectedJobDefManager", (), {}))
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "site-1"])
+
+    assert conn.dicts == []
+    assert len(conn.errors) == 1
+    message, meta = conn.errors[0]
+    assert "job_def_manager in engine is not of type JobDefManagerSpec" in message
+    assert meta[MetaKey.STATUS] == MetaStatusValue.INTERNAL_ERROR
+
+
+def test_get_job_log_all_returns_structured_error_for_invalid_job_def_manager(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", type("ExpectedJobDefManager", (), {}))
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
+
+    assert conn.dicts == []
+    assert len(conn.errors) == 1
+    message, meta = conn.errors[0]
+    assert "job_def_manager in engine is not of type JobDefManagerSpec" in message
+    assert meta[MetaKey.STATUS] == MetaStatusValue.INTERNAL_ERROR
 
 
 def test_get_job_log_all_returns_available_client_logs_and_unavailable_sites(tmp_path, monkeypatch):

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -15,7 +15,7 @@
 import io
 from argparse import Namespace
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
 
 import pytest
@@ -655,6 +655,75 @@ def test_get_job_log_all_returns_workspace_client_logs(tmp_path, monkeypatch):
             "site-2": "site-2 line\n",
         }
     }
+    engine.job_def_manager.get_storage_component.assert_called_once()
+
+
+def test_get_job_log_all_reads_workspace_zip_once_for_client_logs(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    server_log = Path(workspace.get_log_root("job-1")) / WorkspaceConstants.LOG_FILE_NAME
+    server_log.write_text("server line\n", encoding="utf-8")
+    engine.job_def_manager.list_components.return_value = []
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes(
+        {
+            "site-1/log.txt": "site-1 line\n",
+            "site-2/log.txt": "site-2 line\n",
+            "site-3/log.txt": "site-3 line\n",
+        }
+    )
+    job = _FakeListedJob({JobMetaKey.DEPLOY_MAP.value: {"app": ["server", "site-1", "site-2", "site-3"]}})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1", JobCommandModule.JOB: job})
+
+    JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {
+        "logs": {
+            "server": "server line\n",
+            "site-1": "site-1 line\n",
+            "site-2": "site-2 line\n",
+            "site-3": "site-3 line\n",
+        }
+    }
+    engine.job_def_manager.get_storage_component.assert_called_once()
+    engine.job_def_manager.get_client_data.assert_not_called()
+
+
+def test_get_job_log_all_does_not_read_workspace_zip_per_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.list_components.return_value = []
+    engine.job_def_manager.get_storage_component.return_value = _zip_bytes(
+        {
+            "site-1/log.txt": "site-1 line\n",
+            "site-2/log.txt": "site-2 line\n",
+            "site-3/log.txt": "site-3 line\n",
+        }
+    )
+    job = _FakeListedJob({JobMetaKey.DEPLOY_MAP.value: {"app": ["server", "site-1", "site-2", "site-3"]}})
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1", JobCommandModule.JOB: job})
+
+    with patch.object(
+        JobCommandModule,
+        "_read_stored_client_job_log",
+        side_effect=AssertionError("all-sites log retrieval should not read the workspace ZIP per client"),
+    ):
+        JobCommandModule().get_job_log(conn, ["get_job_log", "job-1", "all"])
+
+    payload, _meta = conn.dicts[0]
+    assert payload == {
+        "logs": {
+            "site-1": "site-1 line\n",
+            "site-2": "site-2 line\n",
+            "site-3": "site-3 line\n",
+        },
+        "unavailable": {"server": "server log not available for this job"},
+    }
+    engine.job_def_manager.get_storage_component.assert_called_once()
 
 
 def test_get_job_log_all_marks_missing_server_log_unavailable(tmp_path, monkeypatch):

--- a/tests/unit_test/tool/cli_auth_errors_test.py
+++ b/tests/unit_test/tool/cli_auth_errors_test.py
@@ -66,14 +66,12 @@ def test_run_uses_study_specific_auth_hint_in_json_mode(capsys):
     args.version = False
 
     with patch.object(cli_mod, "parse_args", return_value=(MagicMock(), args, {})):
-        with patch(
-            "nvflare.tool.cli_output.set_output_format",
-            side_effect=lambda fmt: setattr(cli_output, "_output_format", fmt),
-        ):
-            with patch("nvflare.tool.cli_output.set_connect_timeout"):
-                with patch.object(cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(auth_error)}):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_mod.run("nvflare")
+        with patch.object(cli_output, "_output_format", "json"):
+            with patch("nvflare.tool.cli_output.set_output_format"):
+                with patch("nvflare.tool.cli_output.set_connect_timeout"):
+                    with patch.object(cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(auth_error)}):
+                        with pytest.raises(SystemExit) as exc_info:
+                            cli_mod.run("nvflare")
 
     assert exc_info.value.code == 2
     payload = json.loads(capsys.readouterr().out)
@@ -91,14 +89,12 @@ def test_run_uses_cert_specific_hint_for_error_cert_in_json_mode(capsys):
     args.version = False
 
     with patch.object(cli_mod, "parse_args", return_value=(MagicMock(), args, {})):
-        with patch(
-            "nvflare.tool.cli_output.set_output_format",
-            side_effect=lambda fmt: setattr(cli_output, "_output_format", fmt),
-        ):
-            with patch("nvflare.tool.cli_output.set_connect_timeout"):
-                with patch.object(cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(auth_error)}):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_mod.run("nvflare")
+        with patch.object(cli_output, "_output_format", "json"):
+            with patch("nvflare.tool.cli_output.set_output_format"):
+                with patch("nvflare.tool.cli_output.set_connect_timeout"):
+                    with patch.object(cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(auth_error)}):
+                        with pytest.raises(SystemExit) as exc_info:
+                            cli_mod.run("nvflare")
 
     assert exc_info.value.code == 2
     payload = json.loads(capsys.readouterr().out)
@@ -116,14 +112,12 @@ def test_run_routes_authorization_error_through_auth_failed_envelope(capsys):
     args.version = False
 
     with patch.object(cli_mod, "parse_args", return_value=(MagicMock(), args, {})):
-        with patch(
-            "nvflare.tool.cli_output.set_output_format",
-            side_effect=lambda fmt: setattr(cli_output, "_output_format", fmt),
-        ):
-            with patch("nvflare.tool.cli_output.set_connect_timeout"):
-                with patch.object(cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(auth_error)}):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_mod.run("nvflare")
+        with patch.object(cli_output, "_output_format", "json"):
+            with patch("nvflare.tool.cli_output.set_output_format"):
+                with patch("nvflare.tool.cli_output.set_connect_timeout"):
+                    with patch.object(cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(auth_error)}):
+                        with pytest.raises(SystemExit) as exc_info:
+                            cli_mod.run("nvflare")
 
     assert exc_info.value.code == 2
     payload = json.loads(capsys.readouterr().out)
@@ -139,16 +133,14 @@ def test_run_routes_cli_exception_through_error_envelope(capsys):
     args.version = False
 
     with patch.object(cli_mod, "parse_args", return_value=(MagicMock(), args, {})):
-        with patch(
-            "nvflare.tool.cli_output.set_output_format",
-            side_effect=lambda fmt: setattr(cli_output, "_output_format", fmt),
-        ):
-            with patch("nvflare.tool.cli_output.set_connect_timeout"):
-                with patch.object(
-                    cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(CLIException("boom"))}
-                ):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_mod.run("nvflare")
+        with patch.object(cli_output, "_output_format", "json"):
+            with patch("nvflare.tool.cli_output.set_output_format"):
+                with patch("nvflare.tool.cli_output.set_connect_timeout"):
+                    with patch.object(
+                        cli_mod, "handlers", {"job": lambda _args: (_ for _ in ()).throw(CLIException("boom"))}
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            cli_mod.run("nvflare")
 
     assert exc_info.value.code == 1
     payload = json.loads(capsys.readouterr().out)
@@ -164,14 +156,12 @@ def test_run_routes_missing_handler_to_invalid_args_envelope(capsys):
     args.version = False
 
     with patch.object(cli_mod, "parse_args", return_value=(MagicMock(), args, {})):
-        with patch(
-            "nvflare.tool.cli_output.set_output_format",
-            side_effect=lambda fmt: setattr(cli_output, "_output_format", fmt),
-        ):
-            with patch("nvflare.tool.cli_output.set_connect_timeout"):
-                with patch.object(cli_mod, "handlers", {}):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_mod.run("nvflare")
+        with patch.object(cli_output, "_output_format", "json"):
+            with patch("nvflare.tool.cli_output.set_output_format"):
+                with patch("nvflare.tool.cli_output.set_connect_timeout"):
+                    with patch.object(cli_mod, "handlers", {}):
+                        with pytest.raises(SystemExit) as exc_info:
+                            cli_mod.run("nvflare")
 
     assert exc_info.value.code == 4
     payload = json.loads(capsys.readouterr().out)

--- a/tests/unit_test/tool/cli_connect_timeout_test.py
+++ b/tests/unit_test/tool/cli_connect_timeout_test.py
@@ -15,6 +15,21 @@
 from unittest.mock import MagicMock, patch
 
 
+def _called_active_session_mock(*mocks):
+    called = [mock for mock in mocks if mock.called]
+    assert len(called) == 1
+    return called[0]
+
+
+def _call_arg(call, name, position):
+    args, kwargs = call
+    if name in kwargs:
+        return kwargs[name]
+    if len(args) > position:
+        return args[position]
+    return None
+
+
 def test_cli_sets_connect_timeout(monkeypatch):
     from nvflare import cli as cli_mod
 
@@ -34,29 +49,42 @@ def test_cli_sets_connect_timeout(monkeypatch):
     mock_set_timeout.assert_called_once_with(7.5)
 
 
-def test_job_get_session_uses_connect_timeout_env(monkeypatch):
+def test_job_get_session_uses_active_session_with_connect_timeout(monkeypatch):
     from nvflare.tool.job import job_cli
 
-    with patch.object(job_cli, "find_admin_user_and_dir", return_value=("admin", "/tmp/startup")):
-        with patch("nvflare.tool.cli_output.get_connect_timeout", return_value=3.25):
-            with patch("nvflare.tool.job.job_cli.new_cli_session") as mock_session:
-                job_cli._get_session()
+    with (
+        patch("nvflare.tool.cli_output.get_connect_timeout", return_value=3.25),
+        patch(
+            "nvflare.tool.cli_session.new_active_cli_session",
+            return_value=MagicMock(),
+            create=True,
+        ) as shared_active,
+        patch("nvflare.tool.job.job_cli.new_active_cli_session", return_value=MagicMock(), create=True) as job_active,
+    ):
+        job_cli._get_session(study="default")
 
-    _, kwargs = mock_session.call_args
-    assert kwargs["timeout"] == 3.25
+    active_session = _called_active_session_mock(shared_active, job_active)
+    assert _call_arg(active_session.call_args, "timeout", 0) == 3.25
+    assert _call_arg(active_session.call_args, "study", 1) in (None, "default")
 
 
-def test_system_get_session_uses_connect_timeout_env(monkeypatch):
+def test_system_get_session_uses_active_session_with_connect_timeout(monkeypatch):
     from nvflare.tool.system import system_cli
 
-    with patch(
-        "nvflare.tool.job.job_cli._resolve_admin_user_and_dir_from_startup_kit",
-        return_value=("admin", "/tmp/startup"),
+    with (
+        patch("nvflare.tool.cli_output.get_connect_timeout", return_value=4.0),
+        patch(
+            "nvflare.tool.cli_session.new_active_cli_session",
+            return_value=MagicMock(),
+            create=True,
+        ) as shared_active,
+        patch(
+            "nvflare.tool.system.system_cli.new_active_cli_session",
+            return_value=MagicMock(),
+            create=True,
+        ) as system_active,
     ):
-        with patch("nvflare.utils.cli_utils.get_startup_kit_dir_for_target", return_value="/tmp/startup"):
-            with patch("nvflare.tool.cli_output.get_connect_timeout", return_value=4.0):
-                with patch("nvflare.tool.cli_session.new_cli_session") as mock_session:
-                    system_cli._get_system_session()
+        system_cli._get_system_session()
 
-    _, kwargs = mock_session.call_args
-    assert kwargs["timeout"] == 4.0
+    active_session = _called_active_session_mock(shared_active, system_active)
+    assert _call_arg(active_session.call_args, "timeout", 0) == 4.0

--- a/tests/unit_test/tool/cli_errors_test.py
+++ b/tests/unit_test/tool/cli_errors_test.py
@@ -80,8 +80,8 @@ def test_startup_kit_hints_name_kit_registry_commands():
         if code in ERROR_REGISTRY
     ]
     combined = " ".join(hints)
-    assert "nvflare kit list" in combined
-    assert "nvflare kit use <id>" in combined
+    assert "nvflare config kit list" in combined
+    assert "nvflare config kit use <id>" in combined
     assert "NVFLARE_STARTUP_KIT_DIR" in combined
 
 

--- a/tests/unit_test/tool/cli_errors_test.py
+++ b/tests/unit_test/tool/cli_errors_test.py
@@ -73,11 +73,33 @@ def test_internal_error_hint_does_not_reference_verbose():
     assert "--verbose" not in ERROR_REGISTRY["INTERNAL_ERROR"]["hint"]
 
 
-def test_startup_kit_missing_hint_names_current_resolution_sources():
-    hint = ERROR_REGISTRY["STARTUP_KIT_MISSING"]["hint"]
-    assert "--startup-kit" in hint
-    assert "NVFLARE_STARTUP_KIT_DIR" in hint
-    assert "--startup or" not in hint
+def test_startup_kit_hints_name_kit_registry_commands():
+    hints = [
+        ERROR_REGISTRY[code]["hint"]
+        for code in ("STARTUP_KIT_MISSING", "STARTUP_KIT_NOT_CONFIGURED")
+        if code in ERROR_REGISTRY
+    ]
+    combined = " ".join(hints)
+    assert "nvflare kit list" in combined
+    assert "nvflare kit use <id>" in combined
+    assert "NVFLARE_STARTUP_KIT_DIR" in combined
+
+
+def test_no_error_hint_recommends_old_startup_kit_flags():
+    forbidden = [
+        "--startup-kit",
+        "--startup_kit_dir",
+        "poc.startup_kit",
+        "prod.startup_kit",
+        "--{target}.startup_kit",
+    ]
+
+    offenders = {
+        code: entry["hint"]
+        for code, entry in ERROR_REGISTRY.items()
+        if any(old_text in entry["hint"] for old_text in forbidden)
+    }
+    assert offenders == {}
 
 
 def test_missing_substitution_key_falls_back_to_template():

--- a/tests/unit_test/tool/cli_schema_missing_args_test.py
+++ b/tests/unit_test/tool/cli_schema_missing_args_test.py
@@ -33,9 +33,8 @@ class TestSchemaWithMissingArgs:
         with patch("sys.argv", argv):
             from nvflare import cli
 
-            with patch("nvflare.cli.ensure_hidden_config_migrated"):
-                with pytest.raises(SystemExit) as exc_info:
-                    cli.main()
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
         return exc_info.value.code
 
     def test_job_abort_schema_no_job_id(self, capsys):

--- a/tests/unit_test/tool/config_output_test.py
+++ b/tests/unit_test/tool/config_output_test.py
@@ -31,7 +31,7 @@ def _config_getter(values):
 
 
 class TestConfigOutput:
-    """Tests for nvflare config after startup-kit registry ownership moved to nvflare kit."""
+    """Tests for nvflare config after startup-kit registry ownership moved to nvflare config kit."""
 
     @pytest.fixture(autouse=True)
     def json_mode(self, monkeypatch):
@@ -40,12 +40,12 @@ class TestConfigOutput:
     def _make_args(self, **kwargs):
         return SimpleNamespace(
             poc_workspace_dir=kwargs.get("poc_workspace_dir"),
-            job_templates_dir=kwargs.get("job_templates_dir"),
+            config_sub_cmd=kwargs.get("config_sub_cmd"),
             debug=False,
             schema=False,
         )
 
-    def test_config_json_envelope_shape_excludes_startup_kit_fields(self, capsys):
+    def test_config_json_envelope_shape_excludes_legacy_startup_kit_fields(self, capsys):
         from nvflare.cli import handle_config_cmd
 
         args = self._make_args()
@@ -55,7 +55,7 @@ class TestConfigOutput:
                 "poc.startup_kit": "/legacy/poc/startup",
                 "prod.startup_kit": "/legacy/prod/startup",
                 "poc.workspace": "/path/to/poc",
-                "job_template.path": "/path/to/templates",
+                "startup_kits.active": "project_admin",
             }
         )
 
@@ -72,12 +72,12 @@ class TestConfigOutput:
         assert data["exit_code"] == 0
         assert data["data"]["config_file"] == "/fake/config.conf"
         assert data["data"]["poc_workspace_dir"] == "/path/to/poc"
-        assert data["data"]["job_templates_dir"] == "/path/to/templates"
+        assert data["data"]["active_startup_kit"] == "project_admin"
         assert "startup_kit_dir" not in data["data"]
         assert "poc_startup_kit_dir" not in data["data"]
         assert "prod_startup_kit_dir" not in data["data"]
 
-    def test_config_parser_has_schema_flag_and_keeps_non_startup_settings(self):
+    def test_config_parser_has_schema_flag_poc_workspace_and_kit_subcommand(self):
         from nvflare.cli import def_config_parser
 
         root = argparse.ArgumentParser()
@@ -87,9 +87,13 @@ class TestConfigOutput:
         args = root.parse_args(["config", "--schema"])
         assert args.schema is True
 
-        args = root.parse_args(["config", "-pw", "/path/to/poc", "-jt", "/path/to/templates"])
+        args = root.parse_args(["config", "-pw", "/path/to/poc"])
         assert args.poc_workspace_dir == "/path/to/poc"
-        assert args.job_templates_dir == "/path/to/templates"
+
+        args = root.parse_args(["config", "kit", "use", "project_admin"])
+        assert args.config_sub_cmd == "kit"
+        assert args.kit_sub_cmd == "use"
+        assert args.kit_id == "project_admin"
 
     @pytest.mark.parametrize(
         "old_args",
@@ -98,6 +102,8 @@ class TestConfigOutput:
             ["--prod.startup_kit", "/path/to/startup"],
             ["--startup_kit_dir", "/path/to/startup"],
             ["-d", "/path/to/startup"],
+            ["-jt", "/path/to/templates"],
+            ["--job_templates_dir", "/path/to/templates"],
         ],
     )
     def test_config_parser_rejects_old_startup_kit_arguments(self, old_args):
@@ -110,36 +116,34 @@ class TestConfigOutput:
         with pytest.raises(SystemExit):
             root.parse_args(["config", *old_args])
 
-    def test_config_write_updates_only_non_startup_settings(self, capsys):
+    def test_config_write_updates_poc_workspace_only(self, capsys):
         from nvflare.cli import handle_config_cmd
 
-        args = self._make_args(poc_workspace_dir="/path/to/poc", job_templates_dir="/path/to/templates")
+        args = self._make_args(poc_workspace_dir="/path/to/poc")
         mock_config = MagicMock()
         mock_config.get.side_effect = _config_getter(
             {
                 "poc.workspace": "/path/to/poc",
-                "job_template.path": "/path/to/templates",
+                "startup_kits.active": "project_admin",
             }
         )
 
         with (
             patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)),
             patch("nvflare.cli.create_poc_workspace_config", return_value=mock_config) as create_poc,
-            patch("nvflare.cli.create_job_template_config", return_value=mock_config) as create_job_template,
             patch("nvflare.cli.save_config") as save_config,
             patch("nvflare.tool.cli_schema.handle_schema_flag"),
         ):
             handle_config_cmd(args)
 
         create_poc.assert_called_once_with(mock_config, "/path/to/poc")
-        create_job_template.assert_called_once_with(mock_config, "/path/to/templates")
         save_config.assert_called_once_with(mock_config, "/fake/config.conf")
 
         data = json.loads(capsys.readouterr().out)
         assert data["status"] == "ok"
         assert data["data"]["config_file"] == "/fake/config.conf"
         assert data["data"]["poc_workspace_dir"] == "/path/to/poc"
-        assert data["data"]["job_templates_dir"] == "/path/to/templates"
+        assert data["data"]["active_startup_kit"] == "project_admin"
         assert "startup_kit_dir" not in data["data"]
         assert "poc_startup_kit_dir" not in data["data"]
         assert "prod_startup_kit_dir" not in data["data"]

--- a/tests/unit_test/tool/config_output_test.py
+++ b/tests/unit_test/tool/config_output_test.py
@@ -12,238 +12,171 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pyhocon import ConfigFactory as CF
 
 from nvflare.tool import cli_output
 
 
+def _config_getter(values):
+    def _get(key, default=None):
+        return values.get(key, default)
+
+    return _get
+
+
 class TestConfigOutput:
-    """Tests for nvflare config output format."""
+    """Tests for nvflare config after startup-kit registry ownership moved to nvflare kit."""
 
     @pytest.fixture(autouse=True)
     def json_mode(self, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "json")
 
     def _make_args(self, **kwargs):
-        args = MagicMock()
-        args.poc_startup_kit_dir = kwargs.get("poc_startup_kit_dir", None)
-        args.prod_startup_kit_dir = kwargs.get("prod_startup_kit_dir", None)
-        args.legacy_startup_kit_dir = kwargs.get("legacy_startup_kit_dir", None)
-        args.poc_workspace_dir = kwargs.get("poc_workspace_dir", None)
-        args.job_templates_dir = kwargs.get("job_templates_dir", None)
-        args.debug = False
-        return args
+        return SimpleNamespace(
+            poc_workspace_dir=kwargs.get("poc_workspace_dir"),
+            job_templates_dir=kwargs.get("job_templates_dir"),
+            debug=False,
+            schema=False,
+        )
 
-    def test_config_json_envelope_shape(self, capsys):
-        """config command returns JSON with expected keys."""
+    def test_config_json_envelope_shape_excludes_startup_kit_fields(self, capsys):
         from nvflare.cli import handle_config_cmd
 
         args = self._make_args()
-
         mock_config = MagicMock()
-        mock_config.get.return_value = None
+        mock_config.get.side_effect = _config_getter(
+            {
+                "poc.startup_kit": "/legacy/poc/startup",
+                "prod.startup_kit": "/legacy/prod/startup",
+                "poc.workspace": "/path/to/poc",
+                "job_template.path": "/path/to/templates",
+            }
+        )
 
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                handle_config_cmd(args)
+        with (
+            patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)),
+            patch("nvflare.tool.cli_schema.handle_schema_flag"),
+        ):
+            handle_config_cmd(args)
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert data["schema_version"] == "1"
         assert data["status"] == "ok"
         assert data["exit_code"] == 0
-        assert "config_file" in data["data"]
-        assert "startup_kit_dir" in data["data"]
-        assert "poc_startup_kit_dir" in data["data"]
-        assert "prod_startup_kit_dir" in data["data"]
-        assert "poc_workspace_dir" in data["data"]
-        assert "job_templates_dir" in data["data"]
+        assert data["data"]["config_file"] == "/fake/config.conf"
+        assert data["data"]["poc_workspace_dir"] == "/path/to/poc"
+        assert data["data"]["job_templates_dir"] == "/path/to/templates"
+        assert "startup_kit_dir" not in data["data"]
+        assert "poc_startup_kit_dir" not in data["data"]
+        assert "prod_startup_kit_dir" not in data["data"]
 
-    def test_config_parser_has_schema_flag(self):
-        """config parser should have --schema flag."""
-        import argparse
-
+    def test_config_parser_has_schema_flag_and_keeps_non_startup_settings(self):
         from nvflare.cli import def_config_parser
 
         root = argparse.ArgumentParser()
         subs = root.add_subparsers()
         def_config_parser(subs)
+
         args = root.parse_args(["config", "--schema"])
         assert args.schema is True
 
-    def test_config_json_with_dirs_set(self, capsys):
-        """When dirs are set, config output reflects them."""
-        from nvflare.cli import handle_config_cmd
+        args = root.parse_args(["config", "-pw", "/path/to/poc", "-jt", "/path/to/templates"])
+        assert args.poc_workspace_dir == "/path/to/poc"
+        assert args.job_templates_dir == "/path/to/templates"
 
-        args = self._make_args(poc_startup_kit_dir="/path/to/startup")
-
-        mock_config = MagicMock()
-        mock_config.get.return_value = "/path/to/startup"
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch("nvflare.cli.create_startup_kit_config", return_value=mock_config):
-                with patch("nvflare.cli.create_poc_workspace_config", return_value=mock_config):
-                    with patch("nvflare.cli.create_job_template_config", return_value=mock_config):
-                        with patch("nvflare.cli.save_config"):
-                            with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                                handle_config_cmd(args)
-
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        assert data["status"] == "ok"
-        assert data["exit_code"] == 0
-        assert data["data"]["config_file"] == "/fake/config.conf"
-
-    def test_invalid_startup_kit_path_returns_invalid_args(self, capsys):
-        from nvflare.cli import handle_config_cmd
-
-        args = self._make_args(poc_startup_kit_dir="/bad/startup")
-        mock_config = MagicMock()
-        mock_config.get.return_value = None
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch(
-                "nvflare.cli.create_startup_kit_config",
-                side_effect=ValueError("invalid startup kit location '/bad/startup'"),
-            ):
-                with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                    with pytest.raises(SystemExit) as exc_info:
-                        handle_config_cmd(args)
-
-        assert exc_info.value.code == 4
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        assert data["status"] == "error"
-        assert data["error_code"] == "INVALID_ARGS"
-        assert "invalid startup kit location" in data["message"]
-
-    def test_invalid_startup_kit_path_does_not_save_when_output_error_is_mocked(self):
-        from nvflare.cli import handle_config_cmd
-
-        args = self._make_args(poc_startup_kit_dir="/bad/startup")
-        mock_config = MagicMock()
-        mock_config.get.return_value = None
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch(
-                "nvflare.cli.create_startup_kit_config",
-                side_effect=ValueError("invalid startup kit location '/bad/startup'"),
-            ):
-                with patch("nvflare.tool.cli_output.output_error") as output_error:
-                    with patch("nvflare.cli.save_config") as save_config:
-                        with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                            with pytest.raises(SystemExit) as exc_info:
-                                handle_config_cmd(args)
-
-        assert exc_info.value.code == 4
-        output_error.assert_called_once()
-        save_config.assert_not_called()
-
-    def test_invalid_startup_kit_path_still_exits_when_output_error_is_mocked(self):
-        from nvflare.cli import handle_config_cmd
-
-        args = self._make_args(poc_startup_kit_dir="/bad/startup")
-        mock_config = MagicMock()
-        mock_config.get.return_value = None
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch(
-                "nvflare.cli.create_startup_kit_config",
-                side_effect=ValueError("invalid startup kit location '/bad/startup'"),
-            ):
-                with patch("nvflare.tool.cli_output.output_error") as output_error:
-                    with patch("nvflare.cli.save_config") as save_config:
-                        with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                            with pytest.raises(SystemExit) as exc_info:
-                                handle_config_cmd(args)
-
-        assert exc_info.value.code == 4
-        output_error.assert_called_once()
-        save_config.assert_not_called()
-
-    def test_config_parser_accepts_legacy_startup_alias(self):
-        import argparse
-
+    @pytest.mark.parametrize(
+        "old_args",
+        [
+            ["--poc.startup_kit", "/path/to/startup"],
+            ["--prod.startup_kit", "/path/to/startup"],
+            ["--startup_kit_dir", "/path/to/startup"],
+            ["-d", "/path/to/startup"],
+        ],
+    )
+    def test_config_parser_rejects_old_startup_kit_arguments(self, old_args):
         from nvflare.cli import def_config_parser
 
         root = argparse.ArgumentParser()
         subs = root.add_subparsers()
         def_config_parser(subs)
-        args = root.parse_args(["config", "-d", "/path/to/startup"])
-        assert args.legacy_startup_kit_dir == "/path/to/startup"
-        args = root.parse_args(["config", "-pw", "/path/to/poc"])
-        assert args.poc_workspace_dir == "/path/to/poc"
 
-    def test_legacy_startup_alias_warns_and_maps_to_poc(self, capsys):
+        with pytest.raises(SystemExit):
+            root.parse_args(["config", *old_args])
+
+    def test_config_write_updates_only_non_startup_settings(self, capsys):
         from nvflare.cli import handle_config_cmd
 
-        args = self._make_args(legacy_startup_kit_dir="/path/to/startup")
-
+        args = self._make_args(poc_workspace_dir="/path/to/poc", job_templates_dir="/path/to/templates")
         mock_config = MagicMock()
-        mock_config.get.return_value = "/path/to/startup"
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch("nvflare.cli.create_startup_kit_config", return_value=mock_config) as create_startup:
-                with patch("nvflare.cli.create_poc_workspace_config", return_value=mock_config):
-                    with patch("nvflare.cli.create_job_template_config", return_value=mock_config):
-                        with patch("nvflare.cli.save_config"):
-                            with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                                handle_config_cmd(args)
-
-        create_startup.assert_any_call(mock_config, "poc", "/path/to/startup")
-        captured = capsys.readouterr()
-        assert "deprecated" in captured.err.lower()
-        assert "--poc.startup_kit" in captured.err
-
-    def test_legacy_startup_alias_conflicts_with_new_targeted_flags(self, capsys):
-        from nvflare.cli import handle_config_cmd
-
-        args = self._make_args(legacy_startup_kit_dir="/legacy", poc_startup_kit_dir="/new")
-        mock_config = MagicMock()
-        mock_config.get.return_value = None
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                with pytest.raises(SystemExit) as exc_info:
-                    handle_config_cmd(args)
-
-        assert exc_info.value.code == 4
-        data = json.loads(capsys.readouterr().out)
-        assert data["error_code"] == "INVALID_ARGS"
-        assert "startup_kit_dir cannot be used together" in data["message"]
-
-    def test_legacy_startup_alias_conflict_still_exits_when_output_error_is_mocked(self):
-        from nvflare.cli import handle_config_cmd
-
-        args = self._make_args(legacy_startup_kit_dir="/legacy", poc_startup_kit_dir="/new")
-        mock_config = MagicMock()
-        mock_config.get.return_value = None
-
-        with patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)):
-            with patch("nvflare.tool.cli_schema.handle_schema_flag"):
-                with patch("nvflare.tool.cli_output.output_error") as output_error:
-                    with patch("nvflare.cli.save_config") as save_config:
-                        with pytest.raises(SystemExit) as exc_info:
-                            handle_config_cmd(args)
-
-        assert exc_info.value.code == 4
-        output_error.assert_called_once_with(
-            "INVALID_ARGS",
-            exit_code=4,
-            detail="--startup_kit_dir cannot be used together with --poc.startup_kit or --prod.startup_kit",
+        mock_config.get.side_effect = _config_getter(
+            {
+                "poc.workspace": "/path/to/poc",
+                "job_template.path": "/path/to/templates",
+            }
         )
-        save_config.assert_not_called()
 
-    def test_config_parser_accepts_legacy_workspace_alias(self):
-        import argparse
+        with (
+            patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", mock_config, False)),
+            patch("nvflare.cli.create_poc_workspace_config", return_value=mock_config) as create_poc,
+            patch("nvflare.cli.create_job_template_config", return_value=mock_config) as create_job_template,
+            patch("nvflare.cli.save_config") as save_config,
+            patch("nvflare.tool.cli_schema.handle_schema_flag"),
+        ):
+            handle_config_cmd(args)
 
-        from nvflare.cli import def_config_parser
+        create_poc.assert_called_once_with(mock_config, "/path/to/poc")
+        create_job_template.assert_called_once_with(mock_config, "/path/to/templates")
+        save_config.assert_called_once_with(mock_config, "/fake/config.conf")
 
-        root = argparse.ArgumentParser()
-        subs = root.add_subparsers()
-        def_config_parser(subs)
-        args = root.parse_args(["config", "-pw", "/path/to/poc"])
-        assert args.poc_workspace_dir == "/path/to/poc"
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "ok"
+        assert data["data"]["config_file"] == "/fake/config.conf"
+        assert data["data"]["poc_workspace_dir"] == "/path/to/poc"
+        assert data["data"]["job_templates_dir"] == "/path/to/templates"
+        assert "startup_kit_dir" not in data["data"]
+        assert "poc_startup_kit_dir" not in data["data"]
+        assert "prod_startup_kit_dir" not in data["data"]
+
+    def test_config_write_warns_when_startup_kit_keys_are_removed(self, capsys):
+        from nvflare.cli import handle_config_cmd
+
+        args = self._make_args(poc_workspace_dir="/new/poc")
+        config = CF.parse_string(
+            """
+                poc {
+                    workspace = "/old/poc"
+                    startup_kit = "/old/poc/admin@nvidia.com"
+                }
+                prod {
+                    startup_kit = "/old/prod/admin@nvidia.com"
+                }
+            """
+        )
+
+        with (
+            patch("nvflare.cli.load_hidden_config_state", return_value=("/fake/config.conf", config, False)),
+            patch("nvflare.cli.backup_hidden_config_file", return_value="/fake/config.conf.bak") as backup_config,
+            patch("nvflare.cli.save_config") as save_config,
+            patch("nvflare.tool.cli_schema.handle_schema_flag"),
+        ):
+            handle_config_cmd(args)
+
+        backup_config.assert_called_once_with("/fake/config.conf")
+        saved_config = save_config.call_args.args[0]
+        assert saved_config.get("poc.workspace") == "/new/poc"
+        assert saved_config.get("poc.startup_kit", None) is None
+        assert saved_config.get("prod.startup_kit", None) is None
+
+        captured = capsys.readouterr()
+        assert "removed startup kit config keys" in captured.err
+        assert "poc.startup_kit" in captured.err
+        assert "prod.startup_kit" in captured.err
+        assert "backup saved to /fake/config.conf.bak" in captured.err
+        assert json.loads(captured.out)["status"] == "ok"

--- a/tests/unit_test/tool/job/job_list_test.py
+++ b/tests/unit_test/tool/job/job_list_test.py
@@ -21,6 +21,34 @@ from nvflare.fuel.flare_api.api_spec import AuthenticationError
 from nvflare.tool import cli_output
 
 
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}', encoding="utf-8")
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
 class TestJobList:
     """Tests for nvflare job list command."""
 
@@ -104,13 +132,39 @@ class TestJobList:
         args = parser.parse_args(["--study", "all"])
         assert args.study == "all"
 
-    def test_list_parser_accepts_startup_kit(self):
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_target", "prod"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_kit", "/tmp/startup"),
+        ],
+    )
+    def test_list_parser_rejects_old_startup_selectors(self, selector, value):
         self._init_parsers()
         from nvflare.tool.job.job_cli import job_sub_cmd_parser
 
         parser = job_sub_cmd_parser["list"]
-        args = parser.parse_args(["--startup-kit", "/tmp/startup"])
-        assert args.startup_kit == "/tmp/startup"
+        with pytest.raises(SystemExit):
+            parser.parse_args([selector, value])
+
+    def test_list_help_and_schema_omit_old_startup_selectors(self, capsys):
+        self._init_parsers()
+        from nvflare.tool.job.job_cli import cmd_job_list, job_sub_cmd_parser
+
+        help_text = job_sub_cmd_parser["list"].format_help()
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in help_text
+
+        with patch("sys.argv", ["nvflare", "job", "list", "--schema"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_job_list(MagicMock())
+
+        assert exc_info.value.code == 0
+        schema_text = capsys.readouterr().out
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in schema_text
 
     def test_list_forwards_all_study_literal_to_session(self):
         """The literal study name 'all' is forwarded unchanged to session creation."""
@@ -124,6 +178,20 @@ class TestJobList:
             cmd_job_list(args)
 
         assert get_session.call_args.kwargs["study"] == "all"
+
+    def test_list_uses_active_startup_kit_session(self, tmp_path, monkeypatch):
+        from nvflare.tool.job.job_cli import cmd_job_list
+
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        args = self._make_args()
+        mock_sess = MagicMock()
+        mock_sess.list_jobs.return_value = []
+
+        with patch("nvflare.tool.cli_session.new_secure_session", return_value=mock_sess) as new_secure:
+            cmd_job_list(args)
+
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
 
     def test_study_field_injected_in_each_job(self, capsys):
         """cmd_job_list injects study field into each job entry when missing."""

--- a/tests/unit_test/tool/job/job_logs_test.py
+++ b/tests/unit_test/tool/job/job_logs_test.py
@@ -22,12 +22,10 @@ from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotFound, No
 from nvflare.tool import cli_output
 
 
-def _make_args(job_id="abc123", site="server", tail=None, grep=None):
+def _make_args(job_id="abc123", site="server"):
     args = MagicMock()
     args.job_id = job_id
     args.site = site
-    args.tail = tail
-    args.grep = grep
     return args
 
 
@@ -40,7 +38,7 @@ class TestJobLogs:
 
     def _fake_session(self, mock_sess):
         @contextmanager
-        def _ctx():
+        def _ctx(*_args, **_kwargs):
             yield mock_sess
 
         return _ctx
@@ -61,6 +59,7 @@ class TestJobLogs:
         assert envelope["exit_code"] == 0
         data = envelope["data"]
         assert data["job_id"] == "abc123"
+        assert data["target"] == "server"
         assert data["logs"] == {"server": "line1\nline2\n"}
 
     def test_logs_no_log_source_field(self, capsys):
@@ -88,6 +87,40 @@ class TestJobLogs:
 
         data = json.loads(capsys.readouterr().out)["data"]
         assert "server" in data["logs"]
+
+    def test_logs_human_single_site_prints_raw_log_text(self, capsys, monkeypatch):
+        """Human mode prints readable log text instead of a dict/table."""
+        from nvflare.tool.job.job_cli import cmd_job_logs
+
+        monkeypatch.setattr(cli_output, "_output_format", "txt")
+        mock_sess = MagicMock()
+        mock_sess.get_job_logs.return_value = {"logs": {"server": "line1\nline2\n"}}
+
+        with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
+            cmd_job_logs(_make_args())
+
+        captured = capsys.readouterr()
+        assert captured.out == "line1\nline2\n"
+        assert captured.err == ""
+
+    def test_logs_human_all_sites_prints_headers_and_unavailable(self, capsys, monkeypatch):
+        from nvflare.tool.job.job_cli import cmd_job_logs
+
+        monkeypatch.setattr(cli_output, "_output_format", "txt")
+        mock_sess = MagicMock()
+        mock_sess.get_job_logs.return_value = {
+            "logs": {"server": "server log\n", "site-1": "client log\n"},
+            "unavailable": {"site-2": "client log stream not available for this job"},
+        }
+
+        with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
+            cmd_job_logs(_make_args(site="all"))
+
+        captured = capsys.readouterr()
+        assert "===== server =====\nserver log\n" in captured.out
+        assert "===== site-1 =====\nclient log\n" in captured.out
+        assert "Unavailable logs:" in captured.err
+        assert "site-2: client log stream not available for this job" in captured.err
 
     def test_logs_job_not_found_exits_1(self, capsys):
         """JobNotFound maps to JOB_NOT_FOUND, exit 1."""
@@ -130,97 +163,70 @@ class TestJobLogs:
             with pytest.raises(AuthenticationError):
                 cmd_job_logs(_make_args())
 
-    def test_logs_tail_passed_to_session(self):
-        """--tail value is forwarded as tail_lines to get_job_logs."""
+    def test_logs_request_does_not_apply_cli_filters(self):
         from nvflare.tool.job.job_cli import cmd_job_logs
 
         mock_sess = MagicMock()
         mock_sess.get_job_logs.return_value = {"logs": {}}
 
         with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
-            cmd_job_logs(_make_args(tail=50))
+            cmd_job_logs(_make_args())
 
-        mock_sess.get_job_logs.assert_called_once_with(
-            "abc123",
-            target="server",
-            tail_lines=50,
-            grep_pattern=None,
-        )
+        mock_sess.get_job_logs.assert_called_once_with("abc123", target="server")
 
-    def test_logs_grep_passed_to_session(self):
-        """--grep value is forwarded as grep_pattern to get_job_logs."""
+    def test_logs_client_site_calls_session_with_target(self, capsys):
+        """--site with a client name is passed through to the session API."""
         from nvflare.tool.job.job_cli import cmd_job_logs
 
         mock_sess = MagicMock()
-        mock_sess.get_job_logs.return_value = {"logs": {}}
+        mock_sess.get_job_logs.return_value = {"logs": {"site-1": "client log\n"}}
 
         with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
-            cmd_job_logs(_make_args(grep="ERROR"))
-
-        mock_sess.get_job_logs.assert_called_once_with(
-            "abc123",
-            target="server",
-            tail_lines=None,
-            grep_pattern="ERROR",
-        )
-
-    def test_logs_multi_word_grep_passed_without_shell_quotes(self):
-        """Multi-word grep patterns should be passed through literally, not shell-quoted."""
-        from nvflare.tool.job.job_cli import cmd_job_logs
-
-        mock_sess = MagicMock()
-        mock_sess.get_job_logs.return_value = {"logs": {}}
-
-        with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
-            cmd_job_logs(_make_args(grep="CUDA out of memory"))
-
-        mock_sess.get_job_logs.assert_called_once_with(
-            "abc123",
-            target="server",
-            tail_lines=None,
-            grep_pattern="CUDA out of memory",
-        )
-
-    def test_logs_non_server_site_rejected(self, capsys):
-        """--site with a non-server value → INVALID_ARGS, exits 4."""
-        from nvflare.tool.job.job_cli import cmd_job_logs
-
-        with pytest.raises(SystemExit) as exc_info:
             cmd_job_logs(_make_args(site="site-1"))
-        assert exc_info.value.code == 4
 
-        envelope = json.loads(capsys.readouterr().out)
-        assert envelope["error_code"] == "INVALID_ARGS"
+        mock_sess.get_job_logs.assert_called_once_with("abc123", target="site-1")
+        data = json.loads(capsys.readouterr().out)["data"]
+        assert data["target"] == "site-1"
+        assert data["logs"] == {"site-1": "client log\n"}
 
-    def test_logs_all_site_rejected(self, capsys):
-        """--site all → INVALID_ARGS, exits 4 (client streaming not yet available)."""
+    def test_logs_all_site_keeps_unavailable_as_partial_success(self, capsys):
+        """--site all returns available logs plus unavailable sites."""
         from nvflare.tool.job.job_cli import cmd_job_logs
 
-        with pytest.raises(SystemExit) as exc_info:
+        mock_sess = MagicMock()
+        mock_sess.get_job_logs.return_value = {
+            "logs": {"server": "server log\n", "site-1": "client log\n"},
+            "unavailable": {"site-2": "client log stream not available for this job"},
+        }
+
+        with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
             cmd_job_logs(_make_args(site="all"))
-        assert exc_info.value.code == 4
 
-        envelope = json.loads(capsys.readouterr().out)
-        assert envelope["error_code"] == "INVALID_ARGS"
+        data = json.loads(capsys.readouterr().out)["data"]
+        assert data["target"] == "all"
+        assert data["logs"] == {"server": "server log\n", "site-1": "client log\n"}
+        assert data["unavailable"] == {"site-2": "client log stream not available for this job"}
 
-    def test_logs_non_server_site_still_exits_when_output_error_is_mocked(self):
+    def test_logs_specific_missing_client_exits_with_log_not_found(self, capsys):
         from nvflare.tool.job.job_cli import cmd_job_logs
 
-        with patch("nvflare.tool.cli_output.output_error") as output_error:
-            with patch("nvflare.tool.job.job_cli._session") as session_factory:
-                with pytest.raises(SystemExit) as exc_info:
-                    cmd_job_logs(_make_args(site="site-1"))
+        mock_sess = MagicMock()
+        mock_sess.get_job_logs.return_value = {
+            "logs": {},
+            "unavailable": {"site-1": "client log stream not available for this job"},
+        }
 
-        assert exc_info.value.code == 4
-        output_error.assert_called_once_with(
-            "INVALID_ARGS",
-            exit_code=4,
-            detail="only --site server is currently supported; client log streaming is not yet available",
-        )
-        session_factory.assert_not_called()
+        with patch("nvflare.tool.job.job_cli._session", side_effect=self._fake_session(mock_sess)):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_job_logs(_make_args(site="site-1"))
+
+        assert exc_info.value.code == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["error_code"] == "LOG_NOT_FOUND"
+        assert "site-1" in envelope["message"]
 
     def test_logs_parser(self):
-        """'logs' subparser parses job_id, server-only --site, --tail, and --grep correctly."""
+        """'logs' subparser parses job_id and open-ended --site."""
         import argparse
 
         from nvflare.tool.job.job_cli import def_job_cli_parser, job_sub_cmd_parser
@@ -231,11 +237,20 @@ class TestJobLogs:
 
         parser = job_sub_cmd_parser["logs"]
         assert parser is not None
-        args = parser.parse_args(["abc123", "--site", "server", "--tail", "100", "--grep", "OOM"])
+        args = parser.parse_args(["abc123", "--site", "server"])
         assert args.job_id == "abc123"
         assert args.site == "server"
-        assert args.tail == 100
-        assert args.grep == "OOM"
 
+        args = parser.parse_args(["abc123", "--site", "site-1"])
+        assert args.site == "site-1"
+        args = parser.parse_args(["abc123", "--site", "all"])
+        assert args.site == "all"
+        args = parser.parse_args(["abc123", "--sites", "server"])
+        assert args.site == "server"
+        args = parser.parse_args(["--sites", "server", "abc123"])
+        assert args.job_id == "abc123"
+        assert args.site == "server"
         with pytest.raises(SystemExit):
-            parser.parse_args(["abc123", "--site", "all"])
+            parser.parse_args(["abc123", "--tail", "100"])
+        with pytest.raises(SystemExit):
+            parser.parse_args(["abc123", "--grep", "OOM"])

--- a/tests/unit_test/tool/job/job_meta_test.py
+++ b/tests/unit_test/tool/job/job_meta_test.py
@@ -21,6 +21,34 @@ from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotFound
 from nvflare.tool import cli_output
 
 
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}', encoding="utf-8")
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
 class TestJobMeta:
     """Tests for nvflare job meta command."""
 
@@ -89,6 +117,20 @@ class TestJobMeta:
             with pytest.raises(AuthenticationError):
                 cmd_job_meta(args)
 
+    def test_meta_uses_active_startup_kit_session(self, tmp_path, monkeypatch):
+        from nvflare.tool.job.job_cli import cmd_job_meta
+
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        args = self._make_args()
+        mock_sess = MagicMock()
+        mock_sess.get_job_meta.return_value = {"job_id": "abc123", "status": "RUNNING"}
+
+        with patch("nvflare.tool.cli_session.new_secure_session", return_value=mock_sess) as new_secure:
+            cmd_job_meta(args)
+
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
+
     def test_meta_parser_positional_job_id(self):
         """meta parser should accept positional job_id."""
         import argparse
@@ -104,7 +146,16 @@ class TestJobMeta:
         args = parser.parse_args(["abc123"])
         assert args.job_id == "abc123"
 
-    def test_meta_parser_accepts_startup_target(self):
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_target", "prod"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_kit", "/tmp/startup"),
+        ],
+    )
+    def test_meta_parser_rejects_old_startup_selectors(self, selector, value):
         import argparse
 
         from nvflare.tool.job.job_cli import def_job_cli_parser, job_sub_cmd_parser
@@ -114,5 +165,26 @@ class TestJobMeta:
         def_job_cli_parser(subs)
 
         parser = job_sub_cmd_parser["meta"]
-        args = parser.parse_args(["abc123", "--startup-target", "prod"])
-        assert args.startup_target == "prod"
+        with pytest.raises(SystemExit):
+            parser.parse_args(["abc123", selector, value])
+
+    def test_meta_help_and_schema_omit_old_startup_selectors(self, capsys):
+        import argparse
+
+        from nvflare.tool.job.job_cli import cmd_job_meta, def_job_cli_parser, job_sub_cmd_parser
+
+        root = argparse.ArgumentParser()
+        def_job_cli_parser(root.add_subparsers())
+
+        help_text = job_sub_cmd_parser["meta"].format_help()
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in help_text
+
+        with patch("sys.argv", ["nvflare", "job", "meta", "--schema"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_job_meta(MagicMock())
+
+        assert exc_info.value.code == 0
+        schema_text = capsys.readouterr().out
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in schema_text

--- a/tests/unit_test/tool/job/job_monitor_test.py
+++ b/tests/unit_test/tool/job/job_monitor_test.py
@@ -23,6 +23,34 @@ from nvflare.tool import cli_output
 from nvflare.tool.job.job_cli import _parse_monitor_duration_seconds, _parse_monitor_start_ts
 
 
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}', encoding="utf-8")
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
 def _make_args(job_id="abc123", timeout=0, interval=2, stats_target="server", metrics=None):
     args = MagicMock()
     args.job_id = job_id
@@ -78,7 +106,7 @@ def _mock_session(rc, meta):
     mock_sess.show_stats.return_value = {}
 
     @contextmanager
-    def _fake_session():
+    def _fake_session(*args, **kwargs):
         yield mock_sess
 
     return patch("nvflare.tool.job.job_cli._session", side_effect=_fake_session), mock_sess
@@ -110,7 +138,16 @@ class TestJobMonitorOutput:
         assert data["data"]["job_id"] == "abc123"
         assert data["data"]["status"] == "FINISHED_OK"
 
-    def test_monitor_parser_accepts_startup_kit(self):
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_target", "prod"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_kit", "/tmp/startup"),
+        ],
+    )
+    def test_monitor_parser_rejects_old_startup_selectors(self, selector, value):
         import argparse
 
         from nvflare.tool.job.job_cli import def_job_cli_parser, job_sub_cmd_parser
@@ -120,8 +157,29 @@ class TestJobMonitorOutput:
         def_job_cli_parser(subs)
 
         parser = job_sub_cmd_parser["monitor"]
-        args = parser.parse_args(["abc123", "--startup-kit", "/tmp/startup"])
-        assert args.startup_kit == "/tmp/startup"
+        with pytest.raises(SystemExit):
+            parser.parse_args(["abc123", selector, value])
+
+    def test_monitor_help_and_schema_omit_old_startup_selectors(self, capsys):
+        import argparse
+
+        from nvflare.tool.job.job_cli import cmd_job_monitor, def_job_cli_parser, job_sub_cmd_parser
+
+        root = argparse.ArgumentParser()
+        def_job_cli_parser(root.add_subparsers())
+
+        help_text = job_sub_cmd_parser["monitor"].format_help()
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in help_text
+
+        with patch("sys.argv", ["nvflare", "job", "monitor", "--schema"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_job_monitor(MagicMock())
+
+        assert exc_info.value.code == 0
+        schema_text = capsys.readouterr().out
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in schema_text
 
     def test_failed_outputs_error_envelope_exits_1(self, capsys):
         meta = _make_meta("FAILED")
@@ -210,7 +268,7 @@ class TestJobMonitorOutput:
 
     def test_job_not_found_exits_1(self, capsys):
         @contextmanager
-        def _fake_session():
+        def _fake_session(*args, **kwargs):
             sess = MagicMock()
             sess.monitor_job_and_return_job_meta.side_effect = JobNotFound("job does not exist")
             yield sess
@@ -228,7 +286,7 @@ class TestJobMonitorOutput:
 
     def test_connection_error_propagates_to_top_level_handler(self):
         @contextmanager
-        def _fake_session():
+        def _fake_session(*args, **kwargs):
             sess = MagicMock()
             sess.monitor_job_and_return_job_meta.side_effect = NoConnection("connection refused")
             yield sess
@@ -241,7 +299,7 @@ class TestJobMonitorOutput:
 
     def test_authentication_error_propagates_to_top_level_handler(self):
         @contextmanager
-        def _fake_session():
+        def _fake_session(*args, **kwargs):
             sess = MagicMock()
             sess.monitor_job_and_return_job_meta.side_effect = AuthenticationError("bad cert")
             yield sess
@@ -267,7 +325,7 @@ class TestJobMonitorOutput:
 
     def test_unexpected_monitor_exception_exits_internal_error(self, capsys):
         @contextmanager
-        def _fake_session():
+        def _fake_session(*args, **kwargs):
             sess = MagicMock()
             sess.monitor_job_and_return_job_meta.side_effect = KeyError("stats blew up")
             yield sess
@@ -318,7 +376,7 @@ class TestJobMonitorOutput:
         mock_sess.show_stats.return_value = {"server": {"round": 10, "loss": 0.05}}
 
         @contextmanager
-        def _fake_session():
+        def _fake_session(*args, **kwargs):
             yield mock_sess
 
         with patch("nvflare.tool.job.job_cli._session", side_effect=_fake_session):
@@ -328,6 +386,21 @@ class TestJobMonitorOutput:
 
         data = json.loads(capsys.readouterr().out)
         assert "stats_raw" in data["data"]
+
+    def test_monitor_uses_active_startup_kit_session(self, tmp_path, monkeypatch):
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        meta = _make_meta("FINISHED_OK")
+        mock_sess = MagicMock()
+        mock_sess.monitor_job_and_return_job_meta.return_value = (MonitorReturnCode.JOB_FINISHED, meta)
+        mock_sess.show_stats.return_value = {}
+
+        with patch("nvflare.tool.cli_session.new_secure_session", return_value=mock_sess) as new_secure:
+            from nvflare.tool.job.job_cli import cmd_job_monitor
+
+            cmd_job_monitor(_make_args())
+
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
 
     def test_no_human_text_on_stdout(self, capsys):
         """In json mode, stdout contains only one JSON line."""
@@ -362,7 +435,7 @@ class TestJobMonitorOutput:
         mock_sess.show_stats.return_value = {}
 
         @contextmanager
-        def _fake_session():
+        def _fake_session(*args, **kwargs):
             yield mock_sess
 
         with patch("nvflare.tool.job.job_cli._session", side_effect=_fake_session):

--- a/tests/unit_test/tool/job/job_submit_output_test.py
+++ b/tests/unit_test/tool/job/job_submit_output_test.py
@@ -35,8 +35,6 @@ class TestJobSubmitOutput:
         args.debug = False
         args.job_folder = kwargs.get("job_folder", "/fake/job")
         args.config_file = None
-        args.target = kwargs.get("target", None)
-        args.startup_kit = kwargs.get("startup_kit", None)
         return args
 
     def test_json_envelope_on_success(self, capsys):
@@ -174,24 +172,50 @@ class TestJobSubmitOutput:
         with pytest.raises(SystemExit):
             parser.parse_args(["submit", "-j", "./my_job", "-f", "config_fed_server.conf", "num_rounds=1"])
 
-    def test_submit_parser_accepts_startup_target_or_startup_kit(self):
-        root = argparse.ArgumentParser()
-        parser = def_job_cli_parser(root.add_subparsers(dest="sub_command"))["job"]
-
-        args = parser.parse_args(["submit", "-j", "./my_job", "--startup-target", "prod"])
-        assert args.startup_target == "prod"
-        assert args.startup_kit is None
-
-        args = parser.parse_args(["submit", "-j", "./my_job", "--startup-kit", "/tmp/startup"])
-        assert args.startup_kit == "/tmp/startup"
-        assert args.startup_target is None
-
-    def test_submit_parser_rejects_startup_target_with_startup_kit(self):
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_target", "prod"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_kit", "/tmp/startup"),
+        ],
+    )
+    def test_submit_parser_rejects_old_startup_selectors(self, selector, value):
         root = argparse.ArgumentParser()
         parser = def_job_cli_parser(root.add_subparsers(dest="sub_command"))["job"]
 
         with pytest.raises(SystemExit):
-            parser.parse_args(["submit", "-j", "./my_job", "--startup-target", "prod", "--startup-kit", "/tmp/startup"])
+            parser.parse_args(["submit", "-j", "./my_job", selector, value])
+
+    def test_submit_help_omits_old_startup_selectors(self):
+        root = argparse.ArgumentParser()
+        def_job_cli_parser(root.add_subparsers(dest="sub_command"))
+
+        from nvflare.tool.job.job_cli import job_sub_cmd_parser
+
+        help_text = job_sub_cmd_parser["submit"].format_help()
+        assert "--startup-target" not in help_text
+        assert "--startup_target" not in help_text
+        assert "--startup-kit" not in help_text
+        assert "--startup_kit" not in help_text
+
+    def test_submit_schema_omits_old_startup_selectors(self, capsys):
+        root = argparse.ArgumentParser()
+        def_job_cli_parser(root.add_subparsers(dest="sub_command"))
+
+        from nvflare.tool.job.job_cli import submit_job
+
+        with patch("sys.argv", ["nvflare", "job", "submit", "--schema"]):
+            with pytest.raises(SystemExit) as exc_info:
+                submit_job(MagicMock())
+
+        assert exc_info.value.code == 0
+        schema_text = capsys.readouterr().out
+        assert "--startup-target" not in schema_text
+        assert "--startup_target" not in schema_text
+        assert "--startup-kit" not in schema_text
+        assert "--startup_kit" not in schema_text
 
     def test_submit_parser_rejects_legacy_target_alias(self):
         root = argparse.ArgumentParser()

--- a/tests/unit_test/tool/job/job_submit_resolve_test.py
+++ b/tests/unit_test/tool/job/job_submit_resolve_test.py
@@ -16,6 +16,8 @@
 
 import json
 import os
+from argparse import Namespace
+from contextlib import ExitStack, contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,35 +35,74 @@ def _make_valid_job(root: str) -> str:
     return root
 
 
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}', encoding="utf-8")
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
+@contextmanager
+def _assert_no_active_session_created():
+    with ExitStack() as stack:
+        stack.enter_context(patch("nvflare.tool.cli_session.new_secure_session", side_effect=AssertionError))
+        stack.enter_context(
+            patch("nvflare.tool.cli_session.new_active_cli_session", side_effect=AssertionError, create=True)
+        )
+        stack.enter_context(
+            patch("nvflare.tool.job.job_cli.new_active_cli_session", side_effect=AssertionError, create=True)
+        )
+        stack.enter_context(
+            patch("nvflare.tool.job.job_cli.find_admin_user_and_dir", side_effect=AssertionError, create=True)
+        )
+        yield
+
+
 class TestResolveJobFolder:
     """_resolve_job_folder inside submit_job selects the correct folder."""
 
-    def _invoke_submit(self, job_folder, capsys, monkeypatch):
+    def _invoke_submit(self, job_folder, capsys, monkeypatch, tmp_path):
         """Run submit_job up to (but not including) the session connection step."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import patch
 
         from nvflare.tool import cli_output
 
         monkeypatch.setattr(cli_output, "_output_format", "json")
 
-        args = MagicMock()
-        args.job_folder = job_folder
-        args.study = "default"
-        args.debug = False
-        args.config_file = None
-        args.target = None
-        args.startup_kit = None
+        args = Namespace(job_folder=job_folder, study="default", debug=False, config_file=None)
 
-        with patch(
-            "nvflare.tool.job.job_cli.find_admin_user_and_dir", return_value=("admin@nvidia.com", "/tmp/startup")
-        ):
-            with patch("nvflare.tool.job.job_cli.get_app_dirs_from_job_folder", return_value=[]):
-                with patch("nvflare.tool.job.job_cli.prepare_job_config"):
-                    with patch("nvflare.tool.job.job_cli.internal_submit_job"):
-                        with patch("sys.argv", ["nvflare", "job", "submit", "-j", job_folder]):
-                            from nvflare.tool.job.job_cli import submit_job
+        with patch("nvflare.tool.job.job_cli.get_app_dirs_from_job_folder", return_value=[]):
+            with patch("nvflare.tool.job.job_cli.prepare_job_config"):
+                with patch("nvflare.tool.job.job_cli.internal_submit_job") as submit:
+                    with patch("sys.argv", ["nvflare", "job", "submit", "-j", job_folder]):
+                        from nvflare.tool.job.job_cli import submit_job
 
-                            submit_job(args)
+                        submit_job(args)
+
+        submit.assert_called_once()
+        assert submit.call_args.args[0] is None
+        assert submit.call_args.args[1] is None
 
         return capsys.readouterr()
 
@@ -70,7 +111,7 @@ class TestResolveJobFolder:
         job_dir = str(tmp_path / "myjob")
         _make_valid_job(job_dir)
 
-        captured = self._invoke_submit(job_dir, capsys, monkeypatch)
+        captured = self._invoke_submit(job_dir, capsys, monkeypatch, tmp_path)
         # Should NOT print "Using job folder: <subdir>" — no auto-discovery
         assert "Using job folder" not in captured.out + captured.err
 
@@ -81,7 +122,7 @@ class TestResolveJobFolder:
         child = os.path.join(parent, "myjob")
         _make_valid_job(child)
 
-        captured = self._invoke_submit(parent, capsys, monkeypatch)
+        captured = self._invoke_submit(parent, capsys, monkeypatch, tmp_path)
         assert "Using job folder" not in captured.out + captured.err
 
     def test_single_invalid_subdir_falls_back_to_root(self, capsys, monkeypatch, tmp_path):
@@ -90,7 +131,7 @@ class TestResolveJobFolder:
         child = os.path.join(parent, "notajob")
         os.makedirs(child, exist_ok=True)
 
-        captured = self._invoke_submit(parent, capsys, monkeypatch)
+        captured = self._invoke_submit(parent, capsys, monkeypatch, tmp_path)
         assert "Using job folder" not in captured.out + captured.err
 
     def test_multiple_subdirs_falls_back_to_root(self, capsys, monkeypatch, tmp_path):
@@ -99,7 +140,7 @@ class TestResolveJobFolder:
         for name in ("job_a", "job_b"):
             _make_valid_job(os.path.join(parent, name))
 
-        captured = self._invoke_submit(parent, capsys, monkeypatch)
+        captured = self._invoke_submit(parent, capsys, monkeypatch, tmp_path)
         assert "Using job folder" not in captured.out + captured.err
 
     def test_hidden_subdirs_ignored(self, capsys, monkeypatch, tmp_path):
@@ -109,7 +150,7 @@ class TestResolveJobFolder:
         _make_valid_job(os.path.join(parent, "myjob"))
         os.makedirs(os.path.join(parent, ".git"), exist_ok=True)
 
-        captured = self._invoke_submit(parent, capsys, monkeypatch)
+        captured = self._invoke_submit(parent, capsys, monkeypatch, tmp_path)
         assert "Using job folder" not in captured.out + captured.err
 
     def test_yaml_meta_is_recognized(self, capsys, monkeypatch, tmp_path):
@@ -123,7 +164,7 @@ class TestResolveJobFolder:
         with open(os.path.join(config_dir, "config_fed_server.yml"), "w") as f:
             f.write("{}")
 
-        captured = self._invoke_submit(job_dir, capsys, monkeypatch)
+        captured = self._invoke_submit(job_dir, capsys, monkeypatch, tmp_path)
         assert "Using job folder" not in captured.out + captured.err
 
     def test_invalid_job_folder_returns_structured_error_without_help(self, capsys, monkeypatch):
@@ -133,13 +174,7 @@ class TestResolveJobFolder:
 
         monkeypatch.setattr(cli_output, "_output_format", "txt")
 
-        args = MagicMock()
-        args.job_folder = "/no/such/job"
-        args.study = "default"
-        args.debug = False
-        args.config_file = None
-        args.target = None
-        args.startup_kit = None
+        args = Namespace(job_folder="/no/such/job", study="default", debug=False, config_file=None)
 
         with patch("sys.argv", ["nvflare", "job", "submit", "-j", "/no/such/job"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -151,121 +186,128 @@ class TestResolveJobFolder:
         assert "invalid job folder" in captured.err
         assert "usage:" in captured.err
 
-    def test_submit_resolves_target_and_startup_kit_args(self, monkeypatch, tmp_path):
+    def test_submit_uses_active_startup_kit_for_server_connection(self, monkeypatch, tmp_path):
         from nvflare.tool.job.job_cli import submit_job
 
         job_dir = str(tmp_path / "myjob")
         _make_valid_job(job_dir)
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
 
-        args = MagicMock()
-        args.job_folder = job_dir
-        args.study = "default"
-        args.debug = False
-        args.config_file = None
-        args.startup_target = "prod"
-        args.startup_kit = None
+        args = Namespace(job_folder=job_dir, study="default", debug=False, config_file=None)
 
-        with patch(
-            "nvflare.tool.job.job_cli.find_admin_user_and_dir", return_value=("admin@nvidia.com", "/tmp/startup")
-        ) as mock_find:
-            with patch("nvflare.tool.job.job_cli.get_app_dirs_from_job_folder", return_value=[]):
-                with patch("nvflare.tool.job.job_cli.prepare_job_config"):
-                    with patch("nvflare.tool.job.job_cli.internal_submit_job"):
-                        with patch("sys.argv", ["nvflare", "job", "submit", "-j", job_dir, "--startup-target", "prod"]):
-                            submit_job(args)
+        with patch("nvflare.tool.job.job_cli.get_app_dirs_from_job_folder", return_value=[]):
+            with patch("nvflare.tool.job.job_cli.prepare_job_config"):
+                fake_session = MagicMock()
+                fake_session.submit_job.return_value = "job-123"
+                with patch("nvflare.tool.cli_session.new_secure_session", return_value=fake_session) as new_secure:
+                    with patch("sys.argv", ["nvflare", "job", "submit", "-j", job_dir]):
+                        submit_job(args)
 
-        _, kwargs = mock_find.call_args
-        assert kwargs["target"] == "prod"
-        assert kwargs["startup_kit_dir"] is None
-
-    def test_find_admin_user_and_dir_requires_admin_startup_kit_dir(self, tmp_path):
-        from nvflare.tool.job.job_cli import find_admin_user_and_dir
-
-        prod_root = tmp_path / "prod_00"
-        prod_root.mkdir()
-
-        with pytest.raises(ValueError) as exc_info:
-            find_admin_user_and_dir(startup_kit_dir=str(prod_root))
-
-        assert "admin startup kit directory" in str(exc_info.value)
-
-    def test_find_admin_user_and_dir_accepts_admin_dir(self, tmp_path):
-        from nvflare.tool.job.job_cli import find_admin_user_and_dir
-
-        admin_dir = tmp_path / "admin@nvidia.com"
-        startup_dir = admin_dir / "startup"
-        startup_dir.mkdir(parents=True)
-        (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}')
-
-        with patch("nvflare.tool.job.job_cli.get_startup_kit_dir_for_target", return_value=str(admin_dir)):
-            username, resolved = find_admin_user_and_dir(startup_kit_dir=str(admin_dir))
-
-        assert username == "admin@nvidia.com"
-        assert resolved == str(admin_dir)
-
-    def test_find_admin_user_and_dir_accepts_startup_subdir(self, tmp_path):
-        from nvflare.tool.job.job_cli import find_admin_user_and_dir
-
-        admin_dir = tmp_path / "admin@nvidia.com"
-        startup_dir = admin_dir / "startup"
-        startup_dir.mkdir(parents=True)
-        (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}')
-
-        with patch("nvflare.tool.job.job_cli.get_startup_kit_dir_for_target", return_value=str(startup_dir)):
-            username, resolved = find_admin_user_and_dir(startup_kit_dir=str(startup_dir))
-
-        assert username == "admin@nvidia.com"
-        assert resolved == str(admin_dir)
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
+        fake_session.submit_job.assert_called_once()
 
 
-def test_get_session_missing_startup_kit_emits_startup_kit_missing(capsys, monkeypatch):
+def test_get_session_uses_active_startup_kit_config(tmp_path, monkeypatch):
+    from nvflare.tool.job.job_cli import _get_session
+
+    active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+    fake_session = MagicMock()
+
+    with patch("nvflare.tool.cli_session.new_secure_session", return_value=fake_session) as new_secure:
+        sess = _get_session(study="default")
+
+    assert sess is fake_session
+    assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+    assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
+
+
+def test_get_session_missing_startup_kit_emits_startup_kit_missing(capsys, monkeypatch, tmp_path):
     from nvflare.tool import cli_output
     from nvflare.tool.job.job_cli import _get_session
 
     monkeypatch.setattr(cli_output, "_output_format", "json")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
 
-    with patch(
-        "nvflare.tool.job.job_cli.find_admin_user_and_dir",
-        side_effect=ValueError("no startup kit configured"),
-    ):
-        with pytest.raises(SystemExit) as exc_info:
-            _get_session()
+    with pytest.raises(SystemExit) as exc_info:
+        _get_session()
 
     assert exc_info.value.code == 2
     envelope = json.loads(capsys.readouterr().out)
     assert envelope["error_code"] == "STARTUP_KIT_MISSING"
 
 
-def test_get_session_missing_startup_kit_still_exits_when_output_error_is_mocked():
+def test_get_session_missing_startup_kit_still_exits_when_output_error_is_mocked(monkeypatch, tmp_path):
     from nvflare.tool.job.job_cli import _get_session
 
-    with patch(
-        "nvflare.tool.job.job_cli.find_admin_user_and_dir",
-        side_effect=ValueError("startup kit directory /tmp/missing must be an admin startup kit directory"),
-    ):
-        with patch("nvflare.tool.cli_output.output_error") as output_error:
-            with pytest.raises(SystemExit) as exc_info:
-                _get_session()
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    with patch("nvflare.tool.cli_output.output_error") as output_error:
+        with pytest.raises(SystemExit) as exc_info:
+            _get_session()
 
     assert exc_info.value.code == 2
     output_error.assert_called_once()
 
 
-def test_get_session_forwards_startup_args():
-    from nvflare.tool.job.job_cli import _get_session
+def test_list_templates_does_not_require_active_startup_kit(monkeypatch):
+    from nvflare.tool.job import job_cli
 
     args = MagicMock()
-    args.startup_kit = "/tmp/custom-startup"
-    args.startup_target = "prod"
+    args.job_sub_cmd = "list-templates"
+    args.job_templates_dir = None
+    args.debug = False
 
-    with patch(
-        "nvflare.tool.job.job_cli.find_admin_user_and_dir",
-        return_value=("admin@nvidia.com", "/tmp/custom-startup"),
-    ) as find_admin:
-        with patch("nvflare.tool.job.job_cli.new_cli_session") as new_session:
-            _get_session(args=args, study="default")
+    with _assert_no_active_session_created():
+        monkeypatch.setattr(job_cli, "find_job_templates_location", lambda _path=None: "/tmp/templates")
+        monkeypatch.setattr(job_cli, "build_job_template_indices", lambda _path: MagicMock())
+        monkeypatch.setattr(job_cli, "display_available_templates", lambda _conf: None)
+        monkeypatch.setattr(job_cli, "update_job_templates_dir", lambda _path: None)
+        job_cli.list_templates(args)
 
-    _, kwargs = find_admin.call_args
-    assert kwargs["startup_kit_dir"] == "/tmp/custom-startup"
-    assert kwargs["target"] == "prod"
-    assert new_session.called
+
+def test_show_variables_does_not_require_active_startup_kit(monkeypatch, tmp_path):
+    from nvflare.tool.job import job_cli
+
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    args = MagicMock()
+    args.job_sub_cmd = "show-variables"
+    args.job_folder = str(job_dir)
+    args.debug = False
+
+    with _assert_no_active_session_created():
+        monkeypatch.setattr(job_cli, "get_app_dirs_from_job_folder", lambda _path: [])
+        monkeypatch.setattr(job_cli, "build_config_file_indices", lambda _path, _apps: {})
+        monkeypatch.setattr(job_cli, "filter_indices", lambda app_indices_configs=None, **_kwargs: {})
+        monkeypatch.setattr(job_cli, "display_template_variables", lambda _job_folder, _values: None)
+        job_cli.show_variables(args)
+
+
+def test_create_job_does_not_require_active_startup_kit(monkeypatch, tmp_path):
+    from nvflare.tool.job import job_cli
+
+    args = MagicMock()
+    args.job_sub_cmd = "create"
+    args.job_folder = str(tmp_path / "job")
+    args.template = str(tmp_path / "template")
+    args.script_dir = None
+    args.force = False
+    args.debug = False
+
+    with _assert_no_active_session_created():
+        monkeypatch.setattr(job_cli, "get_src_template", lambda _args: args.template)
+        monkeypatch.setattr(job_cli, "get_app_dirs_from_template", lambda _template: [])
+        monkeypatch.setattr(job_cli, "prepare_job_folder", lambda _args: None)
+        monkeypatch.setattr(job_cli, "prepare_app_dirs", lambda _folder, _apps: [])
+        monkeypatch.setattr(job_cli, "prepare_app_scripts", lambda _folder, _dirs, _args: None)
+        monkeypatch.setattr(job_cli, "get_config_dirs", lambda _folder, _apps: [])
+        monkeypatch.setattr(job_cli.ConfigFactory, "search_config_format", lambda *_args, **_kwargs: (None, None))
+        monkeypatch.setattr(job_cli.shutil, "copytree", lambda *args, **kwargs: None)
+        monkeypatch.setattr(job_cli, "remove_extra_files", lambda _path: None)
+        monkeypatch.setattr(job_cli, "prepare_meta_config", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(job_cli, "prepare_job_config", lambda *_args, **_kwargs: {})
+        monkeypatch.setattr(job_cli, "display_template_variables", lambda _job_folder, _values: None)
+        job_cli.create_job(args)

--- a/tests/unit_test/tool/kit/kit_cli_test.py
+++ b/tests/unit_test/tool/kit/kit_cli_test.py
@@ -221,7 +221,7 @@ class TestKitCli:
 
         assert "project_admin" in out
         assert "ok" in out
-        assert "site-1" not in out
+        assert "site-1" in out
         assert "missing_admin" in out
         assert "missing" in out
         assert "invalid_admin" in out

--- a/tests/unit_test/tool/kit/kit_cli_test.py
+++ b/tests/unit_test/tool/kit/kit_cli_test.py
@@ -39,15 +39,15 @@ def _make_invalid_startup_kit(parent: Path, name: str = "invalid@nvidia.com") ->
 
 
 def _run_kit_command(argv, monkeypatch):
-    from nvflare.tool.kit.kit_cli import def_kit_cli_parser, handle_kit_cmd
+    from nvflare.cli import def_config_parser, handle_config_cmd
 
     root = argparse.ArgumentParser(prog="nvflare")
     subparsers = root.add_subparsers(dest="sub_command")
-    def_kit_cli_parser(subparsers)
+    def_config_parser(subparsers)
     argv = [str(arg) for arg in argv]
-    monkeypatch.setattr(sys, "argv", ["nvflare", "kit", *argv])
-    args = root.parse_args(["kit", *argv])
-    handle_kit_cmd(args)
+    monkeypatch.setattr(sys, "argv", ["nvflare", "config", "kit", *argv])
+    args = root.parse_args(["config", "kit", *argv])
+    handle_config_cmd(args)
     return args
 
 
@@ -83,24 +83,24 @@ def _isolated_cli(monkeypatch, tmp_path):
 
 class TestKitCli:
     def test_parser_accepts_all_kit_subcommands_and_schema(self):
-        from nvflare.tool.kit.kit_cli import def_kit_cli_parser
+        from nvflare.cli import def_config_parser
 
         root = argparse.ArgumentParser(prog="nvflare")
         subparsers = root.add_subparsers(dest="sub_command")
-        def_kit_cli_parser(subparsers)
+        def_config_parser(subparsers)
 
-        assert root.parse_args(["kit", "add", "admin", "/tmp/startup", "--force"]).force is True
-        assert root.parse_args(["kit", "use", "admin"]).kit_sub_cmd == "use"
-        assert root.parse_args(["kit", "show"]).kit_sub_cmd == "show"
-        assert root.parse_args(["kit", "list"]).kit_sub_cmd == "list"
-        assert root.parse_args(["kit", "remove", "admin"]).kit_sub_cmd == "remove"
-        assert root.parse_args(["kit", "show", "--schema"]).schema is True
+        assert root.parse_args(["config", "kit", "add", "admin", "/tmp/startup", "--force"]).force is True
+        assert root.parse_args(["config", "kit", "use", "admin"]).kit_sub_cmd == "use"
+        assert root.parse_args(["config", "kit", "show"]).kit_sub_cmd == "show"
+        assert root.parse_args(["config", "kit", "list"]).kit_sub_cmd == "list"
+        assert root.parse_args(["config", "kit", "remove", "admin"]).kit_sub_cmd == "remove"
+        assert root.parse_args(["config", "kit", "show", "--schema"]).schema is True
 
     def test_root_kit_command_prints_help_without_usage_error(self, monkeypatch, capsys):
         _run_kit_command([], monkeypatch)
 
         out = capsys.readouterr().out
-        assert "usage: nvflare kit" in out
+        assert "usage: nvflare config kit" in out
         assert "kit subcommands" in out
         assert "Invalid arguments" not in out
 
@@ -111,7 +111,7 @@ class TestKitCli:
         _run_kit_command(["add", "admin@nvidia.com", kit_dir], monkeypatch)
         out = capsys.readouterr().out
         assert "registered startup kit: admin@nvidia.com" in out or "registered_startup_kit: admin@nvidia.com" in out
-        assert "next_step: nvflare kit use admin@nvidia.com" in out
+        assert "next_step: nvflare config kit use admin@nvidia.com" in out
 
         config = _read_config(home)
         assert _entry(config, "admin@nvidia.com") == kit_dir.resolve()
@@ -120,7 +120,7 @@ class TestKitCli:
         _run_kit_command(["show"], monkeypatch)
         out = capsys.readouterr().out
         assert "No active startup kit" in out
-        assert "nvflare kit use <id>" in out
+        assert "nvflare config kit use <id>" in out
 
         _run_kit_command(["use", "admin@nvidia.com"], monkeypatch)
         out = capsys.readouterr().out
@@ -138,7 +138,7 @@ class TestKitCli:
         out = capsys.readouterr().out
         assert "removed startup kit: admin@nvidia.com" in out or "removed_startup_kit: admin@nvidia.com" in out
         assert "no active startup kit" in out.lower()
-        assert "nvflare kit use <id>" in out
+        assert "nvflare config kit use <id>" in out
 
         config = _read_config(home)
         assert config.get("startup_kits.active", None) is None

--- a/tests/unit_test/tool/kit/kit_cli_test.py
+++ b/tests/unit_test/tool/kit/kit_cli_test.py
@@ -38,6 +38,14 @@ def _make_invalid_startup_kit(parent: Path, name: str = "invalid@nvidia.com") ->
     return kit_dir
 
 
+def _make_site_startup_kit(parent: Path, name: str = "site-1") -> Path:
+    kit_dir = parent / name
+    startup_dir = kit_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_client.json").write_text("{}\n")
+    return kit_dir
+
+
 def _run_kit_command(argv, monkeypatch):
     from nvflare.cli import def_config_parser, handle_config_cmd
 
@@ -189,6 +197,7 @@ class TestKitCli:
     def test_list_marks_stale_entries_without_failing(self, tmp_path, monkeypatch, capsys):
         home = Path.home()
         valid_kit = _make_admin_startup_kit(tmp_path, "admin@nvidia.com")
+        site_kit = _make_site_startup_kit(tmp_path, "site-1")
         missing_kit = tmp_path / "missing_admin"
         invalid_kit = _make_invalid_startup_kit(tmp_path, "invalid_admin@nvidia.com")
         _write_config(
@@ -199,6 +208,7 @@ class TestKitCli:
               active = "missing_admin"
               entries {{
                 project_admin = "{valid_kit}"
+                "site-1" = "{site_kit}"
                 missing_admin = "{missing_kit}"
                 invalid_admin = "{invalid_kit}"
               }}
@@ -211,6 +221,7 @@ class TestKitCli:
 
         assert "project_admin" in out
         assert "ok" in out
+        assert "site-1" not in out
         assert "missing_admin" in out
         assert "missing" in out
         assert "invalid_admin" in out

--- a/tests/unit_test/tool/kit/kit_cli_test.py
+++ b/tests/unit_test/tool/kit/kit_cli_test.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+from pyhocon import ConfigFactory as CF
+
+
+def _make_admin_startup_kit(parent: Path, name: str = "admin@nvidia.com") -> Path:
+    kit_dir = parent / name
+    startup_dir = kit_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "%s"}}\n' % name)
+    (startup_dir / "client.crt").write_text("dummy client cert\n")
+    (startup_dir / "client.key").write_text("dummy client key\n")
+    (startup_dir / "rootCA.pem").write_text("dummy root ca\n")
+    return kit_dir
+
+
+def _make_invalid_startup_kit(parent: Path, name: str = "invalid@nvidia.com") -> Path:
+    kit_dir = parent / name
+    (kit_dir / "startup").mkdir(parents=True)
+    (kit_dir / "startup" / "fed_admin.json").write_text('{"admin": {"username": "%s"}}\n' % name)
+    return kit_dir
+
+
+def _run_kit_command(argv, monkeypatch):
+    from nvflare.tool.kit.kit_cli import def_kit_cli_parser, handle_kit_cmd
+
+    root = argparse.ArgumentParser(prog="nvflare")
+    subparsers = root.add_subparsers(dest="sub_command")
+    def_kit_cli_parser(subparsers)
+    argv = [str(arg) for arg in argv]
+    monkeypatch.setattr(sys, "argv", ["nvflare", "kit", *argv])
+    args = root.parse_args(["kit", *argv])
+    handle_kit_cmd(args)
+    return args
+
+
+def _read_config(home: Path):
+    return CF.parse_file(str(home / ".nvflare" / "config.conf"))
+
+
+def _entry(config, kit_id: str):
+    try:
+        return Path(config.get(f'startup_kits.entries."{kit_id}"')).resolve()
+    except Exception:
+        return None
+
+
+def _write_config(home: Path, text: str) -> Path:
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.conf"
+    config_path.write_text(text.strip() + "\n")
+    return config_path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cli(monkeypatch, tmp_path):
+    from nvflare.tool import cli_output
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    monkeypatch.setattr(cli_output, "_output_format", "txt")
+    return home
+
+
+class TestKitCli:
+    def test_parser_accepts_all_kit_subcommands_and_schema(self):
+        from nvflare.tool.kit.kit_cli import def_kit_cli_parser
+
+        root = argparse.ArgumentParser(prog="nvflare")
+        subparsers = root.add_subparsers(dest="sub_command")
+        def_kit_cli_parser(subparsers)
+
+        assert root.parse_args(["kit", "add", "admin", "/tmp/startup", "--force"]).force is True
+        assert root.parse_args(["kit", "use", "admin"]).kit_sub_cmd == "use"
+        assert root.parse_args(["kit", "show"]).kit_sub_cmd == "show"
+        assert root.parse_args(["kit", "list"]).kit_sub_cmd == "list"
+        assert root.parse_args(["kit", "remove", "admin"]).kit_sub_cmd == "remove"
+        assert root.parse_args(["kit", "show", "--schema"]).schema is True
+
+    def test_root_kit_command_prints_help_without_usage_error(self, monkeypatch, capsys):
+        _run_kit_command([], monkeypatch)
+
+        out = capsys.readouterr().out
+        assert "usage: nvflare kit" in out
+        assert "kit subcommands" in out
+        assert "Invalid arguments" not in out
+
+    def test_add_use_show_list_remove_flow_and_add_never_activates(self, tmp_path, monkeypatch, capsys):
+        home = Path.home()
+        kit_dir = _make_admin_startup_kit(tmp_path, "admin@nvidia.com")
+
+        _run_kit_command(["add", "admin@nvidia.com", kit_dir], monkeypatch)
+        out = capsys.readouterr().out
+        assert "registered startup kit: admin@nvidia.com" in out or "registered_startup_kit: admin@nvidia.com" in out
+        assert "next_step: nvflare kit use admin@nvidia.com" in out
+
+        config = _read_config(home)
+        assert _entry(config, "admin@nvidia.com") == kit_dir.resolve()
+        assert config.get("startup_kits.active", None) is None
+
+        _run_kit_command(["show"], monkeypatch)
+        out = capsys.readouterr().out
+        assert "No active startup kit" in out
+        assert "nvflare kit use <id>" in out
+
+        _run_kit_command(["use", "admin@nvidia.com"], monkeypatch)
+        out = capsys.readouterr().out
+        assert "active startup kit: admin@nvidia.com" in out or "active_startup_kit: admin@nvidia.com" in out
+        assert str(kit_dir) in out
+        assert _read_config(home).get("startup_kits.active") == "admin@nvidia.com"
+
+        _run_kit_command(["list"], monkeypatch)
+        out = capsys.readouterr().out
+        assert "*" in out
+        assert "admin@nvidia.com" in out
+        assert "ok" in out
+
+        _run_kit_command(["remove", "admin@nvidia.com"], monkeypatch)
+        out = capsys.readouterr().out
+        assert "removed startup kit: admin@nvidia.com" in out or "removed_startup_kit: admin@nvidia.com" in out
+        assert "no active startup kit" in out.lower()
+        assert "nvflare kit use <id>" in out
+
+        config = _read_config(home)
+        assert config.get("startup_kits.active", None) is None
+        assert _entry(config, "admin@nvidia.com") is None
+        assert kit_dir.exists()
+
+    def test_duplicate_id_fails_without_force_and_force_replaces_registration(self, tmp_path, monkeypatch):
+        home = Path.home()
+        first_kit = _make_admin_startup_kit(tmp_path / "first", "admin@nvidia.com")
+        replacement_kit = _make_admin_startup_kit(tmp_path / "replacement", "admin@nvidia.com")
+
+        _run_kit_command(["add", "project_admin", first_kit], monkeypatch)
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_kit_command(["add", "project_admin", replacement_kit], monkeypatch)
+        assert exc_info.value.code == 4
+        assert _entry(_read_config(home), "project_admin") == first_kit.resolve()
+
+        _run_kit_command(["add", "project_admin", replacement_kit, "--force"], monkeypatch)
+
+        assert _entry(_read_config(home), "project_admin") == replacement_kit.resolve()
+        assert first_kit.exists()
+
+    def test_email_id_is_persisted_with_hocon_quoting(self, tmp_path, monkeypatch):
+        home = Path.home()
+        kit_dir = _make_admin_startup_kit(tmp_path, "lead@nvidia.com")
+
+        _run_kit_command(["add", "lead@nvidia.com", kit_dir], monkeypatch)
+
+        config_path = home / ".nvflare" / "config.conf"
+        assert '"lead@nvidia.com"' in config_path.read_text()
+        config = CF.parse_file(str(config_path))
+        assert Path(config.get('startup_kits.entries."lead@nvidia.com"')).resolve() == kit_dir.resolve()
+
+    @pytest.mark.parametrize("bad_path_kind", ["missing", "invalid"])
+    def test_add_rejects_missing_or_invalid_startup_kit_paths(self, tmp_path, monkeypatch, bad_path_kind):
+        if bad_path_kind == "missing":
+            kit_path = tmp_path / "missing"
+        else:
+            kit_path = _make_invalid_startup_kit(tmp_path, "bad_admin@nvidia.com")
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_kit_command(["add", "bad_admin", kit_path], monkeypatch)
+
+        assert exc_info.value.code == 4
+        assert not (Path.home() / ".nvflare" / "config.conf").exists()
+
+    def test_list_marks_stale_entries_without_failing(self, tmp_path, monkeypatch, capsys):
+        home = Path.home()
+        valid_kit = _make_admin_startup_kit(tmp_path, "admin@nvidia.com")
+        missing_kit = tmp_path / "missing_admin"
+        invalid_kit = _make_invalid_startup_kit(tmp_path, "invalid_admin@nvidia.com")
+        _write_config(
+            home,
+            f"""
+            version = 2
+            startup_kits {{
+              active = "missing_admin"
+              entries {{
+                project_admin = "{valid_kit}"
+                missing_admin = "{missing_kit}"
+                invalid_admin = "{invalid_kit}"
+              }}
+            }}
+            """,
+        )
+
+        _run_kit_command(["list"], monkeypatch)
+        out = capsys.readouterr().out
+
+        assert "project_admin" in out
+        assert "ok" in out
+        assert "missing_admin" in out
+        assert "missing" in out
+        assert "invalid_admin" in out
+        assert "invalid" in out
+        assert any(line.startswith("*") and "missing_admin" in line for line in out.splitlines())
+
+    def test_use_unknown_or_stale_registration_does_not_change_active(self, tmp_path, monkeypatch):
+        home = Path.home()
+        valid_kit = _make_admin_startup_kit(tmp_path, "admin@nvidia.com")
+        invalid_kit = _make_invalid_startup_kit(tmp_path, "invalid_admin@nvidia.com")
+        _write_config(
+            home,
+            f"""
+            version = 2
+            startup_kits {{
+              active = "project_admin"
+              entries {{
+                project_admin = "{valid_kit}"
+                invalid_admin = "{invalid_kit}"
+              }}
+            }}
+            """,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_kit_command(["use", "missing_admin"], monkeypatch)
+        assert exc_info.value.code == 4
+        assert _read_config(home).get("startup_kits.active") == "project_admin"
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_kit_command(["use", "invalid_admin"], monkeypatch)
+        assert exc_info.value.code == 4
+        assert _read_config(home).get("startup_kits.active") == "project_admin"

--- a/tests/unit_test/tool/kit/kit_config_test.py
+++ b/tests/unit_test/tool/kit/kit_config_test.py
@@ -236,7 +236,7 @@ class TestStartupKitResolution:
         with pytest.raises(Exception) as exc_info:
             resolve_startup_kit_dir()
 
-        _assert_error_contains(exc_info, "active startup kit", "nvflare kit use")
+        _assert_error_contains(exc_info, "active startup kit", "nvflare config kit use")
 
     def test_active_id_absent_reports_kit_list_and_use_hint(self, tmp_path, monkeypatch):
         from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
@@ -258,7 +258,7 @@ class TestStartupKitResolution:
         with pytest.raises(Exception) as exc_info:
             resolve_startup_kit_dir()
 
-        _assert_error_contains(exc_info, "cancer_lead", "nvflare kit list", "nvflare kit use")
+        _assert_error_contains(exc_info, "cancer_lead", "nvflare config kit list", "nvflare config kit use")
 
     def test_active_path_missing_reports_registered_id_and_path(self, tmp_path, monkeypatch):
         from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
@@ -283,7 +283,7 @@ class TestStartupKitResolution:
         with pytest.raises(Exception) as exc_info:
             resolve_startup_kit_dir()
 
-        _assert_error_contains(exc_info, "cancer_lead", str(missing_path), "nvflare kit use")
+        _assert_error_contains(exc_info, "cancer_lead", str(missing_path), "nvflare config kit use")
         assert "missing" in str(exc_info.value).lower() or "does not exist" in str(exc_info.value).lower()
 
     def test_active_path_invalid_reports_registered_id_and_path(self, tmp_path, monkeypatch):
@@ -351,4 +351,4 @@ class TestStartupKitResolution:
         with pytest.raises(Exception) as exc_info:
             resolve_startup_kit_dir()
 
-        _assert_error_contains(exc_info, "active startup kit", "nvflare kit use")
+        _assert_error_contains(exc_info, "active startup kit", "nvflare config kit use")

--- a/tests/unit_test/tool/kit/kit_config_test.py
+++ b/tests/unit_test/tool/kit/kit_config_test.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+from pyhocon import ConfigFactory as CF
+
+
+def _make_admin_startup_kit(parent: Path, name: str = "admin@nvidia.com") -> Path:
+    kit_dir = parent / name
+    startup_dir = kit_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "%s"}}\n' % name)
+    (startup_dir / "client.crt").write_text("dummy client cert\n")
+    (startup_dir / "client.key").write_text("dummy client key\n")
+    (startup_dir / "rootCA.pem").write_text("dummy root ca\n")
+    return kit_dir
+
+
+def _make_poc_admin_startup_kit(parent: Path, name: str = "admin@nvidia.com") -> Path:
+    kit_dir = parent / name
+    startup_dir = kit_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "", "uid_source": "cert"}}\n')
+    (startup_dir / "client.crt").write_text("dummy client cert\n")
+    (startup_dir / "client.key").write_text("dummy client key\n")
+    (startup_dir / "rootCA.pem").write_text("dummy root ca\n")
+    return kit_dir
+
+
+def _make_site_startup_kit(parent: Path, name: str = "site-1") -> Path:
+    kit_dir = parent / name
+    startup_dir = kit_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_client.json").write_text("{}\n")
+    return kit_dir
+
+
+def _make_invalid_startup_kit(parent: Path, name: str = "invalid@nvidia.com") -> Path:
+    kit_dir = parent / name
+    (kit_dir / "startup").mkdir(parents=True)
+    (kit_dir / "startup" / "fed_admin.json").write_text('{"admin": {"username": "%s"}}\n' % name)
+    return kit_dir
+
+
+def _entry_path(config, kit_id: str):
+    try:
+        value = config.get(f'startup_kits.entries."{kit_id}"')
+    except Exception:
+        return None
+    return Path(value).resolve()
+
+
+def _write_cli_config(home: Path, text: str) -> Path:
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.conf"
+    config_path.write_text(text.strip() + "\n")
+    return config_path
+
+
+def _assert_error_contains(exc_info, *parts: str):
+    message = str(exc_info.value)
+    hint = getattr(exc_info.value, "hint", None) or ""
+    message = f"{message}\n{hint}"
+    for part in parts:
+        assert part in message
+
+
+class TestStartupKitRegistryConfig:
+    """Tests for the proposed nvflare.tool.kit.kit_config public helper surface."""
+
+    def test_add_email_id_is_quoted_when_saved_and_never_activates(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit import kit_config
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        kit_dir = _make_admin_startup_kit(tmp_path, "lead@nvidia.com")
+
+        config = CF.parse_string("version = 2")
+        updated = kit_config.add_startup_kit_entry(config, "lead@nvidia.com", str(kit_dir))
+        assert _entry_path(updated, "lead@nvidia.com") == kit_dir.resolve()
+        assert updated.get("startup_kits.active", None) is None
+
+        kit_config.save_cli_config(updated)
+
+        config_path = home / ".nvflare" / "config.conf"
+        persisted = config_path.read_text()
+        assert '"lead@nvidia.com"' in persisted
+
+        loaded = CF.parse_file(str(config_path))
+        assert Path(loaded.get('startup_kits.entries."lead@nvidia.com"')).resolve() == kit_dir.resolve()
+        assert loaded.get("startup_kits.active", None) is None
+
+    def test_duplicate_id_requires_force_and_force_replaces_only_registration(self, tmp_path):
+        from nvflare.tool.kit import kit_config
+
+        old_kit = _make_admin_startup_kit(tmp_path / "old", "admin@nvidia.com")
+        new_kit = _make_admin_startup_kit(tmp_path / "new", "admin@nvidia.com")
+        config = CF.parse_string(
+            """
+            version = 2
+            startup_kits {
+              active = "active_admin"
+            }
+            """
+        )
+
+        config = kit_config.add_startup_kit_entry(config, "active_admin", str(old_kit))
+        with pytest.raises(Exception) as exc_info:
+            kit_config.add_startup_kit_entry(config, "active_admin", str(new_kit))
+        _assert_error_contains(exc_info, "active_admin")
+
+        updated = kit_config.add_startup_kit_entry(config, "active_admin", str(new_kit), force=True)
+        assert _entry_path(updated, "active_admin") == new_kit.resolve()
+        assert updated.get("startup_kits.active") == "active_admin"
+        assert old_kit.exists()
+
+    def test_set_active_validates_registered_path(self, tmp_path):
+        from nvflare.tool.kit import kit_config
+
+        kit_dir = _make_admin_startup_kit(tmp_path, "admin@nvidia.com")
+        config = CF.parse_string("version = 2")
+        config = kit_config.add_startup_kit_entry(config, "project_admin", str(kit_dir))
+
+        updated = kit_config.set_active_startup_kit(config, "project_admin")
+
+        assert updated.get("startup_kits.active") == "project_admin"
+
+    def test_set_active_rejects_unknown_id_without_mutating_active(self, tmp_path):
+        from nvflare.tool.kit import kit_config
+
+        kit_dir = _make_admin_startup_kit(tmp_path, "admin@nvidia.com")
+        config = CF.parse_string(
+            """
+            version = 2
+            startup_kits {
+              active = "project_admin"
+            }
+            """
+        )
+        config = kit_config.add_startup_kit_entry(config, "project_admin", str(kit_dir))
+
+        with pytest.raises(Exception) as exc_info:
+            kit_config.set_active_startup_kit(config, "missing_admin")
+
+        _assert_error_contains(exc_info, "missing_admin")
+        assert config.get("startup_kits.active") == "project_admin"
+
+    def test_site_startup_kit_can_be_registered_but_not_activated(self, tmp_path):
+        from nvflare.tool.kit import kit_config
+
+        site_kit = _make_site_startup_kit(tmp_path, "site-1")
+        config = CF.parse_string("version = 2")
+
+        updated = kit_config.add_startup_kit_entry(config, "site-1", str(site_kit))
+
+        assert _entry_path(updated, "site-1") == site_kit.resolve()
+        status, normalized_path, metadata = kit_config.get_startup_kit_status(str(site_kit))
+        assert status == "ok"
+        assert Path(normalized_path) == site_kit.resolve()
+        assert metadata["identity"] == "site-1"
+        assert metadata["kind"] == "site"
+
+        with pytest.raises(Exception) as exc_info:
+            kit_config.set_active_startup_kit(updated, "site-1")
+
+        _assert_error_contains(exc_info, "admin use")
+        assert updated.get("startup_kits.active", None) is None
+
+
+class TestStartupKitResolution:
+    def test_env_var_resolution_prefers_valid_env_path(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        kit_dir = _make_admin_startup_kit(tmp_path, "env_admin@nvidia.com")
+        monkeypatch.setenv("NVFLARE_STARTUP_KIT_DIR", str(kit_dir))
+
+        assert Path(resolve_startup_kit_dir()).resolve() == kit_dir.resolve()
+
+    def test_env_var_resolution_reports_missing_path(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        missing_path = tmp_path / "missing"
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("NVFLARE_STARTUP_KIT_DIR", str(missing_path))
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "NVFLARE_STARTUP_KIT_DIR", str(missing_path))
+        assert "missing" in str(exc_info.value).lower() or "does not exist" in str(exc_info.value).lower()
+
+    def test_env_var_resolution_reports_invalid_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        invalid_kit = _make_invalid_startup_kit(tmp_path, "env_invalid@nvidia.com")
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("NVFLARE_STARTUP_KIT_DIR", str(invalid_kit))
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "NVFLARE_STARTUP_KIT_DIR", str(invalid_kit))
+        assert "valid startup kit" in str(exc_info.value).lower()
+
+    def test_active_missing_reports_kit_use_hint(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+        _write_cli_config(
+            home,
+            """
+            version = 2
+            startup_kits {
+              entries {}
+            }
+            """,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "active startup kit", "nvflare kit use")
+
+    def test_active_id_absent_reports_kit_list_and_use_hint(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+        _write_cli_config(
+            home,
+            """
+            version = 2
+            startup_kits {
+              active = "cancer_lead"
+              entries {}
+            }
+            """,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "cancer_lead", "nvflare kit list", "nvflare kit use")
+
+    def test_active_path_missing_reports_registered_id_and_path(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        missing_path = tmp_path / "missing_admin"
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+        _write_cli_config(
+            home,
+            f"""
+            version = 2
+            startup_kits {{
+              active = "cancer_lead"
+              entries {{
+                cancer_lead = "{missing_path}"
+              }}
+            }}
+            """,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "cancer_lead", str(missing_path), "nvflare kit use")
+        assert "missing" in str(exc_info.value).lower() or "does not exist" in str(exc_info.value).lower()
+
+    def test_active_path_invalid_reports_registered_id_and_path(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        invalid_kit = _make_invalid_startup_kit(tmp_path, "bad_admin@nvidia.com")
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+        _write_cli_config(
+            home,
+            f"""
+            version = 2
+            startup_kits {{
+              active = "bad_admin"
+              entries {{
+                bad_admin = "{invalid_kit}"
+              }}
+            }}
+            """,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "bad_admin", str(invalid_kit))
+        assert "valid startup kit" in str(exc_info.value).lower()
+
+    def test_resolve_admin_user_falls_back_to_cert_identity_for_poc_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_admin_user_and_dir_from_startup_kit
+
+        kit_dir = _make_poc_admin_startup_kit(tmp_path, "admin@nvidia.com")
+
+        def fake_metadata(path):
+            assert Path(path).resolve() == kit_dir.resolve()
+            return {"identity": "admin@nvidia.com", "cert_role": "project_admin"}
+
+        monkeypatch.setattr("nvflare.tool.kit.kit_config.inspect_startup_kit_metadata", fake_metadata)
+
+        username, resolved_dir = resolve_admin_user_and_dir_from_startup_kit(str(kit_dir))
+
+        assert username == "admin@nvidia.com"
+        assert Path(resolved_dir).resolve() == kit_dir.resolve()
+
+    def test_resolution_ignores_legacy_target_startup_kit_keys(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit.kit_config import resolve_startup_kit_dir
+
+        legacy_kit = _make_admin_startup_kit(tmp_path, "legacy_admin@nvidia.com")
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+        _write_cli_config(
+            home,
+            f"""
+            version = 2
+            poc {{
+              startup_kit = "{legacy_kit}"
+            }}
+            prod {{
+              startup_kit = "{legacy_kit}"
+            }}
+            """,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            resolve_startup_kit_dir()
+
+        _assert_error_contains(exc_info, "active startup kit", "nvflare kit use")

--- a/tests/unit_test/tool/kit/kit_config_test.py
+++ b/tests/unit_test/tool/kit/kit_config_test.py
@@ -159,26 +159,22 @@ class TestStartupKitRegistryConfig:
         _assert_error_contains(exc_info, "missing_admin")
         assert config.get("startup_kits.active") == "project_admin"
 
-    def test_site_startup_kit_can_be_registered_but_not_activated(self, tmp_path):
+    def test_site_startup_kit_cannot_be_registered(self, tmp_path):
         from nvflare.tool.kit import kit_config
 
         site_kit = _make_site_startup_kit(tmp_path, "site-1")
         config = CF.parse_string("version = 2")
 
-        updated = kit_config.add_startup_kit_entry(config, "site-1", str(site_kit))
+        with pytest.raises(Exception) as exc_info:
+            kit_config.add_startup_kit_entry(config, "site-1", str(site_kit))
 
-        assert _entry_path(updated, "site-1") == site_kit.resolve()
+        _assert_error_contains(exc_info, "admin startup kit")
+        assert _entry_path(config, "site-1") is None
         status, normalized_path, metadata = kit_config.get_startup_kit_status(str(site_kit))
         assert status == "ok"
         assert Path(normalized_path) == site_kit.resolve()
         assert metadata["identity"] == "site-1"
         assert metadata["kind"] == "site"
-
-        with pytest.raises(Exception) as exc_info:
-            kit_config.set_active_startup_kit(updated, "site-1")
-
-        _assert_error_contains(exc_info, "admin use")
-        assert updated.get("startup_kits.active", None) is None
 
 
 class TestStartupKitResolution:

--- a/tests/unit_test/tool/kit/kit_config_test.py
+++ b/tests/unit_test/tool/kit/kit_config_test.py
@@ -104,6 +104,28 @@ class TestStartupKitRegistryConfig:
         assert Path(loaded.get('startup_kits.entries."lead@nvidia.com"')).resolve() == kit_dir.resolve()
         assert loaded.get("startup_kits.active", None) is None
 
+    def test_simple_id_is_saved_unquoted_and_email_id_is_saved_quoted(self, tmp_path, monkeypatch):
+        from nvflare.tool.kit import kit_config
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        simple_kit = _make_admin_startup_kit(tmp_path / "simple", "simple@nvidia.com")
+        email_kit = _make_admin_startup_kit(tmp_path / "email", "lead@nvidia.com")
+
+        config = CF.parse_string("version = 2")
+        config = kit_config.add_startup_kit_entry(config, "cancer_lead", str(simple_kit))
+        config = kit_config.add_startup_kit_entry(config, "lead@nvidia.com", str(email_kit))
+        kit_config.save_cli_config(config)
+
+        persisted = (home / ".nvflare" / "config.conf").read_text()
+        assert "cancer_lead = " in persisted
+        assert '"cancer_lead"' not in persisted
+        assert '"lead@nvidia.com" = ' in persisted
+
+        loaded_entries = kit_config.get_startup_kit_entries(kit_config.load_cli_config())
+        assert Path(loaded_entries["cancer_lead"]).resolve() == simple_kit.resolve()
+        assert Path(loaded_entries["lead@nvidia.com"]).resolve() == email_kit.resolve()
+
     def test_duplicate_id_requires_force_and_force_replaces_only_registration(self, tmp_path):
         from nvflare.tool.kit import kit_config
 
@@ -175,6 +197,43 @@ class TestStartupKitRegistryConfig:
         assert Path(normalized_path) == site_kit.resolve()
         assert metadata["identity"] == "site-1"
         assert metadata["kind"] == "site"
+
+    def test_remove_entries_under_workspace_matches_symlink_and_real_paths(self, tmp_path):
+        from nvflare.tool.kit import kit_config
+
+        real_workspace = tmp_path / "real-poc"
+        real_workspace.mkdir()
+        link_workspace = tmp_path / "poc-link"
+        try:
+            link_workspace.symlink_to(real_workspace, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("symlink creation is not supported")
+
+        real_admin = real_workspace / "example_project" / "prod_00" / "admin@nvidia.com"
+        link_lead = link_workspace / "example_project" / "prod_00" / "lead@nvidia.com"
+        external_admin = tmp_path / "external" / "prod_00" / "admin@nvidia.com"
+        for kit_dir in (real_admin, link_lead, external_admin):
+            kit_dir.mkdir(parents=True, exist_ok=True)
+
+        config = CF.parse_string(
+            f"""
+            version = 2
+            startup_kits {{
+              active = "admin@nvidia.com"
+              entries {{
+                "admin@nvidia.com" = "{real_admin}"
+                "lead@nvidia.com" = "{link_lead}"
+                external_admin = "{external_admin}"
+              }}
+            }}
+            """
+        )
+
+        updated, removed = kit_config.remove_entries_under_workspace(config, str(real_workspace))
+
+        assert removed == {"admin@nvidia.com", "lead@nvidia.com"}
+        assert kit_config.get_startup_kit_entries(updated) == {"external_admin": str(external_admin)}
+        assert updated.get("startup_kits.active", None) is None
 
 
 class TestStartupKitResolution:

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -394,6 +394,61 @@ class TestPocForce:
         assert "Not authorized" in captured.err
         assert "lead@nvidia.com" in captured.err
 
+    def test_poc_add_user_preserves_startup_kit_resolution_hint(self, capsys):
+        from nvflare.tool.kit.kit_config import StartupKitConfigError
+        from nvflare.tool.poc.poc_commands import add_poc_user
+
+        args = MagicMock()
+        args.cert_role = "lead"
+        args.email = "bob@nvidia.com"
+        args.org = "nvidia"
+        args.force = False
+        with (
+            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value="/tmp/poc"),
+            patch(
+                "nvflare.tool.poc.poc_commands._require_poc_project_admin",
+                side_effect=StartupKitConfigError(
+                    "active startup kit is stale", hint="Run 'nvflare kit use admin@nvidia.com'"
+                ),
+            ),
+            patch("nvflare.tool.poc.poc_commands._add_poc_user") as add_user,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                add_poc_user(args)
+
+        assert exc_info.value.code == 4
+        add_user.assert_not_called()
+        captured = capsys.readouterr()
+        assert "active startup kit is stale" in captured.err
+        assert "Run 'nvflare kit use admin@nvidia.com'" in captured.err
+
+    def test_poc_add_site_preserves_startup_kit_resolution_hint(self, capsys):
+        from nvflare.tool.kit.kit_config import StartupKitConfigError
+        from nvflare.tool.poc.poc_commands import add_poc_site
+
+        args = MagicMock()
+        args.name = "site-3"
+        args.org = "nvidia"
+        args.force = False
+        with (
+            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value="/tmp/poc"),
+            patch(
+                "nvflare.tool.poc.poc_commands._require_poc_project_admin",
+                side_effect=StartupKitConfigError(
+                    "active startup kit is stale", hint="Run 'nvflare kit use admin@nvidia.com'"
+                ),
+            ),
+            patch("nvflare.tool.poc.poc_commands._add_poc_site") as add_site,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                add_poc_site(args)
+
+        assert exc_info.value.code == 4
+        add_site.assert_not_called()
+        captured = capsys.readouterr()
+        assert "active startup kit is stale" in captured.err
+        assert "Run 'nvflare kit use admin@nvidia.com'" in captured.err
+
     def test_interactive_without_force_prompts(self, tmp_path):
         """In interactive mode without --force, should ask for confirmation."""
         from nvflare.tool.poc.poc_commands import _prepare_poc
@@ -868,6 +923,57 @@ prod {{
         assert entries["cancer_lead"] == str(prod_admin)
         assert config["poc"] == {"mode": "keep"}
         assert config["prod"] == {"mode": "keep"}
+
+    def test_clean_poc_updates_config_when_workspace_remove_fails(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _clean_poc
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc"
+        workspace.mkdir()
+        poc_admin = workspace / "example_project" / "prod_00" / "admin@nvidia.com"
+        dst = tmp_path / ".nvflare" / "config.conf"
+        dst.parent.mkdir()
+        dst.write_text(
+            f"""
+version = 2
+startup_kits {{
+  active = "admin@nvidia.com"
+  entries {{
+    "admin@nvidia.com" = "{poc_admin}"
+  }}
+}}
+poc {{
+  workspace = "{workspace}"
+}}
+"""
+        )
+
+        with (
+            patch(
+                "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
+                return_value=str(dst),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                return_value=({"name": "example_project"}, {SC.FLARE_SERVER: "server"}),
+            ),
+            patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
+            patch("nvflare.tool.poc.poc_commands.is_poc_running", return_value=False),
+            patch("nvflare.tool.poc.poc_commands.shutil.rmtree", side_effect=OSError("boom")),
+            patch("nvflare.tool.cli_output.print_human") as print_human,
+        ):
+            with pytest.raises(OSError, match="boom"):
+                _clean_poc(str(workspace))
+
+        config = _load_config_dict(dst)
+        assert "active" not in config.get("startup_kits", {})
+        assert config["startup_kits"]["entries"] == {}
+        assert "poc" not in config or "workspace" not in config["poc"]
+        print_human.assert_not_called()
 
     def test_save_startup_kit_dir_config_rejects_invalid_project_yaml(self, tmp_path):
         from nvflare.tool.poc.poc_commands import save_startup_kit_dir_config

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -1011,7 +1011,7 @@ prod {{
         assert config["poc"] == {"mode": "keep"}
         assert config["prod"] == {"mode": "keep"}
 
-    def test_clean_poc_updates_config_when_workspace_remove_fails(self, tmp_path, monkeypatch):
+    def test_clean_poc_keeps_config_when_workspace_remove_fails(self, tmp_path, monkeypatch):
         from nvflare.tool.poc.poc_commands import _clean_poc
 
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -1057,9 +1057,9 @@ poc {{
                 _clean_poc(str(workspace))
 
         config = _load_config_dict(dst)
-        assert "active" not in config.get("startup_kits", {})
-        assert config["startup_kits"]["entries"] == {}
-        assert "poc" not in config or "workspace" not in config["poc"]
+        assert config["startup_kits"]["active"] == "admin@nvidia.com"
+        assert config["startup_kits"]["entries"] == {"admin@nvidia.com": str(poc_admin)}
+        assert config["poc"]["workspace"] == str(workspace)
         print_human.assert_not_called()
 
     def test_clean_poc_force_stops_running_system_before_removal(self, tmp_path):

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -286,6 +286,9 @@ class TestPocForce:
         args = root.parse_args(["poc", "prepare", "--force"])
         assert args.force is True
 
+        args = root.parse_args(["poc", "clean", "--force"])
+        assert args.force is True
+
     def test_prepare_jobs_dir_force_flag(self):
         """poc prepare-jobs-dir parser should accept --force flag."""
         import argparse
@@ -974,6 +977,37 @@ poc {{
         assert config["startup_kits"]["entries"] == {}
         assert "poc" not in config or "workspace" not in config["poc"]
         print_human.assert_not_called()
+
+    def test_clean_poc_force_stops_running_system_before_removal(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import _clean_poc
+
+        workspace = tmp_path / "poc"
+        workspace.mkdir()
+        project_config = {"name": "example_project"}
+        service_config = {SC.FLARE_SERVER: "server"}
+
+        with (
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                return_value=(project_config, service_config),
+            ),
+            patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
+            patch("nvflare.tool.poc.poc_commands.is_poc_running", side_effect=[True, False]),
+            patch("nvflare.tool.poc.poc_commands._ensure_poc_stopped") as ensure_stopped,
+            patch("nvflare.tool.poc.poc_commands.shutil.rmtree") as rmtree,
+            patch("nvflare.tool.poc.poc_commands._clean_poc_config") as clean_config,
+            patch("nvflare.tool.cli_output.print_human"),
+        ):
+            assert _clean_poc(str(workspace), force=True) is True
+
+        ensure_stopped.assert_called_once_with(
+            str(workspace),
+            project_config=project_config,
+            service_config=service_config,
+            reason="cleaning the workspace",
+        )
+        rmtree.assert_called_once_with(str(workspace))
+        clean_config.assert_called_once_with(str(workspace))
 
     def test_save_startup_kit_dir_config_rejects_invalid_project_yaml(self, tmp_path):
         from nvflare.tool.poc.poc_commands import save_startup_kit_dir_config

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -533,7 +533,6 @@ participants:
             "admin@nvidia.com": str(prod_dir / "admin@nvidia.com"),
             "org-admin@nvidia.com": str(prod_dir / "org-admin@nvidia.com"),
             "lead@nvidia.com": str(prod_dir / "lead@nvidia.com"),
-            "site-1": str(prod_dir / "site-1"),
         }
         assert config["poc"]["workspace"] == str(workspace)
         assert "startup_kit" not in config["poc"]
@@ -619,7 +618,7 @@ poc {{
         assert config["startup_kits"]["active"] == "admin@nvidia.com"
         assert entries["admin@nvidia.com"] == str(workspace / project_name / "prod_01" / "admin@nvidia.com")
         assert entries["bob@nvidia.com"] == str(workspace / project_name / "prod_01" / "bob@nvidia.com")
-        assert entries["site-1"] == str(workspace / project_name / "prod_01" / "site-1")
+        assert "site-1" not in entries
 
     def test_poc_add_user_auto_activates_when_no_active_kit_exists(self, tmp_path, monkeypatch):
         from nvflare.tool.poc.poc_commands import _add_poc_user
@@ -674,7 +673,7 @@ participants:
         assert result["active"] == "bob@nvidia.com"
         assert "next_step" not in result
 
-    def test_poc_add_site_persists_project_and_registers_site_kit(self, tmp_path, monkeypatch):
+    def test_poc_add_site_persists_project_without_registering_site_kit(self, tmp_path, monkeypatch):
         from nvflare.tool.poc.poc_commands import _add_poc_site
 
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -749,8 +748,6 @@ poc {{
         assert config["startup_kits"]["active"] == "admin@nvidia.com"
         assert entries == {
             "admin@nvidia.com": str(workspace / project_name / "prod_01" / "admin@nvidia.com"),
-            "site-1": str(workspace / project_name / "prod_01" / "site-1"),
-            "site-3": str(workspace / project_name / "prod_01" / "site-3"),
         }
 
     def test_poc_add_rejects_duplicate_without_force(self, tmp_path, monkeypatch):

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -14,6 +14,7 @@
 
 import errno
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -336,7 +337,7 @@ class TestPocForce:
             _require_poc_project_admin()
 
     def test_poc_add_project_admin_guard_rejects_non_project_admin(self):
-        from nvflare.tool.poc.poc_commands import _require_poc_project_admin
+        from nvflare.tool.poc.poc_commands import AuthorizationError, _require_poc_project_admin
 
         with (
             patch("nvflare.tool.poc.poc_commands.resolve_startup_kit_dir", return_value="/startup-kit"),
@@ -345,11 +346,11 @@ class TestPocForce:
                 return_value={"identity": "lead@nvidia.com", "cert_role": "lead"},
             ),
         ):
-            with pytest.raises(PermissionError, match="project_admin"):
+            with pytest.raises(AuthorizationError, match="project_admin"):
                 _require_poc_project_admin()
 
     def test_poc_add_user_rejects_non_project_admin_before_mutation(self, capsys):
-        from nvflare.tool.poc.poc_commands import add_poc_user
+        from nvflare.tool.poc.poc_commands import AuthorizationError, add_poc_user
 
         args = MagicMock()
         args.cert_role = "lead"
@@ -360,7 +361,7 @@ class TestPocForce:
             patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value="/tmp/poc"),
             patch(
                 "nvflare.tool.poc.poc_commands._require_poc_project_admin",
-                side_effect=PermissionError("active identity 'lead@nvidia.com' has role 'lead'"),
+                side_effect=AuthorizationError("active identity 'lead@nvidia.com' has role 'lead'"),
             ),
             patch("nvflare.tool.poc.poc_commands._add_poc_user") as add_user,
         ):
@@ -374,7 +375,7 @@ class TestPocForce:
         assert "lead@nvidia.com" in captured.err
 
     def test_poc_add_site_rejects_non_project_admin_before_mutation(self, capsys):
-        from nvflare.tool.poc.poc_commands import add_poc_site
+        from nvflare.tool.poc.poc_commands import AuthorizationError, add_poc_site
 
         args = MagicMock()
         args.name = "site-3"
@@ -384,7 +385,7 @@ class TestPocForce:
             patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value="/tmp/poc"),
             patch(
                 "nvflare.tool.poc.poc_commands._require_poc_project_admin",
-                side_effect=PermissionError("active identity 'lead@nvidia.com' has role 'lead'"),
+                side_effect=AuthorizationError("active identity 'lead@nvidia.com' has role 'lead'"),
             ),
             patch("nvflare.tool.poc.poc_commands._add_poc_site") as add_site,
         ):
@@ -538,6 +539,93 @@ participants:
         assert "startup_kit" not in config["poc"]
         assert "prod" not in config or "startup_kit" not in config["prod"]
 
+    def test_dynamic_poc_project_config_contains_only_server_and_new_participant(self):
+        from nvflare.tool.poc.poc_commands import _dynamic_poc_project_config
+
+        project_config = {
+            "api_version": 4,
+            "name": "example_project",
+            "participants": [
+                {"name": "server", "type": "server", "org": "nvidia"},
+                {"name": "site-1", "type": "client", "org": "nvidia"},
+                {"name": "admin@nvidia.com", "type": "admin", "role": "project_admin", "org": "nvidia"},
+            ],
+            "studies": {"study-a": {"site_orgs": {"nvidia": ["site-1"]}}},
+        }
+        participant = {"name": "site-3", "type": "client", "org": "nvidia"}
+
+        dynamic_config = _dynamic_poc_project_config(project_config, participant)
+
+        assert dynamic_config["participants"] == [
+            {"name": "server", "type": "server", "org": "nvidia"},
+            {"name": "site-3", "type": "client", "org": "nvidia"},
+        ]
+        assert "studies" not in dynamic_config
+        assert project_config["participants"][1]["name"] == "site-1"
+
+    def test_provision_poc_participant_only_moves_new_kit_into_existing_prod_dir(self, tmp_path, monkeypatch):
+        from nvflare.lighter.constants import CtxKey
+        from nvflare.tool.poc import poc_commands
+
+        workspace = tmp_path / "poc_ws"
+        project_name = "example_project"
+        prod_00 = workspace / project_name / "prod_00"
+        state_dir = workspace / project_name / "state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "cert.json").write_text("{}")
+        server_startup = prod_00 / "server" / SC.STARTUP
+        server_startup.mkdir(parents=True)
+        (server_startup / "rootCA.pem").write_text("root ca")
+        _make_admin_startup_kit(prod_00, "admin@nvidia.com")
+        _make_site_startup_kit(prod_00, "site-1")
+        existing_admin_marker = prod_00 / "admin@nvidia.com" / "marker.txt"
+        existing_admin_marker.write_text("unchanged")
+
+        project_config = {
+            "api_version": 3,
+            "name": project_name,
+            "participants": [
+                {"name": "server", "type": "server", "org": "nvidia"},
+                {"name": "site-1", "type": "client", "org": "nvidia"},
+                {"name": "admin@nvidia.com", "type": "admin", "role": "project_admin", "org": "nvidia"},
+                {"name": "site-3", "type": "client", "org": "nvidia"},
+            ],
+        }
+        participant = {"name": "site-3", "type": "client", "org": "nvidia"}
+        captured_dynamic_config = {}
+
+        def fake_prepare_project(dynamic_config):
+            captured_dynamic_config.update(dynamic_config)
+            return object()
+
+        class FakeProvisioner:
+            def __init__(self, root_dir, builders, packager):
+                assert root_dir == str(workspace)
+                assert builders == ["builder"]
+                assert packager == "packager"
+
+            def provision(self, project, mode=None, logger=None):
+                prod_01 = workspace / project_name / "prod_01"
+                _make_site_startup_kit(prod_01, "site-3")
+                (prod_01 / "server").mkdir(parents=True)
+                return {CtxKey.CURRENT_PROD_DIR: str(prod_01)}
+
+        monkeypatch.setattr(poc_commands, "prepare_project", fake_prepare_project)
+        monkeypatch.setattr(poc_commands, "prepare_builders", lambda dynamic_config: ["builder"])
+        monkeypatch.setattr(poc_commands, "prepare_packager", lambda dynamic_config: "packager")
+        monkeypatch.setattr(poc_commands, "Provisioner", FakeProvisioner)
+
+        result = poc_commands._provision_poc_participant_only(str(workspace), project_config, participant, str(prod_00))
+
+        assert result == str(prod_00 / "site-3")
+        assert (prod_00 / "site-3" / SC.STARTUP / "fed_client.json").is_file()
+        assert not (workspace / project_name / "prod_01").exists()
+        assert existing_admin_marker.read_text() == "unchanged"
+        assert captured_dynamic_config["participants"] == [
+            {"name": "server", "type": "server", "org": "nvidia"},
+            {"name": "site-3", "type": "client", "org": "nvidia"},
+        ]
+
     def test_poc_add_user_persists_project_and_registers_new_admin_kit(self, tmp_path, monkeypatch):
         from nvflare.tool.poc.poc_commands import _add_poc_user
 
@@ -581,43 +669,35 @@ poc {{
 """
         )
 
-        def fake_prepare_poc_provision(
-            clients, number_of_clients, workspace_arg, docker_image, use_he, project_conf_path, examples_dir
-        ):
-            assert clients == []
-            assert number_of_clients == 0
+        def fake_provision_participant_only(workspace_arg, project_config_arg, participant, target_prod_dir, force):
             assert workspace_arg == str(workspace)
-            assert docker_image is None
-            assert use_he is False
-            assert project_conf_path == str(project_file)
-            assert examples_dir is None
-            project_config = yaml.safe_load(project_file.read_text())
-            prod_01 = workspace / project_name / "prod_01"
-            for participant in project_config["participants"]:
-                if participant["type"] == "admin":
-                    _make_admin_startup_kit(prod_01, participant["name"])
-                elif participant["type"] == "client":
-                    _make_site_startup_kit(prod_01, participant["name"])
-                else:
-                    (prod_01 / participant["name"]).mkdir(parents=True, exist_ok=True)
-            return project_config
+            assert target_prod_dir == str(prod_00)
+            assert participant == {"name": "bob@nvidia.com", "type": "admin", "org": "nvidia", "role": "lead"}
+            assert {"name": "site-1", "type": "client", "org": "nvidia"} in project_config_arg["participants"]
+            assert force is False
+            _make_admin_startup_kit(Path(target_prod_dir), participant["name"])
+            return os.path.join(target_prod_dir, participant["name"])
 
-        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision):
+        with patch(
+            "nvflare.tool.poc.poc_commands._provision_poc_participant_only",
+            side_effect=fake_provision_participant_only,
+        ):
             result = _add_poc_user(str(workspace), "lead", "bob@nvidia.com", "nvidia")
 
         persisted = yaml.safe_load(project_file.read_text())
         assert {"name": "bob@nvidia.com", "type": "admin", "role": "lead", "org": "nvidia"} in persisted["participants"]
         assert result["status"] == "added"
         assert result["id"] == "bob@nvidia.com"
-        assert result["startup_kit"] == str(workspace / project_name / "prod_01" / "bob@nvidia.com")
+        assert result["startup_kit"] == str(workspace / project_name / "prod_00" / "bob@nvidia.com")
         assert result["next_step"] == "nvflare config kit use bob@nvidia.com"
         assert "active" not in result
+        assert not (workspace / project_name / "prod_01").exists()
 
         config = _load_config_dict(config_path)
         entries = config["startup_kits"]["entries"]
         assert config["startup_kits"]["active"] == "admin@nvidia.com"
-        assert entries["admin@nvidia.com"] == str(workspace / project_name / "prod_01" / "admin@nvidia.com")
-        assert entries["bob@nvidia.com"] == str(workspace / project_name / "prod_01" / "bob@nvidia.com")
+        assert entries["admin@nvidia.com"] == str(workspace / project_name / "prod_00" / "admin@nvidia.com")
+        assert entries["bob@nvidia.com"] == str(workspace / project_name / "prod_00" / "bob@nvidia.com")
         assert "site-1" not in entries
 
     def test_poc_add_user_auto_activates_when_no_active_kit_exists(self, tmp_path, monkeypatch):
@@ -626,6 +706,8 @@ poc {{
         monkeypatch.setenv("HOME", str(tmp_path))
         workspace = tmp_path / "poc_ws"
         project_name = "example_project"
+        prod_00 = workspace / project_name / "prod_00"
+        _make_admin_startup_kit(prod_00, "admin@nvidia.com")
         workspace.mkdir(parents=True, exist_ok=True)
         project_file = workspace / "project.yml"
         project_file.write_text(
@@ -641,26 +723,18 @@ participants:
 """
         )
 
-        def fake_prepare_poc_provision(
-            clients, number_of_clients, workspace_arg, docker_image, use_he, project_conf_path, examples_dir
-        ):
-            assert clients == []
-            assert number_of_clients == 0
+        def fake_provision_participant_only(workspace_arg, project_config_arg, participant, target_prod_dir, force):
             assert workspace_arg == str(workspace)
-            assert docker_image is None
-            assert use_he is False
-            assert project_conf_path == str(project_file)
-            assert examples_dir is None
-            project_config = yaml.safe_load(project_file.read_text())
-            prod_00 = workspace / project_name / "prod_00"
-            for participant in project_config["participants"]:
-                if participant["type"] == "admin":
-                    _make_admin_startup_kit(prod_00, participant["name"])
-                else:
-                    (prod_00 / participant["name"]).mkdir(parents=True, exist_ok=True)
-            return project_config
+            assert target_prod_dir == str(prod_00)
+            assert participant == {"name": "bob@nvidia.com", "type": "admin", "org": "nvidia", "role": "lead"}
+            assert force is False
+            _make_admin_startup_kit(Path(target_prod_dir), participant["name"])
+            return os.path.join(target_prod_dir, participant["name"])
 
-        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision):
+        with patch(
+            "nvflare.tool.poc.poc_commands._provision_poc_participant_only",
+            side_effect=fake_provision_participant_only,
+        ):
             result = _add_poc_user(str(workspace), "lead", "bob@nvidia.com", "nvidia")
 
         config_path = tmp_path / ".nvflare" / "config.conf"
@@ -716,38 +790,38 @@ poc {{
 """
         )
 
-        def fake_prepare_poc_provision(
-            clients, number_of_clients, workspace_arg, docker_image, use_he, project_conf_path, examples_dir
-        ):
-            assert clients == []
-            assert number_of_clients == 0
+        def fake_provision_participant_only(workspace_arg, project_config_arg, participant, target_prod_dir, force):
             assert workspace_arg == str(workspace)
-            assert project_conf_path == str(project_file)
-            project_config = yaml.safe_load(project_file.read_text())
-            prod_01 = workspace / project_name / "prod_01"
-            for participant in project_config["participants"]:
-                if participant["type"] == "admin":
-                    _make_admin_startup_kit(prod_01, participant["name"])
-                elif participant["type"] == "client":
-                    _make_site_startup_kit(prod_01, participant["name"])
-                else:
-                    (prod_01 / participant["name"]).mkdir(parents=True, exist_ok=True)
-            return project_config
+            assert target_prod_dir == str(prod_00)
+            assert participant == {"name": "site-3", "type": "client", "org": "nvidia"}
+            assert {
+                "name": "admin@nvidia.com",
+                "type": "admin",
+                "role": "project_admin",
+                "org": "nvidia",
+            } in project_config_arg["participants"]
+            assert force is False
+            _make_site_startup_kit(Path(target_prod_dir), participant["name"])
+            return os.path.join(target_prod_dir, participant["name"])
 
-        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision):
+        with patch(
+            "nvflare.tool.poc.poc_commands._provision_poc_participant_only",
+            side_effect=fake_provision_participant_only,
+        ):
             result = _add_poc_site(str(workspace), "site-3", "nvidia")
 
         persisted = yaml.safe_load(project_file.read_text())
         assert {"name": "site-3", "type": "client", "org": "nvidia"} in persisted["participants"]
         assert result["status"] == "added"
         assert result["id"] == "site-3"
-        assert result["startup_kit"] == str(workspace / project_name / "prod_01" / "site-3")
+        assert result["startup_kit"] == str(workspace / project_name / "prod_00" / "site-3")
+        assert not (workspace / project_name / "prod_01").exists()
 
         config = _load_config_dict(config_path)
         entries = config["startup_kits"]["entries"]
         assert config["startup_kits"]["active"] == "admin@nvidia.com"
         assert entries == {
-            "admin@nvidia.com": str(workspace / project_name / "prod_01" / "admin@nvidia.com"),
+            "admin@nvidia.com": str(workspace / project_name / "prod_00" / "admin@nvidia.com"),
         }
 
     def test_poc_add_rejects_duplicate_without_force(self, tmp_path, monkeypatch):
@@ -766,7 +840,7 @@ participants:
 """
         )
 
-        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prepare:
+        with patch("nvflare.tool.poc.poc_commands._provision_poc_participant_only") as mock_prepare:
             with pytest.raises(CLIException, match="already exists"):
                 _add_poc_site(str(workspace), "site-1", "nvidia")
 
@@ -790,7 +864,7 @@ participants:
 """
         )
 
-        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prepare:
+        with patch("nvflare.tool.poc.poc_commands._provision_poc_participant_only") as mock_prepare:
             with pytest.raises(CLIException, match="changing a POC user's certificate role"):
                 _add_poc_user(str(workspace), "org_admin", "bob@nvidia.com", "nvidia", force=True)
 

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -945,6 +945,65 @@ participants:
                 with patch.dict(os.environ, {}, clear=True):
                     assert get_poc_workspace() == str(workspace)
 
+    def test_register_poc_startup_kits_replaces_previous_poc_workspace_entries(self, tmp_path):
+        from nvflare.tool.kit.kit_config import get_startup_kit_entries
+        from nvflare.tool.poc.poc_commands import _register_poc_startup_kits
+
+        old_workspace = tmp_path / "old_poc"
+        new_workspace = tmp_path / "new_poc"
+        old_admin = old_workspace / "example_project" / "prod_00" / "admin@nvidia.com"
+        new_prod_dir = new_workspace / "example_project" / "prod_00"
+        new_admin = _make_admin_startup_kit(new_prod_dir, "admin@nvidia.com")
+        manual_admin = tmp_path / "prod" / "cancer" / "lead@nvidia.com"
+
+        config = CF.parse_string(
+            f"""
+version = 2
+startup_kits {{
+  active = "admin@nvidia.com"
+  entries {{
+    "admin@nvidia.com" = "{old_admin}"
+    cancer_lead = "{manual_admin}"
+  }}
+}}
+poc {{
+  workspace = "{old_workspace}"
+}}
+"""
+        )
+
+        updated, removed_ids = _register_poc_startup_kits(
+            config,
+            str(new_workspace),
+            {"admin@nvidia.com": str(new_admin)},
+        )
+
+        entries = get_startup_kit_entries(updated)
+        assert removed_ids == {"admin@nvidia.com"}
+        assert entries["admin@nvidia.com"] == str(new_admin.resolve())
+        assert entries["cancer_lead"] == str(manual_admin)
+
+    def test_register_poc_startup_kits_rejects_manual_id_conflict(self, tmp_path):
+        from nvflare.tool.poc.poc_commands import _register_poc_startup_kits
+
+        workspace = tmp_path / "poc"
+        new_admin = _make_admin_startup_kit(workspace / "example_project" / "prod_00", "admin@nvidia.com")
+        manual_admin = tmp_path / "prod" / "admin@nvidia.com"
+
+        config = CF.parse_string(
+            f"""
+version = 2
+startup_kits {{
+  entries {{
+    "admin@nvidia.com" = "{manual_admin}"
+  }}
+}}
+"""
+        )
+
+        with pytest.raises(CLIException, match="already exists outside POC workspace"):
+            _register_poc_startup_kits(config, str(workspace), {"admin@nvidia.com": str(new_admin)})
+
     def test_clean_poc_removes_workspace_and_only_canonical_workspace_entries(self, tmp_path, monkeypatch):
         from nvflare.tool.poc.poc_commands import _clean_poc
 

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -411,7 +411,7 @@ class TestPocForce:
             patch(
                 "nvflare.tool.poc.poc_commands._require_poc_project_admin",
                 side_effect=StartupKitConfigError(
-                    "active startup kit is stale", hint="Run 'nvflare kit use admin@nvidia.com'"
+                    "active startup kit is stale", hint="Run 'nvflare config kit use admin@nvidia.com'"
                 ),
             ),
             patch("nvflare.tool.poc.poc_commands._add_poc_user") as add_user,
@@ -423,7 +423,7 @@ class TestPocForce:
         add_user.assert_not_called()
         captured = capsys.readouterr()
         assert "active startup kit is stale" in captured.err
-        assert "Run 'nvflare kit use admin@nvidia.com'" in captured.err
+        assert "Run 'nvflare config kit use admin@nvidia.com'" in captured.err
 
     def test_poc_add_site_preserves_startup_kit_resolution_hint(self, capsys):
         from nvflare.tool.kit.kit_config import StartupKitConfigError
@@ -438,7 +438,7 @@ class TestPocForce:
             patch(
                 "nvflare.tool.poc.poc_commands._require_poc_project_admin",
                 side_effect=StartupKitConfigError(
-                    "active startup kit is stale", hint="Run 'nvflare kit use admin@nvidia.com'"
+                    "active startup kit is stale", hint="Run 'nvflare config kit use admin@nvidia.com'"
                 ),
             ),
             patch("nvflare.tool.poc.poc_commands._add_poc_site") as add_site,
@@ -450,7 +450,7 @@ class TestPocForce:
         add_site.assert_not_called()
         captured = capsys.readouterr()
         assert "active startup kit is stale" in captured.err
-        assert "Run 'nvflare kit use admin@nvidia.com'" in captured.err
+        assert "Run 'nvflare config kit use admin@nvidia.com'" in captured.err
 
     def test_interactive_without_force_prompts(self, tmp_path):
         """In interactive mode without --force, should ask for confirmation."""
@@ -611,7 +611,7 @@ poc {{
         assert result["status"] == "added"
         assert result["id"] == "bob@nvidia.com"
         assert result["startup_kit"] == str(workspace / project_name / "prod_01" / "bob@nvidia.com")
-        assert result["next_step"] == "nvflare kit use bob@nvidia.com"
+        assert result["next_step"] == "nvflare config kit use bob@nvidia.com"
         assert "active" not in result
 
         config = _load_config_dict(config_path)

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -349,6 +349,19 @@ class TestPocForce:
             with pytest.raises(AuthorizationError, match="project_admin"):
                 _require_poc_project_admin()
 
+    def test_poc_add_project_admin_guard_rejects_missing_cert_role(self):
+        from nvflare.tool.poc.poc_commands import AuthorizationError, _require_poc_project_admin
+
+        with (
+            patch("nvflare.tool.poc.poc_commands.resolve_startup_kit_dir", return_value="/startup-kit"),
+            patch(
+                "nvflare.tool.poc.poc_commands.inspect_startup_kit_metadata",
+                return_value={"identity": "admin@nvidia.com", "cert_role": None},
+            ),
+        ):
+            with pytest.raises(AuthorizationError, match="could not determine the certificate role"):
+                _require_poc_project_admin()
+
     def test_poc_add_user_rejects_non_project_admin_before_mutation(self, capsys):
         from nvflare.tool.poc.poc_commands import AuthorizationError, add_poc_user
 

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -17,10 +17,32 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from pyhocon import ConfigFactory as CF
 
 from nvflare.cli_exception import CLIException
+from nvflare.fuel_opt.utils.pyhocon_loader import PyhoconConfig
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
+
+
+def _load_config_dict(path):
+    return PyhoconConfig(CF.parse_file(str(path))).to_dict()
+
+
+def _make_admin_startup_kit(prod_dir, identity):
+    startup_dir = prod_dir / identity / SC.STARTUP
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text("{}")
+    (startup_dir / "client.crt").write_text("")
+    (startup_dir / "rootCA.pem").write_text("")
+    return prod_dir / identity
+
+
+def _make_site_startup_kit(prod_dir, identity):
+    startup_dir = prod_dir / identity / SC.STARTUP
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_client.json").write_text("{}")
+    return prod_dir / identity
 
 
 class TestPocForce:
@@ -276,6 +298,102 @@ class TestPocForce:
         args = root.parse_args(["poc", "prepare-jobs-dir", "--force"])
         assert args.force is True
 
+    def test_poc_add_user_and_site_parser(self):
+        import argparse
+
+        from nvflare.tool.poc.poc_commands import def_poc_parser
+
+        root = argparse.ArgumentParser()
+        subs = root.add_subparsers()
+        def_poc_parser(subs)
+
+        user_args = root.parse_args(["poc", "add", "user", "lead", "bob@nvidia.com", "--org", "nvidia"])
+        assert user_args.poc_sub_cmd == "add"
+        assert user_args.poc_add_sub_cmd == "user"
+        assert user_args.cert_role == "lead"
+        assert user_args.email == "bob@nvidia.com"
+        assert user_args.org == "nvidia"
+
+        site_args = root.parse_args(["poc", "add", "site", "site-3", "--org", "nvidia"])
+        assert site_args.poc_sub_cmd == "add"
+        assert site_args.poc_add_sub_cmd == "site"
+        assert site_args.name == "site-3"
+        assert site_args.org == "nvidia"
+
+    def test_poc_add_project_admin_guard_allows_project_admin(self):
+        from nvflare.tool.poc.poc_commands import _require_poc_project_admin
+
+        with (
+            patch("nvflare.tool.poc.poc_commands.resolve_startup_kit_dir", return_value="/startup-kit"),
+            patch(
+                "nvflare.tool.poc.poc_commands.inspect_startup_kit_metadata",
+                return_value={"identity": "admin@nvidia.com", "cert_role": "project_admin"},
+            ),
+        ):
+            _require_poc_project_admin()
+
+    def test_poc_add_project_admin_guard_rejects_non_project_admin(self):
+        from nvflare.tool.poc.poc_commands import _require_poc_project_admin
+
+        with (
+            patch("nvflare.tool.poc.poc_commands.resolve_startup_kit_dir", return_value="/startup-kit"),
+            patch(
+                "nvflare.tool.poc.poc_commands.inspect_startup_kit_metadata",
+                return_value={"identity": "lead@nvidia.com", "cert_role": "lead"},
+            ),
+        ):
+            with pytest.raises(PermissionError, match="project_admin"):
+                _require_poc_project_admin()
+
+    def test_poc_add_user_rejects_non_project_admin_before_mutation(self, capsys):
+        from nvflare.tool.poc.poc_commands import add_poc_user
+
+        args = MagicMock()
+        args.cert_role = "lead"
+        args.email = "bob@nvidia.com"
+        args.org = "nvidia"
+        args.force = False
+        with (
+            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value="/tmp/poc"),
+            patch(
+                "nvflare.tool.poc.poc_commands._require_poc_project_admin",
+                side_effect=PermissionError("active identity 'lead@nvidia.com' has role 'lead'"),
+            ),
+            patch("nvflare.tool.poc.poc_commands._add_poc_user") as add_user,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                add_poc_user(args)
+
+        assert exc_info.value.code == 1
+        add_user.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Not authorized" in captured.err
+        assert "lead@nvidia.com" in captured.err
+
+    def test_poc_add_site_rejects_non_project_admin_before_mutation(self, capsys):
+        from nvflare.tool.poc.poc_commands import add_poc_site
+
+        args = MagicMock()
+        args.name = "site-3"
+        args.org = "nvidia"
+        args.force = False
+        with (
+            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value="/tmp/poc"),
+            patch(
+                "nvflare.tool.poc.poc_commands._require_poc_project_admin",
+                side_effect=PermissionError("active identity 'lead@nvidia.com' has role 'lead'"),
+            ),
+            patch("nvflare.tool.poc.poc_commands._add_poc_site") as add_site,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                add_poc_site(args)
+
+        assert exc_info.value.code == 1
+        add_site.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Not authorized" in captured.err
+        assert "lead@nvidia.com" in captured.err
+
     def test_interactive_without_force_prompts(self, tmp_path):
         """In interactive mode without --force, should ask for confirmation."""
         from nvflare.tool.poc.poc_commands import _prepare_poc
@@ -290,11 +408,357 @@ class TestPocForce:
             result = _prepare_poc([], 2, workspace, force=False)
         assert result is False
 
-    def test_save_startup_kit_dir_config_uses_poc_admin_dir(self, tmp_path):
+    def test_poc_prepare_registers_admin_kits_and_active_project_admin(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _prepare_poc
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        project_name = "example_project"
+        prod_dir = workspace / project_name / "prod_00"
+        project_config = {
+            "name": project_name,
+            "participants": [
+                {"name": "server", "type": "server"},
+                {"name": "site-1", "type": "client"},
+                {"name": "lead@nvidia.com", "type": "admin", "role": "lead"},
+                {"name": "org-admin@nvidia.com", "type": "admin", "role": "org_admin"},
+                {"name": "admin@nvidia.com", "type": "admin", "role": "project_admin"},
+            ],
+        }
+
+        def fake_prepare_poc_provision(*_args, **_kwargs):
+            workspace.mkdir(parents=True, exist_ok=True)
+            (workspace / "project.yml").write_text(
+                """
+name: example_project
+participants:
+  - name: server
+    type: server
+  - name: site-1
+    type: client
+  - name: lead@nvidia.com
+    type: admin
+    role: lead
+  - name: org-admin@nvidia.com
+    type: admin
+    role: org_admin
+  - name: admin@nvidia.com
+    type: admin
+    role: project_admin
+"""
+            )
+            for identity in ("admin@nvidia.com", "org-admin@nvidia.com", "lead@nvidia.com"):
+                _make_admin_startup_kit(prod_dir, identity)
+            site_startup = prod_dir / "site-1" / SC.STARTUP
+            site_startup.mkdir(parents=True)
+            (site_startup / "fed_client.json").write_text("{}")
+            return project_config
+
+        dst = tmp_path / ".nvflare" / "config.conf"
+        with (
+            patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
+                return_value=str(dst),
+            ),
+        ):
+            assert _prepare_poc([], 2, str(workspace), force=True) is True
+
+        config = _load_config_dict(dst)
+        entries = config["startup_kits"]["entries"]
+        assert config["startup_kits"]["active"] == "admin@nvidia.com"
+        assert entries == {
+            "admin@nvidia.com": str(prod_dir / "admin@nvidia.com"),
+            "org-admin@nvidia.com": str(prod_dir / "org-admin@nvidia.com"),
+            "lead@nvidia.com": str(prod_dir / "lead@nvidia.com"),
+            "site-1": str(prod_dir / "site-1"),
+        }
+        assert config["poc"]["workspace"] == str(workspace)
+        assert "startup_kit" not in config["poc"]
+        assert "prod" not in config or "startup_kit" not in config["prod"]
+
+    def test_poc_add_user_persists_project_and_registers_new_admin_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _add_poc_user
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        project_name = "example_project"
+        prod_00 = workspace / project_name / "prod_00"
+        _make_admin_startup_kit(prod_00, "admin@nvidia.com")
+        _make_site_startup_kit(prod_00, "site-1")
+        workspace.mkdir(parents=True, exist_ok=True)
+        project_file = workspace / "project.yml"
+        project_file.write_text(
+            """
+name: example_project
+participants:
+  - name: server
+    type: server
+  - name: site-1
+    type: client
+    org: nvidia
+  - name: admin@nvidia.com
+    type: admin
+    role: project_admin
+    org: nvidia
+"""
+        )
+        config_path = tmp_path / ".nvflare" / "config.conf"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            f"""
+version = 2
+startup_kits {{
+  active = "admin@nvidia.com"
+  entries {{
+    "admin@nvidia.com" = "{prod_00 / 'admin@nvidia.com'}"
+  }}
+}}
+poc {{
+  workspace = "{workspace}"
+}}
+"""
+        )
+
+        def fake_prepare_poc_provision(
+            clients, number_of_clients, workspace_arg, docker_image, use_he, project_conf_path, examples_dir
+        ):
+            assert clients == []
+            assert number_of_clients == 0
+            assert workspace_arg == str(workspace)
+            assert docker_image is None
+            assert use_he is False
+            assert project_conf_path == str(project_file)
+            assert examples_dir is None
+            project_config = yaml.safe_load(project_file.read_text())
+            prod_01 = workspace / project_name / "prod_01"
+            for participant in project_config["participants"]:
+                if participant["type"] == "admin":
+                    _make_admin_startup_kit(prod_01, participant["name"])
+                elif participant["type"] == "client":
+                    _make_site_startup_kit(prod_01, participant["name"])
+                else:
+                    (prod_01 / participant["name"]).mkdir(parents=True, exist_ok=True)
+            return project_config
+
+        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision):
+            result = _add_poc_user(str(workspace), "lead", "bob@nvidia.com", "nvidia")
+
+        persisted = yaml.safe_load(project_file.read_text())
+        assert {"name": "bob@nvidia.com", "type": "admin", "role": "lead", "org": "nvidia"} in persisted["participants"]
+        assert result["status"] == "added"
+        assert result["id"] == "bob@nvidia.com"
+        assert result["startup_kit"] == str(workspace / project_name / "prod_01" / "bob@nvidia.com")
+        assert result["next_step"] == "nvflare kit use bob@nvidia.com"
+        assert "active" not in result
+
+        config = _load_config_dict(config_path)
+        entries = config["startup_kits"]["entries"]
+        assert config["startup_kits"]["active"] == "admin@nvidia.com"
+        assert entries["admin@nvidia.com"] == str(workspace / project_name / "prod_01" / "admin@nvidia.com")
+        assert entries["bob@nvidia.com"] == str(workspace / project_name / "prod_01" / "bob@nvidia.com")
+        assert entries["site-1"] == str(workspace / project_name / "prod_01" / "site-1")
+
+    def test_poc_add_user_auto_activates_when_no_active_kit_exists(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _add_poc_user
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        project_name = "example_project"
+        workspace.mkdir(parents=True, exist_ok=True)
+        project_file = workspace / "project.yml"
+        project_file.write_text(
+            """
+name: example_project
+participants:
+  - name: server
+    type: server
+  - name: admin@nvidia.com
+    type: admin
+    role: project_admin
+    org: nvidia
+"""
+        )
+
+        def fake_prepare_poc_provision(
+            clients, number_of_clients, workspace_arg, docker_image, use_he, project_conf_path, examples_dir
+        ):
+            assert clients == []
+            assert number_of_clients == 0
+            assert workspace_arg == str(workspace)
+            assert docker_image is None
+            assert use_he is False
+            assert project_conf_path == str(project_file)
+            assert examples_dir is None
+            project_config = yaml.safe_load(project_file.read_text())
+            prod_00 = workspace / project_name / "prod_00"
+            for participant in project_config["participants"]:
+                if participant["type"] == "admin":
+                    _make_admin_startup_kit(prod_00, participant["name"])
+                else:
+                    (prod_00 / participant["name"]).mkdir(parents=True, exist_ok=True)
+            return project_config
+
+        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision):
+            result = _add_poc_user(str(workspace), "lead", "bob@nvidia.com", "nvidia")
+
+        config_path = tmp_path / ".nvflare" / "config.conf"
+        config = _load_config_dict(config_path)
+        entries = config["startup_kits"]["entries"]
+        assert config["startup_kits"]["active"] == "bob@nvidia.com"
+        assert entries["admin@nvidia.com"] == str(workspace / project_name / "prod_00" / "admin@nvidia.com")
+        assert entries["bob@nvidia.com"] == str(workspace / project_name / "prod_00" / "bob@nvidia.com")
+        assert result["id"] == "bob@nvidia.com"
+        assert result["active"] == "bob@nvidia.com"
+        assert "next_step" not in result
+
+    def test_poc_add_site_persists_project_and_registers_site_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _add_poc_site
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        project_name = "example_project"
+        prod_00 = workspace / project_name / "prod_00"
+        _make_admin_startup_kit(prod_00, "admin@nvidia.com")
+        _make_site_startup_kit(prod_00, "site-1")
+        workspace.mkdir(parents=True, exist_ok=True)
+        project_file = workspace / "project.yml"
+        project_file.write_text(
+            """
+name: example_project
+participants:
+  - name: server
+    type: server
+  - name: site-1
+    type: client
+    org: nvidia
+  - name: admin@nvidia.com
+    type: admin
+    role: project_admin
+    org: nvidia
+"""
+        )
+        config_path = tmp_path / ".nvflare" / "config.conf"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            f"""
+version = 2
+startup_kits {{
+  active = "admin@nvidia.com"
+  entries {{
+    "admin@nvidia.com" = "{prod_00 / 'admin@nvidia.com'}"
+  }}
+}}
+poc {{
+  workspace = "{workspace}"
+}}
+"""
+        )
+
+        def fake_prepare_poc_provision(
+            clients, number_of_clients, workspace_arg, docker_image, use_he, project_conf_path, examples_dir
+        ):
+            assert clients == []
+            assert number_of_clients == 0
+            assert workspace_arg == str(workspace)
+            assert project_conf_path == str(project_file)
+            project_config = yaml.safe_load(project_file.read_text())
+            prod_01 = workspace / project_name / "prod_01"
+            for participant in project_config["participants"]:
+                if participant["type"] == "admin":
+                    _make_admin_startup_kit(prod_01, participant["name"])
+                elif participant["type"] == "client":
+                    _make_site_startup_kit(prod_01, participant["name"])
+                else:
+                    (prod_01 / participant["name"]).mkdir(parents=True, exist_ok=True)
+            return project_config
+
+        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision", side_effect=fake_prepare_poc_provision):
+            result = _add_poc_site(str(workspace), "site-3", "nvidia")
+
+        persisted = yaml.safe_load(project_file.read_text())
+        assert {"name": "site-3", "type": "client", "org": "nvidia"} in persisted["participants"]
+        assert result["status"] == "added"
+        assert result["id"] == "site-3"
+        assert result["startup_kit"] == str(workspace / project_name / "prod_01" / "site-3")
+
+        config = _load_config_dict(config_path)
+        entries = config["startup_kits"]["entries"]
+        assert config["startup_kits"]["active"] == "admin@nvidia.com"
+        assert entries == {
+            "admin@nvidia.com": str(workspace / project_name / "prod_01" / "admin@nvidia.com"),
+            "site-1": str(workspace / project_name / "prod_01" / "site-1"),
+            "site-3": str(workspace / project_name / "prod_01" / "site-3"),
+        }
+
+    def test_poc_add_rejects_duplicate_without_force(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _add_poc_site
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        workspace.mkdir(parents=True, exist_ok=True)
+        (workspace / "project.yml").write_text(
+            """
+name: example_project
+participants:
+  - name: site-1
+    type: client
+    org: nvidia
+"""
+        )
+
+        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prepare:
+            with pytest.raises(CLIException, match="already exists"):
+                _add_poc_site(str(workspace), "site-1", "nvidia")
+
+        mock_prepare.assert_not_called()
+
+    def test_poc_add_user_rejects_role_change_before_persisting(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _add_poc_user
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        workspace.mkdir(parents=True, exist_ok=True)
+        project_file = workspace / "project.yml"
+        project_file.write_text(
+            """
+name: example_project
+participants:
+  - name: bob@nvidia.com
+    type: admin
+    role: lead
+    org: nvidia
+"""
+        )
+
+        with patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prepare:
+            with pytest.raises(CLIException, match="changing a POC user's certificate role"):
+                _add_poc_user(str(workspace), "org_admin", "bob@nvidia.com", "nvidia", force=True)
+
+        mock_prepare.assert_not_called()
+        persisted = yaml.safe_load(project_file.read_text())
+        assert persisted["participants"] == [
+            {
+                "name": "bob@nvidia.com",
+                "type": "admin",
+                "role": "lead",
+                "org": "nvidia",
+            }
+        ]
+
+    def test_save_startup_kit_dir_config_writes_registry_and_poc_workspace(self, tmp_path, monkeypatch):
         from nvflare.tool.poc.poc_commands import get_poc_workspace, save_startup_kit_dir_config
 
-        workspace = str(tmp_path / "poc_ws")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc_ws"
+        project_name = "example_project"
+        prod_dir = workspace / project_name / "prod_00"
         os.makedirs(workspace, exist_ok=True)
+        _make_admin_startup_kit(prod_dir, "admin@nvidia.com")
         with open(os.path.join(workspace, "project.yml"), "w") as f:
             f.write(
                 """
@@ -308,20 +772,25 @@ participants:
 """
             )
 
-        dst = str(tmp_path / "config.conf")
+        dst = tmp_path / ".nvflare" / "config.conf"
         with patch(
             "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
             return_value=str(tmp_path),
         ):
             with patch(
                 "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
-                return_value=dst,
+                return_value=str(dst),
             ):
-                save_startup_kit_dir_config(workspace, "example_project")
+                save_startup_kit_dir_config(str(workspace), project_name)
 
-        config = CF.parse_file(dst)
-        assert config.get("poc.startup_kit").endswith("/example_project/prod_00/admin@nvidia.com")
-        assert config.get("poc.workspace") == workspace
+        config = _load_config_dict(dst)
+        assert config["startup_kits"]["active"] == "admin@nvidia.com"
+        assert config["startup_kits"]["entries"] == {
+            "admin@nvidia.com": str(prod_dir / "admin@nvidia.com"),
+        }
+        assert config["poc"]["workspace"] == str(workspace)
+        assert "startup_kit" not in config["poc"]
+        assert "prod" not in config or "startup_kit" not in config["prod"]
 
         with patch(
             "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
@@ -329,10 +798,76 @@ participants:
         ):
             with patch(
                 "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
-                return_value=dst,
+                return_value=str(dst),
             ):
                 with patch.dict(os.environ, {}, clear=True):
-                    assert get_poc_workspace() == workspace
+                    assert get_poc_workspace() == str(workspace)
+
+    def test_clean_poc_removes_workspace_and_only_canonical_workspace_entries(self, tmp_path, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _clean_poc
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        workspace = tmp_path / "poc"
+        workspace.mkdir()
+        poc_admin = workspace / "example_project" / "prod_00" / "admin@nvidia.com"
+        poc_lead = workspace / "example_project" / "prod_00" / ".." / "prod_00" / "lead@nvidia.com"
+        poc_backup_admin = tmp_path / "poc-backup" / "example_project" / "prod_00" / "admin@nvidia.com"
+        prod_admin = tmp_path / "prod" / "cancer" / "lead@nvidia.com"
+        dst = tmp_path / ".nvflare" / "config.conf"
+        dst.parent.mkdir()
+        dst.write_text(
+            f"""
+version = 2
+startup_kits {{
+  active = "admin@nvidia.com"
+  entries {{
+    "admin@nvidia.com" = "{poc_admin}"
+    "lead@nvidia.com" = "{poc_lead}"
+    "poc-backup-admin" = "{poc_backup_admin}"
+    cancer_lead = "{prod_admin}"
+  }}
+}}
+poc {{
+  workspace = "{workspace}"
+  startup_kit = "{poc_admin}"
+  mode = "keep"
+}}
+prod {{
+  startup_kit = "{prod_admin}"
+  mode = "keep"
+}}
+"""
+        )
+
+        with (
+            patch(
+                "nvflare.tool.poc.poc_commands.get_or_create_hidden_nvflare_dir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands.get_hidden_nvflare_config_path",
+                return_value=str(dst),
+            ),
+            patch(
+                "nvflare.tool.poc.poc_commands.setup_service_config",
+                return_value=({"name": "example_project"}, {SC.FLARE_SERVER: "server"}),
+            ),
+            patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
+            patch("nvflare.tool.poc.poc_commands.is_poc_running", return_value=False),
+            patch("nvflare.tool.cli_output.print_human"),
+        ):
+            assert _clean_poc(str(workspace)) is True
+
+        config = _load_config_dict(dst)
+        entries = config["startup_kits"]["entries"]
+        assert not workspace.exists()
+        assert "active" not in config["startup_kits"]
+        assert "admin@nvidia.com" not in entries
+        assert "lead@nvidia.com" not in entries
+        assert entries["poc-backup-admin"] == str(poc_backup_admin)
+        assert entries["cancer_lead"] == str(prod_admin)
+        assert config["poc"] == {"mode": "keep"}
+        assert config["prod"] == {"mode": "keep"}
 
     def test_save_startup_kit_dir_config_rejects_invalid_project_yaml(self, tmp_path):
         from nvflare.tool.poc.poc_commands import save_startup_kit_dir_config

--- a/tests/unit_test/tool/study/study_cli_test.py
+++ b/tests/unit_test/tool/study/study_cli_test.py
@@ -23,6 +23,34 @@ from nvflare.fuel.flare_api.api_spec import CommandError
 from nvflare.tool import cli_output
 
 
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}', encoding="utf-8")
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
 class TestStudyCli:
     @pytest.fixture(autouse=True)
     def json_mode(self, monkeypatch):
@@ -76,70 +104,31 @@ class TestStudyCli:
         assert "Invalid arguments" not in captured.out
         assert captured.err == ""
 
-    def _make_startup_args(self, startup_kit=None, startup_target=None):
-        args = MagicMock()
-        args.startup_kit = startup_kit
-        args.startup_target = startup_target
-        return args
+    def test_study_session_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.study.study_cli import _study_session
 
-    def test_resolve_session_inputs_prefers_explicit_startup_kit_over_env_and_config(self, tmp_path, monkeypatch):
-        from nvflare.tool.study.study_cli import _resolve_session_inputs
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        fake_session = MagicMock()
 
-        explicit_dir = tmp_path / "explicit-admin"
-        env_dir = tmp_path / "env-admin"
-        explicit_dir.mkdir()
-        env_dir.mkdir()
-        args = self._make_startup_args(startup_kit=str(explicit_dir), startup_target=None)
-        monkeypatch.setenv("NVFLARE_STARTUP_KIT_DIR", str(env_dir))
+        with patch("nvflare.tool.cli_session.new_secure_session", return_value=fake_session) as new_secure:
+            with _study_session(Namespace()) as sess:
+                assert sess is fake_session
 
-        with patch("nvflare.utils.cli_utils.find_startup_kit_location") as find_startup:
-            with patch(
-                "nvflare.tool.study.study_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", str(explicit_dir)),
-            ) as resolve_admin:
-                assert _resolve_session_inputs(args) == ("admin@nvidia.com", str(explicit_dir))
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
 
-        find_startup.assert_not_called()
-        resolve_admin.assert_called_once_with(str(explicit_dir))
+    def test_try_get_caller_role_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.study.study_cli import _try_get_caller_role
 
-    def test_resolve_session_inputs_uses_env_before_config(self, tmp_path, monkeypatch):
-        from nvflare.tool.study.study_cli import _resolve_session_inputs
-
-        env_dir = tmp_path / "env-admin"
-        env_dir.mkdir()
-        args = self._make_startup_args(startup_kit=None, startup_target="prod")
-        monkeypatch.setenv("NVFLARE_STARTUP_KIT_DIR", str(env_dir))
-
-        with patch("nvflare.utils.cli_utils.find_startup_kit_location") as find_startup:
-            with patch(
-                "nvflare.tool.study.study_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", str(env_dir)),
-            ) as resolve_admin:
-                assert _resolve_session_inputs(args) == ("admin@nvidia.com", str(env_dir))
-
-        find_startup.assert_not_called()
-        resolve_admin.assert_called_once_with(str(env_dir))
-
-    @pytest.mark.parametrize("startup_target", [None, "prod"])
-    def test_resolve_session_inputs_uses_config_fallback(self, tmp_path, monkeypatch, startup_target):
-        from nvflare.tool.study.study_cli import _resolve_session_inputs
-
-        configured_dir = tmp_path / "configured-admin"
-        configured_dir.mkdir()
-        args = self._make_startup_args(startup_kit=None, startup_target=startup_target)
-        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
 
         with patch(
-            "nvflare.utils.cli_utils.find_startup_kit_location", return_value=str(configured_dir)
-        ) as find_startup:
-            with patch(
-                "nvflare.tool.study.study_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", str(configured_dir)),
-            ) as resolve_admin:
-                assert _resolve_session_inputs(args) == ("admin@nvidia.com", str(configured_dir))
+            "nvflare.tool.study.study_cli._get_caller_role_from_startup_kit",
+            return_value="project_admin",
+        ) as get_role:
+            assert _try_get_caller_role(Namespace()) == "project_admin"
 
-        find_startup.assert_called_once_with(target=startup_target)
-        resolve_admin.assert_called_once_with(str(configured_dir))
+        get_role.assert_called_once_with(str(active_admin_dir))
 
     def test_get_caller_role_from_startup_kit_reads_cert_role(self, tmp_path):
         from nvflare.fuel.hci.client.api_spec import AdminConfigKey
@@ -160,20 +149,118 @@ class TestStudyCli:
                 ):
                     assert _get_caller_role_from_startup_kit(str(tmp_path)) == "project_admin"
 
-    def test_study_session_missing_startup_kit_when_no_source_resolves(self, capsys, monkeypatch):
+    def test_study_session_missing_startup_kit_when_no_source_resolves(self, capsys, monkeypatch, tmp_path):
         from nvflare.tool.study.study_cli import _study_session
 
-        args = self._make_startup_args()
+        args = Namespace()
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
         monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
 
-        with patch("nvflare.utils.cli_utils.find_startup_kit_location", return_value=None):
-            with pytest.raises(SystemExit) as exc_info:
-                with _study_session(args):
-                    pass
+        with pytest.raises(SystemExit) as exc_info:
+            with _study_session(args):
+                pass
 
         assert exc_info.value.code == 4
         payload = json.loads(capsys.readouterr().out)
         assert payload["error_code"] == "STARTUP_KIT_MISSING"
+
+    def test_add_user_uses_active_startup_kit_and_preserves_study_args(self, tmp_path, monkeypatch):
+        from nvflare.tool.study.study_cli import cmd_add_user
+
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        args = Namespace(study="cancer-research", user="trainer@org_a.com")
+        fake_session = MagicMock()
+        fake_session.add_study_user.return_value = {"study": args.study, "user": args.user}
+
+        with patch("sys.argv", ["nvflare", "study", "add-user", args.study, args.user]):
+            with patch("nvflare.tool.cli_session.new_secure_session", return_value=fake_session) as new_secure:
+                cmd_add_user(args)
+
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
+        fake_session.add_study_user.assert_called_once_with("cancer-research", "trainer@org_a.com")
+
+    @pytest.mark.parametrize(
+        ("argv_prefix"),
+        [
+            ["register", "cancer-research", "--site-org", "nvidia:site-1"],
+            ["add-site", "cancer-research", "--site-org", "nvidia:site-2"],
+            ["remove-site", "cancer-research", "--site-org", "nvidia:site-2"],
+            ["remove", "cancer-research"],
+            ["list"],
+            ["show", "cancer-research"],
+            ["add-user", "cancer-research", "trainer@org_a.com"],
+            ["remove-user", "cancer-research", "trainer@org_a.com"],
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_kit", "/tmp/startup"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_target", "prod"),
+        ],
+    )
+    def test_study_parser_rejects_old_startup_selectors(self, argv_prefix, selector, value):
+        import argparse
+
+        from nvflare.tool.study.study_cli import def_study_cli_parser
+
+        root = argparse.ArgumentParser(prog="nvflare")
+        parser = def_study_cli_parser(root.add_subparsers(dest="sub_command"))["study"]
+
+        with pytest.raises(SystemExit):
+            parser.parse_args([*argv_prefix, selector, value])
+
+    def test_study_parser_accepts_multiple_space_delimited_sites(self):
+        import argparse
+
+        from nvflare.tool.study.study_cli import def_study_cli_parser
+
+        root = argparse.ArgumentParser(prog="nvflare")
+        parser = def_study_cli_parser(root.add_subparsers(dest="sub_command"))["study"]
+
+        args = parser.parse_args(["register", "cancer-research", "--sites", "site-1", "site-2"])
+
+        assert args.sites == ["site-1", "site-2"]
+
+    def test_study_help_omits_old_startup_selectors(self):
+        import argparse
+
+        from nvflare.tool.study import study_cli
+
+        root = argparse.ArgumentParser(prog="nvflare")
+        study_cli.def_study_cli_parser(root.add_subparsers(dest="sub_command"))
+
+        for parser in study_cli._study_sub_cmd_parsers.values():
+            help_text = parser.format_help()
+            for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+                assert token not in help_text
+
+    @pytest.mark.parametrize(
+        ("cmd_name", "handler_name"),
+        [
+            ("register", "cmd_register"),
+            ("add-site", "cmd_add_site"),
+            ("remove-site", "cmd_remove_site"),
+            ("remove", "cmd_remove"),
+            ("list", "cmd_list"),
+            ("show", "cmd_show"),
+            ("add-user", "cmd_add_user"),
+            ("remove-user", "cmd_remove_user"),
+        ],
+    )
+    def test_study_schema_omits_old_startup_selectors(self, capsys, cmd_name, handler_name):
+        import nvflare.tool.study.study_cli as study_cli_mod
+
+        with patch("sys.argv", ["nvflare", "study", cmd_name, "--schema"]):
+            with pytest.raises(SystemExit) as exc_info:
+                getattr(study_cli_mod, handler_name)(MagicMock())
+
+        assert exc_info.value.code == 0
+        schema_text = capsys.readouterr().out
+        for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+            assert token not in schema_text
 
     def test_register_missing_sites_is_structured_usage_error(self, capsys):
         from nvflare.tool.study.study_cli import cmd_register
@@ -183,8 +270,9 @@ class TestStudyCli:
         args.sites = None
         args.site_org = []
 
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_register(args)
+        with patch("nvflare.tool.study.study_cli._try_get_caller_role", return_value=None):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_register(args)
 
         assert exc_info.value.code == 4
         payload = json.loads(capsys.readouterr().out)
@@ -310,6 +398,25 @@ class TestStudyCli:
         payload = json.loads(capsys.readouterr().out)
         assert payload["status"] == "ok"
         assert payload["data"]["added"] == ["hospital-b"]
+
+    def test_register_passes_multiple_sites_to_session(self, capsys):
+        from nvflare.tool.study.study_cli import cmd_register
+
+        args = MagicMock()
+        args.name = "cancer-research"
+        args.sites = ["site-1", "site-2"]
+        args.site_org = []
+        mock_sess = MagicMock()
+        mock_sess.register_study.return_value = {"name": "cancer-research", "sites": ["site-1", "site-2"]}
+
+        with patch("nvflare.tool.study.study_cli._study_session", return_value=nullcontext(mock_sess)):
+            with patch("nvflare.tool.study.study_cli._try_get_caller_role", return_value="org_admin"):
+                cmd_register(args)
+
+        mock_sess.register_study.assert_called_once_with("cancer-research", sites=["site-1", "site-2"], site_orgs=None)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "ok"
+        assert payload["data"]["sites"] == ["site-1", "site-2"]
 
     def test_remove_site_outputs_ok_envelope(self, capsys):
         from nvflare.tool.study.study_cli import cmd_remove_site

--- a/tests/unit_test/tool/system/system_status_test.py
+++ b/tests/unit_test/tool/system/system_status_test.py
@@ -22,6 +22,34 @@ from nvflare.fuel.flare_api.api_spec import AuthenticationError, InvalidTarget, 
 from nvflare.tool import cli_output
 
 
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text('{"admin": {"username": "admin@nvidia.com"}}', encoding="utf-8")
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
 class TestSystemStatus:
     """Tests for nvflare system status command."""
 
@@ -32,10 +60,8 @@ class TestSystemStatus:
     def _make_args(self, target=None, client_names=None, output="json"):
         args = MagicMock()
         args.target = target
-        args.startup_target = None
         args.client_names = client_names or []
         args.output = output
-        args.startup_kit = None
         return args
 
     def test_status_json_output_shape(self, capsys):
@@ -157,112 +183,44 @@ class TestSystemStatus:
 
         mock_sess.check_status.assert_called_once_with("all", None)
 
-    def test_get_system_session_missing_username_exits_startup_kit_missing(self, capsys):
+    def test_get_system_session_uses_active_startup_kit(self, tmp_path, monkeypatch):
         from nvflare.tool.system.system_cli import _get_system_session
 
-        args = MagicMock()
-        args.target = None
-        args.startup_target = None
-        args.startup_kit = None
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        fake_session = MagicMock()
 
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            return_value="/tmp/poc-startup",
-        ):
-            with patch(
-                "nvflare.tool.job.job_cli._resolve_admin_user_and_dir_from_startup_kit",
-                side_effect=Exception("bad startup"),
-            ):
-                with pytest.raises(SystemExit) as exc_info:
-                    _get_system_session(args)
+        with patch("nvflare.tool.cli_session.new_secure_session", return_value=fake_session) as new_secure:
+            sess = _get_system_session(argparse.Namespace())
 
-        assert exc_info.value.code == 4
-        envelope = json.loads(capsys.readouterr().out)
-        assert envelope["error_code"] == "STARTUP_KIT_MISSING"
-        assert "admin username could not be resolved" in envelope["message"]
+        assert sess is fake_session
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
 
-    def test_get_system_session_still_exits_if_output_error_is_mocked(self):
+    def test_get_system_session_still_exits_if_output_error_is_mocked(self, monkeypatch, tmp_path):
         from nvflare.tool.system.system_cli import _get_system_session
 
-        args = MagicMock()
-        args.target = None
-        args.startup_target = None
-        args.startup_kit = None
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
 
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            side_effect=ValueError("no startup kit configured"),
-        ):
-            with patch("nvflare.tool.system.system_cli.output_error") as mocked_output_error:
-                with pytest.raises(SystemExit) as exc_info:
-                    _get_system_session(args)
+        with patch("nvflare.tool.system.system_cli.output_error") as mocked_output_error:
+            with pytest.raises(SystemExit) as exc_info:
+                _get_system_session(argparse.Namespace())
 
         assert exc_info.value.code == 4
         mocked_output_error.assert_called_once()
 
-    def test_get_system_session_startup_kit_fallback_error_uses_startup_kit_missing(self, capsys):
+    def test_get_system_session_active_resolver_error_uses_startup_kit_missing(self, capsys, monkeypatch, tmp_path):
         from nvflare.tool.system.system_cli import _get_system_session
 
-        args = MagicMock()
-        args.target = None
-        args.startup_target = None
-        args.startup_kit = None
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
 
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            side_effect=ValueError("no startup kit configured"),
-        ):
-            with pytest.raises(SystemExit) as exc_info:
-                _get_system_session(args)
+        with pytest.raises(SystemExit) as exc_info:
+            _get_system_session(argparse.Namespace())
 
         assert exc_info.value.code == 4
         envelope = json.loads(capsys.readouterr().out)
         assert envelope["error_code"] == "STARTUP_KIT_MISSING"
-        assert "no startup kit configured" in envelope["message"]
-
-    def test_get_system_session_uses_explicit_target(self):
-        from nvflare.tool.system.system_cli import _get_system_session
-
-        args = MagicMock()
-        args.target = "prod"
-        args.startup_target = "prod"
-        args.startup_kit = None
-
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            return_value="/tmp/prod-startup",
-        ) as get_startup:
-            with patch(
-                "nvflare.tool.job.job_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", "/tmp/prod-startup"),
-            ):
-                with patch("nvflare.tool.cli_session.new_cli_session", return_value=MagicMock()):
-                    with patch("nvflare.tool.cli_output.get_connect_timeout", return_value=10.0):
-                        _get_system_session(args)
-
-        get_startup.assert_called_once_with(startup_kit_dir=None, target="prod")
-
-    def test_get_system_session_uses_explicit_startup_kit_override(self):
-        from nvflare.tool.system.system_cli import _get_system_session
-
-        args = MagicMock()
-        args.target = "prod"
-        args.startup_target = "prod"
-        args.startup_kit = "/tmp/custom-startup"
-
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            return_value="/tmp/custom-startup",
-        ) as get_startup:
-            with patch(
-                "nvflare.tool.job.job_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", "/tmp/custom-startup"),
-            ):
-                with patch("nvflare.tool.cli_session.new_cli_session", return_value=MagicMock()):
-                    with patch("nvflare.tool.cli_output.get_connect_timeout", return_value=10.0):
-                        _get_system_session(args)
-
-        get_startup.assert_called_once_with(startup_kit_dir="/tmp/custom-startup", target="prod")
 
     def test_confirm_or_force_does_not_prompt_when_output_error_is_mocked(self):
         from nvflare.tool.system.system_cli import _confirm_or_force
@@ -281,50 +239,6 @@ class TestSystemStatus:
         mocked_output_error.assert_called_once()
         prompt_yn.assert_not_called()
 
-    def test_get_system_session_succeeds_when_defaulting_to_poc_target(self, monkeypatch):
-        from nvflare.tool.system.system_cli import _get_system_session
-
-        monkeypatch.setattr(cli_output, "_output_format", "txt")
-        args = MagicMock()
-        args.target = None
-        args.startup_target = None
-        args.startup_kit = None
-
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            return_value="/tmp/poc-startup",
-        ):
-            with patch(
-                "nvflare.tool.job.job_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", "/tmp/poc-startup"),
-            ):
-                with patch("nvflare.tool.cli_session.new_cli_session", return_value=MagicMock()):
-                    with patch("nvflare.tool.cli_output.get_connect_timeout", return_value=10.0):
-                        _get_system_session(args)  # should not raise
-
-    def test_get_system_session_resolves_startup_kit_once_before_username_lookup(self):
-        from nvflare.tool.system.system_cli import _get_system_session
-
-        args = MagicMock()
-        args.target = "prod"
-        args.startup_target = "prod"
-        args.startup_kit = None
-
-        with patch(
-            "nvflare.utils.cli_utils.get_startup_kit_dir_for_target",
-            return_value="/tmp/prod-startup",
-        ) as get_startup:
-            with patch(
-                "nvflare.tool.job.job_cli._resolve_admin_user_and_dir_from_startup_kit",
-                return_value=("admin@nvidia.com", "/tmp/prod-startup"),
-            ) as resolve_admin:
-                with patch("nvflare.tool.cli_session.new_cli_session", return_value=MagicMock()):
-                    with patch("nvflare.tool.cli_output.get_connect_timeout", return_value=10.0):
-                        _get_system_session(args)
-
-        get_startup.assert_called_once_with(startup_kit_dir=None, target="prod")
-        resolve_admin.assert_called_once_with("/tmp/prod-startup")
-
     def test_system_session_none_guard_when_get_system_session_returns_none(self):
         from nvflare.tool.system.system_cli import _system_session
 
@@ -332,17 +246,184 @@ class TestSystemStatus:
             with _system_session():
                 pass
 
-    def test_system_parser_accepts_startup_kit_after_subcommand(self):
+    @pytest.mark.parametrize(
+        ("argv_prefix"),
+        [
+            ["status"],
+            ["resources"],
+            ["shutdown", "server", "--force"],
+            ["restart", "server", "--force"],
+            ["remove-client", "site-1", "--force"],
+            ["version"],
+            ["log-config", "INFO"],
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_target", "prod"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_kit", "/tmp/startup"),
+        ],
+    )
+    def test_system_parser_rejects_old_startup_selectors_after_subcommand(self, argv_prefix, selector, value):
         from nvflare.tool.system.system_cli import def_system_cli_parser
 
         parser = argparse.ArgumentParser(prog="nvflare system")
         def_system_cli_parser(parser)
 
-        args = parser.parse_args(["status", "--startup-kit", "/tmp/startup", "--startup-target", "prod"])
+        with pytest.raises(SystemExit):
+            parser.parse_args([*argv_prefix, selector, value])
 
-        assert args.system_sub_cmd == "status"
-        assert args.startup_kit == "/tmp/startup"
-        assert args.startup_target == "prod"
+    @pytest.mark.parametrize(
+        ("selector", "value"),
+        [
+            ("--startup-target", "prod"),
+            ("--startup_target", "prod"),
+            ("--startup-kit", "/tmp/startup"),
+            ("--startup_kit", "/tmp/startup"),
+        ],
+    )
+    def test_system_parser_rejects_old_startup_selectors_before_subcommand(self, selector, value):
+        from nvflare.tool.system.system_cli import def_system_cli_parser
+
+        parser = argparse.ArgumentParser(prog="nvflare system")
+        def_system_cli_parser(parser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args([selector, value, "status"])
+
+    def test_system_help_and_schema_omit_old_startup_selectors(self, capsys):
+        from nvflare.tool.system import system_cli
+
+        parser = argparse.ArgumentParser(prog="nvflare system")
+        system_cli.def_system_cli_parser(parser)
+
+        all_help = [parser.format_help()] + [p.format_help() for p in system_cli._system_sub_cmd_parsers.values()]
+        for help_text in all_help:
+            for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+                assert token not in help_text
+
+        schema_cases = [
+            ("status", system_cli.cmd_system_status),
+            ("resources", system_cli.cmd_system_resources),
+            ("shutdown", system_cli.cmd_system_shutdown),
+            ("restart", system_cli.cmd_system_restart),
+            ("remove-client", system_cli.cmd_system_remove_client),
+            ("version", system_cli.cmd_system_version),
+            ("log-config", system_cli.cmd_system_log),
+        ]
+        for cmd_name, handler in schema_cases:
+            with patch("sys.argv", ["nvflare", "system", cmd_name, "--schema"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    handler(MagicMock())
+            assert exc_info.value.code == 0
+            schema_text = capsys.readouterr().out
+            for token in ("--startup-target", "--startup_target", "--startup-kit", "--startup_kit"):
+                assert token not in schema_text
+
+
+class TestSystemActiveStartupKit:
+    @pytest.fixture(autouse=True)
+    def json_mode(self, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    def _run_and_assert_active_session(self, tmp_path, monkeypatch, command_fn, args, configure_session):
+        active_admin_dir = _configure_active_startup_kit(tmp_path, monkeypatch)
+        sess = MagicMock()
+        configure_session(sess)
+
+        with patch("nvflare.tool.cli_session.new_secure_session", return_value=sess) as new_secure:
+            command_fn(args)
+
+        assert new_secure.call_args.kwargs["username"] == "admin@nvidia.com"
+        assert new_secure.call_args.kwargs["startup_kit_location"] == str(active_admin_dir)
+        return sess
+
+    def test_status_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.system.system_cli import cmd_system_status
+
+        args = argparse.Namespace(target=None, client_names=[], output="json")
+        sess = self._run_and_assert_active_session(
+            tmp_path,
+            monkeypatch,
+            cmd_system_status,
+            args,
+            lambda s: setattr(s.check_status, "return_value", {"server_status": "running"}),
+        )
+
+        sess.check_status.assert_called_once_with("all", None)
+
+    def test_resources_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.system.system_cli import cmd_system_resources
+
+        args = argparse.Namespace(target=None, client_names=[], output="json")
+        sess = self._run_and_assert_active_session(
+            tmp_path,
+            monkeypatch,
+            cmd_system_resources,
+            args,
+            lambda s: setattr(s.report_resources, "return_value", {"server": {"cpu": 1}}),
+        )
+
+        sess.report_resources.assert_called_once_with("all", None)
+
+    def test_shutdown_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.system.system_cli import cmd_system_shutdown
+
+        args = argparse.Namespace(target="server", client_names=[], force=True)
+        sess = self._run_and_assert_active_session(
+            tmp_path,
+            monkeypatch,
+            cmd_system_shutdown,
+            args,
+            lambda s: setattr(s.shutdown, "return_value", {"status": "ok"}),
+        )
+
+        sess.shutdown.assert_called_once_with("server", client_names=None)
+
+    def test_restart_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.system.system_cli import cmd_system_restart
+
+        args = argparse.Namespace(target="server", client_names=[], force=True)
+        sess = self._run_and_assert_active_session(
+            tmp_path,
+            monkeypatch,
+            cmd_system_restart,
+            args,
+            lambda s: setattr(s.restart, "return_value", {"status": "ok"}),
+        )
+
+        sess.restart.assert_called_once_with("server", client_names=None)
+
+    def test_version_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.system.system_cli import cmd_system_version
+
+        args = argparse.Namespace(site="server")
+        sess = self._run_and_assert_active_session(
+            tmp_path,
+            monkeypatch,
+            cmd_system_version,
+            args,
+            lambda s: setattr(s.report_version, "return_value", {"server": {"version": "1.0.0"}}),
+        )
+
+        sess.report_version.assert_called_once_with("server", None)
+
+    def test_log_config_uses_active_startup_kit(self, tmp_path, monkeypatch):
+        from nvflare.tool.system.system_cli import cmd_system_log
+
+        args = argparse.Namespace(level="INFO", site="server", schema=False)
+        sess = self._run_and_assert_active_session(
+            tmp_path,
+            monkeypatch,
+            cmd_system_log,
+            args,
+            lambda s: setattr(s.configure_site_log, "return_value", None),
+        )
+
+        sess.configure_site_log.assert_called_once_with("INFO", target="server")
 
 
 class TestSystemResources:
@@ -470,8 +551,6 @@ class TestSystemShutdown:
         args.target = target
         args.client_names = client_names or []
         args.force = force
-        args.startup_target = None
-        args.startup_kit = None
         return args
 
     def _make_session(self, result=None):
@@ -605,8 +684,6 @@ class TestSystemRestart:
         args.target = target
         args.client_names = client_names or []
         args.force = force
-        args.startup_target = None
-        args.startup_kit = None
         return args
 
     def _make_session(self, result=None):
@@ -715,8 +792,6 @@ class TestSystemRemoveClient:
         args = MagicMock()
         args.client_name = client_name
         args.force = force
-        args.startup_target = None
-        args.startup_kit = None
         return args
 
     def test_remove_client_calls_session_remove_client(self, capsys):

--- a/tests/unit_test/utils/cli_utils_test.py
+++ b/tests/unit_test/utils/cli_utils_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from pyhocon import ConfigFactory as CF
@@ -20,14 +19,11 @@ from pyhocon import ConfigFactory as CF
 from nvflare.utils.cli_utils import (
     append_if_not_in_list,
     backup_hidden_config_file,
-    create_startup_kit_config,
-    ensure_hidden_config_migrated,
+    find_startup_kit_config_keys,
     get_hidden_nvflare_config_path,
     get_hidden_nvflare_dir,
-    get_startup_kit_dir_for_target,
     load_hidden_config,
-    migrate_config_to_v2,
-    persist_hidden_config_migration,
+    remove_startup_kit_config_keys,
     save_config,
 )
 
@@ -42,79 +38,53 @@ class TestCLIUtils:
             Path.home() / ".nvflare/config.conf"
         )
 
-    def test_create_startup_kit_config(self):
-        with patch("nvflare.utils.cli_utils.check_startup_dir", side_effect=None) as mock:
-            mock.return_value = ""
-            with patch("os.path.isdir", side_effect=None) as mock1:
-                mock1.return_value = True
-                prev_conf = CF.parse_string(
-                    """
-                        version = 2
-                        poc {
-                            workspace = "/tmp/nvflare/poc"
-                        }
-                    """
-                )
-                config = create_startup_kit_config(
-                    nvflare_config=prev_conf,
-                    target="prod",
-                    startup_kit_dir="/tmp/nvflare/poc/example_project/prod_00",
-                )
-
-                assert "/tmp/nvflare/poc" == config.get("poc.workspace")
-                assert "/tmp/nvflare/poc/example_project/prod_00" == config.get("prod.startup_kit")
-
-                config = create_startup_kit_config(nvflare_config=prev_conf, target="prod", startup_kit_dir="")
-
-                assert config.get("prod.startup_kit", None) is None
-
-    def test_migrate_config_to_v2_copies_legacy_startup_and_workspace(self):
-        legacy = CF.parse_string(
-            """
-                startup_kit {
-                    path = "/tmp/nvflare/legacy/prod_00"
-                }
-                poc_workspace {
-                    path = "/tmp/nvflare/poc"
-                }
-            """
-        )
-
-        config = migrate_config_to_v2(legacy)
-
-        assert 2 == config.get("version")
-        assert "/tmp/nvflare/legacy/prod_00" == config.get("poc.startup_kit")
-        assert "/tmp/nvflare/poc" == config.get("poc.workspace")
-        config_dict = config.as_plain_ordered_dict()
-        assert "version" in config_dict
-        assert "config_version" not in config_dict
-        assert "startup_kit" not in config_dict
-        assert "poc_workspace" not in config_dict
-        assert "prod" not in config_dict
-
-    def test_get_startup_kit_dir_for_target_prefers_env_override(self, monkeypatch):
-        monkeypatch.setenv("NVFLARE_STARTUP_KIT_DIR", "/tmp/override")
-        with patch("nvflare.utils.cli_utils.check_startup_dir"):
-            assert "/tmp/override" == get_startup_kit_dir_for_target(target="prod")
-
-    def test_get_startup_kit_dir_for_target_reads_targeted_v2_config(self):
+    def test_remove_startup_kit_config_keys_preserves_registry(self):
         config = CF.parse_string(
             """
                 version = 2
+                startup_kits {
+                    active = "admin"
+                    entries {
+                        admin = "/tmp/admin"
+                    }
+                }
                 poc {
-                    startup_kit = "/tmp/nvflare/poc/prod_00"
+                    startup_kit = "/tmp/old-poc"
+                    workspace = "/tmp/nvflare/poc"
                 }
                 prod {
-                    startup_kit = "/tmp/nvflare/prod/admin@nvidia.com"
+                    startup_kit = "/tmp/old-prod"
                 }
             """
         )
-        with patch("nvflare.utils.cli_utils.load_hidden_config", return_value=config):
-            with patch("nvflare.utils.cli_utils.check_startup_dir"):
-                assert "/tmp/nvflare/poc/prod_00" == get_startup_kit_dir_for_target(target="poc")
-                assert "/tmp/nvflare/prod/admin@nvidia.com" == get_startup_kit_dir_for_target(target="prod")
 
-    def test_load_hidden_config_migrates_in_memory_without_persisting(self, tmp_path, monkeypatch):
+        updated = remove_startup_kit_config_keys(config)
+
+        assert updated.get("startup_kits.active") == "admin"
+        assert updated.get("startup_kits.entries.admin") == "/tmp/admin"
+        assert updated.get("poc.workspace") == "/tmp/nvflare/poc"
+        assert updated.get("poc.startup_kit", None) is None
+        assert updated.get("prod.startup_kit", None) is None
+
+    def test_find_startup_kit_config_keys_reports_removed_keys(self):
+        config = CF.parse_string(
+            """
+                startup_kits {
+                    active = "admin"
+                }
+                poc {
+                    startup_kit = "/tmp/old-poc"
+                    workspace = "/tmp/nvflare/poc"
+                }
+                prod {
+                    startup_kit = "/tmp/old-prod"
+                }
+            """
+        )
+
+        assert find_startup_kit_config_keys(config) == ["poc.startup_kit", "prod.startup_kit"]
+
+    def test_load_hidden_config_reads_without_migration_or_persistence(self, tmp_path, monkeypatch):
         hidden_dir = tmp_path / ".nvflare"
         hidden_dir.mkdir()
         config_path = hidden_dir / "config.conf"
@@ -130,60 +100,13 @@ poc_workspace {
 
         monkeypatch.setattr("nvflare.utils.cli_utils.get_or_create_hidden_nvflare_dir", lambda: hidden_dir)
 
-        migrated = load_hidden_config()
+        loaded = load_hidden_config()
 
-        assert migrated.get_int("version") == 2
+        assert loaded.get("startup_kit.path") == "/tmp/nvflare/legacy/prod_00"
+        assert loaded.get("poc_workspace.path") == "/tmp/nvflare/poc"
         persisted = config_path.read_text()
         assert persisted.strip() == legacy_text
         assert not (hidden_dir / "config.conf.bak").exists()
-
-    def test_persist_hidden_config_migration_writes_backup_and_migrated_config(self, tmp_path):
-        hidden_dir = tmp_path / ".nvflare"
-        hidden_dir.mkdir()
-        config_path = hidden_dir / "config.conf"
-        legacy_text = """
-startup_kit {
-  path = "/tmp/nvflare/legacy/prod_00"
-}
-poc_workspace {
-  path = "/tmp/nvflare/poc"
-}
-""".strip()
-        config_path.write_text(legacy_text)
-
-        migrated = migrate_config_to_v2(CF.parse_string(legacy_text))
-        persist_hidden_config_migration(str(config_path), migrated)
-
-        persisted = config_path.read_text()
-        assert "version = 2" in persisted
-        assert "config_version" not in persisted
-        assert "startup_kit {" not in persisted
-        backup_path = hidden_dir / "config.conf.bak"
-        assert backup_path.exists()
-        assert backup_path.read_text().strip() == legacy_text
-
-    def test_ensure_hidden_config_migrated_persists_legacy_file_once(self, tmp_path, monkeypatch):
-        hidden_dir = tmp_path / ".nvflare"
-        hidden_dir.mkdir()
-        config_path = hidden_dir / "config.conf"
-        legacy_text = """
-startup_kit {
-  path = "/tmp/nvflare/legacy/prod_00"
-}
-poc_workspace {
-  path = "/tmp/nvflare/poc"
-}
-""".strip()
-        config_path.write_text(legacy_text)
-
-        monkeypatch.setattr("nvflare.utils.cli_utils.get_or_create_hidden_nvflare_dir", lambda: hidden_dir)
-
-        ensure_hidden_config_migrated()
-
-        persisted = config_path.read_text()
-        assert "version = 2" in persisted
-        assert "startup_kit {" not in persisted
-        assert (hidden_dir / "config.conf.bak").read_text().strip() == legacy_text
 
     def test_backup_hidden_config_file_returns_none_when_source_missing(self, tmp_path):
         hidden_dir = tmp_path / ".nvflare"
@@ -195,6 +118,21 @@ poc_workspace {
         assert backup_path is None
         assert not (hidden_dir / "config.conf.bak").exists()
 
+    def test_backup_hidden_config_file_uses_non_overwriting_suffixes(self, tmp_path):
+        config_path = tmp_path / "config.conf"
+        config_path.write_text("current\n")
+        backup_path = tmp_path / "config.conf.bak"
+        backup1_path = tmp_path / "config.conf.bak1"
+        backup_path.write_text("older\n")
+        backup1_path.write_text("older1\n")
+
+        new_backup_path = backup_hidden_config_file(str(config_path))
+
+        assert new_backup_path == str(tmp_path / "config.conf.bak2")
+        assert Path(new_backup_path).read_text() == "current\n"
+        assert backup_path.read_text() == "older\n"
+        assert backup1_path.read_text() == "older1\n"
+
     def test_save_config_replaces_file_atomically_without_temp_leak(self, tmp_path):
         config_path = tmp_path / "config.conf"
         config_path.write_text("version = 1\n")
@@ -202,7 +140,7 @@ poc_workspace {
             """
                 version = 2
                 poc {
-                    startup_kit = "/tmp/nvflare/poc/prod_00"
+                    workspace = "/tmp/nvflare/poc"
                 }
             """
         )
@@ -211,7 +149,7 @@ poc_workspace {
 
         persisted = config_path.read_text()
         assert "version = 2" in persisted
-        assert 'startup_kit = "/tmp/nvflare/poc/prod_00"' in persisted
+        assert 'workspace = "/tmp/nvflare/poc"' in persisted
         assert list(tmp_path.glob("tmp*")) == []
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add a local startup kit registry with the new `nvflare config kit` command so server-connected commands use one active kit instead of repeated `--startup-target` / `--startup-kit` arguments.
- Route `nvflare job`, `nvflare study`, and `nvflare system` through shared active-kit session resolution, with `NVFLARE_STARTUP_KIT_DIR` kept as the automation override.
- Update POC workflows so `poc prepare` and `poc add user` register generated admin/user startup kits in `~/.nvflare/config.conf`; `poc add site` provisions a site kit but does not register it as an active CLI identity.
- Add project-admin validation before `poc add user` / `poc add site` mutate local POC metadata.
- Improve `nvflare config` migration behavior by backing up `config.conf` and warning when old startup-kit keys such as `poc.startup_kit` or `prod.startup_kit` are stripped.
- Expand `nvflare job logs` to read server-side stored logs, including client logs already streamed to the server, with human-readable default output and JSON support.
- Update CLI user guides, migration notes, and the consolidated CLI design doc to match the implemented behavior.

## Details

### Startup kit registry

- Adds `nvflare/tool/kit` with `add`, `use`, `show`, `list`, and `remove` handlers under `nvflare config kit`.
- Stores local kit registrations under `startup_kits.entries` and active selection under `startup_kits.active`.
- Supports admin/user kits for active command sessions.
- Rejects site/server kits through `nvflare config kit add`; if manually edited or migrated config contains stale non-admin entries, `kit list` shows them so users can remove them.
- Keeps startup-kit path management out of the root `nvflare config` options.

### POC workflow

- `poc prepare` registers generated project admin, org admin, lead, and other admin/user startup kits. Site startup kits are not registered because they are service identities, not CLI user identities.
- `poc add user` persists local POC project metadata, reuses the existing POC provisioning state, registers the generated user kit, and preserves the active kit unless no active kit exists.
- `poc add site` persists the new client participant and generates the site startup kit, but does not register the site kit in the active startup-kit registry.
- `poc clean` removes POC-generated registry entries using canonical workspace path matching.

### Job logs

- Removes `--tail` and `--grep` from `nvflare job logs`.
- Defaults to server logs and supports `--site server`, `--site <client>`, and `--site all`.
- Keeps `Session.get_job_logs(..., tail_lines=..., grep_pattern=...)` compatibility for Python callers by filtering locally in the session wrapper.
- Reads live server workspace logs first, then stored job workspace artifacts.
- Reads client logs from server-side live/stored job log locations, with fallback to stored client-data log components.
- Reports missing logs through `LOG_NOT_FOUND` or `unavailable` for partial `--site all` results.

### Study and system CLI

- Adds multi-study lifecycle command handling and startup-kit based session creation.
- Updates system commands to use the same shared active-kit session path.
- Keeps study site parsing backward compatible with comma-delimited and space-delimited `--sites` values.

## Testing

- `python -m pytest tests/unit_test/private/fed/server/job_cmds_test.py tests/unit_test/tool/kit/kit_cli_test.py tests/unit_test/tool/kit/kit_config_test.py tests/unit_test/tool/poc/poc_force_test.py tests/unit_test/fuel/flare_api/session_new_methods_test.py -q`
- `black --check`, `isort --check-only`, and `flake8` on touched Python files
- `git diff --cached --check`
