### PR TITLE
[2.8] Fix aborted job status publication race

### DIFF
--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -528,7 +528,9 @@ class FederatedServer(BaseServer):
         with self.engine.new_context() as fl_ctx:
             job = job_manager.get_job(job_id, fl_ctx)
             if job.meta.get(JobMetaKey.STATUS) == RunStatus.RUNNING:
-                job_manager.set_status(job_id, RunStatus.FINISHED_ABORTED, fl_ctx)
+                error = self.engine.job_runner.mark_run_aborted(job_id, fl_ctx)
+                if error:
+                    self.logger.warning(error)
 
     def _create_server_engine(self, args, snapshot_persistor):
         return ServerEngine(

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import threading
 import time
+from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 from nvflare.apis.client import Client
@@ -46,6 +47,12 @@ from nvflare.private.fed.server.server_state import HotState
 from nvflare.private.fed.utils.app_deployer import AppDeployer
 from nvflare.private.fed.utils.fed_utils import extract_participants, require_signed_jobs, set_message_security_data
 from nvflare.security.logging import secure_format_exception
+
+
+@dataclass
+class _FinishedJobState:
+    status: RunStatus
+    workspace_saved: bool = False
 
 
 def _send_to_clients(admin_server, client_sites: List[str], engine, message, timeout=None, optional=False):
@@ -91,7 +98,7 @@ class JobRunner(FLComponent):
         self.ask_to_stop = False
         self.scheduler = None
         self.running_jobs = {}
-        self._finished_job_statuses = {}
+        self._finished_job_states = {}
         self.lock = threading.Lock()
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
@@ -406,26 +413,38 @@ class JobRunner(FLComponent):
                     if job:
                         with engine.new_context() as completion_ctx:
                             completion_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, job.job_id)
-                            status = self._finished_job_statuses.get(job.job_id)
-                            if status is None:
+                            finished_state = self._finished_job_states.get(job.job_id)
+                            if finished_state is None:
                                 if job.run_aborted:
                                     status = RunStatus.FINISHED_ABORTED
                                 else:
                                     status = self._get_finished_job_status(engine, job, completion_ctx)
-                                self._finished_job_statuses[job.job_id] = status
+                                finished_state = _FinishedJobState(status=status)
+                                self._finished_job_states[job.job_id] = finished_state
+                            status = finished_state.status
                             # Publish terminal status only after artifacts are ready for download.
+                            if not finished_state.workspace_saved:
+                                try:
+                                    self._save_workspace(completion_ctx)
+                                    with self.lock:
+                                        finished_state.workspace_saved = True
+                                except Exception as e:
+                                    self.log_exception(
+                                        completion_ctx,
+                                        f"Failed to save workspace for finished job ({job.job_id}): {secure_format_exception(e)}",
+                                    )
+                                    continue
                             try:
-                                self._save_workspace(completion_ctx)
+                                job_manager.set_status(job.job_id, status, completion_ctx)
                             except Exception as e:
                                 self.log_exception(
                                     completion_ctx,
-                                    f"Failed to save workspace for finished job ({job.job_id}): {secure_format_exception(e)}",
+                                    f"Failed to publish finished status for job ({job.job_id}): {secure_format_exception(e)}",
                                 )
                                 continue
-                            job_manager.set_status(job.job_id, status, completion_ctx)
                             with self.lock:
                                 del self.running_jobs[job_id]
-                                self._finished_job_statuses.pop(job_id, None)
+                                self._finished_job_states.pop(job_id, None)
                             if status == RunStatus.FINISHED_ABORTED:
                                 self.fire_event(EventType.JOB_ABORTED, completion_ctx)
                             self.fire_event(EventType.JOB_COMPLETED, completion_ctx)
@@ -668,7 +687,9 @@ class JobRunner(FLComponent):
 
     def stop_run(self, job_id: str, fl_ctx: FLContext):
         self._stop_run(job_id, fl_ctx)
+        return self.mark_run_aborted(job_id, fl_ctx)
 
+    def mark_run_aborted(self, job_id: str, fl_ctx: FLContext):
         job = self.running_jobs.get(job_id)
         if job:
             self.log_info(fl_ctx, f"Stop the job run: {job_id}")

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nvflare.apis.fl_constant import RunProcessKey
+from nvflare.apis.job_def import JobMetaKey, RunStatus
 from nvflare.apis.job_launcher_spec import JobReturnCode
 from nvflare.apis.shareable import Shareable
 from nvflare.fuel.common.exit_codes import ProcessExitCode
