### PR TITLE
Expose CSE participating clients helper option

### DIFF
--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -785,6 +785,8 @@ Add cross-site evaluation to any training recipe.
     from nvflare.recipe.utils import add_cross_site_evaluation
 
     add_cross_site_evaluation(recipe)
+    # or limit evaluation to selected clients
+    add_cross_site_evaluation(recipe, participating_clients=["site-1", "site-3"])
 
 
 Execution Environments

--- a/nvflare/recipe/utils.py
+++ b/nvflare/recipe/utils.py
@@ -146,6 +146,7 @@ def add_cross_site_evaluation(
     recipe: Recipe,
     submit_model_timeout: int = 600,
     validation_timeout: int = 6000,
+    participating_clients: Optional[List[str]] = None,
 ):
     """Add cross-site evaluation to an existing recipe.
 
@@ -250,6 +251,8 @@ def add_cross_site_evaluation(
         recipe: Recipe instance to augment with cross-site evaluation.
         submit_model_timeout: Timeout (seconds) for submitting models to clients. Defaults to 600.
         validation_timeout: Timeout (seconds) for validation tasks on clients. Defaults to 6000.
+        participating_clients: Optional list of client names to include in cross-site evaluation. If not provided,
+            all clients connected at controller start are used.
 
     Raises:
         ValueError: If the recipe doesn't have a framework attribute or uses an unsupported framework.
@@ -354,6 +357,7 @@ def add_cross_site_evaluation(
         model_locator_id=model_locator_id,
         submit_model_timeout=submit_model_timeout,
         validation_timeout=validation_timeout,
+        participating_clients=participating_clients,
     )
     recipe.job.to_server(eval_controller)
 

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -294,14 +294,23 @@ class TestCrossSiteEvalIdempotency:
         finally:
             os.unlink(train_script)
 
-    def test_participating_clients_passed_to_cross_site_eval_controller(self, tmp_path):
+    def test_participating_clients_passed_to_cross_site_eval_controller(self, tmp_path, monkeypatch):
         from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+        from nvflare.app_common.workflows import cross_site_model_eval
         from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
         from nvflare.recipe.utils import add_cross_site_evaluation
 
         train_script = tmp_path / "client.py"
         train_script.write_text("# dummy train script\n")
         participating_clients = ["site-1", "site-3"]
+        captured_kwargs = {}
+
+        class RecordingCrossSiteModelEval(CrossSiteModelEval):
+            def __init__(self, *args, **kwargs):
+                captured_kwargs.update(kwargs)
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(cross_site_model_eval, "CrossSiteModelEval", RecordingCrossSiteModelEval)
 
         recipe = NumpyFedAvgRecipe(
             name="test_cse_participating_clients",
@@ -313,9 +322,4 @@ class TestCrossSiteEvalIdempotency:
 
         add_cross_site_evaluation(recipe, participating_clients=participating_clients)
 
-        server_app = recipe.job._deploy_map["server"]
-        controllers = [getattr(workflow, "controller", workflow) for workflow in server_app.app_config.workflows]
-        eval_controllers = [controller for controller in controllers if isinstance(controller, CrossSiteModelEval)]
-
-        assert len(eval_controllers) == 1
-        assert eval_controllers[0]._participating_clients == participating_clients
+        assert captured_kwargs["participating_clients"] == participating_clients

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -241,7 +241,8 @@ class TestCrossSiteEvalIdempotency:
     """Tests for resilient idempotency in add_cross_site_evaluation."""
 
     def test_idempotency_survives_missing_flag(self):
-        from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+        from nvflare.fuel.utils.constants import FrameworkType
+        from nvflare.recipe import FedAvgRecipe
         from nvflare.recipe.utils import add_cross_site_evaluation
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -249,12 +250,13 @@ class TestCrossSiteEvalIdempotency:
             train_script = f.name
 
         try:
-            recipe = NumpyFedAvgRecipe(
+            recipe = FedAvgRecipe(
                 name="test_cse_idempotency",
                 model=[1.0, 2.0],
                 min_clients=2,
                 num_rounds=2,
                 train_script=train_script,
+                framework=FrameworkType.NUMPY,
             )
 
             add_cross_site_evaluation(recipe)
@@ -295,9 +297,10 @@ class TestCrossSiteEvalIdempotency:
             os.unlink(train_script)
 
     def test_participating_clients_passed_to_cross_site_eval_controller(self, tmp_path, monkeypatch):
-        from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
         from nvflare.app_common.workflows import cross_site_model_eval
         from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
+        from nvflare.fuel.utils.constants import FrameworkType
+        from nvflare.recipe import FedAvgRecipe
         from nvflare.recipe.utils import add_cross_site_evaluation
 
         train_script = tmp_path / "client.py"
@@ -312,12 +315,13 @@ class TestCrossSiteEvalIdempotency:
 
         monkeypatch.setattr(cross_site_model_eval, "CrossSiteModelEval", RecordingCrossSiteModelEval)
 
-        recipe = NumpyFedAvgRecipe(
+        recipe = FedAvgRecipe(
             name="test_cse_participating_clients",
             model=[1.0, 2.0],
             min_clients=2,
             num_rounds=2,
             train_script=str(train_script),
+            framework=FrameworkType.NUMPY,
         )
 
         add_cross_site_evaluation(recipe, participating_clients=participating_clients)

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -293,3 +293,29 @@ class TestCrossSiteEvalIdempotency:
             assert getattr(recipe, "_cse_added", False) is True
         finally:
             os.unlink(train_script)
+
+    def test_participating_clients_passed_to_cross_site_eval_controller(self, tmp_path):
+        from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+        from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
+        from nvflare.recipe.utils import add_cross_site_evaluation
+
+        train_script = tmp_path / "client.py"
+        train_script.write_text("# dummy train script\n")
+        participating_clients = ["site-1", "site-3"]
+
+        recipe = NumpyFedAvgRecipe(
+            name="test_cse_participating_clients",
+            model=[1.0, 2.0],
+            min_clients=2,
+            num_rounds=2,
+            train_script=str(train_script),
+        )
+
+        add_cross_site_evaluation(recipe, participating_clients=participating_clients)
+
+        server_app = recipe.job._deploy_map["server"]
+        controllers = [getattr(workflow, "controller", workflow) for workflow in server_app.app_config.workflows]
+        eval_controllers = [controller for controller in controllers if isinstance(controller, CrossSiteModelEval)]
+
+        assert len(eval_controllers) == 1
+        assert eval_controllers[0]._participating_clients == participating_clients


### PR DESCRIPTION
## Summary

Expose `participating_clients` so recipe-based CSE can target only the needed sites, avoiding unnecessary evaluation work and saving client/server compute resources.

- Expose `participating_clients` on `add_cross_site_evaluation`.
- Pass the selected client list through to `CrossSiteModelEval`.
- Document the helper option and add focused unit coverage.

## Testing
- `pytest tests/unit_test/recipe/utils_test.py -q`
- `black --check nvflare/recipe/utils.py tests/unit_test/recipe/utils_test.py`
- `isort --check-only nvflare/recipe/utils.py tests/unit_test/recipe/utils_test.py`
- `./build_doc.sh --html --skip-api` (succeeded; repository currently emits 107 existing warnings)