### PR TITLE
Agent PR 1: Add agent skill frontmatter validator

### DIFF
--- a/nvflare/tool/agent_skill_checks/__init__.py
+++ b/nvflare/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation helpers for NVFLARE agent skill source files."""

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal V1 validation for NVFLARE agent skill frontmatter."""
+"""Validation for NVFLARE agent skill frontmatter."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -58,7 +58,7 @@ class SkillFrontmatterError(ValueError):
 def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
     """Parse YAML frontmatter from a SKILL.md file."""
     path = Path(skill_file)
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8-sig")
     lines = text.splitlines()
     if not lines or lines[0].strip() != "---":
         raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
@@ -131,9 +131,17 @@ def _validate_required_fields(
 ) -> None:
     for field in REQUIRED_FRONTMATTER_FIELDS:
         value = metadata.get(field)
-        if not isinstance(value, str) or not value.strip():
+        if value is None or (isinstance(value, str) and not value.strip()):
             issues.append(
                 _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+        elif not isinstance(value, str):
+            issues.append(
+                _issue(
+                    "skill-frontmatter-field-type",
+                    f"frontmatter field '{field}' must be a non-empty string; " f"got {type(value).__name__}={value!r}",
+                    skill_file,
+                )
             )
 
 

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal V1 validation for NVFLARE agent skill frontmatter."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import yaml
+
+SKILL_FILE_NAME = "SKILL.md"
+REQUIRED_FRONTMATTER_FIELDS = ("name", "description", "min_flare_version", "blast_radius")
+VALID_BLAST_RADIUS = frozenset(
+    {
+        "read_only",
+        "edits_files",
+        "runs_simulator",
+        "submits_poc",
+        "submits_production",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SkillValidationIssue:
+    code: str
+    message: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SkillValidationResult:
+    skill_dir: str
+    metadata: Mapping[str, Any]
+    issues: tuple[SkillValidationIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+class SkillFrontmatterError(ValueError):
+    """Raised when SKILL.md frontmatter cannot be parsed."""
+
+
+def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
+    """Parse YAML frontmatter from a SKILL.md file."""
+    path = Path(skill_file)
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
+
+    close_index = _find_closing_delimiter(lines)
+    if close_index is None:
+        raise SkillFrontmatterError("SKILL.md frontmatter must end with delimiter '---'")
+
+    raw_frontmatter = "\n".join(lines[1:close_index])
+    try:
+        metadata = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as e:
+        raise SkillFrontmatterError(f"failed to parse YAML frontmatter: {e}") from e
+
+    if not isinstance(metadata, dict):
+        raise SkillFrontmatterError("SKILL.md frontmatter must be a mapping")
+    return metadata
+
+
+def validate_skill_dir(skill_dir: Path | str) -> SkillValidationResult:
+    """Validate one guide-compatible skill directory."""
+    path = Path(skill_dir)
+    issues: list[SkillValidationIssue] = []
+    metadata: dict[str, Any] = {}
+
+    skill_file = path / SKILL_FILE_NAME
+    if not path.is_dir():
+        issues.append(_issue("skill-dir-missing", "skill path must be a directory", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    if not skill_file.is_file():
+        issues.append(_issue("skill-md-missing", "skill directory must contain SKILL.md", skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    try:
+        metadata = parse_skill_frontmatter(skill_file)
+    except SkillFrontmatterError as e:
+        issues.append(_issue("skill-frontmatter-invalid", str(e), skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    _validate_required_fields(metadata, skill_file, issues)
+    _validate_name_matches_directory(metadata.get("name"), path, skill_file, issues)
+    _validate_blast_radius(metadata.get("blast_radius"), skill_file, issues)
+
+    return SkillValidationResult(str(path), metadata, tuple(issues))
+
+
+def validate_skills_root(skills_root: Path | str) -> list[SkillValidationResult]:
+    """Validate every skill directory under a skills root."""
+    root = Path(skills_root)
+    if not root.is_dir():
+        return [SkillValidationResult(str(root), {}, (_issue("skills-root-missing", "skills root is missing", root),))]
+
+    results = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        results.append(validate_skill_dir(child))
+    return results
+
+
+def _find_closing_delimiter(lines: list[str]) -> Optional[int]:
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return i
+    return None
+
+
+def _validate_required_fields(
+    metadata: Mapping[str, Any], skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    for field in REQUIRED_FRONTMATTER_FIELDS:
+        value = metadata.get(field)
+        if not isinstance(value, str) or not value.strip():
+            issues.append(
+                _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+
+
+def _validate_name_matches_directory(
+    name: Any, skill_dir: Path, skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    if isinstance(name, str) and name.strip() and name != skill_dir.name:
+        issues.append(
+            _issue(
+                "skill-name-directory-mismatch",
+                f"frontmatter name '{name}' must match directory name '{skill_dir.name}'",
+                skill_file,
+            )
+        )
+
+
+def _validate_blast_radius(radius: Any, skill_file: Path, issues: list[SkillValidationIssue]) -> None:
+    if isinstance(radius, str) and radius.strip() and radius not in VALID_BLAST_RADIUS:
+        issues.append(
+            _issue(
+                "skill-blast-radius-invalid",
+                f"blast_radius must be one of: {', '.join(sorted(VALID_BLAST_RADIUS))}",
+                skill_file,
+            )
+        )
+
+
+def _issue(code: str, message: str, path: Path) -> SkillValidationIssue:
+    return SkillValidationIssue(code=code, message=message, path=str(path))

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# NVFLARE Agent Skills
+
+This directory is the source root for NVFLARE-owned agent skills.
+
+V1 skill directories should follow the guide-compatible shape:
+
+```text
+skills/
+  nvflare-example-skill/
+    SKILL.md
+    references/
+    evals/
+      evals.json
+      files/
+    BENCHMARK.md
+```
+
+Milestone 1 establishes the source root and minimal frontmatter validation.
+Public skill content, runtime evals, packaging, and native install/list commands
+land in later milestones.
+
+Required `SKILL.md` frontmatter fields for V1:
+
+```yaml
+---
+name: nvflare-example-skill
+description: Short trigger-oriented description.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+```
+
+`blast_radius` must be one of:
+
+- `read_only`
+- `edits_files`
+- `runs_simulator`
+- `submits_poc`
+- `submits_production`

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ V1 skill directories should follow the guide-compatible shape:
 
 ```text
 skills/
-  nvflare-example-skill/
+  nvflare-your-skill/
     SKILL.md
     references/
     evals/
@@ -23,12 +23,15 @@ Required `SKILL.md` frontmatter fields for V1:
 
 ```yaml
 ---
-name: nvflare-example-skill
+name: nvflare-your-skill
 description: Short trigger-oriented description.
 min_flare_version: "2.8.0"
 blast_radius: read_only
 ---
 ```
+
+The skill name above is illustrative; released skill content lands in later
+milestones.
 
 `blast_radius` must be one of:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,9 @@
 # NVFLARE Agent Skills
 
-This directory is the source root for NVFLARE-owned agent skills.
+This directory contains NVFLARE-owned agent skills for supported coding agents.
 
-V1 skill directories should follow the guide-compatible shape:
+Each skill lives in its own directory with a `SKILL.md` file. Skills may also
+include supporting references, evaluation fixtures, and benchmark notes:
 
 ```text
 skills/
@@ -15,11 +16,7 @@ skills/
     BENCHMARK.md
 ```
 
-Milestone 1 establishes the source root and minimal frontmatter validation.
-Public skill content, runtime evals, packaging, and native install/list commands
-land in later milestones.
-
-Required `SKILL.md` frontmatter fields for V1:
+Required `SKILL.md` frontmatter fields:
 
 ```yaml
 ---
@@ -30,8 +27,8 @@ blast_radius: read_only
 ---
 ```
 
-The skill name above is illustrative; released skill content lands in later
-milestones.
+The skill name above is illustrative; actual skill directories use their
+published skill names.
 
 `blast_radius` must be one of:
 

--- a/tests/unit_test/tool/agent_skill_checks/__init__.py
+++ b/tests/unit_test/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
+++ b/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: nvflare-example-skill
+description: Example fixture skill used by frontmatter validator tests.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+
+# Example Skill
+
+This file exists only as a validator fixture.

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from nvflare.tool.agent_skill_checks.frontmatter import (
+    SkillFrontmatterError,
+    parse_skill_frontmatter,
+    validate_skill_dir,
+    validate_skills_root,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parse_skill_frontmatter_reads_required_fields():
+    metadata = parse_skill_frontmatter(FIXTURES / "valid" / "nvflare-example-skill" / "SKILL.md")
+
+    assert metadata["name"] == "nvflare-example-skill"
+    assert metadata["description"] == "Example fixture skill used by frontmatter validator tests."
+    assert metadata["min_flare_version"] == "2.8.0"
+    assert metadata["blast_radius"] == "read_only"
+
+
+def test_validate_skill_dir_accepts_fixture_skill():
+    result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
+
+    assert result.ok
+    assert result.metadata["name"] == "nvflare-example-skill"
+    assert result.issues == ()
+
+
+def test_validate_skill_dir_requires_directory_name_to_match_frontmatter(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-other-name", name="nvflare-example-skill")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-name-directory-mismatch"}
+
+
+def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-fields"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-missing-fields\n"
+        "description: Missing two required fields.\n"
+        "---\n"
+        "\n"
+        "# Missing Fields\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-required"}
+    assert len(result.issues) == 2
+
+
+def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-blast-radius-invalid"}
+
+
+def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("name: nvflare-no-frontmatter\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must start"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-skill-md"
+    skill_dir.mkdir()
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-md-missing"}
+
+
+def test_validate_skills_root_skips_non_skill_files(tmp_path):
+    _write_skill(tmp_path, "nvflare-valid-one")
+    (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+
+    results = validate_skills_root(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].ok
+    assert results[0].metadata["name"] == "nvflare-valid-one"
+
+
+def test_validate_skills_root_reports_missing_root(tmp_path):
+    results = validate_skills_root(tmp_path / "missing")
+
+    assert len(results) == 1
+    assert not results[0].ok
+    assert _issue_codes(results[0]) == {"skills-root-missing"}
+
+
+def _write_skill(tmp_path, skill_name, *, name=None, blast_radius="read_only"):
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name or skill_name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        f"blast_radius: {blast_radius}\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _issue_codes(result):
+    return {issue.code for issue in result.issues}

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -35,6 +35,24 @@ def test_parse_skill_frontmatter_reads_required_fields():
     assert metadata["blast_radius"] == "read_only"
 
 
+def test_parse_skill_frontmatter_accepts_utf8_bom(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_bytes(
+        b"\xef\xbb\xbf---\n"
+        b"name: nvflare-bom-skill\n"
+        b"description: Test skill fixture.\n"
+        b'min_flare_version: "2.8.0"\n'
+        b"blast_radius: read_only\n"
+        b"---\n"
+        b"\n"
+        b"# Test Skill\n"
+    )
+
+    metadata = parse_skill_frontmatter(skill_file)
+
+    assert metadata["name"] == "nvflare-bom-skill"
+
+
 def test_validate_skill_dir_accepts_fixture_skill():
     result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
 
@@ -72,6 +90,29 @@ def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
     assert len(result.issues) == 2
 
 
+def test_validate_skill_dir_reports_wrong_type_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-wrong-type"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-wrong-type\n"
+        "description: Wrong type fixture.\n"
+        "min_flare_version: 2.8\n"
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Wrong Type\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-type"}
+    assert "min_flare_version" in result.issues[0].message
+    assert "float=2.8" in result.issues[0].message
+
+
 def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
 
@@ -89,6 +130,40 @@ def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
         parse_skill_frontmatter(skill_file)
 
 
+def test_parse_skill_frontmatter_requires_closing_delimiter(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "---\n" "name: nvflare-no-closing-delimiter\n" "description: Missing closing delimiter.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillFrontmatterError, match="must end"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_malformed_yaml(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\nname: [unclosed\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="failed to parse YAML"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_non_mapping(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\n- name\n- description\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must be a mapping"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_directory(tmp_path):
+    result = validate_skill_dir(tmp_path / "nvflare-missing-directory")
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-dir-missing"}
+
+
 def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
     skill_dir = tmp_path / "nvflare-missing-skill-md"
     skill_dir.mkdir()
@@ -102,6 +177,7 @@ def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
 def test_validate_skills_root_skips_non_skill_files(tmp_path):
     _write_skill(tmp_path, "nvflare-valid-one")
     (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+    (tmp_path / ".hidden-dir").mkdir()
 
     results = validate_skills_root(tmp_path)
 


### PR DESCRIPTION
## Summary

- add repo-root `skills/` source root documentation for NVFLARE-owned agent skills
- add minimal `SKILL.md` YAML frontmatter validator for V1 required fields
- add fixture-based tests for valid skills, missing fields, name/directory mismatch, invalid blast radius, malformed frontmatter, missing `SKILL.md`, and root validation

## Scope

Milestone 1 only: skill source layout and frontmatter validation. This PR does not implement install/list, inspect/doctor, wheel packaging, runtime evals, or public skill content.

## Verification

- `python3 -m pytest tests/unit_test/tool/agent_skill_checks/frontmatter_test.py -q`
- `./runtest.sh -s`
- `git diff --check`
