### PR TITLE
[2.8] Use uv for pre-merge unit test installs

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -52,11 +52,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.14"
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --no-cache-dir -e .[dev]
-          python3 -m pip install --no-cache-dir --no-deps "flwr>=1.16,<1.26"
+          uv pip install --system -e ".[dev]"
+          uv pip install --system --no-deps "flwr>=1.16,<1.26"
       - name: Run unit test
         run: ./runtest.sh --numprocesses=auto -u
 


### PR DESCRIPTION
## Summary
- Backport #4612 to install uv in the pre-merge unit-test job.
- Replace pip installs in that job with `uv pip install --system` for the editable dev install and Flower dependency.

## Testing
- `git diff upstream/2.8...HEAD --check`
- Inspected `.github/workflows/premerge.yml` diff; workflow-only change, no local unit tests run for this PR.