### PR TITLE
[2.8] Fix empty job component listing

### DIFF
--- a/nvflare/fuel/hci/proto.py
+++ b/nvflare/fuel/hci/proto.py
@@ -94,7 +94,7 @@ class MetaStatusValue(object):
     JOB_NOT_RUNNING = "job_not_running"
     CLIENTS_RUNNING = "clients_running"
     NO_JOBS = "no_jobs"
-    NO_JOB_COMPONENTS = "no_job_compoents"
+    NO_JOB_COMPONENTS = "no_job_components"
     NO_REPLY = "no_reply"
     NO_CLIENTS = "no_clients"
 

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -1024,10 +1024,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                         "", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_COMPONENTS: filtered_data})
                     )
                 else:
-                    conn.append_error(
-                        "No additional job components found.",
-                        meta=make_meta(MetaStatusValue.NO_JOB_COMPONENTS, "No additional job components found."),
-                    )
+                    conn.append_success("", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_COMPONENTS: []}))
             else:
                 conn.append_error(
                     f"job {job_id} does not exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)

--- a/tests/unit_test/fuel/flare_api/session_new_methods_test.py
+++ b/tests/unit_test/fuel/flare_api/session_new_methods_test.py
@@ -82,6 +82,18 @@ class TestListJobs:
             session.list_jobs(unknown_filter="x")
 
 
+class TestListJobComponents:
+    def test_returns_empty_list(self):
+        session = _make_session()
+        with patch.object(session, "_do_command", return_value=_ok_meta_result({MetaKey.JOB_COMPONENTS: []})):
+            result = session.list_job_components("job-1")
+        assert result == []
+
+
+def test_no_job_components_status_is_spelled_correctly():
+    assert MetaStatusValue.NO_JOB_COMPONENTS == "no_job_components"
+
+
 class TestGetJobMeta:
     def test_sends_get_job_meta_command(self):
         session = _make_session()

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -1056,6 +1056,20 @@ def test_list_jobs_by_submit_token_returns_deleted_status(monkeypatch):
     assert conn.tables == []
 
 
+def test_list_job_components_returns_empty_list_when_no_additional_components(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    engine = _FakeListEngine([])
+    engine.job_def_manager.list_components = MagicMock(return_value=["workspace", "meta", "scheduled", "data"])
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().list_job_components(conn, ["list_job", "job-1"])
+
+    assert conn.errors == []
+    assert conn.successes == [
+        ("", {MetaKey.STATUS: MetaStatusValue.OK, MetaKey.INFO: "", MetaKey.JOB_COMPONENTS: []})
+    ]
+
+
 def test_clone_job_preserves_source_study(monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", object)
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)


### PR DESCRIPTION
## Summary

- Return an OK response with an empty `job_components` list when a job has no additional components.
- Fix the `NO_JOB_COMPONENTS` protocol status spelling from `no_job_compoents` to `no_job_components`.
- Add focused unit coverage for the empty-list server response and the corrected status literal.

## Root Cause

`list_job_components` treated the normal empty result case as a `NO_JOB_COMPONENTS` command error. The public `Session.list_job_components()` API is documented and typed as returning `List[str]`, so callers saw `InternalError` instead of `[]` for jobs without extra components.
