### PR TITLE
[2.8]: Fix session.list_job_components() error

### DIFF
--- a/nvflare/fuel/hci/proto.py
+++ b/nvflare/fuel/hci/proto.py
@@ -94,7 +94,7 @@ class MetaStatusValue(object):
     JOB_NOT_RUNNING = "job_not_running"
     CLIENTS_RUNNING = "clients_running"
     NO_JOBS = "no_jobs"
-    NO_JOB_COMPONENTS = "no_job_compoents"
+    NO_JOB_COMPONENTS = "no_job_components"
     NO_REPLY = "no_reply"
     NO_CLIENTS = "no_clients"
 

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -1014,24 +1014,18 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             )
         with engine.new_context() as fl_ctx:
             list_of_data = job_def_manager.list_components(jid=job_id, fl_ctx=fl_ctx)
-            if list_of_data:
-                system_components = {"workspace", "meta", "scheduled", "data"}
-                filtered_data = [item for item in list_of_data if item not in system_components]
-                if filtered_data:
-                    data_str = ", ".join(filtered_data)
-                    conn.append_string(data_str)
-                    conn.append_success(
-                        "", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_COMPONENTS: filtered_data})
-                    )
-                else:
-                    conn.append_error(
-                        "No additional job components found.",
-                        meta=make_meta(MetaStatusValue.NO_JOB_COMPONENTS, "No additional job components found."),
-                    )
-            else:
+            if not list_of_data:
                 conn.append_error(
                     f"job {job_id} does not exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
                 )
+                return
+
+            system_components = {"workspace", "meta", "scheduled", "data"}
+            filtered_data = [item for item in list_of_data if item not in system_components]
+            if filtered_data:
+                data_str = ", ".join(filtered_data)
+                conn.append_string(data_str)
+            conn.append_success("", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_COMPONENTS: filtered_data}))
 
     def abort_job(self, conn: Connection, args: List[str]):
         engine = conn.app_ctx

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -368,6 +368,26 @@ class _FakeListEngine:
         return FLContext()
 
 
+class _FakeListComponentsJobDefManager:
+    def __init__(self, components):
+        self.components = components
+        self.jid = None
+
+    def list_components(self, jid, fl_ctx):
+        self.jid = jid
+        return self.components
+
+
+class _FakeListComponentsEngine:
+    def __init__(self, components):
+        self.job_def_manager = _FakeListComponentsJobDefManager(components)
+
+    def new_context(self):
+        from nvflare.apis.fl_context import FLContext
+
+        return FLContext()
+
+
 class _FakeWorkspace:
     def __init__(self, root_dir):
         self.root_dir = str(root_dir)
@@ -1054,6 +1074,23 @@ def test_list_jobs_by_submit_token_returns_deleted_status(monkeypatch):
     assert conn.errors[0][1][MetaKey.STATUS] == SUBMIT_TOKEN_JOB_DELETED_STATUS
     assert conn.errors[0][1][MetaKey.JOB_ID] == "job-1"
     assert conn.tables == []
+
+
+def test_list_job_components_returns_empty_list_for_system_components(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    engine = _FakeListComponentsEngine(["data", "meta", "workspace"])
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().list_job_components(conn, ["list_job_components", "job-1"])
+
+    assert conn.errors == []
+    assert conn.strings == []
+    assert len(conn.successes) == 1
+    msg, meta = conn.successes[0]
+    assert msg == ""
+    assert meta[MetaKey.STATUS] == MetaStatusValue.OK
+    assert meta[MetaKey.JOB_COMPONENTS] == []
+    assert engine.job_def_manager.jid == "job-1"
 
 
 def test_clone_job_preserves_source_study(monkeypatch):


### PR DESCRIPTION
### Description

When a job has no components, the session.list_job_components() should return an empty list.  The current codes raise an InternalError.  This PR fixes the issue, and a small typo.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
