### PR TITLE
Update docs for large-model streaming reliability

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -6,6 +6,70 @@ Migration Guide
 
 This guide covers API and configuration changes when upgrading between FLARE releases.
 
+Upgrading from 2.7.2 to 2.8.0
+=============================
+
+Python and Removed Legacy Surfaces
+----------------------------------
+
+FLARE 2.8.0 targets Python 3.10 through 3.14. Python 3.9 is no longer listed as
+a supported development target.
+
+The deprecated FLAdminAPI surface has been removed. Use the FLARE API, Recipe
+API, Client API, and ``nvflare`` CLI workflows for new automation.
+
+HA/Overseer code has also been removed from the 2.8 branch.
+
+Client API Subprocess Timeout Validation
+----------------------------------------
+
+Subprocess-mode Client API jobs now validate two large-model safety settings at
+job initialization:
+
+- ``download_complete_timeout`` must not be ``None``. The subprocess must stay
+  alive after ``send_to_peer()`` ACKs so the server can finish downloading
+  tensors from the subprocess ``DownloadService``.
+- ``max_resends`` must not be ``None`` when using ``ClientAPILauncherExecutor``.
+  Unlimited resends can turn one delayed large-model transfer into an unbounded
+  series of replacement download transactions.
+
+If your 2.7.x job explicitly set either value to ``None``, update it before
+running on 2.8.0:
+
+.. code-block:: python
+
+   recipe.add_client_config({
+       "download_complete_timeout": 1800,
+       "max_resends": 3,  # finite non-negative integer; 0 disables retries
+   })
+
+For large tensor or NumPy payloads, also keep the related streaming timeouts
+consistent. If you explicitly raise ``tensor_streaming_per_request_timeout`` or
+``np_streaming_per_request_timeout``, set ``PEER_READ_TIMEOUT`` and
+``download_complete_timeout`` to values at least as large as the configured
+streaming per-request timeout, and keep ``tensor_min_download_timeout`` or
+``np_min_download_timeout`` at least as large as the same value.
+
+.. code-block:: python
+
+   recipe.add_client_config({
+       "tensor_streaming_per_request_timeout": 600,
+       "tensor_min_download_timeout": 600,
+       "PEER_READ_TIMEOUT": 600,
+       "download_complete_timeout": 1800,
+       "max_resends": 3,
+   })
+
+Late Retry Handling for Finished Download Refs
+----------------------------------------------
+
+FLARE 2.8.0 makes finished ``DownloadService`` refs retry-safe for the same
+requester. If a client completed a large download but retries because the final
+EOF response was delayed, the server returns the same terminal status instead of
+``INVALID_REQUEST`` / ``no ref found``. This is an internal reliability fix and
+does not require job-code changes, but it is most effective when the subprocess
+timeouts above are configured consistently for very large models.
+
 Upcoming Main-Branch Changes
 ============================
 

--- a/docs/programming_guide/tensor_downloader.rst
+++ b/docs/programming_guide/tensor_downloader.rst
@@ -212,6 +212,13 @@ For very large models (multiple GB), you may want to tune chunk sizes for optima
 Larger chunks mean fewer network requests but higher per-chunk memory usage. Smaller chunks
 reduce memory but increase network overhead.
 
+When tensor streaming is used from subprocess-mode Client API jobs, also tune the
+subprocess timeout settings that govern task reads, result ACKs, and server-side
+download completion. In particular, keep ``PEER_READ_TIMEOUT``,
+``download_complete_timeout``, and ``tensor_min_download_timeout`` aligned with
+the configured streaming per-request timeout. See :ref:`timeout_troubleshooting`
+and :doc:`/programming_guide/timeouts`.
+
 **Example config_fed_server.conf with chunk size tuning:**
 
 .. code-block::
@@ -441,3 +448,4 @@ See Also
 - :ref:`decomposer_for_large_object` - Details on the FOBS decomposer system and file-based decomposers
 - :ref:`file_streaming` - File streaming for other large data types
 - :ref:`swarm_learning_large_models` - Parameter tuning for large model workflows
