### PR TITLE
Skip auth filter for cellnet protocol-level bye messages

### DIFF
--- a/nvflare/fuel/f3/cellnet/defs.py
+++ b/nvflare/fuel/f3/cellnet/defs.py
@@ -167,12 +167,14 @@ class CellChannel:
     RETURN_ONLY = "return_only"
     EDGE_REQUEST = "edge_request"
     HCI = "hci_channel"
+    CELLNET = "cellnet.channel"
 
 
 class CellChannelTopic:
 
     Challenge = "challenge"
     Register = "register"
+    Bye = "bye"
     Quit = "quit"
     GET_TASK = "get_task"
     SUBMIT_RESULT = "submit_result"

--- a/nvflare/private/fed/authenticator.py
+++ b/nvflare/private/fed/authenticator.py
@@ -320,6 +320,27 @@ def validate_auth_headers(message: CellMessage, token_verifier: TokenVerifier, l
         logger.debug(f"skip special message {topic=} {channel=}")
         return None
 
+    # Cellnet protocol-level goodbye is broadcast by Cell.stop() with an empty
+    # Message() that carries no FL-level auth headers. Only bypass auth when the
+    # message is for the immediate (direct-neighbor) recipient, i.e. TO_CELL ==
+    # DESTINATION. If it would be forwarded onward (TO_CELL != DESTINATION), a
+    # remote unauthenticated peer could craft a bye with DESTINATION pointing
+    # at a downstream cell whose _peer_goodbye would then drop the immediate
+    # endpoint (the server/relay) from its agents dict — fall through to the
+    # normal auth check in that case. The explicit ``to_cell is not None``
+    # check rejects crafted messages that omit both headers (None == None
+    # would otherwise pass).
+    to_cell = message.get_header(MessageHeaderKey.TO_CELL)
+    destination = message.get_header(MessageHeaderKey.DESTINATION)
+    if (
+        topic == CellChannelTopic.Bye
+        and channel == CellChannel.CELLNET
+        and to_cell is not None
+        and to_cell == destination
+    ):
+        logger.debug(f"skip direct-neighbor cellnet bye {topic=} {channel=}")
+        return None
+
     client_name = message.get_header(CellMessageHeaderKeys.CLIENT_NAME)
     err_text = f"unauthenticated msg ({channel=} {topic=}) received from {origin}"
     if not client_name:


### PR DESCRIPTION
## Summary
- During any cell shutdown (e.g. `nvflare poc stop`), `Cell.stop()` broadcasts a goodbye to all peers using `topic="bye"` on
`channel="cellnet.channel"` with an empty `Message()`. As a cellnet protocol-level lifecycle primitive, this message
intentionally carries no FL-level auth headers — the same reason `Register`/`Challenge` already bypass the auth filter.
- Without this exemption, every shutdown emits a misleading `FederatedServer ERROR unauthenticated msg
(channel='cellnet.channel' topic='bye') missing client name` line in the server log, polluting log analysis. As a side
effect, the receiver's `_peer_goodbye` handler is never invoked, so agent-dict cleanup waits on heartbeat timeout instead of
executing immediately.
- This PR extends the existing `Register`/`Challenge` bypass in `validate_auth_headers()` to cover the symmetric end-of-life
`bye` message.

## Changes
- `nvflare/private/fed/authenticator.py`: extend the auth-filter bypass to `(topic="bye", channel="cellnet.channel")`
alongside the existing `Register`/`Challenge` exemption.

## Repro
Before fix:
~~~
nvflare poc prepare --number_of_clients 2 --force
nvflare poc start --exclude admin@nvidia.com
nvflare poc stop
grep ERROR /tmp/nvflare/poc/example_project/prod_00/server/log.txt
# produces one ERROR line: FederatedServer - ERROR - unauthenticated msg (channel='cellnet.channel' topic='bye') ... missing
client name
~~~
After fix: zero ERROR lines.

## Security
The bye handler `_peer_goodbye` in `nvflare/fuel/f3/cellnet/core_cell.py` only removes the sender from the local `agents`
dict and acks back — no sensitive operations. Allowing unauthenticated bye through has zero security impact.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh` (license + style; full unit tests deferred to CI).
- [ ] In-line docstrings updated.
- [ ] Documentation updated.