### PR TITLE
Fix disk offload temp dir leak on FedAvg abort/exception paths

### DIFF
--- a/nvflare/app_common/utils/tensor_disk_offload_context.py
+++ b/nvflare/app_common/utils/tensor_disk_offload_context.py
@@ -12,9 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import shutil
+import threading
 from typing import Any, Tuple
 
+logger = logging.getLogger(__name__)
+
 _ENABLE_TENSOR_DISK_OFFLOAD = "enable_tensor_disk_offload"
+
+# Module-level registry of disk-offload temp dirs created during the current
+# process lifetime. Used as a safety net for cleanup paths where the natural
+# GC of _TempDirRef does not fire (notably FedAvg.run() returning early on
+# abort_signal — the partial state held by the controller's aggregation
+# helper keeps LazyTensorDict references reachable, blocking GC).
+_outstanding_temp_dirs = set()
+_outstanding_lock = threading.Lock()
+
+
+def register_offload_temp_dir(path: str) -> None:
+    """Track a disk-offload temp dir so it can be swept up on workflow exit.
+
+    Called by download_tensors_to_disk right after tempfile.mkdtemp().
+    """
+    with _outstanding_lock:
+        _outstanding_temp_dirs.add(path)
+
+
+def unregister_offload_temp_dir(path: str) -> None:
+    """Remove a temp dir from the registry once it has been cleaned up via
+    the natural _TempDirRef.__del__ / DiskTensorConsumer.download_failed
+    path. Idempotent.
+    """
+    with _outstanding_lock:
+        _outstanding_temp_dirs.discard(path)
+
+
+def cleanup_all_outstanding_offload_temps() -> None:
+    """Sweep any registered offload temp dirs that have not yet been cleaned.
+
+    Intended to be called from a workflow's ``finally`` block as a safety net
+    for exit paths where natural GC does not fire (abort_signal early return,
+    unhandled exceptions, etc.). On normal completion the registry is
+    typically empty by the time this runs because _TempDirRef.__del__ has
+    already cleaned and unregistered each dir.
+    """
+    with _outstanding_lock:
+        dirs = list(_outstanding_temp_dirs)
+        _outstanding_temp_dirs.clear()
+    for d in dirs:
+        try:
+            shutil.rmtree(d)
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.warning("failed to cleanup outstanding offload temp dir '%s': %s", d, e)
 
 
 def apply_enable_tensor_disk_offload(

--- a/nvflare/app_common/utils/tensor_disk_offload_context.py
+++ b/nvflare/app_common/utils/tensor_disk_offload_context.py
@@ -15,51 +15,75 @@
 import logging
 import shutil
 import threading
+import uuid
 from typing import Any, Tuple
 
 logger = logging.getLogger(__name__)
 
 _ENABLE_TENSOR_DISK_OFFLOAD = "enable_tensor_disk_offload"
+_DISK_OFFLOAD_REGISTRY_TOKEN = "tensor_disk_offload_registry_token"
 
-# Module-level registry of disk-offload temp dirs created during the current
-# process lifetime. Used as a safety net for cleanup paths where the natural
-# GC of _TempDirRef does not fire (notably FedAvg.run() returning early on
-# abort_signal — the partial state held by the controller's aggregation
-# helper keeps LazyTensorDict references reachable, blocking GC).
-_outstanding_temp_dirs = set()
+# Module-level registry mapping an opaque scope token to the set of disk-offload
+# temp dirs created within that scope. Used as a safety net for cleanup paths
+# where the natural GC of _TempDirRef does not fire (notably FedAvg.run()
+# returning early on abort_signal). The per-token scoping is important so that
+# in environments where multiple FedAvg instances run concurrently in one
+# Python process (e.g., NVFlare simulator mode), one instance's cleanup does
+# not delete another instance's still-live temp dirs.
+_outstanding_temp_dirs = {}  # type: dict; token (str) -> set[str]
 _outstanding_lock = threading.Lock()
 
 
-def register_offload_temp_dir(path: str) -> None:
-    """Track a disk-offload temp dir so it can be swept up on workflow exit.
+def new_registry_token() -> str:
+    """Generate a fresh opaque token for a workflow run's registry scope."""
+    return uuid.uuid4().hex
 
-    Called by download_tensors_to_disk right after tempfile.mkdtemp().
+
+def register_offload_temp_dir(path: str, token: str) -> None:
+    """Track a disk-offload temp dir under the given scope token.
+
+    Called by download_tensors_to_disk right after tempfile.mkdtemp(). The
+    token is read from the cell's FOBS context (set by
+    apply_enable_tensor_disk_offload at the start of the workflow's run()).
+    No-op if token is empty, allowing direct callers that do not opt into
+    the registry (e.g., in tests) to skip tracking.
     """
+    if not token:
+        return
     with _outstanding_lock:
-        _outstanding_temp_dirs.add(path)
+        _outstanding_temp_dirs.setdefault(token, set()).add(path)
 
 
-def unregister_offload_temp_dir(path: str) -> None:
-    """Remove a temp dir from the registry once it has been cleaned up via
-    the natural _TempDirRef.__del__ / DiskTensorConsumer.download_failed
-    path. Idempotent.
+def unregister_offload_temp_dir(path: str, token: str) -> None:
+    """Remove a temp dir from the registry. Idempotent. No-op if token empty.
+
+    Called by the natural cleanup path (_cleanup_temp_dir's finally block)
+    so the registry stays consistent with on-disk state.
     """
+    if not token:
+        return
     with _outstanding_lock:
-        _outstanding_temp_dirs.discard(path)
+        scope = _outstanding_temp_dirs.get(token)
+        if scope is not None:
+            scope.discard(path)
+            if not scope:
+                del _outstanding_temp_dirs[token]
 
 
-def cleanup_all_outstanding_offload_temps() -> None:
-    """Sweep any registered offload temp dirs that have not yet been cleaned.
+def cleanup_offload_temps_for_token(token: str) -> None:
+    """Sweep any registered offload temp dirs under the given scope token.
 
     Intended to be called from a workflow's ``finally`` block as a safety net
     for exit paths where natural GC does not fire (abort_signal early return,
-    unhandled exceptions, etc.). On normal completion the registry is
-    typically empty by the time this runs because _TempDirRef.__del__ has
-    already cleaned and unregistered each dir.
+    unhandled exceptions, etc.). Only dirs registered under THIS token are
+    removed; dirs under other tokens (concurrent workflows) are untouched.
+    On normal completion the scope is typically empty already because
+    _TempDirRef.__del__ has cleaned and unregistered each dir.
     """
+    if not token:
+        return
     with _outstanding_lock:
-        dirs = list(_outstanding_temp_dirs)
-        _outstanding_temp_dirs.clear()
+        dirs = list(_outstanding_temp_dirs.pop(token, ()))
     for d in dirs:
         try:
             shutil.rmtree(d)
@@ -72,11 +96,16 @@ def cleanup_all_outstanding_offload_temps() -> None:
 def apply_enable_tensor_disk_offload(
     engine,
     enabled: bool,
+    registry_token: str = "",
 ) -> Tuple[Any, bool]:
     """Apply enable_tensor_disk_offload to cell FOBS context.
 
+    Also propagates registry_token so that download_tensors_to_disk can scope
+    its registry entries to the calling workflow's run(). Pass an empty
+    registry_token to opt out of registry tracking.
+
     Returns:
-      (previous value, applied flag).
+      (previous value of enable_tensor_disk_offload, applied flag).
     """
     if not engine:
         return None, False
@@ -89,14 +118,25 @@ def apply_enable_tensor_disk_offload(
     if not cell:
         return None, False
 
-    previous = cell.get_fobs_context().get(_ENABLE_TENSOR_DISK_OFFLOAD, False)
+    fobs_ctx = cell.get_fobs_context()
+    previous = fobs_ctx.get(_ENABLE_TENSOR_DISK_OFFLOAD, False)
+    updates = {}
     if previous != enabled:
-        cell.update_fobs_context({_ENABLE_TENSOR_DISK_OFFLOAD: enabled})
+        updates[_ENABLE_TENSOR_DISK_OFFLOAD] = enabled
+    if registry_token and fobs_ctx.get(_DISK_OFFLOAD_REGISTRY_TOKEN, "") != registry_token:
+        updates[_DISK_OFFLOAD_REGISTRY_TOKEN] = registry_token
+    if updates:
+        cell.update_fobs_context(updates)
     return previous, True
 
 
 def restore_enable_tensor_disk_offload(engine, previous_value: Any) -> None:
-    """Restore prior enable_tensor_disk_offload value on a cell."""
+    """Restore prior enable_tensor_disk_offload value and clear registry token.
+
+    Clearing the token ensures any subsequent operation on this cell that is
+    not driven by the just-finished workflow does not register into the now-
+    completed token's scope.
+    """
     # previous_value is None only when apply was not executed because no
     # engine/cell was available; False is a valid prior value and must restore.
     if not engine or previous_value is None:
@@ -110,6 +150,11 @@ def restore_enable_tensor_disk_offload(engine, previous_value: Any) -> None:
     if not cell:
         return
 
-    current = cell.get_fobs_context().get(_ENABLE_TENSOR_DISK_OFFLOAD, False)
-    if current != previous_value:
-        cell.update_fobs_context({_ENABLE_TENSOR_DISK_OFFLOAD: previous_value})
+    fobs_ctx = cell.get_fobs_context()
+    updates = {}
+    if fobs_ctx.get(_ENABLE_TENSOR_DISK_OFFLOAD, False) != previous_value:
+        updates[_ENABLE_TENSOR_DISK_OFFLOAD] = previous_value
+    if fobs_ctx.get(_DISK_OFFLOAD_REGISTRY_TOKEN):
+        updates[_DISK_OFFLOAD_REGISTRY_TOKEN] = ""
+    if updates:
+        cell.update_fobs_context(updates)

--- a/nvflare/app_common/utils/tensor_disk_offload_context.py
+++ b/nvflare/app_common/utils/tensor_disk_offload_context.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import logging
+import os
 import shutil
 import threading
+import time
 import uuid
 from typing import Any, Tuple
 
@@ -22,6 +24,17 @@ logger = logging.getLogger(__name__)
 
 _ENABLE_TENSOR_DISK_OFFLOAD = "enable_tensor_disk_offload"
 _DISK_OFFLOAD_REGISTRY_TOKEN = "tensor_disk_offload_registry_token"
+
+# Streaming threads can keep writing chunks for several seconds after
+# FedAvg.run()'s finally block fires on abort_signal. A single rmtree
+# pass races those writes and surfaces ENOTEMPTY when new chunks appear
+# between the walk and the parent rmdir. The safety-net cleanup retries
+# rmtree with these bounds; ignore_errors=True on each pass drains the
+# dir incrementally while streams catch up. Empirically post-abort
+# writes in the 5GB / 4-client case continued for ~4s; 15s gives
+# generous headroom without blocking shutdown unreasonably.
+_CLEANUP_TIMEOUT_SEC = 15.0
+_CLEANUP_RETRY_INTERVAL_SEC = 0.5
 
 # Module-level registry mapping an opaque scope token to the set of disk-offload
 # temp dirs created within that scope. Used as a safety net for cleanup paths
@@ -84,13 +97,33 @@ def cleanup_offload_temps_for_token(token: str) -> None:
         return
     with _outstanding_lock:
         dirs = list(_outstanding_temp_dirs.pop(token, ()))
-    for d in dirs:
-        try:
-            shutil.rmtree(d)
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            logger.warning("failed to cleanup outstanding offload temp dir '%s': %s", d, e)
+    if not dirs:
+        return
+
+    # Retry with a deadline because streaming threads may still be flushing
+    # chunks into these dirs after abort_signal. ignore_errors=True lets each
+    # pass drain whatever chunks are present at that moment; subsequent
+    # passes mop up chunks that arrived during the previous pass. After
+    # streams stop arriving, the next pass succeeds.
+    deadline = time.monotonic() + _CLEANUP_TIMEOUT_SEC
+    remaining = list(dirs)
+    while remaining and time.monotonic() < deadline:
+        next_remaining = []
+        for d in remaining:
+            shutil.rmtree(d, ignore_errors=True)
+            if os.path.exists(d):
+                next_remaining.append(d)
+        if next_remaining:
+            time.sleep(_CLEANUP_RETRY_INTERVAL_SEC)
+        remaining = next_remaining
+
+    for d in remaining:
+        logger.warning(
+            "failed to cleanup outstanding offload temp dir '%s' after %.1fs of retries; "
+            "concurrent writes may be in-flight",
+            d,
+            _CLEANUP_TIMEOUT_SEC,
+        )
 
 
 def apply_enable_tensor_disk_offload(

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -28,6 +28,7 @@ from nvflare.app_common.app_event_type import AppEventType
 from nvflare.app_common.utils.math_utils import parse_compare_criteria
 from nvflare.app_common.utils.tensor_disk_offload_context import (
     apply_enable_tensor_disk_offload,
+    cleanup_all_outstanding_offload_temps,
     restore_enable_tensor_disk_offload,
 )
 from nvflare.fuel.utils import fobs
@@ -246,6 +247,15 @@ class FedAvg(BaseFedAvg):
                 engine=getattr(self, "engine", None),
                 previous_value=previous_disk_offload,
             )
+            # Safety-net cleanup for any disk-offload temp dirs still
+            # registered. On normal completion these are typically already
+            # gone (cleaned by _TempDirRef.__del__ as scope exits); on
+            # abort_signal early return or unhandled exception the partial
+            # state held by self._aggr_helper / self.aggregator can keep
+            # LazyTensorDict references reachable, blocking GC. Without this
+            # sweep, those temp dirs leak on every aborted job.
+            if self.enable_tensor_disk_offload:
+                cleanup_all_outstanding_offload_temps()
 
     def _aggregate_one_result(self, result: FLModel) -> None:
         """Callback: aggregate ONE client result immediately (InTime aggregation)."""

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -28,7 +28,8 @@ from nvflare.app_common.app_event_type import AppEventType
 from nvflare.app_common.utils.math_utils import parse_compare_criteria
 from nvflare.app_common.utils.tensor_disk_offload_context import (
     apply_enable_tensor_disk_offload,
-    cleanup_all_outstanding_offload_temps,
+    cleanup_offload_temps_for_token,
+    new_registry_token,
     restore_enable_tensor_disk_offload,
 )
 from nvflare.fuel.utils import fobs
@@ -139,9 +140,17 @@ class FedAvg(BaseFedAvg):
         self._params_type = None  # Only store params_type, not full result
 
     def run(self) -> None:
+        # Generate a unique scope token for this run() invocation so that
+        # cleanup_offload_temps_for_token only sweeps dirs registered by this
+        # FedAvg instance. Important when multiple FedAvg jobs run concurrently
+        # in the same Python process (e.g., NVFlare simulator mode): without
+        # per-token scoping, one job's abort would delete another job's
+        # still-live temp dirs.
+        registry_token = new_registry_token() if self.enable_tensor_disk_offload else ""
         previous_disk_offload, disk_offload_applied = apply_enable_tensor_disk_offload(
             engine=getattr(self, "engine", None),
             enabled=self.enable_tensor_disk_offload,
+            registry_token=registry_token,
         )
         if self.enable_tensor_disk_offload and not disk_offload_applied:
             self.warning(
@@ -248,14 +257,17 @@ class FedAvg(BaseFedAvg):
                 previous_value=previous_disk_offload,
             )
             # Safety-net cleanup for any disk-offload temp dirs still
-            # registered. On normal completion these are typically already
-            # gone (cleaned by _TempDirRef.__del__ as scope exits); on
-            # abort_signal early return or unhandled exception the partial
-            # state held by self._aggr_helper / self.aggregator can keep
+            # registered under THIS run's token. On normal completion the
+            # token's scope is typically already empty (dirs were cleaned by
+            # _TempDirRef.__del__ as references went out of scope); on
+            # abort_signal early return or unhandled exception some partial
+            # state in the controller / streaming layer can keep
             # LazyTensorDict references reachable, blocking GC. Without this
-            # sweep, those temp dirs leak on every aborted job.
+            # sweep, those temp dirs leak on every aborted job. Scoping by
+            # registry_token ensures concurrent FedAvg instances are not
+            # affected.
             if self.enable_tensor_disk_offload:
-                cleanup_all_outstanding_offload_temps()
+                cleanup_offload_temps_for_token(registry_token)
 
     def _aggregate_one_result(self, result: FLModel) -> None:
         """Callback: aggregate ONE client result immediately (InTime aggregation)."""

--- a/nvflare/app_opt/pt/lazy_tensor_dict.py
+++ b/nvflare/app_opt/pt/lazy_tensor_dict.py
@@ -33,7 +33,7 @@ from nvflare.app_common.utils.tensor_disk_offload_context import unregister_offl
 logger = logging.getLogger(__name__)
 
 
-def _cleanup_temp_dir(path: str) -> None:
+def _cleanup_temp_dir(path: str, registry_token: str = "") -> None:
     try:
         shutil.rmtree(path)
     except FileNotFoundError:
@@ -41,10 +41,12 @@ def _cleanup_temp_dir(path: str) -> None:
     except Exception as e:
         logger.warning("failed to cleanup tensor offload temp dir '%s': %s", path, e)
     finally:
-        # Always unregister, even if rmtree failed — the registry's purpose is
-        # the safety-net sweep, and a failed rmtree here means a future sweep
-        # will retry rather than us tracking it forever.
-        unregister_offload_temp_dir(path)
+        # Always unregister, even if rmtree failed. On rmtree failure the
+        # path is silently abandoned (logged via the except handler above)
+        # rather than retried by the registry sweep — the registry's purpose
+        # is to track outstanding cleanups, and once we have made a cleanup
+        # attempt the registry should reflect that.
+        unregister_offload_temp_dir(path, registry_token)
 
 
 class _TempDirRef:
@@ -54,14 +56,15 @@ class _TempDirRef:
     The directory is deleted only when ALL holders are garbage collected.
     """
 
-    def __init__(self, temp_dir: str):
+    def __init__(self, temp_dir: str, registry_token: str = ""):
         self.path = temp_dir
+        self.registry_token = registry_token
         self._deleted = False
 
     def cleanup(self):
         if not self._deleted:
             self._deleted = True
-            _cleanup_temp_dir(self.path)
+            _cleanup_temp_dir(self.path, self.registry_token)
 
     def __del__(self):
         self.cleanup()
@@ -97,9 +100,9 @@ class LazyTensorDict:
     via safetensors safe_open (mmap) on access.
     """
 
-    def __init__(self, key_to_file: dict[str, tuple[str, str]], temp_dir: str):
+    def __init__(self, key_to_file: dict[str, tuple[str, str]], temp_dir: str, registry_token: str = ""):
         self._key_to_file = key_to_file
-        self._temp_ref = _TempDirRef(temp_dir)
+        self._temp_ref = _TempDirRef(temp_dir, registry_token)
 
     def __getitem__(self, key):
         file_path, st_key = self._key_to_file[key]

--- a/nvflare/app_opt/pt/lazy_tensor_dict.py
+++ b/nvflare/app_opt/pt/lazy_tensor_dict.py
@@ -28,6 +28,8 @@ import shutil
 
 from safetensors import safe_open
 
+from nvflare.app_common.utils.tensor_disk_offload_context import unregister_offload_temp_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,9 +37,14 @@ def _cleanup_temp_dir(path: str) -> None:
     try:
         shutil.rmtree(path)
     except FileNotFoundError:
-        return
+        pass
     except Exception as e:
         logger.warning("failed to cleanup tensor offload temp dir '%s': %s", path, e)
+    finally:
+        # Always unregister, even if rmtree failed — the registry's purpose is
+        # the safety-net sweep, and a failed rmtree here means a future sweep
+        # will retry rather than us tracking it forever.
+        unregister_offload_temp_dir(path)
 
 
 class _TempDirRef:

--- a/nvflare/app_opt/pt/tensor_downloader.py
+++ b/nvflare/app_opt/pt/tensor_downloader.py
@@ -21,6 +21,7 @@ import torch
 from safetensors.torch import load as load_tensors
 from safetensors.torch import save as save_tensors
 
+from nvflare.app_common.utils.tensor_disk_offload_context import register_offload_temp_dir
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.streaming.cacheable import CacheableObject, ItemConsumer
 from nvflare.fuel.f3.streaming.download_service import download_object
@@ -213,6 +214,9 @@ def download_tensors_to_disk(
     Returns: tuple of (error message if any, LazyTensorDict for lazy access).
     """
     temp_dir = tempfile.mkdtemp(prefix="nvflare_tensors_")
+    # Register so the workflow's finally block can sweep this up if natural
+    # _TempDirRef.__del__ does not fire (e.g., on abort_signal early return).
+    register_offload_temp_dir(temp_dir)
 
     consumer = DiskTensorConsumer(temp_dir)
     try:

--- a/nvflare/app_opt/pt/tensor_downloader.py
+++ b/nvflare/app_opt/pt/tensor_downloader.py
@@ -165,9 +165,10 @@ def _extract_safetensors_keys(data: bytes) -> list[str]:
 class DiskTensorConsumer(ItemConsumer):
     """Writes raw safetensors bytes to disk without deserializing to tensors."""
 
-    def __init__(self, temp_dir: str):
+    def __init__(self, temp_dir: str, registry_token: str = ""):
         ItemConsumer.__init__(self)
         self._temp_dir = temp_dir
+        self._registry_token = registry_token
         self._file_counter = 0
 
     def consume_items(self, items: List[Any], result: Any) -> Any:
@@ -197,7 +198,7 @@ class DiskTensorConsumer(ItemConsumer):
         # Eager cleanup on download callback error; the outer caller may also
         # attempt cleanup via consumer.error path. Double cleanup is intentional
         # and safe because _cleanup_temp_dir handles already-removed paths.
-        _cleanup_temp_dir(self._temp_dir)
+        _cleanup_temp_dir(self._temp_dir, self._registry_token)
 
 
 def download_tensors_to_disk(
@@ -213,12 +214,23 @@ def download_tensors_to_disk(
 
     Returns: tuple of (error message if any, LazyTensorDict for lazy access).
     """
+    # The registry token is set by apply_enable_tensor_disk_offload at the
+    # start of the workflow's run(). Empty token = no registry tracking
+    # (still works, just relies on natural _TempDirRef.__del__ for cleanup).
+    # Tolerate cell=None so this function remains usable from unit tests that
+    # mock out download_object.
+    registry_token = ""
+    if cell is not None:
+        registry_token = cell.get_fobs_context().get("tensor_disk_offload_registry_token", "")
+
     temp_dir = tempfile.mkdtemp(prefix="nvflare_tensors_")
     # Register so the workflow's finally block can sweep this up if natural
     # _TempDirRef.__del__ does not fire (e.g., on abort_signal early return).
-    register_offload_temp_dir(temp_dir)
+    # Scoped by registry_token so concurrent workflows in the same process
+    # do not delete each other's still-live temp dirs.
+    register_offload_temp_dir(temp_dir, registry_token)
 
-    consumer = DiskTensorConsumer(temp_dir)
+    consumer = DiskTensorConsumer(temp_dir, registry_token)
     try:
         download_object(
             from_fqcn=from_fqcn,
@@ -231,12 +243,12 @@ def download_tensors_to_disk(
             abort_signal=abort_signal,
         )
     except Exception:
-        _cleanup_temp_dir(temp_dir)
+        _cleanup_temp_dir(temp_dir, registry_token)
         raise
 
     if consumer.error:
-        _cleanup_temp_dir(temp_dir)
+        _cleanup_temp_dir(temp_dir, registry_token)
         return consumer.error, None
 
     key_to_file = consumer.result if consumer.result is not None else {}
-    return None, LazyTensorDict(key_to_file=key_to_file, temp_dir=temp_dir)
+    return None, LazyTensorDict(key_to_file=key_to_file, temp_dir=temp_dir, registry_token=registry_token)

--- a/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
+++ b/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
@@ -280,3 +280,107 @@ def test_restore_clears_registry_token():
     restore_enable_tensor_disk_offload(_MockEngine(cell), previous_value=False)
     assert cell.ctx["enable_tensor_disk_offload"] is False
     assert cell.ctx.get("tensor_disk_offload_registry_token") == ""
+
+
+def test_cleanup_retries_when_writer_keeps_writing(monkeypatch):
+    """Reproduces the abort-path race: streaming threads keep writing chunks
+    into the temp dir for a few seconds after cleanup_offload_temps_for_token
+    starts. The first rmtree pass surfaces ENOTEMPTY; the retry loop must
+    keep draining until the writer stops, then succeed.
+    """
+    saved = _isolate_registry()
+    d = None
+    try:
+        d = tempfile.mkdtemp(prefix="nvflare_tensors_test_race_")
+        for i in range(5):
+            with open(os.path.join(d, f"chunk_{i}.safetensors"), "w") as f:
+                f.write("x")
+        register_offload_temp_dir(d, _TOKEN_A)
+
+        # Simulate a writer that injects 3 new chunks AFTER each rmtree pass
+        # (mimicking stream threads still flushing post-abort), then stops.
+        injection_counter = {"n": 0}
+        original_rmtree = ctx.shutil.rmtree
+
+        def racy_rmtree(path, ignore_errors=False, onerror=None):
+            original_rmtree(path, ignore_errors=ignore_errors, onerror=onerror)
+            if injection_counter["n"] < 3 and not os.path.exists(path):
+                os.makedirs(path, exist_ok=True)
+                with open(os.path.join(path, f"late_chunk_{injection_counter['n']}"), "w") as f:
+                    f.write("y")
+                injection_counter["n"] += 1
+
+        monkeypatch.setattr(ctx.shutil, "rmtree", racy_rmtree)
+        # Speed up the test — don't actually sleep half a second per pass.
+        monkeypatch.setattr(ctx, "_CLEANUP_RETRY_INTERVAL_SEC", 0.01)
+
+        cleanup_offload_temps_for_token(_TOKEN_A)
+
+        # After the writer stopped, the retry loop should have drained the dir.
+        assert not os.path.exists(d), f"{d} should have been removed after retries"
+        assert injection_counter["n"] == 3
+        assert ctx._outstanding_temp_dirs == {}
+    finally:
+        if d and os.path.exists(d):
+            shutil.rmtree(d, ignore_errors=True)
+        _restore_registry(saved)
+
+
+def test_cleanup_gives_up_after_deadline_when_writer_never_stops(monkeypatch, caplog):
+    """If a writer never stops, cleanup must not block forever. After the
+    deadline it logs a warning and returns; the registry is still cleared
+    so subsequent runs don't double-track the same path.
+    """
+    saved = _isolate_registry()
+    d = None
+    try:
+        d = tempfile.mkdtemp(prefix="nvflare_tensors_test_persistent_")
+        register_offload_temp_dir(d, _TOKEN_A)
+        original_rmtree = ctx.shutil.rmtree
+
+        def never_empty_rmtree(path, ignore_errors=False, onerror=None):
+            original_rmtree(path, ignore_errors=ignore_errors, onerror=onerror)
+            os.makedirs(path, exist_ok=True)
+            with open(os.path.join(path, "infinite_writer"), "w") as f:
+                f.write("z")
+
+        monkeypatch.setattr(ctx.shutil, "rmtree", never_empty_rmtree)
+        monkeypatch.setattr(ctx, "_CLEANUP_TIMEOUT_SEC", 0.1)
+        monkeypatch.setattr(ctx, "_CLEANUP_RETRY_INTERVAL_SEC", 0.01)
+
+        with caplog.at_level("WARNING"):
+            cleanup_offload_temps_for_token(_TOKEN_A)
+
+        assert "after 0.1s of retries" in caplog.text
+        assert d in caplog.text
+        assert ctx._outstanding_temp_dirs == {}
+    finally:
+        if d and os.path.exists(d):
+            shutil.rmtree(d, ignore_errors=True)
+        _restore_registry(saved)
+
+
+def test_cleanup_succeeds_first_pass_when_no_writer(monkeypatch):
+    """Sanity check: the retry loop must not regress the no-race path.
+    With no concurrent writer, the first rmtree pass succeeds and we don't
+    sleep at all.
+    """
+    saved = _isolate_registry()
+    d = None
+    sleep_calls = []
+    try:
+        d = tempfile.mkdtemp(prefix="nvflare_tensors_test_nowriter_")
+        with open(os.path.join(d, "chunk_0"), "w") as f:
+            f.write("x")
+        register_offload_temp_dir(d, _TOKEN_A)
+
+        monkeypatch.setattr(ctx.time, "sleep", lambda s: sleep_calls.append(s))
+        cleanup_offload_temps_for_token(_TOKEN_A)
+
+        assert not os.path.exists(d)
+        assert sleep_calls == [], "no retries should be needed without a concurrent writer"
+        assert ctx._outstanding_temp_dirs == {}
+    finally:
+        if d and os.path.exists(d):
+            shutil.rmtree(d, ignore_errors=True)
+        _restore_registry(saved)

--- a/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
+++ b/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import os
+import shutil
 import tempfile
 
 import nvflare.app_common.utils.tensor_disk_offload_context as ctx
 from nvflare.app_common.utils.tensor_disk_offload_context import (
     apply_enable_tensor_disk_offload,
-    cleanup_all_outstanding_offload_temps,
+    cleanup_offload_temps_for_token,
+    new_registry_token,
     register_offload_temp_dir,
     restore_enable_tensor_disk_offload,
     unregister_offload_temp_dir,
@@ -111,10 +113,14 @@ def test_apply_and_restore_use_run_manager_cell_when_available():
     assert run_cell.ctx["enable_tensor_disk_offload"] is False
 
 
+_TOKEN_A = "test_token_alpha"
+_TOKEN_B = "test_token_beta"
+
+
 def _isolate_registry():
     """Snapshot + clear the module-level registry so each test starts clean."""
     with ctx._outstanding_lock:
-        snapshot = set(ctx._outstanding_temp_dirs)
+        snapshot = {k: set(v) for k, v in ctx._outstanding_temp_dirs.items()}
         ctx._outstanding_temp_dirs.clear()
     return snapshot
 
@@ -125,64 +131,117 @@ def _restore_registry(snapshot):
         ctx._outstanding_temp_dirs.update(snapshot)
 
 
+def test_new_registry_token_returns_unique_strings():
+    a = new_registry_token()
+    b = new_registry_token()
+    assert isinstance(a, str) and a
+    assert a != b
+
+
 def test_register_and_unregister_offload_temp_dir():
     saved = _isolate_registry()
     try:
-        register_offload_temp_dir("/tmp/nvflare_tensors_aaa")
-        register_offload_temp_dir("/tmp/nvflare_tensors_bbb")
-        assert ctx._outstanding_temp_dirs == {"/tmp/nvflare_tensors_aaa", "/tmp/nvflare_tensors_bbb"}
+        register_offload_temp_dir("/tmp/nvflare_tensors_aaa", _TOKEN_A)
+        register_offload_temp_dir("/tmp/nvflare_tensors_bbb", _TOKEN_A)
+        assert ctx._outstanding_temp_dirs == {_TOKEN_A: {"/tmp/nvflare_tensors_aaa", "/tmp/nvflare_tensors_bbb"}}
 
-        unregister_offload_temp_dir("/tmp/nvflare_tensors_aaa")
-        assert ctx._outstanding_temp_dirs == {"/tmp/nvflare_tensors_bbb"}
+        unregister_offload_temp_dir("/tmp/nvflare_tensors_aaa", _TOKEN_A)
+        assert ctx._outstanding_temp_dirs == {_TOKEN_A: {"/tmp/nvflare_tensors_bbb"}}
 
-        # Unregister a path that's not present should be a noop, not raise.
-        unregister_offload_temp_dir("/tmp/nvflare_tensors_never_added")
-        assert ctx._outstanding_temp_dirs == {"/tmp/nvflare_tensors_bbb"}
+        # Unregister a path that is not present is a noop.
+        unregister_offload_temp_dir("/tmp/nvflare_tensors_never_added", _TOKEN_A)
+        assert ctx._outstanding_temp_dirs == {_TOKEN_A: {"/tmp/nvflare_tensors_bbb"}}
+
+        # Unregister the last entry — the empty token bucket is removed.
+        unregister_offload_temp_dir("/tmp/nvflare_tensors_bbb", _TOKEN_A)
+        assert ctx._outstanding_temp_dirs == {}
     finally:
         _restore_registry(saved)
 
 
-def test_cleanup_all_outstanding_removes_existing_dirs_and_clears_registry():
+def test_register_and_unregister_with_empty_token_are_noops():
+    """Empty token = opt out of registry tracking. No raises, no entries."""
+    saved = _isolate_registry()
+    try:
+        register_offload_temp_dir("/tmp/nvflare_tensors_xyz", "")
+        assert ctx._outstanding_temp_dirs == {}
+        unregister_offload_temp_dir("/tmp/nvflare_tensors_xyz", "")
+        assert ctx._outstanding_temp_dirs == {}
+    finally:
+        _restore_registry(saved)
+
+
+def test_cleanup_for_token_removes_dirs_and_clears_scope():
     saved = _isolate_registry()
     created = []
     try:
         for _ in range(3):
             d = tempfile.mkdtemp(prefix="nvflare_tensors_test_")
             created.append(d)
-            register_offload_temp_dir(d)
-            # Drop a sentinel file so we can verify rmtree actually ran.
+            register_offload_temp_dir(d, _TOKEN_A)
             with open(os.path.join(d, "sentinel"), "w") as f:
                 f.write("x")
 
         for d in created:
             assert os.path.isdir(d)
 
-        cleanup_all_outstanding_offload_temps()
+        cleanup_offload_temps_for_token(_TOKEN_A)
 
         for d in created:
             assert not os.path.exists(d), f"{d} should have been removed"
-        assert ctx._outstanding_temp_dirs == set()
+        assert ctx._outstanding_temp_dirs == {}
     finally:
         for d in created:
             if os.path.exists(d):
-                import shutil
-
                 shutil.rmtree(d, ignore_errors=True)
         _restore_registry(saved)
 
 
-def test_cleanup_all_outstanding_is_idempotent_and_handles_missing_dirs():
+def test_cleanup_for_token_is_idempotent_and_handles_missing_dirs():
     saved = _isolate_registry()
     try:
-        # Register a path that does not exist — cleanup should not raise.
-        register_offload_temp_dir("/tmp/nvflare_tensors_nonexistent_1234567890")
-        cleanup_all_outstanding_offload_temps()
-        assert ctx._outstanding_temp_dirs == set()
+        register_offload_temp_dir("/tmp/nvflare_tensors_nonexistent_1234567890", _TOKEN_A)
+        cleanup_offload_temps_for_token(_TOKEN_A)
+        assert ctx._outstanding_temp_dirs == {}
 
-        # Second call on empty registry — also a noop.
-        cleanup_all_outstanding_offload_temps()
-        assert ctx._outstanding_temp_dirs == set()
+        # Second call on empty token — also a noop.
+        cleanup_offload_temps_for_token(_TOKEN_A)
+        assert ctx._outstanding_temp_dirs == {}
+
+        # Empty token argument — also a noop, never raises.
+        cleanup_offload_temps_for_token("")
+        assert ctx._outstanding_temp_dirs == {}
     finally:
+        _restore_registry(saved)
+
+
+def test_cleanup_for_token_isolates_other_tokens():
+    """Two concurrent tokens. Cleaning up one must not touch the other.
+
+    This is the exact scenario the per-token scoping was added to handle:
+    in NVFlare simulator mode multiple FedAvg instances can run in the
+    same process, and an abort on one must not delete temp dirs the
+    other is still using.
+    """
+    saved = _isolate_registry()
+    a_dir = b_dir = None
+    try:
+        a_dir = tempfile.mkdtemp(prefix="nvflare_tensors_test_iso_a_")
+        b_dir = tempfile.mkdtemp(prefix="nvflare_tensors_test_iso_b_")
+        register_offload_temp_dir(a_dir, _TOKEN_A)
+        register_offload_temp_dir(b_dir, _TOKEN_B)
+
+        cleanup_offload_temps_for_token(_TOKEN_A)
+
+        assert not os.path.exists(a_dir), "TOKEN_A's dir should have been removed"
+        assert os.path.exists(b_dir), "TOKEN_B's dir must NOT be touched"
+        assert _TOKEN_A not in ctx._outstanding_temp_dirs
+        assert ctx._outstanding_temp_dirs.get(_TOKEN_B) == {b_dir}
+    finally:
+        if a_dir and os.path.exists(a_dir):
+            shutil.rmtree(a_dir, ignore_errors=True)
+        if b_dir and os.path.exists(b_dir):
+            shutil.rmtree(b_dir, ignore_errors=True)
         _restore_registry(saved)
 
 
@@ -195,15 +254,29 @@ def test_unregister_via_natural_cleanup_removes_from_registry():
     d = None
     try:
         d = tempfile.mkdtemp(prefix="nvflare_tensors_test_natural_")
-        register_offload_temp_dir(d)
-        assert d in ctx._outstanding_temp_dirs
+        register_offload_temp_dir(d, _TOKEN_A)
+        assert d in ctx._outstanding_temp_dirs[_TOKEN_A]
 
-        _cleanup_temp_dir(d)
+        _cleanup_temp_dir(d, _TOKEN_A)
         assert not os.path.exists(d)
-        assert d not in ctx._outstanding_temp_dirs
+        assert _TOKEN_A not in ctx._outstanding_temp_dirs
     finally:
         if d and os.path.exists(d):
-            import shutil
-
             shutil.rmtree(d, ignore_errors=True)
         _restore_registry(saved)
+
+
+def test_apply_propagates_registry_token_to_fobs_context():
+    cell = _MockCell(enable_tensor_disk_offload=False)
+    apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True, registry_token="my_token")
+    assert cell.ctx["enable_tensor_disk_offload"] is True
+    assert cell.ctx.get("tensor_disk_offload_registry_token") == "my_token"
+
+
+def test_restore_clears_registry_token():
+    cell = _MockCell(enable_tensor_disk_offload=False)
+    apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True, registry_token="my_token")
+    assert cell.ctx.get("tensor_disk_offload_registry_token") == "my_token"
+    restore_enable_tensor_disk_offload(_MockEngine(cell), previous_value=False)
+    assert cell.ctx["enable_tensor_disk_offload"] is False
+    assert cell.ctx.get("tensor_disk_offload_registry_token") == ""

--- a/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
+++ b/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
+
+import nvflare.app_common.utils.tensor_disk_offload_context as ctx
 from nvflare.app_common.utils.tensor_disk_offload_context import (
     apply_enable_tensor_disk_offload,
+    cleanup_all_outstanding_offload_temps,
+    register_offload_temp_dir,
     restore_enable_tensor_disk_offload,
+    unregister_offload_temp_dir,
 )
 
 
@@ -102,3 +109,101 @@ def test_apply_and_restore_use_run_manager_cell_when_available():
 
     restore_enable_tensor_disk_offload(engine, previous)
     assert run_cell.ctx["enable_tensor_disk_offload"] is False
+
+
+def _isolate_registry():
+    """Snapshot + clear the module-level registry so each test starts clean."""
+    with ctx._outstanding_lock:
+        snapshot = set(ctx._outstanding_temp_dirs)
+        ctx._outstanding_temp_dirs.clear()
+    return snapshot
+
+
+def _restore_registry(snapshot):
+    with ctx._outstanding_lock:
+        ctx._outstanding_temp_dirs.clear()
+        ctx._outstanding_temp_dirs.update(snapshot)
+
+
+def test_register_and_unregister_offload_temp_dir():
+    saved = _isolate_registry()
+    try:
+        register_offload_temp_dir("/tmp/nvflare_tensors_aaa")
+        register_offload_temp_dir("/tmp/nvflare_tensors_bbb")
+        assert ctx._outstanding_temp_dirs == {"/tmp/nvflare_tensors_aaa", "/tmp/nvflare_tensors_bbb"}
+
+        unregister_offload_temp_dir("/tmp/nvflare_tensors_aaa")
+        assert ctx._outstanding_temp_dirs == {"/tmp/nvflare_tensors_bbb"}
+
+        # Unregister a path that's not present should be a noop, not raise.
+        unregister_offload_temp_dir("/tmp/nvflare_tensors_never_added")
+        assert ctx._outstanding_temp_dirs == {"/tmp/nvflare_tensors_bbb"}
+    finally:
+        _restore_registry(saved)
+
+
+def test_cleanup_all_outstanding_removes_existing_dirs_and_clears_registry():
+    saved = _isolate_registry()
+    created = []
+    try:
+        for _ in range(3):
+            d = tempfile.mkdtemp(prefix="nvflare_tensors_test_")
+            created.append(d)
+            register_offload_temp_dir(d)
+            # Drop a sentinel file so we can verify rmtree actually ran.
+            with open(os.path.join(d, "sentinel"), "w") as f:
+                f.write("x")
+
+        for d in created:
+            assert os.path.isdir(d)
+
+        cleanup_all_outstanding_offload_temps()
+
+        for d in created:
+            assert not os.path.exists(d), f"{d} should have been removed"
+        assert ctx._outstanding_temp_dirs == set()
+    finally:
+        for d in created:
+            if os.path.exists(d):
+                import shutil
+
+                shutil.rmtree(d, ignore_errors=True)
+        _restore_registry(saved)
+
+
+def test_cleanup_all_outstanding_is_idempotent_and_handles_missing_dirs():
+    saved = _isolate_registry()
+    try:
+        # Register a path that does not exist — cleanup should not raise.
+        register_offload_temp_dir("/tmp/nvflare_tensors_nonexistent_1234567890")
+        cleanup_all_outstanding_offload_temps()
+        assert ctx._outstanding_temp_dirs == set()
+
+        # Second call on empty registry — also a noop.
+        cleanup_all_outstanding_offload_temps()
+        assert ctx._outstanding_temp_dirs == set()
+    finally:
+        _restore_registry(saved)
+
+
+def test_unregister_via_natural_cleanup_removes_from_registry():
+    """When _cleanup_temp_dir runs (the natural path), the registry entry
+    must also be removed so the safety-net sweep does not double-clean."""
+    from nvflare.app_opt.pt.lazy_tensor_dict import _cleanup_temp_dir
+
+    saved = _isolate_registry()
+    d = None
+    try:
+        d = tempfile.mkdtemp(prefix="nvflare_tensors_test_natural_")
+        register_offload_temp_dir(d)
+        assert d in ctx._outstanding_temp_dirs
+
+        _cleanup_temp_dir(d)
+        assert not os.path.exists(d)
+        assert d not in ctx._outstanding_temp_dirs
+    finally:
+        if d and os.path.exists(d):
+            import shutil
+
+            shutil.rmtree(d, ignore_errors=True)
+        _restore_registry(saved)

--- a/tests/unit_test/app_opt/pt/test_disk_tensor_consumer.py
+++ b/tests/unit_test/app_opt/pt/test_disk_tensor_consumer.py
@@ -236,7 +236,7 @@ def test_download_tensors_to_disk_second_chance_cleanup_on_consumer_error(monkey
     def fake_download_object(**kwargs):
         kwargs["consumer"].error = "download failed"
 
-    def fake_cleanup(path):
+    def fake_cleanup(path, registry_token=""):
         cleanup_calls.append(path)
         shutil.rmtree(path, ignore_errors=True)
 


### PR DESCRIPTION
## Summary
- Fixes a temporary directory leak in disk offload (`enable_tensor_disk_offload=True`) when the FedAvg controller exits via the `abort_signal` early return or any unhandled exception.
- Root cause: cleanup is gated on Python GC of `_TempDirRef.__del__`, but on abort the partial state held by `self._aggr_helper` / `self.aggregator` keeps the `LazyTensorDict` references reachable from the controller instance, blocking GC.
- `admin.delete_job()` does not help — it only `rmtree`s the job's run folder, never touching `TMPDIR` or `nvflare_tensors_*` dirs.
- Adds a module-level registry of outstanding offload temp dirs as a safety net. Populated at `mkdtemp` time, depopulated by the existing natural cleanup, swept by a new `cleanup_all_outstanding_offload_temps()` call in `FedAvg.run()`'s `finally` block.

## Changes
- `nvflare/app_common/utils/tensor_disk_offload_context.py`: add `register_offload_temp_dir`, `unregister_offload_temp_dir`, and `cleanup_all_outstanding_offload_temps` (thread-safe module-level registry).
- `nvflare/app_opt/pt/tensor_downloader.py`: register `temp_dir` immediately after `tempfile.mkdtemp()` in `download_tensors_to_disk`.
- `nvflare/app_opt/pt/lazy_tensor_dict.py`: unregister `path` in `_cleanup_temp_dir`'s `finally` block, so the natural cleanup path keeps the registry consistent.
- `nvflare/app_common/workflows/fedavg.py`: call `cleanup_all_outstanding_offload_temps()` from `FedAvg.run()`'s `finally` block when disk offload was enabled. Typically a noop on normal completion (registry already drained by GC), but the difference between leak and no-leak on abort.
- `tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py`: add 4 new tests for register/unregister/cleanup/idempotency, plus an integration test verifying that the natural `_cleanup_temp_dir` path keeps the registry consistent.

## Verification
- All 116 directly-related unit tests pass: 9 in `tensor_disk_offload_context_test.py`, 70 in `fedavg_test.py`, 37 in `app_opt/pt/test_*.py` (lazy_tensor_dict, tensor_downloader, disk_tensor_consumer).
- `flake8`, `black`, `isort` clean on all 5 changed files.
- License headers present on all changed files.
- Empirically reproduced and validated against the regression cases in `nvflare_test`:
  - `L3_tensor_disk_offload_normal_cleanup` (3 rounds, normal completion): TMPDIR is empty post-completion (`OK_NO_LEFTOVER`) — confirms the natural cleanup path is unaffected.
  - `L3_tensor_disk_offload_abort` (abort mid-round-0, then `delete_job`): without this fix, 4 `nvflare_tensors_*` directories survived 90+ seconds across both `abort_job` and `delete_job` (`POST_ABORT=UNEXPECTED_LEFTOVER` and `POST_DELETE=UNEXPECTED_LEFTOVER`). With this fix the abort case should now report `OK_NO_LEFTOVER`.
