### PR TITLE
[2.8] Add run-scoped tensor offload temp cleanup

### DIFF
--- a/nvflare/app_common/utils/tensor_disk_offload_context.py
+++ b/nvflare/app_common/utils/tensor_disk_offload_context.py
@@ -15,11 +15,13 @@
 from typing import Any, Tuple
 
 _ENABLE_TENSOR_DISK_OFFLOAD = "enable_tensor_disk_offload"
+_TENSOR_DISK_OFFLOAD_ROOT_DIR = "tensor_disk_offload_root_dir"
 
 
 def apply_enable_tensor_disk_offload(
     engine,
     enabled: bool,
+    root_dir: str = None,
 ) -> Tuple[Any, bool]:
     """Apply enable_tensor_disk_offload to cell FOBS context.
 
@@ -38,12 +40,16 @@ def apply_enable_tensor_disk_offload(
         return None, False
 
     previous = cell.get_fobs_context().get(_ENABLE_TENSOR_DISK_OFFLOAD, False)
-    if previous != enabled:
-        cell.update_fobs_context({_ENABLE_TENSOR_DISK_OFFLOAD: enabled})
+    if enabled:
+        if not root_dir:
+            raise ValueError("root_dir must be provided when tensor disk offload is enabled")
+        cell.update_fobs_context({_ENABLE_TENSOR_DISK_OFFLOAD: True, _TENSOR_DISK_OFFLOAD_ROOT_DIR: root_dir})
+    elif previous != enabled:
+        cell.update_fobs_context({_ENABLE_TENSOR_DISK_OFFLOAD: False})
     return previous, True
 
 
-def restore_enable_tensor_disk_offload(engine, previous_value: Any) -> None:
+def restore_enable_tensor_disk_offload(engine, previous_value: Any, root_dir: str = None) -> None:
     """Restore prior enable_tensor_disk_offload value on a cell."""
     # previous_value is None only when apply was not executed because no
     # engine/cell was available; False is a valid prior value and must restore.
@@ -56,6 +62,10 @@ def restore_enable_tensor_disk_offload(engine, previous_value: Any) -> None:
     else:
         cell = engine.get_cell()
     if not cell:
+        return
+
+    if root_dir:
+        cell.update_fobs_context({_ENABLE_TENSOR_DISK_OFFLOAD: previous_value, _TENSOR_DISK_OFFLOAD_ROOT_DIR: None})
         return
 
     current = cell.get_fobs_context().get(_ENABLE_TENSOR_DISK_OFFLOAD, False)

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+import shutil
+import tempfile
 import time
 from typing import Any, Dict, Optional, Set, Union
 
@@ -138,16 +140,25 @@ class FedAvg(BaseFedAvg):
         self._params_type = None  # Only store params_type, not full result
 
     def run(self) -> None:
-        previous_disk_offload, disk_offload_applied = apply_enable_tensor_disk_offload(
-            engine=getattr(self, "engine", None),
-            enabled=self.enable_tensor_disk_offload,
-        )
-        if self.enable_tensor_disk_offload and not disk_offload_applied:
-            self.warning(
-                "enable_tensor_disk_offload=True but no active cell is available; "
-                "falling back to in-memory tensor download"
-            )
+        disk_offload_root_dir = None
+        previous_disk_offload = None
         try:
+            disk_offload_root_dir = (
+                tempfile.mkdtemp(prefix=f"nvflare_tensor_offload_{self.fl_ctx.get_job_id('job')}_")
+                if self.enable_tensor_disk_offload
+                else None
+            )
+            previous_disk_offload, disk_offload_applied = apply_enable_tensor_disk_offload(
+                engine=getattr(self, "engine", None),
+                enabled=self.enable_tensor_disk_offload,
+                root_dir=disk_offload_root_dir,
+            )
+            if self.enable_tensor_disk_offload and not disk_offload_applied:
+                self.warning(
+                    "enable_tensor_disk_offload=True but no active cell is available; "
+                    "falling back to in-memory tensor download"
+                )
+
             self.info(center_message("Start FedAvg."))
 
             # Set NUM_ROUNDS in FL context for persistor and other components.
@@ -245,7 +256,10 @@ class FedAvg(BaseFedAvg):
             restore_enable_tensor_disk_offload(
                 engine=getattr(self, "engine", None),
                 previous_value=previous_disk_offload,
+                root_dir=disk_offload_root_dir,
             )
+            if disk_offload_root_dir:
+                shutil.rmtree(disk_offload_root_dir, ignore_errors=True)
 
     def _aggregate_one_result(self, result: FLModel) -> None:
         """Callback: aggregate ONE client result immediately (InTime aggregation)."""

--- a/nvflare/app_opt/pt/tensor_downloader.py
+++ b/nvflare/app_opt/pt/tensor_downloader.py
@@ -23,6 +23,7 @@ import torch
 from safetensors.torch import load as load_tensors
 from safetensors.torch import save as save_tensors
 
+from nvflare.app_common.utils.tensor_disk_offload_context import _TENSOR_DISK_OFFLOAD_ROOT_DIR
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.streaming.cacheable import CacheableObject, ItemConsumer
 from nvflare.fuel.f3.streaming.download_service import download_object
@@ -242,7 +243,10 @@ def download_tensors_to_disk(
 
     Returns: tuple of (error message if any, LazyTensorDict for lazy access).
     """
