### PR TITLE
[2.8] Fix a potential issue on the server

### DIFF
--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -289,7 +289,11 @@ class K8sJobHandle(JobHandleSpec):
             self.terminal_state = JobState.TERMINATED
         except ApiException as e:
             if getattr(e, "status", None) == 404:
-                self.logger.info(
+                # Expected when terminate() runs as an idempotent cleanup after the
+                # pod already exited gracefully (e.g. server abort path where the SJ
+                # left on its own before the safety-net terminate fires). Not an
+                # event of interest for operators monitoring logs.
+                self.logger.debug(
                     f"job {self.job_id} pod {self.pod_name} not found during termination; assuming terminated"
                 )
             else:

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -380,7 +380,7 @@ class ServerEngine(ServerEngineInternalSpec, StreamableEngine):
         if job_handle is not None:
             try:
                 job_handle.terminate()
-                self.logger.info(f"job {job_id}: terminated job handle after abort cleanup")
+                self.logger.debug(f"job {job_id}: terminated job handle after abort cleanup")
             except Exception as e:
                 self.logger.error(f"job {job_id}: failed to terminate job handle: {secure_format_exception(e)}")
         with self.lock:

--- a/nvflare/private/fed/server/server_engine.py
+++ b/nvflare/private/fed/server/server_engine.py
@@ -340,6 +340,9 @@ class ServerEngine(ServerEngineInternalSpec, StreamableEngine):
         self.logger.info("Abort the server app run.")
         command_data = Shareable()
         command_data.set_header(ServerCommandKey.TURN_TO_COLD, turn_to_cold)
+        with self.lock:
+            job_handle = self.run_processes.get(job_id, {}).get(RunProcessKey.JOB_HANDLE)
+        graceful_wait = 10.0
 
         try:
             status_message = self.send_command_to_child_runner_process(
@@ -351,28 +354,37 @@ class ServerEngine(ServerEngineInternalSpec, StreamableEngine):
             )
             self.logger.info(f"Abort server status: {status_message}")
         except Exception:
-            with self.lock:
-                child_process = self.run_processes.get(job_id, {}).get(RunProcessKey.JOB_HANDLE, None)
-                if child_process:
-                    child_process.terminate()
-        finally:
-            threading.Thread(target=self._remove_run_processes, args=[job_id]).start()
+            graceful_wait = 0.0
+        self._remove_run_processes(job_id, job_handle=job_handle, max_wait=graceful_wait)
 
         self.engine_info.status = MachineStatus.STOPPED
         return ""
 
-    def _remove_run_processes(self, job_id):
-        # wait for the run process to gracefully terminated, and ensure to remove from run_processes.
-        max_wait = 5.0
+    def _remove_run_processes(self, job_id, job_handle=None, max_wait=10.0):
+        # Wait for the run process to terminate gracefully, then always call
+        # terminate() for the captured job handle. For launcher-managed jobs
+        # this is the resource cleanup path, not only a force-kill path.
         start = time.time()
         while True:
-            if job_id not in self.run_processes:
-                # job already gone
-                return
+            with self.lock:
+                run_process = self.run_processes.get(job_id)
+                if job_handle is None and run_process:
+                    job_handle = run_process.get(RunProcessKey.JOB_HANDLE)
+            if run_process is None:
+                # graceful shutdown: wait_for_complete already popped this entry
+                break
             if time.time() - start >= max_wait:
                 break
             time.sleep(0.1)
-        self.run_processes.pop(job_id, None)
+
+        if job_handle is not None:
+            try:
+                job_handle.terminate()
+                self.logger.info(f"job {job_id}: terminated job handle after abort cleanup")
+            except Exception as e:
+                self.logger.error(f"job {job_id}: failed to terminate job handle: {secure_format_exception(e)}")
+        with self.lock:
+            self.run_processes.pop(job_id, None)
 
     def check_app_start_readiness(self, job_id: str) -> str:
         if job_id not in self.run_processes.keys():

--- a/tests/unit_test/private/fed/server/server_engine_test.py
+++ b/tests/unit_test/private/fed/server/server_engine_test.py
@@ -174,3 +174,98 @@ def test_wait_for_complete_records_nonzero_return_code_for_first_failure():
     assert exception_run_processes["job-1"] is run_process_info
     assert run_process_info[RunProcessKey.PROCESS_RETURN_CODE] == ProcessExitCode.EXCEPTION
     assert "job-1" not in engine.run_processes
+
+
+def _make_remove_engine(run_processes):
+    engine = ServerEngine.__new__(ServerEngine)
+    engine.lock = threading.Lock()
+    engine.run_processes = run_processes
+    engine.logger = MagicMock()
+    return engine
+
+
+def _make_abort_engine(job_handle):
+    engine = _make_remove_engine({"job-1": {RunProcessKey.JOB_HANDLE: job_handle}})
+    engine.engine_info = MagicMock()
+    engine.send_command_to_child_runner_process = MagicMock(return_value="OK")
+    return engine
+
+
+def test_abort_app_on_server_waits_for_cleanup_after_in_band_abort():
+    job_handle = MagicMock()
+    engine = _make_abort_engine(job_handle)
+    engine._remove_run_processes = MagicMock()
+
+    result = engine.abort_app_on_server("job-1")
+
+    assert result == ""
+    engine._remove_run_processes.assert_called_once_with("job-1", job_handle=job_handle, max_wait=10.0)
+
+
+def test_abort_app_on_server_skips_graceful_wait_when_in_band_abort_fails():
+    job_handle = MagicMock()
+    engine = _make_abort_engine(job_handle)
+    engine.send_command_to_child_runner_process.side_effect = RuntimeError("child unavailable")
+    engine._remove_run_processes = MagicMock()
+
+    result = engine.abort_app_on_server("job-1")
+
+    assert result == ""
+    engine._remove_run_processes.assert_called_once_with("job-1", job_handle=job_handle, max_wait=0.0)
+
+
+def test_remove_run_processes_terminates_job_handle_when_graceful_wait_expires():
+    """If the SJ does not exit on its own (e.g. K8s pod hung during shutdown), the
+    abort cleanup must call job_handle.terminate() so launcher resources (the K8s
+    server pod) are deleted instead of leaking after an admin abort. Without this
+    fallback, FINISHED:ABORTED can be reported while the pod stays Running.
+    """
+    job_handle = MagicMock()
+    run_process_info = {RunProcessKey.JOB_HANDLE: job_handle}
+    engine = _make_remove_engine({"job-1": run_process_info})
+
+    with patch("nvflare.private.fed.server.server_engine.time.time", side_effect=[0.0, 99.0]):
+        with patch("nvflare.private.fed.server.server_engine.time.sleep"):
+            engine._remove_run_processes("job-1")
+
+    job_handle.terminate.assert_called_once()
+    assert "job-1" not in engine.run_processes
+
+
+def test_remove_run_processes_terminates_captured_handle_when_run_exits_gracefully():
+    """Even if wait_for_complete pops the entry before max_wait expires, abort
+    cleanup must still terminate the captured launcher handle. For K8s this is
+    what deletes the server job pod after an admin abort.
+    """
+    job_handle = MagicMock()
+    engine = _make_remove_engine({})  # entry already removed by wait_for_complete
+
+    engine._remove_run_processes("job-1", job_handle=job_handle)
+
+    job_handle.terminate.assert_called_once()
+
+
+def test_remove_run_processes_has_nothing_to_terminate_without_run_or_handle():
+    engine = _make_remove_engine({})  # entry already removed by wait_for_complete
+
+    engine._remove_run_processes("job-1")
+
+    assert "job-1" not in engine.run_processes
+
+
+def test_remove_run_processes_tolerates_terminate_failure():
+    """A failure to delete the launcher resource (e.g. K8s API error) must not crash
+    abort cleanup; the run_processes entry is still popped so the engine state
+    stays consistent.
+    """
+    job_handle = MagicMock()
+    job_handle.terminate.side_effect = RuntimeError("k8s api down")
+    run_process_info = {RunProcessKey.JOB_HANDLE: job_handle}
+    engine = _make_remove_engine({"job-1": run_process_info})
+
+    with patch("nvflare.private.fed.server.server_engine.time.time", side_effect=[0.0, 99.0]):
+        with patch("nvflare.private.fed.server.server_engine.time.sleep"):
+            engine._remove_run_processes("job-1")
+
+    job_handle.terminate.assert_called_once()
+    assert "job-1" not in engine.run_processes


### PR DESCRIPTION
### Description

When users abort a job running in k8s, the server may not always terminate the job pod while clients do.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x ] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [ ] Documentation updated.
