### PR TITLE
[main] Fix StorageException after every job from empty SystemLogStreamer context

### DIFF
--- a/nvflare/app_common/logging/system_log_streamer.py
+++ b/nvflare/app_common/logging/system_log_streamer.py
@@ -16,7 +16,14 @@ import os
 import threading
 
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_constant import FLContextKey, JobConstants, ProcessType, StreamCtxKey, WorkspaceConstants
+from nvflare.apis.fl_constant import (
+    FLContextKey,
+    JobConstants,
+    ProcessType,
+    ReservedKey,
+    StreamCtxKey,
+    WorkspaceConstants,
+)
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.workspace import Workspace
@@ -232,8 +239,21 @@ class SystemLogStreamer(Widget):
 
         # The event FLContext can be reused after the handler returns, so hand
         # the background uploader its own fresh context.
+        #
+        # CLIENT_PARENT serves multiple jobs over its lifetime, so the parent
+        # engine's ctx_manager does NOT carry per-job RUN_NUM / IDENTITY_NAME
+        # as sticky props. Without explicitly seeding them here, the fresh
+        # context produced by engine.new_context() arrives at the receiver
+        # with empty peer_ctx.get_job_id(), and JobLogReceiver routes the
+        # uploaded error log under the literal "unknown" job_id — which then
+        # fails with `StorageException: path .../jobs-storage/unknown is not
+        # a valid directory`. Seeding these reserved keys preserves the
+        # receiver's existing peer-context-as-trust-source security model.
         engine = fl_ctx.get_engine()
         stream_fl_ctx = engine.new_context() if engine else fl_ctx
+        if stream_fl_ctx is not fl_ctx:
+            stream_fl_ctx.put(key=ReservedKey.RUN_NUM, value=job_id, private=False, sticky=True)
+            stream_fl_ctx.put(key=ReservedKey.IDENTITY_NAME, value=client_name, private=False, sticky=False)
         threading.Thread(
             target=self._stream_completed_log,
             args=(stream_fl_ctx, log_path, client_name, job_id),

--- a/tests/unit_test/app_common/logging/system_log_streamer_test.py
+++ b/tests/unit_test/app_common/logging/system_log_streamer_test.py
@@ -97,6 +97,48 @@ def test_system_log_streamer_uploads_completed_error_log_snapshot(tmp_path):
     assert kwargs["stop_event"].is_set()
 
 
+def test_completed_upload_seeds_run_num_and_identity_on_fresh_context(tmp_path):
+    """Regression for FLARE-2921: CLIENT_PARENT's engine.new_context() returns a
+    fresh context with no per-job RUN_NUM / IDENTITY_NAME, so without explicit
+    seeding the receiver gets back peer_ctx.get_job_id()=='' and routes the
+    upload under the literal 'unknown' job id (StorageException). Verify that
+    the upload thread's public context carries the real job_id and client_name."""
+    os.makedirs(tmp_path / "startup", exist_ok=True)
+    os.makedirs(tmp_path / "local", exist_ok=True)
+    workspace = Workspace(root_dir=str(tmp_path), site_name="site-1")
+    error_log_path = workspace.get_app_error_log_file_path("job-1")
+    os.makedirs(os.path.dirname(error_log_path), exist_ok=True)
+    with open(error_log_path, "w") as f:
+        f.write("boom\n")
+
+    fl_ctx = _make_fl_ctx(tmp_path)
+    stream_fl_ctx = fl_ctx.get_engine().new_context.return_value
+    # Sanity: the fresh context starts with no job_id / identity_name, mirroring
+    # the production CLIENT_PARENT engine.new_context() behavior.
+    assert stream_fl_ctx.get_job_id(default="") == ""
+    assert stream_fl_ctx.get_identity_name(default="") == ""
+    assert ReservedKey.RUN_NUM not in stream_fl_ctx.get_all_public_props()
+    assert ReservedKey.IDENTITY_NAME not in stream_fl_ctx.get_all_public_props()
+
+    streamer = SystemLogStreamer(log_file_name=WorkspaceConstants.ERROR_LOG_FILE_NAME)
+    with (
+        _allow_streaming(True),
+        patch("nvflare.app_common.logging.system_log_streamer.threading.Thread", _ImmediateThread),
+        patch("nvflare.app_common.logging.system_log_streamer.LogStreamer.stream_log"),
+    ):
+        streamer._on_job_completed(EventType.JOB_COMPLETED, fl_ctx)
+
+    assert stream_fl_ctx.get_job_id() == "job-1"
+    assert stream_fl_ctx.get_identity_name() == "site-1"
+
+    # AuxRunner forwards only public props. Rebuild the receiver-side peer ctx
+    # from that public view to verify JobLogReceiver sees the real identity.
+    peer_ctx = FLContext()
+    peer_ctx.set_public_props(stream_fl_ctx.get_all_public_props())
+    assert peer_ctx.get_job_id() == "job-1"
+    assert peer_ctx.get_identity_name() == "site-1"
+
+
 def test_system_log_streamer_skips_completed_upload_for_non_error_logs(tmp_path):
     fl_ctx = _make_fl_ctx(tmp_path)
     streamer = SystemLogStreamer(log_file_name=WorkspaceConstants.LOG_FILE_NAME)


### PR DESCRIPTION
## Summary
Cherry-picks PR #4559 from the 2.8 branch onto `main`.

This seeds the fresh `SystemLogStreamer` upload context with the job id and client identity before uploading the completed `error_log.txt` snapshot. That prevents completed jobs from routing system log storage through an empty job id that falls back to `unknown`.

## Validation
- `~/nvflare-env/3.12/bin/python -m pytest -v tests/unit_test/app_common/logging/system_log_streamer_test.py` -> 7 passed
- `~/nvflare-env/3.12/bin/python -m pytest -v tests/unit_test/app_common/logging` -> 16 passed