### PR TITLE
Fix fstat fd leak in GenerateDataFromFile and add success-path test

### DIFF
--- a/nvflare/fuel/hci/binary_proto.py
+++ b/nvflare/fuel/hci/binary_proto.py
@@ -433,7 +433,11 @@ class GenerateDataFromFile(DataGenerator):
 
     def __init__(self, file_name: str):
         self.file = open(file_name, "rb")
-        self.size = os.fstat(self.file.fileno()).st_size
+        try:
+            self.size = os.fstat(self.file.fileno()).st_size
+        except Exception:
+            self.file.close()
+            raise
 
     def data_size(self) -> int:
         return self.size

--- a/tests/unit_test/fuel/hci/binary_proto_test.py
+++ b/tests/unit_test/fuel/hci/binary_proto_test.py
@@ -131,3 +131,10 @@ class TestGenerateDataFromFile:
         with pytest.raises(IOError):
             send_binary_data(FailingSender(fail_after=3), gen, meta="m")
         assert gen.file.closed
+
+    def test_fd_closed_on_successful_send(self, tmp_path: Path):
+        path = tmp_path / "data.bin"
+        path.write_bytes(b"y" * (MAX_BLOCK_SIZE * 2))
+        gen = GenerateDataFromFile(str(path))
+        send_binary_data(MySender(), gen, meta="m")
+        assert gen.file.closed


### PR DESCRIPTION
## Summary

Follow-up to #4577. Addresses two P2 comments from the Greptile review on #4675:

- **fstat fd leak in `__init__`**: if `os.fstat(self.file.fileno())` raises after `open()`, the fd was leaked. Wrap in `try/except` so `self.file.close()` is called before re-raising.
- **Missing success-path test**: adds `test_fd_closed_on_successful_send` to `TestGenerateDataFromFile` to verify the normal send path closes the fd via the `try/finally` in `send_binary_data`.

## Test plan

- [x] All 9 unit tests pass (`tests/unit_test/fuel/hci/binary_proto_test.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)