### PR TITLE
[2.8] Fix FOBS externalizer shared-state race

### DIFF
--- a/nvflare/fuel/utils/fobs/datum.py
+++ b/nvflare/fuel/utils/fobs/datum.py
@@ -41,25 +41,6 @@ class Datum:
         self.datum_type = datum_type
         self.dot = dot
         self.value = value
-        self.restore_func = None  # func to restore original object.
-        self.restore_func_data = None  # arg to the restore func
-
-    def set_restore_func(self, func, func_data):
-        """Set the restore function and func data.
-        Restore func is set during the serialization process. If set, the func will be called after the serialization
-        to restore the serialized object back to its original state.
-
-         Args:
-             func: the restore function
-             func_data: arg passed to the restore func when called
-
-         Returns: None
-
-        """
-        if not callable(func):
-            raise ValueError(f"func must be callable but got {type(func)}")
-        self.restore_func = func
-        self.restore_func_data = func_data
 
     @staticmethod
     def blob_datum(blob: Union[bytes, bytearray, memoryview], dot=0):
@@ -103,11 +84,6 @@ class DatumManager:
         self.threshold = threshold
         self.datums: Dict[str, Datum] = {}
         self.fobs_ctx = fobs_ctx
-
-        # some decomposers (e.g. Shareable, Learnable, etc.) make a shallow copy of the original object before
-        # serialization. After serialization, only the values in the copy are restored. We need to keep a ref
-        # from the copy to the original object so that values in the original are also restored.
-        self.obj_copies = {}  # copy id => original object
 
         # Post CBs are called after the serialize process is done
         # Post CBs could be used, for example, to prepare files to be downloaded by the message receiver
@@ -190,29 +166,6 @@ class DatumManager:
                 cb(self, **cb_kwargs)
             except Exception as ex:
                 self.set_error(f"exception from post_cb {cb.__name__}: {type(ex)}")
-
-    def register_copy(self, obj_copy, original_obj):
-        """Register the object_copy => original object
-
-        Args:
-            obj_copy: a copy of the original object
-            original_obj: the original object
-
-        Returns: None
-
-        """
-        self.obj_copies[id(obj_copy)] = original_obj
-
-    def get_original(self, obj_copy) -> Any:
-        """Get the registered original object from the object copy.
-
-        Args:
-            obj_copy: a copy of the original object
-
-        Returns: the original object if found; None otherwise.
-
-        """
-        return self.obj_copies.get(id(obj_copy))
 
     def get_datums(self):
         return self.datums

--- a/nvflare/fuel/utils/fobs/decomposer.py
+++ b/nvflare/fuel/utils/fobs/decomposer.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import Any, List, Optional, Type, TypeVar
 
 # Generic type supported by the decomposer.
-from nvflare.fuel.utils.fobs.datum import Datum, DatumManager, DatumRef, DatumType
+from nvflare.fuel.utils.fobs.datum import Datum, DatumManager
 
 T = TypeVar("T")
 
@@ -92,31 +92,6 @@ class Decomposer(ABC):
         pass
 
 
