### PR TITLE
Clear retained training result after accept events

### DIFF
--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -237,6 +237,17 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         else:
             fl_ctx.set_prop(key, value, private=default_private, sticky=default_sticky)
 
+    @staticmethod
+    def _clear_training_result(fl_ctx: FLContext) -> None:
+        detail = fl_ctx.get_prop_detail(AppConstants.TRAINING_RESULT)
+        if detail is not None:
+            fl_ctx.set_prop(
+                AppConstants.TRAINING_RESULT,
+                None,
+                private=detail["private"],
+                sticky=detail["sticky"],
+            )
+
     def _process_result(self, client_task: ClientTask, fl_ctx: FLContext) -> None:
         self.fl_ctx = fl_ctx
         result = client_task.result
@@ -250,9 +261,12 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             self._set_ctx_prop_preserving_attrs(fl_ctx, AppConstants.CURRENT_ROUND, current_round)
 
         # Check return code and handle errors first
-        self.event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT)
-        accepted = self._accept_train_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
-        self.event(AppEventType.AFTER_CONTRIBUTION_ACCEPT)
+        try:
+            self.event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT)
+            accepted = self._accept_train_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
+            self.event(AppEventType.AFTER_CONTRIBUTION_ACCEPT)
+        finally:
+            self._clear_training_result(fl_ctx)
 
         # If result was rejected (error ignored or panic), skip further processing
         if not accepted:

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -869,6 +869,69 @@ class TestFedAvgWorkflowEvents:
         assert detail["sticky"] is False
         mock_warning.assert_not_called()
 
+    def test_process_result_clears_training_result_after_accept_events(self):
+        controller = FedAvg(num_clients=1)
+        fl_ctx = FLContext()
+
+        task_data = Shareable()
+        result = FLModelUtils.to_shareable(FLModel(params={"w": 1.0}))
+        task = Task(
+            name=AppConstants.TASK_TRAIN,
+            data=task_data,
+            props={AppConstants.META_DATA: {}},
+        )
+        client_task = ClientTask(client=Client("site-1", "token"), task=task)
+        client_task.result = result
+
+        training_results_seen = []
+
+        def record_training_result(event_type):
+            if event_type == AppEventType.AFTER_CONTRIBUTION_ACCEPT:
+                training_results_seen.append(fl_ctx.get_prop(AppConstants.TRAINING_RESULT))
+
+        with patch.object(controller, "event", side_effect=record_training_result):
+            controller._process_result(client_task, fl_ctx)
+
+        assert training_results_seen == [result]
+        assert fl_ctx.get_prop(AppConstants.TRAINING_RESULT) is None
+        detail = fl_ctx.get_prop_detail(AppConstants.TRAINING_RESULT)
+        assert detail["private"] is True
+        assert detail["sticky"] is False
+
+    def test_process_result_releases_raw_in_memory_training_result(self):
+        import gc
+        import weakref
+
+        import torch
+
+        controller = FedAvg(num_clients=1)
+        fl_ctx = FLContext()
+
+        tensor = torch.ones((1,), dtype=torch.float32)
+        tensor_ref = weakref.ref(tensor)
+        result = FLModelUtils.to_shareable(FLModel(params={"w": tensor}))
+
+        task_data = Shareable()
+        task = Task(
+            name=AppConstants.TASK_TRAIN,
+            data=task_data,
+            props={AppConstants.META_DATA: {}, AppConstants.TASK_PROP_CALLBACK: lambda _: None},
+        )
+        client_task = ClientTask(client=Client("site-1", "token"), task=task)
+        client_task.result = result
+
+        tensor = None
+        result = None
+
+        with patch.object(controller, "event"):
+            controller._process_result(client_task, fl_ctx)
+
+        assert client_task.result is None
+        gc.collect()
+
+        assert fl_ctx.get_prop(AppConstants.TRAINING_RESULT) is None
+        assert tensor_ref() is None
+
     def test_broadcast_model_does_not_fire_round_started(self):
         controller = FedAvg(num_clients=1)
         controller.fl_ctx = FLContext()


### PR DESCRIPTION
## What changed

This PR clears `AppConstants.TRAINING_RESULT` from the server-side `FLContext` immediately after the contribution-accept event window completes.

`_accept_train_result()` still stores the raw client `Shareable` in `FLContext` so existing `BEFORE_CONTRIBUTION_ACCEPT` / `AFTER_CONTRIBUTION_ACCEPT` handlers can inspect it. After those handlers run, `_process_result()` now resets the property value to `None` while preserving the existing private/sticky attributes.

## Bug

In a normal FedAvg-style workflow, the server receives a client model update as a raw `Shareable`. `BaseModelController._accept_train_result()` stores that raw result under `AppConstants.TRAINING_RESULT` for contribution-accept event handlers.

After the result is accepted, `_process_result()` converts the raw `Shareable` into an `FLModel` and FedAvg aggregates it immediately. The communication/task path then clears `client_task.result`, but the same raw `Shareable` can still be reachable through:

```text
controller.fl_ctx -> FLContext.props -> AppConstants.TRAINING_RESULT -> Shareable -> tensors
```

That keeps the client update live even though FedAvg has already aggregated it. With disk tensor offload disabled, this can retain a full in-memory client model update. For example, with a 5 GB model, built-in streaming FedAvg can remain roughly one extra model-sized update higher than necessary after each accepted result, and can briefly hold the previous retained update plus the next incoming update during result processing.

This is a lifetime bug, not allocator caching: the tensor objects are still strongly reachable from `FLContext`, so garbage collection cannot reclaim them.

## Benefit

The raw client result is now scoped to the event window where it is intended to be visible. After that point, only the objects FedAvg actually needs remain reachable, such as the aggregation accumulator and the updated/global model state.

For large in-memory models, this avoids retaining an unnecessary extra client update after aggregation. In the 5 GB model example, steady memory after aggregating a result can drop from roughly `global model + accumulator + retained raw result` to just `global model + accumulator`.

