### PR TITLE
[2.8] Clarify Docker deployment docs

### DIFF
--- a/docs/programming_guide/provisioning_system.rst
+++ b/docs/programming_guide/provisioning_system.rst
@@ -396,13 +396,13 @@ own requirements:
 
     - :class:`WorkspaceBuilder<nvflare.lighter.impl.workspace.WorkspaceBuilder>`
     - :class:`TemplateBuilder<nvflare.lighter.impl.template.TemplateBuilder>`
-    - :class:`DockerBuilder<nvflare.lighter.impl.docker.DockerBuilder>`
+    - :class:`DockerBuilder<nvflare.lighter.impl.docker.DockerBuilder>` (legacy Docker Compose builder)
     - :class:`StaticFileBuilder<nvflare.lighter.impl.static_file.StaticFileBuilder>`
     - :class:`CertBuilder<nvflare.lighter.impl.cert.CertBuilder>`
     - :class:`SignatureBuilder<nvflare.lighter.impl.signature.SignatureBuilder>`
 
-Docker and Kubernetes runtime launch preparation is handled after startup kits
-are created with ``nvflare deploy prepare``.
+Current Docker and Kubernetes runtime launch preparation is handled after
+startup kits are created with ``nvflare deploy prepare``.
 
 ::
 

--- a/docs/user_guide/admin_guide/deployment/containerized_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/containerized_deployment.rst
@@ -7,13 +7,29 @@ Containerized Deployment
 Containerized Deployment with Docker
 ====================================
 
-.. note::
+Docker support has two common uses:
 
-   This page explains how to build and use a Docker environment for FLARE. To
-   run FLARE parent processes and per-job containers with the Docker job
-   launcher, prepare each server or client startup kit with
-   :ref:`deploy_prepare_command`. For job-level image and container settings,
-   see :ref:`launcher_spec`.
+- Run FLARE inside a generic development container for simulation, notebooks,
+  POC mode, or manual experiments. In this pattern, Docker provides the Python
+  environment and filesystem, while FLARE processes still run normally inside
+  that one container.
+- Prepare provisioned startup kits for Docker runtime execution. This is the
+  recommended path when FLARE parent server/client processes should run in
+  Docker and launch server/client jobs as separate Docker containers.
+
+The current Docker runtime workflow is:
+
+1. Build a parent image with NVFlare installed.
+2. Build a job image with NVFlare and workload dependencies installed.
+3. Provision server, client, and admin startup kits.
+4. Run :ref:`deploy_prepare_command` on each server or client startup kit that
+   should run in Docker.
+5. Start prepared server/client kits with ``startup/start_docker.sh``.
+6. Submit jobs whose ``meta.json`` contains Docker settings in
+   :ref:`launcher_spec`.
+
+For a runnable end-to-end workflow, see the
+:github_nvflare_link:`Docker job launcher example <examples/docker>`.
 
 Prerequisites
 -------------
