### PR TITLE
Cherry-pick CC runtime workspace fix to main

### DIFF
--- a/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
+++ b/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
@@ -293,6 +293,14 @@ Each startup kit (e.g., ``server1.tgz``) contains:
    * - ``vmlinuz``
      - Linux kernel
 
+.. note::
+
+   The ``user_config.qcow2`` and ``user_data.qcow2`` drives are not encrypted. When a provisioned NVFlare startup
+   script is launched from ``/user_config``, it copies the signed startup/local configuration into
+   ``/vault/workspace`` and uses that path as the runtime workspace. This keeps job artifacts such as
+   model checkpoints on the encrypted root filesystem. Set ``NVFL_WORKSPACE`` before launching the script to choose a
+   different encrypted workspace path.
+
 Step 4: User Data
 -----------------
 

--- a/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
+++ b/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
@@ -296,8 +296,8 @@ Each startup kit (e.g., ``server1.tgz``) contains:
 .. note::
 
    The ``user_config.qcow2`` and ``user_data.qcow2`` drives are not encrypted. When a provisioned NVFlare startup
-   script is launched from ``/user_config``, it copies the signed startup/local configuration into
-   ``/vault/workspace`` and uses that path as the runtime workspace. This keeps job artifacts such as
+   script is launched from ``/user_config``, it copies the signed startup/local configuration into a namespaced folder
+   under ``/vault/workspace`` and uses that path as the runtime workspace. This keeps job artifacts such as
    model checkpoints on the encrypted root filesystem. Set ``NVFL_WORKSPACE`` before launching the script to choose a
    different encrypted workspace path.
 

--- a/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
+++ b/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
@@ -296,9 +296,8 @@ Each startup kit (e.g., ``server1.tgz``) contains:
 .. note::
 
    The ``user_config.qcow2`` and ``user_data.qcow2`` drives are not encrypted. When a provisioned NVFlare startup
-   script is launched from ``/user_config``, it copies the signed startup/local configuration into a namespaced folder
-   under ``/vault/workspace`` and uses that path as the runtime workspace. This keeps job artifacts such as
-   model checkpoints on the encrypted root filesystem. Set ``NVFL_WORKSPACE`` before launching the script to choose a
+   script is launched from ``/user_config``, runtime artifacts such as model checkpoints are written to a namespaced
+   encrypted workspace under ``/vault/workspace``. Set ``NVFL_WORKSPACE`` before launching the script to choose a
    different encrypted workspace path.
 
 Step 4: User Data

--- a/examples/advanced/cc_provision/README.md
+++ b/examples/advanced/cc_provision/README.md
@@ -122,9 +122,9 @@ The confidential VM will start, and the NVFLARE server and clients will automati
 You can now use the NVFlare admin console to communicate with the NVFlare system.
 
 > **Note:** `user_config.qcow2` and `user_data.qcow2` are not encrypted. The generated `sub_start.sh` detects when it
-> is launched from `/user_config` and uses `/vault/workspace` as the runtime workspace so job artifacts, such
-> as `FL_global_model.pt`, stay on the encrypted root filesystem. Set `NVFL_WORKSPACE` before launch to choose another
-> encrypted workspace path.
+> is launched from `/user_config` and uses a namespaced folder under `/vault/workspace` as the runtime workspace so job
+> artifacts, such as `FL_global_model.pt`, stay on the encrypted root filesystem. Set `NVFL_WORKSPACE` before launch to
+> choose another encrypted workspace path.
 
 ## 7. Notes on using NVIDIA GPU CC
 

--- a/examples/advanced/cc_provision/README.md
+++ b/examples/advanced/cc_provision/README.md
@@ -121,10 +121,9 @@ cd cvm_xxx
 The confidential VM will start, and the NVFLARE server and clients will automatically connect and begin operation.
 You can now use the NVFlare admin console to communicate with the NVFlare system.
 
