### PR TITLE
[2.8] Validate client API launcher resend settings

### DIFF
--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -97,7 +97,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 expected transfer time.  Configurable via recipe.add_client_config({"submit_result_timeout": N}).
             max_resends (int): Maximum number of times the subprocess retries sending the result if CJ does not
                 ACK within submit_result_timeout.  Defaults to 3.  None means unlimited (unsafe for large models
-                — each retry creates a new download transaction).  Configurable via
+                — each retry creates a new download transaction) and is rejected at job initialization. Configurable via
                 recipe.add_client_config({"max_resends": N}).
             download_complete_timeout (float): How long (seconds) the subprocess waits after send_to_peer() ACKs
                 for the server to finish downloading its tensors from the subprocess DownloadService.  Without
@@ -239,22 +239,46 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         """
         return "np_"
 
-    def _validate_timeout_config(self, fl_ctx: FLContext):
-        """Warn at job start if timeout parameters are inconsistent.
+    def _validate_required_timeout_values(self, fl_ctx: FLContext):
+        if self._download_complete_timeout is None:
+            msg = (
+                "download_complete_timeout is None. This timeout is required to keep the subprocess alive while "
+                "the server downloads large tensor results. Set download_complete_timeout to a positive value "
+                "in job config."
+            )
+            self.log_error(fl_ctx, msg)
+            raise ValueError(msg)
 
-        Checks are advisory (log_warning, not raise) so a misconfigured job
-        can still run — the messages give the operator actionable guidance
-        before the first download attempt.
+        if self._max_resends is None:
+            msg = (
+                "max_resends is None (unbounded). This can turn one delayed large-model transfer into an "
+                "unlimited resend storm. Set max_resends to a bounded value (e.g. 3) in job config."
+            )
+            self.log_error(fl_ctx, msg)
+            raise ValueError(msg)
+
+    def _validate_timeout_config(self, fl_ctx: FLContext):
+        """Validate timeout parameters at job start.
+
+        Timeout relationship checks are advisory so existing jobs continue to run while
+        operators get actionable guidance before the first download attempt. Missing
+        download-completion timeout and unbounded resends are rejected because they break
+        subprocess lifecycle guarantees for large-model transfers.
         """
+        self._validate_required_timeout_values(fl_ctx)
+
         try:
             import nvflare.fuel.utils.app_config_utils as acu
-            from nvflare.apis.fl_constant import ConfigVarName
+            from nvflare.apis.fl_constant import ConfigVarName, SystemConfigs
+            from nvflare.fuel.utils.config_service import ConfigService
         except ImportError as e:
             self.log_warning(fl_ctx, f"_validate_timeout_config skipped: {e}")
             return
 
         prefix = self._decomposer_prefix()
-        per_req = acu.get_positive_float_var(f"{prefix}{ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT}", 600.0)
+        per_req_key = f"{prefix}{ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT}"
+        configured_per_req = ConfigService.get_float_var(per_req_key, conf=SystemConfigs.APPLICATION_CONF, default=None)
+        per_req = acu.get_positive_float_var(per_req_key, 600.0)
         min_dl = acu.get_positive_float_var(
             f"{prefix}{ConfigVarName.MIN_DOWNLOAD_TIMEOUT}", MIN_DOWNLOAD_TIMEOUT_DEFAULT
         )
@@ -268,6 +292,31 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 f"Set {prefix}min_download_timeout >= {per_req}s in job config.",
             )
 
+        if configured_per_req is not None and self.peer_read_timeout is None:
+            self.log_warning(
+                fl_ctx,
+                "Timeout inconsistency: peer_read_timeout is not set after applying job-config overrides. "
+                "Large task payloads may fall back to a shorter pipe default and resend while the subprocess is "
+                f"still downloading. Set peer_read_timeout >= {per_req}s in job config.",
+            )
+        elif configured_per_req is not None and self.peer_read_timeout < per_req:
+            self.log_warning(
+                fl_ctx,
+                f"Timeout inconsistency: peer_read_timeout ({self.peer_read_timeout}s, after job-config overrides) < "
+                f"{prefix}streaming_per_request_timeout ({per_req}s). "
+                "The CJ may resend the task while the subprocess is still downloading large payloads. "
+                f"Set peer_read_timeout >= {per_req}s in job config.",
+            )
+
+        if self._download_complete_timeout < per_req:
+            self.log_warning(
+                fl_ctx,
+                f"Timeout inconsistency: download_complete_timeout ({self._download_complete_timeout}s) < "
+                f"{prefix}streaming_per_request_timeout ({per_req}s). "
+                "The subprocess may stop before the server finishes downloading tensor results. "
+                f"Set download_complete_timeout >= {per_req}s in job config.",
+            )
+
         if self._submit_result_timeout > min_dl:
             self.log_warning(
                 fl_ctx,
@@ -276,13 +325,6 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 f"Each send attempt may expire the download transaction before the next retry. "
                 f"Fix: set {prefix}min_download_timeout >= {self._submit_result_timeout}s in job config "
                 f'(e.g. recipe.add_client_config({{"{prefix}min_download_timeout": {int(self._submit_result_timeout)}}})).',
-            )
-
-        if self._max_resends is None:
-            self.log_warning(
-                fl_ctx,
-                "max_resends is None (unbounded). This risks OOM on large model transfers. "
-                "Set max_resends to a bounded value (e.g. 3) in job config.",
             )
 
     def check_output_shareable(self, task_name: str, shareable: Shareable, fl_ctx: FLContext) -> bool:
