### PR TITLE
Fix Auto-FL research license headers

### DIFF
--- a/research/auto-fl-research/tasks/__init__.py
+++ b/research/auto-fl-research/tasks/__init__.py
@@ -1,1 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Auto-FL task packages."""

--- a/research/auto-fl-research/tasks/shared/__init__.py
+++ b/research/auto-fl-research/tasks/shared/__init__.py
@@ -1,1 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Shared Auto-FL task utilities."""

--- a/research/auto-fl-research/tasks/vlm_med/job.py
+++ b/research/auto-fl-research/tasks/vlm_med/job.py
@@ -5,6 +5,12 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """NVFlare job generator for the local 3-site medical VLM starter."""
 

--- a/research/auto-fl-research/tasks/vlm_med/med_vlm_data_utils.py
+++ b/research/auto-fl-research/tasks/vlm_med/med_vlm_data_utils.py
@@ -1,6 +1,16 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Medical VLM dataset bridge for the Auto-FL NVFlare harness.
 


### PR DESCRIPTION
## Summary

Fix the canonical NVIDIA Apache license headers for the Auto-FL research task files that failed premerge license checking.

## Changes

- Add the full required license header to two Auto-FL task package `__init__.py` files.
- Complete the truncated Apache headers in the VLM task modules.

## Validation

- `.venv/bin/python ci/check_license_header.py nvflare examples tests integration research`
- `git diff --check upstream/main...HEAD`