+- :ref:`timeout_troubleshooting` - Timeout tuning for large Client API subprocess jobs

--- a/docs/programming_guide/timeouts.rst
+++ b/docs/programming_guide/timeouts.rst
@@ -255,10 +255,20 @@ FlareAgent for external process integration (flare_agent.py):
      - Timeout for submitting task result to the client training process. 60 s is too short
        for large models; configure via ``add_client_config({"submit_result_timeout": 1800})``.
    * - max_resends
-     - 3
-     - Maximum send retries on failure. Configurable via ``add_client_config({"max_resends": N})``.
+     - None in raw ``FlareAgent``; 3 through Client API job config
+     - Maximum send retries on failure. For ``ClientAPILauncherExecutor`` jobs,
+       use a finite non-negative value; ``None`` is rejected at job initialization.
+       Configurable via ``add_client_config({"max_resends": N})``.
+   * - download_complete_timeout
+     - 1800.0
+     - Time the subprocess waits after result ACK while the server finishes
+       downloading tensors from the subprocess ``DownloadService``. Must not be
+       ``None`` for ``ClientAPILauncherExecutor`` jobs.
 
-**Note**: FlareAgentWithCellPipe uses 30.0s defaults.
+**Note**: Raw ``FlareAgentWithCellPipe`` defaults to 60.0 s for
+``submit_result_timeout`` and unlimited ``max_resends``. When launched through
+``ClientAPILauncherExecutor``, the generated Client API config supplies the
+safer job defaults described above.
 
 IPC Agent
 ^^^^^^^^^
@@ -526,6 +536,38 @@ The Client API executor extends base timeouts with more conservative defaults
    * - heartbeat_timeout
      - 300.0
      - Extended heartbeat timeout for Client API
+   * - submit_result_timeout
+     - 300.0
+     - Subprocess-side wait for CJ to acknowledge each result message
+   * - max_resends
+     - 3
+     - Maximum retries after the initial result send; ``None`` is rejected
+   * - download_complete_timeout
+     - 1800.0
+     - Time the subprocess remains alive for server-side tensor download completion
+
+For subprocess-mode Client API jobs with large payloads, FLARE validates the
+following at job start:
+
+- ``download_complete_timeout`` must not be ``None``.
+- ``max_resends`` must be a finite non-negative integer. Use ``0`` to disable
+  retries; do not use ``None`` for unlimited retries.
+
+When ``tensor_streaming_per_request_timeout`` or
+``np_streaming_per_request_timeout`` is explicitly configured, FLARE also warns
+if ``peer_read_timeout`` or ``download_complete_timeout`` is shorter than that
+streaming timeout. Set ``PEER_READ_TIMEOUT`` through ``add_client_config`` when
+the parent client job needs a larger pipe-read budget:
+
+.. code-block:: python
+
+   recipe.add_client_config({
+       "tensor_streaming_per_request_timeout": 600,
+       "tensor_min_download_timeout": 600,
+       "PEER_READ_TIMEOUT": 600,
+       "download_complete_timeout": 1800,
+       "max_resends": 3,
+   })
 
 External Pre-Init Override
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1369,6 +1411,9 @@ Object download transaction timeouts (download_service.py, obj_downloader.py):
      - Timeout for each request to object owner
 
 **Note**: Transaction times out if no activity from any receiver for the specified duration.
+Normally finished download refs are tombstoned temporarily so a late retry from
+the same receiver can receive the original EOF or error status instead of a
+fatal missing-ref response. Timeout and deleted transactions are not tombstoned.
 
 
 Tensor Streaming Timeouts