@@ -22,59 +38,140 @@ Before starting with containerized deployment, ensure you have:
 1. Docker installed on your system
 2. NVIDIA Container Toolkit installed for GPU support
 3. System requirements met as per the `NVIDIA Container Toolkit Install Guide <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
+4. Provisioned server/client startup kits when preparing a Docker runtime
+   deployment
 
 Running NVIDIA FLARE in a Docker container provides several benefits:
-    - Consistent environment across different systems
-    - Easy dependency management
-    - Simplified deployment process
-    - Isolated execution environment
-    - GPU support through NVIDIA Container Toolkit
 
-This can be used as an alternative to the bare-metal Python virtual environment and will
-use a similar installation to simplify transitioning between a bare metal and containerized
-environment.
+- Consistent environment across different systems
+- Easy dependency management
+- Repeatable runtime preparation
+- Isolated execution environment
+- GPU support through NVIDIA Container Toolkit
 
-Building the Docker Image
--------------------------
-
-A simple Dockerfile is used to capture the base requirements and dependencies.  In
-this case, we're building an environment that will support PyTorch-based workflows,
-in particular the :github_nvflare_link:`Hello PyTorch <examples/hello-world/hello-pt>`
-example. The base for this build is the NGC PyTorch container.  On this base image,
-we will install the necessary dependencies and clone the NVIDIA FLARE GitHub
-source code into the root workspace directory.
-
-Let's first create a folder called ``build`` and then create a file inside named ``Dockerfile``:
-
-.. code-block:: shell
-
-  mkdir build
-  cd build
-  touch Dockerfile
-
-Using any text editor to edit the Dockerfile and paste the following:
-
-.. literalinclude:: ../../../resources/Dockerfile
-    :language: dockerfile
-
-.. note::
-    Feel free to substitute the base image with the latest version of the NGC PyTorch container.
-    See the `NGC PyTorch Container <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch>`_
-    for the latest versions.
-
-We can then build the new container by running docker build in the directory containing
-this Dockerfile, for example tagging it nvflare-pt:
-
-.. code-block:: shell
-
-  docker build -t nvflare-pt . -f Dockerfile
-
-This will result in a docker image, ``nvflare-pt:latest``.
-
-Running the Container
+Parent and Job Images
 ---------------------
 
-To run the container with GPU support and a persistent workspace:
+The Docker runtime separates parent containers from job containers:
+
+- The parent image runs the long-lived FLARE server process or client process
+  from a prepared startup kit.
+- The job image runs server job and client job processes launched by
+  ``DockerJobLauncher``.
+
+The parent image is configured in the runtime ``docker.yaml`` used by
+``nvflare deploy prepare``. The job image is configured in the submitted job's
+``meta.json`` under ``launcher_spec``. You can use the same image for both
+roles, but keeping them separate is often cleaner: the parent image needs the
+FLARE runtime and Docker SDK access, while the job image needs the workload
+frameworks and training dependencies.
+
+Docker Runtime Workflow
+-----------------------
+
+Build or publish the images that your sites will use. The runnable
+:github_nvflare_link:`Docker job launcher example <examples/docker>` builds an
+example parent image, ``nvflare-site:latest``, and an example job image,
+``nvflare-job:latest``:
+
+.. code-block:: shell
+
+  cd examples/docker
+  bash build_docker.sh
+
+After provisioning a project:
+
+.. code-block:: shell
+
+  nvflare provision -p project.yml
+
+Create a Docker runtime config for ``nvflare deploy prepare``:
+
+.. code-block:: yaml
+
+  runtime: docker
+
+  parent:
+    docker_image: nvflare-site:latest
+    network: nvflare-network
+
+  job_launcher:
+    default_python_path: /usr/local/bin/python
+    default_job_env:
+      NCCL_P2P_DISABLE: "1"
+    default_job_container_kwargs:
+      shm_size: 8g
+      ipc_mode: host
+
+Prepare each server or client startup kit that should run in Docker:
+
+.. code-block:: shell
+
+  nvflare deploy prepare workspace/<project>/prod_00/server \
+    --config docker.yaml \
+    --output workspace/<project>/prepared/server
+
+  nvflare deploy prepare workspace/<project>/prod_00/site-1 \
+    --config docker.yaml \
+    --output workspace/<project>/prepared/site-1
+
+The prepared kits contain ``startup/start_docker.sh``, patched launcher
+configuration, and a ``local/study_data.yaml`` template. Admin startup kits are
+not prepared because they do not run parent server or client processes.
+
+Start prepared parent processes with:
+
+.. code-block:: shell
+
+  cd workspace/<project>/prepared/server
+  bash startup/start_docker.sh
+
+Run the same command from each prepared client kit. The generated script creates
+the configured Docker network if needed and mounts the prepared kit into the
+parent container.
+
+Jobs submitted to Docker-mode sites must specify their job image in
+``launcher_spec``:
+
+.. code-block:: json
+
+  {
+    "launcher_spec": {
+      "default": {
+        "docker": {"image": "nvflare-job:latest"}
+      },
+      "site-1": {
+        "docker": {"shm_size": "8g", "ipc_mode": "host"}
+      }
+    },
+    "resource_spec": {
+      "site-1": {"num_of_gpus": 1}
+    }
+  }
+
+Use ``launcher_spec`` for launcher-specific image and container settings. Keep
+scheduler-facing resource requests, such as ``num_of_gpus``, in
+``resource_spec``. Sites that are not configured with the Docker job launcher
+continue to use their configured launcher, usually process mode.
+
+Development Container
+---------------------
+
+A single-container image can also be useful for local development or simulator
+work. In this case, Docker captures a Python environment with NVFlare and your
+development dependencies installed. This is an alternative to a bare-metal
+Python virtual environment, not a replacement for ``nvflare deploy prepare``
+when using the Docker job launcher.
+
+You can use this single-container pattern to run all FLARE processes on one
+host for development: run the simulator, run POC mode, or start provisioned
+server/client scripts manually from different shells in the same container.
+This is different from Docker runtime deployment. The job launcher remains
+process mode unless the server or client startup kit is prepared with
+``nvflare deploy prepare``.
+
+After you build an image for your environment and tag it ``nvflare-dev:latest``,
+run it with GPU support and a persistent workspace:
 
 .. code-block:: shell
 
@@ -82,7 +179,7 @@ To run the container with GPU support and a persistent workspace:
   docker run --rm -it --gpus all \
       --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
       -v $(pwd -P)/my-workspace:/workspace/my-workspace \
-      nvflare-pt:latest
+      nvflare-dev:latest
 
 Once the container is running, you can also exec into the container, for example if you need another
 terminal to start additional FLARE clients.  First find the ``CONTAINER ID`` using ``docker ps``, and then
@@ -93,45 +190,34 @@ use that ID to exec into the container:
   docker ps  # use the CONTAINER ID in the output
   docker exec -it <CONTAINER ID> /bin/bash
 
-Deployment Scenarios
---------------------
-
-The containerized environment can be used in several ways:
-
-1. FL Simulator
-   - Run the FL simulator inside the container
-   - Mount your application code directory
-   - All dependencies are pre-installed
-   - Useful for development and testing
-
-2. POC Mode
-   - Run multiple containers for server and clients
-   - Use Docker networking for communication
-   - Good for testing multi-party scenarios
-
-3. Production Mode
-   - Deploy containers across different machines
-   - Use proper networking and security configurations
-   - Suitable for real-world deployments
-
-When using the FL Simulator, you can simply mount in any directories needed for
-your FLARE application code, and run the Simulator within the Docker container with
-all dependencies installed.
-
-For a notebook showcasing this example, see the :github_nvflare_link:`NVIDIA FLARE with Docker example <examples/advanced/docker>`.
-
 Best Practices
 --------------
 
 1. Always use the latest compatible NVIDIA Container Toolkit version
-2. Mount volumes for persistent data storage
-3. Use appropriate resource limits (CPU, memory, GPU) based on your workload
-4. Consider using Docker Compose for multi-container deployments
-5. Keep your base images updated for security patches
+2. Use ``nvflare deploy prepare`` for Docker runtime startup kits
+3. Keep parent image and job image responsibilities explicit
+4. Put Docker image and container settings in ``launcher_spec``
+5. Put scheduler-facing resource requests in ``resource_spec``
+6. Mount volumes for persistent data storage
+7. Keep your base images updated for security patches
+
+.. note::
+
+   Docker Compose deployment is deprecated. Use ``nvflare deploy prepare`` for
+   current Docker runtime preparation.
 
 Common Issues and Solutions
 ---------------------------
 
-1. GPU access issues: Ensure NVIDIA Container Toolkit is properly installed
-2. Memory issues: Adjust ulimit settings if needed
-3. Network connectivity: Configure proper network settings for multi-container deployments
+1. Docker daemon access: ensure the user running ``start_docker.sh`` can access
+   the Docker daemon.
+2. Missing job image: ensure every Docker-mode job provides
+   ``launcher_spec[site]["docker"]["image"]`` or
+   ``launcher_spec["default"]["docker"]["image"]``.
+3. GPU access issues: ensure NVIDIA Container Toolkit is properly installed and
+   the job's ``resource_spec`` requests the needed GPUs.
+4. Memory or shared-memory issues: set container kwargs such as ``shm_size`` or
+   ``ipc_mode`` in ``launcher_spec`` or in deploy prepare
+   ``default_job_container_kwargs``.
+5. Network connectivity: keep the configured Docker network and server hostname
+   resolvable from admin, parent, and job containers.

--- a/docs/user_guide/admin_guide/deployment/operation.rst
+++ b/docs/user_guide/admin_guide/deployment/operation.rst
@@ -46,7 +46,7 @@ commands shown as examples of how they may be run with a description.
     download_job,``download_job job_id``,Download folder from the job store containing the job and workspace. Please note that for larger jobs there may be extra delay for workspace creation in the job store (If you try to download the job before that you may not be able to get the workspace data)
     delete_job,``delete_job job_id``,Delete the job from the job store
     cat,``cat server startup/fed_server.json -ns``,Show content of a file (-n: number all output lines; -s: suppress repeated empty output lines)
-    ,``cat clientname startup/docker.sh -bT``,Show content of a file (-b: number nonempty output lines; -T: display TAB characters as ^I)
+    ,``cat clientname startup/start_docker.sh -bT``,Show content of a file (-b: number nonempty output lines; -T: display TAB characters as ^I)
     grep,``grep server "info" -i log.txt``,Search for a pattern in a file (-n: print line number; -i: ignore case)
     head,``head clientname log.txt``,Print the first 10 lines of a file
     ,``head server log.txt -n 15``,Print the first 15 lines of a file (-n: print the first N lines instead of the first 10)

--- a/docs/user_guide/admin_guide/deployment/overview.rst
+++ b/docs/user_guide/admin_guide/deployment/overview.rst
@@ -81,7 +81,7 @@ Customize the provision configuration
 For advanced users, you can customize your provision with additional behavior through additional builders:
 
     - **Zip**: To create password protected zip archives for the startup kits, see :ref:`distribution_builder`
-    - **Docker-compose** *(deprecated)*: Previously used for launching NVIDIA FLARE via docker containers. See :ref:`containerized_deployment` for the current approach.
+    - **Docker Compose** *(deprecated)*: Previously used for launching NVIDIA FLARE via docker containers. See :ref:`containerized_deployment` for the current approach.
     - **Docker and Kubernetes runtime preparation**: Prepare existing server or client startup kits with :ref:`deploy_prepare_command`. For runtime-specific deployment steps, see :ref:`containerized_deployment` and :ref:`helm_chart`.
     - **CUSTOM**: you can build custom builders specific to your needs like in :ref:`distribution_builder`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -185,5 +185,5 @@ When you open a notebook, select the kernel `nvflare_example` using the dropdown
 
 | Example                                                     | Framework | Summary                                                                                                                  |
 |-------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| [Docker](./advanced/docker/README.md)                       | NA        | The notebook in this directory walks through the creation and launch of Docker containers for NVIDIA FLARE. |
+| [Docker Job Launcher](./docker/README.md)                   | NA        | End-to-end Docker runtime example using `nvflare deploy prepare` and per-job Docker containers. |
 | [Monitoring](./advanced/monitoring/README.md)               | NA        | FLARE Monitoring provides an initial solution for tracking system metrics of your federated learning jobs. |

--- a/examples/advanced/docker/README.md
+++ b/examples/advanced/docker/README.md
@@ -1,3 +1,9 @@
-# NVIDIA FLARE with Docker
+# NVIDIA FLARE with Docker (Legacy)
 
-The notebook in this directory walks through the creation and launch of Docker containers for NVIDIA FLARE.
+This notebook shows the older provision-time Docker script flow based on
+`StaticFileBuilder.docker_image`, which generates `startup/docker.sh`.
+
+For new Docker deployments, use the current Docker job launcher example in
+[`examples/docker`](../../docker/README.md). That example uses
+`nvflare deploy prepare`, `startup/start_docker.sh`, and job-level
+`launcher_spec` settings for per-job Docker containers.

--- a/examples/advanced/docker/project.yml
+++ b/examples/advanced/docker/project.yml
@@ -42,7 +42,9 @@ builders:
       # if not set, no app_validator is included in fed_server.json
       # app_validator: PATH_TO_YOUR_OWN_APP_VALIDATOR
 
-      # when docker_image is set to a docker image name, docker.sh will be generated on server/client/admin
+      # Legacy Docker script flow: when docker_image is set to a docker image name,
+      # docker.sh will be generated on server/client/admin.
+      # For new Docker deployments, use nvflare deploy prepare and start_docker.sh.
       docker_image: nvflare-pt-docker
 
       # download_job_url is set to http://download.server.com/ as default in fed_server.json.  You can override this

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -16,8 +16,10 @@ bash build_docker.sh
 ```
 
 This builds two images:
-- `nvflare-site:latest` — used by SP/CP containers (started by `start_docker.sh`)
-- `nvflare-job:latest` — used by SJ/CJ containers (launched automatically per job)
+- `nvflare-site:latest` — used by SP/CP containers (started by `start_docker.sh`),
+  built from this example's `Dockerfile`
+- `nvflare-job:latest` — used by SJ/CJ containers (launched automatically per job),
+  built from this example's `Dockerfile.nvflare-job`
 
 ## Step 1: Provision
 


### PR DESCRIPTION
## What changed

- Reworked the Docker deployment guide around the current `nvflare deploy prepare` flow.
- Clarified the difference between a single development container and Docker runtime deployment with parent/job containers.
- Pointed the examples index to the current `examples/docker` workflow and marked the older `examples/advanced/docker` flow as legacy.


## Why

The Docker documentation mixed the older `docker.sh` provisioning path with the newer Docker job launcher path, which made the Docker section feel disconnected from the code and current example.

