### PR TITLE
[codex] Test pre-merge unit tests with uv installs

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -52,13 +52,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --no-cache-dir -e .[dev]
-          python3 -m pip install --no-cache-dir --no-deps "flwr>=1.16,<1.26"
+          uv pip install --system -e ".[dev]"
+          uv pip install --system --no-deps "flwr>=1.16,<1.26"
       - name: Run unit test
-        run: ./runtest.sh --numprocesses=16 -u
+        run: ./runtest.sh --numprocesses=auto -u
 
   wheel-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -58,7 +58,7 @@ jobs:
           python3 -m pip install --no-cache-dir -e .[dev]
           python3 -m pip install --no-cache-dir --no-deps "flwr>=1.16,<1.26"
       - name: Run unit test
-        run: ./runtest.sh --numprocesses=auto -u
+        run: ./runtest.sh --numprocesses=16 -u
 
   wheel-build:
     runs-on: ${{ matrix.os }}

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -84,9 +84,14 @@ class FakeClock:
     def advance(self, seconds):
         with self._lock:
             self._now += seconds
-        # Allow the controller's monitor/wait threads (sleeping ~1 ms each iteration under
-        # the patched sleep) to observe the new time and run check_tasks.
-        _real_sleep(0.05)
+
+    def wait_until(self, predicate, timeout=5.0, interval=0.001):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            _real_sleep(interval)
+        return predicate()
 
 
 def create_task(name, data=None, timeout=0, before_task_sent_cb=None, result_received_cb=None, task_done_cb=None):
@@ -1234,6 +1239,9 @@ class TestBasic(TestController):
 
         assert controller.get_num_standing_tasks() == 1
         self.clock.advance(timeout + 1)
+        assert self.clock.wait_until(
+            lambda: controller.get_num_standing_tasks() == 0 and task.completion_status == TaskCompletionStatus.TIMEOUT
+        ), "controller did not process task timeout"
         assert controller.get_num_standing_tasks() == 0
         assert task.completion_status == TaskCompletionStatus.TIMEOUT
         launch_thread.join()
@@ -2026,6 +2034,11 @@ class TestRelayBehavior(TestController):
         get_ready(launch_thread)
         assert controller.get_num_standing_tasks() == 1
         self.clock.advance(time_before_first_request)
+        if dynamic_targets and not expected_to_get_task and time_before_first_request > task_assignment_timeout:
+            assert self.clock.wait_until(
+                lambda: controller.get_num_standing_tasks() == 0
+                and task.completion_status == TaskCompletionStatus.TIMEOUT
+            ), "controller did not process dynamic target assignment timeout"
 
         task_name, task_id, data = controller.communicator.process_task_request(client=request_client, fl_ctx=fl_ctx)
         client_get_a_task = True if task_name == "__test_task" else False
@@ -2268,6 +2281,10 @@ class TestRelayBehavior(TestController):
             self.clock.advance(task_result_timeout + 1)
 
         if send_order == SendOrder.SEQUENTIAL:
+            assert self.clock.wait_until(
+                lambda: controller.get_num_standing_tasks() == 0
+                and task.completion_status == TaskCompletionStatus.TIMEOUT
+            ), "controller did not process sequential task timeout"
             assert task.completion_status == TaskCompletionStatus.TIMEOUT
             assert controller.get_num_standing_tasks() == 0
         elif send_order == SendOrder.ANY:

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -19,6 +19,7 @@ import re
 import tempfile
 import threading
 import time
+import types
 import uuid
 import weakref
 from itertools import permutations
@@ -26,6 +27,12 @@ from unittest.mock import Mock
 
 import pytest
 
+import nvflare.apis.controller_spec as _controller_spec_mod
+import nvflare.apis.impl.any_relay_manager as _any_relay_manager_mod
+import nvflare.apis.impl.bcast_manager as _bcast_manager_mod
+import nvflare.apis.impl.send_manager as _send_manager_mod
+import nvflare.apis.impl.seq_relay_manager as _seq_relay_manager_mod
+import nvflare.apis.impl.wf_comm_server as _wf_comm_server_mod
 from nvflare.apis.client import Client
 from nvflare.apis.controller_spec import ClientTask, SendOrder, Task, TaskCompletionStatus
 from nvflare.apis.fl_context import FLContext, FLContextManager
