### PR TITLE
[2.8] Fix Auto-FedRL CIFAR10 paths

### DIFF
--- a/examples/advanced/cifar10/pt/src/data/cifar10_data_split.py
+++ b/examples/advanced/cifar10/pt/src/data/cifar10_data_split.py
@@ -50,6 +50,59 @@ import os
 import numpy as np
 from data.cifar10_data_utils import get_site_class_summary, load_cifar10_data
 
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_component import FLComponent
+from nvflare.apis.fl_context import FLContext
+
+
+class Cifar10DataSplitter(FLComponent):
+    def __init__(self, split_dir: str = None, num_sites: int = 8, alpha: float = 0.5, seed: int = 0):
+        super().__init__()
+        self.split_dir = split_dir
+        self.num_sites = num_sites
+        self.alpha = alpha
+        self.seed = seed
+
+        if self.split_dir is None:
+            raise ValueError("You need to define a valid `split_dir` for splitting the data.")
+        if not os.path.isabs(self.split_dir):
+            raise ValueError("`split_dir` needs to be absolute path.")
+        if alpha < 0.0:
+            raise ValueError(f"Alpha should be larger or equal 0.0 but was {alpha}!")
+
+    def handle_event(self, event_type: str, fl_ctx: FLContext):
+        if event_type == EventType.START_RUN:
+            self.split(fl_ctx)
+
+    def split(self, fl_ctx: FLContext):
+        self.log_info(
+            fl_ctx,
+            f"Partitioning CIFAR-10 dataset into {self.num_sites} sites with Dirichlet sampling under alpha "
+            f"{self.alpha}",
+        )
+
+        site_idx, class_sum = partition_data(self.num_sites, self.alpha, self.seed)
+
+        if not os.path.isdir(self.split_dir):
+            os.makedirs(self.split_dir)
+            self.log_info(fl_ctx, f"Created directory: {self.split_dir}")
+
+        sum_file_name = os.path.join(self.split_dir, "summary.txt")
+        with open(sum_file_name, "w") as sum_file:
+            sum_file.write(f"Number of clients: {self.num_sites} \n")
+            sum_file.write(f"Dirichlet sampling parameter: {self.alpha} \n")
+            sum_file.write("Class counts for each client: \n")
+            sum_file.write(json.dumps(class_sum, indent=2))
+        self.log_info(fl_ctx, f"Saved summary to: {sum_file_name}")
+
+        site_file_path = os.path.join(self.split_dir, "site-")
+        for site in range(self.num_sites):
+            site_file_name = site_file_path + str(site + 1) + ".npy"
+            np.save(site_file_name, np.array(site_idx[site]))
+            self.log_info(fl_ctx, f"Saved site {site + 1} data ({len(site_idx[site])} samples) to: {site_file_name}")
+
+        self.log_info(fl_ctx, f"Split data saved to: {self.split_dir}")
+
 
 def partition_data(num_sites, alpha, seed):
     """

--- a/examples/advanced/cifar10/pt/src/data/cifar10_data_split.py
+++ b/examples/advanced/cifar10/pt/src/data/cifar10_data_split.py
@@ -74,30 +74,66 @@ class Cifar10DataSplitter(FLComponent):
         if event_type == EventType.START_RUN:
             self.split(fl_ctx)
 
-    def split(self, fl_ctx: FLContext):
-        self.log_info(
-            fl_ctx,
-            f"Partitioning CIFAR-10 dataset into {self.num_sites} sites with Dirichlet sampling under alpha "
-            f"{self.alpha}",
-        )
+    def _summary_matches_config(self, sum_file_name: str, fl_ctx: FLContext) -> bool:
+        if not os.path.isfile(sum_file_name):
+            return False
 
-        site_idx, class_sum = partition_data(self.num_sites, self.alpha, self.seed)
+        try:
+            with open(sum_file_name) as sum_file:
+                summary = sum_file.read()
+        except OSError as e:
+            self.log_warning(fl_ctx, f"Could not read split summary {sum_file_name}: {e}")
+            return False
+
+        if f"Number of clients: {self.num_sites}" not in summary:
+            return False
+        if f"Dirichlet sampling parameter: {self.alpha}" not in summary:
+            return False
+
+        seed_line = f"Seed: {self.seed}"
+        return seed_line in summary or ("Seed:" not in summary and self.seed == 0)
+
+    def split(self, fl_ctx: FLContext):
+        sum_file_name = os.path.join(self.split_dir, "summary.txt")
+        site_file_names = [os.path.join(self.split_dir, f"site-{site + 1}.npy") for site in range(self.num_sites)]
+        existing_site_file_count = sum(os.path.isfile(site_file_name) for site_file_name in site_file_names)
+
+        if existing_site_file_count == self.num_sites:
+            if self._summary_matches_config(sum_file_name, fl_ctx):
+                self.log_info(fl_ctx, f"Split data already exists at {self.split_dir}, skipping re-split.")
+                return
+            self.log_warning(
+                fl_ctx,
+                f"Found existing split data at {self.split_dir}, but the summary does not match the requested "
+                "configuration. Regenerating and overwriting existing site files.",
+            )
+        elif existing_site_file_count > 0:
+            self.log_warning(
+                fl_ctx,
+                f"Found incomplete split data at {self.split_dir}. Regenerating and overwriting "
+                f"{existing_site_file_count} existing site file(s).",
+            )
 
         if not os.path.isdir(self.split_dir):
             os.makedirs(self.split_dir)
             self.log_info(fl_ctx, f"Created directory: {self.split_dir}")
 
-        sum_file_name = os.path.join(self.split_dir, "summary.txt")
+        self.log_info(
+            fl_ctx,
+            f"Partitioning CIFAR-10 dataset into {self.num_sites} sites with Dirichlet sampling under alpha "
+            f"{self.alpha}",
+        )
+        site_idx, class_sum = partition_data(self.num_sites, self.alpha, self.seed)
+
         with open(sum_file_name, "w") as sum_file:
             sum_file.write(f"Number of clients: {self.num_sites} \n")
             sum_file.write(f"Dirichlet sampling parameter: {self.alpha} \n")
+            sum_file.write(f"Seed: {self.seed} \n")
             sum_file.write("Class counts for each client: \n")
             sum_file.write(json.dumps(class_sum, indent=2))
         self.log_info(fl_ctx, f"Saved summary to: {sum_file_name}")
 
-        site_file_path = os.path.join(self.split_dir, "site-")
-        for site in range(self.num_sites):
-            site_file_name = site_file_path + str(site + 1) + ".npy"
+        for site, site_file_name in enumerate(site_file_names):
             np.save(site_file_name, np.array(site_idx[site]))
             self.log_info(fl_ctx, f"Saved site {site + 1} data ({len(site_idx[site])} samples) to: {site_file_name}")
 

--- a/research/auto-fed-rl/README.md
+++ b/research/auto-fed-rl/README.md
@@ -20,16 +20,16 @@ The code in this directory is released under Apache v2 License.
 ## 1. Set PYTHONPATH
 Set `PYTHONPATH` to include custom files of this example:
 
-We use both the utils from the [CIFAR-10 examples](../../examples/advanced/cifar10) (e.g., pt.learners, and pt.utils)
+We use both the model and data utilities from the [CIFAR-10 examples](../../examples/advanced/cifar10)
 and files under [./src](./src):
 ```
-export PYTHONPATH=${PWD}/../../examples/advanced/cifar10:${PWD}/../../examples/advanced/cifar10/pt/utils:${PWD}/src
+export PYTHONPATH=${PWD}/../../examples/advanced/cifar10/pt/src:${PWD}/src
 ```
 
 ## 2. Download the CIFAR-10 dataset
 To speed up the following experiments, first download the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) dataset:
 ```
-python3 -m pt.utils.cifar10_data_utils
+python3 -m data.cifar10_data_utils
 ```
 
 ## 3. Run simulated FL experiments

--- a/research/auto-fed-rl/jobs/cifar10_autofedrl/cifar10_autofedrl/config/config_fed_server.json
+++ b/research/auto-fed-rl/jobs/cifar10_autofedrl/cifar10_autofedrl/config/config_fed_server.json
@@ -12,7 +12,7 @@
     "components": [
         {
             "id": "data_splitter",
-            "path": "pt.utils.cifar10_data_splitter.Cifar10DataSplitter",
+            "path": "data.cifar10_data_split.Cifar10DataSplitter",
             "args": {
                 "split_dir": "{TRAIN_SPLIT_ROOT}",
                 "num_sites": "{min_clients}",
@@ -21,7 +21,7 @@
         },
         {
             "id": "model",
-            "path": "pt.networks.cifar10_nets.ModerateCNN",
+            "path": "model.ModerateCNN",
             "args": {}
         },
         {

--- a/research/auto-fed-rl/src/autofedrl/autofedrl_cifar10_learner.py
+++ b/research/auto-fed-rl/src/autofedrl/autofedrl_cifar10_learner.py
@@ -19,8 +19,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
-from pt.utils.cifar10_data_utils import CIFAR10_ROOT
-from pt.utils.cifar10_dataset import CIFAR10_Idx
+from data.cifar10_data_utils import CIFAR10_ROOT
+from data.cifar10_dataset import CIFAR10_Idx
 from torchvision import datasets
 
 from nvflare.apis.dxo import DXO, DataKind, MetaKey, from_shareable
@@ -34,6 +34,7 @@ from nvflare.fuel.utils import fobs
 
 from .autofedrl_constants import AutoFedRLConstants
 from .cifar10_learner import CIFAR10Learner
+
 
 class CIFAR10AutoFedRLearner(CIFAR10Learner):  # TODO: also support CIFAR10ScaffoldLearner
     def __init__(

--- a/research/auto-fed-rl/src/autofedrl/cifar10_learner.py
+++ b/research/auto-fed-rl/src/autofedrl/cifar10_learner.py
@@ -18,9 +18,9 @@ import os
 import numpy as np
 import torch
 import torch.optim as optim
-from pt.networks.cifar10_nets import ModerateCNN
-from pt.utils.cifar10_data_utils import CIFAR10_ROOT
-from pt.utils.cifar10_dataset import CIFAR10_Idx
+from data.cifar10_data_utils import CIFAR10_ROOT
+from data.cifar10_dataset import CIFAR10_Idx
+from model import ModerateCNN
 from torch.utils.tensorboard import SummaryWriter
 from torchvision import datasets, transforms
 


### PR DESCRIPTION
Fixes stale Auto-FedRL CIFAR-10 imports and configuration paths after the example layout changed.

### Description

The Auto-FedRL CIFAR-10 research example on the 2.8 branch still referenced the old CIFAR-10 PyTorch helper layout under `pt.utils` and `pt.networks`, which was removed when the CIFAR-10 examples moved to `examples/advanced/cifar10/pt/src`.

This updates the example to use the current `data` and `model` modules and restores a `Cifar10DataSplitter` FLComponent in `data.cifar10_data_split` for legacy JSON job configs that still split CIFAR-10 data at `START_RUN`.

### Changes

- Update Auto-FedRL learner imports from `pt.utils.*` to `data.*`.
- Update the Auto-FedRL server config to use `data.cifar10_data_split.Cifar10DataSplitter`.
- Update the Auto-FedRL server model component from `pt.networks.cifar10_nets.ModerateCNN` to `model.ModerateCNN`.
- Update the Auto-FedRL README `PYTHONPATH` and CIFAR-10 data prep command for the 2.8 CIFAR-10 layout.

### Validation

- `black examples/advanced/cifar10/pt/src/data/cifar10_data_split.py research/auto-fed-rl/src/autofedrl/cifar10_learner.py research/auto-fed-rl/src/autofedrl/autofedrl_cifar10_learner.py`
- `isort examples/advanced/cifar10/pt/src/data/cifar10_data_split.py research/auto-fed-rl/src/autofedrl/cifar10_learner.py research/auto-fed-rl/src/autofedrl/autofedrl_cifar10_learner.py`
- `python3 -m py_compile examples/advanced/cifar10/pt/src/data/cifar10_data_split.py research/auto-fed-rl/src/autofedrl/cifar10_learner.py research/auto-fed-rl/src/autofedrl/autofedrl_cifar10_learner.py`
- `python3 -m json.tool research/auto-fed-rl/jobs/cifar10_autofedrl/cifar10_autofedrl/config/config_fed_server.json`
- Import check for `Cifar10DataSplitter`, `CIFAR10_ROOT`, `CIFAR10_Idx`, `ModerateCNN`, and the updated Auto-FedRL learner modules with the documented `PYTHONPATH`.
