### PR TITLE
[2.8] Update integration CI suite setup

### DIFF
--- a/ci/run_integration.sh
+++ b/ci/run_integration.sh
@@ -23,6 +23,7 @@ BUILD_TYPE=numpy
 TEST_FOLDER="tests/integration_test"
 PYTHON_BIN=(python)
 PYTEST_ARGS=(-v --log-cli-level=INFO --capture=no)
+XGBOOST_FEDERATED_WHEEL_URL="https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl"
 
 # CRITICAL: Set gRPC environment variables before ANY imports that might use gRPC.
 # See: https://github.com/grpc/grpc/issues/28557
@@ -78,7 +79,7 @@ integration_test_tf() {
 add_dns_entries() {
     echo "adding DNS entries for integration test cases"
     cp /etc/hosts /etc/hosts_bak
-    echo "127.0.0.1 localhost0 localhost1" | tee -a /etc/hosts > /dev/null
+    echo "127.0.0.1 localhost0" | tee -a /etc/hosts > /dev/null
 }
 
 remove_dns_entries() {
@@ -92,6 +93,18 @@ clean_up_snapshot_and_job() {
 
 run_pytest() {
     "${PYTHON_BIN[@]}" -m pytest "${PYTEST_ARGS[@]}" --junitxml=./integration_test.xml "$@"
+}
+
+install_xgboost_federated_wheel() {
+    echo "Installing federated XGBoost wheel for XGBoost recipe tests..."
+    "${PYTHON_BIN[@]}" -m pip install --force-reinstall --no-deps "${XGBOOST_FEDERATED_WHEEL_URL}"
+    "${PYTHON_BIN[@]}" - <<'PY'
+import xgboost
+import xgboost.federated
+
+print("XGBoost version is " + xgboost.__version__)
+print("xgboost.federated import succeeded")
+PY
 }
 
 run_system_test() {
@@ -127,25 +140,8 @@ run_pytest_mode() {
             run_pytest fast
             ;;
         slow)
+            install_xgboost_federated_wheel
             run_pytest slow
-            ;;
-        study_session)
-            run_pytest fast/study_session_test.py
-            ;;
-        preflight)
-            run_pytest slow/preflight_check_test.py
-            ;;
-        tracking)
-            run_pytest slow/experiment_tracking_recipes_test.py
-            ;;
-        provisioning)
-            run_pytest slow/distributed_provisioning_test.py
-            ;;
-        recipe_system)
-            run_pytest slow/recipe_system_test.py
-            ;;
-        xgb_recipe)
-            run_pytest slow/xgb_histogram_recipe_test.py slow/xgb_vertical_recipe_test.py
             ;;
         auto)
             echo "The legacy auto example discovery mode is currently disabled; no tests to run."

--- a/ci/run_integration.sh
+++ b/ci/run_integration.sh
@@ -19,11 +19,14 @@
 #   BUILD_TYPE: tests to execute, default = numpy
 
 set -ex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 BUILD_TYPE=numpy
 TEST_FOLDER="tests/integration_test"
 PYTHON_BIN=(python)
 PYTEST_ARGS=(-v --log-cli-level=INFO --capture=no)
-XGBOOST_FEDERATED_WHEEL_URL="https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/federated-secure/xgboost-2.2.0.dev0%2B4601688195708f7c31fcceeb0e0ac735e7311e61-py3-none-manylinux_2_28_x86_64.whl"
+XGBOOST_REQUIREMENTS_FILE="${REPO_ROOT}/examples/advanced/xgboost/requirements.txt"
+XGBOOST_FEDERATED_WHEEL_URL="${XGBOOST_FEDERATED_WHEEL_URL:-}"
 
 # CRITICAL: Set gRPC environment variables before ANY imports that might use gRPC.
 # See: https://github.com/grpc/grpc/issues/28557
@@ -95,9 +98,26 @@ run_pytest() {
     "${PYTHON_BIN[@]}" -m pytest "${PYTEST_ARGS[@]}" --junitxml=./integration_test.xml "$@"
 }
 
