### PR TITLE
[2.8] Fix dashboard container launch from installed package

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,22 @@ Build from the repository root:
 docker build -f docker/Dockerfile.parent -t nvflare-parent:latest .
 ```
 
+The dashboard can use the same runtime image. If you want a dashboard-specific
+image name, tag the same build with both names:
+
+```bash
+docker build -f docker/Dockerfile.parent \
+  -t nvflare-parent:latest \
+  -t nvflare-dashboard:latest \
+  .
+```
+
+Then start the dashboard with the dashboard tag:
+
+```bash
+nvflare dashboard --start -i nvflare-dashboard:latest --port 8443
+```
+
 Use this image in `docker.yaml` or `k8s.yaml` as the parent image:
 
 ```yaml
@@ -69,6 +85,8 @@ containers include `/etc/pip/constraint.txt` to protect the tested package set.
 ## Choosing an Image
 
 - Use `Dockerfile.parent` for parent server/client processes.
+- Use `Dockerfile.parent` for the dashboard runtime; tag the same build as a
+  dashboard image if you want a dashboard-specific image name.
 - Use `Dockerfile.job` for submitted job containers.
 - Do not rely on a shell being available in the parent image; it is absent by
   design.

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -114,7 +114,7 @@ def start(args):
     try:
         container_obj = client.containers.run(
             dashboard_image,
-            entrypoint=["python", "-m", "nvflare.dashboard.wsgi"],
+            entrypoint=["python3", "-m", "nvflare.dashboard.wsgi"],
             detach=True,
             auto_remove=True,
             name="nvflare-dashboard",

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -17,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 import docker
 import nvflare
@@ -113,12 +114,12 @@ def start(args):
     try:
         container_obj = client.containers.run(
             dashboard_image,
-            entrypoint=["/usr/local/bin/python3", "nvflare/dashboard/wsgi.py"],
+            entrypoint=["python", "-m", "nvflare.dashboard.wsgi"],
             detach=True,
             auto_remove=True,
             name="nvflare-dashboard",
             ports={8443: args.port},
-            volumes={folder: {"bind": "/var/tmp/nvflare/dashboard", "model": "rw"}},
+            volumes={folder: {"bind": "/var/tmp/nvflare/dashboard", "mode": "rw"}},
             environment=environment,
         )
     except docker.errors.APIError as e:
@@ -127,11 +128,37 @@ def start(args):
         print(e)
         exit(1)
     if container_obj:
+        _fail_if_container_exited(container_obj)
         print("Dashboard container started")
         print("Container name nvflare-dashboard")
         print(f"id is {container_obj.id}")
     else:
         print("Container failed to start")
+
+
+def _fail_if_container_exited(container_obj):
+    time.sleep(1)
+    try:
+        container_obj.reload()
+    except docker.errors.NotFound:
+        print("Dashboard container exited immediately and was removed.")
+        exit(1)
+
+    status = getattr(container_obj, "status", None)
+    if status not in {"dead", "exited"}:
+        return
+
+    print(f"Dashboard container exited immediately with status: {status}")
+    try:
+        logs = container_obj.logs(stdout=True, stderr=True, tail=50)
+    except docker.errors.APIError:
+        logs = None
+    if logs:
+        if isinstance(logs, bytes):
+            logs = logs.decode("utf-8", errors="replace")
+        print("Container logs:")
+        print(logs.rstrip())
+    exit(1)
 
 
 def start_local(env):

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -145,7 +145,7 @@ def _fail_if_container_exited(container_obj):
         exit(1)
 
     status = getattr(container_obj, "status", None)
-    if status not in {"dead", "exited"}:
+    if status not in {"dead", "exited", "removing"}:
         return
 
     print(f"Dashboard container exited immediately with status: {status}")

--- a/nvflare/dashboard/wsgi.py
+++ b/nvflare/dashboard/wsgi.py
@@ -15,8 +15,7 @@
 import os
 import ssl
 
-from application import init_app
-
+from nvflare.dashboard.application import init_app
 from nvflare.dashboard.utils import EnvVar, get_web_root
 
 app = init_app()

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -100,7 +100,7 @@ class TestDashboardCli:
 
         client.containers.run.assert_called_once()
         run_kwargs = client.containers.run.call_args.kwargs
-        assert run_kwargs["entrypoint"] == ["python", "-m", "nvflare.dashboard.wsgi"]
+        assert run_kwargs["entrypoint"] == ["python3", "-m", "nvflare.dashboard.wsgi"]
         assert run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]["mode"] == "rw"
         assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
         assert "Dashboard container started" in capsys.readouterr().out
