### PR TITLE
[2.8] Fix Docker SJ workspace tmpfs permissions

### DIFF
--- a/docs/design/docker_job_launcher_design.md
+++ b/docs/design/docker_job_launcher_design.md
@@ -133,7 +133,9 @@ If a job package is intended to be portable across deployments and carries both 
 
 ### Workspace / Storage
 - SP/CP containers receive a read-write bind mount of the host workspace directory.
-- SJ/CJ containers receive an empty tmpfs workspace root at `/var/tmp/nvflare/workspace` with `0555` permissions, read-only bind mounts for `startup/` and `local/`, and a read-write bind mount of only the current job directory at `/var/tmp/nvflare/workspace/<job_id>`.
+- SJ/CJ containers receive an empty tmpfs workspace root at `/var/tmp/nvflare/workspace` with `1777`
+  permissions, read-only bind mounts for `startup/` and `local/`, and a read-write bind mount of only the
+  current job directory at `/var/tmp/nvflare/workspace/<job_id>`.
 - The container-internal workspace mount point is always `/var/tmp/nvflare/workspace` (hardcoded).
 - Docker mode does not need workspace transfer: the job sees startup/local files and its own extracted app directly through bind mounts, while Docker prevents it from reading or writing other job directories through the workspace.
 - SJ/CJ containers use the current job workspace as their process working directory, so relative job outputs persist on the host.
@@ -180,7 +182,7 @@ SP/CP container (site admin grants via start_docker.sh)
 
 SJ/CJ container (DockerJobLauncher controls)
   ├── NO Docker socket                        ← cannot create further containers
-  ├── empty tmpfs workspace root at /var/tmp/nvflare/workspace (0555 mode)
+  ├── empty tmpfs workspace root at /var/tmp/nvflare/workspace (1777 mode)
   ├── startup bind mount at /var/tmp/nvflare/workspace/startup (read-only)
   ├── local bind mount at /var/tmp/nvflare/workspace/local (read-only)
   ├── job workspace bind mount at /var/tmp/nvflare/workspace/<job_id> (read-write)
@@ -404,6 +406,11 @@ By default, NVFlare stores job zips, results, and snapshots under `/tmp/nvflare/
 ```
 
 These paths resolve to `workspace/jobs-storage/` and `workspace/snapshot-storage/` on the host — both inside the bind mount and therefore persistent across container restarts.
