### PR TITLE
[2.8] Backport K8s image pull secret support

### DIFF
--- a/docs/design/site_runtime_packaging_design.md
+++ b/docs/design/site_runtime_packaging_design.md
@@ -128,9 +128,11 @@ to manage those runtime job-pod Secrets in the configured namespace.
 
 K8s image registry credentials follow the same boundary. `nvflare deploy
 prepare` should not create registry credentials, manage private registry login,
-or create image pull Secrets. If private registry access is needed, the site or
-cluster should already be configured through its normal Kubernetes/registry
-process.
+or create image pull Secrets. It may render references to existing image pull
+Secrets on generated parent pod charts and write existing image pull Secret
+references into the prepared `K8sJobLauncher` config for dynamically launched
+job pods. If private registry access is needed, the site or cluster should
+create those Secrets through its normal Kubernetes/registry process.
 
 ## Proposed Command
 
@@ -280,6 +282,8 @@ namespace: default
 
 parent:
   docker_image: nvflare-site:latest
+  image_pull_secrets:
+    - registry-credentials
   parent_port: 8102
   workspace_pvc: nvflws
   workspace_mount_path: /var/tmp/nvflare/workspace
@@ -294,6 +298,8 @@ job_launcher:
   config_file_path: null
   pending_timeout: null
   default_python_path: /usr/local/bin/python3