-    temp_dir = tempfile.mkdtemp(prefix="nvflare_tensors_")
+    root_dir = cell.get_fobs_context().get(_TENSOR_DISK_OFFLOAD_ROOT_DIR)
+    if not root_dir:
+        raise RuntimeError(f"{_TENSOR_DISK_OFFLOAD_ROOT_DIR} is not set in FOBS context")
+    temp_dir = tempfile.mkdtemp(prefix="nvflare_tensors_", dir=root_dir)
 
     consumer = DiskTensorConsumer(temp_dir)
     try:

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -1174,16 +1174,21 @@ class TestBasic(TestController):
             "nvflare.app_opt.pt.tensor_downloader",
             reason="in-flight tensor download cleanup test requires tensor downloader",
         )
+        from nvflare.app_common.utils.tensor_disk_offload_context import _TENSOR_DISK_OFFLOAD_ROOT_DIR
         from nvflare.fuel.f3.cellnet.defs import ReturnCode
         from nvflare.fuel.f3.cellnet.utils import make_reply
         from nvflare.fuel.f3.streaming.download_service import ProduceRC
 
         class BlockingDownloadCell:
-            def __init__(self, chunk: bytes):
+            def __init__(self, chunk: bytes, root_dir: str):
                 self.chunk = chunk
+                self.root_dir = root_dir
                 self.call_count = 0
                 self.second_call_started = threading.Event()
                 self.release_second_call = threading.Event()
+
+            def get_fobs_context(self):
+                return {_TENSOR_DISK_OFFLOAD_ROOT_DIR: self.root_dir}
 
             def send_request(self, **kwargs):
                 self.call_count += 1
@@ -1205,12 +1210,12 @@ class TestBasic(TestController):
 
         temp_dir = tmp_path / "nvflare_tensors_inflight"
 
-        def fake_mkdtemp(prefix):
+        def fake_mkdtemp(prefix, dir=None):
             temp_dir.mkdir()
             return str(temp_dir)
 
         monkeypatch.setattr(tensor_downloader.tempfile, "mkdtemp", fake_mkdtemp)
-        cell = BlockingDownloadCell(safetensors_torch.save({"w": torch.tensor([1.0])}))
+        cell = BlockingDownloadCell(safetensors_torch.save({"w": torch.tensor([1.0])}), str(tmp_path))
         result_holder = {}
 
         def run_download():

--- a/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
+++ b/tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from nvflare.app_common.utils.tensor_disk_offload_context import (
+    _TENSOR_DISK_OFFLOAD_ROOT_DIR,
     apply_enable_tensor_disk_offload,
     restore_enable_tensor_disk_offload,
 )
