### PR TITLE
Agent PR 0: Add agent CLI envelope skeleton

### DIFF
--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -28,6 +28,7 @@ from nvflare.fuel.hci.tools.authz_preview import define_authz_preview_parser, ru
 from nvflare.lighter.provision import define_provision_parser, handle_provision
 from nvflare.private.fed.app.simulator.simulator import define_simulator_parser, run_simulator
 from nvflare.private.fed.app.utils import version_check
+from nvflare.tool.agent.agent_cli import def_agent_cli_parser, handle_agent_cmd
 from nvflare.tool.cert.cert_cli import def_cert_cli_parser, handle_cert_cmd
 from nvflare.tool.deploy.deploy_cli import def_deploy_cli_parser, handle_deploy_cmd
 from nvflare.tool.job.job_cli import def_job_cli_parser, handle_job_cli_cmd
@@ -65,6 +66,7 @@ CMD_PACKAGE = "package"
 CMD_DEPLOY = "deploy"
 CMD_SYSTEM = "system"
 CMD_STUDY = "study"
+CMD_AGENT = "agent"
 
 _JSONL_COMMANDS = {
     (CMD_JOB, "monitor"),
@@ -299,18 +301,17 @@ def _get_subcommand_choices(parser):
     return []
 
 
-def _emit_argparse_error_json(parser, message):
+def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
     from nvflare.tool.cli_output import SCHEMA_VERSION
 
     # Parser errors intentionally expose usage/choices inline because they are generated before any
     # command handler runs and therefore sit outside the normal command data envelope.
     payload = {
         "schema_version": SCHEMA_VERSION,
-        "event": "terminal",
-        "terminal": True,
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
+        "code": "INVALID_ARGS",
         "message": message,
         "hint": "Run with --help to see usage.",
         "data": {
@@ -318,7 +319,12 @@ def _emit_argparse_error_json(parser, message):
             "choices": _get_subcommand_choices(parser),
         },
     }
-    print(json.dumps(payload))
+    if jsonl_mode:
+        payload["event"] = "terminal"
+        payload["terminal"] = True
+        print(json.dumps(payload), flush=True)
+    else:
+        print(json.dumps(payload))
     parser.exit(4)
 
 
@@ -363,7 +369,7 @@ def _display_unknown_args(argv, cmd: str, args, unknown: list) -> list:
     return display_unknown
 
 
-def _patch_help_on_error(parser, json_mode: bool = False):
+def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = False):
     """Recursively patch every parser in the tree to print help before error-exit.
 
     When argparse detects a missing required argument it calls parser.error(),
@@ -373,7 +379,7 @@ def _patch_help_on_error(parser, json_mode: bool = False):
 
     def _error_with_help(message):
         if json_mode:
-            _emit_argparse_error_json(parser, message)
+            _emit_argparse_error_json(parser, message, jsonl_mode=jsonl_mode)
         else:
             _emit_argparse_error_human(parser, message, exit_code=4)
 
@@ -381,7 +387,7 @@ def _patch_help_on_error(parser, json_mode: bool = False):
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for sub in action.choices.values():
-                _patch_help_on_error(sub, json_mode=json_mode)
+                _patch_help_on_error(sub, json_mode=json_mode, jsonl_mode=jsonl_mode)
 
 
 def _build_global_arg_parser():
@@ -466,6 +472,7 @@ def parse_args(prog_name: str):
     sub_cmd_parsers.update(def_package_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_deploy_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_study_cli_parser(sub_cmd))
+    sub_cmd_parsers.update(def_agent_cli_parser(sub_cmd))
     system_parser = sub_cmd.add_parser(CMD_SYSTEM, help="FL system operations (status, shutdown, version, ...)")
     sub_cmd_parsers.update({CMD_SYSTEM: system_parser})
     def_system_cli_parser(system_parser)
@@ -499,13 +506,16 @@ def parse_args(prog_name: str):
         ns.cert_sub_command = sub_sub
         ns.recipe_sub_cmd = sub_sub or "list"
         ns.deploy_sub_cmd = sub_sub
+        ns.agent_sub_cmd = sub_sub
         ns.format = global_args.format
         ns.connect_timeout = global_args.connect_timeout
         ns.version = global_args.version
         return _parser, ns, sub_cmd_parsers
 
     # Patch every parser so it prints full help before exiting on error.
-    _patch_help_on_error(_parser, json_mode=global_args.format in {"json", "jsonl"})
+    _patch_help_on_error(
+        _parser, json_mode=global_args.format in {"json", "jsonl"}, jsonl_mode=global_args.format == "jsonl"
+    )
 
     args, unknown = _parser.parse_known_args(normalized_argv)
     args._raw_sub_command = args.__dict__.get("sub_command")
@@ -517,14 +527,16 @@ def parse_args(prog_name: str):
         display_unknown = _display_unknown_args(normalized_argv, cmd, args, unknown)
         msg = f"unrecognized arguments: {' '.join(display_unknown)}"
         if args.format in {"json", "jsonl"}:
-            _emit_argparse_error_json(sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}")
+            _emit_argparse_error_json(
+                sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}", jsonl_mode=args.format == "jsonl"
+            )
         else:
             _emit_argparse_error_human(sub_cmd_parser or _parser, msg, exit_code=4)
     if args.format == "jsonl":
         command_path = (getattr(args, "sub_command", None), getattr(args, "job_sub_cmd", None))
         if command_path not in _JSONL_COMMANDS:
             detail = "--format jsonl is only supported by streaming commands: nvflare job monitor"
-            _emit_argparse_error_json(sub_cmd_parser or _parser, detail)
+            _emit_argparse_error_json(sub_cmd_parser or _parser, detail, jsonl_mode=True)
     return _parser, args, sub_cmd_parsers
 
 
@@ -543,6 +555,7 @@ handlers = {
     CMD_DEPLOY: handle_deploy_cmd,
     CMD_STUDY: handle_study_cmd,
     CMD_SYSTEM: handle_system_cmd,
+    CMD_AGENT: handle_agent_cmd,
 }
 
 

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -301,7 +301,7 @@ def _get_subcommand_choices(parser):
     return []
 
 
-def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
+def _emit_argparse_error_json(parser, message):
     from nvflare.tool.cli_output import SCHEMA_VERSION
 
     # Parser errors intentionally expose usage/choices inline because they are generated before any
@@ -311,7 +311,6 @@ def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
-        "code": "INVALID_ARGS",
         "message": message,
         "hint": "Run with --help to see usage.",
         "data": {
@@ -319,12 +318,7 @@ def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
             "choices": _get_subcommand_choices(parser),
         },
     }
-    if jsonl_mode:
-        payload["event"] = "terminal"
-        payload["terminal"] = True
-        print(json.dumps(payload), flush=True)
-    else:
-        print(json.dumps(payload))
+    print(json.dumps(payload))
     parser.exit(4)
 
 
@@ -369,7 +363,7 @@ def _display_unknown_args(argv, cmd: str, args, unknown: list) -> list:
     return display_unknown
 
 
-def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = False):
+def _patch_help_on_error(parser, json_mode: bool = False):
     """Recursively patch every parser in the tree to print help before error-exit.
 
     When argparse detects a missing required argument it calls parser.error(),
