### PR TITLE
Clarify Flower example version compatibility

### DIFF
--- a/docs/hello-world/hello-flower/index.rst
+++ b/docs/hello-world/hello-flower/index.rst
@@ -34,6 +34,17 @@ Install the dependencies:
 
    pip install -r requirements.txt
 
+.. warning::
+
+   This ``main`` branch example uses Flower 1.26+ and the newer Flower SuperLink
+   configuration flow. Use the NVFlare 2.8 release candidate line
+   (``nvflare~=2.8.0rc``), or install NVFlare from this repository if that
+   package is not available from PyPI yet.
+
+   If you are using released NVFlare 2.7.x, switch to the 2.7 branch or tag of
+   this example and use ``flwr>=1.16,<1.26``. NVFlare 2.7.x still uses Flower's
+   legacy ``--federation-config`` CLI option, which Flower 1.26+ ignores.
+
 Code Structure
 --------------
 

--- a/docs/user_guide/data_scientist_guide/flower_integration/flower_job_structure.rst
+++ b/docs/user_guide/data_scientist_guide/flower_integration/flower_job_structure.rst
@@ -39,7 +39,7 @@ Here is an example of ``pyproject.toml``, taken from :github_nvflare_link:`this 
 
     # Tested with:
     #   flwr==1.27.0
-    #   nvflare==2.7.2
+    #   nvflare==2.8.0rc1
     #   torch==2.11.0
     #   torchvision==0.26.0
     #   tensorboard==2.20.0
@@ -51,7 +51,7 @@ Here is an example of ``pyproject.toml``, taken from :github_nvflare_link:`this 
     license = "Apache-2.0"
     dependencies = [
         "flwr>=1.26",
-        "nvflare~=2.6.0rc",
+        "nvflare~=2.8.0rc",
         "torch",
         "torchvision",
         "tensorboard"
@@ -79,6 +79,11 @@ Here is an example of ``pyproject.toml``, taken from :github_nvflare_link:`this 
    ``$FLWR_HOME/config.toml`` with the SuperLink connection details. You do not
    need to define a ``[tool.flwr.federations]`` section in ``pyproject.toml`` for
    FLARE execution.
+
+.. note:: Flower 1.26+ support requires the NVFlare 2.8 release candidate line
+   (``nvflare~=2.8.0rc``), or NVFlare installed from current ``main``. If you
+   are using released NVFlare 2.7.x, use ``flwr>=1.16,<1.26`` and the 2.7 branch
+   or tag of the Flower examples.
 
 Project Name
 ~~~~~~~~~~~~

--- a/docs/user_guide/data_scientist_guide/flower_integration/flower_run_as_flare_job.rst
+++ b/docs/user_guide/data_scientist_guide/flower_integration/flower_run_as_flare_job.rst
@@ -3,18 +3,24 @@ Run Flower Application as FLARE Job
 ***********************************
 
 Before running Flower applications with FLARE, you must have both FLARE and Flower frameworks
-installed in your Python environment. NVFlare 2.7 Flower integration currently requires
-``flwr>=1.26``.
+installed in your Python environment. Current NVFlare ``main`` and the NVFlare 2.8 release
+candidate line use Flower's SuperLink configuration flow and require ``flwr>=1.26``.
 
 .. code-block:: shell
 
     pip install 'flwr>=1.26'
 
+If you are using released NVFlare 2.7.x, use ``flwr>=1.16,<1.26`` and the 2.7 branch or tag of
+the Flower examples. NVFlare 2.7.x still uses Flower's legacy ``--federation-config`` CLI
+option, which Flower 1.26+ ignores.
+
 With Flower 1.26 and newer, SuperLink connections are no longer configured in
 ``pyproject.toml`` for NVFlare jobs. Instead, NVFlare writes a job-scoped Flower
 configuration file at ``$FLWR_HOME/config.toml`` and uses it to connect
 ``flwr run``, ``flwr list``, and ``flwr stop`` to the job's dynamically assigned
-SuperLink control API address.
+SuperLink control API address. Do not create a global ``~/.flwr/config.toml`` as a workaround
+for NVFlare 2.7.x compatibility; the dynamic port must be configured by an NVFlare version that
+supports Flower 1.26+.
 
 To run a Flower application as a job in FLARE, follow these steps:
 

--- a/examples/hello-world/hello-flower/README.md
+++ b/examples/hello-world/hello-flower/README.md
@@ -25,6 +25,13 @@ Install the dependency
   pip install -r requirements.txt
 ```
 
+> [!IMPORTANT]
+> This `main` branch example uses Flower 1.26+ and the newer Flower SuperLink configuration flow.
+> Use the NVFlare 2.8 release candidate line (`nvflare~=2.8.0rc`), or install NVFlare from this
+> repository if that package is not available from PyPI yet.
+> If you are using released NVFlare 2.7.x, switch to the 2.7 branch or tag of this example and use `flwr>=1.16,<1.26`.
+> NVFlare 2.7.x still uses Flower's legacy `--federation-config` CLI option, which Flower 1.26+ ignores.
+
 ## Code Structure
 
 ``` 

--- a/examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml
+++ b/examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 # Tested with:
 #   flwr==1.27.0
-#   nvflare==2.7.2
+#   nvflare==2.8.0rc1
 #   torch==2.11.0
 #   torchvision==0.26.0
 #   tensorboard==2.20.0
@@ -16,7 +16,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr>=1.26",
-    "nvflare~=2.6.0rc",
+    "nvflare~=2.8.0rc",
     "torch",
     "torchvision",
     "tensorboard"

--- a/examples/hello-world/hello-flower/flwr-pt/pyproject.toml
+++ b/examples/hello-world/hello-flower/flwr-pt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 # Tested with:
 #   flwr==1.27.0
-#   nvflare==2.7.2
+#   nvflare==2.8.0rc1
 #   torch==2.11.0
 #   torchvision==0.26.0
 #   tensorboard==2.20.0
@@ -16,7 +16,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr>=1.26",
-    "nvflare~=2.6.0rc",
+    "nvflare~=2.8.0rc",
     "torch",
     "torchvision",
     "tensorboard"

--- a/examples/hello-world/hello-flower/requirements.txt
+++ b/examples/hello-world/hello-flower/requirements.txt
@@ -1,4 +1,4 @@
-nvflare~=2.7.2rc
+nvflare~=2.8.0rc
 flwr>=1.26
 torch
 torchvision


### PR DESCRIPTION
## Summary
- update hello-flower dependencies to use the repo's `nvflare~=2.8.0rc` convention with Flower 1.26+
- add warnings to the hello-flower docs/README explaining that released NVFlare 2.7.x must use flwr>=1.16,<1.26
- clarify that Flower 1.26+ dynamic SuperLink ports are handled by NVFlare's job-scoped FLWR_HOME config, not by a user-global ~/.flwr/config.toml workaround

## Why
A customer followed the main-branch hello-flower guidance with nvflare==2.7.2 and flwr==1.27.0. That released NVFlare version still uses Flower's legacy --federation-config CLI option, which Flower 1.26+ ignores, so the job aborts during flwr list/stop status checks. Main already has the Flower 1.26+ configuration-flow fix, but the public guidance was pointing users at an incompatible released version pair.

## Validation
- git diff --check
- python3 ci/check_relative_doc_links.py examples/hello-world/hello-flower/README.md
- python3 -m pytest tests/ci/test_check_relative_doc_links.py -q
- python3 -c 'import tomllib; tomllib.load(open("examples/hello-world/hello-flower/flwr-pt/pyproject.toml", "rb")); tomllib.load(open("examples/hello-world/hello-flower/flwr-pt-tb/pyproject.toml", "rb"))'
- ./build_doc.sh --html --skip-api (succeeded; existing unrelated warnings remain)
