### PR TITLE
[2.8] Align CLI Python support with 3.10-3.14

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, ubuntu-24.04 ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, ubuntu-24.04 ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ nvflare/
 - **Formatter**: black (line length: 120)
 - **Linter**: flake8
 - **Import sorter**: isort (black profile)
-- **Python**: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+- **Python**: 3.10, 3.11, 3.12, 3.13, 3.14
 
 All Python files must include Apache 2.0 license header:
 ```python

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ from the :ref:`fl_introduction` and have reviewed the :ref:`flare_overview` to u
 
 Prerequisites
 =============
-- Python 3.9+ (tested through Python 3.14, including Python 3.13)
+- Python 3.10+ (tested through Python 3.14, including Python 3.13)
 - pip
 - Git
 
@@ -91,7 +91,7 @@ NVFlare provides several optional dependency groups that you can install based o
 
   .. note::
 
-     ``nvflare[HE]`` currently supports Python 3.9-3.13.
+     ``nvflare[HE]`` currently supports Python 3.10-3.13.
      On Python 3.14, ``tenseal`` is not available yet, so the HE extra is not installed.
 
 * **PSI** - Private Set Intersection support:
@@ -102,7 +102,7 @@ NVFlare provides several optional dependency groups that you can install based o
 
   .. note::
 
-     ``nvflare[PSI]`` currently supports Python 3.9-3.13.
+     ``nvflare[PSI]`` currently supports Python 3.10-3.13.
      On Python 3.14, ``openmined.psi`` is not available yet, so the PSI extra is not installed.
 
 * **PT** - PyTorch support:

--- a/nvflare/private/fed/app/utils.py
+++ b/nvflare/private/fed/app/utils.py
@@ -27,6 +27,20 @@ from nvflare.private.fed.runner import Runner
 from nvflare.private.fed.server.admin import FedAdminServer
 from nvflare.private.fed.server.fed_server import FederatedServer
 
+_MIN_PYTHON_VERSION = (3, 10)
+_MAX_PYTHON_VERSION = (3, 14)
+
+
+def _format_python_version(version):
+    return f"{version[0]}.{version[1]}"
+
+
+_SUPPORTED_PYTHON_VERSION_RANGE = (
+    f"{_format_python_version(_MIN_PYTHON_VERSION)} through {_format_python_version(_MAX_PYTHON_VERSION)}"
+)
+_LOWEST_UNSUPPORTED_PYTHON_VERSION = (_MAX_PYTHON_VERSION[0], _MAX_PYTHON_VERSION[1] + 1)
+_HIGHEST_UNSUPPORTED_PYTHON_VERSION = (_MIN_PYTHON_VERSION[0], _MIN_PYTHON_VERSION[1] - 1)
+
 
 def monitor_parent_process(runner: Runner, parent_pid, stop_event: threading.Event):
     while True:
@@ -80,13 +94,18 @@ def create_admin_server(fl_server: FederatedServer, server_conf=None, args=None)
 
 
 def version_check():
-    if sys.version_info >= (3, 13):
+    python_version = sys.version_info[:2]
+    if python_version > _MAX_PYTHON_VERSION:
         raise RuntimeError(
-            "Python versions 3.13 and above are not yet supported. Please use Python version between 3.9 and 3.12."
+            f"Python versions {_format_python_version(_LOWEST_UNSUPPORTED_PYTHON_VERSION)} and above "
+            f"are not yet supported. "
+            f"Please use Python version {_SUPPORTED_PYTHON_VERSION_RANGE}."
         )
-    if sys.version_info < (3, 9):
+    if python_version < _MIN_PYTHON_VERSION:
         raise RuntimeError(
-            "Python versions 3.8 and below are not supported. Please use Python version between 3.9 and 3.12."
+            f"Python versions {_format_python_version(_HIGHEST_UNSUPPORTED_PYTHON_VERSION)} and below "
+            f"are not supported. "
+            f"Please use Python version {_SUPPORTED_PYTHON_VERSION_RANGE}."
         )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ license = Apache-2.0
 license_files =
     LICENSE
 classifiers =
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -18,7 +17,7 @@ classifiers =
 
 [options]
 zip_safe = True
-python_requires = >= 3.9
+python_requires = >= 3.10
 install_requires =
     cryptography>=36.0.0
     Flask==3.0.2

--- a/tests/unit_test/private/fed/app/fed_app_utils_test.py
+++ b/tests/unit_test/private/fed/app/fed_app_utils_test.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nvflare.private.fed.app import utils
+
+
+@pytest.mark.parametrize("version_info", [(3, 10, 0), (3, 13, 0), (3, 14, 0)])
+def test_version_check_accepts_supported_python_versions(monkeypatch, version_info):
+    monkeypatch.setattr(utils.sys, "version_info", version_info)
+
+    utils.version_check()
+
+
+@pytest.mark.parametrize(
+    "version_info, expected_message",
+    [
+        (
+            (3, 9, 18),
+            f"Python versions {utils._format_python_version(utils._HIGHEST_UNSUPPORTED_PYTHON_VERSION)} "
+            "and below are not supported",
+        ),
+        (
+            (3, 15, 0),
+            f"Python versions {utils._format_python_version(utils._LOWEST_UNSUPPORTED_PYTHON_VERSION)} "
+            "and above are not yet supported",
+        ),
+    ],
+)
+def test_version_check_rejects_unsupported_python_versions(monkeypatch, version_info, expected_message):
+    monkeypatch.setattr(utils.sys, "version_info", version_info)
+
+    with pytest.raises(RuntimeError, match=expected_message):
+        utils.version_check()


### PR DESCRIPTION
Backport of #4521 to the 2.8 release branch.

Original main PR: https://github.com/NVIDIA/NVFlare/pull/4521
Cherry-picked from: b51875a9c652f481a06e161a5fc653c38b69418e
Backport commit: 3b8f6f34b

Validation:
- .venv/bin/python -m pytest tests/unit_test/private/fed/app/fed_app_utils_test.py -q (5 passed)