### PR TITLE
[2.8] Fix recipe docs examples

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -55,15 +55,19 @@ Converting existing training code to federated learning requires just 3 changes:
 
 .. code-block:: python
 
+    from model import MyModel
     from nvflare.app_opt.pt.recipes import FedAvgRecipe
+    from nvflare.recipe import SimEnv
 
     recipe = FedAvgRecipe(
         name="my-fedavg-job",
         min_clients=2,
         num_rounds=5,
+        model=MyModel(),
         train_script="train.py",
     )
-    recipe.execute()
+    env = SimEnv(num_clients=2)
+    run = recipe.execute(env)
 
 That's it. Your training logic stays the same -- FLARE handles the communication, aggregation, and orchestration.
 For the full Client API reference, see :ref:`Client API <client_api>`. For pre-built recipes, see :ref:`Available Recipes <available_recipes>`.

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -116,6 +116,7 @@ For framework-agnostic or NumPy-based models.
         name="fedavg-numpy",
         min_clients=2,
         num_rounds=5,
+        model=[0.0, 0.0, 0.0],
         train_script="client.py",
     )
     env = SimEnv(num_clients=2)

--- a/examples/advanced/experiment-tracking/README.md
+++ b/examples/advanced/experiment-tracking/README.md
@@ -8,6 +8,7 @@ These examples use the Recipe API with the `add_experiment_tracking()` utility f
 
 ```python
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
 from nvflare.recipe.utils import add_experiment_tracking
 
 # Create your training recipe
@@ -25,7 +26,8 @@ recipe = FedAvgRecipe(
 # Add experiment tracking with ONE line!
 add_experiment_tracking(recipe, "mlflow")  # or "tensorboard" or "wandb"
 
-recipe.run()
+env = SimEnv(num_clients=2)
+run = recipe.execute(env)
 ```
 
 ## How Metric Tracking Works

--- a/examples/advanced/experiment-tracking/mlflow/hello-lightning-mlflow/README.md
+++ b/examples/advanced/experiment-tracking/mlflow/hello-lightning-mlflow/README.md
@@ -12,6 +12,7 @@ This example demonstrates PyTorch Lightning integration with MLflow tracking:
 
 ```python
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
 from nvflare.recipe.utils import add_experiment_tracking
 
 # Create FedAvg recipe for Lightning model
@@ -39,7 +40,8 @@ add_experiment_tracking(
     }
 )
 
-recipe.run()
+env = SimEnv(num_clients=2)
+run = recipe.execute(env)
 ```
 
 **Note:** This example uses the standard PyTorch `FedAvgRecipe` which automatically handles Lightning models. The recipe integrates with Lightning's callback system and trainer, while maintaining the same simple tracking API as regular PyTorch examples.

--- a/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow-client/README.md
+++ b/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow-client/README.md
@@ -22,6 +22,7 @@ This example shows how to configure per-client MLflow tracking:
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
 from nvflare.app_opt.tracking.mlflow.mlflow_receiver import MLflowReceiver
 from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE
+from nvflare.recipe import SimEnv
 
 # Create recipe WITHOUT default server-side tracking
 recipe = FedAvgRecipe(
@@ -48,7 +49,8 @@ for i in range(2):
 
     recipe.job.to(receiver, site_name, id="mlflow_receiver")
 
-recipe.run()
+env = SimEnv(num_clients=2)
+run = recipe.execute(env)
 ```
 
 **Key points**:

--- a/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow/README.md
+++ b/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow/README.md
@@ -36,6 +36,7 @@ python3 job.py
 The Recipe API makes it simple:
 ```python
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
 from nvflare.recipe.utils import add_experiment_tracking
 
 # Create training recipe
@@ -63,7 +64,8 @@ add_experiment_tracking(
     }
 )
 
-recipe.run()
+env = SimEnv(num_clients=2)
+run = recipe.execute(env)
 ```
 
 ### 4. Access the logs and results

--- a/examples/advanced/experiment-tracking/tensorboard/README.md
+++ b/examples/advanced/experiment-tracking/tensorboard/README.md
@@ -14,6 +14,7 @@ This example uses the `FedAvgRecipe` with the `add_experiment_tracking()` utilit
 
 ```python
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
 from nvflare.recipe.utils import add_experiment_tracking
 
 # Create training recipe
@@ -32,7 +33,8 @@ recipe = FedAvgRecipe(
 add_experiment_tracking(recipe, "tensorboard", tracking_config={"tb_folder": "tb_events"})
 
 # Run
-recipe.run()
+env = SimEnv(num_clients=2)
+run = recipe.execute(env)
 ```
 
 ## Setup

--- a/examples/advanced/experiment-tracking/wandb/README.md
+++ b/examples/advanced/experiment-tracking/wandb/README.md
@@ -12,6 +12,7 @@ This example demonstrates Weights & Biases tracking with flexible options for se
 
 ```python
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
 from nvflare.recipe.utils import add_experiment_tracking
 
 # Create FedAvg recipe
@@ -42,7 +43,8 @@ wandb_config = {
 # Server-side tracking (centralized)
 add_experiment_tracking(recipe, "wandb", tracking_config=wandb_config)
 
-recipe.run()
+env = SimEnv(num_clients=2)
+run = recipe.execute(env)
 ```
 
 ## Setup and Running


### PR DESCRIPTION
## Summary

- Update the quickstart Recipe snippet to include a model source and execute through `SimEnv`.
- Add a required initial model to the NumPy FedAvg recipe example.
- Replace stale `recipe.run()` README snippets in experiment-tracking docs with `SimEnv` plus `recipe.execute(env)`.

## Why

Several Recipe examples were first-touch docs but no longer matched the current Recipe API. The snippets either omitted required constructor inputs or called `run()` without an execution environment.
