### PR TITLE
[2.8] Fix XGBoost review diagnostics

### DIFF
--- a/ci/run_integration.sh
+++ b/ci/run_integration.sh
@@ -115,9 +115,9 @@ resolve_xgboost_federated_wheel_url() {
 
 install_xgboost_federated_wheel() {
     local wheel_url
-    wheel_url=$(resolve_xgboost_federated_wheel_url)
+    wheel_url=$(resolve_xgboost_federated_wheel_url) || return $?
     echo "Installing federated XGBoost wheel for XGBoost recipe tests..."
-    "${PYTHON_BIN[@]}" -m pip install --force-reinstall "${wheel_url}"
+    "${PYTHON_BIN[@]}" -m pip install --force-reinstall "${wheel_url}" || return $?
     "${PYTHON_BIN[@]}" - <<'PY'
 import xgboost
 import xgboost.federated
@@ -160,7 +160,7 @@ run_pytest_mode() {
             run_pytest fast
             ;;
         slow)
-            install_xgboost_federated_wheel
+            install_xgboost_federated_wheel || return $?
             run_pytest slow
             ;;
         auto)

--- a/nvflare/app_opt/xgboost/recipes/vertical.py
+++ b/nvflare/app_opt/xgboost/recipes/vertical.py
@@ -226,6 +226,20 @@ class XGBVerticalRecipe(Recipe):
                     f"client_ranks must include exactly the per_site_config clients: expected "
                     f"{sorted(expected_clients)}, got {sorted(ranked_clients)}"
                 )
+            non_integer_ranks = {
+                client_name: rank
+                for client_name, rank in self.client_ranks.items()
+                if not isinstance(rank, int) or isinstance(rank, bool)
+            }
+            if non_integer_ranks:
+                raise ValueError(f"client_ranks values must be integers, got {non_integer_ranks}")
+            expected_ranks = set(range(len(per_site_config)))
+            actual_ranks = set(self.client_ranks.values())
+            if actual_ranks != expected_ranks:
+                raise ValueError(
+                    f"client_ranks values must be unique and consecutive from 0 to {len(per_site_config) - 1}: "
+                    f"got {self.client_ranks}"
+                )
             if self.client_ranks.get(self.label_owner) != 0:
                 raise ValueError("label_owner must be assigned rank 0 for vertical XGBoost")
         else:

--- a/tests/integration_test/slow/xgb_vertical_recipe_test.py
+++ b/tests/integration_test/slow/xgb_vertical_recipe_test.py
@@ -156,6 +156,40 @@ class TestXGBVerticalRecipe:
                 per_site_config=_make_vertical_per_site_config(label_owner="site-2"),
             )
 
+    def test_client_ranks_validation(self):
+        """Test that client_ranks validation catches malformed rank mappings."""
+        per_site_config = _make_vertical_per_site_config(num_clients=3)
+
+        with pytest.raises(ValueError, match="client_ranks values must be integers"):
+            XGBVerticalRecipe(
+                name="test_non_integer_ranks",
+                min_clients=3,
+                num_rounds=1,
+                label_owner="site-1",
+                client_ranks={"site-1": 0, "site-2": "1", "site-3": 2},
+                per_site_config=per_site_config,
+            )
+
+        with pytest.raises(ValueError, match="client_ranks values must be unique and consecutive"):
+            XGBVerticalRecipe(
+                name="test_duplicate_ranks",
+                min_clients=3,
+                num_rounds=1,
+                label_owner="site-1",
+                client_ranks={"site-1": 0, "site-2": 1, "site-3": 1},
+                per_site_config=per_site_config,
+            )
+
+        with pytest.raises(ValueError, match="client_ranks values must be unique and consecutive"):
+            XGBVerticalRecipe(
+                name="test_non_consecutive_ranks",
+                min_clients=3,
+                num_rounds=1,
+                label_owner="site-1",
+                client_ranks={"site-1": 0, "site-2": 1, "site-3": 3},
+                per_site_config=per_site_config,
+            )
+
     def test_custom_xgb_params(self):
         """Test that custom XGBoost parameters are accepted."""
         custom_params = {


### PR DESCRIPTION
## Summary
- fail fast when the federated XGBoost wheel URL cannot be resolved or installed before slow integration tests
- validate vertical XGBoost client_ranks values during recipe construction
- add validation coverage for non-integer, duplicate, and non-consecutive ranks
