### PR TITLE
Fix PT persistor bootstrap from empty checkpoint

### DIFF
--- a/nvflare/app_opt/pt/model_persistence_format_manager.py
+++ b/nvflare/app_opt/pt/model_persistence_format_manager.py
@@ -127,6 +127,10 @@ class PTModelPersistenceFormatManager(object):
                 persistence_dict[k] = v
         return persistence_dict
 
+    def _update_var_dict(self, learned_weights: dict):
+        for k, v in learned_weights.items():
+            self.var_dict[k] = v
+
     def update(self, ml: ModelLearnable):
         """Update the persistence data with the learned values.
 
@@ -156,8 +160,7 @@ class PTModelPersistenceFormatManager(object):
         # note that the original weights that are not learned are still kept!
         learned_weights = ml.get(ModelLearnableKey.WEIGHTS, {})
         if learned_weights and not self.var_dict:
-            for k, v in learned_weights.items():
-                self.var_dict[k] = v
+            self._update_var_dict(learned_weights)
             return
 
         report = inspect_model_params(self.var_dict, learned_weights)
@@ -171,8 +174,7 @@ class PTModelPersistenceFormatManager(object):
         if report.unexpected_keys:
             raise ValueError(report.format_unexpected_keys_error())
 
-        for k, v in learned_weights.items():
-            self.var_dict[k] = v
+        self._update_var_dict(learned_weights)
 
     @staticmethod
     def get_persist_model_format():

--- a/nvflare/app_opt/pt/model_persistence_format_manager.py
+++ b/nvflare/app_opt/pt/model_persistence_format_manager.py
@@ -137,13 +137,15 @@ class PTModelPersistenceFormatManager(object):
             ValueError: if the incoming learnable is invalid, if any matching key
                 has a shape mismatch, if a non-empty update has zero compatible
                 matches with the persisted checkpoint, or if the update would
-                introduce keys that do not already exist in the checkpoint.
+                introduce keys that do not already exist in the checkpoint after
+                the checkpoint schema has been initialized.
 
         Notes:
             The persisted checkpoint is the server schema for client updates.
             Partial updates are supported: learned weights only need to cover a
             subset of checkpoint keys that the client actually trained. New
-            client keys outside the server schema are rejected.
+            client keys outside the server schema are rejected. If no persisted
+            checkpoint exists yet, the first non-empty learnable initializes it.
         """
         err = validate_model_learnable(ml)
         if err:
@@ -153,6 +155,11 @@ class PTModelPersistenceFormatManager(object):
         # update with value of the model learnable
         # note that the original weights that are not learned are still kept!
         learned_weights = ml.get(ModelLearnableKey.WEIGHTS, {})
+        if learned_weights and not self.var_dict:
+            for k, v in learned_weights.items():
+                self.var_dict[k] = v
+            return
+
         report = inspect_model_params(self.var_dict, learned_weights)
 
         if report.shape_mismatches:

--- a/tests/unit_test/app_opt/pt/pt_param_validation_test.py
+++ b/tests/unit_test/app_opt/pt/pt_param_validation_test.py
@@ -109,6 +109,27 @@ def test_persistence_manager_accepts_partial_known_updates():
     assert torch.equal(manager.var_dict["fc.bias"], model.state_dict()["fc.bias"])
 
 
+def test_persistence_manager_bootstraps_empty_checkpoint_from_first_update():
+    """InitializeGlobalWeights can seed the server checkpoint from the first client model."""
+    model = SimpleNet()
+    manager = PTModelPersistenceFormatManager({})
+    weights = _clone_state_dict(model)
+
+    manager.update(make_model_learnable(weights=weights, meta_props={}))
+
+    assert set(manager.var_dict) == set(weights)
+    for key, value in weights.items():
+        assert torch.equal(manager.var_dict[key], value)
+
+    with pytest.raises(ValueError, match=r"None of the 1 incoming model parameter\(s\) matched"):
+        manager.update(
+            make_model_learnable(
+                weights={"model.fc.weight": torch.ones_like(model.state_dict()["fc.weight"])},
+                meta_props={},
+            )
+        )
+
+
 def test_persistence_manager_rejects_client_keys_outside_server_schema():
     """Client updates may not introduce keys outside the server checkpoint schema."""
     model = SimpleNet()

--- a/tests/unit_test/app_opt/pt/pt_param_validation_test.py
+++ b/tests/unit_test/app_opt/pt/pt_param_validation_test.py
@@ -130,6 +130,30 @@ def test_persistence_manager_bootstraps_empty_checkpoint_from_first_update():
         )
 
 
+def test_persistence_manager_bootstraps_empty_complex_checkpoint_from_first_update():
+    """Complex persistence dicts with an empty model section can be bootstrapped."""
+    model = SimpleNet()
+    data = {
+        PTModelPersistenceFormatManager.PERSISTENCE_KEY_MODEL: {},
+        PTModelPersistenceFormatManager.PERSISTENCE_KEY_TRAIN_CONF: {"train": {"model": "SimpleNet"}},
+        "extra_prop": "kept",
+    }
+    manager = PTModelPersistenceFormatManager(data)
+    weights = _clone_state_dict(model)
+
+    manager.update(make_model_learnable(weights=weights, meta_props={}))
+
+    assert manager.var_dict is data[PTModelPersistenceFormatManager.PERSISTENCE_KEY_MODEL]
+    assert set(manager.var_dict) == set(weights)
+    persistence_dict = manager.to_persistence_dict()
+    assert set(persistence_dict[PTModelPersistenceFormatManager.PERSISTENCE_KEY_MODEL]) == set(weights)
+    assert (
+        persistence_dict[PTModelPersistenceFormatManager.PERSISTENCE_KEY_TRAIN_CONF]
+        == data[PTModelPersistenceFormatManager.PERSISTENCE_KEY_TRAIN_CONF]
+    )
+    assert persistence_dict["extra_prop"] == "kept"
+
+
 def test_persistence_manager_rejects_client_keys_outside_server_schema():
     """Client updates may not introduce keys outside the server checkpoint schema."""
     model = SimpleNet()


### PR DESCRIPTION
## Summary

Cherry-pick PR #4602 to `main`.

Allow the PyTorch persistence format manager to seed an intentionally empty server checkpoint from the first non-empty incoming learnable. Strict state-dict validation remains unchanged after the checkpoint schema is initialized.

## Root Cause

The stricter PyTorch parameter validation validates incoming weights against the persisted checkpoint schema. When the server checkpoint is intentionally empty, every incoming key is treated as unexpected and the update raises before `InitializeGlobalWeights` can seed the server model from a client.

## Change

- Add a narrow empty-checkpoint bootstrap path in `PTModelPersistenceFormatManager.update()`.
- Reuse a helper for copying incoming learned weights into `var_dict`.
- Add unit coverage for empty-checkpoint bootstrap, complex persistence dict bootstrap, and later unknown-key rejection.

## Validation

- `black nvflare/app_opt/pt/model_persistence_format_manager.py tests/unit_test/app_opt/pt/pt_param_validation_test.py`
- `isort nvflare/app_opt/pt/model_persistence_format_manager.py tests/unit_test/app_opt/pt/pt_param_validation_test.py`
- `python3 -m pytest tests/unit_test/app_opt/pt/pt_param_validation_test.py -q`
- `git diff --check upstream/main...HEAD`