### PR TITLE
Validate launcher_spec image field is a string

### DIFF
--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -393,6 +393,11 @@ class DockerJobLauncher(JobLauncherSpec):
         docker_spec = get_job_launcher_spec(job_meta, site_name, "docker")
         job_image = docker_spec.get("image")
         container_name = _sanitize_container_name(f"{site_name}-{job_id}")
+        if job_image is not None and not isinstance(job_image, str):
+            raise RuntimeError(
+                f"launcher_spec docker image for site '{site_name}' must be a string, "
+                f"got {type(job_image).__name__}: {job_image!r}"
+            )
         if not job_image:
             raise RuntimeError(
                 f"DockerJobLauncher is configured for site '{site_name}' but no job image "

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -476,6 +476,38 @@ class TestDockerJobLauncherLaunchJob:
         with pytest.raises(RuntimeError, match="no job image was specified"):
             launcher.launch_job(job_meta, fl_ctx)
 
+    @pytest.mark.parametrize(
+        "bad_image,type_name",
+        [
+            # Truthy non-string values.
+            (123, "int"),
+            (1.5, "float"),
+            (True, "bool"),
+            (["nvflare-job", "latest"], "list"),
+            ({"name": "nvflare-job"}, "dict"),
+            # Falsy non-None non-string values — also non-string, so the
+            # isinstance(str) guard fires before the existing falsy-image
+            # branch. Both paths are valid error reports; this set pins the
+            # type-check path so future refactors don't accidentally let
+            # `False` / `0` reach the docker daemon.
+            (False, "bool"),
+            (0, "int"),
+            (0.0, "float"),
+            ([], "list"),
+            ({}, "dict"),
+        ],
+    )
+    def test_launch_raises_if_image_is_not_a_string(self, bad_image, type_name):
+        launcher = _make_launcher()
+        fl_ctx, _ = _make_fl_ctx(identity_name="site-1")
+        job_meta = _make_job_meta(site_name="site-1", docker_spec={"image": bad_image})
+
+        with pytest.raises(
+            RuntimeError,
+            match=rf"launcher_spec docker image for site 'site-1' must be a string, got {type_name}",
+        ):
+            launcher.launch_job(job_meta, fl_ctx)
+
     def test_launch_returns_handle(self):
         launcher = _make_launcher()
         dc = launcher._docker_client


### PR DESCRIPTION
Summary:
- Cherry-pick PR #4656 from 2.8 to main.
- Validate Docker launcher_spec image values before invoking the Docker SDK.
- Add coverage for truthy and falsy non-string image values.

Tests:
- pytest tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
- git diff --check upstream/main...HEAD
- ./runtest.sh -s