### PR TITLE
Add cleanup parameter to recipe Run.get_result() (default True)

### DIFF
--- a/nvflare/recipe/run.py
+++ b/nvflare/recipe/run.py
@@ -74,13 +74,19 @@ class Run:
                 self.logger.warning(f"Failed to get job status: {e}")
                 return None
 
-    def get_result(self, timeout: float = 0.0) -> Optional[str]:
+    def get_result(self, timeout: float = 0.0, cleanup: bool = True) -> Optional[str]:
         """Get the result workspace of the run.
 
         Waits for job to complete, caches status, then stops execution environment.
 
         Args:
             timeout (float, optional): Timeout for job completion. Defaults to 0.0 (no timeout).
+            cleanup (bool, optional): Whether to remove the execution-environment workspace
+                (e.g. the POC workspace) when stopping. Defaults to True, preserving the
+                existing "each run is independent" behavior. Pass ``cleanup=False`` to keep
+                the workspace on disk after the run so server/client log files (including
+                the per-service ``poc_console.log`` introduced in #4500) remain available
+                for debugging or test assertions.
 
         Returns:
             Optional[str]: Result workspace path, or None if job not finished or on error.
@@ -104,7 +110,7 @@ class Run:
                 self._cached_status = None
 
             try:
-                self.exec_env.stop(clean_up=True)
+                self.exec_env.stop(clean_up=cleanup)
             except Exception as e:
                 self.logger.warning(f"Failed to stop execution environment: {e}")
             finally:

--- a/tests/unit_test/recipe/run_test.py
+++ b/tests/unit_test/recipe/run_test.py
@@ -76,6 +76,15 @@ class TestRunClass:
         assert self.run._cached_status == "FINISHED"
         assert self.run._cached_result == "/tmp/workspace/test_job_123"
 
+    def test_get_result_cleanup_false_preserves_workspace(self):
+        """Test that get_result(cleanup=False) forwards clean_up=False to exec_env.stop()."""
+        self.mock_env.get_job_result.return_value = "/tmp/workspace/test_job_123"
+        self.mock_env.get_job_status.return_value = "FINISHED"
+
+        self.run.get_result(cleanup=False)
+
+        self.mock_env.stop.assert_called_once_with(clean_up=False)
+
     def test_get_result_default_timeout(self):
         """Test get_result with default timeout."""
         self.mock_env.get_job_result.return_value = "/tmp/workspace/test_job_123"


### PR DESCRIPTION
## Summary
- Run.get_result() previously hard-coded `exec_env.stop(clean_up=True)` with no way for callers to opt out of workspace removal.
- After PR #4500 moved subprocess stdout into per-service `poc_console.log` files **inside the workspace**, this hard-coded cleanup also wipes those console logs the moment `get_result()` returns. Combined with the "each run is independent" cleanup from PR #4084, this means `print(\"Result can be found in :\", run.get_result())` (the pattern used by every official `examples/*/job.py`) prints a path that has already been rmtree'd, and no per-service log — including `poc_console.log` — survives for inspection.
- This PR adds a `cleanup: bool = True` parameter to `Run.get_result()` and forwards it to `exec_env.stop(clean_up=cleanup)`. **The default is preserved as `True`**, so existing behavior is unchanged. New callers (debuggers, test frameworks asserting against per-service logs, agent workflows) can now opt to keep the workspace by calling `run.get_result(cleanup=False)`.

## Behaviour
| Call | Services stopped | Workspace |
|---|---|---|
| `run.get_result()` (default, unchanged) | yes | removed |
| `run.get_result(cleanup=False)` (new opt-out) | yes | preserved on disk |

## Why this matters now
PR #4500 changed where subprocess stdout goes: instead of inheriting parent stdout, each service writes to `<workspace>/example_project/prod_NN/<service>/poc_console.log`. That file is the only post-run record of the service's stdout. Today it disappears together with the workspace inside `get_result()`, so users / tests / agents that want to inspect what server and clients actually printed have no way to do so without forking NVFlare.

## Changes
- `nvflare/recipe/run.py`: add `cleanup: bool = True` parameter to `Run.get_result()`; forward to `exec_env.stop(clean_up=cleanup)` instead of hard-coded `True`. Docstring updated to call out the relationship with `poc_console.log` and PR #4500.
- `tests/unit_test/recipe/run_test.py`: existing assertions on `clean_up=True` remain unchanged. Added `test_get_result_cleanup_false_preserves_workspace` covering the `cleanup=False` propagation path.

## Verified locally
- Two consecutive `recipe.execute(env=PocEnv(...))` runs with `cleanup=False` succeed; the second run lands in `prod_01/` next to the preserved `prod_00/` from the first run, services correctly stopped between runs.
- All 21 `Run` unit tests pass; license, black, isort, flake8 clean.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh` (license + style + targeted unit tests `tests/unit_test/recipe/run_test.py` 21 passed, 3 skipped).
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

(Docstring of `Run.get_result()` itself updated; no public docs touched.)