+
+For SJ containers launched by `DockerJobLauncher`, the same paths exist under the isolated tmpfs workspace root.
+They are writable so server-job startup can initialize, but they are ephemeral and are not connected to the parent
+server's host-backed storage. The tmpfs uses sticky `1777` permissions so the non-root job-container user can
+initialize these directories even when Docker owns the tmpfs root as root.
 
 ### Step 3 — Start SP/CP in Docker mode
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -96,7 +96,7 @@ tail -f \
 ```bash
 nvflare job submit \
   -j examples/docker/jobs/hello-numpy-docker \
-  -w workspace/docker_test_project/prod_00/admin@nvidia.com
+  --startup-kit workspace/docker_test_project/prod_00/admin@nvidia.com
 ```
 
 Available jobs:

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -62,27 +62,33 @@ This example runs in **hybrid mode**: site-1 uses Docker job launcher (`start_do
 site-2 runs in process mode (`start.sh`). This tests that both modes work together in the
 same federation.
 
-Run each block in a separate terminal from the repo root.
+The first `start_docker.sh` command creates `nvflare-network` if it does not
+already exist, so no separate `docker network create` command is required.
 
-Terminal 1:
+Start all three parent processes from the repo root:
+
 ```bash
-# Server (Docker mode)
-cd workspace/docker_test_project/prepared/server
-bash startup/start_docker.sh
+(
+  cd workspace/docker_test_project/prepared/server
+  nohup bash startup/start_docker.sh > server.log 2>&1 < /dev/null &
+)
+(
+  cd workspace/docker_test_project/prepared/site-1
+  nohup bash startup/start_docker.sh > site-1.log 2>&1 < /dev/null &
+)
+(
+  cd workspace/docker_test_project/prod_00/site-2
+  nohup bash startup/start.sh > site-2.log 2>&1 < /dev/null &
+)
 ```
 
-Terminal 2:
-```bash
-# site-1 (Docker mode — job containers launched per job)
-cd workspace/docker_test_project/prepared/site-1
-bash startup/start_docker.sh
-```
+You can watch startup logs with:
 
-Terminal 3:
 ```bash
-# site-2 (process mode — jobs run as subprocesses of CP)
-cd workspace/docker_test_project/prod_00/site-2
-bash startup/start.sh
+tail -f \
+  workspace/docker_test_project/prepared/server/server.log \
+  workspace/docker_test_project/prepared/site-1/site-1.log \
+  workspace/docker_test_project/prod_00/site-2/site-2.log
 ```
 
 ## Step 5: Submit a job

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -34,12 +34,12 @@ Prepare the server and site-1 startup kits for Docker mode:
 ```bash
 nvflare deploy prepare \
   workspace/docker_test_project/prod_00/server \
-  --config examples/docker/docker.yaml \
+  --config docker.yaml \
   --output workspace/docker_test_project/prepared/server
 
 nvflare deploy prepare \
   workspace/docker_test_project/prod_00/site-1 \
-  --config examples/docker/docker.yaml \
+  --config docker.yaml \
   --output workspace/docker_test_project/prepared/site-1
 ```
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -7,12 +7,12 @@ SP/CP containers are started manually; SJ/CJ containers are launched automatical
 
 - Docker with a working daemon
 - NVFlare installed (development install from repo root: `pip install -e .[dev,PT]`)
-- Run all commands from the **repo root** unless noted otherwise
+- Run all commands from the `examples/docker` directory unless noted otherwise
 
 ## Step 0: Build Docker images
 
 ```bash
-bash examples/docker/build_docker.sh
+bash build_docker.sh
 ```
 
 This builds two images:
@@ -22,7 +22,7 @@ This builds two images:
 ## Step 1: Provision
 
 ```bash
-nvflare provision -p examples/docker/project.yml
+nvflare provision -p project.yml
 ```
 
 This generates a workspace under `workspace/docker_test_project/` relative to the current directory.
@@ -65,7 +65,7 @@ same federation.
 The first `start_docker.sh` command creates `nvflare-network` if it does not
 already exist, so no separate `docker network create` command is required.
 
-Start all three parent processes from the repo root:
+Start all three parent processes from the `examples/docker` directory:
 
 ```bash
 (
@@ -95,7 +95,7 @@ tail -f \
 
 ```bash
 nvflare job submit \
-  -j examples/docker/jobs/hello-numpy-docker \
+  -j jobs/hello-numpy-docker \
   --startup-kit workspace/docker_test_project/prod_00/admin@nvidia.com
 ```
 

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -52,7 +52,9 @@ class DockerStatus:
 
 
 TERMINAL_STATUSES = {DockerStatus.EXITED, DockerStatus.DEAD}
-_WORKSPACE_TMPFS_MODE = 0o555
+# Docker tmpfs mounts are commonly owned by root; use sticky world-writable mode so the
+# non-root job-container user can initialize ephemeral top-level workspace directories.
+_WORKSPACE_TMPFS_MODE = 0o1777
 _RESERVED_WORKSPACE_CHILD_NAMES = {
     WorkspaceConstants.STARTUP_FOLDER_NAME,
     WorkspaceConstants.SITE_FOLDER_NAME,
@@ -269,7 +271,8 @@ class DockerJobLauncher(JobLauncherSpec):
     Assumptions:
     - Docker network already exists (created by start_docker.sh or site admin).
     - Job containers get an isolated workspace view at /var/tmp/nvflare/workspace:
-      startup/local are read-only; only the current job workspace is read-write.
+      the root is writable ephemeral tmpfs, startup/local are read-only, and only the current
+      job workspace is read-write and persistent on the host.
     - SP/CP container name is known and reachable via Docker DNS on the network.
     - parent_url is derived at runtime from the site name and the port in JOB_PROCESS_ARGS.
     """
@@ -495,8 +498,10 @@ class DockerJobLauncher(JobLauncherSpec):
         if num_gpus and "device_requests" not in job_container_kwargs:
             merged_container_kwargs["device_requests"] = [{"Count": num_gpus, "Capabilities": [["gpu"]]}]
 
-        # Give the job an isolated workspace view: startup/local are read-only,
-        # and only this job's workspace is read-write and persistent on the host.
+        # Give the job an isolated workspace view. The root tmpfs must be writable by the non-root
+        # container user because server job startup may create ephemeral storage dirs such as
+        # snapshot-storage and jobs-storage.
+        # startup/local are read-only, and only this job's workspace is read-write and persistent on the host.
         job_workspace_name = WorkspaceConstants.WORKSPACE_PREFIX + str(job_id)
         host_job_workspace = _safe_workspace_child_path(workspace, job_workspace_name)
         host_startup_dir = _safe_workspace_child_path(

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -549,7 +549,7 @@ class TestDockerJobLauncherLaunchJob:
             "Source": None,
             "Type": "tmpfs",
             "ReadOnly": False,
-            "tmpfs_mode": 0o555,
+            "tmpfs_mode": 0o1777,
         }
         assert mounts_by_target["/var/tmp/nvflare/workspace/startup"] == {
             "Target": "/var/tmp/nvflare/workspace/startup",


### PR DESCRIPTION
## Summary

- make the Docker job launcher workspace tmpfs writable with sticky `1777` permissions
- keep `startup/` and `local/` read-only and the current job directory as the only host-backed writable mount
- update the Docker launcher unit expectation and design doc to describe the ephemeral SJ/CJ storage behavior
- make the Docker example startup commands copy/pasteable by backgrounding parent processes with per-site logs
- update the Docker example job submit command to use `--startup-kit`
- make Docker example paths consistently relative to `examples/docker`

## Root Cause

`deploy prepare` rewrites server storage paths to `/var/tmp/nvflare/workspace/snapshot-storage` and `/var/tmp/nvflare/workspace/jobs-storage`. Server job containers inherit those resources, but the Docker job launcher mounted `/var/tmp/nvflare/workspace` as a read-only-style `0555` tmpfs. During SJ boot, `snapshot_persistor` and `job_manager` both try to create their storage directories under the tmpfs root and fail with `EACCES`.

## Impact

SJ/CJ containers still do not receive the parent site workspace bind mount. The top-level workspace root is now writable only as ephemeral tmpfs so startup-time storage initialization can succeed, matching the K8s emptyDir behavior more closely. Host-backed writes remain limited to `/var/tmp/nvflare/workspace/<job_id>`.
