### PR TITLE
Make SP service name in k8s configurable

### DIFF
--- a/docs/design/site_runtime_packaging_design.md
+++ b/docs/design/site_runtime_packaging_design.md
@@ -280,6 +280,7 @@ namespace: default
 
 parent:
   docker_image: nvflare-site:latest
+  service_name: nvflare-server
   parent_port: 8102
   workspace_pvc: nvflws
   workspace_mount_path: /var/tmp/nvflare/workspace
@@ -317,6 +318,14 @@ Supported `parent` keys:
   - Default: none
   - Description: image used by the parent server/client pod in the generated
     Helm chart.
+
+- `service_name`
+  - Required: no
+  - Default: `nvflare-server` for server kits; ignored for client kits
+  - Description: Kubernetes Service name for the parent server pod. This value
+    is rendered into the server Helm chart and written into
+    `local/comm_config.json` so dynamically launched server job pods connect to
+    the same Service host.
 
 - `parent_port`
   - Required: no

--- a/docs/user_guide/admin_guide/deployment/brev_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/brev_deployment.rst
@@ -419,6 +419,7 @@ Prepare the server and client startup kits for Kubernetes:
    namespace: nvflare
    parent:
      docker_image: registry.example.com/nvflare:dev
+     service_name: nvflare-server
      parent_port: 8102
      workspace_pvc: nvflws
      workspace_mount_path: /var/tmp/nvflare/workspace
@@ -432,12 +433,13 @@ Prepare the server and client startup kits for Kubernetes:
    nvflare deploy prepare "$PROD_DIR/server1" --output /tmp/nvflare-prepared/server1 --config /tmp/nvflare-k8s.yaml
    nvflare deploy prepare "$PROD_DIR/site-1" --output /tmp/nvflare-prepared/site-1 --config /tmp/nvflare-k8s.yaml
 
-The example above only sets the keys this guide needs. ``parent`` also accepts
-optional ``resources`` (parent pod CPU/memory requests and limits) and
-``pod_security_context``, and ``job_launcher`` accepts optional
-``job_pod_security_context``. See :ref:`deploy_prepare_command` for the full
-runtime config schema and :ref:`helm_chart` for how the prepared chart is
-installed.
+The example above only sets the keys this guide needs. ``parent.service_name``
+sets the server Kubernetes Service name and is ignored when the same config is
+used to prepare client kits. ``parent`` also accepts optional ``resources``
+(parent pod CPU/memory requests and limits) and ``pod_security_context``, and
+``job_launcher`` accepts optional ``job_pod_security_context``. See
+:ref:`deploy_prepare_command` for the full runtime config schema and
+:ref:`helm_chart` for how the prepared chart is installed.
 
 The prepared folders should contain one ``helm_chart`` directory under the
 server and client:

--- a/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
@@ -149,7 +149,7 @@ Useful Overrides
 
 Common optional environment variables:
 
-``NAMESPACE``, ``PARENT_PORT``, ``WORKSPACE_PVC``, and
+``NAMESPACE``, ``SERVER_SERVICE_NAME``, ``PARENT_PORT``, ``WORKSPACE_PVC``, and
 ``WORKSPACE_MOUNT_PATH`` are deploy-prepare inputs that are embedded into the
 prepared resources and ``helm_chart/``. Set them when running
 ``prepare_brev_startup_kits.sh``. Do not change them only at launch time; rerun
@@ -176,6 +176,9 @@ Prepare-only overrides:
 * ``PARENT_PORT``: in-cluster parent service port written by
   ``nvflare deploy prepare``, default ``8102``. The launch script reads the
   prepared Helm chart and launcher config; it does not read this variable.
+* ``SERVER_SERVICE_NAME``: server Kubernetes Service name written by
+  ``nvflare deploy prepare``, default ``nvflare-server``. The same value is
+  written into the server chart and server ``local/comm_config.json``.
 * ``WORKSPACE_MOUNT_PATH``: parent and job pod workspace path written by
   ``nvflare deploy prepare``, default ``/var/tmp/nvflare/workspace``. The
   launch script verifies the prepared value from ``resources.json.default``; it