-> **Note:** `user_config.qcow2` and `user_data.qcow2` are not encrypted. The generated `sub_start.sh` detects when it
-> is launched from `/user_config` and uses a namespaced folder under `/vault/workspace` as the runtime workspace so job
-> artifacts, such as `FL_global_model.pt`, stay on the encrypted root filesystem. Set `NVFL_WORKSPACE` before launch to
-> choose another encrypted workspace path.
+> **Note:** `user_config.qcow2` and `user_data.qcow2` are not encrypted. When a provisioned NVFlare startup script is
+> launched from `/user_config`, runtime artifacts such as `FL_global_model.pt` are written to a namespaced encrypted
+> workspace under `/vault/workspace`. Set `NVFL_WORKSPACE` before launch to choose another encrypted workspace path.
 
 ## 7. Notes on using NVIDIA GPU CC
 

--- a/examples/advanced/cc_provision/README.md
+++ b/examples/advanced/cc_provision/README.md
@@ -121,6 +121,11 @@ cd cvm_xxx
 The confidential VM will start, and the NVFLARE server and clients will automatically connect and begin operation.
 You can now use the NVFlare admin console to communicate with the NVFlare system.
 
+> **Note:** `user_config.qcow2` and `user_data.qcow2` are not encrypted. The generated `sub_start.sh` detects when it
+> is launched from `/user_config` and uses `/vault/workspace` as the runtime workspace so job artifacts, such
+> as `FL_global_model.pt`, stay on the encrypted root filesystem. Set `NVFL_WORKSPACE` before launch to choose another
+> encrypted workspace path.
+
 ## 7. Notes on using NVIDIA GPU CC
 
 1. Follow the [NVIDIA Confidential Computing documentation](https://nvflare.readthedocs.io/en/main/user_guide/confidential_computing/on_premises/cc_deployment_guide.html) to set up a machine with NVIDIA GPU CC enabled.
@@ -163,4 +168,3 @@ echo 10de $NVIDIA_PASSTHROUGH > /sys/bus/pci/drivers/vfio-pci/new_id
 
 1. Before re-building the initramfs for the CVM, remove the ``initrd.img`` file from the ``image_builder/base_images/`` directory.
    This ensures the Image Builder regenerates a fresh initramfs during the build process.
-

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -535,8 +535,10 @@ stop_fl_sh: |
   SOURCE_WORKSPACE="$( cd "$DIR/.." >/dev/null 2>&1 && pwd )"
   if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
     WORKSPACE="$NVFL_WORKSPACE"
-  elif [[ "$SOURCE_WORKSPACE" == "/user_config" || "$SOURCE_WORKSPACE" == /user_config/* ]]; then
-    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"
+  elif [[ "$SOURCE_WORKSPACE" == "/user_config" ]]; then
+    WORKSPACE="/vault/workspace/kit"
+  elif [[ "$SOURCE_WORKSPACE" == /user_config/* ]]; then
+    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"
   else
     WORKSPACE="$SOURCE_WORKSPACE"
   fi
@@ -568,8 +570,10 @@ sub_start_sh: |
   SOURCE_WORKSPACE="$( cd "$DIR/.." >/dev/null 2>&1 && pwd )"
   if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
     WORKSPACE="$NVFL_WORKSPACE"
-  elif [[ "$SOURCE_WORKSPACE" == "/user_config" || "$SOURCE_WORKSPACE" == /user_config/* ]]; then
-    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"
+  elif [[ "$SOURCE_WORKSPACE" == "/user_config" ]]; then
+    WORKSPACE="/vault/workspace/kit"
+  elif [[ "$SOURCE_WORKSPACE" == /user_config/* ]]; then
+    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"
   else
     WORKSPACE="$SOURCE_WORKSPACE"
   fi
@@ -578,19 +582,47 @@ sub_start_sh: |
     exit 1
   fi
 
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --verify)
+        doVerify=true
+      ;;
+      --once)
+        doOnce=true
+      ;;
+    esac
+    shift
+  done
+
+  check_daemon() {
+    if [[ -f "$WORKSPACE/daemon_pid.fl" ]]; then
+      dpid=`cat "$WORKSPACE/daemon_pid.fl"`
+      kill -0 ${dpid} 2> /dev/null 1>&2
+      if [[ $? -eq 0 ]]; then
+        echo "There seems to be one instance, pid=$dpid, running."
+        echo "If you are sure it's not the case, please kill process $dpid and then remove daemon_pid.fl in $WORKSPACE"
+        exit
+      fi
+      rm -f "$WORKSPACE/daemon_pid.fl"
+    fi
+  }
+
   if [[ "$WORKSPACE" != "$SOURCE_WORKSPACE" ]]; then
-    mkdir -p "$WORKSPACE"
+    check_daemon
+    mkdir -p "$(dirname "$WORKSPACE")"
+    rm -rf "$WORKSPACE"
+    cp -a "$SOURCE_WORKSPACE" "$WORKSPACE"
     chmod 700 "$WORKSPACE"
-    # startup/ and local/ are treated as ephemeral here: they are wiped and re-sourced
-    # from SOURCE_WORKSPACE on every launch, since the signed config in SOURCE_WORKSPACE
-    # (e.g. /user_config) is the canonical copy. Edits made to these dirs in WORKSPACE
-    # between launches will not persist.
-    rm -rf "$WORKSPACE/startup" "$WORKSPACE/local"
-    cp -a "$SOURCE_WORKSPACE/startup" "$WORKSPACE/startup"
-    if [[ -d "$SOURCE_WORKSPACE/local" ]]; then
-      cp -a "$SOURCE_WORKSPACE/local" "$WORKSPACE/local"
-    else
-      mkdir -p "$WORKSPACE/local"
+  fi
+
+  if [[ "$doVerify" == "true" ]]; then
+    python3 -m nvflare.tool.verify_startup_kits -f "$WORKSPACE" -c "$WORKSPACE/startup/rootCA.pem"
+    verification_status=$?
+    if [[ $verification_status -ne 0 ]]; then
+      echo "verification failed"
+      exit 1
     fi
   fi
 
@@ -618,20 +650,6 @@ sub_start_sh: |
   # Limit glibc memory arenas to reduce RSS fragmentation (ignored by jemalloc)
   # Recommended: MALLOC_ARENA_MAX=2 for clients, MALLOC_ARENA_MAX=4 for servers
   export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-4}
-
-  while [[ $# -gt 0 ]]
-  do
-    key="$1"
-    case $key in
-      --verify)
-        doVerify=true
-      ;;
-      --once)
-        doOnce=true
-      ;;
-    esac
-    shift
-  done
 
   SECONDS=0
   lst=-400
@@ -674,15 +692,6 @@ sub_start_sh: |
     rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" 2> /dev/null 1>&2
   }
 
-  if [[ "$doVerify" == "true" ]]; then
-    python3 -m nvflare.tool.verify_startup_kits -f "$WORKSPACE" -c "$WORKSPACE/startup/rootCA.pem"
-    verification_status=$?
-    if [[ $verification_status -ne 0 ]]; then
-      echo "verification failed"
-      exit 1
-    fi
-  fi
-
   if [[ "$doOnce" == "true" ]]; then
     echo "Start NVFlare directly"
     rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" 2> /dev/null 1>&2
@@ -690,16 +699,7 @@ sub_start_sh: |
     exit $?
   fi
 
-  if [[ -f "$WORKSPACE/daemon_pid.fl" ]]; then
-    dpid=`cat "$WORKSPACE/daemon_pid.fl"`
-    kill -0 ${dpid} 2> /dev/null 1>&2
-    if [[ $? -eq 0 ]]; then
-      echo "There seems to be one instance, pid=$dpid, running."
-      echo "If you are sure it's not the case, please kill process $dpid and then remove daemon_pid.fl in $WORKSPACE"
-      exit
-    fi
-    rm -f "$WORKSPACE/daemon_pid.fl"
-  fi
+  check_daemon
 
   echo $BASHPID > "$WORKSPACE/daemon_pid.fl"
 

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -536,9 +536,9 @@ stop_fl_sh: |
   if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
     WORKSPACE="$NVFL_WORKSPACE"
   elif [[ "$SOURCE_WORKSPACE" == "/user_config" ]]; then
-    WORKSPACE="/vault/workspace/kit"
+    WORKSPACE="/vault/workspace"
   elif [[ "$SOURCE_WORKSPACE" == /user_config/* ]]; then
-    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"
+    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"
   else
     WORKSPACE="$SOURCE_WORKSPACE"
   fi
@@ -571,9 +571,9 @@ sub_start_sh: |
   if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
     WORKSPACE="$NVFL_WORKSPACE"
   elif [[ "$SOURCE_WORKSPACE" == "/user_config" ]]; then
-    WORKSPACE="/vault/workspace/kit"
+    WORKSPACE="/vault/workspace"
   elif [[ "$SOURCE_WORKSPACE" == /user_config/* ]]; then
-    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"
+    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"
   else
     WORKSPACE="$SOURCE_WORKSPACE"
   fi
@@ -609,16 +609,21 @@ sub_start_sh: |
     fi
   }
 
+  KIT_WORKSPACE="$WORKSPACE"
   if [[ "$WORKSPACE" != "$SOURCE_WORKSPACE" ]]; then
     check_daemon
-    mkdir -p "$(dirname "$WORKSPACE")"
-    rm -rf "$WORKSPACE"
-    cp -a "$SOURCE_WORKSPACE" "$WORKSPACE"
-    chmod 700 "$WORKSPACE"
+    KIT_WORKSPACE="$WORKSPACE/kit"
+    mkdir -p "$WORKSPACE"
+    rm -rf "$KIT_WORKSPACE"
+    cp -a "$SOURCE_WORKSPACE" "$KIT_WORKSPACE"
+    chmod 700 "$WORKSPACE" "$KIT_WORKSPACE"
+    rm -rf "$WORKSPACE/startup" "$WORKSPACE/local"
+    ln -s "$KIT_WORKSPACE/startup" "$WORKSPACE/startup"
+    ln -s "$KIT_WORKSPACE/local" "$WORKSPACE/local"
   fi
 
   if [[ "$doVerify" == "true" ]]; then
-    python3 -m nvflare.tool.verify_startup_kits -f "$WORKSPACE" -c "$WORKSPACE/startup/rootCA.pem"
+    python3 -m nvflare.tool.verify_startup_kits -f "$KIT_WORKSPACE" -c "$KIT_WORKSPACE/startup/rootCA.pem"
     verification_status=$?
     if [[ $verification_status -ne 0 ]]; then
       echo "verification failed"

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -544,7 +544,6 @@ stop_fl_sh: |
     echo "Invalid WORKSPACE: '$WORKSPACE'"
     exit 1
   fi
-  mkdir -p "$WORKSPACE"
   echo "Please use FL admin console to issue shutdown client command to properly stop this client."
   echo "This stop_fl.sh script can only be used as the last resort to stop this client."
   echo "It will not properly deregister the client to the server."
@@ -554,6 +553,7 @@ stop_fl_sh: |
     y|Y)
       echo
       echo "Shutdown request created.  Wait for local FL process to shutdown."
+      mkdir -p "$WORKSPACE"
       touch "$WORKSPACE/shutdown.fl"
       ;;
     n|N|*)
@@ -580,6 +580,11 @@ sub_start_sh: |
 
   if [[ "$WORKSPACE" != "$SOURCE_WORKSPACE" ]]; then
     mkdir -p "$WORKSPACE"
+    chmod 700 "$WORKSPACE"
+    # startup/ and local/ are treated as ephemeral here: they are wiped and re-sourced
+    # from SOURCE_WORKSPACE on every launch, since the signed config in SOURCE_WORKSPACE
+    # (e.g. /user_config) is the canonical copy. Edits made to these dirs in WORKSPACE
+    # between launches will not persist.
     rm -rf "$WORKSPACE/startup" "$WORKSPACE/local"
     cp -a "$SOURCE_WORKSPACE/startup" "$WORKSPACE/startup"
     if [[ -d "$SOURCE_WORKSPACE/local" ]]; then

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -532,6 +532,19 @@ start_svr_sh: |
 stop_fl_sh: |
   #!/usr/bin/env bash
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  SOURCE_WORKSPACE="$( cd "$DIR/.." >/dev/null 2>&1 && pwd )"
+  if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
+    WORKSPACE="$NVFL_WORKSPACE"
+  elif [[ "$SOURCE_WORKSPACE" == "/user_config" || "$SOURCE_WORKSPACE" == /user_config/* ]]; then
+    WORKSPACE="/vault/workspace"
+  else
+    WORKSPACE="$SOURCE_WORKSPACE"
+  fi
+  if [[ -z "$WORKSPACE" || "$WORKSPACE" == "/" ]]; then
+    echo "Invalid WORKSPACE: '$WORKSPACE'"
+    exit 1
+  fi
+  mkdir -p "$WORKSPACE"
   echo "Please use FL admin console to issue shutdown client command to properly stop this client."
   echo "This stop_fl.sh script can only be used as the last resort to stop this client."
   echo "It will not properly deregister the client to the server."
@@ -541,7 +554,7 @@ stop_fl_sh: |
     y|Y)
       echo
       echo "Shutdown request created.  Wait for local FL process to shutdown."
-      touch $DIR/../shutdown.fl
+      touch "$WORKSPACE/shutdown.fl"
       ;;
     n|N|*)
       echo
@@ -552,8 +565,32 @@ stop_fl_sh: |
 sub_start_sh: |
   #!/usr/bin/env bash
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-  echo "WORKSPACE set to $DIR/.."
-  mkdir -p $DIR/../transfer
+  SOURCE_WORKSPACE="$( cd "$DIR/.." >/dev/null 2>&1 && pwd )"
+  if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
+    WORKSPACE="$NVFL_WORKSPACE"
+  elif [[ "$SOURCE_WORKSPACE" == "/user_config" || "$SOURCE_WORKSPACE" == /user_config/* ]]; then
+    WORKSPACE="/vault/workspace"
+  else
+    WORKSPACE="$SOURCE_WORKSPACE"
+  fi
+  if [[ -z "$WORKSPACE" || "$WORKSPACE" == "/" ]]; then
+    echo "Invalid WORKSPACE: '$WORKSPACE'"
+    exit 1
+  fi
+
+  if [[ "$WORKSPACE" != "$SOURCE_WORKSPACE" ]]; then
+    mkdir -p "$WORKSPACE"
+    rm -rf "$WORKSPACE/startup" "$WORKSPACE/local"
+    cp -a "$SOURCE_WORKSPACE/startup" "$WORKSPACE/startup"
+    if [[ -d "$SOURCE_WORKSPACE/local" ]]; then
+      cp -a "$SOURCE_WORKSPACE/local" "$WORKSPACE/local"
+    else
+      mkdir -p "$WORKSPACE/local"
+    fi
+  fi
+
+  echo "WORKSPACE set to $WORKSPACE"
+  mkdir -p "$WORKSPACE/transfer"
   export PYTHONPATH=/local/custom:$PYTHONPATH
   echo "PYTHONPATH is $PYTHONPATH"
 
@@ -596,7 +633,7 @@ sub_start_sh: |
   restart_count=0
 
   start_python() {
-    python3 -u -m nvflare.private.fed.app.{~~type~~}.{~~app_name~~} -m $DIR/.. -s fed_{~~type~~}.json --set secure_train=true {~~cln_uid~~} org={~~org_name~~} config_folder={~~config_folder~~}
+    python3 -u -m nvflare.private.fed.app.{~~type~~}.{~~app_name~~} -m "$WORKSPACE" -s fed_{~~type~~}.json --set secure_train=true {~~cln_uid~~} org={~~org_name~~} config_folder={~~config_folder~~}
   }
 
   start_fl() {
@@ -607,21 +644,21 @@ sub_start_sh: |
     fi
     if [[ $(($SECONDS - $lst )) -lt 300 && $restart_count -ge 5 ]]; then
       echo "System is in trouble and unable to start the task!!!!!"
-      rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl $DIR/../daemon_pid.fl
+      rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" "$WORKSPACE/daemon_pid.fl"
       exit
     fi
     lst=$SECONDS
-    (start_python 2>&1 & echo $! >&3 ) 3>$DIR/../pid.fl
-    pid=`cat $DIR/../pid.fl`
+    (start_python 2>&1 & echo $! >&3 ) 3>"$WORKSPACE/pid.fl"
+    pid=`cat "$WORKSPACE/pid.fl"`
     echo "new pid ${pid}"
   }
 
   stop_fl() {
-    if [[ ! -f "$DIR/../pid.fl" ]]; then
+    if [[ ! -f "$WORKSPACE/pid.fl" ]]; then
       echo "No pid.fl.  No need to kill process."
       return
     fi
-    pid=`cat $DIR/../pid.fl`
+    pid=`cat "$WORKSPACE/pid.fl"`
     sleep 5
     kill -0 ${pid} 2> /dev/null 1>&2
     if [[ $? -ne 0 ]]; then
@@ -629,11 +666,11 @@ sub_start_sh: |
       return
     fi
     kill -9 $pid
-    rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl 2> /dev/null 1>&2
+    rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" 2> /dev/null 1>&2
   }
 
   if [[ "$doVerify" == "true" ]]; then
-    python3 -m nvflare.tool.verify_startup_kits -f $DIR/../ -c $DIR/rootCA.pem
+    python3 -m nvflare.tool.verify_startup_kits -f "$WORKSPACE" -c "$WORKSPACE/startup/rootCA.pem"
     verification_status=$?
     if [[ $verification_status -ne 0 ]]; then
       echo "verification failed"
@@ -643,36 +680,36 @@ sub_start_sh: |
 
   if [[ "$doOnce" == "true" ]]; then
     echo "Start NVFlare directly"
-    rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl 2> /dev/null 1>&2
+    rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" 2> /dev/null 1>&2
     start_python
     exit $?
   fi
 
-  if [[ -f "$DIR/../daemon_pid.fl" ]]; then
-    dpid=`cat $DIR/../daemon_pid.fl`
+  if [[ -f "$WORKSPACE/daemon_pid.fl" ]]; then
+    dpid=`cat "$WORKSPACE/daemon_pid.fl"`
     kill -0 ${dpid} 2> /dev/null 1>&2
     if [[ $? -eq 0 ]]; then
       echo "There seems to be one instance, pid=$dpid, running."
-      echo "If you are sure it's not the case, please kill process $dpid and then remove daemon_pid.fl in $DIR/.."
+      echo "If you are sure it's not the case, please kill process $dpid and then remove daemon_pid.fl in $WORKSPACE"
       exit
     fi
-    rm -f $DIR/../daemon_pid.fl
+    rm -f "$WORKSPACE/daemon_pid.fl"
   fi
 
-  echo $BASHPID > $DIR/../daemon_pid.fl
+  echo $BASHPID > "$WORKSPACE/daemon_pid.fl"
 
   while true
   do
     sleep 5
-    if [[ ! -f "$DIR/../pid.fl" ]]; then
+    if [[ ! -f "$WORKSPACE/pid.fl" ]]; then
       echo "start fl because of no pid.fl"
       start_fl
       continue
     fi
-    pid=`cat $DIR/../pid.fl`
+    pid=`cat "$WORKSPACE/pid.fl"`
     kill -0 ${pid} 2> /dev/null 1>&2
     if [[ $? -ne 0 ]]; then
-      if [[ -f "$DIR/../shutdown.fl" ]]; then
+      if [[ -f "$WORKSPACE/shutdown.fl" ]]; then
         echo "Gracefully shutdown."
         break
       fi
@@ -680,18 +717,18 @@ sub_start_sh: |
       start_fl
       continue
     fi
-    if [[ -f "$DIR/../shutdown.fl" ]]; then
+    if [[ -f "$WORKSPACE/shutdown.fl" ]]; then
       echo "About to shutdown."
       stop_fl
       break
     fi
-    if [[ -f "$DIR/../restart.fl" ]]; then
+    if [[ -f "$WORKSPACE/restart.fl" ]]; then
       echo "About to restart."
       stop_fl
     fi
   done
 
-  rm -f $DIR/../pid.fl $DIR/../shutdown.fl $DIR/../restart.fl $DIR/../daemon_pid.fl
+  rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" "$WORKSPACE/daemon_pid.fl"
 
 docker_cln_sh: |
   #!/usr/bin/env bash

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -536,7 +536,7 @@ stop_fl_sh: |
   if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
     WORKSPACE="$NVFL_WORKSPACE"
   elif [[ "$SOURCE_WORKSPACE" == "/user_config" || "$SOURCE_WORKSPACE" == /user_config/* ]]; then
-    WORKSPACE="/vault/workspace"
+    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"
   else
     WORKSPACE="$SOURCE_WORKSPACE"
   fi
@@ -569,7 +569,7 @@ sub_start_sh: |
   if [[ -n "${NVFL_WORKSPACE:-}" ]]; then
     WORKSPACE="$NVFL_WORKSPACE"
   elif [[ "$SOURCE_WORKSPACE" == "/user_config" || "$SOURCE_WORKSPACE" == /user_config/* ]]; then
-    WORKSPACE="/vault/workspace"
+    WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"
   else
     WORKSPACE="$SOURCE_WORKSPACE"
   fi

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -156,11 +156,20 @@ class TestStaticFileBuilder:
 
         sub_start = template["sub_start_sh"]
         stop_fl = template["stop_fl_sh"]
+        copy_cmd = 'cp -a "$SOURCE_WORKSPACE" "$WORKSPACE"'
+        verify_cmd = 'verify_startup_kits -f "$WORKSPACE" -c "$WORKSPACE/startup/rootCA.pem"'
 
         assert 'SOURCE_WORKSPACE" == "/user_config"' in sub_start
         assert 'SOURCE_WORKSPACE" == /user_config/*' in sub_start
-        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"' in sub_start
-        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"' in stop_fl
+        assert 'SOURCE_WORKSPACE" == "/user_config"' in stop_fl
+        assert 'SOURCE_WORKSPACE" == /user_config/*' in stop_fl
+        assert 'WORKSPACE="/vault/workspace/kit"' in sub_start
+        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"' in sub_start
+        assert 'WORKSPACE="/vault/workspace/kit"' in stop_fl
+        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"' in stop_fl
+        assert copy_cmd in sub_start
         assert '-m "$WORKSPACE"' in sub_start
-        assert 'verify_startup_kits -f "$WORKSPACE"' in sub_start
+        assert verify_cmd in sub_start
+        assert sub_start.index(copy_cmd) < sub_start.index(verify_cmd)
+        assert sub_start.index(verify_cmd) < sub_start.index('mkdir -p "$WORKSPACE/transfer"')
         assert 'touch "$WORKSPACE/shutdown.fl"' in stop_fl

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -156,18 +156,23 @@ class TestStaticFileBuilder:
 
         sub_start = template["sub_start_sh"]
         stop_fl = template["stop_fl_sh"]
-        copy_cmd = 'cp -a "$SOURCE_WORKSPACE" "$WORKSPACE"'
-        verify_cmd = 'verify_startup_kits -f "$WORKSPACE" -c "$WORKSPACE/startup/rootCA.pem"'
+        copy_cmd = 'cp -a "$SOURCE_WORKSPACE" "$KIT_WORKSPACE"'
+        verify_cmd = 'verify_startup_kits -f "$KIT_WORKSPACE" -c "$KIT_WORKSPACE/startup/rootCA.pem"'
 
         assert 'SOURCE_WORKSPACE" == "/user_config"' in sub_start
         assert 'SOURCE_WORKSPACE" == /user_config/*' in sub_start
         assert 'SOURCE_WORKSPACE" == "/user_config"' in stop_fl
         assert 'SOURCE_WORKSPACE" == /user_config/*' in stop_fl
-        assert 'WORKSPACE="/vault/workspace/kit"' in sub_start
-        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"' in sub_start
-        assert 'WORKSPACE="/vault/workspace/kit"' in stop_fl
-        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")/kit"' in stop_fl
+        assert 'WORKSPACE="/vault/workspace"' in sub_start
+        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"' in sub_start
+        assert 'WORKSPACE="/vault/workspace"' in stop_fl
+        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"' in stop_fl
+        assert 'KIT_WORKSPACE="$WORKSPACE/kit"' in sub_start
         assert copy_cmd in sub_start
+        assert 'rm -rf "$KIT_WORKSPACE"' in sub_start
+        assert 'rm -rf "$WORKSPACE"' not in sub_start
+        assert 'ln -s "$KIT_WORKSPACE/startup" "$WORKSPACE/startup"' in sub_start
+        assert 'ln -s "$KIT_WORKSPACE/local" "$WORKSPACE/local"' in sub_start
         assert '-m "$WORKSPACE"' in sub_start
         assert verify_cmd in sub_start
         assert sub_start.index(copy_cmd) < sub_start.index(verify_cmd)

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -158,7 +158,9 @@ class TestStaticFileBuilder:
         stop_fl = template["stop_fl_sh"]
 
         assert 'SOURCE_WORKSPACE" == "/user_config"' in sub_start
-        assert 'WORKSPACE="/vault/workspace"' in sub_start
+        assert 'SOURCE_WORKSPACE" == /user_config/*' in sub_start
+        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"' in sub_start
+        assert 'WORKSPACE="/vault/workspace/$(basename "$SOURCE_WORKSPACE")"' in stop_fl
         assert '-m "$WORKSPACE"' in sub_start
         assert 'verify_startup_kits -f "$WORKSPACE"' in sub_start
         assert 'touch "$WORKSPACE/shutdown.fl"' in stop_fl

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -135,3 +135,30 @@ class TestStaticFileBuilder:
         lead = authz["permissions"]["lead"]
         assert "server-predeployed-flwr" in lead
         assert lead["server-predeployed-flwr"] == "none"
+
+    def test_master_template_moves_user_config_runtime_workspace(self):
+        """CC startup kits live in plaintext /user_config, so runtime artifacts must not default there."""
+        import os
+
+        import yaml
+
+        template_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+            "nvflare",
+            "lighter",
+            "templates",
+            "master_template.yml",
+        )
+        assert os.path.exists(template_path)
+
+        with open(template_path, "r") as f:
+            template = yaml.safe_load(f)
+
+        sub_start = template["sub_start_sh"]
+        stop_fl = template["stop_fl_sh"]
+
+        assert 'SOURCE_WORKSPACE" == "/user_config"' in sub_start
+        assert 'WORKSPACE="/vault/workspace"' in sub_start
+        assert '-m "$WORKSPACE"' in sub_start
+        assert 'verify_startup_kits -f "$WORKSPACE"' in sub_start
+        assert 'touch "$WORKSPACE/shutdown.fl"' in stop_fl


### PR DESCRIPTION
## Summary

Cherry-picks NVIDIA/NVFlare#4649 from the 2.8 branch to `main`.

This updates the Confidential Computing startup path so provisioned startup kits launched from `/user_config` use an encrypted runtime workspace under `/vault/workspace`, copy the complete signed startup kit root into `$WORKSPACE/kit`, and preserve runtime artifacts across restarts.

## Root Cause

The generated `sub_start.sh` used `$DIR/..` as the runtime workspace. In CC deployments where the startup kit lives at `/user_config/nvflare`, this caused job artifacts such as model checkpoints to be written under the plaintext user config drive.

## Changes

- Moves `/user_config` CC runtime writes to `/vault/workspace[/<site>]`.
- Copies the signed startup kit into `$WORKSPACE/kit` so verification can validate the complete copied kit.
- Refreshes only kit/startup/local links on restart while preserving job artifacts under `$WORKSPACE`.
- Updates CC docs and example notes for the encrypted runtime workspace contract.
- Adds focused regression coverage for the generated startup/stop templates.

## Validation

- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/lighter/static_file_builder_test.py`
- `PATH=/Users/zhihongz/nvflare-env/3.12/bin:$PATH ./runtest.sh -s --skip-install tests/unit_test/lighter/static_file_builder_test.py`
- `git diff --check upstream/main..HEAD`

Note: full `./runtest.sh -s` was attempted, but this checkout's existing `examples/.../node_modules/.../flatted.py` vendor files fail `black --check`; the scoped style check for the touched Python test file passes.