### PR TITLE
Fail server job process on streamed submit_update decode failure

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -56,17 +56,18 @@ def _is_stream_channel(channel: str) -> bool:
 
 
 def _is_server_job_cell(my_info) -> bool:
-    """Return True only for the server child cell that owns one job run.
+    """Return True only for server cells owned by one job run.
 
-    Parent server cell FQCN is "server"; server job cells are "server.<job_id>".
-    The fail-fast path must only exit the job process, never the parent server.
+    Parent server cell FQCN is "server"; server job cells start with
+    "server.<job_id>" and may have nested children like "server.<job_id>.cell_pipe".
+    The fail-fast path must only exit a job process, never the parent server.
     """
     fqcn = getattr(my_info, "fqcn", "")
     if not fqcn:
         return False
 
     path = FQCN.split(fqcn)
-    return len(path) == 2 and path[0] == FQCN.ROOT_SERVER
+    return len(path) >= 2 and path[0] == FQCN.ROOT_SERVER
 
 
 class SimpleWaiter:

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -14,13 +14,16 @@
 
 import concurrent.futures
 import copy
+import os
 import threading
 import uuid
 from typing import Dict, List, Union
 
+from nvflare.apis.fl_constant import ServerCommandNames
 from nvflare.apis.signal import Signal
 from nvflare.fuel.f3.cellnet.core_cell import CoreCell, TargetMessage
 from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey, MessagePropKey, MessageType, ReturnCode
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.utils import decode_payload, encode_payload, make_reply
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.stream_cell import StreamCell
@@ -50,6 +53,15 @@ def _is_stream_channel(channel: str) -> bool:
         return False
     # if not excluded, all channels supporting streaming capabilities
     return True
+
+
+def _is_server_job_cell(my_info) -> bool:
+    fqcn = getattr(my_info, "fqcn", "")
+    if not fqcn:
+        return False
+
+    path = FQCN.split(fqcn)
+    return len(path) == 2 and path[0] == FQCN.ROOT_SERVER
 
 
 class SimpleWaiter:
@@ -82,13 +94,26 @@ class Adapter:
         # activates LazyDownloadRef decode so tensors are not downloaded at
         # this hop.
         channel = request.get_header(StreamHeaderKey.CHANNEL)
+        topic = request.get_header(StreamHeaderKey.TOPIC)
         passthrough = bool(request.get_header(MessageHeaderKey.PASS_THROUGH, False))
         if channel in self.cell.decode_pass_through_channels:
             passthrough = True
         decode_ctx = self.cell.get_fobs_context(props={FOBSContextKey.PASS_THROUGH: passthrough})
-        decode_payload(request, StreamHeaderKey.PAYLOAD_ENCODING, fobs_ctx=decode_ctx)
+        try:
+            decode_payload(request, StreamHeaderKey.PAYLOAD_ENCODING, fobs_ctx=decode_ctx)
+        except Exception as ex:
+            if (
+                channel == CellChannel.SERVER_COMMAND
+                and topic == ServerCommandNames.SUBMIT_UPDATE
+                and _is_server_job_cell(self.my_info)
+            ):
+                self.logger.critical(
+                    f"failed to decode streamed submit_update in server job cell {self.my_info.fqcn}; "
+                    f"exiting job process to fail the job: {secure_format_exception(ex)}"
+                )
+                os._exit(1)
+            raise
         request.set_header(MessageHeaderKey.CHANNEL, channel)
-        topic = request.get_header(StreamHeaderKey.TOPIC)
         request.set_header(MessageHeaderKey.TOPIC, topic)
         self.logger.debug(f"Call back on {stream_req_id=}: {channel=}, {topic=}")
 

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -56,6 +56,11 @@ def _is_stream_channel(channel: str) -> bool:
 
 
 def _is_server_job_cell(my_info) -> bool:
+    """Return True only for the server child cell that owns one job run.
+
+    Parent server cell FQCN is "server"; server job cells are "server.<job_id>".
+    The fail-fast path must only exit the job process, never the parent server.
+    """
     fqcn = getattr(my_info, "fqcn", "")
     if not fqcn:
         return False

--- a/tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py
+++ b/tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py
@@ -127,6 +127,18 @@ def _headers_without_pass_through(stream_req_id=""):
     }
 
 
+def _stream_headers(channel, topic):
+    return {
+        StreamHeaderKey.STREAM_REQ_ID: "stream-1",
+        StreamHeaderKey.CHANNEL: channel,
+        StreamHeaderKey.TOPIC: topic,
+        MessageHeaderKey.ORIGIN: "client1",
+        MessageHeaderKey.REQ_ID: "req-1",
+        MessageHeaderKey.SECURE: False,
+        MessageHeaderKey.OPTIONAL: False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # 1-3: Adapter.call() — per-message decode_ctx construction
 # ---------------------------------------------------------------------------
@@ -283,21 +295,14 @@ class TestAdapterPassThroughHeader:
         cell = adapter.cell
         cell.get_fobs_context.assert_called_once_with(props={FOBSContextKey.PASS_THROUGH: True})
 
-    def test_submit_update_decode_failure_exits_server_job_process(self):
+    @pytest.mark.parametrize("fqcn", ["server.job-1", "server.job-1.cell_pipe"])
+    def test_submit_update_decode_failure_exits_server_job_process(self, fqcn):
         captured = {}
         cell = _make_mock_cell(captured)
         cb = MagicMock()
-        adapter = Adapter(cb=cb, my_info=SimpleNamespace(fqcn="server.job-1"), cell=cell)
+        adapter = Adapter(cb=cb, my_info=SimpleNamespace(fqcn=fqcn), cell=cell)
 
-        headers = {
-            StreamHeaderKey.STREAM_REQ_ID: "stream-1",
-            StreamHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
-            StreamHeaderKey.TOPIC: ServerCommandNames.SUBMIT_UPDATE,
-            MessageHeaderKey.ORIGIN: "client1",
-            MessageHeaderKey.REQ_ID: "req-1",
-            MessageHeaderKey.SECURE: False,
-            MessageHeaderKey.OPTIONAL: False,
-        }
+        headers = _stream_headers(CellChannel.SERVER_COMMAND, ServerCommandNames.SUBMIT_UPDATE)
         future = _make_future(headers, payload=b"encoded-result")
 
         with patch("nvflare.fuel.f3.cellnet.cell.decode_payload", side_effect=OSError("No space left on device")):
@@ -316,15 +321,31 @@ class TestAdapterPassThroughHeader:
         cb = MagicMock()
         adapter = Adapter(cb=cb, my_info=SimpleNamespace(fqcn="server"), cell=cell)
 
-        headers = {
-            StreamHeaderKey.STREAM_REQ_ID: "stream-1",
-            StreamHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
-            StreamHeaderKey.TOPIC: ServerCommandNames.SUBMIT_UPDATE,
-            MessageHeaderKey.ORIGIN: "client1",
-            MessageHeaderKey.REQ_ID: "req-1",
-            MessageHeaderKey.SECURE: False,
-            MessageHeaderKey.OPTIONAL: False,
-        }
+        headers = _stream_headers(CellChannel.SERVER_COMMAND, ServerCommandNames.SUBMIT_UPDATE)
+        future = _make_future(headers, payload=b"encoded-result")
+
+        with patch("nvflare.fuel.f3.cellnet.cell.decode_payload", side_effect=OSError("No space left on device")):
+            with patch("nvflare.fuel.f3.cellnet.cell.os._exit") as mock_exit:
+                with pytest.raises(OSError, match="No space left on device"):
+                    adapter.call(future)
+
+        mock_exit.assert_not_called()
+        cb.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "channel, topic",
+        [
+            (CellChannel.SERVER_COMMAND, ServerCommandNames.GET_TASK),
+            (CellChannel.AUX_COMMUNICATION, ServerCommandNames.SUBMIT_UPDATE),
+        ],
+    )
+    def test_decode_failure_on_other_server_job_streams_is_raised(self, channel, topic):
+        captured = {}
+        cell = _make_mock_cell(captured)
+        cb = MagicMock()
+        adapter = Adapter(cb=cb, my_info=SimpleNamespace(fqcn="server.job-1"), cell=cell)
+
+        headers = _stream_headers(channel, topic)
         future = _make_future(headers, payload=b"encoded-result")
 
         with patch("nvflare.fuel.f3.cellnet.cell.decode_payload", side_effect=OSError("No space left on device")):

--- a/tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py
+++ b/tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py
@@ -52,10 +52,14 @@ Tests verify:
 """
 
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from nvflare.apis.fl_constant import ServerCommandNames
 from nvflare.fuel.f3.cellnet.cell import Adapter, Cell