--- a/docs/user_guide/admin_guide/deployment/brev_scripts/prepare_brev_startup_kits.sh
+++ b/docs/user_guide/admin_guide/deployment/brev_scripts/prepare_brev_startup_kits.sh
@@ -172,7 +172,7 @@ runtime: k8s
 namespace: ${NAMESPACE}
 parent:
   docker_image: "${IMAGE}"
-  service_name: ${SERVER_SERVICE_NAME}
+  service_name: "${SERVER_SERVICE_NAME}"
   parent_port: ${PARENT_PORT}
   workspace_pvc: ${WORKSPACE_PVC}
   workspace_mount_path: ${WORKSPACE_MOUNT_PATH}

--- a/docs/user_guide/admin_guide/deployment/brev_scripts/prepare_brev_startup_kits.sh
+++ b/docs/user_guide/admin_guide/deployment/brev_scripts/prepare_brev_startup_kits.sh
@@ -28,6 +28,7 @@ Defaults:
   SITE_1_PARTICIPANT=site-1
   SITE_2_PARTICIPANT=site-2
   NAMESPACE=nvflare
+  SERVER_SERVICE_NAME=nvflare-server
   FED_LEARN_PORT=8002
   PARENT_PORT=8102
   WORKSPACE_PVC=nvflws
@@ -171,6 +172,7 @@ runtime: k8s
 namespace: ${NAMESPACE}
 parent:
   docker_image: "${IMAGE}"
+  service_name: ${SERVER_SERVICE_NAME}
   parent_port: ${PARENT_PORT}
   workspace_pvc: ${WORKSPACE_PVC}
   workspace_mount_path: ${WORKSPACE_MOUNT_PATH}
@@ -308,6 +310,7 @@ PREPARE_CONFIG="${PREPARE_CONFIG:-${KIT_DIR}/deploy-prepare-k8s.yaml}"
 FED_LEARN_PORT="${FED_LEARN_PORT:-8002}"
 PARENT_PORT="${PARENT_PORT:-8102}"
 NAMESPACE="${NAMESPACE:-nvflare}"
+SERVER_SERVICE_NAME="${SERVER_SERVICE_NAME:-nvflare-server}"
 WORKSPACE_PVC="${WORKSPACE_PVC:-nvflws}"
 WORKSPACE_MOUNT_PATH="${WORKSPACE_MOUNT_PATH:-/var/tmp/nvflare/workspace}"
 ORG="${ORG:-nvidia}"

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -30,9 +30,9 @@ Role/RoleBinding that allow the launcher to create job pods.
 The parent Service is the stable in-cluster address for dynamically launched job
 pods. ``nvflare deploy prepare`` patches the prepared kit's internal
 communication settings to use the generated Service name and ``parent_port``, so
-job pods do not depend on the parent pod IP. If you rename or replace the
-Service, keep the Service name, Service port, and prepared kit communication
-settings consistent.
+job pods do not depend on the parent pod IP. For server kits, configure
+``parent.service_name`` in ``k8s.yaml`` before preparation if the Service should
+not be named ``nvflare-server``.
 
 Each prepared participant folder contains its own chart:
 
@@ -80,6 +80,7 @@ Example ``k8s.yaml``:
    namespace: nvflare
    parent:
      docker_image: registry.example.com/nvflare:dev
+     service_name: nvflare-server
      parent_port: 8102
      workspace_pvc: nvflws
      workspace_mount_path: /var/tmp/nvflare/workspace
@@ -97,8 +98,11 @@ The runtime config controls site-level Kubernetes settings:
 
 * ``namespace`` is where the parent pod and dynamically launched job pods run.
 * ``parent`` values are rendered into the Helm chart. They set the parent image,
