### PR TITLE
Update available HE recipes docs

### DIFF
--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -590,6 +590,12 @@ Federated Kaplan-Meier survival analysis with optional homomorphic encryption ov
 The ``KMRecipe`` is defined in the Kaplan-Meier example's ``job.py`` rather than exported as a package-level
 recipe.
 
+Run the snippet from the Kaplan-Meier example directory so ``from job import KMRecipe`` resolves correctly:
+
+.. code-block:: bash
+
+    cd examples/advanced/kaplan-meier-he
+
 .. code-block:: python
 
     from job import KMRecipe

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -155,7 +155,7 @@ FedAvg with secure aggregation using homomorphic encryption.
 .. code-block:: python
 
     from nvflare.app_opt.pt.recipes import FedAvgRecipeWithHE
-    from nvflare.recipe import SimEnv
+    from nvflare.recipe import ProdEnv
 
     recipe = FedAvgRecipeWithHE(
         name="fedavg-he",
@@ -164,12 +164,19 @@ FedAvg with secure aggregation using homomorphic encryption.
         model=MyModel(),
         train_script="client.py",
     )
-    env = SimEnv(num_clients=2)
+    env = ProdEnv(
+        startup_kit_location="/path/to/startup_kit/admin@nvidia.com",
+        username="admin@nvidia.com",
+    )
     run = recipe.execute(env)
+
+.. note::
+   ``FedAvgRecipeWithHE`` requires provisioned startup kits with homomorphic encryption context files.
+   Use ``ProdEnv`` or ``PocEnv`` with HE provisioning; ``SimEnv`` is not supported.
 
 **Examples:**
 
-- `examples/advanced/kaplan-meier-he <https://github.com/NVIDIA/NVFlare/tree/main/examples/advanced/kaplan-meier-he>`_
+- `examples/advanced/cifar10/pt/cifar10-real-world#secure-aggregation-using-homomorphic-encryption <https://github.com/NVIDIA/NVFlare/tree/main/examples/advanced/cifar10/pt/cifar10-real-world#42-secure-aggregation-using-homomorphic-encryption>`_
 
 
 FedProx
@@ -575,6 +582,33 @@ Compute federated statistics across distributed data.
 - `examples/hello-world/hello-tabular-stats <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world/hello-tabular-stats>`_
 - `examples/advanced/federated-statistics/df_stats <https://github.com/NVIDIA/NVFlare/tree/main/examples/advanced/federated-statistics/df_stats>`_
 - `examples/advanced/federated-statistics/image_stats <https://github.com/NVIDIA/NVFlare/tree/main/examples/advanced/federated-statistics/image_stats>`_
+
+Kaplan-Meier Survival Analysis
+------------------------------
+
+Federated Kaplan-Meier survival analysis with optional homomorphic encryption over binned event histograms.
+The ``KMRecipe`` is defined in the Kaplan-Meier example's ``job.py`` rather than exported as a package-level
+recipe.
+
+.. code-block:: python
+
+    from job import KMRecipe
+    from nvflare.recipe import SimEnv
+
+    # KMRecipe is defined in examples/advanced/kaplan-meier-he/job.py
+    recipe = KMRecipe(
+        num_clients=5,
+        encryption=True,
+        data_root="/tmp/nvflare/dataset/km_data",
+        he_context_path_client="/tmp/nvflare/he_context/he_context_client.txt",
+        he_context_path_server="/tmp/nvflare/he_context/he_context_server.txt",
+    )
+    env = SimEnv(num_clients=5)
+    run = recipe.execute(env)
+
+**Examples:**
+
+- `examples/advanced/kaplan-meier-he <https://github.com/NVIDIA/NVFlare/tree/main/examples/advanced/kaplan-meier-he>`_
 
 
 Federated Evaluation


### PR DESCRIPTION
## What changed
- Point the FedAvg with Homomorphic Encryption recipe example to the CIFAR-10 real-world HE section.
- Update the FedAvg HE snippet to use a provisioned `ProdEnv` and note that `SimEnv` is not supported.
- Add the Kaplan-Meier `KMRecipe` as a separate Federated Statistics entry.

## Why
The FedAvg HE section previously linked to the Kaplan-Meier HE example, which uses its own example-local `KMRecipe` rather than `FedAvgRecipeWithHE`. The catalog now separates those entries and reflects the current HE recipe execution requirements.

## Validation
- `./build_doc.sh --html --skip-api`