### PR TITLE
[2.8] Backport job not found admin error normalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Prefer `rg` and `rg --files` for fast codebase search.
 - Keep edits scoped to the task; do not modify unrelated files in a dirty worktree.
 - Start with targeted tests for changed files, then run broader checks as needed.
+- Before pushing or opening a PR, run the project style check (`./runtest.sh -s`, or the closest scoped equivalent when justified). If it cannot be run, state that clearly before pushing.
 - Read `CLAUDE.md` for shared repo guidance such as project overview, architecture notes, commands, package layout, and style/testing conventions. Keep `AGENTS.md` limited to agent-specific addenda.
 
 ## Main Branch Versioning

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -106,6 +106,10 @@ def _active_study_from_conn(conn: Connection) -> str:
     return conn.get_prop(ConnProps.ACTIVE_STUDY, DEFAULT_STUDY) or DEFAULT_STUDY
 
 
+def _append_no_such_job_error(conn: Connection, job_id: str):
+    conn.append_error(f"no such job: {job_id}", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id))
+
+
 def _create_list_job_cmd_parser():
     parser = SafeArgumentParser(prog=AdminCommandNames.LIST_JOBS)
     parser.add_argument("job_id", nargs="?", help="Job ID prefix")
@@ -288,16 +292,12 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             job = job_def_manager.get_job(job_id, fl_ctx)
 
         if not job:
-            conn.append_error(
-                f"Job with ID {job_id} doesn't exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
-            )
+            _append_no_such_job_error(conn, job_id)
             return PreAuthzReturnCode.ERROR
 
         requested_study = _active_study_from_conn(conn)
         if requested_study and get_job_meta_study(job.meta) != requested_study:
-            conn.append_error(
-                f"Job with ID {job_id} doesn't exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
-            )
+            _append_no_such_job_error(conn, job_id)
             return PreAuthzReturnCode.ERROR
 
         conn.set_prop(self.JOB, job)
@@ -534,9 +534,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                     normalized_meta, meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_META: normalized_meta})
                 )
             else:
-                conn.append_error(
-                    f"job {job_id} does not exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
-                )
+                _append_no_such_job_error(conn, job_id)
 
     def get_job_log(self, conn: Connection, args: List[str]):
         try:
@@ -1015,9 +1013,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
         with engine.new_context() as fl_ctx:
             list_of_data = job_def_manager.list_components(jid=job_id, fl_ctx=fl_ctx)
             if not list_of_data:
-                conn.append_error(
-                    f"job {job_id} does not exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
-                )
+                _append_no_such_job_error(conn, job_id)
                 return
 
             system_components = {"workspace", "meta", "scheduled", "data"}

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -1689,9 +1689,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             if require_finished:
                 job = job_def_manager.get_job(job_id, fl_ctx)
                 if not job:
-                    conn.append_error(
-                        f"job {job_id} does not exist", meta=make_meta(MetaStatusValue.INVALID_JOB_ID, job_id)
-                    )
+                    _append_no_such_job_error(conn, job_id)
                     return
                 job_status = job.meta.get(JobMetaKey.STATUS)
                 if not job_status or not job_status.startswith("FINISHED:"):

--- a/tests/integration_test/fast/study_session_test.py
+++ b/tests/integration_test/fast/study_session_test.py
@@ -57,6 +57,7 @@ from nvflare.fuel.flare_api.flare_api import new_secure_session
 from nvflare.fuel.hci.client.api import APIStatus, ResultKey
 from nvflare.fuel.hci.client.api_spec import AdminConfigKey
 from nvflare.fuel.hci.client.config import secure_load_admin_config
+from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
 from nvflare.recipe import ProdEnv
 from tests.integration_test.src import NVFTestDriver, ProvisionSiteLauncher
 from tests.integration_test.src.utils import _get_job_store_path_from_workspace, get_job_meta
@@ -176,6 +177,14 @@ def _extract_table_rows(response: dict) -> list[list[str]]:
         if isinstance(item, dict) and item.get("type") == "table":
             return item.get("rows", [])
     raise AssertionError(f"No table rows found in response: {response}")
+
+
+def _extract_error_messages(response: dict) -> list[str]:
+    return [
+        item.get("data")
+        for item in response.get("data", [])
+        if isinstance(item, dict) and item.get("type") == "error"
+    ]
 
 
 def _extract_client_names_from_check_status(response: dict) -> set[str]:
@@ -453,6 +462,12 @@ class TestMultiStudySessionIntegration:
             study_b_session.clone_job(job_id)
         with pytest.raises(JobNotFound):
             default_session.get_job_meta(job_id)
