### PR TITLE
Add Helm pod annotation support

### DIFF
--- a/devops/multicloud/aws-server.yaml
+++ b/devops/multicloud/aws-server.yaml
@@ -15,6 +15,8 @@ clouds:
     pull_policy: Always
     helm_overrides: []
     security_context: { seLinuxOptions: { type: spc_t } }
+    pod_annotations:
+      karpenter.sh/do-not-disrupt: "true"
     pvc_config:
       nvflws:   { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
       nvfldata: { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }

--- a/devops/multicloud/deploy.py
+++ b/devops/multicloud/deploy.py
@@ -66,6 +66,7 @@ class Participant:
     security_context: dict | None = None
     pending_timeout: int | None = None
     pvc_config: dict = field(default_factory=dict)
+    pod_annotations: dict = field(default_factory=dict)
     # Kubernetes imagePullPolicy override. `None` keeps whatever the helm chart
     # defaults to (typically IfNotPresent). Set to "Always" on mutable dev tags.
     pull_policy: str | None = None
@@ -174,6 +175,7 @@ def load_config(config_path: Path) -> DeployConfig:
                 security_context=merged.get("security_context"),
                 pending_timeout=merged.get("pending_timeout"),
                 pvc_config=merged.get("pvc_config") or {},
+                pod_annotations=merged.get("pod_annotations") or {},
                 pull_policy=merged.get("pull_policy"),
             )
         )
@@ -184,7 +186,7 @@ def load_config(config_path: Path) -> DeployConfig:
 
     gcp = cloud_derived.get("gcp", {})
     aws = cloud_derived.get("aws", {})
-    azure = (clouds.get("azure") or {})
+    azure = clouds.get("azure") or {}
     return DeployConfig(
         participants=participants,
         server_cloud=server_cloud,
@@ -843,6 +845,11 @@ def deploy_participant(
         if p.security_context:
             for k, v in _flatten_set("securityContext", p.security_context):
                 helm_args += ["--set", f"{k}={v}"]
+
+        for k, v in p.pod_annotations.items():
+            escaped = k.replace(".", r"\.").replace("/", r"\/")
+            escaped_v = str(v).replace("\\", r"\\").replace(",", r"\,").replace("=", r"\=")
+            helm_args += ["--set-string", f"podAnnotations.{escaped}={escaped_v}"]
 
         if ":" in p.image:
             repo, tag = p.image.rsplit(":", 1)

--- a/devops/multicloud/gcp-server.yaml
+++ b/devops/multicloud/gcp-server.yaml
@@ -15,6 +15,8 @@ clouds:
     pull_policy: Always
     helm_overrides: []
     security_context: { seLinuxOptions: { type: spc_t } }
+    pod_annotations:
+      karpenter.sh/do-not-disrupt: "true"
     pvc_config:
       nvflws:   { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
       nvfldata: { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }

--- a/nvflare/lighter/impl/helm_chart.py
+++ b/nvflare/lighter/impl/helm_chart.py
@@ -175,6 +175,7 @@ class HelmChartBuilder(Builder):
                 "annotations": {},
                 "automountServiceAccountToken": True,
             },
+            "podAnnotations": {},
             "rbac": {
                 "create": True,
             },
@@ -295,6 +296,7 @@ class HelmChartBuilder(Builder):
                 "annotations": {},
                 "automountServiceAccountToken": True,
             },
+            "podAnnotations": {},
             "rbac": {
                 "create": True,
             },

--- a/nvflare/lighter/templates/helm/client/deployment.yaml
+++ b/nvflare/lighter/templates/helm/client/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         {{- include "nvflare-client.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "nvflare-client.name" . }}

--- a/nvflare/lighter/templates/helm/server/deployment.yaml
+++ b/nvflare/lighter/templates/helm/server/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         {{- include "nvflare-server.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "nvflare-server.name" . }}

--- a/tests/unit_test/devops/multicloud_deploy_test.py
+++ b/tests/unit_test/devops/multicloud_deploy_test.py
@@ -100,6 +100,7 @@ class TestHelmDeployFlow:
             launcher_class="launcher",
             image="repo/image:tag",
             pvc_config={"nvflws": {"sc": "sc", "access": "ReadWriteMany", "size": "10Gi"}},
+            pod_annotations={"karpenter.sh/do-not-disrupt": r"value,with=helm\chars"},
         )
 
         kubectl_calls = []
@@ -125,6 +126,8 @@ class TestHelmDeployFlow:
         kubeconfig, helm_args = helm_calls[0]
         assert kubeconfig == "/tmp/kubeconfig"
         assert helm_args[:4] == ("upgrade", "--install", "site-1", str(chart_dir))
+        assert "--set-string" in helm_args
+        assert r"podAnnotations.karpenter\.sh\/do-not-disrupt=value\,with\=helm\\chars" in helm_args
 
 
 class TestAzureIpValidation:


### PR DESCRIPTION
Adds pod annotation support to generated Helm charts and wires multicloud deployment config through to Helm as `podAnnotations` values. This lets internal AWS/Karpenter deployments mark NVFlare pods with `karpenter.sh/do-not-disrupt: "true"` from the multicloud YAML files.
