### PR TITLE
[2.8] Auto-remove Docker job containers

### DIFF
--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -15,6 +15,7 @@ import logging
 import os
 import posixpath
 import re
+import threading
 import time
 from abc import abstractmethod
 
@@ -58,6 +59,18 @@ _WORKSPACE_TMPFS_MODE = 0o1777
 _RESERVED_WORKSPACE_CHILD_NAMES = {
     WorkspaceConstants.STARTUP_FOLDER_NAME,
     WorkspaceConstants.SITE_FOLDER_NAME,
+}
+_RESERVED_CONTAINER_KWARGS = {
+    "volumes",
+    "mounts",
+    "network",
+    "environment",
+    "command",
+    "name",
+    "detach",
+    "auto_remove",
+    "user",
+    "working_dir",
 }
 
 
@@ -122,6 +135,8 @@ class DockerJobHandle(JobHandleSpec):
         container_name: str,
         docker_client,
         timeout: int = 30,
+        container=None,
+        watch_exit: bool = True,
     ):
         super().__init__()
         self.container_id = container_id
@@ -130,18 +145,81 @@ class DockerJobHandle(JobHandleSpec):
         self.timeout = timeout
         self.terminal_state: JobReturnCode = None  # set once, never cleared
         self.logger = logging.getLogger(self.__class__.__name__)
+        self._state_lock = threading.Lock()
+        self._exit_watch_done = threading.Event()
+        self._exit_watcher = None
+        self._terminating = False
+        if watch_exit and container is not None:
+            self._start_exit_watcher(container)
+
+    def _get_terminal_state(self) -> JobReturnCode:
+        with self._state_lock:
+            return self.terminal_state
+
+    def _set_terminal_state(self, return_code: JobReturnCode):
+        with self._state_lock:
+            if self.terminal_state is None:
+                self.terminal_state = return_code
+
+    def _set_terminating(self):
+        with self._state_lock:
+            self._terminating = True
+
+    def _is_terminating(self) -> bool:
+        with self._state_lock:
+            return self._terminating
+
+    def _start_exit_watcher(self, container):
+        self._exit_watcher = threading.Thread(
+            target=self._watch_container_exit,
+            args=(container,),
+            name=f"docker-job-wait-{self.container_name}",
+            daemon=True,
+        )
+        self._exit_watcher.start()
+
+    def _watch_container_exit(self, container):
+        """Cache the exit code while Docker still has container metadata."""
+        try:
+            wait_result = container.wait()
+            if not isinstance(wait_result, dict):
+                self.logger.warning(f"unexpected wait result for container {self.container_name}: {wait_result}")
+                return
+            exit_code = wait_result.get("StatusCode")
+            if exit_code is None:
+                self.logger.warning(f"wait result for container {self.container_name} did not include StatusCode")
+                return
+            try:
+                exit_code = int(exit_code)
+            except (TypeError, ValueError):
+                self.logger.warning(f"invalid exit code for container {self.container_name}: {exit_code}")
+                return
+            return_code = JobReturnCode.ABORTED if self._is_terminating() else _exit_code_to_return_code(exit_code)
+            self._set_terminal_state(return_code)
+        except docker.errors.NotFound:
+            self.logger.info(
+                f"container {self.container_name} not found while waiting; exit code unavailable, marking aborted"
+            )
+            self._set_terminal_state(JobReturnCode.ABORTED)
+        except docker.errors.APIError as e:
+            self.logger.warning(f"error waiting for container {self.container_name}: {e}")
+        except Exception as e:
+            self.logger.warning(f"unexpected error waiting for container {self.container_name}: {e}")
+        finally:
+            self._exit_watch_done.set()
 
     def _get_container(self):
         """Query Docker for the current container object.
 
-        Returns None if not found (sets terminal_state) or on API error.
+        Returns None if not found or on API error. NotFound sets terminal_state only
+        when no exit watcher can still provide the container's final exit code.
         """
         try:
             return self.docker_client.containers.get(self.container_id)
         except docker.errors.NotFound:
-            self.logger.info(f"container {self.container_name} not found; assuming terminated")
-            if self.terminal_state is None:
-                self.terminal_state = JobReturnCode.ABORTED
+            self.logger.info(f"container {self.container_name} not found")
+            if self._exit_watcher is None or self._exit_watch_done.is_set():
+                self._set_terminal_state(JobReturnCode.ABORTED)
             return None
         except docker.errors.APIError as e:
             self.logger.warning(f"error querying container {self.container_name}: {e}")
@@ -171,34 +249,41 @@ class DockerJobHandle(JobHandleSpec):
 
     def poll(self) -> JobReturnCode:
         """Non-blocking status check. Returns UNKNOWN while still running."""
-        if self.terminal_state is not None:
-            return self.terminal_state
+        terminal_state = self._get_terminal_state()
+        if terminal_state is not None:
+            return terminal_state
         container = self._get_container()
+        terminal_state = self._get_terminal_state()
         if container is None:
