### PR TITLE
CPU-only torch backend for github pre-merge workflow

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: Run style checks
-        run: ./runtest.sh -s
+        run: ./runtest.sh --torch-backend=cpu -s
 
   unit-tests:
     runs-on: ${{ matrix.os }}
@@ -58,10 +58,10 @@ jobs:
           version: "0.11.14"
       - name: Install dependencies
         run: |
-          uv pip install --system -e ".[dev]"
+          ./runtest.sh --torch-backend=cpu -p
           uv pip install --system --no-deps "flwr>=1.16,<1.26"
       - name: Run unit test
-        run: ./runtest.sh --numprocesses=auto -u
+        run: ./runtest.sh --skip-install --numprocesses=auto -u
 
   wheel-build:
     runs-on: ${{ matrix.os }}
@@ -82,8 +82,8 @@ jobs:
           version: "0.11.14"
       - name: Install dependencies
         run: |
-          uv pip install --system -e ".[dev]"
+          ./runtest.sh --torch-backend=cpu -p
           uv pip install --system --no-deps "flwr>=1.16,<1.26"
-          uv pip install --system build twine torch torchvision
+          uv pip install --system build twine
       - name: Run wheel build
         run: python3 -m build --wheel

--- a/ci/install_cpu_torch.sh
+++ b/ci/install_cpu_torch.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+packages=("$@")
+if [[ ${#packages[@]} -eq 0 ]]; then
+    packages=(torch torchvision)
+fi
+
+if command -v uv >/dev/null 2>&1; then
+    echo "Downloading and installing CPU-only PyTorch packages with uv: ${packages[*]}"
+    uv_system_flag=()
+    if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+        uv_system_flag=(--system)
+    fi
+    UV_TORCH_BACKEND=cpu uv pip install "${uv_system_flag[@]}" --torch-backend=cpu "${packages[@]}"
+else
+    echo "Downloading and installing CPU-only PyTorch packages with pip: ${packages[*]}"
+    python3 -m pip install "${packages[@]}" --index-url https://download.pytorch.org/whl/cpu
+fi
+
+python3 - <<'PY'
+import importlib
+
+torch = importlib.import_module("torch")
+if torch.version.cuda is not None or "+cu" in torch.__version__:
+    raise SystemExit(f"Expected CPU-only PyTorch, got torch {torch.__version__} with CUDA {torch.version.cuda}")
+
+print(f"Installed CPU-only torch {torch.__version__}")
+
+try:
+    torchvision = importlib.import_module("torchvision")
+except ModuleNotFoundError:
+    torchvision = None
+
+if torchvision is not None:
+    print(f"Installed torchvision {torchvision.__version__}")
+PY

--- a/runtest.sh
+++ b/runtest.sh
@@ -30,17 +30,24 @@ function install_deps {
     local extras
     if [[ $(uname) == "Darwin" ]]; then
       extras=".[dev_mac]"
+    elif [[ "${torch_backend}" == "cpu" ]]; then
+      extras=".[dev_cpu]"
     else
       extras=".[dev]"
     fi
 
+    if [[ "${torch_backend}" == "cpu" && $(uname) != "Darwin" ]]; then
+      export UV_TORCH_BACKEND=cpu
+      bash "${WORK_DIR}/ci/install_cpu_torch.sh"
+    fi
+
     if command -v uv >/dev/null 2>&1; then
       echo "Installing dependencies with uv..."
-      if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-        uv pip install -e "${extras}"
-      else
-        uv pip install --system -e "${extras}"
+      local uv_system_flag=""
+      if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+        uv_system_flag="--system"
       fi
+      uv pip install ${uv_system_flag} -e "${extras}"
     else
       echo "Installing dependencies with pip..."
       python3 -m pip install -e "${extras}"
@@ -288,6 +295,8 @@ function help() {
     echo "    -p | --dependencies           : only install dependencies"
     echo "    -c | --coverage               : used with -u command, turn on coverage flag,  It has no effect without -u "
     echo "         --numprocesses=<N|auto>  : number of parallel pytest workers (default: 8)"
+    echo "         --torch-backend=cpu      : install CPU-only PyTorch wheels on Linux"
+    echo "         --skip-install           : skip dependency installation before running the selected command"
     echo "    -v | --verbose                : verbose output (adds -v to pytest)"
     echo "    -d | --dry-run                : set dry run flag, print out command"
     echo "         --clean                  : clean py and other artifacts generated"
@@ -310,6 +319,8 @@ unit_test_report=false
 dry_run_flag=false
 pytest_numprocesses=8
 verbose_flag=false
+torch_backend=""
+skip_install=false
 
 # notebook test defaults
 nb_timeout=1200
@@ -396,6 +407,18 @@ do
             pytest_numprocesses="${key#*=}"
         ;;
 
+        --torch-backend=*)
+            torch_backend="${key#*=}"
+            if [[ "${torch_backend}" != "cpu" ]]; then
+                echo "${red}Error: --torch-backend currently supports only 'cpu'. Got: '${torch_backend}'${noColor}"
+                exit 1
+            fi
+        ;;
+
+        --skip-install)
+            skip_install=true
+        ;;
+
         -v|--verbose)
             verbose_flag=true
         ;;
@@ -448,7 +471,11 @@ echo "                 "
 if [[ $dry_run_flag = "true" ]]; then
     dry_run "$cmd"
 else
-    install_deps
+    if [[ "${skip_install}" != "true" ]]; then
+        install_deps
+    else
+        echo "Skipping dependency installation"
+    fi
     eval "$cmd"
 fi
 echo "Done"

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,31 @@ dev =
 dev_mac =
     %(doc)s
     %(test_mac)s
+# CPU-only variant of `app_opt`: omits torch (install separately from
+# https://download.pytorch.org/whl/cpu first) and bitsandbytes (GPU-only).
+# torchvision is included so the extra is self-sufficient for tests; install
+# the CPU torch (and a matching torchvision) from the CPU index beforehand to
+# avoid pip pulling the GPU torchvision wheel from PyPI as a dependency.
+app_opt_cpu =
+    %(HE)s
+    %(PSI)s
+    %(SKLEARN)s
+    %(TRACKING)s
+    %(MONITORING)s
+    %(K8S)s
+    pytorch_lightning
+    torchvision
+    xgboost
+all_cpu =
+    %(core_opt)s
+    %(app_opt_cpu)s
+test_cpu =
+    %(all_cpu)s
+    %(test_support)s
+    fastdigest==0.4.0; python_version < "3.14"
+dev_cpu =
+    %(doc)s
+    %(test_cpu)s
 
 [options.entry_points]
 console_scripts =

--- a/tests/unit_test/app_opt/quantization/test_dequantizer.py
+++ b/tests/unit_test/app_opt/quantization/test_dequantizer.py
@@ -15,13 +15,16 @@
 import unittest
 
 import numpy as np
+import pytest
 import torch
 
-from nvflare.apis.dxo import DXO, DataKind, MetaKey
-from nvflare.apis.fl_context import FLContext
-from nvflare.apis.shareable import Shareable
-from nvflare.app_opt.pt.quantization.dequantizer import ModelDequantizer
-from nvflare.app_opt.pt.quantization.quantizer import ModelQuantizer
+pytest.importorskip("bitsandbytes")
+
+from nvflare.apis.dxo import DXO, DataKind, MetaKey  # noqa: E402
+from nvflare.apis.fl_context import FLContext  # noqa: E402
+from nvflare.apis.shareable import Shareable  # noqa: E402
+from nvflare.app_opt.pt.quantization.dequantizer import ModelDequantizer  # noqa: E402
+from nvflare.app_opt.pt.quantization.quantizer import ModelQuantizer  # noqa: E402
 
 
 class TestModelDequantizer(unittest.TestCase):

--- a/tests/unit_test/app_opt/quantization/test_quantizer.py
+++ b/tests/unit_test/app_opt/quantization/test_quantizer.py
@@ -15,12 +15,15 @@
 import unittest
 
 import numpy as np
+import pytest
 import torch
 
-from nvflare.apis.dxo import DXO, DataKind, MetaKey
-from nvflare.apis.fl_context import FLContext
-from nvflare.apis.shareable import Shareable
-from nvflare.app_opt.pt.quantization.quantizer import ModelQuantizer
+pytest.importorskip("bitsandbytes")
+
+from nvflare.apis.dxo import DXO, DataKind, MetaKey  # noqa: E402
+from nvflare.apis.fl_context import FLContext  # noqa: E402
+from nvflare.apis.shareable import Shareable  # noqa: E402
+from nvflare.app_opt.pt.quantization.quantizer import ModelQuantizer  # noqa: E402
 
 
 class TestModelQuantizer(unittest.TestCase):


### PR DESCRIPTION
### Description

Since github workers don't have GPU, the torch backend can be cpu-only.  This PR switches the pre-merge workflow to install cpu-only pytorch and torchvision.  It should speed up the dependency installation process.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