-  Python executable, workspace PVC, parent service port, parent pod resources,
-  and optional parent pod security context. ``parent.python_path`` controls the
+  Python executable, workspace PVC, parent service name and port, parent pod
+  resources, and optional parent pod security context. For server kits,
+  ``parent.service_name`` defaults to ``nvflare-server`` and is also written to
+  ``local/comm_config.json`` so dynamically launched job pods use the same
+  Service host. ``parent.python_path`` controls the
   long-lived SP/CP parent pod command. ``parent.workspace_mount_path`` is also
   written into the K8s launcher config so spawned SJ/CJ job pods mount their job
   workspace and startup kit at the same in-container path.
@@ -284,6 +288,10 @@ Expose FL Traffic
 
 The generated server chart creates a Kubernetes Service for the FL server. The
 service defaults to ``ClusterIP``, which is reachable only inside the cluster.
+The server Service name defaults to ``nvflare-server`` and can be changed with
+``parent.service_name`` in the server ``k8s.yaml`` before running
+``nvflare deploy prepare``. If you change it, replace ``nvflare-server`` in
+the commands below with your configured Service name.
 If clients or admin consoles connect from outside the cluster, expose the FL
 server ports with the mechanism that matches your Kubernetes environment:
 
@@ -304,7 +312,7 @@ server ports with the mechanism that matches your Kubernetes environment:
 
 * For single-node or ingress-based clusters, configure your cluster's TCP
   routing, firewall rules, or host ports so the FL and admin ports from
-  ``project.yml`` reach the ``nvflare-server`` Service.
+  ``project.yml`` reach the configured server Service.
 
 Make sure the server host name used during provisioning resolves to the exposed
 address. For example, update DNS or ``/etc/hosts`` for the admin console and for

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -122,6 +122,7 @@ Example ``k8s.yaml``:
 
    parent:
      docker_image: registry.example.com/nvflare-site:2.8
+     service_name: nvflare-server
      parent_port: 8102
      workspace_pvc: nvflws
      workspace_mount_path: /var/tmp/nvflare/workspace
@@ -149,6 +150,9 @@ Top-level keys:
 ``parent`` keys:
 
 - ``docker_image``: required parent image used by the Helm chart.
+- ``service_name``: Kubernetes Service name for a server kit. Defaults to
+  ``nvflare-server``. This key is ignored for client kits, whose Service name
+  is derived from the client site name.
 - ``parent_port``: port that job pods use to reach the parent pod's FLARE
   process.
   Defaults to ``8102``.
@@ -187,9 +191,9 @@ mounts that PVC at ``workspace_mount_path``.
 
 ``nvflare deploy prepare`` also patches the prepared kit's internal
 communication settings so dynamically launched job pods connect to the generated
-parent Kubernetes Service on ``parent_port``. If you customize the chart's
-Service name or port, keep that Service endpoint consistent with the prepared
-kit.
+parent Kubernetes Service on ``parent_port``. For server kits, setting
+``parent.service_name`` writes the same Service host into
+``local/comm_config.json`` and the generated Helm chart.
 
 The command writes:
 

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -268,7 +268,10 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
     job_launcher = config.get("job_launcher") or {}
     parent_port = parent.get("parent_port", 8102)
     workspace_mount_path = parent.get("workspace_mount_path", WORKSPACE_MOUNT_PATH)
