### PR TITLE
[2.8] Fix slow integration recipe tests

### DIFF
--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -194,7 +194,9 @@ class FedJobConfig:
                 new_env = os.environ.copy()
                 process = subprocess.Popen(shlex.split(command, True), shell=False, preexec_fn=os.setsid, env=new_env)
 
-                process.wait()
+                return_code = process.wait()
+                if return_code != 0:
+                    raise RuntimeError(f"Simulator run failed with exit code {return_code}.")
 
             except KeyboardInterrupt:
                 self.logger.info("KeyboardInterrupt, terminate all the child processes.")

--- a/tests/integration_test/slow/experiment_tracking_recipes_test.py
+++ b/tests/integration_test/slow/experiment_tracking_recipes_test.py
@@ -31,6 +31,7 @@ To run manually:
     pytest slow/experiment_tracking_recipes_test.py -v
 """
 
+import json
 import os
 
 import pytest
@@ -76,7 +77,19 @@ class TestExperimentTrackingRecipes:
 
     def _add_model_to_apps(self, recipe):
         recipe.job.add_file_to_server(self.model_path)
-        recipe.job.add_file_to_clients(self.model_path)
+        for site_name in ("site-1", "site-2"):
+            recipe.job.add_file_to(self.model_path, site_name)
+
+    def _assert_exported_client_configs_have_executors(self, recipe, export_root: str):
+        recipe.export(export_root)
+        job_root = os.path.join(export_root, recipe.name)
+        assert os.path.exists(os.path.join(job_root, "app_server", "custom", "model.py"))
+        for site_name in ("site-1", "site-2"):
+            client_config_path = os.path.join(job_root, f"app_{site_name}", "config", "config_fed_client.json")
+            with open(client_config_path, "r") as f:
+                client_config = json.load(f)
+            assert client_config.get("executors"), f"{client_config_path} has no executors"
+            assert os.path.exists(os.path.join(job_root, f"app_{site_name}", "custom", "model.py"))
 
     def _per_site_config(self, dataset_path: str, model_dir: str) -> dict[str, dict[str, str]]:
         return {
@@ -90,12 +103,29 @@ class TestExperimentTrackingRecipes:
             for site_name in ("site-1", "site-2")
         }
 
+    def test_per_site_export_preserves_client_executors(self, tmp_path):
+        """Adding shared model files must not replace per-site client apps."""
+        recipe = FedAvgRecipe(
+            name="test_export",
+            min_clients=2,
+            num_rounds=1,
+            model={"class_path": "model.SimpleNetwork", "args": {}},
+            train_script=self.client_script_path,
+            per_site_config=self._per_site_config(str(tmp_path / "data"), str(tmp_path)),
+        )
+        self._add_model_to_apps(recipe)
+
+        # Exercise the same mutation path as the runtime tests.
+        add_experiment_tracking(recipe, "tensorboard")
+
+        self._assert_exported_client_configs_have_executors(recipe, str(tmp_path / "export"))
+
     def test_tensorboard_tracking_integration(self, cifar10_data_root):
         """Test TensorBoard tracking can be added and job completes."""
         import tempfile
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            env = SimEnv(num_clients=2, workspace_root=os.path.join(tmpdir, "test_tensorboard"))
+            env = SimEnv(clients=["site-1", "site-2"], workspace_root=os.path.join(tmpdir, "test_tensorboard"))
             recipe = FedAvgRecipe(
                 name="test_tensorboard",
                 min_clients=2,
@@ -120,7 +150,7 @@ class TestExperimentTrackingRecipes:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             mlflow_dir = os.path.join(tmpdir, "test_mlflow")
-            env = SimEnv(num_clients=2, workspace_root=mlflow_dir)
+            env = SimEnv(clients=["site-1", "site-2"], workspace_root=mlflow_dir)
             recipe = FedAvgRecipe(
                 name="test_mlflow",
                 min_clients=2,

--- a/tests/integration_test/slow/recipe_system_test.py
+++ b/tests/integration_test/slow/recipe_system_test.py
@@ -132,7 +132,7 @@ class TestRecipeSystemIntegration:
             "submit_model and/or validation path may not have completed."
         )
 
-    def test_dict_model_config_simulation(self):
+    def test_dict_model_config_simulation(self, tmp_path):
         """Test that dict model config works in simulation (end-to-end validation)."""
         import sys
 
@@ -156,16 +156,17 @@ class TestRecipeSystemIntegration:
             "args": {},
         }
 
-        env = SimEnv(num_clients=2, workspace_root="/tmp/test_dict_config")
+        env = SimEnv(num_clients=2, workspace_root=str(tmp_path / "test_dict_config"))
         recipe = FedAvgRecipe(
             name="test_dict_config",
             min_clients=2,
             num_rounds=1,
             model=model_config,
             train_script=os.path.join(examples_dir, "client.py"),
+            train_args="--synthetic_data --train_size 32 --test_size 16 --batch_size 16 --num_workers 0 --epochs 1",
         )
         run = recipe.execute(env)
 
         # Verify job was created (simulation returns immediately)
         assert run.get_job_id() == "test_dict_config"
-        assert run.get_result() == "/tmp/test_dict_config/test_dict_config"
+        assert run.get_result() == os.path.join(env.workspace_root, run.get_job_id())

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 import os
 import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
 
 from nvflare.job_config.fed_job_config import FedJobConfig
 
@@ -40,3 +43,13 @@ class TestFedJobConfig:
         assert expected == job_config._trim_whitespace("site-0, site-1")
         assert expected == job_config._trim_whitespace(" site-0,site-1 ")
         assert expected == job_config._trim_whitespace(" site-0, site-1 ")
+
+    def test_simulator_run_raises_on_failure(self, tmp_path):
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        process = Mock()
+        process.wait.return_value = 2
+
+        with patch.object(job_config, "generate_job_config"):
+            with patch("nvflare.job_config.fed_job_config.subprocess.Popen", return_value=process):
+                with pytest.raises(RuntimeError, match="Simulator run failed with exit code 2"):
+                    job_config.simulator_run(workspace=str(tmp_path), clients="site-1", threads=1)


### PR DESCRIPTION
## What changed

- Use recipe-level file helpers in `experiment_tracking_recipes_test.py` so shared files are added to existing per-site client apps instead of creating an `@ALL` client app without executors.
- Add an export-only regression check that verifies per-site client configs keep executors and receive `model.py`.
- Make `test_dict_model_config_simulation` use tiny synthetic data and a pytest temp workspace instead of full CIFAR training under `/tmp`.

## Why

The slow integration suite exposed simulator-side aborts that pytest could still mark as passed because `SimEnv.get_result()` returns a workspace path even when client execution logs errors. Two cases were noisy or unstable:

- Mixing `per_site_config` with direct `job.add_file_to_clients(...)` could export client configs with no executors.
- The dict model config simulation test ran the full `hello-pt` CIFAR workload on CPU, which could take hours or fail on dataset cache/download state.