+resolve_xgboost_federated_wheel_url() {
+    if [[ -n "${XGBOOST_FEDERATED_WHEEL_URL}" ]]; then
+        echo "${XGBOOST_FEDERATED_WHEEL_URL}"
+        return
+    fi
+
+    local wheel_url
+    wheel_url=$(grep -E '^https://.*xgboost.*\.whl$' "${XGBOOST_REQUIREMENTS_FILE}" | tail -n 1)
+    if [[ -z "${wheel_url}" ]]; then
+        echo "ERROR: could not find federated XGBoost wheel URL in ${XGBOOST_REQUIREMENTS_FILE}" >&2
+        return 1
+    fi
+    echo "${wheel_url}"
+}
+
 install_xgboost_federated_wheel() {
+    local wheel_url
+    wheel_url=$(resolve_xgboost_federated_wheel_url)
     echo "Installing federated XGBoost wheel for XGBoost recipe tests..."
-    "${PYTHON_BIN[@]}" -m pip install --force-reinstall --no-deps "${XGBOOST_FEDERATED_WHEEL_URL}"
+    "${PYTHON_BIN[@]}" -m pip install --force-reinstall "${wheel_url}"
     "${PYTHON_BIN[@]}" - <<'PY'
 import xgboost
 import xgboost.federated

--- a/ci/run_premerge.sh
+++ b/ci/run_premerge.sh
@@ -50,7 +50,7 @@ remove_pipenv() {
 add_dns_entries() {
     echo "adding DNS entries for integration test cases"
     cp /etc/hosts /etc/hosts_bak
-    echo "127.0.0.1 localhost0 localhost1" | tee -a /etc/hosts > /dev/null
+    echo "127.0.0.1 localhost0" | tee -a /etc/hosts > /dev/null
 }
 
 remove_dns_entries() {

--- a/nvflare/app_opt/xgboost/histogram_based_v2/runners/xgb_client_runner.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/runners/xgb_client_runner.py
@@ -222,12 +222,14 @@ class XGBClientRunner(AppRunner, FLComponent):
             bst.save_model(os.path.join(self._model_dir, self.model_file_name))
             xgb.collective.communicator_print("Finished training\n")
 
-            if self._data_split_mode == 0:
+            enable_explainability = self._xgb_options.get("enable_explainability", True)
+            if self._data_split_mode == 0 and enable_explainability:
                 # Save explainability outputs based on val_data
                 try:
                     import matplotlib.pyplot as plt
                     import shap
 
+                    xgb.collective.communicator_print("Generating explainability plots\n")
                     explainer = shap.TreeExplainer(bst)
                     explanation = explainer(val_data)
 
@@ -236,10 +238,13 @@ class XGBClientRunner(AppRunner, FLComponent):
                     img = plt.gcf()
                     img.subplots_adjust(left=0.3, right=0.9, bottom=0.3, top=0.9)
                     img.savefig(os.path.join(self._model_dir, "shap_beeswarm.png"), bbox_inches="tight")
+                    xgb.collective.communicator_print("Finished explainability plots\n")
                 except ImportError:
                     xgb.collective.communicator_print(
                         "Warning: shap and/or matplotlib not installed. Skipping explainability plots.\n"
                     )
+            elif self._data_split_mode == 0:
+                xgb.collective.communicator_print("Skipping explainability plots\n")
 
         self._stopped = True
 

--- a/nvflare/app_opt/xgboost/recipes/vertical.py
+++ b/nvflare/app_opt/xgboost/recipes/vertical.py
@@ -80,12 +80,11 @@ class XGBVerticalRecipe(Recipe):
         use_gpus (bool, optional): Whether to use GPUs for training. Default is False.
         secure (bool, optional): Enable secure training with Homomorphic Encryption (HE). Default is False.
             Requires encryption plugins to be installed and configured.
-            When secure=True, client_ranks must be provided.
-        client_ranks (dict, optional): Mapping of client names to ranks for secure training.
-            Required when secure=True. Maps each client name to a unique rank (0-indexed).
+        client_ranks (dict, optional): Mapping of client names to unique ranks (0-indexed).
             Example: {"site-1": 0, "site-2": 1, "site-3": 2}.
             In vertical mode, the label owner must be assigned rank 0. If client_ranks is omitted,
             the recipe assigns the label owner rank 0 and assigns the remaining clients by name.
+            For secure training, provide client_ranks when a stable secure-rank mapping is required.
         xgb_params (dict, optional): XGBoost parameters passed to xgboost.train(). If None, uses default params.
             Default params: max_depth=8, eta=0.1, objective='binary:logistic', eval_metric='auc',
             tree_method='hist', nthread=16.

--- a/nvflare/app_opt/xgboost/recipes/vertical.py
+++ b/nvflare/app_opt/xgboost/recipes/vertical.py
@@ -84,6 +84,8 @@ class XGBVerticalRecipe(Recipe):
         client_ranks (dict, optional): Mapping of client names to ranks for secure training.
             Required when secure=True. Maps each client name to a unique rank (0-indexed).
             Example: {"site-1": 0, "site-2": 1, "site-3": 2}.
+            In vertical mode, the label owner must be assigned rank 0. If client_ranks is omitted,
+            the recipe assigns the label owner rank 0 and assigns the remaining clients by name.
         xgb_params (dict, optional): XGBoost parameters passed to xgboost.train(). If None, uses default params.
             Default params: max_depth=8, eta=0.1, objective='binary:logistic', eval_metric='auc',
             tree_method='hist', nthread=16.
@@ -214,6 +216,23 @@ class XGBVerticalRecipe(Recipe):
                 "Each site must specify a 'data_loader' in the config dictionary."
             )
 
+        if self.label_owner not in per_site_config:
+            raise ValueError(f"label_owner {self.label_owner!r} must be included in per_site_config")
+
+        if self.client_ranks:
+            expected_clients = set(per_site_config)
+            ranked_clients = set(self.client_ranks)
+            if ranked_clients != expected_clients:
+                raise ValueError(
+                    f"client_ranks must include exactly the per_site_config clients: expected "
+                    f"{sorted(expected_clients)}, got {sorted(ranked_clients)}"
+                )
+            if self.client_ranks.get(self.label_owner) != 0:
+                raise ValueError("label_owner must be assigned rank 0 for vertical XGBoost")
+        else:
+            ranked_clients = [self.label_owner] + sorted(c for c in per_site_config if c != self.label_owner)
+            self.client_ranks = {client_name: rank for rank, client_name in enumerate(ranked_clients)}
+
         # Configure the job
         self.job = self.configure()
         Recipe.__init__(self, self.job)
@@ -231,11 +250,11 @@ class XGBVerticalRecipe(Recipe):
             "secure_training": self.secure,
             "xgb_options": {"early_stopping_rounds": self.early_stopping_rounds, "use_gpus": self.use_gpus},
             "xgb_params": self.xgb_params,
+            "client_ranks": self.client_ranks,
         }
 
-        # Add client_ranks if secure training is enabled
-        if self.secure and self.client_ranks:
-            controller_kwargs["client_ranks"] = self.client_ranks
+        # In-process execution is required for secure training.
+        if self.secure:
             controller_kwargs["in_process"] = True  # Required for secure training
 
         controller = XGBFedController(**controller_kwargs)
@@ -252,7 +271,7 @@ class XGBVerticalRecipe(Recipe):
         for site_name, site_config in self.per_site_config.items():
             data_loader = site_config.get("data_loader")
             if data_loader is None:
-                raise ValueError(f"per_site_config for '{site_name}' must include 'data_loader' key")
+                raise ValueError(f"per_site_config for {site_name!r} must include 'data_loader' key")
 
             # Add executor
             executor = FedXGBHistogramExecutor(

--- a/tests/integration_test/README.md
+++ b/tests/integration_test/README.md
@@ -3,7 +3,7 @@
 ## Setup
 
 Some integration test configs use local host aliases when provisioning the test system.
-That requires `localhost0` and `localhost1` to map to `127.0.0.1`.
+That requires `localhost0` to map to `127.0.0.1`.
 You need to either modify the `/etc/hosts` file before running the test,
 or, if you are running in a docker container, use `--add-host localhost0:127.0.0.1`.
 
@@ -26,6 +26,10 @@ python -m pytest -v --log-cli-level=INFO --capture=no fast
 python -m pytest -v --log-cli-level=INFO --capture=no slow
 ```
 
+The slow suite includes XGBoost recipe tests that require the federated XGBoost wheel. CI installs it
+through `ci/run_integration.sh slow`. For direct local pytest runs, install the wheel from
+`examples/advanced/xgboost/requirements.txt` first, or run the suite through `ci/run_integration.sh slow`.
+
 Run one direct pytest suite:
 
 ```bash
@@ -46,6 +50,10 @@ NVFLARE_TEST_FRAMEWORK=client_api python -m pytest -v --log-cli-level=INFO --cap
 ```
 
 Add `--junitxml=./integration_test.xml` to any command when you need a JUnit report.
+
+Config-driven `system_test.py` event sequences time out after 1800 seconds by default.
+Set `NVFLARE_EVENT_SEQUENCE_TIMEOUT` to override this globally, or set `event_sequence_timeout`
+in a test config YAML. Use `0` to disable the harness timeout.
 
 CI uses `ci/run_integration.sh` for environment setup and mode dispatch. This directory intentionally
 does not provide a second local wrapper script.
@@ -93,6 +101,11 @@ An example would be `tests/integration_test/data/test_configs/one_job/test_hello
 | `jobs_root_dir` | The directory that contains the job folders to upload                                  |
 | `tests`         | The test cases to run                                                                  |
 
+Optional attributes for both config types:
+
+| Attributes                 | Description                                                              |
+|----------------------------|--------------------------------------------------------------------------|
+| `event_sequence_timeout`   | Max seconds to wait for one event sequence. (Default to 1800 seconds.)   |
 
 An example would be `tests/integration_test/data/test_configs/authorization/list_job.yml`.
 

--- a/tests/integration_test/README.md
+++ b/tests/integration_test/README.md
@@ -105,7 +105,7 @@ Optional attributes for both config types:
 
 | Attributes                 | Description                                                              |
 |----------------------------|--------------------------------------------------------------------------|
-| `event_sequence_timeout`   | Max seconds to wait for one event sequence. (Default to 1800 seconds.)   |
+| `event_sequence_timeout`   | Max seconds to wait for one event sequence. (Defaults to 1800 seconds.)  |
 
 An example would be `tests/integration_test/data/test_configs/authorization/list_job.yml`.
 

--- a/tests/integration_test/data/jobs/higgs_2_histogram_v2_uniform_split_uniform_lr/app_server/config/config_fed_server.json
+++ b/tests/integration_test/data/jobs/higgs_2_histogram_v2_uniform_split_uniform_lr/app_server/config/config_fed_server.json
@@ -18,6 +18,7 @@
                 },
                 "xgb_options": {
                     "early_stopping_rounds": 2,
+                    "enable_explainability": false,
                     "use_gpus": false
                 }
             }

