### PR TITLE
Agent PR 2+3: Add native agent skill packaging and install commands

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include versioneer.py
 include nvflare/_version.py
 include nvflare/libs/*.so
 include nvflare/fuel/utils/*.json
+recursive-include skills *
 recursive-include nvflare/lighter/templates *
 recursive-include nvflare/tool/deploy/templates *

--- a/nvflare/app_opt/kaggle/download_data.py
+++ b/nvflare/app_opt/kaggle/download_data.py
@@ -15,12 +15,22 @@
 import shutil
 from pathlib import Path
 
-import kagglehub
+kagglehub = None
+
+
+def _get_kagglehub():
+    global kagglehub
+
+    if kagglehub is None:
+        import kagglehub as imported_kagglehub
+
+        kagglehub = imported_kagglehub
+    return kagglehub
 
 
 def download(input_path: str, output_path: str, overwrite: bool = False):
     # Download latest version
-    path = kagglehub.dataset_download(input_path)
+    path = _get_kagglehub().dataset_download(input_path)
     print("Path to dataset files:", path)
 
     # Move downloaded data to output path

--- a/nvflare/app_opt/kaggle/download_data.py
+++ b/nvflare/app_opt/kaggle/download_data.py
@@ -15,22 +15,12 @@
 import shutil
 from pathlib import Path
 
-kagglehub = None
-
-
-def _get_kagglehub():
-    global kagglehub
-
-    if kagglehub is None:
-        import kagglehub as imported_kagglehub
-
-        kagglehub = imported_kagglehub
-    return kagglehub
+import kagglehub
 
 
 def download(input_path: str, output_path: str, overwrite: bool = False):
     # Download latest version
-    path = _get_kagglehub().dataset_download(input_path)
+    path = kagglehub.dataset_download(input_path)
     print("Path to dataset files:", path)
 
     # Move downloaded data to output path

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -28,6 +28,7 @@ from nvflare.fuel.hci.tools.authz_preview import define_authz_preview_parser, ru
 from nvflare.lighter.provision import define_provision_parser, handle_provision
 from nvflare.private.fed.app.simulator.simulator import define_simulator_parser, run_simulator
 from nvflare.private.fed.app.utils import version_check
+from nvflare.tool.agent.agent_cli import def_agent_cli_parser, handle_agent_cmd
 from nvflare.tool.cert.cert_cli import def_cert_cli_parser, handle_cert_cmd
 from nvflare.tool.deploy.deploy_cli import def_deploy_cli_parser, handle_deploy_cmd
 from nvflare.tool.job.job_cli import def_job_cli_parser, handle_job_cli_cmd
@@ -65,6 +66,7 @@ CMD_PACKAGE = "package"
 CMD_DEPLOY = "deploy"
 CMD_SYSTEM = "system"
 CMD_STUDY = "study"
+CMD_AGENT = "agent"
 
 _JSONL_COMMANDS = {
     (CMD_JOB, "monitor"),
@@ -299,18 +301,17 @@ def _get_subcommand_choices(parser):
     return []
 
 
-def _emit_argparse_error_json(parser, message):
+def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
     from nvflare.tool.cli_output import SCHEMA_VERSION
 
     # Parser errors intentionally expose usage/choices inline because they are generated before any
     # command handler runs and therefore sit outside the normal command data envelope.
     payload = {
         "schema_version": SCHEMA_VERSION,
-        "event": "terminal",
-        "terminal": True,
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
+        "code": "INVALID_ARGS",
         "message": message,
         "hint": "Run with --help to see usage.",
         "data": {
@@ -318,7 +319,12 @@ def _emit_argparse_error_json(parser, message):
             "choices": _get_subcommand_choices(parser),
         },
     }
-    print(json.dumps(payload))
+    if jsonl_mode:
+        payload["event"] = "terminal"
+        payload["terminal"] = True
+        print(json.dumps(payload), flush=True)
+    else:
+        print(json.dumps(payload))
     parser.exit(4)
 
 
@@ -363,7 +369,7 @@ def _display_unknown_args(argv, cmd: str, args, unknown: list) -> list:
     return display_unknown
 
 
-def _patch_help_on_error(parser, json_mode: bool = False):
+def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = False):
     """Recursively patch every parser in the tree to print help before error-exit.
 
     When argparse detects a missing required argument it calls parser.error(),
@@ -373,7 +379,7 @@ def _patch_help_on_error(parser, json_mode: bool = False):
 
     def _error_with_help(message):
         if json_mode:
-            _emit_argparse_error_json(parser, message)
+            _emit_argparse_error_json(parser, message, jsonl_mode=jsonl_mode)
         else:
             _emit_argparse_error_human(parser, message, exit_code=4)
 
@@ -381,7 +387,7 @@ def _patch_help_on_error(parser, json_mode: bool = False):
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for sub in action.choices.values():
-                _patch_help_on_error(sub, json_mode=json_mode)
+                _patch_help_on_error(sub, json_mode=json_mode, jsonl_mode=jsonl_mode)
 
 
 def _build_global_arg_parser():
@@ -466,6 +472,7 @@ def parse_args(prog_name: str):
     sub_cmd_parsers.update(def_package_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_deploy_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_study_cli_parser(sub_cmd))
+    sub_cmd_parsers.update(def_agent_cli_parser(sub_cmd))
     system_parser = sub_cmd.add_parser(CMD_SYSTEM, help="FL system operations (status, shutdown, version, ...)")
     sub_cmd_parsers.update({CMD_SYSTEM: system_parser})
     def_system_cli_parser(system_parser)
@@ -499,13 +506,16 @@ def parse_args(prog_name: str):
         ns.cert_sub_command = sub_sub
         ns.recipe_sub_cmd = sub_sub or "list"
         ns.deploy_sub_cmd = sub_sub
+        ns.agent_sub_cmd = sub_sub
         ns.format = global_args.format
         ns.connect_timeout = global_args.connect_timeout
         ns.version = global_args.version
         return _parser, ns, sub_cmd_parsers
 
     # Patch every parser so it prints full help before exiting on error.
-    _patch_help_on_error(_parser, json_mode=global_args.format in {"json", "jsonl"})
+    _patch_help_on_error(
+        _parser, json_mode=global_args.format in {"json", "jsonl"}, jsonl_mode=global_args.format == "jsonl"
+    )
 
     args, unknown = _parser.parse_known_args(normalized_argv)
     args._raw_sub_command = args.__dict__.get("sub_command")
@@ -517,14 +527,16 @@ def parse_args(prog_name: str):
         display_unknown = _display_unknown_args(normalized_argv, cmd, args, unknown)
         msg = f"unrecognized arguments: {' '.join(display_unknown)}"
         if args.format in {"json", "jsonl"}:
-            _emit_argparse_error_json(sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}")
+            _emit_argparse_error_json(
+                sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}", jsonl_mode=args.format == "jsonl"
+            )
         else:
             _emit_argparse_error_human(sub_cmd_parser or _parser, msg, exit_code=4)
     if args.format == "jsonl":
         command_path = (getattr(args, "sub_command", None), getattr(args, "job_sub_cmd", None))
         if command_path not in _JSONL_COMMANDS:
             detail = "--format jsonl is only supported by streaming commands: nvflare job monitor"
-            _emit_argparse_error_json(sub_cmd_parser or _parser, detail)
+            _emit_argparse_error_json(sub_cmd_parser or _parser, detail, jsonl_mode=True)
     return _parser, args, sub_cmd_parsers
 
 
@@ -543,6 +555,7 @@ handlers = {
     CMD_DEPLOY: handle_deploy_cmd,
     CMD_STUDY: handle_study_cmd,
     CMD_SYSTEM: handle_system_cmd,
+    CMD_AGENT: handle_agent_cmd,
 }
 
 

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -301,7 +301,7 @@ def _get_subcommand_choices(parser):
     return []
 
 
-def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
+def _emit_argparse_error_json(parser, message):
     from nvflare.tool.cli_output import SCHEMA_VERSION
 
     # Parser errors intentionally expose usage/choices inline because they are generated before any
@@ -311,7 +311,6 @@ def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
-        "code": "INVALID_ARGS",
         "message": message,
         "hint": "Run with --help to see usage.",
         "data": {
@@ -319,12 +318,7 @@ def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
             "choices": _get_subcommand_choices(parser),
         },
     }
-    if jsonl_mode:
-        payload["event"] = "terminal"
-        payload["terminal"] = True
-        print(json.dumps(payload), flush=True)
-    else:
-        print(json.dumps(payload))
+    print(json.dumps(payload))
     parser.exit(4)
 
 
@@ -369,7 +363,7 @@ def _display_unknown_args(argv, cmd: str, args, unknown: list) -> list:
     return display_unknown
 
 
-def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = False):
+def _patch_help_on_error(parser, json_mode: bool = False):
     """Recursively patch every parser in the tree to print help before error-exit.
 
     When argparse detects a missing required argument it calls parser.error(),
@@ -379,7 +373,7 @@ def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = Fal
 
     def _error_with_help(message):
         if json_mode:
-            _emit_argparse_error_json(parser, message, jsonl_mode=jsonl_mode)
+            _emit_argparse_error_json(parser, message)
         else:
             _emit_argparse_error_human(parser, message, exit_code=4)
 
@@ -387,7 +381,7 @@ def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = Fal
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for sub in action.choices.values():
-                _patch_help_on_error(sub, json_mode=json_mode, jsonl_mode=jsonl_mode)
+                _patch_help_on_error(sub, json_mode=json_mode)
 
 
 def _build_global_arg_parser():
@@ -513,9 +507,7 @@ def parse_args(prog_name: str):
         return _parser, ns, sub_cmd_parsers
 
     # Patch every parser so it prints full help before exiting on error.
-    _patch_help_on_error(
-        _parser, json_mode=global_args.format in {"json", "jsonl"}, jsonl_mode=global_args.format == "jsonl"
-    )
+    _patch_help_on_error(_parser, json_mode=global_args.format in {"json", "jsonl"})
 
     args, unknown = _parser.parse_known_args(normalized_argv)
     args._raw_sub_command = args.__dict__.get("sub_command")
@@ -527,16 +519,14 @@ def parse_args(prog_name: str):
         display_unknown = _display_unknown_args(normalized_argv, cmd, args, unknown)
         msg = f"unrecognized arguments: {' '.join(display_unknown)}"
         if args.format in {"json", "jsonl"}:
-            _emit_argparse_error_json(
-                sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}", jsonl_mode=args.format == "jsonl"
-            )
+            _emit_argparse_error_json(sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}")
         else:
             _emit_argparse_error_human(sub_cmd_parser or _parser, msg, exit_code=4)
     if args.format == "jsonl":
         command_path = (getattr(args, "sub_command", None), getattr(args, "job_sub_cmd", None))
         if command_path not in _JSONL_COMMANDS:
             detail = "--format jsonl is only supported by streaming commands: nvflare job monitor"
-            _emit_argparse_error_json(sub_cmd_parser or _parser, detail, jsonl_mode=True)
+            _emit_argparse_error_json(sub_cmd_parser or _parser, detail)
     return _parser, args, sub_cmd_parsers
 
 

--- a/nvflare/tool/agent/__init__.py
+++ b/nvflare/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -301,7 +301,8 @@ def _output_agent_skill_target_error(output_error_message, target, error: ValueE
     output_error_message(
         "AGENT_SKILL_TARGET_INVALID",
         "Invalid agent skill target.",
-        "Choose a target directory without symlink components.",
+        "Choose a target directory without symlink components. On macOS, use real paths such as /private/tmp "
+        "instead of /tmp.",
         exit_code=4,
         detail=str(error),
         data={"target": target},

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-facing CLI command group."""
+
+import argparse
+import sys
+from typing import Optional
+
+import nvflare
+from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
+
+CMD_AGENT_INFO = "info"
+
+_AGENT_OUTPUT_MODES = ["json"]
+_AGENT_EXAMPLES = [
+    "nvflare agent info --format json",
+    "nvflare agent info --schema",
+]
+_agent_parser: Optional[argparse.ArgumentParser] = None
+_agent_sub_cmd_parsers = {}
+
+
+def def_agent_cli_parser(sub_cmd) -> dict:
+    """Register the top-level `nvflare agent` command group."""
+    global _agent_parser
+
+    parser = sub_cmd.add_parser(
+        "agent",
+        description="Agent-facing NVFLARE command surface.",
+        help="Agent-facing NVFLARE helpers.",
+    )
+    parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    agent_subparser = parser.add_subparsers(title="agent subcommands", metavar="", dest="agent_sub_cmd")
+
+    info_parser = agent_subparser.add_parser(
+        CMD_AGENT_INFO,
+        description="Show the available NVFLARE agent command surface.",
+        help="show agent command surface metadata",
+    )
+    info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
+
+    _agent_parser = parser
+    return {"agent": parser}
+
+
+def _agent_info_data() -> dict:
+    return {
+        "nvflare_version": nvflare.__version__,
+        "commands": [
+            {
+                "name": "info",
+                "command": "nvflare agent info",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            }
+        ],
+    }
+
+
+def handle_agent_cmd(args) -> None:
+    from nvflare.tool.cli_output import output_error_message, output_ok
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    sub_cmd = getattr(args, "agent_sub_cmd", None)
+
+    if sub_cmd is None:
+        handle_schema_flag(
+            _agent_parser,
+            "nvflare agent",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SUBCOMMAND_REQUIRED",
+            "Agent subcommand required.",
+            "Run 'nvflare agent --help' or 'nvflare agent info --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if sub_cmd == CMD_AGENT_INFO:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_INFO],
+            "nvflare agent info",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_ok(
+            _agent_info_data(),
+            code="OK",
+            message="NVFLARE agent command surface is available.",
+            hint="Use --schema on agent-facing commands to inspect argument contracts.",
+        )
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -228,12 +228,16 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
             mutating=True,
             idempotent=True,
         )
-        plan = install_skills(
-            agent=args.agent,
-            skill_name=getattr(args, "skill", None),
-            dry_run=getattr(args, "dry_run", False),
-            target_dir=getattr(args, "target", None),
-        )
+        try:
+            plan = install_skills(
+                agent=args.agent,
+                skill_name=getattr(args, "skill", None),
+                dry_run=getattr(args, "dry_run", False),
+                target_dir=getattr(args, "target", None),
+            )
+        except ValueError as e:
+            _output_agent_skill_target_error(output_error_message, getattr(args, "target", None), e)
+            return
         if plan["missing"]:
             output_error_message(
                 "AGENT_SKILL_NOT_FOUND",
@@ -277,7 +281,11 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
             mutating=False,
             idempotent=True,
         )
-        data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        try:
+            data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        except ValueError as e:
+            _output_agent_skill_target_error(output_error_message, getattr(args, "target", None), e)
+            return
         output_ok(
             data,
             code="OK",
@@ -287,6 +295,18 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
         return
 
     raise CLIUnknownCmdException(f"unknown agent skills subcommand: {skills_sub_cmd}")
+
+
+def _output_agent_skill_target_error(output_error_message, target, error: ValueError) -> None:
+    output_error_message(
+        "AGENT_SKILL_TARGET_INVALID",
+        "Invalid agent skill target.",
+        "Choose a target directory without symlink components.",
+        exit_code=4,
+        detail=str(error),
+        data={"target": target},
+        recovery_category="FIXABLE_BY_CONFIG",
+    )
 
 
 def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -22,14 +22,25 @@ import nvflare
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
 
 CMD_AGENT_INFO = "info"
+CMD_AGENT_SKILLS = "skills"
+CMD_AGENT_SKILLS_INSTALL = "install"
+CMD_AGENT_SKILLS_LIST = "list"
 
 _AGENT_OUTPUT_MODES = ["json"]
 _AGENT_EXAMPLES = [
     "nvflare agent info --format json",
+    "nvflare agent skills install --agent codex --dry-run --format json",
+    "nvflare agent skills list --agent claude --format json",
     "nvflare agent info --schema",
+]
+_AGENT_SKILLS_EXAMPLES = [
+    "nvflare agent skills install --agent codex --dry-run --format json",
+    "nvflare agent skills install --agent claude --skill nvflare-orient --format json",
+    "nvflare agent skills list --agent codex --format json",
 ]
 _agent_parser: Optional[argparse.ArgumentParser] = None
 _agent_sub_cmd_parsers = {}
+_agent_skills_sub_cmd_parsers = {}
 
 
 def def_agent_cli_parser(sub_cmd) -> dict:
@@ -52,8 +63,44 @@ def def_agent_cli_parser(sub_cmd) -> dict:
     info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
 
+    skills_parser = agent_subparser.add_parser(
+        CMD_AGENT_SKILLS,
+        description="Install and list NVFLARE-owned agent skills.",
+        help="install and list NVFLARE-owned agent skills",
+    )
+    skills_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    skills_subparser = skills_parser.add_subparsers(
+        title="agent skills subcommands", metavar="", dest="agent_skills_sub_cmd"
+    )
+    install_parser = skills_subparser.add_parser(
+        CMD_AGENT_SKILLS_INSTALL,
+        description="Install NVFLARE-owned skills into a local agent skill directory.",
+        help="install NVFLARE-owned skills",
+    )
+    _add_agent_target_args(install_parser)
+    install_parser.add_argument("--skill", help="install one skill by name; omit to install all available skills")
+    install_parser.add_argument("--dry-run", action="store_true", help="show the install plan without copying files")
+    install_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    list_parser = skills_subparser.add_parser(
+        CMD_AGENT_SKILLS_LIST,
+        description="List available and installed NVFLARE-owned skills for an agent target.",
+        help="list NVFLARE-owned skills",
+    )
+    _add_agent_target_args(list_parser)
+    list_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    _agent_sub_cmd_parsers[CMD_AGENT_SKILLS] = skills_parser
+    _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL] = install_parser
+    _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST] = list_parser
+
     _agent_parser = parser
     return {"agent": parser}
+
+
+def _add_agent_target_args(parser) -> None:
+    parser.add_argument("--agent", choices=["codex", "claude"], required=True, help="agent skill target to manage")
+    parser.add_argument("--target", help="override the resolved agent skill directory")
 
 
 def _agent_info_data() -> dict:
@@ -66,7 +113,21 @@ def _agent_info_data() -> dict:
                 "status": "available",
                 "mutating": False,
                 "streaming": False,
-            }
+            },
+            {
+                "name": "skills install",
+                "command": "nvflare agent skills install",
+                "status": "available",
+                "mutating": True,
+                "streaming": False,
+            },
+            {
+                "name": "skills list",
+                "command": "nvflare agent skills list",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            },
         ],
     }
 
@@ -116,4 +177,111 @@ def handle_agent_cmd(args) -> None:
         )
         return
 
+    if sub_cmd == CMD_AGENT_SKILLS:
+        _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
     raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")
+
+
+def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.skill_manager import SUPPORTED_AGENT_TARGETS, install_skills, list_skills
+
+    skills_sub_cmd = getattr(args, "agent_skills_sub_cmd", None)
+    schema_sub_cmd = _schema_agent_skills_sub_cmd(getattr(args, "_argv", sys.argv[1:]))
+
+    if skills_sub_cmd is None and schema_sub_cmd in _agent_skills_sub_cmd_parsers:
+        skills_sub_cmd = schema_sub_cmd
+
+    if skills_sub_cmd is None:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_SKILLS],
+            "nvflare agent skills",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SKILLS_SUBCOMMAND_REQUIRED",
+            "Agent skills subcommand required.",
+            "Run 'nvflare agent skills --help' or 'nvflare agent skills list --agent codex --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if skills_sub_cmd == CMD_AGENT_SKILLS_INSTALL:
+        handle_schema_flag(
+            _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL],
+            "nvflare agent skills install",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=True,
+            idempotent=True,
+        )
+        plan = install_skills(
+            agent=args.agent,
+            skill_name=getattr(args, "skill", None),
+            dry_run=getattr(args, "dry_run", False),
+            target_dir=getattr(args, "target", None),
+        )
+        if plan["missing"]:
+            output_error_message(
+                "AGENT_SKILL_NOT_FOUND",
+                f"NVFLARE skill not found: {', '.join(plan['missing'])}.",
+                "Run 'nvflare agent skills list --agent <codex|claude> --format json' to inspect available skills.",
+                exit_code=4,
+                data=plan,
+                recovery_category="FIXABLE_BY_CONFIG",
+            )
+            return
+        output_ok(
+            plan,
+            code="OK",
+            message=(
+                "NVFLARE agent skills install plan completed."
+                if plan["applied"]
+                else "NVFLARE agent skills install dry run completed."
+            ),
+            hint="Review conflicts before relying on skipped skills." if plan["conflicts"] else "",
+        )
+        return
+
+    if skills_sub_cmd == CMD_AGENT_SKILLS_LIST:
+        handle_schema_flag(
+            _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST],
+            "nvflare agent skills list",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        output_ok(
+            data,
+            code="OK",
+            message="NVFLARE agent skills listed.",
+            hint=f"Supported agent targets: {', '.join(SUPPORTED_AGENT_TARGETS)}.",
+        )
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent skills subcommand: {skills_sub_cmd}")
+
+
+def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:
+    if "--schema" not in argv or CMD_AGENT_SKILLS not in argv:
+        return None
+    index = argv.index(CMD_AGENT_SKILLS) + 1
+    while index < len(argv):
+        token = argv[index]
+        if token in _agent_skills_sub_cmd_parsers:
+            return token
+        index += 1
+    return None

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -99,7 +99,11 @@ def def_agent_cli_parser(sub_cmd) -> dict:
 
 
 def _add_agent_target_args(parser) -> None:
-    parser.add_argument("--agent", choices=["codex", "claude"], required=True, help="agent skill target to manage")
+    from nvflare.tool.agent.skill_manager import SUPPORTED_AGENT_TARGETS
+
+    parser.add_argument(
+        "--agent", choices=list(SUPPORTED_AGENT_TARGETS), required=True, help="agent skill target to manage"
+    )
     parser.add_argument("--target", help="override the resolved agent skill directory")
 
 
@@ -240,6 +244,16 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
                 recovery_category="FIXABLE_BY_CONFIG",
             )
             return
+        if plan["errors"]:
+            output_error_message(
+                "AGENT_SKILL_INSTALL_FAILED",
+                "One or more NVFLARE skills failed to install.",
+                "Review data.errors and rerun the install after fixing the reported filesystem issue.",
+                exit_code=1,
+                data=plan,
+                recovery_category="FIXABLE_BY_ENV",
+            )
+            return
         output_ok(
             plan,
             code="OK",
@@ -276,6 +290,8 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
 
 
 def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:
+    # The top-level CLI bypasses nested argparse parsing for --schema, so infer
+    # the third-level agent skills command from argv until that parser path is generalized.
     if "--schema" not in argv or CMD_AGENT_SKILLS not in argv:
         return None
     index = argv.index(CMD_AGENT_SKILLS) + 1

--- a/nvflare/tool/agent/bundled_skills/__init__.py
+++ b/nvflare/tool/agent/bundled_skills/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bundled NVFLARE-owned agent skills and manifest."""

--- a/nvflare/tool/agent/bundled_skills/manifest.json
+++ b/nvflare/tool/agent/bundled_skills/manifest.json
@@ -1,0 +1,7 @@
+{
+  "findings": [],
+  "nvflare_version": "",
+  "schema_version": "1",
+  "skills": [],
+  "source_type": "wheel"
+}

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -109,10 +109,13 @@ def install_skills(
                 _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
                 entry["status"] = "installed"
             elif entry["action"] == "replace":
-                backup_path = Path(entry["backup_path"])
-                backup_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(entry["target_path"], backup_path)
-                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                _replace_skill(
+                    source.root / entry["relative_path"],
+                    Path(entry["target_path"]),
+                    Path(entry["backup_path"]),
+                    entry,
+                    source,
+                )
                 entry["status"] = "replaced"
             else:
                 entry["status"] = "skipped"
@@ -234,24 +237,57 @@ def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: Sk
     target_dir.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
         temp_skill_dir = Path(temp_root) / target_dir.name
-        shutil.copytree(source_dir, temp_skill_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
-        manifest = {
-            "schema_version": "1",
-            "managed_by": "nvflare",
-            "name": plan_entry["name"],
-            "skill_version": plan_entry.get("skill_version"),
-            "nvflare_version": nvflare.__version__,
-            "source_type": source.source_type,
-            "source_hash": plan_entry["source_hash"],
-            "installed_paths": [str(target_dir)],
-            "installed_at": datetime.now(timezone.utc).isoformat(),
-        }
-        (temp_skill_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
+        _stage_skill(source_dir, temp_skill_dir, plan_entry, source, installed_path=target_dir)
         if target_dir.exists():
             raise FileExistsError(f"target skill directory already exists: {target_dir}")
-        shutil.move(temp_skill_dir, target_dir)
+        _publish_staged_skill(temp_skill_dir, target_dir)
+
+
+def _replace_skill(
+    source_dir: Path, target_dir: Path, backup_path: Path, plan_entry: dict, source: SkillSource
+) -> None:
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
+        temp_skill_dir = Path(temp_root) / target_dir.name
+        _stage_skill(source_dir, temp_skill_dir, plan_entry, source, installed_path=target_dir)
+        if not target_dir.exists():
+            raise FileNotFoundError(f"target skill directory no longer exists: {target_dir}")
+        if backup_path.exists():
+            raise FileExistsError(f"backup skill directory already exists: {backup_path}")
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(target_dir, backup_path)
+        try:
+            _publish_staged_skill(temp_skill_dir, target_dir)
+        except Exception:
+            if not target_dir.exists() and backup_path.exists():
+                shutil.move(backup_path, target_dir)
+            raise
+
+
+def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:
+    if target_dir.exists():
+        raise FileExistsError(f"target skill directory already exists: {target_dir}")
+    os.replace(staged_dir, target_dir)
+
+
+def _stage_skill(
+    source_dir: Path, staged_dir: Path, plan_entry: dict, source: SkillSource, *, installed_path: Path
+) -> None:
+    shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+    manifest = {
+        "schema_version": "1",
+        "managed_by": "nvflare",
+        "name": plan_entry["name"],
+        "skill_version": plan_entry.get("skill_version"),
+        "nvflare_version": nvflare.__version__,
+        "source_type": source.source_type,
+        "source_hash": plan_entry["source_hash"],
+        "installed_paths": [str(installed_path)],
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (staged_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -177,7 +177,9 @@ def _install_plan(
     planned_skills = []
     conflicts = []
     for skill in skills:
+        source_skill_dir = source.root / skill["relative_path"]
         target_skill_dir = target / skill["name"]
+        source_symlink = _first_symlink_in_tree(source_skill_dir)
         # version_delta: new, unknown external state, blocked local edit, same, or update.
         entry = {
             "name": skill["name"],
@@ -185,10 +187,21 @@ def _install_plan(
             "source_hash": skill["source_hash"],
             "relative_path": skill["relative_path"],
             "target_path": str(target_skill_dir),
-            "files": _files_to_copy(source.root / skill["relative_path"], target_skill_dir),
+            "files": [] if source_symlink else _files_to_copy(source_skill_dir, target_skill_dir),
             "version_delta": "new",
         }
-        if not target_skill_dir.exists():
+        if source_symlink:
+            entry["action"] = "skip"
+            entry["conflict"] = "source_symlink_detected"
+            entry["version_delta"] = "blocked"
+            entry["source_issue"] = {
+                "code": "source_symlink_detected",
+                "message": "source skill directory contains a symlink",
+                "source_path": str(source_skill_dir),
+                "symlink_path": str(source_symlink),
+            }
+            conflicts.append(_source_conflict(skill["name"], source_skill_dir, source_symlink))
+        elif not target_skill_dir.exists():
             entry["action"] = "copy"
         else:
             install_manifest = _read_install_manifest(target_skill_dir)
@@ -410,6 +423,16 @@ def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
         "code": code,
         "message": messages.get(code, code),
         "target_path": str(target_path),
+    }
+
+
+def _source_conflict(skill_name: str, source_path: Path, symlink_path: Path) -> dict:
+    return {
+        "skill": skill_name,
+        "code": "source_symlink_detected",
+        "message": "source skill directory contains a symlink",
+        "source_path": str(source_path),
+        "symlink_path": str(symlink_path),
     }
 
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -134,6 +134,8 @@ def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: 
     target = resolve_agent_target_dir(agent, target_dir=target_dir)
     installed = []
     conflicts = []
+    available = source.manifest.get("skills", [])
+    available_names = {skill["name"] for skill in available}
 
     if target.is_dir():
         for child in sorted(target.iterdir(), key=lambda p: p.name):
@@ -150,7 +152,7 @@ def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: 
                         "source_type": install_manifest.get("source_type"),
                     }
                 )
-            else:
+            elif child.name in available_names:
                 conflicts.append(
                     {
                         "skill": child.name,
@@ -164,7 +166,7 @@ def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: 
         "agent": agent,
         "target_path": str(target),
         "source": _source_summary(source),
-        "available": source.manifest.get("skills", []),
+        "available": available,
         "installed": installed,
         "conflicts": conflicts,
     }

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native install/list support for NVFLARE-owned agent skills."""
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import resources
+from pathlib import Path
+from typing import Optional
+
+import nvflare
+from nvflare.tool.agent.skill_manifest import (
+    IGNORED_SKILL_FILE_NAMES,
+    MANIFEST_FILE_NAME,
+    build_skill_manifest,
+    load_manifest,
+    skill_tree_hash,
+)
+
+INSTALL_MANIFEST_FILE_NAME = ".nvflare_skill_install.json"
+SUPPORTED_AGENT_TARGETS = ("codex", "claude")
+BUNDLED_SKILLS_PACKAGE = "nvflare.tool.agent.bundled_skills"
+
+
+@dataclass(frozen=True)
+class SkillSource:
+    source_type: str
+    root: Path
+    manifest: dict
+
+
+def resolve_agent_target_dir(
+    agent: str, *, target_dir: Optional[Path | str] = None, env: Optional[dict] = None
+) -> Path:
+    """Resolve a named agent target to its skill installation directory."""
+    if target_dir:
+        return Path(target_dir).expanduser()
+
+    env_map = env or os.environ
+    if agent == "codex":
+        codex_home = env_map.get("CODEX_HOME")
+        if codex_home:
+            return Path(codex_home).expanduser() / "skills"
+        return Path.home() / ".codex" / "skills"
+    if agent == "claude":
+        return Path.home() / ".claude" / "skills"
+    raise ValueError(f"unsupported agent target: {agent}")
+
+
+def find_skill_source() -> SkillSource:
+    """Find skills from an editable/source checkout first, then from the installed package bundle."""
+    source_root = Path(__file__).resolve().parents[3] / "skills"
+    if source_root.is_dir():
+        return SkillSource(
+            source_type="editable",
+            root=source_root,
+            manifest=build_skill_manifest(source_root, source_type="editable", nvflare_version=nvflare.__version__),
+        )
+
+    bundle_root = Path(str(resources.files(BUNDLED_SKILLS_PACKAGE)))
+    manifest_path = bundle_root / MANIFEST_FILE_NAME
+    manifest = (
+        load_manifest(manifest_path)
+        if manifest_path.is_file()
+        else build_skill_manifest(bundle_root, source_type="wheel")
+    )
+    return SkillSource(source_type="wheel", root=bundle_root, manifest=manifest)
+
+
+def install_skills(
+    *,
+    agent: str,
+    skill_name: Optional[str] = None,
+    dry_run: bool = False,
+    target_dir: Optional[Path | str] = None,
+    source: Optional[SkillSource] = None,
+) -> dict:
+    """Plan or apply a native NVFLARE skill installation."""
+    source = source or find_skill_source()
+    target = resolve_agent_target_dir(agent, target_dir=target_dir)
+    selected, missing = _select_skills(source.manifest, skill_name)
+    plan = _install_plan(source, selected, target, agent=agent, requested_skill=skill_name)
+    plan["missing"] = missing
+    plan["applied"] = False
+
+    if dry_run or missing:
+        return plan
+
+    target.mkdir(parents=True, exist_ok=True)
+    for entry in plan["skills"]:
+        if entry["action"] == "copy":
+            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+            entry["status"] = "installed"
+        elif entry["action"] == "replace":
+            backup_path = Path(entry["backup_path"])
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(entry["target_path"], backup_path)
+            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+            entry["status"] = "replaced"
+        else:
+            entry["status"] = "skipped"
+    plan["applied"] = True
+    return plan
+
+
+def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: Optional[SkillSource] = None) -> dict:
+    """List available packaged skills and installed managed skills for an agent target."""
+    source = source or find_skill_source()
+    target = resolve_agent_target_dir(agent, target_dir=target_dir)
+    installed = []
+    conflicts = []
+
+    if target.is_dir():
+        for child in sorted(target.iterdir(), key=lambda p: p.name):
+            if child.name.startswith(".") or not child.is_dir():
+                continue
+            install_manifest = _read_install_manifest(child)
+            if install_manifest and install_manifest.get("managed_by") == "nvflare":
+                installed.append(
+                    {
+                        "name": install_manifest.get("name", child.name),
+                        "skill_version": install_manifest.get("skill_version"),
+                        "source_hash": install_manifest.get("source_hash"),
+                        "target_path": str(child),
+                        "source_type": install_manifest.get("source_type"),
+                    }
+                )
+            else:
+                conflicts.append(
+                    {
+                        "skill": child.name,
+                        "code": "external_install_detected",
+                        "message": "target skill directory is not managed by nvflare",
+                        "target_path": str(child),
+                    }
+                )
+
+    return {
+        "agent": agent,
+        "target_path": str(target),
+        "source": _source_summary(source),
+        "available": source.manifest.get("skills", []),
+        "installed": installed,
+        "conflicts": conflicts,
+    }
+
+
+def _install_plan(
+    source: SkillSource, skills: list[dict], target: Path, *, agent: str, requested_skill: Optional[str]
+) -> dict:
+    now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    planned_skills = []
+    conflicts = []
+    for skill in skills:
+        target_skill_dir = target / skill["name"]
+        entry = {
+            "name": skill["name"],
+            "skill_version": skill.get("skill_version"),
+            "source_hash": skill["source_hash"],
+            "relative_path": skill["relative_path"],
+            "target_path": str(target_skill_dir),
+            "files": _files_to_copy(source.root / skill["relative_path"], target_skill_dir),
+            "version_delta": "new",
+        }
+        if not target_skill_dir.exists():
+            entry["action"] = "copy"
+        else:
+            install_manifest = _read_install_manifest(target_skill_dir)
+            if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+                entry["action"] = "skip"
+                entry["conflict"] = "external_install_detected"
+                entry["version_delta"] = "unknown"
+                conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
+            elif skill_tree_hash(target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}) != install_manifest.get(
+                "source_hash"
+            ):
+                entry["action"] = "skip"
+                entry["conflict"] = "local_modifications_detected"
+                entry["version_delta"] = "blocked"
+                conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
+            elif install_manifest.get("source_hash") == skill["source_hash"]:
+                entry["action"] = "skip"
+                entry["reason"] = "already_installed"
+                entry["version_delta"] = "same"
+            else:
+                backup_path = target / ".nvflare_bak" / now / skill["name"]
+                entry["action"] = "replace"
+                entry["backup_path"] = str(backup_path)
+                entry["version_delta"] = "update"
+        planned_skills.append(entry)
+
+    return {
+        "agent": agent,
+        "target_path": str(target),
+        "requested_skill": requested_skill,
+        "source": _source_summary(source),
+        "available": source.manifest.get("skills", []),
+        "skills": planned_skills,
+        "conflicts": conflicts,
+        "deprecated_skills_skipped": [],
+    }
+
+
+def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: SkillSource) -> None:
+    shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+    manifest = {
+        "schema_version": "1",
+        "managed_by": "nvflare",
+        "name": plan_entry["name"],
+        "skill_version": plan_entry.get("skill_version"),
+        "nvflare_version": nvflare.__version__,
+        "source_type": source.source_type,
+        "source_hash": plan_entry["source_hash"],
+        "installed_paths": [str(target_dir)],
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (target_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:
+    skills = manifest.get("skills", [])
+    if not skill_name:
+        return skills, []
+    selected = [skill for skill in skills if skill.get("name") == skill_name]
+    return selected, [] if selected else [skill_name]
+
+
+def _source_summary(source: SkillSource) -> dict:
+    return {
+        "type": source.source_type,
+        "root": str(source.root),
+        "nvflare_version": source.manifest.get("nvflare_version"),
+        "manifest_schema_version": source.manifest.get("schema_version"),
+        "skill_count": len(source.manifest.get("skills", [])),
+        "findings": source.manifest.get("findings", []),
+    }
+
+
+def _files_to_copy(source_dir: Path, target_dir: Path) -> list[dict]:
+    files = []
+    for file_path in sorted(source_dir.rglob("*"), key=lambda p: p.relative_to(source_dir).as_posix()):
+        if not file_path.is_file():
+            continue
+        rel_path = file_path.relative_to(source_dir)
+        if "__pycache__" in rel_path.parts or file_path.suffix in {".pyc", ".pyo"}:
+            continue
+        files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
+    return files
+
+
+def _read_install_manifest(skill_dir: Path) -> Optional[dict]:
+    manifest_path = skill_dir / INSTALL_MANIFEST_FILE_NAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
+    messages = {
+        "external_install_detected": "target skill directory is not managed by nvflare",
+        "local_modifications_detected": "managed skill content differs from its install manifest",
+    }
+    return {
+        "skill": skill_name,
+        "code": code,
+        "message": messages[code],
+        "target_path": str(target_path),
+    }

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -17,6 +17,7 @@
 import json
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib import resources
@@ -64,8 +65,8 @@ def resolve_agent_target_dir(
 
 def find_skill_source() -> SkillSource:
     """Find skills from an editable/source checkout first, then from the installed package bundle."""
-    source_root = Path(__file__).resolve().parents[3] / "skills"
-    if source_root.is_dir():
+    source_root = _source_checkout_root()
+    if source_root:
         return SkillSource(
             source_type="editable",
             root=source_root,
@@ -103,18 +104,29 @@ def install_skills(
 
     target.mkdir(parents=True, exist_ok=True)
     for entry in plan["skills"]:
-        if entry["action"] == "copy":
-            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
-            entry["status"] = "installed"
-        elif entry["action"] == "replace":
-            backup_path = Path(entry["backup_path"])
-            backup_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(entry["target_path"], backup_path)
-            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
-            entry["status"] = "replaced"
-        else:
-            entry["status"] = "skipped"
-    plan["applied"] = True
+        try:
+            if entry["action"] == "copy":
+                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                entry["status"] = "installed"
+            elif entry["action"] == "replace":
+                backup_path = Path(entry["backup_path"])
+                backup_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(entry["target_path"], backup_path)
+                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                entry["status"] = "replaced"
+            else:
+                entry["status"] = "skipped"
+        except Exception as e:
+            error = {
+                "skill": entry["name"],
+                "code": "skill_install_failed",
+                "type": type(e).__name__,
+                "message": str(e),
+            }
+            entry["status"] = "failed"
+            entry["error"] = error
+            plan["errors"].append(error)
+    plan["applied"] = not plan["errors"]
     return plan
 
 
@@ -168,6 +180,7 @@ def _install_plan(
     conflicts = []
     for skill in skills:
         target_skill_dir = target / skill["name"]
+        # version_delta: new, unknown external state, blocked local edit, same, or update.
         entry = {
             "name": skill["name"],
             "skill_version": skill.get("skill_version"),
@@ -212,26 +225,33 @@ def _install_plan(
         "available": source.manifest.get("skills", []),
         "skills": planned_skills,
         "conflicts": conflicts,
+        "errors": [],
         "deprecated_skills_skipped": [],
     }
 
 
 def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: SkillSource) -> None:
-    shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
-    manifest = {
-        "schema_version": "1",
-        "managed_by": "nvflare",
-        "name": plan_entry["name"],
-        "skill_version": plan_entry.get("skill_version"),
-        "nvflare_version": nvflare.__version__,
-        "source_type": source.source_type,
-        "source_hash": plan_entry["source_hash"],
-        "installed_paths": [str(target_dir)],
-        "installed_at": datetime.now(timezone.utc).isoformat(),
-    }
-    (target_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
+        temp_skill_dir = Path(temp_root) / target_dir.name
+        shutil.copytree(source_dir, temp_skill_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+        manifest = {
+            "schema_version": "1",
+            "managed_by": "nvflare",
+            "name": plan_entry["name"],
+            "skill_version": plan_entry.get("skill_version"),
+            "nvflare_version": nvflare.__version__,
+            "source_type": source.source_type,
+            "source_hash": plan_entry["source_hash"],
+            "installed_paths": [str(target_dir)],
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        (temp_skill_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if target_dir.exists():
+            raise FileExistsError(f"target skill directory already exists: {target_dir}")
+        shutil.move(temp_skill_dir, target_dir)
 
 
 def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:
@@ -286,3 +306,11 @@ def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
         "message": messages[code],
         "target_path": str(target_path),
     }
+
+
+def _source_checkout_root() -> Optional[Path]:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_root = repo_root / "skills"
+    if source_root.is_dir() and (repo_root / "pyproject.toml").is_file() and (repo_root / "setup.py").is_file():
+        return source_root
+    return None

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -50,7 +50,7 @@ def resolve_agent_target_dir(
 ) -> Path:
     """Resolve a named agent target to its skill installation directory."""
     if target_dir:
-        return Path(target_dir).expanduser()
+        return _resolve_target_override(target_dir)
 
     env_map = env or os.environ
     if agent == "codex":
@@ -295,6 +295,9 @@ def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:
 def _stage_skill(
     source_dir: Path, staged_dir: Path, plan_entry: dict, source: SkillSource, *, installed_path: Path
 ) -> None:
+    symlink = _first_symlink_in_tree(source_dir)
+    if symlink:
+        raise ValueError(f"skill source must not contain symlinks: {symlink.relative_to(source_dir).as_posix()}")
     shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
     manifest = {
         "schema_version": "1",
@@ -331,15 +334,59 @@ def _source_summary(source: SkillSource) -> dict:
     }
 
 
+def _resolve_target_override(target_dir: Path | str) -> Path:
+    target = Path(target_dir).expanduser()
+    symlink = _first_symlink_component(target)
+    if symlink:
+        raise ValueError(f"agent skill target must not contain symlink components: {symlink}")
+    return target.resolve(strict=False)
+
+
+def _first_symlink_component(path: Path) -> Optional[Path]:
+    current = Path(path.anchor) if path.is_absolute() else Path.cwd()
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    for part in parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            current = current.parent
+            continue
+        current = current / part
+        if current.is_symlink():
+            return current
+    return None
+
+
+def _first_symlink_in_tree(root_dir: Path) -> Optional[Path]:
+    for root, dir_names, file_names in os.walk(root_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        for name in dir_names + file_names:
+            path = root_path / name
+            if path.is_symlink():
+                return path
+        dir_names[:] = [name for name in dir_names if not (root_path / name).is_symlink()]
+    return None
+
+
 def _files_to_copy(source_dir: Path, target_dir: Path) -> list[dict]:
     files = []
-    for file_path in sorted(source_dir.rglob("*"), key=lambda p: p.relative_to(source_dir).as_posix()):
-        if not file_path.is_file():
-            continue
-        rel_path = file_path.relative_to(source_dir)
-        if "__pycache__" in rel_path.parts or file_path.suffix in {".pyc", ".pyo"}:
-            continue
-        files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
+    for root, dir_names, file_names in os.walk(source_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        dir_names[:] = [name for name in dir_names if name != "__pycache__" and not (root_path / name).is_symlink()]
+        for file_name in file_names:
+            file_path = root_path / file_name
+            if file_path.is_symlink():
+                continue
+            if file_path.suffix in {".pyc", ".pyo"}:
+                continue
+            if not file_path.is_file():
+                continue
+            rel_path = file_path.relative_to(source_dir)
+            files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
     return files
 
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -303,7 +303,7 @@ def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
     return {
         "skill": skill_name,
         "code": code,
-        "message": messages[code],
+        "message": messages.get(code, code),
         "target_path": str(target_path),
     }
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -257,9 +257,17 @@ def _replace_skill(
             if not target_dir.exists() and backup_path.exists():
                 try:
                     shutil.move(backup_path, target_dir)
+                    _remove_empty_dir(backup_path.parent)
                 except Exception as recovery_error:
                     publish_error.recovery_error = recovery_error
             raise
+
+
+def _remove_empty_dir(path: Path) -> None:
+    try:
+        path.rmdir()
+    except OSError:
+        pass
 
 
 def _install_error(skill_name: str, error: Exception) -> dict:

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -204,28 +204,51 @@ def _install_plan(
         elif not target_skill_dir.exists():
             entry["action"] = "copy"
         else:
-            install_manifest = _read_install_manifest(target_skill_dir)
-            if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+            target_symlink = _first_symlink_in_tree(target_skill_dir)
+            if target_symlink:
                 entry["action"] = "skip"
-                entry["conflict"] = "external_install_detected"
-                entry["version_delta"] = "unknown"
-                conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
-            elif skill_tree_hash(target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}) != install_manifest.get(
-                "source_hash"
-            ):
-                entry["action"] = "skip"
-                entry["conflict"] = "local_modifications_detected"
+                entry["conflict"] = "target_symlink_detected"
                 entry["version_delta"] = "blocked"
-                conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
-            elif install_manifest.get("source_hash") == skill["source_hash"]:
-                entry["action"] = "skip"
-                entry["reason"] = "already_installed"
-                entry["version_delta"] = "same"
+                entry["target_issue"] = {
+                    "code": "target_symlink_detected",
+                    "message": "target skill directory contains a symlink",
+                    "target_path": str(target_skill_dir),
+                    "symlink_path": str(target_symlink),
+                }
+                conflicts.append(_target_symlink_conflict(skill["name"], target_skill_dir, target_symlink))
             else:
-                backup_path = target / ".nvflare_bak" / now / skill["name"]
-                entry["action"] = "replace"
-                entry["backup_path"] = str(backup_path)
-                entry["version_delta"] = "update"
+                install_manifest = _read_install_manifest(target_skill_dir)
+                if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+                    entry["action"] = "skip"
+                    entry["conflict"] = "external_install_detected"
+                    entry["version_delta"] = "unknown"
+                    conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
+                else:
+                    try:
+                        installed_source_hash = skill_tree_hash(
+                            target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}
+                        )
+                    except ValueError as e:
+                        installed_source_hash = None
+                        entry["target_issue"] = {
+                            "code": "local_modifications_detected",
+                            "message": str(e),
+                            "target_path": str(target_skill_dir),
+                        }
+                    if installed_source_hash != install_manifest.get("source_hash"):
+                        entry["action"] = "skip"
+                        entry["conflict"] = "local_modifications_detected"
+                        entry["version_delta"] = "blocked"
+                        conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
+                    elif install_manifest.get("source_hash") == skill["source_hash"]:
+                        entry["action"] = "skip"
+                        entry["reason"] = "already_installed"
+                        entry["version_delta"] = "same"
+                    else:
+                        backup_path = target / ".nvflare_bak" / now / skill["name"]
+                        entry["action"] = "replace"
+                        entry["backup_path"] = str(backup_path)
+                        entry["version_delta"] = "update"
         planned_skills.append(entry)
 
     return {
@@ -371,6 +394,8 @@ def _first_symlink_component(path: Path) -> Optional[Path]:
 
 
 def _first_symlink_in_tree(root_dir: Path) -> Optional[Path]:
+    if root_dir.is_symlink():
+        return root_dir
     for root, dir_names, file_names in os.walk(root_dir, topdown=True, followlinks=False):
         root_path = Path(root)
         dir_names.sort()
@@ -432,6 +457,16 @@ def _source_conflict(skill_name: str, source_path: Path, symlink_path: Path) -> 
         "code": "source_symlink_detected",
         "message": "source skill directory contains a symlink",
         "source_path": str(source_path),
+        "symlink_path": str(symlink_path),
+    }
+
+
+def _target_symlink_conflict(skill_name: str, target_path: Path, symlink_path: Path) -> dict:
+    return {
+        "skill": skill_name,
+        "code": "target_symlink_detected",
+        "message": "target skill directory contains a symlink",
+        "target_path": str(target_path),
         "symlink_path": str(symlink_path),
     }
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -120,12 +120,7 @@ def install_skills(
             else:
                 entry["status"] = "skipped"
         except Exception as e:
-            error = {
-                "skill": entry["name"],
-                "code": "skill_install_failed",
-                "type": type(e).__name__,
-                "message": str(e),
-            }
+            error = _install_error(entry["name"], e)
             entry["status"] = "failed"
             entry["error"] = error
             plan["errors"].append(error)
@@ -258,10 +253,29 @@ def _replace_skill(
         shutil.move(target_dir, backup_path)
         try:
             _publish_staged_skill(temp_skill_dir, target_dir)
-        except Exception:
+        except Exception as publish_error:
             if not target_dir.exists() and backup_path.exists():
-                shutil.move(backup_path, target_dir)
+                try:
+                    shutil.move(backup_path, target_dir)
+                except Exception as recovery_error:
+                    publish_error.recovery_error = recovery_error
             raise
+
+
+def _install_error(skill_name: str, error: Exception) -> dict:
+    result = {
+        "skill": skill_name,
+        "code": "skill_install_failed",
+        "type": type(error).__name__,
+        "message": str(error),
+    }
+    recovery_error = getattr(error, "recovery_error", None)
+    if recovery_error is not None:
+        result["recovery_error"] = {
+            "type": type(recovery_error).__name__,
+            "message": str(recovery_error),
+        }
+    return result
 
 
 def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -18,6 +18,7 @@ import hashlib
 import importlib
 import importlib.util
 import json
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -108,7 +109,9 @@ def copy_released_skills_to_bundle(
     for child in list(target_root.iterdir()):
         if child.name == "__init__.py":
             continue
-        if child.is_dir():
+        if child.is_symlink():
+            child.unlink()
+        elif child.is_dir():
             shutil.rmtree(child)
         else:
             child.unlink()
@@ -125,14 +128,34 @@ def copy_released_skills_to_bundle(
 
 
 def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
-    for path in sorted(skill_dir.rglob("*"), key=lambda p: p.relative_to(skill_dir).as_posix()):
-        if not path.is_file():
+    for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        rel_root = root_path.relative_to(skill_dir)
+        if any(part in exclude_names for part in rel_root.parts):
+            dir_names[:] = []
             continue
-        if any(part in exclude_names for part in path.relative_to(skill_dir).parts):
-            continue
-        if path.suffix in {".pyc", ".pyo"}:
-            continue
-        yield path
+
+        dir_names.sort()
+        file_names.sort()
+        for dir_name in list(dir_names):
+            dir_path = root_path / dir_name
+            if dir_path.is_symlink():
+                raise ValueError(f"skill directory contains symlink: {dir_path.relative_to(skill_dir).as_posix()}")
+            if dir_name in exclude_names:
+                dir_names.remove(dir_name)
+
+        for file_name in file_names:
+            file_path = root_path / file_name
+            rel_path = file_path.relative_to(skill_dir)
+            if file_path.is_symlink():
+                raise ValueError(f"skill directory contains symlink: {rel_path.as_posix()}")
+            if any(part in exclude_names for part in rel_path.parts):
+                continue
+            if file_path.suffix in {".pyc", ".pyo"}:
+                continue
+            if not file_path.is_file():
+                continue
+            yield file_path
 
 
 def _validate_skill_dir(skill_dir: Path):

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -15,6 +15,7 @@
 """Build and validate the manifest for NVFLARE-owned agent skills."""
 
 import hashlib
+import importlib
 import importlib.util
 import json
 import shutil
@@ -138,14 +139,25 @@ def _validate_skill_dir(skill_dir: Path):
     global _FRONTMATTER_MODULE
 
     if _FRONTMATTER_MODULE is None:
-        module_name = "nvflare_agent_skill_frontmatter"
-        module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
-        spec = importlib.util.spec_from_file_location(module_name, module_path)
-        if spec is None or spec.loader is None:
-            raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
-        _FRONTMATTER_MODULE = module
+        _FRONTMATTER_MODULE = _load_frontmatter_module()
 
     return _FRONTMATTER_MODULE.validate_skill_dir(skill_dir)
+
+
+def _load_frontmatter_module():
+    try:
+        return importlib.import_module("nvflare.tool.agent_skill_checks.frontmatter")
+    except ImportError:
+        pass
+
+    # setup.py loads this file before build isolation has all NVFLARE runtime
+    # dependencies, so fall back to loading the validator file directly.
+    module_name = "nvflare_agent_skill_frontmatter"
+    module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -128,6 +128,8 @@ def copy_released_skills_to_bundle(
 
 
 def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
+    if skill_dir.is_symlink():
+        raise ValueError("skill directory contains symlink: .")
     for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
         root_path = Path(root)
         rel_root = root_path.relative_to(skill_dir)

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build and validate the manifest for NVFLARE-owned agent skills."""
+
+import hashlib
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+MANIFEST_FILE_NAME = "manifest.json"
+MANIFEST_SCHEMA_VERSION = "1"
+IGNORED_SKILL_FILE_NAMES = {"__pycache__", "*.pyc", "*.pyo"}
+_FRONTMATTER_MODULE = None
+
+
+def skill_tree_hash(skill_dir: Path, *, exclude_names: Optional[set[str]] = None) -> str:
+    """Hash a skill directory by relative paths and file contents."""
+    excluded = {"__pycache__"}
+    if exclude_names:
+        excluded.update(exclude_names)
+    digest = hashlib.sha256()
+    for file_path in _iter_skill_files(skill_dir, exclude_names=excluded):
+        rel_path = file_path.relative_to(skill_dir).as_posix()
+        digest.update(rel_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_version: str = "") -> dict:
+    """Build the released-skill manifest for a skills source root."""
+    root = Path(skills_root)
+    skills = []
+    findings = []
+    if root.is_dir():
+        for child in sorted(root.iterdir(), key=lambda p: p.name):
+            if child.name.startswith(".") or not child.is_dir():
+                continue
+            result = _validate_skill_dir(child)
+            if not result.ok:
+                findings.append(
+                    {
+                        "skill_dir": child.name,
+                        "issues": [
+                            {"code": issue.code, "message": issue.message, "path": issue.path}
+                            for issue in result.issues
+                        ],
+                    }
+                )
+                continue
+            metadata = dict(result.metadata)
+            skills.append(
+                {
+                    "name": metadata["name"],
+                    "skill_version": metadata.get("skill_version", "0.0.0"),
+                    "min_flare_version": metadata["min_flare_version"],
+                    "max_flare_version": metadata.get("max_flare_version"),
+                    "blast_radius": metadata["blast_radius"],
+                    "source_hash": skill_tree_hash(child),
+                    "relative_path": child.name,
+                }
+            )
+
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "source_type": source_type,
+        "nvflare_version": nvflare_version,
+        "skills": skills,
+        "findings": findings,
+    }
+
+
+def write_manifest(manifest: dict, manifest_path: Path | str) -> None:
+    path = Path(manifest_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_manifest(manifest_path: Path | str) -> dict:
+    return json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+
+
+def copy_released_skills_to_bundle(
+    skills_root: Path | str, bundle_root: Path | str, *, nvflare_version: str = ""
+) -> dict:
+    """Copy valid released skills and write their manifest into a package bundle directory."""
+    source_root = Path(skills_root)
+    target_root = Path(bundle_root)
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    for child in list(target_root.iterdir()):
+        if child.name == "__init__.py":
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    manifest = build_skill_manifest(source_root, source_type="wheel", nvflare_version=nvflare_version)
+    for skill in manifest["skills"]:
+        shutil.copytree(
+            source_root / skill["relative_path"],
+            target_root / skill["relative_path"],
+            ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES),
+        )
+    write_manifest(manifest, target_root / MANIFEST_FILE_NAME)
+    return manifest
+
+
+def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
+    for path in sorted(skill_dir.rglob("*"), key=lambda p: p.relative_to(skill_dir).as_posix()):
+        if not path.is_file():
+            continue
+        if any(part in exclude_names for part in path.relative_to(skill_dir).parts):
+            continue
+        if path.suffix in {".pyc", ".pyo"}:
+            continue
+        yield path
+
+
+def _validate_skill_dir(skill_dir: Path):
+    global _FRONTMATTER_MODULE
+
+    if _FRONTMATTER_MODULE is None:
+        module_name = "nvflare_agent_skill_frontmatter"
+        module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        _FRONTMATTER_MODULE = module
+
+    return _FRONTMATTER_MODULE.validate_skill_dir(skill_dir)

--- a/nvflare/tool/agent_skill_checks/__init__.py
+++ b/nvflare/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation helpers for NVFLARE agent skill source files."""

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal V1 validation for NVFLARE agent skill frontmatter."""
+"""Validation for NVFLARE agent skill frontmatter."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -58,7 +58,7 @@ class SkillFrontmatterError(ValueError):
 def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
     """Parse YAML frontmatter from a SKILL.md file."""
     path = Path(skill_file)
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8-sig")
     lines = text.splitlines()
     if not lines or lines[0].strip() != "---":
         raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
@@ -131,9 +131,17 @@ def _validate_required_fields(
 ) -> None:
     for field in REQUIRED_FRONTMATTER_FIELDS:
         value = metadata.get(field)
-        if not isinstance(value, str) or not value.strip():
+        if value is None or (isinstance(value, str) and not value.strip()):
             issues.append(
                 _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+        elif not isinstance(value, str):
+            issues.append(
+                _issue(
+                    "skill-frontmatter-field-type",
+                    f"frontmatter field '{field}' must be a non-empty string; " f"got {type(value).__name__}={value!r}",
+                    skill_file,
+                )
             )
 
 

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal V1 validation for NVFLARE agent skill frontmatter."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import yaml
+
+SKILL_FILE_NAME = "SKILL.md"
+REQUIRED_FRONTMATTER_FIELDS = ("name", "description", "min_flare_version", "blast_radius")
+VALID_BLAST_RADIUS = frozenset(
+    {
+        "read_only",
+        "edits_files",
+        "runs_simulator",
+        "submits_poc",
+        "submits_production",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SkillValidationIssue:
+    code: str
+    message: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SkillValidationResult:
+    skill_dir: str
+    metadata: Mapping[str, Any]
+    issues: tuple[SkillValidationIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+class SkillFrontmatterError(ValueError):
+    """Raised when SKILL.md frontmatter cannot be parsed."""
+
+
+def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
+    """Parse YAML frontmatter from a SKILL.md file."""
+    path = Path(skill_file)
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
+
+    close_index = _find_closing_delimiter(lines)
+    if close_index is None:
+        raise SkillFrontmatterError("SKILL.md frontmatter must end with delimiter '---'")
+
+    raw_frontmatter = "\n".join(lines[1:close_index])
+    try:
+        metadata = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as e:
+        raise SkillFrontmatterError(f"failed to parse YAML frontmatter: {e}") from e
+
+    if not isinstance(metadata, dict):
+        raise SkillFrontmatterError("SKILL.md frontmatter must be a mapping")
+    return metadata
+
+
+def validate_skill_dir(skill_dir: Path | str) -> SkillValidationResult:
+    """Validate one guide-compatible skill directory."""
+    path = Path(skill_dir)
+    issues: list[SkillValidationIssue] = []
+    metadata: dict[str, Any] = {}
+
+    skill_file = path / SKILL_FILE_NAME
+    if not path.is_dir():
+        issues.append(_issue("skill-dir-missing", "skill path must be a directory", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    if not skill_file.is_file():
+        issues.append(_issue("skill-md-missing", "skill directory must contain SKILL.md", skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    try:
+        metadata = parse_skill_frontmatter(skill_file)
+    except SkillFrontmatterError as e:
+        issues.append(_issue("skill-frontmatter-invalid", str(e), skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    _validate_required_fields(metadata, skill_file, issues)
+    _validate_name_matches_directory(metadata.get("name"), path, skill_file, issues)
+    _validate_blast_radius(metadata.get("blast_radius"), skill_file, issues)
+
+    return SkillValidationResult(str(path), metadata, tuple(issues))
+
+
+def validate_skills_root(skills_root: Path | str) -> list[SkillValidationResult]:
+    """Validate every skill directory under a skills root."""
+    root = Path(skills_root)
+    if not root.is_dir():
+        return [SkillValidationResult(str(root), {}, (_issue("skills-root-missing", "skills root is missing", root),))]
+
+    results = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        results.append(validate_skill_dir(child))
+    return results
+
+
+def _find_closing_delimiter(lines: list[str]) -> Optional[int]:
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return i
+    return None
+
+
+def _validate_required_fields(
+    metadata: Mapping[str, Any], skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    for field in REQUIRED_FRONTMATTER_FIELDS:
+        value = metadata.get(field)
+        if not isinstance(value, str) or not value.strip():
+            issues.append(
+                _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+
+
+def _validate_name_matches_directory(
+    name: Any, skill_dir: Path, skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    if isinstance(name, str) and name.strip() and name != skill_dir.name:
+        issues.append(
+            _issue(
+                "skill-name-directory-mismatch",
+                f"frontmatter name '{name}' must match directory name '{skill_dir.name}'",
+                skill_file,
+            )
+        )
+
+
+def _validate_blast_radius(radius: Any, skill_file: Path, issues: list[SkillValidationIssue]) -> None:
+    if isinstance(radius, str) and radius.strip() and radius not in VALID_BLAST_RADIUS:
+        issues.append(
+            _issue(
+                "skill-blast-radius-invalid",
+                f"blast_radius must be one of: {', '.join(sorted(VALID_BLAST_RADIUS))}",
+                skill_file,
+            )
+        )
+
+
+def _issue(code: str, message: str, path: Path) -> SkillValidationIssue:
+    return SkillValidationIssue(code=code, message=message, path=str(path))

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -14,6 +14,7 @@
 
 """Validation for NVFLARE agent skill frontmatter."""
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional
@@ -85,8 +86,14 @@ def validate_skill_dir(skill_dir: Path | str) -> SkillValidationResult:
     metadata: dict[str, Any] = {}
 
     skill_file = path / SKILL_FILE_NAME
+    if path.is_symlink():
+        issues.append(_issue("skill-symlink-not-allowed", "skill path must not be a symlink", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
     if not path.is_dir():
         issues.append(_issue("skill-dir-missing", "skill path must be a directory", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    _validate_no_symlinks(path, issues)
+    if issues:
         return SkillValidationResult(str(path), metadata, tuple(issues))
     if not skill_file.is_file():
         issues.append(_issue("skill-md-missing", "skill directory must contain SKILL.md", skill_file))
@@ -167,6 +174,18 @@ def _validate_blast_radius(radius: Any, skill_file: Path, issues: list[SkillVali
                 skill_file,
             )
         )
+
+
+def _validate_no_symlinks(skill_dir: Path, issues: list[SkillValidationIssue]) -> None:
+    for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        for name in dir_names + file_names:
+            path = root_path / name
+            if path.is_symlink():
+                issues.append(_issue("skill-symlink-not-allowed", "skill directories must not contain symlinks", path))
+        dir_names[:] = [name for name in dir_names if not (root_path / name).is_symlink()]
 
 
 def _issue(code: str, message: str, path: Path) -> SkillValidationIssue:

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -201,7 +201,7 @@ def output_ok(
             recovery_category=recovery_category,
             suggested_skill=suggested_skill,
         )
-        print(json.dumps(payload))
+        print(json.dumps(payload), flush=True)
     else:
         _render_table(data)
     if exit_code != 0:

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -147,14 +147,61 @@ def output(data: Any, fmt: Optional[str]) -> None:
         _render_table(data)
 
 
-def output_ok(data: Any, exit_code: int = 0) -> None:
-    """Print command success output."""
+def _add_agent_envelope_fields(
+    payload: dict,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> dict:
+    if code is not None:
+        payload["code"] = code
+    if message is not None:
+        payload["message"] = message
+    if hint is not None:
+        payload["hint"] = hint
+    if recovery_category is not None:
+        payload["recovery_category"] = recovery_category
+    if suggested_skill is not None:
+        payload["suggested_skill"] = suggested_skill
+    return payload
+
+
+def output_ok(
+    data: Any,
+    exit_code: int = 0,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> None:
+    """Print command success output.
+
+    code/message/hint/recovery fields are emitted in JSON/JSONL modes only;
+    human mode renders command data.
+    """
     if _is_jsonl_mode():
-        output_jsonl_event(
-            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True}
+        payload = _add_agent_envelope_fields(
+            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
         )
+        output_jsonl_event(payload)
     elif _is_json_mode():
-        print(json.dumps({"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data}))
+        payload = _add_agent_envelope_fields(
+            {"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        print(json.dumps(payload))
     else:
         _render_table(data)
     if exit_code != 0:
@@ -167,6 +214,8 @@ def output_error(
     hint: str = None,
     data: Any = None,
     detail: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
     **kwargs,
 ) -> None:
     """Print an error from ERROR_REGISTRY and exit. Never returns."""
@@ -187,9 +236,15 @@ def output_error(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
+            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
         if data is not None:
             payload["data"] = data
         if _is_jsonl_mode():
@@ -224,8 +279,16 @@ def output_error_message(
     fmt: Optional[str] = None,
     exit_code: int = 1,
     detail: str = None,
+    data: Any = None,
+    include_data: bool = False,
+    recovery_category: str = None,
+    suggested_skill: str = None,
 ) -> None:
-    """Print an explicit error message/hint pair and exit. Never returns."""
+    """Print an explicit error message/hint pair and exit. Never returns.
+
+    In machine modes, data is omitted when data is None unless include_data=True.
+    This lets callers distinguish an absent data field from an explicit JSON null.
+    """
     resolved_hint = hint or ""
     if detail:
         message = f"{message} \u2014 {detail}"
@@ -236,9 +299,17 @@ def output_error_message(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
+            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        if include_data or data is not None:
+            payload["data"] = data
         if jsonl_mode:
             payload["event"] = "terminal"
             payload["terminal"] = True

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -201,7 +201,7 @@ def output_ok(
             recovery_category=recovery_category,
             suggested_skill=suggested_skill,
         )
-        print(json.dumps(payload), flush=True)
+        print(json.dumps(payload))
     else:
         _render_table(data)
     if exit_code != 0:
@@ -236,7 +236,6 @@ def output_error(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
@@ -299,7 +298,6 @@ def output_error_message(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "versioneer"]
+requires = ["setuptools>=61.0", "wheel", "versioneer", "PyYAML>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ tmp_job_template_folder = "./nvflare/tool/job/templates"
 copy_package(src_dir="job_templates", dst_dir=tmp_job_template_folder)
 job_templates = package_files(root="nvflare/tool/job", starting="templates")
 deploy_templates = package_files(root="nvflare/tool/deploy", starting="templates")
+agent_skill_package_data = ["manifest.json", "*", "*/*", "*/*/*", "*/*/*/*", "*/*/*/*/*"]
 
 cmdclass = versioneer.get_cmdclass()
 _base_build_py = cmdclass["build_py"]
