### PR TITLE
Add K8s launcher ephemeral storage overrides

### DIFF
--- a/docs/design/job_launcher_and_job_handle.md
+++ b/docs/design/job_launcher_and_job_handle.md
@@ -131,7 +131,7 @@ If a job lacks required configuration for the site's launcher (e.g. no image on 
     },
     "site-1": {
       "docker": { "image": "nvflare-pt:2.7", "shm_size": "8g" },
-      "k8s":    { "image": "nvflare-pt:2.7", "cpu": "4", "memory": "16Gi", "num_of_gpus": 1 }
+      "k8s":    { "image": "nvflare-pt:2.7", "cpu": "4", "memory": "16Gi", "num_of_gpus": 1, "ephemeral_storage": "8Gi" }
     }
   }
 }
@@ -357,6 +357,7 @@ Constructor parameters:
 | `namespace` | `"default"` | Kubernetes namespace. |
 | `pending_timeout` | `120` | Stuck-detection threshold (poll iterations) when `timeout` is `None`. |
 | `default_python_path` | `"/usr/local/bin/python"` | Default Python executable in the pod command. Job meta can override with `launcher_spec[site][k8s].python_path`. |
+| `ephemeral_storage` | `"1Gi"` | Default job pod workspace `emptyDir` size and `ephemeral-storage` request/limit. Job meta can override with `launcher_spec[site][k8s].ephemeral_storage`. |
 
 Launch sequence:
 
@@ -365,7 +366,7 @@ Launch sequence:
 | 0 | Lazy init: load kubeconfig and create `CoreV1Api`. |
 | 1 | Sanitize job ID via `uuid4_to_rfc1123`. Extract `site_name`, `job_image` from `get_job_launcher_spec(job_meta, site_name, "k8s")`. Raise if `WORKSPACE_OBJECT` missing. |
 | 2 | Read `JOB_PROCESS_ARGS`; raise if absent or `EXE_MODULE` missing. Resolve dataset PVC mounts from `study_data_pvc_file_path` when the YAML file contains entries for the job study. |
-| 3 | Build `job_config`: name, image, args from `get_module_args()`. Use `launcher_spec[site][k8s].python_path` for the pod command when present, falling back to `default_python_path`. Add K8s `resources.limits` from `launcher_spec` `num_of_gpus`, `cpu`, and `memory` when present; `num_of_gpus` falls back to flat `resource_spec[site]` for backward compatibility. Missing study entries skip data PVC mounts. |
+| 3 | Build `job_config`: name, image, args from `get_module_args()`. Use `launcher_spec[site][k8s].python_path` for the pod command when present, falling back to `default_python_path`. Add the workspace `emptyDir.sizeLimit` and `resources.requests/limits["ephemeral-storage"]` from `launcher_spec[site][k8s].ephemeral_storage` when present, falling back to the launcher default. Add K8s `resources.limits` from `launcher_spec` `num_of_gpus`, `cpu`, and `memory` when present; `num_of_gpus` falls back to flat `resource_spec[site]` for backward compatibility. Missing study entries skip data PVC mounts. |
 | 4 | Create `K8sJobHandle`. |
 | 5 | `core_v1.create_namespaced_pod()`. On any exception: set `terminal_state = TERMINATED`, return handle. |
 | 6 | `job_handle.enter_states([RUNNING])`. On any `BaseException`: `terminate()` then re-raise. |

--- a/docs/design/job_meta_launcher_config.md
+++ b/docs/design/job_meta_launcher_config.md
@@ -102,7 +102,7 @@ launcher_spec: launcher-specific execution configuration, namespaced by launcher
   },
   "launcher_spec": {
     "site-1": {
-      "k8s": { "image": "repo/nvflare:2.7.2", "cpu": "500m", "memory": "2Gi" },
+      "k8s": { "image": "repo/nvflare:2.7.2", "cpu": "500m", "memory": "2Gi", "ephemeral_storage": "4Gi" },
       "docker": { "image": "repo/nvflare:2.7.2", "shm_size": "8g" }
     }
   }
@@ -111,7 +111,7 @@ In this model, num_of_gpus can remain in resource_spec as the scheduler-facing r
 Docker: --gpus=2
 K8s: resources.limits["nvidia.com/gpu"] = 2
 Process: passed as an environment variable or argument
