### PR TITLE
[2.8] Clear retained training result after accept events

### DIFF
--- a/nvflare/app_common/workflows/base_model_controller.py
+++ b/nvflare/app_common/workflows/base_model_controller.py
@@ -237,6 +237,17 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
         else:
             fl_ctx.set_prop(key, value, private=default_private, sticky=default_sticky)
 
+    @staticmethod
+    def _clear_training_result(fl_ctx: FLContext) -> None:
+        detail = fl_ctx.get_prop_detail(AppConstants.TRAINING_RESULT)
+        if detail is not None:
+            fl_ctx.set_prop(
+                AppConstants.TRAINING_RESULT,
+                None,
+                private=detail["private"],
+                sticky=detail["sticky"],
+            )
+
     def _process_result(self, client_task: ClientTask, fl_ctx: FLContext) -> None:
         self.fl_ctx = fl_ctx
         result = client_task.result
@@ -250,9 +261,12 @@ class BaseModelController(Controller, FLComponentWrapper, ABC):
             self._set_ctx_prop_preserving_attrs(fl_ctx, AppConstants.CURRENT_ROUND, current_round)
 
         # Check return code and handle errors first
-        self.event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT)
-        accepted = self._accept_train_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
-        self.event(AppEventType.AFTER_CONTRIBUTION_ACCEPT)
+        try:
+            self.event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT)
+            accepted = self._accept_train_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
+            self.event(AppEventType.AFTER_CONTRIBUTION_ACCEPT)
+        finally:
+            self._clear_training_result(fl_ctx)
 
         # If result was rejected (error ignored or panic), skip further processing
         if not accepted:

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -869,6 +869,69 @@ class TestFedAvgWorkflowEvents:
         assert detail["sticky"] is False
         mock_warning.assert_not_called()
 
+    def test_process_result_clears_training_result_after_accept_events(self):
+        controller = FedAvg(num_clients=1)
+        fl_ctx = FLContext()
+
+        task_data = Shareable()
+        result = FLModelUtils.to_shareable(FLModel(params={"w": 1.0}))
+        task = Task(
+            name=AppConstants.TASK_TRAIN,
+            data=task_data,
+            props={AppConstants.META_DATA: {}},
+        )
+        client_task = ClientTask(client=Client("site-1", "token"), task=task)
+        client_task.result = result
+
+        training_results_seen = []
+
+        def record_training_result(event_type):
+            if event_type == AppEventType.AFTER_CONTRIBUTION_ACCEPT:
+                training_results_seen.append(fl_ctx.get_prop(AppConstants.TRAINING_RESULT))
+
+        with patch.object(controller, "event", side_effect=record_training_result):
+            controller._process_result(client_task, fl_ctx)
+
+        assert training_results_seen == [result]
+        assert fl_ctx.get_prop(AppConstants.TRAINING_RESULT) is None
+        detail = fl_ctx.get_prop_detail(AppConstants.TRAINING_RESULT)
+        assert detail["private"] is True
+        assert detail["sticky"] is False
+
+    def test_process_result_releases_raw_in_memory_training_result(self):
+        import gc
+        import weakref
+
+        import torch
+
+        controller = FedAvg(num_clients=1)
+        fl_ctx = FLContext()
+
+        tensor = torch.ones((1,), dtype=torch.float32)
+        tensor_ref = weakref.ref(tensor)
+        result = FLModelUtils.to_shareable(FLModel(params={"w": tensor}))
+
+        task_data = Shareable()
+        task = Task(
+            name=AppConstants.TASK_TRAIN,
+            data=task_data,
+            props={AppConstants.META_DATA: {}, AppConstants.TASK_PROP_CALLBACK: lambda _: None},
+        )
+        client_task = ClientTask(client=Client("site-1", "token"), task=task)
+        client_task.result = result
+
+        tensor = None
+        result = None
+
+        with patch.object(controller, "event"):
+            controller._process_result(client_task, fl_ctx)
+
+        assert client_task.result is None
+        gc.collect()
+
+        assert fl_ctx.get_prop(AppConstants.TRAINING_RESULT) is None
+        assert tensor_ref() is None
+
     def test_broadcast_model_does_not_fire_round_started(self):
         controller = FedAvg(num_clients=1)
         controller.fl_ctx = FLContext()


### PR DESCRIPTION
Backport of #4520 to the 2.8 release branch.

Original main PR: https://github.com/NVIDIA/NVFlare/pull/4520
Cherry-picked from: bdaabc014185ab7594d0c293ca125306ddc1e2d4
Backport commit: 7c1148368

Validation:
- .venv/bin/python -m pytest tests/unit_test/app_common/workflow/fedavg_test.py -q (72 passed)