### PR TITLE
Harden job metadata path containment

### DIFF
--- a/nvflare/apis/impl/job_def_manager.py
+++ b/nvflare/apis/impl/job_def_manager.py
@@ -397,8 +397,11 @@ class SimpleJobDefManager(JobDefManagerSpec):
             job_id_dir = self._load_job_data_from_store(job, temp_dir, fl_ctx)
             job_folder = os.path.join(job_id_dir, job.meta[JobMetaKey.JOB_FOLDER_NAME.value])
             fullpath_src = os.path.join(job_folder, app_name)
+            job_id_dir_real = os.path.realpath(job_id_dir)
             job_folder_real = os.path.realpath(job_folder)
             fullpath_src_real = os.path.realpath(fullpath_src)
+            if os.path.commonpath([job_id_dir_real, job_folder_real]) != job_id_dir_real:
+                raise ValueError(f"job folder for app '{app_name}' escapes job data folder")
             if os.path.commonpath([job_folder_real, fullpath_src_real]) != job_folder_real:
                 raise ValueError(f"app '{app_name}' escapes job folder")
             result = zip_directory_to_bytes(fullpath_src_real, "")

--- a/nvflare/apis/impl/job_def_manager.py
+++ b/nvflare/apis/impl/job_def_manager.py
@@ -35,6 +35,7 @@ from nvflare.apis.job_def import (
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec, RunStatus
 from nvflare.apis.server_engine_spec import ServerEngineSpec
 from nvflare.apis.storage import WORKSPACE, StorageException, StorageSpec
+from nvflare.apis.utils.format_check import check_job_app_name, check_job_id
 from nvflare.apis.utils.job_submit_token import (
     canonical_job_content_hash,
     canonical_json_hash,
@@ -151,6 +152,7 @@ class SimpleJobDefManager(JobDefManagerSpec):
         return store
 
     def job_uri(self, jid: str):
+        check_job_id(jid)
         return os.path.join(self.uri_root, jid)
 
     def submit_record_uri(self, study: str, submitter, submit_token: str):
@@ -310,6 +312,8 @@ class SimpleJobDefManager(JobDefManagerSpec):
         if not jid:
             jid = new_job_id()
             meta[JobMetaKey.JOB_ID.value] = jid
+        else:
+            check_job_id(jid)
 
         now = time.time()
         meta[JobMetaKey.SUBMIT_TIME.value] = now
@@ -321,14 +325,17 @@ class SimpleJobDefManager(JobDefManagerSpec):
 
         # write it to the store
         store = self._get_job_store(fl_ctx)
-        store.create_object(self.job_uri(jid), uploaded_content, meta, overwrite_existing=True)
+        store.create_object(self.job_uri(jid), uploaded_content, meta, overwrite_existing=False)
         return meta
 
     def clone(self, from_jid: str, meta: dict, fl_ctx: FLContext) -> Dict[str, Any]:
+        check_job_id(from_jid)
         jid = meta.get(JobMetaKey.JOB_ID.value, None)
         if not jid:
             jid = new_job_id()
             meta[JobMetaKey.JOB_ID.value] = jid
+        else:
+            check_job_id(jid)
 
         now = time.time()
         meta[JobMetaKey.SUBMIT_TIME.value] = now
@@ -340,7 +347,7 @@ class SimpleJobDefManager(JobDefManagerSpec):
         # write it to the store
         store = self._get_job_store(fl_ctx)
         store.clone_object(
-            from_uri=self.job_uri(from_jid), to_uri=self.job_uri(jid), meta=meta, overwrite_existing=True
+            from_uri=self.job_uri(from_jid), to_uri=self.job_uri(jid), meta=meta, overwrite_existing=False
         )
         return meta
 
@@ -384,15 +391,21 @@ class SimpleJobDefManager(JobDefManagerSpec):
         return self.get_job(jid, fl_ctx)
 
     def get_app(self, job: Job, app_name: str, fl_ctx: FLContext) -> bytes:
-        temp_dir = tempfile.mkdtemp()
-        job_id_dir = self._load_job_data_from_store(job, temp_dir, fl_ctx)
-        job_folder = os.path.join(job_id_dir, job.meta[JobMetaKey.JOB_FOLDER_NAME.value])
-        fullpath_src = os.path.join(job_folder, app_name)
-        result = zip_directory_to_bytes(fullpath_src, "")
-        shutil.rmtree(temp_dir)
+        check_job_id(job.job_id)
+        check_job_app_name(app_name)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            job_id_dir = self._load_job_data_from_store(job, temp_dir, fl_ctx)
+            job_folder = os.path.join(job_id_dir, job.meta[JobMetaKey.JOB_FOLDER_NAME.value])
+            fullpath_src = os.path.join(job_folder, app_name)
+            job_folder_real = os.path.realpath(job_folder)
+            fullpath_src_real = os.path.realpath(fullpath_src)
+            if os.path.commonpath([job_folder_real, fullpath_src_real]) != job_folder_real:
+                raise ValueError(f"app '{app_name}' escapes job folder")
+            result = zip_directory_to_bytes(fullpath_src_real, "")
         return result
 
     def _load_job_data_from_store(self, job: Job, temp_dir: str, fl_ctx: FLContext):
+        check_job_id(job.job_id)
         data_bytes = self.get_content(job.meta, fl_ctx)
         job_id_dir = os.path.join(temp_dir, job.job_id)
         if os.path.exists(job_id_dir):
@@ -566,6 +579,7 @@ class SimpleJobDefManager(JobDefManagerSpec):
             fl_ctx: FLContext
         """
         store = self._get_job_store(fl_ctx)
+        job_uri = self.job_uri(jid)
         os.makedirs(os.path.join(download_dir, jid), exist_ok=True)
         destination_file = os.path.join(download_dir, jid, download_file)
-        store.get_data_for_download(self.job_uri(jid), component, destination_file)
+        store.get_data_for_download(job_uri, component, destination_file)

--- a/nvflare/apis/utils/format_check.py
+++ b/nvflare/apis/utils/format_check.py
@@ -43,6 +43,22 @@ def name_check(name: str, entity_type: str):
         )
 
 
+def check_job_id(job_id: str):
+    if not isinstance(job_id, str) or not job_id:
+        raise ValueError("job_id must be a non-empty string")
+    invalid, message = name_check(job_id, "job_name")
+    if invalid:
+        raise ValueError(f"invalid job_id '{job_id}': {message}")
+
+
+def check_job_app_name(app_name: str):
+    if not isinstance(app_name, str) or not app_name:
+        raise ValueError("job app name must be a non-empty string")
+    invalid, message = name_check(app_name, "job_name")
+    if invalid:
+        raise ValueError(f"invalid job app name '{app_name}': {message}")
+
+
 def validate_class_methods_args(cls):
     for name, method in inspect.getmembers(cls, inspect.isfunction):
         if name != "__init_subclass__":

--- a/nvflare/apis/workspace.py
+++ b/nvflare/apis/workspace.py
@@ -17,6 +17,7 @@ import os
 from typing import List, Union
 
 from nvflare.apis.fl_constant import WorkspaceConstants
+from nvflare.apis.utils.format_check import check_job_id
 
 
 class Workspace:
@@ -106,6 +107,22 @@ class Workspace:
         else:
             return None
 
+    @staticmethod
+    def _check_job_id(job_id: str):
+        if job_id is None:
+            raise ValueError("job_id must not be None")
+        job_id = str(job_id)
+        check_job_id(job_id)
+        return job_id
+
+    @staticmethod
+    def _join_under_root(root: str, *parts: str) -> str:
+        root_real = os.path.realpath(root)
+        path = os.path.realpath(os.path.join(root_real, *parts))
+        if os.path.commonpath([root_real, path]) != root_real:
+            raise ValueError(f"path {path} escapes root {root_real}")
+        return path
+
     def _fallback_path(self, file_names: [str]):
         for n in file_names:
             f = self.get_file_path_in_site_config(n)
@@ -181,7 +198,8 @@ class Workspace:
 
     def _get_site_root_dir(self, root, job_id=None):
         if job_id:
-            site_root_dir = os.path.join(root, self.site_name, job_id)
+            job_id = self._check_job_id(job_id)
+            site_root_dir = self._join_under_root(root, self.site_name, job_id)
             if not os.path.exists(site_root_dir):
                 os.makedirs(site_root_dir, exist_ok=True)
             return site_root_dir
@@ -200,7 +218,8 @@ class Workspace:
         return self.root_dir
 
     def get_run_dir(self, job_id: str) -> str:
-        return os.path.join(self.root_dir, WorkspaceConstants.WORKSPACE_PREFIX + str(job_id))
+        job_id = self._check_job_id(job_id)
+        return self._join_under_root(self.root_dir, WorkspaceConstants.WORKSPACE_PREFIX + job_id)
 
     def get_app_dir(self, job_id: str) -> str:
         return os.path.join(self.get_run_dir(job_id), WorkspaceConstants.APP_PREFIX + self.site_name)

--- a/nvflare/app_common/storages/filesystem_storage.py
+++ b/nvflare/app_common/storages/filesystem_storage.py
@@ -143,11 +143,33 @@ class FilesystemStorage(StorageSpec):
             raise ValueError(f"root_dir {root_dir} exists but is not a directory.")
         if not os.path.exists(root_dir):
             os.makedirs(root_dir, exist_ok=False)
-        self.root_dir = root_dir
+        self.root_dir = os.path.realpath(root_dir)
         self.uri_root = uri_root
 
     def _object_path(self, uri: str):
-        return os.path.join(self.root_dir, uri.lstrip(self.uri_root))
+        uri_root = os.path.normpath(self.uri_root or os.sep)
+        if not os.path.isabs(uri_root):
+            uri_root = os.path.normpath(os.path.join(os.sep, uri_root))
+
+        uri_path = os.path.normpath(uri)
+        if not os.path.isabs(uri_path):
+            uri_path = os.path.normpath(os.path.join(os.sep, uri_path))
+
+        if uri_root != os.sep:
+            try:
+                if os.path.commonpath([uri_root, uri_path]) != uri_root:
+                    raise StorageException(f"uri {uri} is outside storage uri_root {self.uri_root}")
+            except ValueError as e:
+                raise StorageException(f"invalid storage uri {uri}: {secure_format_exception(e)}")
+
+        rel_path = os.path.relpath(uri_path, uri_root)
+        if rel_path == os.curdir:
+            rel_path = ""
+
+        full_path = os.path.realpath(os.path.join(self.root_dir, rel_path))
+        if os.path.commonpath([self.root_dir, full_path]) != self.root_dir:
+            raise StorageException(f"uri {uri} escapes storage root")
+        return full_path
 
     def create_object(self, uri: str, data, meta: dict, overwrite_existing: bool = False):
         """Creates an object.

--- a/nvflare/private/fed/server/job_meta_validator.py
+++ b/nvflare/private/fed/server/job_meta_validator.py
@@ -22,6 +22,7 @@ from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.fl_constant import JobConstants
 from nvflare.apis.job_def import ALL_SITES, SERVER_SITE_NAME, JobMetaKey
 from nvflare.apis.job_meta_validator_spec import JobMetaValidatorSpec
+from nvflare.apis.utils.format_check import check_job_app_name, check_job_id
 from nvflare.fuel.utils.config import ConfigFormat
 from nvflare.fuel.utils.config_factory import ConfigFactory
 from nvflare.private.fed.utils.fed_utils import extract_participants
@@ -89,6 +90,10 @@ class JobMetaValidator(JobMetaValidatorSpec):
                 meta_data = zf.read(meta_file)
                 meta = config_loader.load_config_from_str(meta_data.decode()).to_dict()
                 break
+        if meta:
+            job_id = meta.get(JobMetaKey.JOB_ID.value)
+            if job_id:
+                check_job_id(job_id)
         return meta
 
     @staticmethod
@@ -102,9 +107,12 @@ class JobMetaValidator(JobMetaValidatorSpec):
         deploy_map = meta.get(JobMetaKey.DEPLOY_MAP.value)
         if not deploy_map:
             raise ValueError(f"deploy_map is empty for job {job_name}")
+        if not isinstance(deploy_map, dict):
+            raise ValueError(f"deploy_map must be a dictionary for job {job_name}")
 
         site_list = []
-        for deployments in deploy_map.values():
+        for app, deployments in deploy_map.items():
+            check_job_app_name(app)
             if isinstance(deployments, list):
                 for item in deployments:
                     if isinstance(item, dict):
@@ -142,6 +150,7 @@ class JobMetaValidator(JobMetaValidatorSpec):
 
         has_byoc = False
         for app, deployments in deploy_map.items():
+            check_job_app_name(app)
             deployments = extract_participants(deployments)
 
             config_folder = job_name + "/" + app + CONFIG_FOLDER

--- a/nvflare/private/fed/server/job_meta_validator.py
+++ b/nvflare/private/fed/server/job_meta_validator.py
@@ -150,7 +150,6 @@ class JobMetaValidator(JobMetaValidatorSpec):
 
         has_byoc = False
         for app, deployments in deploy_map.items():
-            check_job_app_name(app)
             deployments = extract_participants(deployments)
 
             config_folder = job_name + "/" + app + CONFIG_FOLDER

--- a/nvflare/private/fed/server/run_manager.py
+++ b/nvflare/private/fed/server/run_manager.py
@@ -73,7 +73,8 @@ class RunManager(EngineSpec):
         )
 
         self.workspace = workspace
-        self.run_info = RunInfo(job_id=job_id, app_path=self.workspace.get_app_dir(job_id))
+        app_path = self.workspace.get_app_dir(job_id) if job_id else ""
+        self.run_info = RunInfo(job_id=job_id, app_path=app_path)
 
         self.components = components
         self.cell = None

--- a/tests/unit_test/apis/impl/job_def_manager_test.py
+++ b/tests/unit_test/apis/impl/job_def_manager_test.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.impl.job_def_manager import SimpleJobDefManager
-from nvflare.apis.job_def import JobMetaKey
+from nvflare.apis.job_def import JobMetaKey, job_from_meta
 from nvflare.apis.storage import WORKSPACE, StorageException
 from nvflare.app_common.storages.filesystem_storage import FilesystemStorage
 from nvflare.fuel.utils.zip_utils import zip_directory_to_bytes
@@ -45,6 +45,15 @@ class TestJobManager(unittest.TestCase):
             data, meta = self._create_job()
             content = self.job_manager.get_content(meta, self.fl_ctx)
             assert content == data
+
+    def test_get_app_rejects_escaping_job_folder_name(self):
+        with mock.patch("nvflare.apis.impl.job_def_manager.SimpleJobDefManager._get_job_store") as mock_store:
+            mock_store.return_value = FilesystemStorage()
+
+            _, meta = self._create_job()
+            meta[JobMetaKey.JOB_FOLDER_NAME.value] = "../../outside"
+            with self.assertRaisesRegex(ValueError, "job folder.*escapes"):
+                self.job_manager.get_app(job_from_meta(meta), "sag", self.fl_ctx)
 
     def _create_job(self):
         data = zip_directory_to_bytes(self.data_folder, "valid_job")

--- a/tests/unit_test/apis/impl/job_def_manager_test.py
+++ b/tests/unit_test/apis/impl/job_def_manager_test.py
@@ -21,7 +21,7 @@ from unittest import mock
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.impl.job_def_manager import SimpleJobDefManager
 from nvflare.apis.job_def import JobMetaKey
-from nvflare.apis.storage import WORKSPACE
+from nvflare.apis.storage import WORKSPACE, StorageException
 from nvflare.app_common.storages.filesystem_storage import FilesystemStorage
 from nvflare.fuel.utils.zip_utils import zip_directory_to_bytes
 from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
@@ -63,3 +63,22 @@ class TestJobManager(unittest.TestCase):
             self.job_manager.save_workspace(job_id, data, self.fl_ctx)
             result = self.job_manager.get_storage_component(job_id, WORKSPACE, self.fl_ctx)
             assert result == data
+
+    def test_create_rejects_traversing_job_id(self):
+        with mock.patch("nvflare.apis.impl.job_def_manager.SimpleJobDefManager._get_job_store") as mock_store:
+            mock_store.return_value = FilesystemStorage()
+
+            meta = {JobMetaKey.JOB_ID.value: "../outside"}
+            with self.assertRaises(ValueError):
+                self.job_manager.create(meta, b"data", self.fl_ctx)
+
+    def test_create_does_not_overwrite_existing_job_id(self):
+        with mock.patch("nvflare.apis.impl.job_def_manager.SimpleJobDefManager._get_job_store") as mock_store:
+            mock_store.return_value = FilesystemStorage()
+
+            data, meta = self._create_job()
+            with self.assertRaises(StorageException):
+                self.job_manager.create(dict(meta), b"replacement", self.fl_ctx)
+
+            content = self.job_manager.get_content(meta, self.fl_ctx)
+            assert content == data

--- a/tests/unit_test/apis/workspace_test.py
+++ b/tests/unit_test/apis/workspace_test.py
@@ -21,6 +21,12 @@ from nvflare.apis.workspace import Workspace
 
 
 class TestWorkspace:
+    @staticmethod
+    def _make_workspace(root_dir: str):
+        os.makedirs(os.path.join(root_dir, "startup"), exist_ok=True)
+        os.makedirs(os.path.join(root_dir, "local"), exist_ok=True)
+        return Workspace(root_dir)
+
     @pytest.mark.parametrize(
         "root_vars, expected",
         [
@@ -65,3 +71,24 @@ class TestWorkspace:
                 os.environ.pop(n, None)
 
             assert result == expected
+
+    @pytest.mark.parametrize(
+        "job_id",
+        [
+            "../outside",
+            "good/../../outside",
+            "/tmp/outside",
+            "bad\\id",
+            "",
+            None,
+        ],
+    )
+    def test_get_run_dir_rejects_unsafe_job_id(self, job_id):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root_dir = os.path.join(tmp_dir, "config")
+            ws = self._make_workspace(root_dir)
+
+            with pytest.raises(ValueError):
+                ws.get_run_dir(job_id)
+
+            assert not os.path.exists(os.path.join(tmp_dir, "outside"))

--- a/tests/unit_test/app_common/storages/storage_test.py
+++ b/tests/unit_test/app_common/storages/storage_test.py
@@ -187,6 +187,14 @@ class TestStorage:
 
         storage.delete_object(uri)
 
+    def test_rejects_uri_that_escapes_storage_root(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            storage = FilesystemStorage(root_dir=os.path.join(tmp_dir, "storage"), uri_root="/jobs")
+            with pytest.raises(StorageException):
+                storage.create_object("/jobs/../outside", b"data", {}, overwrite_existing=True)
+
+            assert not os.path.exists(os.path.join(tmp_dir, "outside"))
+
     @pytest.mark.parametrize(
         "uri",
         ["/test_dir/test_object"],

--- a/tests/unit_test/private/fed/server/job_meta_validator_test.py
+++ b/tests/unit_test/private/fed/server/job_meta_validator_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import io
+import json
 import os
 import sys
 import zipfile
@@ -70,6 +71,9 @@ META_WITH_VALID_DEPLOY_MAP = [
 
 META_WITH_INVALID_DEPLOY_MAP = [
     pytest.param({"deploy_map": {"app1": ["@ALL", "server"]}}, id="all_other"),
+    pytest.param({"deploy_map": {"/tmp/app": ["server"]}}, id="absolute_app"),
+    pytest.param({"deploy_map": {"../app": ["server"]}}, id="traversing_app"),
+    pytest.param({"deploy_map": {"app/sub": ["server"]}}, id="nested_app"),
     pytest.param({"deploy_map": {"app1": ["@ALL"], "app2": ["@all"]}}, id="dup_all"),
     pytest.param({"deploy_map": {"app1": ["server", "site-1", "site-2"], "app2": ["site-2"]}}, id="dup_client"),
     pytest.param({"deploy_map": {"app1": ["server", "site-1"], "app2": ["server", "site-2"]}}, id="dup_server"),
@@ -145,6 +149,26 @@ class TestJobMetaValidator:
         }}
         """
         self._assert_invalid(job_name, meta)
+
+    @pytest.mark.parametrize(
+        "job_id",
+        [
+            pytest.param("../outside", id="relative_traversal"),
+            pytest.param("good/../../outside", id="nested_traversal"),
+            pytest.param("/tmp/outside", id="absolute_path"),
+            pytest.param("bad\\id", id="windows_separator"),
+        ],
+    )
+    def test_invalid_job_id(self, job_id):
+        meta = f"""
+        {{
+            "job_id": {json.dumps(job_id)},
+            "name": "sag",
+            "resource_spec": {{}},
+            "deploy_map": {{"sag": ["server", "site-1", "site-2"]}}
+        }}
+        """
+        self._assert_invalid("valid_job", meta)
 
     def _assert_valid(self, job_name: str):
         data = _zip_job_with_meta(job_name, "")

--- a/tests/unit_test/private/fed/utils/app_deployer_test.py
+++ b/tests/unit_test/private/fed/utils/app_deployer_test.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nvflare.apis.workspace import Workspace
+from nvflare.private.fed.utils.app_deployer import AppDeployer
+
+
+def _make_workspace(root_dir: str) -> Workspace:
+    os.makedirs(os.path.join(root_dir, "startup"), exist_ok=True)
+    os.makedirs(os.path.join(root_dir, "local"), exist_ok=True)
+    return Workspace(root_dir, site_name="site-1")
+
+
+def test_deploy_rejects_traversing_job_id_before_touching_outside_path(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "marker.txt"
+    marker.write_text("keep")
+
+    with pytest.raises(Exception, match="invalid job_id"):
+        AppDeployer().deploy(
+            workspace=workspace,
+            job_id="good/../../outside",
+            job_meta={},
+            app_name="app",
+            app_data=b"not-needed",
+            fl_ctx=None,
+        )
+
+    assert marker.read_text() == "keep"


### PR DESCRIPTION
## What changed

- Added shared validation for submitted job IDs and deploy-map app names.
- Hardened job-store and workspace path construction with validation and containment checks.
- Prevented submitted metadata from overwriting existing jobs by refusing duplicate job IDs.
- Hardened filesystem storage URI resolution so object paths cannot escape the configured storage root.
- Added regression coverage for job metadata validation, job creation overwrite behavior, storage containment, workspace run paths, and client app deployment traversal.

## Why

Submitted job metadata could previously preserve attacker-controlled `job_id` values and deploy-map app names. Those values reached filesystem paths in the server job store, server app zipping path, and client workspace deploy path. That allowed path traversal, overwriting existing jobs, and zipping/deploying outside intended directories.
