### PR TITLE
Add generic Kubernetes support to multicloud deploy

### DIFF
--- a/devops/multicloud/README.md
+++ b/devops/multicloud/README.md
@@ -15,7 +15,10 @@ this example.
 Shipped config:
 - `all-clouds.yaml` — GCP server with GCP, AWS, and Azure clients
 
-Cluster topology is defined in the YAML (`clouds:` + `participants:`).
+Cluster topology is defined by the NVFlare project YAML plus the deploy YAML.
+The project YAML owns the FLARE participant list. The deploy YAML maps those
+same participant names to clouds, namespaces, runtime images, PVCs, and Helm
+settings.
 The deploy tool reads kubeconfigs from `.tmp/kubeconfigs/<cloud>.yaml`.
 `fetch_kubeconfigs.py` discovers clusters from the active cloud CLI contexts
 and supports environment variable overrides when discovery is ambiguous.
@@ -26,8 +29,10 @@ Cloud-specific behavior lives in provider modules under
 
 ## Topology Selection
 
-The `participants:` section is the primary control for what is deployed. The
-default `all-clouds.yaml` topology creates one server and three clients:
+The project YAML participant list and the deploy YAML `participants:` section
+must agree. `deploy.py` validates this before provisioning and does not generate
+or rewrite project participants. The default `all-clouds.yaml` topology uses
+`project.yml` and creates one server and three clients:
 
 ```yaml
 participants:
@@ -37,10 +42,12 @@ participants:
   - { name: azure-client-3, cloud: azure, namespace: nvflare-client-3, role: client }
 ```
 
-Edit that list to choose a smaller topology. For example, to deploy only on
-GCP, keep the GCP server and GCP client entries and remove the AWS/Azure client
-entries. To deploy two clouds, keep only participants for those clouds. Exactly
-one participant must have `role: server`; all other participants are clients.
+Edit both the project YAML and the deploy YAML to choose a different topology.
+For example, to deploy only on GCP, keep the GCP server and GCP client entries
+in both files and remove the AWS/Azure client entries. To keep a separate
+project YAML for an experiment, add `project_file: path/to/project.yml` to the
+deploy YAML. Exactly one participant must be a server; all other deploy
+participants are clients.
 
 `fetch_kubeconfigs.py`, `build_and_push.py`, and `deploy.py` operate on the
 clouds referenced by `participants:`.

--- a/devops/multicloud/clouds/__init__.py
+++ b/devops/multicloud/clouds/__init__.py
@@ -1,13 +1,15 @@
 from .aws import AwsProvider
 from .azure import AzureProvider
 from .gcp import GcpProvider
+from .kubernetes import KubernetesProvider
 
-CLOUD_ORDER = ("gcp", "aws", "azure")
+CLOUD_ORDER = ("gcp", "aws", "azure", "kubernetes")
 
 PROVIDERS = {
     "gcp": GcpProvider(),
     "aws": AwsProvider(),
     "azure": AzureProvider(),
+    "kubernetes": KubernetesProvider(),
 }
 
 

--- a/devops/multicloud/clouds/base.py
+++ b/devops/multicloud/clouds/base.py
@@ -19,8 +19,17 @@ class CloudProvider:
     def release_ip(self, *, run, ip_name, state):
         raise NotImplementedError
 
+    def server_service_type(self, *, state):
+        return "LoadBalancer"
+
     def server_service_helm_args(self, *, server_ip, state):
         raise NotImplementedError
+
+    def status_endpoint(self, *, state, config):
+        return "IP name", state.get("ip_name", "N/A")
+
+    def admin_endpoint(self, *, config, server_ip):
+        return None
 
 
 def service_annotation_args(annotations: dict[str, str]) -> list[str]:

--- a/devops/multicloud/clouds/kubernetes.py
+++ b/devops/multicloud/clouds/kubernetes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from .base import CloudProvider, service_annotation_args
+
+
+class KubernetesProvider(CloudProvider):
+    name = "kubernetes"
+    auth_check_cmd = []
+    auth_failed_message = ""
+    auth_expired_message = ""
+
+    def _server_config(self, config) -> dict:
+        if not config:
+            return {}
+        return (config.cloud_configs.get(config.server_cloud) or {}).get("server") or {}
+
+    def _server_participant(self, config):
+        return next(p for p in config.participants if p.role == "server")
+
+    def _default_server_address(self, config) -> str:
+        server = self._server_participant(config)
+        return f"nvflare-server.{server.namespace}.svc.cluster.local"
+
+    def validate_server_config(self, config):
+        server_config = self._server_config(config)
+        service_type = server_config.get("service_type", "ClusterIP")
+        if service_type not in {"ClusterIP", "LoadBalancer", "NodePort"}:
+            raise SystemExit(f"clouds.{self.name}.server.service_type must be ClusterIP, LoadBalancer, or NodePort")
+
+    def reserve_ip(self, *, run, ip_tag, config=None, **kwargs):
+        server_config = self._server_config(config)
+        address = server_config.get("address") or self._default_server_address(config)
+        print(f"Using Kubernetes service address {address} ({self.name})")
+        return address, ip_tag
+
+    def prepare_server_state(self, *, run, state, config, ip_name, **kwargs):
+        server_config = self._server_config(config)
+        state["kubernetes_service_type"] = server_config.get("service_type", "ClusterIP")
+        state["kubernetes_service_annotations"] = server_config.get("annotations") or {}
+        state["kubernetes_load_balancer_ip"] = server_config.get("load_balancer_ip")
+
+    def release_ip(self, *, run, ip_name, state):
+        print(f"No external IP to release for {self.name}.")
+
+    def server_service_type(self, *, state):
+        return state.get("kubernetes_service_type") or "ClusterIP"
+
+    def server_service_helm_args(self, *, server_ip, state):
+        args = []
+        annotations = state.get("kubernetes_service_annotations") or {}
+        if annotations:
+            args += service_annotation_args(annotations)
+        load_balancer_ip = state.get("kubernetes_load_balancer_ip")
+        if load_balancer_ip:
+            args += ["--set", f"service.loadBalancerIP={load_balancer_ip}"]
+        return args
+
+    def status_endpoint(self, *, state, config):
+        server_config = self._server_config(config)
+        return "Server address", server_config.get("address") or self._default_server_address(config)
+
+    def admin_endpoint(self, *, config, server_ip):
+        server_config = self._server_config(config)
+        admin_config = server_config.get("admin") or {}
+        service_type = server_config.get("service_type", "ClusterIP")
+        if admin_config.get("host") or admin_config.get("port"):
+            return admin_config.get("host") or server_ip, int(admin_config.get("port") or 8003)
+        if service_type == "ClusterIP":
+            return "localhost", 18003
+        return None

--- a/devops/multicloud/deploy.py
+++ b/devops/multicloud/deploy.py
@@ -25,20 +25,20 @@ from __future__ import annotations
 
 import argparse
 import copy
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import hashlib
 import json
+import os
 import re
 import shlex
 import shutil
 import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
-
 from clouds import CLOUD_ORDER, get_provider
 
 DRY_RUN = False
@@ -110,7 +110,8 @@ class Participant:
     kubeconfig: str
     role: str  # "server" or "client"
     cloud: str
-    prepare: dict
+    provider: str = ""
+    prepare: dict = field(default_factory=dict)
     helm_overrides: list = field(default_factory=list)
     pvc_config: dict = field(default_factory=dict)
     pod_annotations: dict = field(default_factory=dict)
@@ -118,6 +119,8 @@ class Participant:
     # Kubernetes imagePullPolicy override. `None` keeps whatever the helm chart
     # defaults to (typically IfNotPresent). Set to "Always" on mutable dev tags.
     pull_policy: str | None = None
+    create_namespace: bool = True
+    delete_namespace: bool = True
 
 
 @dataclass
@@ -131,6 +134,9 @@ class DeployConfig:
     aws_eks_cluster_name: str | None
     azure_resource_group: str | None
     azure_location: str | None
+    project_file: Path = PROJECT_TEMPLATE
+    server_provider: str = ""
+    cloud_configs: dict = field(default_factory=dict)
     monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
 
 
@@ -218,14 +224,57 @@ def _normalize_study_data(study_data: dict | None) -> dict:
     return result
 
 
