### PR TITLE
[2.8] Fix admin CLI login rejection handling

### DIFF
--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -470,7 +470,7 @@ class AdminClient(cmd.Cmd, EventHandler):
             self.api.close()
 
     @staticmethod
-    def _format_login_failure(result: dict) -> str:
+    def _format_login_failure(result) -> str:
         if not isinstance(result, dict):
             return "Login failed: no login response"
 

--- a/nvflare/fuel/hci/client/cli.py
+++ b/nvflare/fuel/hci/client/cli.py
@@ -36,7 +36,7 @@ from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandRegist
 from nvflare.fuel.hci.table import Table
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
 
-from .api import AdminAPI, CommandInfo
+from .api import AdminAPI, CommandInfo, ResultKey
 from .api_spec import AdminConfigKey, UidSource
 from .api_status import APIStatus
 from .event import EventContext, EventHandler, EventPropKey, EventType
@@ -450,7 +450,11 @@ class AdminClient(cmd.Cmd, EventHandler):
     def run(self):
         try:
             self.api.connect(self.login_timeout)
-            self.api.login()
+            login_result = self.api.login()
+            if not isinstance(login_result, dict) or login_result.get(ResultKey.STATUS) != APIStatus.SUCCESS:
+                self.write_string(self._format_login_failure(login_result))
+                return
+
             self.last_active_time = time.time()
             monitor = threading.Thread(target=self._monitor_user, daemon=True)
             monitor.start()
@@ -464,6 +468,20 @@ class AdminClient(cmd.Cmd, EventHandler):
         finally:
             self.stopped = True
             self.api.close()
+
+    @staticmethod
+    def _format_login_failure(result: dict) -> str:
+        if not isinstance(result, dict):
+            return "Login failed: no login response"
+
+        details = result.get(ResultKey.DETAILS) or "login failed"
+        auth_code = result.get(ResultKey.AUTH_CODE)
+        if auth_code:
+            details = f"{auth_code}: {details}"
+
+        if result.get(ResultKey.STATUS) == APIStatus.ERROR_AUTHENTICATION:
+            return f"Login rejected: {details}"
+        return f"Login failed: {details}"
 
     def print_resp(self, resp: dict):
         """Prints the server response

--- a/tests/unit_test/fuel/hci/admin_cli_study_test.py
+++ b/tests/unit_test/fuel/hci/admin_cli_study_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from nvflare.apis.fl_constant import ConnectionSecurity
 from nvflare.apis.job_def import DEFAULT_STUDY
-from nvflare.fuel.hci.client.api import CommandInfo
+from nvflare.fuel.hci.client.api import CommandInfo, ResultKey
 from nvflare.fuel.hci.client.api_spec import AdminConfigKey, UidSource
 from nvflare.fuel.hci.client.api_status import APIStatus
 from nvflare.fuel.hci.client.cli import AdminClient
@@ -189,3 +189,40 @@ def test_admin_client_passes_study_to_admin_api(tmp_path):
         )
 
     assert captured["study"] == "cancer-research"
+
+
+def test_admin_client_run_reports_login_rejection_and_skips_cmdloop():
+    calls = []
+    output = []
+    client = AdminClient.__new__(AdminClient)
+
+    class _FakeAPI:
+        @staticmethod
+        def connect(timeout):
+            calls.append(("connect", timeout))
+
+        @staticmethod
+        def login():
+            calls.append(("login",))
+            return {
+                ResultKey.STATUS: APIStatus.ERROR_AUTHENTICATION,
+                ResultKey.DETAILS: "unknown study 'study-a'",
+                ResultKey.AUTH_CODE: "AUTH_UNKNOWN_STUDY",
+            }
+
+        @staticmethod
+        def close():
+            calls.append(("close",))
+
+    client.api = _FakeAPI()
+    client.login_timeout = 5.0
+    client.debug = False
+    client.stopped = False
+    client.write_string = output.append
+    client.cmdloop = lambda *_args, **_kwargs: calls.append(("cmdloop",))
+
+    client.run()
+
+    assert output == ["Login rejected: AUTH_UNKNOWN_STUDY: unknown study 'study-a'"]
+    assert calls == [("connect", 5.0), ("login",), ("close",)]
+    assert client.stopped is True


### PR DESCRIPTION
## Summary
- Check the `AdminAPI.login()` result before entering the interactive admin CLI command loop.
- Print structured login rejection details, including `AUTH_*` codes when available.
- Add a regression test covering rejected login behavior so the prompt is not shown after failed authentication.

## Root Cause
`AdminClient.run()` discarded the return value from `AdminAPI.login()` and always started `cmdloop()`. When a multi-study login was rejected, `_after_login()` was skipped and server commands were never registered, so users saw a misleading prompt followed by `Undefined command` for server-side commands.
