### PR TITLE
fix(xgboost): correct tree count in update_model for multi:softprob (#4484)

### DIFF
--- a/nvflare/app_opt/xgboost/tree_based/utils.py
+++ b/nvflare/app_opt/xgboost/tree_based/utils.py
@@ -46,7 +46,5 @@ def update_model(prev_model, model_update):
             prev_model["learner"]["gradient_booster"]["model"]["trees"].append(append_info[tree_ct])
             prev_model["learner"]["gradient_booster"]["model"]["tree_info"].append(append_tree_info[tree_ct])
         # append iteration_indptr
-        prev_model["learner"]["gradient_booster"]["model"]["iteration_indptr"].append(
-            pre_num_trees + add_num_trees
-        )
+        prev_model["learner"]["gradient_booster"]["model"]["iteration_indptr"].append(pre_num_trees + add_num_trees)
         return prev_model

--- a/nvflare/app_opt/xgboost/tree_based/utils.py
+++ b/nvflare/app_opt/xgboost/tree_based/utils.py
@@ -40,10 +40,11 @@ def update_model(prev_model, model_update):
         )
         # append the new trees
         append_info = model_update["learner"]["gradient_booster"]["model"]["trees"]
+        append_tree_info = model_update["learner"]["gradient_booster"]["model"]["tree_info"]
         for tree_ct in range(add_num_trees):
             append_info[tree_ct]["id"] = pre_num_trees + tree_ct
             prev_model["learner"]["gradient_booster"]["model"]["trees"].append(append_info[tree_ct])
-            prev_model["learner"]["gradient_booster"]["model"]["tree_info"].append(0)
+            prev_model["learner"]["gradient_booster"]["model"]["tree_info"].append(append_tree_info[tree_ct])
         # append iteration_indptr
         prev_model["learner"]["gradient_booster"]["model"]["iteration_indptr"].append(
             pre_num_trees + add_num_trees

--- a/nvflare/app_opt/xgboost/tree_based/utils.py
+++ b/nvflare/app_opt/xgboost/tree_based/utils.py
@@ -36,16 +36,16 @@ def update_model(prev_model, model_update):
                 f"add_num_parallel_tree should not change, previous {pre_num_parallel_tree}, current {cur_num_parallel_tree}"
             )
         prev_model["learner"]["gradient_booster"]["model"]["gbtree_model_param"]["num_trees"] = str(
-            pre_num_trees + cur_num_parallel_tree
+            pre_num_trees + add_num_trees
         )
         # append the new trees
         append_info = model_update["learner"]["gradient_booster"]["model"]["trees"]
-        for tree_ct in range(cur_num_parallel_tree):
+        for tree_ct in range(add_num_trees):
             append_info[tree_ct]["id"] = pre_num_trees + tree_ct
             prev_model["learner"]["gradient_booster"]["model"]["trees"].append(append_info[tree_ct])
             prev_model["learner"]["gradient_booster"]["model"]["tree_info"].append(0)
         # append iteration_indptr
         prev_model["learner"]["gradient_booster"]["model"]["iteration_indptr"].append(
-            pre_num_trees + cur_num_parallel_tree
+            pre_num_trees + add_num_trees
         )
         return prev_model

