### PR TITLE
Fix -gpu flag for nvflare poc start in Docker mode (#4445)

### DIFF
--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -1916,7 +1916,7 @@ def prepare_env(service_name, gpu_ids: Optional[List[int]], service_config: Dict
     if service_config.get(SC.IS_DOCKER_RUN):
         my_env = os.environ.copy() if my_env is None else my_env
         if gpu_ids:
-            my_env["GPU2USE"] = f"--gpus={my_env['CUDA_VISIBLE_DEVICES']}"
+            my_env["GPU2USE"] = f'--gpus="device={my_env["CUDA_VISIBLE_DEVICES"]}"'
 
         my_env["MY_DATA_DIR"] = os.path.join(get_poc_workspace(), "data")
         my_env["SVR_NAME"] = service_name

--- a/tests/unit_test/lighter/poc_commands_test.py
+++ b/tests/unit_test/lighter/poc_commands_test.py
@@ -23,6 +23,7 @@ from nvflare.tool.poc.poc_commands import (
     get_service_command,
     get_service_config,
     prepare_builders,
+    prepare_env,
     update_clients,
 )
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
@@ -66,6 +67,33 @@ class TestPOCCommands:
         with pytest.raises(CLIException) as e:
             # gpu id =1 is not valid GPU ID as the host only has 1 gpu where id = 0
             gpu_ids = get_gpu_ids([0, 1], host_gpu_ids)
+
+    def test_prepare_env_docker_single_gpu(self):
+        my_env = prepare_env("site-1", [0], {SC.IS_DOCKER_RUN: True})
+        assert my_env["CUDA_VISIBLE_DEVICES"] == "0"
+        assert my_env["GPU2USE"] == '--gpus="device=0"'
+        assert my_env["SVR_NAME"] == "site-1"
+        assert "MY_DATA_DIR" in my_env
+
+    def test_prepare_env_docker_multi_gpu(self):
+        my_env = prepare_env("site-1", [0, 1], {SC.IS_DOCKER_RUN: True})
+        assert my_env["CUDA_VISIBLE_DEVICES"] == "0,1"
+        assert my_env["GPU2USE"] == '--gpus="device=0,1"'
+
+    def test_prepare_env_docker_no_gpu(self, monkeypatch):
+        monkeypatch.delenv("GPU2USE", raising=False)
+        my_env = prepare_env("site-1", [], {SC.IS_DOCKER_RUN: True})
+        assert "GPU2USE" not in my_env
+        assert my_env["SVR_NAME"] == "site-1"
+        assert "MY_DATA_DIR" in my_env
+
+    def test_prepare_env_non_docker_with_gpu(self, monkeypatch):
+        monkeypatch.delenv("GPU2USE", raising=False)
+        monkeypatch.delenv("SVR_NAME", raising=False)
+        my_env = prepare_env("site-1", [0], {})
+        assert my_env["CUDA_VISIBLE_DEVICES"] == "0"
+        assert "GPU2USE" not in my_env
+        assert "SVR_NAME" not in my_env
 
     def test_get_package_command(self):
         cmd = get_service_command(SC.CMD_START, "/tmp/nvflare/poc", SC.FLARE_SERVER, {})


### PR DESCRIPTION
Fixes #4445

### Description

`nvflare poc start -gpu 0` was producing the Docker argument `--gpus=0`, which Docker interprets as a *GPU count* ("give me zero GPUs") rather than a device selector. Spawned client containers therefore launched with no GPU access — `nvidia-smi` and `torch.cuda.is_available()` both failed inside them.

`prepare_env()` in `nvflare/tool/poc/poc_commands.py` is now updated to emit the `--gpus="device=N"` form, matching the format already documented by example in the `docker_cln_sh` template comments at [`nvflare/lighter/templates/master_template.yml:709`](https://github.com/NVIDIA/NVFlare/blob/main/nvflare/lighter/templates/master_template.yml#L709). Single-GPU (`-gpu 0`), multi-GPU (`-gpu 0 1`), and "all" (`-gpu -1`, resolved upstream by `get_gpu_ids()` to a concrete device list) all flow through the same code path. The non-Docker process-launch path and the no-`-gpu`-flag path are unchanged.

**Before:** `GPU2USE=--gpus=0` → `docker run --gpus=0 …` → containers run on the host CPU only.
**After:** `GPU2USE=--gpus="device=0"` → `docker run --gpus="device=0" …` → GPU 0 bound into the container.

Four unit tests added in `tests/unit_test/lighter/poc_commands_test.py` covering: Docker + single GPU, Docker + multi-GPU, Docker + no GPU, non-Docker + GPU.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.