### PR TITLE
[doc][2.8] Backport LLM-friendly docs outputs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,11 +24,15 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import sphinx_rtd_theme
 import os
-import sys
-from sphinx.domains.python import PythonDomain
+import re
 import subprocess
+import sys
+from pathlib import Path
+
+import sphinx_rtd_theme
+from sphinx.domains.python import PythonDomain
+from sphinx.errors import ExtensionError
 
 
 class PatchedPythonDomain(PythonDomain):
@@ -73,6 +77,7 @@ _skip_api = os.environ.get("SKIP_API_DOCS", "").lower() in ("1", "true", "yes")
 
 extensions = [
     "recommonmark",
+    "sphinx_llm.txt",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
@@ -93,6 +98,13 @@ if not _skip_api:
 autoclass_content = "both"
 add_module_names = False
 autosectionlabel_prefix_document = True
+llms_txt_description = (
+    "NVIDIA FLARE is an open-source SDK for federated learning, with tools for simulation, job authoring, "
+    "deployment, security, and production federated ML workflows."
+)
+llms_txt_full_build = False
+llms_txt_build_parallel = False
+llms_txt_suffix_mode = "replace"
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
@@ -100,7 +112,7 @@ autosectionlabel_prefix_document = True
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["_build"]
 
 if _skip_api:
     # Exclude auto-generated API files but keep the committed stub
@@ -149,7 +161,31 @@ def generate_apidocs(*args):
     )
 
 
+def copy_curated_llms_txt(app, exception):
+    """Publish the curated llms.txt after generated Markdown pages are copied."""
+    if exception or not app.builder or app.builder.name not in ("html", "dirhtml"):
+        return
+
+    source_path = Path(app.confdir) / "llms.txt.in"
+    target_path = Path(app.builder.outdir) / "llms.txt"
+    llms_txt = source_path.read_text(encoding="utf-8")
+    missing_links = []
+
+    for link in re.findall(r"\]\(([^)]+)\)", llms_txt):
+        if "://" in link or link.startswith("#"):
+            continue
+        linked_path = link.split("#", 1)[0]
+        if linked_path and not (Path(app.builder.outdir) / linked_path).is_file():
+            missing_links.append(link)
+
+    if missing_links:
+        raise ExtensionError(f"Missing generated Markdown files referenced by llms.txt: {missing_links}")
+
+    target_path.write_text(llms_txt, encoding="utf-8")
+
+
 def setup(app):
     app.connect("builder-inited", generate_apidocs)
+    app.connect("build-finished", copy_curated_llms_txt, priority=200)
     app.add_domain(PatchedPythonDomain, override=True)
     app.add_css_file("css/additions.css")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ def generate_apidocs(*args):
 
 def copy_curated_llms_txt(app, exception):
     """Publish the curated llms.txt after generated Markdown pages are copied."""
-    if exception or not app.builder or app.builder.name not in ("html", "dirhtml"):
+    if exception or not app.builder or app.builder.name != "html":
         return
 
     source_path = Path(app.confdir) / "llms.txt.in"

