### PR TITLE
Fix task cleanup on workflow finalization

### DIFF
--- a/nvflare/apis/impl/wf_comm_server.py
+++ b/nvflare/apis/impl/wf_comm_server.py
@@ -793,6 +793,10 @@ class WFCommServer(FLComponent, WFCommSpec):
         task.before_task_sent_cb = None
         task.after_task_sent_cb = None
         task.result_received_cb = None
+        # finalize_run is called after controller.run has exited and the
+        # communicator is being torn down. Normal task-exit callbacks are run
+        # by the task monitor drain path; finalization only releases any task
+        # references still owned by this communicator.
         task.task_done_cb = None
 
     def _clear_standing_tasks(
@@ -1139,7 +1143,7 @@ class WFCommServer(FLComponent, WFCommSpec):
                 self.cancel_task(task, fl_ctx=None, completion_status=TaskCompletionStatus.ABORTED)
                 break
 
-            task_done = task.props[_TASK_KEY_DONE]
+            task_done = task.props.get(_TASK_KEY_DONE, False)
             if task_done:
                 break
             time.sleep(self._task_check_period)

--- a/nvflare/apis/impl/wf_comm_server.py
+++ b/nvflare/apis/impl/wf_comm_server.py
@@ -754,6 +754,9 @@ class WFCommServer(FLComponent, WFCommSpec):
     def cancel_all_tasks(self, completion_status=TaskCompletionStatus.CANCELLED, fl_ctx: Optional[FLContext] = None):
         """Cancel all standing tasks in this controller.
 
+        This only marks tasks completed. In the normal running path, the task
+        monitor later removes completed tasks and drops their owned resources.
+
         Args:
             completion_status (str, optional): the completion status for this cancellation.
                 Defaults to TaskCompletionStatus.CANCELLED.
@@ -762,6 +765,54 @@ class WFCommServer(FLComponent, WFCommSpec):
         with self._task_lock:
             for t in self._tasks:
                 t.completion_status = completion_status
+
+    def _release_task_resources(self, task: Task, fl_ctx: Optional[FLContext] = None):
+        """Drop references owned by a task after it leaves the communicator."""
+        try:
+            msg_root_id = getattr(task, "msg_root_id", None)
+            if msg_root_id:
+                delete_msg_root(msg_root_id)
+        except Exception as e:
+            self.log_warning(
+                fl_ctx,
+                "error cleaning up download transactions for task {}: {}".format(task.name, secure_format_exception(e)),
+            )
+
+        if hasattr(task, "_broadcast_data"):
+            delattr(task, "_broadcast_data")
+
+        for client_task in task.client_tasks:
+            client_task.result = None
+            client_task.props.clear()
+            client_task.task = None
+
+        task.client_tasks.clear()
+        task.last_client_task_map.clear()
+        task.props.clear()
+        task.data = None
+        task.before_task_sent_cb = None
+        task.after_task_sent_cb = None
+        task.result_received_cb = None
+        task.task_done_cb = None
+
+    def _clear_standing_tasks(
+        self, completion_status=TaskCompletionStatus.CANCELLED, fl_ctx: Optional[FLContext] = None
+    ):
+        """Cancel and remove standing tasks, releasing references synchronously.
+
+        finalize_run stops the task monitor, so it cannot rely on
+        cancel_all_tasks() plus a later monitor pass to drain task state.
+        """
+        with self._task_lock:
+            exit_tasks = list(self._tasks)
+            self._tasks.clear()
+            self._client_task_map.clear()
+
+        for task in exit_tasks:
+            if task.completion_status is None:
+                task.completion_status = completion_status
+            task.is_standing = False
+            self._release_task_resources(task, fl_ctx)
 
     def finalize_run(self, fl_ctx: FLContext):
         """Do cleanup of the coordinator implementation.
@@ -773,8 +824,9 @@ class WFCommServer(FLComponent, WFCommSpec):
         Args:
             fl_ctx (FLContext): FLContext associated with this action
         """
-        self.cancel_all_tasks()  # unconditionally cancel all tasks
-        self._all_done = True
+        with self._controller_lock:
+            self._clear_standing_tasks(fl_ctx=fl_ctx)
+            self._all_done = True
 
     def relay(
         self,

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -34,7 +34,6 @@ from nvflare.apis.impl.wf_comm_server import WFCommServer
 from nvflare.apis.server_engine_spec import ServerEngineSpec
 from nvflare.apis.shareable import ReservedHeaderKey, Shareable
 from nvflare.apis.signal import Signal
-from nvflare.app_opt.pt.lazy_tensor_dict import LazyTensorDict
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -59,11 +58,14 @@ def create_client(name, token=None):
 
 
 def attach_lazy_result(client_task: ClientTask, base_dir):
+    lazy_tensor_dict = pytest.importorskip(
+        "nvflare.app_opt.pt.lazy_tensor_dict", reason="lazy tensor cleanup test requires safetensors"
+    )
     temp_dir = tempfile.mkdtemp(prefix="nvflare_tensors_test_finalize_", dir=str(base_dir))
     file_path = os.path.join(temp_dir, "chunk_0.safetensors")
     with open(file_path, "wb"):
         pass
-    lazy_tensors = LazyTensorDict(key_to_file={"w": (file_path, "w")}, temp_dir=temp_dir)
+    lazy_tensors = lazy_tensor_dict.LazyTensorDict(key_to_file={"w": (file_path, "w")}, temp_dir=temp_dir)
     lazy_ref = lazy_tensors.make_lazy_ref("w")
     lazy_ref_ref = weakref.ref(lazy_ref)
     client_task.result = Shareable({"params": {"w": lazy_ref}})

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import logging
+import os
 import re
+import tempfile
 import threading
 import time
 import uuid
+import weakref
 from itertools import permutations
 from unittest.mock import Mock
 
@@ -30,6 +34,7 @@ from nvflare.apis.impl.wf_comm_server import WFCommServer
 from nvflare.apis.server_engine_spec import ServerEngineSpec
 from nvflare.apis.shareable import ReservedHeaderKey, Shareable
 from nvflare.apis.signal import Signal
+from nvflare.app_opt.pt.lazy_tensor_dict import LazyTensorDict
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -51,6 +56,18 @@ def create_task(name, data=None, timeout=0, before_task_sent_cb=None, result_rec
 def create_client(name, token=None):
     token = str(uuid.uuid4()) if token is None else token
     return Client(name=name, token=token)
+
+
+def attach_lazy_result(client_task: ClientTask, base_dir):
+    temp_dir = tempfile.mkdtemp(prefix="nvflare_tensors_test_finalize_", dir=str(base_dir))
+    file_path = os.path.join(temp_dir, "chunk_0.safetensors")
+    with open(file_path, "wb"):
+        pass
+    lazy_tensors = LazyTensorDict(key_to_file={"w": (file_path, "w")}, temp_dir=temp_dir)
+    lazy_ref = lazy_tensors.make_lazy_ref("w")
+    lazy_ref_ref = weakref.ref(lazy_ref)
+    client_task.result = Shareable({"params": {"w": lazy_ref}})
+    return temp_dir, lazy_ref_ref
 
 
 def assert_task_data_valid(data, input_data, method):
@@ -1122,6 +1139,29 @@ class TestBasic(TestController):
         assert task1.completion_status == TaskCompletionStatus.CANCELLED
         launch_thread.join()
         self.teardown_system(controller, fl_ctx)
+
+    def test_finalize_run_releases_client_task_results(self, tmp_path):
+        controller, fl_ctx, clients = self.setup_system()
+        client = clients[0]
+        task = create_task("__test_task")
+
+        controller.broadcast(task=task, fl_ctx=fl_ctx, targets=[client])
+        _, task_id, _ = controller.communicator.process_task_request(client=client, fl_ctx=fl_ctx)
+        client_task = controller.communicator._client_task_map[task_id]
+        temp_dir, lazy_ref_ref = attach_lazy_result(client_task, tmp_path)
+
+        assert os.path.exists(temp_dir)
+        assert controller.get_num_standing_tasks() == 1
+
+        controller.communicator.finalize_run(fl_ctx=fl_ctx)
+        gc.collect()
+
+        assert controller.get_num_standing_tasks() == 0
+        assert controller.communicator._client_task_map == {}
+        assert client_task.result is None
+        assert client_task.task is None
+        assert lazy_ref_ref() is None
+        assert not os.path.exists(temp_dir)
 
 
 @pytest.mark.parametrize("method", ["broadcast", "broadcast_and_wait"])


### PR DESCRIPTION
## Summary

Fixes FLARE-2909 by making workflow finalization release communicator-owned task state synchronously.

The previous `WFCommServer.finalize_run()` path called `cancel_all_tasks()` and then stopped the task monitor with `_all_done = True`. `cancel_all_tasks()` only marks standing tasks completed; the monitor is normally responsible for later removing those tasks from `_tasks` / `_client_task_map` and dropping task/client-task references. On abort/finalize, the monitor could be stopped before that drain pass, leaving task results reachable. For tensor disk offload, those task results can hold `LazyTensorDict` / `_LazyRef` objects, which prevents normal GC from running `_TempDirRef.__del__` and removing the offload temp directory.

This PR keeps the existing GC-based disk cleanup model and fixes the owner lifecycle instead of adding an explicit temp-dir registry.

## Changes

- Add synchronous task-resource release for `WFCommServer.finalize_run()`.
- Preserve `cancel_all_tasks()` semantics as mark-only; normal running paths still let the monitor drain tasks.
- Clear communicator-owned references from completed tasks and client tasks during finalization.
- Add a focused regression test proving finalization releases a lazy tensor ref and its temp directory through normal GC.