@@ -379,7 +373,7 @@ def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = Fal
 
     def _error_with_help(message):
         if json_mode:
-            _emit_argparse_error_json(parser, message, jsonl_mode=jsonl_mode)
+            _emit_argparse_error_json(parser, message)
         else:
             _emit_argparse_error_human(parser, message, exit_code=4)
 
@@ -387,7 +381,7 @@ def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = Fal
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for sub in action.choices.values():
-                _patch_help_on_error(sub, json_mode=json_mode, jsonl_mode=jsonl_mode)
+                _patch_help_on_error(sub, json_mode=json_mode)
 
 
 def _build_global_arg_parser():
@@ -513,9 +507,7 @@ def parse_args(prog_name: str):
         return _parser, ns, sub_cmd_parsers
 
     # Patch every parser so it prints full help before exiting on error.
-    _patch_help_on_error(
-        _parser, json_mode=global_args.format in {"json", "jsonl"}, jsonl_mode=global_args.format == "jsonl"
-    )
+    _patch_help_on_error(_parser, json_mode=global_args.format in {"json", "jsonl"})
 
     args, unknown = _parser.parse_known_args(normalized_argv)
     args._raw_sub_command = args.__dict__.get("sub_command")
@@ -527,16 +519,14 @@ def parse_args(prog_name: str):
         display_unknown = _display_unknown_args(normalized_argv, cmd, args, unknown)
         msg = f"unrecognized arguments: {' '.join(display_unknown)}"
         if args.format in {"json", "jsonl"}:
