### PR TITLE
[2.8] Add cleanup parameter to recipe Run.get_result() (#4541)

### DIFF
--- a/nvflare/recipe/run.py
+++ b/nvflare/recipe/run.py
@@ -74,13 +74,19 @@ class Run:
                 self.logger.warning(f"Failed to get job status: {e}")
                 return None
 
-    def get_result(self, timeout: float = 0.0) -> Optional[str]:
+    def get_result(self, timeout: float = 0.0, cleanup: bool = True) -> Optional[str]:
         """Get the result workspace of the run.
 
         Waits for job to complete, caches status, then stops execution environment.
 
         Args:
             timeout (float, optional): Timeout for job completion. Defaults to 0.0 (no timeout).
+            cleanup (bool, optional): Whether to remove the execution-environment workspace
+                (e.g. the POC workspace) when stopping. Defaults to True, preserving the
+                existing "each run is independent" behavior. Pass ``cleanup=False`` to keep
+                the workspace on disk after the run so server/client log files (including
+                the per-service ``poc_console.log`` introduced in #4500) remain available
+                for debugging or test assertions.
 
         Returns:
             Optional[str]: Result workspace path, or None if job not finished or on error.
@@ -104,7 +110,7 @@ class Run:
                 self._cached_status = None
 
             try:
-                self.exec_env.stop(clean_up=True)
+                self.exec_env.stop(clean_up=cleanup)
             except Exception as e:
                 self.logger.warning(f"Failed to stop execution environment: {e}")
             finally:

--- a/tests/unit_test/recipe/run_test.py
+++ b/tests/unit_test/recipe/run_test.py
@@ -76,6 +76,15 @@ class TestRunClass:
         assert self.run._cached_status == "FINISHED"
         assert self.run._cached_result == "/tmp/workspace/test_job_123"
 
+    def test_get_result_cleanup_false_preserves_workspace(self):
+        """Test that get_result(cleanup=False) forwards clean_up=False to exec_env.stop()."""
+        self.mock_env.get_job_result.return_value = "/tmp/workspace/test_job_123"
+        self.mock_env.get_job_status.return_value = "FINISHED"
+
+        self.run.get_result(cleanup=False)
+
+        self.mock_env.stop.assert_called_once_with(clean_up=False)
+
     def test_get_result_default_timeout(self):
         """Test get_result with default timeout."""
         self.mock_env.get_job_result.return_value = "/tmp/workspace/test_job_123"


### PR DESCRIPTION
## Summary
- Backport of #4541 (merged to `main` 2026-05-07) to the `2.8` release branch.
- Adds a `cleanup: bool = True` parameter to `Run.get_result()` and forwards it to `exec_env.stop(clean_up=cleanup)`. Default preserved as `True`, so all existing 2.8 callers — including every `examples/*/job.py` and the in-tree `nvflare/app_opt/sklearn/recipes/*` — behave identically.
- Lets new callers opt out via `run.get_result(cleanup=False)` to keep the workspace and per-service `poc_console.log` (introduced by #4500) on disk for debugging or test assertions.

## Why backport
On `main`, #4500 moved subprocess stdout to `<workspace>/example_project/prod_NN/<service>/poc_console.log` *inside the workspace*. Because `Run.get_result()` hard-coded `clean_up=True`, the workspace (and the only post-run record of service stdout) is rmtree'd before the canonical `print("Result can be found in :", run.get_result())` line even renders the path. The same surface exists on 2.8; this PR brings the opt-out so 2.8 users get the same escape hatch.

## Cherry-pick
~~~
git cherry-pick -x ceda71c4b
~~~
Original commit `ceda71c4b637403cfa1a20e9e96409d95fc6adcb` applied cleanly. Subject prefixed with `[2.8]` to match release-branch convention.

## Verified locally
- `tests/unit_test/recipe/run_test.py`: **21 passed, 3 skipped** (Python 3.12, pytest 8.3.4) — matches the original PR's CI numbers, including the new `test_get_result_cleanup_false_preserves_workspace`.
- License + style clean.

## Test plan
- [ ] CI: license + style + full unit test suite green on the 2.8 base.
- [ ] Optional: smoke `recipe.execute(env=PocEnv(...))` twice with `cleanup=False` and verify the second run lands in `prod_01/` next to the preserved `prod_00/` (verified locally on `main`; behavior identical on 2.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)