@@ -37,6 +44,49 @@ from nvflare.apis.signal import Signal
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
+
+_real_sleep = time.sleep
+
+# Production modules whose `time` reference is replaced with a FakeClock-backed namespace.
+# Each module imports `time` at the top, so we patch the module-level attribute.
+_TIME_PATCHED_MODULES = (
+    _controller_spec_mod,
+    _wf_comm_server_mod,
+    _send_manager_mod,
+    _seq_relay_manager_mod,
+    _any_relay_manager_mod,
+    _bcast_manager_mod,
+)
+
+
+class FakeClock:
+    """Controllable clock that replaces real time in the controller runtime modules.
+
+    Production code reads time via the patched ``time.time``; this returns the fake "now".
+    Production code's ``time.sleep`` calls are converted to brief real yields (1 ms) that
+    do NOT advance the fake clock — so monitor threads still spin cooperatively but cannot
+    trigger timeouts on their own. Tests advance the fake clock explicitly via ``advance()``.
+    """
+
+    def __init__(self, start: float = 1_000_000.0):
+        self._now = start
+        self._lock = threading.Lock()
+
+    def time(self):
+        with self._lock:
+            return self._now
+
+    def sleep(self, seconds):
+        # Yield to other threads but do not advance the fake clock.
+        # Tests control time progression via `advance()`.
+        _real_sleep(0.001)
+
+    def advance(self, seconds):
+        with self._lock:
+            self._now += seconds
+        # Allow the controller's monitor/wait threads (sleeping ~1 ms each iteration under
+        # the patched sleep) to observe the new time and run check_tasks.
+        _real_sleep(0.05)
 
 
 def create_task(name, data=None, timeout=0, before_task_sent_cb=None, result_received_cb=None, task_done_cb=None):
@@ -187,6 +237,17 @@ class TestController:
     # Non-broadcast methods - for tests where per-client data modification is needed
     # (broadcast uses _broadcast_data which is copied before callbacks run)
     NON_BROADCAST = ["send", "send_and_wait", "relay", "relay_and_wait"]
+
+    @pytest.fixture(autouse=True)
+    def _install_fake_clock(self, monkeypatch):
+        # Replace the `time` module reference inside the controller runtime modules
+        # with a FakeClock-backed namespace. Tests advance time via `self.clock.advance()`
+        # instead of blocking on `time.sleep(...)`.
+        clock = FakeClock()
+        fake_time = types.SimpleNamespace(time=clock.time, sleep=clock.sleep)
+        for mod in _TIME_PATCHED_MODULES:
+            monkeypatch.setattr(mod, "time", fake_time)
+        self.clock = clock
 
     @staticmethod
     def setup_system(num_of_clients=1):
@@ -341,7 +402,7 @@ class TestTaskManagement(TestController):
         task_name_out, client_task_id, data = controller.communicator.process_task_request(client, fl_ctx)
         controller.cancel_task(task)
         assert task.completion_status == TaskCompletionStatus.CANCELLED
-        time.sleep(1)
+        time.sleep(0.1)
         print(controller.communicator._tasks)
 
         # in here we make up client results:
@@ -745,7 +806,7 @@ class TestCallback(TestController):
                         client=client, task_name="__test_task", task_id=client_task_id, fl_ctx=fl_ctx, result=result
                     )
         if task_complete == "timeout":
-            time.sleep(timeout)
+            self.clock.advance(timeout)
             controller.communicator.check_tasks()
             assert task.completion_status == TaskCompletionStatus.TIMEOUT
         elif task_complete == "cancel":
@@ -934,7 +995,9 @@ class TestCallback(TestController):
         self.teardown_system(controller, ctx)
 
     def test_broadcast_schedule_task_in_result_received_cb(self):
-        num_of_clients = 100
+        # 20 clients still exercises the recursive scheduling (20 outer + 20*20 inner tasks)
+        # without the quadratic blowup of the original 100 (which dominated the suite at ~13s).
+        num_of_clients = 20
         controller, ctx, clients = self.setup_system(num_of_clients=num_of_clients)
 
         # callback needs to have args name client_task and fl_ctx
@@ -1170,7 +1233,7 @@ class TestBasic(TestController):
         get_ready(launch_thread)
 
         assert controller.get_num_standing_tasks() == 1
-        time.sleep(timeout + 1)
+        self.clock.advance(timeout + 1)
         assert controller.get_num_standing_tasks() == 0
         assert task.completion_status == TaskCompletionStatus.TIMEOUT
         launch_thread.join()