+  image_pull_secrets:
+    - job-registry-credentials
   job_pod_security_context: {}
 ```
 
@@ -317,6 +323,13 @@ Supported `parent` keys:
   - Default: none
   - Description: image used by the parent server/client pod in the generated
     Helm chart.
+
+- `image_pull_secrets`
+  - Required: no
+  - Default: `[]`
+  - Description: existing Kubernetes Secret names rendered as
+    `imagePullSecrets` on the parent server/client pod in the generated Helm
+    chart. `nvflare deploy prepare` does not create these Secrets.
 
 - `parent_port`
   - Required: no
@@ -381,6 +394,13 @@ Supported `job_launcher` keys:
   - Required: no
   - Default: `{}`
   - Description: job pod security context passed to `K8sJobLauncher`.
+
+- `image_pull_secrets`
+  - Required: no
+  - Default: `[]`
+  - Description: existing Kubernetes Secret names attached as
+    `imagePullSecrets` to every dynamically launched job pod for this prepared
+    site.
 
 
 ## Docker Runtime Preparation

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -80,6 +80,8 @@ Example ``k8s.yaml``:
    namespace: nvflare
    parent:
      docker_image: registry.example.com/nvflare:dev
+     image_pull_secrets:
+       - registry-credentials
      parent_port: 8102
      workspace_pvc: nvflws
      workspace_mount_path: /var/tmp/nvflare/workspace
@@ -91,6 +93,8 @@ Example ``k8s.yaml``:
    job_launcher:
      config_file_path:
      default_python_path: /usr/local/bin/python3
+     image_pull_secrets:
+       - job-registry-credentials
      pending_timeout: 300
 
 The runtime config controls site-level Kubernetes settings:
@@ -100,16 +104,25 @@ The runtime config controls site-level Kubernetes settings:
   to ``nvflare-server``.
 * ``parent`` values are rendered into the Helm chart. They set the parent image,
   Python executable, workspace PVC, parent service port, parent pod resources,
-  and optional parent pod security context. ``parent.python_path`` controls the
-  long-lived SP/CP parent pod command. ``parent.workspace_mount_path`` is also
-  written into the K8s launcher config so spawned SJ/CJ job pods mount their job
-  workspace and startup kit at the same in-container path.
+  optional parent pod security context, and optional image pull Secret
+  references. ``parent.image_pull_secrets`` must name Kubernetes Secrets that
+  already exist in the target namespace; NVFLARE does not create registry
+  credentials. This setting applies to the generated parent pod chart; use
+  ``job_launcher.image_pull_secrets`` for dynamically launched job pods.
+  ``parent.python_path`` controls the long-lived SP/CP parent pod command.
+  ``parent.workspace_mount_path`` is also written into the K8s launcher config
+  so spawned SJ/CJ job pods mount their job workspace and startup kit at the
+  same in-container path.
 * ``job_launcher`` values are written into the participant's
   ``local/resources.json.default`` so the parent process can create job pods.
   ``config_file_path`` may be empty for in-cluster configuration, and
   ``default_python_path`` controls SJ/CJ job pods when a job does not override
   ``launcher_spec[site][k8s].python_path``. It does not control the SP/CP parent
   pod Python path; use ``parent.python_path`` for that command.
+  ``image_pull_secrets`` names existing Kubernetes image pull Secrets attached
+  to every dynamically launched job pod for this prepared site. Configure this
+  during deployment preparation when job images live in a private registry; job
+  authors still only specify the job image in ``meta.json``.
   ``pending_timeout`` controls how long a dynamically launched job pod can stay
   in ``Pending`` or ``Unknown`` before the launcher deletes it and reports the
   run as an execution exception. The admin ``list_jobs`` command then shows

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -122,6 +122,8 @@ Example ``k8s.yaml``:
 
    parent:
      docker_image: registry.example.com/nvflare-site:2.8
+     image_pull_secrets:
+       - registry-credentials
      parent_port: 8102
      workspace_pvc: nvflws
      workspace_mount_path: /var/tmp/nvflare/workspace
@@ -136,6 +138,8 @@ Example ``k8s.yaml``:
      config_file_path: null
      pending_timeout: 300
      default_python_path: /usr/local/bin/python3
+     image_pull_secrets:
+       - job-registry-credentials
      job_pod_security_context: {}
 
 Top-level keys:
@@ -150,6 +154,11 @@ Top-level keys:
 ``parent`` keys:
 
 - ``docker_image``: required parent image used by the Helm chart.
+- ``image_pull_secrets``: optional list of existing Kubernetes Secret names to
+  render as ``imagePullSecrets`` on the parent server/client pod. Create these
+  registry pull Secrets in the target namespace before installing the chart.
+  This setting applies to the generated parent pod chart. Use
+  ``job_launcher.image_pull_secrets`` for dynamically launched job pods.
 - ``parent_port``: port that job pods use to reach the parent pod's FLARE
   process.
   Defaults to ``8102``.
@@ -172,6 +181,10 @@ Top-level keys:
 - ``default_python_path``: Python executable used in job pods unless a job
   overrides it with ``launcher_spec[site]["k8s"]["python_path"]``. Defaults to
   ``/usr/local/bin/python3``.
+- ``image_pull_secrets``: optional list of existing Kubernetes Secret names
+  attached to every dynamically launched job pod for this prepared site. This
+  is configured by the deployment owner and does not require job authors to add
+  registry Secret names to ``meta.json``.
 - ``job_pod_security_context``: security context passed to dynamically
   launched job pods.
 

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -104,6 +104,17 @@ def _keep_startup_file(fname: str) -> bool:
     return fname.endswith(_STARTUP_KEEP_SUFFIXES)
 
 
+def _normalize_image_pull_secrets(image_pull_secrets) -> list[str]:
+    if image_pull_secrets is None:
+        return []
+    if not isinstance(image_pull_secrets, list):
+        raise ValueError("image_pull_secrets must be a list of Kubernetes Secret names")
+    for name in image_pull_secrets:
+        if not isinstance(name, str) or not name:
+            raise ValueError("image_pull_secrets entries must be non-empty strings")
+    return list(image_pull_secrets)
+
+
 def uuid4_to_rfc1123(uuid_str: str) -> str:
     name = uuid_str.lower()
     # Strip any chars that aren't alphanumeric or hyphen
@@ -221,6 +232,9 @@ class K8sJobHandle(JobHandleSpec):
         self.pod_manifest["metadata"]["name"] = job_config.get("name")
         self.pod_manifest["spec"]["containers"] = self.container_list
         self.pod_manifest["spec"]["volumes"] = self.volume_list
+        image_pull_secrets = _normalize_image_pull_secrets(job_config.get("image_pull_secrets"))
+        if image_pull_secrets:
+            self.pod_manifest["spec"]["imagePullSecrets"] = [{"name": name} for name in image_pull_secrets]
         security_context = job_config.get("security_context")
         if security_context:
             self.pod_manifest["spec"]["securityContext"] = security_context
@@ -389,6 +403,7 @@ class K8sJobLauncher(JobLauncherSpec):
         ephemeral_storage: str = DEFAULT_EPHEMERAL_STORAGE,
         default_python_path: str = None,
         workspace_mount_path: str = WORKSPACE_MOUNT_PATH,
+        image_pull_secrets: list[str] = None,
     ):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -409,6 +424,7 @@ class K8sJobLauncher(JobLauncherSpec):
         if not isinstance(workspace_mount_path, str) or not workspace_mount_path:
             raise ValueError("workspace_mount_path must be a non-empty string")
         self.workspace_mount_path = workspace_mount_path
+        self.image_pull_secrets = _normalize_image_pull_secrets(image_pull_secrets)
         self.study_data_pvc_dict = None
         self.core_v1 = None
 
@@ -575,6 +591,8 @@ class K8sJobLauncher(JobLauncherSpec):
                 "module_args": self.get_module_args(job_id, fl_ctx),
                 "env": env,
             }
+            if self.image_pull_secrets:
+                job_config["image_pull_secrets"] = self.image_pull_secrets
             if args is not None and getattr(args, "set", None) is not None:
                 job_config.update({"set_list": args.set})
             resources = {

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -110,7 +110,7 @@ def _normalize_image_pull_secrets(image_pull_secrets) -> list[str]:
     if not isinstance(image_pull_secrets, list):
         raise ValueError("image_pull_secrets must be a list of Kubernetes Secret names")
     for name in image_pull_secrets:
-        if not isinstance(name, str) or not name:
+        if not isinstance(name, str) or not name.strip():
             raise ValueError("image_pull_secrets entries must be non-empty strings")
     return list(image_pull_secrets)
 

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -394,12 +394,12 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
         _optional_str(parent, "python_path", "parent")
         _optional_mapping(parent, "resources", "parent")
         _optional_mapping(parent, "pod_security_context", "parent")
-        _optional_k8s_secret_name_list(parent, "image_pull_secrets", "parent")
+        _optional_k8s_secret_name_list(parent, "image_pull_secrets", "parent image pull references")
         _optional_str(job_launcher, "config_file_path", "job_launcher")
         _optional_str(job_launcher, "default_python_path", "job_launcher")
         _optional_int(job_launcher, "pending_timeout", "job_launcher")
         _optional_mapping(job_launcher, "job_pod_security_context", "job_launcher")
-        _optional_k8s_secret_name_list(job_launcher, "image_pull_secrets", "job_launcher")
+        _optional_k8s_secret_name_list(job_launcher, "image_pull_secrets", "job launcher image pull references")
 
 
 def _validate_kit(kit_dir: Path) -> KitInfo:
@@ -1052,7 +1052,7 @@ def _validate_k8s_service_name(data: dict[str, Any], key: str, where: str) -> No
         )
 
 
-def _validate_k8s_secret_name(name: str, where: str) -> None:
+def _validate_k8s_secret_name(name: str, label: str) -> None:
     if (
         not isinstance(name, str)
         or not name
@@ -1061,20 +1061,20 @@ def _validate_k8s_secret_name(name: str, where: str) -> None:
     ):
         _fail(
             "INVALID_CONFIG",
-            f"{where} entries must be valid Kubernetes Secret names (DNS subdomains).",
+            f"{label} must contain valid Kubernetes object names.",
             "Use lower case alphanumeric characters, '-', or '.', start and end with an alphanumeric character, "
-            f"and keep length <= {K8S_SECRET_NAME_MAX_LENGTH}.",
+            "and keep length <= 253.",
         )
 
 
-def _optional_k8s_secret_name_list(data: dict[str, Any], key: str, where: str) -> list[str] | None:
+def _optional_k8s_secret_name_list(data: dict[str, Any], key: str, label: str) -> list[str] | None:
     if key not in data or data[key] is None:
         return None
     names = data[key]
     if not isinstance(names, list):
-        _fail("INVALID_CONFIG", f"{where}.{key} must be a list of Kubernetes Secret names.", "Fix the runtime config.")
+        _fail("INVALID_CONFIG", f"{label} must be a list of Kubernetes object names.", "Fix the runtime config.")
     for name in names:
-        _validate_k8s_secret_name(name, f"{where}.{key}")
+        _validate_k8s_secret_name(name, label)
     return names
 
 

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -1061,7 +1061,7 @@ def _validate_k8s_secret_name(name: str, where: str) -> None:
     ):
         _fail(
             "INVALID_CONFIG",
-            f"{where} entries must be valid Kubernetes Secret names (DNS subdomains): {name!r}.",
+            f"{where} entries must be valid Kubernetes Secret names (DNS subdomains).",
             "Use lower case alphanumeric characters, '-', or '.', start and end with an alphanumeric character, "
             f"and keep length <= {K8S_SECRET_NAME_MAX_LENGTH}.",
         )

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -109,8 +109,10 @@ STUDY_DATA_TEMPLATE = """# Study data mapping used by Docker and Kubernetes job 
 
 K8S_NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
 K8S_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+K8S_SECRET_NAME_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
 K8S_NAMESPACE_MAX_LENGTH = 63
 K8S_SERVICE_NAME_MAX_LENGTH = 63
+K8S_SECRET_NAME_MAX_LENGTH = 253
 HELM_RELEASE_NAME_MAX_LENGTH = 53
 DEFAULT_K8S_SERVER_SERVICE_NAME = "nvflare-server"
 
@@ -282,6 +284,8 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
         launcher_args["pending_timeout"] = job_launcher["pending_timeout"]
     if job_launcher.get("job_pod_security_context"):
         launcher_args["security_context"] = job_launcher["job_pod_security_context"]
+    if job_launcher.get("image_pull_secrets") is not None:
+        launcher_args["image_pull_secrets"] = job_launcher["image_pull_secrets"]
 
     _patch_resources(kit_info.kit_dir, "k8s_launcher", launcher_path, launcher_args)
     _patch_comm_config_for_k8s(kit_info.kit_dir, kit_info.role, kit_info.name, parent_port, server_service_name)
@@ -364,12 +368,19 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
                 "python_path",
                 "resources",
                 "pod_security_context",
+                "image_pull_secrets",
             },
             "parent",
         )
         _validate_allowed_keys(
             job_launcher,
-            {"config_file_path", "pending_timeout", "default_python_path", "job_pod_security_context"},
+            {
+                "config_file_path",
+                "pending_timeout",
+                "default_python_path",
+                "job_pod_security_context",
+                "image_pull_secrets",
+            },
             "job_launcher",
         )
         _required_str(parent, "docker_image", "parent")
@@ -383,10 +394,12 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
         _optional_str(parent, "python_path", "parent")
         _optional_mapping(parent, "resources", "parent")
         _optional_mapping(parent, "pod_security_context", "parent")
+        _optional_k8s_secret_name_list(parent, "image_pull_secrets", "parent")
         _optional_str(job_launcher, "config_file_path", "job_launcher")
         _optional_str(job_launcher, "default_python_path", "job_launcher")
         _optional_int(job_launcher, "pending_timeout", "job_launcher")
         _optional_mapping(job_launcher, "job_pod_security_context", "job_launcher")
+        _optional_k8s_secret_name_list(job_launcher, "image_pull_secrets", "job_launcher")
 
 
 def _validate_kit(kit_dir: Path) -> KitInfo:
@@ -828,6 +841,7 @@ def _write_server_helm_chart(
         "name": kit_info.name,
         "serviceName": server_service_name,
         "image": {"repository": repo, "tag": tag, "pullPolicy": "IfNotPresent"},
+        "imagePullSecrets": _image_pull_secret_refs(parent),
         "serviceAccount": {"create": True, "annotations": {}, "automountServiceAccountToken": True},
         "podAnnotations": {},
         "rbac": {"create": True},
@@ -893,6 +907,7 @@ def _write_client_helm_chart(
         "siteName": kit_info.name,
         "serviceName": _k8s_parent_service_name(kit_info.role, kit_info.name),
         "image": {"repository": repo, "tag": tag, "pullPolicy": "Always"},
+        "imagePullSecrets": _image_pull_secret_refs(parent),
         "serviceAccount": {"create": True, "annotations": {}, "automountServiceAccountToken": True},
         "podAnnotations": {},
         "rbac": {"create": True},
@@ -951,6 +966,10 @@ def _split_image(docker_image: str) -> tuple[str, str]:
     if ":" in docker_image:
         return docker_image.rsplit(":", 1)
     return docker_image, ""
+
+
+def _image_pull_secret_refs(parent: dict[str, Any]) -> list[dict[str, str]]:
+    return [{"name": name} for name in parent.get("image_pull_secrets") or []]
 
 
 def _helm_src(role: str, filename: str) -> Path:
@@ -1031,6 +1050,32 @@ def _validate_k8s_service_name(data: dict[str, Any], key: str, where: str) -> No
             "Use lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, "
             f"and keep length <= {K8S_SERVICE_NAME_MAX_LENGTH}.",
         )
+
+
+def _validate_k8s_secret_name(name: str, where: str) -> None:
+    if (
+        not isinstance(name, str)
+        or not name
+        or len(name) > K8S_SECRET_NAME_MAX_LENGTH
+        or not K8S_SECRET_NAME_PATTERN.fullmatch(name)
+    ):
+        _fail(
+            "INVALID_CONFIG",
+            f"{where} entries must be valid Kubernetes Secret names (DNS subdomains): {name!r}.",
+            "Use lower case alphanumeric characters, '-', or '.', start and end with an alphanumeric character, "
+            f"and keep length <= {K8S_SECRET_NAME_MAX_LENGTH}.",
+        )
+
+
+def _optional_k8s_secret_name_list(data: dict[str, Any], key: str, where: str) -> list[str] | None:
+    if key not in data or data[key] is None:
+        return None
+    names = data[key]
+    if not isinstance(names, list):
+        _fail("INVALID_CONFIG", f"{where}.{key} must be a list of Kubernetes Secret names.", "Fix the runtime config.")
+    for name in names:
+        _validate_k8s_secret_name(name, f"{where}.{key}")
+    return names
 
 
 def _optional_str(data: dict[str, Any], key: str, where: str) -> str | None:

--- a/nvflare/tool/deploy/templates/helm/client/deployment.yaml
+++ b/nvflare/tool/deploy/templates/helm/client/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "nvflare-client.name" . }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/nvflare/tool/deploy/templates/helm/server/deployment.yaml
+++ b/nvflare/tool/deploy/templates/helm/server/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "nvflare-server.name" . }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -291,6 +291,14 @@ class TestK8sJobHandle:
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
         assert handle.get_manifest()["spec"]["restartPolicy"] == "Never"
 
+    def test_manifest_image_pull_secrets(self):
+        cfg = _make_job_config(image_pull_secrets=["job-regcred", "site.registry.example.com"])
+        handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
+        assert handle.get_manifest()["spec"]["imagePullSecrets"] == [
+            {"name": "job-regcred"},
+            {"name": "site.registry.example.com"},
+        ]
+
     def test_manifest_volumes(self):
         cfg = _make_job_config()
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)
@@ -1016,12 +1024,14 @@ class TestK8sJobLauncherInit:
             study_data_pvc_file_path="/fake/study_data.yaml",
             timeout=60,
             namespace="test-ns",
+            image_pull_secrets=["job-regcred"],
         )
 
         assert launcher.study_data_pvc_file_path == "/fake/study_data.yaml"
         assert launcher.timeout == 60
         assert launcher.namespace == "test-ns"
         assert launcher.workspace_mount_path == WORKSPACE_MOUNT_PATH
+        assert launcher.image_pull_secrets == ["job-regcred"]
         # study_data.yaml is populated lazily
         assert launcher.study_data_pvc_dict is None
 
@@ -1074,6 +1084,20 @@ class TestK8sJobLauncherInit:
                 config_file_path="/fake/kube/config",
                 study_data_pvc_file_path="/fake/study_data.yaml",
                 ephemeral_storage=1,
+            )
+
+    @pytest.mark.parametrize(
+        "image_pull_secrets",
+        ["job-regcred", [""], [7]],
+    )
+    def test_init_rejects_invalid_image_pull_secrets(self, image_pull_secrets):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        with pytest.raises(ValueError, match="image_pull_secrets"):
+            ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path="/fake/study_data.yaml",
+                image_pull_secrets=image_pull_secrets,
             )
 
 
@@ -1227,6 +1251,7 @@ class TestK8sJobLauncherLaunchJob:
         default_python_path=None,
         ephemeral_storage=None,
         workspace_mount_path=None,
+        image_pull_secrets=None,
     ):
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
 
@@ -1254,6 +1279,8 @@ class TestK8sJobLauncherLaunchJob:
             launcher_kwargs["ephemeral_storage"] = ephemeral_storage
         if workspace_mount_path is not None:
             launcher_kwargs["workspace_mount_path"] = workspace_mount_path
+        if image_pull_secrets is not None:
+            launcher_kwargs["image_pull_secrets"] = image_pull_secrets
         launcher = ClientK8sJobLauncher(**launcher_kwargs)
         return launcher, mock_api
 
@@ -1352,6 +1379,20 @@ class TestK8sJobLauncherLaunchJob:
             launcher.launch_job(_make_launch_job_meta(), _make_launch_fl_ctx())
             manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
             assert manifest["spec"]["restartPolicy"] == "Never"
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_image_pull_secrets_from_launcher_config(self):
+        patches = _make_k8s_launcher_patches()
+        launcher, mock_api = self._setup(patches, image_pull_secrets=["job-regcred", "mirror-regcred"])
+        self._prime_running(mock_api)
+        try:
+            launcher.launch_job(_make_launch_job_meta(), _make_launch_fl_ctx())
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            assert manifest["spec"]["imagePullSecrets"] == [
+                {"name": "job-regcred"},
+                {"name": "mirror-regcred"},
+            ]
         finally:
             _exit_patches(patches)
 

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -1088,7 +1088,7 @@ class TestK8sJobLauncherInit:
 
     @pytest.mark.parametrize(
         "image_pull_secrets",
-        ["job-regcred", [""], [7]],
+        ["job-regcred", [""], ["  "], [7]],
     )
     def test_init_rejects_invalid_image_pull_secrets(self, image_pull_secrets):
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -615,6 +615,7 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
                 "pending_timeout": 7,
                 "default_python_path": "/usr/bin/python3",
                 "job_pod_security_context": {"runAsNonRoot": True},
+                "image_pull_secrets": ["job-regcred", "site.registry.example.com"],
             },
         },
     )
@@ -630,6 +631,7 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
     assert launcher["args"]["default_python_path"] == "/usr/bin/python3"
     assert launcher["args"]["pending_timeout"] == 7
     assert launcher["args"]["security_context"] == {"runAsNonRoot": True}
+    assert launcher["args"]["image_pull_secrets"] == ["job-regcred", "site.registry.example.com"]
 
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["internal"]["resources"] == {
@@ -656,6 +658,39 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
     assert values["securityContext"] == {"runAsUser": 1000}
     assert values["resources"] == {"requests": {"cpu": "1", "memory": "2Gi"}}
     assert (output / "helm_chart" / "templates" / "client-deployment.yaml").exists()
+
+
+@pytest.mark.parametrize(
+    "make_kit, template_name",
+    [
+        (_make_server_kit, "server-deployment.yaml"),
+        (_make_client_kit, "client-deployment.yaml"),
+    ],
+)
+def test_prepare_k8s_parent_image_pull_secrets_written_to_chart(tmp_path, capsys, make_kit, template_name):
+    kit = make_kit(tmp_path)
+    output = tmp_path / "prepared-k8s"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "k8s",
+            "parent": {
+                "docker_image": "repo/nvflare:dev",
+                "image_pull_secrets": ["gitlab-regcred", "mirror.registry.example.com"],
+            },
+        },
+    )
+    capsys.readouterr()
+
+    values = yaml.safe_load((output / "helm_chart" / "values.yaml").read_text())
+    deployment = (output / "helm_chart" / "templates" / template_name).read_text()
+    assert values["imagePullSecrets"] == [
+        {"name": "gitlab-regcred"},
+        {"name": "mirror.registry.example.com"},
+    ]
+    assert ".Values.imagePullSecrets" in deployment
 
 
 @pytest.mark.parametrize("namespace", ["nvflare", "1abc", "2026-prod"])
@@ -698,6 +733,58 @@ def test_prepare_k8s_rejects_invalid_namespace(tmp_path, capsys, namespace):
     err = capsys.readouterr().err
     assert "INVALID_CONFIG" in err
     assert "k8s config.namespace" in err
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    "image_pull_secrets",
+    ["gitlab-regcred", [""], ["GitLab-Regcred"], ["gitlab_regcred"], [7], ["bad..name"], ["a."], [".a"]],
+)
+def test_prepare_k8s_rejects_invalid_parent_image_pull_secrets(tmp_path, capsys, image_pull_secrets):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "prepared"
+
+    with pytest.raises(SystemExit):
+        _run_prepare(
+            kit,
+            output,
+            {
+                "runtime": "k8s",
+                "parent": {
+                    "docker_image": "repo/nvflare:dev",
+                    "image_pull_secrets": image_pull_secrets,
+                },
+            },
+        )
+
+    err = capsys.readouterr().err
+    assert "INVALID_CONFIG" in err
+    assert "parent.image_pull_secrets" in err
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    "image_pull_secrets",
+    ["gitlab-regcred", [""], ["GitLab-Regcred"], ["gitlab_regcred"], [7], ["bad..name"], ["a."], [".a"]],
+)
+def test_prepare_k8s_rejects_invalid_job_launcher_image_pull_secrets(tmp_path, capsys, image_pull_secrets):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "prepared"
+
+    with pytest.raises(SystemExit):
+        _run_prepare(
+            kit,
+            output,
+            {
+                "runtime": "k8s",
+                "parent": {"docker_image": "repo/nvflare:dev"},
+                "job_launcher": {"image_pull_secrets": image_pull_secrets},
+            },
+        )
+
+    err = capsys.readouterr().err
+    assert "INVALID_CONFIG" in err
+    assert "job_launcher.image_pull_secrets" in err
     assert not output.exists()
 
 

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -759,7 +759,7 @@ def test_prepare_k8s_rejects_invalid_parent_image_pull_secrets(tmp_path, capsys,
 
     err = capsys.readouterr().err
     assert "INVALID_CONFIG" in err
-    assert "parent.image_pull_secrets" in err
+    assert "parent image pull references" in err
     assert not output.exists()
 
 
@@ -784,7 +784,7 @@ def test_prepare_k8s_rejects_invalid_job_launcher_image_pull_secrets(tmp_path, c
 
     err = capsys.readouterr().err
     assert "INVALID_CONFIG" in err
-    assert "job_launcher.image_pull_secrets" in err
+    assert "job launcher image pull references" in err
     assert not output.exists()
 
 


### PR DESCRIPTION
## Summary

Backport of #4647 to the `2.8` branch.

- Add optional `parent.image_pull_secrets` support for generated K8s Helm parent pod charts.
- Add optional per-site `job_launcher.image_pull_secrets` support so dynamically launched job pods receive registry pull secret references from deploy preparation.
- Include the follow-up validation and CodeQL wording fixes from the merged main PR.