--- a/tests/integration_test/slow/experiment_tracking_recipes_test.py
+++ b/tests/integration_test/slow/experiment_tracking_recipes_test.py
@@ -37,12 +37,25 @@ or run in a separate recipe test suite (takes ~1-2 minutes).
 
 import os
 
+import pytest
+
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
 from nvflare.recipe import SimEnv
 from nvflare.recipe.utils import add_experiment_tracking
 
 INTEGRATION_TEST_ROOT = os.path.dirname(os.path.dirname(__file__))
 REPO_ROOT = os.path.dirname(os.path.dirname(INTEGRATION_TEST_ROOT))
+
+
+@pytest.fixture(scope="module")
+def cifar10_data_root(tmp_path_factory):
+    """Download CIFAR-10 once so simulated clients do not race on the same download/extract path."""
+    from torchvision.datasets import CIFAR10
+
+    data_root = str(tmp_path_factory.mktemp("cifar10_data"))
+    CIFAR10(root=data_root, train=True, download=True)
+    CIFAR10(root=data_root, train=False, download=True)
+    return data_root
 
 
 class TestExperimentTrackingRecipes:
@@ -69,7 +82,19 @@ class TestExperimentTrackingRecipes:
         recipe.job.add_file_to_server(self.model_path)
         recipe.job.add_file_to_clients(self.model_path)
 
