### PR TITLE
Fix monitoring pair duration after missing end event

### DIFF
--- a/nvflare/metrics/job_metrics_collector.py
+++ b/nvflare/metrics/job_metrics_collector.py
@@ -42,44 +42,46 @@ class JobMetricsCollector(MetricsCollector):
             AppEventType.AFTER_AGGREGATION,
         ]
 
-        self.pair_events = {
-            EventType.START_WORKFLOW: "_workflow",
-            EventType.END_WORKFLOW: "_workflow",
-            EventType.START_RUN: "_run",
-            EventType.END_RUN: "_run",
-            EventType.JOB_STARTED: "_job",
-            EventType.JOB_COMPLETED: "_job",
-            EventType.JOB_ABORTED: "_job",
-            EventType.JOB_CANCELLED: "_job",
-            EventType.BEFORE_PULL_TASK: "_pull_task",
-            EventType.AFTER_PULL_TASK: "_pull_task",
-            EventType.BEFORE_PROCESS_TASK_REQUEST: "_process_task",
-            EventType.AFTER_PROCESS_TASK_REQUEST: "_process_task",
-            EventType.BEFORE_PROCESS_SUBMISSION: "_process_submission",
-            EventType.AFTER_PROCESS_SUBMISSION: "_process_submission",
-            EventType.BEFORE_TASK_DATA_FILTER: "_data_filter",
-            EventType.AFTER_TASK_DATA_FILTER: "_data_filter",
-            EventType.BEFORE_TASK_RESULT_FILTER: "_result_filter",
-            EventType.AFTER_TASK_RESULT_FILTER: "_result_filter",
-            EventType.BEFORE_TASK_EXECUTION: "_task_execution",
-            EventType.AFTER_TASK_EXECUTION: "_task_execution",
-            EventType.ABORT_TASK: "_task_execution",
-            EventType.BEFORE_SEND_TASK_RESULT: "_send_task_result",
-            EventType.AFTER_SEND_TASK_RESULT: "_send_task_result",
-            EventType.BEFORE_PROCESS_RESULT_OF_UNKNOWN_TASK: "_process_result_of_unknown_task",
-            EventType.AFTER_PROCESS_RESULT_OF_UNKNOWN_TASK: "_process_result_of_unknown_task",
-            # Application
-            AppEventType.BEFORE_AGGREGATION: "_aggregation",
-            AppEventType.END_AGGREGATION: "_aggregation",
-            AppEventType.RECEIVE_BEST_MODEL: "_receive_best_model",
-            AppEventType.BEFORE_TRAIN: "_train",
-            AppEventType.AFTER_TRAIN: "_train",
-            AppEventType.TRAIN_DONE: "_train_done",
-            AppEventType.TRAINING_STARTED: "_training",
-            AppEventType.TRAINING_FINISHED: "_training",
-            AppEventType.ROUND_STARTED: "_round",
-            AppEventType.ROUND_DONE: "_round",
-        }
+        self.pair_events, self.pair_start_events = self._build_pair_event_maps(
+            [
+                (EventType.START_WORKFLOW, EventType.END_WORKFLOW, "_workflow"),
+                (EventType.START_RUN, EventType.END_RUN, "_run"),
+                (
+                    EventType.JOB_STARTED,
+                    EventType.JOB_COMPLETED,
+                    EventType.JOB_ABORTED,
+                    EventType.JOB_CANCELLED,
+                    "_job",
+                ),
+                (EventType.BEFORE_PULL_TASK, EventType.AFTER_PULL_TASK, "_pull_task"),
+                (
+                    EventType.BEFORE_PROCESS_TASK_REQUEST,
+                    EventType.AFTER_PROCESS_TASK_REQUEST,
+                    "_process_task",
+                ),
+                (EventType.BEFORE_PROCESS_SUBMISSION, EventType.AFTER_PROCESS_SUBMISSION, "_process_submission"),
+                (EventType.BEFORE_TASK_DATA_FILTER, EventType.AFTER_TASK_DATA_FILTER, "_data_filter"),
+                (EventType.BEFORE_TASK_RESULT_FILTER, EventType.AFTER_TASK_RESULT_FILTER, "_result_filter"),
+                (
+                    EventType.BEFORE_TASK_EXECUTION,
+                    EventType.AFTER_TASK_EXECUTION,
+                    EventType.ABORT_TASK,
+                    "_task_execution",
+                ),
+                (EventType.BEFORE_SEND_TASK_RESULT, EventType.AFTER_SEND_TASK_RESULT, "_send_task_result"),
+                (
+                    EventType.BEFORE_PROCESS_RESULT_OF_UNKNOWN_TASK,
+                    EventType.AFTER_PROCESS_RESULT_OF_UNKNOWN_TASK,
+                    "_process_result_of_unknown_task",
+                ),
+                (AppEventType.BEFORE_AGGREGATION, AppEventType.END_AGGREGATION, "_aggregation"),
+                (AppEventType.RECEIVE_BEST_MODEL, "_receive_best_model"),
+                (AppEventType.BEFORE_TRAIN, AppEventType.AFTER_TRAIN, "_train"),
+                (AppEventType.TRAIN_DONE, "_train_done"),
+                (AppEventType.TRAINING_STARTED, AppEventType.TRAINING_FINISHED, "_training"),
+                (AppEventType.ROUND_STARTED, AppEventType.ROUND_DONE, "_round"),
+            ]
+        )
 
     def handle_event(self, event: str, fl_ctx: FLContext):
         job_id = fl_ctx.get_job_id()