@@ -1916,7 +1979,7 @@ class TestRelayBehavior(TestController):
         get_ready(launch_thread)
         assert controller.get_num_standing_tasks() == 1
 
-        time.sleep(task_assignment_timeout + 1)
+        self.clock.advance(task_assignment_timeout + 1)
 
         for client in clients[1:]:
             task_name_out, client_task_id, data = controller.communicator.process_task_request(client, fl_ctx)
@@ -1962,7 +2025,7 @@ class TestRelayBehavior(TestController):
         )
         get_ready(launch_thread)
         assert controller.get_num_standing_tasks() == 1
-        time.sleep(time_before_first_request)
+        self.clock.advance(time_before_first_request)
 
         task_name, task_id, data = controller.communicator.process_task_request(client=request_client, fl_ctx=fl_ctx)
         client_get_a_task = True if task_name == "__test_task" else False
@@ -2055,7 +2118,7 @@ class TestRelayBehavior(TestController):
         get_ready(launch_thread)
         assert controller.get_num_standing_tasks() == 1
 
-        time.sleep(time_before_first_request)
+        self.clock.advance(time_before_first_request)
 
         for request_order, expected_client_to_get_task in zip(request_orders, expected_clients_to_get_task):
             task_name_out = ""
@@ -2133,14 +2196,14 @@ class TestRelayBehavior(TestController):
         assert_task_data_valid(data, input_data, method)
         assert task.last_client_task_map[clients[0].name].task_send_count == 1
 
-        time.sleep(task_result_timeout + 1)
+        self.clock.advance(task_result_timeout + 1)
 
         # same client ask should get the same task
         task_name_out, client_task_id, data = controller.communicator.process_task_request(clients[0], fl_ctx)
         assert client_task_id == old_client_task_id
         assert task.last_client_task_map[clients[0].name].task_send_count == 2
 
-        time.sleep(task_result_timeout + 1)
+        self.clock.advance(task_result_timeout + 1)
 
         # second client ask should get a task since task_result_timeout passed
         task_name_out, client_task_id_1, data = controller.communicator.process_task_request(clients[1], fl_ctx)
@@ -2202,7 +2265,7 @@ class TestRelayBehavior(TestController):
             assert_task_data_valid(data, input_data, method)
             assert task.last_client_task_map[client.name].task_send_count == 1
 
-            time.sleep(task_result_timeout + 1)
+            self.clock.advance(task_result_timeout + 1)
 
         if send_order == SendOrder.SEQUENTIAL:
             assert task.completion_status == TaskCompletionStatus.TIMEOUT
@@ -2379,7 +2442,7 @@ class TestSendBehavior(TestController):
         get_ready(launch_thread)
         assert controller.get_num_standing_tasks() == 1
 
-        time.sleep(time_before_first_request)
+        self.clock.advance(time_before_first_request)
 
         for client in request_order:
             data = None

--- a/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
@@ -16,7 +16,6 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_context import FLContext, FLContextManager
 from nvflare.app_common.resource_managers.gpu_resource_manager import GPUResourceManager
 

--- a/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from unittest.mock import patch
 
 import pytest
@@ -311,20 +310,22 @@ class TestGPUResourceManager:
         assert result == {0: 8, 1: 8, 2: 8, 3: 8}
 
     def test_check_and_timeout(self):
-        timeout = 5
         engine = MockEngine()
-        gpu_resource_manager = GPUResourceManager(num_of_gpus=4, mem_per_gpu_in_GiB=16, expiration_period=timeout)
+        gpu_resource_manager = GPUResourceManager(num_of_gpus=4, mem_per_gpu_in_GiB=16, expiration_period=1)
         resource_requirement = _gen_requirement(1, 8)
 
         with engine.new_context() as fl_ctx:
-            gpu_resource_manager.handle_event(event_type=EventType.SYSTEM_START, fl_ctx=fl_ctx)
             check_result, token = gpu_resource_manager.check_resources(
                 resource_requirement=resource_requirement, fl_ctx=fl_ctx
             )
             assert {0: 8} == gpu_resource_manager.reserved_resources[token][0]