-    def test_tensorboard_tracking_integration(self):
+    def _per_site_config(self, dataset_path: str, model_dir: str) -> dict[str, dict[str, str]]:
+        return {
+            site_name: {
+                "train_args": (
+                    f"--dataset_path {dataset_path} "
+                    f"--model_path {os.path.join(model_dir, site_name + '_cifar_net.pth')} "
+                    "--batch_size 512 --num_workers 0 --local_epochs 1"
+                )
+            }
+            for site_name in ("site-1", "site-2")
+        }
+
+    def test_tensorboard_tracking_integration(self, cifar10_data_root):
         """Test TensorBoard tracking can be added and job completes."""
         import tempfile
 
@@ -81,6 +106,7 @@ class TestExperimentTrackingRecipes:
                 num_rounds=1,
                 model={"class_path": "model.SimpleNetwork", "args": {}},
                 train_script=self.client_script_path,
+                per_site_config=self._per_site_config(cifar10_data_root, tmpdir),
             )
             self._add_model_to_apps(recipe)
 
@@ -92,7 +118,7 @@ class TestExperimentTrackingRecipes:
             assert run.get_result() is not None
             assert os.path.exists(run.get_result())
 
-    def test_mlflow_tracking_integration(self):
+    def test_mlflow_tracking_integration(self, cifar10_data_root):
         """Test MLflow tracking can be added and job completes."""
         import tempfile
 
