### PR TITLE
Don't use kagglehub==1.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ test_support =
     pandas>=1.5.1
     nbformat
     nbmake
-    kagglehub
+    kagglehub!=1.0.1
 
 test =
     %(all)s


### PR DESCRIPTION
### Description

See this issue (https://github.com/Kaggle/kagglehub/issues/301)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
