### PR TITLE
[2.8] Avoid logging numpy trainer weights

### DIFF
--- a/nvflare/app_common/ccwf/comps/np_trainer.py
+++ b/nvflare/app_common/ccwf/comps/np_trainer.py
@@ -58,6 +58,13 @@ class NPTrainer(Executor):
         self._submit_model_task_name = submit_model_task_name
         self._validate_model_task_name = validate_model_task_name
 
+    @staticmethod
+    def _model_summary(np_data):
+        weights = np_data.get(NPConstants.NUMPY_KEY) if isinstance(np_data, dict) else None
+        if weights is None:
+            return f"{NPConstants.NUMPY_KEY}=missing"
+        return f"shape={getattr(weights, 'shape', None)}, dtype={getattr(weights, 'dtype', None)}"
+
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         # if event_type == EventType.START_RUN:
         #     Create all major components here. This is a simple app that doesn't need any components.
@@ -87,9 +94,9 @@ class NPTrainer(Executor):
 
         # Display properties.
         self.log_info(fl_ctx, f"Incoming data kind: {incoming_dxo.data_kind}")
-        self.log_info(fl_ctx, f"Model: \n{np_data}")
-        self.log_info(fl_ctx, f"Current Round: {current_round}")
-        self.log_info(fl_ctx, f"Total Rounds: {total_rounds}")
+        self.log_info(
+            fl_ctx, f"Model received for round {current_round}/{total_rounds}: {self._model_summary(np_data)}"
+        )
         self.log_info(fl_ctx, f"Client identity: {fl_ctx.get_identity_name()}")
 
         # Check abort signal
@@ -119,7 +126,8 @@ class NPTrainer(Executor):
 
         self.log_info(
             fl_ctx,
-            f"Model after training: {np_data}",
+            f"Completed mock training for round {current_round}/{total_rounds}: "
+            f"added delta={self._delta} to {NPConstants.NUMPY_KEY}; {self._model_summary(np_data)}",
         )
 
         # Checking abort signal again.
@@ -203,7 +211,7 @@ class NPTrainer(Executor):
 
     def _validate_model(self, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> Shareable:
         dxo = from_shareable(shareable)
-        self.log_info(fl_ctx, f"Validating model {dxo}")
+        self.log_info(fl_ctx, f"Validating model: data_kind={dxo.data_kind}, {self._model_summary(dxo.data)}")
         fake_metric = random.uniform(0.1, 1.0)
         val_results = {"val_accuracy": fake_metric}
         metric_dxo = DXO(data_kind=DataKind.METRICS, data=val_results)

--- a/nvflare/app_common/np/np_trainer.py
+++ b/nvflare/app_common/np/np_trainer.py
@@ -55,6 +55,13 @@ class NPTrainer(Executor):
         self._train_task_name = train_task_name
         self._submit_model_task_name = submit_model_task_name
 
+    @staticmethod
+    def _model_summary(np_data):
+        weights = np_data.get(NPConstants.NUMPY_KEY) if isinstance(np_data, dict) else None
+        if weights is None:
+            return f"{NPConstants.NUMPY_KEY}=missing"
+        return f"shape={getattr(weights, 'shape', None)}, dtype={getattr(weights, 'dtype', None)}"
+
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         # if event_type == EventType.START_RUN:
         #     Create all major components here. This is a simple app that doesn't need any components.
@@ -84,9 +91,9 @@ class NPTrainer(Executor):
 
         # Display properties.
         self.log_info(fl_ctx, f"Incoming data kind: {incoming_dxo.data_kind}")
-        self.log_info(fl_ctx, f"Model: \n{np_data}")
-        self.log_info(fl_ctx, f"Current Round: {current_round}")
-        self.log_info(fl_ctx, f"Total Rounds: {total_rounds}")
+        self.log_info(
+            fl_ctx, f"Model received for round {current_round}/{total_rounds}: {self._model_summary(np_data)}"
+        )
         self.log_info(fl_ctx, f"Client identity: {fl_ctx.get_identity_name()}")
 
         # Check abort signal
@@ -116,7 +123,8 @@ class NPTrainer(Executor):
 
         self.log_info(
             fl_ctx,
-            f"Model after training: {np_data}",
+            f"Completed mock training for round {current_round}/{total_rounds}: "
+            f"added delta={self._delta} to {NPConstants.NUMPY_KEY}; {self._model_summary(np_data)}",
         )
 
         # Checking abort signal again.


### PR DESCRIPTION
## Summary
- Replace raw NumPy model logging in the demo NP trainers with metadata-only summaries.
- Apply the same change to the CCWF NP trainer copy.

## Why
The trainers previously interpolated the full `np_data` dictionary into `log_info`, which could persist NumPy weight contents in FL logs. The updated logs preserve progress visibility with shape and dtype while avoiding tensor/array disclosure.