@@ -136,7 +137,7 @@ setup(
         "nvflare.dashboard.application": extra_files,
         "nvflare.tool.job": job_templates,
         "nvflare.tool.deploy": deploy_templates,
-        "nvflare.tool.agent.bundled_skills": ["manifest.json", "**/*"],
+        "nvflare.tool.agent.bundled_skills": agent_skill_package_data,
     },
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ import shutil
 
 from setuptools import find_packages, setup
 
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__)) if "__file__" in globals() else os.getcwd()
+
 
 def load_local_versioneer():
-    root = os.path.abspath(os.path.dirname(__file__)) if "__file__" in globals() else os.getcwd()
-    versioneer_path = os.path.join(root, "versioneer.py")
+    versioneer_path = os.path.join(ROOT_DIR, "versioneer.py")
     spec = importlib.util.spec_from_file_location("nvflare_local_versioneer", versioneer_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Failed to load versioneer from {versioneer_path}")
@@ -31,7 +32,19 @@ def load_local_versioneer():
     return module
 
 
+def load_local_module(module_name, module_path):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 versioneer = load_local_versioneer()
+agent_skill_manifest = load_local_module(
+    "nvflare_agent_skill_manifest", os.path.join(ROOT_DIR, "nvflare", "tool", "agent", "skill_manifest.py")
+)
 
 # read the contents of your README file
 
@@ -89,11 +102,27 @@ copy_package(src_dir="job_templates", dst_dir=tmp_job_template_folder)
 job_templates = package_files(root="nvflare/tool/job", starting="templates")
 deploy_templates = package_files(root="nvflare/tool/deploy", starting="templates")
 
+cmdclass = versioneer.get_cmdclass()
+_base_build_py = cmdclass["build_py"]
+
+
+class AgentSkillsBuildPy(_base_build_py):
+    def run(self):
+        super().run()
+        agent_skill_manifest.copy_released_skills_to_bundle(
+            os.path.join(ROOT_DIR, "skills"),
+            os.path.join(self.build_lib, "nvflare", "tool", "agent", "bundled_skills"),
+            nvflare_version=version,
+        )
+
+
+cmdclass["build_py"] = AgentSkillsBuildPy
+
 
 setup(
     name=package_name,
     version=version,
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclass,
     package_dir={"nvflare": "nvflare"},
     packages=find_packages(
         where=".",
@@ -107,6 +136,7 @@ setup(
         "nvflare.dashboard.application": extra_files,
         "nvflare.tool.job": job_templates,
         "nvflare.tool.deploy": deploy_templates,
+        "nvflare.tool.agent.bundled_skills": ["manifest.json", "**/*"],
     },
     include_package_data=True,
 )

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# NVFLARE Agent Skills
+
+This directory is the source root for NVFLARE-owned agent skills.
+
+V1 skill directories should follow the guide-compatible shape:
+
+```text
+skills/
+  nvflare-example-skill/
+    SKILL.md
+    references/
+    evals/
+      evals.json
+      files/
+    BENCHMARK.md
+```
+
+Milestone 1 establishes the source root and minimal frontmatter validation.
+Public skill content, runtime evals, packaging, and native install/list commands
+land in later milestones.
+
+Required `SKILL.md` frontmatter fields for V1:
+
+```yaml
+---
+name: nvflare-example-skill
+description: Short trigger-oriented description.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+```
+
+`blast_radius` must be one of:
+
+- `read_only`
+- `edits_files`
+- `runs_simulator`
+- `submits_poc`
+- `submits_production`

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ V1 skill directories should follow the guide-compatible shape:
 
 ```text
 skills/
-  nvflare-example-skill/
+  nvflare-your-skill/
     SKILL.md
     references/
     evals/
@@ -23,12 +23,15 @@ Required `SKILL.md` frontmatter fields for V1:
 
 ```yaml
 ---
-name: nvflare-example-skill
+name: nvflare-your-skill
 description: Short trigger-oriented description.
 min_flare_version: "2.8.0"
 blast_radius: read_only
 ---
 ```
+
+The skill name above is illustrative; released skill content lands in later
+milestones.
 
 `blast_radius` must be one of:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,9 @@
 # NVFLARE Agent Skills
 
-This directory is the source root for NVFLARE-owned agent skills.
+This directory contains NVFLARE-owned agent skills for supported coding agents.
 
-V1 skill directories should follow the guide-compatible shape:
+Each skill lives in its own directory with a `SKILL.md` file. Skills may also
+include supporting references, evaluation fixtures, and benchmark notes:
 
 ```text
 skills/
@@ -15,11 +16,7 @@ skills/
     BENCHMARK.md
 ```
 
-Milestone 1 establishes the source root and minimal frontmatter validation.
-Public skill content, runtime evals, packaging, and native install/list commands
-land in later milestones.
-
-Required `SKILL.md` frontmatter fields for V1:
+Required `SKILL.md` frontmatter fields:
 
 ```yaml
 ---
@@ -30,8 +27,8 @@ blast_radius: read_only
 ---
 ```
 
-The skill name above is illustrative; released skill content lands in later
-milestones.
+The skill name above is illustrative; actual skill directories use their
+published skill names.
 
 `blast_radius` must be one of:
 

--- a/tests/unit_test/tool/agent/__init__.py
+++ b/tests/unit_test/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.tool import cli_output
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_output_state(monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "txt")
+    monkeypatch.setattr(cli_output, "_connect_timeout", 5.0)
+
+
+def _run_main(argv):
+    from nvflare import cli
+
+    with patch("sys.argv", argv), patch("nvflare.cli.version_check"):
+        try:
+            cli.main()
+        except SystemExit as e:
+            return e.code
+    return 0
+
+
+def _parse_for_agent_parser():
+    from nvflare import cli
+
+    with patch("sys.argv", ["nvflare", "agent", "--schema"]):
+        _prog_parser, args, sub_cmd_parsers = cli.parse_args("nvflare")
+
+    assert args.sub_command == "agent"
+    assert "agent" in sub_cmd_parsers
+    return sub_cmd_parsers["agent"]
+
+
+def _subparser_choices(parser):
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action.choices
+    return {}
+
+
+def _required_operational_args(parser):
+    required_args = []
+    for action in parser._actions:
+        if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
+            continue
+        if action.dest == "schema" or action.help == argparse.SUPPRESS:
+            continue
+        positional_required = not action.option_strings and action.nargs not in (
+            argparse.OPTIONAL,
+            argparse.ZERO_OR_MORE,
+        )
+        optional_required = bool(getattr(action, "required", False) or getattr(action, "schema_required", False))
+        if positional_required or optional_required:
+            required_args.append(action.dest)
+    return required_args
+
+
+def _minimal_agent_command():
+    agent_parser = _parse_for_agent_parser()
+    choices = _subparser_choices(agent_parser)
+    assert choices, "PR1 should register at least one minimal nvflare agent subcommand"
+
+    for name, parser in choices.items():
+        if _required_operational_args(parser):
+            continue
+        return name, parser
+
+    assert False, "PR1 should expose a read-only nvflare agent subcommand that needs no operational arguments"
+
+
+def _load_single_stdout_json(captured):
+    stdout = captured.out.strip()
+    assert stdout
+    assert len(stdout.splitlines()) == 1
+    return json.loads(stdout)
+
+
+def _assert_envelope_shape(payload, expected_status, require_data=True):
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == expected_status
+    assert "message" in payload
+    assert "hint" in payload
+    if require_data:
+        assert "data" in payload
+    if "code" in payload:
+        assert payload["code"]
+    else:
+        assert payload["error_code"]
+
+
+def test_agent_command_parser_is_registered(monkeypatch):
+    from nvflare import cli
+
+    command_name, _parser = _minimal_agent_command()
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["nvflare", "agent", command_name, "--format", "json"],
+    )
+
+    _prog_parser, args, _sub_cmd_parsers = cli.parse_args("nvflare")
+    assert args.sub_command == "agent"
+
+
+def test_agent_success_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    cli_output.output_ok(
+        {"ready": True},
+        code="AGENT_OK",
+        message="Agent command completed.",
+        hint="",
+        recovery_category="FIXABLE_BY_CONFIG",
+        suggested_skill="agent",
+    )
+
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "ok"
+    assert payload["code"] == "AGENT_OK"
+    assert payload["message"] == "Agent command completed."
+    assert payload["hint"] == ""
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+    assert payload["data"] == {"ready": True}
+
+
+def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_output.output_error_message(
+            "AGENT_ERROR",
+            "Agent command failed.",
+            hint="Use a valid agent command.",
+            exit_code=4,
+            recovery_category="FIXABLE_BY_CONFIG",
+            suggested_skill="agent",
+        )
+
+    assert exc_info.value.code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "error"
+    assert payload["code"] == "AGENT_ERROR"
+    assert payload["error_code"] == "AGENT_ERROR"
+    assert payload["message"] == "Agent command failed."
+    assert payload["hint"] == "Use a valid agent command."
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+
+
+def test_agent_schema_exits_zero_and_emits_raw_schema_json(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"].startswith("nvflare agent")
+    assert "status" not in schema
+    assert "args" in schema
+    assert "examples" in schema
+
+
+def test_agent_minimal_subcommand_schema_does_not_require_operational_args(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"] == f"nvflare agent {command_name}"
+    assert "status" not in schema
+    assert schema["output_modes"] == ["json"]
+    assert schema["streaming"] is False
+    assert schema["mutating"] is False
+    assert schema["idempotent"] is True
+
+
+def test_agent_minimal_subcommand_json_success_is_single_stdout_envelope(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "ok")
+
+
+def test_agent_human_output_stays_off_stdout_in_json_mode(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    assert payload["status"] == "ok"
+
+
+def test_agent_missing_subcommand_json_error_is_non_interactive(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert payload["data"] is None
+    assert captured.err == ""
+
+
+def test_agent_missing_subcommand_stops_when_error_helper_is_mocked():
+    from nvflare.tool.agent.agent_cli import handle_agent_cmd
+
+    with patch("sys.argv", ["nvflare", "agent"]), patch("nvflare.tool.cli_output.output_error_message") as output_error:
+        handle_agent_cmd(SimpleNamespace(agent_sub_cmd=None))
+
+    output_error.assert_called_once()
+
+
+def test_agent_invalid_subcommand_json_error_is_structured(capsys):
+    exit_code = _run_main(["nvflare", "agent", "not-a-pr1-command", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert "event" not in payload
+    assert "terminal" not in payload
+    assert "not-a-pr1-command" in payload["message"]
+    assert captured.err == ""

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -77,14 +77,14 @@ def _required_operational_args(parser):
 def _minimal_agent_command():
     agent_parser = _parse_for_agent_parser()
     choices = _subparser_choices(agent_parser)
-    assert choices, "PR1 should register at least one minimal nvflare agent subcommand"
+    assert choices, "nvflare agent should register at least one read-only subcommand"
 
     for name, parser in choices.items():
         if _required_operational_args(parser):
             continue
         return name, parser
 
-    assert False, "PR1 should expose a read-only nvflare agent subcommand that needs no operational arguments"
+    assert False, "nvflare agent should expose a read-only subcommand that needs no operational arguments"
 
 
 def _load_single_stdout_json(captured):

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 import pytest
 
 from nvflare.tool import cli_output
+from nvflare.tool.agent.skill_manager import SkillSource
+from nvflare.tool.agent.skill_manifest import build_skill_manifest
 
 
 @pytest.fixture(autouse=True)
@@ -255,3 +257,143 @@ def test_agent_invalid_subcommand_json_error_is_structured(capsys):
     assert "terminal" not in payload
     assert "not-a-pr1-command" in payload["message"]
     assert captured.err == ""
+
+
+def test_agent_skills_install_dry_run_json_uses_native_source(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["applied"] is False
+    assert payload["data"]["source"]["type"] == "editable"
+    assert payload["data"]["skills"][0]["name"] == "nvflare-test-skill"
+    assert not target.exists()
+
+
+def test_agent_skills_install_and_list_json(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    install_exit = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--format",
+            "json",
+        ]
+    )
+    install_payload = _load_single_stdout_json(capsys.readouterr())
+    assert install_exit == 0
+    assert install_payload["data"]["applied"] is True
+    assert target.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+    list_exit = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "list",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--format",
+            "json",
+        ]
+    )
+    list_payload = _load_single_stdout_json(capsys.readouterr())
+    assert list_exit == 0
+    assert list_payload["data"]["available"][0]["name"] == "nvflare-test-skill"
+    assert list_payload["data"]["installed"][0]["name"] == "nvflare-test-skill"
+
+
+def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(tmp_path / "target"),
+            "--skill",
+            "nvflare-missing",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["code"] == "AGENT_SKILL_NOT_FOUND"
+    assert payload["data"]["missing"] == ["nvflare-missing"]
+
+
+def test_agent_skills_install_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "skills", "install", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent skills install"
+    assert schema["mutating"] is True
+    assert schema["output_modes"] == ["json"]
+
+
+def _patch_skill_source(monkeypatch, tmp_path):
+    from nvflare.tool.agent import skill_manager
+
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    monkeypatch.setattr(skill_manager, "find_skill_source", lambda: source)
+    return source
+
+
+def _write_skill(root, name):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -354,7 +354,8 @@ def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monke
     assert exit_code == 4
     payload = _load_single_stdout_json(capsys.readouterr())
     _assert_envelope_shape(payload, "error")
-    assert payload["code"] == "AGENT_SKILL_NOT_FOUND"
+    assert payload["error_code"] == "AGENT_SKILL_NOT_FOUND"
+    assert "code" not in payload
     assert payload["data"]["missing"] == ["nvflare-missing"]
 
 
@@ -397,7 +398,8 @@ def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypat
     assert exit_code == 1
     payload = _load_single_stdout_json(capsys.readouterr())
     _assert_envelope_shape(payload, "error")
-    assert payload["code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert payload["error_code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert "code" not in payload
     assert payload["recovery_category"] == "FIXABLE_BY_ENV"
     assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
 

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -162,8 +162,8 @@ def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
     payload = _load_single_stdout_json(capsys.readouterr())
     assert payload["schema_version"] == "1"
     assert payload["status"] == "error"
-    assert payload["code"] == "AGENT_ERROR"
     assert payload["error_code"] == "AGENT_ERROR"
+    assert "code" not in payload
     assert payload["message"] == "Agent command failed."
     assert payload["hint"] == "Use a valid agent command."
     assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -358,6 +358,50 @@ def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monke
     assert payload["data"]["missing"] == ["nvflare-missing"]
 
 
+def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    from nvflare.tool.agent import skill_manager
+
+    monkeypatch.setattr(
+        skill_manager,
+        "install_skills",
+        lambda **_kwargs: {
+            "agent": "codex",
+            "target_path": str(tmp_path / "target"),
+            "requested_skill": None,
+            "source": {},
+            "available": [],
+            "skills": [],
+            "conflicts": [],
+            "errors": [{"skill": "nvflare-test-skill", "code": "skill_install_failed", "message": "disk full"}],
+            "deprecated_skills_skipped": [],
+            "missing": [],
+            "applied": False,
+        },
+    )
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(tmp_path / "target"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert payload["recovery_category"] == "FIXABLE_BY_ENV"
+    assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
+
+
 def test_agent_skills_install_schema_exits_zero(capsys):
     exit_code = _run_main(["nvflare", "agent", "skills", "install", "--schema"])
 

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -14,6 +14,7 @@
 
 import argparse
 import json
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -402,6 +403,38 @@ def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypat
     assert "code" not in payload
     assert payload["recovery_category"] == "FIXABLE_BY_ENV"
     assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_agent_skills_target_symlink_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    actual_target = tmp_path / "actual-target"
+    actual_target.mkdir()
+    link_target = tmp_path / "link-target"
+    link_target.symlink_to(actual_target, target_is_directory=True)
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(link_target),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_SKILL_TARGET_INVALID"
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["data"]["target"] == str(link_target)
 
 
 def test_agent_skills_install_schema_exits_zero(capsys):

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -434,6 +434,7 @@ def test_agent_skills_target_symlink_is_structured_json_error(capsys, monkeypatc
     _assert_envelope_shape(payload, "error")
     assert payload["error_code"] == "AGENT_SKILL_TARGET_INVALID"
     assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert "/private/tmp" in payload["hint"]
     assert payload["data"]["target"] == str(link_target)
 
 

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -575,7 +575,7 @@ def test_install_skills_reports_installed_skill_root_symlink_conflict(tmp_path):
     assert plan["conflicts"][0]["symlink_path"] == str(installed_skill)
 
 
-def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):
+def test_list_skills_reports_available_installed_and_ignores_unrelated_external_skills(tmp_path):
     source = _skill_source(tmp_path)
     target = tmp_path / "target"
     install_skills(agent="codex", target_dir=target, source=source)
@@ -585,7 +585,27 @@ def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path
 
     assert data["available"][0]["name"] == "nvflare-test-skill"
     assert data["installed"][0]["name"] == "nvflare-test-skill"
-    assert data["conflicts"][0]["skill"] == "external-skill"
+    assert data["conflicts"] == []
+
+
+def test_list_skills_flags_name_overlap_external_skill_as_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    external = target / "nvflare-test-skill"
+    external.mkdir(parents=True)
+    external.joinpath("SKILL.md").write_text("external content\n", encoding="utf-8")
+
+    data = list_skills(agent="codex", target_dir=target, source=source)
+
+    assert data["installed"] == []
+    assert data["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "external_install_detected",
+            "message": "target skill directory is not managed by nvflare",
+            "target_path": str(external),
+        }
+    ]
 
 
 def test_conflict_falls_back_to_code_for_unknown_conflict(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -14,6 +14,7 @@
 
 import json
 import shutil
+from pathlib import Path
 
 from nvflare.tool.agent import skill_manager
 from nvflare.tool.agent.skill_manager import (
@@ -228,6 +229,52 @@ def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, t
     ]
     assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
     assert not (target / ".nvflare_bak").exists()
+
+
+def test_install_skills_replace_reports_publish_error_when_recovery_fails(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    real_move = shutil.move
+
+    def publish_with_failure(src, dst):
+        raise OSError("publish failed")
+
+    def move_with_recovery_failure(src, dst, *args, **kwargs):
+        if ".nvflare_bak" in Path(src).parts:
+            raise OSError("restore failed")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(skill_manager, "_publish_staged_skill", publish_with_failure)
+    monkeypatch.setattr(skill_manager.shutil, "move", move_with_recovery_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "publish failed",
+            "recovery_error": {"type": "OSError", "message": "restore failed"},
+        }
+    ]
+    assert not (target / "nvflare-test-skill").exists()
+    assert any((target / ".nvflare_bak").iterdir())
 
 
 def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -241,6 +241,13 @@ def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path
     assert data["conflicts"][0]["skill"] == "external-skill"
 
 
+def test_conflict_falls_back_to_code_for_unknown_conflict(tmp_path):
+    conflict = skill_manager._conflict("nvflare-test-skill", "future_conflict", tmp_path / "target")
+
+    assert conflict["code"] == "future_conflict"
+    assert conflict["message"] == "future_conflict"
+
+
 def _skill_source(tmp_path):
     root = tmp_path / "skills"
     _write_skill(root, "nvflare-test-skill")

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 import json
+import shutil
 
+from nvflare.tool.agent import skill_manager
 from nvflare.tool.agent.skill_manager import (
     INSTALL_MANIFEST_FILE_NAME,
     SkillSource,
+    find_skill_source,
     install_skills,
     list_skills,
     resolve_agent_target_dir,
 )
-from nvflare.tool.agent.skill_manifest import build_skill_manifest
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, write_manifest
 
 
 def test_resolve_codex_target_uses_codex_home(tmp_path):
@@ -36,6 +39,48 @@ def test_resolve_claude_target_uses_home(monkeypatch, tmp_path):
     target = resolve_agent_target_dir("claude")
 
     assert target == tmp_path / ".claude" / "skills"
+
+
+def test_resolve_target_override_skips_agent_home_resolution(tmp_path):
+    target = resolve_agent_target_dir("codex", target_dir=tmp_path / "custom-target", env={"CODEX_HOME": "ignored"})
+
+    assert target == tmp_path / "custom-target"
+
+
+def test_resolve_unsupported_agent_raises_value_error():
+    try:
+        resolve_agent_target_dir("unsupported")
+    except ValueError as e:
+        assert "unsupported agent target" in str(e)
+    else:
+        assert False, "unsupported agent target should raise ValueError"
+
+
+def test_find_skill_source_does_not_misclassify_site_packages_skills(monkeypatch, tmp_path):
+    fake_site_packages = tmp_path / "site-packages"
+    fake_module = fake_site_packages / "nvflare" / "tool" / "agent" / "skill_manager.py"
+    fake_module.parent.mkdir(parents=True)
+    fake_module.write_text("# fake installed module\n", encoding="utf-8")
+    _write_skill(fake_site_packages / "skills", "unrelated-skill")
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    write_manifest(
+        {
+            "schema_version": "1",
+            "source_type": "wheel",
+            "nvflare_version": "2.8.0",
+            "skills": [],
+            "findings": [],
+        },
+        bundle_root / "manifest.json",
+    )
+    monkeypatch.setattr(skill_manager, "__file__", str(fake_module))
+    monkeypatch.setattr(skill_manager.resources, "files", lambda _package: bundle_root)
+
+    source = find_skill_source()
+
+    assert source.source_type == "wheel"
+    assert source.root == bundle_root
 
 
 def test_install_skills_dry_run_reports_plan_without_copying(tmp_path):
@@ -145,6 +190,42 @@ def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path
     assert len(backup_runs) == 1
     backup_file = backup_runs[0] / "nvflare-test-skill" / "SKILL.md"
     assert "First Skill" in backup_file.read_text(encoding="utf-8")
+
+
+def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-a-skill")
+    _write_skill(root, "nvflare-failing-skill")
+    _write_skill(root, "nvflare-z-skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    real_copytree = shutil.copytree
+
+    def copytree_with_failure(src, dst, *args, **kwargs):
+        if src.name == "nvflare-failing-skill":
+            raise OSError("disk full")
+        return real_copytree(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(skill_manager.shutil, "copytree", copytree_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-failing-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "disk full",
+        }
+    ]
+    assert (target / "nvflare-a-skill" / "SKILL.md").is_file()
+    assert not (target / "nvflare-failing-skill").exists()
+    assert (target / "nvflare-z-skill" / "SKILL.md").is_file()
 
 
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent.skill_manager import (
+    INSTALL_MANIFEST_FILE_NAME,
+    SkillSource,
+    install_skills,
+    list_skills,
+    resolve_agent_target_dir,
+)
+from nvflare.tool.agent.skill_manifest import build_skill_manifest
+
+
+def test_resolve_codex_target_uses_codex_home(tmp_path):
+    target = resolve_agent_target_dir("codex", env={"CODEX_HOME": str(tmp_path / "codex-home")})
+
+    assert target == tmp_path / "codex-home" / "skills"
+
+
+def test_resolve_claude_target_uses_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    target = resolve_agent_target_dir("claude")
+
+    assert target == tmp_path / ".claude" / "skills"
+
+
+def test_install_skills_dry_run_reports_plan_without_copying(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", dry_run=True, target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["skills"][0]["action"] == "copy"
+    assert plan["skills"][0]["files"]
+    assert not target.exists()
+
+
+def test_install_skills_installs_all_by_default(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    skill_dir = target / "nvflare-test-skill"
+    assert plan["applied"] is True
+    assert skill_dir.joinpath("SKILL.md").is_file()
+    install_manifest = json.loads(skill_dir.joinpath(INSTALL_MANIFEST_FILE_NAME).read_text(encoding="utf-8"))
+    assert install_manifest["managed_by"] == "nvflare"
+    assert install_manifest["name"] == "nvflare-test-skill"
+
+
+def test_install_skills_reports_missing_named_skill(tmp_path):
+    source = _skill_source(tmp_path)
+
+    plan = install_skills(agent="codex", skill_name="nvflare-missing", target_dir=tmp_path / "target", source=source)
+
+    assert plan["applied"] is False
+    assert plan["missing"] == ["nvflare-missing"]
+    assert plan["skills"] == []
+
+
+def test_install_skills_preserves_external_target_directory(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    external = target / "nvflare-test-skill"
+    external.mkdir(parents=True)
+    external.joinpath("SKILL.md").write_text("external content\n", encoding="utf-8")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["conflicts"][0]["code"] == "external_install_detected"
+    assert external.joinpath("SKILL.md").read_text(encoding="utf-8") == "external content\n"
+
+
+def test_install_skills_is_idempotent_for_same_managed_version(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["reason"] == "already_installed"
+
+
+def test_install_skills_preserves_modified_managed_install(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    skill_file = target / "nvflare-test-skill" / "SKILL.md"
+    skill_file.write_text(skill_file.read_text(encoding="utf-8") + "\n# User Edit\n", encoding="utf-8")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "local_modifications_detected"
+    assert plan["conflicts"][0]["code"] == "local_modifications_detected"
+    assert "# User Edit" in skill_file.read_text(encoding="utf-8")
+
+
+def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    skill_plan = plan["skills"][0]
+    assert skill_plan["action"] == "replace"
+    assert skill_plan["status"] == "replaced"
+    assert skill_plan["version_delta"] == "update"
+    assert "Second Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    backup_runs = list((target / ".nvflare_bak").iterdir())
+    assert len(backup_runs) == 1
+    backup_file = backup_runs[0] / "nvflare-test-skill" / "SKILL.md"
+    assert "First Skill" in backup_file.read_text(encoding="utf-8")
+
+
+def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    (target / "external-skill").mkdir()
+
+    data = list_skills(agent="codex", target_dir=target, source=source)
+
+    assert data["available"][0]["name"] == "nvflare-test-skill"
+    assert data["installed"][0]["name"] == "nvflare-test-skill"
+    assert data["conflicts"][0]["skill"] == "external-skill"
+
+
+def _skill_source(tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill")
+    return SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+
+def _write_skill(root, name, heading="Test Skill"):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        f"# {heading}\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -192,6 +192,44 @@ def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path
     assert "First Skill" in backup_file.read_text(encoding="utf-8")
 
 
+def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+    def copytree_with_failure(src, dst, *args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(skill_manager.shutil, "copytree", copytree_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "disk full",
+        }
+    ]
+    assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert not (target / ".nvflare_bak").exists()
+
+
 def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
     root = tmp_path / "skills"
     _write_skill(root, "nvflare-a-skill")

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -378,7 +378,7 @@ def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
-def test_install_skills_rejects_source_symlink_before_copytree(tmp_path):
+def test_install_skills_dry_run_reports_source_symlink_conflict(tmp_path):
     root = tmp_path / "skills"
     skill_dir = _write_skill(root, "nvflare-test-skill")
     outside_file = tmp_path / "outside.txt"
@@ -402,13 +402,82 @@ def test_install_skills_rejects_source_symlink_before_copytree(tmp_path):
             "findings": [],
         },
     )
+    target = tmp_path / "target"
 
-    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source)
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
 
     assert plan["applied"] is False
-    assert plan["errors"][0]["type"] == "ValueError"
-    assert "skill source must not contain symlinks" in plan["errors"][0]["message"]
-    assert not (tmp_path / "target" / "nvflare-test-skill").exists()
+    assert plan["errors"] == []
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "source_symlink_detected"
+    assert plan["skills"][0]["files"] == []
+    assert plan["skills"][0]["source_issue"]["symlink_path"] == str(skill_dir / "outside-link.txt")
+    assert plan["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "source_symlink_detected",
+            "message": "source skill directory contains a symlink",
+            "source_path": str(skill_dir),
+            "symlink_path": str(skill_dir / "outside-link.txt"),
+        }
+    ]
+    assert not (target / "nvflare-test-skill").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_skips_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["errors"] == []
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["status"] == "skipped"
+    assert plan["conflicts"][0]["code"] == "source_symlink_detected"
+    assert not (target / "nvflare-test-skill").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_stage_skill_rejects_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(source_type="editable", root=root, manifest={})
+
+    with pytest.raises(ValueError, match="skill source must not contain symlinks"):
+        skill_manager._stage_skill(
+            skill_dir,
+            tmp_path / "staged",
+            {"name": "nvflare-test-skill", "source_hash": "fake-source-hash"},
+            source,
+            installed_path=tmp_path / "target" / "nvflare-test-skill",
+        )
 
 
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -480,6 +480,101 @@ def test_stage_skill_rejects_source_symlink_before_copytree(tmp_path):
         )
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_source_symlink_root_conflict(tmp_path):
+    actual_root = tmp_path / "actual-skills"
+    skill_dir = _write_skill(actual_root, "nvflare-test-skill")
+    root = tmp_path / "skills"
+    root.mkdir()
+    source_link = root / "nvflare-test-skill"
+    source_link.symlink_to(skill_dir, target_is_directory=True)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+
+    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "source_symlink_detected"
+    assert plan["conflicts"][0]["symlink_path"] == str(source_link)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_stage_skill_rejects_source_symlink_root(tmp_path):
+    actual_root = tmp_path / "actual-skills"
+    skill_dir = _write_skill(actual_root, "nvflare-test-skill")
+    source_link = tmp_path / "nvflare-test-skill"
+    source_link.symlink_to(skill_dir, target_is_directory=True)
+    source = SkillSource(source_type="editable", root=tmp_path, manifest={})
+
+    with pytest.raises(ValueError, match="skill source must not contain symlinks"):
+        skill_manager._stage_skill(
+            source_link,
+            tmp_path / "staged",
+            {"name": "nvflare-test-skill", "source_hash": "fake-source-hash"},
+            source,
+            installed_path=tmp_path / "target" / "nvflare-test-skill",
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_installed_skill_nested_symlink_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    symlink = target / "nvflare-test-skill" / "outside-link.txt"
+    symlink.symlink_to(outside_file)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "target_symlink_detected"
+    assert plan["skills"][0]["target_issue"]["symlink_path"] == str(symlink)
+    assert plan["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "target_symlink_detected",
+            "message": "target skill directory contains a symlink",
+            "target_path": str(target / "nvflare-test-skill"),
+            "symlink_path": str(symlink),
+        }
+    ]
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_installed_skill_root_symlink_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    installed_skill = target / "nvflare-test-skill"
+    actual_skill = tmp_path / "actual-installed-skill"
+    shutil.move(installed_skill, actual_skill)
+    installed_skill.symlink_to(actual_skill, target_is_directory=True)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "target_symlink_detected"
+    assert plan["conflicts"][0]["symlink_path"] == str(installed_skill)
+
+
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):
     source = _skill_source(tmp_path)
     target = tmp_path / "target"

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import json
+import os
 import shutil
 from pathlib import Path
+
+import pytest
 
 from nvflare.tool.agent import skill_manager
 from nvflare.tool.agent.skill_manager import (
@@ -46,6 +49,28 @@ def test_resolve_target_override_skips_agent_home_resolution(tmp_path):
     target = resolve_agent_target_dir("codex", target_dir=tmp_path / "custom-target", env={"CODEX_HOME": "ignored"})
 
     assert target == tmp_path / "custom-target"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_resolve_target_override_rejects_symlink_target(tmp_path):
+    actual_target = tmp_path / "actual-target"
+    actual_target.mkdir()
+    link_target = tmp_path / "link-target"
+    link_target.symlink_to(actual_target, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink components"):
+        resolve_agent_target_dir("codex", target_dir=link_target)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_resolve_target_override_rejects_symlink_parent(tmp_path):
+    actual_parent = tmp_path / "actual-parent"
+    actual_parent.mkdir()
+    link_parent = tmp_path / "link-parent"
+    link_parent.symlink_to(actual_parent, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink components"):
+        resolve_agent_target_dir("codex", target_dir=link_parent / "skills")
 
 
 def test_resolve_unsupported_agent_raises_value_error():
@@ -350,6 +375,40 @@ def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
     assert (target / "nvflare-a-skill" / "SKILL.md").is_file()
     assert not (target / "nvflare-failing-skill").exists()
     assert (target / "nvflare-z-skill" / "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_rejects_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+
+    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source)
+
+    assert plan["applied"] is False
+    assert plan["errors"][0]["type"] == "ValueError"
+    assert "skill source must not contain symlinks" in plan["errors"][0]["message"]
+    assert not (tmp_path / "target" / "nvflare-test-skill").exists()
 
 
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -231,6 +231,45 @@ def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, t
     assert not (target / ".nvflare_bak").exists()
 
 
+def test_install_skills_replace_publish_error_restores_existing_install(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+    def publish_with_failure(src, dst):
+        raise OSError("publish failed")
+
+    monkeypatch.setattr(skill_manager, "_publish_staged_skill", publish_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "publish failed",
+        }
+    ]
+    assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Second Skill" not in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert not any((target / ".nvflare_bak").iterdir())
+
+
 def test_install_skills_replace_reports_publish_error_when_recovery_fails(monkeypatch, tmp_path):
     root = tmp_path / "skills"
     _write_skill(root, "nvflare-test-skill", heading="First Skill")

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from importlib import resources
+
+from nvflare.tool.agent import bundled_skills
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, copy_released_skills_to_bundle, skill_tree_hash
+
+
+def test_build_skill_manifest_includes_valid_skill(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["schema_version"] == "1"
+    assert manifest["source_type"] == "editable"
+    assert manifest["nvflare_version"] == "2.8.0"
+    assert manifest["findings"] == []
+    assert manifest["skills"] == [
+        {
+            "name": "nvflare-test-skill",
+            "skill_version": "0.0.0",
+            "min_flare_version": "2.8.0",
+            "max_flare_version": None,
+            "blast_radius": "read_only",
+            "source_hash": skill_tree_hash(skill_dir),
+            "relative_path": "nvflare-test-skill",
+        }
+    ]
+
+
+def test_skill_tree_hash_changes_when_skill_content_changes(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    first_hash = skill_tree_hash(skill_dir)
+
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "notes.md").write_text("new reference\n", encoding="utf-8")
+
+    assert skill_tree_hash(skill_dir) != first_hash
+
+
+def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    _write_skill(source_root, "nvflare-test-skill")
+
+    manifest = copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("manifest.json").is_file()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+    saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert saved_manifest == manifest
+    assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+
+
+def test_bundled_skill_manifest_resource_exists():
+    manifest = resources.files(bundled_skills).joinpath("manifest.json")
+
+    assert manifest.is_file()
+    assert json.loads(manifest.read_text(encoding="utf-8"))["schema_version"] == "1"
+
+
+def _write_skill(root, name):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -95,6 +95,16 @@ def test_skill_tree_hash_rejects_skill_symlinks(tmp_path):
         skill_tree_hash(skill_dir)
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_skill_tree_hash_rejects_symlink_skill_root(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    link_dir = tmp_path / "nvflare-link-skill"
+    link_dir.symlink_to(skill_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        skill_tree_hash(link_dir)
+
+
 def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
     first_hash = skill_tree_hash(skill_dir)

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -51,6 +51,32 @@ def test_skill_tree_hash_changes_when_skill_content_changes(tmp_path):
     assert skill_tree_hash(skill_dir) != first_hash
 
 
+def test_build_skill_manifest_reports_invalid_skill_findings(tmp_path):
+    skill_dir = tmp_path / "nvflare-invalid-skill"
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n" "name: nvflare-invalid-skill\n" "description: Missing required fields.\n" "---\n",
+        encoding="utf-8",
+    )
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["skills"] == []
+    assert manifest["findings"][0]["skill_dir"] == "nvflare-invalid-skill"
+    assert manifest["findings"][0]["issues"][0]["code"] == "skill-frontmatter-field-required"
+
+
+def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    first_hash = skill_tree_hash(skill_dir)
+    cache_dir = skill_dir / "__pycache__"
+    cache_dir.mkdir()
+    cache_dir.joinpath("SKILL.cpython-310.pyc").write_bytes(b"compiled cache")
+    skill_dir.joinpath("cache.pyo").write_bytes(b"optimized cache")
+
+    assert skill_tree_hash(skill_dir) == first_hash
+
+
 def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
     source_root = tmp_path / "skills"
     bundle_root = tmp_path / "bundle"
@@ -63,6 +89,25 @@ def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
     saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
     assert saved_manifest == manifest
     assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+
+
+def test_copy_released_skills_to_bundle_cleans_existing_bundle_content(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    bundle_root.joinpath("__init__.py").write_text("# keep package marker\n", encoding="utf-8")
+    bundle_root.joinpath("stale.txt").write_text("stale\n", encoding="utf-8")
+    stale_dir = bundle_root / "stale-skill"
+    stale_dir.mkdir()
+    stale_dir.joinpath("SKILL.md").write_text("stale\n", encoding="utf-8")
+    _write_skill(source_root, "nvflare-test-skill")
+
+    copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("__init__.py").is_file()
+    assert not bundle_root.joinpath("stale.txt").exists()
+    assert not stale_dir.exists()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
 
 
 def test_bundled_skill_manifest_resource_exists():

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import json
+import os
 from importlib import resources
+
+import pytest
 
 from nvflare.tool.agent import bundled_skills
 from nvflare.tool.agent.skill_manifest import build_skill_manifest, copy_released_skills_to_bundle, skill_tree_hash
@@ -66,6 +69,32 @@ def test_build_skill_manifest_reports_invalid_skill_findings(tmp_path):
     assert manifest["findings"][0]["issues"][0]["code"] == "skill-frontmatter-field-required"
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_build_skill_manifest_rejects_skill_symlinks(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "outside-link.txt").symlink_to(outside_file)
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["skills"] == []
+    assert manifest["findings"][0]["skill_dir"] == "nvflare-test-skill"
+    assert manifest["findings"][0]["issues"][0]["code"] == "skill-symlink-not-allowed"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_skill_tree_hash_rejects_skill_symlinks(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        skill_tree_hash(skill_dir)
+
+
 def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
     first_hash = skill_tree_hash(skill_dir)
@@ -107,6 +136,23 @@ def test_copy_released_skills_to_bundle_cleans_existing_bundle_content(tmp_path)
     assert bundle_root.joinpath("__init__.py").is_file()
     assert not bundle_root.joinpath("stale.txt").exists()
     assert not stale_dir.exists()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_copy_released_skills_to_bundle_unlinks_stale_bundle_symlink(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    stale_target = tmp_path / "stale-target"
+    stale_target.mkdir()
+    bundle_root.joinpath("stale-link").symlink_to(stale_target, target_is_directory=True)
+    _write_skill(source_root, "nvflare-test-skill")
+
+    copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert not bundle_root.joinpath("stale-link").exists()
+    assert stale_target.is_dir()
     assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
 
 

--- a/tests/unit_test/tool/agent_skill_checks/__init__.py
+++ b/tests/unit_test/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
+++ b/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: nvflare-example-skill
+description: Example fixture skill used by frontmatter validator tests.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+
+# Example Skill
+
+This file exists only as a validator fixture.

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from nvflare.tool.agent_skill_checks.frontmatter import (
+    SkillFrontmatterError,
+    parse_skill_frontmatter,
+    validate_skill_dir,
+    validate_skills_root,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parse_skill_frontmatter_reads_required_fields():
+    metadata = parse_skill_frontmatter(FIXTURES / "valid" / "nvflare-example-skill" / "SKILL.md")
+
+    assert metadata["name"] == "nvflare-example-skill"
+    assert metadata["description"] == "Example fixture skill used by frontmatter validator tests."
+    assert metadata["min_flare_version"] == "2.8.0"
+    assert metadata["blast_radius"] == "read_only"
+
+
+def test_validate_skill_dir_accepts_fixture_skill():
+    result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
+
+    assert result.ok
+    assert result.metadata["name"] == "nvflare-example-skill"
+    assert result.issues == ()
+
+
+def test_validate_skill_dir_requires_directory_name_to_match_frontmatter(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-other-name", name="nvflare-example-skill")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-name-directory-mismatch"}
+
+
+def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-fields"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-missing-fields\n"
+        "description: Missing two required fields.\n"
+        "---\n"
+        "\n"
+        "# Missing Fields\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-required"}
+    assert len(result.issues) == 2
+
+
+def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-blast-radius-invalid"}
+
+
+def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("name: nvflare-no-frontmatter\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must start"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-skill-md"
+    skill_dir.mkdir()
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-md-missing"}
+
+
+def test_validate_skills_root_skips_non_skill_files(tmp_path):
+    _write_skill(tmp_path, "nvflare-valid-one")
+    (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+
+    results = validate_skills_root(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].ok
+    assert results[0].metadata["name"] == "nvflare-valid-one"
+
+
+def test_validate_skills_root_reports_missing_root(tmp_path):
+    results = validate_skills_root(tmp_path / "missing")
+
+    assert len(results) == 1
+    assert not results[0].ok
+    assert _issue_codes(results[0]) == {"skills-root-missing"}
+
+
+def _write_skill(tmp_path, skill_name, *, name=None, blast_radius="read_only"):
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name or skill_name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        f"blast_radius: {blast_radius}\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _issue_codes(result):
+    return {issue.code for issue in result.issues}

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -35,6 +35,24 @@ def test_parse_skill_frontmatter_reads_required_fields():
     assert metadata["blast_radius"] == "read_only"
 
 
+def test_parse_skill_frontmatter_accepts_utf8_bom(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_bytes(
+        b"\xef\xbb\xbf---\n"
+        b"name: nvflare-bom-skill\n"
+        b"description: Test skill fixture.\n"
+        b'min_flare_version: "2.8.0"\n'
+        b"blast_radius: read_only\n"
+        b"---\n"
+        b"\n"
+        b"# Test Skill\n"
+    )
+
+    metadata = parse_skill_frontmatter(skill_file)
+
+    assert metadata["name"] == "nvflare-bom-skill"
+
+
 def test_validate_skill_dir_accepts_fixture_skill():
     result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
 
@@ -72,6 +90,29 @@ def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
     assert len(result.issues) == 2
 
 
+def test_validate_skill_dir_reports_wrong_type_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-wrong-type"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-wrong-type\n"
+        "description: Wrong type fixture.\n"
+        "min_flare_version: 2.8\n"
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Wrong Type\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-type"}
+    assert "min_flare_version" in result.issues[0].message
+    assert "float=2.8" in result.issues[0].message
+
+
 def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
 
@@ -89,6 +130,40 @@ def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
         parse_skill_frontmatter(skill_file)
 
 
+def test_parse_skill_frontmatter_requires_closing_delimiter(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "---\n" "name: nvflare-no-closing-delimiter\n" "description: Missing closing delimiter.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillFrontmatterError, match="must end"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_malformed_yaml(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\nname: [unclosed\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="failed to parse YAML"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_non_mapping(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\n- name\n- description\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must be a mapping"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_directory(tmp_path):
+    result = validate_skill_dir(tmp_path / "nvflare-missing-directory")
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-dir-missing"}
+
+
 def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
     skill_dir = tmp_path / "nvflare-missing-skill-md"
     skill_dir.mkdir()
@@ -102,6 +177,7 @@ def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
 def test_validate_skills_root_skips_non_skill_files(tmp_path):
     _write_skill(tmp_path, "nvflare-valid-one")
     (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+    (tmp_path / ".hidden-dir").mkdir()
 
     results = validate_skills_root(tmp_path)
 

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,7 +58,7 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
-    assert payload["code"] == "INVALID_ARGS"
+    assert "code" not in payload
     assert "event" not in payload
     assert "terminal" not in payload
     assert "usage" in payload["data"]
@@ -109,7 +109,7 @@ def test_jsonl_rejected_for_non_streaming_command(capsys, monkeypatch):
     assert exc_info.value.code == 4
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["event"] == "terminal"
-    assert payload["terminal"] is True
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert payload["error_code"] == "INVALID_ARGS"
     assert "nvflare job monitor" in payload["message"]

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,6 +58,9 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
+    assert payload["code"] == "INVALID_ARGS"
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert "usage" in payload["data"]
     assert "list" in payload["data"]["choices"]
 

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -201,6 +201,15 @@ class TestOutputOk:
         mock_print.assert_called_once()
         assert mock_print.call_args.kwargs["flush"] is True
 
+    def test_json_mode_output_ok_flushes_stdout(self, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with patch("builtins.print") as mock_print:
+            output_ok({"key": "value"})
+
+        mock_print.assert_called_once()
+        assert mock_print.call_args.kwargs["flush"] is True
+
     def test_human_mode_dict_renders_as_table(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "txt")
         output_ok({"status": "running", "id": "abc"})

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -382,6 +382,23 @@ class TestOutputError:
         assert "message" in envelope
         assert "hint" in envelope
 
+    def test_error_envelope_supports_agent_fields(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with pytest.raises(SystemExit) as exc_info:
+            output_error(
+                "CONNECTION_FAILED",
+                recovery_category="RETRYABLE",
+                suggested_skill="nvflare-diagnose-job",
+            )
+
+        assert exc_info.value.code == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["error_code"] == "CONNECTION_FAILED"
+        assert envelope["code"] == "CONNECTION_FAILED"
+        assert envelope["recovery_category"] == "RETRYABLE"
+        assert envelope["suggested_skill"] == "nvflare-diagnose-job"
+
     def test_custom_exit_code(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "json")
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -201,15 +201,6 @@ class TestOutputOk:
         mock_print.assert_called_once()
         assert mock_print.call_args.kwargs["flush"] is True
 
-    def test_json_mode_output_ok_flushes_stdout(self, monkeypatch):
-        monkeypatch.setattr(cli_output, "_output_format", "json")
-
-        with patch("builtins.print") as mock_print:
-            output_ok({"key": "value"})
-
-        mock_print.assert_called_once()
-        assert mock_print.call_args.kwargs["flush"] is True
-
     def test_human_mode_dict_renders_as_table(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "txt")
         output_ok({"status": "running", "id": "abc"})
@@ -404,7 +395,7 @@ class TestOutputError:
         assert exc_info.value.code == 1
         envelope = json.loads(capsys.readouterr().out)
         assert envelope["error_code"] == "CONNECTION_FAILED"
-        assert envelope["code"] == "CONNECTION_FAILED"
+        assert "code" not in envelope
         assert envelope["recovery_category"] == "RETRYABLE"
         assert envelope["suggested_skill"] == "nvflare-diagnose-job"
 


### PR DESCRIPTION
## Summary
- add released-skill manifest generation and bundled skill package support for wheel builds
- add native nvflare agent skills install/list with dry-run JSON plans, codex/claude target resolution, managed install manifests, conflict handling, and safe managed replacement backups
- add unit coverage for manifest hashing/copying, package resources, install/list CLI JSON/schema paths, target resolution, idempotency, external conflict handling, local edit preservation, and managed replacement

## Scope
Implements agent skills milestones 2 and 3. This branch is stacked on PR #4689 and PR #4690 while those are open; the incremental milestone 2/3 commit is 8d32b7eba.

## Verification
- python3 -m pytest tests/unit_test/tool/agent/agent_cli_test.py tests/unit_test/tool/agent/skill_manifest_test.py tests/unit_test/tool/agent/skill_manager_test.py tests/unit_test/tool/agent_skill_checks/frontmatter_test.py -q
- ./runtest.sh -s
- python3 setup.py bdist_wheel --dist-dir /private/tmp/nvflare-agent-pr3-wheel
- unzip -l /private/tmp/nvflare-agent-pr3-wheel/*.whl | rg "nvflare/tool/agent/bundled_skills|__pycache__|\.pyc"
- python3 -m nvflare.cli agent skills install --agent codex --target /private/tmp/nvflare-agent-pr3-install-smoke --dry-run --format json