### PR TITLE
[2.8] Bind auth tokens to runtime origins

### DIFF
--- a/nvflare/apis/impl/wf_comm_server.py
+++ b/nvflare/apis/impl/wf_comm_server.py
@@ -439,12 +439,24 @@ class WFCommServer(FLComponent, WFCommSpec):
 
         task = client_task.task
         with task.cb_lock:
+            if client_task.client.name != client.name:
+                self.log_warning(
+                    fl_ctx,
+                    f"submission client mismatch for {task_name}:{task_id} - got {client.name} "
+                    f"but task is assigned to {client_task.client.name}",
+                )
+                return
+
             if task.name != task_name:
                 raise ValueError("client specified task name {} doesn't match {}".format(task_name, task.name))
 
             if task.completion_status is not None:
                 # the task is already finished - drop the result
                 self.log_info(fl_ctx, "task is already finished - submission dropped")
+                return
+
+            if client_task.result_received_time is not None:
+                self.log_info(fl_ctx, "client task result is already received - submission dropped")
                 return
 
             # do client task CB processing outside the lock

--- a/nvflare/fuel/sec/authn.py
+++ b/nvflare/fuel/sec/authn.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 from nvflare.apis.fl_constant import CellMessageAuthHeaderKey
 from nvflare.fuel.f3.cellnet.cell import Cell
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
+from nvflare.fuel.f3.cellnet.fqcn import FqcnInfo
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.utils.validation_utils import check_object_type, check_str
+
+
+def _is_server_fqcn(fqcn: str) -> bool:
+    return bool(fqcn) and FqcnInfo(fqcn).is_on_server
 
 
 def add_authentication_headers(msg: Message, client_name: str, auth_token, token_signature, ssid=None):