@@ -105,6 +131,7 @@ class TestExperimentTrackingRecipes:
                 num_rounds=1,
                 model={"class_path": "model.SimpleNetwork", "args": {}},
                 train_script=self.client_script_path,
+                per_site_config=self._per_site_config(cifar10_data_root, tmpdir),
             )
             self._add_model_to_apps(recipe)
 

--- a/tests/integration_test/slow/experiment_tracking_recipes_test.py
+++ b/tests/integration_test/slow/experiment_tracking_recipes_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for experiment tracking with recipes.
+"""Slow integration tests for experiment tracking with recipes.
 
 These are smoke tests to verify that add_experiment_tracking() works with recipes without errors.
 Tests verify:
@@ -24,15 +24,11 @@ Tests do NOT verify:
 - Metrics are logged correctly
 - Tracking output content or format
 
-NOTE: These tests are currently NOT triggered by any automated test suite.
-They use CIFAR-10 dataset and run real training.
+These tests use the CIFAR-10 dataset and run real training.
 
 To run manually:
     cd tests/integration_test
     pytest slow/experiment_tracking_recipes_test.py -v
-
-TODO: Decide if these should be added to an existing test category (e.g., CIFAR integration tests)
-or run in a separate recipe test suite (takes ~1-2 minutes).
 """
 
 import os

--- a/tests/integration_test/slow/xgb_vertical_recipe_test.py
+++ b/tests/integration_test/slow/xgb_vertical_recipe_test.py
@@ -57,8 +57,8 @@ class MockVerticalDataLoader(XGBDataLoader):
     def load_data(self):
         """Generate synthetic vertical data (features split across clients)."""
         # Generate random features for this client
-        X_train = np.random.rand(self.n_samples, self.n_features)
-        X_val = np.random.rand(self.n_samples // 4, self.n_features)
+        x_train = np.random.rand(self.n_samples, self.n_features)
+        x_val = np.random.rand(self.n_samples // 4, self.n_features)
 
         if self.has_labels:
             # Only label owner has labels
@@ -70,8 +70,8 @@ class MockVerticalDataLoader(XGBDataLoader):
             y_val = None
 
         # Create DMatrix objects with data_split_mode=1 (vertical/column mode)
-        dtrain = xgb.DMatrix(X_train, label=y_train, data_split_mode=self.data_split_mode)
-        dval = xgb.DMatrix(X_val, label=y_val, data_split_mode=self.data_split_mode)
+        dtrain = xgb.DMatrix(x_train, label=y_train, data_split_mode=self.data_split_mode)
+        dval = xgb.DMatrix(x_val, label=y_val, data_split_mode=self.data_split_mode)
 
         return dtrain, dval
 
@@ -133,6 +133,7 @@ class TestXGBVerticalRecipe:
             per_site_config=_make_vertical_per_site_config(),
         )
         assert recipe.label_owner == "site-1"
+        assert recipe.client_ranks["site-1"] == 0
 
         # Invalid format should raise error
         with pytest.raises(ValueError, match="label_owner must be in format 'site-X'"):
@@ -142,6 +143,17 @@ class TestXGBVerticalRecipe:
                 num_rounds=1,
                 label_owner="client1",  # Invalid format
                 per_site_config=_make_vertical_per_site_config(),
+            )
+
+        # Label owner must be rank 0 for vertical XGBoost.
+        with pytest.raises(ValueError, match="label_owner must be assigned rank 0"):
+            XGBVerticalRecipe(
+                name="test_invalid_rank",
+                min_clients=2,
+                num_rounds=1,
+                label_owner="site-2",
+                client_ranks={"site-1": 0, "site-2": 1},
+                per_site_config=_make_vertical_per_site_config(label_owner="site-2"),
             )
 
     def test_custom_xgb_params(self):
@@ -183,6 +195,7 @@ class TestXGBVerticalRecipe:
                 label_owner="site-2",  # site-2 has labels
                 per_site_config=per_site_config,
             )
