### PR TITLE
Update multi-study documentation links

### DIFF
--- a/docs/design/site_runtime_packaging_design.md
+++ b/docs/design/site_runtime_packaging_design.md
@@ -508,7 +508,10 @@ This replaces the separate per-runtime files used previously:
 Both launchers and `workspace_cell_transfer.py` must be updated to use
 `local/study_data.yaml`.
 
-The detailed study data schema follows [Study Dataset Mapping](https://docs.google.com/document/d/1JCKHbjQaDto_SBuTB-wSAaEvfIO8NLA_T2I_u8rf2sQ/edit?tab=t.0#heading=h.s3ol8f3q17a5).
+For the shipped multi-study design and study-scoped behavior, see
+[Multi-Study Support](../user_guide/admin_guide/multi_study_guide.rst). For
+runtime dataset mapping examples, see
+[Docker Job Launcher Design](docker_job_launcher_design.md).
 
 ## Job Python, GPU, and Resource Handling
 

--- a/docs/release_notes/flare_280.rst
+++ b/docs/release_notes/flare_280.rst
@@ -191,7 +191,8 @@ commands, and data access scoped to that study. Study support is available in
 administration workflows, CLI workflows, the FLARE API, production environments,
 and local PoC development.
 
-See :ref:`multi_study_guide` and :ref:`study_command`.
+See :ref:`multi_study_guide` for design and configuration details, and
+:ref:`study_command` for runtime management.
 
 Live Log Streaming
 ------------------


### PR DESCRIPTION
Summary:
- Clarify the What's New multi-study pointers.
- Replace the Google Docs study-data reference with local NVFlare docs.

Validation:
- git diff --check
- python3 ci/check_relative_doc_links.py --repo-root "$PWD" docs/design/site_runtime_packaging_design.md
- ./runtest.sh -s