### PR TITLE
[2.8] Fix job pods stuck in certain states

### DIFF
--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -306,12 +306,13 @@ class K8sJobHandle(JobHandleSpec):
                 self.logger.info(f"job {self.job_id} pod not found during querying; assuming terminated")
                 self.terminal_state = JobState.TERMINATED
                 self._remove_workspace_job()
+                return PodPhase.UNKNOWN.value
             else:
                 self.logger.warning(f"failed to query pod phase {self.job_id}: {e}")
-            return PodPhase.UNKNOWN.value
+            return None  # no pod phase was observed
         except Exception as e:
             self.logger.warning(f"unexpected error querying pod phase {self.job_id}: {e}")
-            return PodPhase.UNKNOWN.value
+            return None  # no pod phase was observed
         return resp.status.phase
 
     def _query_state(self):
@@ -319,6 +320,8 @@ class K8sJobHandle(JobHandleSpec):
         return POD_STATE_MAPPING.get(pod_phase, JobState.UNKNOWN)
 
     def _stuck_in_pending(self, current_phase):
+        if current_phase is None:
+            return False
         if current_phase in (PodPhase.PENDING.value, PodPhase.UNKNOWN.value):
             self._stuck_count += 1
             if self._max_stuck_count is not None and self._stuck_count >= self._max_stuck_count:

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -335,6 +335,8 @@ class K8sJobHandle(JobHandleSpec):
             if self.terminal_state is not None:
                 return
             job_state = self._query_state()
+            if self.terminal_state is not None:
+                return
             if job_state in (JobState.SUCCEEDED, JobState.TERMINATED):
                 self.terminal_state = job_state  # persist so poll() stays accurate
                 self._remove_workspace_job()

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -242,7 +242,11 @@ class K8sJobHandle(JobHandleSpec):
         if not all([isinstance(js, JobState) for js in job_states_to_enter]):
             raise ValueError(f"expect job_states_to_enter with valid values, but get {job_states_to_enter}")
         while True:
+            if self.terminal_state is not None:
+                return False
             pod_phase = self._query_phase()
+            if self.terminal_state is not None:
+                return False
             if self._stuck_in_pending(pod_phase):
                 self.terminate()
                 return False
@@ -315,7 +319,7 @@ class K8sJobHandle(JobHandleSpec):
         return POD_STATE_MAPPING.get(pod_phase, JobState.UNKNOWN)
 
     def _stuck_in_pending(self, current_phase):
-        if current_phase == PodPhase.PENDING.value:
+        if current_phase in (PodPhase.PENDING.value, PodPhase.UNKNOWN.value):
             self._stuck_count += 1
             if self._max_stuck_count is not None and self._stuck_count >= self._max_stuck_count:
                 return True

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -591,6 +591,17 @@ class TestK8sJobHandle:
         handle.wait()
         api.read_namespaced_pod.assert_not_called()
 
+    @patch("nvflare.app_opt.job_launcher.k8s_launcher.time.sleep")
+    def test_wait_returns_without_sleep_when_query_marks_terminal(self, mock_sleep):
+        api = _make_api_instance()
+        api.read_namespaced_pod.side_effect = _FakeApiException(status=404, reason="Not Found")
+        handle = _make_handle(api=api)
+
+        handle.wait()
+
+        assert handle.terminal_state == JobState.TERMINATED
+        mock_sleep.assert_not_called()
+
     def test_wait_persists_succeeded_terminal_state(self):
         api = _make_api_instance()
         resp = Mock()

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -509,6 +509,14 @@ class TestK8sJobHandle:
         handle = _make_handle(api=api)
         assert handle._query_phase() == PodPhase.UNKNOWN.value
 
+    def test_query_phase_sets_terminal_state_on_not_found(self):
+        api = _make_api_instance()
+        api.read_namespaced_pod.side_effect = _FakeApiException(status=404, reason="Not Found")
+        handle = _make_handle(api=api)
+
+        assert handle._query_phase() == PodPhase.UNKNOWN.value
+        assert handle.terminal_state == JobState.TERMINATED
+
     # -- _stuck_in_pending ----------------------------------------------------
     def test_stuck_in_pending_returns_true_at_max_count(self):
         # With _stuck_count seeded to max-1, one more PENDING call increments to
@@ -545,6 +553,13 @@ class TestK8sJobHandle:
         handle._stuck_in_pending(PodPhase.PENDING.value)
         assert handle._stuck_count == initial + 1
 
+    def test_stuck_in_pending_counts_unknown_as_not_making_progress(self):
+        api = _make_api_instance()
+        handle = K8sJobHandle("job-1", api, _make_job_config(), timeout=None, pending_timeout=2)
+
+        assert handle._stuck_in_pending(PodPhase.UNKNOWN.value) is False
+        assert handle._stuck_in_pending(PodPhase.UNKNOWN.value) is True
+
     def test_stuck_in_pending_returns_false_when_under_max(self):
         api = _make_api_instance()
         handle = K8sJobHandle("job-1", api, _make_job_config(), timeout=None, pending_timeout=100)
@@ -558,6 +573,7 @@ class TestK8sJobHandle:
         # Drive _stuck_count very high — must not raise and must return False
         handle._stuck_count = 10_000
         assert handle._stuck_in_pending(PodPhase.PENDING.value) is False
+        assert handle._stuck_in_pending(PodPhase.UNKNOWN.value) is False
 
     # -- wait -----------------------------------------------------------------
     def test_wait_returns_immediately_if_terminal_state_set(self):
@@ -663,6 +679,27 @@ class TestK8sJobHandle:
         handle = _make_handle(api=api)
         assert handle.enter_states([JobState.RUNNING]) is False
         assert handle.terminal_state == JobState.SUCCEEDED