@@ -1478,6 +1523,19 @@ Framework-level settings for large payload transfers (fl_constant.py:553, comm_c
      - 2097152
      - Chunk size for PyTorch tensor downloads (bytes)
 
+For Client API subprocess jobs, keep these download settings aligned with the
+subprocess pipe settings:
+
+- ``tensor_min_download_timeout`` / ``np_min_download_timeout`` should be at
+  least ``tensor_streaming_per_request_timeout`` /
+  ``np_streaming_per_request_timeout``.
+- ``PEER_READ_TIMEOUT`` should be at least the configured streaming per-request
+  timeout so the parent client job does not resend the task while the subprocess
+  is still downloading a large payload.
+- ``download_complete_timeout`` should be at least the configured streaming
+  per-request timeout and long enough for the server to pull large tensor
+  results from the subprocess after result ACK.
+
 Swarm Learning Large Model Setup
 --------------------------------
 
@@ -1505,7 +1563,9 @@ Recommended timeouts for large models in Swarm Learning:
    # Subprocess-mode timeouts (when launch_external_process=True)
    recipe.add_client_config({
        "submit_result_timeout": 1800,
+       "download_complete_timeout": 1800,
        "tensor_min_download_timeout": 600,
+       "PEER_READ_TIMEOUT": 600,
        "max_resends": 5,
    })
 

--- a/docs/programming_guide/timeouts.rst
+++ b/docs/programming_guide/timeouts.rst
@@ -555,7 +555,7 @@ following at job start:
 
 When ``tensor_streaming_per_request_timeout`` or
 ``np_streaming_per_request_timeout`` is explicitly configured, FLARE also warns
-if ``peer_read_timeout`` or ``download_complete_timeout`` is shorter than that
+if ``PEER_READ_TIMEOUT`` or ``download_complete_timeout`` is shorter than that
 streaming timeout. Set ``PEER_READ_TIMEOUT`` through ``add_client_config`` when
 the parent client job needs a larger pipe-read budget:
 

--- a/docs/release_notes/flare_280.rst
+++ b/docs/release_notes/flare_280.rst
@@ -52,6 +52,11 @@ Release Highlights
   holding all client tensor updates in memory simultaneously, each update is written
   to a temporary safetensors file on disk and consumed lazily during aggregation.
   The benefit scales with model size and client count.
+- **Large-model streaming reliability**: large tensor broadcasts are more robust
+  when many clients retry after delayed EOF responses. Finished download refs are
+  handled idempotently, and subprocess Client API jobs now reject unbounded result
+  resends or missing download-completion waits that can turn one slow transfer into
+  repeated large-model retries.
 - **New examples and contributed research**: MedGemma, Qwen3-VL, Codon-FM,
   FedUMM, financial-services fraud detection, Docker job examples, distributed
   provisioning examples, Hello JAX, and Hello log streaming help teams start
@@ -258,6 +263,32 @@ These improvements help large-model FL jobs operate under tighter memory and
 runtime constraints, while the new examples give teams concrete starting points
 for multimodal and language-model workloads.
 
+Large-Model Streaming Reliability
+---------------------------------
+
+The streaming layer now treats late retries of normally finished download refs
+as idempotent terminal responses instead of fatal missing-ref errors. This
+addresses high-fanout large-model broadcasts where a client has completed a
+download but retries because the final EOF response was delayed by network or
+server-side contention.
+
+The fix applies at the ``DownloadService`` layer, so it benefits large payload
+transfers regardless of whether they come from FedAvg, Client API subprocess
+jobs, tensor disk offload, or another feature built on the same streaming
+path. Cleanup caused by transaction timeout or explicit deletion still returns
+an invalid-ref error; only normally finished transactions are tombstoned for
+late terminal retries.
+
+Subprocess Client API jobs also validate risky retry settings earlier. In
+particular, ``max_resends=None`` is now rejected for
+``ClientAPILauncherExecutor`` jobs because unlimited resends can create an
+unbounded sequence of large download transactions, and
+``download_complete_timeout=None`` is rejected because the subprocess must stay
+alive while the server finishes pulling tensors from it. Jobs with explicitly
+configured large streaming request timeouts now receive warnings when related
+pipe/download-completion timeouts are shorter than the configured streaming
+timeout.
+
 Server Memory: Tensor Disk Offload
 -----------------------------------
 
@@ -311,8 +342,8 @@ Docker, Kubernetes, and server-connected workflows.
 Notable improvements include more consistent job status publication, clearer
 errors for missing or running jobs, more reliable startup and log-streaming
 behavior, Docker and Kubernetes runtime fixes, better GPU visibility handling,
-cleaner client failure reporting, and refreshed integration-test and CI
-coverage.
+cleaner client failure reporting, corrected paired-duration monitoring metrics
+when an end event is skipped, and refreshed integration-test and CI coverage.
 
 New Examples and Research
 =========================

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -824,8 +824,10 @@ Decentralized federated learning without a central server.
      Increase for 7B+ models where P2P tensor streaming can take several minutes.
    - ``pipe_type`` (default ``"cell_pipe"``): set to ``"file_pipe"`` when cell networking
      is unavailable or for third-party subprocess integrations.
-   - ``submit_result_timeout`` and ``tensor_min_download_timeout``: set via
-     ``recipe.add_client_config({...})`` — see :ref:`timeout_troubleshooting`.
+   - ``submit_result_timeout``, ``download_complete_timeout``,
+     ``tensor_min_download_timeout``, ``PEER_READ_TIMEOUT``, and finite
+     ``max_resends``: set via ``recipe.add_client_config({...})`` — see
+     :ref:`timeout_troubleshooting`.
 
 
 Edge Recipes

--- a/docs/user_guide/timeout_troubleshooting.rst
+++ b/docs/user_guide/timeout_troubleshooting.rst
@@ -142,12 +142,12 @@ clients, logs may also show repeated ``no ref found`` messages from
 ``DownloadService`` after delayed retries.
 
 **Cause**: ``submit_result_timeout`` is the time the training subprocess waits for
-the client job process to acknowledge its result. ``peer_read_timeout`` is the
-parent client job's corresponding wait for the subprocess to read a task. For
-large models (5 GB+) and many clients, either side can exceed short defaults if
-streaming request timeouts are configured higher than the pipe timeout. The
-subprocess also must remain alive long enough for the server to finish pulling
-tensors from its ``DownloadService`` after result ACK.
+the client job process to acknowledge its result. ``PEER_READ_TIMEOUT`` is the
+client config key for the parent client job's corresponding wait for the
+subprocess to read a task. For large models (5 GB+) and many clients, either side
+can exceed short defaults if streaming request timeouts are configured higher
+than the pipe timeout. The subprocess also must remain alive long enough for the
+server to finish pulling tensors from its ``DownloadService`` after result ACK.
 
 **Solution**:
 

--- a/docs/user_guide/timeout_troubleshooting.rst
+++ b/docs/user_guide/timeout_troubleshooting.rst
@@ -137,11 +137,17 @@ Subprocess Large-Model Result Submission Timeout
 **Applies to**: Subprocess-mode clients (``launch_external_process=True``) with large models
 
 **Symptom**: Training completes in the subprocess but the job hangs or fails immediately
-after, with no result acknowledgment received.
+after, with no result acknowledgment received. With very large payloads and many
+clients, logs may also show repeated ``no ref found`` messages from
+``DownloadService`` after delayed retries.
 
-**Cause**: ``submit_result_timeout`` (default 60 s) is the time the training subprocess
-waits for the client training process to acknowledge its result.  For large models (5 GB+),
-the transfer alone exceeds this limit.
+**Cause**: ``submit_result_timeout`` is the time the training subprocess waits for
+the client job process to acknowledge its result. ``peer_read_timeout`` is the
+parent client job's corresponding wait for the subprocess to read a task. For
+large models (5 GB+) and many clients, either side can exceed short defaults if
+streaming request timeouts are configured higher than the pipe timeout. The
+subprocess also must remain alive long enough for the server to finish pulling
+tensors from its ``DownloadService`` after result ACK.
 
 **Solution**:
 
@@ -149,8 +155,11 @@ the transfer alone exceeds this limit.
 
    recipe.add_client_config({
        "submit_result_timeout": 1800,      # 30 min for LLM-scale results
+       "download_complete_timeout": 1800,  # keep subprocess alive for server tensor download
+       "PEER_READ_TIMEOUT": 600,           # parent CJ read budget; match configured streaming timeout
        "tensor_min_download_timeout": 600, # PyTorch: increase if inter-chunk gaps exceed 300s default
        # "np_min_download_timeout": 600,   # NumPy/sklearn: same, use instead of tensor variant
+       "max_resends": 3,                   # finite value; 0 disables retries, None is rejected
    })
 
 .. note::
@@ -159,6 +168,12 @@ the transfer alone exceeds this limit.
    for the client to deliver a result.  For large models, set ``submit_task_result_timeout``
    (server-side) to be at least as large as ``submit_result_timeout`` (subprocess-side)
    so the server is still listening when the subprocess finishes sending.
+
+.. note::
+   In FLARE 2.8.0, ``ClientAPILauncherExecutor`` rejects
+   ``download_complete_timeout=None`` and ``max_resends=None`` at job
+   initialization. Use a positive ``download_complete_timeout`` and a finite
+   non-negative ``max_resends`` value.
 
 Swarm Learning P2P Transfer Timeout
 ------------------------------------
@@ -221,14 +236,20 @@ Most Commonly Adjusted Timeouts
      - None
      - Large result payloads
    * - submit_result_timeout (subprocess mode only)
-     - 60 s
+     - 300 s through Client API job config; 60 s in raw ``FlareAgent``
      - Large model result transfers from subprocess; set 1800 s for LLMs
    * - tensor_min_download_timeout / np_min_download_timeout (subprocess mode only)
      - 300 s
      - 70B+ models on congested networks; increase to 600 s (tensor = PyTorch, np = NumPy/sklearn)
+   * - PEER_READ_TIMEOUT (Client API subprocess only)
+     - 300 s
+     - Large task payloads when streaming per-request timeout is explicitly increased
+   * - download_complete_timeout (subprocess mode only)
+     - 1800 s
+     - Keep subprocess alive while the server downloads large tensor results
    * - max_resends (subprocess mode only)
      - 3
-     - Persistent network failures; increase to 5–10
+     - Persistent network failures; use a finite non-negative value
    * - round_timeout (Swarm Learning only)
      - 3600 s
      - 7B+ model P2P transfers between Swarm peers
@@ -323,7 +344,9 @@ Large Model Training (100M+ parameters)
        "get_task_timeout": 600,
        "submit_task_result_timeout": 600,
        "submit_result_timeout": 600,        # subprocess mode only
+       "download_complete_timeout": 1800,   # subprocess mode only
        "tensor_min_download_timeout": 300,  # subprocess mode only; use np_min_download_timeout for NumPy
+       "PEER_READ_TIMEOUT": 600,            # subprocess mode only
    })
 
 
@@ -336,7 +359,9 @@ LLM/Foundation Model Training
        "get_task_timeout": 1200,
        "submit_task_result_timeout": 1800,  # server-side; must be >= submit_result_timeout
        "submit_result_timeout": 1800,       # subprocess mode only
+       "download_complete_timeout": 1800,   # subprocess mode only
        "tensor_min_download_timeout": 600,  # PyTorch; use np_min_download_timeout for NumPy
+       "PEER_READ_TIMEOUT": 600,            # subprocess mode only
        "max_resends": 5,                    # subprocess mode only
    })
 


### PR DESCRIPTION
## Summary
- document finished download-ref retry handling for large-model streaming
- add migration guidance for Client API subprocess timeout validation
- update timeout troubleshooting, recipe, and tensor downloader guidance

## Verification
- git diff --check HEAD~1
- ./runtest.sh -s