--- a/docs/llms.txt.in
+++ b/docs/llms.txt.in
@@ -1,0 +1,49 @@
+# NVIDIA FLARE
+
+> NVIDIA FLARE is an open-source SDK for federated learning, with tools for simulation, job authoring, deployment, security, and production federated ML workflows.
+
+## Get Started
+
+- [Installation](installation.md): Install NVIDIA FLARE and set up development or runtime environments.
+- [Quick Start](quickstart.md): Run a first federated learning example and learn the basic workflow.
+- [Migration Guide](migration_guide.md): Upgrade between NVIDIA FLARE versions and understand behavior changes.
+
+## User Workflows
+
+- [Client API](user_guide/data_scientist_guide/client_api_usage.md): Use the high-level API for federated training scripts.
+- [Job Recipe API](user_guide/data_scientist_guide/job_recipe.md): Create jobs with pre-built recipes for common federated learning workflows.
+- [Available Recipes](user_guide/data_scientist_guide/available_recipes.md): Browse bundled job recipes and supported patterns.
+- [FLARE API](user_guide/data_scientist_guide/flare_api.md): Use runtime APIs to submit, monitor, and manage jobs.
+- [CLI Tools](user_guide/nvflare_cli/nvflare_cli.md): Use NVFlare command-line tools for local and deployed systems.
+
+## Examples And Tutorials
+
+- [Example Applications And Algorithms](example_applications_algorithms.md): Find example applications, algorithms, and reference implementations.
+- [Tutorials](tutorials.md): Learn from tutorials and notebook-based walkthroughs.
+- [Federated LLM Fine-Tuning](programming_guide/llm_fine_tuning.md): Fine-tune large language models with NVIDIA FLARE.
+- [Federated XGBoost](user_guide/data_scientist_guide/federated_xgboost/federated_xgboost.md): Train XGBoost models in federated settings.
+
+## Deployment And Operations
+
+- [Deployment Overview](user_guide/admin_guide/deployment/overview.md): Plan and run production NVIDIA FLARE deployments.
+- [Provisioning System](programming_guide/provisioning_system.md): Provision participants, startup kits, and deployment assets.
+- [Distributed Provisioning](user_guide/nvflare_cli/distributed_provisioning.md): Use distributed provisioning workflows.
+- [Preflight Check](user_guide/nvflare_cli/preflight_check.md): Validate system readiness before launch.
+- [System Configuration](user_guide/admin_guide/configurations/system_configuration.md): Configure runtime system behavior.
+- [Monitoring](user_guide/admin_guide/monitoring.md): Monitor running federated learning systems.
+
+## Security And Compliance
+
+- [Security Overview](system_architecture/security_overview.md): Understand authentication, authorization, privacy, and auditing.
+- [Identity And Access Control](user_guide/admin_guide/security/identity_security.md): Configure identity and access controls.
+- [Communication Security](user_guide/admin_guide/security/communication_security.md): Secure network communication.
+- [Data Privacy Protection](user_guide/admin_guide/security/data_privacy_protection.md): Protect data with filters and privacy mechanisms.
+- [Differential Privacy](user_guide/admin_guide/security/differential_privacy.md): Apply differential privacy in federated learning.
+- [Confidential Computing](user_guide/confidential_computing/index.md): Deploy with hardware-backed trusted execution environments.
+
+## Developer Reference
+
+- [Developer Guide](developer_guide.md): Understand architecture, controllers, filters, and extension points.
+- [API Reference](apidocs/modules.md): Browse generated Python API documentation.
+- [Glossary](glossary.md): Look up NVIDIA FLARE terms and concepts.
+- [Contributing](contributing.md): Build docs, run tests, and contribute changes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,9 +79,10 @@ app_opt_mac =
 core_opt =
     %(CONFIG)s
 doc =
-    sphinx>=4.1.1
+    sphinx>=5
     sphinx_rtd_theme
     recommonmark
+    sphinx-llm>=0.4.1
     sphinx-copybutton
     sphinxcontrib-jquery
 all =


### PR DESCRIPTION
## What changed

Backports PR #4519 to the `2.8` branch.

Cherry-picked commits:

- `7890111cc3251bcf211949dc6eb921861e11d600` - Add LLM-friendly docs outputs
- `614bcbbcccf0696fb9682681bd23b3c8a401a3c7` - Limit curated llms.txt copy to HTML builds

This adds the generated Markdown docs output and curated `llms.txt` index to the 2.8 documentation build.

## Validation

- `.venv/bin/python -m py_compile docs/conf.py`
- `SKIP_API_DOCS=1 .venv/bin/sphinx-build -b html docs /private/tmp/nvflare-llms-2.8-html-check`
- `SKIP_API_DOCS=1 .venv/bin/sphinx-build -b dirhtml docs /private/tmp/nvflare-llms-2.8-dirhtml-check`
- Confirmed `/private/tmp/nvflare-llms-2.8-html-check/llms.txt` matches `docs/llms.txt.in`
- Confirmed both builds emitted 216 generated Markdown pages

The Sphinx builds completed successfully with existing documentation warnings.
