### PR TITLE
[2.8] Make K8s server service name configurable

### DIFF
--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -96,6 +96,8 @@ Example ``k8s.yaml``:
 The runtime config controls site-level Kubernetes settings:
 
 * ``namespace`` is where the parent pod and dynamically launched job pods run.
+* ``server_service_name`` sets the FL server Kubernetes Service name. It defaults
+  to ``nvflare-server``.
 * ``parent`` values are rendered into the Helm chart. They set the parent image,
   Python executable, workspace PVC, parent service port, parent pod resources,
   and optional parent pod security context. ``parent.python_path`` controls the

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -143,6 +143,7 @@ Top-level keys:
 - ``runtime``: required, must be ``k8s``.
 - ``namespace``: Kubernetes namespace for parent and job pods. Defaults to
   ``default``.
+- ``server_service_name``: optional Kubernetes Service name for the FL server.
 - ``parent``: required mapping for the generated parent Helm chart.
 - ``job_launcher``: optional mapping for dynamically launched job pods.
 

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -1024,6 +1024,7 @@ def _validate_k8s_service_name(data: dict[str, Any], key: str, where: str) -> No
     service_name = data.get(key)
     if not isinstance(service_name, str) or not service_name:
         _fail("INVALID_CONFIG", f"{where}.{key} must be a non-empty string.", "Fix the runtime config.")