+
+    def test_enter_states_returns_false_when_query_marks_terminal(self):
+        api = _make_api_instance()
+        api.read_namespaced_pod.side_effect = _FakeApiException(status=404, reason="Not Found")
+        handle = _make_handle(api=api, timeout=None, pending_timeout=120)
+
+        assert handle.enter_states([JobState.RUNNING]) is False
+        assert handle.terminal_state == JobState.TERMINATED
+        api.delete_namespaced_pod.assert_not_called()
+
+    def test_enter_states_terminates_after_repeated_unknown_phase(self):
+        api = _make_api_instance()
+        resp = Mock()
+        resp.status.phase = PodPhase.UNKNOWN.value
+        api.read_namespaced_pod.return_value = resp
+        handle = _make_handle(api=api, timeout=None, pending_timeout=2)
+
+        assert handle.enter_states([JobState.RUNNING]) is False
+        assert handle.terminal_state == JobState.TERMINATED
+        assert api.read_namespaced_pod.call_count == 2
+        api.delete_namespaced_pod.assert_called_once()
 
     def test_enter_states_raises_on_invalid_state(self):
         handle = _make_handle()

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -497,17 +497,17 @@ class TestK8sJobHandle:
         api.delete_namespaced_pod.assert_called_once_with(name="job-1", namespace="custom-ns", grace_period_seconds=0)
 
     # -- _query_phase ---------------------------------------------------------
-    def test_query_phase_returns_unknown_on_api_error(self):
+    def test_query_phase_returns_none_on_api_error(self):
         api = _make_api_instance()
         api.read_namespaced_pod.side_effect = _FakeApiException(status=500, reason="Error")
         handle = _make_handle(api=api)
-        assert handle._query_phase() == PodPhase.UNKNOWN.value
+        assert handle._query_phase() is None
 
-    def test_query_phase_returns_unknown_on_generic_exception(self):
+    def test_query_phase_returns_none_on_generic_exception(self):
         api = _make_api_instance()
         api.read_namespaced_pod.side_effect = RuntimeError("connection lost")
         handle = _make_handle(api=api)
-        assert handle._query_phase() == PodPhase.UNKNOWN.value
+        assert handle._query_phase() is None
 
     def test_query_phase_sets_terminal_state_on_not_found(self):
         api = _make_api_instance()
@@ -552,6 +552,14 @@ class TestK8sJobHandle:
         initial = handle._stuck_count
         handle._stuck_in_pending(PodPhase.PENDING.value)
         assert handle._stuck_count == initial + 1
+
+    def test_stuck_in_pending_ignores_unobserved_phase(self):
+        api = _make_api_instance()
+        handle = K8sJobHandle("job-1", api, _make_job_config(), timeout=None, pending_timeout=2)
+        handle._stuck_count = handle._max_stuck_count - 1
+
+        assert handle._stuck_in_pending(None) is False
+        assert handle._stuck_count == handle._max_stuck_count - 1
 
     def test_stuck_in_pending_counts_unknown_as_not_making_progress(self):
         api = _make_api_instance()
@@ -689,7 +697,8 @@ class TestK8sJobHandle:
         assert handle.terminal_state == JobState.TERMINATED
         api.delete_namespaced_pod.assert_not_called()
 
-    def test_enter_states_terminates_after_repeated_unknown_phase(self):
+    @patch("nvflare.app_opt.job_launcher.k8s_launcher.time.sleep")
+    def test_enter_states_terminates_after_repeated_unknown_phase(self, mock_sleep):
         api = _make_api_instance()
         resp = Mock()
         resp.status.phase = PodPhase.UNKNOWN.value
@@ -701,17 +710,34 @@ class TestK8sJobHandle:
         assert api.read_namespaced_pod.call_count == 2
         api.delete_namespaced_pod.assert_called_once()
 
+    @patch("nvflare.app_opt.job_launcher.k8s_launcher.time.sleep")
+    def test_enter_states_does_not_count_api_errors_as_pending(self, mock_sleep):
+        api = _make_api_instance()
+        pending_resp = Mock()
+        pending_resp.status.phase = PodPhase.PENDING.value
+        running_resp = Mock()
+        running_resp.status.phase = PodPhase.RUNNING.value
+        api.read_namespaced_pod.side_effect = [
+            pending_resp,
+            _FakeApiException(status=500, reason="Internal"),
+            running_resp,
+        ]
+        handle = _make_handle(api=api, timeout=None, pending_timeout=2)
+
+        assert handle.enter_states([JobState.RUNNING]) is True
+        assert handle._stuck_count == 0
+        assert api.read_namespaced_pod.call_count == 3
+        api.delete_namespaced_pod.assert_not_called()
+
     def test_enter_states_raises_on_invalid_state(self):
         handle = _make_handle()
         with pytest.raises(ValueError, match="expect job_states_to_enter"):
             handle.enter_states(["not_a_state"])
 
     # -- enter_states: wall-clock timeout branch ------------------------------
-    # The pod is placed in UNKNOWN phase (non-pending so stuck detection does
-    # not fire, non-terminal so the terminal-phase branch is skipped) and
-    # time.time is mocked so the elapsed-time check fires on the first
-    # iteration.  This is the branch that existing tests miss because they
-    # use timeout=0 with a PENDING pod, which hits stuck detection instead.
+    # The pod is placed in UNKNOWN phase. Stuck detection does not fire before
+    # the mocked elapsed-time check because the threshold is higher than one
+    # iteration. This covers the wall-clock timeout branch.
 
     @patch("nvflare.app_opt.job_launcher.k8s_launcher.time")
     def test_enter_states_wall_clock_timeout_returns_false(self, mock_time):


### PR DESCRIPTION
### Description

More checks in k8s job launcher states.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