-            return self.terminal_state if self.terminal_state is not None else JobReturnCode.UNKNOWN
+            return terminal_state if terminal_state is not None else JobReturnCode.UNKNOWN
         if container.status in TERMINAL_STATUSES:
             rc = self._resolve_terminal_return_code(container)
-            self.terminal_state = rc
+            self._set_terminal_state(rc)
             self._remove_container()
-            return rc
+            return self._get_terminal_state()
         return JobReturnCode.UNKNOWN
 
     def wait(self):
         """Block until the container reaches a terminal state."""
         while True:
-            if self.terminal_state is not None:
+            if self._get_terminal_state() is not None:
                 return
+            if self._exit_watcher is not None and not self._exit_watch_done.is_set():
+                self._exit_watch_done.wait(timeout=1)
+                continue
             container = self._get_container()
             if container is None:
                 return
             if container.status in TERMINAL_STATUSES:
-                self.terminal_state = self._resolve_terminal_return_code(container)
+                self._set_terminal_state(self._resolve_terminal_return_code(container))
                 self._remove_container()
                 return
             time.sleep(1)
 
     def terminate(self):
         """Stop and remove the container. Always sets terminal_state."""
+        if self._get_terminal_state() is None:
+            self._set_terminating()
         try:
             container = self.docker_client.containers.get(self.container_id)
             container.stop(timeout=0)
@@ -211,8 +296,7 @@ class DockerJobHandle(JobHandleSpec):
             self.logger.error(f"unexpected error terminating container {self.container_name}: {e}")
         finally:
             # Always set terminal_state so poll()/wait() return immediately
