### PR TITLE
[2.8] Clarify remove_client token cleanup semantics

### DIFF
--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -223,7 +223,7 @@ Only commands that serve common end-user or admin tasks are exposed. Diagnostic,
 | `report_resources` | Admin | Yes -> `nvflare system resources` |
 | `shutdown` | Admin | Yes -> `nvflare system shutdown` |
 | `restart` | Admin | Yes -> `nvflare system restart` |
-| `remove_client` | Admin | No — legacy interactive-console registry cleanup only |
+| `remove_client` | Admin | No — legacy hidden interactive-console token cleanup only; client may register again |
 | `disable_client` | Admin | Yes -> `nvflare system disable-client`; persists a server-side disabled flag and rejects reconnect/heartbeat |
 | `enable_client` | Admin | Yes -> `nvflare system enable-client`; clears the server-side disabled flag |
 | `sys_info` | Both | Yes -> `nvflare system version` |
@@ -1889,8 +1889,9 @@ instead of `--timeout 0` for fire-and-forget operation. `restart all --wait`
 waits for the server restart and for previously connected clients to reconnect.
 
 `remove-client` is not exposed as a supported `nvflare system` CLI command. The legacy
-interactive-console `remove_client` operation removes only the current active registry
-entry; it does not stop the client process, revoke credentials, or prevent reconnect.
+interactive-console `remove_client` command is hidden from normal help and removes only
+the current active token entry so the client may register again. It does not stop the
+client process, revoke credentials, or prevent reconnect.
 `disable-client` is the durable operational control: it persists a disabled flag, removes
 any active registry entry, and rejects subsequent registration or heartbeat from the same
 client name until `enable-client` clears the flag. This is not certificate revocation.
@@ -2004,7 +2005,7 @@ Already exposed:
 - `download_job`
 - `shutdown(target_type, client_names=None)` — `target_type` in `server|client|all`; closes session when server/all
 - `restart(target_type, client_names=None)` — `target_type` in `server|client|all`
-- `remove_client(client_name)` — removes a single connected client from the active registry
+- `remove_client(client_name)` — legacy helper that releases a connected client's active token
 - `disable_client(client_name)` — disables a client from reconnecting until enabled
 - `enable_client(client_name)` — enables a disabled client to reconnect
 - `check_status`

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -86,9 +86,10 @@ Client Disable Semantics
 ------------------------
 
 ``nvflare system remove-client`` is not exposed as a supported public CLI
-command. The legacy interactive-console ``remove_client`` operation remains a
-registry cleanup operation only; it does not stop the client process, revoke
-credentials, or prevent reconnect.
+command. The legacy interactive-console ``remove_client`` command is hidden
+from normal help and remains a registry cleanup operation only: it releases
+the active token so the client can register again. It does not stop the client
+process, revoke credentials, or prevent reconnect.
 
 Use the new durable access-control commands when the intent is to keep a client
 out of the federation:

--- a/docs/programming_guide/migrating_to_flare_api.rst
+++ b/docs/programming_guide/migrating_to_flare_api.rst
@@ -126,7 +126,7 @@ and the new way with FLARE API.
     reset_errors,reset_errors,2.4.0,
     get_connected_client_list,get_connected_client_list,2.4.0,
     abort,,2.4.0,obsolete
-    remove_client,,2.4.0,not exposed
+    remove_client,remove_client,2.4.0,Releases the active client token only; use disable_client to prevent reconnect
 
 Get System Info from Check Status
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user_guide/admin_guide/deployment/operation.rst
+++ b/docs/user_guide/admin_guide/deployment/operation.rst
@@ -60,7 +60,6 @@ commands shown as examples of how they may be run with a description.
     ,``configure_site_log client <client-name>... config``,Configure the site log on the target client(s).
     sys_info,``sys_info server``,Get system information
     ,``sys_info client *clientname*``,Get system information. Individual clients can be shutdown by specifying *clientname*.
-    remove_client,``remove_client clientname``,Issue command for server to release client before the 10 minute timeout to allow client to rejoin after manual restart.
     restart,``restart client``,Restarts all of the clients. Individual clients can be restarted by specifying *clientname*.
     ,``restart server``,Restarts the server. Clients will also be restarted. Note that the admin client will need to log in again after the server restarts.
     shutdown,``shutdown client``,Shuts down all of the clients. Individual clients can be shutdown by specifying *clientname*. Please note that this may not be instant but may take time for the command to take effect.

--- a/nvflare/fuel/flare_api/api_spec.py
+++ b/nvflare/fuel/flare_api/api_spec.py
@@ -679,13 +679,16 @@ class SessionSpec(ABC):
 
     @abstractmethod
     def remove_client(self, client_name: str) -> None:
-        """Remove a connected client from the system.
+        """Release a connected client's active token.
 
         Args:
-            client_name: name of the client to remove
+            client_name: name of the client whose active token should be released
 
         Returns: None
 
+        Note:
+            This does not stop the client, revoke credentials, or prevent reconnect.
+            Use disable_client to prevent a client from reconnecting.
         """
         pass
 

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -1323,13 +1323,16 @@ class Session(SessionSpec):
         return self._get_dict_data(reply)
 
     def remove_client(self, client_name: str) -> None:
-        """Remove a client from the system.
+        """Release a connected client's active token.
 
         Args:
-            client_name (str): name of the client to remove
+            client_name (str): name of the client whose active token should be released
 
         Returns: None
 
+        Note:
+            This does not stop the client, revoke credentials, or prevent reconnect.
+            Use disable_client to prevent a client from reconnecting.
         """
         if not client_name or not isinstance(client_name, str):
             raise ValueError("client_name must be a non-empty str")

