### PR TITLE
Fix CLI docs: provisioning paths, admin_port, K8s status, ephemeral_storage

### DIFF
--- a/docs/system_architecture/system_architecture.rst
+++ b/docs/system_architecture/system_architecture.rst
@@ -198,7 +198,9 @@ K8s-native Architecture: Control and Execution Planes Separation
 
 .. note::
 
-   The K8s-native feature is coming soon.
+   K8s-native deployment support was introduced in FLARE 2.8.0. For deployment
+   steps, Helm chart generation, parent pods, and dynamically launched job
+   pods, see :ref:`helm_chart`.
 
 Parent pods manage the system lifecycle and spawn job pods (server job pod, client job pod) for workload execution.
 The server hosts the central coordination logic and is designed to be resilient, scalable, and capable of handling

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -855,7 +855,10 @@ Supported ``launcher_spec[site][k8s]`` keys include:
   should be lower than the limit.
 * ``ephemeral_storage``: Kubernetes quantity string for the job workspace
   ``emptyDir.sizeLimit`` and the container ``ephemeral-storage`` request and
-  limit. If omitted, the launcher uses its configured default.
+  limit. Set this in ``launcher_spec.default.k8s`` or in a site-specific
+  ``launcher_spec[site].k8s`` block. If omitted, the built-in launcher default
+  is used. The current ``deploy prepare`` runtime config does not expose
+  ``job_launcher.ephemeral_storage`` as a ``k8s.yaml`` setting.
 
 Job pods are created with ``imagePullPolicy: Always``. Tag changes take effect
 immediately, but every submitted job pulls the image once per site. For private

--- a/docs/user_guide/nvflare_cli/cert_command.rst
+++ b/docs/user_guide/nvflare_cli/cert_command.rst
@@ -214,7 +214,7 @@ profile:
 
 .. code-block:: shell
 
-   nvflare cert approve hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare cert approve hospital-a/hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
 
 This validates the request zip, verifies that the request project matches the
 CA and project profile, signs the CSR, injects the Project Admin-approved
@@ -223,7 +223,7 @@ server endpoint from ``project_profile.yaml``, signs CA metadata into
 
 .. code-block:: text
 
-   hospital-a.signed.zip
+   hospital-a/hospital-a.signed.zip
      signed.json
      signed.json.sig
      site.yaml
@@ -249,7 +249,7 @@ Use ``--out`` to choose the signed zip location:
 
 .. code-block:: shell
 
-   nvflare cert approve hospital-a.request.zip \
+   nvflare cert approve hospital-a/hospital-a.request.zip \
        --ca-dir ./ca \
        --profile project_profile.yaml \
        --out ./signed/hospital-a.signed.zip
@@ -284,13 +284,13 @@ Project Admin:
 .. code-block:: shell
 
    nvflare cert init --profile project_profile.yaml -o ./ca --deploy-version 00
-   nvflare cert approve hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare cert approve hospital-a/hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
 
 Requester:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare package hospital-a/hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 For the full workflow, including participant definition examples and artifact
 layout, see :ref:`distributed_provisioning`.

--- a/docs/user_guide/nvflare_cli/distributed_provisioning.rst
+++ b/docs/user_guide/nvflare_cli/distributed_provisioning.rst
@@ -254,18 +254,18 @@ Project Admin approves the request:
 
 .. code-block:: shell
 
-   nvflare cert approve hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare cert approve hospital-a/hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
 
-This creates ``hospital-a.signed.zip`` and prints
-``rootca_fingerprint_sha256``. The signed zip already includes ``rootCA.pem``;
-return the signed zip to the Site Admin and share only the fingerprint through
-a trusted out-of-band channel.
+This creates ``hospital-a/hospital-a.signed.zip`` (next to the request zip)
+and prints ``rootca_fingerprint_sha256``. The signed zip already includes
+``rootCA.pem``; return the signed zip to the Site Admin and share only the
+fingerprint through a trusted out-of-band channel.
 
 Site Admin packages the startup kit:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare package hospital-a/hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 The output goes under:
 
@@ -313,13 +313,13 @@ Project Admin approves it:
 
 .. code-block:: shell
 
-   nvflare cert approve alice@hospital-alpha.org.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare cert approve alice@hospital-alpha.org/alice@hospital-alpha.org.request.zip --ca-dir ./ca --profile project_profile.yaml
 
 Requester packages the returned signed zip:
 
 .. code-block:: shell
 
-   nvflare package alice@hospital-alpha.org.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare package alice@hospital-alpha.org/alice@hospital-alpha.org.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 The generated user startup kit contains ``startup/fl_admin.sh``.
 