@@ -95,3 +97,6 @@ class JobMetricsCollector(MetricsCollector):
 
     def get_pair_events(self):
         return self.pair_events
+
+    def get_pair_start_events(self):
+        return self.pair_start_events

--- a/nvflare/metrics/metrics_collector.py
+++ b/nvflare/metrics/metrics_collector.py
@@ -46,6 +46,34 @@ class MetricsCollector(FLComponent, ABC):
     def get_pair_events() -> Dict:
         pass
 
+    def get_pair_start_events(self):
+        """Returns events that explicitly start duration measurements.
+
+        Subclasses that define multiple pair events for one duration metric should
+        list the start event here. If this returns None or no start event is
+        defined for a metric, the collector preserves legacy toggle behavior for
+        that metric.
+        """
+        return None
+
+    @staticmethod
+    def _build_pair_event_maps(pair_event_specs):
+        """Build pair-event lookup maps from (start_event, *end_events, metric_name) specs.
+
+        A spec with only one event keeps the legacy toggle behavior and does not
+        declare an explicit start event.
+        """
+        pair_events = {}
+        pair_start_events = []
+        for *events, metric_name in pair_event_specs:
+            if not events:
+                continue
+            for event in events:
+                pair_events[event] = metric_name
+            if len(events) > 1:
+                pair_start_events.append(events[0])
+        return pair_events, pair_start_events
+
     def collect_event_metrics(self, event: str, tags, fl_ctx: FLContext):
 
         current_time = time.time()
@@ -53,23 +81,56 @@ class MetricsCollector(FLComponent, ABC):
 
         metrics = {MetricKeys.count: 1, MetricKeys.type: MetricTypes.COUNTER}
         duration_metrics = {MetricKeys.time_taken: 0, MetricKeys.type: MetricTypes.GAUGE}
+        pair_events = self.get_pair_events()
+        pair_start_events = self.get_pair_start_events()
+        if pair_start_events is not None:
+            pair_start_events = set(pair_start_events)
 
         if event in self.get_single_events():
             self.publish_metrics(metrics, metric_name, tags, fl_ctx)
-        elif event in self.get_pair_events().keys():
+        elif event in pair_events.keys():
             self.publish_metrics(metrics, metric_name, tags, fl_ctx)
-            key = self.pair_events.get(event)
-            if not self.event_start_time.get(key):
-                # begin
+            key = pair_events.get(event)
+            pair_event_role = self._get_pair_event_role(
+                event=event, key=key, pair_events=pair_events, pair_start_events=pair_start_events
+            )
+            if pair_event_role == "start":
                 self.event_start_time[key] = current_time
+            elif pair_event_role == "end":
+                self._publish_pair_duration(key, current_time, duration_metrics, tags, fl_ctx)
             else:
-                # end
-                time_taken = current_time - self.event_start_time.get(key)
-                # wipe out the start time for next event
-                self.event_start_time[key] = None
-                duration_metrics[MetricKeys.time_taken] = time_taken
-                metric_name = key
-                self.publish_metrics(duration_metrics, metric_name, tags, fl_ctx)
+                self._collect_legacy_pair_event(key, current_time, duration_metrics, tags, fl_ctx)
+
+    def _get_pair_event_role(self, event: str, key: str, pair_events: Dict, pair_start_events: set):
+        if pair_start_events is None:
+            return None
+        if event in pair_start_events:
+            return "start"
+
+        events_for_metric = [event_name for event_name, metric_key in pair_events.items() if metric_key == key]
+        if len(events_for_metric) <= 1:
+            return None
+        if any(event_name in pair_start_events for event_name in events_for_metric):
+            return "end"
+        return None
+
+    def _collect_legacy_pair_event(
+        self, key: str, current_time: float, duration_metrics: dict, tags, fl_ctx: FLContext
+    ):
+        if self.event_start_time.get(key) is None:
+            self.event_start_time[key] = current_time
+        else:
+            self._publish_pair_duration(key, current_time, duration_metrics, tags, fl_ctx)
+
+    def _publish_pair_duration(self, key: str, current_time: float, duration_metrics: dict, tags, fl_ctx: FLContext):
+        start_time = self.event_start_time.get(key)
+        if start_time is None:
+            return
+
+        time_taken = current_time - start_time
+        self.event_start_time[key] = None
+        duration_metrics[MetricKeys.time_taken] = time_taken
+        self.publish_metrics(duration_metrics, key, tags, fl_ctx)
 
     def publish_metrics(self, metrics: dict, metric_name: str, tags: dict, fl_ctx: FLContext):
 

