### PR TITLE
[2.8] Fix FedBPT CMA fobs registration

### DIFF
--- a/research/fed-bpt/src/cma_decomposer.py
+++ b/research/fed-bpt/src/cma_decomposer.py
@@ -19,7 +19,7 @@ import cma
 import numpy as np
 from cma import CMADataLogger, CMAOptions
 from cma.constraints_handler import BoundNone
-from cma.evolution_strategy import _CMAParameters, _CMASolutionDict_functional, _CMAStopDict
+from cma.evolution_strategy import _CMAParameters, _CMASolutionDict_functional, _CMAStopDict, _StopTolXStagnation
 from cma.optimization_tools import BestSolution
 from cma.recombination_weights import RecombinationWeights
 from cma.sampler import GaussFullSampler
@@ -164,6 +164,7 @@ def register_decomposers():
         DictFromTagsInString,
         ElapsedWCTime,
         _CMAStopDict,
+        _StopTolXStagnation,
         MoreToWrite,
     )
 

--- a/tests/unit_test/examples/fedbpt_cma_decomposer_test.py
+++ b/tests/unit_test/examples/fedbpt_cma_decomposer_test.py
@@ -45,8 +45,12 @@ def test_cma_evolution_strategy_roundtrip_after_fobs_reset():
         register_decomposers()
         restored = fobs.loads(data)
     finally:
-        fobs.reset()
-        sys.path.pop(0)
+        try:
+            fobs.reset()
+        finally:
+            if fedbpt_src in sys.path:
+                sys.path.remove(fedbpt_src)
+            sys.modules.pop("cma_decomposer", None)
 
     assert isinstance(restored, cma.CMAEvolutionStrategy)
     assert isinstance(restored._stoptolxstagnation, cma.evolution_strategy._StopTolXStagnation)

--- a/tests/unit_test/examples/fedbpt_cma_decomposer_test.py
+++ b/tests/unit_test/examples/fedbpt_cma_decomposer_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from nvflare.fuel.utils import fobs
+
+HAS_CMA_DEPS = importlib.util.find_spec("cma") is not None
+pytestmark = pytest.mark.skipif(not HAS_CMA_DEPS, reason="FedBPT CMA dependencies are not installed")
+
+
+def test_cma_evolution_strategy_roundtrip_after_fobs_reset():
+    import cma
+    import cma.evolution_strategy
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    fedbpt_src = os.path.join(repo_root, "research", "fed-bpt", "src")
+
+    sys.path.insert(0, fedbpt_src)
+    try:
+        from cma_decomposer import register_decomposers
+
+        fobs.reset()
+        register_decomposers()
+        strategy = cma.CMAEvolutionStrategy(4 * [5], 10, {"ftarget": 1e-9, "seed": 5, "verbose": -9})
+        data = fobs.dumps(strategy)
+
+        fobs.reset()
+        register_decomposers()
+        restored = fobs.loads(data)
+    finally:
+        fobs.reset()
+        sys.path.pop(0)
+
+    assert isinstance(restored, cma.CMAEvolutionStrategy)
+    assert isinstance(restored._stoptolxstagnation, cma.evolution_strategy._StopTolXStagnation)
+    np.testing.assert_allclose(restored.mean, strategy.mean)
+    assert restored.sigma == strategy.sigma


### PR DESCRIPTION
## Summary

- Register `cma.evolution_strategy._StopTolXStagnation` in the FedBPT CMA decomposer.
- Add a dependency-gated regression test for `CMAEvolutionStrategy` fobs round-tripping after `fobs.reset()`.

## Root Cause

NVFlare 2.8 tightened fobs deserialization to require registered or whitelisted types. FedBPT already registers CMA decomposers, but `CMAEvolutionStrategy` embeds a `_StopTolXStagnation` helper that was auto-registered only in the sending process. A fresh receiver process then rejected that type while deserializing task data.

## Validation

- `PYTHONPATH=/private/tmp/codex_cma_340:/private/tmp/nvflare-fedbpt MPLCONFIGDIR=/private/tmp/mpl-cache python3 -m pytest tests/unit_test/examples/fedbpt_cma_decomposer_test.py -v`
- `MPLCONFIGDIR=/private/tmp/mpl-cache python3 -m pytest tests/unit_test/examples/fedbpt_cma_decomposer_test.py -v`
- `PYTHONPATH=/private/tmp/codex_cma_340:/private/tmp/nvflare-fedbpt/research/fed-bpt/src:/private/tmp/nvflare-fedbpt MPLCONFIGDIR=/private/tmp/mpl-cache python3 research/fed-bpt/src/cma_decomposer.py`
- `./runtest.sh -s`

This restores FedBPT CMA task-data deserialization in a fresh receiver process.
