### PR TITLE
Use uv for pre-merge unit test installs

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -52,11 +52,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.14"
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --no-cache-dir -e .[dev]
-          python3 -m pip install --no-cache-dir --no-deps "flwr>=1.16,<1.26"
+          uv pip install --system -e ".[dev]"
+          uv pip install --system --no-deps "flwr>=1.16,<1.26"
       - name: Run unit test
         run: ./runtest.sh --numprocesses=auto -u
 


### PR DESCRIPTION
## What changed

Switch the pre-merge `unit-tests` dependency installation from `pip` to `uv` 
The `wheel-build` job is intentionally unchanged so this PR only changes the unit-test install path.

## Why

The unit-test runtime improvements from NVIDIA/NVFlare#4608 made dependency installation a larger share of the pre-merge job duration. A draft CI experiment showed that switching this job to `uv` materially reduces the GitHub Actions unit-test matrix time without changing test parallelism.

## Benchmark evidence

Observed on GitHub Actions:

- PR #4608 `auto + pip` run 25885609611: unit-test jobs averaged 293.4s; max 331s.
- Draft PR #4611 `auto + uv` run 25888359292: unit-test jobs averaged 206.6s; max 215s.