-        time.sleep(timeout + 1)
-        with engine.new_context() as fl_ctx:
-            gpu_resource_manager.handle_event(event_type=EventType.SYSTEM_END, fl_ctx=fl_ctx)
+
+        with patch(
+            "nvflare.app_common.resource_managers.auto_clean_resource_manager.time.sleep",
+            side_effect=lambda _: gpu_resource_manager._stop_event.set(),
+        ):
+            gpu_resource_manager._check_expired()
+
         assert gpu_resource_manager.reserved_resources == {}
         for r, v in gpu_resource_manager.resources.items():
             assert v.memory == 16

--- a/tests/unit_test/app_common/resource_managers/list_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/list_resource_manager_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from collections import deque
+from unittest.mock import patch
 
 import pytest
 
@@ -167,21 +167,23 @@ class TestListResourceManager:
         assert result == {"gpu": ["gpu_0", "gpu_1", "gpu_2", "gpu_3"]}
 
     def test_check_and_timeout(self):
-        timeout = 5
         engine = MockEngine()
         list_resource_manager = ListResourceManager(
-            resources={"gpu": [f"gpu_{i}" for i in range(4)]}, expiration_period=timeout
+            resources={"gpu": [f"gpu_{i}" for i in range(4)]}, expiration_period=1
         )
         resource_requirement = {"gpu": 1}
 
         with engine.new_context() as fl_ctx:
-            list_resource_manager.handle_event(event_type=EventType.SYSTEM_START, fl_ctx=fl_ctx)
             check_result, token = list_resource_manager.check_resources(
                 resource_requirement=resource_requirement, fl_ctx=fl_ctx
             )
             assert {"gpu": ["gpu_0"]} == list_resource_manager.reserved_resources[token][0]
-        time.sleep(timeout + 1)
-        with engine.new_context() as fl_ctx:
-            list_resource_manager.handle_event(event_type=EventType.SYSTEM_END, fl_ctx=fl_ctx)
+
+        with patch(
+            "nvflare.app_common.resource_managers.auto_clean_resource_manager.time.sleep",
+            side_effect=lambda _: list_resource_manager._stop_event.set(),
+        ):
+            list_resource_manager._check_expired()
+
         assert list_resource_manager.reserved_resources == {}
         assert list_resource_manager.resources == {"gpu": deque(["gpu_0", "gpu_1", "gpu_2", "gpu_3"])}

--- a/tests/unit_test/app_common/resource_managers/list_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/list_resource_manager_test.py
@@ -17,7 +17,6 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_context import FLContext, FLContextManager
 from nvflare.app_common.resource_managers.list_resource_manager import ListResourceManager
 

--- a/tests/unit_test/app_common/workflow/statistics_controller_test.py
+++ b/tests/unit_test/app_common/workflow/statistics_controller_test.py
@@ -60,25 +60,25 @@ class TestStatisticsController:
             else:
                 assert mc.config == {"*": {"bins": 10}, "Age": {"bins": 5, "range": [0, 120]}}
 
-    def test_wait_for_all_results(self):
-
-        # waiting for 1 more client
+    def test_wait_for_all_results_stops_after_missing_results_arrive(self):
         client_statistics = {
             "count": {"site-1": {}},
-            "mean": {"site-2": {}},
-            "sum": {"site-3": {}},
-            "stddev": {"site-4": {}},
         }
 
-        with patch("nvflare.app_common.workflows.statistics_controller.time.sleep") as mock_sleep:
+        def receive_remaining_results(seconds):
+            assert seconds == 0.1
+            client_statistics["count"].update({"site-2": {}, "site-3": {}})
+
+        with patch(
+            "nvflare.app_common.workflows.statistics_controller.time.sleep", side_effect=receive_remaining_results
+        ) as mock_sleep:
             result = StatisticsController._wait_for_all_results(
                 self.stats_controller.logger, 0.5, 3, client_statistics, 0.1
             )
 
         assert result is True
-        # Four statistics, each with a 0.5 second timeout and 0.1 second sleep interval.
-        assert mock_sleep.call_count == 20
-        mock_sleep.assert_called_with(0.1)
+        assert set(client_statistics["count"]) == {"site-1", "site-2", "site-3"}
+        mock_sleep.assert_called_once_with(0.1)
 
     def test_prepare_input(self):
         xs = self.stats_controller._prepare_inputs(SC.STATS_1st_STATISTICS)