+
+        abort_response = study_b_session.do_command(f"abort_job {job_id}")
+        assert abort_response[ResultKey.STATUS] == APIStatus.SUCCESS
+        assert abort_response[ResultKey.META][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_ID
+        assert abort_response[ResultKey.META][MetaKey.INFO] == job_id
+        assert _extract_error_messages(abort_response) == [f"no such job: {job_id}"]
 
     def test_multistudy_membership_does_not_override_certificate_role(self, multi_study_system):
         lead_admin_root = multi_study_system["admin_roots"][LEAD_ADMIN]

--- a/tests/integration_test/fast/study_session_test.py
+++ b/tests/integration_test/fast/study_session_test.py
@@ -181,9 +181,7 @@ def _extract_table_rows(response: dict) -> list[list[str]]:
 
 def _extract_error_messages(response: dict) -> list[str]:
     return [
-        item.get("data")
-        for item in response.get("data", [])
-        if isinstance(item, dict) and item.get("type") == "error"
+        item.get("data") for item in response.get("data", []) if isinstance(item, dict) and item.get("type") == "error"
     ]
 
 

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -1891,6 +1891,20 @@ def test_download_job_rejects_unfinished_job_before_packaging(monkeypatch, tmp_p
     engine.job_def_manager.get_storage_for_download.assert_not_called()
 
 
+def test_download_job_uses_canonical_missing_job_message(monkeypatch, tmp_path):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    job_id = "123e4567-e89b-42d3-a456-426614174000"
+    engine = _FakeListEngine([])
+    engine.job_def_manager.get_storage_for_download = MagicMock()
+    conn = _MockConnection(app_ctx=engine, props={ConnProps.DOWNLOAD_DIR: str(tmp_path)})
+
+    JobCommandModule().download_job(conn, ["download_job", job_id])
+
+    assert conn.errors and conn.errors[0][0] == f"no such job: {job_id}"
+    assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_ID
+    engine.job_def_manager.get_storage_for_download.assert_not_called()
+
+
 def test_download_job_packages_all_default_components_for_finished_job(monkeypatch, tmp_path):
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
     engine = _FakeListEngine(

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -1243,6 +1243,19 @@ def test_get_job_meta_uses_canonical_missing_job_message(monkeypatch):
     assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_ID
 
 
+def test_list_job_components_uses_canonical_missing_job_message(monkeypatch, tmp_path):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    job_id = "123e4567-e89b-42d3-a456-426614174000"
+    engine = _FakeServerEngine(_FakeWorkspace(tmp_path))
+    engine.job_def_manager.list_components.return_value = []
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: job_id})
+
+    JobCommandModule().list_job_components(conn, ["list_job_components", job_id])
+
+    assert conn.errors and conn.errors[0][0] == f"no such job: {job_id}"
+    assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_ID
+
+
 def test_get_job_log_client_target_returns_persisted_log(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -1232,6 +1232,17 @@ def test_get_job_meta_normalizes_legacy_job_study(monkeypatch):
     assert conn.dicts[0][0][JobMetaKey.STUDY.value] == "default"
 
 
+def test_get_job_meta_uses_canonical_missing_job_message(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    job_id = "123e4567-e89b-42d3-a456-426614174000"
+    conn = _MockConnection(app_ctx=_FakeListEngine([]), props={JobCommandModule.JOB_ID: job_id})
+
+    JobCommandModule().get_job_meta(conn, ["get_job_meta", job_id])
+
+    assert conn.errors and conn.errors[0][0] == f"no such job: {job_id}"
+    assert conn.errors[0][1][MetaKey.STATUS] == MetaStatusValue.INVALID_JOB_ID
+
+
 def test_get_job_log_client_target_returns_persisted_log(tmp_path, monkeypatch):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
     monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
@@ -1676,7 +1687,7 @@ def test_authorize_job_id_hides_jobs_from_other_studies(monkeypatch):
     rc = JobCommandModule().authorize_job_id(conn, ["authorize_job_id", job_id])
 
     assert rc == PreAuthzReturnCode.ERROR
-    assert conn.errors and conn.errors[0][0] == f"Job with ID {job_id} doesn't exist"
+    assert conn.errors and conn.errors[0][0] == f"no such job: {job_id}"
     assert conn.get_prop(JobCommandModule.JOB) is None
     assert conn.get_prop(ConnProps.SUBMITTER_ROLE) is None
 
@@ -1705,7 +1716,7 @@ def test_authorize_job_id_hides_non_default_jobs_from_default_session_without_re
     rc = JobCommandModule().authorize_job_id(conn, ["authorize_job_id", job_id])
 
     assert rc == PreAuthzReturnCode.ERROR
-    assert conn.errors and conn.errors[0][0] == f"Job with ID {job_id} doesn't exist"
+    assert conn.errors and conn.errors[0][0] == f"no such job: {job_id}"
     assert conn.get_prop(JobCommandModule.JOB) is None
     assert conn.get_prop(ConnProps.SUBMITTER_ROLE) is None
 


### PR DESCRIPTION
## What changed

Backport of #4621 to the 2.8 branch.

- Normalizes server-side `invalid_job_id` admin command errors to the canonical `no such job: <job_id>` wording.
- Applies the canonical wording to missing jobs and cross-study hidden jobs in shared job authorization, `get_job_meta`, `list_job_components`, and download-job missing-job handling.
- Adds focused unit coverage and a multi-study integration regression for the reported raw `abort_job` behavior.