--- a/nvflare/private/fed/server/client_manager.py
+++ b/nvflare/private/fed/server/client_manager.py
@@ -188,13 +188,13 @@ class ClientManager:
         return client
 
     def remove_client(self, token):
-        """Remove a registered client.
+        """Remove a registered client's active token entry.
 
         Args:
             token: client token
 
         Returns:
-            The removed Client object
+            The removed Client object, if the token was active
         """
         with self.lock:
             client = self.clients.pop(token, None)

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -569,6 +569,7 @@ class ServerEngine(ServerEngineInternalSpec, StreamableEngine):
         return ""
 
     def remove_clients(self, clients: List[str]) -> str:
+        """Remove active client-token entries so those clients can register again."""
         for client in clients:
             self._remove_dead_client(client)
         return ""

--- a/nvflare/private/fed/server/server_engine_internal_spec.py
+++ b/nvflare/private/fed/server/server_engine_internal_spec.py
@@ -148,10 +148,10 @@ class ServerEngineInternalSpec(ServerEngineSpec, ABC):
 
     @abstractmethod
     def remove_clients(self, clients: [str]) -> str:
-        """Remove specified clients.
+        """Remove active client-token entries for specified clients.
 
         Args:
-            clients: clients to be removed
+            clients: client tokens to be removed
 
         Returns:
              An error message. An empty string if successful.

--- a/nvflare/private/fed/server/training_cmds.py
+++ b/nvflare/private/fed/server/training_cmds.py
@@ -59,11 +59,11 @@ class TrainingCommandModule(CommandModule, CommandUtil):
                 ),
                 CommandSpec(
                     name=AdminCommandNames.REMOVE_CLIENT,
-                    description="remove a FL client",
+                    description="release a client's active token so the client may register again",
                     usage="remove_client <client-name>",
                     handler_func=self.remove_client,
                     authz_func=self.authorize_client_operation,
-                    visible=True,
+                    visible=False,
                     confirm=ConfirmMethod.AUTH,
                 ),
                 CommandSpec(
@@ -201,7 +201,7 @@ class TrainingCommandModule(CommandModule, CommandUtil):
                 return
         conn.append_success("")
 
-    # Remove Clients
+    # Remove active client tokens.
     def remove_client(self, conn: Connection, args: List[str]):
         engine = conn.app_ctx
         if not isinstance(engine, ServerEngineInternalSpec):

--- a/tests/unit_test/fuel/flare_api/session_new_methods_test.py
+++ b/tests/unit_test/fuel/flare_api/session_new_methods_test.py
@@ -351,7 +351,7 @@ class TestRestart:
 
 
 class TestRemoveClient:
-    def test_sends_remove_client_command(self):
+    def test_remove_client_keeps_legacy_command_for_compatibility(self):
         session = _make_session()
         with patch.object(session, "_do_command", return_value=_ok_meta_result()) as mock_cmd:
             session.remove_client("site-1")

--- a/tests/unit_test/private/fed/server/training_cmds_test.py
+++ b/tests/unit_test/private/fed/server/training_cmds_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nvflare.apis.fl_constant import AdminCommandNames
 from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
 from nvflare.private.fed.server import training_cmds as training_cmds_module
 from nvflare.private.fed.server.training_cmds import TrainingCommandModule
@@ -68,3 +69,15 @@ def test_enable_client_reports_engine_exception_as_structured_error(monkeypatch)
     assert len(conn.errors) == 1
     assert "persist failed" in conn.errors[0][0]
     assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INTERNAL_ERROR
+
+
+def test_remove_client_is_hidden_and_described_as_token_cleanup():
+    spec = TrainingCommandModule().get_spec()
+    commands = {cmd.name: cmd for cmd in spec.cmd_specs}
+
+    remove_cmd = commands[AdminCommandNames.REMOVE_CLIENT]
+
+    assert remove_cmd.visible is False
+    assert remove_cmd.usage == "remove_client <client-name>"
+    assert "active token" in remove_cmd.description
+    assert "register again" in remove_cmd.description


### PR DESCRIPTION
## What changed
- Hide the legacy interactive-console `remove_client` command from normal help.
- Clarify docs and API/server docstrings that `remove_client` only releases the active client token and allows the client to register again.
- Remove the command from the user-facing admin operation table.
- Add/adjust focused tests for the hidden command metadata and legacy Session API routing.

## Why
`remove_client` sounds like it removes or disables a client, but the implementation only clears the current active token. During code freeze this keeps behavior/API stable while reducing user-facing confusion.

## Validation
- `/private/tmp/nvflare-deploy-test-venv/bin/python -m pytest tests/unit_test/private/fed/server/training_cmds_test.py tests/unit_test/fuel/flare_api/session_new_methods_test.py tests/unit_test/tool/system/system_status_test.py::TestSystemStatus::test_system_parser_rejects_unsupported_remove_client_command -q`
- `python3 -m compileall -q nvflare/private/fed/server/training_cmds.py nvflare/fuel/flare_api/api_spec.py nvflare/fuel/flare_api/flare_api.py nvflare/private/fed/server/client_manager.py nvflare/private/fed/server/server_engine.py nvflare/private/fed/server/server_engine_internal_spec.py tests/unit_test/private/fed/server/training_cmds_test.py tests/unit_test/fuel/flare_api/session_new_methods_test.py`
- `git diff upstream/2.8 --check`
- GitHub reports the PGP-signed commit as verified.