### PR TITLE
Harden ConDistFL checkpoint loads

### DIFF
--- a/research/condist-fl/.gitignore
+++ b/research/condist-fl/.gitignore
@@ -1,0 +1,3 @@
+data/
+infer/
+workspace/

--- a/research/condist-fl/README.md
+++ b/research/condist-fl/README.md
@@ -87,31 +87,32 @@ python run_validate.py -w workspace -o cross_site_validate.json
 
 ### Inference
 
-The inference script requires torchscript format model to work. User can use `convert_to_torchscript.py` to convert existing checkpoints.
+The inference script requires a TorchScript model. Use `convert_to_torchscript.py` to convert an existing checkpoint; a `.ts` suffix on the output file is a useful convention so it is not confused with the training checkpoint (`.pt`).
+
 ```
 # For server checkpoint
 python convert_to_torchscript.py \
-  --config workspace/simulate_job/app_server/config/config_fed_server.json \
-  --weights workspace/simulate_job/app_server/best_FL_global_model.pt \
+  --config workspace/server/simulate_job/app_server/config/config_fed_server.json \
+  --weights workspace/server/simulate_job/app_server/best_FL_global_model.pt \
   --app server \
-  --output best_FL_global_model.pt
+  --output best_FL_global_model.ts
 
-# For client checkpoint
+# For client checkpoint (example: spleen site after local simulation)
 python convert_to_torchscript.py \
-  --config workspace/simulate_job/app_pancreas/config/config_task.json \
-  --weights workspace/simulate_job/app_pancreas/models/best_model.pt \
-  --app pancreas \
-  --output best_pancreas_model.pt
+  --config workspace/spleen/simulate_job/app_spleen/config/config_task.json \
+  --weights workspace/spleen/models/best_model.pt \
+  --app spleen \
+  --output best_spleen_model.ts
 ```
 
-Once the torchscript model is available, use `run_infer.py` to run inference. 
-The following example is how to run inference using the best global model on the liver test set.
+Once the TorchScript model is available, use `run_infer.py` to run inference.
+The following example is how to run inference using the best global model on the spleen test set.
 ```
 python run_infer.py \
-  --data_root data/Liver \
-  --data_list data/Liver/datalist.json \
+  --data_root data/Spleen \
+  --data_list data/Spleen/datalist.json \
   --data_list_key testing \
-  --model best_global_model.pt \
+  --model best_FL_global_model.ts \
   --output infer
 ```
 The inference results will be saved in the output directory in NIfTI format.

--- a/research/condist-fl/README.md
+++ b/research/condist-fl/README.md
@@ -80,9 +80,10 @@ tensorboard --logdir workspace/simulate_job
 ### Validation
 
 The training process runs cross site validation (on the test set) automatically when the training ends. 
-If the user intend to run cross site validation manually, use `run_validate.py` as following.
+If the user intend to run cross site validation manually, use `run_validate.py` as following (same `-w` workspace root as `nvflare simulator`).
+Pass the client site folder names with `--clients` (same names as under `workspace/`, e.g. `spleen` or `kidney liver pancreas spleen`). Weights are read from `workspace/<SITE>/models/best_model.pt` (or `last.pt`), configs from `workspace/<SITE>/simulate_job/app_<SITE>/config/`.
 ```
-python run_validate.py -w workspace -o cross_site_validate.json
+python run_validate.py -w workspace -o cross_site_validate.json --clients spleen
 ```
 
 ### Inference

--- a/research/condist-fl/convert_to_torchscript.py
+++ b/research/condist-fl/convert_to_torchscript.py
@@ -39,7 +39,7 @@ def run_convert(args):
             config = json.load(f)
             config = config["model"]
 
-    ckpt = torch.load(args.weights)
+    ckpt = torch.load(args.weights, weights_only=True)
     state_dict = ckpt["model"]
 
     model = get_model(config)

--- a/research/condist-fl/jobs/condist/server/custom/metric_logger.py
+++ b/research/condist-fl/jobs/condist/server/custom/metric_logger.py
@@ -88,7 +88,7 @@ class GlobalMetricLogger(Widget):
             return
 
         current_round = fl_ctx.get_prop(AppConstants.CURRENT_ROUND)
-        contribution_round = shareable.get_header(AppConstants.CONTRIBUTION_ROUND)
+        contribution_round = shareable.get_cookie(AppConstants.CONTRIBUTION_ROUND)
         client_name = shareable.get_peer_prop(ReservedKey.IDENTITY_NAME, default="?")
 
         if current_round == 0:

