### PR TITLE
[2.8] Fix DownloadService late EOF retry race

### DIFF
--- a/nvflare/fuel/f3/streaming/download_service.py
+++ b/nvflare/fuel/f3/streaming/download_service.py
@@ -344,6 +344,9 @@ class DownloadService:
     _init_lock = threading.Lock()
     _tx_table = {}
     _ref_table = {}
+    # Finished refs are tombstoned briefly so a late retry of a lost EOF response can still complete cleanly.
+    _finished_ref_table = {}
+    _finished_ref_ttl = 900.0
     _logger = None
     _tx_monitor = None
     _tx_lock = threading.Lock()
@@ -403,6 +406,7 @@ class DownloadService:
         ref = tx.add_object(obj, ref_id)
         with cls._tx_lock:
             cls._ref_table[ref.rid] = ref
+            cls._finished_ref_table.pop(ref.rid, None)
         return ref.rid
 
     @classmethod
@@ -410,7 +414,7 @@ class DownloadService:
         with cls._tx_lock:
             tx = cls._tx_table.get(transaction_id)
             if tx:
-                cls._delete_tx(tx)
+                cls._delete_tx(tx, TransactionDoneStatus.DELETED)
                 tx.transaction_done(TransactionDoneStatus.DELETED)
 
     @classmethod
@@ -424,16 +428,28 @@ class DownloadService:
             tx_list = list(cls._tx_table.values())
             if tx_list:
                 for tx in tx_list:
-                    cls._delete_tx(tx)
+                    cls._delete_tx(tx, TransactionDoneStatus.DELETED)
                     tx.transaction_done(TransactionDoneStatus.DELETED)
+            cls._finished_ref_table.clear()
 
     @classmethod
-    def _delete_tx(cls, tx: _Transaction):
+    def _delete_tx(cls, tx: _Transaction, status: str = TransactionDoneStatus.DELETED):
         cls._tx_table.pop(tx.tid, None)
+        ref_expiration_time = time.time() + cls._finished_ref_ttl
 
         # remove all refs
         for r in tx.refs:
             cls._ref_table.pop(r.rid, None)
+            if status == TransactionDoneStatus.FINISHED:
+                cls._finished_ref_table[r.rid] = ref_expiration_time
+            else:
+                cls._finished_ref_table.pop(r.rid, None)
+
+    @classmethod
+    def _purge_finished_refs(cls, now: float):
+        expired_refs = [rid for rid, expiration_time in cls._finished_ref_table.items() if expiration_time <= now]
+        for rid in expired_refs:
+            cls._finished_ref_table.pop(rid, None)
 
     @classmethod
     def get_transaction_info(cls, transaction_id: str) -> Optional[TransactionInfo]:
@@ -464,8 +480,12 @@ class DownloadService:
 
         current_state = payload.get(_PropKey.STATE)
         with cls._tx_lock:
+            now = time.time()
+            cls._purge_finished_refs(now)
             ref = cls._ref_table.get(rid)
             if not ref:
+                if rid in cls._finished_ref_table:
+                    return make_reply(ReturnCode.OK, body={_PropKey.STATUS: ProduceRC.EOF})
                 cls._logger.error(f"no ref found for {rid} from {requester}")
                 return make_reply(ReturnCode.INVALID_REQUEST)
 
@@ -522,11 +542,13 @@ class DownloadService:
                 for tx in expired_tx:
                     assert isinstance(tx, _Transaction)
                     tx.transaction_done(TransactionDoneStatus.TIMEOUT)
-                    cls._delete_tx(tx)
+                    cls._delete_tx(tx, TransactionDoneStatus.TIMEOUT)
 
                 for tx in finished_tx:
                     tx.transaction_done(TransactionDoneStatus.FINISHED)
-                    cls._delete_tx(tx)
+                    cls._delete_tx(tx, TransactionDoneStatus.FINISHED)
+
+                cls._purge_finished_refs(now)
 
             time.sleep(5.0)
 

