### PR TITLE
[2.8] Restore devops examples under examples/devops

### DIFF
--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -13,6 +13,12 @@ kits and then preparing each server or client kit for the Kubernetes runtime.
 The prepared kit contains a participant-specific Helm chart plus the
 ``startup/`` and ``local/`` folders that must be staged into Kubernetes storage.
 
+For example scripts that automate temporary Kubernetes and managed cloud cluster
+testing flows, see
+:github_nvflare_link:`examples/devops <examples/devops>`. These scripts are
+for development, smoke testing, demos, and learning only; they are not
+production deployment guidance.
+
 Prerequisites
 =============
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -181,9 +181,10 @@ When you open a notebook, select the kernel `nvflare_example` using the dropdown
 |-------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
 | [Flare Edge](./advanced/edge/README.md) | NA        | This example demonstrates FLARE mobile training jobs |
 
-## 14. System Monitoring & Misc.
+## 14. Deployment, Monitoring & Misc.
 
 | Example                                                     | Framework | Summary                                                                                                                  |
 |-------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
 | [Docker Job Launcher](./docker/README.md)                   | NA        | End-to-end Docker runtime example using `nvflare deploy prepare` and per-job Docker containers. |
+| [DevOps Deployment Examples](./devops/README.md)            | NA        | Test-only helper scripts for trying NVFlare deployment flows on Kubernetes and managed cloud clusters; not production deployment guidance. |
 | [Monitoring](./advanced/monitoring/README.md)               | NA        | FLARE Monitoring provides an initial solution for tracking system metrics of your federated learning jobs. |

--- a/examples/devops/README.md
+++ b/examples/devops/README.md
@@ -1,0 +1,46 @@
+# NVFlare DevOps Examples
+
+This directory contains example scripts for quickly testing NVFlare deployment
+flows on Kubernetes and managed cloud clusters. They are intended for local
+development, smoke testing, demos, and learning.
+
+These scripts are not production quality. They are not a hardened deployment
+blueprint and do not replace site-specific review for security, networking,
+identity, storage, monitoring, backups, upgrade strategy, cost controls, or
+operations.
+
+## Scope
+
+Use these examples to create temporary test clusters, build and push a test
+NVFlare image, deploy a small NVFlare system, inspect it, and tear it down.
+They assume you already have an NVFlare development environment and the
+required cloud CLIs configured for the target accounts or projects.
+
+Before running a deployment, copy or edit `examples/devops/multicloud/all-clouds.yaml`
+and replace the placeholder image tag, kubeconfig inputs, namespaces, storage
+classes, and participants for the clusters you want to test.
+
+## Layout
+
+- `multicloud/` - YAML-driven NVFlare deployment, status, dashboard, and image
+  build/push helpers.
+- `gcp/gke/`, `aws/eks/`, `azure/aks/` - cloud cluster setup scripts and notes.
+- `examples/devops/.tmp/` - local generated kubeconfigs and state; not intended for
+  commit.
+
+## Typical Flow
+
+Run these commands from the NVFlare repository root after updating the config:
+
+```bash
+python examples/devops/multicloud/fetch_kubeconfigs.py --config examples/devops/multicloud/all-clouds.yaml
+python examples/devops/multicloud/build_and_push.py --config examples/devops/multicloud/all-clouds.yaml
+python examples/devops/multicloud/deploy.py --config examples/devops/multicloud/all-clouds.yaml up
+python examples/devops/multicloud/k8sview.py --config examples/devops/multicloud/all-clouds.yaml
+```
+
+To tear down a deployed test system:
+
+```bash
+python examples/devops/multicloud/deploy.py --config examples/devops/multicloud/all-clouds.yaml down
+```

--- a/examples/devops/aws/eks/README.md
+++ b/examples/devops/aws/eks/README.md
@@ -1,0 +1,52 @@
+# AWS EKS Auto Mode
+
+Cluster lifecycle + NVFlare storage bootstrap.
+
+## Prereqs
+
+`aws` (authenticated), `eksctl`, `kubectl`. SSO: `aws configure sso && aws sso login --profile <p>`.
+
+## Create
+
+Edit `cluster.yaml` for a different name/region, then:
+
+```bash
+./create_cluster.sh
+```
+
+Script:
+- saves kubeconfig to `.tmp/kubeconfigs/aws.yaml`
+- does not modify `~/.kube/config`
+- creates EFS filesystem + mount targets + `efs-sc` StorageClass (RWX)
+- installs the EFS CSI driver with its IAM role
+- uses built-in `auto-ebs-sc` for RWO
+
+## Verify + smoke test
+
+```bash
+export KUBECONFIG="$(pwd)/../../.tmp/kubeconfigs/aws.yaml"
+kubectl get nodepools
+kubectl apply -f inflate.yaml
+kubectl get pods -w   # triggers node provisioning
+kubectl delete -f inflate.yaml
+```
+
+## Delete
+
+```bash
+./delete_cluster.sh
+```
+
+Also cleans up the EFS filesystem and its security group.
+
+## Notes
+
+- Bottlerocket nodes run SELinux enforcing; pods sharing PVCs need
+  `securityContext.seLinuxOptions.type: spc_t` (deploy tool does this
+  automatically via the YAML config).
+- Push images to ECR:
+  ```bash
+  aws ecr create-repository --repository-name nvflare/nvflare --region <region>
+  aws ecr get-login-password --region <region> | \
+    docker login --username AWS --password-stdin <account>.dkr.ecr.<region>.amazonaws.com
+  ```

--- a/examples/devops/aws/eks/cluster.yaml
+++ b/examples/devops/aws/eks/cluster.yaml
@@ -1,0 +1,16 @@
+# Edit `name` and `region` if you want different values.
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: nvflare-auto-test
+  region: us-west-2
+
+autoModeConfig:
+  enabled: true
+
+availabilityZones: [us-west-2a, us-west-2b, us-west-2c]
+
+vpc:
+  nat:
+    gateway: Single

--- a/examples/devops/aws/eks/create_cluster.sh
+++ b/examples/devops/aws/eks/create_cluster.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+KUBECONFIG="${REPO_ROOT}/.tmp/kubeconfigs/aws.yaml"
+export KUBECONFIG
+mkdir -p "$(dirname -- "${KUBECONFIG}")"
+
+# Extract cluster name and region from cluster.yaml
+CLUSTER_NAME="$(grep 'name:' "${SCRIPT_DIR}/cluster.yaml" | head -1 | awk '{print $2}')"
+REGION="$(grep 'region:' "${SCRIPT_DIR}/cluster.yaml" | awk '{print $2}')"
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+
+eksctl create cluster -f "${SCRIPT_DIR}/cluster.yaml"
+
+aws eks update-kubeconfig --name "${CLUSTER_NAME}" --region "${REGION}" \
+  --kubeconfig "${KUBECONFIG}"
+echo "Kubeconfig saved to ${KUBECONFIG}"
+
+# ---------------------------------------------------------------------------
+# EBS StorageClass (RWO) — EKS Auto Mode has no usable default
+# ---------------------------------------------------------------------------
+kubectl apply -f - <<'EOF'
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: auto-ebs-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  encrypted: "true"
+EOF
+
+# ---------------------------------------------------------------------------
+# EFS (RWX) — needed for K8sJobLauncher workspace PVC sharing
+# ---------------------------------------------------------------------------
+
+# Get the VPC and subnets used by the cluster
+VPC_ID="$(aws eks describe-cluster --name "${CLUSTER_NAME}" --region "${REGION}" \
+  --query 'cluster.resourcesVpcConfig.vpcId' --output text)"
+SUBNET_IDS="$(aws eks describe-cluster --name "${CLUSTER_NAME}" --region "${REGION}" \
+  --query 'cluster.resourcesVpcConfig.subnetIds' --output text)"
+
+# Create EFS filesystem
+EFS_ID="$(aws efs create-file-system \
+  --region "${REGION}" \
+  --performance-mode generalPurpose \
+  --throughput-mode bursting \
+  --encrypted \
+  --tags Key=Name,Value="${CLUSTER_NAME}-nvflare" \
+  --query 'FileSystemId' --output text)"
+echo "Created EFS filesystem: ${EFS_ID}"
+
+# Wait for EFS to be available
+echo "Waiting for EFS to be available ..."
+aws efs describe-file-systems --file-system-id "${EFS_ID}" --region "${REGION}" \
+  --query 'FileSystems[0].LifeCycleState' --output text
+STATE=""
+for i in $(seq 1 30); do
+  STATE="$(aws efs describe-file-systems --file-system-id "${EFS_ID}" --region "${REGION}" \
+    --query 'FileSystems[0].LifeCycleState' --output text)"
+  if [[ "${STATE}" == "available" ]]; then break; fi
+  sleep 5
+done
+if [[ "${STATE}" != "available" ]]; then
+  echo "EFS ${EFS_ID} did not reach 'available' state after 150s (current: ${STATE})" >&2
+  exit 1
+fi
+
+# Create a security group allowing NFS from the VPC CIDR
+VPC_CIDR="$(aws ec2 describe-vpcs --vpc-ids "${VPC_ID}" --region "${REGION}" \
+  --query 'Vpcs[0].CidrBlock' --output text)"
+SG_ID="$(aws ec2 create-security-group \
+  --group-name "${CLUSTER_NAME}-efs-sg" \
+  --description "NFS access for NVFlare EFS" \
+  --vpc-id "${VPC_ID}" \
+  --region "${REGION}" \
+  --query 'GroupId' --output text)"
+aws ec2 authorize-security-group-ingress \
+  --group-id "${SG_ID}" \
+  --protocol tcp --port 2049 \
+  --cidr "${VPC_CIDR}" \
+  --region "${REGION}"
+
+# Create mount targets in each subnet
+for SUBNET in ${SUBNET_IDS}; do
+  aws efs create-mount-target \
+    --file-system-id "${EFS_ID}" \
+    --subnet-id "${SUBNET}" \
+    --security-groups "${SG_ID}" \
+    --region "${REGION}" 2>/dev/null || true
+done
+echo "EFS mount targets created"
+
+# Create IAM role for EFS CSI driver (Pod Identity / IRSA)
+OIDC_ID="$(aws eks describe-cluster --name "${CLUSTER_NAME}" --region "${REGION}" \
+  --query 'cluster.identity.oidc.issuer' --output text | sed 's|https://||')"
+
+# Ensure OIDC provider exists
+aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[?ends_with(Arn, '${OIDC_ID}')].Arn" --output text | grep -q . || \
+  eksctl utils associate-iam-oidc-provider --cluster "${CLUSTER_NAME}" --region "${REGION}" --approve
+
+# Create the EFS CSI driver service account with IAM role
+eksctl create iamserviceaccount \
+  --cluster "${CLUSTER_NAME}" \
+  --region "${REGION}" \
+  --namespace kube-system \
+  --name efs-csi-controller-sa \
+  --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy \
+  --approve \
+  --override-existing-serviceaccounts 2>/dev/null || true
+
+# Install EFS CSI driver add-on
+echo "Installing EFS CSI driver add-on ..."
+aws eks create-addon \
+  --cluster-name "${CLUSTER_NAME}" \
+  --addon-name aws-efs-csi-driver \
+  --region "${REGION}" || { echo "ERROR: EFS CSI driver install failed" >&2; exit 1; }
+
+echo "Waiting for EFS CSI driver to become active ..."
+if ! aws eks wait addon-active \
+  --cluster-name "${CLUSTER_NAME}" \
+  --addon-name aws-efs-csi-driver \
+  --region "${REGION}"; then
+  echo "ERROR: EFS CSI driver did not become active" >&2
+  exit 1
+fi
+
+# Create EFS StorageClass
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: ${EFS_ID}
+  directoryPerms: "700"
+EOF
+
+echo "EFS setup complete: ${EFS_ID}"
+echo "Use storageClassName: efs-sc for RWX PVCs"

--- a/examples/devops/aws/eks/delete_cluster.sh
+++ b/examples/devops/aws/eks/delete_cluster.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+CLUSTER_NAME="$(grep 'name:' "${SCRIPT_DIR}/cluster.yaml" | head -1 | awk '{print $2}')"
+REGION="$(grep 'region:' "${SCRIPT_DIR}/cluster.yaml" | awk '{print $2}')"
+
+# Clean up EFS resources before deleting the cluster
+EFS_IDS="$(aws efs describe-file-systems --region "${REGION}" \
+  --query "FileSystems[?Tags[?Key=='Name'&&Value=='${CLUSTER_NAME}-nvflare']].FileSystemId" \
+  --output text 2>/dev/null || true)"
+
+for EFS_ID in ${EFS_IDS}; do
+  echo "Cleaning up EFS ${EFS_ID} ..."
+  # Delete mount targets first
+  MT_IDS="$(aws efs describe-mount-targets --file-system-id "${EFS_ID}" --region "${REGION}" \
+    --query 'MountTargets[].MountTargetId' --output text 2>/dev/null || true)"
+  for MT in ${MT_IDS}; do
+    aws efs delete-mount-target --mount-target-id "${MT}" --region "${REGION}" 2>/dev/null || true
+  done
+  # Poll until all mount targets are gone (async; can take well over 15s)
+  for i in $(seq 1 30); do
+    MT_COUNT="$(aws efs describe-mount-targets --file-system-id "${EFS_ID}" --region "${REGION}" \
+      --query 'length(MountTargets)' --output text 2>/dev/null || echo 1)"
+    [[ "${MT_COUNT}" == "0" ]] && break
+    sleep 5
+  done
+  if ! aws efs delete-file-system --file-system-id "${EFS_ID}" --region "${REGION}"; then
+    echo "ERROR: Failed to delete EFS ${EFS_ID} (mount targets still present?)" >&2
+    exit 1
+  fi
+  echo "Deleted EFS ${EFS_ID}"
+done
+
+# Delete the EFS security group
+SG_ID="$(aws ec2 describe-security-groups --region "${REGION}" \
+  --filters "Name=group-name,Values=${CLUSTER_NAME}-efs-sg" \
+  --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || true)"
+if [[ -n "${SG_ID}" && "${SG_ID}" != "None" ]]; then
+  aws ec2 delete-security-group --group-id "${SG_ID}" --region "${REGION}" 2>/dev/null || true
+  echo "Deleted security group ${SG_ID}"
+fi
+
+eksctl delete cluster -f "${SCRIPT_DIR}/cluster.yaml" --wait

--- a/examples/devops/aws/eks/inflate.yaml
+++ b/examples/devops/aws/eks/inflate.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      nodeSelector:
+        eks.amazonaws.com/compute-type: auto
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      containers:
+        - name: inflate
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
+          resources:
+            requests:
+              cpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false

--- a/examples/devops/azure/README.md
+++ b/examples/devops/azure/README.md
@@ -1,0 +1,197 @@
+# Azure NVFlare Deployment Example
+
+This directory contains Azure-specific example pieces for testing NVFlare on
+AKS. These scripts are for development and smoke testing only; they are not
+production quality deployment guidance.
+
+Current supported path:
+- create an AKS Automatic cluster with `examples/devops/azure/aks/create_cluster.sh`
+- deploy NVFlare with `examples/devops/multicloud/deploy.py`
+
+Start from `examples/devops/multicloud/all-clouds.yaml` and trim it to an Azure-only
+topology if you do not want to test multiple clouds.
+
+## Azure-specific Values
+
+The Azure deployment uses the following storage layout:
+
+- `nvflws`
+  - storage class: `managed-csi`
+  - access mode: `ReadWriteOnce`
+  - purpose: per-site workspace PVC
+- `nvfldata`
+  - storage class: `managed-csi`
+  - access mode: `ReadWriteOnce`
+  - purpose: study data / job data
+
+An Azure server deployment also requires:
+- `clouds.azure.resource_group`
+- `clouds.azure.location`
+
+These values are used by `deploy.py` to reserve and release the Azure Public IP
+for the server `LoadBalancer` service.
+
+## Required Steps
+
+### 1. Prerequisites
+
+You need:
+- `az`
+- `kubectl`
+- `helm`
+- NVFlare development dependencies installed in the repo virtual environment
+- `nvflare` available either on `$PATH` or at `.venv/bin/nvflare`
+
+Example setup from the NVFlare repository root:
+
+```bash
+az login
+az aks install-cli
+uv venv --python 3.14 .venv
+uv pip install -e .[dev_mac]
+```
+
+You also need an NVFlare container image pushed to Azure Container Registry or
+another registry that AKS can pull from.
+
+Quick ACR example:
+
+```bash
+az acr login --name <acr-name>
+docker tag nvflare-job:latest <acr>.azurecr.io/<repo>:<tag>
+docker push <acr>.azurecr.io/<repo>:<tag>
+```
+
+### 2. Create The AKS Cluster
+
+```bash
+RESOURCE_GROUP=myResourceGroup CLUSTER_NAME=myAKSAutomaticCluster LOCATION=westus2 \
+  ./examples/devops/azure/aks/create_cluster.sh
+```
+
+This script:
+- creates the AKS Automatic cluster
+- saves kubeconfig to `examples/devops/.tmp/kubeconfigs/azure.yaml`
+
+### 3. Create An Azure-only Config
+
+Copy the shipped config to a local ignored path:
+
+```bash
+mkdir -p examples/devops/.tmp/azure
+cp examples/devops/multicloud/all-clouds.yaml examples/devops/.tmp/azure/azure.yaml
+cp examples/devops/multicloud/project.yml examples/devops/.tmp/azure/project.yml
+```
+
+Edit `examples/devops/.tmp/azure/azure.yaml` and `examples/devops/.tmp/azure/project.yml`:
+- add `project_file: project.yml`
+- keep one Azure server and any Azure clients you want to test
+- remove GCP and AWS participants from both files
+- set `clouds.azure.prepare.parent.docker_image` to a real image
+- set `clouds.azure.resource_group`
+- set `clouds.azure.location`
+
+Minimal config shape:
+
+```yaml
+name: azure-test
+project_file: project.yml
+
+participants:
+  - { name: azure-server,   cloud: azure, namespace: nvflare-server,   role: server }
+  - { name: azure-client-1, cloud: azure, namespace: nvflare-client-1, role: client }
+
+clouds:
+  azure:
+    resource_group: myResourceGroup
+    location: westus2
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: <acr>.azurecr.io/<repo>:<tag>
+        workspace_pvc: nvflws
+        workspace_mount_path: /var/tmp/nvflare/workspace
+      job_launcher:
+        default_python_path: /usr/local/bin/python3
+    helm_overrides: []
+    pvc_config:
+      nvflws:   { sc: managed-csi, access: ReadWriteOnce, size: 10Gi }
+      nvfldata: { sc: managed-csi, access: ReadWriteOnce, size: 1Gi  }
+```
+
+### 4. Deploy
+
+```bash
+python3 examples/devops/multicloud/deploy.py --config examples/devops/.tmp/azure/azure.yaml up
+```
+
+The tool is config-driven, not `-cloud azure` driven.
+
+### 5. Inspect Or Tear Down
+
+```bash
+python3 examples/devops/multicloud/deploy.py --config examples/devops/.tmp/azure/azure.yaml status
+python3 examples/devops/multicloud/deploy.py --config examples/devops/.tmp/azure/azure.yaml down
+```
+
+Optional dry run:
+
+```bash
+python3 examples/devops/multicloud/deploy.py --config examples/devops/.tmp/azure/azure.yaml --dry-run up
+```
+
+## Common Ops
+
+Check parent pod status:
+
+```bash
+kubectl get pods -n nvflare-server
+kubectl get pods -n nvflare-client-1
+kubectl describe pod <pod-name> -n nvflare-server
+kubectl logs <pod-name> -n nvflare-server
+```
+
+Example `meta.json` launcher settings for AKS job pods:
+
+```json
+{
+  "name": "hello-numpy-k8s",
+  "min_clients": 1,
+  "deploy_map": {
+    "app": ["@ALL"]
+  },
+  "resource_spec": {},
+  "launcher_spec": {
+    "default": {
+      "k8s": {
+        "image": "mynvflareregistry.azurecr.io/nvflare/nvflare:2.8.0",
+        "cpu": "1000m",
+        "memory": "4Gi"
+      }
+    }
+  }
+}
+```
+
+Use `cpu` and `memory` alone for the common case. NVFlare treats them as the
+limit values and, when `cpu_request` or `memory_request` is omitted, mirrors
+the same values into the pod requests.
+
+## Notes
+
+- The server is exposed through an Azure `LoadBalancer` service backed by a
+  reserved Azure Public IP.
+- `managed-csi` is used for both the site workspace PVC and the study data PVC
+  in the current Azure deployment path.
+- K8s-launched job pods must specify `launcher_spec.<site>.k8s.image`.
+- For AKS Automatic job pods launched via `K8sJobLauncher`, specify
+  `launcher_spec.<site>.k8s.cpu` and `launcher_spec.<site>.k8s.memory` for
+  predictable scheduling.
+- If `python3 examples/devops/multicloud/deploy.py ...` fails with
+  `ModuleNotFoundError: No module named 'yaml'`, install `pyyaml` in the Python
+  environment you are using.
+
+## See Also
+
+- [AKS README](aks/README.md)
+- [Multicloud README](../multicloud/README.md)

--- a/examples/devops/azure/aks/README.md
+++ b/examples/devops/azure/aks/README.md
@@ -1,0 +1,53 @@
+# Azure AKS Automatic
+
+Cluster lifecycle for the Azure multicloud NVFlare path.
+
+For the end-to-end Azure deployment flow, config shape, and required
+NVFlare values, start with [../README.md](../README.md).
+
+## Prereqs
+
+`az` (authenticated), `kubectl`.
+
+```bash
+az login                     # or: az login --use-device-code
+az aks install-cli           # if kubectl missing
+```
+
+## Create
+
+```bash
+./create_cluster.sh
+```
+
+Defaults: `RESOURCE_GROUP=myResourceGroup`, `CLUSTER_NAME=myAKSAutomaticCluster`, `LOCATION=westus2`. Override via env vars (use the same ones on `delete_cluster.sh`).
+
+This script:
+- creates the AKS Automatic cluster
+- saves kubeconfig to `.tmp/kubeconfigs/azure.yaml`
+- does not modify `~/.kube/config`
+
+NVFlare uses the AKS default class `managed-csi` for its RWO PVCs.
+
+## Verify + smoke test
+
+```bash
+export KUBECONFIG="$(pwd)/../../.tmp/kubeconfigs/azure.yaml"
+kubectl get nodes
+kubectl apply -f inflate.yaml
+kubectl get pods -w
+kubectl delete -f inflate.yaml
+```
+
+## Delete
+
+```bash
+./delete_cluster.sh
+```
+
+## Notes
+
+- AKS Automatic is Azure's closest equivalent to EKS Auto Mode.
+- First workload can take a few minutes while node auto-provisioning
+  allocates VMs. Subscription D-series quota can block provisioning.
+- NVFlare deploy and teardown commands live in [../README.md](../README.md).

--- a/examples/devops/azure/aks/create_cluster.sh
+++ b/examples/devops/azure/aks/create_cluster.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+KUBECONFIG="${REPO_ROOT}/.tmp/kubeconfigs/azure.yaml"
+export KUBECONFIG
+mkdir -p "$(dirname -- "${KUBECONFIG}")"
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-myResourceGroup}"
+CLUSTER_NAME="${CLUSTER_NAME:-myAKSAutomaticCluster}"
+LOCATION="${LOCATION:-westus2}"
+
+az group create --name "${RESOURCE_GROUP}" --location "${LOCATION}"
+az aks create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --location "${LOCATION}" \
+  --sku automatic
+
+az aks get-credentials \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER_NAME}" \
+  --file "${KUBECONFIG}" \
+  --overwrite-existing
+echo "Kubeconfig saved to ${KUBECONFIG}"
+echo "Using AKS default StorageClass managed-csi for RWO PVCs"

--- a/examples/devops/azure/aks/delete_cluster.sh
+++ b/examples/devops/azure/aks/delete_cluster.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-myResourceGroup}"
+
+az group delete --name "${RESOURCE_GROUP}" --yes

--- a/examples/devops/azure/aks/inflate.yaml
+++ b/examples/devops/azure/aks/inflate.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: inflate
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+          securityContext:
+            allowPrivilegeEscalation: false