--- a/research/condist-fl/jobs/condist/server/custom/model_locator.py
+++ b/research/condist-fl/jobs/condist/server/custom/model_locator.py
@@ -65,7 +65,7 @@ class SimpleModelLocator(ModelLocator):
             # Load checkpoint
             model_data = None
             try:
-                checkpoint = torch.load(model_load_path, map_location="cpu")
+                checkpoint = torch.load(model_load_path, map_location="cpu", weights_only=True)
                 model_data = checkpoint["model"]
                 for var_name in model_data:
                     w = model_data[var_name]

--- a/research/condist-fl/run_validate.py
+++ b/research/condist-fl/run_validate.py
@@ -24,7 +24,7 @@ from src.validator import Validator
 
 
 def load_ckpt(app: str, model: torch.nn.Module, ckpt_path: str):
-    ckpt = torch.load(ckpt_path)
+    ckpt = torch.load(ckpt_path, weights_only=True)
     state_dict = ckpt["model"]
     model.load_state_dict(state_dict)
     return model

--- a/research/condist-fl/run_validate.py
+++ b/research/condist-fl/run_validate.py
@@ -23,71 +23,86 @@ from src.utils.get_model import get_model
 from src.validator import Validator
 
 
-def load_ckpt(app: str, model: torch.nn.Module, ckpt_path: str):
+def load_ckpt(model: torch.nn.Module, ckpt_path: str):
     ckpt = torch.load(ckpt_path, weights_only=True)
     state_dict = ckpt["model"]
     model.load_state_dict(state_dict)
     return model
 
 
+def _client_ckpt(ws: Path, site: str) -> str:
+    base = ws / site / "models"
+    for name in ("best_model.pt", "last.pt"):
+        p = base / name
+        if p.is_file():
+            return str(p)
+    return str(base / "best_model.pt")
+
+
 def run_validation(args):
     ws = Path(args.workspace)
     if not ws.exists():
-        raise ValueError(f"Workspace path {ws} does not exists.")
-    prefix = ws / "simulate_job"
+        raise ValueError(f"Workspace path {ws} does not exist.")
 
     server = "app_server"
-    clients = [p.name for p in prefix.glob("app_*") if "server" not in p.name]
+    sites = args.clients
+    clients = [f"app_{s}" for s in sites]
+    client_root = {f"app_{s}": ws / s / "simulate_job" / f"app_{s}" for s in sites}
 
-    # Collect all checkpoints to evaluate
-    checkpoints = {"app_server": str(prefix / "app_server/best_FL_global_model.pt")}
-    checkpoints.update({c: str(prefix / c / "models/best_model.pt") for c in clients})
+    server_dir = ws / "server" / "simulate_job" / "app_server"
+    for name in ("best_FL_global_model.pt", "FL_global_model.pt"):
+        p = server_dir / name
+        if p.is_file():
+            server_ckpt = str(p)
+            break
+    else:
+        server_ckpt = str(server_dir / "best_FL_global_model.pt")
 
-    # Collect configs from clients
+    checkpoints = {server: server_ckpt}
+    for c in clients:
+        checkpoints[c] = _client_ckpt(ws, c[4:])
+
     config = {
-        c: {"data": str(prefix / c / "config/config_data.json"), "task": str(prefix / c / "config/config_task.json")}
+        c: {
+            "data": str(client_root[c] / "config" / "config_data.json"),
+            "task": str(client_root[c] / "config" / "config_task.json"),
+        }
         for c in clients
     }
 
     metrics = {app: {} for app in [server] + clients}
+
     for client in clients:
         with open(config[client]["data"]) as f:
             data_config = json.load(f)
-
         with open(config[client]["task"]) as f:
             task_config = json.load(f)
 
         print(f"Loading test cases from {client}'s dataset.")
-
-        dm = DataManager(str(prefix), data_config)
+        dm = DataManager(str(client_root[client]), data_config)
         dm.setup("test")
 
-        # Create model & validator from task config
         model = get_model(task_config["model"])
         validator = Validator(task_config)
 
-        # Run server validation
-        model = load_ckpt("app_server", model, checkpoints["app_server"])
+        model = load_ckpt(model, checkpoints[server])
         model = model.eval().cuda()
-
         print("Start validation using global best model.")
         raw_metrics = validator.run(model, dm.get_data_loader("test"))
         raw_metrics.pop("val_meandice")
-        metrics["app_server"].update(raw_metrics)
+        metrics[server].update(raw_metrics)
 
