### PR TITLE
Fix dashboard container launch from installed package

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,22 @@ Build from the repository root:
 docker build -f docker/Dockerfile.parent -t nvflare-parent:latest .
 ```
 
+The dashboard can use the same runtime image. If you want a dashboard-specific
+image name, tag the same build with both names:
+
+```bash
+docker build -f docker/Dockerfile.parent \
+  -t nvflare-parent:latest \
+  -t nvflare-dashboard:latest \
+  .
+```
+
+Then start the dashboard with the dashboard tag:
+
+```bash
+nvflare dashboard --start -i nvflare-dashboard:latest --port 8443
+```
+
 Use this image in `docker.yaml` or `k8s.yaml` as the parent image:
 
 ```yaml
@@ -69,6 +85,8 @@ containers include `/etc/pip/constraint.txt` to protect the tested package set.
 ## Choosing an Image
 
 - Use `Dockerfile.parent` for parent server/client processes.
+- Use `Dockerfile.parent` for the dashboard runtime; tag the same build as a
+  dashboard image if you want a dashboard-specific image name.
 - Use `Dockerfile.job` for submitted job containers.
 - Do not rely on a shell being available in the parent image; it is absent by
   design.

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -101,7 +101,7 @@ def start(args):
     try:
         container_obj = client.containers.run(
             dashboard_image,
-            entrypoint=["python", "-m", "nvflare.dashboard.wsgi"],
+            entrypoint=["python3", "-m", "nvflare.dashboard.wsgi"],
             detach=True,
             auto_remove=True,
             name="nvflare-dashboard",

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -132,7 +132,7 @@ def _fail_if_container_exited(container_obj):
         exit(1)
 
     status = getattr(container_obj, "status", None)
-    if status not in {"dead", "exited"}:
+    if status not in {"dead", "exited", "removing"}:
         return
 
     print(f"Dashboard container exited immediately with status: {status}")

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -17,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 import docker
 import nvflare
@@ -100,12 +101,12 @@ def start(args):
     try:
         container_obj = client.containers.run(
             dashboard_image,
-            entrypoint=["/usr/local/bin/python3", "nvflare/dashboard/wsgi.py"],
+            entrypoint=["python", "-m", "nvflare.dashboard.wsgi"],
             detach=True,
             auto_remove=True,
             name="nvflare-dashboard",
             ports={8443: args.port},
-            volumes={folder: {"bind": "/var/tmp/nvflare/dashboard", "model": "rw"}},
+            volumes={folder: {"bind": "/var/tmp/nvflare/dashboard", "mode": "rw"}},
             environment=environment,
         )
     except docker.errors.APIError as e:
@@ -114,11 +115,37 @@ def start(args):
         print(e)
         exit(1)
     if container_obj:
+        _fail_if_container_exited(container_obj)
         print("Dashboard container started")
         print("Container name nvflare-dashboard")
         print(f"id is {container_obj.id}")
     else:
         print("Container failed to start")
+
+
+def _fail_if_container_exited(container_obj):
+    time.sleep(1)
+    try:
+        container_obj.reload()
+    except docker.errors.NotFound:
+        print("Dashboard container exited immediately and was removed.")
+        exit(1)
+
+    status = getattr(container_obj, "status", None)
+    if status not in {"dead", "exited"}:
+        return
+
+    print(f"Dashboard container exited immediately with status: {status}")
+    try:
+        logs = container_obj.logs(stdout=True, stderr=True, tail=50)
+    except docker.errors.APIError:
+        logs = None
+    if logs:
+        if isinstance(logs, bytes):
+            logs = logs.decode("utf-8", errors="replace")
+        print("Container logs:")
+        print(logs.rstrip())
+    exit(1)
 
 
 def start_local(env):

--- a/nvflare/dashboard/wsgi.py
+++ b/nvflare/dashboard/wsgi.py
@@ -15,8 +15,7 @@
 import os
 import ssl
 
-from application import init_app
-
+from nvflare.dashboard.application import init_app
 from nvflare.dashboard.utils import EnvVar, get_web_root
 
 app = init_app()

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -41,7 +41,7 @@ def test_start_uses_installed_package_entrypoint(capsys):
 
     client.containers.run.assert_called_once()
     run_kwargs = client.containers.run.call_args.kwargs
-    assert run_kwargs["entrypoint"] == ["python", "-m", "nvflare.dashboard.wsgi"]
+    assert run_kwargs["entrypoint"] == ["python3", "-m", "nvflare.dashboard.wsgi"]
     assert run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]["mode"] == "rw"
     assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
     assert "Dashboard container started" in capsys.readouterr().out