--- a/nvflare/metrics/system_metrics_collector.py
+++ b/nvflare/metrics/system_metrics_collector.py
@@ -26,16 +26,18 @@ class SysMetricsCollector(MetricsCollector):
         """
         super().__init__(tags=tags, streaming_to_server=streaming_to_server)
 
-        self.pair_events = {
-            EventType.SYSTEM_START: "_system",
-            EventType.SYSTEM_END: "_system",
-            EventType.BEFORE_CHECK_CLIENT_RESOURCES: "_check_client_resources",
-            EventType.AFTER_CHECK_CLIENT_RESOURCES: "_check_client_resources",
-            EventType.BEFORE_CLIENT_REGISTER: "_client_register",
-            EventType.AFTER_CLIENT_REGISTER: "_client_register",
-            EventType.BEFORE_CLIENT_HEARTBEAT: "_client_heartbeat",
-            EventType.AFTER_CLIENT_HEARTBEAT: "_client_heartbeat",
-        }
+        self.pair_events, self.pair_start_events = self._build_pair_event_maps(
+            [
+                (EventType.SYSTEM_START, EventType.SYSTEM_END, "_system"),
+                (
+                    EventType.BEFORE_CHECK_CLIENT_RESOURCES,
+                    EventType.AFTER_CHECK_CLIENT_RESOURCES,
+                    "_check_client_resources",
+                ),
+                (EventType.BEFORE_CLIENT_REGISTER, EventType.AFTER_CLIENT_REGISTER, "_client_register"),
+                (EventType.BEFORE_CLIENT_HEARTBEAT, EventType.AFTER_CLIENT_HEARTBEAT, "_client_heartbeat"),
+            ]
+        )
 
         self.single_events = [
             EventType.CLIENT_DISCONNECTED,
@@ -59,3 +61,6 @@ class SysMetricsCollector(MetricsCollector):
 
     def get_pair_events(self):
         return self.pair_events
+
+    def get_pair_start_events(self):
+        return self.pair_start_events

--- a/tests/unit_test/metrics/job_metrics_collector_test.py
+++ b/tests/unit_test/metrics/job_metrics_collector_test.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+from nvflare.apis.event_type import EventType
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.metrics.job_metrics_collector import JobMetricsCollector
+from nvflare.metrics.metrics_collector import MetricsCollector
+from nvflare.metrics.metrics_keys import MetricKeys
+
+
+class _ReorderedPairMetricsCollector(MetricsCollector):
+    def __init__(self):
+        super().__init__(tags={})
+        self.single_events = []
+        self.pair_events = {
+            "END": "_custom",
+            "START": "_custom",
+        }
+        self.pair_start_events = ["START"]
+
+    def get_single_events(self):
+        return self.single_events
+
+    def get_pair_events(self):
+        return self.pair_events
+
+    def get_pair_start_events(self):
+        return self.pair_start_events
+
+
+class _LegacyMultiPairMetricsCollector(MetricsCollector):
+    def __init__(self):
+        super().__init__(tags={})
+        self.single_events = []
+        self.pair_events = {
+            "A": "_legacy",
+            "B": "_legacy",
+        }
+
+    def get_single_events(self):
+        return self.single_events
+
+    def get_pair_events(self):
+        return self.pair_events
+
+
+def _collector_with_captured_metrics():
+    collector = JobMetricsCollector(tags={})
+    published_metrics = []
+
+    def capture(metrics: dict, metric_name: str, tags: dict, fl_ctx):
+        published_metrics.append((metric_name, dict(metrics)))
+
+    collector.publish_metrics = capture
+    return collector, published_metrics
+
+
+def _duration_values(published_metrics, metric_name: str):
+    return [
+        metrics[MetricKeys.time_taken]
+        for name, metrics in published_metrics
+        if name == metric_name and MetricKeys.time_taken in metrics
+    ]
+
+
+def test_repeated_task_execution_begin_refreshes_start_time(monkeypatch):
+    event_times = iter([100.0, 101.0, 109.0])
+    monkeypatch.setattr("nvflare.metrics.metrics_collector.time.time", lambda: next(event_times))
+    collector, published_metrics = _collector_with_captured_metrics()
+
+    collector.collect_event_metrics(EventType.BEFORE_TASK_EXECUTION, {}, MagicMock())
+    collector.collect_event_metrics(EventType.BEFORE_TASK_EXECUTION, {}, MagicMock())
+    collector.collect_event_metrics(EventType.AFTER_TASK_EXECUTION, {}, MagicMock())
+
+    assert _duration_values(published_metrics, "_task_execution") == [8.0]
+    assert collector.event_start_time["_task_execution"] is None
+
+
+def test_explicit_start_events_do_not_depend_on_pair_event_order(monkeypatch):
+    event_times = iter([20.0, 24.5])
+    monkeypatch.setattr("nvflare.metrics.metrics_collector.time.time", lambda: next(event_times))
+    collector = _ReorderedPairMetricsCollector()
+    published_metrics = []
+
+    def capture(metrics: dict, metric_name: str, tags: dict, fl_ctx):
+        published_metrics.append((metric_name, dict(metrics)))
+
+    collector.publish_metrics = capture
+
+    collector.collect_event_metrics("START", {}, MagicMock())
+    collector.collect_event_metrics("END", {}, MagicMock())
+
+    assert _duration_values(published_metrics, "_custom") == [4.5]
+    assert collector.event_start_time["_custom"] is None
+
+
+def test_multi_event_pair_without_explicit_start_preserves_legacy_toggle(monkeypatch):
+    event_times = iter([30.0, 34.5])
+    monkeypatch.setattr("nvflare.metrics.metrics_collector.time.time", lambda: next(event_times))
+    collector = _LegacyMultiPairMetricsCollector()
+    published_metrics = []
+
+    def capture(metrics: dict, metric_name: str, tags: dict, fl_ctx):
+        published_metrics.append((metric_name, dict(metrics)))
+
+    collector.publish_metrics = capture
+
+    collector.collect_event_metrics("B", {}, MagicMock())
+    collector.collect_event_metrics("A", {}, MagicMock())
+
+    assert _duration_values(published_metrics, "_legacy") == [4.5]
+    assert collector.event_start_time["_legacy"] is None
+
+
+def test_task_execution_end_without_start_does_not_publish_duration(monkeypatch):
+    monkeypatch.setattr("nvflare.metrics.metrics_collector.time.time", lambda: 109.0)
+    collector, published_metrics = _collector_with_captured_metrics()
+
+    collector.collect_event_metrics(EventType.AFTER_TASK_EXECUTION, {}, MagicMock())
+    collector.collect_event_metrics(EventType.ABORT_TASK, {}, MagicMock())
+
+    assert _duration_values(published_metrics, "_task_execution") == []
+    assert collector.event_start_time.get("_task_execution") is None
+
+
+def test_abort_task_ends_task_execution_pair(monkeypatch):
+    event_times = iter([200.0, 203.25])
+    monkeypatch.setattr("nvflare.metrics.metrics_collector.time.time", lambda: next(event_times))
+    collector, published_metrics = _collector_with_captured_metrics()
+
+    collector.collect_event_metrics(EventType.BEFORE_TASK_EXECUTION, {}, MagicMock())
+    collector.collect_event_metrics(EventType.ABORT_TASK, {}, MagicMock())
+
+    assert _duration_values(published_metrics, "_task_execution") == [3.25]
+    assert collector.event_start_time["_task_execution"] is None
+
+
+def test_legacy_singleton_pair_event_toggle_is_preserved(monkeypatch):
+    event_times = iter([10.0, 13.5])
+    monkeypatch.setattr("nvflare.metrics.metrics_collector.time.time", lambda: next(event_times))
+    collector, published_metrics = _collector_with_captured_metrics()
+
+    collector.collect_event_metrics(AppEventType.RECEIVE_BEST_MODEL, {}, MagicMock())
+    collector.collect_event_metrics(AppEventType.RECEIVE_BEST_MODEL, {}, MagicMock())
+
+    assert _duration_values(published_metrics, "_receive_best_model") == [3.5]
+    assert collector.event_start_time["_receive_best_model"] is None


### PR DESCRIPTION
## Summary
- classify metrics pair events as explicit start/end events when the pair mapping defines multiple events for the same duration metric
- refresh the start time on repeated begin events instead of publishing a duration from stale state
- skip duration publication for end events with no valid start, while preserving legacy singleton pair-event toggle behavior

## Tests
- python3 -m pytest tests/unit_test/metrics/job_metrics_collector_test.py -q
- ./runtest.sh -s