### PR TITLE
Cherry-pick [2.8]: Fix session.list_job_components() error (#4622)

### DIFF
--- a/nvflare/fuel/hci/proto.py
+++ b/nvflare/fuel/hci/proto.py
@@ -94,7 +94,7 @@ class MetaStatusValue(object):
     JOB_NOT_RUNNING = "job_not_running"
     CLIENTS_RUNNING = "clients_running"
     NO_JOBS = "no_jobs"
-    NO_JOB_COMPONENTS = "no_job_compoents"
+    NO_JOB_COMPONENTS = "no_job_components"
     NO_REPLY = "no_reply"
     NO_CLIENTS = "no_clients"
 

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -1018,14 +1018,9 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                 if filtered_data:
                     data_str = ", ".join(filtered_data)
                     conn.append_string(data_str)
-                    conn.append_success(
-                        "", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_COMPONENTS: filtered_data})
-                    )
-                else:
-                    conn.append_error(
-                        "No additional job components found.",
-                        meta=make_meta(MetaStatusValue.NO_JOB_COMPONENTS, "No additional job components found."),
-                    )
+                conn.append_success(
+                    "", meta=make_meta(MetaStatusValue.OK, extra={MetaKey.JOB_COMPONENTS: filtered_data})
+                )
             else:
                 _append_no_such_job_error(conn, job_id)
 

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -368,6 +368,26 @@ class _FakeListEngine:
         return FLContext()
 
 
+class _FakeListComponentsJobDefManager:
+    def __init__(self, components):
+        self.components = components
+        self.jid = None
+
+    def list_components(self, jid, fl_ctx):
+        self.jid = jid
+        return self.components
+
+
+class _FakeListComponentsEngine:
+    def __init__(self, components):
+        self.job_def_manager = _FakeListComponentsJobDefManager(components)
+
+    def new_context(self):
+        from nvflare.apis.fl_context import FLContext
+
+        return FLContext()
+
+
 class _FakeWorkspace:
     def __init__(self, root_dir):
         self.root_dir = str(root_dir)
@@ -1054,6 +1074,23 @@ def test_list_jobs_by_submit_token_returns_deleted_status(monkeypatch):
     assert conn.errors[0][1][MetaKey.STATUS] == SUBMIT_TOKEN_JOB_DELETED_STATUS
     assert conn.errors[0][1][MetaKey.JOB_ID] == "job-1"
     assert conn.tables == []
+
+
+def test_list_job_components_returns_empty_list_for_system_components(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+    engine = _FakeListComponentsEngine(["data", "meta", "workspace"])
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.JOB_ID: "job-1"})
+
+    JobCommandModule().list_job_components(conn, ["list_job_components", "job-1"])
+
+    assert conn.errors == []
+    assert conn.strings == []
+    assert len(conn.successes) == 1
+    msg, meta = conn.successes[0]
+    assert msg == ""
+    assert meta[MetaKey.STATUS] == MetaStatusValue.OK
+    assert meta[MetaKey.JOB_COMPONENTS] == []
+    assert engine.job_def_manager.jid == "job-1"
 
 
 def test_clone_job_preserves_source_study(monkeypatch):


### PR DESCRIPTION
When a job has no components, the session.list_job_components() should return an empty list. The current codes raise an InternalError. This PR fixes the issue, and a small typo.

<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