-            _emit_argparse_error_json(
-                sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}", jsonl_mode=args.format == "jsonl"
-            )
+            _emit_argparse_error_json(sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}")
         else:
             _emit_argparse_error_human(sub_cmd_parser or _parser, msg, exit_code=4)
     if args.format == "jsonl":
         command_path = (getattr(args, "sub_command", None), getattr(args, "job_sub_cmd", None))
         if command_path not in _JSONL_COMMANDS:
             detail = "--format jsonl is only supported by streaming commands: nvflare job monitor"
-            _emit_argparse_error_json(sub_cmd_parser or _parser, detail, jsonl_mode=True)
+            _emit_argparse_error_json(sub_cmd_parser or _parser, detail)
     return _parser, args, sub_cmd_parsers
 
 

--- a/nvflare/tool/agent/__init__.py
+++ b/nvflare/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-facing CLI command group."""
+
+import argparse
+import sys
+from typing import Optional
+
+import nvflare
+from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
+
+CMD_AGENT_INFO = "info"
+
+_AGENT_OUTPUT_MODES = ["json"]
+_AGENT_EXAMPLES = [
+    "nvflare agent info --format json",
+    "nvflare agent info --schema",
+]
+_agent_parser: Optional[argparse.ArgumentParser] = None
+_agent_sub_cmd_parsers = {}
+
+
+def def_agent_cli_parser(sub_cmd) -> dict:
+    """Register the top-level `nvflare agent` command group."""
+    global _agent_parser
+
+    parser = sub_cmd.add_parser(
+        "agent",
+        description="Agent-facing NVFLARE command surface.",
+        help="Agent-facing NVFLARE helpers.",
+    )
+    parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    agent_subparser = parser.add_subparsers(title="agent subcommands", metavar="", dest="agent_sub_cmd")
+
+    info_parser = agent_subparser.add_parser(
+        CMD_AGENT_INFO,
+        description="Show the available NVFLARE agent command surface.",
+        help="show agent command surface metadata",
+    )
+    info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
+
+    _agent_parser = parser
+    return {"agent": parser}
+
+
+def _agent_info_data() -> dict:
+    return {
+        "nvflare_version": nvflare.__version__,
+        "commands": [
+            {
+                "name": "info",
+                "command": "nvflare agent info",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            }
+        ],
+    }
+
+
+def handle_agent_cmd(args) -> None:
+    from nvflare.tool.cli_output import output_error_message, output_ok
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    sub_cmd = getattr(args, "agent_sub_cmd", None)
+
+    if sub_cmd is None:
+        handle_schema_flag(
+            _agent_parser,
+            "nvflare agent",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SUBCOMMAND_REQUIRED",
+            "Agent subcommand required.",
+            "Run 'nvflare agent --help' or 'nvflare agent info --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if sub_cmd == CMD_AGENT_INFO:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_INFO],
+            "nvflare agent info",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_ok(
+            _agent_info_data(),
+            code="OK",
+            message="NVFLARE agent command surface is available.",
+            hint="Use --schema on agent-facing commands to inspect argument contracts.",
+        )
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -201,7 +201,7 @@ def output_ok(
             recovery_category=recovery_category,
             suggested_skill=suggested_skill,
         )
-        print(json.dumps(payload))
+        print(json.dumps(payload), flush=True)
     else:
         _render_table(data)
     if exit_code != 0:

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -147,14 +147,61 @@ def output(data: Any, fmt: Optional[str]) -> None:
         _render_table(data)
 
 
-def output_ok(data: Any, exit_code: int = 0) -> None:
-    """Print command success output."""
+def _add_agent_envelope_fields(
+    payload: dict,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> dict:
+    if code is not None:
+        payload["code"] = code
+    if message is not None:
+        payload["message"] = message
+    if hint is not None:
+        payload["hint"] = hint
+    if recovery_category is not None:
+        payload["recovery_category"] = recovery_category
+    if suggested_skill is not None:
+        payload["suggested_skill"] = suggested_skill
+    return payload
+
+
+def output_ok(
+    data: Any,
+    exit_code: int = 0,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> None:
+    """Print command success output.
+
+    code/message/hint/recovery fields are emitted in JSON/JSONL modes only;
+    human mode renders command data.
+    """
     if _is_jsonl_mode():
-        output_jsonl_event(
-            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True}
+        payload = _add_agent_envelope_fields(
+            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
         )
+        output_jsonl_event(payload)
     elif _is_json_mode():
-        print(json.dumps({"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data}))
+        payload = _add_agent_envelope_fields(
+            {"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        print(json.dumps(payload))
     else:
         _render_table(data)
     if exit_code != 0:
@@ -167,6 +214,8 @@ def output_error(
     hint: str = None,
     data: Any = None,
     detail: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
     **kwargs,
 ) -> None:
     """Print an error from ERROR_REGISTRY and exit. Never returns."""
@@ -187,9 +236,15 @@ def output_error(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
+            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
         if data is not None:
             payload["data"] = data
         if _is_jsonl_mode():
@@ -224,8 +279,16 @@ def output_error_message(
     fmt: Optional[str] = None,
     exit_code: int = 1,
     detail: str = None,
+    data: Any = None,
+    include_data: bool = False,
+    recovery_category: str = None,
+    suggested_skill: str = None,
 ) -> None:
-    """Print an explicit error message/hint pair and exit. Never returns."""
+    """Print an explicit error message/hint pair and exit. Never returns.
+
+    In machine modes, data is omitted when data is None unless include_data=True.
+    This lets callers distinguish an absent data field from an explicit JSON null.
+    """
     resolved_hint = hint or ""
     if detail:
         message = f"{message} \u2014 {detail}"
@@ -236,9 +299,17 @@ def output_error_message(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
+            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        if include_data or data is not None:
+            payload["data"] = data
         if jsonl_mode:
             payload["event"] = "terminal"
             payload["terminal"] = True

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -201,7 +201,7 @@ def output_ok(
             recovery_category=recovery_category,
             suggested_skill=suggested_skill,
         )
-        print(json.dumps(payload), flush=True)
+        print(json.dumps(payload))
     else:
         _render_table(data)
     if exit_code != 0:
@@ -236,7 +236,6 @@ def output_error(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
@@ -299,7 +298,6 @@ def output_error_message(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }

--- a/tests/unit_test/tool/agent/__init__.py
+++ b/tests/unit_test/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.tool import cli_output
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_output_state(monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "txt")
+    monkeypatch.setattr(cli_output, "_connect_timeout", 5.0)
+
+
+def _run_main(argv):
+    from nvflare import cli
+
+    with patch("sys.argv", argv), patch("nvflare.cli.version_check"):
+        try:
+            cli.main()
+        except SystemExit as e:
+            return e.code
+    return 0
+
+
+def _parse_for_agent_parser():
+    from nvflare import cli
+
+    with patch("sys.argv", ["nvflare", "agent", "--schema"]):
+        _prog_parser, args, sub_cmd_parsers = cli.parse_args("nvflare")
+
+    assert args.sub_command == "agent"
+    assert "agent" in sub_cmd_parsers
+    return sub_cmd_parsers["agent"]
+
+
+def _subparser_choices(parser):
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action.choices
+    return {}
+
+
+def _required_operational_args(parser):
+    required_args = []
+    for action in parser._actions:
+        if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
+            continue
+        if action.dest == "schema" or action.help == argparse.SUPPRESS:
+            continue
+        positional_required = not action.option_strings and action.nargs not in (
+            argparse.OPTIONAL,
+            argparse.ZERO_OR_MORE,
+        )
+        optional_required = bool(getattr(action, "required", False) or getattr(action, "schema_required", False))
+        if positional_required or optional_required:
+            required_args.append(action.dest)
+    return required_args
+
+
+def _minimal_agent_command():
+    agent_parser = _parse_for_agent_parser()
+    choices = _subparser_choices(agent_parser)
+    assert choices, "PR1 should register at least one minimal nvflare agent subcommand"
+
+    for name, parser in choices.items():
+        if _required_operational_args(parser):
+            continue
+        return name, parser
+
+    assert False, "PR1 should expose a read-only nvflare agent subcommand that needs no operational arguments"
+
+
+def _load_single_stdout_json(captured):
+    stdout = captured.out.strip()
+    assert stdout
+    assert len(stdout.splitlines()) == 1
+    return json.loads(stdout)
+
+
+def _assert_envelope_shape(payload, expected_status, require_data=True):
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == expected_status
+    assert "message" in payload
+    assert "hint" in payload
+    if require_data:
+        assert "data" in payload
+    if "code" in payload:
+        assert payload["code"]
+    else:
+        assert payload["error_code"]
+
+
+def test_agent_command_parser_is_registered(monkeypatch):
+    from nvflare import cli
+
+    command_name, _parser = _minimal_agent_command()
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["nvflare", "agent", command_name, "--format", "json"],
+    )
+
+    _prog_parser, args, _sub_cmd_parsers = cli.parse_args("nvflare")
+    assert args.sub_command == "agent"
+
+
+def test_agent_success_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    cli_output.output_ok(
+        {"ready": True},
+        code="AGENT_OK",
+        message="Agent command completed.",
+        hint="",
+        recovery_category="FIXABLE_BY_CONFIG",
+        suggested_skill="agent",
+    )
+
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "ok"
+    assert payload["code"] == "AGENT_OK"
+    assert payload["message"] == "Agent command completed."
+    assert payload["hint"] == ""
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+    assert payload["data"] == {"ready": True}
+
+
+def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_output.output_error_message(
+            "AGENT_ERROR",
+            "Agent command failed.",
+            hint="Use a valid agent command.",
+            exit_code=4,
+            recovery_category="FIXABLE_BY_CONFIG",
+            suggested_skill="agent",
+        )
+
+    assert exc_info.value.code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "error"
+    assert payload["code"] == "AGENT_ERROR"
+    assert payload["error_code"] == "AGENT_ERROR"
+    assert payload["message"] == "Agent command failed."
+    assert payload["hint"] == "Use a valid agent command."
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+
+
+def test_agent_schema_exits_zero_and_emits_raw_schema_json(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"].startswith("nvflare agent")
+    assert "status" not in schema
+    assert "args" in schema
+    assert "examples" in schema
+
+
+def test_agent_minimal_subcommand_schema_does_not_require_operational_args(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"] == f"nvflare agent {command_name}"
+    assert "status" not in schema
+    assert schema["output_modes"] == ["json"]
+    assert schema["streaming"] is False
+    assert schema["mutating"] is False
+    assert schema["idempotent"] is True
+
+
+def test_agent_minimal_subcommand_json_success_is_single_stdout_envelope(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "ok")
+
+
+def test_agent_human_output_stays_off_stdout_in_json_mode(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    assert payload["status"] == "ok"
+
+
+def test_agent_missing_subcommand_json_error_is_non_interactive(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert payload["data"] is None
+    assert captured.err == ""
+
+
+def test_agent_missing_subcommand_stops_when_error_helper_is_mocked():
+    from nvflare.tool.agent.agent_cli import handle_agent_cmd
+
+    with patch("sys.argv", ["nvflare", "agent"]), patch("nvflare.tool.cli_output.output_error_message") as output_error:
+        handle_agent_cmd(SimpleNamespace(agent_sub_cmd=None))
+
+    output_error.assert_called_once()
+
+
+def test_agent_invalid_subcommand_json_error_is_structured(capsys):
+    exit_code = _run_main(["nvflare", "agent", "not-a-pr1-command", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert "event" not in payload
+    assert "terminal" not in payload
+    assert "not-a-pr1-command" in payload["message"]
+    assert captured.err == ""

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -77,14 +77,14 @@ def _required_operational_args(parser):
 def _minimal_agent_command():
     agent_parser = _parse_for_agent_parser()
     choices = _subparser_choices(agent_parser)
-    assert choices, "PR1 should register at least one minimal nvflare agent subcommand"
+    assert choices, "nvflare agent should register at least one read-only subcommand"
 
     for name, parser in choices.items():
         if _required_operational_args(parser):
             continue
         return name, parser
 
-    assert False, "PR1 should expose a read-only nvflare agent subcommand that needs no operational arguments"
+    assert False, "nvflare agent should expose a read-only subcommand that needs no operational arguments"
 
 
 def _load_single_stdout_json(captured):

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -162,8 +162,8 @@ def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
     payload = _load_single_stdout_json(capsys.readouterr())
     assert payload["schema_version"] == "1"
     assert payload["status"] == "error"
-    assert payload["code"] == "AGENT_ERROR"
     assert payload["error_code"] == "AGENT_ERROR"
+    assert "code" not in payload
     assert payload["message"] == "Agent command failed."
     assert payload["hint"] == "Use a valid agent command."
     assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,7 +58,7 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
-    assert payload["code"] == "INVALID_ARGS"
+    assert "code" not in payload
     assert "event" not in payload
     assert "terminal" not in payload
     assert "usage" in payload["data"]
@@ -109,7 +109,7 @@ def test_jsonl_rejected_for_non_streaming_command(capsys, monkeypatch):
     assert exc_info.value.code == 4
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["event"] == "terminal"
-    assert payload["terminal"] is True
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert payload["error_code"] == "INVALID_ARGS"
     assert "nvflare job monitor" in payload["message"]

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,6 +58,9 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
+    assert payload["code"] == "INVALID_ARGS"
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert "usage" in payload["data"]
     assert "list" in payload["data"]["choices"]
 

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -201,6 +201,15 @@ class TestOutputOk:
         mock_print.assert_called_once()
         assert mock_print.call_args.kwargs["flush"] is True
 
+    def test_json_mode_output_ok_flushes_stdout(self, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with patch("builtins.print") as mock_print:
+            output_ok({"key": "value"})
+
+        mock_print.assert_called_once()
+        assert mock_print.call_args.kwargs["flush"] is True
+
     def test_human_mode_dict_renders_as_table(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "txt")
         output_ok({"status": "running", "id": "abc"})

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -382,6 +382,23 @@ class TestOutputError:
         assert "message" in envelope
         assert "hint" in envelope
 
+    def test_error_envelope_supports_agent_fields(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with pytest.raises(SystemExit) as exc_info:
+            output_error(
+                "CONNECTION_FAILED",
+                recovery_category="RETRYABLE",
+                suggested_skill="nvflare-diagnose-job",
+            )
+
+        assert exc_info.value.code == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["error_code"] == "CONNECTION_FAILED"
+        assert envelope["code"] == "CONNECTION_FAILED"
+        assert envelope["recovery_category"] == "RETRYABLE"
+        assert envelope["suggested_skill"] == "nvflare-diagnose-job"
+
     def test_custom_exit_code(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "json")
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -201,15 +201,6 @@ class TestOutputOk:
         mock_print.assert_called_once()
         assert mock_print.call_args.kwargs["flush"] is True
 
-    def test_json_mode_output_ok_flushes_stdout(self, monkeypatch):
-        monkeypatch.setattr(cli_output, "_output_format", "json")
-
-        with patch("builtins.print") as mock_print:
-            output_ok({"key": "value"})
-
-        mock_print.assert_called_once()
-        assert mock_print.call_args.kwargs["flush"] is True
-
     def test_human_mode_dict_renders_as_table(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "txt")
         output_ok({"status": "running", "id": "abc"})
@@ -404,7 +395,7 @@ class TestOutputError:
         assert exc_info.value.code == 1
         envelope = json.loads(capsys.readouterr().out)
         assert envelope["error_code"] == "CONNECTION_FAILED"
-        assert envelope["code"] == "CONNECTION_FAILED"
+        assert "code" not in envelope
         assert envelope["recovery_category"] == "RETRYABLE"
         assert envelope["suggested_skill"] == "nvflare-diagnose-job"
 


### PR DESCRIPTION
## Summary

- add the `nvflare agent` command group and a minimal read-only `nvflare agent info` surface
- extend CLI JSON helpers with agent-facing envelope fields (`code`, `message`, `hint`, `recovery_category`, `suggested_skill`)
- keep JSONL-only `event`/`terminal` markers out of plain `--format json` argparse errors
- add unit coverage for agent command registration, schemas, JSON envelopes, non-interactive errors, and helper behavior

## Scope

Milestone 0 only: CLI envelope and `nvflare agent` skeleton. This PR does not implement skills install/list, inspect, doctor, packaging, validators, receipts, provenance, workflow state, or skill content.

## Verification

- `python3 -m pytest tests/unit_test/tool/agent/agent_cli_test.py tests/unit_test/tool/cli_output_test.py tests/unit_test/tool/cli_schema_missing_args_test.py tests/unit_test/tool/cli_invalid_args_json_test.py tests/unit_test/tool/cli_global_args_test.py -q`
- `./runtest.sh -s`
- `git diff --check`