+            assert recipe.client_ranks["site-2"] == 0
 
             run = recipe.execute(env)
             assert run.get_result() is not None

--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -49,6 +49,47 @@ class NVFTestError(Exception):
     pass
 
 
+DEFAULT_EVENT_SEQUENCE_TIMEOUT = 1800
+EVENT_SEQUENCE_TIMEOUT_ENV = "NVFLARE_EVENT_SEQUENCE_TIMEOUT"
+
+
+def _is_terminal_run_status(job_run_status: str) -> bool:
+    return isinstance(job_run_status, str) and job_run_status.startswith("FINISHED:")
+
+
+def _is_failed_terminal_run_status(job_run_status: str) -> bool:
+    return _is_terminal_run_status(job_run_status) and job_run_status != RunStatus.FINISHED_COMPLETED.value
+
+
+def _expects_successful_run_state(result_or_trigger: dict) -> bool:
+    return (
+        isinstance(result_or_trigger, dict)
+        and result_or_trigger.get("type") == "run_state"
+        and result_or_trigger.get("data", {}).get("run_finished") is True
+    )
+
+
+def _event_waits_for_successful_run(event: dict, event_triggered: bool) -> bool:
+    if not event_triggered and _expects_successful_run_state(event.get("trigger")):
+        return True
+    return event_triggered and _expects_successful_run_state(event.get("result"))
+
+
+def _resolve_event_sequence_timeout(event_sequence_timeout):
+    env_timeout = os.environ.get(EVENT_SEQUENCE_TIMEOUT_ENV)
+    if env_timeout not in ("", None):
+        event_sequence_timeout = env_timeout
+    elif event_sequence_timeout is None:
+        event_sequence_timeout = DEFAULT_EVENT_SEQUENCE_TIMEOUT
+    if event_sequence_timeout in ("", None):
+        return None
+
+    event_sequence_timeout = float(event_sequence_timeout)
+    if event_sequence_timeout <= 0:
+        return None
+    return event_sequence_timeout
+
+
 def _parse_workflow_states(stats_message: dict):
     # {
     #     'ScatterAndGather':
@@ -115,13 +156,21 @@ def _update_run_state(stats: dict, run_state: dict, job_run_status: str):
     if stats and isinstance(stats, dict) and isinstance(stats.get("server"), dict):
         run_state["workflows"] = _parse_workflow_states(stats_message=stats["server"])
 
+    run_state["job_status"] = job_run_status
+    run_state["job_terminal"] = _is_terminal_run_status(job_run_status)
     run_state["run_finished"] = job_run_status == RunStatus.FINISHED_COMPLETED.value
 
     return run_state != prev_run_state, run_state
 
 
 class NVFTestDriver:
-    def __init__(self, download_root_dir: str, site_launcher: SiteLauncher, poll_period=1):
+    def __init__(
+        self,
+        download_root_dir: str,
+        site_launcher: SiteLauncher,
+        poll_period=1,
+        event_sequence_timeout=None,
+    ):
         """FL system test driver.
 
         Args:
@@ -129,10 +178,12 @@ class NVFTestDriver:
             site_launcher (SiteLauncher): a SiteLauncher object
             poll_period (int): note that this value can't be too small,
                 otherwise will have resource issue
+            event_sequence_timeout: max seconds to wait for a test event sequence.
         """
         self.download_root_dir = download_root_dir
         self.site_launcher = site_launcher
         self.poll_period = poll_period
+        self.event_sequence_timeout = _resolve_event_sequence_timeout(event_sequence_timeout)
 
         self.super_admin_api = None
         self.super_admin_user_name = None
@@ -172,7 +223,7 @@ class NVFTestDriver:
             )
             login_result = ensure_admin_api_logged_in(admin_api)
         except Exception as e:
-            raise NVFTestError(f"create and login to admin failed: {e}")
+            raise NVFTestError(f"create and login to admin failed: {e}") from e
         if not login_result:
             raise NVFTestError(f"initialize_super_user {super_user_name} failed.")
 
@@ -192,7 +243,7 @@ class NVFTestDriver:
                 login_result = ensure_admin_api_logged_in(admin_api)
             except Exception as e:
                 self.admin_apis = None
-                raise NVFTestError(f"create and login to admin failed: {e}")
+                raise NVFTestError(f"create and login to admin failed: {e}") from e
             if not login_result:
                 self.admin_apis = None
                 raise NVFTestError(f"initialize_admin_users {user_name} failed.")
