### PR TITLE
[2.8] Replace scikit-survival (GPL-3.0) with download_data.py in KM examples

### DIFF
--- a/examples/advanced/kaplan-meier-he/README.md
+++ b/examples/advanced/kaplan-meier-he/README.md
@@ -60,7 +60,7 @@ This section describes the key components of the federated Kaplan-Meier example.
 
 ### Data
 
-**Dataset**: This example uses the `veterans_lung_cancer` dataset from `sksurv.datasets.load_veterans_lung_cancer`. The dataset contains survival information for veterans with advanced lung cancer.
+**Dataset**: This example uses the Veterans' Lung Cancer Trial dataset (originally from R's `survival` package), downloaded from the [Rdatasets collection](https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv). The dataset contains survival information for veterans with advanced lung cancer.
 
 **Key Features**:
 - `Survival Days`: Time from observation start to end (event time)
@@ -292,7 +292,12 @@ This example supports both **Simulation Mode** (for local testing) and **Product
 
 For simulation mode (testing and development), we manually prepare the data and HE context:
 
-**Step 1: Prepare Data**
+**Step 1: Download and Prepare Data**
+
+Download the Veterans' Lung Cancer dataset:
+```commandline
+python utils/download_data.py
+```
 
 Split and generate data files for each client with binning interval of 7 days:
 ```commandline

--- a/examples/advanced/kaplan-meier-he/requirements.txt
+++ b/examples/advanced/kaplan-meier-he/requirements.txt
@@ -1,3 +1,2 @@
 lifelines
 tenseal
-scikit-survival

--- a/examples/advanced/kaplan-meier-he/utils/baseline_kaplan_meier.py
+++ b/examples/advanced/kaplan-meier-he/utils/baseline_kaplan_meier.py
@@ -17,8 +17,10 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 from lifelines import KaplanMeierFitter
-from sksurv.datasets import load_veterans_lung_cancer
+
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
 
 
 def args_parser():
@@ -29,14 +31,19 @@ def args_parser():
         default="/tmp/nvflare/baseline/km_curve_baseline.png",
         help="save path for the output curve",
     )
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Veterans' Lung Cancer dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
     return parser
 
 
-def prepare_data(bin_days: int = 7):
-    data_x, data_y = load_veterans_lung_cancer()
-    total_data_num = data_x.shape[0]
-    event = data_y["Status"]
-    time = data_y["Survival_in_days"]
+def prepare_data(data_path: str, bin_days: int = 7):
+    data = pd.read_csv(data_path)
+    event = data["status"].astype(bool)
+    time = data["time"].astype(float)
     # Categorize data to a bin, default is a week (7 days)
     time = np.ceil(time / bin_days).astype(int) * bin_days
     return event, time
@@ -56,7 +63,7 @@ def main():
     # Fit and plot Kaplan Meier curve with lifelines
 
     # Generate data with binning
-    event, time = prepare_data(bin_days=7)
+    event, time = prepare_data(args.data_path, bin_days=7)
     kmf = KaplanMeierFitter()
     # Fit the survival data
     kmf.fit(time, event)
@@ -64,7 +71,7 @@ def main():
     kmf.plot_survival_function(label="Binned Weekly")
 
     # Generate data without binning
-    event, time = prepare_data(bin_days=1)
+    event, time = prepare_data(args.data_path, bin_days=1)
     kmf = KaplanMeierFitter()
     # Fit the survival data
     kmf.fit(time, event)

--- a/examples/advanced/kaplan-meier-he/utils/download_data.py
+++ b/examples/advanced/kaplan-meier-he/utils/download_data.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+import requests
+
+# Veterans' Lung Cancer Trial dataset from the R survival package,
+# hosted by the Rdatasets collection (MIT-licensed mirror of public R datasets).
+VETERAN_URL = "https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv"
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
+
+
+def download_veteran_data(output_path: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    r = requests.get(VETERAN_URL, timeout=30)
+    r.raise_for_status()
+    with open(output_path, "wb") as f:
+        f.write(r.content)
+    print(f"Saved Veterans' Lung Cancer dataset to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download the Veterans' Lung Cancer dataset")
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to save the dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
+    args = parser.parse_args()
+    download_veteran_data(args.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/kaplan-meier-he/utils/prepare_data.py
+++ b/examples/advanced/kaplan-meier-he/utils/prepare_data.py
@@ -17,14 +17,21 @@ import os
 
 import numpy as np
 import pandas as pd
-from sksurv.datasets import load_veterans_lung_cancer
 
 np.random.seed(77)
+
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
 
 
 def data_split_args_parser():
     parser = argparse.ArgumentParser(description="Generate data split for dataset")
     parser.add_argument("--num_clients", type=int, default=5, help="Total number of clients, default is 5")
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Veterans' Lung Cancer dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
     parser.add_argument(
         "--site_name_prefix",
         type=str,
@@ -64,9 +71,10 @@ def main():
     parser = data_split_args_parser()
     args = parser.parse_args()
 
-    # Load data
+    # Load data — run download_data.py first if the file does not exist
     # For this KM analysis, we use full timeline and event label only
-    _, data = load_veterans_lung_cancer()
+    data = pd.read_csv(args.data_path)
+    data = data.rename(columns={"time": "Survival_in_days", "status": "Status"})
 
     # Prepare data
     event_clients, time_clients = prepare_data(data=data, num_clients=args.num_clients, bin_days=args.bin_days)

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/requirements.txt
@@ -1,4 +1,3 @@
 nvflare~=2.7.2rc
 lifelines
 tenseal
-scikit-survival

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/utils/baseline_kaplan_meier.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/utils/baseline_kaplan_meier.py
@@ -17,8 +17,10 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 from lifelines import KaplanMeierFitter
-from sksurv.datasets import load_veterans_lung_cancer
+
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
 
 
 def args_parser():
@@ -29,14 +31,19 @@ def args_parser():
         default="/tmp/nvflare/baseline/km_curve_baseline.png",
         help="save path for the output curve",
     )
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Veterans' Lung Cancer dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
     return parser
 
 
-def prepare_data(bin_days: int = 7):
-    data_x, data_y = load_veterans_lung_cancer()
-    total_data_num = data_x.shape[0]
-    event = data_y["Status"]
-    time = data_y["Survival_in_days"]
+def prepare_data(data_path: str, bin_days: int = 7):
+    data = pd.read_csv(data_path)
+    event = data["status"].astype(bool)
+    time = data["time"].astype(float)
     # Categorize data to a bin, default is a week (7 days)
     time = np.ceil(time / bin_days).astype(int) * bin_days
     return event, time
@@ -59,7 +66,7 @@ def main():
     # Fit and plot Kaplan Meier curve with lifelines
 
     # Generate data with binning
-    event, time = prepare_data(bin_days=7)
+    event, time = prepare_data(args.data_path, bin_days=7)
     kmf = KaplanMeierFitter()
     # Fit the survival data
     kmf.fit(time, event)
@@ -67,7 +74,7 @@ def main():
     kmf.plot_survival_function(label="Binned Weekly")
 
     # Generate data without binning
-    event, time = prepare_data(bin_days=1)
+    event, time = prepare_data(args.data_path, bin_days=1)
     kmf = KaplanMeierFitter()
     # Fit the survival data
     kmf.fit(time, event)

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/utils/download_data.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/utils/download_data.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+import requests
+
+# Veterans' Lung Cancer Trial dataset from the R survival package,
+# hosted by the Rdatasets collection (MIT-licensed mirror of public R datasets).
+VETERAN_URL = "https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv"
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
+
+
+def download_veteran_data(output_path: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    r = requests.get(VETERAN_URL, timeout=30)
+    r.raise_for_status()
+    with open(output_path, "wb") as f:
+        f.write(r.content)
+    print(f"Saved Veterans' Lung Cancer dataset to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download the Veterans' Lung Cancer dataset")
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to save the dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
+    args = parser.parse_args()
+    download_veteran_data(args.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/utils/prepare_data.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/code/utils/prepare_data.py
@@ -17,9 +17,10 @@ import os
 
 import numpy as np
 import pandas as pd
-from sksurv.datasets import load_veterans_lung_cancer
 
 np.random.seed(77)
+
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
 
 
 def data_split_args_parser():
@@ -33,6 +34,12 @@ def data_split_args_parser():
     )
     parser.add_argument("--bin_days", type=int, default=1, help="Bin days for categorizing data")
     parser.add_argument("--out_path", type=str, help="Output root path for split data files")
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Veterans' Lung Cancer dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
     return parser
 
 
@@ -64,9 +71,10 @@ def main():
     parser = data_split_args_parser()
     args = parser.parse_args()
 
-    # Load data
+    # Load data — run download_data.py first if the file does not exist
     # For this KM analysis, we use full timeline and event label only
-    _, data = load_veterans_lung_cancer()
+    data = pd.read_csv(args.data_path)
+    data = data.rename(columns={"time": "Survival_in_days", "status": "Status"})
 
     # Prepare data
     event_clients, time_clients = prepare_data(data=data, site_num=args.site_num, bin_days=args.bin_days)

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/convert_survival_analysis_to_fl.ipynb
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/convert_survival_analysis_to_fl.ipynb
@@ -110,6 +110,14 @@
   },
   {
    "cell_type": "code",
+   "id": "dcfdad2f",
+   "source": "! python3 code/utils/download_data.py",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "41206a7d",
    "metadata": {
@@ -170,15 +178,7 @@
    "cell_type": "markdown",
    "id": "302c4285",
    "metadata": {},
-   "source": "## Run the job\nFirst, download the dataset and prepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days.\n"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "survival-download-data",
-   "metadata": {},
-   "outputs": [],
-   "source": "! python3 code/utils/download_data.py"
+   "source": "## Run the job\nPrepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days."
   },
   {
    "cell_type": "code",

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/convert_survival_analysis_to_fl.ipynb
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.4_convert_machine_learning_to_federated_learning/02.4.3_convert_survival_analysis_to_federated_learning/convert_survival_analysis_to_fl.ipynb
@@ -106,13 +106,7 @@
    "cell_type": "markdown",
    "id": "d4b57b15",
    "metadata": {},
-   "source": [
-    "## Baseline Kaplan-Meier Analysis\n",
-    "We first illustrate the baseline centralized Kaplan-Meier analysis without any secure features. We used veterans_lung_cancer dataset by\n",
-    "`from sksurv.datasets import load_veterans_lung_cancer`, and used `Status` as the event type and `Survival_in_days` as the event time to construct the event list.\n",
-    "\n",
-    "To run the baseline script, simply execute:"
-   ]
+   "source": "## Baseline Kaplan-Meier Analysis\nWe first illustrate the baseline centralized Kaplan-Meier analysis without any secure features. We used the Veterans' Lung Cancer Trial dataset (originally from R's `survival` package, available via the [Rdatasets collection](https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv)), with `status` as the event indicator and `time` as the survival time.\n\nDownload the dataset first, then run the baseline script:\n"
   },
   {
    "cell_type": "code",
@@ -176,10 +170,15 @@
    "cell_type": "markdown",
    "id": "302c4285",
    "metadata": {},
-   "source": [
-    "## Run the job\n",
-    "First, we prepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days."
-   ]
+   "source": "## Run the job\nFirst, download the dataset and prepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "survival-download-data",
+   "metadata": {},
+   "outputs": [],
+   "source": "! python3 code/utils/download_data.py"
   },
   {
    "cell_type": "code",

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/05.3.2_kaplan_meier_survival_analysis_with_he.ipynb
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/05.3.2_kaplan_meier_survival_analysis_with_he.ipynb
@@ -101,13 +101,7 @@
    "cell_type": "markdown",
    "id": "fc5fecdf-66ab-4ab3-ace1-384868efe36f",
    "metadata": {},
-   "source": [
-    "## Baseline Kaplan-Meier Analysis\n",
-    "We first illustrate the baseline centralized Kaplan-Meier analysis without any secure features. We used veterans_lung_cancer dataset by\n",
-    "`from sksurv.datasets import load_veterans_lung_cancer`, and used `Status` as the event type and `Survival_in_days` as the event time to construct the event list.\n",
-    "\n",
-    "To run the baseline script, simply execute:"
-   ]
+   "source": "## Baseline Kaplan-Meier Analysis\nWe first illustrate the baseline centralized Kaplan-Meier analysis without any secure features. We used the Veterans' Lung Cancer Trial dataset (originally from R's `survival` package, available via the [Rdatasets collection](https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv)), with `status` as the event indicator and `time` as the survival time.\n\nDownload the dataset first, then run the baseline script:\n"
   },
   {
    "cell_type": "code",
@@ -184,10 +178,15 @@
    "cell_type": "markdown",
    "id": "a36acc98-b940-4460-8e93-a3fb1f8af09e",
    "metadata": {},
-   "source": [
-    "## Run the job\n",
-    "First, we prepared data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days. "
-   ]
+   "source": "## Run the job\nFirst, download the dataset and prepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days. "
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "km-he-download-data",
+   "metadata": {},
+   "outputs": [],
+   "source": "! python utils/download_data.py"
   },
   {
    "cell_type": "code",

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/05.3.2_kaplan_meier_survival_analysis_with_he.ipynb
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/05.3.2_kaplan_meier_survival_analysis_with_he.ipynb
@@ -105,6 +105,14 @@
   },
   {
    "cell_type": "code",
+   "id": "51b2421c",
+   "source": "! python utils/download_data.py",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "8b07ed4b-2a87-4d79-8d84-731ac1537e14",
    "metadata": {},
@@ -178,15 +186,7 @@
    "cell_type": "markdown",
    "id": "a36acc98-b940-4460-8e93-a3fb1f8af09e",
    "metadata": {},
-   "source": "## Run the job\nFirst, download the dataset and prepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days. "
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "km-he-download-data",
-   "metadata": {},
-   "outputs": [],
-   "source": "! python utils/download_data.py"
+   "source": "## Run the job\nPrepare data for a 5-client federated job. We split and generate the data files for each client with binning interval of 7 days."
   },
   {
    "cell_type": "code",

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/requirements.txt
@@ -3,5 +3,4 @@ torch
 torchvision
 tensorboard
 lifelines
-scikit-survival
 matplotlib

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/utils/baseline_kaplan_meier.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/utils/baseline_kaplan_meier.py
@@ -17,8 +17,10 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 from lifelines import KaplanMeierFitter
-from sksurv.datasets import load_veterans_lung_cancer
+
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
 
 
 def args_parser():
@@ -29,14 +31,19 @@ def args_parser():
         default="/tmp/nvflare/baseline/km_curve_baseline.png",
         help="save path for the output curve",
     )
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Veterans' Lung Cancer dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
     return parser
 
 
-def prepare_data(bin_days: int = 7):
-    data_x, data_y = load_veterans_lung_cancer()
-    total_data_num = data_x.shape[0]
-    event = data_y["Status"]
-    time = data_y["Survival_in_days"]
+def prepare_data(data_path: str, bin_days: int = 7):
+    data = pd.read_csv(data_path)
+    event = data["status"].astype(bool)
+    time = data["time"].astype(float)
     # Categorize data to a bin, default is a week (7 days)
     time = np.ceil(time / bin_days).astype(int) * bin_days
     return event, time
@@ -56,7 +63,7 @@ def main():
     # Fit and plot Kaplan Meier curve with lifelines
 
     # Generate data with binning
-    event, time = prepare_data(bin_days=7)
+    event, time = prepare_data(args.data_path, bin_days=7)
     kmf = KaplanMeierFitter()
     # Fit the survival data
     kmf.fit(time, event)
@@ -64,7 +71,7 @@ def main():
     kmf.plot_survival_function(label="Binned Weekly")
 
     # Generate data without binning
-    event, time = prepare_data(bin_days=1)
+    event, time = prepare_data(args.data_path, bin_days=1)
     kmf = KaplanMeierFitter()
     # Fit the survival data
     kmf.fit(time, event)

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/utils/download_data.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/utils/download_data.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+import requests
+
+# Veterans' Lung Cancer Trial dataset from the R survival package,
+# hosted by the Rdatasets collection (MIT-licensed mirror of public R datasets).
+VETERAN_URL = "https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv"
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
+
+
+def download_veteran_data(output_path: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    r = requests.get(VETERAN_URL, timeout=30)
+    r.raise_for_status()
+    with open(output_path, "wb") as f:
+        f.write(r.content)
+    print(f"Saved Veterans' Lung Cancer dataset to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download the Veterans' Lung Cancer dataset")
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to save the dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
+    args = parser.parse_args()
+    download_veteran_data(args.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/utils/prepare_data.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/utils/prepare_data.py
@@ -17,14 +17,21 @@ import os
 
 import numpy as np
 import pandas as pd
-from sksurv.datasets import load_veterans_lung_cancer
 
 np.random.seed(77)
+
+DEFAULT_DATA_PATH = "/tmp/nvflare/dataset/veteran/veteran.csv"
 
 
 def data_split_args_parser():
     parser = argparse.ArgumentParser(description="Generate data split for dataset")
     parser.add_argument("--site_num", type=int, default=5, help="Total number of sites, default is 5")
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Veterans' Lung Cancer dataset CSV. Default: {DEFAULT_DATA_PATH}",
+    )
     parser.add_argument(
         "--site_name_prefix",
         type=str,
@@ -64,9 +71,10 @@ def main():
     parser = data_split_args_parser()
     args = parser.parse_args()
 
-    # Load data
+    # Load data — run download_data.py first if the file does not exist
     # For this KM analysis, we use full timeline and event label only
-    _, data = load_veterans_lung_cancer()
+    data = pd.read_csv(args.data_path)
+    data = data.rename(columns={"time": "Survival_in_days", "status": "Status"})
 
     # Prepare data
     event_clients, time_clients = prepare_data(data=data, site_num=args.site_num, bin_days=args.bin_days)


### PR DESCRIPTION
## Summary

- `scikit-survival` is GPL-3.0 licensed; it was used **only** to load the Veterans' Lung Cancer dataset (`load_veterans_lung_cancer`) — no survival analysis algorithms from it were used.
- Replace with a `download_data.py` script that fetches the same dataset from the [Rdatasets collection](https://vincentarelbundock.github.io/Rdatasets/csv/survival/veteran.csv) (public domain data, MIT-licensed mirror).
- No new dependencies introduced — `requests` is already a core NVFlare dependency.

## Affected examples (3 locations)
- `examples/advanced/kaplan-meier-he`
- `examples/tutorials/.../05.3_homomorphic_encryption`
- `examples/tutorials/.../02.4.3_convert_survival_analysis_to_federated_learning`

## Changes per example
- **Added** `utils/download_data.py` — downloads `veteran.csv` to `/tmp/nvflare/dataset/veteran/`
- **Updated** `utils/prepare_data.py` — removed sksurv import, added `pd.read_csv` + `--data_path` arg
- **Updated** `utils/baseline_kaplan_meier.py` — same replacement + `--data_path` arg
- **Updated** `requirements.txt` — removed `scikit-survival`
- **Updated** README / notebooks — replaced sksurv references, added download step

## Test plan
- [ ] `python utils/download_data.py` downloads `veteran.csv` successfully
- [ ] `python utils/prepare_data.py --num_clients 5 --bin_days 7 --out_path /tmp/nvflare/dataset/km_data` produces correct splits
- [ ] `python utils/baseline_kaplan_meier.py` generates KM curve without sksurv installed
- [ ] `pip install -r requirements.txt` succeeds with no GPL packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