@@ -330,6 +372,8 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         return not launcher.needs_deferred_stop()
 
     def prepare_config_for_launch(self, fl_ctx: FLContext):
+        self._validate_required_timeout_values(fl_ctx)
+
         pipe_export_class, pipe_export_args = self.pipe.export(ExportMode.PEER)
         task_exchange_attributes = {
             ConfigKey.TRAIN_WITH_EVAL: self._train_with_evaluation,

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -95,9 +95,10 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 microseconds), so 300 s is a very generous allowance.  Without reverse PASS_THROUGH, CJ must
                 download the full result before ACKing; in that case this should be at least as large as the
                 expected transfer time.  Configurable via recipe.add_client_config({"submit_result_timeout": N}).
-            max_resends (int): Maximum number of times the subprocess retries sending the result if CJ does not
-                ACK within submit_result_timeout.  Defaults to 3.  None means unlimited (unsafe for large models
-                — each retry creates a new download transaction) and is rejected at job initialization. Configurable via
+            max_resends (int): Maximum number of retries after the initial result send if CJ does not ACK within
+                submit_result_timeout. Defaults to 3. Set to a finite non-negative integer; 0 disables retries.
+                None means unlimited retries (unsafe for large models because each retry creates a new download
+                transaction) and is rejected at job initialization. Configurable via
                 recipe.add_client_config({"max_resends": N}).
             download_complete_timeout (float): How long (seconds) the subprocess waits after send_to_peer() ACKs
                 for the server to finish downloading its tensors from the subprocess DownloadService.  Without
@@ -252,7 +253,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         if self._max_resends is None:
             msg = (
                 "max_resends is None (unbounded). This can turn one delayed large-model transfer into an "
-                "unlimited resend storm. Set max_resends to a bounded value (e.g. 3) in job config."
+                "unlimited resend storm. Set max_resends to a finite non-negative integer (e.g. 3) in job config."
             )
             self.log_error(fl_ctx, msg)
             raise ValueError(msg)
@@ -261,9 +262,11 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         """Validate timeout parameters at job start.
 
         Timeout relationship checks are advisory so existing jobs continue to run while
-        operators get actionable guidance before the first download attempt. Missing
-        download-completion timeout and unbounded resends are rejected because they break
-        subprocess lifecycle guarantees for large-model transfers.
+        operators get actionable guidance before the first download attempt. The None
+        cases are rejected because they remove bounded lifecycle guarantees entirely:
+        without a download-completion wait the subprocess can exit before the server
+        finishes pulling tensors, and unbounded resends can create an unlimited number of
+        replacement download transactions.
         """
         self._validate_required_timeout_values(fl_ctx)
 
@@ -308,7 +311,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 f"Set peer_read_timeout >= {per_req}s in job config.",
             )
 
-        if self._download_complete_timeout < per_req:
+        if configured_per_req is not None and self._download_complete_timeout < per_req:
             self.log_warning(
                 fl_ctx,
                 f"Timeout inconsistency: download_complete_timeout ({self._download_complete_timeout}s) < "

--- a/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
+++ b/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
@@ -590,7 +590,10 @@ def test_cj_cleanup_passes_cuda_empty_cache(monkeypatch):
 def _make_validating_executor(monkeypatch, **executor_kwargs):
     """Return an executor whose initialize() runs _validate_timeout_config() and
     records all log_warning calls into a list for assertion."""
+    from nvflare.fuel.utils.config_service import ConfigService
+
     warnings_emitted = []
+    errors_emitted = []
 
     monkeypatch.setattr(ClientAPILauncherExecutor, "prepare_config_for_launch", lambda self, fl_ctx: None)
     monkeypatch.setattr(LauncherExecutor, "initialize", lambda self, fl_ctx: None)
@@ -600,10 +603,16 @@ def _make_validating_executor(monkeypatch, **executor_kwargs):
         "log_warning",
         lambda self, fl_ctx, msg: warnings_emitted.append(msg),
     )