@@ -47,31 +48,55 @@ class _MockRunManager:
 
 def test_apply_returns_previous_and_updates():
     cell = _MockCell(enable_tensor_disk_offload=False)
+    root_dir = "/tmp/nvflare_tensor_offload_test"
 
-    previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True)
+    previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True, root_dir=root_dir)
 
     assert previous is False
     assert applied is True
     assert cell.ctx["enable_tensor_disk_offload"] is True
+    assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] == root_dir
     assert cell.update_calls == 1
 
 
-def test_apply_skips_update_when_value_unchanged():
-    cell = _MockCell(enable_tensor_disk_offload=True)
+def test_apply_sets_and_restore_clears_root_dir():
+    cell = _MockCell(enable_tensor_disk_offload=False)
+    root_dir = "/tmp/nvflare_tensor_offload_test"
 
-    previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True)
+    previous, applied = apply_enable_tensor_disk_offload(
+        engine=_MockEngine(cell),
+        enabled=True,
+        root_dir=root_dir,
+    )
 
-    assert previous is True
+    assert previous is False
     assert applied is True
     assert cell.ctx["enable_tensor_disk_offload"] is True
+    assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] == root_dir
+
+    restore_enable_tensor_disk_offload(_MockEngine(cell), previous, root_dir=root_dir)
+
+    assert cell.ctx["enable_tensor_disk_offload"] is False
+    assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] is None
+
+
+def test_apply_skips_update_when_value_unchanged():
+    cell = _MockCell(enable_tensor_disk_offload=False)
+
+    previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=False)
+
+    assert previous is False
+    assert applied is True
+    assert cell.ctx["enable_tensor_disk_offload"] is False
     assert cell.update_calls == 0
 
 
 def test_restore_sets_previous_value():
     cell = _MockCell(enable_tensor_disk_offload=False)
-    previous, _ = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True)
+    root_dir = "/tmp/nvflare_tensor_offload_test"
+    previous, _ = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True, root_dir=root_dir)
 
-    restore_enable_tensor_disk_offload(_MockEngine(cell), previous)
+    restore_enable_tensor_disk_offload(_MockEngine(cell), previous, root_dir=root_dir)
     assert cell.ctx["enable_tensor_disk_offload"] is False
 
 
@@ -92,13 +117,15 @@ def test_apply_and_restore_use_run_manager_cell_when_available():
     parent_cell = _MockCell(enable_tensor_disk_offload=False)
     run_cell = _MockCell(enable_tensor_disk_offload=False)
     engine = _MockEngine(cell=parent_cell, run_manager=_MockRunManager(run_cell))
+    root_dir = "/tmp/nvflare_tensor_offload_test"
 
-    previous, applied = apply_enable_tensor_disk_offload(engine=engine, enabled=True)
+    previous, applied = apply_enable_tensor_disk_offload(engine=engine, enabled=True, root_dir=root_dir)
 
     assert previous is False
     assert applied is True
     assert run_cell.ctx["enable_tensor_disk_offload"] is True
+    assert run_cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] == root_dir
     assert parent_cell.ctx["enable_tensor_disk_offload"] is False
 
-    restore_enable_tensor_disk_offload(engine, previous)
+    restore_enable_tensor_disk_offload(engine, previous, root_dir=root_dir)
     assert run_cell.ctx["enable_tensor_disk_offload"] is False

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import nvflare.app_common.workflows.fedavg as fedavg_module
 from nvflare.apis.client import Client
 from nvflare.apis.controller_spec import ClientTask, Task
 from nvflare.apis.fl_constant import FLMetaKey
@@ -26,6 +27,7 @@ from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
 from nvflare.app_common.utils.fl_model_utils import FLModelUtils
 from nvflare.app_common.utils.tensor_disk_offload_context import (
+    _TENSOR_DISK_OFFLOAD_ROOT_DIR,
     apply_enable_tensor_disk_offload,
     restore_enable_tensor_disk_offload,
 )
