### PR TITLE
Map running job delete to JOB_NOT_DONE

### DIFF
--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -1677,7 +1677,7 @@ def cmd_job_download(cmd_args):
 
 
 def cmd_job_delete(cmd_args):
-    from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotFound, NoConnection
+    from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotDone, JobNotFound, NoConnection
     from nvflare.tool.cli_output import output_error, output_ok
     from nvflare.tool.cli_schema import handle_schema_flag
 
@@ -1689,6 +1689,10 @@ def cmd_job_delete(cmd_args):
     )
 
     study = get_arg_value(cmd_args, "study", "default")
+    job_abort_hint = (
+        f"Use 'nvflare job abort {cmd_args.job_id} --study {study}' to stop the job first, "
+        "or wait/monitor until it finishes before deleting."
+    )
     if not cmd_args.force:
         if not sys.stdin.isatty():
             output_error(
@@ -1712,6 +1716,15 @@ def cmd_job_delete(cmd_args):
             job_id=cmd_args.job_id,
             detail=f"searched study '{study}'",
             hint=_job_not_found_hint(study),
+        )
+        return
+    except JobNotDone as e:
+        output_error(
+            "JOB_NOT_DONE",
+            exit_code=4,
+            job_id=cmd_args.job_id,
+            detail=f"{e}; searched study '{study}'",
+            hint=job_abort_hint,
         )
         return
     except AuthenticationError:

--- a/tests/unit_test/tool/job/job_delete_test.py
+++ b/tests/unit_test/tool/job/job_delete_test.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotFound
+from nvflare.fuel.flare_api.api_spec import AuthenticationError, JobNotDone, JobNotFound
 from nvflare.tool import cli_output
 
 
@@ -160,6 +160,27 @@ class TestJobDelete:
         assert envelope["error_code"] == "JOB_NOT_FOUND"
         assert "searched study 'default'" in envelope["message"]
         assert "nvflare job list --study <study_name>" in envelope["hint"]
+
+    def test_delete_running_job_exits_job_not_done(self, capsys):
+        """Running jobs are not deleted as internal errors."""
+        from nvflare.tool.job.job_cli import cmd_job_delete
+
+        args = self._make_args(job_id="running", force=True)
+        args.study = "cancer"
+        mock_sess = MagicMock()
+        mock_sess.delete_job.side_effect = JobNotDone("job running is still running")
+
+        with patch("nvflare.tool.job.job_cli._get_session", return_value=mock_sess):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_job_delete(args)
+
+        assert exc_info.value.code == 4
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["status"] == "error"
+        assert envelope["error_code"] == "JOB_NOT_DONE"
+        assert envelope["exit_code"] == 4
+        assert "job running is still running; searched study 'cancer'" in envelope["message"]
+        assert "nvflare job abort running --study cancer" in envelope["hint"]
 
     def test_delete_authentication_error_propagates(self):
         from nvflare.tool.job.job_cli import cmd_job_delete


### PR DESCRIPTION
## Summary

Port #4596 from `2.8` to `main`.

- Map failed deletion of a still-running job to `JOB_NOT_DONE`.
- Preserve existing delete behavior for completed/non-running jobs.
- Add focused unit coverage in `tests/unit_test/tool/job/job_delete_test.py`.

## Why

Deleting a running job should surface the existing `JOB_NOT_DONE` condition instead of a less specific failure path, matching the 2.8 behavior.

## Validation

- `python3 -m py_compile nvflare/tool/job/job_cli.py tests/unit_test/tool/job/job_delete_test.py`
- `/Users/yuantingh/NVFlare/venv/bin/python -m pytest tests/unit_test/tool/job/job_delete_test.py -q` (`10 passed`)
- `git diff --check upstream/main...HEAD`