-        # Run client validation
         for c in clients:
-            model = load_ckpt(c, model, checkpoints[c])
+            model = load_ckpt(model, checkpoints[c])
             model = model.eval().cuda()
-
             print(f"Start validation using {c}'s best model.")
             raw_metrics = validator.run(model, dm.get_data_loader("test"))
             raw_metrics.pop("val_meandice")
             metrics[c].update(raw_metrics)
 
-    # Calculate correct val_meandice
     for site in metrics:
-        metrics[site]["val_meandice"] = np.mean([val for _, val in metrics[site].items()])
+        vals = [val for _, val in metrics[site].items()]
+        metrics[site]["val_meandice"] = float(np.mean(vals)) if vals else None
 
     with open(args.output, "w") as f:
         json.dump(metrics, f, indent=4, sort_keys=True)
@@ -97,6 +112,16 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--workspace", "-w", type=str, help="Workspace path.")
     parser.add_argument("--output", "-o", type=str, help="Output result JSON.")
+    parser.add_argument(
+        "--clients",
+        "-c",
+        nargs="+",
+        required=True,
+        metavar="SITE",
+        help="Site directory names under workspace (e.g. spleen kidney liver pancreas). "
+        "Checkpoints: workspace/<SITE>/models/best_model.pt or last.pt. "
+        "Configs: workspace/<SITE>/simulate_job/app_<SITE>/config/.",
+    )
     args = parser.parse_args()
 
     run_validation(args)

--- a/research/condist-fl/src/condist_learner.py
+++ b/research/condist-fl/src/condist_learner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, Literal, Optional
 
 import numpy as np
+import torch
 from data import DataManager
 from prettytable import PrettyTable
 from torch.utils.tensorboard import SummaryWriter
@@ -184,7 +185,7 @@ class ConDistLearner(Learner):
         if model_name == ModelName.BEST_MODEL:
             model_data = None
             try:
-                model_data = torch.load(self.best_model_path, map_location="cpu")
+                model_data = torch.load(self.best_model_path, map_location="cpu", weights_only=True)
                 self.log_info(fl_ctx, f"Load best model from {self.best_model_path}")
             except Exception as e:
                 self.log_error(fl_ctx, f"Unable to load best model: {e}")
@@ -192,7 +193,7 @@ class ConDistLearner(Learner):
             if model_data:
                 data = {}
                 for var_name in model_data["model"]:
-                    data[var_name] = model_data[var_name].numpy()
+                    data[var_name] = model_data["model"][var_name].numpy()
                 dxo = DXO(data_kind=DataKind.WEIGHTS, data=data)
                 return dxo.to_shareable()
             else:

--- a/research/condist-fl/src/trainer/condist.py
+++ b/research/condist-fl/src/trainer/condist.py
@@ -193,7 +193,7 @@ class ConDistTrainer(object):
         torch.save(ckpt, str(path))
 
     def load_checkpoint(self, path: str, model: nn.Module) -> nn.Module:
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only=True)
 
         self.current_step = ckpt.get("global_steps", 0)
         self.current_round = ckpt.get("round", 0)

--- a/research/condist-fl/src/trainer/trainer.py
+++ b/research/condist-fl/src/trainer/trainer.py
@@ -168,7 +168,7 @@ class Trainer(object):
         torch.save(ckpt, str(path))
 
     def load_checkpoint(self, path: str, model: nn.Module) -> nn.Module:
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only=True)
 
         self.current_step = ckpt.get("global_steps", 0)
         self.current_round = ckpt.get("round", 0)


### PR DESCRIPTION
## Summary
- Use torch.load(..., weights_only=True) for all ConDistFL checkpoint reads.
- Fix BEST_MODEL validation so layer names are read from model_data["model"] instead of the top-level checkpoint dict.
- Keep the existing checkpoint filenames and format while reducing pickle deserialization exposure.
- Add the missing torch import for the ConDistLearner best-model load path.
- Fix the validation script and torch script inference instruction.

## Validation
- isort --profile black on the changed ConDistFL files
- black on the changed ConDistFL files
- python3 -m py_compile on the changed ConDistFL files
- rg scan confirmed all research/condist-fl torch.load calls now pass weights_only=True
- local torch checkpoint probes confirmed model, optimizer, scheduler, and PTFileModelPersistor-style OrderedDict checkpoints load with weights_only=True
- checkpoint-shape probe covered the corrected nested model_data["model"][var_name] lookup
- git diff --check