--- a/tests/unit_test/app_opt/xgboost/tree_based/__init__.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+import unittest
+
+import numpy as np
+import xgboost as xgb
+
+from nvflare.app_opt.xgboost.tree_based.utils import update_model
+
+
+def _make_client_model(num_class: int, num_parallel_tree: int) -> dict:
+    X = np.random.rand(100, 4)
+    y = np.random.randint(0, num_class, 100)
+    dtrain = xgb.DMatrix(X, label=y)
+    objective = "multi:softprob" if num_class > 1 else "binary:logistic"
+    params = {
+        "objective": objective,
+        "num_parallel_tree": num_parallel_tree,
+        "tree_method": "hist",
+    }
+    if num_class > 1:
+        params["num_class"] = num_class
+    bst = xgb.train(params, dtrain, num_boost_round=1)
+    return json.loads(bst.save_raw("json"))
+
+
+class TestUpdateModel(unittest.TestCase):
+    def test_binary_two_clients(self):
+        """Binary: num_trees == num_parallel_tree, merging 2 clients is correct."""
+        num_parallel_tree = 5
+        client = _make_client_model(num_class=1, num_parallel_tree=num_parallel_tree)
+        merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
+        model_body = merged["learner"]["gradient_booster"]["model"]
+        expected = 2 * num_parallel_tree
+        self.assertEqual(len(model_body["trees"]), expected)
+        self.assertEqual(int(model_body["gbtree_model_param"]["num_trees"]), expected)
+
+    def test_multiclass_two_clients(self):
+        """multi:softprob: each client has num_class * num_parallel_tree trees.
+        Merging 2 clients must produce 2 * num_class * num_parallel_tree trees."""
+        num_class, num_parallel_tree = 6, 5
+        client = _make_client_model(num_class=num_class, num_parallel_tree=num_parallel_tree)
+        trees_per_client = len(client["learner"]["gradient_booster"]["model"]["trees"])
+        self.assertEqual(trees_per_client, num_class * num_parallel_tree)
+
+        merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
+        model_body = merged["learner"]["gradient_booster"]["model"]
+        expected = 2 * trees_per_client
+        self.assertEqual(len(model_body["trees"]), expected,
+                         f"Expected {expected} trees, got {len(model_body['trees'])} "
+                         f"(num_class blindness bug)")
+        self.assertEqual(int(model_body["gbtree_model_param"]["num_trees"]), expected)
+
+    def test_tree_ids_are_sequential(self):
+        """After merging, tree ids must be 0..N-1 with no gaps."""
+        client = _make_client_model(num_class=6, num_parallel_tree=5)
+        merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
+        trees = merged["learner"]["gradient_booster"]["model"]["trees"]
+        ids = [t["id"] for t in trees]
+        self.assertEqual(ids, list(range(len(trees))))
+
+    def test_first_client_none_prev(self):
+        """update_model with no prior model returns the client model unchanged."""
+        client = _make_client_model(num_class=6, num_parallel_tree=5)
+        result = update_model(None, copy.deepcopy(client))
+        n = len(result["learner"]["gradient_booster"]["model"]["trees"])
+        self.assertEqual(n, 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
@@ -82,6 +82,14 @@ class TestUpdateModel(unittest.TestCase):
         n = len(result["learner"]["gradient_booster"]["model"]["trees"])
         self.assertEqual(n, 30)
 
+    def test_iteration_indptr_multiclass(self):
+        """iteration_indptr must advance by add_num_trees (not num_parallel_tree)."""
+        num_class, num_parallel_tree = 6, 5
+        client = _make_client_model(num_class=num_class, num_parallel_tree=num_parallel_tree)
+        trees_per_client = num_class * num_parallel_tree
+        merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
+        indptr = merged["learner"]["gradient_booster"]["model"]["iteration_indptr"]
+        self.assertEqual(indptr, [0, trees_per_client, 2 * trees_per_client])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
@@ -55,6 +55,7 @@ class TestUpdateModel(unittest.TestCase):
         num_class, num_parallel_tree = 6, 5
         client = _make_client_model(num_class=num_class, num_parallel_tree=num_parallel_tree)
         trees_per_client = len(client["learner"]["gradient_booster"]["model"]["trees"])
+        client_tree_info = client["learner"]["gradient_booster"]["model"]["tree_info"]
         self.assertEqual(trees_per_client, num_class * num_parallel_tree)
 
         merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
@@ -66,6 +67,7 @@ class TestUpdateModel(unittest.TestCase):
         self.assertEqual(int(model_body["gbtree_model_param"]["num_trees"]), expected)
         indptr = model_body["iteration_indptr"]
         self.assertEqual(indptr[-1], expected)
+        self.assertEqual(model_body["tree_info"], client_tree_info + client_tree_info)
 
     def test_tree_ids_are_sequential(self):
         """After merging, tree ids must be 0..N-1 with no gaps."""

--- a/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
@@ -64,6 +64,8 @@ class TestUpdateModel(unittest.TestCase):
                          f"Expected {expected} trees, got {len(model_body['trees'])} "
                          f"(num_class blindness bug)")
         self.assertEqual(int(model_body["gbtree_model_param"]["num_trees"]), expected)
+        indptr = model_body["iteration_indptr"]
+        self.assertEqual(indptr[-1], expected)
 
     def test_tree_ids_are_sequential(self):
         """After merging, tree ids must be 0..N-1 with no gaps."""

--- a/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
+++ b/tests/unit_test/app_opt/xgboost/tree_based/utils_test.py
@@ -61,9 +61,11 @@ class TestUpdateModel(unittest.TestCase):
         merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
         model_body = merged["learner"]["gradient_booster"]["model"]
         expected = 2 * trees_per_client
-        self.assertEqual(len(model_body["trees"]), expected,
-                         f"Expected {expected} trees, got {len(model_body['trees'])} "
-                         f"(num_class blindness bug)")
+        self.assertEqual(
+            len(model_body["trees"]),
+            expected,
+            f"Expected {expected} trees, got {len(model_body['trees'])} " f"(num_class blindness bug)",
+        )
         self.assertEqual(int(model_body["gbtree_model_param"]["num_trees"]), expected)
         indptr = model_body["iteration_indptr"]
         self.assertEqual(indptr[-1], expected)
@@ -92,6 +94,7 @@ class TestUpdateModel(unittest.TestCase):
         merged = update_model(copy.deepcopy(client), copy.deepcopy(client))
         indptr = merged["learner"]["gradient_booster"]["model"]["iteration_indptr"]
         self.assertEqual(indptr, [0, trees_per_client, 2 * trees_per_client])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #4484

## Problem
`update_model()` in `utils.py` used `range(cur_num_parallel_tree)` to
append trees from each client. For `multi:softprob` with `num_class=C`,
XGBoost stores `C × num_parallel_tree` trees per round, so only 1/C of
each client's trees were copied. The variable `add_num_trees` was already
being read from the model JSON but was never used (dead variable).

For binary objectives `num_trees == num_parallel_tree`, so the bug was
invisible in all existing tests.

## Fix
Changed all three occurrences of `cur_num_parallel_tree` to `add_num_trees`
in the merge logic:
- loop range
- `num_trees` param update
- `iteration_indptr` append

## Tests added
`tests/unit_test/app_opt/xgboost/tree_based/utils_test.py`
- `test_binary_two_clients` — regression guard for existing binary case
- `test_multiclass_two_clients` — the failing case, now passes
- `test_tree_ids_are_sequential` — verifies IDs are 0..N-1 after merge
- `test_first_client_none_prev` — verifies None prev_model passthrough