-Launcher-only fields such as image, shm_size, and K8s CPU or memory values live only in launcher_spec.
+Launcher-only fields such as image, shm_size, and K8s CPU, memory, or ephemeral storage values live only in launcher_spec.
 This makes image a first-class launcher field for both Docker and K8s, instead of an implicit value derived from unrelated configuration.
 Pros:
 Separation of concerns is explicit and unambiguous

--- a/docs/design/site_runtime_packaging_design.md
+++ b/docs/design/site_runtime_packaging_design.md
@@ -506,12 +506,15 @@ image-specific Python overrides:
 
 - `launcher_spec[<site>][k8s].num_of_gpus`
 - `launcher_spec[<site>][k8s].python_path`
+- `launcher_spec[<site>][k8s].ephemeral_storage`
 - legacy `resource_spec[<site>][k8s].num_of_gpus`
 - `launcher_spec[<site>][k8s].cpu`
 - `launcher_spec[<site>][k8s].memory`
 
 `K8sJobLauncher` maps `num_of_gpus` to the pod container limit
 `nvidia.com/gpu`.
+`launcher_spec[<site>][k8s].ephemeral_storage` maps to the job workspace
+`emptyDir.sizeLimit` and the pod container `ephemeral-storage` request/limit.
 `launcher_spec[<site>][k8s].python_path` overrides
 `job_launcher.default_python_path` for jobs whose image uses a different Python
 location.

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -361,6 +361,8 @@ class K8sJobLauncher(JobLauncherSpec):
         if not isinstance(self.default_python_path, str) or not self.default_python_path:
             raise ValueError("default_python_path must be a non-empty string")
         self.security_context = security_context
+        if not isinstance(ephemeral_storage, str) or not ephemeral_storage:
+            raise ValueError("ephemeral_storage must be a non-empty string")
         self.ephemeral_storage = ephemeral_storage
         self.study_data_pvc_dict = None
         self.core_v1 = None
@@ -432,7 +434,11 @@ class K8sJobLauncher(JobLauncherSpec):
             raise RuntimeError(f"missing {FLContextKey.ARGS} in FLContext")
         k8s_spec = get_job_launcher_spec(job_meta, site_name, "k8s")
         job_image = k8s_spec.get("image")