+    monkeypatch.setattr(
+        ClientAPILauncherExecutor,
+        "log_error",
+        lambda self, fl_ctx, msg: errors_emitted.append(msg),
+    )
+    monkeypatch.setattr(ConfigService, "get_float_var", lambda name, conf=None, default=None: default)
 
     executor = ClientAPILauncherExecutor(pipe_id="test_pipe", **executor_kwargs)
     executor.pipe = _make_fake_cell_pipe()
-    return executor, warnings_emitted
+    return executor, warnings_emitted, errors_emitted
 
 
 def test_timeout_warning_min_dl_less_than_per_req(monkeypatch):
@@ -611,7 +620,7 @@ def test_timeout_warning_min_dl_less_than_per_req(monkeypatch):
     import nvflare.fuel.utils.app_config_utils as acu
     from nvflare.apis.fl_constant import ConfigVarName
 
-    executor, warnings = _make_validating_executor(monkeypatch)
+    executor, warnings, _ = _make_validating_executor(monkeypatch)
     cell = _FakeCell()
     fl_ctx = _FakeFLContext(cell)
 
@@ -633,7 +642,7 @@ def test_no_timeout_warning_when_min_dl_ge_per_req(monkeypatch):
     import nvflare.fuel.utils.app_config_utils as acu
     from nvflare.apis.fl_constant import ConfigVarName
 
-    executor, warnings = _make_validating_executor(monkeypatch)
+    executor, warnings, _ = _make_validating_executor(monkeypatch)
     cell = _FakeCell()
     fl_ctx = _FakeFLContext(cell)
 
@@ -655,7 +664,7 @@ def test_timeout_warning_submit_exceeds_min_dl(monkeypatch):
     import nvflare.fuel.utils.app_config_utils as acu
     from nvflare.apis.fl_constant import ConfigVarName
 
-    executor, warnings = _make_validating_executor(monkeypatch, submit_result_timeout=400.0)
+    executor, warnings, _ = _make_validating_executor(monkeypatch, submit_result_timeout=400.0)
     cell = _FakeCell()
     fl_ctx = _FakeFLContext(cell)
 
@@ -672,12 +681,12 @@ def test_timeout_warning_submit_exceeds_min_dl(monkeypatch):
     assert any("submit_result_timeout" in w for w in warnings), warnings
 
 
-def test_timeout_warning_unbounded_max_resends(monkeypatch):
-    """A warning must fire when max_resends is None (unbounded)."""
+def test_timeout_error_unbounded_max_resends(monkeypatch):
+    """Initialization must fail when max_resends is None (unbounded)."""
     import nvflare.fuel.utils.app_config_utils as acu
     from nvflare.apis.fl_constant import ConfigVarName
 
-    executor, warnings = _make_validating_executor(monkeypatch, max_resends=None)
+    executor, _warnings, errors = _make_validating_executor(monkeypatch, max_resends=None)
     cell = _FakeCell()
     fl_ctx = _FakeFLContext(cell)
 
@@ -690,9 +699,55 @@ def test_timeout_warning_unbounded_max_resends(monkeypatch):
         return default
 
     monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
-    executor.initialize(fl_ctx)
 
-    assert any("max_resends" in w for w in warnings), warnings
+    with pytest.raises(ValueError, match="max_resends is None"):
+        executor.initialize(fl_ctx)
+
+    assert any("max_resends" in e for e in errors), errors
+
+
+def test_timeout_error_download_complete_timeout_none(monkeypatch):
+    """Initialization must fail when download_complete_timeout is None."""
+    executor, _warnings, errors = _make_validating_executor(monkeypatch, download_complete_timeout=None)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    with pytest.raises(ValueError, match="download_complete_timeout is None"):
+        executor.initialize(fl_ctx)
+
+    assert any("download_complete_timeout" in e for e in errors), errors
+
+
+@pytest.mark.parametrize(
+    "executor_kwargs,error_match",
+    [
+        ({"max_resends": None}, "max_resends is None"),
+        ({"download_complete_timeout": None}, "download_complete_timeout is None"),
+    ],
+)
+def test_required_timeout_errors_stop_before_config_write(monkeypatch, executor_kwargs, error_match):
+    """Invalid required timeout values must fail before writing subprocess config."""
+    from unittest.mock import MagicMock
+
+    writes = []
+    errors = []
+    monkeypatch.setattr(
+        "nvflare.app_common.executors.client_api_launcher_executor.write_config_to_file",
+        lambda config_data, config_file_path: writes.append(config_data),
+    )
+    monkeypatch.setattr(
+        ClientAPILauncherExecutor,
+        "log_error",
+        lambda self, fl_ctx, msg: errors.append(msg),
+    )
+
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe", **executor_kwargs)
+
+    with pytest.raises(ValueError, match=error_match):
+        executor.prepare_config_for_launch(MagicMock())
+
+    assert writes == []
+    assert any(error_match in e for e in errors), errors
 
 
 def test_no_warning_when_all_timeouts_consistent(monkeypatch):