-def _kubeconfig_path(cloud: str) -> Path:
+def _namespace_options(config_path: Path, cloud: str, cloud_cfg: dict, entry: dict) -> tuple[bool, bool]:
+    namespace_cfg = cloud_cfg.get("namespace")
+    if namespace_cfg is None:
+        namespace_cfg = {}
+    if not isinstance(namespace_cfg, dict):
+        raise ValueError(f"{config_path}: clouds.{cloud}.namespace must be a YAML mapping when set")
+
+    configured_name = namespace_cfg.get("name")
+    if configured_name and configured_name != entry["namespace"]:
+        raise ValueError(
+            f"{config_path}: participant {entry['name']} namespace {entry['namespace']!r} does not match "
+            f"clouds.{cloud}.namespace.name {configured_name!r}"
+        )
+
+    create_namespace = bool(namespace_cfg.get("create", True))
+    delete_namespace = bool(namespace_cfg.get("delete_on_down", True))
+    return create_namespace, delete_namespace
+
+
+def _resolve_path(path: str | Path, *, base: Path) -> Path:
+    path = Path(path).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def _kubeconfig_path(cloud: str, cloud_config: dict | None = None, *, config_dir: Path | None = None) -> Path:
+    kubeconfig = (cloud_config or {}).get("kubeconfig")
+    if kubeconfig:
+        return _resolve_path(kubeconfig, base=config_dir or Path.cwd())
     return (DEFAULT_KUBECONFIG_DIR / f"{cloud}.yaml").resolve()
+
+
+def _provider_name(cloud: str, cloud_cfg: dict | None = None) -> str:
+    return (cloud_cfg or {}).get("provider") or cloud
+
+
+def _cloud_provider_or_none(provider_name: str):
+    try:
+        return get_provider(provider_name)
+    except ValueError:
+        return None
 
 
 def load_config(config_path: Path) -> DeployConfig:
     config_path = config_path.resolve()
     raw = yaml.safe_load(config_path.read_text())
     name = raw.get("name") or config_path.stem
+    project_file = _resolve_path(raw.get("project_file") or PROJECT_TEMPLATE, base=config_path.parent)
+    if not project_file.is_file():
+        raise ValueError(f"{config_path}: project_file not found: {project_file}")
     monitoring = load_monitoring_config(raw, config_name=name, config_path=config_path)
     clouds = raw.get("clouds") or {}
     if not clouds:
@@ -236,9 +285,10 @@ def load_config(config_path: Path) -> DeployConfig:
 
     cloud_derived: dict[str, dict] = {}
     for cloud_name, cloud_cfg in clouds.items():
-        kc_path = _kubeconfig_path(cloud_name)
-        if kc_path.exists():
-            cloud_derived[cloud_name] = get_provider(cloud_name).parse_kubeconfig(kc_path)
+        kc_path = _kubeconfig_path(cloud_name, cloud_cfg, config_dir=config_path.parent)
+        provider = _cloud_provider_or_none(_provider_name(cloud_name, cloud_cfg))
+        if kc_path.exists() and provider:
+            cloud_derived[cloud_name] = provider.parse_kubeconfig(kc_path)
 
     participants: list[Participant] = []
     servers: list[str] = []
@@ -256,15 +306,19 @@ def load_config(config_path: Path) -> DeployConfig:
             servers.append(entry["name"])
 
         cloud_cfg = clouds[cloud] or {}
+        provider_name = _provider_name(cloud, cloud_cfg)
+        if not _cloud_provider_or_none(provider_name):
+            raise ValueError(f"{config_path}: cloud {cloud!r} uses unknown provider {provider_name!r}")
         merged = {**cloud_cfg, **entry}
         prepare = copy.deepcopy(entry.get("prepare") or cloud_cfg.get("prepare") or {})
         if not prepare:
             raise ValueError(f"{config_path}: participant {entry['name']} has no prepare config")
         if prepare.get("runtime") != K8S_RUNTIME:
             raise ValueError(f"{config_path}: participant {entry['name']} prepare.runtime must be '{K8S_RUNTIME}'")
-        kc_path = _kubeconfig_path(cloud)
+        kc_path = _kubeconfig_path(cloud, cloud_cfg, config_dir=config_path.parent)
         pvc_config = merged.get("pvc_config") or {}
         study_data = _normalize_study_data(merged.get("study_data"))
+        create_namespace, delete_namespace = _namespace_options(config_path, cloud, cloud_cfg, entry)
 
         participants.append(
             Participant(
@@ -273,26 +327,32 @@ def load_config(config_path: Path) -> DeployConfig:
                 kubeconfig=str(kc_path),
                 role=role,
                 cloud=cloud,
+                provider=provider_name,
                 prepare=prepare,
                 helm_overrides=list(merged.get("helm_overrides") or []),
                 pvc_config=pvc_config,
                 pod_annotations=merged.get("pod_annotations") or {},
                 study_data=study_data,
                 pull_policy=merged.get("pull_policy"),
+                create_namespace=create_namespace,
+                delete_namespace=delete_namespace,
             )
         )
 
     if len(servers) != 1:
         raise ValueError(f"{config_path}: expected exactly one server participant, found {len(servers)}: {servers}")
     server_cloud = next(p.cloud for p in participants if p.role == "server")
+    server_provider = next(p.provider for p in participants if p.role == "server")
 
     gcp = cloud_derived.get("gcp", {})
     aws = cloud_derived.get("aws", {})
     azure = clouds.get("azure") or {}
     return DeployConfig(
         name=name,
+        project_file=project_file,
         participants=participants,
         server_cloud=server_cloud,
+        server_provider=server_provider,
         monitoring=monitoring,
         gcp_project=gcp.get("project"),
         gcp_region=gcp.get("region"),
@@ -300,6 +360,7 @@ def load_config(config_path: Path) -> DeployConfig:
         aws_eks_cluster_name=aws.get("eks_cluster_name"),
         azure_resource_group=azure.get("resource_group"),
         azure_location=azure.get("location"),
+        cloud_configs=clouds,
     )
 
 
@@ -377,21 +438,25 @@ def helm(kubeconfig: str, *args) -> subprocess.CompletedProcess:
     return run(["helm", "--kubeconfig", kubeconfig] + list(args))
 
 
-def check_auth(clouds_used: set):
+def check_auth(providers_used: set):
     print("Checking cloud auth ...")
-    for cloud in CLOUD_ORDER:
-        if cloud not in clouds_used:
+    for provider_name in CLOUD_ORDER:
+        if provider_name not in providers_used:
             continue
-        provider = get_provider(cloud)
+        provider = get_provider(provider_name)
+        if not provider.auth_check_cmd:
+            continue
         r = run_quiet(provider.auth_check_cmd)
         if r.returncode != 0:
             sys.exit(provider.auth_failed_message)
     print("  Auth OK")
 
 
-def check_auth_for(cloud: str):
+def check_auth_for(provider_name: str):
     """Re-check auth before cloud-specific operations."""
-    provider = get_provider(cloud)
+    provider = get_provider(provider_name)
+    if not provider.auth_check_cmd:
+        return
     r = run_quiet(provider.auth_check_cmd)
     if r.returncode != 0:
         sys.exit(provider.auth_expired_message)
@@ -409,7 +474,26 @@ def _safe_resource_name(name: str) -> str:
 
 
 def _participant_state(p: Participant) -> dict:
-    return {"kubeconfig": p.kubeconfig, "namespace": p.namespace, "cloud": p.cloud, "role": p.role}
+    return {
+        "kubeconfig": p.kubeconfig,
+        "namespace": p.namespace,
+        "cloud": p.cloud,
+        "provider": p.provider,
+        "role": p.role,
+        "delete_namespace": p.delete_namespace,
+        "pvc_names": list(p.pvc_config),
+        "cleanup_pvc_names": _participant_cleanup_pvc_names(p),
+    }
+
+
+def _participant_cleanup_pvc_names(p: Participant) -> list[str]:
+    names = list(p.pvc_config)
+    for datasets in (p.study_data or {}).values():
+        for dataset in (datasets or {}).values():
+            source = (dataset or {}).get("source")
+            if source:
+                names.append(source)
+    return list(dict.fromkeys(names))
 
 
 def deployment_state(config: DeployConfig, *, gcp_project: str | None = None) -> dict:
@@ -420,9 +504,10 @@ def deployment_state(config: DeployConfig, *, gcp_project: str | None = None) ->
         "gcp_region": config.gcp_region or "us-central1",
         "aws_region": config.aws_region,
         "server_cloud": config.server_cloud,
+        "server_provider": config.server_provider,
         "azure_resource_group": config.azure_resource_group,
         "azure_location": config.azure_location,
-        "azure_pip_name": ip_name if config.server_cloud == "azure" else None,
+        "azure_pip_name": ip_name if config.server_provider == "azure" else None,
         "participants": {p.name: _participant_state(p) for p in config.participants},
     }
 
@@ -436,10 +521,59 @@ def helm_release_exists(kubeconfig: str, name: str, ns: str) -> bool:
 
 
 def nvflare_cmd() -> str:
+    override = os.environ.get("NVFLARE_CMD")
+    if override:
+        return override
     if DRY_RUN:
         return "nvflare"
     nvflare = REPO_ROOT / ".venv" / "bin" / "nvflare"
     return str(nvflare) if nvflare.exists() else "nvflare"
+
+
+def _project_deploy_participants(project: dict, project_file: Path) -> dict[str, str]:
+    participants = project.get("participants")
+    if not isinstance(participants, list):
+        raise ValueError(f"{project_file}: project participants must be a YAML list")
+
+    result = {}
+    for entry in participants:
+        if not isinstance(entry, dict):
+            raise ValueError(f"{project_file}: project participant must be a YAML mapping: {entry}")
+        participant_type = entry.get("type")
+        if participant_type not in VALID_ROLES:
+            continue
+        name = entry.get("name")
+        if not name:
+            raise ValueError(f"{project_file}: project {participant_type} participant is missing name")
+        if name in result:
+            raise ValueError(f"{project_file}: duplicate project participant name: {name}")
+        result[name] = participant_type
+    return result
+
+
+def _validate_project_participants(project: dict, config: DeployConfig) -> None:
+    expected = {p.name: p.role for p in config.participants}
+    actual = _project_deploy_participants(project, config.project_file)
+    if actual == expected:
+        return
+
+    expected_items = ", ".join(f"{name}:{role}" for name, role in sorted(expected.items()))
+    actual_items = ", ".join(f"{name}:{role}" for name, role in sorted(actual.items()))
+    raise ValueError(
+        f"{config.project_file}: project participants do not match {config.name} participants. "
+        f"deploy.py no longer generates participants; update the project YAML instead. "
+        f"project=[{actual_items}] config=[{expected_items}]"
+    )
+
+
+def render_project(server_ip: str, config: DeployConfig) -> str:
+    project_text = config.project_file.read_text()
+    project_text = project_text.replace("__SERVER_IP__", server_ip)
+    project = yaml.safe_load(project_text)
+    if not isinstance(project, dict):
+        raise ValueError(f"{config.project_file}: project file must be a YAML mapping")
+    _validate_project_participants(project, config)
+    return project_text
 
 
 # ---------------------------------------------------------------------------
@@ -447,6 +581,7 @@ def nvflare_cmd() -> str:
 # ---------------------------------------------------------------------------
 def provision(server_ip: str, config: DeployConfig) -> Path:
     print("Provisioning ...")
+    project_text = render_project(server_ip, config)
     if DRY_RUN:
         project_file = WORK_DIR / "project.yml"
         provision_dir = WORK_DIR / "provision"
@@ -454,24 +589,8 @@ def provision(server_ip: str, config: DeployConfig) -> Path:
         return Path("<prod_dir>")
 
     WORK_DIR.mkdir(parents=True, exist_ok=True)
-    project_text = PROJECT_TEMPLATE.read_text()
-    project_text = project_text.replace("__SERVER_IP__", server_ip)
-    project = yaml.safe_load(project_text)
-
-    template_server = next(e for e in project["participants"] if e.get("type") == "server")
-    template_admin = next(e for e in project["participants"] if e.get("type") == "admin")
-
-    new_participants = []
-    for p in config.participants:
-        if p.role == "server":
-            new_participants.append({**template_server, "name": p.name})
-        else:
-            new_participants.append({"name": p.name, "type": "client", "org": "nvidia"})
-    new_participants.append(template_admin)
-    project["participants"] = new_participants
-
     project_file = WORK_DIR / "project.yml"
-    project_file.write_text(yaml.dump(project, default_flow_style=False, sort_keys=False))
+    project_file.write_text(project_text)
 
     provision_dir = WORK_DIR / "provision"
     if provision_dir.exists():
@@ -483,6 +602,19 @@ def provision(server_ip: str, config: DeployConfig) -> Path:
     if not prod_dirs:
         sys.exit("Provisioning produced no output")
     return prod_dirs[-1]
+
+
+def configure_admin_endpoint(prod_dir: Path, host: str, port: int):
+    fed_admin_path = prod_dir / "admin@nvidia.com" / "startup" / "fed_admin.json"
+    if DRY_RUN:
+        print(f"  Would set admin endpoint in {_mask(str(fed_admin_path))} to {host}:{port}")
+        return
+    data = json.loads(fed_admin_path.read_text())
+    data.setdefault("admin", {})
+    data["admin"]["host"] = host
+    data["admin"]["port"] = port
+    fed_admin_path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"Configured local admin endpoint {host}:{port}")
 
 
 def _write_yaml_file(path: Path, data: dict):
@@ -528,9 +660,9 @@ def teardown_monitoring_stack(config: DeployConfig) -> bool:
     server = next(p for p in config.participants if p.role == "server")
     print(f"Tearing down monitoring stack ({monitoring.namespace}) ...")
     try:
-        check_auth_for(server.cloud)
+        check_auth_for(server.provider)
     except SystemExit:
-        print(f"  Auth failed for {server.cloud} — skipping")
+        print(f"  Auth failed for {server.provider} — skipping")
         return False
     r = run(
         [
@@ -670,12 +802,18 @@ def deploy_participant(
     print(f"Deploying {p.name} → {p.namespace}")
     print(f"{'=' * 60}")
 
-    check_auth_for(p.cloud)
+    check_auth_for(p.provider)
 
     # 1. Namespace
     if not namespace_exists(p.kubeconfig, p.namespace):
-        print(f"  Creating namespace {p.namespace}")
-        kubectl(p.kubeconfig, "create", "ns", p.namespace)
+        if not p.create_namespace:
+            if DRY_RUN:
+                print(f"  Namespace {p.namespace} must already exist")
+            else:
+                raise RuntimeError(f"Namespace {p.namespace} does not exist and create_namespace is disabled")
+        else:
+            print(f"  Creating namespace {p.namespace}")
+            kubectl(p.kubeconfig, "create", "ns", p.namespace)
     else:
         print(f"  Namespace {p.namespace} exists")
 
@@ -758,8 +896,11 @@ def deploy_participant(
     helm_args += p.helm_overrides
 
     if p.role == "server" and server_ip:
-        helm_args += ["--set", "service.type=LoadBalancer"]
-        helm_args += get_provider(p.cloud).server_service_helm_args(server_ip=server_ip, state=state or {})
+        provider = get_provider(p.provider)
+        service_type = provider.server_service_type(state=state or {})
+        if service_type:
+            helm_args += ["--set", f"service.type={service_type}"]
+        helm_args += provider.server_service_helm_args(server_ip=server_ip, state=state or {})
 
     for k, v in p.pod_annotations.items():
         escaped = k.replace(".", r"\.").replace("/", r"\/")
@@ -826,14 +967,14 @@ def deploy_participants(participants: list[Participant], kit_dirs: dict[str, Pat
 def cmd_up(args):
     config = load_config(Path(args.config))
     participants = config.participants
-    clouds_used = {p.cloud for p in participants}
-    check_auth(clouds_used)
+    providers_used = {p.provider for p in participants}
+    check_auth(providers_used)
 
-    server_provider = get_provider(config.server_cloud)
-    server_provider.validate_server_config(config)
+    server_provider_impl = get_provider(config.server_provider)
+    server_provider_impl.validate_server_config(config)
 
     gcp_project = None
-    if "gcp" in clouds_used:
+    if "gcp" in providers_used:
         gcp_project = (
             config.gcp_project or run(["gcloud", "config", "get-value", "project"], capture=True).stdout.strip()
         )
@@ -841,10 +982,11 @@ def cmd_up(args):
     aws_region = config.aws_region
 
     state = deployment_state(config, gcp_project=gcp_project)
-    server_ip, ip_name = server_provider.reserve_ip(
+    server_ip, ip_name = server_provider_impl.reserve_ip(
         run=run,
         ip_tag=state["ip_name"],
         state=state,
+        config=config,
         gcp_project=gcp_project,
         gcp_region=gcp_region,
         aws_region=aws_region,
@@ -852,12 +994,17 @@ def cmd_up(args):
         azure_location=config.azure_location,
     )
 
-    server_provider.prepare_server_state(run=run, state=state, config=config, ip_name=ip_name, aws_region=aws_region)
+    server_provider_impl.prepare_server_state(
+        run=run, state=state, config=config, ip_name=ip_name, aws_region=aws_region
+    )
     state["server_ip"] = server_ip
 
     deploy_monitoring_stack(config)
 
     prod_dir = provision(server_ip, config)
+    admin_endpoint = server_provider_impl.admin_endpoint(config=config, server_ip=server_ip)
+    if admin_endpoint:
+        configure_admin_endpoint(prod_dir, host=admin_endpoint[0], port=admin_endpoint[1])
     kit_dirs = prepare_runtime_kits(prod_dir, participants, monitoring=config.monitoring)
 
     deploy_participants(participants, kit_dirs, server_ip=server_ip, state=state)
@@ -869,16 +1016,78 @@ def cmd_up(args):
     print(f"{'=' * 60}")
 
 
+def _pods_using_pvcs(kubeconfig: str, ns: str, pvc_names: list[str]) -> list[str]:
+    # Reused namespaces cannot be removed wholesale during teardown. Find any
+    # leftover pods that still mount deployment-owned PVCs so the PVC cleanup
+    # below does not hang on active volume attachments.
+    if not pvc_names:
+        return []
+    r = run(["kubectl", "--kubeconfig", kubeconfig, "-n", ns, "get", "pods", "-o", "json"], check=False, capture=True)
+    if r.returncode != 0:
+        detail = f": {r.stderr.strip()}" if r.stderr else ""
+        print(f"  Warning: failed to list pods before PVC cleanup{detail}")
+        return []
+    try:
+        data = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError as e:
+        print(f"  Warning: failed to parse pod list before PVC cleanup: {e}")
+        return []
+
+    pvc_set = set(pvc_names)
+    pod_names = []
+    for item in data.get("items") or []:
+        name = (item.get("metadata") or {}).get("name")
+        if not name:
+            continue
+        volumes = (item.get("spec") or {}).get("volumes") or []
+        if any((volume.get("persistentVolumeClaim") or {}).get("claimName") in pvc_set for volume in volumes):
+            pod_names.append(name)
+    return sorted(set(pod_names))
+
+
+def delete_pods_using_pvcs(kubeconfig: str, ns: str, pvc_names: list[str]):
+    pod_names = _pods_using_pvcs(kubeconfig, ns, pvc_names)
+    for pod_name in pod_names:
+        run(
+            [
+                "kubectl",
+                "--kubeconfig",
+                kubeconfig,
+                "-n",
+                ns,
+                "delete",
+                "pod",
+                pod_name,
+                "--ignore-not-found",
+                "--timeout=60s",
+            ],
+            check=False,
+        )
+
+
 def teardown_participant(name: str, info: dict) -> bool:
-    kc, ns, cloud = info["kubeconfig"], info["namespace"], info.get("cloud", "")
+    kc, ns = info["kubeconfig"], info["namespace"]
+    provider_name = info.get("provider") or info.get("cloud", "")
     print(f"Tearing down {name} ({ns}) ...")
     try:
-        check_auth_for(cloud)
+        check_auth_for(provider_name)
     except SystemExit:
         print(f"  Auth failed for {kc} — skipping")
         return False
 
     run(["helm", "--kubeconfig", kc, "uninstall", name, "-n", ns], check=False)
+    if not info.get("delete_namespace", True):
+        # In shared namespaces, delete only this participant's Helm release,
+        # transient pods using its PVCs, and its workspace PVCs. Study-data PVCs
+        # can appear in cleanup_pvc_names to unblock pods, but are not deleted.
+        delete_pods_using_pvcs(kc, ns, info.get("cleanup_pvc_names") or info.get("pvc_names") or [])
+        for pvc_name in info.get("pvc_names") or []:
+            run(
+                ["kubectl", "--kubeconfig", kc, "-n", ns, "delete", "pvc", pvc_name, "--ignore-not-found"],
+                check=False,
+            )
+        return True
+
     r = run(["kubectl", "--kubeconfig", kc, "delete", "ns", ns, "--ignore-not-found", "--timeout=120s"], check=False)
     if r.returncode != 0:
         return False
@@ -928,19 +1137,37 @@ def cmd_down(args):
         print("Partial teardown. Re-run down with the same config after fixing the failure.")
         sys.exit(1)
 
-    get_provider(state.get("server_cloud", "gcp")).release_ip(run=run, ip_name=state["ip_name"], state=state)
+    get_provider(state.get("server_provider") or state.get("server_cloud", "gcp")).release_ip(
+        run=run, ip_name=state["ip_name"], state=state
+    )
     print("Destroyed.")
 
 
 def cmd_status(args):
     config = load_config(Path(args.config))
     state = deployment_state(config)
+    status_label, status_value = get_provider(config.server_provider or config.server_cloud).status_endpoint(
+        state=state, config=config
+    )
 
-    print(f"IP name:   {state.get('ip_name', 'N/A')}")
+    print(f"{status_label}:   {status_value}")
     for name, info in state.get("participants", {}).items():
         kc, ns = info["kubeconfig"], info["namespace"]
         print(f"\n{name} ({ns}):")
-        r = run_quiet(["kubectl", "--kubeconfig", kc, "-n", ns, "get", "pods", "--no-headers"])
+        r = run_quiet(
+            [
+                "kubectl",
+                "--kubeconfig",
+                kc,
+                "-n",
+                ns,
+                "get",
+                "pods",
+                "-l",
+                f"app.kubernetes.io/name={name}",
+                "--no-headers",
+            ]
+        )
         if r.returncode == 0 and r.stdout.strip():
             for line in r.stdout.strip().split("\n"):
                 print(f"  {line}")

--- a/devops/multicloud/fetch_kubeconfigs.py
+++ b/devops/multicloud/fetch_kubeconfigs.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 import yaml
 
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 DEFAULT_CONFIG = SCRIPT_DIR / "all-clouds.yaml"
@@ -115,6 +114,13 @@ def used_clouds(config: dict) -> list[str]:
         if cloud and cloud not in clouds:
             clouds.append(cloud)
     return clouds
+
+
+def configured_kubeconfig(cloud_config: dict, *, config_dir: Path) -> Path | None:
+    kubeconfig = cloud_config.get("kubeconfig")
+    if not kubeconfig:
+        return None
+    return resolve_path(Path(kubeconfig), base=config_dir)
 
 
 def kubeconfig_path(cloud: str, out_dir: Path) -> Path:
@@ -271,6 +277,13 @@ def main() -> int:
         cloud_config = clouds_config.get(cloud)
         if not isinstance(cloud_config, dict):
             fail(f"cloud '{cloud}' is used by participants but is not configured")
+
+        configured = configured_kubeconfig(cloud_config, config_dir=config_path.parent)
+        if configured:
+            if not args.dry_run and not configured.is_file():
+                fail(f"configured kubeconfig does not exist for cloud '{cloud}': {configured}")
+            print(f"Using configured kubeconfig for {cloud}: {configured}")
+            continue
 
         kubeconfig = kubeconfig_path(cloud, out_dir)
         run(["mkdir", "-p", str(kubeconfig.parent)], dry_run=args.dry_run)

--- a/devops/multicloud/k8sview.py
+++ b/devops/multicloud/k8sview.py
@@ -27,12 +27,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import re
 import sys
 import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -84,12 +85,42 @@ STATUS_COLORS = {
 }
 
 
+def site_name_to_rfc1123(site_name: str, max_length: int = 47) -> str:
+    digest = hashlib.sha256(site_name.encode("utf-8")).hexdigest()[:8]
+    name = site_name.lower()
+    name = re.sub(r"[^a-z0-9-]", "", name).strip("-")
+    if not name:
+        name = "site"
+    if name[0].isdigit():
+        name = "s" + name
+    head_max = max_length - len(digest) - 1
+    name = name[:head_max].rstrip("-") or "site"
+    return f"{name}-{digest}"
+
+
+def display_job_id(job_prefix: str) -> str:
+    if re.fullmatch(r"j[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", job_prefix):
+        return job_prefix[1:]
+    return job_prefix
+
+
 @dataclass
 class Participant:
     name: str
     cloud: str
     namespace: str
     kubeconfig: str
+    pvc_names: tuple[str, ...] = ()
+    role: str = field(default="", compare=False)
+
+
+@dataclass
+class NamespaceTarget:
+    name: str
+    cloud: str
+    namespace: str
+    kubeconfig: str
+    job_site_suffixes: tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True)
@@ -151,12 +182,35 @@ def load_participants(config_path: Path) -> list[Participant]:
     for e in entries:
         cloud_cfg = clouds.get(e["cloud"], {}) or {}
         merged = {**cloud_cfg, **e}
-        kc = resolve_kubeconfig(e["cloud"])
-        out.append(Participant(merged["name"], e["cloud"], merged["namespace"], str(kc)))
+        kc = resolve_kubeconfig(e["cloud"], cloud_cfg, config_dir=config_path.parent)
+        pvc_names = _participant_pvc_names(merged)
+        out.append(
+            Participant(merged["name"], e["cloud"], merged["namespace"], str(kc), pvc_names, merged.get("role", ""))
+        )
     return out
 
 
-def resolve_kubeconfig(cloud: str) -> Path:
+def _participant_pvc_names(config: dict) -> tuple[str, ...]:
+    names = list((config.get("pvc_config") or {}).keys())
+    for datasets in (config.get("study_data") or {}).values():
+        for dataset in (datasets or {}).values():
+            pvc = (dataset or {}).get("pvc") or (dataset or {}).get("source")
+            if pvc:
+                names.append(pvc)
+    return tuple(dict.fromkeys(names))
+
+
+def resolve_path(path: str | Path, *, base: Path) -> Path:
+    path = Path(path).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def resolve_kubeconfig(cloud: str, cloud_config: dict | None = None, *, config_dir: Path | None = None) -> Path:
+    kubeconfig = (cloud_config or {}).get("kubeconfig")
+    if kubeconfig:
+        return resolve_path(kubeconfig, base=config_dir or Path.cwd())
     return (DEFAULT_KUBECONFIG_DIR / f"{cloud}.yaml").resolve()
 
 
@@ -237,16 +291,74 @@ def _call(p: Participant, cache: ApiCache, method_name: str, **kwargs):
         return PodFetchError(f"{type(e).__name__}: {e}")
 
 
+def _participant_label_selector(p: Participant) -> str:
+    return f"app.kubernetes.io/name={p.name}"
+
+
+def unique_namespace_targets(participants: list[Participant]) -> list[NamespaceTarget]:
+    targets = {}
+    for p in participants:
+        key = (p.cloud, p.namespace, p.kubeconfig)
+        target = targets.get(key)
+        if target is None:
+            target = {
+                "name": f"{p.cloud}/{p.namespace}",
+                "cloud": p.cloud,
+                "namespace": p.namespace,
+                "kubeconfig": p.kubeconfig,
+                "job_site_suffixes": [],
+            }
+            targets[key] = target
+        site_names = [p.name]
+        if p.role == "server":
+            site_names.append("server")
+        for site_name in site_names:
+            target["job_site_suffixes"].append((site_name, site_name_to_rfc1123(site_name, max_length=20)))
+    return [
+        NamespaceTarget(
+            name=t["name"],
+            cloud=t["cloud"],
+            namespace=t["namespace"],
+            kubeconfig=t["kubeconfig"],
+            job_site_suffixes=tuple(t["job_site_suffixes"]),
+        )
+        for t in targets.values()
+    ]
+
+
+def _filter_participant_pvcs(p: Participant, result):
+    if isinstance(result, PodFetchError) or not p.pvc_names:
+        return result
+    allowed = set(p.pvc_names)
+    return [pvc for pvc in result if pvc.metadata.name in allowed]
+
+
 def fetch_pods(p: Participant, cache: ApiCache):
-    return _call(p, cache, "list_namespaced_pod")
+    return _call(p, cache, "list_namespaced_pod", label_selector=_participant_label_selector(p))
+
+
+def _job_info_from_pod(p: NamespaceTarget, pod) -> tuple[str, str] | None:
+    pod_name = pod.metadata.name
+    for site_name, site_suffix in p.job_site_suffixes:
+        suffix = f"-{site_suffix}"
+        if pod_name.endswith(suffix):
+            return display_job_id(pod_name[: -len(suffix)] or "-"), site_name
+    return None
+
+
+def fetch_job_pods(p: NamespaceTarget, cache: ApiCache):
+    result = _call(p, cache, "list_namespaced_pod")
+    if isinstance(result, PodFetchError):
+        return result
+    return [pod for pod in result if _job_info_from_pod(p, pod)]
 
 
 def fetch_pvcs(p: Participant, cache: ApiCache):
-    return _call(p, cache, "list_namespaced_persistent_volume_claim")
+    return _filter_participant_pvcs(p, _call(p, cache, "list_namespaced_persistent_volume_claim"))
 
 
 def fetch_services(p: Participant, cache: ApiCache):
-    return _call(p, cache, "list_namespaced_service")
+    return _call(p, cache, "list_namespaced_service", label_selector=_participant_label_selector(p))
 
 
 def fetch_events(p: Participant, cache: ApiCache):
@@ -424,7 +536,13 @@ def status_text(status: str) -> Text:
 # ---------------------------------------------------------------------------
 def build_pod_table(snapshots: list[tuple[Participant, object]]) -> Table:
     total_pods = sum(len(r) for _, r in snapshots if isinstance(r, list))
-    table = Table(caption=f"{total_pods} pods", caption_style="dim", expand=True, title="Pods", title_style="bold")
+    table = Table(
+        caption=f"{total_pods} pods",
+        caption_style="dim",
+        expand=True,
+        title="Participant Pods",
+        title_style="bold",
+    )
     for col, style, width in [
         ("CLOUD", "cyan", None),
         ("PARTICIPANT", "cyan", None),
@@ -461,6 +579,77 @@ def build_pod_table(snapshots: list[tuple[Participant, object]]) -> Table:
                 p.name,
                 p.namespace,
                 pod.metadata.name,
+                ready_fraction(pod),
+                status_text(derive_status(pod)),
+                str(restart_count(pod)),
+                age_str(pod),
+                pod.spec.node_name or "—",
+            )
+    return table
+
+
+def _pod_gpu_resources(pod) -> str:
+    values = []
+    for container in pod.spec.containers or []:
+        resources = container.resources
+        if not resources:
+            continue
+        requests = resources.requests or {}
+        limits = resources.limits or {}
+        gpu = requests.get("nvidia.com/gpu") or limits.get("nvidia.com/gpu")
+        if gpu:
+            values.append(str(gpu))
+    return _ip_join(values)
+
+
+def build_job_pod_table(snapshots: list[tuple[NamespaceTarget, object]]) -> Table:
+    total_pods = sum(len(r) for _, r in snapshots if isinstance(r, list))
+    table = Table(caption=f"{total_pods} pods", caption_style="dim", expand=True, title="Job Pods", title_style="bold")
+    for col, style, width in [
+        ("CLOUD", "cyan", None),
+        ("NS", "cyan", None),
+        ("JOB", "white", None),
+        ("SITE", "cyan", None),
+        ("POD", "white", None),
+        ("GPU", None, 5),
+        ("READY", None, 6),
+        ("STATUS", None, None),
+        ("RESTARTS", None, 8),
+        ("AGE", None, 6),
+        ("NODE", "dim", None),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=(col != "NODE"))
+
+    for p, result in snapshots:
+        if isinstance(result, PodFetchError):
+            table.add_row(
+                p.cloud,
+                p.namespace,
+                "—",
+                "—",
+                "—",
+                "—",
+                "—",
+                Text(f"ERROR: {result.msg}", style="red"),
+                "—",
+                "—",
+                "—",
+            )
+            continue
+        if not result:
+            table.add_row(p.cloud, p.namespace, Text("(no job pods)", style="dim"), "", "", "", "", "", "", "", "")
+            continue
+        for pod in sorted(
+            result, key=lambda x: (str(_ensure_aware_utc(x.metadata.creation_timestamp)), x.metadata.name)
+        ):
+            job_id, site_name = _job_info_from_pod(p, pod) or ("-", "-")
+            table.add_row(
+                p.cloud,
+                p.namespace,
+                job_id,
+                site_name,
+                pod.metadata.name,
+                _pod_gpu_resources(pod),
                 ready_fraction(pod),
                 status_text(derive_status(pod)),
                 str(restart_count(pod)),
@@ -547,6 +736,7 @@ def build_summary(
     svc_snaps: list[tuple[Participant, object]],
     config_path: Path,
     interval: float,
+    job_pod_snaps: list[tuple[Participant, object]] | None = None,
 ) -> Text:
     pod_counts: Counter = Counter()
     pod_errors = 0
@@ -580,6 +770,16 @@ def build_summary(
         f"Pods: {_fmt(pod_counts)}" + (f"  [red]{pod_errors} fetch errors[/]" if pod_errors else ""),
         f"PVCs: {_fmt(pvc_counts)}",
     ]
+    if job_pod_snaps is not None:
+        job_counts: Counter = Counter()
+        job_errors = 0
+        for _, r in job_pod_snaps:
+            if isinstance(r, PodFetchError):
+                job_errors += 1
+                continue
+            for pod in r or []:
+                job_counts[derive_status(pod)] += 1
+        lines.append(f"Job pods: {_fmt(job_counts)}" + (f"  [red]{job_errors} fetch errors[/]" if job_errors else ""))
     eps = _lb_endpoints(svc_snaps)
     if eps:
         for name, ep, state in eps:
@@ -1152,6 +1352,7 @@ def main():
     )
     parser.add_argument("--interval", type=float, default=2.0, help="Refresh interval in seconds")
     parser.add_argument("--events-window", type=float, default=300.0, help="Show Warning events newer than N seconds")
+    parser.add_argument("--once", action="store_true", help="Render one snapshot and exit")
     args = parser.parse_args()
 
     cache = ApiCache()
@@ -1161,22 +1362,39 @@ def main():
     if args.config:
         config_path = Path(args.config).resolve()
         participants = load_participants(config_path)
+        namespace_targets = unique_namespace_targets(participants)
+
+        def _focused_view() -> Group:
+            pod_snap = gather(participants, cache, fetch_pods)
+            pod_snap, _ = prune_pod_snapshots(pod_snap, cache)
+            job_pod_snap = gather(namespace_targets, cache, fetch_job_pods)
+            job_pod_snap, _ = prune_pod_snapshots(job_pod_snap, cache)
+            pvc_snap = gather(participants, cache, fetch_pvcs)
+            svc_snap = gather(participants, cache, fetch_services)
+            evt_snap = gather(participants, cache, fetch_events)
+            return Group(
+                build_summary(
+                    pod_snap,
+                    pvc_snap,
+                    svc_snap,
+                    config_path,
+                    args.interval,
+                    job_pod_snaps=job_pod_snap,
+                ),
+                build_pod_table(pod_snap),
+                build_job_pod_table(job_pod_snap),
+                build_pvc_table(pvc_snap),
+                build_events_table(evt_snap, args.events_window),
+            )
+
+        if args.once:
+            console.print(_focused_view())
+            return
+
         with Live(console=console, refresh_per_second=4, screen=False) as live:
             try:
                 while True:
-                    pod_snap = gather(participants, cache, fetch_pods)
-                    pod_snap, _ = prune_pod_snapshots(pod_snap, cache)
-                    pvc_snap = gather(participants, cache, fetch_pvcs)
-                    svc_snap = gather(participants, cache, fetch_services)
-                    evt_snap = gather(participants, cache, fetch_events)
-                    live.update(
-                        Group(
-                            build_summary(pod_snap, pvc_snap, svc_snap, config_path, args.interval),
-                            build_pod_table(pod_snap),
-                            build_pvc_table(pvc_snap),
-                            build_events_table(evt_snap, args.events_window),
-                        )
-                    )
+                    live.update(_focused_view())
                     time.sleep(args.interval)
             except KeyboardInterrupt:
                 pass
@@ -1184,6 +1402,12 @@ def main():
 
     kubeconfig_dir = Path(args.kubeconfig_dir).resolve()
     clusters = load_clusters(kubeconfig_dir)
+    if args.once:
+        snapshots, prune_stats = gather_cluster_snapshots(clusters, cache)
+        rows = build_site_rows(snapshots)
+        console.print(build_all_cloud_view(snapshots, prune_stats, kubeconfig_dir, args.interval, rows))
+        return
+
     with Live(console=console, refresh_per_second=4, screen=False) as live:
         try:
             while True:

--- a/devops/multicloud/setting-up-dev-cluster.md
+++ b/devops/multicloud/setting-up-dev-cluster.md
@@ -6,7 +6,8 @@ Use this file when prompted to create an NVFlare multicloud dev cluster. Keep al
 
 - The target config shape is `devops/multicloud/all-clouds.yaml`.
 - The default topology is GCP server plus GCP, AWS, and Azure clients.
-- The `participants:` section controls which clouds and sites are deployed.
+- The project YAML controls FLARE participants; the deploy YAML maps those
+  participant names to clouds and namespaces.
 - Real image tags are required for `clouds.<cloud>.prepare.parent.docker_image`.
 - Kubeconfig discovery uses active cloud CLI contexts plus env overrides, not local YAML override files.
 
@@ -17,12 +18,14 @@ RUN_ID=$(date +%Y%m%d-%H%M%S)
 CONFIG=.tmp/multicloud/${RUN_ID}/all-clouds.yaml
 mkdir -p "$(dirname "$CONFIG")"
 cp devops/multicloud/all-clouds.yaml "$CONFIG"
+cp devops/multicloud/project.yml "$(dirname "$CONFIG")/project.yml"
 ```
 
 Edit `$CONFIG`:
 
 - Set top-level `name` to a unique value, for example `all-clouds-${RUN_ID}`.
-- Set each participant `name` to a unique value if multiple dev clusters may coexist.
+- Add `project_file: project.yml`.
+- Set each participant `name` in both `$CONFIG` and the copied project YAML to a unique value if multiple dev clusters may coexist.
 - Set each participant `namespace` to a unique value if multiple dev clusters may coexist.
 - Replace all placeholder `clouds.<cloud>.prepare.parent.docker_image` values with real registry tags.
 - Do not add project names, cluster names, subscription IDs, or account IDs to the YAML.
@@ -40,8 +43,8 @@ example an image built with `.[K8S,MONITORING]`. The default `docker/Dockerfile`
 installs only `.[K8S]`, so either use a custom Dockerfile for monitoring runs or
 set the config image fields to an already-built monitoring-capable image.
 
-To select clouds, edit `participants:`. The config must have exactly one server.
-For a GCP-only smoke setup:
+To select clouds, edit `participants:` in both `$CONFIG` and the copied project
+YAML. The config must have exactly one server. For a GCP-only smoke setup:
 
 ```yaml
 participants:

--- a/tests/unit_test/devops/multicloud_deploy_test.py
+++ b/tests/unit_test/devops/multicloud_deploy_test.py
@@ -231,7 +231,6 @@ clouds:
         docker_image: repo/image:tag
     pvc_config:
       nvflws: {sc: standard-rwo, access: ReadWriteOnce, size: 1Gi}
-      nvfldata: {sc: standard-rwo, access: ReadWriteOnce, size: 1Gi}
     study_data:
       default:
         data: {pvc: nvfldata, mode: ro}
@@ -243,6 +242,9 @@ participants:
         config = DEPLOY_MODULE.load_config(config_path)
 
         assert config.participants[0].study_data == {"default": {"data": {"source": "nvfldata", "mode": "ro"}}}
+        state = DEPLOY_MODULE.deployment_state(config)
+        assert state["participants"]["gcp-server"]["pvc_names"] == ["nvflws"]
+        assert state["participants"]["gcp-server"]["cleanup_pvc_names"] == ["nvflws", "nvfldata"]
 
     @pytest.mark.parametrize("entry", [{"mode": "ro"}, {"pvc": "nvfldata"}])
     def test_rejects_study_data_without_pvc_or_mode(self, tmp_path, entry):
@@ -295,6 +297,87 @@ participants:
         assert config.monitoring.statsd_port == 9125
         assert config.monitoring.env == "all-clouds"
 
+    def test_render_project_keeps_project_participants_and_templates_server_ip(self, tmp_path):
+        project_path = tmp_path / "project.yml"
+        project_path.write_text(
+            """
+api_version: 3
+name: explicit-project
+participants:
+  - name: site-server
+    type: server
+    org: nvidia
+    default_host: __SERVER_IP__
+    fed_learn_port: 8002
+    admin_port: 8003
+  - name: site-client
+    type: client
+    org: nvidia
+  - name: admin@nvidia.com
+    type: admin
+    org: nvidia
+    role: project_admin
+builders: []
+"""
+        )
+        config_path = tmp_path / "deploy.yaml"
+        config_path.write_text(
+            """
+name: explicit-project
+project_file: project.yml
+clouds:
+  gcp:
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: repo/image:tag
+participants:
+  - {name: site-server, cloud: gcp, namespace: nvflare-server, role: server}
+  - {name: site-client, cloud: gcp, namespace: nvflare-client, role: client}
+"""
+        )
+
+        config = DEPLOY_MODULE.load_config(config_path)
+        rendered = yaml.safe_load(DEPLOY_MODULE.render_project("10.1.2.3", config))
+
+        assert config.project_file == project_path
+        assert [p["name"] for p in rendered["participants"]] == ["site-server", "site-client", "admin@nvidia.com"]
+        assert rendered["participants"][0]["default_host"] == "10.1.2.3"
+
+    def test_render_project_rejects_participant_mismatch(self, tmp_path):
+        project_path = tmp_path / "project.yml"
+        project_path.write_text(
+            """
+api_version: 3
+name: explicit-project
+participants:
+  - {name: site-server, type: server, org: nvidia, default_host: __SERVER_IP__}
+  - {name: other-client, type: client, org: nvidia}
+  - {name: admin@nvidia.com, type: admin, org: nvidia, role: project_admin}
+builders: []
+"""
+        )
+        config_path = tmp_path / "deploy.yaml"
+        config_path.write_text(
+            """
+name: explicit-project
+project_file: project.yml
+clouds:
+  gcp:
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: repo/image:tag
+participants:
+  - {name: site-server, cloud: gcp, namespace: nvflare-server, role: server}
+  - {name: site-client, cloud: gcp, namespace: nvflare-client, role: client}
+"""
+        )
+        config = DEPLOY_MODULE.load_config(config_path)
+
+        with pytest.raises(ValueError, match="deploy.py no longer generates participants"):
+            DEPLOY_MODULE.render_project("10.1.2.3", config)
+
 
 class TestMonitoringStack:
     def test_dry_run_applies_monitoring_stack(self, monkeypatch, capsys):
@@ -331,6 +414,42 @@ class TestMonitoringStack:
         assert "apply -f -" in output
         assert "name: nvflare-all-clouds-monitoring" in output
 
+    def test_teardown_monitoring_uses_provider_not_cloud_alias(self, monkeypatch):
+        config = DEPLOY_MODULE.DeployConfig(
+            name="alias-cloud",
+            participants=[
+                DEPLOY_MODULE.Participant(
+                    name="site-server",
+                    namespace="nvflare",
+                    kubeconfig="/tmp/kubeconfig",
+                    role="server",
+                    cloud="local-cluster",
+                    provider="kubernetes",
+                    prepare={},
+                )
+            ],
+            server_cloud="local-cluster",
+            server_provider="kubernetes",
+            gcp_project=None,
+            gcp_region=None,
+            aws_region=None,
+            aws_eks_cluster_name=None,
+            azure_resource_group=None,
+            azure_location=None,
+            monitoring=DEPLOY_MODULE.MonitoringConfig(enabled=True, namespace="nvflare-monitoring"),
+        )
+        auth_checks = []
+        run_calls = []
+
+        monkeypatch.setattr(DEPLOY_MODULE, "check_auth_for", lambda provider: auth_checks.append(provider))
+        monkeypatch.setattr(
+            DEPLOY_MODULE, "run", lambda cmd, **kwargs: run_calls.append((cmd, kwargs)) or DEPLOY_MODULE.FakeProc(0)
+        )
+
+        assert DEPLOY_MODULE.teardown_monitoring_stack(config)
+        assert auth_checks == ["kubernetes"]
+        assert run_calls[0][0][:5] == ["kubectl", "--kubeconfig", "/tmp/kubeconfig", "delete", "ns"]
+
 
 class TestDryRunGoldenOutput:
     @pytest.mark.parametrize(
@@ -355,6 +474,71 @@ class TestDryRunGoldenOutput:
         )
 
         assert capsys.readouterr().out == (DRY_RUN_GOLD_DIR / f"{config_name}.{command}.txt").read_text()
+
+
+class TestStatus:
+    def test_kubernetes_status_shows_service_address_not_ip_name(self, monkeypatch, tmp_path, capsys):
+        config_path = tmp_path / "local-cluster.yaml"
+        config_path.write_text(
+            """
+name: local-cluster
+server_cloud: local-cluster
+clouds:
+  local-cluster:
+    provider: kubernetes
+    kubeconfig: /tmp/kubeconfig
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: repo/image:tag
+    server:
+      service_type: ClusterIP
+participants:
+  - {name: local-server, cloud: local-cluster, namespace: nvflare, role: server}
+"""
+        )
+
+        monkeypatch.setattr(DEPLOY_MODULE, "run_quiet", lambda cmd: DEPLOY_MODULE.FakeProc(0, stdout="pod-row\n"))
+
+        DEPLOY_MODULE.cmd_status(SimpleNamespace(config=str(config_path)))
+
+        out = capsys.readouterr().out
+        assert "Server address:   nvflare-server.nvflare.svc.cluster.local" in out
+        assert "IP name:" not in out
+
+
+class TestKubernetesAdminEndpoint:
+    def test_kubernetes_clusterip_defaults_admin_endpoint_to_local_port_forward(self):
+        provider = DEPLOY_MODULE.get_provider("kubernetes")
+        config = SimpleNamespace(
+            server_cloud="local-cluster",
+            cloud_configs={"local-cluster": {"server": {"service_type": "ClusterIP"}}},
+            participants=[
+                DEPLOY_MODULE.Participant(
+                    name="local-server",
+                    namespace="nvflare",
+                    kubeconfig="/tmp/kubeconfig",
+                    role="server",
+                    cloud="local-cluster",
+                    prepare={"runtime": "k8s", "parent": {"docker_image": "repo/image:tag"}},
+                )
+            ],
+        )
+
+        assert provider.admin_endpoint(config=config, server_ip="nvflare-server.nvflare.svc.cluster.local") == (
+            "localhost",
+            18003,
+        )
+
+    def test_configure_admin_endpoint_rewrites_admin_startup(self, tmp_path):
+        startup_dir = tmp_path / "prod_00" / "admin@nvidia.com" / "startup"
+        startup_dir.mkdir(parents=True)
+        fed_admin = startup_dir / "fed_admin.json"
+        fed_admin.write_text(json.dumps({"admin": {"host": "nvflare-server.nvflare.svc.cluster.local", "port": 8003}}))
+
+        DEPLOY_MODULE.configure_admin_endpoint(tmp_path / "prod_00", host="localhost", port=18003)
+
+        assert json.loads(fed_admin.read_text())["admin"] == {"host": "localhost", "port": 18003}
 
 
 class TestHelmDeployFlow:
@@ -420,6 +604,50 @@ class TestHelmDeployFlow:
 
 
 class TestTeardownFlow:
+    def test_teardown_deletes_pods_using_configured_pvcs_before_pvcs(self, monkeypatch):
+        calls = []
+        pod_list = {
+            "items": [
+                {
+                    "metadata": {"name": "job-pod"},
+                    "spec": {"volumes": [{"persistentVolumeClaim": {"claimName": "client-study-data"}}]},
+                },
+                {
+                    "metadata": {"name": "other-pod"},
+                    "spec": {"volumes": [{"persistentVolumeClaim": {"claimName": "other-data"}}]},
+                },
+            ]
+        }
+
+        def _run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            if cmd[:7] == ["kubectl", "--kubeconfig", "/tmp/kubeconfig", "-n", "nvflare", "get", "pods"]:
+                return DEPLOY_MODULE.FakeProc(0, stdout=json.dumps(pod_list))
+            return DEPLOY_MODULE.FakeProc(0)
+
+        monkeypatch.setattr(DEPLOY_MODULE, "check_auth_for", lambda provider: None)
+        monkeypatch.setattr(DEPLOY_MODULE, "run", _run)
+
+        assert DEPLOY_MODULE.teardown_participant(
+            "local-client-1",
+            {
+                "kubeconfig": "/tmp/kubeconfig",
+                "namespace": "nvflare",
+                "provider": "kubernetes",
+                "role": "client",
+                "delete_namespace": False,
+                "pvc_names": ["client-ws"],
+                "cleanup_pvc_names": ["client-ws", "client-study-data"],
+            },
+        )
+
+        commands = [cmd for cmd, _kwargs in calls]
+        delete_pod_index = next(i for i, cmd in enumerate(commands) if cmd[5:8] == ["delete", "pod", "job-pod"])
+        delete_pvc_index = next(i for i, cmd in enumerate(commands) if cmd[5:8] == ["delete", "pvc", "client-ws"])
+        assert delete_pod_index < delete_pvc_index
+        assert not any(cmd[5:8] == ["delete", "pod", "other-pod"] for cmd in commands)
+        assert not any(cmd[5:8] == ["delete", "pvc", "client-study-data"] for cmd in commands)
+
     def test_cmd_down_attempts_server_after_client_failure(self, monkeypatch):
         config = DEPLOY_MODULE.DeployConfig(
             name="test-cluster",

--- a/tests/unit_test/devops/multicloud_dry_run_configs/aws-server-project.yml
+++ b/tests/unit_test/devops/multicloud_dry_run_configs/aws-server-project.yml
@@ -1,9 +1,9 @@
 api_version: 3
-name: nvflare_multicloud
-description: NVFlare multicloud end-to-end test project
+name: aws-server
+description: NVFlare multicloud dry-run test project
 
 participants:
-  - name: gcp-server
+  - name: aws-server
     type: server
     org: nvidia
     default_host: __SERVER_IP__
@@ -13,9 +13,6 @@ participants:
     type: client
     org: nvidia
   - name: aws-client-2
-    type: client
-    org: nvidia
-  - name: azure-client-3
     type: client
     org: nvidia
   - name: admin@nvidia.com

--- a/tests/unit_test/devops/multicloud_dry_run_configs/aws-server.yaml
+++ b/tests/unit_test/devops/multicloud_dry_run_configs/aws-server.yaml
@@ -1,4 +1,5 @@
 name: aws-server
+project_file: aws-server-project.yml
 
 clouds:
   gcp:

--- a/tests/unit_test/devops/multicloud_dry_run_configs/azure-server-project.yml
+++ b/tests/unit_test/devops/multicloud_dry_run_configs/azure-server-project.yml
@@ -1,21 +1,15 @@
 api_version: 3
-name: nvflare_multicloud
-description: NVFlare multicloud end-to-end test project
+name: azure-server
+description: NVFlare multicloud dry-run test project
 
 participants:
-  - name: gcp-server
+  - name: azure-server
     type: server
     org: nvidia
     default_host: __SERVER_IP__
     fed_learn_port: 8002
     admin_port: 8003
-  - name: gcp-client-1
-    type: client
-    org: nvidia
-  - name: aws-client-2
-    type: client
-    org: nvidia
-  - name: azure-client-3
+  - name: azure-client-1
     type: client
     org: nvidia
   - name: admin@nvidia.com

--- a/tests/unit_test/devops/multicloud_dry_run_configs/azure-server.yaml
+++ b/tests/unit_test/devops/multicloud_dry_run_configs/azure-server.yaml
@@ -1,4 +1,5 @@
 name: azure-server
+project_file: azure-server-project.yml
 
 clouds:
   azure:

--- a/tests/unit_test/devops/multicloud_dry_run_configs/gcp-server-project.yml
+++ b/tests/unit_test/devops/multicloud_dry_run_configs/gcp-server-project.yml
@@ -1,6 +1,6 @@
 api_version: 3
-name: nvflare_multicloud
-description: NVFlare multicloud end-to-end test project
+name: gcp-server
+description: NVFlare multicloud dry-run test project
 
 participants:
   - name: gcp-server
@@ -13,9 +13,6 @@ participants:
     type: client
     org: nvidia
   - name: aws-client-2
-    type: client
-    org: nvidia
-  - name: azure-client-3
     type: client
     org: nvidia
   - name: admin@nvidia.com

--- a/tests/unit_test/devops/multicloud_dry_run_configs/gcp-server.yaml
+++ b/tests/unit_test/devops/multicloud_dry_run_configs/gcp-server.yaml
@@ -1,4 +1,5 @@
 name: gcp-server
+project_file: gcp-server-project.yml
 
 clouds:
   gcp:

--- a/tests/unit_test/devops/multicloud_k8sview_test.py
+++ b/tests/unit_test/devops/multicloud_k8sview_test.py
@@ -200,6 +200,43 @@ participants:
     ]
 
 
+def test_load_participants_includes_study_data_pvcs(tmp_path):
+    config = tmp_path / "all-clouds.yaml"
+    config.write_text(
+        """
+clouds:
+  gcp:
+    study_data:
+      study1:
+        data: { pvc: client-study-data, mode: ro }
+participants:
+  - name: gcp-client
+    cloud: gcp
+    namespace: nvflare-client
+    role: client
+    pvc_config:
+      nvflws: { sc: standard-rwo, access: ReadWriteOnce, size: 1Gi }
+"""
+    )
+
+    participants = K8SVIEW.load_participants(config)
+
+    assert participants[0].pvc_names == ("nvflws", "client-study-data")
+
+
+def test_job_info_displays_raw_uuid_for_digit_prefixed_k8s_pod_name():
+    target = K8SVIEW.NamespaceTarget(
+        name="local-cluster/nvflare",
+        cloud="local-cluster",
+        namespace="nvflare",
+        kubeconfig="/tmp/kubeconfig",
+        job_site_suffixes=(("server", K8SVIEW.site_name_to_rfc1123("server", max_length=20)),),
+    )
+    pod = _pod("j0c772668-d240-4fc2-ad62-cb7406aaad77-server-b3eacd33", namespace="nvflare")
+
+    assert K8SVIEW._job_info_from_pod(target, pod) == ("0c772668-d240-4fc2-ad62-cb7406aaad77", "server")
+
+
 def test_build_site_rows_summarizes_job_pods_and_ips_without_listing_jobs():
     cluster = K8SVIEW.Cluster(name="gcp", cloud="gcp", kubeconfig="/tmp/gcp.yaml")
     snapshot = K8SVIEW.ClusterSnapshot(


### PR DESCRIPTION
## Summary

Adds generic Kubernetes support to the multicloud devops tooling without requiring cloud-specific IP reservation or namespace ownership.

Key changes:
- add a `kubernetes` provider for existing clusters, configurable service type, configured kubeconfig paths, and local admin port-forward defaults for ClusterIP deployments
- make `deploy.py` consume an explicit project YAML instead of generating participant entries, while still templating `__SERVER_IP__`
- support reused namespaces with opt-in namespace creation/deletion behavior and scoped PVC cleanup
- update `k8sview.py` to distinguish participant pods from job pods in shared namespaces and show GPU requests on job pods
- add focused unit coverage and dry-run project fixtures