-        job_ephemeral_storage = k8s_spec.get("ephemeral_storage", self.ephemeral_storage)
+        job_ephemeral_storage = k8s_spec.get("ephemeral_storage")
+        if job_ephemeral_storage is None:
+            job_ephemeral_storage = self.ephemeral_storage
+        if not isinstance(job_ephemeral_storage, str) or not job_ephemeral_storage:
+            raise RuntimeError(f"launcher_spec['{site_name}']['k8s']['ephemeral_storage'] must be a non-empty string")
         if not job_image:
             raise RuntimeError(
                 f"K8sJobLauncher is configured for site '{site_name}' but no job image "

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -432,6 +432,7 @@ class K8sJobLauncher(JobLauncherSpec):
             raise RuntimeError(f"missing {FLContextKey.ARGS} in FLContext")
         k8s_spec = get_job_launcher_spec(job_meta, site_name, "k8s")
         job_image = k8s_spec.get("image")
+        job_ephemeral_storage = k8s_spec.get("ephemeral_storage", self.ephemeral_storage)
         if not job_image:
             raise RuntimeError(
                 f"K8sJobLauncher is configured for site '{site_name}' but no job image "
@@ -488,7 +489,7 @@ class K8sJobLauncher(JobLauncherSpec):
             env[ENV_WORKSPACE_TRANSFER_TOKEN] = workspace_transfer_token
 
             volume_list = [
-                {"name": "workspace-job", "emptyDir": {"sizeLimit": self.ephemeral_storage}},
+                {"name": "workspace-job", "emptyDir": {"sizeLimit": job_ephemeral_storage}},
                 {"name": "startup-kit", "secret": {"secretName": startup_secret_name}},
             ]
             volume_mount_list = [
@@ -519,8 +520,8 @@ class K8sJobLauncher(JobLauncherSpec):
             if args is not None and getattr(args, "set", None) is not None:
                 job_config.update({"set_list": args.set})
             resources = {
-                "requests": {"ephemeral-storage": self.ephemeral_storage},
-                "limits": {"ephemeral-storage": self.ephemeral_storage},
+                "requests": {"ephemeral-storage": job_ephemeral_storage},
+                "limits": {"ephemeral-storage": job_ephemeral_storage},
             }
             for key in ("cpu", "memory"):
                 limit_val = k8s_spec.get(key)

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -861,6 +861,26 @@ class TestK8sJobLauncherInit:
         # study_data.yaml is populated lazily
         assert launcher.study_data_pvc_dict is None
 
+    def test_init_rejects_empty_ephemeral_storage(self):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        with pytest.raises(ValueError, match="ephemeral_storage"):
+            ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path="/fake/study_data.yaml",
+                ephemeral_storage="",
+            )
+
+    def test_init_rejects_non_string_ephemeral_storage(self):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        with pytest.raises(ValueError, match="ephemeral_storage"):
+            ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path="/fake/study_data.yaml",
+                ephemeral_storage=1,
+            )
+
 
 # ---------------------------------------------------------------------------
 # ClientK8sJobLauncher.get_module_args
@@ -1204,6 +1224,35 @@ class TestK8sJobLauncherLaunchJob:
             assert vol_map["workspace-job"]["emptyDir"]["sizeLimit"] == "8Gi"
             assert resources["requests"]["ephemeral-storage"] == "8Gi"
             assert resources["limits"]["ephemeral-storage"] == "8Gi"
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_ephemeral_storage_null_uses_launcher_default(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, mock_api = self._setup(patches, ephemeral_storage="3Gi")
+        self._prime_running(mock_api)
+        try:
+            meta = _make_launch_job_meta()
+            meta[JobMetaKey.JOB_LAUNCHER_SPEC.value]["site-1"]["k8s"]["ephemeral_storage"] = None
+            launcher.launch_job(meta, _make_launch_fl_ctx())
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            vol_map = {v["name"]: v for v in manifest["spec"]["volumes"]}
+            resources = manifest["spec"]["containers"][0]["resources"]
+            assert vol_map["workspace-job"]["emptyDir"]["sizeLimit"] == "3Gi"
+            assert resources["requests"]["ephemeral-storage"] == "3Gi"
+            assert resources["limits"]["ephemeral-storage"] == "3Gi"
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_rejects_non_string_ephemeral_storage_from_launcher_spec(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, mock_api = self._setup(patches, ephemeral_storage="3Gi")
+        self._prime_running(mock_api)
+        try:
+            meta = _make_launch_job_meta(ephemeral_storage=1)
+            with pytest.raises(RuntimeError, match="ephemeral_storage"):
+                launcher.launch_job(meta, _make_launch_fl_ctx())
+            mock_api.create_namespaced_pod.assert_not_called()
         finally:
             _exit_patches(patches)
 

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -948,10 +948,14 @@ _JOB_UUID = "550e8400-e29b-41d4-a716-446655440000"
 _EXPECTED_JOB_ID = uuid4_to_rfc1123(_JOB_UUID)
 
 
-def _make_launch_job_meta(site_name="site-1", image="nvflare/nvflare:latest", gpu=None, study=None):
+def _make_launch_job_meta(
+    site_name="site-1", image="nvflare/nvflare:latest", gpu=None, study=None, ephemeral_storage=None
+):
     k8s_spec = {"image": image}
     if gpu is not None:
         k8s_spec["num_of_gpus"] = gpu
+    if ephemeral_storage is not None:
+        k8s_spec["ephemeral_storage"] = ephemeral_storage
     meta = {
         JobConstants.JOB_ID: _JOB_UUID,
         JobMetaKey.JOB_LAUNCHER_SPEC.value: {site_name: {"k8s": k8s_spec}},
@@ -994,7 +998,9 @@ class TestK8sJobLauncherLaunchJob:
     enter_states returns True on the first iteration without sleeping.
     """
 
-    def _setup(self, patches, namespace="test-ns", study_data_pvc_dict=None, default_python_path=None):
+    def _setup(
+        self, patches, namespace="test-ns", study_data_pvc_dict=None, default_python_path=None, ephemeral_storage=None
+    ):
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
         mock_open, mock_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
@@ -1011,12 +1017,15 @@ class TestK8sJobLauncherLaunchJob:
         mock_transfer.owner_fqcn = "site-1.parent"
         mock_transfer.add_job.return_value = "transfer-token"
         self.mock_transfer = mock_transfer
-        launcher = ClientK8sJobLauncher(
-            config_file_path="/fake/kube/config",
-            study_data_pvc_file_path="/fake/study_data.yaml",
-            namespace=namespace,
-            default_python_path=default_python_path,
-        )
+        launcher_kwargs = {
+            "config_file_path": "/fake/kube/config",
+            "study_data_pvc_file_path": "/fake/study_data.yaml",
+            "namespace": namespace,
+            "default_python_path": default_python_path,
+        }
+        if ephemeral_storage is not None:
+            launcher_kwargs["ephemeral_storage"] = ephemeral_storage
+        launcher = ClientK8sJobLauncher(**launcher_kwargs)
         return launcher, mock_api
 
     def _prime_running(self, mock_api):
@@ -1165,6 +1174,58 @@ class TestK8sJobLauncherLaunchJob:
             assert "secret" in vol_map["startup-kit"]
             # no study in meta means no study-data mounts
             assert len(volumes) == 2
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_ephemeral_storage_uses_launcher_default(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, mock_api = self._setup(patches, ephemeral_storage="3Gi")
+        self._prime_running(mock_api)
+        try:
+            launcher.launch_job(_make_launch_job_meta(), _make_launch_fl_ctx())
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            vol_map = {v["name"]: v for v in manifest["spec"]["volumes"]}
+            resources = manifest["spec"]["containers"][0]["resources"]
+            assert vol_map["workspace-job"]["emptyDir"]["sizeLimit"] == "3Gi"
+            assert resources["requests"]["ephemeral-storage"] == "3Gi"
+            assert resources["limits"]["ephemeral-storage"] == "3Gi"
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_ephemeral_storage_from_launcher_spec(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, mock_api = self._setup(patches, ephemeral_storage="3Gi")
+        self._prime_running(mock_api)
+        try:
+            launcher.launch_job(_make_launch_job_meta(ephemeral_storage="8Gi"), _make_launch_fl_ctx())
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            vol_map = {v["name"]: v for v in manifest["spec"]["volumes"]}
+            resources = manifest["spec"]["containers"][0]["resources"]
+            assert vol_map["workspace-job"]["emptyDir"]["sizeLimit"] == "8Gi"
+            assert resources["requests"]["ephemeral-storage"] == "8Gi"
+            assert resources["limits"]["ephemeral-storage"] == "8Gi"
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_ephemeral_storage_from_default_launcher_spec(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, mock_api = self._setup(patches, ephemeral_storage="3Gi")
+        self._prime_running(mock_api)
+        try:
+            meta = {
+                JobConstants.JOB_ID: _JOB_UUID,
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {
+                    "default": {"k8s": {"image": "nvflare/nvflare:latest", "ephemeral_storage": "4Gi"}},
+                    "site-1": {"k8s": {}},
+                },
+            }
+            launcher.launch_job(meta, _make_launch_fl_ctx())
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            vol_map = {v["name"]: v for v in manifest["spec"]["volumes"]}
+            resources = manifest["spec"]["containers"][0]["resources"]
+            assert vol_map["workspace-job"]["emptyDir"]["sizeLimit"] == "4Gi"
+            assert resources["requests"]["ephemeral-storage"] == "4Gi"
+            assert resources["limits"]["ephemeral-storage"] == "4Gi"
         finally:
             _exit_patches(patches)
 


### PR DESCRIPTION
## Summary
- Allow K8s jobs to override ephemeral storage with `launcher_spec[site][k8s].ephemeral_storage`.
- Apply the resolved value consistently to `emptyDir.sizeLimit` and container `ephemeral-storage` requests/limits.
- Add unit coverage for launcher defaults, site overrides, and default launcher spec inheritance.
- Update K8s launcher design docs for the new launcher_spec key.