@@ -700,7 +755,7 @@ def test_no_warning_when_all_timeouts_consistent(monkeypatch):
     import nvflare.fuel.utils.app_config_utils as acu
     from nvflare.apis.fl_constant import ConfigVarName
 
-    executor, warnings = _make_validating_executor(monkeypatch, submit_result_timeout=200.0, max_resends=3)
+    executor, warnings, _ = _make_validating_executor(monkeypatch, submit_result_timeout=200.0, max_resends=3)
     cell = _FakeCell()
     fl_ctx = _FakeFLContext(cell)
 
@@ -715,6 +770,106 @@ def test_no_warning_when_all_timeouts_consistent(monkeypatch):
     executor.initialize(fl_ctx)
 
     assert warnings == [], warnings
+
+
+def test_timeout_warning_peer_read_less_than_per_req(monkeypatch):
+    """A warning must fire when peer_read_timeout is lower than streaming_per_request_timeout."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, peer_read_timeout=300.0)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert any("peer_read_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
+
+
+def test_timeout_warning_peer_read_none_when_per_req_is_configured(monkeypatch):
+    """A warning must fire when peer_read_timeout is unset and streaming timeout is configured."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, peer_read_timeout=None)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert any("peer_read_timeout is not set" in w for w in warnings), warnings
+
+
+def test_default_peer_read_timeout_does_not_warn_without_configured_per_req(monkeypatch):
+    """The production default peer_read_timeout should not warn when streaming timeout is only the fallback."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    executor.initialize(fl_ctx)
+
+    assert not any("peer_read_timeout" in w for w in warnings), warnings
+
+
+def test_timeout_warning_download_complete_less_than_per_req(monkeypatch):
+    """A warning must fire when download_complete_timeout is lower than streaming_per_request_timeout."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, download_complete_timeout=300.0)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    executor.initialize(fl_ctx)
+
+    assert any("download_complete_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
+++ b/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
@@ -854,6 +854,34 @@ def test_timeout_warning_download_complete_less_than_per_req(monkeypatch):
     """A warning must fire when download_complete_timeout is lower than streaming_per_request_timeout."""
     import nvflare.fuel.utils.app_config_utils as acu
     from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, download_complete_timeout=300.0)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert any("download_complete_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
+
+
+def test_download_complete_timeout_does_not_warn_without_configured_per_req(monkeypatch):
+    """The download_complete_timeout check should not warn when streaming timeout is only the fallback."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
 
     executor, warnings, _ = _make_validating_executor(monkeypatch, download_complete_timeout=300.0)
     cell = _FakeCell()
@@ -869,7 +897,7 @@ def test_timeout_warning_download_complete_less_than_per_req(monkeypatch):
     monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
     executor.initialize(fl_ctx)
 
-    assert any("download_complete_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
+    assert not any("download_complete_timeout" in w for w in warnings), warnings
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- warn when explicitly configured ClientAPILauncherExecutor timeout settings can resend or stop large streaming transfers too early
- avoid emitting the new peer_read_timeout warning for default fallback-only streaming timeout values
- reject max_resends=None and download_complete_timeout=None before initialization/config write to avoid unbounded resend storms and unsafe subprocess lifecycle
- add unit coverage for peer_read_timeout, peer_read_timeout=None, default no-warning behavior, download_complete_timeout, required timeout config-write guards, and unbounded max_resends validation

Relationship to #4708:
- #4708 fixes the streaming-layer finished-ref retry race and duplicate completion handling
- this PR is the launcher-side follow-up for unsafe timeout/resend configuration

Verification:
- python -m pytest tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
- ./runtest.sh -s