### PR TITLE
Fix K8s custom folder imports

### DIFF
--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -457,11 +457,17 @@ class K8sJobLauncher(JobLauncherSpec):
             raise RuntimeError(f"missing {JobProcessArgs.EXE_MODULE} in {FLContextKey.JOB_PROCESS_ARGS}")
         _, job_cmd = exe_module_entry
 
+        workspace_root = args.workspace
         env = {}
         if app_custom_folder:
-            env["PYTHONPATH"] = app_custom_folder.replace(args.workspace, WORKSPACE_MOUNT_PATH, 1)
+            workspace_root_abs = os.path.abspath(workspace_root)
+            custom_folder_abs = os.path.abspath(app_custom_folder)
+            if os.path.commonpath([workspace_root_abs, custom_folder_abs]) != workspace_root_abs:
+                raise RuntimeError(f"custom folder {app_custom_folder} is not under workspace {workspace_root}")
+            env["PYTHONPATH"] = os.path.join(
+                WORKSPACE_MOUNT_PATH, os.path.relpath(custom_folder_abs, workspace_root_abs)
+            )
 
-        workspace_root = args.workspace
         startup_dir = workspace_obj.get_startup_kit_dir()
         engine = fl_ctx.get_engine()
         owner_cell = getattr(engine, "cell", None) if engine else None

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -459,7 +459,7 @@ class K8sJobLauncher(JobLauncherSpec):
 
         env = {}
         if app_custom_folder:
-            env["PYTHONPATH"] = app_custom_folder
+            env["PYTHONPATH"] = app_custom_folder.replace(args.workspace, WORKSPACE_MOUNT_PATH, 1)
 
         workspace_root = args.workspace
         startup_dir = workspace_obj.get_startup_kit_dir()

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -40,6 +40,7 @@ from nvflare.private.fed.utils.fed_utils import (
     set_stats_pool_config_for_job,
 )
 from nvflare.security.logging import secure_format_exception
+from nvflare.utils.job_launcher_utils import refresh_custom_dir_import_path
 
 
 def main(args):
@@ -59,6 +60,7 @@ def main(args):
     args.env = os.path.join("config", "environment.json")
     download_workspace(args, secure_train)
     workspace = Workspace(args.workspace, args.client_name, config_folder)
+    refresh_custom_dir_import_path(workspace.get_app_custom_dir(args.job_id))
     set_stats_pool_config_for_job(workspace, args.job_id)
 
     try:

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -42,6 +42,7 @@ from nvflare.private.fed.utils.fed_utils import (
     set_stats_pool_config_for_job,
 )
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
+from nvflare.utils.job_launcher_utils import refresh_custom_dir_import_path
 
 
 def main(args):
@@ -65,6 +66,7 @@ def main(args):
     secure_train = kv_list.get("secure_train", False)
     download_workspace(args, secure_train)
     workspace = Workspace(root_dir=args.workspace, site_name=SiteType.SERVER)
+    refresh_custom_dir_import_path(workspace.get_app_custom_dir(args.job_id))
     set_stats_pool_config_for_job(workspace, args.job_id)
 
     try:

--- a/nvflare/utils/job_launcher_utils.py
+++ b/nvflare/utils/job_launcher_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import importlib
 import logging
 import os
 import sys
@@ -191,3 +192,12 @@ def add_custom_dir_to_path(app_custom_folder, new_env):
     sys_path = copy.copy(sys.path)
     sys_path.append(app_custom_folder)
     new_env[SystemVarName.PYTHONPATH] = os.pathsep.join(sys_path)
+
+
+def refresh_custom_dir_import_path(app_custom_folder):
+    """Refresh import state after a job custom dir is created post-interpreter startup."""
+    if not app_custom_folder or not os.path.isdir(app_custom_folder):
+        return
+    if app_custom_folder not in sys.path:
+        sys.path.append(app_custom_folder)
+    importlib.invalidate_caches()

--- a/nvflare/utils/job_launcher_utils.py
+++ b/nvflare/utils/job_launcher_utils.py
@@ -196,7 +196,12 @@ def add_custom_dir_to_path(app_custom_folder, new_env):
 
 def refresh_custom_dir_import_path(app_custom_folder):
     """Refresh import state after a job custom dir is created post-interpreter startup."""
-    if not app_custom_folder or not os.path.isdir(app_custom_folder):
+    if not app_custom_folder:
+        return
+    if not os.path.isdir(app_custom_folder):
+        logging.getLogger(__name__).debug(
+            "refresh_custom_dir_import_path: custom dir not found, skipping: %s", app_custom_folder
+        )
         return
     if app_custom_folder not in sys.path:
         sys.path.append(app_custom_folder)

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -1508,6 +1508,17 @@ class TestK8sJobLauncherLaunchJob:
         finally:
             _exit_patches(patches)
 