-from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.message import Message as F3Message
 from nvflare.fuel.f3.streaming.stream_const import StreamHeaderKey
 from nvflare.fuel.utils.fobs import FOBSContextKey
@@ -278,6 +282,58 @@ class TestAdapterPassThroughHeader:
         # Verify the cell method was called with props, not without
         cell = adapter.cell
         cell.get_fobs_context.assert_called_once_with(props={FOBSContextKey.PASS_THROUGH: True})
+
+    def test_submit_update_decode_failure_exits_server_job_process(self):
+        captured = {}
+        cell = _make_mock_cell(captured)
+        cb = MagicMock()
+        adapter = Adapter(cb=cb, my_info=SimpleNamespace(fqcn="server.job-1"), cell=cell)
+
+        headers = {
+            StreamHeaderKey.STREAM_REQ_ID: "stream-1",
+            StreamHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
+            StreamHeaderKey.TOPIC: ServerCommandNames.SUBMIT_UPDATE,
+            MessageHeaderKey.ORIGIN: "client1",
+            MessageHeaderKey.REQ_ID: "req-1",
+            MessageHeaderKey.SECURE: False,
+            MessageHeaderKey.OPTIONAL: False,
+        }
+        future = _make_future(headers, payload=b"encoded-result")
+
+        with patch("nvflare.fuel.f3.cellnet.cell.decode_payload", side_effect=OSError("No space left on device")):
+            with patch("nvflare.fuel.f3.cellnet.cell.os._exit", side_effect=SystemExit(1)) as mock_exit:
+                with pytest.raises(SystemExit) as ex_info:
+                    adapter.call(future)
+
+        assert ex_info.value.code == 1
+        mock_exit.assert_called_once_with(1)
+        cb.assert_not_called()
+        cell.send_blob.assert_not_called()
+
+    def test_submit_update_decode_failure_on_parent_server_cell_is_raised(self):
+        captured = {}
+        cell = _make_mock_cell(captured)
+        cb = MagicMock()
+        adapter = Adapter(cb=cb, my_info=SimpleNamespace(fqcn="server"), cell=cell)
+
+        headers = {
+            StreamHeaderKey.STREAM_REQ_ID: "stream-1",
+            StreamHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
+            StreamHeaderKey.TOPIC: ServerCommandNames.SUBMIT_UPDATE,
+            MessageHeaderKey.ORIGIN: "client1",
+            MessageHeaderKey.REQ_ID: "req-1",
+            MessageHeaderKey.SECURE: False,
+            MessageHeaderKey.OPTIONAL: False,
+        }
+        future = _make_future(headers, payload=b"encoded-result")
+
+        with patch("nvflare.fuel.f3.cellnet.cell.decode_payload", side_effect=OSError("No space left on device")):
+            with patch("nvflare.fuel.f3.cellnet.cell.os._exit") as mock_exit:
+                with pytest.raises(OSError, match="No space left on device"):
+                    adapter.call(future)
+
+        mock_exit.assert_not_called()
+        cb.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- fail the server job process when streamed `submit_update` payload decoding fails inside a server job cell
- leave parent server and non-job cells on the existing exception path
- add unit coverage for the guarded job-cell exit and parent-server non-exit behavior

## Root Cause

For FLARE-2908, disk-full failures during streamed `submit_update` decoding can occur before the request reaches the job command layer. The streaming callback catches ordinary exceptions and the client can keep retrying, so the job does not fail cleanly.

## Validation

- `.venv/bin/python -m pytest tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py -q`
- `.venv/bin/python -m black --check nvflare/fuel/f3/cellnet/cell.py tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py`
- `.venv/bin/python -m isort --check-only nvflare/fuel/f3/cellnet/cell.py tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py`
- `git diff --check`
- isolated GCP FLARE deployment with patched image:
  - normal `hello-numpy` full-update jobs completed
  - normal `hello-numpy-diff` job completed
  - forced streamed `submit_update` decode failure exited the server job process, failed the job, and left the parent server running
