### PR TITLE
[2.8] Fix Docker socket access on macOS

### DIFF
--- a/docs/design/docker_job_launcher_design.md
+++ b/docs/design/docker_job_launcher_design.md
@@ -175,7 +175,7 @@ docker run ... -e NVFL_DOCKER_WORKSPACE="$HOST_WORKSPACE" ...
 SP/CP container (site admin grants via start_docker.sh)
   ├── /var/run/docker.sock mounted            ← can create job containers
   ├── --user $(id -u):$(id -g)               ← runs as calling user (workspace files not root-owned)
-  ├── --group-add <docker-socket-gid>         ← grants socket access; omitted when GID is 0 or unavailable (macOS Docker Desktop)
+  ├── --group-add 0 and <docker-socket-gid>   ← grants socket access across Docker engines
   ├── workspace bind mount at /var/tmp/nvflare/workspace
   ├── nvflare-network                         ← intra-site: SP↔SJ / CP↔CJ (PARENT_URL, Docker DNS)
   └── host network (-p fed_learn_port)        ← cross-site: CP→SP over HTTPS, same as process mode

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -697,6 +697,32 @@ def _write_docker_start_script(kit_info: KitInfo, docker_image: str, network: st
 DIR="$( cd "$( dirname "${{BASH_SOURCE[0]}}" )" >/dev/null 2>&1 && pwd )"
 HOST_WORKSPACE="$(cd "$DIR/.." && pwd)"
 DOCKER_IMAGE=${{NVFL_P_IMAGE:-{_bash_double_quote(docker_image)}}}
+DOCKER_SOCK="${{NVFL_DOCKER_SOCK:-/var/run/docker.sock}}"
+
+if [ -z "${{NVFL_DOCKER_SOCK:-}}" ] && [ -L "$DOCKER_SOCK" ]; then
+    RESOLVED_DOCKER_SOCK=$(readlink "$DOCKER_SOCK")
+    if [ -n "$RESOLVED_DOCKER_SOCK" ]; then
+        case "$RESOLVED_DOCKER_SOCK" in
+            /*)
+                DOCKER_SOCK="$RESOLVED_DOCKER_SOCK"
+                ;;
+            *)
+                RESOLVED_DOCKER_SOCK_DIR="$(
+                    cd "$(dirname "$DOCKER_SOCK")" &&
+                    cd "$(dirname "$RESOLVED_DOCKER_SOCK")" &&
+                    pwd
+                )"
+                DOCKER_SOCK="$RESOLVED_DOCKER_SOCK_DIR/$(basename "$RESOLVED_DOCKER_SOCK")"
+                ;;
+        esac
+    fi
+fi
+
+if [ ! -S "$DOCKER_SOCK" ]; then
+    echo "ERROR: Docker socket not found or not a socket: $DOCKER_SOCK"
+    echo "Set NVFL_DOCKER_SOCK=/path/to/docker.sock to override the Docker socket path."
+    exit 1
+fi
 
 if ! docker info > /dev/null 2>&1; then
     echo "ERROR: cannot connect to Docker daemon. Make sure your user has permission to run docker."
@@ -716,18 +742,18 @@ fi
 
 rm -f "$HOST_WORKSPACE/daemon_pid.fl"
 
-SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null || echo "")
-GROUP_ADD_ARG=""
+SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK" 2>/dev/null || stat -f '%g' "$DOCKER_SOCK" 2>/dev/null || echo "")
+GROUP_ADD_ARGS=(--group-add 0)
 if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
-    GROUP_ADD_ARG="--group-add $SOCK_GID"
+    GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")
 fi
 
 docker run --name {shlex.quote(kit_info.name)} \\
     --user "$(id -u):$(id -g)" \\
-    $GROUP_ADD_ARG \\
+    "${{GROUP_ADD_ARGS[@]}}" \\
     --network "$NETWORK_NAME" \\
 {network_alias}    -v "$HOST_WORKSPACE":{WORKSPACE_MOUNT_PATH} \\
-    -v /var/run/docker.sock:/var/run/docker.sock \\
+    -v "$DOCKER_SOCK":/var/run/docker.sock \\
     -e NVFL_DOCKER_WORKSPACE="$HOST_WORKSPACE" \\
 {publish_port}    --rm "$DOCKER_IMAGE" \\
     {_docker_parent_command(kit_info)}

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -264,6 +264,37 @@ def test_prepare_docker_client_copies_and_patches_runtime_files(tmp_path, capsys
     assert (output / "local" / "study_data.yaml").exists()
 
 
+def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_path, capsys):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+
+    script = (output / "startup" / "start_docker.sh").read_text()
+    assert 'DOCKER_SOCK="${NVFL_DOCKER_SOCK:-/var/run/docker.sock}"' in script
+    assert 'if [ -z "${NVFL_DOCKER_SOCK:-}" ] && [ -L "$DOCKER_SOCK" ]; then' in script
+    assert 'RESOLVED_DOCKER_SOCK=$(readlink "$DOCKER_SOCK")' in script
+    assert 'if [ ! -S "$DOCKER_SOCK" ]; then' in script
+    assert "Set NVFL_DOCKER_SOCK=/path/to/docker.sock" in script
+    assert (
+        "SOCK_GID=$(stat -c '%g' \"$DOCKER_SOCK\" 2>/dev/null || "
+        "stat -f '%g' \"$DOCKER_SOCK\" 2>/dev/null || echo \"\")"
+    ) in script
+    assert "GROUP_ADD_ARGS=(--group-add 0)" in script
+    assert 'GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")' in script
+    assert '"${GROUP_ADD_ARGS[@]}"' in script
+    assert '-v "$DOCKER_SOCK":/var/run/docker.sock' in script
+    assert "-v /var/run/docker.sock:/var/run/docker.sock" not in script
+
+
 @pytest.mark.parametrize(
     "admin_port, expected_admin_publish_count",
     [


### PR DESCRIPTION
## What changed
- Update generated `startup/start_docker.sh` to support `NVFL_DOCKER_SOCK`, resolve the default Docker socket symlink, and validate the selected socket path before launching the parent container.
- Keep parent containers running as the host UID/GID while adding supplemental group `0` plus the selected socket GID when nonzero.
- Mount the selected Docker socket path into the parent container at `/var/run/docker.sock`.
- Add unit coverage for the generated socket handling and update the Docker launcher design note.

## Why
On Docker Desktop for macOS, the Docker socket visible inside the Linux parent container can appear as `root:root` with mode `0660`, even when the host socket resolves to the user-owned Docker Desktop socket. The generated script previously skipped group `0` and only added a nonzero host socket GID, leaving the non-root parent container unable to access the Docker daemon.

## Impact
This keeps Linux Docker behavior intact by still adding the socket GID, while allowing Docker Desktop for macOS to use the documented Docker launcher flow without running parent containers as root.