+        return
     if len(service_name) > K8S_SERVICE_NAME_MAX_LENGTH or not K8S_NAME_PATTERN.fullmatch(service_name):
         _fail(
             "INVALID_CONFIG",

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -1024,7 +1024,6 @@ def _validate_k8s_service_name(data: dict[str, Any], key: str, where: str) -> No
     service_name = data.get(key)
     if not isinstance(service_name, str) or not service_name:
         _fail("INVALID_CONFIG", f"{where}.{key} must be a non-empty string.", "Fix the runtime config.")
-        return
     if len(service_name) > K8S_SERVICE_NAME_MAX_LENGTH or not K8S_NAME_PATTERN.fullmatch(service_name):
         _fail(
             "INVALID_CONFIG",

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -112,6 +112,7 @@ K8S_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 K8S_NAMESPACE_MAX_LENGTH = 63
 K8S_SERVICE_NAME_MAX_LENGTH = 63
 HELM_RELEASE_NAME_MAX_LENGTH = 53
+DEFAULT_K8S_SERVER_SERVICE_NAME = "nvflare-server"
 
 
 @dataclass
@@ -267,6 +268,7 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
     job_launcher = config.get("job_launcher") or {}
     parent_port = parent.get("parent_port", 8102)
     workspace_mount_path = parent.get("workspace_mount_path", WORKSPACE_MOUNT_PATH)
+    server_service_name = config.get("server_service_name", DEFAULT_K8S_SERVER_SERVICE_NAME)
 
     launcher_path = K8S_SERVER_LAUNCHER if kit_info.role == ROLE_SERVER else K8S_CLIENT_LAUNCHER
     launcher_args = {
@@ -282,7 +284,7 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
         launcher_args["security_context"] = job_launcher["job_pod_security_context"]
 
     _patch_resources(kit_info.kit_dir, "k8s_launcher", launcher_path, launcher_args)
-    _patch_comm_config_for_k8s(kit_info.kit_dir, kit_info.role, kit_info.name, parent_port)
+    _patch_comm_config_for_k8s(kit_info.kit_dir, kit_info.role, kit_info.name, parent_port, server_service_name)
     _ensure_study_data_template(kit_info.kit_dir)
     if kit_info.role == ROLE_SERVER:
         _relocate_server_storage_to_workspace(kit_info.kit_dir, workspace_mount_path)
@@ -345,7 +347,11 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
                     "Remove keys controlled by DockerJobLauncher.",
                 )
     elif runtime == RUNTIME_K8S:
-        _validate_allowed_keys(config, {"runtime", "namespace", "parent", "job_launcher"}, "k8s config")
+        _validate_allowed_keys(
+            config,
+            {"runtime", "namespace", "server_service_name", "parent", "job_launcher"},
+            "k8s config",
+        )
         parent = _mapping(config.get("parent"), "parent")
         job_launcher = _mapping(config.get("job_launcher", {}), "job_launcher")
         _validate_allowed_keys(
@@ -369,6 +375,8 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
         _required_str(parent, "docker_image", "parent")
         if "namespace" in config:
             _validate_k8s_namespace(config, "namespace", "k8s config")
+        if "server_service_name" in config:
+            _validate_k8s_service_name(config, "server_service_name", "k8s config")
         _optional_int(parent, "parent_port", "parent")
         _optional_str(parent, "workspace_pvc", "parent")
         _optional_str(parent, "workspace_mount_path", "parent")
@@ -569,13 +577,19 @@ def _patch_comm_config_for_docker(kit_dir: Path) -> None:
     _write_json(comm_config_path, comm_config)
 
 
-def _patch_comm_config_for_k8s(kit_dir: Path, role: str, site_name: str, parent_port: int) -> None:
+def _patch_comm_config_for_k8s(
+    kit_dir: Path,
+    role: str,
+    site_name: str,
+    parent_port: int,
+    server_service_name: str = DEFAULT_K8S_SERVER_SERVICE_NAME,
+) -> None:
     comm_config_path = kit_dir / "local" / COMM_CONFIG_JSON
     comm_config = _load_or_default_comm_config(comm_config_path)
     resources = _internal_resources(comm_config)
     resources.update(
         {
-            "host": _k8s_parent_service_name(role, site_name),
+            "host": _k8s_parent_service_name(role, site_name, server_service_name),
             "port": parent_port,
             "connection_security": "clear",
         }
@@ -623,9 +637,11 @@ def _remove_start_scripts(kit_dir: Path, keep: set[str]) -> None:
             path.unlink()
 
 
-def _k8s_parent_service_name(role: str, site_name: str) -> str:
+def _k8s_parent_service_name(
+    role: str, site_name: str, server_service_name: str = DEFAULT_K8S_SERVER_SERVICE_NAME
+) -> str:
     if role == ROLE_SERVER:
-        return "nvflare-server"
+        return server_service_name
     return _k8s_service_name(site_name)
 
 
@@ -746,6 +762,7 @@ def _write_helm_chart(kit_info: KitInfo, config: dict[str, Any]) -> Path:
     workspace_pvc = parent.get("workspace_pvc", "nvflws")
     workspace_mount_path = parent.get("workspace_mount_path", WORKSPACE_MOUNT_PATH)
     parent_python_path = parent.get("python_path") or K8S_PARENT_PYTHON_PATH
+    server_service_name = config.get("server_service_name", DEFAULT_K8S_SERVER_SERVICE_NAME)
     chart_dir = kit_info.kit_dir / HELM_CHART_DIR
     if chart_dir.exists():
         shutil.rmtree(chart_dir)
@@ -762,6 +779,7 @@ def _write_helm_chart(kit_info: KitInfo, config: dict[str, Any]) -> Path:
             workspace_mount_path,
             parent_python_path,
             parent,
+            server_service_name,
         )
         _copy_helm_templates("server", templates_dir)
     else:
@@ -788,6 +806,7 @@ def _write_server_helm_chart(
     workspace_mount_path: str,
     parent_python_path: str,
     parent: dict[str, Any],
+    server_service_name: str,
 ) -> None:
     repo, tag = _split_image(docker_image)
     _write_yaml(
@@ -807,7 +826,7 @@ def _write_server_helm_chart(
     admin_port = kit_info.admin_port if kit_info.admin_port != fed_learn_port else None
     values = {
         "name": kit_info.name,
-        "serviceName": _k8s_parent_service_name(kit_info.role, kit_info.name),
+        "serviceName": server_service_name,
         "image": {"repository": repo, "tag": tag, "pullPolicy": "IfNotPresent"},
         "serviceAccount": {"create": True, "annotations": {}, "automountServiceAccountToken": True},
         "podAnnotations": {},
@@ -998,6 +1017,19 @@ def _validate_k8s_namespace(data: dict[str, Any], key: str, where: str) -> None:
             f"{where}.{key} must be a valid Kubernetes namespace (DNS-1123 label): {namespace!r}.",
             "Use lower case alphanumeric characters or '-', start and end with an alphanumeric character, "
             f"and keep length <= {K8S_NAMESPACE_MAX_LENGTH}.",
+        )
+
+
+def _validate_k8s_service_name(data: dict[str, Any], key: str, where: str) -> None:
+    service_name = data.get(key)
+    if not isinstance(service_name, str) or not service_name:
+        _fail("INVALID_CONFIG", f"{where}.{key} must be a non-empty string.", "Fix the runtime config.")
+    if len(service_name) > K8S_SERVICE_NAME_MAX_LENGTH or not K8S_NAME_PATTERN.fullmatch(service_name):
+        _fail(
+            "INVALID_CONFIG",
+            f"{where}.{key} must be a valid Kubernetes Service name (DNS-1035 label): {service_name!r}.",
+            "Use lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, "
+            f"and keep length <= {K8S_SERVICE_NAME_MAX_LENGTH}.",
         )
 
 

--- a/nvflare/tool/deploy/templates/helm/server/service.yaml
+++ b/nvflare/tool/deploy/templates/helm/server/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nvflare-server
+  name: {{ .Values.serviceName }}
   labels:
     {{- include "nvflare-server.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/nvflare/tool/deploy/templates/helm/server/tcp-services.yaml
+++ b/nvflare/tool/deploy/templates/helm/server/tcp-services.yaml
@@ -5,8 +5,8 @@ metadata:
   name: nginx-ingress-microk8s-conf
   namespace: ingress
 data:
-  {{ .Values.fedLearnPort | quote }}: {{ printf "%s/nvflare-server:%v" .Release.Namespace .Values.fedLearnPort | quote }}
+  {{ .Values.fedLearnPort | quote }}: {{ printf "%s/%s:%v" .Release.Namespace .Values.serviceName .Values.fedLearnPort | quote }}
   {{- if .Values.adminPort }}
-  {{ .Values.adminPort | quote }}: {{ printf "%s/nvflare-server:%v" .Release.Namespace .Values.adminPort | quote }}
+  {{ .Values.adminPort | quote }}: {{ printf "%s/%s:%v" .Release.Namespace .Values.serviceName .Values.adminPort | quote }}
   {{- end }}
 {{- end }}

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -366,6 +366,34 @@ def test_prepare_k8s_server_exposes_admin_port_only_when_distinct(tmp_path, caps
     assert ".Values.adminPort" in tcp_services
 
 
+def test_prepare_k8s_server_uses_configured_service_name(tmp_path, capsys):
+    kit = _make_server_kit(tmp_path, fed_learn_port=8002, admin_port=8003)
+    output = tmp_path / "server-k8s"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "k8s",
+            "namespace": "nvflare",
+            "server_service_name": "custom-nvflare-server",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+
+    values = yaml.safe_load((output / "helm_chart" / "values.yaml").read_text())
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    service = (output / "helm_chart" / "templates" / "server-service.yaml").read_text()
+    tcp_services = (output / "helm_chart" / "templates" / "server-tcp-services.yaml").read_text()
+
+    assert values["serviceName"] == "custom-nvflare-server"
+    assert comm_config["internal"]["resources"]["host"] == "custom-nvflare-server"
+    assert "name: {{ .Values.serviceName }}" in service
+    assert "nvflare-server:%v" not in tcp_services
+    assert ".Values.serviceName" in tcp_services
+
+
 def test_prepare_k8s_server_uses_parent_python_path_for_chart_command(tmp_path, capsys):
     kit = _make_server_kit(tmp_path)
     output = tmp_path / "server-k8s"
@@ -670,6 +698,31 @@ def test_prepare_k8s_rejects_invalid_namespace(tmp_path, capsys, namespace):
     err = capsys.readouterr().err
     assert "INVALID_CONFIG" in err
     assert "k8s config.namespace" in err
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    "service_name",
+    ["Nvflare", "server_name", "server.name", "-server", "server-", "1server", "", "a" * 64, None, 7],
+)
+def test_prepare_k8s_rejects_invalid_server_service_name(tmp_path, capsys, service_name):
+    kit = _make_server_kit(tmp_path)
+    output = tmp_path / "prepared"
+
+    with pytest.raises(SystemExit):
+        _run_prepare(
+            kit,
+            output,
+            {
+                "runtime": "k8s",
+                "server_service_name": service_name,
+                "parent": {"docker_image": "repo/nvflare:dev"},
+            },
+        )
+
+    err = capsys.readouterr().err
+    assert "INVALID_CONFIG" in err
+    assert "k8s config.server_service_name" in err
     assert not output.exists()
 
 


### PR DESCRIPTION
## Summary
- Backport #4598 to make the Kubernetes FL server Service name configurable with `server_service_name`.
- Render the configured name into generated server Helm values, Service, tcp-services, and comm config.
- Add 2.8 deploy-prep unit coverage and docs for the new runtime key.