-    service_name = _k8s_parent_service_name(kit_info.role, kit_info.name, parent.get("service_name"))
+    server_service_name = None
+    if kit_info.role == ROLE_SERVER:
+        server_service_name = _optional_k8s_service_name(parent, "service_name", "parent")
+    service_name = _k8s_parent_service_name(kit_info.role, kit_info.name, server_service_name)
 
     launcher_path = K8S_SERVER_LAUNCHER if kit_info.role == ROLE_SERVER else K8S_CLIENT_LAUNCHER
     launcher_args = {
@@ -372,7 +375,6 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
         _required_str(parent, "docker_image", "parent")
         if "namespace" in config:
             _validate_k8s_namespace(config, "namespace", "k8s config")
-        _optional_k8s_service_name(parent, "service_name", "parent")
         _optional_int(parent, "parent_port", "parent")
         _optional_str(parent, "workspace_pvc", "parent")
         _optional_str(parent, "workspace_mount_path", "parent")

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -60,6 +60,7 @@ DOCKER_START_SH = "start_docker.sh"
 WORKSPACE_MOUNT_PATH = "/var/tmp/nvflare/workspace"
 WORKSPACE_VOLUME_NAME = "workspace"
 K8S_PARENT_PYTHON_PATH = "/usr/local/bin/python3"
+K8S_SERVER_SERVICE_NAME = "nvflare-server"
 HELM_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates" / "helm"
 
 PASSTHROUGH_RESOURCE_MANAGER = (
@@ -267,6 +268,7 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
     job_launcher = config.get("job_launcher") or {}
     parent_port = parent.get("parent_port", 8102)
     workspace_mount_path = parent.get("workspace_mount_path", WORKSPACE_MOUNT_PATH)
+    service_name = _k8s_parent_service_name(kit_info.role, kit_info.name, parent.get("service_name"))
 
     launcher_path = K8S_SERVER_LAUNCHER if kit_info.role == ROLE_SERVER else K8S_CLIENT_LAUNCHER
     launcher_args = {
@@ -282,12 +284,12 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
         launcher_args["security_context"] = job_launcher["job_pod_security_context"]
 
     _patch_resources(kit_info.kit_dir, "k8s_launcher", launcher_path, launcher_args)
-    _patch_comm_config_for_k8s(kit_info.kit_dir, kit_info.role, kit_info.name, parent_port)
+    _patch_comm_config_for_k8s(kit_info.kit_dir, service_name, parent_port)
     _ensure_study_data_template(kit_info.kit_dir)
     if kit_info.role == ROLE_SERVER:
         _relocate_server_storage_to_workspace(kit_info.kit_dir, workspace_mount_path)
     _remove_start_scripts(kit_info.kit_dir, keep=set())
-    _write_helm_chart(kit_info, config)
+    _write_helm_chart(kit_info, config, service_name)
 
     release_name = _k8s_release_name(kit_info.name)
     final_chart_dir = final_output / HELM_CHART_DIR
@@ -352,6 +354,7 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
             parent,
             {
                 "docker_image",
+                "service_name",
                 "parent_port",
                 "workspace_pvc",
                 "workspace_mount_path",
@@ -369,6 +372,7 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
         _required_str(parent, "docker_image", "parent")
         if "namespace" in config:
             _validate_k8s_namespace(config, "namespace", "k8s config")
+        _optional_k8s_service_name(parent, "service_name", "parent")
         _optional_int(parent, "parent_port", "parent")
         _optional_str(parent, "workspace_pvc", "parent")
         _optional_str(parent, "workspace_mount_path", "parent")
@@ -569,13 +573,13 @@ def _patch_comm_config_for_docker(kit_dir: Path) -> None:
     _write_json(comm_config_path, comm_config)
 
 
-def _patch_comm_config_for_k8s(kit_dir: Path, role: str, site_name: str, parent_port: int) -> None:
+def _patch_comm_config_for_k8s(kit_dir: Path, service_name: str, parent_port: int) -> None:
     comm_config_path = kit_dir / "local" / COMM_CONFIG_JSON
     comm_config = _load_or_default_comm_config(comm_config_path)
     resources = _internal_resources(comm_config)
     resources.update(
         {
-            "host": _k8s_parent_service_name(role, site_name),
+            "host": service_name,
             "port": parent_port,
             "connection_security": "clear",
         }
@@ -623,9 +627,9 @@ def _remove_start_scripts(kit_dir: Path, keep: set[str]) -> None:
             path.unlink()
 
 
-def _k8s_parent_service_name(role: str, site_name: str) -> str:
+def _k8s_parent_service_name(role: str, site_name: str, server_service_name: str | None = None) -> str:
     if role == ROLE_SERVER:
-        return "nvflare-server"
+        return server_service_name or K8S_SERVER_SERVICE_NAME
     return _k8s_service_name(site_name)
 
 
@@ -739,7 +743,7 @@ def _docker_parent_command(kit_info: KitInfo) -> str:
     return " \\\n    ".join(shlex.quote(arg) for arg in command)
 
 
-def _write_helm_chart(kit_info: KitInfo, config: dict[str, Any]) -> Path:
+def _write_helm_chart(kit_info: KitInfo, config: dict[str, Any], service_name: str) -> Path:
     parent = config.get("parent") or {}
     docker_image = parent["docker_image"]
     parent_port = parent.get("parent_port", 8102)
@@ -761,6 +765,7 @@ def _write_helm_chart(kit_info: KitInfo, config: dict[str, Any]) -> Path:
             workspace_pvc,
             workspace_mount_path,
             parent_python_path,
+            service_name,
             parent,
         )
         _copy_helm_templates("server", templates_dir)
@@ -773,6 +778,7 @@ def _write_helm_chart(kit_info: KitInfo, config: dict[str, Any]) -> Path:
             workspace_pvc,
             workspace_mount_path,
             parent_python_path,
+            service_name,
             parent,
         )
         _copy_helm_templates("client", templates_dir)
@@ -787,6 +793,7 @@ def _write_server_helm_chart(
     workspace_pvc: str,
     workspace_mount_path: str,
     parent_python_path: str,
+    service_name: str,
     parent: dict[str, Any],
 ) -> None:
     repo, tag = _split_image(docker_image)
@@ -807,7 +814,7 @@ def _write_server_helm_chart(
     admin_port = kit_info.admin_port if kit_info.admin_port != fed_learn_port else None
     values = {
         "name": kit_info.name,
-        "serviceName": _k8s_parent_service_name(kit_info.role, kit_info.name),
+        "serviceName": service_name,
         "image": {"repository": repo, "tag": tag, "pullPolicy": "IfNotPresent"},
         "serviceAccount": {"create": True, "annotations": {}, "automountServiceAccountToken": True},
         "podAnnotations": {},
@@ -853,6 +860,7 @@ def _write_client_helm_chart(
     workspace_pvc: str,
     workspace_mount_path: str,
     parent_python_path: str,
+    service_name: str,
     parent: dict[str, Any],
 ) -> None:
     repo, tag = _split_image(docker_image)
@@ -872,7 +880,7 @@ def _write_client_helm_chart(
     values = {
         "name": kit_info.name,
         "siteName": kit_info.name,
-        "serviceName": _k8s_parent_service_name(kit_info.role, kit_info.name),
+        "serviceName": service_name,
         "image": {"repository": repo, "tag": tag, "pullPolicy": "Always"},
         "serviceAccount": {"create": True, "annotations": {}, "automountServiceAccountToken": True},
         "podAnnotations": {},
@@ -999,6 +1007,20 @@ def _validate_k8s_namespace(data: dict[str, Any], key: str, where: str) -> None:
             "Use lower case alphanumeric characters or '-', start and end with an alphanumeric character, "
             f"and keep length <= {K8S_NAMESPACE_MAX_LENGTH}.",
         )
+
+
+def _optional_k8s_service_name(data: dict[str, Any], key: str, where: str) -> str | None:
+    service_name = _optional_str(data, key, where)
+    if service_name is None:
+        return None
+    if len(service_name) > K8S_SERVICE_NAME_MAX_LENGTH or not K8S_NAME_PATTERN.match(service_name):
+        _fail(
+            "INVALID_CONFIG",
+            f"{where}.{key} must be a valid Kubernetes Service name (DNS-1035 label): {service_name!r}.",
+            "Use lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric "
+            f"character, and keep length <= {K8S_SERVICE_NAME_MAX_LENGTH}.",
+        )
+    return service_name
 
 
 def _optional_str(data: dict[str, Any], key: str, where: str) -> str | None:

--- a/nvflare/tool/deploy/templates/helm/server/_helpers.tpl
+++ b/nvflare/tool/deploy/templates/helm/server/_helpers.tpl
@@ -5,6 +5,10 @@ NVFlare server chart helpers
 {{- default .Chart.Name .Values.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "nvflare-server.serviceName" -}}
+{{- default "nvflare-server" .Values.serviceName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "nvflare-server.labels" -}}
 app.kubernetes.io/name: {{ include "nvflare-server.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/nvflare/tool/deploy/templates/helm/server/service.yaml
+++ b/nvflare/tool/deploy/templates/helm/server/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nvflare-server
+  name: {{ include "nvflare-server.serviceName" . }}
   labels:
     {{- include "nvflare-server.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
@@ -30,7 +30,7 @@ spec:
       port: {{ .Values.adminPort }}
       targetPort: {{ .Values.adminPort }}
     {{- end }}
-    - name: nvflare-server
+    - name: parent-port
       protocol: TCP
       port: {{ .Values.parentPort }}
       targetPort: {{ .Values.parentPort }}

--- a/nvflare/tool/deploy/templates/helm/server/tcp-services.yaml
+++ b/nvflare/tool/deploy/templates/helm/server/tcp-services.yaml
@@ -5,8 +5,8 @@ metadata:
   name: nginx-ingress-microk8s-conf
   namespace: ingress
 data:
-  {{ .Values.fedLearnPort | quote }}: {{ printf "%s/nvflare-server:%v" .Release.Namespace .Values.fedLearnPort | quote }}
+  {{ .Values.fedLearnPort | quote }}: {{ printf "%s/%s:%v" .Release.Namespace (include "nvflare-server.serviceName" .) .Values.fedLearnPort | quote }}
   {{- if .Values.adminPort }}
-  {{ .Values.adminPort | quote }}: {{ printf "%s/nvflare-server:%v" .Release.Namespace .Values.adminPort | quote }}
+  {{ .Values.adminPort | quote }}: {{ printf "%s/%s:%v" .Release.Namespace (include "nvflare-server.serviceName" .) .Values.adminPort | quote }}
   {{- end }}
 {{- end }}

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -360,10 +360,48 @@ def test_prepare_k8s_server_exposes_admin_port_only_when_distinct(tmp_path, caps
     assert values["fedLearnPort"] == 8002
     assert values["adminPort"] == expected_admin_port
     assert values["command"] == ["/usr/local/bin/python3"]
+    assert values["serviceName"] == "nvflare-server"
+
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    assert comm_config["internal"]["resources"]["host"] == "nvflare-server"
 
     tcp_services = (output / "helm_chart" / "templates" / "server-tcp-services.yaml").read_text()
     assert ".Values.fedLearnPort" in tcp_services
     assert ".Values.adminPort" in tcp_services
+    assert 'include "nvflare-server.serviceName"' in tcp_services
+
+
+def test_prepare_k8s_server_uses_configured_service_name(tmp_path, capsys):
+    kit = _make_server_kit(tmp_path)
+    output = tmp_path / "server-k8s"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "k8s",
+            "parent": {"docker_image": "repo/nvflare:dev", "service_name": "team-flare-server"},
+        },
+    )
+    capsys.readouterr()
+
+    values = yaml.safe_load((output / "helm_chart" / "values.yaml").read_text())
+    assert values["serviceName"] == "team-flare-server"
+
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    assert comm_config["internal"]["resources"] == {
+        "host": "team-flare-server",
+        "port": 8102,
+        "connection_security": "clear",
+    }
+
+    service_template = (output / "helm_chart" / "templates" / "server-service.yaml").read_text()
+    assert 'name: {{ include "nvflare-server.serviceName" . }}' in service_template
+    assert "name: nvflare-server" not in service_template
+
+    tcp_services = (output / "helm_chart" / "templates" / "server-tcp-services.yaml").read_text()
+    assert 'include "nvflare-server.serviceName"' in tcp_services
+    assert "/nvflare-server:" not in tcp_services
 
 
 def test_prepare_k8s_server_uses_parent_python_path_for_chart_command(tmp_path, capsys):
@@ -576,6 +614,7 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
             "namespace": "flare",
             "parent": {
                 "docker_image": "repo/nvflare:dev",
+                "service_name": "server-in-shared-config",
                 "parent_port": 9102,
                 "workspace_pvc": "nvflws.team.example.com",
                 "workspace_mount_path": "/workspace",
@@ -670,6 +709,27 @@ def test_prepare_k8s_rejects_invalid_namespace(tmp_path, capsys, namespace):
     err = capsys.readouterr().err
     assert "INVALID_CONFIG" in err
     assert "k8s config.namespace" in err
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("service_name", ["MyService", "service_", "-bad", "bad-", "bad.name", "", "1bad", "a" * 64])
+def test_prepare_k8s_rejects_invalid_service_name(tmp_path, capsys, service_name):
+    kit = _make_server_kit(tmp_path)
+    output = tmp_path / "prepared"
+
+    with pytest.raises(SystemExit):
+        _run_prepare(
+            kit,
+            output,
+            {
+                "runtime": "k8s",
+                "parent": {"docker_image": "repo/nvflare:dev", "service_name": service_name},
+            },
+        )
+
+    err = capsys.readouterr().err
+    assert "INVALID_CONFIG" in err
+    assert "parent.service_name" in err
     assert not output.exists()
 
 
@@ -853,6 +913,10 @@ def test_prepare_rejects_admin_kit_without_writing_output(tmp_path, capsys):
         (
             {"runtime": "k8s", "parent": {"docker_image": "repo/nvflare:dev", "workspace_mount_path": []}},
             "parent.workspace_mount_path",
+        ),
+        (
+            {"runtime": "k8s", "parent": {"docker_image": "repo/nvflare:dev", "service_name": 7}},
+            "parent.service_name",
         ),
         (
             {"runtime": "k8s", "parent": {"docker_image": "repo/nvflare:dev", "python_path": 7}},

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -712,7 +712,7 @@ def test_prepare_k8s_rejects_invalid_namespace(tmp_path, capsys, namespace):
     assert not output.exists()
 
 
-@pytest.mark.parametrize("service_name", ["MyService", "service_", "-bad", "bad-", "bad.name", "", "1bad", "a" * 64])
+@pytest.mark.parametrize("service_name", ["MyService", "service_", "-bad", "bad-", "bad.name", "", "1bad", "a" * 64, 7])
 def test_prepare_k8s_rejects_invalid_service_name(tmp_path, capsys, service_name):
     kit = _make_server_kit(tmp_path)
     output = tmp_path / "prepared"
@@ -731,6 +731,26 @@ def test_prepare_k8s_rejects_invalid_service_name(tmp_path, capsys, service_name
     assert "INVALID_CONFIG" in err
     assert "parent.service_name" in err
     assert not output.exists()
+
+
+def test_prepare_k8s_client_ignores_server_service_name(tmp_path, capsys):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-k8s"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "k8s",
+            "parent": {"docker_image": "repo/nvflare:dev", "service_name": 7},
+        },
+    )
+    capsys.readouterr()
+
+    values = yaml.safe_load((output / "helm_chart" / "values.yaml").read_text())
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    assert values["serviceName"] == "site-1"
+    assert comm_config["internal"]["resources"]["host"] == "site-1"
 
 
 def test_prepare_warns_when_replacing_custom_resource_and_launcher_config(tmp_path, capsys):
@@ -913,10 +933,6 @@ def test_prepare_rejects_admin_kit_without_writing_output(tmp_path, capsys):
         (
             {"runtime": "k8s", "parent": {"docker_image": "repo/nvflare:dev", "workspace_mount_path": []}},
             "parent.workspace_mount_path",
-        ),
-        (
-            {"runtime": "k8s", "parent": {"docker_image": "repo/nvflare:dev", "service_name": 7}},
-            "parent.service_name",
         ),
         (
             {"runtime": "k8s", "parent": {"docker_image": "repo/nvflare:dev", "python_path": 7}},


### PR DESCRIPTION
### Description

Default is nvflare-server and the configuration is in k8s.yaml of server

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ x Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
