### PR TITLE
[2.8] Add FedBPT Job API entry point

### DIFF
--- a/research/fed-bpt/README.md
+++ b/research/fed-bpt/README.md
@@ -25,44 +25,14 @@ The example uses `job.py` to create and run the NVFlare job without registering 
 We utilize the [SST-2 dataset](https://huggingface.co/datasets/stanfordnlp/sst2) and the RoBerTa-large model for training.
 ```commandline
 N_CLIENTS=10
-SEED=1234
-K_SHOT=200
-python job.py \
-  --num_clients ${N_CLIENTS} \
-  --num_rounds 200 \
-  --seed ${SEED} \
-  --task_name sst2 \
-  --n_prompt_tokens 50 \
-  --intrinsic_dim 500 \
-  --k_shot ${K_SHOT} \
-  --device cuda:0 \
-  --loss_type ce \
-  --cat_or_add add \
-  --local_iter 8 \
-  --num_users ${N_CLIENTS} \
-  --iid 1 \
-  --local_popsize 5 \
-  --perturb 1 \
-  --model_name roberta-large \
-  --eval_clients site-1 \
-  --llama_causal 1
+python job.py --num_clients ${N_CLIENTS}
 ```
-By default, we only evaluate the global model on client `site-1` as in our setting, the global test set is shared by clients.
+The command uses the default FedBPT settings for SST-2, RoBERTa-large, 200 global rounds, and 200 shots per class. By default, we only evaluate the global model on client `site-1` as in our setting, the global test set is shared by clients.
 
 The following setting requires a GPU with at least 24 GB memory and enough system memory to run the clients in parallel (we recommend at least 40 GB).
 For a system with less resources, you can set `--threads` to be a lower number and simulate the clients running sequentially.
 ```commandline
-python job.py --num_clients ${N_CLIENTS} --num_rounds 200 --seed ${SEED} \
-  --k_shot ${K_SHOT} \
-  --task_name sst2 \
-  --local_popsize 20 \
-  --local_iter 50 \
-  --aggregation_epochs 50 \
-  --sigma0 1 \
-  --perturb 1 \
-  --model_name roberta-large \
-  --eval_clients site-1 \
-  --llama_causal 1 \
+python job.py --num_clients ${N_CLIENTS} \
   --threads 2 \
   --gpu 0 \
   --workspace /tmp/nvflare/fedbpt
@@ -71,7 +41,7 @@ If you have more GPUs available on your system, you can use `--gpu` to run clien
 
 To export the job without running the simulator, add `--export`:
 ```commandline
-python job.py --export --export-dir ./jobs --num_clients ${N_CLIENTS} --num_rounds 200 --seed ${SEED}
+python job.py --export --export-dir ./jobs --num_clients ${N_CLIENTS}
 ```
 This writes the job to `./jobs/fedbpt`.
 

--- a/research/fed-bpt/README.md
+++ b/research/fed-bpt/README.md
@@ -51,7 +51,20 @@ By default, we only evaluate the global model on client `site-1` as in our setti
 The following setting requires a GPU with at least 24 GB memory and enough system memory to run the clients in parallel (we recommend at least 40 GB).
 For a system with less resources, you can set `--threads` to be a lower number and simulate the clients running sequentially.
 ```commandline
-python job.py --num_clients ${N_CLIENTS} --threads 2 --gpu 0 --workspace /tmp/nvflare/fedbpt
+python job.py --num_clients ${N_CLIENTS} --num_rounds 200 --seed ${SEED} \
+  --k_shot ${K_SHOT} \
+  --task_name sst2 \
+  --local_popsize 20 \
+  --local_iter 50 \
+  --aggregation_epochs 50 \
+  --sigma0 1 \
+  --perturb 1 \
+  --model_name roberta-large \
+  --eval_clients site-1 \
+  --llama_causal 1 \
+  --threads 2 \
+  --gpu 0 \
+  --workspace /tmp/nvflare/fedbpt
 ```
 If you have more GPUs available on your system, you can use `--gpu` to run clients on different GPUs in parallel.
 

--- a/research/fed-bpt/README.md
+++ b/research/fed-bpt/README.md
@@ -26,6 +26,7 @@ We utilize the [SST-2 dataset](https://huggingface.co/datasets/stanfordnlp/sst2)
 ```commandline
 N_CLIENTS=10
 SEED=1234
+K_SHOT=200
 python job.py \
   --num_clients ${N_CLIENTS} \
   --num_rounds 200 \
@@ -33,7 +34,7 @@ python job.py \
   --task_name sst2 \
   --n_prompt_tokens 50 \
   --intrinsic_dim 500 \
-  --k_shot 200 \
+  --k_shot ${K_SHOT} \
   --device cuda:0 \
   --loss_type ce \
   --cat_or_add add \

--- a/research/fed-bpt/README.md
+++ b/research/fed-bpt/README.md
@@ -17,47 +17,49 @@ with the addition of installing NVFlare for running federated learning and some 
 conda create --name fedbpt python=3.12
 conda activate fedbpt
 pip install -r requirements.txt
+pip install -e ../..
 ```
 
 ## 2. Run a federated learning experiment
-First, we set the location of NVFlare job templates directory.
-```commandline
-nvflare config -jt ./job_templates
-```
-Next, we generate a job configuration from the template to run FL on `N_CLIENTS` clients. 
+The example uses `job.py` to create and run the NVFlare job without registering global job templates.
 We utilize the [SST-2 dataset](https://huggingface.co/datasets/stanfordnlp/sst2) and the RoBerTa-large model for training.
 ```commandline
 N_CLIENTS=10
 SEED=1234
-nvflare job create -force -j "./jobs/fedbpt" -w "fedbpt" -sd "./src" \
--f app/config/config_fed_client.conf app_script="fedbpt_train.py" app_config="--task_name sst2 \
---n_prompt_tokens 50 \
---intrinsic_dim 500 \
---k_shot 200 \
---device cuda:0 \
---seed ${SEED} \
---loss_type ce \
---cat_or_add add \
---local_iter 8 \
---num_users ${N_CLIENTS} \
---iid 1 \
---local_popsize 5 \
---perturb 1 \
---model_name roberta-large \
---eval_clients site-1 \
---llama_causal 1" \
--f app/config/config_fed_server.conf min_clients=${N_CLIENTS} num_rounds=200 seed=${SEED}
+python job.py \
+  --num_clients ${N_CLIENTS} \
+  --num_rounds 200 \
+  --seed ${SEED} \
+  --task_name sst2 \
+  --n_prompt_tokens 50 \
+  --intrinsic_dim 500 \
+  --k_shot 200 \
+  --device cuda:0 \
+  --loss_type ce \
+  --cat_or_add add \
+  --local_iter 8 \
+  --num_users ${N_CLIENTS} \
+  --iid 1 \
+  --local_popsize 5 \
+  --perturb 1 \
+  --model_name roberta-large \
+  --eval_clients site-1 \
+  --llama_causal 1
 ```
 By default, we only evaluate the global model on client `site-1` as in our setting, the global test set is shared by clients.
 
-Start the FL simulator with `N_CLIENTS` clients in parallel.
 The following setting requires a GPU with at least 24 GB memory and enough system memory to run the clients in parallel (we recommend at least 40 GB).
-For a system with less resources, you can set -t to be a lower number and simulate the clients running sequentially.
+For a system with less resources, you can set `--threads` to be a lower number and simulate the clients running sequentially.
 ```commandline
-OUT_DIR="/tmp/nvflare/fedbpt"
-nvflare simulator ./jobs/fedbpt -n ${N_CLIENTS} -t ${N_CLIENTS} -w ${OUT_DIR}
+python job.py --num_clients ${N_CLIENTS} --threads 2 --gpu 0 --workspace /tmp/nvflare/fedbpt
 ```
-If you have more GPUs available on your system, you can use the `--gpu` argument of the simulator to run clients on different GPUs in parallel.
+If you have more GPUs available on your system, you can use `--gpu` to run clients on different GPUs in parallel.
+
+To export the job without running the simulator, add `--export`:
+```commandline
+python job.py --export --export-dir ./jobs --num_clients ${N_CLIENTS} --num_rounds 200 --seed ${SEED}
+```
+This writes the job to `./jobs/fedbpt`.
 
 ## 3. Example results
 The training results showing the global testing accuracy over 200 rounds is shown below. 

--- a/research/fed-bpt/job.py
+++ b/research/fed-bpt/job.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import shlex
+import sys
+from typing import Iterable
+
+FEDBPT_DIR = os.path.abspath(os.path.dirname(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(FEDBPT_DIR, os.pardir, os.pardir))
+SRC_DIR = os.path.join(FEDBPT_DIR, "src")
+TRAIN_SCRIPT = os.path.join(SRC_DIR, "fedbpt_train.py")
+DEFAULT_WORKSPACE = "/tmp/nvflare/fedbpt"
+
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from nvflare.client.config import ExchangeFormat, TransferType  # noqa: E402
+from nvflare.fuel.utils.constants import FrameworkType  # noqa: E402
+from nvflare.job_config.api import FedJob  # noqa: E402
+from nvflare.job_config.script_runner import BaseScriptRunner  # noqa: E402
+
+
+def define_parser():
+    parser = argparse.ArgumentParser(description="Run or export the FedBPT NVFlare job.")
+
+    parser.add_argument("--job_name", default="fedbpt", help="Name of the generated NVFlare job.")
+    parser.add_argument("--num_clients", type=int, default=10, help="Number of FedBPT clients.")
+    parser.add_argument("--min_clients", type=int, default=None, help="Minimum clients required to start the job.")
+    parser.add_argument("--num_rounds", type=int, default=200, help="Number of global FedBPT rounds.")
+    parser.add_argument("--seed", type=int, default=1234, help="Random seed used by the server and client scripts.")
+    parser.add_argument("--workspace", default=DEFAULT_WORKSPACE, help="Simulation workspace root.")
+    parser.add_argument("--threads", type=int, default=None, help="Number of simulator worker threads.")
+    parser.add_argument("--gpu", default=None, help="Simulator GPU assignment string, for example '0,1,2,3'.")
+    parser.add_argument("--log_config", default=None, help="Simulator log config mode or path.")
+    parser.add_argument("--export", action="store_true", help="Export the job and exit without running simulation.")
+    parser.add_argument("--export-dir", default="./jobs", help="Directory where the job folder is exported.")
+
+    parser.add_argument("--frac", type=float, default=1.0, help="Fraction of clients used by GlobalES.")
+    parser.add_argument("--sigma", type=float, default=1.0, help="Initial GlobalES sigma.")
+    parser.add_argument("--intrinsic_dim", type=int, default=500, help="Intrinsic dimension for GlobalES and clients.")
+    parser.add_argument("--bound", type=int, default=0, help="GlobalES bound, 0 disables bounds.")
+
+    parser.add_argument("--task_name", default="sst2", help="Task name passed to fedbpt_train.py.")
+    parser.add_argument("--n_prompt_tokens", type=int, default=50, help="Number of prompt tokens.")
+    parser.add_argument("--k_shot", type=int, default=200, help="Few-shot samples per class.")
+    parser.add_argument("--batch_size", type=int, default=None, help="Optional client batch size override.")
+    parser.add_argument("--device", default="cuda:0", help="Device passed to fedbpt_train.py.")
+    parser.add_argument("--loss_type", default="ce", help="Loss type passed to fedbpt_train.py.")
+    parser.add_argument("--cat_or_add", default="add", help="Prompt mode passed to fedbpt_train.py.")
+    parser.add_argument("--local_iter", type=int, default=8, help="Local CMA iterations per round.")
+    parser.add_argument("--num_users", type=int, default=None, help="Number of client data shards.")
+    parser.add_argument("--iid", type=int, default=1, help="Whether to split client data IID.")
+    parser.add_argument("--local_popsize", type=int, default=5, help="Local CMA population size.")
+    parser.add_argument("--perturb", type=int, default=1, help="Whether to use perturbed data fitness.")
+    parser.add_argument("--model_name", default="roberta-large", choices=["roberta-base", "roberta-large"])
+    parser.add_argument("--eval_clients", default="site-1", help="Comma-separated clients that run global eval.")
+    parser.add_argument("--llama_causal", type=int, default=1, help="FedBPT compatibility flag.")
+    parser.add_argument(
+        "--train_args",
+        default="",
+        help="Additional fedbpt_train.py arguments appended after generated arguments.",
+    )
+    return parser
+
+
+def _quote_args(args: Iterable[object]) -> str:
+    return " ".join(shlex.quote(str(arg)) for arg in args if arg is not None)
+
+
+def _make_train_args(args, extra_train_args: list[str]) -> str:
+    num_users = args.num_users if args.num_users is not None else args.num_clients
+    train_args = [
+        "--task_name",
+        args.task_name,
+        "--n_prompt_tokens",
+        args.n_prompt_tokens,
+        "--intrinsic_dim",
+        args.intrinsic_dim,
+        "--k_shot",
+        args.k_shot,
+        "--device",
+        args.device,
+        "--seed",
+        args.seed,
+        "--loss_type",
+        args.loss_type,
+        "--cat_or_add",
+        args.cat_or_add,
+        "--local_iter",
+        args.local_iter,
+        "--num_users",
+        num_users,
+        "--iid",
+        args.iid,
+        "--local_popsize",
+        args.local_popsize,
+        "--perturb",
+        args.perturb,
+        "--model_name",
+        args.model_name,
+        "--eval_clients",
+        args.eval_clients,
+        "--llama_causal",
+        args.llama_causal,
+    ]
+    if args.batch_size is not None:
+        train_args.extend(["--batch_size", args.batch_size])
+    if args.train_args:
+        train_args.extend(shlex.split(args.train_args))
+    train_args.extend(extra_train_args)
+    return _quote_args(train_args)
+
+
+def _load_fedbpt_components():
+    if SRC_DIR not in sys.path:
+        sys.path.insert(0, SRC_DIR)
+
+    from decomposer_widget import RegisterDecomposer
+    from global_es import GlobalES
+
+    return GlobalES, RegisterDecomposer
+
+
+def create_recipe(args, extra_train_args: list[str] | None = None):
+    from nvflare.app_common.launchers.subprocess_launcher import SubprocessLauncher
+    from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
+    from nvflare.recipe.spec import Recipe
+
+    GlobalES, RegisterDecomposer = _load_fedbpt_components()
+
+    extra_train_args = extra_train_args or []
+    min_clients = args.min_clients if args.min_clients is not None else args.num_clients
+    train_args = _make_train_args(args, extra_train_args)
+
+    job = FedJob(name=args.job_name, min_clients=min_clients)
+    job.to_server(
+        GlobalES(
+            num_clients=args.num_clients,
+            num_rounds=args.num_rounds,
+            frac=args.frac,
+            sigma=args.sigma,
+            intrinsic_dim=args.intrinsic_dim,
+            seed=args.seed,
+            bound=args.bound,
+        ),
+        id="global_es",
+    )
+    job.to_server(TBAnalyticsReceiver(events=["fed.analytix_log_stats"]), id="receiver")
+    job.to_server(RegisterDecomposer(), id="register_decomposer")
+
+    launcher = SubprocessLauncher(
+        script=f"python3 -u custom/fedbpt_train.py {train_args}",
+        launch_once=True,
+        shutdown_timeout=0.0,
+    )
+    runner = BaseScriptRunner(
+        script=TRAIN_SCRIPT,
+        launch_external_process=True,
+        framework=FrameworkType.NUMPY,
+        server_expected_format=ExchangeFormat.NUMPY,
+        params_transfer_type=TransferType.FULL,
+        launcher=launcher,
+    )
+    job.to_clients(runner, tasks=["train"])
+    job.to_clients(RegisterDecomposer(), id="register_decomposer")
+    return Recipe(job)
+
+
+def main():
+    parser = define_parser()
+    args, extra_train_args = parser.parse_known_args()
+
+    recipe = create_recipe(args, extra_train_args)
+    if args.export:
+        recipe.export(args.export_dir)
+        print(f"Job exported to: {os.path.join(args.export_dir, args.job_name)}")
+        return
+
+    from nvflare.recipe.sim_env import SimEnv
+
+    env = SimEnv(
+        num_clients=args.num_clients,
+        num_threads=args.threads,
+        gpu_config=args.gpu,
+        log_config=args.log_config,
+        workspace_root=args.workspace,
+    )
+    run = recipe.run(env)
+    print()
+    print("Job Status is:", run.get_status())
+    print("Result can be found in:", run.get_result(clean_up=False))
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/research/fed-bpt/job.py
+++ b/research/fed-bpt/job.py
@@ -77,7 +77,10 @@ def define_parser():
 
 
 def _quote_args(args: Iterable[object]) -> str:
-    return " ".join(shlex.quote(str(arg)) for arg in args if arg is not None)
+    args = list(args)
+    if any(arg is None for arg in args):
+        raise ValueError(f"None value encountered in train args list: {args}")
+    return " ".join(shlex.quote(str(arg)) for arg in args)
 
 
 def _make_train_args(args, extra_train_args: list[str]) -> str:
@@ -164,7 +167,7 @@ def create_recipe(args, extra_train_args: list[str] | None = None):
     launcher = SubprocessLauncher(
         script=f"python3 -u custom/fedbpt_train.py {train_args}",
         launch_once=True,
-        shutdown_timeout=0.0,
+        shutdown_timeout=10.0,
     )
     runner = BaseScriptRunner(
         script=TRAIN_SCRIPT,

--- a/research/fed-bpt/requirements.txt
+++ b/research/fed-bpt/requirements.txt
@@ -5,4 +5,3 @@ cma==3.4.0
 scikit-learn
 tensorboard
 cvxopt
-nvflare~=2.5.1rc

--- a/research/fed-bpt/src/cma_decomposer.py
+++ b/research/fed-bpt/src/cma_decomposer.py
@@ -33,6 +33,19 @@ from nvflare.fuel.utils.fobs import Decomposer
 from nvflare.fuel.utils.fobs.datum import DatumManager
 
 
+class RangeDecomposer(Decomposer):
+    """A decomposer for serializing Python range objects in CMA state."""
+
+    def supported_type(self) -> Type[range]:
+        return range
+
+    def decompose(self, target: range, manager: DatumManager = None) -> Any:
+        return target.start, target.stop, target.step
+
+    def recompose(self, data: tuple, manager: DatumManager = None) -> range:
+        return range(*data)
+
+
 class GaussFullSamplerDecomposer(Decomposer):
     """A decomposer for serializing and deserializing GaussFullSampler objects.
 
@@ -143,6 +156,7 @@ class CMADataLoggerDecomposer(Decomposer):
 
 
 def register_decomposers():
+    fobs.register(RangeDecomposer)
     fobs.register(NumpyArrayDecomposer)
     fobs.register(Float64ScalarDecomposer)
     fobs.register(GaussFullSamplerDecomposer)

--- a/research/fed-bpt/src/fedbpt_train.py
+++ b/research/fed-bpt/src/fedbpt_train.py
@@ -370,5 +370,6 @@ while flare.is_running():
         metrics={"global_test_accuracy": global_test_acc},
     )
     # send model back to NVFlare
+    output_param_keys = list(output_model.params.keys())
     flare.send(output_model)
-    print("Send params back", list(output_model.params.keys()))
+    print("Send params back", output_param_keys)

--- a/tests/unit_test/examples/fedbpt_job_test.py
+++ b/tests/unit_test/examples/fedbpt_job_test.py
@@ -15,6 +15,7 @@
 import importlib.util
 import json
 import os
+import sys
 
 import pytest
 
@@ -78,3 +79,27 @@ def test_fedbpt_job_exports_recipe_config(tmp_path):
     assert any(c["path"] == "decomposer_widget.RegisterDecomposer" for c in server["components"])
     assert any(c["path"] == "decomposer_widget.RegisterDecomposer" for c in client["components"])
     assert any("custom/fedbpt_train.py" in c["args"].get("script", "") for c in client["components"])
+
+
+def test_fedbpt_cma_decomposer_serializes_range_state():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    src_dir = os.path.join(repo_root, "research", "fed-bpt", "src")
+    sys.path.insert(0, src_dir)
+    try:
+        import cma
+        from cma_decomposer import register_decomposers
+
+        from nvflare.fuel.utils import fobs
+    finally:
+        sys.path.remove(src_dir)
+
+    register_decomposers()
+
+    decoded_range = fobs.loads(fobs.dumps(range(1, 5, 2)))
+    assert list(decoded_range) == [1, 3]
+
+    strategy = cma.CMAEvolutionStrategy(4 * [5], 1, {"ftarget": 1e-9, "seed": 5})
+    decoded_strategy = fobs.loads(fobs.dumps(strategy))
+
+    assert decoded_strategy.N == strategy.N
+    assert decoded_strategy.sigma == strategy.sigma

--- a/tests/unit_test/examples/fedbpt_job_test.py
+++ b/tests/unit_test/examples/fedbpt_job_test.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import json
+import os
+
+import pytest
+
+HAS_FEDBPT_EXPORT_DEPS = importlib.util.find_spec("cma") is not None and importlib.util.find_spec("torch") is not None
+pytestmark = pytest.mark.skipif(not HAS_FEDBPT_EXPORT_DEPS, reason="FedBPT job export dependencies are not installed")
+
+
+def _load_fedbpt_job_module():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    job_path = os.path.join(repo_root, "research", "fed-bpt", "job.py")
+    spec = importlib.util.spec_from_file_location("fedbpt_job", job_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fedbpt_job_exports_recipe_config(tmp_path):
+    job_module = _load_fedbpt_job_module()
+    parser = job_module.define_parser()
+    args, extra_args = parser.parse_known_args(
+        [
+            "--num_clients",
+            "2",
+            "--num_rounds",
+            "1",
+            "--seed",
+            "42",
+            "--model_name",
+            "roberta-base",
+            "--k_shot",
+            "1",
+            "--local_popsize",
+            "2",
+            "--local_iter",
+            "1",
+            "--eval_clients",
+            "none",
+        ]
+    )
+
+    recipe = job_module.create_recipe(args, extra_args)
+    recipe.export(str(tmp_path))
+
+    job_dir = tmp_path / "fedbpt"
+    server_config = job_dir / "app" / "config" / "config_fed_server.json"
+    client_config = job_dir / "app" / "config" / "config_fed_client.json"
+    custom_dir = job_dir / "app" / "custom"
+
+    assert (job_dir / "meta.json").exists()
+    assert (custom_dir / "fedbpt_train.py").exists()
+    assert (custom_dir / "cma_decomposer.py").exists()
+
+    with open(server_config) as f:
+        server = json.load(f)
+    with open(client_config) as f:
+        client = json.load(f)
+
+    assert server["workflows"][0]["path"] == "global_es.GlobalES"
+    assert server["workflows"][0]["args"]["num_clients"] == 2
+    assert server["workflows"][0]["args"]["num_rounds"] == 1
+    assert any(c["path"] == "decomposer_widget.RegisterDecomposer" for c in server["components"])
+    assert any(c["path"] == "decomposer_widget.RegisterDecomposer" for c in client["components"])
+    assert any("custom/fedbpt_train.py" in c["args"].get("script", "") for c in client["components"])


### PR DESCRIPTION
## What

Adds a `job.py` entry point for `research/fed-bpt` so the example can be created, exported, and simulated through the Job API/Recipe flow instead of relying on deprecated global job template registration.

Also removes the stale `nvflare~=2.5.1rc` dependency from the FedBPT requirements so the documented `pip install -e ../..` setup actually runs against the 2.8 checkout at simulator runtime.

## Why

QA verification on `upstream/2.8` was blocked because the documented global job template no longer existed:

```text
nvflare job create -w fedbpt
Invalid template name fedbpt
```

The updated README now uses `python job.py ...` and provides an export-only path for QA or users who need a generated job folder.

## Validation

- `python3 research/fed-bpt/job.py --help`
- `PYTHONPATH=/private/tmp/codex_cma_340_real MPLCONFIGDIR=/private/tmp/mpl-cache python3 -m pytest tests/unit_test/examples/fedbpt_job_test.py tests/unit_test/examples/fedbpt_cma_decomposer_test.py -v`
- `MPLCONFIGDIR=/private/tmp/mpl-cache python3 -m pytest tests/unit_test/examples/fedbpt_job_test.py tests/unit_test/examples/fedbpt_cma_decomposer_test.py -v` (dependency skip path)
- `PYTHONPATH=/private/tmp/codex_cma_340_real MPLCONFIGDIR=/private/tmp/mpl-cache python3 research/fed-bpt/job.py --export --export-dir /private/tmp/fedbpt-job-export2 --num_clients 2 --num_rounds 1 --seed 42 --model_name roberta-base --k_shot 1 --local_popsize 2 --local_iter 1 --eval_clients none`
- `./runtest.sh -s`
- H100 reduced smoke on `hroth@172.16.1.14`, commit `63d4f7ef5e4766cac04e0490f41fa1a8e37d9c43`, container `nvcr.io/nvidia/vllm:25.09-py3`:
  - setup: `pip install -r research/fed-bpt/requirements.txt && pip install -e /workspace`
  - export: `python3 job.py --export --export-dir /host_out/jobs --num_clients 2 --num_rounds 1 --seed 42 --model_name roberta-base --n_prompt_tokens 4 --intrinsic_dim 4 --k_shot 1 --local_popsize 2 --local_iter 1 --eval_clients none`
  - simulation: `python3 job.py --num_clients 2 --num_rounds 1 --seed 42 --model_name roberta-base --n_prompt_tokens 4 --intrinsic_dim 4 --k_shot 1 --local_popsize 2 --local_iter 1 --eval_clients none --threads 1 --gpu 0 --workspace /tmp/nvflare/fedbpt_smoke --device cuda:0`
  - output root: `/scratch/hroth/Code/nvflare/fedbpt-output/smoke_req_fixed_2c_20260518_110510`
  - observed both clients returning train results; exported job contains nested `dataloaders`, `metrics`, and `models` custom modules.