--- a/tests/unit_test/fuel/f3/streaming/download_service_test.py
+++ b/tests/unit_test/fuel/f3/streaming/download_service_test.py
@@ -19,6 +19,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from nvflare.fuel.f3.cellnet.core_cell import CoreCell
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.streaming.download_service import (
     Consumer,
     Downloadable,
@@ -102,9 +104,19 @@ def _make_isolated_download_service():
     class IsolatedDownloadService(DownloadService):
         _tx_table = {}
         _ref_table = {}
+        _finished_ref_table = {}
+        _finished_ref_ttl = 900.0
+        _logger = Mock()
         _tx_lock = threading.Lock()
 
     return IsolatedDownloadService
+
+
+def _make_download_request(ref_id: str, state: dict = None, requester: str = "receiver"):
+    payload = {"ref_id": ref_id}
+    if state is not None:
+        payload["state"] = state
+    return Message(headers={MessageHeaderKey.ORIGIN: requester}, payload=payload)
 
 
 def _run_monitor_once(service_cls, now):
@@ -346,16 +358,82 @@ class TestDownloadService:
 
             assert tx.is_finished()
             tx.transaction_done(TransactionDoneStatus.FINISHED)
-            service._delete_tx(tx)
+            service._delete_tx(tx, TransactionDoneStatus.FINISHED)
 
             assert tx.tid not in service._tx_table
             assert ref.rid not in service._ref_table
+            assert ref.rid in service._finished_ref_table
 
         # Verify transaction_done was called
         assert len(obj.transaction_done_calls) == 1
         transaction_id, status = obj.transaction_done_calls[0]
         assert transaction_id == tx_id
         assert status == TransactionDoneStatus.FINISHED
+
+    def test_finished_ref_late_retry_returns_eof(self):
+        """Late retry after normal transaction completion should receive EOF, not INVALID_REQUEST."""
+        from nvflare.fuel.f3.streaming.download_service import _Transaction
+
+        service = _make_isolated_download_service()
+        obj = MockDownloadable([b"chunk1"])
+        tx = _Transaction(timeout=10.0, num_receivers=1)
+        ref = tx.add_object(obj)
+
+        with service._tx_lock:
+            service._tx_table[tx.tid] = tx
+            service._ref_table[ref.rid] = ref
+            ref.obj_downloaded(to_receiver="receiver", status=DownloadStatus.SUCCESS)
+            assert tx.is_finished()
+            service._delete_tx(tx, TransactionDoneStatus.FINISHED)
+
+        reply = service._handle_download(_make_download_request(ref.rid, state={"chunk_idx": 1}))
+
+        assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
+        assert reply.payload == {"status": ProduceRC.EOF}
+        service._logger.error.assert_not_called()
+
+    @pytest.mark.parametrize("status", [TransactionDoneStatus.TIMEOUT, TransactionDoneStatus.DELETED])
+    def test_non_finished_ref_late_retry_remains_invalid(self, status):
+        """Only normally finished refs get EOF tombstones; timeout/deleted refs still fail."""
+        from nvflare.fuel.f3.streaming.download_service import _Transaction
+
+        service = _make_isolated_download_service()
+        obj = MockDownloadable([b"chunk1"])
+        tx = _Transaction(timeout=10.0, num_receivers=1)
+        ref = tx.add_object(obj)
+
+        with service._tx_lock:
+            service._tx_table[tx.tid] = tx
+            service._ref_table[ref.rid] = ref
+            service._delete_tx(tx, status)
+
+        reply = service._handle_download(_make_download_request(ref.rid, state={"chunk_idx": 1}))
+
+        assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.INVALID_REQUEST
+        assert ref.rid not in service._finished_ref_table
+
+    def test_finished_ref_tombstone_expires(self):
+        """Finished-ref tombstones are temporary and eventually return to invalid-ref behavior."""
+        from nvflare.fuel.f3.streaming import download_service as download_service_module
+        from nvflare.fuel.f3.streaming.download_service import _Transaction
+
+        service = _make_isolated_download_service()
+        service._finished_ref_ttl = 10.0
+        obj = MockDownloadable([b"chunk1"])
+        tx = _Transaction(timeout=10.0, num_receivers=1)
+        ref = tx.add_object(obj)
+
+        with patch.object(download_service_module.time, "time", return_value=100.0):
+            with service._tx_lock:
+                service._tx_table[tx.tid] = tx
+                service._ref_table[ref.rid] = ref
+                service._delete_tx(tx, TransactionDoneStatus.FINISHED)
+
+        with patch.object(download_service_module.time, "time", return_value=111.0):
+            reply = service._handle_download(_make_download_request(ref.rid, state={"chunk_idx": 1}))
+
+        assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.INVALID_REQUEST
+        assert ref.rid not in service._finished_ref_table
 
     def test_get_transaction_id_from_ref_id(self, cell):
         """Test retrieving transaction ID from reference ID."""


### PR DESCRIPTION
This is the fix for NVBug 6235401.

## Summary
- Add short-lived tombstones for refs from normally finished `DownloadService` transactions.
- Return `OK` + `EOF` for late retries of finished refs, avoiding fatal `no ref found` failures when the original EOF reply was delayed or timed out.
- Keep `TIMEOUT` and `DELETED` transactions as invalid-ref failures, and expire tombstones automatically.
- Add regression coverage for late EOF retries, non-finished ref cleanup, and tombstone expiry.

## Root Cause
During high-concurrency large-model broadcasts, a client can timeout waiting for the final EOF reply and retry with the same ref/state. The server may already have marked the transaction `FINISHED` and removed its refs from `_ref_table`, so the retry hits `_handle_download()` after cleanup and receives `INVALID_REQUEST` with `no ref found`. The client treats that as fatal even though the download already completed successfully server-side.

## Validation
- `PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache /Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/f3/streaming/download_service_test.py` (`19 passed`)
- `PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache /Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/f3/streaming` (`117 passed`)
- `black --check nvflare/fuel/f3/streaming/download_service.py tests/unit_test/fuel/f3/streaming/download_service_test.py`
- `isort --check-only nvflare/fuel/f3/streaming/download_service.py tests/unit_test/fuel/f3/streaming/download_service_test.py`
- `flake8 nvflare/fuel/f3/streaming/download_service.py tests/unit_test/fuel/f3/streaming/download_service_test.py`
- `git diff --check upstream/2.8..HEAD`
- `env PATH=/Users/zhihongz/nvflare-env/3.12/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache ./runtest.sh -s nvflare/fuel/f3/streaming/download_service.py tests/unit_test/fuel/f3/streaming/download_service_test.py`