@@ -762,13 +764,16 @@ class TestFedAvgLazyCompatibility:
 class TestFedAvgDownloadToDiskContext:
     def test_set_enable_tensor_disk_offload(self):
         cell = _MockCell(enable_tensor_disk_offload=False)
-        previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True)
+        root_dir = "/tmp/nvflare_tensor_offload_test"
+        previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell), enabled=True, root_dir=root_dir)
         assert previous is False
         assert applied is True
         assert cell.ctx["enable_tensor_disk_offload"] is True
+        assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] == root_dir
 
-        restore_enable_tensor_disk_offload(_MockEngine(cell), previous)
+        restore_enable_tensor_disk_offload(_MockEngine(cell), previous, root_dir=root_dir)
         assert cell.ctx["enable_tensor_disk_offload"] is False
+        assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] is None
 
     def test_set_enable_tensor_disk_offload_without_cell(self):
         previous, applied = apply_enable_tensor_disk_offload(engine=_MockEngine(cell=None), enabled=True)
@@ -790,6 +795,38 @@ class TestFedAvgDownloadToDiskContext:
 
         controller.run()
         assert cell.ctx["enable_tensor_disk_offload"] is False
+
+    def test_run_cleans_tensor_disk_offload_root_dir(self, tmp_path, monkeypatch):
+        controller = FedAvg(num_clients=1, num_rounds=1, model={"w": 1.0}, enable_tensor_disk_offload=True)
+        cell = _MockCell(enable_tensor_disk_offload=False)
+        controller.engine = _MockEngine(cell)
+        controller.fl_ctx = FLContext()
+        controller.abort_signal = Signal()
+        controller.sample_clients = lambda _: ["site-1"]
+        root_dir = tmp_path / "nvflare_tensor_offload_root"
+
+        def fake_mkdtemp(prefix):
+            root_dir.mkdir()
+            return str(root_dir)
+
+        def fake_send_model(**kwargs):
+            assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] == str(root_dir)
+            retained_dir = root_dir / "nvflare_tensors_retained"
+            retained_dir.mkdir()
+            (retained_dir / "chunk_0.safetensors").write_bytes(b"retained")
+
+        monkeypatch.setattr(fedavg_module.tempfile, "mkdtemp", fake_mkdtemp)
+        controller.send_model = fake_send_model
+        controller.get_num_standing_tasks = lambda: 0
+        controller._get_aggregated_result = lambda: FLModel(params={"w": 1.0})
+        controller.update_model = lambda model, aggr_result: model
+        controller.save_model = lambda model: None
+
+        controller.run()
+
+        assert cell.ctx["enable_tensor_disk_offload"] is False
+        assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] is None
+        assert not root_dir.exists()
 
 
 class TestFedAvgWorkflowEvents:

--- a/tests/unit_test/app_opt/pt/test_disk_tensor_consumer.py
+++ b/tests/unit_test/app_opt/pt/test_disk_tensor_consumer.py
@@ -22,6 +22,7 @@ from safetensors.torch import save as save_tensors
 
 import nvflare.app_opt.pt.lazy_tensor_dict as lazy_tensor_dict
 import nvflare.app_opt.pt.tensor_downloader as tensor_downloader
+from nvflare.app_common.utils.tensor_disk_offload_context import _TENSOR_DISK_OFFLOAD_ROOT_DIR
 from nvflare.app_opt.pt.lazy_tensor_dict import LazyTensorDict
 from nvflare.app_opt.pt.tensor_downloader import DiskTensorConsumer, _extract_safetensors_keys
 
@@ -172,10 +173,18 @@ class TestDiskTensorConsumer:
         assert consumer.error == "timeout"
 
 
+class _FakeCell:
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+
+    def get_fobs_context(self):
+        return {_TENSOR_DISK_OFFLOAD_ROOT_DIR: self.root_dir}
+
+
 def test_download_tensors_to_disk_cleans_temp_dir_on_exception(monkeypatch, tmp_path):
     temp_dir = tmp_path / "nvflare_tensors_exception"
 
