### PR TITLE
[2.8] Don't use kagglehub==1.0.1 (#4692)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ test_support =
     pandas>=1.5.1
     nbformat
     nbmake
-    kagglehub
+    kagglehub!=1.0.1
 
 test =
     %(all)s


### PR DESCRIPTION
## Summary

Cherry-pick of #4692 to the `2.8` branch.

`kagglehub==1.0.1` imports a symbol (`kagglesdk.kaggle_env.get_web_endpoint`) that is missing in older `kagglesdk` versions installed in CI. This breaks test collection at `tests/unit_test/app_opt/kaggle/download_data_test.py`:

```
ImportError: cannot import name 'get_web_endpoint' from 'kagglesdk.kaggle_env'
```

The fix is the one-line `setup.cfg` change from #4692: pin away from the bad version with `kagglehub!=1.0.1` in the `test_support` extras.

Upstream issue reference: https://github.com/Kaggle/kagglehub/issues/301

## Changes

- `setup.cfg`: `kagglehub` → `kagglehub!=1.0.1` (1 file, +1 / -1).

## Provenance

Cherry-picked from `main` commit `0ce2d51a7b8da7ceaae4bb3694819e4c7915acf3` (PR #4692, merged 2026-05-27 20:05 UTC). Original author: Isaac Yang. `[2.8]` prefix added per branch convention.

## Why this PR

CI on the `2.8` branch fails for any PR that runs the full unit test suite (e.g., #4694 — the parallel docs PR). Landing this kagglehub pin unblocks that and any other 2.8 PRs that hit the same broken environment.

## Test plan

- [ ] CI on 2.8 collects `tests/unit_test/app_opt/kaggle/download_data_test.py` without an ImportError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