@@ -40,8 +46,21 @@ def add_authentication_headers(msg: Message, client_name: str, auth_token, token
     msg.set_header(CellMessageAuthHeaderKey.TOKEN_SIGNATURE, token_signature if token_signature else "NA")
 
 
+def add_server_path_reply_authentication_headers(
+    msg: Message, client_name: str, auth_token, token_signature, ssid=None
+):
+    origin = msg.get_header(MessageHeaderKey.ORIGIN)
+    destination = msg.get_header(MessageHeaderKey.DESTINATION)
+    to_cell = msg.get_header(MessageHeaderKey.TO_CELL)
+    # Auth headers are for the server trust boundary, not for peer clients. A peer reply routed through the server
+    # must authenticate to the server on the next hop, and the server strips these headers before forwarding to peer.
+    # Server-owned job/transfer cells also keep auth on replies from or to server paths.
+    if _is_server_fqcn(origin) or _is_server_fqcn(destination) or _is_server_fqcn(to_cell):
+        add_authentication_headers(msg, client_name, auth_token, token_signature, ssid)
+
+
 def set_add_auth_headers_filters(cell: Cell, client_name: str, auth_token: str, token_signature: str, ssid=None):
-    """Set filters for adding auth headers.
+    """Set filters for adding auth headers to outgoing requests and server-path replies.
 
     Args:
         cell: the cell to add the filters to.
@@ -67,7 +86,7 @@ def set_add_auth_headers_filters(cell: Cell, client_name: str, auth_token: str, 
     cell.core_cell.add_outgoing_reply_filter(
         channel="*",
         topic="*",
-        cb=add_authentication_headers,
+        cb=add_server_path_reply_authentication_headers,
         client_name=client_name,
         auth_token=auth_token,
         token_signature=token_signature,

--- a/nvflare/private/fed/authenticator.py
+++ b/nvflare/private/fed/authenticator.py
@@ -15,6 +15,7 @@ import socket
 import time
 import traceback
 import uuid
+from typing import Callable, Optional
 
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import FLCommunicationError
@@ -31,6 +32,8 @@ from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.private.defs import CellChannel, CellChannelTopic, CellMessageHeaderKeys, ClientRegMsgKey, new_cell_message
 from nvflare.private.fed.utils.identity_utils import IdentityAsserter, IdentityVerifier, TokenVerifier, load_crt_bytes
+
+MISSING_CLIENT_FQCN = ""
 
 
 def _get_client_ip():
@@ -299,12 +302,24 @@ class Authenticator:
         return token, token_signature, ssid, token_verifier
 
 
-def validate_auth_headers(message: CellMessage, token_verifier: TokenVerifier, logger):
+def _origin_matches_fqcn(origin: str, fqcn: str) -> bool:
+    return bool(origin) and bool(fqcn) and (origin == fqcn or FQCN.is_ancestor(fqcn, origin))
+
+
+def validate_auth_headers(
+    message: CellMessage,
+    token_verifier: TokenVerifier,
+    logger,
+    client_fqcn_resolver: Optional[Callable[[str, str], Optional[str]]] = None,
+):
     """Validate auth headers from messages that go through the server.
 
     Args:
         message: the message to validate
         token_verifier: the TokenVerifier to be used to verify the token and signature
+        client_fqcn_resolver: optional resolver used to bind a client token to its registered CellNet origin.
+            Return None only when the token/name cannot be resolved; return MISSING_CLIENT_FQCN for a registered
+            client with no stored origin so validation fails closed.
 
     Returns:
     """
@@ -364,6 +379,17 @@ def validate_auth_headers(message: CellMessage, token_verifier: TokenVerifier, l
         err = "invalid auth token signature"
         logger.error(f"{err_text}: {err}")
         return make_cellnet_reply(rc=F3ReturnCode.UNAUTHENTICATED, error=err)
+
+    if client_fqcn_resolver:
+        client_fqcn = client_fqcn_resolver(client_name, token)
+        if client_fqcn is not None and not _origin_matches_fqcn(origin, client_fqcn):
+            registered_origin = client_fqcn or "<missing>"
+            err = (
+                f"auth token for client {client_name} is bound to origin {registered_origin}, "
+                f"not message origin {origin}"
+            )
+            logger.error(f"{err_text}: {err}")
+            return make_cellnet_reply(rc=F3ReturnCode.UNAUTHENTICATED, error=err)
 
     # all good
     logger.debug(f"auth headers valid from {origin}: {topic=} {channel=}")

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -46,9 +46,9 @@ from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.core_cell import Message
 from nvflare.fuel.f3.cellnet.core_cell import make_reply as make_cellnet_reply
-from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey
+from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, MessageType
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
-from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo
 from nvflare.fuel.f3.cellnet.net_agent import NetAgent
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
@@ -66,7 +66,7 @@ from nvflare.private.defs import (
     JobFailureMsgKey,
     new_cell_message,
 )
-from nvflare.private.fed.authenticator import validate_auth_headers
+from nvflare.private.fed.authenticator import MISSING_CLIENT_FQCN, validate_auth_headers
 from nvflare.private.fed.server.cred_keeper import CredKeeper
 from nvflare.private.fed.server.server_command_agent import ServerCommandAgent
 from nvflare.private.fed.server.server_runner import ServerRunner
@@ -413,6 +413,24 @@ class FederatedServer(BaseServer):
         )
         self.logger.debug(f"added auth headers:  {origin=} {dest=} {channel=} {topic=}")
 
+    def _strip_peer_transit_reply_auth_headers(self, message: Message):
+        if message.get_header(MessageHeaderKey.MSG_TYPE) != MessageType.REPLY:
+            return
+
+        destination = message.get_header(MessageHeaderKey.DESTINATION)
+        if not destination or FqcnInfo(destination).is_on_server:
+            return
+
+        # Model: peer replies authenticate to the server if the server is the next hop, but peer clients must not
+        # receive another client's bearer material. This runs after successful server validation and before forwarding.
+        for key in [
+            CellMessageHeaderKeys.CLIENT_NAME,
+            CellMessageHeaderKeys.TOKEN,
+            CellMessageHeaderKeys.TOKEN_SIGNATURE,
+            CellMessageHeaderKeys.SSID,
+        ]:
+            message.remove_header(key)
+
     def _validate_auth_headers(self, message: Message):
         """Validate auth headers from messages that go through the server.
         Args:
@@ -425,11 +443,21 @@ class FederatedServer(BaseServer):
 
         token_verifier = TokenVerifier(id_asserter.cert)
 
-        return validate_auth_headers(
+        reply = validate_auth_headers(
             message=message,
             token_verifier=token_verifier,
             logger=self.logger,
+            client_fqcn_resolver=self._resolve_client_fqcn_for_auth,
         )
+        if not reply:
+            self._strip_peer_transit_reply_auth_headers(message)
+        return reply
+
+    def _resolve_client_fqcn_for_auth(self, client_name: str, token: str):
+        client = self.client_manager.clients.get(token)
+        if client and client.name == client_name:
+            return client.get_fqcn() or MISSING_CLIENT_FQCN
+        return None
 
     def sign_auth_token(self, client_name: str, token: str):
         id_asserter = self._get_id_asserter()
@@ -1065,7 +1093,6 @@ class FederatedServer(BaseServer):
                 cb=self._validate_auth_headers,
             )
 
-            # set filter to add additional auth headers
             core_cell.add_outgoing_reply_filter(channel="*", topic="*", cb=self._add_auth_headers)
             core_cell.add_outgoing_request_filter(channel="*", topic="*", cb=self._add_auth_headers)
 

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -1053,6 +1053,103 @@ class TestBasic(TestController):
         launch_thread.join()
         self.teardown_system(controller, fl_ctx)
 
+    def test_process_submission_rejects_unassigned_client_task_id(self):
+        controller, fl_ctx, clients = self.setup_system(num_of_clients=2)
+        assigned_client, other_client = clients
+        task = create_task("__test_task")
+        launch_thread = threading.Thread(
+            target=launch_task,
+            kwargs={
+                "controller": controller,
+                "task": task,
+                "method": "send",
+                "fl_ctx": fl_ctx,
+                "kwargs": {"targets": [assigned_client]},
+            },
+        )
+        get_ready(launch_thread)
+
+        task_name_out, client_task_id, _ = controller.communicator.process_task_request(assigned_client, fl_ctx)
+        assert task_name_out == "__test_task"
+
+        forged_result = Shareable()
+        forged_result["result"] = "forged"
+        controller.communicator.process_submission(
+            client=other_client,
+            task_name="__test_task",
+            task_id=client_task_id,
+            fl_ctx=fl_ctx,
+            result=forged_result,
+        )
+
+        client_task = task.last_client_task_map[assigned_client.name]
+        assert client_task.result is None
+        assert client_task.result_received_time is None
+
+        result = Shareable()
+        result["result"] = "result"
+        controller.communicator.process_submission(
+            client=assigned_client,
+            task_name="__test_task",
+            task_id=client_task_id,
+            fl_ctx=fl_ctx,
+            result=result,
+        )
+        assert client_task.result == result
+        launch_thread.join()
+        self.teardown_system(controller, fl_ctx)
+
+    def test_process_submission_drops_duplicate_result(self):
+        result_count = 0
+
+        def result_received_cb(client_task: ClientTask, **kwargs):
+            nonlocal result_count
+            result_count += 1
+
+        controller, fl_ctx, clients = self.setup_system()
+        client = clients[0]
+        task = create_task("__test_task", result_received_cb=result_received_cb)
+        launch_thread = threading.Thread(
+            target=launch_task,
+            kwargs={
+                "controller": controller,
+                "task": task,
+                "method": "send",
+                "fl_ctx": fl_ctx,
+                "kwargs": {"targets": [client]},
+            },
+        )
+        get_ready(launch_thread)
+
+        task_name_out, client_task_id, _ = controller.communicator.process_task_request(client, fl_ctx)
+        assert task_name_out == "__test_task"
+
+        result = Shareable()
+        result["result"] = "first"
+        controller.communicator.process_submission(
+            client=client,
+            task_name="__test_task",
+            task_id=client_task_id,
+            fl_ctx=fl_ctx,
+            result=result,
+        )
+
+        duplicate_result = Shareable()
+        duplicate_result["result"] = "duplicate"
+        controller.communicator.process_submission(
+            client=client,
+            task_name="__test_task",
+            task_id=client_task_id,
+            fl_ctx=fl_ctx,
+            result=duplicate_result,
+        )
+
+        client_task = task.last_client_task_map[client.name]
+        assert result_count == 1
+        assert client_task.result == result
+        launch_thread.join()
+        self.teardown_system(controller, fl_ctx)
+
     @pytest.mark.parametrize("method", TestController.ALL_APIS)
     @pytest.mark.parametrize("timeout", [1, 2])
     def test_task_timeout(self, method, timeout):

--- a/tests/unit_test/fuel/sec/__init__.py
+++ b/tests/unit_test/fuel/sec/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/fuel/sec/authn_test.py
+++ b/tests/unit_test/fuel/sec/authn_test.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from nvflare.apis.fl_constant import CellMessageAuthHeaderKey
+from nvflare.fuel.f3.cellnet.cell import Cell
+from nvflare.fuel.f3.cellnet.core_cell import CoreCell
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessageType, ReturnCode
+from nvflare.fuel.f3.endpoint import Endpoint
+from nvflare.fuel.f3.message import Message
+from nvflare.fuel.sec.authn import set_add_auth_headers_filters
+from nvflare.private.fed.server.fed_server import FederatedServer
+
+AUTH_HEADERS = [
+    CellMessageAuthHeaderKey.CLIENT_NAME,
+    CellMessageAuthHeaderKey.TOKEN,
+    CellMessageAuthHeaderKey.TOKEN_SIGNATURE,
+    CellMessageAuthHeaderKey.SSID,
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_core_cells():
+    original_cells = dict(CoreCell.ALL_CELLS)
+    CoreCell.ALL_CELLS.clear()
+    yield
+    for cell in CoreCell.ALL_CELLS.values():
+        cell.running = False
+    CoreCell.ALL_CELLS.clear()
+    CoreCell.ALL_CELLS.update(original_cells)
+
+
+def _make_running_cell(fqcn: str):
+    cell = Cell(fqcn=fqcn, root_url="tcp://127.0.0.1:8002", secure=False, credentials={})
+    cell.core_cell.running = True
+    return cell
+
+
+def _unique_fqcn(prefix: str):
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _auth_header_values(message):
+    return {k: message.get_header(k) for k in AUTH_HEADERS}
+
+
+class _TokenVerifier:
+    def verify(self, _client_name, _token, _signature):
+        return True
+
+
+class _Cert:
+    def public_key(self):
+        return None
+
+
+def _make_server_auth_filter(monkeypatch):
+    server_auth = FederatedServer.__new__(FederatedServer)
+    server_auth.logger = logging.getLogger(__name__)
+    server_auth._get_id_asserter = lambda: SimpleNamespace(cert=_Cert())
+    server_auth._resolve_client_fqcn_for_auth = lambda client_name, _token: client_name
+    monkeypatch.setattr("nvflare.private.fed.server.fed_server.TokenVerifier", lambda _cert: _TokenVerifier())
+    return server_auth._validate_auth_headers
+
+
+def _make_routed_message(
+    destination: str, msg_type: str, origin: str = "site-a", req_id: str = "req-1", with_auth: bool = False
+):
+    headers = {
+        MessageHeaderKey.CHANNEL: "peer",
+        MessageHeaderKey.TOPIC: "ping",
+        MessageHeaderKey.ORIGIN: origin,
+        MessageHeaderKey.DESTINATION: destination,
+        MessageHeaderKey.MSG_TYPE: msg_type,
+        MessageHeaderKey.REQ_ID: req_id,
+    }
+    if with_auth:
+        headers.update(
+            {
+                CellMessageAuthHeaderKey.CLIENT_NAME: origin,
+                CellMessageAuthHeaderKey.TOKEN: f"token-{origin}",
+                CellMessageAuthHeaderKey.TOKEN_SIGNATURE: f"sig-{origin}",
+            }
+        )
+    return Message(headers=headers)
+
+
+def test_auth_filter_does_not_add_client_credentials_to_peer_replies():
+    victim = _make_running_cell(_unique_fqcn("victim"))
+    peer = _make_running_cell(_unique_fqcn("peer"))
+    set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
+
+    victim.core_cell.register_request_cb("probe", "ping", lambda _request: Message(payload="pong"))
+
+    reply = peer.send_request("probe", "ping", victim.get_fqcn(), Message(payload="hello"), timeout=1.0)
+
+    assert reply.payload == "pong"
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: None,
+        CellMessageAuthHeaderKey.TOKEN: None,
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: None,
+        CellMessageAuthHeaderKey.SSID: None,
+    }
+
+
+def test_client_to_client_reply_routed_through_server_is_not_blocked_by_server_auth(monkeypatch):
+    server = _make_running_cell(f"server.{_unique_fqcn('auth_server')}")
+    site_a = _make_running_cell(_unique_fqcn("site_a"))
+    site_b = _make_running_cell(_unique_fqcn("site_b"))
+    server.core_cell.add_incoming_filter(channel="*", topic="*", cb=_make_server_auth_filter(monkeypatch))
+    set_add_auth_headers_filters(site_a, site_a.get_fqcn(), "tok-a", "sig-a")
+    set_add_auth_headers_filters(site_b, site_b.get_fqcn(), "tok-b", "sig-b")
+    site_b.core_cell.register_request_cb("peer", "ping", lambda _request: Message(payload="pong"))
+
+    original_find_ep = site_a.core_cell._try_find_ep
+
+    def _route_site_b_via_server(target_fqcn, for_msg):
+        if target_fqcn == site_b.get_fqcn():
+            return Endpoint(server.get_fqcn())
+        return original_find_ep(target_fqcn, for_msg)
+
+    monkeypatch.setattr(site_a.core_cell, "_try_find_ep", _route_site_b_via_server)
+
+    reply = site_a.send_request("peer", "ping", site_b.get_fqcn(), Message(payload="hello"), timeout=0.2)
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
+    assert reply.payload == "pong"
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: None,
+        CellMessageAuthHeaderKey.TOKEN: None,
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: None,
+        CellMessageAuthHeaderKey.SSID: None,
+    }
+
+
+def test_server_auth_filter_strips_validated_client_reply_transit_auth(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+    reply_msg = _make_routed_message("site-a", MessageType.REPLY, origin="site-b", with_auth=True)
+
+    assert auth_filter(reply_msg) is None
+    assert _auth_header_values(reply_msg) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: None,
+        CellMessageAuthHeaderKey.TOKEN: None,
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: None,
+        CellMessageAuthHeaderKey.SSID: None,
+    }
+
+
+def test_server_auth_filter_rejects_untracked_unauthenticated_client_reply_transit(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+
+    reply = auth_filter(_make_routed_message("site-a", MessageType.REPLY, origin="site-b"))
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_server_auth_filter_keeps_auth_on_validated_server_destination_reply(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+    reply_msg = _make_routed_message("server.job-1", MessageType.REPLY, origin="site-b", with_auth=True)
+
+    assert auth_filter(reply_msg) is None
+    assert _auth_header_values(reply_msg) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "site-b",
+        CellMessageAuthHeaderKey.TOKEN: "token-site-b",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-site-b",
+        CellMessageAuthHeaderKey.SSID: None,
+    }
+
+
+def test_server_auth_filter_still_rejects_unauthenticated_client_request_transit(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+
+    reply = auth_filter(_make_routed_message("site-b", MessageType.REQ))
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_server_auth_filter_still_rejects_unauthenticated_server_destination(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+
+    reply = auth_filter(_make_routed_message("server.job-1", MessageType.REPLY))
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_auth_filter_keeps_auth_on_outgoing_requests():
+    victim = _make_running_cell(_unique_fqcn("victim"))
+    peer = _make_running_cell(_unique_fqcn("peer"))
+    set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
+    peer.core_cell.register_request_cb("probe", "echo", lambda request: Message(payload=_auth_header_values(request)))
+
+    reply = victim.send_request("probe", "echo", peer.get_fqcn(), Message(payload="hello"), timeout=1.0)
+
+    assert reply.payload == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "victim",
+        CellMessageAuthHeaderKey.TOKEN: "tok-victim",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-victim",
+        CellMessageAuthHeaderKey.SSID: "ssid-victim",
+    }
+
+
+def test_auth_filter_keeps_client_reply_auth_on_server_path():
+    victim = _make_running_cell(_unique_fqcn("victim"))
+    server = _make_running_cell(f"server.{_unique_fqcn('authn')}")
+    set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
+    victim.core_cell.register_request_cb("probe", "ping", lambda _request: Message(payload="pong"))
+
+    reply = server.send_request("probe", "ping", victim.get_fqcn(), Message(payload="hello"), timeout=1.0)
+
+    assert reply.payload == "pong"
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "victim",
+        CellMessageAuthHeaderKey.TOKEN: "tok-victim",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-victim",
+        CellMessageAuthHeaderKey.SSID: "ssid-victim",
+    }
+
+
+def test_auth_filter_keeps_auth_on_replies_from_server_path_origin():
+    server = _make_running_cell(f"server.{_unique_fqcn('job')}")
+    client = _make_running_cell(_unique_fqcn("client"))
+    set_add_auth_headers_filters(server, "server-job", "tok-server", "sig-server", "ssid-server")
+
+    def _reply(_request):
+        return Message(payload="pong")
+
+    server.core_cell.register_request_cb("probe", "ping", _reply)
+
+    reply = client.send_request("probe", "ping", server.get_fqcn(), Message(payload="hello"), timeout=1.0)
+
+    assert reply.payload == "pong"
+    assert reply.get_header(MessageHeaderKey.ORIGIN) == server.get_fqcn()
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "server-job",
+        CellMessageAuthHeaderKey.TOKEN: "tok-server",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-server",
+        CellMessageAuthHeaderKey.SSID: "ssid-server",
+    }

--- a/tests/unit_test/private/fed/authenticator_test.py
+++ b/tests/unit_test/private/fed/authenticator_test.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+
+from nvflare.apis.fl_constant import ServerCommandNames
+from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.message import Message
+from nvflare.private.defs import CellMessageHeaderKeys
+from nvflare.private.fed.authenticator import MISSING_CLIENT_FQCN, validate_auth_headers
+
+
+class _TokenVerifier:
+    def verify(self, _client_name, _token, _signature):
+        return True
+
+
+def _make_message(origin):
+    return Message(
+        headers={
+            MessageHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
+            MessageHeaderKey.TOPIC: ServerCommandNames.GET_TASK,
+            MessageHeaderKey.ORIGIN: origin,
+            CellMessageHeaderKeys.CLIENT_NAME: "site-a",
+            CellMessageHeaderKeys.TOKEN: "token-a",
+            CellMessageHeaderKeys.TOKEN_SIGNATURE: "sig-a",
+        }
+    )
+
+
+def _validate(origin, client_fqcn_resolver):
+    return validate_auth_headers(
+        message=_make_message(origin),
+        token_verifier=_TokenVerifier(),
+        logger=logging.getLogger(__name__),
+        client_fqcn_resolver=client_fqcn_resolver,
+    )
+
+
+@pytest.mark.parametrize("origin", ["site-a", "site-a.job-1", "site-a.site-a-child.job-1"])
+def test_validate_auth_headers_accepts_token_from_registered_origin(origin):
+    # Job and hierarchical child cells under a registered site are still part of that site's trust boundary.
+    assert _validate(origin, lambda _client_name, _token: "site-a") is None
+
+
+def test_validate_auth_headers_rejects_token_from_different_origin():
+    reply = _validate("site-b", lambda _client_name, _token: "site-a")
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_rejects_registered_token_with_missing_origin_binding():
+    reply = _validate("site-a", lambda _client_name, _token: MISSING_CLIENT_FQCN)
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_keeps_compatibility_when_origin_cannot_be_resolved():
+    assert _validate("site-b", lambda _client_name, _token: None) is None

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -24,11 +24,22 @@ from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
 from nvflare.private.defs import CellMessageHeaderKeys, ClientRegMsgKey, JobFailureMsgKey, new_cell_message
+from nvflare.private.fed.authenticator import MISSING_CLIENT_FQCN
 from nvflare.private.fed.server.fed_server import FederatedServer
 from nvflare.private.fed.server.server_state import DEFAULT_SERVICE_SESSION_ID, HotState
 
 
 class TestFederatedServer:
+    def test_resolve_client_fqcn_for_auth_fails_closed_for_registered_client_with_missing_fqcn(self):
+        server = object.__new__(FederatedServer)
+        client = MagicMock()
+        client.name = "site-a"
+        client.get_fqcn.return_value = None
+        server.client_manager = MagicMock()
+        server.client_manager.clients = {"token-a": client}
+
+        assert server._resolve_client_fqcn_for_auth("site-a", "token-a") == MISSING_CLIENT_FQCN
+
     def test_hot_state_defaults_to_non_empty_session_id(self):
         assert HotState().ssid == DEFAULT_SERVICE_SESSION_ID
 


### PR DESCRIPTION
## Summary

- Backports #4597 to the 2.8 branch.
- Binds auth token validation to the runtime origin/FQCN so a token issued for one client cannot be replayed from a forged origin.
- Keeps the peer-reply transit model explicit: peer replies authenticate to the server hop, and the server strips bearer auth headers before forwarding the reply to another peer client.
- Rejects forged workflow result submissions from the wrong client and drops duplicate result submissions.

Cherry-picked from `7d36f93c9e4c55e08d54615bd97bb2b0bd5aa8f4`.
