### PR TITLE
Fix swarm CIFAR10 example: SwarmServerConfig.min_clients default + start_task_timeout

### DIFF
--- a/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
+++ b/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
@@ -34,7 +34,12 @@ if __name__ == "__main__":
 
     aggregator = InTimeAccumulateWeightedAggregator(expected_data_kind=DataKind.WEIGHTS)
     job.add_swarm(
-        server_config=SwarmServerConfig(num_rounds=num_rounds),
+        server_config=SwarmServerConfig(
+            num_rounds=num_rounds,
+            # Default 10s is too short for clients that initialize CIFAR-10 dataset
+            # and the PyTorch model after responding to swarm_config.
+            start_task_timeout=300,
+        ),
         client_config=SwarmClientConfig(
             executor=ScriptRunner(script=train_script),
             aggregator=aggregator,

--- a/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
+++ b/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
@@ -46,7 +46,12 @@ if __name__ == "__main__":
             persistor=PTFileModelPersistor(model=Net()),
             shareable_generator=SimpleModelShareableGenerator(),
         ),
-        cse_config=CrossSiteEvalConfig(eval_task_timeout=300),
+        cse_config=CrossSiteEvalConfig(
+            # Default 10s is too short for clients that need to (re)load CIFAR-10
+            # before responding to cse_start, same race as swarm_start above.
+            start_task_timeout=300,
+            eval_task_timeout=300,
+        ),
     )
 
     # job.export_job("/tmp/nvflare/jobs/job_config")

--- a/nvflare/app_common/ccwf/ccwf_job.py
+++ b/nvflare/app_common/ccwf/ccwf_job.py
@@ -48,7 +48,7 @@ class SwarmServerConfig:
         private_p2p: bool = True,
         aggr_clients=None,
         train_clients=None,
-        min_clients=None,
+        min_clients: int = 0,
     ):
         self.num_rounds = num_rounds
         self.start_round = start_round

--- a/tests/unit_test/app_common/ccwf/test_ccwf_job_config.py
+++ b/tests/unit_test/app_common/ccwf/test_ccwf_job_config.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for ccwf_job config dataclass defaults.
+
+SwarmServerConfig.min_clients was previously defaulted to None, which the
+add_swarm() wiring forwarded to SwarmServerController.__init__ (typed
+min_clients: int = 0). The value then reached BaseServerCtl.__init__ where
+`if min_clients < 0:` raised TypeError ("'<' not supported between instances
+of 'NoneType' and 'int'") at construction time, making the swarm CIFAR10
+example fail before any simulator was even started.
+
+The fix sets SwarmServerConfig.min_clients default to 0 so that the type
+contract (int) is honored end-to-end and the documented "0 means all
+participating clients are required" semantics from BaseServerCtl applies.
+"""
+
+from nvflare.app_common.ccwf.ccwf_job import SwarmServerConfig
+
+
+def test_swarm_server_config_default_min_clients_is_zero():
+    """Default SwarmServerConfig must use min_clients=0, not None.
+
+    None as a default would propagate through add_swarm() into
+    BaseServerCtl.__init__ where `if min_clients < 0:` raises TypeError.
+    """
+    config = SwarmServerConfig(num_rounds=1)
+    assert config.min_clients == 0
+    assert config.min_clients is not None
+
+
+def test_swarm_server_config_explicit_min_clients_preserved():
+    """Explicit min_clients value passes through unchanged."""
+    config = SwarmServerConfig(num_rounds=1, min_clients=2)
+    assert config.min_clients == 2


### PR DESCRIPTION
Fixes # .

### Description

The swarm CIFAR10 example fails out of the box on both NVFlare `main` and `2.7.2` with two distinct issues, both of which need to be fixed for the example to complete a single round.

## Summary

### Bug 1 — `SwarmServerConfig.min_clients` defaulted to `None`
`add_swarm()` forwards every `server_config` field — including this `None` — to `SwarmServerController(min_clients=...)`, overriding the controller's typed default of `int = 0`. The value then reaches `BaseServerCtl.__init__` where `if min_clients < 0:` raises:
~~~
TypeError: '<' not supported between instances of 'NoneType' and 'int'
~~~
The example crashes at construction time, before any simulator is launched.

The other `Optional[List[str]]` fields (`aggr_clients`, `train_clients`, `result_clients`) tolerate `None` because the controller normalizes them via `if not x: x = []`. `min_clients` has no such normalization — its type contract is `int`, and the documented "0 means all participating clients are required" semantics in `BaseServerCtl` already covers the "not specified" case.

**Fix:** change `SwarmServerConfig.min_clients` default from `None` to `int = 0`, matching the type and default of both `SwarmServerController.__init__` and `BaseServerCtl.__init__`.

### Bug 2 — `start_task_timeout` left at 10s default
`swarm_script_runner_cifar10.py` did not pass `start_task_timeout`, so the example used the framework default of 10s (`nvflare/app_common/ccwf/common.py:81 START_TASK_TIMEOUT = 10`). After Bug 1 is fixed, the simulator starts and configures both sites, but `swarm_start` times out after 10s while site-1 is still initializing CIFAR-10 + PyTorch model, and the run aborts with `FATAL_SYSTEM_ERROR ("failed to start workflow controller on client site-1")`.

**Fix:** pass `start_task_timeout=300` in the example, matching the pattern already used in `examples/advanced/swarm_learning/swarm_pt/job.py` (`start_task_timeout=1200`). Sibling PR #4554 applies the same example-side fix to the cyclic CIFAR10 example.

## Changes
- `nvflare/app_common/ccwf/ccwf_job.py`: `SwarmServerConfig.min_clients` default `None` → `int = 0`.
- `examples/advanced/job_api/pt/swarm_script_runner_cifar10.py`: pass `start_task_timeout=300` to `SwarmServerConfig`.
- `tests/unit_test/app_common/ccwf/test_ccwf_job_config.py`: new regression test asserting `SwarmServerConfig().min_clients == 0` so the default cannot silently regress to `None`.

## Repro
Before fix (on a 256-core / A100X host, both `main` and `2.7.2`):
~~~
cd examples/advanced/job_api/pt/
python swarm_script_runner_cifar10.py
# Python exits immediately:
# TypeError: '<' not supported between instances of 'NoneType' and 'int'
# in nvflare/app_common/ccwf/server_ctl.py:161 (BaseServerCtl.__init__).
# Workdir does not even contain a pt_swarm subdir.
~~~

After fix (Bug 1 only): the simulator starts, both sites are configured, then:
~~~
WFCommServer - INFO - task swarm_start exit with status TaskCompletionStatus.TIMEOUT
ServerRunner - ERROR - Aborting current RUN due to FATAL_SYSTEM_ERROR received:
                       failed to start workflow controller on client site-1
~~~

After both fixes: a 3-round swarm CCWF run completes in ~6:45 with no `FATAL_SYSTEM_ERROR` lines in the resulting `pt_swarm/server/log.txt`. All 92 existing ccwf unit tests still pass.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally (`pytest tests/unit_test/app_common/ccwf/` 92 passed; black + isort + flake8 clean on changed files; full `./runtest.sh` deferred to CI).
- [ ] In-line docstrings updated.
- [ ] Documentation updated.