--- a/examples/devops/gcp/gke/README.md
+++ b/examples/devops/gcp/gke/README.md
@@ -1,0 +1,68 @@
+# Google Cloud GKE Autopilot
+
+Cluster lifecycle + NVFlare storage bootstrap.
+
+## Prereqs
+
+`gcloud` (authenticated, project selected), `kubectl`, `gke-gcloud-auth-plugin`.
+
+```bash
+gcloud auth login
+gcloud config set project <project>
+gcloud services enable container.googleapis.com
+gcloud components install gke-gcloud-auth-plugin
+```
+
+## Create
+
+```bash
+./create_cluster.sh
+```
+
+Defaults: `CLUSTER_NAME=gke-auto-test`, `LOCATION=us-central1`, `NETWORK_NAME=gke-test`. Override with env vars:
+
+```bash
+PROJECT_ID=<p> CLUSTER_NAME=<c> LOCATION=<r> ./create_cluster.sh
+```
+
+Script:
+- saves kubeconfig to `.tmp/kubeconfigs/gcp.yaml`
+- does not modify `~/.kube/config`
+- enables `file.googleapis.com`
+- creates a `filestore-rwx` StorageClass bound to the cluster VPC
+
+## Verify + smoke test
+
+```bash
+export KUBECONFIG="$(pwd)/../../.tmp/kubeconfigs/gcp.yaml"
+kubectl get nodes
+kubectl apply -f inflate.yaml
+kubectl get pods -w
+kubectl delete -f inflate.yaml
+```
+
+## Delete
+
+```bash
+./delete_cluster.sh
+```
+
+Removes the VPC only if this script created it.
+
+## Notes
+
+- Filestore: 1 TiB minimum (~$200/mo), 3–5 min to provision. If you
+  hit zone capacity errors, pin a zone:
+  `FILESTORE_ZONE=us-central1-a ./create_cluster.sh`.
+- Push images to Artifact Registry:
+  ```bash
+  gcloud artifacts repositories create nvflare \
+    --repository-format=docker --location=us-central1 --project=<p>
+  gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+  # grant node SA pull access:
+  PROJECT_NUM=$(gcloud projects describe <p> --format="value(projectNumber)")
+  gcloud artifacts repositories add-iam-policy-binding nvflare \
+    --project=<p> --location=us-central1 \
+    --member="serviceAccount:${PROJECT_NUM}-compute@developer.gserviceaccount.com" \
+    --role="roles/artifactregistry.reader"
+  ```

--- a/examples/devops/gcp/gke/create_cluster.sh
+++ b/examples/devops/gcp/gke/create_cluster.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+KUBECONFIG="${REPO_ROOT}/.tmp/kubeconfigs/gcp.yaml"
+export KUBECONFIG
+
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
+CLUSTER_NAME="${CLUSTER_NAME:-gke-auto-test}"
+LOCATION="${LOCATION:-us-central1}"
+NETWORK_NAME="${NETWORK_NAME:-gke-test}"
+
+if [[ -z "${PROJECT_ID}" ]]; then
+  echo "Set PROJECT_ID or configure a default gcloud project before creating the cluster." >&2
+  exit 1
+fi
+
+if ! gcloud compute networks describe "${NETWORK_NAME}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud compute networks create "${NETWORK_NAME}" \
+    --subnet-mode=auto \
+    --description="nvflare-managed" \
+    --project "${PROJECT_ID}"
+fi
+
+create_cmd=(
+  gcloud
+  container
+  clusters
+  create-auto
+  "${CLUSTER_NAME}"
+  --location
+  "${LOCATION}"
+  --project
+  "${PROJECT_ID}"
+  --network
+  "${NETWORK_NAME}"
+)
+
+credentials_cmd=(
+  gcloud
+  container
+  clusters
+  get-credentials
+  "${CLUSTER_NAME}"
+  --location
+  "${LOCATION}"
+  --project
+  "${PROJECT_ID}"
+)
+
+"${create_cmd[@]}"
+
+mkdir -p "$(dirname -- "${KUBECONFIG}")"
+"${credentials_cmd[@]}"
+echo "Kubeconfig saved to ${KUBECONFIG}"
+
+# Enable Filestore API for RWX PVCs
+gcloud services enable file.googleapis.com --project "${PROJECT_ID}"
+
+# Create Filestore StorageClass with correct VPC.
+# The default standard-rwx assumes VPC "default" which fails on custom VPC clusters.
+# Set FILESTORE_ZONE to pin to a specific zone (e.g. us-central1-a) if you hit
+# zone capacity errors. Without it, the CSI driver picks the zone from the pod's node.
+FILESTORE_ZONE="${FILESTORE_ZONE:-}"
+
+if [[ -n "${FILESTORE_ZONE}" ]]; then
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: filestore-rwx
+provisioner: filestore.csi.storage.gke.io
+parameters:
+  tier: BASIC_HDD
+  network: ${NETWORK_NAME}
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+allowedTopologies:
+  - matchLabelExpressions:
+    - key: topology.gke.io/zone
+      values:
+      - ${FILESTORE_ZONE}
+EOF
+else
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: filestore-rwx
+provisioner: filestore.csi.storage.gke.io
+parameters:
+  tier: BASIC_HDD
+  network: ${NETWORK_NAME}
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+EOF
+fi

--- a/examples/devops/gcp/gke/delete_cluster.sh
+++ b/examples/devops/gcp/gke/delete_cluster.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
+CLUSTER_NAME="${CLUSTER_NAME:-gke-auto-test}"
+LOCATION="${LOCATION:-us-central1}"
+NETWORK_NAME="${NETWORK_NAME:-gke-test}"
+
+if [[ -z "${PROJECT_ID}" ]]; then
+  echo "Set PROJECT_ID or configure a default gcloud project before deleting the cluster." >&2
+  exit 1
+fi
+
+gcloud container clusters delete "${CLUSTER_NAME}" \
+  --location "${LOCATION}" \
+  --project "${PROJECT_ID}" \
+  --quiet
+
+# GKE can leave network-scoped firewall rules behind briefly after cluster deletion.
+while IFS= read -r firewall_rule; do
+  [[ -n "${firewall_rule}" ]] || continue
+  gcloud compute firewall-rules delete "${firewall_rule}" \
+    --project "${PROJECT_ID}" \
+    --quiet
+done < <(
+  gcloud compute firewall-rules list \
+    --filter="network=${NETWORK_NAME} AND name~'^gke-'" \
+    --format="value(name)" \
+    --project "${PROJECT_ID}"
+)
+
+# Only delete the network if create_cluster.sh created it (tagged with nvflare-managed).
+NETWORK_DESC="$(gcloud compute networks describe "${NETWORK_NAME}" --project "${PROJECT_ID}" --format="value(description)" 2>/dev/null || true)"
+if [[ "${NETWORK_DESC}" == *"nvflare-managed"* ]]; then
+  gcloud compute networks delete "${NETWORK_NAME}" \
+    --project "${PROJECT_ID}" \
+    --quiet
+else
+  echo "Keeping network ${NETWORK_NAME} (not created by create_cluster.sh)"
+fi

--- a/examples/devops/gcp/gke/inflate.yaml
+++ b/examples/devops/gcp/gke/inflate.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: inflate
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+          securityContext:
+            allowPrivilegeEscalation: false

--- a/examples/devops/multicloud/.gitignore
+++ b/examples/devops/multicloud/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+.work/
+__pycache__/
+scripts/__pycache__/

--- a/examples/devops/multicloud/README.md
+++ b/examples/devops/multicloud/README.md
@@ -1,0 +1,303 @@
+# Multicloud NVFlare Deployment
+
+YAML-driven deploy of one NVFlare server + N clients across existing
+Kubernetes clusters.
+
+## Audience And Scope
+
+This example is for NVFlare developers and users who want a simple Kubernetes
+deployment for multicloud testing, experimentation, and learning. These scripts
+are not production quality and are not a production deployment blueprint. Real
+production deployments usually have site-specific cluster ownership, security
+policy, networking, registry, storage, monitoring, and operational requirements
+that are outside the scope of this example.
+
+Shipped config:
+- `all-clouds.yaml` — GCP server with GCP, AWS, and Azure clients
+
+Cluster topology is defined by the NVFlare project YAML plus the deploy YAML.
+The project YAML owns the FLARE participant list. The deploy YAML maps those
+same participant names to clouds, namespaces, runtime images, PVCs, and Helm
+settings.
+The deploy tool reads cloud-provider kubeconfigs from
+`examples/devops/.tmp/kubeconfigs/<cloud>.yaml`. Static kubeconfig paths for generic
+Kubernetes clusters can be specified directly in the deploy YAML.
+
+The deploy tool supports GCP, AWS, Azure, or generic Kubernetes as the server
+cloud. Cloud-specific behavior lives in provider modules under
+`examples/devops/multicloud/clouds/`; `deploy.py` owns the common flow.
+
+## Topology Selection
+
+The project YAML participant list and the deploy YAML `participants:` section
+must agree. `deploy.py` validates this before provisioning and does not generate
+or rewrite project participants. The default `all-clouds.yaml` topology uses
+`project.yml` and creates one server and three clients:
+
+```yaml
+participants:
+  - { name: gcp-server,     cloud: gcp,   namespace: nvflare-server,   role: server }
+  - { name: gcp-client-1,   cloud: gcp,   namespace: nvflare-client-1, role: client }
+  - { name: aws-client-2,   cloud: aws,   namespace: nvflare-client-2, role: client }
+  - { name: azure-client-3, cloud: azure, namespace: nvflare-client-3, role: client }
+```
+
+Edit both the project YAML and the deploy YAML to choose a different topology.
+For example, to deploy only on GCP, keep the GCP server and GCP client entries
+in both files and remove the AWS/Azure client entries. To keep a separate
+project YAML for an experiment, add `project_file: path/to/project.yml` to the
+deploy YAML. Exactly one participant must be a server; all other deploy
+participants are clients.
+
+`fetch_kubeconfigs.py`, `build_and_push.py`, and `deploy.py` operate on the
+clouds referenced by `participants:`.
+
+## Prerequisites
+
+- Clusters created via `examples/devops/gcp/gke/create_cluster.sh` and
+  `examples/devops/aws/eks/create_cluster.sh` — each saves a kubeconfig under
+  `examples/devops/.tmp/kubeconfigs/<cloud>.yaml`.
+- Azure clusters can be created via `examples/devops/azure/aks/create_cluster.sh`
+  which saves `examples/devops/.tmp/kubeconfigs/azure.yaml`.
+- NVFlare image pushed to the registry used by each cloud config.
+- `helm`, `kubectl`, and the cloud CLIs on `$PATH`.
+- NVFlare development dependencies installed in the repo virtual environment.
+- `nvflare` available on `$PATH` or at `.venv/bin/nvflare`.
+
+## Roles And Permissions
+
+Cluster creation and FLARE site deployment can be separate roles:
+
+- Cluster creator: permission to create and manage the target GKE, EKS, or AKS
+  clusters, node pools/autoscaling settings, storage classes, and container
+  registries.
+- FLARE site deployer: permission to use the kubeconfig for each target site
+  cluster and create/delete namespaces, PVCs, pods, services, deployments, and
+  Helm release resources for that site.
+- FLARE server site deployer: the FLARE site deployer permissions plus
+  permission to reserve and release the public/static IP used by the server
+  service.
+
+The server cloud means the cloud where the FLARE server participant is
+deployed. For GCP, the server IP is a regional compute address; for AWS, it is
+an Elastic IP; for Azure, it is a Public IP in the configured resource group.
+When AWS is the server cloud, the deployer also needs permission to describe
+the EKS cluster and public subnets. When Azure is the server cloud,
+`clouds.azure.resource_group` and `clouds.azure.location` must identify where
+the Public IP is managed.
+
+## Hardware And Sizing
+
+This flow is intended for auto/autoscaling Kubernetes clusters. The FLARE
+server and client parent pods are lightweight; the real CPU, memory, GPU, and
+storage needs are driven by the jobs you submit. Job pod resources come from
+the job/runtime configuration. Workspace and study-data PVC sizes are configured
+under each cloud's `pvc_config`.
+
+GPU jobs have not been validated by this example yet. GPU deployments need
+cluster GPU capacity, device plugin/runtime support, and job resource requests
+that match the target cloud and cluster setup.
+
+## Fetch kubeconfigs
+
+If the clusters already exist, fetch kubeconfigs from the active cloud CLI
+contexts:
+
+```bash
+python examples/devops/multicloud/fetch_kubeconfigs.py --config examples/devops/multicloud/all-clouds.yaml
+```
+
+This writes `examples/devops/.tmp/kubeconfigs/gcp.yaml`,
+`examples/devops/.tmp/kubeconfigs/aws.yaml`, and
+`examples/devops/.tmp/kubeconfigs/azure.yaml`. The script uses:
+
+- GCP: active `gcloud` project, and the only matching GKE cluster unless `GCP_CLUSTER`/`GCP_LOCATION` are set.
+- AWS: `AWS_REGION`, `AWS_DEFAULT_REGION`, or `aws configure get region`, and the only EKS cluster unless `AWS_CLUSTER` is set.
+- Azure: active `az` subscription, and the only AKS cluster unless `AZURE_CLUSTER`/`AZURE_RESOURCE_GROUP` are set.
+
+Preview the cloud CLI commands without writing kubeconfigs:
+
+```bash
+python examples/devops/multicloud/fetch_kubeconfigs.py --dry-run
+```
+
+## Deploy
+
+Default config is `all-clouds.yaml`. Image URLs come from the per-cloud
+`prepare.parent.docker_image` values.
+
+Build and push the image tags referenced by a config:
+
+```bash
+python examples/devops/multicloud/build_and_push.py --config examples/devops/multicloud/all-clouds.yaml
+```
+
+Before running the all-clouds config:
+- confirm `clouds.gcp.prepare.parent.docker_image`
+- confirm `clouds.aws.prepare.parent.docker_image`
+- confirm `clouds.azure.prepare.parent.docker_image`
+- run `python examples/devops/multicloud/fetch_kubeconfigs.py` if
+  `examples/devops/.tmp/kubeconfigs/*.yaml` does not exist yet
+
+Deploy:
+
+```bash
+python examples/devops/multicloud/deploy.py --config examples/devops/multicloud/all-clouds.yaml up
+```
+
+`up` always re-runs `nvflare provision`, runs `nvflare deploy prepare` for
+each participant, refreshes the staged startup/local kit files in each
+participant workspace PVC, uninstalls any existing Helm release for each
+participant, then installs the prepared chart. The cloud IP name is
+deterministic from the config `name`, for example `all-clouds` uses
+`nvflare-all-clouds`. If an IP with that name already exists, `up` reuses it.
+
+The server is deployed first and must become available before clients are
+started. Clients are deployed in parallel. `down` tears down clients in
+parallel first, then tears down the server and releases the deterministic
+cloud IP.
+
+## What Gets Created
+
+`up` creates or refreshes:
+
+- Local provision output under `examples/devops/multicloud/.work/provision`.
+- A prepared K8s runtime kit per participant from `nvflare deploy prepare`.
+- A deterministic public/static server IP named from config `name`, for example
+  `nvflare-all-clouds`.
+- One Kubernetes namespace per participant.
+- The configured PVCs in each participant namespace, including `nvflws` for the
+  workspace and `nvfldata` for study data in the shipped config.
+- A temporary `kit-copy-*` pod per participant to stage `startup/` and `local/`
+  files into the workspace PVC.
+- One Helm release per participant, which installs the parent Deployment and
+  Service.
+
+Job pods are not created by deploy. They are created later by the FLARE runtime
+when jobs are submitted.
+
+## Dev Cluster Runbook
+
+For an isolated dev cluster, use `setting-up-dev-cluster.md`. It covers
+creating a temporary config, choosing unique names/namespaces, setting image
+tags, building/pushing images, fetching kubeconfigs, deploying, validating,
+and tearing down.
+
+For AI-agent-assisted setup, prompt the agent with:
+
+```text
+Use examples/devops/multicloud/setting-up-dev-cluster.md to create a multicloud dev cluster.
+```
+
+## Inspect / tear down
+
+```bash
+python examples/devops/multicloud/deploy.py status
+python examples/devops/multicloud/deploy.py down
+python examples/devops/multicloud/deploy.py --dry-run up       # print commands, don't execute
+```
+
+## Optional System Monitoring
+
+Multicloud monitoring uses the FLARE connection instead of cross-cloud StatsD
+networking. Clients collect FLARE system lifecycle metrics and stream them to
+the server through CellNet. Only the server sends metrics to `statsd-exporter`
+in the server cluster:
+
+```text
+client SysMetricsCollector
+  -> ConvertToFedEvent
+  -> FLARE/CellNet
+  -> server RemoteMetricsReceiver
+  -> server StatsDReporter
+  -> statsd-exporter -> Prometheus -> Grafana
+```
+
+Enable this in a local config:
+
+```yaml
+monitoring:
+  enabled: true
+```
+
+The runtime image must include the `MONITORING` extra because
+`StatsDReporter` requires the `datadog` package. For example, build a runtime
+image that installs `.[K8S,MONITORING]` before enabling monitoring.
+
+When monitoring is enabled, `deploy.py up` applies
+`examples/devops/multicloud/monitoring-stack.yaml` in the server cluster before starting
+FLARE. The stack runs in a namespace derived from the config name, for example
+`all-clouds` uses `nvflare-all-clouds-monitoring`; `deploy.py down` removes
+that namespace.
+
+Open Grafana with the server cloud kubeconfig. For the default GCP-server
+config:
+
+```bash
+MONITORING_NS=nvflare-all-clouds-monitoring
+kubectl --kubeconfig examples/devops/.tmp/kubeconfigs/gcp.yaml \
+  -n "$MONITORING_NS" port-forward svc/grafana 3000:3000
+```
+
+Use the Grafana development login, then use the Prometheus datasource in
+Grafana Explore. Useful starter queries:
+
+```promql
+_system_start_count
+_client_register_received_count
+_client_heartbeat_received_count
+_client_heartbeat_time_taken
+{env="all-clouds"}
+```
+
+These are FLARE lifecycle metrics, not CPU or memory metrics.
+
+## Flags
+
+| Flag | Default | Applies to |
+|------|---------|-----------|
+| `--config <path>` | `examples/devops/multicloud/all-clouds.yaml` | all subcommands |
+| `--dry-run` | false | all subcommands |
+
+## Live dashboard
+
+`k8sview.py` renders a live all-cloud dashboard by default. It reads
+`examples/devops/.tmp/kubeconfigs/*.yaml`, discovers NVFlare namespaces, groups them into
+systems, and shows cluster node/pod totals plus server/client sites, pod IPs,
+service IPs, external server IPs, PVCs, and job pod counts:
+
+```bash
+python examples/devops/multicloud/k8sview.py
+```
+
+If `examples/devops/.tmp/kubeconfigs` has not been created yet, the all-cloud view
+starts as an empty dashboard. Use `--config` for configs that carry explicit
+kubeconfig paths.
+
+Pass `--config` for a focused pod / PVC / LB / events view across every
+participant in one deploy config:
+
+```bash
+python examples/devops/multicloud/k8sview.py --config examples/devops/multicloud/all-clouds.yaml
+```
+
+`k8sview.py` automatically deletes terminal pods (`Succeeded` or `Failed`) after
+5 minutes.
+
+Requires the NVFlare development dependencies in the repo virtual environment.
+
+## Basic Local Checks
+
+After changing provider logic or deploy command generation, run:
+
+```bash
+python -m py_compile examples/devops/multicloud/*.py examples/devops/multicloud/clouds/*.py
+python examples/devops/multicloud/deploy.py --config examples/devops/multicloud/all-clouds.yaml --dry-run up
+```
+
+## See also
+
+- `examples/devops/gcp/gke/README.md` — GKE cluster setup
+- `examples/devops/aws/eks/README.md` — EKS cluster setup + SELinux/ECR notes
+- `azure/README.md` — Azure run steps and required values
+- `examples/devops/azure/aks/README.md` — AKS setup for the Azure deployment path

