### PR TITLE
Allow CellPipe stream aliases for auth binding

### DIFF
--- a/nvflare/private/fed/authenticator.py
+++ b/nvflare/private/fed/authenticator.py
@@ -29,6 +29,7 @@ from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.message import Message as CellMessage
+from nvflare.fuel.f3.streaming.stream_const import STREAM_CHANNEL
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.private.defs import CellChannel, CellChannelTopic, CellMessageHeaderKeys, ClientRegMsgKey, new_cell_message
 from nvflare.private.fed.utils.identity_utils import IdentityAsserter, IdentityVerifier, TokenVerifier, load_crt_bytes
@@ -302,8 +303,29 @@ class Authenticator:
         return token, token_signature, ssid, token_verifier
 
 
-def _origin_matches_fqcn(origin: str, fqcn: str) -> bool:
-    return bool(origin) and bool(fqcn) and (origin == fqcn or FQCN.is_ancestor(fqcn, origin))
+def _origin_matches_fqcn(origin: str, fqcn: str, channel: Optional[str] = None) -> bool:
+    if not origin or not fqcn:
+        return False
+    if origin == fqcn or FQCN.is_ancestor(fqcn, origin):
+        return True
+
+    # Direct CellPipe stream cells use sibling names such as
+    # "site-1_<job-id>_active" and "site-1_<job-id>_passive", but their auth
+    # token is issued to the registered site FQCN ("site-1").  Treat only those
+    # stream aliases as the owning site; normal server-command origins remain
+    # bound to the exact registered FQCN/descendant relationship above.
+    if channel != STREAM_CHANNEL or not origin.startswith(f"{fqcn}_"):
+        return False
+
+    runtime_id, sep, mode = origin[len(fqcn) + 1 :].rpartition("_")
+    if not sep or mode not in {"active", "passive"}:
+        return False
+
+    # Deployed CellPipe aliases use the job UUID as the runtime id. Do not allow
+    # FQCN separators or alias separators inside this portion: otherwise a token
+    # for "site" could validate an origin such as "site_x_<job>_active" when
+    # "site_x" is also a valid client FQCN.
+    return bool(runtime_id) and "." not in runtime_id and "_" not in runtime_id
 
 
 def validate_auth_headers(
@@ -361,7 +383,7 @@ def validate_auth_headers(
 
     if client_fqcn_resolver:
         client_fqcn = client_fqcn_resolver(client_name, token)
-        if client_fqcn is not None and not _origin_matches_fqcn(origin, client_fqcn):
+        if client_fqcn is not None and not _origin_matches_fqcn(origin, client_fqcn, channel):
             registered_origin = client_fqcn or "<missing>"
             err = (
                 f"auth token for client {client_name} is bound to origin {registered_origin}, "

--- a/tests/unit_test/private/fed/authenticator_test.py
+++ b/tests/unit_test/private/fed/authenticator_test.py
@@ -19,6 +19,7 @@ import pytest
 from nvflare.apis.fl_constant import ServerCommandNames
 from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.streaming.stream_const import STREAM_CHANNEL, STREAM_DATA_TOPIC
 from nvflare.private.defs import CellMessageHeaderKeys
 from nvflare.private.fed.authenticator import MISSING_CLIENT_FQCN, validate_auth_headers
 
@@ -28,11 +29,11 @@ class _TokenVerifier:
         return True
 
 
-def _make_message(origin):
+def _make_message(origin, channel=CellChannel.SERVER_COMMAND, topic=ServerCommandNames.GET_TASK):
     return Message(
         headers={
-            MessageHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
-            MessageHeaderKey.TOPIC: ServerCommandNames.GET_TASK,
+            MessageHeaderKey.CHANNEL: channel,
+            MessageHeaderKey.TOPIC: topic,
             MessageHeaderKey.ORIGIN: origin,
             CellMessageHeaderKeys.CLIENT_NAME: "site-a",
             CellMessageHeaderKeys.TOKEN: "token-a",
@@ -41,9 +42,9 @@ def _make_message(origin):
     )
 
 
-def _validate(origin, client_fqcn_resolver):
+def _validate(origin, client_fqcn_resolver, channel=CellChannel.SERVER_COMMAND, topic=ServerCommandNames.GET_TASK):
     return validate_auth_headers(
-        message=_make_message(origin),
+        message=_make_message(origin, channel=channel, topic=topic),
         token_verifier=_TokenVerifier(),
         logger=logging.getLogger(__name__),
         client_fqcn_resolver=client_fqcn_resolver,
@@ -56,8 +57,80 @@ def test_validate_auth_headers_accepts_token_from_registered_origin(origin):
     assert _validate(origin, lambda _client_name, _token: "site-a") is None
 
 
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "site-a_8065f1c4-fd35-47ef-b945-800f4d0d5176_active",
+        "site-a_8065f1c4-fd35-47ef-b945-800f4d0d5176_passive",
+    ],
+)
+def test_validate_auth_headers_accepts_direct_cell_pipe_stream_alias(origin):
+    assert (
+        _validate(
+            origin,
+            lambda _client_name, _token: "site-a",
+            channel=STREAM_CHANNEL,
+            topic=STREAM_DATA_TOPIC,
+        )
+        is None
+    )
+
+
 def test_validate_auth_headers_rejects_token_from_different_origin():
     reply = _validate("site-b", lambda _client_name, _token: "site-a")
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_rejects_cell_pipe_alias_for_different_client():
+    reply = _validate(
+        "site-b_8065f1c4-fd35-47ef-b945-800f4d0d5176_passive",
+        lambda _client_name, _token: "site-a",
+        channel=STREAM_CHANNEL,
+        topic=STREAM_DATA_TOPIC,
+    )
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_rejects_cell_pipe_alias_on_non_stream_channel():
+    reply = _validate(
+        "site-a_8065f1c4-fd35-47ef-b945-800f4d0d5176_passive",
+        lambda _client_name, _token: "site-a",
+    )
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_rejects_cell_pipe_alias_with_hierarchical_runtime_id():
+    reply = _validate(
+        "site-a_8065f1c4-fd35-47ef-b945-800f4d0d5176.child_passive",
+        lambda _client_name, _token: "site-a",
+        channel=STREAM_CHANNEL,
+        topic=STREAM_DATA_TOPIC,
+    )
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_rejects_cell_pipe_alias_with_underscore_runtime_id():
+    reply = _validate(
+        "site-a_simulate_job_passive",
+        lambda _client_name, _token: "site-a",
+        channel=STREAM_CHANNEL,
+        topic=STREAM_DATA_TOPIC,
+    )
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+
+
+def test_validate_auth_headers_rejects_underscore_prefixed_client_ambiguity():
+    reply = _validate(
+        "site-a_x_8065f1c4-fd35-47ef-b945-800f4d0d5176_passive",
+        lambda _client_name, _token: "site-a",
+        channel=STREAM_CHANNEL,
+        topic=STREAM_DATA_TOPIC,
+    )
 
     assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
 


### PR DESCRIPTION
## Summary

- Allow server auth origin binding to accept CellPipe stream runtime aliases for the authenticated client only on the stream channel.
- Preserve exact FQCN and descendant FQCN validation for normal traffic.
- Reject stream-alias runtime IDs containing FQCN or alias separators so underscore-prefixed sibling client names cannot pass as the shorter client.
- Add unit coverage for accepted UUID stream aliases and rejected wrong-client, non-stream, dotted-runtime, underscore-runtime, and underscore-prefixed sibling cases.

This is the main-branch equivalent of the 2.8 fix merged in #4627, with an additional guard for underscore-delimited FQCN prefix ambiguity.

