### PR TITLE
[2.8] Respect visible GPUs in resource manager

### DIFF
--- a/docs/programming_guide/resource_manager_and_consumer.rst
+++ b/docs/programming_guide/resource_manager_and_consumer.rst
@@ -93,7 +93,8 @@ GPUResourceManager (:mod:`nvflare.app_common.resource_managers.gpu_resource_mana
 GPUResourceManager and GPUResourceConsumer
 ==========================================
 
-During initialization, the GPUResourceManager will detect automatically (using nvidia-smi) if the system's GPU count and memory is enough. (i.e. larger than what specified in arguments).
+During initialization, the GPUResourceManager will detect automatically (using nvidia-smi) if the managed GPU count
+and memory are enough. When ``CUDA_VISIBLE_DEVICES`` contains GPU IDs, the startup check is restricted to those GPUs.
 
 NOTE that the current implementation of GPUResourceManager will NOT keep updating the GPU count and memory usage. This means that it just checks using nvidia-smi at init time and then virtually assumes it has this much resources on site.
 

--- a/nvflare/app_common/resource_managers/gpu_resource_manager.py
+++ b/nvflare/app_common/resource_managers/gpu_resource_manager.py
@@ -12,10 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+import os
+from typing import Optional, Union
 
 from nvflare.app_common.resource_managers.auto_clean_resource_manager import AutoCleanResourceManager
 from nvflare.fuel.utils.gpu_utils import get_host_gpu_ids, get_host_gpu_memory_total
+
+CUDA_VISIBLE_DEVICES = "CUDA_VISIBLE_DEVICES"
+
+
+def _get_cuda_visible_device_indices(host_gpu_ids: list[int]) -> Optional[list[int]]:
+    """Gets visible nvidia-smi GPU indices from CUDA_VISIBLE_DEVICES.
+
+    NVIDIA CUDA also supports GPU UUID and MIG identifiers in CUDA_VISIBLE_DEVICES. Those are not interpreted here
+    because GPUResourceManager uses nvidia-smi integer GPU indices as resource IDs, and POC -gpu sets integer IDs.
+    """
+    value = os.environ.get(CUDA_VISIBLE_DEVICES)
+    if value is None:
+        return None
+
+    value = value.strip()
+    if not value:
+        return []
+
+    gpu_ids = []
+    seen = set()
+    for item in value.split(","):
+        item = item.strip()
+        if not item:
+            break
+        try:
+            gpu_id = int(item)
+        except ValueError:
+            return None
+        if gpu_id not in host_gpu_ids:
+            break
+        if gpu_id not in seen:
+            gpu_ids.append(gpu_id)
+            seen.add(gpu_id)
+    return gpu_ids
+
+
+def _get_managed_host_gpu_ids(host_gpu_ids: list[int]) -> list[int]:
+    visible_gpu_ids = _get_cuda_visible_device_indices(host_gpu_ids)
+    if visible_gpu_ids is None:
+        return host_gpu_ids
+
+    return visible_gpu_ids
 
 
 class GPUResource:
@@ -69,22 +112,36 @@ class GPUResourceManager(AutoCleanResourceManager):
         if not isinstance(ignore_host, bool):
             raise ValueError(f"ignore_host should be of type bool, but got {type(ignore_host)}.")
 
+        resource_gpu_ids = list(range(num_of_gpus))
         if not ignore_host:
             if num_of_gpus > 0:
-                num_host_gpus = len(get_host_gpu_ids())
+                host_gpu_ids = get_host_gpu_ids()
+                managed_host_gpu_ids = _get_managed_host_gpu_ids(host_gpu_ids)
+                num_host_gpus = len(managed_host_gpu_ids)
                 if num_of_gpus > num_host_gpus:
                     raise ValueError(f"num_of_gpus specified ({num_of_gpus}) exceeds available GPUs: {num_host_gpus}.")
 
                 host_gpu_mem = get_host_gpu_memory_total()
-                for i in host_gpu_mem:
-                    if mem_per_gpu_in_GiB * 1024 > i:
+                host_gpu_mem_by_id = {
+                    gpu_id: host_gpu_mem[index]
+                    for index, gpu_id in enumerate(host_gpu_ids)
+                    if index < len(host_gpu_mem)
+                }
+                resource_gpu_ids = managed_host_gpu_ids[:num_of_gpus]
+                for gpu_id in resource_gpu_ids:
+                    try:
+                        available_gpu_mem = host_gpu_mem_by_id[gpu_id]
+                    except KeyError as e:
+                        raise RuntimeError(f"Failed to determine GPU memory for GPU ID {gpu_id}.") from e
+                    if mem_per_gpu_in_GiB * 1024 > available_gpu_mem:
                         raise ValueError(
-                            f"Memory per GPU specified ({mem_per_gpu_in_GiB * 1024}) exceeds available GPU memory: {i}."
+                            f"Memory per GPU specified ({mem_per_gpu_in_GiB * 1024}) exceeds available GPU memory "
+                            f"for GPU ID {gpu_id}: {available_gpu_mem}."
                         )
 
         self.num_gpu_key = num_gpu_key
         self.gpu_mem_key = gpu_mem_key
-        resources = {i: GPUResource(gpu_id=i, gpu_memory=mem_per_gpu_in_GiB) for i in range(num_of_gpus)}
+        resources = {i: GPUResource(gpu_id=i, gpu_memory=mem_per_gpu_in_GiB) for i in resource_gpu_ids}
 
         super().__init__(resources=resources, expiration_period=expiration_period)
 

--- a/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
@@ -58,14 +58,122 @@ TEST_CASES = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def clear_cuda_visible_devices(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+
 @pytest.fixture(scope="class", autouse=True)
 def mock_get_host_gpu_ids():
-    with patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as _fixture:
-        _fixture.return_value = [0, 1, 2, 3]
-        yield _fixture
+    with (
+        patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as ids_fixture,
+        patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mem_fixture,
+    ):
+        ids_fixture.return_value = [0, 1, 2, 3]
+        mem_fixture.return_value = [32768, 32768, 32768, 32768]
+        yield ids_fixture
 
 
 class TestGPUResourceManager:
+    def test_init_respects_cuda_visible_devices_for_memory_check(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3, 4]
+            mock_mem.return_value = [81920, 81920, 81920, 4096, 81920]
+
+            gpu_resource_manager = GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16)
+
+        assert list(gpu_resource_manager.resources) == [0]
+
+    def test_init_uses_visible_gpu_ids_as_managed_resources(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3, 4]
+            mock_mem.return_value = [81920, 81920, 81920, 4096, 81920]
+
+            gpu_resource_manager = GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16)
+
+        assert list(gpu_resource_manager.resources) == [4]
+
+    def test_init_checks_selected_visible_gpu_memory(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3, 4]
+            mock_mem.return_value = [81920, 81920, 81920, 4096, 81920]
+
+            with pytest.raises(ValueError, match="4096"):
+                GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16)
+
+    def test_init_reports_selected_gpu_id_for_insufficient_memory(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3, 4]
+            mock_mem.return_value = [81920, 81920, 81920, 4096, 81920]
+
+            with pytest.raises(ValueError, match="GPU ID 3"):
+                GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16)
+
+    def test_init_raises_when_selected_gpu_memory_is_missing(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3]
+            mock_mem.return_value = [32768, 32768, 32768]
+
+            with pytest.raises(RuntimeError, match="GPU ID 3"):
+                GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16)
+
+    def test_init_checks_visible_gpu_count(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3]
+            mock_mem.return_value = [32768, 32768, 32768, 32768]
+
+            with pytest.raises(ValueError, match="exceeds available GPUs: 1"):
+                GPUResourceManager(num_of_gpus=2, mem_per_gpu_in_GiB=16)
+
+    def test_init_stops_at_invalid_cuda_visible_device_index(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,2,-1,1")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3]
+            mock_mem.return_value = [32768, 32768, 32768, 32768]
+
+            gpu_resource_manager = GPUResourceManager(num_of_gpus=2, mem_per_gpu_in_GiB=16)
+
+        assert list(gpu_resource_manager.resources) == [0, 2]
+
+    def test_init_empty_cuda_visible_devices_has_no_available_gpus(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+        with (
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_ids") as mock_ids,
+            patch("nvflare.app_common.resource_managers.gpu_resource_manager.get_host_gpu_memory_total") as mock_mem,
+        ):
+            mock_ids.return_value = [0, 1, 2, 3]
+            mock_mem.return_value = [32768, 32768, 32768, 32768]
+
+            with pytest.raises(ValueError, match="exceeds available GPUs: 0"):
+                GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16)
+
     @pytest.mark.parametrize(
         "gpus, gpu_mem, resource_requirement, expected_check_result, expected_reserved_resources", CHECK_TEST_CASES
     )


### PR DESCRIPTION
## Summary
- Restrict GPUResourceManager host validation to integer GPU IDs selected by CUDA_VISIBLE_DEVICES.
- Preserve CUDA documented semantics for unset, empty, and invalid integer CUDA_VISIBLE_DEVICES entries.
- Add unit coverage for mixed-memory GPUs, selected GPU IDs, empty visibility, and invalid-index stopping behavior.

## Why
POC clients started with `nvflare poc start -gpu ...` receive `CUDA_VISIBLE_DEVICES`, but GPUResourceManager was validating memory against every physical GPU returned by nvidia-smi. On hosts with a small display GPU plus large training GPUs, the startup check failed on the unused display GPU.

## Validation
- `python3 -m compileall -q nvflare/app_common/resource_managers/gpu_resource_manager.py tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py`
- `git diff --check`
- Manual stubbed GPUResourceManager checks for mixed-memory visible GPU scenarios