--- a/tests/unit_test/app_common/workflow/statistics_controller_test.py
+++ b/tests/unit_test/app_common/workflow/statistics_controller_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from unittest.mock import patch
+
 from nvflare.app_common.abstract.statistics_spec import StatisticConfig
 from nvflare.app_common.app_constant import StatisticsConstants as SC
 from nvflare.app_common.workflows.statistics_controller import StatisticsController
@@ -67,14 +69,16 @@ class TestStatisticsController:
             "sum": {"site-3": {}},
             "stddev": {"site-4": {}},
         }
-        import time
 
-        t0 = time.time()
-        StatisticsController._wait_for_all_results(self.stats_controller.logger, 0.5, 3, client_statistics, 0.1)
-        t = time.time()
-        second_spent = t - t0
-        # for 4 statistic, each have 0.5 second timeout
-        assert second_spent > 0.5 * 4
+        with patch("nvflare.app_common.workflows.statistics_controller.time.sleep") as mock_sleep:
+            result = StatisticsController._wait_for_all_results(
+                self.stats_controller.logger, 0.5, 3, client_statistics, 0.1
+            )
+
+        assert result is True
+        # Four statistics, each with a 0.5 second timeout and 0.1 second sleep interval.
+        assert mock_sleep.call_count == 20
+        mock_sleep.assert_called_with(0.1)
 
     def test_prepare_input(self):
         xs = self.stats_controller._prepare_inputs(SC.STATS_1st_STATISTICS)

--- a/tests/unit_test/fuel/f3/streaming/download_service_test.py
+++ b/tests/unit_test/fuel/f3/streaming/download_service_test.py
@@ -313,11 +313,10 @@ class TestDownloadService:
         # Check if transaction is finished
         with DownloadService._tx_lock:
             tx = DownloadService._tx_table.get(tx_id)
-            if tx:
-                assert isinstance(tx, _Transaction)
-                if tx.is_finished():
-                    tx.transaction_done(TransactionDoneStatus.FINISHED)
-                    DownloadService._delete_tx(tx)
+            assert isinstance(tx, _Transaction)
+            assert tx.is_finished()
+            tx.transaction_done(TransactionDoneStatus.FINISHED)
+            DownloadService._delete_tx(tx)
 
         # Verify transaction_done was called
         assert len(obj.transaction_done_calls) == 1

--- a/tests/unit_test/fuel/f3/streaming/download_service_test.py
+++ b/tests/unit_test/fuel/f3/streaming/download_service_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from typing import Any, Tuple
 from unittest.mock import Mock, patch
 
@@ -250,34 +249,49 @@ class TestDownloadService:
         assert transaction_id == tx_id
         assert status == TransactionDoneStatus.DELETED
 
-    def test_transaction_done_on_timeout(self, cell):
+    def test_transaction_done_on_timeout(self):
         """Test that transaction times out after inactivity."""
-        # Use very short timeout for testing
-        tx_id = DownloadService.new_transaction(cell=cell, timeout=0.1, num_receivers=2)
-
-        data_chunks = [b"chunk1"]
-        obj = MockDownloadable(data_chunks)
-        DownloadService.add_object(tx_id, obj)
-
-        # The monitor thread runs every 5 seconds; simulate an expired clock and trigger its timeout path manually.
+        from nvflare.fuel.f3.streaming import download_service as download_service_module
         from nvflare.fuel.f3.streaming.download_service import _Transaction
 
-        with DownloadService._tx_lock:
-            tx = DownloadService._tx_table.get(tx_id)
-            if tx:
-                assert isinstance(tx, _Transaction)
-                expired_time = tx.last_active_time + tx.timeout + 1.0
-                with patch("time.time", return_value=expired_time):
-                    assert time.time() - tx.last_active_time > tx.timeout
-                    # Simulate what monitor does
-                    tx.transaction_done(TransactionDoneStatus.TIMEOUT)
-                    DownloadService._delete_tx(tx)
+        class MonitorIterationDone(Exception):
+            pass
 