@@ -368,8 +368,8 @@ Then use the same request, approval, and package workflow:
 .. code-block:: shell
 
    nvflare cert request --participant server.yaml
-   nvflare cert approve server1.hospital-central.org.request.zip --ca-dir ./ca --profile project_profile.yaml
-   nvflare package server1.hospital-central.org.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare cert approve server1.hospital-central.org/server1.hospital-central.org.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare package server1.hospital-central.org/server1.hospital-central.org.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 The server participant name follows the same validation convention as
 centralized ``project.yaml`` server participants. A DNS name is recommended for
@@ -389,13 +389,15 @@ Requester machine:
 
    nvflare cert request --participant hospital-a.yaml
 
-Transfer this file to the Project Admin:
+Transfer this file to the Project Admin (for example, copy it into the
+Project Admin's working directory as ``hospital-a.request.zip``):
 
 .. code-block:: text
 
    hospital-a/hospital-a.request.zip
 
-Project Admin machine:
+Project Admin machine (file received as ``hospital-a.request.zip`` in the
+working directory):
 
 .. code-block:: shell
 
@@ -407,18 +409,15 @@ Transfer this file back to the requester:
 
    hospital-a.signed.zip
 
-Requester machine:
-
-.. code-block:: shell
-
-   nvflare package hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
-
-If the signed zip is not next to the local request folder and package cannot
-find the folder from local request state, specify it:
+Requester machine (signed zip placed in the working directory, separate from
+the original ``./hospital-a/`` request folder):
 
 .. code-block:: shell
 
    nvflare package hospital-a.signed.zip --request-dir ./hospital-a --fingerprint <rootca_fingerprint_sha256>
+
+``--request-dir`` is required here because the signed zip is no longer next to
+the local request folder.
 
 *****************************
 Root CA Fingerprint Check
@@ -439,8 +438,8 @@ fingerprint:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
-   nvflare package hospital-a.signed.zip \
+   nvflare package hospital-a/hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare package hospital-a/hospital-a.signed.zip \
        --fingerprint <rootca_fingerprint_sha256>
 
 Use ``--fingerprint <rootca_fingerprint_sha256>`` when you have the expected
@@ -449,7 +448,7 @@ verification, omit the fingerprint option:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip
+   nvflare package hospital-a/hospital-a.signed.zip
 
 Without either option, packaging still validates the signed zip, metadata,
 certificate chain, and local private-key match, but it does not prompt and does
@@ -582,14 +581,14 @@ Project Admin:
 
    # create project_profile.yaml
    nvflare cert init --profile project_profile.yaml -o ./ca --deploy-version 00
-   nvflare cert approve hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare cert approve hospital-a/hospital-a.request.zip --ca-dir ./ca --profile project_profile.yaml
 
 Requester:
 
 .. code-block:: shell
 
    nvflare cert request --participant hospital-a.yaml
-   nvflare package hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare package hospital-a/hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 With explicit locations:
 

--- a/docs/user_guide/nvflare_cli/package_command.rst
+++ b/docs/user_guide/nvflare_cli/package_command.rst
@@ -23,11 +23,12 @@ The ``input`` positional argument is the ``*.signed.zip`` file produced by
 Basic Package Flow
 *******************
 
-For a site request created in ``./hospital-a``:
+For a site request created in ``./hospital-a`` and approved with the default
+``--out`` (which writes the signed zip next to the request zip):
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip
+   nvflare package hospital-a/hospital-a.signed.zip
 
 This still validates the signed zip, signed metadata, certificate chain, and
 local private-key match. It does not perform an out-of-band root CA fingerprint
@@ -38,17 +39,18 @@ Admin through a trusted out-of-band channel, pass the expected fingerprint:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare package hospital-a/hospital-a.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 The longer spelling ``--expected-fingerprint`` is also accepted:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip \
+   nvflare package hospital-a/hospital-a.signed.zip \
        --expected-fingerprint <rootca_fingerprint_sha256>
 
-If the signed zip is not next to the request folder and package cannot find the
-folder from local request state, specify it:
+If the signed zip is not next to the request folder (for example, after a
+remote transfer back to the requester), specify the local request folder
+explicitly:
 
 .. code-block:: shell
 
@@ -174,8 +176,8 @@ For a lead user:
 .. code-block:: shell
 
    nvflare cert request --participant alice.yaml
-   nvflare cert approve alice@hospital-alpha.org.request.zip --ca-dir ./ca --profile project_profile.yaml
-   nvflare package alice@hospital-alpha.org.signed.zip --fingerprint <rootca_fingerprint_sha256>
+   nvflare cert approve alice@hospital-alpha.org/alice@hospital-alpha.org.request.zip --ca-dir ./ca --profile project_profile.yaml
+   nvflare package alice@hospital-alpha.org/alice@hospital-alpha.org.signed.zip --fingerprint <rootca_fingerprint_sha256>
 
 The generated startup kit contains:
 
@@ -222,7 +224,7 @@ The top-level CLI also supports JSON output mode:
 
 .. code-block:: shell
 
-   nvflare package hospital-a.signed.zip \
+   nvflare package hospital-a/hospital-a.signed.zip \
        --fingerprint <rootca_fingerprint_sha256> \
        --format json
 


### PR DESCRIPTION
## Summary

Manual validation of the distributed provisioning and Kubernetes deployment flows on `2.8` surfaced three user-visible doc mismatches. The same docs are identical on `main`, so this PR brings the same fixes forward. The matching PR against `2.8` is #4694.

A fourth concern about `server.admin_port` being required in `project_profile.yaml` is being addressed by a separate implementation fix (#4700 on main, #4699 on 2.8) rather than a docs change — the docs were correct that `admin_port` is optional; the implementation is what needs to match.

### Issue 1 — Distributed provisioning paths don't match `cert request` default output

`nvflare cert request` creates a nested directory: `<name>/<name>.request.zip`. The local quick-start examples used the flat-path form (`hospital-a.request.zip`), which fails with `REQUEST_ZIP_NOT_FOUND` when run literally from the same working directory.

**Changes:**
- Local quick-start `approve`/`package` commands in `distributed_provisioning.rst`, `cert_command.rst`, and `package_command.rst` now use the nested paths (`hospital-a/hospital-a.request.zip`, `hospital-a/hospital-a.signed.zip`).
- The "Remote Transfer Flow" section keeps the flat-path commands but adds explicit transfer-step language so readers see where the file lives in each machine's working directory and why `--request-dir` is needed after a remote transfer.

### Issue 2 — System architecture page still says K8s-native is "coming soon"

`system_architecture.rst` carried a "The K8s-native feature is coming soon" note that contradicts the FLARE 2.8.0 release notes and the Helm chart deployment guide.

**Change:** replace the outdated note with one stating K8s-native deployment was introduced in 2.8.0 and linking to `:ref:helm_chart`.

### Issue 3 — Helm chart guide implies `ephemeral_storage` is a `k8s.yaml` launcher default

The `ephemeral_storage` description in `helm_chart.rst` reads as if `job_launcher.ephemeral_storage` is a `deploy prepare` runtime config key. It is not — `deploy prepare` accepts only `config_file_path`, `pending_timeout`, `default_python_path`, `job_pod_security_context`, and `image_pull_secrets`. The actual override path is per job: `launcher_spec.default.k8s.ephemeral_storage` or `launcher_spec[site].k8s.ephemeral_storage`.

**Change:** clarify that `ephemeral_storage` is set in `launcher_spec.default.k8s` or `launcher_spec[site].k8s`, and explicitly note that `deploy prepare` does not currently expose a `job_launcher.ephemeral_storage` setting.

## Related — `admin_port` handled in separate impl PR (not in this docs PR)

The original report flagged `server.admin_port` in `project_profile.yaml` as required by `cert approve`. The docs in this branch correctly describe it as **optional** (defaults to `fed_learn_port` when omitted). The implementation gap is fixed in #4700, which makes `_load_project_profile` honor that default. This docs PR's first commit briefly relabeled `admin_port` as required and a second commit reverted that change — net effect on `admin_port` text is unchanged from `main`.

## Files changed

- `docs/system_architecture/system_architecture.rst`
- `docs/user_guide/admin_guide/deployment/helm_chart.rst`
- `docs/user_guide/nvflare_cli/cert_command.rst`
- `docs/user_guide/nvflare_cli/distributed_provisioning.rst`
- `docs/user_guide/nvflare_cli/package_command.rst`

5 files, +44 / -36 net.

## Test plan

- [ ] Sphinx build clean: `./build_doc.sh --html`
- [ ] Spot-check: run `nvflare cert approve hospital-a/hospital-a.request.zip ...` against a generated request — succeeds where the flat-path form fails with `REQUEST_ZIP_NOT_FOUND`
- [ ] After #4700 lands: `nvflare cert approve` accepts a `project_profile.yaml` without `server.admin_port` (defaults to `fed_learn_port`) — matches the docs in this PR
- [ ] Verify the `:ref:helm_chart` cross-reference resolves in the rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