@@ -129,3 +129,28 @@ class TestDashboardCli:
         assert f"Dashboard container exited immediately with status: {status}" in output
         assert "Container logs:" in output
         assert "can't open file" in output
+
+    def test_start_reports_auto_removed_container_exit(self, capsys):
+        """auto_remove=True often removes the container before reload() returns;
+        that path raises docker.errors.NotFound and must exit 1 with a clear message."""
+        args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+        container = SimpleNamespace(
+            id="container-1",
+            status="running",
+            reload=Mock(side_effect=dashboard_cli.docker.errors.NotFound("gone")),
+            logs=Mock(),
+        )
+        client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+        client.containers.run.return_value = container
+
+        with (
+            patch.object(dashboard_cli.docker, "from_env", return_value=client),
+            patch.object(dashboard_cli.time, "sleep"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            dashboard_cli.start(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Dashboard container exited immediately and was removed." in output
+        container.logs.assert_not_called()

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import argparse
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -84,3 +85,46 @@ class TestDashboardCli:
             dashboard_cli.handle_dashboard(args)
 
         start_mock.assert_called_once_with(args)
+
+    def test_start_uses_installed_package_entrypoint(self, capsys):
+        args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+        container = SimpleNamespace(id="container-1", status="running", reload=Mock(), logs=Mock())
+        client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+        client.containers.run.return_value = container
+
+        with (
+            patch.object(dashboard_cli.docker, "from_env", return_value=client),
+            patch.object(dashboard_cli.time, "sleep"),
+        ):
+            dashboard_cli.start(args)
+
+        client.containers.run.assert_called_once()
+        run_kwargs = client.containers.run.call_args.kwargs
+        assert run_kwargs["entrypoint"] == ["python", "-m", "nvflare.dashboard.wsgi"]
+        assert run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]["mode"] == "rw"
+        assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
+        assert "Dashboard container started" in capsys.readouterr().out
+
+    def test_start_reports_immediate_container_exit(self, capsys):
+        args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+        container = SimpleNamespace(
+            id="container-1",
+            status="exited",
+            reload=Mock(),
+            logs=Mock(return_value=b"python: can't open file '/app/nvflare/dashboard/wsgi.py'"),
+        )
+        client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+        client.containers.run.return_value = container
+
+        with (
+            patch.object(dashboard_cli.docker, "from_env", return_value=client),
+            patch.object(dashboard_cli.time, "sleep"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            dashboard_cli.start(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Dashboard container exited immediately with status: exited" in output
+        assert "Container logs:" in output
+        assert "can't open file" in output

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -105,11 +105,12 @@ class TestDashboardCli:
         assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
         assert "Dashboard container started" in capsys.readouterr().out
 
-    def test_start_reports_immediate_container_exit(self, capsys):
+    @pytest.mark.parametrize("status", ["exited", "removing"])
+    def test_start_reports_immediate_container_exit(self, capsys, status):
         args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
         container = SimpleNamespace(
             id="container-1",
-            status="exited",
+            status=status,
             reload=Mock(),
             logs=Mock(return_value=b"python: can't open file '/app/nvflare/dashboard/wsgi.py'"),
         )
@@ -125,6 +126,6 @@ class TestDashboardCli:
 
         assert exc_info.value.code == 1
         output = capsys.readouterr().out
-        assert "Dashboard container exited immediately with status: exited" in output
+        assert f"Dashboard container exited immediately with status: {status}" in output
         assert "Container logs:" in output
         assert "can't open file" in output


### PR DESCRIPTION
## Summary
- launch the dashboard container with python -m nvflare.dashboard.wsgi so installed-package images do not require the source tree under /app
- make the dashboard WSGI module use a package-qualified import
- report immediate dashboard container exits with recent logs instead of printing a successful start message
- fix the dashboard volume option key from model to mode

## Tests
- python -m pytest tests/unit_test/dashboard/cli_test.py
- python -m pytest tests/unit_test/dashboard
- git diff --check
- ./runtest.sh -s