@@ -283,8 +334,39 @@ class NVFTestDriver:
             except (JobNotFound, JobNotRunning, ConnectionError, SessionClosed):
                 stats = None
             # update run_state
-            changed, run_state = _update_run_state(stats=stats, run_state=run_state, job_run_status=job_run_status)
+            _, run_state = _update_run_state(stats=stats, run_state=run_state, job_run_status=job_run_status)
         return run_state
+
+    def _build_event_sequence_error(self, message: str, run_state: dict, event_idx: int, event_triggered: list) -> str:
+        return (
+            f"{message} "
+            f"event_idx={event_idx}, event_triggered={event_triggered}, "
+            f"job_id={self.job_id!r}, job_name={self.last_job_name!r}, "
+            f"run_state={run_state}, server_status={self.server_status()}, client_status={self.client_status()}"
+        )
+
+    def _check_for_failed_terminal_job(
+        self,
+        event: dict,
+        event_is_triggered: bool,
+        run_state: dict,
+        event_idx: int,
+        event_triggered: list,
+    ):
+        job_status = run_state.get("job_status")
+        if not _is_failed_terminal_run_status(job_status):
+            return
+        if not _event_waits_for_successful_run(event=event, event_triggered=event_is_triggered):
+            return
+
+        raise NVFTestError(
+            self._build_event_sequence_error(
+                message=f"Job reached terminal status {job_status!r} while waiting for run_finished=True.",
+                run_state=run_state,
+                event_idx=event_idx,
+                event_triggered=event_triggered,
+            )
+        )
 
     def reset_test_info(self, reset_job_info=False):
         self.test_done = False
@@ -294,7 +376,8 @@ class NVFTestDriver:
             self.last_job_name = None
 
     def run_event_sequence(self, event_sequence):
-        run_state = {"run_finished": None, "workflows": None}
+        run_state = {"job_status": None, "job_terminal": None, "run_finished": None, "workflows": None}
+        start_time = time.time()
 
         event_idx = 0
         # whether event has been successfully triggered
@@ -306,6 +389,13 @@ class NVFTestDriver:
             run_state = self._get_run_state(run_state)
 
             if event_idx < len(event_sequence):
+                self._check_for_failed_terminal_job(
+                    event=event_sequence[event_idx],
+                    event_is_triggered=event_triggered[event_idx],
+                    run_state=run_state,
+                    event_idx=event_idx,
+                    event_triggered=event_triggered,
+                )
                 if not event_triggered[event_idx]:
                     # check if event is triggered -> then execute the corresponding actions
                     event_trigger = event_sequence[event_idx]["trigger"]
@@ -335,7 +425,7 @@ class NVFTestDriver:
                     if _check_event_trigger(
                         event_trigger=trigger_data, string_to_check=strings_to_check, run_state=run_state
                     ):