@@ -71,6 +72,24 @@ class TestFederatedServer:
 
             result = server.client_heartbeat(request)
             assert result.get_header(CellMessageHeaderKeys.ABORT_JOBS, []) == expected
+
+    def test_set_job_aborted_marks_runner_without_publishing_status(self):
+        server = object.__new__(FederatedServer)
+        server.logger = MagicMock()
+        server.engine = MagicMock()
+
+        job_manager = MagicMock()
+        server.engine.get_component.return_value = job_manager
+        job_manager.get_job.return_value = MagicMock(meta={JobMetaKey.STATUS: RunStatus.RUNNING})
+
+        fl_ctx = MagicMock()
+        server.engine.new_context.return_value = nullcontext(fl_ctx)
+        server.engine.job_runner.mark_run_aborted.return_value = ""
+
+        server._set_job_aborted("job-1")
+
+        server.engine.job_runner.mark_run_aborted.assert_called_once_with("job-1", fl_ctx)
+        job_manager.set_status.assert_not_called()
 
     def test_sync_client_jobs_legacy_reports_missing_immediately(self):
         with (

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -578,7 +578,57 @@ def test_job_complete_process_retries_save_without_recomputing_finished_status()
     ]
     engine.remove_exception_process.assert_called_once_with("job-1")
     assert "job-1" not in runner.running_jobs
-    assert "job-1" not in runner._finished_job_statuses
+    assert "job-1" not in runner._finished_job_states
+
+
+def test_job_complete_process_retries_status_publish_without_resaving_workspace():
+    runner = JobRunner(workspace_root="/tmp")
+    runner.fire_event = MagicMock()
+    runner.log_debug = MagicMock()
+    runner.log_exception = MagicMock()
+    runner._save_workspace = MagicMock()
+    runner.ask_to_stop = False
+
+    engine = MagicMock()
+    engine.run_processes = {}
+    engine.exception_run_processes = {}
+
+    job_manager = MagicMock()
+    job_manager.set_status.side_effect = [RuntimeError("storage unavailable"), None]
+    engine.get_component.return_value = job_manager
+
+    first_ctx = MagicMock()
+    second_ctx = MagicMock()
+    engine.new_context.side_effect = [nullcontext(first_ctx), nullcontext(second_ctx)]
+
+    job = MagicMock()
+    job.job_id = "job-1"
+    job.run_aborted = True
+    runner.running_jobs = {"job-1": job}
+
+    sleep_count = 0
+
+    def _stop_after_second_pass(_):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count == 2:
+            runner.ask_to_stop = True
+
+    with patch("nvflare.private.fed.server.job_runner.time.sleep", side_effect=_stop_after_second_pass):
+        runner._job_complete_process(engine)
+
+    runner._save_workspace.assert_called_once_with(first_ctx)
+    assert job_manager.set_status.call_args_list == [
+        call("job-1", RunStatus.FINISHED_ABORTED, first_ctx),
+        call("job-1", RunStatus.FINISHED_ABORTED, second_ctx),
+    ]
+    runner.log_exception.assert_called_once()
+    assert runner.fire_event.call_args_list == [
+        call(EventType.JOB_ABORTED, second_ctx),
+        call(EventType.JOB_COMPLETED, second_ctx),
+    ]
+    assert "job-1" not in runner.running_jobs
+    assert "job-1" not in runner._finished_job_states
 
 
 @patch("nvflare.private.fed.server.job_runner.check_client_replies")


### PR DESCRIPTION
## Summary
- Route heartbeat-driven aborted jobs through `JobRunner` instead of publishing `FINISHED_ABORTED` directly from `FederatedServer`.
- Retry final status publication without re-saving the workspace after workspace save has already succeeded.
- Add focused unit coverage for both paths.

## Why
The previous fixes moved most terminal-status publication behind workspace save, but `_set_job_aborted()` could still publish `FINISHED_ABORTED` directly. That leaves a race where a job appears finished before its artifacts are ready for download.

This keeps the final completion sequence centralized in `JobRunner`: compute final status, save workspace, publish terminal status, then fire completion events.

