### PR TITLE
[2.8] Clarify Externalizer nested list subclass caveat

### DIFF
--- a/nvflare/fuel/utils/fobs/decomposer.py
+++ b/nvflare/fuel/utils/fobs/decomposer.py
@@ -107,7 +107,7 @@ class Externalizer:
         Dict/list subclasses are reconstructed with no-arg constructors at every level. This matches the contract
         already required by DictDecomposer.recompose() for top-level dict subclasses, but also means nested container
         subclasses (both dict and list) must tolerate no-arg construction and may not preserve constructor state such
-        as a defaultdict's default_factory or a list subclass that requires a capacity/initializer argument.
+        as a defaultdict's default_factory or the capacity/initializer argument of a list subclass.
         """
         if not self.manager:
             return target

--- a/nvflare/fuel/utils/fobs/decomposer.py
+++ b/nvflare/fuel/utils/fobs/decomposer.py
@@ -106,8 +106,8 @@ class Externalizer:
 
         Dict/list subclasses are reconstructed with no-arg constructors at every level. This matches the contract
         already required by DictDecomposer.recompose() for top-level dict subclasses, but also means nested container
-        subclasses must tolerate no-arg construction and may not preserve constructor state such as a defaultdict's
-        default_factory.
+        subclasses (both dict and list) must tolerate no-arg construction and may not preserve constructor state such
+        as a defaultdict's default_factory or a list subclass that requires a capacity/initializer argument.
         """
         if not self.manager:
             return target


### PR DESCRIPTION
## What changed

This is a small follow-up to #4707 that ports the documentation-only clarification from #4718 that was not present in the 2.8 PR.

The `Externalizer.externalize()` docstring now explicitly says the no-arg constructor requirement applies to nested dict and list subclasses, including list subclasses that require constructor state such as a capacity or initializer argument.

## Why

#4707 already added the FOBS non-mutating Externalizer fix on `2.8`, but #4718's review follow-up clarified the nested list subclass edge case as well. This keeps the `2.8` docs aligned with `main`.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache /Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/utils/fobs/decomposer_test.py`
- `git diff --check`
- `env PATH=/Users/zhihongz/nvflare-env/3.12/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin PYTHONPYCACHEPREFIX=/private/tmp/nvflare-pycache ./runtest.sh -s nvflare/fuel/utils/fobs/decomposer.py`