--- a/examples/devops/multicloud/all-clouds.yaml
+++ b/examples/devops/multicloud/all-clouds.yaml
@@ -1,0 +1,65 @@
+name: all-clouds
+
+x-nvflare-image: &nvflare_image registry.example.com/nvflare/nvflare:dev
+
+participants:
+  - { name: gcp-server,     cloud: gcp,   namespace: nvflare-server,   role: server }
+  - { name: gcp-client-1,   cloud: gcp,   namespace: nvflare-client-1, role: client }
+  - { name: aws-client-2,   cloud: aws,   namespace: nvflare-client-2, role: client }
+  - { name: azure-client-3, cloud: azure, namespace: nvflare-client-3, role: client }
+
+clouds:
+  gcp:
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: *nvflare_image
+        workspace_pvc: nvflws
+        workspace_mount_path: /var/tmp/nvflare/workspace
+      job_launcher:
+        default_python_path: /usr/local/bin/python3
+    pull_policy: Always
+    helm_overrides: []
+    pvc_config:
+      nvflws:   { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
+      nvfldata: { sc: standard-rwo,  access: ReadWriteOnce,  size: 1Gi }
+    study_data:
+      default:
+        data: { pvc: nvfldata, mode: ro }
+  aws:
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: *nvflare_image
+        workspace_pvc: nvflws
+        workspace_mount_path: /var/tmp/nvflare/workspace
+        pod_security_context: { seLinuxOptions: { type: spc_t } }
+      job_launcher:
+        default_python_path: /usr/local/bin/python3
+        job_pod_security_context: { seLinuxOptions: { type: spc_t } }
+    pull_policy: Always
+    helm_overrides: []
+    pod_annotations:
+      karpenter.sh/do-not-disrupt: "true"
+    pvc_config:
+      nvflws:   { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
+      nvfldata: { sc: auto-ebs-sc, access: ReadWriteOnce, size: 1Gi }
+    study_data:
+      default:
+        data: { pvc: nvfldata, mode: ro }
+  azure:
+    prepare:
+      runtime: k8s
+      parent:
+        docker_image: *nvflare_image
+        workspace_pvc: nvflws
+        workspace_mount_path: /var/tmp/nvflare/workspace
+      job_launcher:
+        default_python_path: /usr/local/bin/python3
+    helm_overrides: []
+    pvc_config:
+      nvflws:   { sc: managed-csi,   access: ReadWriteOnce, size: 10Gi }
+      nvfldata: { sc: managed-csi,   access: ReadWriteOnce, size: 1Gi  }
+    study_data:
+      default:
+        data: { pvc: nvfldata, mode: ro }

--- a/examples/devops/multicloud/build_and_push.py
+++ b/examples/devops/multicloud/build_and_push.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEVOPS_ROOT = SCRIPT_DIR.parent
+REPO_ROOT = DEVOPS_ROOT.parent.parent
+DEFAULT_CONFIG = SCRIPT_DIR / "all-clouds.yaml"
+DEFAULT_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build the NVFlare image and push it to every registry used by a multicloud config."
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="multicloud deploy config")
+    parser.add_argument("--dockerfile", type=Path, default=DEFAULT_DOCKERFILE, help="Dockerfile to build")
+    parser.add_argument("--context", type=Path, default=REPO_ROOT, help="docker build context")
+    parser.add_argument("--platform", default="linux/amd64", help="docker build platform")
+    parser.add_argument("--dry-run", action="store_true", help="print commands without running them")
+    return parser.parse_args()
+
+
+def fail(message: str, exit_code: int = 1) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def resolve_path(path: Path, *, base: Path | None = None) -> Path:
+    path = path.expanduser()
+    if not path.is_absolute():
+        path = (base or Path.cwd()) / path
+    return path.resolve()
+
+
+def print_cmd(cmd: list[str]) -> None:
+    print("  $ " + " ".join(shlex.quote(part) for part in cmd))
+
+
+def run(
+    cmd: list[str], *, dry_run: bool, input_text: str | None = None, quiet: bool = False
+) -> subprocess.CompletedProcess:
+    print_cmd(cmd)
+    if dry_run:
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    try:
+        return subprocess.run(
+            cmd,
+            check=True,
+            input=input_text,
+            text=True,
+            stdout=subprocess.DEVNULL if quiet else None,
+        )
+    except FileNotFoundError:
+        fail(f"command not found: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(e.returncode) from e
+
+
+def capture(cmd: list[str]) -> str:
+    print_cmd(cmd)
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        fail(f"command not found: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        if e.stderr:
+            print(e.stderr, file=sys.stderr, end="")
+        raise SystemExit(e.returncode) from e
+    return result.stdout
+
+
+def load_config(config_path: Path) -> dict:
+    if not config_path.is_file():
+        fail(f"config not found: {config_path}")
+    with config_path.open("rt", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    if not isinstance(config, dict):
+        fail(f"config must be a YAML mapping: {config_path}")
+    return config
+
+
+def used_clouds(config: dict) -> list[str]:
+    participants = config.get("participants") or []
+    clouds = []
+    for participant in participants:
+        if not isinstance(participant, dict):
+            continue
+        cloud = participant.get("cloud")
+        if cloud and cloud not in clouds:
+            clouds.append(cloud)
+    return clouds
+
+
+def image_for_cloud(cloud_name: str, cloud_config: dict) -> str:
+    prepare = cloud_config.get("prepare") or {}
+    parent = prepare.get("parent") or {}
+    image = parent.get("docker_image")
+    if not isinstance(image, str) or not image.strip():
+        fail(f"clouds.{cloud_name}.prepare.parent.docker_image is required")
+    return image.strip()
+
+
+def collect_images(config: dict) -> list[str]:
+    cloud_configs = config.get("clouds") or {}
+    cloud_names = used_clouds(config) or list(cloud_configs)
+    images = []
+    for cloud_name in cloud_names:
+        cloud_config = cloud_configs.get(cloud_name)
+        if not isinstance(cloud_config, dict):
+            fail(f"cloud '{cloud_name}' is used by participants but is not configured")
+        image = image_for_cloud(cloud_name, cloud_config)
+        if image not in images:
+            images.append(image)
+    if not images:
+        fail("no clouds.<name>.prepare.parent.docker_image entries found")
+    return images
+
+
+def registry_host(image: str) -> str:
+    if "/" not in image:
+        return ""
+    return image.split("/", 1)[0]
+
+
+def validate_images(images: list[str], *, dry_run: bool) -> None:
+    placeholders = [image for image in images if registry_host(image).endswith(".example.com")]
+    if placeholders and not dry_run:
+        fail(
+            "replace placeholder image registry values before building:\n"
+            + "\n".join(f"  {image}" for image in placeholders)
+        )
+
+
+def auth_registry(image: str, *, dry_run: bool) -> None:
+    host = registry_host(image)
+    if host.endswith(".pkg.dev"):
+        run(["gcloud", "auth", "configure-docker", host, "--quiet"], dry_run=dry_run, quiet=True)
+    elif ".dkr.ecr." in host and host.endswith(".amazonaws.com"):
+        parts = host.split(".")
+        if len(parts) < 6:
+            fail(f"could not parse AWS ECR region from image host: {host}")
+        region = parts[3]
+        if dry_run:
+            print(
+                "  $ "
+                + " ".join(
+                    [
+                        "aws",
+                        "ecr",
+                        "get-login-password",
+                        "--region",
+                        shlex.quote(region),
+                        "|",
+                        "docker",
+                        "login",
+                        "--username",
+                        "AWS",
+                        "--password-stdin",
+                        shlex.quote(host),
+                    ]
+                )
+            )
+            return
+        password = capture(["aws", "ecr", "get-login-password", "--region", region])
+        run(
+            ["docker", "login", "--username", "AWS", "--password-stdin", host],
+            input_text=password,
+            dry_run=False,
+            quiet=True,
+        )
+    elif host.endswith(".azurecr.io"):
+        acr_name = host.removesuffix(".azurecr.io")
+        run(["az", "acr", "login", "--name", acr_name], dry_run=dry_run, quiet=True)
+    else:
+        print(f"warning: unknown registry host {host}; assuming docker is already authenticated", file=sys.stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    config_path = resolve_path(args.config)
+    dockerfile = resolve_path(args.dockerfile)
+    context = resolve_path(args.context)
+    config = load_config(config_path)
+    images = collect_images(config)
+    validate_images(images, dry_run=args.dry_run)
+
+    primary = images[0]
+    print(f"primary build tag: {primary}")
+    for image in images[1:]:
+        print(f"also tag:           {image}")
+
+    for image in images:
+        auth_registry(image, dry_run=args.dry_run)
+
+    run(
+        ["docker", "build", "--platform", args.platform, "-t", primary, "-f", str(dockerfile), str(context)],
+        dry_run=args.dry_run,
+    )
+    for image in images[1:]:
+        run(["docker", "tag", primary, image], dry_run=args.dry_run)
+    for image in images:
+        run(["docker", "push", image], dry_run=args.dry_run)
+
+    print(f"=== built and pushed {len(images)} tag(s) ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/devops/multicloud/clouds/__init__.py
+++ b/examples/devops/multicloud/clouds/__init__.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .aws import AwsProvider
 from .azure import AzureProvider
 from .gcp import GcpProvider

--- a/examples/devops/multicloud/clouds/__init__.py
+++ b/examples/devops/multicloud/clouds/__init__.py
@@ -1,0 +1,20 @@
+from .aws import AwsProvider
+from .azure import AzureProvider
+from .gcp import GcpProvider
+from .kubernetes import KubernetesProvider
+
+CLOUD_ORDER = ("gcp", "aws", "azure", "kubernetes")
+
+PROVIDERS = {
+    "gcp": GcpProvider(),
+    "aws": AwsProvider(),
+    "azure": AzureProvider(),
+    "kubernetes": KubernetesProvider(),
+}
+
+
+def get_provider(name: str):
+    try:
+        return PROVIDERS[name]
+    except KeyError:
+        raise ValueError(f"unknown cloud: {name}") from None

--- a/examples/devops/multicloud/clouds/aws.py
+++ b/examples/devops/multicloud/clouds/aws.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from .base import CloudProvider, service_annotation_args
+
+
+class AwsProvider(CloudProvider):
+    name = "aws"
+    auth_check_cmd = ["aws", "sts", "get-caller-identity"]
+    auth_failed_message = "AWS auth failed. Run: aws sso login"
+    auth_expired_message = "AWS session expired. Run: aws sso login"
+
+    def _resolve_region(self, run, region: str | None) -> str:
+        if isinstance(region, str) and region.strip():
+            return region.strip()
+
+        r = run(["aws", "configure", "get", "region"], capture=True, check=False)
+        if r.returncode == 0 and r.stdout.strip():
+            return r.stdout.strip()
+
+        raise RuntimeError("AWS region is required. Set AWS_REGION or run 'aws configure set region <region>'.")
+
+    def parse_kubeconfig(self, kc_path):
+        data = yaml.safe_load(kc_path.read_text())
+        current_ctx = data.get("current-context")
+        if not current_ctx:
+            raise ValueError(f"{kc_path}: no current-context")
+        ctx = next((c for c in data.get("contexts", []) if c.get("name") == current_ctx), None)
+        if not ctx:
+            raise ValueError(f"{kc_path}: current-context {current_ctx!r} not found in contexts")
+        cluster_name = ctx["context"]["cluster"]
+        if not cluster_name.startswith("arn:aws:eks:"):
+            raise ValueError(f"{kc_path}: EKS context cluster {cluster_name!r} is not an ARN")
+        parts = cluster_name.split(":")
+        if len(parts) < 6:
+            raise ValueError(f"{kc_path}: malformed EKS ARN {cluster_name!r}")
+        return {"region": parts[3], "eks_cluster_name": parts[5].split("/", 1)[1]}
+
+    def validate_server_config(self, config):
+        if not config.aws_eks_cluster_name:
+            raise SystemExit("clouds.aws.eks_cluster_name is required when the server is in AWS")
+
+    def reserve_ip(self, *, run, ip_tag, aws_region=None, state=None, **kwargs):
+        aws_region = self._resolve_region(run, aws_region)
+        addresses = self._find_addresses_by_name(run, ip_tag, aws_region)
+        if len(addresses) > 1:
+            raise RuntimeError(f"found multiple Elastic IPs tagged Name={ip_tag}; refusing to choose one")
+        if addresses:
+            address = addresses[0]
+            alloc_id = address.get("AllocationId", "")
+            ip = address.get("PublicIp", "")
+            if state is not None:
+                state["aws_eip_allocation_id"] = alloc_id
+            print(f"Using Elastic IP {ip_tag}: {ip} ({alloc_id})")
+            return ip, ip_tag
+
+        print(f"Allocating Elastic IP {ip_tag} ...")
+        r = run(
+            [
+                "aws",
+                "ec2",
+                "allocate-address",
+                "--domain",
+                "vpc",
+                "--region",
+                aws_region,
+                "--tag-specifications",
+                f"ResourceType=elastic-ip,Tags=[{{Key=Name,Value={ip_tag}}}]",
+                "--output",
+                "json",
+            ],
+            capture=True,
+        )
+        resp = json.loads(r.stdout) if r.stdout.strip() else {}
+        ip = resp.get("PublicIp", "")
+        alloc_id = resp.get("AllocationId", "")
+        if not ip or not alloc_id:
+            raise RuntimeError(f"allocate-address returned unexpected response: {r.stdout!r}")
+        if state is not None:
+            state["aws_eip_allocation_id"] = alloc_id
+        print(f"  Reserved: {ip} ({alloc_id})")
+        return ip, ip_tag
+
+    def _find_addresses_by_name(self, run, ip_name: str, region: str) -> list[dict]:
+        r = run(
+            [
+                "aws",
+                "ec2",
+                "describe-addresses",
+                "--filters",
+                f"Name=tag:Name,Values={ip_name}",
+                "--region",
+                region,
+                "--query",
+                "Addresses[].{PublicIp:PublicIp,AllocationId:AllocationId}",
+                "--output",
+                "json",
+            ],
+            capture=True,
+            check=False,
+        )
+        if r.returncode != 0:
+            detail = ""
+            stderr = getattr(r, "stderr", "") or ""
+            if stderr.strip():
+                detail = f": {stderr.strip()}"
+            raise RuntimeError(f"failed to describe Elastic IPs tagged Name={ip_name} in region {region}{detail}")
+        addresses = json.loads(r.stdout) if r.stdout.strip() else []
+        if not isinstance(addresses, list):
+            raise RuntimeError(f"describe-addresses returned unexpected response: {r.stdout!r}")
+        return addresses
+
+    def prepare_server_state(self, *, run, state, config, ip_name, aws_region=None, **kwargs):
+        aws_region = self._resolve_region(run, aws_region)
+        if not state.get("aws_eip_allocation_id"):
+            addresses = self._find_addresses_by_name(run, ip_name, aws_region)
+            if len(addresses) != 1:
+                raise RuntimeError(f"expected one Elastic IP tagged Name={ip_name}, found {len(addresses)}")
+            state["aws_eip_allocation_id"] = addresses[0].get("AllocationId")
+        nlb_subnet = state.get("aws_nlb_subnet_id") or self._discover_public_subnet(
+            run, config.aws_eks_cluster_name, aws_region
+        )
+        state["aws_nlb_subnet_id"] = nlb_subnet
+
+    def _discover_public_subnet(self, run, cluster_name: str, region: str) -> str:
+        print(f"Discovering public subnet for EKS cluster {cluster_name} ...")
+        r = run(
+            [
+                "aws",
+                "eks",
+                "describe-cluster",
+                "--name",
+                cluster_name,
+                "--region",
+                region,
+                "--query",
+                "cluster.resourcesVpcConfig.vpcId",
+                "--output",
+                "text",
+            ],
+            capture=True,
+        )
+        vpc_id = r.stdout.strip()
+        if not vpc_id:
+            raise RuntimeError(f"could not resolve VPC id for EKS cluster {cluster_name}")
+        r = run(
+            [
+                "aws",
+                "ec2",
+                "describe-subnets",
+                "--filters",
+                f"Name=vpc-id,Values={vpc_id}",
+                "Name=tag:kubernetes.io/role/elb,Values=1",
+                "--region",
+                region,
+                "--query",
+                "Subnets[0].SubnetId",
+                "--output",
+                "text",
+            ],
+            capture=True,
+        )
+        subnet_id = r.stdout.strip()
+        if not subnet_id or subnet_id == "None":
+            raise RuntimeError(f"no public subnet (tag kubernetes.io/role/elb=1) in VPC {vpc_id}")
+        print(f"  Using subnet: {subnet_id}")
+        return subnet_id
+
+    def release_ip(self, *, run, ip_name, state):
+        aws_region = self._resolve_region(run, state.get("aws_region"))
+        try:
+            addresses = self._find_addresses_by_name(run, ip_name, aws_region)
+        except RuntimeError as e:
+            print(f"  Warning: {e}. The Elastic IP may still be allocated and require manual cleanup.")
+            return
+        if not addresses:
+            print(f"No Elastic IP tagged Name={ip_name} found.")
+            return
+        if len(addresses) > 1:
+            raise RuntimeError(f"found multiple Elastic IPs tagged Name={ip_name}; refusing to release any")
+
+        alloc_id = addresses[0].get("AllocationId", "")
+        print(f"Releasing Elastic IP {ip_name} ({alloc_id}) ...")
+        run(
+            ["aws", "ec2", "release-address", "--allocation-id", alloc_id, "--region", aws_region],
+            check=False,
+        )
+
+    def server_service_helm_args(self, *, server_ip, state):
+        aws_server_alloc_id = state.get("aws_eip_allocation_id")
+        aws_server_subnet = state.get("aws_nlb_subnet_id")
+        if not aws_server_alloc_id or not aws_server_subnet:
+            raise RuntimeError("AWS server requires EIP allocation id and NLB subnet id")
+        return service_annotation_args(
+            {
+                "service.beta.kubernetes.io/aws-load-balancer-type": "external",
+                "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
+                "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+                "service.beta.kubernetes.io/aws-load-balancer-eip-allocations": aws_server_alloc_id,
+                "service.beta.kubernetes.io/aws-load-balancer-subnets": aws_server_subnet,
+                # Single-AZ NLB (one subnet annotation) needs cross-zone to reach pods in other AZs.
+                "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+            }
+        )

--- a/examples/devops/multicloud/clouds/aws.py
+++ b/examples/devops/multicloud/clouds/aws.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import json

--- a/examples/devops/multicloud/clouds/azure.py
+++ b/examples/devops/multicloud/clouds/azure.py
@@ -1,0 +1,113 @@
+import yaml
+
+from .base import CloudProvider, service_annotation_args
+
+
+class AzureProvider(CloudProvider):
+    name = "azure"
+    auth_check_cmd = ["az", "account", "show"]
+    auth_failed_message = "Azure auth failed. Run: az login"
+    auth_expired_message = "Azure session expired. Run: az login"
+
+    def parse_kubeconfig(self, kc_path):
+        data = yaml.safe_load(kc_path.read_text())
+        current_ctx = data.get("current-context")
+        if not current_ctx:
+            raise ValueError(f"{kc_path}: no current-context")
+        if not any(c.get("name") == current_ctx for c in data.get("contexts", [])):
+            raise ValueError(f"{kc_path}: current-context {current_ctx!r} not found in contexts")
+        return {}
+
+    def validate_server_config(self, config):
+        if not config.azure_resource_group:
+            raise SystemExit("clouds.azure.resource_group is required when the server is in Azure")
+        if not config.azure_location:
+            raise SystemExit("clouds.azure.location is required when the server is in Azure")
+
+    def reserve_ip(self, *, run, ip_tag, azure_resource_group=None, azure_location=None, **kwargs):
+        if not isinstance(azure_resource_group, str) or not azure_resource_group.strip():
+            raise ValueError(
+                "Azure static IP reservation requires a non-empty resource_group. "
+                "Set clouds.azure.resource_group in the deploy config."
+            )
+        if not isinstance(azure_location, str) or not azure_location.strip():
+            raise ValueError(
+                "Azure static IP reservation requires a non-empty location. "
+                "Set clouds.azure.location in the deploy config."
+            )
+        print(f"Reserving Azure Public IP {ip_tag} ...")
+        run(
+            [
+                "az",
+                "network",
+                "public-ip",
+                "create",
+                "--resource-group",
+                azure_resource_group,
+                "--name",
+                ip_tag,
+                "--sku",
+                "Standard",
+                "--allocation-method",
+                "Static",
+                "--location",
+                azure_location,
+            ],
+            check=False,
+        )
+        r = run(
+            [
+                "az",
+                "network",
+                "public-ip",
+                "show",
+                "--resource-group",
+                azure_resource_group,
+                "--name",
+                ip_tag,
+                "--query",
+                "ipAddress",
+                "--output",
+                "tsv",
+            ],
+            capture=True,
+        )
+        ip = r.stdout.strip()
+        if not ip:
+            raise RuntimeError(f"az network public-ip show returned no IP for {ip_tag}")
+        print(f"  Reserved: {ip} ({ip_tag})")
+        return ip, ip_tag
+
+    def release_ip(self, *, run, ip_name, state):
+        resource_group = state.get("azure_resource_group")
+        if not isinstance(resource_group, str) or not resource_group.strip():
+            raise ValueError(
+                "Azure static IP release requires a non-empty resource_group. "
+                "Pass a config that includes clouds.azure.resource_group."
+            )
+        print(f"Releasing Azure Public IP {ip_name} ...")
+        r = run(
+            ["az", "network", "public-ip", "delete", "--resource-group", resource_group, "--name", ip_name],
+            check=False,
+        )
+        if r.returncode != 0:
+            detail = ""
+            stderr = getattr(r, "stderr", "") or ""
+            if stderr.strip():
+                detail = f": {stderr.strip()}"
+            print(
+                f"  Warning: failed to delete Azure Public IP {ip_name} in resource group {resource_group}{detail}. "
+                "The IP may still be allocated and require manual cleanup."
+            )
+
+    def server_service_helm_args(self, *, server_ip, state):
+        azure_pip_name = state.get("azure_pip_name")
+        azure_resource_group = state.get("azure_resource_group")
+        if not azure_pip_name or not azure_resource_group:
+            raise RuntimeError("Azure server requires azure_pip_name and azure_resource_group")
+        return service_annotation_args(
+            {
+                "service.beta.kubernetes.io/azure-pip-name": azure_pip_name,
+                "service.beta.kubernetes.io/azure-load-balancer-resource-group": azure_resource_group,
+            }
+        )

--- a/examples/devops/multicloud/clouds/azure.py
+++ b/examples/devops/multicloud/clouds/azure.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import yaml
 
 from .base import CloudProvider, service_annotation_args

--- a/examples/devops/multicloud/clouds/base.py
+++ b/examples/devops/multicloud/clouds/base.py
@@ -1,0 +1,46 @@
+class CloudProvider:
+    name = ""
+    auth_check_cmd: list[str] = []
+    auth_failed_message = ""
+    auth_expired_message = ""
+
+    def parse_kubeconfig(self, kc_path):
+        return {}
+
+    def validate_server_config(self, config):
+        pass
+
+    def reserve_ip(self, *, run, ip_tag, **kwargs):
+        raise NotImplementedError
+
+    def prepare_server_state(self, *, run, state, config, ip_name, **kwargs):
+        pass
+
+    def release_ip(self, *, run, ip_name, state):
+        raise NotImplementedError
+
+    def server_service_type(self, *, state):
+        return "LoadBalancer"
+
+    def server_service_helm_args(self, *, server_ip, state):
+        raise NotImplementedError
+
+    def status_endpoint(self, *, state, config):
+        return "IP name", state.get("ip_name", "N/A")
+
+    def admin_endpoint(self, *, config, server_ip):
+        return None
+
+    def after_server_deploy(self, *, run, state, config, server):
+        pass
+
+    def cleanup_server_resources(self, *, run, state, config):
+        return True
+
+
+def service_annotation_args(annotations: dict[str, str]) -> list[str]:
+    args = []
+    for k, v in annotations.items():
+        escaped = k.replace(".", r"\.")
+        args += ["--set-string", f"service.annotations.{escaped}={v}"]
+    return args

--- a/examples/devops/multicloud/clouds/base.py
+++ b/examples/devops/multicloud/clouds/base.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 class CloudProvider:
     name = ""
     auth_check_cmd: list[str] = []

--- a/examples/devops/multicloud/clouds/gcp.py
+++ b/examples/devops/multicloud/clouds/gcp.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import yaml
+
+from .base import CloudProvider
+
+
+class GcpProvider(CloudProvider):
+    name = "gcp"
+    auth_check_cmd = ["gcloud", "auth", "print-access-token"]
+    auth_failed_message = "GCP auth failed. Run: gcloud auth login"
+    auth_expired_message = "GCP auth expired. Run: gcloud auth login"
+
+    def _resolve_project(self, run, project: str | None) -> str:
+        if isinstance(project, str) and project.strip():
+            return project.strip()
+
+        r = run(["gcloud", "config", "get-value", "project"], capture=True, check=False)
+        project = r.stdout.strip()
+        if r.returncode == 0 and project and project != "(unset)":
+            return project
+
+        raise RuntimeError("GCP project is required. Run 'gcloud config set project <project>'.")
+
+    def parse_kubeconfig(self, kc_path):
+        data = yaml.safe_load(kc_path.read_text())
+        current_ctx = data.get("current-context")
+        if not current_ctx:
+            raise ValueError(f"{kc_path}: no current-context")
+        ctx = next((c for c in data.get("contexts", []) if c.get("name") == current_ctx), None)
+        if not ctx:
+            raise ValueError(f"{kc_path}: current-context {current_ctx!r} not found in contexts")
+        cluster_name = ctx["context"]["cluster"]
+        parts = cluster_name.split("_")
+        if len(parts) < 4 or parts[0] != "gke":
+            raise ValueError(
+                f"{kc_path}: GKE context cluster {cluster_name!r} not in 'gke_<project>_<region>_<cluster>' form"
+            )
+        return {"project": parts[1], "region": parts[2]}
+
+    def reserve_ip(self, *, run, ip_tag, gcp_project=None, gcp_region=None, **kwargs):
+        gcp_project = self._resolve_project(run, gcp_project)
+        gcp_region = gcp_region or "us-central1"
+        print(f"Ensuring static IP {ip_tag} ...")
+        run(
+            [
+                "gcloud",
+                "compute",
+                "addresses",
+                "create",
+                ip_tag,
+                f"--region={gcp_region}",
+                f"--project={gcp_project}",
+                "--quiet",
+            ],
+            check=False,
+        )
+        r = run(
+            [
+                "gcloud",
+                "compute",
+                "addresses",
+                "describe",
+                ip_tag,
+                f"--region={gcp_region}",
+                f"--project={gcp_project}",
+                "--format=value(address)",
+            ],
+            capture=True,
+        )
+        ip = r.stdout.strip()
+        print(f"  Using: {ip} ({ip_tag})")
+        return ip, ip_tag
+
+    def release_ip(self, *, run, ip_name, state):
+        gcp_project = self._resolve_project(run, state.get("gcp_project"))
+        gcp_region = state.get("gcp_region") or "us-central1"
+        print(f"Releasing IP {ip_name} ...")
+        run(
+            [
+                "gcloud",
+                "compute",
+                "addresses",
+                "delete",
+                ip_name,
+                f"--region={gcp_region}",
+                f"--project={gcp_project}",
+                "--quiet",
+            ],
+            check=False,
+        )
+
+    def server_service_helm_args(self, *, server_ip, state):
+        return ["--set", f"service.loadBalancerIP={server_ip}"]

--- a/examples/devops/multicloud/clouds/gcp.py
+++ b/examples/devops/multicloud/clouds/gcp.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import yaml

--- a/examples/devops/multicloud/clouds/kubernetes.py
+++ b/examples/devops/multicloud/clouds/kubernetes.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+
+from .base import CloudProvider, service_annotation_args
+
+
+class KubernetesProvider(CloudProvider):
+    name = "kubernetes"
+    auth_check_cmd = []
+    auth_failed_message = ""
+    auth_expired_message = ""
+
+    def _server_config(self, config) -> dict:
+        if not config:
+            return {}
+        return (config.cloud_configs.get(config.server_cloud) or {}).get("server") or {}
+
+    def _server_participant(self, config):
+        return next(p for p in config.participants if p.role == "server")
+
+    def _default_server_address(self, config) -> str:
+        server = self._server_participant(config)
+        return f"nvflare-server.{server.namespace}.svc.cluster.local"
+
+    def _public_service_config(self, config) -> dict:
+        return self._server_config(config).get("public_service") or {}
+
+    def _public_service_namespace(self, config, public_service: dict) -> str:
+        return public_service.get("namespace") or self._server_participant(config).namespace
+
+    def _public_service_name(self, public_service: dict) -> str:
+        return public_service.get("name") or "nvflare-server-public"
+
+    def _run_text(self, run, cmd: list[str], *, check=True) -> str:
+        result = run(cmd, check=check, capture=True)
+        return (result.stdout or "").strip()
+
+    def validate_server_config(self, config):
+        server_config = self._server_config(config)
+        service_type = server_config.get("service_type", "ClusterIP")
+        if service_type not in {"ClusterIP", "LoadBalancer", "NodePort"}:
+            raise SystemExit(f"clouds.{self.name}.server.service_type must be ClusterIP, LoadBalancer, or NodePort")
+        public_service = self._public_service_config(config)
+        if not public_service:
+            return
+        metallb = public_service.get("metallb") or {}
+        if public_service.get("load_balancer_ip") or metallb.get("pool"):
+            return
+        raise SystemExit(
+            f"clouds.{self.name}.server.public_service requires load_balancer_ip or metallb.pool when enabled"
+        )
+
+    def reserve_ip(self, *, run, ip_tag, config=None, **kwargs):
+        server_config = self._server_config(config)
+        public_service = self._public_service_config(config)
+        address = server_config.get("address")
+        if not address and public_service:
+            address = self._public_service_ip(run, config, public_service)
+        if not address:
+            address = self._default_server_address(config)
+        print(f"Using Kubernetes service address {address} ({self.name})")
+        return address, ip_tag
+
+    def _public_service_ip(self, run, config, public_service: dict) -> str:
+        configured_ip = public_service.get("load_balancer_ip")
+        if configured_ip:
+            return configured_ip
+
+        server = self._server_participant(config)
+        namespace = self._public_service_namespace(config, public_service)
+        name = self._public_service_name(public_service)
+        existing_ip = self._run_text(
+            run,
+            [
+                "kubectl",
+                "--kubeconfig",
+                server.kubeconfig,
+                "-n",
+                namespace,
+                "get",
+                "svc",
+                name,
+                "-o",
+                "jsonpath={.status.loadBalancer.ingress[0].ip}",
+            ],
+            check=False,
+        )
+        if existing_ip:
+            return existing_ip
+
+        metallb = public_service.get("metallb") or {}
+        pool = metallb.get("pool")
+        if not pool:
+            return ""
+        metallb_namespace = metallb.get("namespace") or "metallb-system"
+        pool_range = self._run_text(
+            run,
+            [
+                "kubectl",
+                "--kubeconfig",
+                server.kubeconfig,
+                "-n",
+                metallb_namespace,
+                "get",
+                "ipaddresspool",
+                pool,
+                "-o",
+                "jsonpath={.spec.addresses[0]}",
+            ],
+        )
+        if not pool_range:
+            # Dry-run command output is intentionally synthetic.
+            return "<metallb-ip>"
+        used_ips = self._run_text(
+            run,
+            [
+                "kubectl",
+                "--kubeconfig",
+                server.kubeconfig,
+                "get",
+                "svc",
+                "-A",
+                "-o",
+                'jsonpath={range .items[*]}{range .status.loadBalancer.ingress[*]}{.ip}{"\\n"}{end}{end}',
+            ],
+        )
+        used = {line.strip() for line in used_ips.splitlines() if line.strip()}
+        return self._first_free_ip(pool_range, used)
+
+    def _first_free_ip(self, pool_range: str, used: set[str]) -> str:
+        if "-" in pool_range:
+            start_s, end_s = pool_range.split("-", 1)
+            start = ipaddress.ip_address(start_s.strip())
+            end = ipaddress.ip_address(end_s.strip())
+            for value in range(int(start), int(end) + 1):
+                ip = str(ipaddress.ip_address(value))
+                if ip not in used:
+                    return ip
+        else:
+            network = ipaddress.ip_network(pool_range, strict=False)
+            for ip_obj in network.hosts():
+                ip = str(ip_obj)
+                if ip not in used:
+                    return ip
+        raise SystemExit(f"No free IP found in MetalLB pool range {pool_range}")
+
+    def prepare_server_state(self, *, run, state, config, ip_name, **kwargs):
+        server_config = self._server_config(config)
+        state["kubernetes_service_type"] = server_config.get("service_type", "ClusterIP")
+        state["kubernetes_service_annotations"] = server_config.get("annotations") or {}
+        state["kubernetes_load_balancer_ip"] = server_config.get("load_balancer_ip")
+        public_service = self._public_service_config(config)
+        if public_service:
+            state["kubernetes_public_service"] = {
+                "name": self._public_service_name(public_service),
+                "namespace": self._public_service_namespace(config, public_service),
+            }
+
+    def release_ip(self, *, run, ip_name, state):
+        print(f"No external IP to release for {self.name}.")
+
+    def server_service_type(self, *, state):
+        return state.get("kubernetes_service_type") or "ClusterIP"
+
+    def server_service_helm_args(self, *, server_ip, state):
+        args = []
+        annotations = state.get("kubernetes_service_annotations") or {}
+        if annotations:
+            args += service_annotation_args(annotations)
+        load_balancer_ip = state.get("kubernetes_load_balancer_ip")
+        if load_balancer_ip:
+            args += ["--set", f"service.loadBalancerIP={load_balancer_ip}"]
+        return args
+
+    def status_endpoint(self, *, state, config):
+        server_config = self._server_config(config)
+        public_service = self._public_service_config(config)
+        if public_service:
+            return "Server address", server_config.get("address") or public_service.get("load_balancer_ip") or "N/A"
+        return "Server address", server_config.get("address") or self._default_server_address(config)
+
+    def admin_endpoint(self, *, config, server_ip):
+        server_config = self._server_config(config)
+        admin_config = server_config.get("admin") or {}
+        service_type = server_config.get("service_type", "ClusterIP")
+        if admin_config.get("host") or admin_config.get("port"):
+            return admin_config.get("host") or server_ip, int(admin_config.get("port") or 8003)
+        if service_type == "ClusterIP":
+            return "localhost", 18003
+        return None
+
+    def after_server_deploy(self, *, run, state, config, server):
+        public_service = self._public_service_config(config)
+        if not public_service:
+            return
+        server_ip = state.get("server_ip")
+        if not server_ip:
+            raise SystemExit("server_ip missing; cannot apply Kubernetes public service")
+
+        namespace = self._public_service_namespace(config, public_service)
+        name = self._public_service_name(public_service)
+        port = int(public_service.get("port") or 8002)
+        target_port = int(public_service.get("target_port") or port)
+        annotations = public_service.get("annotations") or {}
+        metallb = public_service.get("metallb") or {}
+        pool = metallb.get("pool")
+        if pool:
+            annotations = {
+                "metallb.universe.tf/address-pool": pool,
+                "metallb.io/address-pool": pool,
+                **annotations,
+            }
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": name, "namespace": namespace, "annotations": annotations},
+            "spec": {
+                "type": "LoadBalancer",
+                "loadBalancerIP": server_ip,
+                "selector": {"app.kubernetes.io/name": server.name},
+                "ports": [
+                    {
+                        "name": public_service.get("port_name") or "fl-port",
+                        "protocol": public_service.get("protocol") or "TCP",
+                        "port": port,
+                        "targetPort": target_port,
+                    }
+                ],
+            },
+        }
+        print(f"Applying Kubernetes public service {namespace}/{name} ({server_ip}:{port}) ...")
+        run(
+            ["kubectl", "--kubeconfig", server.kubeconfig, "-n", namespace, "apply", "-f", "-"],
+            input=json.dumps(manifest),
+        )
+
+    def cleanup_server_resources(self, *, run, state, config):
+        public_service = self._public_service_config(config)
+        if not public_service:
+            return True
+        server = self._server_participant(config)
+        namespace = self._public_service_namespace(config, public_service)
+        name = self._public_service_name(public_service)
+        print(f"Deleting Kubernetes public service {namespace}/{name} ...")
+        namespace_result = run(
+            ["kubectl", "--kubeconfig", server.kubeconfig, "get", "ns", namespace],
+            check=False,
+            capture=True,
+        )
+        if namespace_result.returncode != 0:
+            return True
+        result = run(
+            [
+                "kubectl",
+                "--kubeconfig",
+                server.kubeconfig,
+                "-n",
+                namespace,
+                "delete",
+                "svc",
+                name,
+                "--ignore-not-found",
+            ],
+            check=False,
+        )
+        return result.returncode == 0

--- a/examples/devops/multicloud/clouds/kubernetes.py
+++ b/examples/devops/multicloud/clouds/kubernetes.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import ipaddress

--- a/examples/devops/multicloud/deploy.py
+++ b/examples/devops/multicloud/deploy.py
@@ -1,0 +1,1237 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multicloud NVFlare deploy/destroy tool.
+
+Usage:
+    python deploy.py up     # deploy server + clients
+    python deploy.py down   # tear everything down
+    python deploy.py status # show current state
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from clouds import CLOUD_ORDER, get_provider
+
+DRY_RUN = False
+
+TOOL_DIR = Path(__file__).resolve().parent
+DEVOPS_ROOT = TOOL_DIR.parent
+REPO_ROOT = DEVOPS_ROOT.parent.parent
+WORK_DIR = TOOL_DIR / ".work"
+PROJECT_TEMPLATE = TOOL_DIR / "project.yml"
+MONITORING_STACK = TOOL_DIR / "monitoring-stack.yaml"
+DEFAULT_KUBECONFIG_DIR = DEVOPS_ROOT / ".tmp" / "kubeconfigs"
+K8S_RUNTIME = "k8s"
+VALID_ROLES = {"server", "client"}
+STARTUP_STABILITY_SECONDS = 20
+MONITORING_STACK_NAMESPACE = "nvflare-monitoring"
+MONITORING_NAMESPACE_PREFIX = "nvflare-"
+MONITORING_NAMESPACE_SUFFIX = "-monitoring"
+STATSD_SERVICE_NAME = "statsd-exporter"
+STATSD_PORT = 9125
+MONITORING_COMPONENT_IDS = {
+    "sys_metrics_collector",
+    "remote_metrics_receiver",
+    "statsd_reporter",
+    "event_to_fed",
+}
+
+
+def _safe_k8s_name(value: str, *, max_len: int = 63) -> str:
+    name = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
+    name = name or "system"
+    if len(name) <= max_len:
+        return name
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:8]
+    return f"{name[: max_len - 9].rstrip('-')}-{digest}"
+
+
+def monitoring_namespace(config_name: str) -> str:
+    name_budget = 63 - len(MONITORING_NAMESPACE_PREFIX) - len(MONITORING_NAMESPACE_SUFFIX)
+    return (
+        f"{MONITORING_NAMESPACE_PREFIX}{_safe_k8s_name(config_name, max_len=name_budget)}{MONITORING_NAMESPACE_SUFFIX}"
+    )
+
+
+def statsd_host(namespace: str) -> str:
+    return f"{STATSD_SERVICE_NAME}.{namespace}.svc.cluster.local"
+
+
+DEFAULT_MONITORING_NAMESPACE = monitoring_namespace("default")
+
+
+# ---------------------------------------------------------------------------
+# Monitoring config
+# ---------------------------------------------------------------------------
+@dataclass
+class MonitoringConfig:
+    enabled: bool = False
+    namespace: str = DEFAULT_MONITORING_NAMESPACE
+    statsd_host: str = statsd_host(DEFAULT_MONITORING_NAMESPACE)
+    statsd_port: int = STATSD_PORT
+    env: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Participant config
+# ---------------------------------------------------------------------------
+@dataclass
+class Participant:
+    name: str
+    namespace: str
+    kubeconfig: str
+    role: str  # "server" or "client"
+    cloud: str
+    provider: str = ""
+    prepare: dict = field(default_factory=dict)
+    helm_overrides: list = field(default_factory=list)
+    pvc_config: dict = field(default_factory=dict)
+    pod_annotations: dict = field(default_factory=dict)
+    study_data: dict = field(default_factory=dict)
+    # Kubernetes imagePullPolicy override. `None` keeps whatever the helm chart
+    # defaults to (typically IfNotPresent). Set to "Always" on mutable dev tags.
+    pull_policy: str | None = None
+    create_namespace: bool = True
+    delete_namespace: bool = True
+
+
+@dataclass
+class DeployConfig:
+    name: str
+    participants: list[Participant]
+    server_cloud: str
+    gcp_project: str | None
+    gcp_region: str | None
+    aws_region: str | None
+    aws_eks_cluster_name: str | None
+    azure_resource_group: str | None
+    azure_location: str | None
+    project_file: Path = PROJECT_TEMPLATE
+    server_provider: str = ""
+    cloud_configs: dict = field(default_factory=dict)
+    monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
+    admin_name: str = ""
+
+
+def load_monitoring_config(raw: dict, *, config_name: str, config_path: Path) -> MonitoringConfig:
+    cfg = raw.get("monitoring", {})
+    if cfg is None:
+        cfg = {}
+    if isinstance(cfg, bool):
+        enabled = cfg
+    elif isinstance(cfg, dict):
+        enabled = bool(cfg.get("enabled", False))
+    else:
+        raise ValueError(f"{config_path}: monitoring must be true, false, or a YAML mapping")
+
+    namespace = monitoring_namespace(config_name)
+    return MonitoringConfig(enabled=enabled, namespace=namespace, statsd_host=statsd_host(namespace), env=config_name)
+
+
+def _site_tag(participant_name: str, role: str) -> str:
+    return "server" if role == "server" else participant_name
+
+
+def system_monitoring_components(participant_name: str, role: str, monitoring: MonitoringConfig) -> list[dict]:
+    tags = {"site": _site_tag(participant_name, role), "env": monitoring.env}
+    if role == "server":
+        return [
+            {
+                "id": "sys_metrics_collector",
+                "path": "nvflare.metrics.system_metrics_collector.SysMetricsCollector",
+                "args": {"tags": tags},
+            },
+            {
+                "id": "remote_metrics_receiver",
+                "path": "nvflare.metrics.remote_metrics_receiver.RemoteMetricsReceiver",
+                "args": {"events": ["fed.metrics_event"]},
+            },
+            {
+                "id": "statsd_reporter",
+                "path": "nvflare.fuel_opt.statsd.statsd_reporter.StatsDReporter",
+                "args": {"site": "server", "host": monitoring.statsd_host, "port": monitoring.statsd_port},
+            },
+        ]
+
+    return [
+        {
+            "id": "sys_metrics_collector",
+            "path": "nvflare.metrics.system_metrics_collector.SysMetricsCollector",
+            "args": {"tags": tags, "streaming_to_server": True},
+        },
+        {
+            "id": "event_to_fed",
+            "path": "nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent",
+            "args": {"events_to_convert": ["metrics_event"]},
+        },
+    ]
+
+
+def patch_resources_for_system_monitoring(
+    resources_path: Path, *, participant_name: str, role: str, monitoring: MonitoringConfig
+) -> None:
+    resources = json.loads(resources_path.read_text())
+    components = resources.setdefault("components", [])
+    if not isinstance(components, list):
+        raise ValueError(f"{resources_path}: components must be a list")
+
+    resources["components"] = [c for c in components if c.get("id") not in MONITORING_COMPONENT_IDS]
+    resources["components"] = system_monitoring_components(participant_name, role, monitoring) + resources["components"]
+    resources_path.write_text(json.dumps(resources, indent=4) + "\n")
+
+    active_resources = resources_path.with_name("resources.json")
+    if active_resources.exists():
+        active_resources.unlink()
+
+
+def _normalize_study_data(study_data: dict | None) -> dict:
+    result = {}
+    for study, datasets in (study_data or {}).items():
+        result[study] = {}
+        for dataset, cfg in datasets.items():
+            pvc = cfg.get("pvc")
+            mode = cfg.get("mode")
+            if not pvc or not mode:
+                raise ValueError(f"study_data entry '{study}/{dataset}' must define pvc and mode.")
+            result[study][dataset] = {"source": pvc, "mode": mode}
+    return result
+
+
+def _namespace_options(config_path: Path, cloud: str, cloud_cfg: dict, entry: dict) -> tuple[bool, bool]:
+    namespace_cfg = cloud_cfg.get("namespace")
+    if namespace_cfg is None:
+        namespace_cfg = {}
+    if not isinstance(namespace_cfg, dict):
+        raise ValueError(f"{config_path}: clouds.{cloud}.namespace must be a YAML mapping when set")
+
+    configured_name = namespace_cfg.get("name")
+    if configured_name and configured_name != entry["namespace"]:
+        raise ValueError(
+            f"{config_path}: participant {entry['name']} namespace {entry['namespace']!r} does not match "
+            f"clouds.{cloud}.namespace.name {configured_name!r}"
+        )
+
+    create_namespace = bool(namespace_cfg.get("create", True))
+    delete_namespace = bool(namespace_cfg.get("delete_on_down", True))
+    return create_namespace, delete_namespace
+
+
+def _resolve_path(path: str | Path, *, base: Path) -> Path:
+    path = Path(path).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def _kubeconfig_path(cloud: str, cloud_config: dict | None = None, *, config_dir: Path | None = None) -> Path:
+    kubeconfig = (cloud_config or {}).get("kubeconfig")
+    if kubeconfig:
+        return _resolve_path(kubeconfig, base=config_dir or Path.cwd())
+    return (DEFAULT_KUBECONFIG_DIR / f"{cloud}.yaml").resolve()
+
+
+def _provider_name(cloud: str, cloud_cfg: dict | None = None) -> str:
+    return (cloud_cfg or {}).get("provider") or cloud
+
+
+def _cloud_provider_or_none(provider_name: str):
+    try:
+        return get_provider(provider_name)
+    except ValueError:
+        return None
+
+
+def load_config(config_path: Path) -> DeployConfig:
+    config_path = config_path.resolve()
+    raw = yaml.safe_load(config_path.read_text())
+    name = raw.get("name") or config_path.stem
+    project_file = _resolve_path(raw.get("project_file") or PROJECT_TEMPLATE, base=config_path.parent)
+    if not project_file.is_file():
+        raise ValueError(f"{config_path}: project_file not found: {project_file}")
+    project = yaml.safe_load(project_file.read_text())
+    if not isinstance(project, dict):
+        raise ValueError(f"{project_file}: project file must be a YAML mapping")
+    admin_name = _project_admin_name(project, project_file)
+    monitoring = load_monitoring_config(raw, config_name=name, config_path=config_path)
+    clouds = raw.get("clouds") or {}
+    if not clouds:
+        raise ValueError(f"{config_path}: missing 'clouds' section")
+    raw_participants = raw.get("participants") or []
+    if not raw_participants:
+        raise ValueError(f"{config_path}: missing 'participants' section")
+
+    cloud_derived: dict[str, dict] = {}
+    for cloud_name, cloud_cfg in clouds.items():
+        kc_path = _kubeconfig_path(cloud_name, cloud_cfg, config_dir=config_path.parent)
+        provider = _cloud_provider_or_none(_provider_name(cloud_name, cloud_cfg))
+        if kc_path.exists() and provider:
+            cloud_derived[cloud_name] = provider.parse_kubeconfig(kc_path)
+
+    participants: list[Participant] = []
+    servers: list[str] = []
+    for entry in raw_participants:
+        for key in ("name", "cloud", "namespace", "role"):
+            if key not in entry:
+                raise ValueError(f"{config_path}: participant missing '{key}': {entry}")
+        cloud = entry["cloud"]
+        if cloud not in clouds:
+            raise ValueError(f"{config_path}: participant {entry['name']} references unknown cloud '{cloud}'")
+        role = entry["role"]
+        if role not in VALID_ROLES:
+            raise ValueError(f"{config_path}: participant {entry['name']} has invalid role '{role}'")
+        if role == "server":
+            servers.append(entry["name"])
+
+        cloud_cfg = clouds[cloud] or {}
+        provider_name = _provider_name(cloud, cloud_cfg)
+        if not _cloud_provider_or_none(provider_name):
+            raise ValueError(f"{config_path}: cloud {cloud!r} uses unknown provider {provider_name!r}")
+        merged = {**cloud_cfg, **entry}
+        prepare = copy.deepcopy(entry.get("prepare") or cloud_cfg.get("prepare") or {})
+        if not prepare:
+            raise ValueError(f"{config_path}: participant {entry['name']} has no prepare config")
+        if prepare.get("runtime") != K8S_RUNTIME:
+            raise ValueError(f"{config_path}: participant {entry['name']} prepare.runtime must be '{K8S_RUNTIME}'")
+        kc_path = _kubeconfig_path(cloud, cloud_cfg, config_dir=config_path.parent)
+        pvc_config = merged.get("pvc_config") or {}
+        study_data = _normalize_study_data(merged.get("study_data"))
+        create_namespace, delete_namespace = _namespace_options(config_path, cloud, cloud_cfg, entry)
+
+        participants.append(
+            Participant(
+                name=merged["name"],
+                namespace=merged["namespace"],
+                kubeconfig=str(kc_path),
+                role=role,
+                cloud=cloud,
+                provider=provider_name,
+                prepare=prepare,
+                helm_overrides=list(merged.get("helm_overrides") or []),
+                pvc_config=pvc_config,
+                pod_annotations=merged.get("pod_annotations") or {},
+                study_data=study_data,
+                pull_policy=merged.get("pull_policy"),
+                create_namespace=create_namespace,
+                delete_namespace=delete_namespace,
+            )
+        )
+
+    if len(servers) != 1:
+        raise ValueError(f"{config_path}: expected exactly one server participant, found {len(servers)}: {servers}")
+    server_cloud = next(p.cloud for p in participants if p.role == "server")
+    server_provider = next(p.provider for p in participants if p.role == "server")
+
+    gcp = cloud_derived.get("gcp", {})
+    aws = cloud_derived.get("aws", {})
+    azure = clouds.get("azure") or {}
+    return DeployConfig(
+        name=name,
+        project_file=project_file,
+        participants=participants,
+        server_cloud=server_cloud,
+        server_provider=server_provider,
+        monitoring=monitoring,
+        gcp_project=gcp.get("project"),
+        gcp_region=gcp.get("region"),
+        aws_region=aws.get("region"),
+        aws_eks_cluster_name=aws.get("eks_cluster_name"),
+        azure_resource_group=azure.get("resource_group"),
+        azure_location=azure.get("location"),
+        cloud_configs=clouds,
+        admin_name=admin_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+@dataclass
+class FakeProc:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _dry_run_stdout(cmd: list[str]) -> str:
+    if cmd[:4] == ["gcloud", "config", "get-value", "project"]:
+        return "<gcp-project>\n"
+    if cmd[:4] == ["gcloud", "compute", "addresses", "describe"]:
+        return "<server-ip>\n"
+    if cmd[:3] == ["aws", "ec2", "describe-addresses"]:
+        return json.dumps([{"PublicIp": "<server-ip>", "AllocationId": "<alloc-id>"}]) + "\n"
+    if cmd[:4] == ["aws", "configure", "get", "region"]:
+        return "<aws-region>\n"
+    if cmd[:3] == ["aws", "ec2", "allocate-address"]:
+        return json.dumps({"PublicIp": "<server-ip>", "AllocationId": "<alloc-id>"}) + "\n"
+    if cmd[:3] == ["aws", "eks", "describe-cluster"]:
+        return "<vpc-id>\n"
+    if cmd[:3] == ["aws", "ec2", "describe-subnets"]:
+        return "<subnet-id>\n"
+    if cmd[:4] == ["az", "network", "public-ip", "show"]:
+        return "<server-ip>\n"
+    return ""
+
+
+def _mask(text: str) -> str:
+    return text.replace(str(REPO_ROOT), "<repo>")
+
+
+def _print_cmd(cmd: list[str], tag: str = "$"):
+    if DRY_RUN:
+        print(f"  {tag} {_mask(shlex.join(cmd))}")
+    else:
+        print(f"  {tag} {' '.join(cmd[:6])}{'...' if len(cmd) > 6 else ''}")
+
+
+def run(cmd: list[str], check=True, capture=False, **kwargs) -> subprocess.CompletedProcess:
+    _print_cmd(cmd)
+    if DRY_RUN:
+        stdin = kwargs.get("input")
+        if stdin:
+            for line in stdin.splitlines():
+                print(f"    | {_mask(line)}")
+        return FakeProc(0, stdout=_dry_run_stdout(cmd))
+    return subprocess.run(cmd, check=check, capture_output=capture, text=True, **kwargs)
+
+
+def run_quiet(cmd: list[str]) -> subprocess.CompletedProcess:
+    if DRY_RUN:
+        _print_cmd(cmd, tag="?")
+        # Auth checks pass; existence checks miss so the "create from scratch" path runs.
+        if (
+            (cmd[0] == "gcloud" and "auth" in cmd)
+            or (cmd[0] == "aws" and "sts" in cmd)
+            or (cmd[0] == "az" and "account" in cmd)
+        ):
+            return FakeProc(0)
+        return FakeProc(1)
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def kubectl(kubeconfig: str, *args, **kwargs) -> subprocess.CompletedProcess:
+    return run(["kubectl", "--kubeconfig", kubeconfig] + list(args), **kwargs)
+
+
+def helm(kubeconfig: str, *args) -> subprocess.CompletedProcess:
+    return run(["helm", "--kubeconfig", kubeconfig] + list(args))
+
+
+def check_auth(providers_used: set):
+    print("Checking cloud auth ...")
+    for provider_name in CLOUD_ORDER:
+        if provider_name not in providers_used:
+            continue
+        provider = get_provider(provider_name)
+        if not provider.auth_check_cmd:
+            continue
+        r = run_quiet(provider.auth_check_cmd)
+        if r.returncode != 0:
+            sys.exit(provider.auth_failed_message)
+    print("  Auth OK")
+
+
+def check_auth_for(provider_name: str):
+    """Re-check auth before cloud-specific operations."""
+    provider = get_provider(provider_name)
+    if not provider.auth_check_cmd:
+        return
+    r = run_quiet(provider.auth_check_cmd)
+    if r.returncode != 0:
+        sys.exit(provider.auth_expired_message)
+
+
+def _safe_resource_name(name: str) -> str:
+    base = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-")
+    if not base:
+        base = "cluster"
+    full = f"nvflare-{base}"
+    if len(full) <= 63:
+        return full
+    digest = hashlib.sha1(full.encode("utf-8")).hexdigest()[:8]
+    return f"{full[:54].rstrip('-')}-{digest}"
+
+
+def _participant_state(p: Participant) -> dict:
+    return {
+        "kubeconfig": p.kubeconfig,
+        "namespace": p.namespace,
+        "cloud": p.cloud,
+        "provider": p.provider,
+        "role": p.role,
+        "delete_namespace": p.delete_namespace,
+        "pvc_names": list(p.pvc_config),
+        "cleanup_pvc_names": _participant_cleanup_pvc_names(p),
+    }
+
+
+def _participant_cleanup_pvc_names(p: Participant) -> list[str]:
+    names = list(p.pvc_config)
+    for datasets in (p.study_data or {}).values():
+        for dataset in (datasets or {}).values():
+            source = (dataset or {}).get("source")
+            if source:
+                names.append(source)
+    return list(dict.fromkeys(names))
+
+
+def deployment_state(config: DeployConfig, *, gcp_project: str | None = None) -> dict:
+    ip_name = _safe_resource_name(config.name)
+    return {
+        "ip_name": ip_name,
+        "gcp_project": gcp_project or config.gcp_project,
+        "gcp_region": config.gcp_region or "us-central1",
+        "aws_region": config.aws_region,
+        "server_cloud": config.server_cloud,
+        "server_provider": config.server_provider,
+        "azure_resource_group": config.azure_resource_group,
+        "azure_location": config.azure_location,
+        "azure_pip_name": ip_name if config.server_provider == "azure" else None,
+        "participants": {p.name: _participant_state(p) for p in config.participants},
+    }
+
+
+def namespace_exists(kubeconfig: str, ns: str) -> bool:
+    return run_quiet(["kubectl", "--kubeconfig", kubeconfig, "get", "ns", ns]).returncode == 0
+
+
+def helm_release_exists(kubeconfig: str, name: str, ns: str) -> bool:
+    return run_quiet(["helm", "--kubeconfig", kubeconfig, "status", name, "-n", ns]).returncode == 0
+
+
+def nvflare_cmd() -> str:
+    override = os.environ.get("NVFLARE_CMD")
+    if override:
+        return override
+    if DRY_RUN:
+        return "nvflare"
+    nvflare = REPO_ROOT / ".venv" / "bin" / "nvflare"
+    return str(nvflare) if nvflare.exists() else "nvflare"
+
+
+def _project_deploy_participants(project: dict, project_file: Path) -> dict[str, str]:
+    participants = project.get("participants")
+    if not isinstance(participants, list):
+        raise ValueError(f"{project_file}: project participants must be a YAML list")
+
+    result = {}
+    for entry in participants:
+        if not isinstance(entry, dict):
+            raise ValueError(f"{project_file}: project participant must be a YAML mapping: {entry}")
+        participant_type = entry.get("type")
+        if participant_type not in VALID_ROLES:
+            continue
+        name = entry.get("name")
+        if not name:
+            raise ValueError(f"{project_file}: project {participant_type} participant is missing name")
+        if name in result:
+            raise ValueError(f"{project_file}: duplicate project participant name: {name}")
+        result[name] = participant_type
+    return result
+
+
+def _project_admin_name(project: dict, project_file: Path) -> str:
+    participants = project.get("participants")
+    if not isinstance(participants, list):
+        raise ValueError(f"{project_file}: project participants must be a YAML list")
+
+    admins = [
+        entry.get("name")
+        for entry in participants
+        if isinstance(entry, dict) and entry.get("type") == "admin" and entry.get("name")
+    ]
+    if not admins:
+        raise ValueError(f"{project_file}: project must define at least one admin participant")
+    return admins[0]
+
+
+def _validate_project_participants(project: dict, config: DeployConfig) -> None:
+    expected = {p.name: p.role for p in config.participants}
+    actual = _project_deploy_participants(project, config.project_file)
+    if actual == expected:
+        return
+
+    expected_items = ", ".join(f"{name}:{role}" for name, role in sorted(expected.items()))
+    actual_items = ", ".join(f"{name}:{role}" for name, role in sorted(actual.items()))
+    raise ValueError(
+        f"{config.project_file}: project participants do not match {config.name} participants. "
+        f"deploy.py no longer generates participants; update the project YAML instead. "
+        f"project=[{actual_items}] config=[{expected_items}]"
+    )
+
+
+def render_project(server_ip: str, config: DeployConfig) -> str:
+    project_text = config.project_file.read_text()
+    project_text = project_text.replace("__SERVER_IP__", server_ip)
+    project = yaml.safe_load(project_text)
+    if not isinstance(project, dict):
+        raise ValueError(f"{config.project_file}: project file must be a YAML mapping")
+    _validate_project_participants(project, config)
+    return project_text
+
+
+# ---------------------------------------------------------------------------
+# Provision
+# ---------------------------------------------------------------------------
+def provision(server_ip: str, config: DeployConfig) -> Path:
+    print("Provisioning ...")
+    project_text = render_project(server_ip, config)
+    if DRY_RUN:
+        project_file = WORK_DIR / "project.yml"
+        provision_dir = WORK_DIR / "provision"
+        run(["nvflare", "provision", "-p", str(project_file), "-w", str(provision_dir)])
+        return Path("<prod_dir>")
+
+    WORK_DIR.mkdir(parents=True, exist_ok=True)
+    project_file = WORK_DIR / "project.yml"
+    project_file.write_text(project_text)
+
+    provision_dir = WORK_DIR / "provision"
+    if provision_dir.exists():
+        shutil.rmtree(provision_dir)
+
+    run([nvflare_cmd(), "provision", "-p", str(project_file), "-w", str(provision_dir)])
+
+    prod_dirs = sorted(provision_dir.glob("*/prod_*"))
+    if not prod_dirs:
+        sys.exit("Provisioning produced no output")
+    return prod_dirs[-1]
+
+
+def configure_admin_endpoint(prod_dir: Path, host: str, port: int, admin_name: str):
+    fed_admin_path = prod_dir / admin_name / "startup" / "fed_admin.json"
+    if DRY_RUN:
+        print(f"  Would set admin endpoint in {_mask(str(fed_admin_path))} to {host}:{port}")
+        return
+    data = json.loads(fed_admin_path.read_text())
+    data.setdefault("admin", {})
+    data["admin"]["host"] = host
+    data["admin"]["port"] = port
+    fed_admin_path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"Configured local admin endpoint {host}:{port}")
+
+
+def _write_yaml_file(path: Path, data: dict):
+    payload = yaml.safe_dump(data, sort_keys=False)
+    if DRY_RUN:
+        print(f"  Would write {_mask(str(path))}:")
+        for line in payload.splitlines():
+            print(f"    | {line}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload)
+
+
+def render_monitoring_stack(namespace: str) -> str:
+    return MONITORING_STACK.read_text().replace(MONITORING_STACK_NAMESPACE, namespace)
+
+
+def deploy_monitoring_stack(config: DeployConfig):
+    monitoring = config.monitoring
+    if not monitoring.enabled:
+        return
+
+    server = next(p for p in config.participants if p.role == "server")
+    print(f"Deploying monitoring stack in {server.cloud}/{monitoring.namespace} ...")
+    kubectl(server.kubeconfig, "apply", "-f", "-", input=render_monitoring_stack(monitoring.namespace))
+    for deployment in ("statsd-exporter", "prometheus", "grafana"):
+        kubectl(
+            server.kubeconfig,
+            "-n",
+            monitoring.namespace,
+            "rollout",
+            "status",
+            f"deployment/{deployment}",
+            "--timeout=300s",
+        )
+
+
+def teardown_monitoring_stack(config: DeployConfig) -> bool:
+    monitoring = config.monitoring
+    if not monitoring.enabled:
+        return True
+
+    server = next(p for p in config.participants if p.role == "server")
+    print(f"Tearing down monitoring stack ({monitoring.namespace}) ...")
+    try:
+        check_auth_for(server.provider)
+    except SystemExit:
+        print(f"  Auth failed for {server.provider} — skipping")
+        return False
+    r = run(
+        [
+            "kubectl",
+            "--kubeconfig",
+            server.kubeconfig,
+            "delete",
+            "ns",
+            monitoring.namespace,
+            "--ignore-not-found",
+            "--timeout=120s",
+        ],
+        check=False,
+    )
+    return r.returncode == 0
+
+
+def inject_system_monitoring(kit_dir: Path, participant: Participant, monitoring: MonitoringConfig):
+    if not monitoring.enabled:
+        return
+
+    resources_path = kit_dir / "local" / "resources.json.default"
+    if DRY_RUN:
+        print(f"  Would inject system monitoring into {_mask(str(resources_path))}")
+        return
+    patch_resources_for_system_monitoring(
+        resources_path,
+        participant_name=participant.name,
+        role=participant.role,
+        monitoring=monitoring,
+    )
+
+
+def prepare_runtime_kits(
+    prod_dir: Path, participants: list[Participant], monitoring: MonitoringConfig | None = None
+) -> dict[str, Path]:
+    print("Preparing K8s runtime kits ...")
+    config_dir = WORK_DIR / "prepare-configs"
+    if not DRY_RUN and config_dir.exists():
+        shutil.rmtree(config_dir)
+
+    monitoring = monitoring or MonitoringConfig()
+    kit_dirs = {}
+    for p in participants:
+        kit_dir = prod_dir / p.name
+        prepare_config = copy.deepcopy(p.prepare)
+        prepare_config["namespace"] = p.namespace
+        if p.study_data:
+            _write_yaml_file(kit_dir / "local" / "study_data.yaml", p.study_data)
+
+        config_path = config_dir / f"{p.name}.yaml"
+        output_dir = kit_dir / "prepared" / K8S_RUNTIME
+        _write_yaml_file(config_path, prepare_config)
+        run(
+            [
+                nvflare_cmd(),
+                "deploy",
+                "prepare",
+                "--kit",
+                str(kit_dir),
+                "--output",
+                str(output_dir),
+                "--config",
+                str(config_path),
+            ]
+        )
+        inject_system_monitoring(output_dir, p, monitoring)
+        kit_dirs[p.name] = output_dir
+    return kit_dirs
+
+
+def verify_deployment_stable(p: Participant, seconds: int = STARTUP_STABILITY_SECONDS):
+    if DRY_RUN:
+        return
+
+    def _pods():
+        r = kubectl(
+            p.kubeconfig,
+            "-n",
+            p.namespace,
+            "get",
+            "pods",
+            "-l",
+            f"app.kubernetes.io/name={p.name}",
+            "-o",
+            "json",
+            capture=True,
+        )
+        return json.loads(r.stdout).get("items", [])
+
+    pods = _pods()
+    if not pods:
+        raise RuntimeError(f"No pod found for deployment {p.name} in namespace {p.namespace}")
+    restart_baseline = {
+        pod["metadata"]["name"]: sum(
+            status.get("restartCount", 0) for status in pod.get("status", {}).get("containerStatuses") or []
+        )
+        for pod in pods
+    }
+
+    time.sleep(seconds)
+    pods = _pods()
+    if not pods:
+        raise RuntimeError(f"No pod found for deployment {p.name} in namespace {p.namespace}")
+
+    failures = []
+    for pod in pods:
+        pod_name = pod["metadata"]["name"]
+        phase = pod.get("status", {}).get("phase")
+        statuses = pod.get("status", {}).get("containerStatuses") or []
+        restarts = sum(status.get("restartCount", 0) for status in statuses)
+        ready = statuses and all(status.get("ready") for status in statuses)
+        baseline = restart_baseline.get(pod_name)
+        if baseline is None:
+            failures.append(f"{pod_name}: appeared during stability check")
+        elif phase != "Running" or not ready:
+            failures.append(f"{pod_name}: phase={phase} ready={ready} restarts={restarts}")
+        elif restarts > baseline:
+            failures.append(f"{pod_name}: restarts increased from {baseline} to {restarts}")
+
+    if failures:
+        raise RuntimeError(f"{p.name} did not stay stable after startup: " + "; ".join(failures))
+
+
+# ---------------------------------------------------------------------------
+# Deploy one participant
+# ---------------------------------------------------------------------------
+def deploy_participant(
+    p: Participant,
+    kit_dir: Path,
+    server_ip: str | None = None,
+    state: dict | None = None,
+):
+    chart_dir = kit_dir / "helm_chart"
+
+    print(f"\n{'=' * 60}")
+    print(f"Deploying {p.name} → {p.namespace}")
+    print(f"{'=' * 60}")
+
+    check_auth_for(p.provider)
+
+    # 1. Namespace
+    if not namespace_exists(p.kubeconfig, p.namespace):
+        if not p.create_namespace:
+            if DRY_RUN:
+                print(f"  Namespace {p.namespace} must already exist")
+            else:
+                raise RuntimeError(f"Namespace {p.namespace} does not exist and create_namespace is disabled")
+        else:
+            print(f"  Creating namespace {p.namespace}")
+            kubectl(p.kubeconfig, "create", "ns", p.namespace)
+    else:
+        print(f"  Namespace {p.namespace} exists")
+
+    # 2. PVCs
+    print("  Applying PVCs ...")
+    for pvc_name, cfg in p.pvc_config.items():
+        pvc_yaml = json.dumps(
+            {
+                "apiVersion": "v1",
+                "kind": "PersistentVolumeClaim",
+                "metadata": {"name": pvc_name, "namespace": p.namespace},
+                "spec": {
+                    "storageClassName": cfg["sc"],
+                    "accessModes": [cfg["access"]],
+                    "resources": {"requests": {"storage": cfg["size"]}},
+                },
+            }
+        )
+        run(["kubectl", "--kubeconfig", p.kubeconfig, "-n", p.namespace, "apply", "-f", "-"], input=pvc_yaml)
+
+    # 3. Remove any running participant so the fresh kit is the only source of truth.
+    if helm_release_exists(p.kubeconfig, p.name, p.namespace):
+        print(f"  Removing existing Helm release {p.name} ...")
+        helm(p.kubeconfig, "uninstall", p.name, "-n", p.namespace, "--wait", "--timeout=600s")
+
+    # 4. Stage kit files
+    print("  Staging kit files via temp pod ...")
+    pod_name = f"kit-copy-{p.name}"
+
+    parent_prepare = p.prepare.get("parent") or {}
+    sec_ctx = {}
+    security_context = parent_prepare.get("pod_security_context")
+    if security_context:
+        sec_ctx = {"securityContext": security_context}
+    workspace_pvc = parent_prepare.get("workspace_pvc", "nvflws")
+
+    copy_image = "busybox:1.36"
+    pod_spec = {
+        "spec": {
+            **sec_ctx,
+            "volumes": [{"name": "ws", "persistentVolumeClaim": {"claimName": workspace_pvc}}],
+            "containers": [
+                {
+                    "name": "copy",
+                    "image": copy_image,
+                    "command": ["sleep", "600"],
+                    "volumeMounts": [{"name": "ws", "mountPath": "/ws"}],
+                    "resources": {
+                        "requests": {"cpu": "10m", "memory": "64Mi"},
+                        "limits": {"cpu": "100m", "memory": "128Mi"},
+                    },
+                }
+            ],
+        }
+    }
+
+    kubectl(p.kubeconfig, "-n", p.namespace, "delete", "pod", pod_name, "--ignore-not-found", "--timeout=60s")
+    kubectl(
+        p.kubeconfig,
+        "-n",
+        p.namespace,
+        "run",
+        pod_name,
+        f"--image={copy_image}",
+        "--restart=Never",
+        f"--overrides={json.dumps(pod_spec)}",
+    )
+
+    print("  Waiting for staging pod ...")
+    kubectl(p.kubeconfig, "-n", p.namespace, "wait", "--for=condition=Ready", f"pod/{pod_name}", "--timeout=600s")
+
+    kubectl(p.kubeconfig, "-n", p.namespace, "exec", pod_name, "--", "rm", "-rf", "/ws/startup", "/ws/local")
+    kubectl(p.kubeconfig, "-n", p.namespace, "cp", str(kit_dir / "startup"), f"{pod_name}:/ws/startup")
+    kubectl(p.kubeconfig, "-n", p.namespace, "cp", str(kit_dir / "local"), f"{pod_name}:/ws/local")
+    kubectl(p.kubeconfig, "-n", p.namespace, "delete", "pod", pod_name, "--timeout=60s")
+
+    # 5. Helm install
+    print(f"  Helm installing {p.name} ...")
+    helm_args = ["upgrade", "--install", p.name, str(chart_dir), "-n", p.namespace]
+    helm_args += p.helm_overrides
+
+    if p.role == "server" and server_ip:
+        provider = get_provider(p.provider)
+        service_type = provider.server_service_type(state=state or {})
+        if service_type:
+            helm_args += ["--set", f"service.type={service_type}"]
+        helm_args += provider.server_service_helm_args(server_ip=server_ip, state=state or {})
+
+    for k, v in p.pod_annotations.items():
+        escaped = k.replace(".", r"\.").replace("/", r"\/")
+        escaped_v = str(v).replace("\\", r"\\").replace(",", r"\,").replace("=", r"\=")
+        helm_args += ["--set-string", f"podAnnotations.{escaped}={escaped_v}"]
+
+    if p.pull_policy:
+        helm_args += ["--set", f"image.pullPolicy={p.pull_policy}"]
+
+    helm(p.kubeconfig, *helm_args)
+
+    # 6. Wait for server deployment
+    if p.role == "server":
+        print("  Waiting for server to be ready ...")
+        kubectl(
+            p.kubeconfig,
+            "-n",
+            p.namespace,
+            "wait",
+            "--for=condition=available",
+            f"deployment/{p.name}",
+            "--timeout=600s",
+        )
+        verify_deployment_stable(p)
+
+
+def deploy_participants(
+    config: DeployConfig, participants: list[Participant], kit_dirs: dict[str, Path], server_ip: str, state: dict
+):
+    servers = [p for p in participants if p.role == "server"]
+    clients = [p for p in participants if p.role != "server"]
+    server_provider = get_provider(config.server_provider)
+
+    for server in servers:
+        deploy_participant(server, kit_dirs[server.name], server_ip=server_ip, state=state)
+        server_provider.after_server_deploy(run=run, state=state, config=config, server=server)
+
+    if DRY_RUN or len(clients) <= 1:
+        for client in clients:
+            deploy_participant(client, kit_dirs[client.name], server_ip=server_ip, state=state)
+        return
+
+    print(f"\nDeploying {len(clients)} clients in parallel ...")
+    errors = []
+    with ThreadPoolExecutor(max_workers=len(clients)) as executor:
+        future_to_participant = {
+            executor.submit(deploy_participant, client, kit_dirs[client.name], server_ip=server_ip, state=state): client
+            for client in clients
+        }
+        for future in as_completed(future_to_participant):
+            participant = future_to_participant[future]
+            try:
+                future.result()
+            except BaseException as e:
+                if isinstance(e, KeyboardInterrupt):
+                    raise
+                errors.append((participant.name, e))
+
+    if errors:
+        for name, error in errors:
+            print(f"  {name} failed: {error}")
+        raise RuntimeError("Client deploy failed for: " + ", ".join(name for name, _ in errors))
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+def cmd_up(args):
+    config = load_config(Path(args.config))
+    participants = config.participants
+    providers_used = {p.provider for p in participants}
+    check_auth(providers_used)
+
+    server_provider_impl = get_provider(config.server_provider)
+    server_provider_impl.validate_server_config(config)
+
+    gcp_project = None
+    if "gcp" in providers_used:
+        gcp_project = (
+            config.gcp_project or run(["gcloud", "config", "get-value", "project"], capture=True).stdout.strip()
+        )
+    gcp_region = config.gcp_region or "us-central1"
+    aws_region = config.aws_region
+
+    state = deployment_state(config, gcp_project=gcp_project)
+    server_ip, ip_name = server_provider_impl.reserve_ip(
+        run=run,
+        ip_tag=state["ip_name"],
+        state=state,
+        config=config,
+        gcp_project=gcp_project,
+        gcp_region=gcp_region,
+        aws_region=aws_region,
+        azure_resource_group=config.azure_resource_group,
+        azure_location=config.azure_location,
+    )
+
+    server_provider_impl.prepare_server_state(
+        run=run, state=state, config=config, ip_name=ip_name, aws_region=aws_region
+    )
+    state["server_ip"] = server_ip
+
+    deploy_monitoring_stack(config)
+
+    prod_dir = provision(server_ip, config)
+    admin_endpoint = server_provider_impl.admin_endpoint(config=config, server_ip=server_ip)
+    if admin_endpoint:
+        configure_admin_endpoint(prod_dir, host=admin_endpoint[0], port=admin_endpoint[1], admin_name=config.admin_name)
+    kit_dirs = prepare_runtime_kits(prod_dir, participants, monitoring=config.monitoring)
+
+    deploy_participants(config, participants, kit_dirs, server_ip=server_ip, state=state)
+
+    print(f"\n{'=' * 60}")
+    print("Deployment complete.")
+    print(f"  Server IP:   {server_ip}")
+    print(f"  Admin kit:   {prod_dir / config.admin_name}")
+    print(f"{'=' * 60}")
+
+
+def _pods_using_pvcs(kubeconfig: str, ns: str, pvc_names: list[str]) -> list[str]:
+    # Reused namespaces cannot be removed wholesale during teardown. Find any
+    # leftover pods that still mount deployment-owned PVCs so the PVC cleanup
+    # below does not hang on active volume attachments.
+    if not pvc_names:
+        return []
+    r = run(["kubectl", "--kubeconfig", kubeconfig, "-n", ns, "get", "pods", "-o", "json"], check=False, capture=True)
+    if r.returncode != 0:
+        detail = f": {r.stderr.strip()}" if r.stderr else ""
+        print(f"  Warning: failed to list pods before PVC cleanup{detail}")
+        return []
+    try:
+        data = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError as e:
+        print(f"  Warning: failed to parse pod list before PVC cleanup: {e}")
+        return []
+
+    pvc_set = set(pvc_names)
+    pod_names = []
+    for item in data.get("items") or []:
+        name = (item.get("metadata") or {}).get("name")
+        if not name:
+            continue
+        volumes = (item.get("spec") or {}).get("volumes") or []
+        if any((volume.get("persistentVolumeClaim") or {}).get("claimName") in pvc_set for volume in volumes):
+            pod_names.append(name)
+    return sorted(set(pod_names))
+
+
+def delete_pods_using_pvcs(kubeconfig: str, ns: str, pvc_names: list[str]):
+    pod_names = _pods_using_pvcs(kubeconfig, ns, pvc_names)
+    for pod_name in pod_names:
+        run(
+            [
+                "kubectl",
+                "--kubeconfig",
+                kubeconfig,
+                "-n",
+                ns,
+                "delete",
+                "pod",
+                pod_name,
+                "--ignore-not-found",
+                "--timeout=60s",
+            ],
+            check=False,
+        )
+
+
+def teardown_participant(name: str, info: dict) -> bool:
+    kc, ns = info["kubeconfig"], info["namespace"]
+    provider_name = info.get("provider") or info.get("cloud", "")
+    print(f"Tearing down {name} ({ns}) ...")
+    try:
+        check_auth_for(provider_name)
+    except SystemExit:
+        print(f"  Auth failed for {kc} — skipping")
+        return False
+
+    run(["helm", "--kubeconfig", kc, "uninstall", name, "-n", ns], check=False)
+    if not info.get("delete_namespace", True):
+        # In shared namespaces, delete only this participant's Helm release,
+        # transient pods using its PVCs, and its workspace PVCs. Study-data PVCs
+        # can appear in cleanup_pvc_names to unblock pods, but are not deleted.
+        delete_pods_using_pvcs(kc, ns, info.get("cleanup_pvc_names") or info.get("pvc_names") or [])
+        for pvc_name in info.get("pvc_names") or []:
+            run(
+                ["kubectl", "--kubeconfig", kc, "-n", ns, "delete", "pvc", pvc_name, "--ignore-not-found"],
+                check=False,
+            )
+        return True
+
+    r = run(["kubectl", "--kubeconfig", kc, "delete", "ns", ns, "--ignore-not-found", "--timeout=120s"], check=False)
+    if r.returncode != 0:
+        return False
+
+    return True
+
+
+def teardown_participants(items: list[tuple[str, dict]], parallel: bool = True) -> bool:
+    if not items:
+        return True
+
+    if DRY_RUN or not parallel or len(items) <= 1:
+        ok = True
+        for name, info in items:
+            ok = teardown_participant(name, info) and ok
+        return ok
+
+    errors = []
+    with ThreadPoolExecutor(max_workers=len(items)) as executor:
+        future_to_name = {executor.submit(teardown_participant, name, info): name for name, info in items}
+        for future in as_completed(future_to_name):
+            name = future_to_name[future]
+            try:
+                if not future.result():
+                    errors.append(name)
+            except BaseException as e:
+                if isinstance(e, KeyboardInterrupt):
+                    raise
+                print(f"  {name} failed: {e}")
+                errors.append(name)
+
+    return not errors
+
+
+def cmd_down(args):
+    config = load_config(Path(args.config))
+    state = deployment_state(config)
+    participants = state.get("participants", {})
+    participant_items = list(participants.items())
+    client_items = [(name, info) for name, info in participant_items if info["role"] != "server"]
+    server_items = [(name, info) for name, info in participant_items if info["role"] == "server"]
+    server_cleanup_ok = get_provider(
+        state.get("server_provider") or state.get("server_cloud", "gcp")
+    ).cleanup_server_resources(run=run, state=state, config=config)
+    clients_ok = teardown_participants(client_items)
+    server_ok = teardown_participants(server_items)
+    monitoring_ok = teardown_monitoring_stack(config)
+
+    if not clients_ok or not server_ok or not monitoring_ok or not server_cleanup_ok:
+        print("Partial teardown. Re-run down with the same config after fixing the failure.")
+        sys.exit(1)
+
+    get_provider(state.get("server_provider") or state.get("server_cloud", "gcp")).release_ip(
+        run=run, ip_name=state["ip_name"], state=state
+    )
+    print("Destroyed.")
+
+
+def cmd_status(args):
+    config = load_config(Path(args.config))
+    state = deployment_state(config)
+    status_label, status_value = get_provider(config.server_provider or config.server_cloud).status_endpoint(
+        state=state, config=config
+    )
+
+    print(f"{status_label}:   {status_value}")
+    for name, info in state.get("participants", {}).items():
+        kc, ns = info["kubeconfig"], info["namespace"]
+        print(f"\n{name} ({ns}):")
+        r = run_quiet(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "--kubeconfig",
+                kc,
+                "-n",
+                ns,
+                "-l",
+                f"app.kubernetes.io/name={name}",
+                "--no-headers",
+            ]
+        )
+        if r.returncode != 0:
+            detail = (r.stderr or r.stdout or "").strip()
+            print(f"  Error listing pods: {detail or 'kubectl failed'}")
+        elif r.stdout.strip():
+            for line in r.stdout.strip().split("\n"):
+                print(f"  {line}")
+        else:
+            print("  No pods")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    default_config = str(TOOL_DIR / "all-clouds.yaml")
+    parser = argparse.ArgumentParser(description="Multicloud NVFlare deploy tool")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
+    parser.add_argument("--config", default=default_config, help="Path to deploy config YAML")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("up", help="Deploy server + clients")
+
+    sub.add_parser("down", help="Tear down everything")
+    sub.add_parser("status", help="Show deployment status")
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    global DRY_RUN
+    DRY_RUN = args.dry_run
+
+    {"up": cmd_up, "down": cmd_down, "status": cmd_status}[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/devops/multicloud/fetch_kubeconfigs.py
+++ b/examples/devops/multicloud/fetch_kubeconfigs.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEVOPS_ROOT = SCRIPT_DIR.parent
+REPO_ROOT = DEVOPS_ROOT.parent.parent
+DEFAULT_CONFIG = SCRIPT_DIR / "all-clouds.yaml"
+DEFAULT_OUT_DIR = DEVOPS_ROOT / ".tmp" / "kubeconfigs"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch kubeconfigs for the clouds used by a multicloud deploy config.")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="multicloud deploy config")
+    parser.add_argument("--dry-run", action="store_true", help="print cloud CLI commands without writing kubeconfigs")
+    return parser.parse_args()
+
+
+def fail(message: str, exit_code: int = 1) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def env_first(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value.strip()
+    return ""
+
+
+def quote_command(cmd: list[str], env: dict[str, str] | None = None) -> str:
+    parts = []
+    for key, value in (env or {}).items():
+        parts.append(f"{key}={shlex.quote(value)}")
+    parts.extend(shlex.quote(part) for part in cmd)
+    return "  $ " + " ".join(parts)
+
+
+def run(cmd: list[str], *, dry_run: bool, env: dict[str, str] | None = None) -> None:
+    print(quote_command(cmd, env=env))
+    if dry_run:
+        return
+
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    try:
+        subprocess.run(cmd, check=True, env=full_env)
+    except FileNotFoundError:
+        fail(f"command not found: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(e.returncode) from e
+
+
+def capture(cmd: list[str]) -> str:
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        fail(f"command not found: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        if e.stderr:
+            print(e.stderr, file=sys.stderr, end="")
+        raise SystemExit(e.returncode) from e
+    return result.stdout.strip()
+
+
+def resolve_path(path: Path, *, base: Path | None = None) -> Path:
+    path = path.expanduser()
+    if not path.is_absolute():
+        path = (base or Path.cwd()) / path
+    return path.resolve()
+
+
+def load_config(config_path: Path) -> dict:
+    if not config_path.is_file():
+        fail(f"config not found: {config_path}")
+    with config_path.open("rt", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    if not isinstance(config, dict):
+        fail(f"config must be a YAML mapping: {config_path}")
+    return config
+
+
+def used_clouds(config: dict) -> list[str]:
+    participants = config.get("participants") or []
+    clouds = []
+    for participant in participants:
+        if not isinstance(participant, dict):
+            continue
+        cloud = participant.get("cloud")
+        if cloud and cloud not in clouds:
+            clouds.append(cloud)
+    return clouds
+
+
+def configured_kubeconfig(cloud_config: dict, *, config_dir: Path) -> Path | None:
+    kubeconfig = cloud_config.get("kubeconfig")
+    if not kubeconfig:
+        return None
+    return resolve_path(Path(kubeconfig), base=config_dir)
+
+
+def kubeconfig_path(cloud: str, out_dir: Path) -> Path:
+    return out_dir / f"{cloud}.yaml"
+
+
+def split_tsv_rows(output: str) -> list[tuple[str, str]]:
+    rows = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            rows.append((parts[0], parts[1]))
+    return rows
+
+
+def discover_gcp(project: str, cluster: str, location: str) -> tuple[str, str, str]:
+    if not project:
+        project = capture(["gcloud", "config", "get-value", "project"])
+        if project == "(unset)":
+            project = ""
+    if not project:
+        fail("GCP project is not set. Run 'gcloud config set project <project>' or set GCP_PROJECT.")
+
+    if cluster and location:
+        return project, cluster, location
+
+    output = capture(["gcloud", "container", "clusters", "list", "--project", project, "--format=value(name,location)"])
+    rows = [
+        (name, loc)
+        for name, loc in split_tsv_rows(output)
+        if (not cluster or name == cluster) and (not location or loc == location)
+    ]
+
+    if len(rows) == 1:
+        cluster, location = rows[0]
+        return project, cluster, location
+    if not rows:
+        fail(f"No GKE clusters found for project {project}. Set GCP_CLUSTER and GCP_LOCATION.")
+
+    print("Multiple GKE clusters matched. Set GCP_CLUSTER and GCP_LOCATION:", file=sys.stderr)
+    for name, loc in rows:
+        print(f"  {name}|{loc}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def discover_aws(cluster: str, region: str) -> tuple[str, str]:
+    if not region:
+        region = capture(["aws", "configure", "get", "region"])
+    if not region:
+        fail("AWS region is not set. Run 'aws configure set region <region>' or set AWS_REGION.")
+
+    if cluster:
+        return cluster, region
+
+    output = capture(["aws", "eks", "list-clusters", "--region", region, "--query", "clusters[]", "--output", "text"])
+    clusters = [name for name in output.split() if name]
+
+    if len(clusters) == 1:
+        return clusters[0], region
+    if not clusters:
+        fail(f"No EKS clusters found in region {region}. Set AWS_CLUSTER.")
+
+    print(f"Multiple EKS clusters found in region {region}. Set AWS_CLUSTER:", file=sys.stderr)
+    for name in clusters:
+        print(f"  {name}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def discover_azure(cluster: str, resource_group: str) -> tuple[str, str]:
+    if cluster and resource_group:
+        return cluster, resource_group
+
+    output = capture(["az", "aks", "list", "--query", "[].{name:name,resourceGroup:resourceGroup}", "--output", "tsv"])
+    rows = [
+        (name, rg)
+        for name, rg in split_tsv_rows(output)
+        if (not cluster or name == cluster) and (not resource_group or rg == resource_group)
+    ]
+
+    if len(rows) == 1:
+        cluster, resource_group = rows[0]
+        return cluster, resource_group
+    if not rows:
+        fail("No AKS clusters found in the active Azure subscription. Set AZURE_CLUSTER and AZURE_RESOURCE_GROUP.")
+
+    print(
+        "Multiple AKS clusters matched in the active Azure subscription. Set AZURE_CLUSTER and AZURE_RESOURCE_GROUP:",
+        file=sys.stderr,
+    )
+    for name, rg in rows:
+        print(f"  {name}|{rg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def fetch_gcp(kubeconfig: Path, dry_run: bool) -> None:
+    if dry_run:
+        project = env_first("GCP_PROJECT") or "<gcp-project>"
+        cluster = env_first("GCP_CLUSTER") or "<gke-cluster>"
+        location = env_first("GCP_LOCATION") or "<gcp-location>"
+    else:
+        project, cluster, location = discover_gcp(
+            env_first("GCP_PROJECT"),
+            env_first("GCP_CLUSTER"),
+            env_first("GCP_LOCATION"),
+        )
+    print(f"Fetching GKE kubeconfig: cluster={cluster} location={location} project={project}")
+    run(
+        ["gcloud", "container", "clusters", "get-credentials", cluster, "--location", location, "--project", project],
+        dry_run=dry_run,
+        env={"KUBECONFIG": str(kubeconfig)},
+    )
+
+
+def fetch_aws(kubeconfig: Path, dry_run: bool) -> None:
+    if dry_run:
+        cluster = env_first("AWS_CLUSTER", "AWS_CLUSTER_NAME") or "<eks-cluster>"
+        region = env_first("AWS_REGION", "AWS_DEFAULT_REGION") or "<aws-region>"
+    else:
+        cluster, region = discover_aws(
+            env_first("AWS_CLUSTER", "AWS_CLUSTER_NAME"), env_first("AWS_REGION", "AWS_DEFAULT_REGION")
+        )
+    print(f"Fetching EKS kubeconfig: cluster={cluster} region={region}")
+    run(
+        ["aws", "eks", "update-kubeconfig", "--name", cluster, "--region", region, "--kubeconfig", str(kubeconfig)],
+        dry_run=dry_run,
+    )
+
+
+def fetch_azure(kubeconfig: Path, dry_run: bool) -> None:
+    if dry_run:
+        cluster = env_first("AZURE_CLUSTER", "AZURE_CLUSTER_NAME") or "<aks-cluster>"
+        resource_group = env_first("AZURE_RESOURCE_GROUP") or "<azure-resource-group>"
+    else:
+        cluster, resource_group = discover_azure(
+            env_first("AZURE_CLUSTER", "AZURE_CLUSTER_NAME"), env_first("AZURE_RESOURCE_GROUP")
+        )
+    print(f"Fetching AKS kubeconfig: cluster={cluster} resource_group={resource_group}")
+    run(
+        [
+            "az",
+            "aks",
+            "get-credentials",
+            "--resource-group",
+            resource_group,
+            "--name",
+            cluster,
+            "--file",
+            str(kubeconfig),
+            "--overwrite-existing",
+        ],
+        dry_run=dry_run,
+    )
+    if shutil.which("kubelogin"):
+        run(["kubelogin", "convert-kubeconfig", "-l", "azurecli", "--kubeconfig", str(kubeconfig)], dry_run=dry_run)
+    else:
+        print("  kubelogin not found; leaving Azure kubeconfig as written by az.")
+
+
+def main() -> int:
+    args = parse_args()
+    config_path = resolve_path(args.config)
+    out_dir = DEFAULT_OUT_DIR
+    config = load_config(config_path)
+    clouds_config = config.get("clouds") or {}
+
+    for cloud in used_clouds(config):
+        cloud_config = clouds_config.get(cloud)
+        if not isinstance(cloud_config, dict):
+            fail(f"cloud '{cloud}' is used by participants but is not configured")
+
+        configured = configured_kubeconfig(cloud_config, config_dir=config_path.parent)
+        if configured:
+            if not args.dry_run and not configured.is_file():
+                fail(f"configured kubeconfig does not exist for cloud '{cloud}': {configured}")
+            print(f"Using configured kubeconfig for {cloud}: {configured}")
+            continue
+
+        kubeconfig = kubeconfig_path(cloud, out_dir)
+        run(["mkdir", "-p", str(kubeconfig.parent)], dry_run=args.dry_run)
+        if not args.dry_run:
+            kubeconfig.parent.mkdir(parents=True, exist_ok=True)
+
+        if cloud == "gcp":
+            fetch_gcp(kubeconfig, args.dry_run)
+        elif cloud == "aws":
+            fetch_aws(kubeconfig, args.dry_run)
+        elif cloud == "azure":
+            fetch_azure(kubeconfig, args.dry_run)
+        else:
+            fail(f"unsupported cloud: {cloud}")
+        print(f"Wrote {kubeconfig}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/devops/multicloud/k8sview.py
+++ b/examples/devops/multicloud/k8sview.py
@@ -1,0 +1,1437 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live multicloud pod dashboard.
+
+By default, discovers every NVFlare namespace reachable through kubeconfigs in
+examples/devops/.tmp/kubeconfigs and renders a top-like all-cloud summary. Pass --config
+for the older focused view that reads the same YAML config as deploy.py.
+
+Usage:
+    k8sview.py [--interval 2]
+    k8sview.py --config all-clouds.yaml [--interval 2]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+try:
+    from rich.console import Console, Group
+    from rich.live import Live
+    from rich.table import Table
+    from rich.text import Text
+except ImportError:
+    sys.exit("k8sview requires 'rich'. Install with: uv pip install rich")
+
+try:
+    from kubernetes import client as k8s_client
+    from kubernetes import config as k8s_config
+    from kubernetes.client.exceptions import ApiException
+    from kubernetes.config.config_exception import ConfigException
+except ImportError:
+    sys.exit("k8sview requires 'kubernetes'. Install with: uv pip install kubernetes")
+
+
+TOOL_DIR = Path(__file__).resolve().parent
+DEVOPS_ROOT = TOOL_DIR.parent
+REPO_ROOT = DEVOPS_ROOT.parent.parent
+DEFAULT_KUBECONFIG_DIR = DEVOPS_ROOT / ".tmp" / "kubeconfigs"
+NVFLARE_NAMESPACE_PREFIX = "nvflare"
+PRUNE_TERMINAL_PODS_AFTER = 300.0
+PRUNE_TERMINAL_POD_PHASES = frozenset({"Succeeded", "Failed"})
+ACCELERATOR_RESOURCE = os.environ.get("K8SVIEW_ACCELERATOR_RESOURCE", "")
+
+STATUS_COLORS = {
+    "Running": "green",
+    "Succeeded": "dim",
+    "Completed": "dim",
+    "Pending": "yellow",
+    "ContainerCreating": "yellow",
+    "PodInitializing": "yellow",
+    "NotReady": "yellow",
+    "Terminating": "dim yellow",
+    "Failed": "red",
+    "Error": "red",
+    "CrashLoopBackOff": "red",
+    "ImagePullBackOff": "red",
+    "ErrImagePull": "red",
+    "CreateContainerConfigError": "red",
+    "InvalidImageName": "red",
+    "ERROR": "red",
+    "Bound": "green",
+    "Lost": "red",
+}
+
+
+def site_name_to_rfc1123(site_name: str, max_length: int = 47) -> str:
+    digest = hashlib.sha256(site_name.encode("utf-8")).hexdigest()[:8]
+    name = site_name.lower()
+    name = re.sub(r"[^a-z0-9-]", "", name).strip("-")
+    if not name:
+        name = "site"
+    if name[0].isdigit():
+        name = "s" + name
+    head_max = max_length - len(digest) - 1
+    name = name[:head_max].rstrip("-") or "site"
+    return f"{name}-{digest}"
+
+
+def display_job_id(job_prefix: str) -> str:
+    if re.fullmatch(r"j[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", job_prefix):
+        return job_prefix[1:]
+    return job_prefix
+
+
+@dataclass
+class Participant:
+    name: str
+    cloud: str
+    namespace: str
+    kubeconfig: str
+    pvc_names: tuple[str, ...] = ()
+    role: str = field(default="", compare=False)
+
+
+@dataclass
+class NamespaceTarget:
+    name: str
+    cloud: str
+    namespace: str
+    kubeconfig: str
+    job_site_suffixes: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class Cluster:
+    name: str
+    cloud: str
+    kubeconfig: str
+
+
+@dataclass
+class NamespaceResources:
+    cluster: Cluster
+    namespace: str
+    pods: list
+    pvcs: list
+    services: list
+    error: str | None = None
+
+
+@dataclass
+class ClusterSnapshot:
+    cluster: Cluster
+    namespaces: list[NamespaceResources]
+    nodes: list | None = None
+    all_pods: list | None = None
+    node_error: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class SiteRow:
+    system: str
+    cloud: str
+    role: str
+    site: str
+    namespace: str
+    site_pod: str
+    site_pods_running: int
+    site_pods_total: int
+    pod_ips: list[str]
+    service_ips: list[str]
+    external_ips: list[str]
+    pvc_summary: str
+    pvc_bound: int
+    pvc_total: int
+    job_pods_running: int
+    job_pods_total: int
+    age: str
+
+
+def load_participants(config_path: Path) -> list[Participant]:
+    config_path = config_path.resolve()
+    raw = yaml.safe_load(config_path.read_text())
+    clouds = raw.get("clouds") or {}
+    entries = raw.get("participants") or []
+    if not clouds or not entries:
+        raise ValueError(f"{config_path}: missing 'clouds' or 'participants' section")
+    out: list[Participant] = []
+    for e in entries:
+        cloud_cfg = clouds.get(e["cloud"], {}) or {}
+        merged = {**cloud_cfg, **e}
+        kc = resolve_kubeconfig(e["cloud"], cloud_cfg, config_dir=config_path.parent)
+        pvc_names = _participant_pvc_names(merged)
+        out.append(
+            Participant(merged["name"], e["cloud"], merged["namespace"], str(kc), pvc_names, merged.get("role", ""))
+        )
+    return out
+
+
+def _participant_pvc_names(config: dict) -> tuple[str, ...]:
+    names = list((config.get("pvc_config") or {}).keys())
+    for datasets in (config.get("study_data") or {}).values():
+        for dataset in (datasets or {}).values():
+            pvc = (dataset or {}).get("pvc") or (dataset or {}).get("source")
+            if pvc:
+                names.append(pvc)
+    return tuple(dict.fromkeys(names))
+
+
+def resolve_path(path: str | Path, *, base: Path) -> Path:
+    path = Path(path).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve()
+
+
+def resolve_kubeconfig(cloud: str, cloud_config: dict | None = None, *, config_dir: Path | None = None) -> Path:
+    kubeconfig = (cloud_config or {}).get("kubeconfig")
+    if kubeconfig:
+        return resolve_path(kubeconfig, base=config_dir or Path.cwd())
+    return (DEFAULT_KUBECONFIG_DIR / f"{cloud}.yaml").resolve()
+
+
+def load_clusters(kubeconfig_dir: Path) -> list[Cluster]:
+    kubeconfig_dir = kubeconfig_dir.resolve()
+    if not kubeconfig_dir.exists():
+        return []
+    out = []
+    for path in sorted(kubeconfig_dir.glob("*.yaml")):
+        cloud = path.stem
+        out.append(Cluster(name=cloud, cloud=cloud, kubeconfig=str(path.resolve())))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Kubernetes API cache + pod fetch
+# ---------------------------------------------------------------------------
+class ApiCache:
+    def __init__(self):
+        self._apis: dict[str, k8s_client.CoreV1Api] = {}
+
+    def get(self, p: Participant) -> k8s_client.CoreV1Api:
+        return self._get(f"participant:{p.name}:{p.kubeconfig}", p.kubeconfig)
+
+    def get_cluster(self, c: Cluster) -> k8s_client.CoreV1Api:
+        return self._get(f"cluster:{c.name}:{c.kubeconfig}", c.kubeconfig)
+
+    def _get(self, key: str, kubeconfig: str) -> k8s_client.CoreV1Api:
+        api = self._apis.get(key)
+        if api is not None:
+            return api
+        api_client = k8s_config.new_client_from_config(config_file=kubeconfig)
+        api = k8s_client.CoreV1Api(api_client)
+        self._apis[key] = api
+        return api
+
+    def drop(self, p: Participant) -> None:
+        self._apis.pop(f"participant:{p.name}:{p.kubeconfig}", None)
+
+    def drop_cluster(self, c: Cluster) -> None:
+        self._apis.pop(f"cluster:{c.name}:{c.kubeconfig}", None)
+
+
+@dataclass
+class PodFetchError:
+    msg: str
+
+
+@dataclass
+class PruneStats:
+    deleted: set[tuple[str, str, str]]
+    errors: list[str]
+
+    @classmethod
+    def empty(cls) -> "PruneStats":
+        return cls(deleted=set(), errors=[])
+
+    def extend(self, other: "PruneStats") -> None:
+        self.deleted.update(other.deleted)
+        self.errors.extend(other.errors)
+
+
+def _call(p: Participant, cache: ApiCache, method_name: str, **kwargs):
+    try:
+        api = cache.get(p)
+        resp = getattr(api, method_name)(p.namespace, _request_timeout=8, **kwargs)
+        return resp.items
+    except ApiException as e:
+        cache.drop(p)
+        return PodFetchError(e.reason or f"HTTP {e.status}")
+    except ConfigException as e:
+        cache.drop(p)
+        return PodFetchError(f"config: {e}")
+    except Exception as e:
+        cache.drop(p)
+        return PodFetchError(f"{type(e).__name__}: {e}")
+
+
+def _participant_label_selector(p: Participant) -> str:
+    return f"app.kubernetes.io/name={p.name}"
+
+
+def unique_namespace_targets(participants: list[Participant]) -> list[NamespaceTarget]:
+    targets = {}
+    for p in participants:
+        key = (p.cloud, p.namespace, p.kubeconfig)
+        target = targets.get(key)
+        if target is None:
+            target = {
+                "name": f"{p.cloud}/{p.namespace}",
+                "cloud": p.cloud,
+                "namespace": p.namespace,
+                "kubeconfig": p.kubeconfig,
+                "job_site_suffixes": [],
+            }
+            targets[key] = target
+        site_names = [p.name]
+        if p.role == "server":
+            site_names.append("server")
+        for site_name in site_names:
+            target["job_site_suffixes"].append((site_name, site_name_to_rfc1123(site_name, max_length=20)))
+    return [
+        NamespaceTarget(
+            name=t["name"],
+            cloud=t["cloud"],
+            namespace=t["namespace"],
+            kubeconfig=t["kubeconfig"],
+            job_site_suffixes=tuple(t["job_site_suffixes"]),
+        )
+        for t in targets.values()
+    ]
+
+
+def _filter_participant_pvcs(p: Participant, result):
+    if isinstance(result, PodFetchError) or not p.pvc_names:
+        return result
+    allowed = set(p.pvc_names)
+    return [pvc for pvc in result if pvc.metadata.name in allowed]
+
+
+def fetch_pods(p: Participant, cache: ApiCache):
+    return _call(p, cache, "list_namespaced_pod", label_selector=_participant_label_selector(p))
+
+
+def _job_info_from_pod(p: NamespaceTarget, pod) -> tuple[str, str] | None:
+    pod_name = pod.metadata.name
+    for site_name, site_suffix in p.job_site_suffixes:
+        suffix = f"-{site_suffix}"
+        if pod_name.endswith(suffix):
+            return display_job_id(pod_name[: -len(suffix)] or "-"), site_name
+    return None
+
+
+def fetch_job_pods(p: NamespaceTarget, cache: ApiCache):
+    result = _call(p, cache, "list_namespaced_pod")
+    if isinstance(result, PodFetchError):
+        return result
+    return [pod for pod in result if _job_info_from_pod(p, pod)]
+
+
+def fetch_pvcs(p: Participant, cache: ApiCache):
+    return _filter_participant_pvcs(p, _call(p, cache, "list_namespaced_persistent_volume_claim"))
+
+
+def fetch_services(p: Participant, cache: ApiCache):
+    return _call(p, cache, "list_namespaced_service", label_selector=_participant_label_selector(p))
+
+
+def fetch_events(p: Participant, cache: ApiCache):
+    return _call(p, cache, "list_namespaced_event", field_selector="type=Warning")
+
+
+# ---------------------------------------------------------------------------
+# Pod pruning
+# ---------------------------------------------------------------------------
+def _ensure_aware_utc(ts: datetime | None) -> datetime | None:
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
+def _pod_finished_at(pod) -> datetime | None:
+    finished = []
+    for cs in (pod.status.init_container_statuses or []) + (pod.status.container_statuses or []):
+        terminated = getattr(cs.state, "terminated", None)
+        finished_at = _ensure_aware_utc(getattr(terminated, "finished_at", None))
+        if finished_at is not None:
+            finished.append(finished_at)
+    if finished:
+        return max(finished)
+    return None
+
+
+def pod_prune_age_start(pod) -> datetime | None:
+    if pod.status.phase not in PRUNE_TERMINAL_POD_PHASES:
+        return None
+    return _pod_finished_at(pod) or _ensure_aware_utc(pod.metadata.creation_timestamp)
+
+
+def should_prune_pod(pod, now: datetime) -> bool:
+    if pod.metadata.deletion_timestamp:
+        return False
+    prune_age_start = pod_prune_age_start(pod)
+    if prune_age_start is None:
+        return False
+    return (now - prune_age_start).total_seconds() >= PRUNE_TERMINAL_PODS_AFTER
+
+
+def prune_pods(
+    api: k8s_client.CoreV1Api,
+    cache_drop,
+    *,
+    cluster_name: str,
+    namespace: str,
+    pods,
+) -> tuple[list, PruneStats]:
+    stats = PruneStats.empty()
+    if not pods:
+        return pods or [], stats
+    now = datetime.now(timezone.utc)
+    candidates = [pod for pod in pods if should_prune_pod(pod, now)]
+    if not candidates:
+        return pods, stats
+    deleted_names = set()
+    for pod in candidates:
+        pod_name = pod.metadata.name
+        try:
+            api.delete_namespaced_pod(
+                name=pod_name,
+                namespace=namespace,
+                grace_period_seconds=0,
+                _request_timeout=8,
+            )
+            deleted_names.add(pod_name)
+            stats.deleted.add((cluster_name, namespace, pod_name))
+        except ApiException as e:
+            if e.status == 404:
+                deleted_names.add(pod_name)
+                stats.deleted.add((cluster_name, namespace, pod_name))
+                continue
+            cache_drop()
+            stats.errors.append(f"{cluster_name}/{namespace}/{pod_name}: {e.reason or f'HTTP {e.status}'}")
+        except Exception as e:
+            cache_drop()
+            stats.errors.append(f"{cluster_name}/{namespace}/{pod_name}: {type(e).__name__}: {e}")
+    return [pod for pod in pods if pod.metadata.name not in deleted_names], stats
+
+
+def prune_pod_snapshots(
+    snapshots: list[tuple[Participant, object]],
+    cache: ApiCache,
+) -> tuple[list[tuple[Participant, object]], PruneStats]:
+    stats = PruneStats.empty()
+    filtered = []
+    for p, result in snapshots:
+        if isinstance(result, list):
+            try:
+                api = cache.get(p)
+            except Exception as e:
+                stats.errors.append(f"{p.name}: {type(e).__name__}: {e}")
+                filtered.append((p, result))
+                continue
+            result, prune_stats = prune_pods(
+                api,
+                lambda p=p: cache.drop(p),
+                cluster_name=p.name,
+                namespace=p.namespace,
+                pods=result,
+            )
+            stats.extend(prune_stats)
+        filtered.append((p, result))
+    return filtered, stats
+
+
+# ---------------------------------------------------------------------------
+# Pod → row
+# ---------------------------------------------------------------------------
+def derive_status(pod) -> str:
+    if pod.metadata.deletion_timestamp:
+        return "Terminating"
+    statuses = pod.status.container_statuses or []
+    init_statuses = pod.status.init_container_statuses or []
+    for cs in init_statuses + statuses:
+        waiting = getattr(cs.state, "waiting", None)
+        if waiting and waiting.reason:
+            return waiting.reason
+    for cs in statuses:
+        terminated = getattr(cs.state, "terminated", None)
+        if terminated and terminated.reason and terminated.reason != "Completed":
+            return terminated.reason
+    phase = pod.status.phase or "Unknown"
+    if phase == "Running" and statuses and not all(cs.ready for cs in statuses):
+        return "NotReady"
+    return phase
+
+
+def ready_fraction(pod) -> str:
+    statuses = pod.status.container_statuses or []
+    if not statuses:
+        return "0/0"
+    ready = sum(1 for cs in statuses if cs.ready)
+    return f"{ready}/{len(statuses)}"
+
+
+def restart_count(pod) -> int:
+    statuses = pod.status.container_statuses or []
+    return max((cs.restart_count for cs in statuses), default=0)
+
+
+def age_str(obj) -> str:
+    ts = obj.metadata.creation_timestamp
+    if ts is None:
+        return "-"
+    delta = datetime.now(timezone.utc) - ts
+    return age_str_from_seconds(delta.total_seconds())
+
+
+def age_str_from_seconds(seconds: float) -> str:
+    s = int(seconds)
+    if s < 0:
+        return "0s"
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m"
+    if s < 86400:
+        h, m = divmod(s, 3600)
+        return f"{h}h{m // 60}m" if m // 60 else f"{h}h"
+    d, rem = divmod(s, 86400)
+    return f"{d}d{rem // 3600}h" if rem // 3600 else f"{d}d"
+
+
+def status_text(status: str) -> Text:
+    return Text(status, style=STATUS_COLORS.get(status, ""))
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+def build_pod_table(snapshots: list[tuple[Participant, object]]) -> Table:
+    total_pods = sum(len(r) for _, r in snapshots if isinstance(r, list))
+    table = Table(
+        caption=f"{total_pods} pods",
+        caption_style="dim",
+        expand=True,
+        title="Participant Pods",
+        title_style="bold",
+    )
+    for col, style, width in [
+        ("CLOUD", "cyan", None),
+        ("PARTICIPANT", "cyan", None),
+        ("NS", "cyan", None),
+        ("POD", "white", None),
+        ("READY", None, 6),
+        ("STATUS", None, None),
+        ("RESTARTS", None, 8),
+        ("AGE", None, 6),
+        ("NODE", "dim", None),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=(col != "NODE"))
+
+    for p, result in snapshots:
+        if isinstance(result, PodFetchError):
+            table.add_row(
+                p.cloud,
+                p.name,
+                p.namespace,
+                "—",
+                "—",
+                Text(f"ERROR: {result.msg}", style="red"),
+                "—",
+                "—",
+                "—",
+            )
+            continue
+        if not result:
+            table.add_row(p.cloud, p.name, p.namespace, Text("(no pods)", style="dim"), "", "", "", "", "")
+            continue
+        for pod in sorted(result, key=lambda x: x.metadata.name):
+            table.add_row(
+                p.cloud,
+                p.name,
+                p.namespace,
+                pod.metadata.name,
+                ready_fraction(pod),
+                status_text(derive_status(pod)),
+                str(restart_count(pod)),
+                age_str(pod),
+                pod.spec.node_name or "—",
+            )
+    return table
+
+
+def _pod_accelerator_resources(pod) -> str:
+    if not ACCELERATOR_RESOURCE:
+        return ""
+    values = []
+    for container in pod.spec.containers or []:
+        resources = container.resources
+        if not resources:
+            continue
+        requests = resources.requests or {}
+        limits = resources.limits or {}
+        accelerator = requests.get(ACCELERATOR_RESOURCE) or limits.get(ACCELERATOR_RESOURCE)
+        if accelerator:
+            values.append(str(accelerator))
+    return _ip_join(values)
+
+
+def build_job_pod_table(snapshots: list[tuple[NamespaceTarget, object]]) -> Table:
+    total_pods = sum(len(r) for _, r in snapshots if isinstance(r, list))
+    table = Table(caption=f"{total_pods} pods", caption_style="dim", expand=True, title="Job Pods", title_style="bold")
+    for col, style, width in [
+        ("CLOUD", "cyan", None),
+        ("NS", "cyan", None),
+        ("JOB", "white", None),
+        ("SITE", "cyan", None),
+        ("POD", "white", None),
+        ("ACCEL", None, 6),
+        ("READY", None, 6),
+        ("STATUS", None, None),
+        ("RESTARTS", None, 8),
+        ("AGE", None, 6),
+        ("NODE", "dim", None),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=(col != "NODE"))
+
+    for p, result in snapshots:
+        if isinstance(result, PodFetchError):
+            table.add_row(
+                p.cloud,
+                p.namespace,
+                "—",
+                "—",
+                "—",
+                "—",
+                "—",
+                Text(f"ERROR: {result.msg}", style="red"),
+                "—",
+                "—",
+                "—",
+            )
+            continue
+        if not result:
+            table.add_row(p.cloud, p.namespace, Text("(no job pods)", style="dim"), "", "", "", "", "", "", "", "")
+            continue
+        for pod in sorted(
+            result, key=lambda x: (str(_ensure_aware_utc(x.metadata.creation_timestamp)), x.metadata.name)
+        ):
+            job_id, site_name = _job_info_from_pod(p, pod) or ("-", "-")
+            table.add_row(
+                p.cloud,
+                p.namespace,
+                job_id,
+                site_name,
+                pod.metadata.name,
+                _pod_accelerator_resources(pod),
+                ready_fraction(pod),
+                status_text(derive_status(pod)),
+                str(restart_count(pod)),
+                age_str(pod),
+                pod.spec.node_name or "—",
+            )
+    return table
+
+
+def build_pvc_table(snapshots: list[tuple[Participant, object]]) -> Table:
+    total = sum(len(r) for _, r in snapshots if isinstance(r, list))
+    caption = f"{total} PVCs"
+    table = Table(caption=caption, caption_style="dim", expand=True, title="PersistentVolumeClaims", title_style="bold")
+    for col, style, width in [
+        ("CLOUD", "cyan", None),
+        ("PARTICIPANT", "cyan", None),
+        ("NS", "cyan", None),
+        ("NAME", "white", None),
+        ("STATUS", None, None),
+        ("CAPACITY", None, 10),
+        ("ACCESS", None, 8),
+        ("STORAGECLASS", "dim", None),
+        ("AGE", None, 6),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=True)
+
+    for p, result in snapshots:
+        if isinstance(result, PodFetchError):
+            table.add_row(
+                p.cloud, p.name, p.namespace, "—", Text(f"ERROR: {result.msg}", style="red"), "—", "—", "—", "—"
+            )
+            continue
+        if not result:
+            table.add_row(p.cloud, p.name, p.namespace, Text("(no pvcs)", style="dim"), "", "", "", "", "")
+            continue
+        for pvc in sorted(result, key=lambda x: x.metadata.name):
+            capacity = ""
+            if pvc.status.capacity and "storage" in pvc.status.capacity:
+                capacity = pvc.status.capacity["storage"]
+            elif pvc.spec.resources and pvc.spec.resources.requests:
+                capacity = pvc.spec.resources.requests.get("storage", "")
+            access = ",".join(
+                m.replace("ReadWrite", "RW").replace("ReadOnly", "RO") for m in (pvc.spec.access_modes or [])
+            )
+            table.add_row(
+                p.cloud,
+                p.name,
+                p.namespace,
+                pvc.metadata.name,
+                status_text(pvc.status.phase or "Unknown"),
+                capacity,
+                access,
+                pvc.spec.storage_class_name or "—",
+                age_str(pvc),
+            )
+    return table
+
+
+def _lb_endpoints(svc_snapshots: list[tuple[Participant, object]]) -> list[tuple[str, str, str]]:
+    """(participant, endpoint_str, state) for every type=LoadBalancer service."""
+    out = []
+    for p, result in svc_snapshots:
+        if isinstance(result, PodFetchError) or not result:
+            continue
+        for svc in result:
+            if svc.spec.type != "LoadBalancer":
+                continue
+            ingress = []
+            if svc.status and svc.status.load_balancer:
+                ingress = svc.status.load_balancer.ingress or []
+            port = (svc.spec.ports or [None])[0]
+            port_str = str(port.port) if port else "?"
+            if ingress:
+                ep = ingress[0].ip or ingress[0].hostname or "?"
+                out.append((p.name, f"{ep}:{port_str}", "ready"))
+            else:
+                out.append((p.name, f":{port_str}", "pending"))
+    return out
+
+
+def build_summary(
+    pod_snaps: list[tuple[Participant, object]],
+    pvc_snaps: list[tuple[Participant, object]],
+    svc_snaps: list[tuple[Participant, object]],
+    config_path: Path,
+    interval: float,
+    job_pod_snaps: list[tuple[Participant, object]] | None = None,
+) -> Text:
+    pod_counts: Counter = Counter()
+    pod_errors = 0
+    for _, r in pod_snaps:
+        if isinstance(r, PodFetchError):
+            pod_errors += 1
+            continue
+        for pod in r or []:
+            pod_counts[derive_status(pod)] += 1
+
+    pvc_counts: Counter = Counter()
+    for _, r in pvc_snaps:
+        if isinstance(r, list):
+            for pvc in r:
+                pvc_counts[pvc.status.phase or "Unknown"] += 1
+
+    def _fmt(counts: Counter) -> str:
+        if not counts:
+            return "0"
+        total = sum(counts.values())
+        parts = [str(total)]
+        for k, v in counts.most_common():
+            color = STATUS_COLORS.get(k, "")
+            seg = f"{v} {k}"
+            parts.append(f"[{color}]{seg}[/{color}]" if color else seg)
+        return f"{parts[0]} ({', '.join(parts[1:])})"
+
+    ts = datetime.now().strftime("%H:%M:%S")
+    lines = [
+        f"[bold]k8sview[/] · {config_path.name} · {ts} · refresh={interval}s · Ctrl-C to quit",
+        f"Pods: {_fmt(pod_counts)}" + (f"  [red]{pod_errors} fetch errors[/]" if pod_errors else ""),
+        f"PVCs: {_fmt(pvc_counts)}",
+    ]
+    if job_pod_snaps is not None:
+        job_counts: Counter = Counter()
+        job_errors = 0
+        for _, r in job_pod_snaps:
+            if isinstance(r, PodFetchError):
+                job_errors += 1
+                continue
+            for pod in r or []:
+                job_counts[derive_status(pod)] += 1
+        lines.append(f"Job pods: {_fmt(job_counts)}" + (f"  [red]{job_errors} fetch errors[/]" if job_errors else ""))
+    eps = _lb_endpoints(svc_snaps)
+    if eps:
+        for name, ep, state in eps:
+            tag = "[green]ready[/]" if state == "ready" else "[yellow]pending[/]"
+            lines.append(f"LB {name}: {ep} ({tag})")
+    return Text.from_markup("\n".join(lines))
+
+
+def build_events_table(event_snaps: list[tuple[Participant, object]], window_s: float, limit: int = 20) -> Table:
+    now = datetime.now(timezone.utc)
+    rows: list[tuple[float, Participant, object]] = []
+    for p, result in event_snaps:
+        if isinstance(result, PodFetchError) or not result:
+            continue
+        for ev in result:
+            ts = ev.last_timestamp or ev.event_time or ev.metadata.creation_timestamp
+            if ts is None:
+                continue
+            age = (now - ts).total_seconds()
+            if age > window_s:
+                continue
+            rows.append((age, p, ev))
+    rows.sort(key=lambda t: t[0])
+    rows = rows[:limit]
+
+    title = f"Warnings (last {int(window_s)}s, showing {len(rows)})"
+    table = Table(title=title, title_style="bold yellow", expand=True, show_lines=False)
+    for col, style, width in [
+        ("AGE", None, 6),
+        ("CLOUD", "cyan", None),
+        ("PARTICIPANT", "cyan", None),
+        ("NS", "cyan", None),
+        ("OBJECT", "white", None),
+        ("REASON", None, None),
+        ("COUNT", None, 5),
+        ("MESSAGE", "dim", None),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=(col != "MESSAGE"))
+    if not rows:
+        table.add_row("—", "—", "—", "—", "—", Text("(no recent warnings)", style="dim green"), "—", "—")
+        return table
+    for age, p, ev in rows:
+        obj = f"{ev.involved_object.kind}/{ev.involved_object.name}"
+        age_s = int(age)
+        age_str_ev = f"{age_s}s" if age_s < 60 else f"{age_s // 60}m"
+        msg = (ev.message or "").replace("\n", " ")
+        table.add_row(
+            age_str_ev,
+            p.cloud,
+            p.name,
+            p.namespace,
+            obj,
+            Text(ev.reason or "", style="yellow"),
+            str(ev.count or 1),
+            msg,
+        )
+    return table
+
+
+def gather(participants: list[Participant], cache: ApiCache, fetch_fn) -> list[tuple[Participant, object]]:
+    with ThreadPoolExecutor(max_workers=max(1, len(participants))) as ex:
+        futures = {ex.submit(fetch_fn, p, cache): p for p in participants}
+        by_name: dict[str, object] = {}
+        for fut in as_completed(futures):
+            p = futures[fut]
+            try:
+                by_name[p.name] = fut.result()
+            except Exception as e:
+                by_name[p.name] = PodFetchError(f"{type(e).__name__}: {e}")
+    return [(p, by_name[p.name]) for p in participants]
+
+
+# ---------------------------------------------------------------------------
+# All-cloud discovery view
+# ---------------------------------------------------------------------------
+def is_nvflare_namespace(namespace: str) -> bool:
+    return namespace == NVFLARE_NAMESPACE_PREFIX or namespace.startswith(f"{NVFLARE_NAMESPACE_PREFIX}-")
+
+
+def namespace_system_role(namespace: str) -> tuple[str, str]:
+    if namespace == "nvflare-server":
+        return "nvflare", "server"
+    if re.fullmatch(r"nvflare-client-\d+", namespace):
+        return "nvflare", "client"
+    m = re.fullmatch(r"nvflare-(?P<system>.+)-server", namespace)
+    if m:
+        return m.group("system"), "server"
+    m = re.fullmatch(r"nvflare-(?P<system>.+)-client-\d+", namespace)
+    if m:
+        return m.group("system"), "client"
+    if namespace.endswith("-server"):
+        return namespace.removeprefix("nvflare-").removesuffix("-server"), "server"
+    if "-client-" in namespace or namespace.endswith("-client"):
+        return namespace.removeprefix("nvflare-").split("-client", 1)[0] or "nvflare", "client"
+    return namespace.removeprefix("nvflare-") or "nvflare", "unknown"
+
+
+def is_job_pod(pod) -> bool:
+    if pod.metadata.name.startswith("kit-copy-"):
+        return False
+    return pod.spec.restart_policy == "Never"
+
+
+def _cluster_call(cluster: Cluster, cache: ApiCache, fn):
+    try:
+        api = cache.get_cluster(cluster)
+        return fn(api)
+    except ApiException as e:
+        cache.drop_cluster(cluster)
+        return PodFetchError(e.reason or f"HTTP {e.status}")
+    except ConfigException as e:
+        cache.drop_cluster(cluster)
+        return PodFetchError(f"config: {e}")
+    except Exception as e:
+        cache.drop_cluster(cluster)
+        return PodFetchError(f"{type(e).__name__}: {e}")
+
+
+def fetch_cluster_snapshot(cluster: Cluster, cache: ApiCache) -> tuple[ClusterSnapshot, PruneStats]:
+    def _fetch(api):
+        pods = api.list_pod_for_all_namespaces(_request_timeout=8).items
+        pvcs = api.list_persistent_volume_claim_for_all_namespaces(_request_timeout=8).items
+        services = api.list_service_for_all_namespaces(_request_timeout=8).items
+        try:
+            nodes = api.list_node(_request_timeout=8).items
+            node_error = None
+        except ApiException as e:
+            nodes = []
+            node_error = e.reason or f"HTTP {e.status}"
+        except Exception as e:
+            nodes = []
+            node_error = f"{type(e).__name__}: {e}"
+        return pods, pvcs, services, nodes, node_error
+
+    result = _cluster_call(cluster, cache, _fetch)
+    if isinstance(result, PodFetchError):
+        return ClusterSnapshot(cluster=cluster, namespaces=[], error=result.msg), PruneStats.empty()
+
+    pods, pvcs, services, nodes, node_error = result
+    namespaces = sorted(
+        {
+            item.metadata.namespace
+            for items in (pods, pvcs, services)
+            for item in items
+            if item.metadata.namespace and is_nvflare_namespace(item.metadata.namespace)
+        }
+    )
+    try:
+        api = cache.get_cluster(cluster)
+    except Exception as e:
+        return (
+            ClusterSnapshot(cluster=cluster, namespaces=[], error=f"{type(e).__name__}: {e}"),
+            PruneStats.empty(),
+        )
+
+    prune_stats = PruneStats.empty()
+    resources = []
+    for namespace in namespaces:
+        ns_pods = [pod for pod in pods if pod.metadata.namespace == namespace]
+        ns_pods, stats = prune_pods(
+            api,
+            lambda cluster=cluster: cache.drop_cluster(cluster),
+            cluster_name=cluster.name,
+            namespace=namespace,
+            pods=ns_pods,
+        )
+        prune_stats.extend(stats)
+        resources.append(
+            NamespaceResources(
+                cluster=cluster,
+                namespace=namespace,
+                pods=ns_pods,
+                pvcs=[pvc for pvc in pvcs if pvc.metadata.namespace == namespace],
+                services=[svc for svc in services if svc.metadata.namespace == namespace],
+            )
+        )
+    deleted = prune_stats.deleted
+    all_pods = [pod for pod in pods if (cluster.name, pod.metadata.namespace, pod.metadata.name) not in deleted]
+    return (
+        ClusterSnapshot(cluster=cluster, namespaces=resources, nodes=nodes, all_pods=all_pods, node_error=node_error),
+        prune_stats,
+    )
+
+
+def gather_cluster_snapshots(clusters: list[Cluster], cache: ApiCache) -> tuple[list[ClusterSnapshot], PruneStats]:
+    stats = PruneStats.empty()
+    with ThreadPoolExecutor(max_workers=max(1, len(clusters))) as ex:
+        futures = {ex.submit(fetch_cluster_snapshot, cluster, cache): cluster for cluster in clusters}
+        by_name: dict[str, ClusterSnapshot] = {}
+        for fut in as_completed(futures):
+            cluster = futures[fut]
+            try:
+                snapshot, prune_stats = fut.result()
+                by_name[cluster.name] = snapshot
+                stats.extend(prune_stats)
+            except Exception as e:
+                by_name[cluster.name] = ClusterSnapshot(
+                    cluster=cluster,
+                    namespaces=[],
+                    error=f"{type(e).__name__}: {e}",
+                )
+    return [by_name[cluster.name] for cluster in clusters], stats
+
+
+def _site_name(ns: NamespaceResources, site_pods: list) -> str:
+    for svc in sorted(ns.services, key=lambda s: s.metadata.name):
+        labels = svc.metadata.labels or {}
+        name = labels.get("app.kubernetes.io/name") or labels.get("app.kubernetes.io/instance")
+        if name:
+            return name
+    for pod in sorted(site_pods, key=lambda p: p.metadata.name):
+        labels = pod.metadata.labels or {}
+        name = labels.get("app.kubernetes.io/name") or labels.get("app.kubernetes.io/instance")
+        if name:
+            return name
+    return ns.namespace
+
+
+def _ip_join(values: list[str], none: str = "-") -> str:
+    compact = [v for v in values if v and v != "None"]
+    if not compact:
+        return none
+    return ", ".join(sorted(dict.fromkeys(compact)))
+
+
+def _service_cluster_ips(services: list) -> list[str]:
+    return [svc.spec.cluster_ip for svc in services if svc.spec.cluster_ip and svc.spec.cluster_ip != "None"]
+
+
+def _service_external_ips(services: list) -> list[str]:
+    out = []
+    for svc in services:
+        if svc.spec.type != "LoadBalancer":
+            continue
+        if svc.spec.load_balancer_ip:
+            out.append(svc.spec.load_balancer_ip)
+        ingress = []
+        if svc.status and svc.status.load_balancer:
+            ingress = svc.status.load_balancer.ingress or []
+        for item in ingress:
+            endpoint = item.ip or item.hostname
+            if endpoint:
+                out.append(endpoint)
+    return out
+
+
+def _pvc_capacity(pvc) -> str:
+    if pvc.status.capacity and "storage" in pvc.status.capacity:
+        return pvc.status.capacity["storage"]
+    if pvc.spec.resources and pvc.spec.resources.requests:
+        return pvc.spec.resources.requests.get("storage", "")
+    return ""
+
+
+def _pvc_summary(pvcs: list) -> tuple[str, int, int]:
+    if not pvcs:
+        return "-", 0, 0
+    bound = sum(1 for pvc in pvcs if pvc.status.phase == "Bound")
+    parts = []
+    for pvc in sorted(pvcs, key=lambda p: p.metadata.name):
+        capacity = _pvc_capacity(pvc)
+        status = "" if pvc.status.phase == "Bound" else f" {pvc.status.phase or 'Unknown'}"
+        suffix = f" {capacity}" if capacity else ""
+        parts.append(f"{pvc.metadata.name}{status}{suffix}")
+    return f"{bound}/{len(pvcs)} Bound: {', '.join(parts)}", bound, len(pvcs)
+
+
+def _status_summary(pods: list) -> tuple[str, int, int]:
+    if not pods:
+        return "-", 0, 0
+    counts = Counter(derive_status(pod) for pod in pods)
+    running = counts.get("Running", 0)
+    parts = [f"{count} {status}" for status, count in counts.most_common()]
+    return ", ".join(parts), running, len(pods)
+
+
+def _oldest_age(objs: list) -> str:
+    timestamps = [_ensure_aware_utc(obj.metadata.creation_timestamp) for obj in objs if obj.metadata.creation_timestamp]
+    if not timestamps:
+        return "-"
+    return age_str_from_seconds((datetime.now(timezone.utc) - min(timestamps)).total_seconds())
+
+
+def node_is_ready(node) -> bool:
+    for condition in node.status.conditions or []:
+        if condition.type == "Ready":
+            return condition.status == "True"
+    return False
+
+
+def pod_is_running(pod) -> bool:
+    return pod.status.phase == "Running" and not pod.metadata.deletion_timestamp
+
+
+def cluster_infra_counts(snapshot: ClusterSnapshot) -> dict[str, int]:
+    nodes = snapshot.nodes or []
+    pods = snapshot.all_pods or []
+    return {
+        "nodes_ready": sum(1 for node in nodes if node_is_ready(node)),
+        "nodes_total": len(nodes),
+        "pods_running": sum(1 for pod in pods if pod_is_running(pod)),
+        "pods_total": len(pods),
+    }
+
+
+def cluster_nvflare_pod_counts(snapshot: ClusterSnapshot) -> dict[str, int]:
+    pods = [pod for ns in snapshot.namespaces for pod in ns.pods]
+    return {
+        "running": sum(1 for pod in pods if pod_is_running(pod)),
+        "total": len(pods),
+    }
+
+
+def build_site_rows(snapshots: list[ClusterSnapshot]) -> list[SiteRow]:
+    rows = []
+    for snapshot in snapshots:
+        for ns in snapshot.namespaces:
+            system, role = namespace_system_role(ns.namespace)
+            job_pods = [pod for pod in ns.pods if is_job_pod(pod)]
+            site_pods = [pod for pod in ns.pods if not is_job_pod(pod)]
+            site_pod_summary, site_pods_running, site_pods_total = _status_summary(site_pods)
+            pvc_summary, pvc_bound, pvc_total = _pvc_summary(ns.pvcs)
+            rows.append(
+                SiteRow(
+                    system=system,
+                    cloud=ns.cluster.cloud,
+                    role=role,
+                    site=_site_name(ns, site_pods),
+                    namespace=ns.namespace,
+                    site_pod=site_pod_summary,
+                    site_pods_running=site_pods_running,
+                    site_pods_total=site_pods_total,
+                    pod_ips=[pod.status.pod_ip for pod in site_pods if pod.status.pod_ip],
+                    service_ips=_service_cluster_ips(ns.services),
+                    external_ips=_service_external_ips(ns.services),
+                    pvc_summary=pvc_summary,
+                    pvc_bound=pvc_bound,
+                    pvc_total=pvc_total,
+                    job_pods_running=sum(1 for pod in job_pods if pod.status.phase == "Running"),
+                    job_pods_total=len(job_pods),
+                    age=_oldest_age(ns.pods + ns.pvcs + ns.services),
+                )
+            )
+    return sorted(rows, key=lambda r: (r.system, r.role != "server", r.cloud, r.namespace))
+
+
+def build_all_cloud_summary(
+    snapshots: list[ClusterSnapshot],
+    rows: list[SiteRow],
+    prune_stats: PruneStats,
+    kubeconfig_dir: Path,
+    interval: float,
+) -> Text:
+    ts = datetime.now().strftime("%H:%M:%S")
+    cluster_errors = [s for s in snapshots if s.error]
+    systems = len({row.system for row in rows})
+    clients = sum(1 for row in rows if row.role == "client")
+    servers = sum(1 for row in rows if row.role == "server")
+    job_running = sum(row.job_pods_running for row in rows)
+    job_total = sum(row.job_pods_total for row in rows)
+    reachable_clusters = sum(1 for snapshot in snapshots if not snapshot.error)
+    nodes_ready = sum(cluster_infra_counts(snapshot)["nodes_ready"] for snapshot in snapshots)
+    nodes_total = sum(cluster_infra_counts(snapshot)["nodes_total"] for snapshot in snapshots)
+    pods_running = sum(cluster_infra_counts(snapshot)["pods_running"] for snapshot in snapshots)
+    pods_total = sum(cluster_infra_counts(snapshot)["pods_total"] for snapshot in snapshots)
+    lines = [
+        f"[bold]k8sview[/] · all-cloud · {ts} · refresh={interval}s · Ctrl-C to quit",
+        f"Kubeconfigs: {kubeconfig_dir}",
+        f"Clusters: {reachable_clusters}/{len(snapshots)} reachable · nodes={nodes_ready}/{nodes_total} Ready "
+        f"· all pods={pods_running}/{pods_total} Running",
+        f"Systems: {systems} · servers={servers} · clients={clients} · job pods={job_running}/{job_total} Running",
+    ]
+    if not snapshots:
+        if kubeconfig_dir.exists():
+            lines.append("[yellow]No kubeconfig YAML files found. Run a cloud create script or pass --config.[/]")
+        else:
+            lines.append(
+                "[yellow]Kubeconfig directory does not exist yet. Run a cloud create script or pass --config.[/]"
+            )
+    if prune_stats.deleted:
+        lines.append(f"Pruned terminal pods: [green]{len(prune_stats.deleted)}[/]")
+    if cluster_errors or prune_stats.errors:
+        lines.append(f"[red]Errors: {len(cluster_errors) + len(prune_stats.errors)}[/]")
+    return Text.from_markup("\n".join(lines))
+
+
+def build_systems_table(rows: list[SiteRow], snapshots: list[ClusterSnapshot]) -> Table:
+    table = Table(title="Systems", title_style="bold", expand=True)
+    for col, style, width in [
+        ("SYSTEM", "cyan", None),
+        ("SERVER", None, 8),
+        ("CLIENTS", None, 8),
+        ("CLOUDS", None, None),
+        ("EXTERNAL", None, None),
+        ("SITE PODS", None, 10),
+        ("JOB PODS", None, 9),
+        ("PVC", None, 8),
+        ("NS", None, 4),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=(col not in {"CLOUDS", "EXTERNAL"}))
+
+    systems = sorted({row.system for row in rows})
+    if not systems:
+        errors = [s for s in snapshots if s.error]
+        if errors:
+            for snapshot in errors:
+                table.add_row(
+                    snapshot.cluster.name,
+                    "-",
+                    "-",
+                    snapshot.cluster.cloud,
+                    Text(f"ERROR: {snapshot.error}", style="red"),
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                )
+        else:
+            table.add_row("-", "-", "-", "-", Text("(no NVFlare namespaces found)", style="dim"), "-", "-", "-", "-")
+        return table
+
+    for system in systems:
+        sys_rows = [row for row in rows if row.system == system]
+        servers = [row for row in sys_rows if row.role == "server"]
+        clients = [row for row in sys_rows if row.role == "client"]
+        site_running = sum(row.site_pods_running for row in sys_rows)
+        site_total = sum(row.site_pods_total for row in sys_rows)
+        job_running = sum(row.job_pods_running for row in sys_rows)
+        job_total = sum(row.job_pods_total for row in sys_rows)
+        pvc_bound = sum(row.pvc_bound for row in sys_rows)
+        pvc_total = sum(row.pvc_total for row in sys_rows)
+        external = _ip_join([ip for row in servers for ip in row.external_ips])
+        table.add_row(
+            system,
+            str(len(servers)),
+            str(len(clients)),
+            ", ".join(sorted({row.cloud for row in sys_rows})),
+            external,
+            f"{site_running}/{site_total}",
+            f"{job_running}/{job_total}",
+            f"{pvc_bound}/{pvc_total}",
+            str(len(sys_rows)),
+        )
+    return table
+
+
+def build_clusters_table(snapshots: list[ClusterSnapshot]) -> Table:
+    table = Table(title="Clusters", title_style="bold", expand=True)
+    for col, style, width in [
+        ("CLOUD", "cyan", None),
+        ("STATUS", None, 10),
+        ("NODES", None, 9),
+        ("ALL PODS", None, 10),
+        ("NVFLARE NS", None, 10),
+        ("NVFLARE PODS", None, 12),
+        ("ERROR", "red", None),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=(col != "ERROR"))
+
+    if not snapshots:
+        table.add_row("-", Text("EMPTY", style="yellow"), "-", "-", "-", "-", "no kubeconfig YAML files")
+        return table
+
+    for snapshot in snapshots:
+        counts = cluster_infra_counts(snapshot)
+        nvflare_counts = cluster_nvflare_pod_counts(snapshot)
+        if snapshot.error:
+            status = Text("ERROR", style="red")
+            error = snapshot.error
+        elif snapshot.node_error:
+            status = Text("PARTIAL", style="yellow")
+            error = f"nodes: {snapshot.node_error}"
+        else:
+            status = Text("OK", style="green")
+            error = "-"
+        table.add_row(
+            snapshot.cluster.cloud,
+            status,
+            f"{counts['nodes_ready']}/{counts['nodes_total']}",
+            f"{counts['pods_running']}/{counts['pods_total']}",
+            str(len(snapshot.namespaces)),
+            f"{nvflare_counts['running']}/{nvflare_counts['total']}",
+            error,
+        )
+    return table
+
+
+def build_sites_table(rows: list[SiteRow]) -> Table:
+    table = Table(title="Sites", title_style="bold", expand=True)
+    for col, style, width in [
+        ("SYSTEM", "cyan", None),
+        ("ROLE", None, 7),
+        ("CLOUD", "cyan", None),
+        ("SITE", "white", None),
+        ("NAMESPACE", "cyan", None),
+        ("POD IP", None, None),
+        ("SERVICE IP", None, None),
+        ("EXTERNAL", None, None),
+        ("SITE PODS", None, 12),
+        ("JOB PODS", None, 9),
+        ("PVC", None, None),
+        ("AGE", None, 6),
+    ]:
+        table.add_column(col, style=style, width=width, no_wrap=True)
+    if not rows:
+        table.add_row("-", "-", "-", "-", "-", "-", "-", "-", "-", "-", Text("(none)", style="dim"), "-")
+        return table
+    for row in rows:
+        role = Text(row.role, style="bold green" if row.role == "server" else "")
+        table.add_row(
+            row.system,
+            role,
+            row.cloud,
+            row.site,
+            row.namespace,
+            _ip_join(row.pod_ips),
+            _ip_join(row.service_ips),
+            _ip_join(row.external_ips),
+            row.site_pod,
+            f"{row.job_pods_running}/{row.job_pods_total}",
+            row.pvc_summary,
+            row.age,
+        )
+    return table
+
+
+def build_errors_table(snapshots: list[ClusterSnapshot], prune_stats: PruneStats) -> Table | None:
+    rows = []
+    for snapshot in snapshots:
+        if snapshot.error:
+            rows.append((snapshot.cluster.name, snapshot.error))
+        if snapshot.node_error:
+            rows.append((f"{snapshot.cluster.name}/nodes", snapshot.node_error))
+    for error in prune_stats.errors:
+        rows.append(("prune", error))
+    if not rows:
+        return None
+    table = Table(title="Errors", title_style="bold red", expand=True)
+    table.add_column("SOURCE", style="cyan", no_wrap=True)
+    table.add_column("MESSAGE", style="red")
+    for source, message in rows[:12]:
+        table.add_row(source, message)
+    return table
+
+
+def build_all_cloud_view(
+    snapshots: list[ClusterSnapshot],
+    prune_stats: PruneStats,
+    kubeconfig_dir: Path,
+    interval: float,
+    rows: list[SiteRow] | None = None,
+) -> Group:
+    if rows is None:
+        rows = build_site_rows(snapshots)
+    parts = [
+        build_all_cloud_summary(snapshots, rows, prune_stats, kubeconfig_dir, interval),
+        build_systems_table(rows, snapshots),
+        build_sites_table(rows),
+    ]
+    parts.append(build_clusters_table(snapshots))
+    errors = build_errors_table(snapshots, prune_stats)
+    if errors is not None:
+        parts.append(errors)
+    return Group(*parts)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="Live multicloud dashboard.")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to deploy config YAML. When omitted, discover all NVFlare namespaces in examples/devops/.tmp/kubeconfigs.",
+    )
+    parser.add_argument(
+        "--kubeconfig-dir",
+        default=str(DEFAULT_KUBECONFIG_DIR),
+        help="Directory of kubeconfig YAML files for the all-cloud view",
+    )
+    parser.add_argument("--interval", type=float, default=2.0, help="Refresh interval in seconds")
+    parser.add_argument("--events-window", type=float, default=300.0, help="Show Warning events newer than N seconds")
+    parser.add_argument("--once", action="store_true", help="Render one snapshot and exit")
+    args = parser.parse_args()
+
+    cache = ApiCache()
+    console = Console()
+    console.clear()
+
+    if args.config:
+        config_path = Path(args.config).resolve()
+        participants = load_participants(config_path)
+        namespace_targets = unique_namespace_targets(participants)
+
+        def _focused_view() -> Group:
+            pod_snap = gather(participants, cache, fetch_pods)
+            pod_snap, _ = prune_pod_snapshots(pod_snap, cache)
+            job_pod_snap = gather(namespace_targets, cache, fetch_job_pods)
+            job_pod_snap, _ = prune_pod_snapshots(job_pod_snap, cache)
+            pvc_snap = gather(participants, cache, fetch_pvcs)
+            svc_snap = gather(participants, cache, fetch_services)
+            evt_snap = gather(participants, cache, fetch_events)
+            return Group(
+                build_summary(
+                    pod_snap,
+                    pvc_snap,
+                    svc_snap,
+                    config_path,
+                    args.interval,
+                    job_pod_snaps=job_pod_snap,
+                ),
+                build_pod_table(pod_snap),
+                build_job_pod_table(job_pod_snap),
+                build_pvc_table(pvc_snap),
+                build_events_table(evt_snap, args.events_window),
+            )
+
+        if args.once:
+            console.print(_focused_view())
+            return
+
+        with Live(console=console, refresh_per_second=4, screen=False) as live:
+            try:
+                while True:
+                    live.update(_focused_view())
+                    time.sleep(args.interval)
+            except KeyboardInterrupt:
+                pass
+        return
+
+    kubeconfig_dir = Path(args.kubeconfig_dir).resolve()
+    clusters = load_clusters(kubeconfig_dir)
+    if args.once:
+        snapshots, prune_stats = gather_cluster_snapshots(clusters, cache)
+        rows = build_site_rows(snapshots)
+        console.print(build_all_cloud_view(snapshots, prune_stats, kubeconfig_dir, args.interval, rows))
+        return
+
+    with Live(console=console, refresh_per_second=4, screen=False) as live:
+        try:
+            while True:
+                snapshots, prune_stats = gather_cluster_snapshots(clusters, cache)
+                rows = build_site_rows(snapshots)
+                live.update(build_all_cloud_view(snapshots, prune_stats, kubeconfig_dir, args.interval, rows))
+                time.sleep(args.interval)
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/devops/multicloud/monitoring-stack.yaml
+++ b/examples/devops/multicloud/monitoring-stack.yaml
@@ -1,0 +1,195 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvflare-monitoring
+  labels:
+    app.kubernetes.io/name: nvflare-monitoring
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statsd-exporter
+  namespace: nvflare-monitoring
+  labels:
+    app: statsd-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: statsd-exporter
+  template:
+    metadata:
+      labels:
+        app: statsd-exporter
+    spec:
+      containers:
+        - name: statsd-exporter
+          image: prom/statsd-exporter:v0.29.0
+          args:
+            - --statsd.listen-udp=:9125
+            - --statsd.listen-tcp=:9125
+            - --web.listen-address=:9102
+          ports:
+            - {name: statsd-udp, containerPort: 9125, protocol: UDP}
+            - {name: statsd-tcp, containerPort: 9125, protocol: TCP}
+            - {name: metrics, containerPort: 9102, protocol: TCP}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 3
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: statsd-exporter
+  namespace: nvflare-monitoring
+  labels:
+    app: statsd-exporter
+spec:
+  type: ClusterIP
+  selector:
+    app: statsd-exporter
+  ports:
+    - {name: statsd-udp, port: 9125, protocol: UDP, targetPort: statsd-udp}
+    - {name: statsd-tcp, port: 9125, protocol: TCP, targetPort: statsd-tcp}
+    - {name: metrics, port: 9102, protocol: TCP, targetPort: metrics}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: nvflare-monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: statsd
+        static_configs:
+          - targets: ["statsd-exporter:9102"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: nvflare-monitoring
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v3.10.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+          ports:
+            - {name: http, containerPort: 9090}
+          volumeMounts:
+            - {name: config, mountPath: /etc/prometheus}
+            - {name: data, mountPath: /prometheus}
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: nvflare-monitoring
+  labels:
+    app: prometheus
+spec:
+  type: ClusterIP
+  selector:
+    app: prometheus
+  ports:
+    - {name: http, port: 9090, targetPort: http}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: nvflare-monitoring
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: nvflare-monitoring
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:12.4.1
+          ports:
+            - {name: http, containerPort: 3000}
+          env:
+            - {name: GF_SECURITY_ADMIN_USER, value: admin}
+            - {name: GF_USERS_ALLOW_SIGN_UP, value: "false"}
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: nvflare-monitoring
+  labels:
+    app: grafana
+spec:
+  type: ClusterIP
+  selector:
+    app: grafana
+  ports:
+    - {name: http, port: 3000, targetPort: http}

--- a/examples/devops/multicloud/project.yml
+++ b/examples/devops/multicloud/project.yml
@@ -1,0 +1,36 @@
+api_version: 3
+name: nvflare_multicloud
+description: NVFlare multicloud end-to-end test project
+
+participants:
+  - name: gcp-server
+    type: server
+    org: example_org
+    default_host: __SERVER_IP__
+    fed_learn_port: 8002
+    admin_port: 8003
+  - name: gcp-client-1
+    type: client
+    org: example_org
+  - name: aws-client-2
+    type: client
+    org: example_org
+  - name: azure-client-3
+    type: client
+    org: example_org
+  - name: admin@example.com
+    type: admin
+    org: example_org
+    role: project_admin
+
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+    args:
+      template_file:
+        - master_template.yml
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      config_folder: config
+      scheme: tcp
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/examples/devops/multicloud/setting-up-dev-cluster.md
+++ b/examples/devops/multicloud/setting-up-dev-cluster.md
@@ -1,0 +1,212 @@
+# Setting Up A Multicloud Dev Cluster
+
+Use this file when creating an NVFlare multicloud dev cluster from the
+repository root. Keep private project, cluster, account, and registry values
+out of checked-in files. Use a generated config under `examples/devops/.tmp/` for local
+edits.
+
+These steps are for testing only. They are not production deployment guidance.
+
+## Inputs To Confirm
+
+- The target config shape is `examples/devops/multicloud/all-clouds.yaml`.
+- The default topology is GCP server plus GCP, AWS, and Azure clients.
+- The project YAML controls FLARE participants; the deploy YAML maps those
+  participant names to clouds and namespaces.
+- Real image tags are required for `clouds.<cloud>.prepare.parent.docker_image`.
+- Kubeconfig discovery uses active cloud CLI contexts plus env overrides, not
+  local YAML override files.
+
+## Create A Temporary Config
+
+```bash
+RUN_ID=$(date +%Y%m%d-%H%M%S)
+CONFIG=examples/devops/.tmp/multicloud/${RUN_ID}/all-clouds.yaml
+mkdir -p "$(dirname "$CONFIG")"
+cp examples/devops/multicloud/all-clouds.yaml "$CONFIG"
+cp examples/devops/multicloud/project.yml "$(dirname "$CONFIG")/project.yml"
+```
+
+Edit `$CONFIG`:
+
+- Set top-level `name` to a unique value, for example `all-clouds-${RUN_ID}`.
+- Add `project_file: project.yml`.
+- Set each participant `name` in both `$CONFIG` and the copied project YAML to
+  a unique value if multiple dev clusters may coexist.
+- Set each participant `namespace` to a unique value if multiple dev clusters
+  may coexist.
+- Replace all placeholder `clouds.<cloud>.prepare.parent.docker_image` values
+  with real registry tags.
+- Do not add project names, cluster names, subscription IDs, or account IDs to
+  the YAML.
+- Do not add kubeconfig paths to the YAML; deploy reads
+  `examples/devops/.tmp/kubeconfigs/<cloud>.yaml`.
+
+Optional: enable FLARE system monitoring in the temporary config:
+
+```yaml
+monitoring:
+  enabled: true
+```
+
+If monitoring is enabled, use a runtime image that includes `datadog`, for
+example an image built with `.[K8S,MONITORING]`.
+
+To select clouds, edit `participants:` in both `$CONFIG` and the copied project
+YAML. The config must have exactly one server. For a GCP-only smoke setup:
+
+```yaml
+participants:
+  - { name: gcp-server,   cloud: gcp, namespace: nvflare-server,   role: server }
+  - { name: gcp-client-1, cloud: gcp, namespace: nvflare-client-1, role: client }
+```
+
+For a two-cloud setup with a GCP server and AWS client:
+
+```yaml
+participants:
+  - { name: gcp-server,   cloud: gcp, namespace: nvflare-server,   role: server }
+  - { name: aws-client-2, cloud: aws, namespace: nvflare-client-2, role: client }
+```
+
+If all clouds can pull the same image, use a YAML anchor so the tag is edited in
+one place:
+
+```yaml
+x-dev-image: &dev_image registry.example.com/nvflare/nvflare:dev
+
+clouds:
+  gcp:
+    prepare:
+      parent:
+        docker_image: *dev_image
+```
+
+Repeat `docker_image: *dev_image` for the other clouds. YAML resolves the
+anchor before the deploy scripts read the config.
+
+## Preflight
+
+Confirm the deployer has access before starting:
+
+```bash
+gcloud auth print-access-token >/dev/null
+aws sts get-caller-identity
+az account show
+kubectl --kubeconfig examples/devops/.tmp/kubeconfigs/gcp.yaml auth can-i create namespaces
+helm version
+```
+
+For AWS, also confirm the configured region:
+
+```bash
+aws configure get region
+```
+
+## Build And Push The Image
+
+```bash
+python examples/devops/multicloud/build_and_push.py --config "$CONFIG"
+```
+
+This reads the image tags from `$CONFIG`, authenticates to recognized
+registries, builds `docker/Dockerfile` once from the NVFlare repository root,
+tags the same image for every used cloud, and pushes all tags.
+
+If monitoring is enabled and the config points to images that still need to be
+built, pass a Dockerfile that installs `.[K8S,MONITORING]`:
+
+```bash
+python examples/devops/multicloud/build_and_push.py --config "$CONFIG" --dockerfile /path/to/Dockerfile.monitoring
+```
+
+Use dry-run first when changing the config:
+
+```bash
+python examples/devops/multicloud/build_and_push.py --config "$CONFIG" --dry-run
+```
+
+## Fetch Kubeconfigs
+
+Use env vars only when CLI discovery is ambiguous:
+
+```bash
+# Optional examples:
+# export GCP_CLUSTER=<cluster>
+# export GCP_LOCATION=<location>
+# export AWS_CLUSTER=<cluster>
+# export AWS_REGION=<region>
+# export AZURE_CLUSTER=<cluster>
+# export AZURE_RESOURCE_GROUP=<resource-group>
+
+python examples/devops/multicloud/fetch_kubeconfigs.py --config "$CONFIG"
+```
+
+The script writes `examples/devops/.tmp/kubeconfigs/gcp.yaml`,
+`examples/devops/.tmp/kubeconfigs/aws.yaml`, and
+`examples/devops/.tmp/kubeconfigs/azure.yaml`.
+
+Preview discovery commands:
+
+```bash
+python examples/devops/multicloud/fetch_kubeconfigs.py --config "$CONFIG" --dry-run
+```
+
+## Deploy
+
+```bash
+python examples/devops/multicloud/deploy.py --config "$CONFIG" up
+```
+
+Expected behavior:
+
+- `up` provisions fresh.
+- `nvflare deploy prepare` creates each runtime kit.
+- Startup/local kit files are staged into the workspace PVC.
+- The server is deployed first.
+- Clients are deployed in parallel.
+- The deterministic cloud IP name comes from the config `name`.
+- One namespace and Helm release are created per participant.
+- Job pods are created only after a job is submitted.
+- If `monitoring.enabled` is true, the monitoring stack is deployed in the
+  server cluster.
+
+## Validate
+
+```bash
+python examples/devops/multicloud/k8sview.py --config "$CONFIG"
+```
+
+If a known sample job is available, run a small smoke job after all
+participants are ready. For example, use the prepared `hello-numpy` job if it
+exists in the local environment:
+
+```bash
+ADMIN_KIT=examples/devops/multicloud/.work/provision/nvflare_multicloud/prod_00/admin@example.com/startup
+JOB=/tmp/nvflare/jobs/job_config/hello-numpy
+./.venv/bin/nvflare job submit -j "$JOB" --startup-kit "$ADMIN_KIT"
+```
+
+Use `nvflare job list` and `nvflare job monitor` to confirm the job completes.
+
+If monitoring is enabled, open Grafana from the server cluster. This default
+runbook uses a GCP server; use the server cloud kubeconfig if you changed the
+server cloud:
+
+```bash
+MONITORING_NS=nvflare-all-clouds-${RUN_ID}-monitoring
+kubectl --kubeconfig examples/devops/.tmp/kubeconfigs/gcp.yaml \
+  -n "$MONITORING_NS" port-forward svc/grafana 3000:3000
+```
+
+Use the Grafana development login and query the Prometheus datasource for
+FLARE system metrics such as `_system_start_count`.
+
+## Tear Down
+
+```bash
+python examples/devops/multicloud/deploy.py --config "$CONFIG" down
+```
+
+`down` tears down clients in parallel first, then the server, then the
+deterministic cloud IP.


### PR DESCRIPTION
## What changed

- Restores the DevOps helper scripts under `examples/devops` so they are clearly presented as examples.
- Adds explicit README warnings that these scripts are for development, smoke testing, demos, and learning only, and are not production deployment guidance.
- Adds pointers from `examples/README.md` and the Helm chart deployment guide.
- Keeps generated kubeconfigs/provisioning output ignored; no top-level `examples/devops/.gitignore` or `examples/devops/requirements.txt` is included.
