### PR TITLE
[2.8] Add Flower run_config regression test

### DIFF
--- a/tests/unit_test/recipe/flower_recipe_test.py
+++ b/tests/unit_test/recipe/flower_recipe_test.py
@@ -53,6 +53,19 @@ def test_flower_recipe_accepts_compatible_flwr_version(flwr_version):
     assert kwargs["extra_env"] == {CLIENT_API_TYPE_KEY: ClientAPIType.EX_PROCESS_API.value}
 
 
+def test_flower_recipe_forwards_run_config():
+    fake_job = object()
+    run_config = {"learning-rate": 0.01, "momentum": 0.9}
+
+    with patch("nvflare.app_opt.flower.recipe.get_package_version", return_value="1.26.0"):
+        with patch("nvflare.app_opt.flower.recipe._create_flower_job", return_value=fake_job) as mock_flower_job:
+            recipe = FlowerRecipe(flower_content="mock_flower_content", run_config=run_config)
+
+    assert recipe.job is fake_job
+    kwargs = mock_flower_job.call_args.kwargs
+    assert kwargs["run_config"] == run_config
+
+
 @pytest.mark.parametrize("flwr_version", ["1.26.0", "1.26.1", "1.27.5"])
 def test_flower_recipe_merges_extra_env(flwr_version):
     fake_job = object()


### PR DESCRIPTION
## Summary
- add a focused FlowerRecipe regression test for the reported `run_config` compatibility failure
- verify FlowerRecipe accepts run_config and forwards it into FlowerJob creation

## Why
QA reported a TypeError when `examples/hello-world/hello-flower/job.py` passed `run_config`. Current upstream/2.8 and the published 2.8.0rc1 wheel already include the run_config parameter, so this PR preserves that expected behavior with a direct unit test.

## Validation
- isort tests/unit_test/recipe/flower_recipe_test.py
- black tests/unit_test/recipe/flower_recipe_test.py
- python3 -m pytest tests/unit_test/recipe/flower_recipe_test.py -q
- PYTHONPATH=/Users/hroth/.codex/worktrees/9461/nvflare /private/tmp/flower_runconfig_venv/bin/python job.py --job_name flwr-pt --content_dir ./flwr-pt --export_job --export_dir /private/tmp/flower_runconfig_export_flwr129.poFEBY
- PYTHONPATH=/Users/hroth/.codex/worktrees/9461/nvflare /private/tmp/flower_runconfig_venv/bin/python job.py --job_name flwr-pt --content_dir ./flwr-pt --learning_rate 0.01 --momentum 0.9 --export_job --export_dir /private/tmp/flower_runconfig_export_flwr129_runconfig.GtkWu0