### PR TITLE
Revert post-merge Blossom CI trigger

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -16,8 +16,6 @@ name: Blossom-CI
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [closed]
   workflow_dispatch:
       inputs:
           platform:
@@ -43,18 +41,9 @@ jobs:
     outputs:
       args: ${{ env.args }}
 
-    # This job runs for /build comments or merged pull requests
+    # This job only runs for pull request comments
     if: |
-      (
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.comment.body == '/build'
-        ) ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.merged == true
-        )
-      ) &&
+      github.event.comment.body == '/build' &&
       (
         github.actor == 'chesterxgchen' ||
         github.actor == 'pxLi' ||


### PR DESCRIPTION
## What changed

Reverts PR #4636, removing the `pull_request: closed` trigger from the Blossom CI workflow and restoring the original `/build` issue-comment-only condition.

## Why

The post-merge `pull_request` trigger fired, but fork-origin PR events do not receive repository secrets. Blossom failed during authorization because `secrets.BLOSSOM_KEY` was unavailable as `REPO_KEY_DATA`, so the workflow never reached Jenkins.