-        # Verify transaction_done was called with TIMEOUT status
-        assert len(obj.transaction_done_calls) == 1
-        transaction_id, status = obj.transaction_done_calls[0]
-        assert transaction_id == tx_id
-        assert status == TransactionDoneStatus.TIMEOUT
+        def run_monitor_once(now):
+            with (
+                patch.object(download_service_module.time, "time", return_value=now),
+                patch.object(download_service_module.time, "sleep", side_effect=MonitorIterationDone),
+            ):
+                with pytest.raises(MonitorIterationDone):
+                    DownloadService._monitor_tx()
+
+        fake_start_time = 1_000_000_000_000.0
+        timeout = 1.0
+        data_chunks = [b"chunk1"]
+        obj = MockDownloadable(data_chunks)
+        with patch.object(download_service_module.time, "time", return_value=fake_start_time):
+            tx = _Transaction(timeout=timeout, num_receivers=2)
+        ref = tx.add_object(obj)
+
+        assert isinstance(tx, _Transaction)
+        with DownloadService._tx_lock:
+            DownloadService._tx_table[tx.tid] = tx
+            DownloadService._ref_table[ref.rid] = ref
+
+        try:
+            run_monitor_once(fake_start_time + timeout)
+            assert obj.transaction_done_calls == []
+            assert tx.tid in DownloadService._tx_table
+            assert ref.rid in DownloadService._ref_table
+
+            run_monitor_once(fake_start_time + timeout + 0.001)
+            assert obj.transaction_done_calls == [(tx.tid, TransactionDoneStatus.TIMEOUT)]
+            assert tx.tid not in DownloadService._tx_table
+            assert ref.rid not in DownloadService._ref_table
+        finally:
+            with DownloadService._tx_lock:
+                DownloadService._tx_table.pop(tx.tid, None)
+                DownloadService._ref_table.pop(ref.rid, None)
 
     def test_transaction_done_on_completion(self, cell):
         """Test that transaction_done is called when all objects downloaded to all receivers."""

--- a/tests/unit_test/fuel/f3/streaming/download_service_test.py
+++ b/tests/unit_test/fuel/f3/streaming/download_service_test.py
@@ -14,7 +14,7 @@
 
 import time
 from typing import Any, Tuple
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -259,21 +259,19 @@ class TestDownloadService:
         obj = MockDownloadable(data_chunks)
         DownloadService.add_object(tx_id, obj)
 
-        # Wait for timeout (with buffer)
-        time.sleep(0.5)
-
-        # Wait for monitor thread to process (it runs every 5 seconds, but processes expired ones)
-        # Since we can't wait 5 seconds, we'll manually trigger timeout check
+        # The monitor thread runs every 5 seconds; simulate an expired clock and trigger its timeout path manually.
         from nvflare.fuel.f3.streaming.download_service import _Transaction
 
         with DownloadService._tx_lock:
             tx = DownloadService._tx_table.get(tx_id)
             if tx:
                 assert isinstance(tx, _Transaction)
-                assert time.time() - tx.last_active_time > tx.timeout
-                # Simulate what monitor does
-                tx.transaction_done(TransactionDoneStatus.TIMEOUT)
-                DownloadService._delete_tx(tx)
+                expired_time = tx.last_active_time + tx.timeout + 1.0
+                with patch("time.time", return_value=expired_time):
+                    assert time.time() - tx.last_active_time > tx.timeout
+                    # Simulate what monitor does
+                    tx.transaction_done(TransactionDoneStatus.TIMEOUT)
+                    DownloadService._delete_tx(tx)
 
         # Verify transaction_done was called with TIMEOUT status
         assert len(obj.transaction_done_calls) == 1


### PR DESCRIPTION
Experimental PR based on NVIDIA/NVFlare#4608.

This keeps the pre-merge unit-test job on:

```bash
./runtest.sh --numprocesses=auto -u
```

and switches only the unit-test dependency installation from `pip` to `uv`:

```bash
uv pip install --system -e ".[dev]"
uv pip install --system --no-deps "flwr>=1.16,<1.26"
```

The goal is to trigger GitHub Actions and compare the unit-test matrix duration against PR #4608's current `pip` install path without changing pytest worker count.

Context:
- The earlier fixed `--numprocesses=16` experiment was slower on Actions and introduced unit-test failures.
- This version restores `--numprocesses=auto` and isolates package installation as the remaining variable.

Validation:
- `git diff --check`
- GitHub Actions pre-merge run 25888359292 passed

Observed timing:
- `auto + pip` on PR #4608 run 25885609611: unit-test jobs averaged 293.4s; max 331s.
- `auto + uv` on this PR run 25888359292: unit-test jobs averaged 206.6s; max 215s.
- The earlier fixed `--numprocesses=16` run averaged 338.3s and had 3 unit-test failures.
