### PR TITLE
Enable Blossom CI after PR merge

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -16,6 +16,8 @@ name: Blossom-CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [closed]
   workflow_dispatch:
       inputs:
           platform:
@@ -41,9 +43,18 @@ jobs:
     outputs:
       args: ${{ env.args }}
 
-    # This job only runs for pull request comments
+    # This job runs for /build comments or merged pull requests
     if: |
-      github.event.comment.body == '/build' &&
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == '/build'
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.merged == true
+        )
+      ) &&
       (
         github.actor == 'chesterxgchen' ||
         github.actor == 'pxLi' ||


### PR DESCRIPTION
## What changed

Adds a `pull_request` `closed` trigger to the Blossom CI workflow and updates the authorization job condition so merged PR close events can trigger the existing Blossom/Jenkins path. Existing `/build` issue-comment behavior is preserved.

## Why

Blossom's GitHub integration supports merged PR payloads and uses the merged PR SHA for post-merge runs. This lets the same Jenkins build run automatically after a PR is merged.