-            if self.terminal_state is None:
-                self.terminal_state = JobReturnCode.ABORTED
+            self._set_terminal_state(JobReturnCode.ABORTED)
 
     def enter_states(self, states_to_enter: list) -> bool:
         """Poll until the container enters one of the target states.
@@ -225,7 +309,7 @@ class DockerJobHandle(JobHandleSpec):
             states_to_enter = [states_to_enter]
 
         while True:
-            if self.terminal_state is not None:
+            if self._get_terminal_state() is not None:
                 return False
 
             container = self._get_container()
@@ -238,7 +322,7 @@ class DockerJobHandle(JobHandleSpec):
                 return True
 
             if status in TERMINAL_STATUSES:
-                self.terminal_state = self._resolve_terminal_return_code(container)
+                self._set_terminal_state(self._resolve_terminal_return_code(container))
                 self._remove_container()
                 return False
 
@@ -308,8 +392,8 @@ class DockerJobLauncher(JobLauncherSpec):
                                           (underscores, not hyphens).
                                           Example: {"shm_size": "8g", "ipc_mode": "host"}
                                           Note: "volumes", "mounts", "network", "environment", "command",
-                                          "name", "detach", "user", "working_dir" are controlled by the launcher
-                                          and cannot be overridden here.
+                                          "name", "detach", "auto_remove", "user", "working_dir" are controlled
+                                          by the launcher and cannot be overridden here.
             default_job_env: site-level default environment variables injected into every job
                              container launched by this site. Useful for site/runtime-specific
                              settings such as NCCL workarounds. Launcher-controlled variables
@@ -332,18 +416,7 @@ class DockerJobLauncher(JobLauncherSpec):
             raise ValueError("default_python_path must be a non-empty string")
         self.timeout = timeout
         default_job_container_kwargs = default_job_container_kwargs or {}
-        _RESERVED_KWARGS = {
-            "volumes",
-            "mounts",
-            "network",
-            "environment",
-            "command",
-            "name",
-            "detach",
-            "user",
-            "working_dir",
-        }
-        reserved_used = _RESERVED_KWARGS & set(default_job_container_kwargs.keys())
+        reserved_used = _RESERVED_CONTAINER_KWARGS & set(default_job_container_kwargs.keys())
         if reserved_used:
             raise ValueError(
                 f"default_job_container_kwargs must not contain reserved keys: {sorted(reserved_used)}. "
@@ -472,19 +545,8 @@ class DockerJobLauncher(JobLauncherSpec):
         _site_rs = (job_meta.get(JobMetaKey.RESOURCE_SPEC.value) or {}).get(site_name) or {}
         _flat_gpus = 0 if any(k in _site_rs for k in ("process", "docker", "k8s")) else _site_rs.get("num_of_gpus", 0)
         num_gpus = docker_spec["num_of_gpus"] if "num_of_gpus" in docker_spec else _flat_gpus
-        _RESERVED_KWARGS = {
-            "volumes",
-            "mounts",
-            "network",
-            "environment",
-            "command",
-            "name",
-            "detach",
-            "user",
-            "working_dir",
-        }
-        _NON_CONTAINER_KEYS = {"num_of_gpus", "image", "python_path"} | _RESERVED_KWARGS
-        reserved_in_spec = _RESERVED_KWARGS & set(docker_spec.keys())
+        _NON_CONTAINER_KEYS = {"num_of_gpus", "image", "python_path"} | _RESERVED_CONTAINER_KWARGS
+        reserved_in_spec = _RESERVED_CONTAINER_KWARGS & set(docker_spec.keys())
         if reserved_in_spec:
             self.logger.warning(
                 f"job {job_id}: launcher_spec['{site_name}']['docker'] contains reserved keys "
@@ -579,6 +641,7 @@ class DockerJobLauncher(JobLauncherSpec):
                 name=container_name,
                 network=self.network,
                 detach=True,
+                auto_remove=True,
                 environment=environment if environment else None,
                 mounts=mounts,
                 working_dir=container_job_workspace,
@@ -598,6 +661,8 @@ class DockerJobLauncher(JobLauncherSpec):
             container_name=container_name,
             docker_client=docker_client,
             timeout=self.timeout,
+            container=container,
+            watch_exit=True,
         )
 
         try:

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -14,6 +14,7 @@
 
 import logging
 import sys
+import threading
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
@@ -267,6 +268,61 @@ class TestDockerJobHandleTerminalState:
         assert rc == JobReturnCode.SUCCESS
         assert h.terminal_state == JobReturnCode.SUCCESS
 
+    def test_wait_watcher_caches_exit_code_before_auto_remove(self):
+        dc = _make_docker_client()
+        dc.containers.get.side_effect = _NotFound()
+        container = MagicMock()
+        container.wait.return_value = {"StatusCode": 0}
+        h = _make_handle(docker_client=dc, container=container, watch_exit=True)
+
+        h.wait()
+
+        assert h.terminal_state == JobReturnCode.SUCCESS
+        assert h.poll() == JobReturnCode.SUCCESS
+
+    def test_auto_removed_container_is_unknown_until_wait_watcher_finishes(self):
+        dc = _make_docker_client()
+        dc.containers.get.side_effect = _NotFound()
+        wait_can_finish = threading.Event()
+
+        def wait_for_exit():
+            assert wait_can_finish.wait(timeout=5)
+            return {"StatusCode": 0}
+
+        container = MagicMock()
+        container.wait.side_effect = wait_for_exit
+        h = _make_handle(docker_client=dc, container=container, watch_exit=True)
+
+        assert h.poll() == JobReturnCode.UNKNOWN
+        assert h.terminal_state is None
+
+        wait_can_finish.set()
+        h.wait()
+        assert h.terminal_state == JobReturnCode.SUCCESS
+
+    @pytest.mark.parametrize("wait_result", [None, {}, {"StatusCode": None}, {"StatusCode": "bad"}])
+    def test_wait_watcher_invalid_result_falls_back_to_container_poll(self, wait_result):
+        dc = _make_docker_client()
+        dc.containers.get.return_value = _make_container("exited", exit_code=0)
+        container = MagicMock()
+        container.wait.return_value = wait_result
+        h = _make_handle(docker_client=dc, container=container)
+
+        h.wait()
+
+        assert h.terminal_state == JobReturnCode.SUCCESS
+
+    def test_wait_watcher_api_error_falls_back_to_container_poll(self):
+        dc = _make_docker_client()
+        dc.containers.get.return_value = _make_container("exited", exit_code=0)
+        container = MagicMock()
+        container.wait.side_effect = _APIError("wait failed")
+        h = _make_handle(docker_client=dc, container=container)
+
+        h.wait()
+
+        assert h.terminal_state == JobReturnCode.SUCCESS
+
 
 # ---------------------------------------------------------------------------
 # DockerJobHandle — terminate
@@ -384,7 +440,7 @@ class TestDockerJobLauncherInit:
         assert launcher.workspace == "/host/ws"
 
     def test_raises_if_default_job_container_kwargs_contains_reserved_key(self):
-        for reserved in ("volumes", "mounts", "network", "environment", "command", "name", "detach"):
+        for reserved in ("volumes", "mounts", "network", "environment", "command", "name", "detach", "auto_remove"):
             with pytest.raises(ValueError, match="reserved"):
                 _make_launcher(default_job_container_kwargs={reserved: "anything"})
 
@@ -522,6 +578,7 @@ class TestDockerJobLauncherLaunchJob:
 
         assert handle is not None
         assert isinstance(handle, DockerJobHandle)
+        assert dc.containers.run.call_args[1]["auto_remove"] is True
 
     def test_launch_overrides_parent_url(self):
         """Launcher must derive parent_url from site name + port; localhost must not reach job container."""


### PR DESCRIPTION
## What changed

- Launch Docker SJ/CJ job containers with `auto_remove=True` so Docker removes them after exit even if the supervising SP/CP process dies.
- Add a `DockerJobHandle` exit watcher that calls Docker `wait()` and caches the exit code while the parent process is alive, avoiding false `ABORTED` results when auto-removed containers disappear before polling.
- Reserve `auto_remove` as launcher-controlled and add unit coverage for the auto-remove/`NotFound` race.

## Why

When the parent SP/CP container is killed unexpectedly, the existing `_remove_container()` cleanup path never runs. The job container can finish and remain in `Exited` state indefinitely, consuming Docker metadata and holding its container-name slot until manual cleanup.
