### PR TITLE
cert: make project_profile.yaml server.admin_port optional

### DIFF
--- a/nvflare/tool/cert/cert_commands.py
+++ b/nvflare/tool/cert/cert_commands.py
@@ -2380,7 +2380,7 @@ def _load_project_profile(profile_path: str, request_project: str = None) -> dic
             "Invalid arguments.",
             _USAGE_HINT,
             exit_code=4,
-            detail="project profile server must be a mapping with host, fed_learn_port, and admin_port",
+            detail="project profile server must be a mapping with host and fed_learn_port",
         )
         return None
     server_host = server.get("host")
@@ -2405,7 +2405,10 @@ def _load_project_profile(profile_path: str, request_project: str = None) -> dic
         return None
     if not _validate_port(server.get("fed_learn_port"), "project profile server.fed_learn_port"):
         return None
-    if not _validate_port(server.get("admin_port"), "project profile server.admin_port"):
+    admin_port = server.get("admin_port")
+    if admin_port is None:
+        admin_port = server["fed_learn_port"]
+    elif not _validate_port(admin_port, "project profile server.admin_port"):
         return None
     return {
         "name": profile_project,
@@ -2414,7 +2417,7 @@ def _load_project_profile(profile_path: str, request_project: str = None) -> dic
         "server": {
             "host": server_host.strip(),
             "fed_learn_port": server["fed_learn_port"],
-            "admin_port": server["admin_port"],
+            "admin_port": admin_port,
         },
     }
 

--- a/tests/unit_test/tool/cert/cert_commands_test.py
+++ b/tests/unit_test/tool/cert/cert_commands_test.py
@@ -2694,6 +2694,38 @@ class TestDistributedCertParticipantWorkflow:
         output_error.assert_called_once()
         assert "server.host is invalid" in output_error.call_args.kwargs["detail"]
 
+    def test_load_project_profile_defaults_admin_port_to_fed_learn_port_when_omitted(self, tmp_path):
+        profile_path = tmp_path / "project_profile.yaml"
+        _write_participant_definition(
+            profile_path,
+            {
+                "name": "example_project",
+                "scheme": "grpc",
+                "connection_security": "tls",
+                "server": {
+                    "host": "fl-server",
+                    "fed_learn_port": 8002,
+                },
+            },
+        )
+
+        profile = _load_project_profile(str(profile_path))
+
+        assert profile is not None
+        assert profile["server"]["fed_learn_port"] == 8002
+        assert profile["server"]["admin_port"] == 8002
+
+    def test_load_project_profile_rejects_invalid_admin_port_when_present(self, tmp_path):
+        profile_path = tmp_path / "project_profile.yaml"
+        _write_project_profile(profile_path, admin_port=-1)
+
+        with patch("nvflare.tool.cert.cert_commands.output_error_message") as output_error:
+            profile = _load_project_profile(str(profile_path))
+
+        assert profile is None
+        output_error.assert_called_once()
+        assert "server.admin_port" in output_error.call_args.kwargs["detail"]
+
     def test_request_from_client_participant_definition_derives_identity_and_sanitizes_zip(
         self, tmp_path, capsys, monkeypatch
     ):


### PR DESCRIPTION
## Summary

`nvflare cert approve` previously rejected any `project_profile.yaml` that omitted `server.admin_port`, with:

```
project profile server.admin_port must be an integer from 1 to 65535
```

The docs and the server-participant validation path both treat `admin_port` as **optional** (it falls back to `fed_learn_port`). The unconditional rejection inside `_load_project_profile` was the outlier and the cause of a user-visible setup foot-gun.

This PR makes the implementation match the documented (and intended) behavior:

- In `_load_project_profile`, default `admin_port` to the resolved `fed_learn_port` when the profile omits it.
- Keep the range check (1..65535) when an explicit value is supplied.
- Drop "and admin_port" from the "server must be a mapping with ..." error message since `admin_port` is no longer a required key in that block.

Matching `2.8` PR: #4699.

## Test coverage

Two new unit tests in `tests/unit_test/tool/cert/cert_commands_test.py`:

- `test_load_project_profile_defaults_admin_port_to_fed_learn_port_when_omitted` — confirms omitted `admin_port` yields a profile where `admin_port == fed_learn_port`.
- `test_load_project_profile_rejects_invalid_admin_port_when_present` — confirms an explicit out-of-range `admin_port` (e.g. -1) still fails validation.

Full cert test suite (`pytest tests/unit_test/tool/cert/`): 249 passed.

## Changes

| File | + / − |
|---|---|
| `nvflare/tool/cert/cert_commands.py` | +6 / −3 |
| `tests/unit_test/tool/cert/cert_commands_test.py` | +32 / 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