+    def test_pod_manifest_rejects_custom_folder_outside_workspace(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, _mock_api = self._setup(patches)
+        self._prime_running(_mock_api)
+        try:
+            fl_ctx = _make_launch_fl_ctx(app_custom_folder=f"/tmp/fake/workspace/{_JOB_UUID}/app_site-1/custom")
+            with pytest.raises(RuntimeError, match="custom folder .* is not under workspace"):
+                launcher.launch_job(_make_launch_job_meta(), fl_ctx)
+        finally:
+            _exit_patches(patches)
+
     def test_pod_manifest_no_pythonpath_when_no_custom_folder(self):
         patches = _make_k8s_launcher_patches()
         launcher, mock_api = self._setup(patches)

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -1497,13 +1497,14 @@ class TestK8sJobLauncherLaunchJob:
         launcher, mock_api = self._setup(patches)
         self._prime_running(mock_api)
         try:
-            fl_ctx = _make_launch_fl_ctx(app_custom_folder="/custom/app")
+            app_custom_folder = f"/fake/workspace/{_JOB_UUID}/app_site-1/custom"
+            fl_ctx = _make_launch_fl_ctx(app_custom_folder=app_custom_folder)
             launcher.launch_job(_make_launch_job_meta(), fl_ctx)
             manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
             container = manifest["spec"]["containers"][0]
             assert "env" in container
             env_map = {e["name"]: e["value"] for e in container["env"]}
-            assert env_map["PYTHONPATH"] == "/custom/app"
+            assert env_map["PYTHONPATH"] == f"{WORKSPACE_MOUNT_PATH}/{_JOB_UUID}/app_site-1/custom"
         finally:
             _exit_patches(patches)
 

--- a/tests/unit_test/utils/job_launcher_utils_test.py
+++ b/tests/unit_test/utils/job_launcher_utils_test.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import logging
+import sys
 
-from nvflare.utils.job_launcher_utils import _validate_launcher_spec, get_job_launcher_spec
+from nvflare.utils.job_launcher_utils import (
+    _validate_launcher_spec,
+    get_job_launcher_spec,
+    refresh_custom_dir_import_path,
+)
 
 
 class TestGetJobLauncherSpec:
@@ -112,3 +118,29 @@ class TestValidateLauncherSpec:
         with caplog.at_level(logging.WARNING, logger="nvflare.utils.job_launcher_utils"):
             get_job_launcher_spec(meta, "site-1", "docker")
         assert any("defaults" in msg for msg in caplog.messages)
+
+
+class TestRefreshCustomDirImportPath:
+    def test_refreshes_importer_cache_for_dir_created_after_startup(self, tmp_path):
+        module_name = "nvflare_refresh_path_probe"
+        custom_dir = tmp_path / "app" / "custom"
+        custom_path = str(custom_dir)
+        sys.path.append(custom_path)
+        try:
+            assert importlib.util.find_spec(module_name) is None
+            assert sys.path_importer_cache.get(custom_path) is None
+
+            custom_dir.mkdir(parents=True)
+            (custom_dir / f"{module_name}.py").write_text("VALUE = 123\n")
+
+            assert importlib.util.find_spec(module_name) is None
+            refresh_custom_dir_import_path(custom_path)
+
+            spec = importlib.util.find_spec(module_name)
+            assert spec is not None
+            assert spec.origin == str(custom_dir / f"{module_name}.py")
+        finally:
+            sys.modules.pop(module_name, None)
+            if custom_path in sys.path:
+                sys.path.remove(custom_path)
+            sys.path_importer_cache.pop(custom_path, None)

--- a/tests/unit_test/utils/job_launcher_utils_test.py
+++ b/tests/unit_test/utils/job_launcher_utils_test.py
@@ -121,6 +121,15 @@ class TestValidateLauncherSpec:
 
 
 class TestRefreshCustomDirImportPath:
+    def test_logs_when_custom_dir_is_missing(self, tmp_path, caplog):
+        custom_path = str(tmp_path / "missing" / "custom")
+
+        with caplog.at_level(logging.DEBUG, logger="nvflare.utils.job_launcher_utils"):
+            refresh_custom_dir_import_path(custom_path)
+
+        assert "custom dir not found" in caplog.text
+        assert custom_path in caplog.text
+
     def test_refreshes_importer_cache_for_dir_created_after_startup(self, tmp_path):
         module_name = "nvflare_refresh_path_probe"
         custom_dir = tmp_path / "app" / "custom"


### PR DESCRIPTION
## Summary

- Set K8s job pod `PYTHONPATH` to the workspace path visible inside the pod.
- Refresh Python import caches after the job workspace is downloaded so app custom modules can be imported when the custom folder did not exist at interpreter startup.

## Root Cause

K8s job pods start Python before the `emptyDir` workspace contains the downloaded job app. If Python probes the job custom folder while it is still missing, importlib can cache that missing path. Later imports from the job custom folder, such as `model.SimpleNetwork`, can then fail even after `download_workspace()` creates the directory.