-def restore_position(manager: DatumManager, datum: Datum, position):
-    """
-    This function is used for restoring object state at the specified position.
-
-    Args:
-        manager: the datum manager
-        datum: the datum that contains the value of the original object at the position.
-        position: the position to be restored
-
-    Returns: None
-
-    """
-    target, key = position
-    original_obj = manager.get_original(target)  # also need to restore values in the original object if any
-    if datum.datum_type in (DatumType.BLOB, DatumType.TEXT):
-        target[key] = datum.value
-        if original_obj:
-            original_obj[key] = datum.value
-    else:
-        # file datum - app provided
-        target[key] = datum
-        if original_obj:
-            original_obj[key] = datum
-
-
 class Externalizer:
     """
     This class is used to help creating 'decompose' method of decomposers of arbitrary classes.
@@ -126,32 +101,30 @@ class Externalizer:
     def __init__(self, manager: DatumManager):
         self.manager = manager
 
-    def _set_position(self, ext_result: Any, target, key):
-        if isinstance(ext_result, DatumRef):
-            datum = self.manager.get_datum(ext_result.datum_id)
-            if datum:
-                datum.set_restore_func(restore_position, (target, key))
-
     def externalize(self, target: Any):
-        """Recursively go through object tree (dict or list) and externalize leaf nodes."""
+        """Recursively externalize leaf nodes without mutating the source containers.
+
+        Dict/list subclasses are reconstructed with no-arg constructors at every level. This matches the contract
+        already required by DictDecomposer.recompose() for top-level dict subclasses, but also means nested container
+        subclasses must tolerate no-arg construction and may not preserve constructor state such as a defaultdict's
+        default_factory.
+        """
         if not self.manager:
             return target
 
         if isinstance(target, dict):
+            new_target = type(target)()
             for k, v in target.items():
-                d = self.externalize(v)
-                target[k] = d
-                self._set_position(d, target, k)  # remember the position so it can be restored
-        elif isinstance(target, list):  # note: tuple is not supported since it is immutable.
-            for i, v in enumerate(target):
-                d = self.externalize(v)
-                target[i] = d
-                self._set_position(d, target, i)
+                new_target[k] = self.externalize(v)
+            return new_target
+        elif isinstance(target, list):
+            # Note: tuple is not supported since it is immutable.
+            new_target = type(target)()
+            for v in target:
+                new_target.append(self.externalize(v))
+            return new_target
         else:
-            # leaf node
-            target = self.manager.externalize(target)
-
-        return target
+            return self.manager.externalize(target)
 
 
 class Internalizer:
@@ -190,9 +163,9 @@ class DictDecomposer(Decomposer):
         return self.dict_type
 
     def decompose(self, target: dict, manager: DatumManager = None) -> Any:
-        # need to create a new object; otherwise msgpack will try to decompose this object endlessly.
+        # Convert the top-level dict subclass to a plain dict. Externalizer preserves dict/list subclass types,
+        # including nested subclasses, so starting from a plain copy prevents msgpack from re-entering this decomposer.
         tc = target.copy()
-        manager.register_copy(tc, target)
         externalizer = Externalizer(manager)
         return externalizer.externalize(tc)
 

--- a/nvflare/fuel/utils/fobs/lobs.py
+++ b/nvflare/fuel/utils/fobs/lobs.py
@@ -78,8 +78,8 @@ def dump_to_stream(obj: Any, stream: BinaryIO, max_value_size=None, fobs_ctx: Op
     - the 1st section is the main body (serialized with fobs/msgpack) of the object
     - if the object contains large binary data, they will be converted to datums, and each datum has one section
 
-    During serialization, the object may be altered (replace large value with datums). After serialization, the object
-    is restored to its original state.
+    During serialization, large values are represented by datum references in the serialized main body. The input
+    object is not modified.
 
     Args:
         obj: the object to be serialized.
@@ -100,14 +100,6 @@ def dump_to_stream(obj: Any, stream: BinaryIO, max_value_size=None, fobs_ctx: Op
 
     datums = mgr.get_datums()
     for datum_id, datum in datums.items():
-        if datum.restore_func is not None:
-            # restore original object state
-            restore_func = datum.restore_func
-            func_data = datum.restore_func_data
-            datum.restore_func_data = None
-            datum.restore_func = None
-            restore_func(mgr, datum, func_data)
-
         if datum.datum_type == DatumType.TEXT:
             # text representation is platform specific.
             # we convert it to utf-8 based bytes, which is platform independent.

--- a/tests/unit_test/fuel/utils/fobs/decomposer_test.py
+++ b/tests/unit_test/fuel/utils/fobs/decomposer_test.py
@@ -17,8 +17,10 @@ from enum import Enum, IntEnum
 
 import pytest
 
+from nvflare.apis.shareable import Shareable, make_copy
 from nvflare.fuel.utils import fobs
-from nvflare.fuel.utils.fobs.decomposer import DictDecomposer
+from nvflare.fuel.utils.fobs.datum import DatumManager, DatumRef
+from nvflare.fuel.utils.fobs.decomposer import DictDecomposer, Externalizer
 
 
 class DataClass:
@@ -103,6 +105,30 @@ class TestDecomposers:
         new_list = list(new_data.items())
 
         assert test_list == new_list
+
+    def test_externalizer_does_not_mutate_shared_nested_payload(self):
+        blob = b"x" * 2048
+        list_blob = b"y" * 2048
+        nested_list_blob = b"z" * 2048
+        source = Shareable({"data": {"blob": blob, "items": [list_blob, {"nested": nested_list_blob}]}})
+
+        first_copy = make_copy(source)
+        # Payloads are larger than the 1024-byte threshold, so externalize()
+        # must replace them with DatumRefs in the returned tree only.
+        Externalizer(DatumManager(1024)).externalize(first_copy)
+
+        assert source["data"]["blob"] == blob
+        assert source["data"]["items"][0] == list_blob
+        assert source["data"]["items"][1]["nested"] == nested_list_blob
+        assert not isinstance(source["data"]["blob"], DatumRef)
+        assert not isinstance(source["data"]["items"][0], DatumRef)
+        assert not isinstance(source["data"]["items"][1]["nested"], DatumRef)
+
+        second_copy = make_copy(source)
+        restored = fobs.loads(fobs.dumps(second_copy, max_value_size=1024))
+        assert restored["data"]["blob"] == blob
+        assert restored["data"]["items"][0] == list_blob
+        assert restored["data"]["items"][1]["nested"] == nested_list_blob
 
     @staticmethod
     def _check_decomposer(data, clear_decomposers=True):


### PR DESCRIPTION
## Summary
- Make FOBS externalization build fresh dict/list containers instead of mutating caller-owned containers.
- Remove obsolete restore-position bookkeeping from the recursive externalization path.
- Add regression coverage for shallow `Shareable` copies that share nested payload containers.

## Root Cause
`Externalizer.externalize()` temporarily replaced large bytes/str leaves with `DatumRef` values inside source dict/list containers. Since `Shareable.make_copy()` is shallow, concurrent serializers can share nested containers. One serializer could observe another serializer's temporary `DatumRef` and emit a main body without the matching LOBS datum section, which later fails with `can't find datum for <uuid>` during decode.

## Validation
- `PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache /Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/utils/fobs/decomposer_test.py` (`6 passed`)
- `PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache /Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/utils/fobs` (`57 passed`)
- `PYTHONPATH=/Users/zhihongz/work/NVFlare PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache /Users/zhihongz/nvflare-env/3.12/bin/python /private/tmp/repro_fobs_missing_datum.py --rounds 10 --tasks 128 --workers 32` (`completed without reproducing`)
- `git diff --check HEAD~1..HEAD`
- `env PATH=/Users/zhihongz/nvflare-env/3.12/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache ./runtest.sh -s nvflare/fuel/utils/fobs/decomposer.py tests/unit_test/fuel/utils/fobs/decomposer_test.py`