-                        print(f"EVENT TRIGGER '{trigger_data}' is TRIGGERED.")
+                        print(f"EVENT TRIGGER {trigger_data!r} is TRIGGERED.")
                         event_triggered[event_idx] = True
                         self.execute_actions(
                             actions=event_sequence[event_idx]["actions"],
@@ -354,14 +444,30 @@ class NVFTestDriver:
                     elif result["type"] == "admin_api_response":
                         if self.admin_api_response is None:
                             raise NVFTestError("Missing admin_api_response.")
-                        assert (
-                            self.admin_api_response == result["data"]
-                        ), f"Failed: admin_api_response: {self.admin_api_response} does not equal to result {result['data']}"
+                        msg = (
+                            f"Failed: admin_api_response: {self.admin_api_response} "
+                            f"does not equal to result {result['data']}"
+                        )
+                        assert self.admin_api_response == result["data"], msg
                         event_idx += 1
                     elif result["type"] == "job_submit_success":
                         if self.job_id is None or self.last_job_name is None:
                             raise NVFTestError(f"Job submission failed with: {self.admin_api_response}")
                         event_idx += 1
+
+            elapsed = time.time() - start_time
+            if self.event_sequence_timeout and elapsed > self.event_sequence_timeout:
+                raise NVFTestError(
+                    self._build_event_sequence_error(
+                        message=(
+                            f"Event sequence timed out after {self.event_sequence_timeout:.1f} seconds "
+                            f"while waiting for event {event_idx}."
+                        ),
+                        run_state=run_state,
+                        event_idx=event_idx,
+                        event_triggered=event_triggered,
+                    )
+                )
 
             time.sleep(self.poll_period)
 

--- a/tests/integration_test/src/nvf_test_driver.py
+++ b/tests/integration_test/src/nvf_test_driver.py
@@ -76,15 +76,21 @@ def _event_waits_for_successful_run(event: dict, event_triggered: bool) -> bool:
 
 
 def _resolve_event_sequence_timeout(event_sequence_timeout):
+    timeout_source = "event_sequence_timeout"
     env_timeout = os.environ.get(EVENT_SEQUENCE_TIMEOUT_ENV)
     if env_timeout not in ("", None):
         event_sequence_timeout = env_timeout
+        timeout_source = EVENT_SEQUENCE_TIMEOUT_ENV
     elif event_sequence_timeout is None:
         event_sequence_timeout = DEFAULT_EVENT_SEQUENCE_TIMEOUT
+        timeout_source = "default event_sequence_timeout"
     if event_sequence_timeout in ("", None):
         return None
 
-    event_sequence_timeout = float(event_sequence_timeout)
+    try:
+        event_sequence_timeout = float(event_sequence_timeout)
+    except (TypeError, ValueError) as e:
+        raise NVFTestError(f"Invalid {timeout_source} value {event_sequence_timeout!r}: must be a number") from e
     if event_sequence_timeout <= 0:
         return None
     return event_sequence_timeout

--- a/tests/integration_test/system_test.py
+++ b/tests/integration_test/system_test.py
@@ -101,6 +101,7 @@ def setup_and_teardown_system(request):
     cleanup = test_config["cleanup"]
     has_project_yaml = "project_yaml" in test_config
     poll_period = test_config.get("poll_period", 5)
+    event_sequence_timeout = test_config.get("event_sequence_timeout")
     additional_python_paths = [
         _resolve_test_config_path(suite_root, p) for p in test_config.get("additional_python_paths", [])
     ]
@@ -150,7 +151,10 @@ def setup_and_teardown_system(request):
         download_root_dir = os.path.join(test_temp_dir, "download_result")
         os.mkdir(download_root_dir)
         test_driver = NVFTestDriver(
-            site_launcher=site_launcher, download_root_dir=download_root_dir, poll_period=poll_period
+            site_launcher=site_launcher,
+            download_root_dir=download_root_dir,
+            poll_period=poll_period,
+            event_sequence_timeout=event_sequence_timeout,
         )
         test_driver.initialize_super_user(
             workspace_root_dir=workspace_root, upload_root_dir=jobs_root_dir, super_user_name=super_user_name
@@ -199,12 +203,12 @@ class TestSystem:
 
             test_driver.run_event_sequence(event_sequence)
 
-            job_result = None
-            if test_driver.job_id is not None:
-                job_result = test_driver.get_job_result(test_driver.job_id)
-
             # Get the job validator
             if validators:
+                job_result = None
+                if test_driver.job_id is not None:
+                    job_result = test_driver.get_job_result(test_driver.job_id)
+
                 validate_result = True
                 for validator in validators:
                     validator_module = validator["path"]
@@ -227,7 +231,7 @@ class TestSystem:
                 validate_result = "No Validators"
             test_validate_results.append((test_name, validate_result))
 
-            print(f"Finished running test '{test_name}' in {time.time() - start_time} seconds.")
+            print(f"Finished running test {test_name!r} in {time.time() - start_time} seconds.")
             for command in teardown:
                 print(f"Running teardown command: {command}")
                 process = run_command_in_subprocess(command)


### PR DESCRIPTION
## What changed

- Install the federated XGBoost wheel before running the direct `slow` integration suite, so XGBoost recipe tests have `xgboost.federated` available.
- Remove duplicate direct-suite aliases from `ci/run_integration.sh`; `fast` and `slow` now cover those pytest directories.
- Clean up stale `localhost1` host alias setup and docs, keeping only `localhost0` for remaining provisioned integration configs.
- Document the XGBoost wheel requirement for direct local slow-suite pytest runs.

## Why

The slow integration suite now includes XGBoost recipe tests. Those tests need the same federated XGBoost wheel already used by the XGBoost integration configs, while Jenkins should avoid duplicate direct-suite entry points that are already covered by `fast` and `slow`.