-    def fake_mkdtemp(prefix):
+    def fake_mkdtemp(prefix, dir=None):
         os.makedirs(temp_dir, exist_ok=False)
         return str(temp_dir)
 
@@ -190,7 +199,7 @@ def test_download_tensors_to_disk_cleans_temp_dir_on_exception(monkeypatch, tmp_
             from_fqcn="server",
             ref_id="ref",
             per_request_timeout=1.0,
-            cell=None,
+            cell=_FakeCell(str(tmp_path)),
         )
 
     assert not temp_dir.exists()
@@ -199,7 +208,7 @@ def test_download_tensors_to_disk_cleans_temp_dir_on_exception(monkeypatch, tmp_
 def test_download_tensors_to_disk_logs_cleanup_warning(monkeypatch, tmp_path, caplog):
     temp_dir = tmp_path / "nvflare_tensors_warn"
 
-    def fake_mkdtemp(prefix):
+    def fake_mkdtemp(prefix, dir=None):
         os.makedirs(temp_dir, exist_ok=False)
         return str(temp_dir)
 
@@ -218,7 +227,7 @@ def test_download_tensors_to_disk_logs_cleanup_warning(monkeypatch, tmp_path, ca
             from_fqcn="server",
             ref_id="ref",
             per_request_timeout=1.0,
-            cell=None,
+            cell=_FakeCell(str(tmp_path)),
         )
 
     assert "failed to cleanup tensor offload temp dir" in caplog.text
@@ -229,7 +238,7 @@ def test_download_tensors_to_disk_second_chance_cleanup_on_consumer_error(monkey
     temp_dir = tmp_path / "nvflare_tensors_consumer_error"
     cleanup_calls = []
 
-    def fake_mkdtemp(prefix):
+    def fake_mkdtemp(prefix, dir=None):
         os.makedirs(temp_dir, exist_ok=False)
         return str(temp_dir)
 
@@ -248,10 +257,40 @@ def test_download_tensors_to_disk_second_chance_cleanup_on_consumer_error(monkey
         from_fqcn="server",
         ref_id="ref",
         per_request_timeout=1.0,
-        cell=None,
+        cell=_FakeCell(str(tmp_path)),
     )
 
     assert err == "download failed"
     assert result is None
     assert cleanup_calls == [str(temp_dir)]
     assert not temp_dir.exists()
+
+
+def test_download_tensors_to_disk_uses_scoped_root_dir(monkeypatch, tmp_path):
+    root_dir = tmp_path / "nvflare_tensor_offload_root"
+    root_dir.mkdir()
+
+    def fake_download_object(**kwargs):
+        kwargs["consumer"].result = kwargs["consumer"].consume_items(
+            [save_tensors({"w": torch.tensor([1.0])})],
+            None,
+        )
+
+    monkeypatch.setattr(tensor_downloader, "download_object", fake_download_object)
+
+    err, lazy_tensors = tensor_downloader.download_tensors_to_disk(
+        from_fqcn="server",
+        ref_id="ref",
+        per_request_timeout=1.0,
+        cell=_FakeCell(str(root_dir)),
+    )
+
+    assert err is None
+    assert lazy_tensors is not None
+    temp_dirs = list(root_dir.iterdir())
+    assert len(temp_dirs) == 1
+    assert temp_dirs[0].name.startswith("nvflare_tensors_")
+
+    shutil.rmtree(root_dir)
+
+    assert not root_dir.exists()


### PR DESCRIPTION
Backport of #4522 to the 2.8 release branch.

Original main PR: https://github.com/NVIDIA/NVFlare/pull/4522
Cherry-picked from: a707f4de5661de9b8434106aa5d708a90a4b9968
Backport commit: 166e12d57e92cf7e4d5ba1c87280791d982d5c51

Validation:
- .venv/bin/python -m pytest tests/unit_test/app_common/utils/tensor_disk_offload_context_test.py tests/unit_test/app_common/workflow/fedavg_test.py tests/unit_test/app_opt/pt/test_disk_tensor_consumer.py tests/unit_test/apis/impl/controller_test.py -q (632 passed)