@@ -71,3 +71,29 @@ def test_start_reports_immediate_container_exit(capsys, status):
     assert f"Dashboard container exited immediately with status: {status}" in output
     assert "Container logs:" in output
     assert "can't open file" in output
+
+
+def test_start_reports_auto_removed_container_exit(capsys):
+    """auto_remove=True often removes the container before reload() returns;
+    that path raises docker.errors.NotFound and must exit 1 with a clear message."""
+    args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+    container = SimpleNamespace(
+        id="container-1",
+        status="running",
+        reload=Mock(side_effect=dashboard_cli.docker.errors.NotFound("gone")),
+        logs=Mock(),
+    )
+    client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+    client.containers.run.return_value = container
+
+    with (
+        patch.object(dashboard_cli.docker, "from_env", return_value=client),
+        patch.object(dashboard_cli.time, "sleep"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dashboard_cli.start(args)
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "Dashboard container exited immediately and was removed." in output
+    container.logs.assert_not_called()

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -47,11 +47,12 @@ def test_start_uses_installed_package_entrypoint(capsys):
     assert "Dashboard container started" in capsys.readouterr().out
 
 
-def test_start_reports_immediate_container_exit(capsys):
+@pytest.mark.parametrize("status", ["exited", "removing"])
+def test_start_reports_immediate_container_exit(capsys, status):
     args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
     container = SimpleNamespace(
         id="container-1",
-        status="exited",
+        status=status,
         reload=Mock(),
         logs=Mock(return_value=b"python: can't open file '/app/nvflare/dashboard/wsgi.py'"),
     )
@@ -67,6 +68,6 @@ def test_start_reports_immediate_container_exit(capsys):
 
     assert exc_info.value.code == 1
     output = capsys.readouterr().out
-    assert "Dashboard container exited immediately with status: exited" in output
+    assert f"Dashboard container exited immediately with status: {status}" in output
     assert "Container logs:" in output
     assert "can't open file" in output

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nvflare.dashboard import cli as dashboard_cli
+
+
+def _parse_dashboard_args(argv):
+    parser = argparse.ArgumentParser(prog="nvflare dashboard")
+    dashboard_cli.define_dashboard_parser(parser)
+    return parser.parse_args(argv)
+
+
+def test_start_uses_installed_package_entrypoint(capsys):
+    args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+    container = SimpleNamespace(id="container-1", status="running", reload=Mock(), logs=Mock())
+    client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+    client.containers.run.return_value = container
+
+    with (
+        patch.object(dashboard_cli.docker, "from_env", return_value=client),
+        patch.object(dashboard_cli.time, "sleep"),
+    ):
+        dashboard_cli.start(args)
+
+    client.containers.run.assert_called_once()
+    run_kwargs = client.containers.run.call_args.kwargs
+    assert run_kwargs["entrypoint"] == ["python", "-m", "nvflare.dashboard.wsgi"]
+    assert run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]["mode"] == "rw"
+    assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
+    assert "Dashboard container started" in capsys.readouterr().out
+
+
+def test_start_reports_immediate_container_exit(capsys):
+    args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+    container = SimpleNamespace(
+        id="container-1",
+        status="exited",
+        reload=Mock(),
+        logs=Mock(return_value=b"python: can't open file '/app/nvflare/dashboard/wsgi.py'"),
+    )
+    client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+    client.containers.run.return_value = container
+
+    with (
+        patch.object(dashboard_cli.docker, "from_env", return_value=client),
+        patch.object(dashboard_cli.time, "sleep"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dashboard_cli.start(args)
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "Dashboard container exited immediately with status: exited" in output
+    assert "Container logs:" in output
+    assert "can't open file" in output


### PR DESCRIPTION
## Summary
- launch the dashboard container with python -m nvflare.dashboard.wsgi so installed-package images do not require the source tree under /app
- make the dashboard WSGI module use a package-qualified import
- report immediate dashboard container exits with recent logs instead of printing a successful start message
- fix the dashboard volume option key from model to mode
- document using Dockerfile.parent for dashboard by tagging the same build with a dashboard image name

## Tests
- python -m pytest tests/unit_test/dashboard
- git diff --check HEAD~1..HEAD
- git diff --check
- ./runtest.sh -s