### PR TITLE
Agent PR 5: Add agent skill admission lints

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include versioneer.py
 include nvflare/_version.py
 include nvflare/libs/*.so
 include nvflare/fuel/utils/*.json
+recursive-include skills *
 recursive-include nvflare/lighter/templates *
 recursive-include nvflare/tool/deploy/templates *

--- a/nvflare/app_opt/kaggle/download_data.py
+++ b/nvflare/app_opt/kaggle/download_data.py
@@ -15,12 +15,22 @@
 import shutil
 from pathlib import Path
 
-import kagglehub
+kagglehub = None
+
+
+def _get_kagglehub():
+    global kagglehub
+
+    if kagglehub is None:
+        import kagglehub as imported_kagglehub
+
+        kagglehub = imported_kagglehub
+    return kagglehub
 
 
 def download(input_path: str, output_path: str, overwrite: bool = False):
     # Download latest version
-    path = kagglehub.dataset_download(input_path)
+    path = _get_kagglehub().dataset_download(input_path)
     print("Path to dataset files:", path)
 
     # Move downloaded data to output path

--- a/nvflare/app_opt/kaggle/download_data.py
+++ b/nvflare/app_opt/kaggle/download_data.py
@@ -15,22 +15,12 @@
 import shutil
 from pathlib import Path
 
-kagglehub = None
-
-
-def _get_kagglehub():
-    global kagglehub
-
-    if kagglehub is None:
-        import kagglehub as imported_kagglehub
-
-        kagglehub = imported_kagglehub
-    return kagglehub
+import kagglehub
 
 
 def download(input_path: str, output_path: str, overwrite: bool = False):
     # Download latest version
-    path = _get_kagglehub().dataset_download(input_path)
+    path = kagglehub.dataset_download(input_path)
     print("Path to dataset files:", path)
 
     # Move downloaded data to output path

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -28,6 +28,7 @@ from nvflare.fuel.hci.tools.authz_preview import define_authz_preview_parser, ru
 from nvflare.lighter.provision import define_provision_parser, handle_provision
 from nvflare.private.fed.app.simulator.simulator import define_simulator_parser, run_simulator
 from nvflare.private.fed.app.utils import version_check
+from nvflare.tool.agent.agent_cli import def_agent_cli_parser, handle_agent_cmd
 from nvflare.tool.cert.cert_cli import def_cert_cli_parser, handle_cert_cmd
 from nvflare.tool.deploy.deploy_cli import def_deploy_cli_parser, handle_deploy_cmd
 from nvflare.tool.job.job_cli import def_job_cli_parser, handle_job_cli_cmd
@@ -65,6 +66,7 @@ CMD_PACKAGE = "package"
 CMD_DEPLOY = "deploy"
 CMD_SYSTEM = "system"
 CMD_STUDY = "study"
+CMD_AGENT = "agent"
 
 _JSONL_COMMANDS = {
     (CMD_JOB, "monitor"),
@@ -299,18 +301,17 @@ def _get_subcommand_choices(parser):
     return []
 
 
-def _emit_argparse_error_json(parser, message):
+def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
     from nvflare.tool.cli_output import SCHEMA_VERSION
 
     # Parser errors intentionally expose usage/choices inline because they are generated before any
     # command handler runs and therefore sit outside the normal command data envelope.
     payload = {
         "schema_version": SCHEMA_VERSION,
-        "event": "terminal",
-        "terminal": True,
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
+        "code": "INVALID_ARGS",
         "message": message,
         "hint": "Run with --help to see usage.",
         "data": {
@@ -318,7 +319,12 @@ def _emit_argparse_error_json(parser, message):
             "choices": _get_subcommand_choices(parser),
         },
     }
-    print(json.dumps(payload))
+    if jsonl_mode:
+        payload["event"] = "terminal"
+        payload["terminal"] = True
+        print(json.dumps(payload), flush=True)
+    else:
+        print(json.dumps(payload))
     parser.exit(4)
 
 
@@ -363,7 +369,7 @@ def _display_unknown_args(argv, cmd: str, args, unknown: list) -> list:
     return display_unknown
 
 
-def _patch_help_on_error(parser, json_mode: bool = False):
+def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = False):
     """Recursively patch every parser in the tree to print help before error-exit.
 
     When argparse detects a missing required argument it calls parser.error(),
@@ -373,7 +379,7 @@ def _patch_help_on_error(parser, json_mode: bool = False):
 
     def _error_with_help(message):
         if json_mode:
-            _emit_argparse_error_json(parser, message)
+            _emit_argparse_error_json(parser, message, jsonl_mode=jsonl_mode)
         else:
             _emit_argparse_error_human(parser, message, exit_code=4)
 
@@ -381,7 +387,7 @@ def _patch_help_on_error(parser, json_mode: bool = False):
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for sub in action.choices.values():
-                _patch_help_on_error(sub, json_mode=json_mode)
+                _patch_help_on_error(sub, json_mode=json_mode, jsonl_mode=jsonl_mode)
 
 
 def _build_global_arg_parser():
@@ -466,6 +472,7 @@ def parse_args(prog_name: str):
     sub_cmd_parsers.update(def_package_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_deploy_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_study_cli_parser(sub_cmd))
+    sub_cmd_parsers.update(def_agent_cli_parser(sub_cmd))
     system_parser = sub_cmd.add_parser(CMD_SYSTEM, help="FL system operations (status, shutdown, version, ...)")
     sub_cmd_parsers.update({CMD_SYSTEM: system_parser})
     def_system_cli_parser(system_parser)
@@ -499,13 +506,16 @@ def parse_args(prog_name: str):
         ns.cert_sub_command = sub_sub
         ns.recipe_sub_cmd = sub_sub or "list"
         ns.deploy_sub_cmd = sub_sub
+        ns.agent_sub_cmd = sub_sub
         ns.format = global_args.format
         ns.connect_timeout = global_args.connect_timeout
         ns.version = global_args.version
         return _parser, ns, sub_cmd_parsers
 
     # Patch every parser so it prints full help before exiting on error.
-    _patch_help_on_error(_parser, json_mode=global_args.format in {"json", "jsonl"})
+    _patch_help_on_error(
+        _parser, json_mode=global_args.format in {"json", "jsonl"}, jsonl_mode=global_args.format == "jsonl"
+    )
 
     args, unknown = _parser.parse_known_args(normalized_argv)
     args._raw_sub_command = args.__dict__.get("sub_command")
@@ -517,14 +527,16 @@ def parse_args(prog_name: str):
         display_unknown = _display_unknown_args(normalized_argv, cmd, args, unknown)
         msg = f"unrecognized arguments: {' '.join(display_unknown)}"
         if args.format in {"json", "jsonl"}:
-            _emit_argparse_error_json(sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}")
+            _emit_argparse_error_json(
+                sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}", jsonl_mode=args.format == "jsonl"
+            )
         else:
             _emit_argparse_error_human(sub_cmd_parser or _parser, msg, exit_code=4)
     if args.format == "jsonl":
         command_path = (getattr(args, "sub_command", None), getattr(args, "job_sub_cmd", None))
         if command_path not in _JSONL_COMMANDS:
             detail = "--format jsonl is only supported by streaming commands: nvflare job monitor"
-            _emit_argparse_error_json(sub_cmd_parser or _parser, detail)
+            _emit_argparse_error_json(sub_cmd_parser or _parser, detail, jsonl_mode=True)
     return _parser, args, sub_cmd_parsers
 
 
@@ -543,6 +555,7 @@ handlers = {
     CMD_DEPLOY: handle_deploy_cmd,
     CMD_STUDY: handle_study_cmd,
     CMD_SYSTEM: handle_system_cmd,
+    CMD_AGENT: handle_agent_cmd,
 }
 
 

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -301,7 +301,7 @@ def _get_subcommand_choices(parser):
     return []
 
 
-def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
+def _emit_argparse_error_json(parser, message):
     from nvflare.tool.cli_output import SCHEMA_VERSION
 
     # Parser errors intentionally expose usage/choices inline because they are generated before any
@@ -311,7 +311,6 @@ def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
-        "code": "INVALID_ARGS",
         "message": message,
         "hint": "Run with --help to see usage.",
         "data": {
@@ -319,12 +318,7 @@ def _emit_argparse_error_json(parser, message, jsonl_mode: bool = False):
             "choices": _get_subcommand_choices(parser),
         },
     }
-    if jsonl_mode:
-        payload["event"] = "terminal"
-        payload["terminal"] = True
-        print(json.dumps(payload), flush=True)
-    else:
-        print(json.dumps(payload))
+    print(json.dumps(payload))
     parser.exit(4)
 
 
@@ -369,7 +363,7 @@ def _display_unknown_args(argv, cmd: str, args, unknown: list) -> list:
     return display_unknown
 
 
-def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = False):
+def _patch_help_on_error(parser, json_mode: bool = False):
     """Recursively patch every parser in the tree to print help before error-exit.
 
     When argparse detects a missing required argument it calls parser.error(),
@@ -379,7 +373,7 @@ def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = Fal
 
     def _error_with_help(message):
         if json_mode:
-            _emit_argparse_error_json(parser, message, jsonl_mode=jsonl_mode)
+            _emit_argparse_error_json(parser, message)
         else:
             _emit_argparse_error_human(parser, message, exit_code=4)
 
@@ -387,7 +381,7 @@ def _patch_help_on_error(parser, json_mode: bool = False, jsonl_mode: bool = Fal
     for action in parser._actions:
         if isinstance(action, argparse._SubParsersAction):
             for sub in action.choices.values():
-                _patch_help_on_error(sub, json_mode=json_mode, jsonl_mode=jsonl_mode)
+                _patch_help_on_error(sub, json_mode=json_mode)
 
 
 def _build_global_arg_parser():
@@ -513,9 +507,7 @@ def parse_args(prog_name: str):
         return _parser, ns, sub_cmd_parsers
 
     # Patch every parser so it prints full help before exiting on error.
-    _patch_help_on_error(
-        _parser, json_mode=global_args.format in {"json", "jsonl"}, jsonl_mode=global_args.format == "jsonl"
-    )
+    _patch_help_on_error(_parser, json_mode=global_args.format in {"json", "jsonl"})
 
     args, unknown = _parser.parse_known_args(normalized_argv)
     args._raw_sub_command = args.__dict__.get("sub_command")
@@ -527,16 +519,14 @@ def parse_args(prog_name: str):
         display_unknown = _display_unknown_args(normalized_argv, cmd, args, unknown)
         msg = f"unrecognized arguments: {' '.join(display_unknown)}"
         if args.format in {"json", "jsonl"}:
-            _emit_argparse_error_json(
-                sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}", jsonl_mode=args.format == "jsonl"
-            )
+            _emit_argparse_error_json(sub_cmd_parser or _parser, f"{prog_name} {cmd}: {msg}")
         else:
             _emit_argparse_error_human(sub_cmd_parser or _parser, msg, exit_code=4)
     if args.format == "jsonl":
         command_path = (getattr(args, "sub_command", None), getattr(args, "job_sub_cmd", None))
         if command_path not in _JSONL_COMMANDS:
             detail = "--format jsonl is only supported by streaming commands: nvflare job monitor"
-            _emit_argparse_error_json(sub_cmd_parser or _parser, detail, jsonl_mode=True)
+            _emit_argparse_error_json(sub_cmd_parser or _parser, detail)
     return _parser, args, sub_cmd_parsers
 
 

--- a/nvflare/tool/agent/__init__.py
+++ b/nvflare/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -296,7 +296,8 @@ def _handle_agent_inspect_cmd(args, handle_schema_flag, output_error_message, ou
 
 
 def _handle_agent_doctor_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
-    from nvflare.tool.agent.doctor import doctor_environment
+    from nvflare.tool.agent.doctor import doctor_environment, format_doctor_human
+    from nvflare.tool.cli_output import is_json_mode, is_jsonl_mode, print_human
 
     handle_schema_flag(
         _agent_sub_cmd_parsers[CMD_AGENT_DOCTOR],
@@ -320,6 +321,10 @@ def _handle_agent_doctor_cmd(args, handle_schema_flag, output_error_message, out
             include_data=True,
             recovery_category="ENVIRONMENT_FAILURE",
         )
+        return
+
+    if not is_json_mode() and not is_jsonl_mode():
+        print_human(format_doctor_human(data))
         return
 
     output_ok(

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -301,7 +301,8 @@ def _output_agent_skill_target_error(output_error_message, target, error: ValueE
     output_error_message(
         "AGENT_SKILL_TARGET_INVALID",
         "Invalid agent skill target.",
-        "Choose a target directory without symlink components.",
+        "Choose a target directory without symlink components. On macOS, use real paths such as /private/tmp "
+        "instead of /tmp.",
         exit_code=4,
         detail=str(error),
         data={"target": target},

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-facing CLI command group."""
+
+import argparse
+import sys
+from typing import Optional
+
+import nvflare
+from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
+
+CMD_AGENT_INFO = "info"
+
+_AGENT_OUTPUT_MODES = ["json"]
+_AGENT_EXAMPLES = [
+    "nvflare agent info --format json",
+    "nvflare agent info --schema",
+]
+_agent_parser: Optional[argparse.ArgumentParser] = None
+_agent_sub_cmd_parsers = {}
+
+
+def def_agent_cli_parser(sub_cmd) -> dict:
+    """Register the top-level `nvflare agent` command group."""
+    global _agent_parser
+
+    parser = sub_cmd.add_parser(
+        "agent",
+        description="Agent-facing NVFLARE command surface.",
+        help="Agent-facing NVFLARE helpers.",
+    )
+    parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    agent_subparser = parser.add_subparsers(title="agent subcommands", metavar="", dest="agent_sub_cmd")
+
+    info_parser = agent_subparser.add_parser(
+        CMD_AGENT_INFO,
+        description="Show the available NVFLARE agent command surface.",
+        help="show agent command surface metadata",
+    )
+    info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
+
+    _agent_parser = parser
+    return {"agent": parser}
+
+
+def _agent_info_data() -> dict:
+    return {
+        "nvflare_version": nvflare.__version__,
+        "commands": [
+            {
+                "name": "info",
+                "command": "nvflare agent info",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            }
+        ],
+    }
+
+
+def handle_agent_cmd(args) -> None:
+    from nvflare.tool.cli_output import output_error_message, output_ok
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    sub_cmd = getattr(args, "agent_sub_cmd", None)
+
+    if sub_cmd is None:
+        handle_schema_flag(
+            _agent_parser,
+            "nvflare agent",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SUBCOMMAND_REQUIRED",
+            "Agent subcommand required.",
+            "Run 'nvflare agent --help' or 'nvflare agent info --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if sub_cmd == CMD_AGENT_INFO:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_INFO],
+            "nvflare agent info",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_ok(
+            _agent_info_data(),
+            code="OK",
+            message="NVFLARE agent command surface is available.",
+            hint="Use --schema on agent-facing commands to inspect argument contracts.",
+        )
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -228,12 +228,16 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
             mutating=True,
             idempotent=True,
         )
-        plan = install_skills(
-            agent=args.agent,
-            skill_name=getattr(args, "skill", None),
-            dry_run=getattr(args, "dry_run", False),
-            target_dir=getattr(args, "target", None),
-        )
+        try:
+            plan = install_skills(
+                agent=args.agent,
+                skill_name=getattr(args, "skill", None),
+                dry_run=getattr(args, "dry_run", False),
+                target_dir=getattr(args, "target", None),
+            )
+        except ValueError as e:
+            _output_agent_skill_target_error(output_error_message, getattr(args, "target", None), e)
+            return
         if plan["missing"]:
             output_error_message(
                 "AGENT_SKILL_NOT_FOUND",
@@ -277,7 +281,11 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
             mutating=False,
             idempotent=True,
         )
-        data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        try:
+            data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        except ValueError as e:
+            _output_agent_skill_target_error(output_error_message, getattr(args, "target", None), e)
+            return
         output_ok(
             data,
             code="OK",
@@ -287,6 +295,18 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
         return
 
     raise CLIUnknownCmdException(f"unknown agent skills subcommand: {skills_sub_cmd}")
+
+
+def _output_agent_skill_target_error(output_error_message, target, error: ValueError) -> None:
+    output_error_message(
+        "AGENT_SKILL_TARGET_INVALID",
+        "Invalid agent skill target.",
+        "Choose a target directory without symlink components.",
+        exit_code=4,
+        detail=str(error),
+        data={"target": target},
+        recovery_category="FIXABLE_BY_CONFIG",
+    )
 
 
 def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -22,6 +22,8 @@ import nvflare
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
 
 CMD_AGENT_INFO = "info"
+CMD_AGENT_INSPECT = "inspect"
+CMD_AGENT_DOCTOR = "doctor"
 CMD_AGENT_SKILLS = "skills"
 CMD_AGENT_SKILLS_INSTALL = "install"
 CMD_AGENT_SKILLS_LIST = "list"
@@ -29,6 +31,9 @@ CMD_AGENT_SKILLS_LIST = "list"
 _AGENT_OUTPUT_MODES = ["json"]
 _AGENT_EXAMPLES = [
     "nvflare agent info --format json",
+    "nvflare agent inspect ./train.py --format json",
+    "nvflare agent doctor --format json",
+    "nvflare agent doctor --online --format json",
     "nvflare agent skills install --agent codex --dry-run --format json",
     "nvflare agent skills list --agent claude --format json",
     "nvflare agent info --schema",
@@ -63,6 +68,33 @@ def def_agent_cli_parser(sub_cmd) -> dict:
     info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
 
+    inspect_parser = agent_subparser.add_parser(
+        CMD_AGENT_INSPECT,
+        description="Statically inspect local code or FLARE job artifacts for agent routing.",
+        help="statically inspect local code or FLARE job artifacts",
+    )
+    inspect_parser.add_argument("path", help="local file or directory to inspect without executing user code")
+    inspect_parser.add_argument(
+        "--redact",
+        choices=["on", "off"],
+        default="on",
+        help="redact secret-like literals and sensitive absolute paths (default: on)",
+    )
+    inspect_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    doctor_parser = agent_subparser.add_parser(
+        CMD_AGENT_DOCTOR,
+        description="Check local NVFLARE agent readiness without modifying state.",
+        help="check local NVFLARE agent readiness",
+    )
+    doctor_parser.add_argument(
+        "--online",
+        action="store_true",
+        help="also run a bounded read-only status check through the selected startup kit",
+    )
+    _add_startup_kit_selection_args(doctor_parser)
+    doctor_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
     skills_parser = agent_subparser.add_parser(
         CMD_AGENT_SKILLS,
         description="Install and list NVFLARE-owned agent skills.",
@@ -90,6 +122,8 @@ def def_agent_cli_parser(sub_cmd) -> dict:
     _add_agent_target_args(list_parser)
     list_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
 
+    _agent_sub_cmd_parsers[CMD_AGENT_INSPECT] = inspect_parser
+    _agent_sub_cmd_parsers[CMD_AGENT_DOCTOR] = doctor_parser
     _agent_sub_cmd_parsers[CMD_AGENT_SKILLS] = skills_parser
     _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL] = install_parser
     _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST] = list_parser
@@ -107,6 +141,12 @@ def _add_agent_target_args(parser) -> None:
     parser.add_argument("--target", help="override the resolved agent skill directory")
 
 
+def _add_startup_kit_selection_args(parser) -> None:
+    from nvflare.tool.cli_session import add_startup_kit_selection_args
+
+    add_startup_kit_selection_args(parser)
+
+
 def _agent_info_data() -> dict:
     return {
         "nvflare_version": nvflare.__version__,
@@ -114,6 +154,20 @@ def _agent_info_data() -> dict:
             {
                 "name": "info",
                 "command": "nvflare agent info",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            },
+            {
+                "name": "inspect",
+                "command": "nvflare agent inspect",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            },
+            {
+                "name": "doctor",
+                "command": "nvflare agent doctor",
                 "status": "available",
                 "mutating": False,
                 "streaming": False,
@@ -181,11 +235,99 @@ def handle_agent_cmd(args) -> None:
         )
         return
 
+    if sub_cmd == CMD_AGENT_INSPECT:
+        _handle_agent_inspect_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
+    if sub_cmd == CMD_AGENT_DOCTOR:
+        _handle_agent_doctor_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
     if sub_cmd == CMD_AGENT_SKILLS:
         _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok)
         return
 
     raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")
+
+
+def _handle_agent_inspect_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.inspector import inspect_path
+
+    handle_schema_flag(
+        _agent_sub_cmd_parsers[CMD_AGENT_INSPECT],
+        "nvflare agent inspect",
+        _AGENT_EXAMPLES,
+        sys.argv[1:],
+        streaming=False,
+        output_modes=_AGENT_OUTPUT_MODES,
+        mutating=False,
+        idempotent=True,
+    )
+    try:
+        data = inspect_path(args.path, redact=getattr(args, "redact", "on") != "off")
+    except FileNotFoundError as e:
+        output_error_message(
+            "AGENT_INSPECT_PATH_NOT_FOUND",
+            str(e),
+            "Pass an existing local file or directory to inspect.",
+            exit_code=4,
+            include_data=True,
+            recovery_category="FIXABLE_BY_CONFIG",
+        )
+        return
+    except Exception as e:
+        output_error_message(
+            "AGENT_INSPECT_FAILED",
+            "Static inspection failed.",
+            "Check file permissions or reduce the inspected path scope.",
+            exit_code=1,
+            detail=str(e),
+            include_data=True,
+            recovery_category="ENVIRONMENT_FAILURE",
+        )
+        return
+
+    output_ok(
+        data,
+        code="OK",
+        message="NVFLARE agent inspect completed.",
+        hint="Use the framework and conversion_state fields to choose the next skill.",
+    )
+
+
+def _handle_agent_doctor_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.doctor import doctor_environment
+
+    handle_schema_flag(
+        _agent_sub_cmd_parsers[CMD_AGENT_DOCTOR],
+        "nvflare agent doctor",
+        _AGENT_EXAMPLES,
+        sys.argv[1:],
+        streaming=False,
+        output_modes=_AGENT_OUTPUT_MODES,
+        mutating=False,
+        idempotent=True,
+    )
+    try:
+        data = doctor_environment(online=getattr(args, "online", False), args=args)
+    except Exception as e:
+        output_error_message(
+            "AGENT_DOCTOR_FAILED",
+            "NVFLARE agent doctor failed.",
+            "Review local NVFLARE installation and startup-kit configuration.",
+            exit_code=1,
+            detail=str(e),
+            include_data=True,
+            recovery_category="ENVIRONMENT_FAILURE",
+        )
+        return
+
+    output_ok(
+        data,
+        code="OK",
+        message="NVFLARE agent doctor completed.",
+        hint="Resolve warning/error findings before production or online workflows.",
+    )
 
 
 def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -22,14 +22,25 @@ import nvflare
 from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
 
 CMD_AGENT_INFO = "info"
+CMD_AGENT_SKILLS = "skills"
+CMD_AGENT_SKILLS_INSTALL = "install"
+CMD_AGENT_SKILLS_LIST = "list"
 
 _AGENT_OUTPUT_MODES = ["json"]
 _AGENT_EXAMPLES = [
     "nvflare agent info --format json",
+    "nvflare agent skills install --agent codex --dry-run --format json",
+    "nvflare agent skills list --agent claude --format json",
     "nvflare agent info --schema",
+]
+_AGENT_SKILLS_EXAMPLES = [
+    "nvflare agent skills install --agent codex --dry-run --format json",
+    "nvflare agent skills install --agent claude --skill nvflare-orient --format json",
+    "nvflare agent skills list --agent codex --format json",
 ]
 _agent_parser: Optional[argparse.ArgumentParser] = None
 _agent_sub_cmd_parsers = {}
+_agent_skills_sub_cmd_parsers = {}
 
 
 def def_agent_cli_parser(sub_cmd) -> dict:
@@ -52,8 +63,44 @@ def def_agent_cli_parser(sub_cmd) -> dict:
     info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
     _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
 
+    skills_parser = agent_subparser.add_parser(
+        CMD_AGENT_SKILLS,
+        description="Install and list NVFLARE-owned agent skills.",
+        help="install and list NVFLARE-owned agent skills",
+    )
+    skills_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    skills_subparser = skills_parser.add_subparsers(
+        title="agent skills subcommands", metavar="", dest="agent_skills_sub_cmd"
+    )
+    install_parser = skills_subparser.add_parser(
+        CMD_AGENT_SKILLS_INSTALL,
+        description="Install NVFLARE-owned skills into a local agent skill directory.",
+        help="install NVFLARE-owned skills",
+    )
+    _add_agent_target_args(install_parser)
+    install_parser.add_argument("--skill", help="install one skill by name; omit to install all available skills")
+    install_parser.add_argument("--dry-run", action="store_true", help="show the install plan without copying files")
+    install_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    list_parser = skills_subparser.add_parser(
+        CMD_AGENT_SKILLS_LIST,
+        description="List available and installed NVFLARE-owned skills for an agent target.",
+        help="list NVFLARE-owned skills",
+    )
+    _add_agent_target_args(list_parser)
+    list_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    _agent_sub_cmd_parsers[CMD_AGENT_SKILLS] = skills_parser
+    _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL] = install_parser
+    _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST] = list_parser
+
     _agent_parser = parser
     return {"agent": parser}
+
+
+def _add_agent_target_args(parser) -> None:
+    parser.add_argument("--agent", choices=["codex", "claude"], required=True, help="agent skill target to manage")
+    parser.add_argument("--target", help="override the resolved agent skill directory")
 
 
 def _agent_info_data() -> dict:
@@ -66,7 +113,21 @@ def _agent_info_data() -> dict:
                 "status": "available",
                 "mutating": False,
                 "streaming": False,
-            }
+            },
+            {
+                "name": "skills install",
+                "command": "nvflare agent skills install",
+                "status": "available",
+                "mutating": True,
+                "streaming": False,
+            },
+            {
+                "name": "skills list",
+                "command": "nvflare agent skills list",
+                "status": "available",
+                "mutating": False,
+                "streaming": False,
+            },
         ],
     }
 
@@ -116,4 +177,111 @@ def handle_agent_cmd(args) -> None:
         )
         return
 
+    if sub_cmd == CMD_AGENT_SKILLS:
+        _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
     raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")
+
+
+def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.skill_manager import SUPPORTED_AGENT_TARGETS, install_skills, list_skills
+
+    skills_sub_cmd = getattr(args, "agent_skills_sub_cmd", None)
+    schema_sub_cmd = _schema_agent_skills_sub_cmd(getattr(args, "_argv", sys.argv[1:]))
+
+    if skills_sub_cmd is None and schema_sub_cmd in _agent_skills_sub_cmd_parsers:
+        skills_sub_cmd = schema_sub_cmd
+
+    if skills_sub_cmd is None:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_SKILLS],
+            "nvflare agent skills",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SKILLS_SUBCOMMAND_REQUIRED",
+            "Agent skills subcommand required.",
+            "Run 'nvflare agent skills --help' or 'nvflare agent skills list --agent codex --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if skills_sub_cmd == CMD_AGENT_SKILLS_INSTALL:
+        handle_schema_flag(
+            _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL],
+            "nvflare agent skills install",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=True,
+            idempotent=True,
+        )
+        plan = install_skills(
+            agent=args.agent,
+            skill_name=getattr(args, "skill", None),
+            dry_run=getattr(args, "dry_run", False),
+            target_dir=getattr(args, "target", None),
+        )
+        if plan["missing"]:
+            output_error_message(
+                "AGENT_SKILL_NOT_FOUND",
+                f"NVFLARE skill not found: {', '.join(plan['missing'])}.",
+                "Run 'nvflare agent skills list --agent <codex|claude> --format json' to inspect available skills.",
+                exit_code=4,
+                data=plan,
+                recovery_category="FIXABLE_BY_CONFIG",
+            )
+            return
+        output_ok(
+            plan,
+            code="OK",
+            message=(
+                "NVFLARE agent skills install plan completed."
+                if plan["applied"]
+                else "NVFLARE agent skills install dry run completed."
+            ),
+            hint="Review conflicts before relying on skipped skills." if plan["conflicts"] else "",
+        )
+        return
+
+    if skills_sub_cmd == CMD_AGENT_SKILLS_LIST:
+        handle_schema_flag(
+            _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST],
+            "nvflare agent skills list",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        output_ok(
+            data,
+            code="OK",
+            message="NVFLARE agent skills listed.",
+            hint=f"Supported agent targets: {', '.join(SUPPORTED_AGENT_TARGETS)}.",
+        )
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent skills subcommand: {skills_sub_cmd}")
+
+
+def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:
+    if "--schema" not in argv or CMD_AGENT_SKILLS not in argv:
+        return None
+    index = argv.index(CMD_AGENT_SKILLS) + 1
+    while index < len(argv):
+        token = argv[index]
+        if token in _agent_skills_sub_cmd_parsers:
+            return token
+        index += 1
+    return None

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -99,7 +99,11 @@ def def_agent_cli_parser(sub_cmd) -> dict:
 
 
 def _add_agent_target_args(parser) -> None:
-    parser.add_argument("--agent", choices=["codex", "claude"], required=True, help="agent skill target to manage")
+    from nvflare.tool.agent.skill_manager import SUPPORTED_AGENT_TARGETS
+
+    parser.add_argument(
+        "--agent", choices=list(SUPPORTED_AGENT_TARGETS), required=True, help="agent skill target to manage"
+    )
     parser.add_argument("--target", help="override the resolved agent skill directory")
 
 
@@ -240,6 +244,16 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
                 recovery_category="FIXABLE_BY_CONFIG",
             )
             return
+        if plan["errors"]:
+            output_error_message(
+                "AGENT_SKILL_INSTALL_FAILED",
+                "One or more NVFLARE skills failed to install.",
+                "Review data.errors and rerun the install after fixing the reported filesystem issue.",
+                exit_code=1,
+                data=plan,
+                recovery_category="FIXABLE_BY_ENV",
+            )
+            return
         output_ok(
             plan,
             code="OK",
@@ -276,6 +290,8 @@ def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, out
 
 
 def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:
+    # The top-level CLI bypasses nested argparse parsing for --schema, so infer
+    # the third-level agent skills command from argv until that parser path is generalized.
     if "--schema" not in argv or CMD_AGENT_SKILLS not in argv:
         return None
     index = argv.index(CMD_AGENT_SKILLS) + 1

--- a/nvflare/tool/agent/bundled_skills/__init__.py
+++ b/nvflare/tool/agent/bundled_skills/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bundled NVFLARE-owned agent skills and manifest."""

--- a/nvflare/tool/agent/bundled_skills/manifest.json
+++ b/nvflare/tool/agent/bundled_skills/manifest.json
@@ -1,0 +1,7 @@
+{
+  "findings": [],
+  "nvflare_version": "",
+  "schema_version": "1",
+  "skills": [],
+  "source_type": "wheel"
+}

--- a/nvflare/tool/agent/doctor.py
+++ b/nvflare/tool/agent/doctor.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-only agent environment readiness checks."""
+
+import importlib.util
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import nvflare
+from nvflare.tool.agent.skill_manager import find_skill_source
+
+OPTIONAL_DEPENDENCIES = ("torch", "tensorflow", "sklearn", "xgboost", "jax", "flwr")
+
+
+def doctor_environment(*, online: bool = False, args=None) -> dict:
+    """Return a read-only local readiness snapshot, optionally with a bounded online check."""
+    data = {
+        "schema_version": "1",
+        "timestamp": _now_utc(),
+        "nvflare": {"import_ok": True, "version": nvflare.__version__},
+        "commands": _command_registry(),
+        "startup_kits": _startup_kit_summary(),
+        "optional_dependencies": _optional_dependency_summary(),
+        "skills": _skills_summary(),
+        "poc": _poc_summary(),
+        "online": {"enabled": False, "status": "not_requested"},
+        "findings": [],
+    }
+    data["findings"].extend(data["startup_kits"].get("findings", []))
+    data["findings"].extend(data["skills"].get("findings", []))
+    data["findings"].extend(data["poc"].get("findings", []))
+
+    if online:
+        data["online"] = _online_summary(args)
+        data["findings"].extend(data["online"].get("findings", []))
+
+    data["status"] = "attention" if data["findings"] else "ok"
+    return data
+
+
+def _command_registry() -> dict:
+    commands = [
+        {"command": "nvflare agent info", "mutating": False, "streaming": False},
+        {"command": "nvflare agent inspect", "mutating": False, "streaming": False},
+        {"command": "nvflare agent doctor", "mutating": False, "streaming": False},
+        {"command": "nvflare agent skills install", "mutating": True, "streaming": False},
+        {"command": "nvflare agent skills list", "mutating": False, "streaming": False},
+    ]
+    return {"status": "ok", "commands": commands}
+
+
+def _startup_kit_summary() -> dict:
+    from nvflare.tool.kit.kit_config import (
+        StartupKitConfigError,
+        get_active_startup_kit_id,
+        get_cli_config_path,
+        get_startup_kit_entries,
+        get_startup_kit_status,
+        load_cli_config,
+    )
+
+    config_file = str(get_cli_config_path())
+    try:
+        config = load_cli_config()
+        active = get_active_startup_kit_id(config)
+        entries = get_startup_kit_entries(config)
+    except StartupKitConfigError as e:
+        return {
+            "config_file": config_file,
+            "active_id": None,
+            "entries": [],
+            "findings": [_finding("STARTUP_KIT_CONFIG_INVALID", "error", str(e), getattr(e, "hint", None))],
+        }
+
+    findings = []
+    if not active:
+        findings.append(
+            _finding(
+                "STARTUP_KIT_NOT_CONFIGURED",
+                "warning",
+                "No active startup kit is configured.",
+                "Run nvflare config list and nvflare config use <id>, or pass --startup-kit for online checks.",
+            )
+        )
+
+    entry_rows = []
+    for kit_id, path in sorted(entries.items()):
+        status, normalized_path, metadata = get_startup_kit_status(path)
+        entry_rows.append(
+            {
+                "id": kit_id,
+                "path": path,
+                "normalized_path": normalized_path,
+                "active": kit_id == active,
+                "status": status,
+                "metadata": metadata,
+            }
+        )
+        for finding in metadata.get("findings", []):
+            finding = dict(finding)
+            finding["startup_kit_id"] = kit_id
+            findings.append(finding)
+
+    return {
+        "config_file": config_file,
+        "active_id": active,
+        "entries": entry_rows,
+        "findings": findings,
+    }
+
+
+def _optional_dependency_summary() -> list[dict]:
+    return [{"name": name, "available": importlib.util.find_spec(name) is not None} for name in OPTIONAL_DEPENDENCIES]
+
+
+def _skills_summary() -> dict:
+    try:
+        source = find_skill_source()
+    except Exception as e:
+        return {
+            "status": "error",
+            "source": None,
+            "available_count": 0,
+            "findings": [_finding("AGENT_SKILL_SOURCE_UNAVAILABLE", "error", str(e))],
+        }
+
+    manifest = source.manifest or {}
+    return {
+        "status": "ok",
+        "source": {
+            "type": source.source_type,
+            "root": str(source.root),
+            "manifest_schema_version": manifest.get("schema_version"),
+            "nvflare_version": manifest.get("nvflare_version"),
+        },
+        "available_count": len(manifest.get("skills", [])),
+        "available": manifest.get("skills", []),
+        "findings": manifest.get("findings", []),
+    }
+
+
+def _poc_summary() -> dict:
+    from nvflare.tool.poc.poc_commands import DEFAULT_WORKSPACE
+
+    workspace = os.getenv("NVFLARE_POC_WORKSPACE") or _configured_poc_workspace() or DEFAULT_WORKSPACE
+    workspace_path = Path(workspace).expanduser()
+    findings = []
+    status = "present" if workspace_path.exists() else "missing"
+    if status == "missing":
+        findings.append(
+            _finding(
+                "POC_WORKSPACE_MISSING",
+                "info",
+                f"POC workspace does not exist: {workspace}",
+                "Run nvflare poc prepare when local POC execution is needed.",
+            )
+        )
+    return {
+        "workspace": str(workspace_path),
+        "status": status,
+        "startup_dir_exists": (workspace_path / "startup").is_dir(),
+        "local_dir_exists": (workspace_path / "local").is_dir(),
+        "findings": findings,
+    }
+
+
+def _configured_poc_workspace() -> str | None:
+    from nvflare.tool.kit.kit_config import get_cli_config_path
+
+    try:
+        from pyhocon import ConfigFactory as CF
+    except ImportError:
+        return None
+
+    config_path = get_cli_config_path()
+    if not config_path.is_file():
+        return None
+    try:
+        config = CF.parse_file(str(config_path))
+    except Exception:
+        return None
+    return config.get("poc.workspace", None) or config.get("poc_workspace.path", None)
+
+
+def _online_summary(args) -> dict:
+    from nvflare.fuel.flare_api.api_spec import AuthenticationError, NoConnection
+    from nvflare.tool.cli_output import get_connect_timeout
+    from nvflare.tool.cli_session import new_cli_session_for_args, resolve_startup_kit_info_for_args
+    from nvflare.tool.kit.kit_config import StartupKitConfigError
+
+    try:
+        startup_kit = resolve_startup_kit_info_for_args(args)
+    except StartupKitConfigError as e:
+        return {
+            "enabled": True,
+            "status": "skipped",
+            "startup_kit": None,
+            "recommended_ttl_seconds": 0,
+            "findings": [_finding("STARTUP_KIT_NOT_READY", "warning", str(e), getattr(e, "hint", None))],
+        }
+
+    read_only_finding = _online_read_only_preflight(startup_kit)
+    if read_only_finding:
+        return {
+            "enabled": True,
+            "status": "skipped",
+            "startup_kit": startup_kit,
+            "recommended_ttl_seconds": 0,
+            "findings": [read_only_finding],
+        }
+
+    session = None
+    try:
+        session = new_cli_session_for_args(args=args, timeout=get_connect_timeout())
+        status = session.check_status("all", None)
+        return {
+            "enabled": True,
+            "status": "ok",
+            "startup_kit": startup_kit,
+            "server_status": status.get("server_status"),
+            "server_start_time": status.get("server_start_time"),
+            "clients": status.get("clients", []),
+            "client_status": status.get("client_status", []),
+            "jobs": status.get("jobs", []),
+            "recommended_ttl_seconds": 30,
+            "findings": [],
+        }
+    except AuthenticationError as e:
+        return _online_error("AUTHENTICATION_FAILED", "authentication_failed", str(e), startup_kit)
+    except NoConnection as e:
+        return _online_error("CONNECTION_FAILED", "connection_failed", str(e), startup_kit)
+    except Exception as e:
+        return _online_error("ONLINE_CHECK_FAILED", "error", str(e), startup_kit)
+    finally:
+        if session is not None:
+            session.close()
+
+
+def _online_error(code: str, status: str, message: str, startup_kit: dict) -> dict:
+    return {
+        "enabled": True,
+        "status": status,
+        "startup_kit": startup_kit,
+        "recommended_ttl_seconds": 0,
+        "findings": [_finding(code, "warning", message)],
+    }
+
+
+def _online_read_only_preflight(startup_kit: dict) -> dict | None:
+    """Skip online checks when the existing session API would create local directories."""
+    kit_path = Path(startup_kit["path"])
+    admin_config_path = kit_path / "startup" / "fed_admin.json"
+    try:
+        config = json.loads(admin_config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return _finding(
+            "ONLINE_CHECK_ADMIN_CONFIG_UNREADABLE",
+            "warning",
+            "Online check skipped because fed_admin.json could not be read without side effects.",
+        )
+
+    admin = config.get("admin") if isinstance(config, dict) else None
+    download_dir = admin.get("download_dir") if isinstance(admin, dict) else None
+    if not download_dir:
+        return _finding(
+            "ONLINE_CHECK_REQUIRES_DOWNLOAD_DIR",
+            "warning",
+            "Online check skipped because the active admin config has no pre-existing download_dir.",
+            "Create the startup kit transfer directory or use nvflare system status for the normal CLI path.",
+        )
+
+    download_path = Path(download_dir)
+    if not download_path.is_absolute():
+        download_path = kit_path / download_path
+    if not download_path.is_dir():
+        return _finding(
+            "ONLINE_CHECK_WOULD_CREATE_DOWNLOAD_DIR",
+            "warning",
+            "Online check skipped because the normal session path would create download_dir.",
+            "Create the configured download_dir first or use nvflare system status for the normal CLI path.",
+        )
+    return None
+
+
+def _finding(code: str, severity: str, message: str, hint: str = None) -> dict:
+    result = {"code": code, "severity": severity, "message": message}
+    if hint:
+        result["hint"] = hint
+    return result
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/nvflare/tool/agent/doctor.py
+++ b/nvflare/tool/agent/doctor.py
@@ -260,6 +260,86 @@ def _online_error(code: str, status: str, message: str, startup_kit: dict) -> di
     }
 
 
+def format_doctor_human(data: dict) -> str:
+    """Render a concise human-readable doctor summary."""
+    lines = ["NVFLARE Agent Doctor", f"status: {data.get('status', 'unknown')}", ""]
+
+    nvflare_info = data.get("nvflare") or {}
+    nvflare_status = "import ok" if nvflare_info.get("import_ok") else "import failed"
+    lines.append(f"nvflare: {nvflare_info.get('version', 'unknown')} ({nvflare_status})")
+
+    commands = data.get("commands") or {}
+    lines.append(f"commands: {commands.get('status', 'unknown')} ({len(commands.get('commands', []))} registered)")
+
+    startup_kits = data.get("startup_kits") or {}
+    startup_entries = startup_kits.get("entries", [])
+    valid_startup_count = sum(1 for entry in startup_entries if entry.get("status") == "valid")
+    active_id = startup_kits.get("active_id") or "none"
+    lines.append(f"startup kits: {valid_startup_count}/{len(startup_entries)} valid (active: {active_id})")
+
+    skills = data.get("skills") or {}
+    source = skills.get("source")
+    if source:
+        lines.append(
+            f"skills: {skills.get('available_count', 0)} available "
+            f"({source.get('type', 'unknown')}: {source.get('root', 'unknown')})"
+        )
+    else:
+        lines.append(f"skills: {skills.get('status', 'unknown')}")
+
+    optional_dependencies = data.get("optional_dependencies", [])
+    available_deps = [dep["name"] for dep in optional_dependencies if dep.get("available")]
+    missing_deps = [dep["name"] for dep in optional_dependencies if not dep.get("available")]
+    lines.append(f"optional dependencies: available {_join_names(available_deps)}; missing {_join_names(missing_deps)}")
+
+    poc = data.get("poc") or {}
+    lines.append(f"poc: {poc.get('status', 'unknown')} (workspace: {poc.get('workspace', 'unknown')})")
+
+    online = data.get("online") or {}
+    if online.get("enabled"):
+        online_line = f"online: {online.get('status', 'unknown')}"
+        first_online_finding = _first_finding(online.get("findings", []))
+        if first_online_finding:
+            online_line += f" ({first_online_finding})"
+        lines.append(online_line)
+    else:
+        lines.append(f"online: {online.get('status', 'not_requested')}")
+
+    findings = data.get("findings", [])
+    if findings:
+        lines.append("")
+        lines.append(f"findings ({len(findings)}):")
+        for finding in findings:
+            lines.extend(_format_finding(finding))
+    else:
+        lines.append("")
+        lines.append("findings: none")
+
+    return "\n".join(lines)
+
+
+def _join_names(names: list[str]) -> str:
+    return ", ".join(names) if names else "none"
+
+
+def _first_finding(findings: list[dict]) -> str | None:
+    if not findings:
+        return None
+    finding = findings[0]
+    return f"{finding.get('severity', 'info')} {finding.get('code', 'UNKNOWN')}"
+
+
+def _format_finding(finding: dict) -> list[str]:
+    severity = finding.get("severity", "info")
+    code = finding.get("code", "UNKNOWN")
+    message = str(finding.get("message", "")).splitlines() or [""]
+    lines = [f"- {severity} {code}: {message[0]}"]
+    lines.extend(f"  {line}" for line in message[1:])
+    if finding.get("hint"):
+        lines.append(f"  hint: {finding['hint']}")
+    return lines
+
+
 def _online_read_only_preflight(startup_kit: dict) -> dict | None:
     """Skip online checks when the existing session API would create local directories."""
     kit_path = Path(startup_kit["path"])

--- a/nvflare/tool/agent/inspector.py
+++ b/nvflare/tool/agent/inspector.py
@@ -1,0 +1,566 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static read-only inspection for agent workflows."""
+
+import ast
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import nvflare
+
+DEFAULT_MAX_FILES = 250
+DEFAULT_MAX_FILE_BYTES = 512 * 1024
+MAX_EVIDENCE_PER_BUCKET = 12
+
+PYTHON_SUFFIXES = {".py"}
+SKIPPED_DIR_NAMES = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "env",
+    "node_modules",
+    "venv",
+}
+SENSITIVE_FILE_SUFFIXES = {".key", ".pem", ".p12", ".pfx"}
+SENSITIVE_FILE_NAMES = {"id_rsa", "id_dsa", "id_ecdsa", "id_ed25519"}
+SECRET_NAME_PATTERN = re.compile(r"(api[_-]?key|secret|token|password|passwd|credential|access[_-]?key)", re.I)
+
+FRAMEWORK_IMPORTS = {
+    "torch": "pytorch",
+    "torchvision": "pytorch",
+    "torchaudio": "pytorch",
+    "pytorch_lightning": "pytorch_lightning",
+    "lightning": "pytorch_lightning",
+    "tensorflow": "tensorflow",
+    "keras": "tensorflow",
+    "xgboost": "xgboost",
+    "sklearn": "sklearn",
+    "jax": "jax",
+    "flax": "jax",
+    "optax": "jax",
+    "numpy": "numpy",
+}
+FRAMEWORK_SKILLS = {
+    "pytorch": "nvflare-convert-pytorch",
+    "pytorch_lightning": "nvflare-convert-lightning",
+    "tensorflow": "nvflare-convert-tensorflow",
+    "xgboost": "nvflare-convert-xgboost",
+    "sklearn": "nvflare-convert-sklearn",
+    "jax": "nvflare-convert-jax",
+    "numpy": "nvflare-convert-numpy",
+}
+
+
+@dataclass
+class InspectState:
+    root: Path
+    redact: bool
+    files_considered: int = 0
+    files_scanned: int = 0
+    bytes_scanned: int = 0
+    files_skipped_count: int = 0
+    files_skipped: list[dict] = field(default_factory=list)
+    findings: list[dict] = field(default_factory=list)
+    framework_evidence: dict[str, list[dict]] = field(default_factory=dict)
+    flare_imports: list[dict] = field(default_factory=list)
+    flare_calls: set[str] = field(default_factory=set)
+    entry_points: list[dict] = field(default_factory=list)
+    job_py: Optional[str] = None
+    sim_env_used: bool = False
+    export_support: bool = False
+    exported_job_markers: list[str] = field(default_factory=list)
+    distributed_patterns: list[dict] = field(default_factory=list)
+    dynamic_patterns: list[dict] = field(default_factory=list)
+    absolute_path_findings: list[dict] = field(default_factory=list)
+
+
+def inspect_path(
+    path: Path | str,
+    *,
+    redact: bool = True,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+) -> dict:
+    """Inspect a path without importing or executing user code."""
+    target = Path(path).expanduser()
+    state = InspectState(root=target, redact=redact)
+
+    if not target.exists():
+        raise FileNotFoundError(f"inspect path does not exist: {path}")
+
+    if target.is_symlink():
+        _record_symlink_skip(target, state)
+    elif target.is_file():
+        _inspect_file(target, state, max_file_bytes)
+    else:
+        _inspect_dir(target, state, max_files=max_files, max_file_bytes=max_file_bytes)
+
+    frameworks = _rank_frameworks(state)
+    detected_framework = frameworks[0]["name"] if frameworks else None
+    conversion_state = _conversion_state(state, detected_framework)
+    target_type = _target_type(target, state, detected_framework, conversion_state)
+
+    return {
+        "schema_version": "1",
+        "nvflare_version": nvflare.__version__,
+        "path": _display_path(target, target, redact=False),
+        "target_type": target_type,
+        "static_only": True,
+        "redaction": "on" if redact else "off",
+        "limits": {
+            "max_files": max_files,
+            "max_file_bytes": max_file_bytes,
+            "max_evidence_per_bucket": MAX_EVIDENCE_PER_BUCKET,
+        },
+        "scan": {
+            "files_considered": state.files_considered,
+            "files_scanned": state.files_scanned,
+            "bytes_scanned": state.bytes_scanned,
+            "files_skipped_count": state.files_skipped_count,
+            "files_skipped_truncated": state.files_skipped_count > len(state.files_skipped),
+            "files_skipped": state.files_skipped,
+        },
+        "frameworks": frameworks,
+        "entry_points": state.entry_points[:MAX_EVIDENCE_PER_BUCKET],
+        "flare_integration": {
+            "present": bool(state.flare_imports or state.flare_calls),
+            "imports": state.flare_imports[:MAX_EVIDENCE_PER_BUCKET],
+            "calls": sorted(state.flare_calls),
+        },
+        "conversion_state": conversion_state,
+        "job": {
+            "job_py": state.job_py,
+            "sim_env_used": state.sim_env_used,
+            "export_support": state.export_support,
+            "exported_job_markers": state.exported_job_markers[:MAX_EVIDENCE_PER_BUCKET],
+        },
+        "patterns": {
+            "distributed": state.distributed_patterns[:MAX_EVIDENCE_PER_BUCKET],
+            "dynamic": state.dynamic_patterns[:MAX_EVIDENCE_PER_BUCKET],
+            "absolute_data_paths": state.absolute_path_findings[:MAX_EVIDENCE_PER_BUCKET],
+        },
+        "findings": state.findings[:MAX_EVIDENCE_PER_BUCKET],
+        "skill_selection": _skill_selection(detected_framework, conversion_state, state),
+        "recommended_next_commands": _recommended_next_commands(detected_framework, conversion_state, state),
+    }
+
+
+def _inspect_dir(root: Path, state: InspectState, *, max_files: int, max_file_bytes: int) -> None:
+    stack = [root]
+    while stack:
+        directory = stack.pop()
+        try:
+            children = sorted(directory.iterdir(), key=lambda p: p.name)
+        except OSError as e:
+            _add_skip(state, _skip_entry(directory, state, "UNREADABLE_DIRECTORY", "could not read directory", e))
+            continue
+
+        for child in children:
+            if child.is_symlink():
+                _record_symlink_skip(child, state)
+                continue
+            if child.is_dir():
+                if _should_skip_dir(child, root):
+                    _add_skip(state, _skip_entry(child, state, "DIRECTORY_SKIPPED", "directory skipped"))
+                    continue
+                stack.append(child)
+                continue
+            if not child.is_file():
+                continue
+            if state.files_considered >= max_files:
+                _add_skip(state, _skip_entry(child, state, "FILE_LIMIT_REACHED", "file scan limit reached"))
+                return
+            _inspect_file(child, state, max_file_bytes)
+
+
+def _inspect_file(path: Path, state: InspectState, max_file_bytes: int) -> None:
+    state.files_considered += 1
+    rel_path = _display_path(path, state.root, state.redact)
+    if _is_sensitive_file(path):
+        _add_skip(state, _skip_entry(path, state, "SENSITIVE_FILE_SKIPPED", "sensitive file skipped"))
+        return
+    if _is_exported_job_marker(path):
+        state.exported_job_markers.append(rel_path)
+    if path.suffix not in PYTHON_SUFFIXES:
+        return
+
+    try:
+        size = path.stat().st_size
+    except OSError as e:
+        _add_skip(state, _skip_entry(path, state, "UNREADABLE_FILE", "could not stat file", e))
+        return
+    if size > max_file_bytes:
+        _add_skip(state, _skip_entry(path, state, "FILE_TOO_LARGE", "file exceeds static inspection cap"))
+        return
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        _add_skip(state, _skip_entry(path, state, "NON_UTF8_FILE", "file is not UTF-8 text"))
+        return
+    except OSError as e:
+        _add_skip(state, _skip_entry(path, state, "UNREADABLE_FILE", "could not read file", e))
+        return
+
+    state.files_scanned += 1
+    state.bytes_scanned += size
+    if path.name == "job.py":
+        state.job_py = rel_path
+
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError as e:
+        state.findings.append(
+            {
+                "code": "PYTHON_PARSE_ERROR",
+                "severity": "warning",
+                "file": rel_path,
+                "line": e.lineno,
+                "message": "Python file could not be parsed statically.",
+            }
+        )
+        return
+
+    visitor = _PythonInspector(path, rel_path, state)
+    visitor.visit(tree)
+    _add_entry_point(path, rel_path, tree, state)
+
+
+class _PythonInspector(ast.NodeVisitor):
+    def __init__(self, path: Path, rel_path: str, state: InspectState):
+        self.path = path
+        self.rel_path = rel_path
+        self.state = state
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._record_import(alias.name, node.lineno)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        self._record_import(module, node.lineno)
+        for alias in node.names:
+            if alias.name in {"FedJob", "FLModel", "SimEnv"}:
+                self.state.flare_imports.append(
+                    _evidence(self.rel_path, node.lineno, "from_import", f"{module}.{alias.name}")
+                )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_name = _call_name(node.func)
+        if call_name:
+            self._record_call(call_name, node.lineno)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self._inspect_secret_assignment(node.targets, node.value, getattr(node, "lineno", None))
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._inspect_secret_assignment([node.target], node.value, getattr(node, "lineno", None))
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str):
+            self._inspect_string_literal(node.value, getattr(node, "lineno", None))
+        self.generic_visit(node)
+
+    def _record_import(self, module: str, lineno: int) -> None:
+        if not module:
+            return
+        framework = _framework_for_import(module)
+        if framework:
+            _append_capped(
+                self.state.framework_evidence,
+                framework,
+                _evidence(self.rel_path, lineno, "import", module),
+            )
+        if module == "nvflare" or module.startswith("nvflare."):
+            self.state.flare_imports.append(_evidence(self.rel_path, lineno, "import", module))
+        if module in {"hydra", "omegaconf"} or module.startswith(("hydra.", "omegaconf.")):
+            self.state.dynamic_patterns.append(_evidence(self.rel_path, lineno, "dynamic_config", module))
+        if module == "torch.distributed" or module.startswith("torch.distributed."):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "distributed_import", module))
+        if module == "accelerate" or module.startswith("accelerate."):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "accelerate_import", module))
+
+    def _record_call(self, call_name: str, lineno: int) -> None:
+        if call_name.startswith("flare.") or call_name.startswith("nvflare."):
+            self.state.flare_calls.add(call_name)
+        if call_name in {"FedJob", "FLModel", "SimEnv"}:
+            self.state.flare_calls.add(call_name)
+        if call_name == "SimEnv" or call_name.endswith(".SimEnv"):
+            self.state.sim_env_used = True
+        if call_name.endswith(".export"):
+            self.state.export_support = True
+        if call_name in {"importlib.import_module", "__import__", "getattr"}:
+            self.state.dynamic_patterns.append(_evidence(self.rel_path, lineno, "dynamic_dispatch", call_name))
+        if call_name in {"torch.compile", "compile"}:
+            self.state.dynamic_patterns.append(_evidence(self.rel_path, lineno, "torch_compile", call_name))
+        if call_name.endswith("DistributedDataParallel") or call_name.endswith("DataParallel"):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "distributed_call", call_name))
+        if call_name.endswith("FSDP") or call_name.endswith("Accelerator"):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "distributed_call", call_name))
+
+    def _inspect_secret_assignment(self, targets: list[ast.AST], value: ast.AST, lineno: Optional[int]) -> None:
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            return
+        for target in targets:
+            name = _target_name(target)
+            if name and SECRET_NAME_PATTERN.search(name):
+                self.state.findings.append(
+                    {
+                        "code": "SECRET_LITERAL_REDACTED",
+                        "severity": "warning",
+                        "file": self.rel_path,
+                        "line": lineno,
+                        "name": name,
+                        "value": "<REDACTED>" if self.state.redact else value.value,
+                    }
+                )
+
+    def _inspect_string_literal(self, value: str, lineno: Optional[int]) -> None:
+        if _looks_like_absolute_path(value):
+            self.state.absolute_path_findings.append(
+                {
+                    "code": "ABSOLUTE_DATA_PATH",
+                    "severity": "warning",
+                    "file": self.rel_path,
+                    "line": lineno,
+                    "pattern_type": "absolute_path_literal",
+                    "value": _redact_literal(value, self.state.redact),
+                }
+            )
+
+
+def _framework_for_import(module: str) -> Optional[str]:
+    parts = module.split(".")
+    if not parts:
+        return None
+    first = parts[0]
+    if first == "lightning" and len(parts) > 1 and parts[1] == "pytorch":
+        return "pytorch_lightning"
+    if first == "sklearn":
+        return "sklearn"
+    return FRAMEWORK_IMPORTS.get(first)
+
+
+def _rank_frameworks(state: InspectState) -> list[dict]:
+    total = sum(len(evidence) for evidence in state.framework_evidence.values())
+    ranked = []
+    for framework, evidence in state.framework_evidence.items():
+        count = len(evidence)
+        confidence = 0.0
+        if total:
+            confidence = min(0.99, 0.45 + (count / total) * 0.5)
+        ranked.append(
+            {
+                "name": framework,
+                "confidence": round(confidence, 2),
+                "evidence": evidence[:MAX_EVIDENCE_PER_BUCKET],
+                "contradicting_evidence": [],
+            }
+        )
+    return sorted(ranked, key=lambda item: (-item["confidence"], item["name"]))
+
+
+def _conversion_state(state: InspectState, detected_framework: Optional[str]) -> str:
+    if state.exported_job_markers:
+        return "exported_job"
+    if state.job_py or state.sim_env_used:
+        return "flare_job"
+    if {"flare.receive", "flare.send"} <= state.flare_calls or "FLModel" in state.flare_calls:
+        return "client_api_converted"
+    if state.flare_imports or state.flare_calls:
+        return "partial_client_api"
+    if detected_framework:
+        return "not_converted"
+    return "unknown"
+
+
+def _target_type(path: Path, state: InspectState, detected_framework: Optional[str], conversion_state: str) -> str:
+    if path.is_file():
+        return "single_training_script" if path.suffix == ".py" else "unknown_target"
+    if conversion_state == "exported_job":
+        return "exported_submit_ready_flare_job"
+    if conversion_state == "flare_job":
+        return "flare_job_source"
+    if detected_framework and conversion_state in {"partial_client_api", "client_api_converted"}:
+        return "mixed_workspace"
+    if detected_framework:
+        return "training_repository"
+    return "unknown_target"
+
+
+def _add_entry_point(path: Path, rel_path: str, tree: ast.Module, state: InspectState) -> None:
+    functions = [node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    main_guard = any(_is_main_guard(node) for node in tree.body if isinstance(node, ast.If))
+    likely = path.name in {"client.py", "server.py", "train.py", "trainer.py", "main.py", "job.py"} or main_guard
+    if likely or any(name in {"main", "train", "fit", "evaluate"} for name in functions):
+        state.entry_points.append(
+            {
+                "path": rel_path,
+                "kind": "python_script",
+                "functions": functions[:MAX_EVIDENCE_PER_BUCKET],
+                "main_guard": main_guard,
+            }
+        )
+
+
+def _is_main_guard(node: ast.If) -> bool:
+    left = getattr(node.test, "left", None)
+    comparators = getattr(node.test, "comparators", [])
+    if not isinstance(left, ast.Name) or left.id != "__name__" or not comparators:
+        return False
+    value = comparators[0]
+    return isinstance(value, ast.Constant) and value.value == "__main__"
+
+
+def _skill_selection(detected_framework: Optional[str], conversion_state: str, state: InspectState) -> dict:
+    recommended = []
+    if conversion_state == "exported_job":
+        recommended.append("nvflare-job-lifecycle")
+    elif detected_framework and conversion_state == "not_converted":
+        skill = FRAMEWORK_SKILLS.get(detected_framework)
+        if skill:
+            recommended.append(skill)
+    if state.findings or state.files_skipped:
+        recommended.append("nvflare-orient")
+
+    return {
+        "detected_framework": detected_framework,
+        "conversion_state": conversion_state,
+        "exported_job": conversion_state == "exported_job",
+        "recommended_skills": recommended,
+        "safety_findings": [finding["code"] for finding in state.findings[:MAX_EVIDENCE_PER_BUCKET]],
+    }
+
+
+def _recommended_next_commands(
+    detected_framework: Optional[str], conversion_state: str, state: InspectState
+) -> list[str]:
+    commands = ["nvflare agent doctor --format json"]
+    if conversion_state == "exported_job":
+        commands.append("nvflare job submit <job-folder> --format json")
+    elif state.job_py and state.export_support:
+        commands.append("python job.py --export --export-dir <job-dir>")
+    elif detected_framework and conversion_state == "not_converted":
+        commands.append("Use the matching nvflare-convert-* skill before editing.")
+    return commands
+
+
+def _record_symlink_skip(path: Path, state: InspectState) -> None:
+    try:
+        target = os.readlink(path)
+    except OSError:
+        target = ""
+    _add_skip(
+        state,
+        {
+            "code": "SYMLINK_SKIPPED",
+            "path": _display_path(path, state.root, state.redact),
+            "target": _redact_literal(target, state.redact),
+            "message": "symlink was not followed during static inspection",
+        },
+    )
+
+
+def _add_skip(state: InspectState, entry: dict) -> None:
+    state.files_skipped_count += 1
+    if len(state.files_skipped) < MAX_EVIDENCE_PER_BUCKET:
+        state.files_skipped.append(entry)
+
+
+def _skip_entry(path: Path, state: InspectState, code: str, message: str, error: Exception = None) -> dict:
+    result = {"code": code, "path": _display_path(path, state.root, state.redact), "message": message}
+    if error is not None:
+        result["error_type"] = type(error).__name__
+    return result
+
+
+def _should_skip_dir(path: Path, root: Path) -> bool:
+    if path == root:
+        return False
+    return path.name in SKIPPED_DIR_NAMES or path.name.startswith(".")
+
+
+def _is_sensitive_file(path: Path) -> bool:
+    return path.name in SENSITIVE_FILE_NAMES or path.suffix.lower() in SENSITIVE_FILE_SUFFIXES
+
+
+def _is_exported_job_marker(path: Path) -> bool:
+    return path.name in {"meta.json", "config_fed_server.json", "config_fed_client.json"}
+
+
+def _display_path(path: Path, root: Path, redact: bool) -> str:
+    base = root if root.is_dir() else root.parent
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError:
+        if redact and path.is_absolute():
+            return f"<REDACTED_PATH>/{path.name}"
+        return str(path)
+
+
+def _redact_literal(value: str, redact: bool) -> str:
+    if not redact:
+        return value
+    if _looks_like_absolute_path(value):
+        return "<REDACTED_PATH>"
+    if SECRET_NAME_PATTERN.search(value):
+        return "<REDACTED>"
+    return value
+
+
+def _looks_like_absolute_path(value: str) -> bool:
+    return value.startswith(("/", "~")) or bool(re.match(r"^[A-Za-z]:[\\/]", value))
+
+
+def _evidence(file_path: str, line: Optional[int], kind: str, value: str) -> dict:
+    return {"file": file_path, "line": line, "kind": kind, "value": value}
+
+
+def _append_capped(target: dict[str, list[dict]], key: str, value: dict) -> None:
+    bucket = target.setdefault(key, [])
+    if len(bucket) < MAX_EVIDENCE_PER_BUCKET:
+        bucket.append(value)
+
+
+def _call_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def _target_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -109,10 +109,13 @@ def install_skills(
                 _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
                 entry["status"] = "installed"
             elif entry["action"] == "replace":
-                backup_path = Path(entry["backup_path"])
-                backup_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(entry["target_path"], backup_path)
-                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                _replace_skill(
+                    source.root / entry["relative_path"],
+                    Path(entry["target_path"]),
+                    Path(entry["backup_path"]),
+                    entry,
+                    source,
+                )
                 entry["status"] = "replaced"
             else:
                 entry["status"] = "skipped"
@@ -234,24 +237,57 @@ def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: Sk
     target_dir.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
         temp_skill_dir = Path(temp_root) / target_dir.name
-        shutil.copytree(source_dir, temp_skill_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
-        manifest = {
-            "schema_version": "1",
-            "managed_by": "nvflare",
-            "name": plan_entry["name"],
-            "skill_version": plan_entry.get("skill_version"),
-            "nvflare_version": nvflare.__version__,
-            "source_type": source.source_type,
-            "source_hash": plan_entry["source_hash"],
-            "installed_paths": [str(target_dir)],
-            "installed_at": datetime.now(timezone.utc).isoformat(),
-        }
-        (temp_skill_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
+        _stage_skill(source_dir, temp_skill_dir, plan_entry, source, installed_path=target_dir)
         if target_dir.exists():
             raise FileExistsError(f"target skill directory already exists: {target_dir}")
-        shutil.move(temp_skill_dir, target_dir)
+        _publish_staged_skill(temp_skill_dir, target_dir)
+
+
+def _replace_skill(
+    source_dir: Path, target_dir: Path, backup_path: Path, plan_entry: dict, source: SkillSource
+) -> None:
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
+        temp_skill_dir = Path(temp_root) / target_dir.name
+        _stage_skill(source_dir, temp_skill_dir, plan_entry, source, installed_path=target_dir)
+        if not target_dir.exists():
+            raise FileNotFoundError(f"target skill directory no longer exists: {target_dir}")
+        if backup_path.exists():
+            raise FileExistsError(f"backup skill directory already exists: {backup_path}")
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(target_dir, backup_path)
+        try:
+            _publish_staged_skill(temp_skill_dir, target_dir)
+        except Exception:
+            if not target_dir.exists() and backup_path.exists():
+                shutil.move(backup_path, target_dir)
+            raise
+
+
+def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:
+    if target_dir.exists():
+        raise FileExistsError(f"target skill directory already exists: {target_dir}")
+    os.replace(staged_dir, target_dir)
+
+
+def _stage_skill(
+    source_dir: Path, staged_dir: Path, plan_entry: dict, source: SkillSource, *, installed_path: Path
+) -> None:
+    shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+    manifest = {
+        "schema_version": "1",
+        "managed_by": "nvflare",
+        "name": plan_entry["name"],
+        "skill_version": plan_entry.get("skill_version"),
+        "nvflare_version": nvflare.__version__,
+        "source_type": source.source_type,
+        "source_hash": plan_entry["source_hash"],
+        "installed_paths": [str(installed_path)],
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (staged_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -177,7 +177,9 @@ def _install_plan(
     planned_skills = []
     conflicts = []
     for skill in skills:
+        source_skill_dir = source.root / skill["relative_path"]
         target_skill_dir = target / skill["name"]
+        source_symlink = _first_symlink_in_tree(source_skill_dir)
         # version_delta: new, unknown external state, blocked local edit, same, or update.
         entry = {
             "name": skill["name"],
@@ -185,10 +187,21 @@ def _install_plan(
             "source_hash": skill["source_hash"],
             "relative_path": skill["relative_path"],
             "target_path": str(target_skill_dir),
-            "files": _files_to_copy(source.root / skill["relative_path"], target_skill_dir),
+            "files": [] if source_symlink else _files_to_copy(source_skill_dir, target_skill_dir),
             "version_delta": "new",
         }
-        if not target_skill_dir.exists():
+        if source_symlink:
+            entry["action"] = "skip"
+            entry["conflict"] = "source_symlink_detected"
+            entry["version_delta"] = "blocked"
+            entry["source_issue"] = {
+                "code": "source_symlink_detected",
+                "message": "source skill directory contains a symlink",
+                "source_path": str(source_skill_dir),
+                "symlink_path": str(source_symlink),
+            }
+            conflicts.append(_source_conflict(skill["name"], source_skill_dir, source_symlink))
+        elif not target_skill_dir.exists():
             entry["action"] = "copy"
         else:
             install_manifest = _read_install_manifest(target_skill_dir)
@@ -410,6 +423,16 @@ def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
         "code": code,
         "message": messages.get(code, code),
         "target_path": str(target_path),
+    }
+
+
+def _source_conflict(skill_name: str, source_path: Path, symlink_path: Path) -> dict:
+    return {
+        "skill": skill_name,
+        "code": "source_symlink_detected",
+        "message": "source skill directory contains a symlink",
+        "source_path": str(source_path),
+        "symlink_path": str(symlink_path),
     }
 
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -134,6 +134,8 @@ def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: 
     target = resolve_agent_target_dir(agent, target_dir=target_dir)
     installed = []
     conflicts = []
+    available = source.manifest.get("skills", [])
+    available_names = {skill["name"] for skill in available}
 
     if target.is_dir():
         for child in sorted(target.iterdir(), key=lambda p: p.name):
@@ -150,7 +152,7 @@ def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: 
                         "source_type": install_manifest.get("source_type"),
                     }
                 )
-            else:
+            elif child.name in available_names:
                 conflicts.append(
                     {
                         "skill": child.name,
@@ -164,7 +166,7 @@ def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: 
         "agent": agent,
         "target_path": str(target),
         "source": _source_summary(source),
-        "available": source.manifest.get("skills", []),
+        "available": available,
         "installed": installed,
         "conflicts": conflicts,
     }

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native install/list support for NVFLARE-owned agent skills."""
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import resources
+from pathlib import Path
+from typing import Optional
+
+import nvflare
+from nvflare.tool.agent.skill_manifest import (
+    IGNORED_SKILL_FILE_NAMES,
+    MANIFEST_FILE_NAME,
+    build_skill_manifest,
+    load_manifest,
+    skill_tree_hash,
+)
+
+INSTALL_MANIFEST_FILE_NAME = ".nvflare_skill_install.json"
+SUPPORTED_AGENT_TARGETS = ("codex", "claude")
+BUNDLED_SKILLS_PACKAGE = "nvflare.tool.agent.bundled_skills"
+
+
+@dataclass(frozen=True)
+class SkillSource:
+    source_type: str
+    root: Path
+    manifest: dict
+
+
+def resolve_agent_target_dir(
+    agent: str, *, target_dir: Optional[Path | str] = None, env: Optional[dict] = None
+) -> Path:
+    """Resolve a named agent target to its skill installation directory."""
+    if target_dir:
+        return Path(target_dir).expanduser()
+
+    env_map = env or os.environ
+    if agent == "codex":
+        codex_home = env_map.get("CODEX_HOME")
+        if codex_home:
+            return Path(codex_home).expanduser() / "skills"
+        return Path.home() / ".codex" / "skills"
+    if agent == "claude":
+        return Path.home() / ".claude" / "skills"
+    raise ValueError(f"unsupported agent target: {agent}")
+
+
+def find_skill_source() -> SkillSource:
+    """Find skills from an editable/source checkout first, then from the installed package bundle."""
+    source_root = Path(__file__).resolve().parents[3] / "skills"
+    if source_root.is_dir():
+        return SkillSource(
+            source_type="editable",
+            root=source_root,
+            manifest=build_skill_manifest(source_root, source_type="editable", nvflare_version=nvflare.__version__),
+        )
+
+    bundle_root = Path(str(resources.files(BUNDLED_SKILLS_PACKAGE)))
+    manifest_path = bundle_root / MANIFEST_FILE_NAME
+    manifest = (
+        load_manifest(manifest_path)
+        if manifest_path.is_file()
+        else build_skill_manifest(bundle_root, source_type="wheel")
+    )
+    return SkillSource(source_type="wheel", root=bundle_root, manifest=manifest)
+
+
+def install_skills(
+    *,
+    agent: str,
+    skill_name: Optional[str] = None,
+    dry_run: bool = False,
+    target_dir: Optional[Path | str] = None,
+    source: Optional[SkillSource] = None,
+) -> dict:
+    """Plan or apply a native NVFLARE skill installation."""
+    source = source or find_skill_source()
+    target = resolve_agent_target_dir(agent, target_dir=target_dir)
+    selected, missing = _select_skills(source.manifest, skill_name)
+    plan = _install_plan(source, selected, target, agent=agent, requested_skill=skill_name)
+    plan["missing"] = missing
+    plan["applied"] = False
+
+    if dry_run or missing:
+        return plan
+
+    target.mkdir(parents=True, exist_ok=True)
+    for entry in plan["skills"]:
+        if entry["action"] == "copy":
+            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+            entry["status"] = "installed"
+        elif entry["action"] == "replace":
+            backup_path = Path(entry["backup_path"])
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(entry["target_path"], backup_path)
+            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+            entry["status"] = "replaced"
+        else:
+            entry["status"] = "skipped"
+    plan["applied"] = True
+    return plan
+
+
+def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: Optional[SkillSource] = None) -> dict:
+    """List available packaged skills and installed managed skills for an agent target."""
+    source = source or find_skill_source()
+    target = resolve_agent_target_dir(agent, target_dir=target_dir)
+    installed = []
+    conflicts = []
+
+    if target.is_dir():
+        for child in sorted(target.iterdir(), key=lambda p: p.name):
+            if child.name.startswith(".") or not child.is_dir():
+                continue
+            install_manifest = _read_install_manifest(child)
+            if install_manifest and install_manifest.get("managed_by") == "nvflare":
+                installed.append(
+                    {
+                        "name": install_manifest.get("name", child.name),
+                        "skill_version": install_manifest.get("skill_version"),
+                        "source_hash": install_manifest.get("source_hash"),
+                        "target_path": str(child),
+                        "source_type": install_manifest.get("source_type"),
+                    }
+                )
+            else:
+                conflicts.append(
+                    {
+                        "skill": child.name,
+                        "code": "external_install_detected",
+                        "message": "target skill directory is not managed by nvflare",
+                        "target_path": str(child),
+                    }
+                )
+
+    return {
+        "agent": agent,
+        "target_path": str(target),
+        "source": _source_summary(source),
+        "available": source.manifest.get("skills", []),
+        "installed": installed,
+        "conflicts": conflicts,
+    }
+
+
+def _install_plan(
+    source: SkillSource, skills: list[dict], target: Path, *, agent: str, requested_skill: Optional[str]
+) -> dict:
+    now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    planned_skills = []
+    conflicts = []
+    for skill in skills:
+        target_skill_dir = target / skill["name"]
+        entry = {
+            "name": skill["name"],
+            "skill_version": skill.get("skill_version"),
+            "source_hash": skill["source_hash"],
+            "relative_path": skill["relative_path"],
+            "target_path": str(target_skill_dir),
+            "files": _files_to_copy(source.root / skill["relative_path"], target_skill_dir),
+            "version_delta": "new",
+        }
+        if not target_skill_dir.exists():
+            entry["action"] = "copy"
+        else:
+            install_manifest = _read_install_manifest(target_skill_dir)
+            if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+                entry["action"] = "skip"
+                entry["conflict"] = "external_install_detected"
+                entry["version_delta"] = "unknown"
+                conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
+            elif skill_tree_hash(target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}) != install_manifest.get(
+                "source_hash"
+            ):
+                entry["action"] = "skip"
+                entry["conflict"] = "local_modifications_detected"
+                entry["version_delta"] = "blocked"
+                conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
+            elif install_manifest.get("source_hash") == skill["source_hash"]:
+                entry["action"] = "skip"
+                entry["reason"] = "already_installed"
+                entry["version_delta"] = "same"
+            else:
+                backup_path = target / ".nvflare_bak" / now / skill["name"]
+                entry["action"] = "replace"
+                entry["backup_path"] = str(backup_path)
+                entry["version_delta"] = "update"
+        planned_skills.append(entry)
+
+    return {
+        "agent": agent,
+        "target_path": str(target),
+        "requested_skill": requested_skill,
+        "source": _source_summary(source),
+        "available": source.manifest.get("skills", []),
+        "skills": planned_skills,
+        "conflicts": conflicts,
+        "deprecated_skills_skipped": [],
+    }
+
+
+def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: SkillSource) -> None:
+    shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+    manifest = {
+        "schema_version": "1",
+        "managed_by": "nvflare",
+        "name": plan_entry["name"],
+        "skill_version": plan_entry.get("skill_version"),
+        "nvflare_version": nvflare.__version__,
+        "source_type": source.source_type,
+        "source_hash": plan_entry["source_hash"],
+        "installed_paths": [str(target_dir)],
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (target_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:
+    skills = manifest.get("skills", [])
+    if not skill_name:
+        return skills, []
+    selected = [skill for skill in skills if skill.get("name") == skill_name]
+    return selected, [] if selected else [skill_name]
+
+
+def _source_summary(source: SkillSource) -> dict:
+    return {
+        "type": source.source_type,
+        "root": str(source.root),
+        "nvflare_version": source.manifest.get("nvflare_version"),
+        "manifest_schema_version": source.manifest.get("schema_version"),
+        "skill_count": len(source.manifest.get("skills", [])),
+        "findings": source.manifest.get("findings", []),
+    }
+
+
+def _files_to_copy(source_dir: Path, target_dir: Path) -> list[dict]:
+    files = []
+    for file_path in sorted(source_dir.rglob("*"), key=lambda p: p.relative_to(source_dir).as_posix()):
+        if not file_path.is_file():
+            continue
+        rel_path = file_path.relative_to(source_dir)
+        if "__pycache__" in rel_path.parts or file_path.suffix in {".pyc", ".pyo"}:
+            continue
+        files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
+    return files
+
+
+def _read_install_manifest(skill_dir: Path) -> Optional[dict]:
+    manifest_path = skill_dir / INSTALL_MANIFEST_FILE_NAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
+    messages = {
+        "external_install_detected": "target skill directory is not managed by nvflare",
+        "local_modifications_detected": "managed skill content differs from its install manifest",
+    }
+    return {
+        "skill": skill_name,
+        "code": code,
+        "message": messages[code],
+        "target_path": str(target_path),
+    }

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -17,6 +17,7 @@
 import json
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib import resources
@@ -64,8 +65,8 @@ def resolve_agent_target_dir(
 
 def find_skill_source() -> SkillSource:
     """Find skills from an editable/source checkout first, then from the installed package bundle."""
-    source_root = Path(__file__).resolve().parents[3] / "skills"
-    if source_root.is_dir():
+    source_root = _source_checkout_root()
+    if source_root:
         return SkillSource(
             source_type="editable",
             root=source_root,
@@ -103,18 +104,29 @@ def install_skills(
 
     target.mkdir(parents=True, exist_ok=True)
     for entry in plan["skills"]:
-        if entry["action"] == "copy":
-            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
-            entry["status"] = "installed"
-        elif entry["action"] == "replace":
-            backup_path = Path(entry["backup_path"])
-            backup_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(entry["target_path"], backup_path)
-            _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
-            entry["status"] = "replaced"
-        else:
-            entry["status"] = "skipped"
-    plan["applied"] = True
+        try:
+            if entry["action"] == "copy":
+                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                entry["status"] = "installed"
+            elif entry["action"] == "replace":
+                backup_path = Path(entry["backup_path"])
+                backup_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(entry["target_path"], backup_path)
+                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                entry["status"] = "replaced"
+            else:
+                entry["status"] = "skipped"
+        except Exception as e:
+            error = {
+                "skill": entry["name"],
+                "code": "skill_install_failed",
+                "type": type(e).__name__,
+                "message": str(e),
+            }
+            entry["status"] = "failed"
+            entry["error"] = error
+            plan["errors"].append(error)
+    plan["applied"] = not plan["errors"]
     return plan
 
 
@@ -168,6 +180,7 @@ def _install_plan(
     conflicts = []
     for skill in skills:
         target_skill_dir = target / skill["name"]
+        # version_delta: new, unknown external state, blocked local edit, same, or update.
         entry = {
             "name": skill["name"],
             "skill_version": skill.get("skill_version"),
@@ -212,26 +225,33 @@ def _install_plan(
         "available": source.manifest.get("skills", []),
         "skills": planned_skills,
         "conflicts": conflicts,
+        "errors": [],
         "deprecated_skills_skipped": [],
     }
 
 
 def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: SkillSource) -> None:
-    shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
-    manifest = {
-        "schema_version": "1",
-        "managed_by": "nvflare",
-        "name": plan_entry["name"],
-        "skill_version": plan_entry.get("skill_version"),
-        "nvflare_version": nvflare.__version__,
-        "source_type": source.source_type,
-        "source_hash": plan_entry["source_hash"],
-        "installed_paths": [str(target_dir)],
-        "installed_at": datetime.now(timezone.utc).isoformat(),
-    }
-    (target_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
+        temp_skill_dir = Path(temp_root) / target_dir.name
+        shutil.copytree(source_dir, temp_skill_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+        manifest = {
+            "schema_version": "1",
+            "managed_by": "nvflare",
+            "name": plan_entry["name"],
+            "skill_version": plan_entry.get("skill_version"),
+            "nvflare_version": nvflare.__version__,
+            "source_type": source.source_type,
+            "source_hash": plan_entry["source_hash"],
+            "installed_paths": [str(target_dir)],
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        (temp_skill_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if target_dir.exists():
+            raise FileExistsError(f"target skill directory already exists: {target_dir}")
+        shutil.move(temp_skill_dir, target_dir)
 
 
 def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:
@@ -286,3 +306,11 @@ def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
         "message": messages[code],
         "target_path": str(target_path),
     }
+
+
+def _source_checkout_root() -> Optional[Path]:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_root = repo_root / "skills"
+    if source_root.is_dir() and (repo_root / "pyproject.toml").is_file() and (repo_root / "setup.py").is_file():
+        return source_root
+    return None

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -50,7 +50,7 @@ def resolve_agent_target_dir(
 ) -> Path:
     """Resolve a named agent target to its skill installation directory."""
     if target_dir:
-        return Path(target_dir).expanduser()
+        return _resolve_target_override(target_dir)
 
     env_map = env or os.environ
     if agent == "codex":
@@ -295,6 +295,9 @@ def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:
 def _stage_skill(
     source_dir: Path, staged_dir: Path, plan_entry: dict, source: SkillSource, *, installed_path: Path
 ) -> None:
+    symlink = _first_symlink_in_tree(source_dir)
+    if symlink:
+        raise ValueError(f"skill source must not contain symlinks: {symlink.relative_to(source_dir).as_posix()}")
     shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
     manifest = {
         "schema_version": "1",
@@ -331,15 +334,59 @@ def _source_summary(source: SkillSource) -> dict:
     }
 
 
+def _resolve_target_override(target_dir: Path | str) -> Path:
+    target = Path(target_dir).expanduser()
+    symlink = _first_symlink_component(target)
+    if symlink:
+        raise ValueError(f"agent skill target must not contain symlink components: {symlink}")
+    return target.resolve(strict=False)
+
+
+def _first_symlink_component(path: Path) -> Optional[Path]:
+    current = Path(path.anchor) if path.is_absolute() else Path.cwd()
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    for part in parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            current = current.parent
+            continue
+        current = current / part
+        if current.is_symlink():
+            return current
+    return None
+
+
+def _first_symlink_in_tree(root_dir: Path) -> Optional[Path]:
+    for root, dir_names, file_names in os.walk(root_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        for name in dir_names + file_names:
+            path = root_path / name
+            if path.is_symlink():
+                return path
+        dir_names[:] = [name for name in dir_names if not (root_path / name).is_symlink()]
+    return None
+
+
 def _files_to_copy(source_dir: Path, target_dir: Path) -> list[dict]:
     files = []
-    for file_path in sorted(source_dir.rglob("*"), key=lambda p: p.relative_to(source_dir).as_posix()):
-        if not file_path.is_file():
-            continue
-        rel_path = file_path.relative_to(source_dir)
-        if "__pycache__" in rel_path.parts or file_path.suffix in {".pyc", ".pyo"}:
-            continue
-        files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
+    for root, dir_names, file_names in os.walk(source_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        dir_names[:] = [name for name in dir_names if name != "__pycache__" and not (root_path / name).is_symlink()]
+        for file_name in file_names:
+            file_path = root_path / file_name
+            if file_path.is_symlink():
+                continue
+            if file_path.suffix in {".pyc", ".pyo"}:
+                continue
+            if not file_path.is_file():
+                continue
+            rel_path = file_path.relative_to(source_dir)
+            files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
     return files
 
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -303,7 +303,7 @@ def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
     return {
         "skill": skill_name,
         "code": code,
-        "message": messages[code],
+        "message": messages.get(code, code),
         "target_path": str(target_path),
     }
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -257,9 +257,17 @@ def _replace_skill(
             if not target_dir.exists() and backup_path.exists():
                 try:
                     shutil.move(backup_path, target_dir)
+                    _remove_empty_dir(backup_path.parent)
                 except Exception as recovery_error:
                     publish_error.recovery_error = recovery_error
             raise
+
+
+def _remove_empty_dir(path: Path) -> None:
+    try:
+        path.rmdir()
+    except OSError:
+        pass
 
 
 def _install_error(skill_name: str, error: Exception) -> dict:

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -204,28 +204,51 @@ def _install_plan(
         elif not target_skill_dir.exists():
             entry["action"] = "copy"
         else:
-            install_manifest = _read_install_manifest(target_skill_dir)
-            if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+            target_symlink = _first_symlink_in_tree(target_skill_dir)
+            if target_symlink:
                 entry["action"] = "skip"
-                entry["conflict"] = "external_install_detected"
-                entry["version_delta"] = "unknown"
-                conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
-            elif skill_tree_hash(target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}) != install_manifest.get(
-                "source_hash"
-            ):
-                entry["action"] = "skip"
-                entry["conflict"] = "local_modifications_detected"
+                entry["conflict"] = "target_symlink_detected"
                 entry["version_delta"] = "blocked"
-                conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
-            elif install_manifest.get("source_hash") == skill["source_hash"]:
-                entry["action"] = "skip"
-                entry["reason"] = "already_installed"
-                entry["version_delta"] = "same"
+                entry["target_issue"] = {
+                    "code": "target_symlink_detected",
+                    "message": "target skill directory contains a symlink",
+                    "target_path": str(target_skill_dir),
+                    "symlink_path": str(target_symlink),
+                }
+                conflicts.append(_target_symlink_conflict(skill["name"], target_skill_dir, target_symlink))
             else:
-                backup_path = target / ".nvflare_bak" / now / skill["name"]
-                entry["action"] = "replace"
-                entry["backup_path"] = str(backup_path)
-                entry["version_delta"] = "update"
+                install_manifest = _read_install_manifest(target_skill_dir)
+                if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+                    entry["action"] = "skip"
+                    entry["conflict"] = "external_install_detected"
+                    entry["version_delta"] = "unknown"
+                    conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
+                else:
+                    try:
+                        installed_source_hash = skill_tree_hash(
+                            target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}
+                        )
+                    except ValueError as e:
+                        installed_source_hash = None
+                        entry["target_issue"] = {
+                            "code": "local_modifications_detected",
+                            "message": str(e),
+                            "target_path": str(target_skill_dir),
+                        }
+                    if installed_source_hash != install_manifest.get("source_hash"):
+                        entry["action"] = "skip"
+                        entry["conflict"] = "local_modifications_detected"
+                        entry["version_delta"] = "blocked"
+                        conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
+                    elif install_manifest.get("source_hash") == skill["source_hash"]:
+                        entry["action"] = "skip"
+                        entry["reason"] = "already_installed"
+                        entry["version_delta"] = "same"
+                    else:
+                        backup_path = target / ".nvflare_bak" / now / skill["name"]
+                        entry["action"] = "replace"
+                        entry["backup_path"] = str(backup_path)
+                        entry["version_delta"] = "update"
         planned_skills.append(entry)
 
     return {
@@ -371,6 +394,8 @@ def _first_symlink_component(path: Path) -> Optional[Path]:
 
 
 def _first_symlink_in_tree(root_dir: Path) -> Optional[Path]:
+    if root_dir.is_symlink():
+        return root_dir
     for root, dir_names, file_names in os.walk(root_dir, topdown=True, followlinks=False):
         root_path = Path(root)
         dir_names.sort()
@@ -432,6 +457,16 @@ def _source_conflict(skill_name: str, source_path: Path, symlink_path: Path) -> 
         "code": "source_symlink_detected",
         "message": "source skill directory contains a symlink",
         "source_path": str(source_path),
+        "symlink_path": str(symlink_path),
+    }
+
+
+def _target_symlink_conflict(skill_name: str, target_path: Path, symlink_path: Path) -> dict:
+    return {
+        "skill": skill_name,
+        "code": "target_symlink_detected",
+        "message": "target skill directory contains a symlink",
+        "target_path": str(target_path),
         "symlink_path": str(symlink_path),
     }
 

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -120,12 +120,7 @@ def install_skills(
             else:
                 entry["status"] = "skipped"
         except Exception as e:
-            error = {
-                "skill": entry["name"],
-                "code": "skill_install_failed",
-                "type": type(e).__name__,
-                "message": str(e),
-            }
+            error = _install_error(entry["name"], e)
             entry["status"] = "failed"
             entry["error"] = error
             plan["errors"].append(error)
@@ -258,10 +253,29 @@ def _replace_skill(
         shutil.move(target_dir, backup_path)
         try:
             _publish_staged_skill(temp_skill_dir, target_dir)
-        except Exception:
+        except Exception as publish_error:
             if not target_dir.exists() and backup_path.exists():
-                shutil.move(backup_path, target_dir)
+                try:
+                    shutil.move(backup_path, target_dir)
+                except Exception as recovery_error:
+                    publish_error.recovery_error = recovery_error
             raise
+
+
+def _install_error(skill_name: str, error: Exception) -> dict:
+    result = {
+        "skill": skill_name,
+        "code": "skill_install_failed",
+        "type": type(error).__name__,
+        "message": str(error),
+    }
+    recovery_error = getattr(error, "recovery_error", None)
+    if recovery_error is not None:
+        result["recovery_error"] = {
+            "type": type(recovery_error).__name__,
+            "message": str(recovery_error),
+        }
+    return result
 
 
 def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -18,6 +18,7 @@ import hashlib
 import importlib
 import importlib.util
 import json
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -108,7 +109,9 @@ def copy_released_skills_to_bundle(
     for child in list(target_root.iterdir()):
         if child.name == "__init__.py":
             continue
-        if child.is_dir():
+        if child.is_symlink():
+            child.unlink()
+        elif child.is_dir():
             shutil.rmtree(child)
         else:
             child.unlink()
@@ -125,14 +128,34 @@ def copy_released_skills_to_bundle(
 
 
 def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
-    for path in sorted(skill_dir.rglob("*"), key=lambda p: p.relative_to(skill_dir).as_posix()):
-        if not path.is_file():
+    for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        rel_root = root_path.relative_to(skill_dir)
+        if any(part in exclude_names for part in rel_root.parts):
+            dir_names[:] = []
             continue
-        if any(part in exclude_names for part in path.relative_to(skill_dir).parts):
-            continue
-        if path.suffix in {".pyc", ".pyo"}:
-            continue
-        yield path
+
+        dir_names.sort()
+        file_names.sort()
+        for dir_name in list(dir_names):
+            dir_path = root_path / dir_name
+            if dir_path.is_symlink():
+                raise ValueError(f"skill directory contains symlink: {dir_path.relative_to(skill_dir).as_posix()}")
+            if dir_name in exclude_names:
+                dir_names.remove(dir_name)
+
+        for file_name in file_names:
+            file_path = root_path / file_name
+            rel_path = file_path.relative_to(skill_dir)
+            if file_path.is_symlink():
+                raise ValueError(f"skill directory contains symlink: {rel_path.as_posix()}")
+            if any(part in exclude_names for part in rel_path.parts):
+                continue
+            if file_path.suffix in {".pyc", ".pyo"}:
+                continue
+            if not file_path.is_file():
+                continue
+            yield file_path
 
 
 def _validate_skill_dir(skill_dir: Path):

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -15,6 +15,7 @@
 """Build and validate the manifest for NVFLARE-owned agent skills."""
 
 import hashlib
+import importlib
 import importlib.util
 import json
 import shutil
@@ -138,14 +139,25 @@ def _validate_skill_dir(skill_dir: Path):
     global _FRONTMATTER_MODULE
 
     if _FRONTMATTER_MODULE is None:
-        module_name = "nvflare_agent_skill_frontmatter"
-        module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
-        spec = importlib.util.spec_from_file_location(module_name, module_path)
-        if spec is None or spec.loader is None:
-            raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
-        _FRONTMATTER_MODULE = module
+        _FRONTMATTER_MODULE = _load_frontmatter_module()
 
     return _FRONTMATTER_MODULE.validate_skill_dir(skill_dir)
+
+
+def _load_frontmatter_module():
+    try:
+        return importlib.import_module("nvflare.tool.agent_skill_checks.frontmatter")
+    except ImportError:
+        pass
+
+    # setup.py loads this file before build isolation has all NVFLARE runtime
+    # dependencies, so fall back to loading the validator file directly.
+    module_name = "nvflare_agent_skill_frontmatter"
+    module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -128,6 +128,8 @@ def copy_released_skills_to_bundle(
 
 
 def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
+    if skill_dir.is_symlink():
+        raise ValueError("skill directory contains symlink: .")
     for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
         root_path = Path(root)
         rel_root = root_path.relative_to(skill_dir)

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build and validate the manifest for NVFLARE-owned agent skills."""
+
+import hashlib
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+MANIFEST_FILE_NAME = "manifest.json"
+MANIFEST_SCHEMA_VERSION = "1"
+IGNORED_SKILL_FILE_NAMES = {"__pycache__", "*.pyc", "*.pyo"}
+_FRONTMATTER_MODULE = None
+
+
+def skill_tree_hash(skill_dir: Path, *, exclude_names: Optional[set[str]] = None) -> str:
+    """Hash a skill directory by relative paths and file contents."""
+    excluded = {"__pycache__"}
+    if exclude_names:
+        excluded.update(exclude_names)
+    digest = hashlib.sha256()
+    for file_path in _iter_skill_files(skill_dir, exclude_names=excluded):
+        rel_path = file_path.relative_to(skill_dir).as_posix()
+        digest.update(rel_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_version: str = "") -> dict:
+    """Build the released-skill manifest for a skills source root."""
+    root = Path(skills_root)
+    skills = []
+    findings = []
+    if root.is_dir():
+        for child in sorted(root.iterdir(), key=lambda p: p.name):
+            if child.name.startswith(".") or not child.is_dir():
+                continue
+            result = _validate_skill_dir(child)
+            if not result.ok:
+                findings.append(
+                    {
+                        "skill_dir": child.name,
+                        "issues": [
+                            {"code": issue.code, "message": issue.message, "path": issue.path}
+                            for issue in result.issues
+                        ],
+                    }
+                )
+                continue
+            metadata = dict(result.metadata)
+            skills.append(
+                {
+                    "name": metadata["name"],
+                    "skill_version": metadata.get("skill_version", "0.0.0"),
+                    "min_flare_version": metadata["min_flare_version"],
+                    "max_flare_version": metadata.get("max_flare_version"),
+                    "blast_radius": metadata["blast_radius"],
+                    "source_hash": skill_tree_hash(child),
+                    "relative_path": child.name,
+                }
+            )
+
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "source_type": source_type,
+        "nvflare_version": nvflare_version,
+        "skills": skills,
+        "findings": findings,
+    }
+
+
+def write_manifest(manifest: dict, manifest_path: Path | str) -> None:
+    path = Path(manifest_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_manifest(manifest_path: Path | str) -> dict:
+    return json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+
+
+def copy_released_skills_to_bundle(
+    skills_root: Path | str, bundle_root: Path | str, *, nvflare_version: str = ""
+) -> dict:
+    """Copy valid released skills and write their manifest into a package bundle directory."""
+    source_root = Path(skills_root)
+    target_root = Path(bundle_root)
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    for child in list(target_root.iterdir()):
+        if child.name == "__init__.py":
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    manifest = build_skill_manifest(source_root, source_type="wheel", nvflare_version=nvflare_version)
+    for skill in manifest["skills"]:
+        shutil.copytree(
+            source_root / skill["relative_path"],
+            target_root / skill["relative_path"],
+            ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES),
+        )
+    write_manifest(manifest, target_root / MANIFEST_FILE_NAME)
+    return manifest
+
+
+def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
+    for path in sorted(skill_dir.rglob("*"), key=lambda p: p.relative_to(skill_dir).as_posix()):
+        if not path.is_file():
+            continue
+        if any(part in exclude_names for part in path.relative_to(skill_dir).parts):
+            continue
+        if path.suffix in {".pyc", ".pyo"}:
+            continue
+        yield path
+
+
+def _validate_skill_dir(skill_dir: Path):
+    global _FRONTMATTER_MODULE
+
+    if _FRONTMATTER_MODULE is None:
+        module_name = "nvflare_agent_skill_frontmatter"
+        module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        _FRONTMATTER_MODULE = module
+
+    return _FRONTMATTER_MODULE.validate_skill_dir(skill_dir)

--- a/nvflare/tool/agent_skill_checks/__init__.py
+++ b/nvflare/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation helpers for NVFLARE agent skill source files."""

--- a/nvflare/tool/agent_skill_checks/__main__.py
+++ b/nvflare/tool/agent_skill_checks/__main__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvflare.tool.agent_skill_checks.cli import main
+
+raise SystemExit(main())

--- a/nvflare/tool/agent_skill_checks/cli.py
+++ b/nvflare/tool/agent_skill_checks/cli.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local admission-gate entry point for NVFLARE agent skills."""
+
+import argparse
+import json
+from pathlib import Path
+
+from nvflare.tool.agent_skill_checks.lints import run_v1_lints
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m nvflare.tool.agent_skill_checks",
+        description="Run deterministic v1 lint checks for NVFLARE agent skills.",
+    )
+    parser.add_argument("--skills-root", default="skills", help="path to the skills source root")
+    parser.add_argument("--docs-root", help="optional docs/design root for cross-document link checks")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="output format")
+    parser.add_argument("--check", action="append", help="run one lint ID; may be repeated")
+    args = parser.parse_args(argv)
+
+    result = run_v1_lints(
+        Path(args.skills_root),
+        docs_root=Path(args.docs_root) if args.docs_root else None,
+        checks=args.check,
+    )
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_text_result(result)
+    return 0 if result["status"] == "ok" else 1
+
+
+def _print_text_result(result: dict) -> None:
+    summary = result["summary"]
+    print(
+        "agent skill checks: "
+        f"{summary.get('error_count', 0)} error(s), "
+        f"{summary.get('warning_count', 0)} warning(s), "
+        f"{summary.get('info_count', 0)} info finding(s)"
+    )
+    for finding in result["findings"]:
+        location = finding["file"]
+        if finding.get("line"):
+            location = f"{location}:{finding['line']}"
+        skill = f" [{finding['skill']}]" if finding.get("skill") else ""
+        print(f"{finding['severity'].upper()} {finding['id']}{skill} {location}: {finding['message']}")
+        if finding.get("hint"):
+            print(f"  hint: {finding['hint']}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal V1 validation for NVFLARE agent skill frontmatter."""
+"""Validation for NVFLARE agent skill frontmatter."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -58,7 +58,7 @@ class SkillFrontmatterError(ValueError):
 def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
     """Parse YAML frontmatter from a SKILL.md file."""
     path = Path(skill_file)
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8-sig")
     lines = text.splitlines()
     if not lines or lines[0].strip() != "---":
         raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
@@ -131,9 +131,17 @@ def _validate_required_fields(
 ) -> None:
     for field in REQUIRED_FRONTMATTER_FIELDS:
         value = metadata.get(field)
-        if not isinstance(value, str) or not value.strip():
+        if value is None or (isinstance(value, str) and not value.strip()):
             issues.append(
                 _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+        elif not isinstance(value, str):
+            issues.append(
+                _issue(
+                    "skill-frontmatter-field-type",
+                    f"frontmatter field '{field}' must be a non-empty string; " f"got {type(value).__name__}={value!r}",
+                    skill_file,
+                )
             )
 
 

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal V1 validation for NVFLARE agent skill frontmatter."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import yaml
+
+SKILL_FILE_NAME = "SKILL.md"
+REQUIRED_FRONTMATTER_FIELDS = ("name", "description", "min_flare_version", "blast_radius")
+VALID_BLAST_RADIUS = frozenset(
+    {
+        "read_only",
+        "edits_files",
+        "runs_simulator",
+        "submits_poc",
+        "submits_production",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SkillValidationIssue:
+    code: str
+    message: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SkillValidationResult:
+    skill_dir: str
+    metadata: Mapping[str, Any]
+    issues: tuple[SkillValidationIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+class SkillFrontmatterError(ValueError):
+    """Raised when SKILL.md frontmatter cannot be parsed."""
+
+
+def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
+    """Parse YAML frontmatter from a SKILL.md file."""
+    path = Path(skill_file)
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
+
+    close_index = _find_closing_delimiter(lines)
+    if close_index is None:
+        raise SkillFrontmatterError("SKILL.md frontmatter must end with delimiter '---'")
+
+    raw_frontmatter = "\n".join(lines[1:close_index])
+    try:
+        metadata = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as e:
+        raise SkillFrontmatterError(f"failed to parse YAML frontmatter: {e}") from e
+
+    if not isinstance(metadata, dict):
+        raise SkillFrontmatterError("SKILL.md frontmatter must be a mapping")
+    return metadata
+
+
+def validate_skill_dir(skill_dir: Path | str) -> SkillValidationResult:
+    """Validate one guide-compatible skill directory."""
+    path = Path(skill_dir)
+    issues: list[SkillValidationIssue] = []
+    metadata: dict[str, Any] = {}
+
+    skill_file = path / SKILL_FILE_NAME
+    if not path.is_dir():
+        issues.append(_issue("skill-dir-missing", "skill path must be a directory", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    if not skill_file.is_file():
+        issues.append(_issue("skill-md-missing", "skill directory must contain SKILL.md", skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    try:
+        metadata = parse_skill_frontmatter(skill_file)
+    except SkillFrontmatterError as e:
+        issues.append(_issue("skill-frontmatter-invalid", str(e), skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    _validate_required_fields(metadata, skill_file, issues)
+    _validate_name_matches_directory(metadata.get("name"), path, skill_file, issues)
+    _validate_blast_radius(metadata.get("blast_radius"), skill_file, issues)
+
+    return SkillValidationResult(str(path), metadata, tuple(issues))
+
+
+def validate_skills_root(skills_root: Path | str) -> list[SkillValidationResult]:
+    """Validate every skill directory under a skills root."""
+    root = Path(skills_root)
+    if not root.is_dir():
+        return [SkillValidationResult(str(root), {}, (_issue("skills-root-missing", "skills root is missing", root),))]
+
+    results = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        results.append(validate_skill_dir(child))
+    return results
+
+
+def _find_closing_delimiter(lines: list[str]) -> Optional[int]:
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return i
+    return None
+
+
+def _validate_required_fields(
+    metadata: Mapping[str, Any], skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    for field in REQUIRED_FRONTMATTER_FIELDS:
+        value = metadata.get(field)
+        if not isinstance(value, str) or not value.strip():
+            issues.append(
+                _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+
+
+def _validate_name_matches_directory(
+    name: Any, skill_dir: Path, skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    if isinstance(name, str) and name.strip() and name != skill_dir.name:
+        issues.append(
+            _issue(
+                "skill-name-directory-mismatch",
+                f"frontmatter name '{name}' must match directory name '{skill_dir.name}'",
+                skill_file,
+            )
+        )
+
+
+def _validate_blast_radius(radius: Any, skill_file: Path, issues: list[SkillValidationIssue]) -> None:
+    if isinstance(radius, str) and radius.strip() and radius not in VALID_BLAST_RADIUS:
+        issues.append(
+            _issue(
+                "skill-blast-radius-invalid",
+                f"blast_radius must be one of: {', '.join(sorted(VALID_BLAST_RADIUS))}",
+                skill_file,
+            )
+        )
+
+
+def _issue(code: str, message: str, path: Path) -> SkillValidationIssue:
+    return SkillValidationIssue(code=code, message=message, path=str(path))

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -14,6 +14,7 @@
 
 """Validation for NVFLARE agent skill frontmatter."""
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional
@@ -85,8 +86,14 @@ def validate_skill_dir(skill_dir: Path | str) -> SkillValidationResult:
     metadata: dict[str, Any] = {}
 
     skill_file = path / SKILL_FILE_NAME
+    if path.is_symlink():
+        issues.append(_issue("skill-symlink-not-allowed", "skill path must not be a symlink", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
     if not path.is_dir():
         issues.append(_issue("skill-dir-missing", "skill path must be a directory", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    _validate_no_symlinks(path, issues)
+    if issues:
         return SkillValidationResult(str(path), metadata, tuple(issues))
     if not skill_file.is_file():
         issues.append(_issue("skill-md-missing", "skill directory must contain SKILL.md", skill_file))
@@ -167,6 +174,18 @@ def _validate_blast_radius(radius: Any, skill_file: Path, issues: list[SkillVali
                 skill_file,
             )
         )
+
+
+def _validate_no_symlinks(skill_dir: Path, issues: list[SkillValidationIssue]) -> None:
+    for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        for name in dir_names + file_names:
+            path = root_path / name
+            if path.is_symlink():
+                issues.append(_issue("skill-symlink-not-allowed", "skill directories must not contain symlinks", path))
+        dir_names[:] = [name for name in dir_names if not (root_path / name).is_symlink()]
 
 
 def _issue(code: str, message: str, path: Path) -> SkillValidationIssue:

--- a/nvflare/tool/agent_skill_checks/lints.py
+++ b/nvflare/tool/agent_skill_checks/lints.py
@@ -1,0 +1,1279 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic v1 admission lints for NVFLARE-owned agent skills."""
+
+import json
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from nvflare.tool.agent_skill_checks.frontmatter import SKILL_FILE_NAME, parse_skill_frontmatter, validate_skill_dir
+
+V1_LINT_IDS = (
+    "skill-frontmatter-lint",
+    "skill-md-size-lint",
+    "skill-trigger-lint",
+    "skill-trigger-overlap-lint",
+    "skill-catalog-category-lint",
+    "skill-global-negative-lint",
+    "skill-policy-coverage-lint",
+    "skill-command-drift-lint",
+    "skill-helper-script-lint",
+    "skill-fixture-lint",
+    "agent-doc-crosslink-lint",
+)
+
+LINT_SKILL_FRONTMATTER = "skill-frontmatter-lint"
+LINT_SKILL_MD_SIZE = "skill-md-size-lint"
+LINT_SKILL_TRIGGER = "skill-trigger-lint"
+LINT_SKILL_TRIGGER_OVERLAP = "skill-trigger-overlap-lint"
+LINT_SKILL_CATALOG_CATEGORY = "skill-catalog-category-lint"
+LINT_SKILL_GLOBAL_NEGATIVE = "skill-global-negative-lint"
+LINT_SKILL_POLICY_COVERAGE = "skill-policy-coverage-lint"
+LINT_SKILL_COMMAND_DRIFT = "skill-command-drift-lint"
+LINT_SKILL_HELPER_SCRIPT = "skill-helper-script-lint"
+LINT_SKILL_FIXTURE = "skill-fixture-lint"
+LINT_AGENT_DOC_CROSSLINK = "agent-doc-crosslink-lint"
+
+FINDING_ERROR = "error"
+FINDING_WARNING = "warning"
+FINDING_INFO = "info"
+SKILL_MD_MAX_LINES = 200
+SKILL_MD_ADVISORY_WORDS = 2000
+
+_PUBLIC_EXEMPT_STATUS = {"draft", "internal", "private"}
+_SIZE_EXCEPTION_MARKERS = (
+    "nvflare-lint: allow skill-md-size-lint",
+    "skill-md-size-lint: approved-exception",
+)
+_TRIGGER_TERMS = (
+    "trigger",
+    "use when",
+    "when to use",
+    "use this skill",
+    "do not use",
+    "do-not-use",
+    "boundary",
+)
+_BOUNDARY_TERMS = ("do not use", "do-not-use", "use boundary", "boundary", "negative")
+_NORMATIVE_RE = re.compile(r"\b(must|must not|required|prohibited|approval)\b", re.IGNORECASE)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+_BACKTICK_NVFLARE_RE = re.compile(r"`(nvflare(?:\s+[^`]+)?)`")
+_SIGNIFICANT_TOKEN_RE = re.compile(r"[a-z][a-z0-9_-]{2,}")
+_STOPWORDS = {
+    "and",
+    "for",
+    "the",
+    "this",
+    "that",
+    "with",
+    "into",
+    "from",
+    "using",
+    "when",
+    "skill",
+    "nvflare",
+    "flare",
+    "federated",
+    "workflow",
+}
+_KNOWN_NVFLARE_ROOT_COMMANDS = {
+    "agent",
+    "authz-preview",
+    "cert",
+    "config",
+    "dashboard",
+    "deploy",
+    "job",
+    "package",
+    "poc",
+    "preflight-check",
+    "provision",
+    "recipe",
+    "simulator",
+    "study",
+    "system",
+}
+_KNOWN_AGENT_COMMANDS = {"doctor", "info", "inspect", "skills"}
+_KNOWN_AGENT_SKILLS_COMMANDS = {"install", "list"}
+_KNOWN_AGENT_FLAGS = {
+    "agent": {"--format", "--schema"},
+    "agent doctor": {"--format", "--online", "--schema", "--startup-kit", "--project", "--org"},
+    "agent info": {"--format", "--schema"},
+    "agent inspect": {"--format", "--redact", "--schema"},
+    "agent skills": {"--format", "--schema"},
+    "agent skills install": {"--agent", "--dry-run", "--format", "--schema", "--skill", "--target"},
+    "agent skills list": {"--agent", "--format", "--schema", "--target"},
+}
+_DOC_FILES = (
+    "agent_implementation_plan.md",
+    "agent_integration.md",
+    "agent_skill_authoring.md",
+    "agent_skill_evaluation.md",
+    "agent_skills_deferred_roadmap.md",
+)
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    id: str
+    severity: str
+    file: str
+    message: str
+    hint: str
+    line: Optional[int] = None
+    code: Optional[str] = None
+    skill: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data = {
+            "id": self.id,
+            "severity": self.severity,
+            "file": self.file,
+            "message": self.message,
+            "hint": self.hint,
+        }
+        if self.line is not None:
+            data["line"] = self.line
+        if self.code is not None:
+            data["code"] = self.code
+        if self.skill is not None:
+            data["skill"] = self.skill
+        return data
+
+
+@dataclass
+class SkillRecord:
+    name: str
+    skill_dir: Path
+    skill_file: Path
+    metadata: dict[str, Any]
+    text: str
+    body: str
+    evals: list[dict[str, Any]]
+    evals_path: Path
+    evals_error: Optional[str]
+
+    @property
+    def public(self) -> bool:
+        status = str(self.metadata.get("status", "public")).strip().lower()
+        return status not in _PUBLIC_EXEMPT_STATUS
+
+
+@dataclass
+class LintContext:
+    skills_root: Path
+    docs_root: Optional[Path]
+    max_skill_md_lines: int
+    records: list[SkillRecord]
+    findings: list[LintFinding]
+    skipped_checks: list[dict[str, str]]
+
+
+def run_v1_lints(
+    skills_root: Path | str = "skills",
+    *,
+    docs_root: Path | str | None = None,
+    checks: Optional[Iterable[str]] = None,
+    max_skill_md_lines: int = SKILL_MD_MAX_LINES,
+) -> dict[str, Any]:
+    """Run deterministic v1 admission lints and return structured findings."""
+    selected = tuple(checks or V1_LINT_IDS)
+    unknown = sorted(set(selected).difference(V1_LINT_IDS))
+    if unknown:
+        raise ValueError(f"unknown agent skill lint check(s): {', '.join(unknown)}")
+
+    root = Path(skills_root)
+    resolved_docs_root = _resolve_docs_root(docs_root)
+    findings: list[LintFinding] = []
+    records = _load_skill_records(root, findings)
+    context = LintContext(
+        skills_root=root,
+        docs_root=resolved_docs_root,
+        max_skill_md_lines=max_skill_md_lines,
+        records=records,
+        findings=findings,
+        skipped_checks=[],
+    )
+
+    lint_functions = {
+        "skill-frontmatter-lint": _lint_frontmatter,
+        "skill-md-size-lint": _lint_md_size,
+        "skill-trigger-lint": _lint_trigger,
+        "skill-trigger-overlap-lint": _lint_trigger_overlap,
+        "skill-catalog-category-lint": _lint_catalog_category,
+        "skill-global-negative-lint": _lint_global_negative,
+        "skill-policy-coverage-lint": _lint_policy_coverage,
+        "skill-command-drift-lint": _lint_command_drift,
+        "skill-helper-script-lint": _lint_helper_scripts,
+        "skill-fixture-lint": _lint_fixtures,
+        "agent-doc-crosslink-lint": _lint_doc_crosslinks,
+    }
+
+    for check in selected:
+        lint_functions[check](context)
+
+    summary = _summary_from_lint_findings(context.findings, len(records))
+    status = "failed" if summary["error_count"] else "ok"
+    return {
+        "schema_version": "1",
+        "status": status,
+        "passed": status == "ok",
+        "skills_root": str(root),
+        "docs_root": str(resolved_docs_root) if resolved_docs_root is not None else None,
+        "checks": list(selected),
+        "skipped_checks": context.skipped_checks,
+        "summary": summary,
+        "findings": [finding.as_dict() for finding in context.findings],
+    }
+
+
+def validate_skills(
+    skills_root: Path | str = "skills",
+    *,
+    skill_name: Optional[str] = None,
+    docs_root: Path | str | None = None,
+    max_skill_md_lines: int = SKILL_MD_MAX_LINES,
+) -> dict[str, Any]:
+    """Compatibility wrapper for callers that validate one skill source root."""
+    result = run_v1_lints(skills_root, docs_root=docs_root, max_skill_md_lines=max_skill_md_lines)
+
+    if skill_name is not None:
+        result["requested_skill"] = skill_name
+        result["findings"] = [finding for finding in result["findings"] if finding.get("skill") in {None, skill_name}]
+        result["summary"] = _summary_from_findings(
+            result["findings"], _matching_skill_count(Path(skills_root), skill_name)
+        )
+        result["status"] = "failed" if result["summary"]["error_count"] else "ok"
+        result["passed"] = result["status"] == "ok"
+    else:
+        result["requested_skill"] = None
+    return result
+
+
+def _summary_from_findings(findings: list[dict[str, Any]], skill_count: int) -> dict[str, int]:
+    severity_counts = Counter(finding.get("severity", FINDING_ERROR) for finding in findings)
+    return _summary_from_counts(severity_counts, len(findings), skill_count)
+
+
+def _summary_from_lint_findings(findings: list[LintFinding], skill_count: int) -> dict[str, int]:
+    severity_counts = Counter(finding.severity for finding in findings)
+    return _summary_from_counts(severity_counts, len(findings), skill_count)
+
+
+def _summary_from_counts(severity_counts: Counter, finding_count: int, skill_count: int) -> dict[str, int]:
+    return {
+        "skill_count": skill_count,
+        "finding_count": finding_count,
+        "error_count": severity_counts.get(FINDING_ERROR, 0),
+        "warning_count": severity_counts.get(FINDING_WARNING, 0),
+        "info_count": severity_counts.get(FINDING_INFO, 0),
+        "error": severity_counts.get(FINDING_ERROR, 0),
+        "warning": severity_counts.get(FINDING_WARNING, 0),
+        "info": severity_counts.get(FINDING_INFO, 0),
+    }
+
+
+def _load_skill_records(skills_root: Path, findings: list[LintFinding]) -> list[SkillRecord]:
+    if not skills_root.exists():
+        findings.append(
+            _finding(
+                "skill-frontmatter-lint",
+                FINDING_ERROR,
+                skills_root,
+                "skills root does not exist",
+                "Pass --skills-root pointing at the repository skills/ directory.",
+                code="skills-root-missing",
+            )
+        )
+        return []
+    if not skills_root.is_dir():
+        findings.append(
+            _finding(
+                "skill-frontmatter-lint",
+                FINDING_ERROR,
+                skills_root,
+                "skills root is not a directory",
+                "Pass --skills-root pointing at the repository skills/ directory.",
+                code="skills-root-not-directory",
+            )
+        )
+        return []
+
+    records = []
+    for child in sorted(skills_root.iterdir(), key=lambda p: p.name):
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        skill_file = child / SKILL_FILE_NAME
+        text = skill_file.read_text(encoding="utf-8-sig") if skill_file.is_file() else ""
+        metadata = _try_parse_frontmatter(skill_file) if skill_file.is_file() else {}
+        evals_path = child / "evals" / "evals.json"
+        evals, evals_error = _load_evals(evals_path)
+        records.append(
+            SkillRecord(
+                name=str(metadata.get("name") or child.name),
+                skill_dir=child,
+                skill_file=skill_file,
+                metadata=metadata,
+                text=text,
+                body=_skill_body(text),
+                evals=evals,
+                evals_path=evals_path,
+                evals_error=evals_error,
+            )
+        )
+    return records
+
+
+def _matching_skill_count(skills_root: Path, skill_name: str) -> int:
+    return sum(1 for record in _load_skill_records(skills_root, []) if record.name == skill_name)
+
+
+def _lint_frontmatter(context: LintContext) -> None:
+    for record in context.records:
+        result = validate_skill_dir(record.skill_dir)
+        for issue in result.issues:
+            context.findings.append(
+                _finding(
+                    "skill-frontmatter-lint",
+                    FINDING_ERROR,
+                    Path(issue.path),
+                    issue.message,
+                    "Fix SKILL.md frontmatter before publishing this skill.",
+                    code=issue.code,
+                    skill=record.name,
+                    line=_line_for_frontmatter_issue(record.skill_file, issue.code, issue.message),
+                )
+            )
+
+        if record.public and _has_valid_name(record.metadata) and not record.name.startswith("nvflare-"):
+            context.findings.append(
+                _finding(
+                    "skill-frontmatter-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"public NVFLARE skill name '{record.name}' must start with 'nvflare-'",
+                    "Rename the skill directory and frontmatter name, or mark the skill draft/internal.",
+                    code="skill-name-prefix-required",
+                    skill=record.name,
+                    line=_line_for_field(record.skill_file, "name"),
+                )
+            )
+
+
+def _has_valid_name(metadata: dict[str, Any]) -> bool:
+    name = metadata.get("name")
+    return isinstance(name, str) and bool(name.strip())
+
+
+def _lint_md_size(context: LintContext) -> None:
+    for record in context.records:
+        if not record.skill_file.is_file():
+            continue
+        lines = record.text.splitlines()
+        max_lines = context.max_skill_md_lines
+        if len(lines) > max_lines and not _has_size_exception(record.text):
+            context.findings.append(
+                _finding(
+                    "skill-md-size-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"SKILL.md has {len(lines)} lines; v1 hard limit is {max_lines}",
+                    "Move detailed workflow notes into references/ or add an approved exception marker.",
+                    code="skill-md-too-large",
+                    skill=record.name,
+                    line=max_lines + 1,
+                )
+            )
+        word_count = len(record.text.split())
+        if word_count > SKILL_MD_ADVISORY_WORDS:
+            context.findings.append(
+                _finding(
+                    "skill-md-size-lint",
+                    FINDING_INFO,
+                    record.skill_file,
+                    f"SKILL.md has about {word_count} whitespace-delimited tokens",
+                    "The roughly 2,000-token target is advisory; keep SKILL.md concise when practical.",
+                    code="skill-md-token-advisory",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_trigger(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        searchable = f"{record.metadata.get('description', '')}\n{record.body}".lower()
+        if not any(term in searchable for term in _TRIGGER_TERMS):
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    "skill is missing trigger or use-boundary text",
+                    "Add concise trigger guidance and negative boundary language to SKILL.md.",
+                    code="skill-trigger-text-missing",
+                    skill=record.name,
+                )
+            )
+
+        if record.evals_error:
+            _add_evals_error(context, "skill-trigger-lint", record)
+            continue
+        if not record.evals_path.is_file():
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "evals/evals.json is required for public skill trigger checks",
+                    "Add guide-compatible evals/evals.json with positive and adjacent negative trigger evals.",
+                    code="skill-evals-missing",
+                    skill=record.name,
+                )
+            )
+            continue
+        if not any(_is_positive_eval(item, record.name) for item in record.evals):
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing positive trigger eval for this skill",
+                    "Add an eval whose nvflare.expected_skill matches this skill.",
+                    code="skill-positive-trigger-eval-missing",
+                    skill=record.name,
+                )
+            )
+        if not any(_is_adjacent_negative_eval(item, record.name) for item in record.evals):
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing adjacent negative trigger eval for this skill",
+                    "Add an eval whose nvflare.negative_for names this skill and expected_skill names the neighbor.",
+                    code="skill-adjacent-negative-eval-missing",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_trigger_overlap(context: LintContext) -> None:
+    if context.docs_root is None or not context.docs_root.is_dir():
+        _skip(context, "skill-trigger-overlap-lint", "docs root is not available")
+        return
+
+    category_map = _category_map(context)
+    if not category_map:
+        _skip(context, "skill-trigger-overlap-lint", "catalog categories are not available")
+        return
+
+    grouped: dict[str, list[SkillRecord]] = defaultdict(list)
+    for record in _public_records(context.records):
+        category = category_map.get(record.name)
+        if category:
+            grouped[category].append(record)
+
+    for category, records in grouped.items():
+        for i, left in enumerate(records):
+            for right in records[i + 1 :]:
+                if not _records_overlap(left, right):
+                    continue
+                if _has_boundary_text(left) and _has_boundary_text(right) and _has_adjacent_negative_pair(left, right):
+                    continue
+                context.findings.append(
+                    _finding(
+                        "skill-trigger-overlap-lint",
+                        FINDING_ERROR,
+                        left.skill_file,
+                        f"same-category skills '{left.name}' and '{right.name}' have overlapping trigger language",
+                        "Add use/do-not-use boundaries and adjacent negative evals covering the overlap.",
+                        code="skill-trigger-overlap",
+                        skill=left.name,
+                    )
+                )
+
+
+def _lint_catalog_category(context: LintContext) -> None:
+    docs_root = context.docs_root
+    if docs_root is None or not docs_root.is_dir():
+        _skip(context, "skill-catalog-category-lint", "docs root is not available")
+        return
+
+    product = _parse_product_catalog(docs_root / "agent_integration.md")
+    conversion = _parse_conversion_table(docs_root / "agent_skill_authoring.md")
+    if not product:
+        context.findings.append(
+            _finding(
+                "skill-catalog-category-lint",
+                FINDING_ERROR,
+                docs_root / "agent_integration.md",
+                "product skill catalog could not be parsed",
+                "Keep the catalog markdown table headed by Category, Skill, Tier, and Purpose.",
+                code="skill-catalog-unparseable",
+            )
+        )
+        return
+
+    for record in _public_records(context.records):
+        if record.name not in product:
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"public skill '{record.name}' is missing from the product skill catalog",
+                    "Add the skill to agent_integration.md or mark it draft/internal.",
+                    code="skill-catalog-entry-missing",
+                    skill=record.name,
+                )
+            )
+
+    for skill, conversion_tier in conversion.items():
+        product_row = product.get(skill)
+        if product_row is None:
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    docs_root / "agent_skill_authoring.md",
+                    f"conversion-family skill '{skill}' is missing from the product catalog",
+                    "Keep conversion-family rows and the product catalog in sync.",
+                    code="conversion-skill-catalog-missing",
+                    skill=skill,
+                )
+            )
+            continue
+        if product_row["category"] != "Conversion":
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    docs_root / "agent_integration.md",
+                    f"conversion-family skill '{skill}' has category '{product_row['category']}'",
+                    "Conversion-family skills should use the Conversion category for overlap checks.",
+                    code="conversion-skill-category-mismatch",
+                    skill=skill,
+                )
+            )
+        product_tier = _strip_backticks(product_row["tier"])
+        conversion_tier = _strip_backticks(conversion_tier)
+        if conversion_tier and product_tier and conversion_tier != product_tier:
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    docs_root / "agent_integration.md",
+                    f"skill '{skill}' tier differs between catalog and conversion-family table",
+                    "Use one tier consistently across the authoring and integration docs.",
+                    code="skill-catalog-tier-mismatch",
+                    skill=skill,
+                )
+            )
+
+
+def _lint_global_negative(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        if record.evals_error:
+            _add_evals_error(context, "skill-global-negative-lint", record)
+            continue
+        if not record.evals_path.is_file():
+            context.findings.append(
+                _finding(
+                    "skill-global-negative-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "evals/evals.json is required for global negative coverage",
+                    "Add at least one eval representing an unrelated prompt that should trigger no FLARE skill.",
+                    code="skill-evals-missing",
+                    skill=record.name,
+                )
+            )
+            continue
+        if not any(_is_global_negative_eval(item) for item in record.evals):
+            context.findings.append(
+                _finding(
+                    "skill-global-negative-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing global negative eval",
+                    "Add an eval for an unrelated prompt with nvflare.expected_skill set to null or 'none'.",
+                    code="skill-global-negative-eval-missing",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_policy_coverage(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        has_behavior_ids = any(_behavior_id_count(item) for item in record.evals)
+        has_helper_tests = _skill_has_helper_tests(record.skill_dir)
+        has_checklist = _skill_text_contains(record.skill_dir, "checklist")
+        if has_behavior_ids or has_helper_tests or has_checklist:
+            continue
+
+        for file_path, text in _iter_skill_text_files(record.skill_dir):
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                if _NORMATIVE_RE.search(line):
+                    context.findings.append(
+                        _finding(
+                            "skill-policy-coverage-lint",
+                            FINDING_ERROR,
+                            file_path,
+                            "normative rule has no measurable behavior ID, helper test, or checklist coverage",
+                            "Map required/prohibited behavior to evals/evals.json nvflare behavior IDs or tests.",
+                            code="skill-policy-coverage-missing",
+                            skill=record.name,
+                            line=line_no,
+                        )
+                    )
+                    break
+            else:
+                continue
+            break
+
+
+def _lint_command_drift(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        for file_path, text in _iter_skill_text_files(record.skill_dir, include_scripts=True):
+            for line_no, command in _extract_nvflare_commands(text):
+                message = _command_drift_message(command)
+                if message is None:
+                    continue
+                context.findings.append(
+                    _finding(
+                        "skill-command-drift-lint",
+                        FINDING_ERROR,
+                        file_path,
+                        message,
+                        "Update the referenced nvflare command or the CLI command schema before publishing.",
+                        code="skill-command-drift",
+                        skill=record.name,
+                        line=line_no,
+                    )
+                )
+
+
+def _lint_helper_scripts(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        scripts_dir = record.skill_dir / "scripts"
+        if not scripts_dir.is_dir():
+            continue
+        script_files = [p for p in sorted(scripts_dir.rglob("*")) if p.is_file()]
+        if script_files and not _skill_has_helper_tests(record.skill_dir):
+            context.findings.append(
+                _finding(
+                    "skill-helper-script-lint",
+                    FINDING_ERROR,
+                    scripts_dir,
+                    "helper scripts are shipped without tests",
+                    "Add tests under the skill or repository test tree for each shipped helper script.",
+                    code="skill-helper-tests-missing",
+                    skill=record.name,
+                )
+            )
+
+        for script in script_files:
+            text = script.read_text(encoding="utf-8", errors="replace")
+            lowered = text.lower()
+            if "promoted_to:" in lowered or "_promoted_to:" in lowered:
+                context.findings.append(
+                    _finding(
+                        "skill-helper-script-lint",
+                        FINDING_ERROR,
+                        script,
+                        "helper script is marked as promoted to a product CLI command",
+                        "Update SKILL.md to call the product CLI command instead of the promoted helper script.",
+                        code="skill-helper-promoted",
+                        skill=record.name,
+                    )
+                )
+            if "json" in lowered and "json.dumps" not in text and "json.dump" not in text:
+                context.findings.append(
+                    _finding(
+                        "skill-helper-script-lint",
+                        FINDING_WARNING,
+                        script,
+                        "script mentions JSON but does not appear to write JSON with the json module",
+                        "Ensure machine-readable stdout is valid JSON and diagnostics go to stderr.",
+                        code="skill-helper-json-unclear",
+                        skill=record.name,
+                    )
+                )
+
+
+def _lint_fixtures(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        if record.evals_error:
+            _add_evals_error(context, "skill-fixture-lint", record)
+            continue
+        if not record.evals_path.is_file():
+            continue
+
+        for item in record.evals:
+            files = item.get("files", [])
+            if files is None:
+                files = []
+            if not isinstance(files, list):
+                context.findings.append(
+                    _finding(
+                        "skill-fixture-lint",
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' files field must be a list",
+                        "Use guide-compatible files: [...] entries relative to the skill directory.",
+                        code="skill-fixture-files-type",
+                        skill=record.name,
+                    )
+                )
+                continue
+
+            if _eval_mentions_file_editing(item) and not files:
+                context.findings.append(
+                    _finding(
+                        "skill-fixture-lint",
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' describes file editing without input fixtures",
+                        "Add deterministic input files under evals/files/ and reference them from the eval.",
+                        code="skill-fixture-input-missing",
+                        skill=record.name,
+                    )
+                )
+
+            for rel_path in files:
+                fixture_path = record.skill_dir / str(rel_path)
+                if not fixture_path.is_file():
+                    context.findings.append(
+                        _finding(
+                            "skill-fixture-lint",
+                            FINDING_ERROR,
+                            record.evals_path,
+                            f"eval fixture does not exist: {rel_path}",
+                            "Place deterministic fixtures under evals/files/ and reference existing files.",
+                            code="skill-fixture-file-missing",
+                            skill=record.name,
+                        )
+                    )
+
+        files_dir = record.skill_dir / "evals" / "files"
+        if _has_files(files_dir) and not _has_fixture_notes(record.skill_dir):
+            context.findings.append(
+                _finding(
+                    "skill-fixture-lint",
+                    FINDING_ERROR,
+                    files_dir,
+                    "eval fixtures are missing source/provenance notes",
+                    "Add evals/README.md, evals/files/README.md, or evals/files/SOURCE.md.",
+                    code="skill-fixture-notes-missing",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_doc_crosslinks(context: LintContext) -> None:
+    docs_root = context.docs_root
+    if docs_root is None or not docs_root.is_dir():
+        _skip(context, "agent-doc-crosslink-lint", "docs root is not available")
+        return
+
+    anchors_by_file = {
+        doc_path.name: _markdown_anchors(doc_path.read_text(encoding="utf-8", errors="replace"))
+        for doc_path in _iter_existing_doc_files(docs_root)
+    }
+    for doc_path in _iter_existing_doc_files(docs_root):
+        text = doc_path.read_text(encoding="utf-8", errors="replace")
+        for line_no, href in _iter_markdown_links(text):
+            if href.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _, anchor = href.partition("#")
+            target_path = (doc_path.parent / target).resolve() if target else doc_path.resolve()
+            if target and not target_path.exists():
+                context.findings.append(
+                    _finding(
+                        "agent-doc-crosslink-lint",
+                        FINDING_ERROR,
+                        doc_path,
+                        f"markdown link target does not exist: {href}",
+                        "Update the link or restore the referenced design document.",
+                        code="agent-doc-link-missing",
+                        line=line_no,
+                    )
+                )
+                continue
+            if anchor:
+                target_name = target_path.name if target else doc_path.name
+                if _normalize_anchor(anchor) not in anchors_by_file.get(target_name, set()):
+                    context.findings.append(
+                        _finding(
+                            "agent-doc-crosslink-lint",
+                            FINDING_ERROR,
+                            doc_path,
+                            f"markdown link anchor does not exist: {href}",
+                            "Update the link anchor to match the target heading.",
+                            code="agent-doc-anchor-missing",
+                            line=line_no,
+                        )
+                    )
+
+    eval_doc = docs_root / "agent_skill_evaluation.md"
+    if eval_doc.is_file():
+        text = eval_doc.read_text(encoding="utf-8", errors="replace")
+        for lint_id in V1_LINT_IDS:
+            if f"`{lint_id}`" not in text:
+                context.findings.append(
+                    _finding(
+                        "agent-doc-crosslink-lint",
+                        FINDING_ERROR,
+                        eval_doc,
+                        f"lint id '{lint_id}' is missing from the canonical evaluation doc",
+                        "Keep agent_skill_evaluation.md#v1-engineering-lints as the canonical lint table.",
+                        code="agent-doc-lint-id-missing",
+                    )
+                )
+
+    for doc_path in _iter_existing_doc_files(docs_root):
+        if doc_path.name == "agent_skills_deferred_roadmap.md":
+            continue
+        text = doc_path.read_text(encoding="utf-8", errors="replace")
+        for line_no, command in _extract_nvflare_commands(text):
+            if not command.startswith("nvflare agent"):
+                continue
+            message = _command_drift_message(command, check_flags=False)
+            if message is None:
+                continue
+            context.findings.append(
+                _finding(
+                    "agent-doc-crosslink-lint",
+                    FINDING_ERROR,
+                    doc_path,
+                    f"agent command reference is stale: {message}",
+                    "Update the design doc command reference or the agent CLI command surface.",
+                    code="agent-doc-command-reference-stale",
+                    line=line_no,
+                )
+            )
+
+
+def _resolve_docs_root(docs_root: Path | str | None) -> Optional[Path]:
+    if docs_root is not None:
+        return Path(docs_root)
+    candidate = Path.cwd() / "docs" / "design"
+    return candidate if (candidate / "agent_skill_evaluation.md").is_file() else None
+
+
+def _try_parse_frontmatter(skill_file: Path) -> dict[str, Any]:
+    try:
+        return parse_skill_frontmatter(skill_file)
+    except Exception:
+        return {}
+
+
+def _skill_body(text: str) -> str:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[index + 1 :])
+    return text
+
+
+def _load_evals(evals_path: Path) -> tuple[list[dict[str, Any]], Optional[str]]:
+    if not evals_path.is_file():
+        return [], None
+    try:
+        raw = json.loads(evals_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        return [], f"failed to parse evals/evals.json: {e}"
+    if isinstance(raw, dict):
+        items = raw.get("evals", [])
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return [], "evals/evals.json must be an object with an evals list or a list"
+    if not isinstance(items, list):
+        return [], "evals/evals.json field 'evals' must be a list"
+    evals = [item for item in items if isinstance(item, dict)]
+    if len(evals) != len(items):
+        return evals, "each evals/evals.json entry must be an object"
+    return evals, None
+
+
+def _add_evals_error(context: LintContext, lint_id: str, record: SkillRecord) -> None:
+    context.findings.append(
+        _finding(
+            lint_id,
+            FINDING_ERROR,
+            record.evals_path,
+            record.evals_error or "evals/evals.json is invalid",
+            "Use guide-compatible JSON with an evals list.",
+            code="skill-evals-invalid",
+            skill=record.name,
+        )
+    )
+
+
+def _public_records(records: list[SkillRecord]) -> list[SkillRecord]:
+    return [record for record in records if record.public]
+
+
+def _is_positive_eval(item: dict[str, Any], skill_name: str) -> bool:
+    nvflare = _nvflare_ext(item)
+    if nvflare.get("expected_skill") == skill_name:
+        return True
+    tags = _eval_tags(item)
+    return "positive" in tags or "positive-trigger" in tags
+
+
+def _is_adjacent_negative_eval(item: dict[str, Any], skill_name: str) -> bool:
+    nvflare = _nvflare_ext(item)
+    if nvflare.get("negative_for") == skill_name:
+        return True
+    tags = _eval_tags(item)
+    return "adjacent-negative" in tags or "adjacent_negative" in tags
+
+
+def _is_global_negative_eval(item: dict[str, Any]) -> bool:
+    nvflare = _nvflare_ext(item)
+    expected_skill = nvflare.get("expected_skill")
+    if expected_skill is None and "expected_skill" in nvflare:
+        return True
+    if isinstance(expected_skill, str) and expected_skill.lower() in {"none", "no-skill", "no_skill"}:
+        return True
+    if nvflare.get("negative_for") == "*":
+        return True
+    tags = _eval_tags(item)
+    text = _eval_text(item).lower()
+    return "global-negative" in tags or "global_negative" in tags or "trigger no flare skill" in text
+
+
+def _eval_tags(item: dict[str, Any]) -> set[str]:
+    values = item.get("tags", [])
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return set()
+    return {str(value).strip().lower() for value in values}
+
+
+def _nvflare_ext(item: dict[str, Any]) -> dict[str, Any]:
+    nvflare = item.get("nvflare", {})
+    return nvflare if isinstance(nvflare, dict) else {}
+
+
+def _behavior_id_count(item: dict[str, Any]) -> int:
+    nvflare = _nvflare_ext(item)
+    count = 0
+    for key in ("mandatory_behavior", "optional_behavior", "prohibited_behavior"):
+        values = nvflare.get(key, [])
+        if isinstance(values, list):
+            count += len(values)
+    return count
+
+
+def _eval_text(item: dict[str, Any]) -> str:
+    parts = [str(item.get("id", "")), str(item.get("prompt", "")), str(item.get("expected_output", ""))]
+    assertions = item.get("assertions", [])
+    if isinstance(assertions, list):
+        parts.extend(str(assertion) for assertion in assertions)
+    return "\n".join(parts)
+
+
+def _records_overlap(left: SkillRecord, right: SkillRecord) -> bool:
+    left_tokens = _trigger_tokens(left)
+    right_tokens = _trigger_tokens(right)
+    if not left_tokens or not right_tokens:
+        return False
+    shared = left_tokens.intersection(right_tokens)
+    smaller = min(len(left_tokens), len(right_tokens))
+    return len(shared) >= 4 and (len(shared) / smaller) >= 0.35
+
+
+def _trigger_tokens(record: SkillRecord) -> set[str]:
+    prompts = "\n".join(str(item.get("prompt", "")) for item in record.evals)
+    text = f"{record.metadata.get('description', '')}\n{prompts}"
+    return {
+        token
+        for token in _SIGNIFICANT_TOKEN_RE.findall(text.lower())
+        if token not in _STOPWORDS and not token.startswith("nvflare")
+    }
+
+
+def _has_boundary_text(record: SkillRecord) -> bool:
+    text = f"{record.metadata.get('description', '')}\n{record.body}".lower()
+    return any(term in text for term in _BOUNDARY_TERMS)
+
+
+def _has_adjacent_negative_pair(left: SkillRecord, right: SkillRecord) -> bool:
+    return any(_negative_for_neighbor(item, left.name, right.name) for item in left.evals) or any(
+        _negative_for_neighbor(item, right.name, left.name) for item in right.evals
+    )
+
+
+def _negative_for_neighbor(item: dict[str, Any], skill_name: str, neighbor_name: str) -> bool:
+    nvflare = _nvflare_ext(item)
+    return nvflare.get("negative_for") == skill_name and nvflare.get("expected_skill") == neighbor_name
+
+
+def _category_map(context: LintContext) -> dict[str, str]:
+    if context.docs_root is None or not context.docs_root.is_dir():
+        return {}
+    product = _parse_product_catalog(context.docs_root / "agent_integration.md")
+    return {skill: row["category"] for skill, row in product.items()}
+
+
+def _parse_product_catalog(path: Path) -> dict[str, dict[str, str]]:
+    if not path.is_file():
+        return {}
+    rows = {}
+    in_table = False
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Category | Skill | Tier | Purpose |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            break
+        if set(stripped.replace("|", "").replace("-", "").replace(" ", "")) == set():
+            continue
+        columns = [column.strip() for column in stripped.strip("|").split("|")]
+        if len(columns) < 4 or columns[0] == "Category":
+            continue
+        skill = _strip_backticks(columns[1])
+        if skill:
+            rows[skill] = {"category": columns[0], "tier": columns[2]}
+    return rows
+
+
+def _parse_conversion_table(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    rows = {}
+    in_table = False
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Code Family | Skill | Scope | Current Repo Evidence | Tier |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            break
+        columns = [column.strip() for column in stripped.strip("|").split("|")]
+        if len(columns) < 5 or columns[0] == "Code Family" or columns[0].startswith("---"):
+            continue
+        skill = _strip_backticks(columns[1])
+        if skill:
+            rows[skill] = columns[4]
+    return rows
+
+
+def _strip_backticks(value: str) -> str:
+    return value.strip().strip("`")
+
+
+def _extract_nvflare_commands(text: str) -> list[tuple[int, str]]:
+    commands = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        matches = list(_BACKTICK_NVFLARE_RE.finditer(line))
+        if matches:
+            commands.extend((line_no, match.group(1).strip()) for match in matches)
+            continue
+        index = line.find("nvflare ")
+        if index == -1:
+            continue
+        commands.append((line_no, _trim_command(line[index:])))
+    return commands
+
+
+def _trim_command(text: str) -> str:
+    text = text.strip()
+    for separator in ("&&", "|", ";"):
+        if separator in text:
+            text = text.split(separator, 1)[0].strip()
+    return text
+
+
+def _command_drift_message(command: str, *, check_flags: bool = True) -> Optional[str]:
+    tokens = _command_tokens(command)
+    if not tokens or tokens[0] != "nvflare":
+        return None
+    positional = [token for token in tokens[1:] if not token.startswith("-") and not _looks_like_value(token)]
+    if not positional:
+        return None
+    root = positional[0]
+    if root not in _KNOWN_NVFLARE_ROOT_COMMANDS:
+        return f"unknown nvflare command root '{root}' in '{command}'"
+    if root != "agent":
+        return None
+
+    if len(positional) >= 2 and positional[1] not in _KNOWN_AGENT_COMMANDS:
+        return f"unknown nvflare agent command '{positional[1]}' in '{command}'"
+    if len(positional) >= 3 and positional[1] == "skills" and positional[2] not in _KNOWN_AGENT_SKILLS_COMMANDS:
+        return f"unknown nvflare agent skills command '{positional[2]}' in '{command}'"
+
+    command_key = " ".join(positional[:3] if len(positional) >= 3 and positional[1] == "skills" else positional[:2])
+    allowed_flags = _KNOWN_AGENT_FLAGS.get(command_key, _KNOWN_AGENT_FLAGS.get(root, set()))
+    if check_flags:
+        for token in tokens:
+            if token.startswith("--"):
+                flag = token.split("=", 1)[0]
+                if flag not in allowed_flags:
+                    return f"unknown flag '{flag}' for 'nvflare {command_key}' in '{command}'"
+    return None
+
+
+def _command_tokens(command: str) -> list[str]:
+    return re.findall(r"nvflare|--?[A-Za-z0-9][\w-]*(?:=[^\s`]+)?|<[^>]+>|[A-Za-z0-9][\w.-]*", command)
+
+
+def _looks_like_value(token: str) -> bool:
+    return token.startswith("<") or "/" in token or token in {"on", "off", "json", "jsonl", "human"}
+
+
+def _skill_has_helper_tests(skill_dir: Path) -> bool:
+    tests_dir = skill_dir / "tests"
+    if tests_dir.is_dir() and any(path.is_file() for path in tests_dir.rglob("*")):
+        return True
+    return any(path.name.endswith(("_test.py", ".test.py")) for path in skill_dir.rglob("*") if path.is_file())
+
+
+def _skill_text_contains(skill_dir: Path, needle: str) -> bool:
+    needle = needle.lower()
+    return any(needle in text.lower() for _, text in _iter_skill_text_files(skill_dir))
+
+
+def _iter_skill_text_files(skill_dir: Path, *, include_scripts: bool = False) -> Iterable[tuple[Path, str]]:
+    candidates = [skill_dir / SKILL_FILE_NAME]
+    references_dir = skill_dir / "references"
+    if references_dir.is_dir():
+        candidates.extend(sorted(path for path in references_dir.rglob("*") if path.suffix.lower() in {".md", ".txt"}))
+    if include_scripts:
+        scripts_dir = skill_dir / "scripts"
+        if scripts_dir.is_dir():
+            candidates.extend(sorted(path for path in scripts_dir.rglob("*") if path.is_file()))
+    for path in candidates:
+        if path.is_file():
+            yield path, path.read_text(encoding="utf-8", errors="replace")
+
+
+def _eval_mentions_file_editing(item: dict[str, Any]) -> bool:
+    text = _eval_text(item).lower()
+    return any(term in text for term in ("edit", "generate", "create", "export", "artifact", "file"))
+
+
+def _has_files(path: Path) -> bool:
+    return path.is_dir() and any(child.is_file() for child in path.rglob("*"))
+
+
+def _has_fixture_notes(skill_dir: Path) -> bool:
+    note_paths = (
+        skill_dir / "evals" / "README.md",
+        skill_dir / "evals" / "files" / "README.md",
+        skill_dir / "evals" / "files" / "SOURCE.md",
+    )
+    return any(path.is_file() for path in note_paths)
+
+
+def _iter_existing_doc_files(docs_root: Path) -> Iterable[Path]:
+    for name in _DOC_FILES:
+        path = docs_root / name
+        if path.is_file():
+            yield path
+
+
+def _iter_markdown_links(text: str) -> Iterable[tuple[int, str]]:
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for match in _MARKDOWN_LINK_RE.finditer(line):
+            yield line_no, match.group(1).strip()
+
+
+def _markdown_anchors(text: str) -> set[str]:
+    anchors = set()
+    for line in text.splitlines():
+        if not line.startswith("#"):
+            continue
+        heading = line.lstrip("#").strip()
+        if heading:
+            anchors.add(_normalize_anchor(heading))
+    return anchors
+
+
+def _normalize_anchor(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"`([^`]+)`", r"\1", value)
+    value = re.sub(r"[^a-z0-9 _-]", "", value)
+    value = value.replace(" ", "-")
+    value = re.sub(r"-+", "-", value)
+    return value.strip("-")
+
+
+def _line_for_frontmatter_issue(skill_file: Path, code: str, message: str) -> Optional[int]:
+    if code == "skill-frontmatter-field-required":
+        match = re.search(r"field '([^']+)'", message)
+        if match:
+            return _line_for_field(skill_file, match.group(1))
+    if code in {"skill-name-directory-mismatch", "skill-blast-radius-invalid", "skill-frontmatter-field-type"}:
+        for field in ("name", "blast_radius", "description", "min_flare_version"):
+            if field in message:
+                return _line_for_field(skill_file, field)
+    return 1 if skill_file.is_file() else None
+
+
+def _line_for_field(skill_file: Path, field: str) -> Optional[int]:
+    if not skill_file.is_file():
+        return None
+    prefix = f"{field}:"
+    for line_no, line in enumerate(skill_file.read_text(encoding="utf-8-sig", errors="replace").splitlines(), start=1):
+        if line.strip().startswith(prefix):
+            return line_no
+    return 1
+
+
+def _has_size_exception(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _SIZE_EXCEPTION_MARKERS)
+
+
+def _skip(context: LintContext, check: str, reason: str) -> None:
+    context.skipped_checks.append({"id": check, "reason": reason})
+
+
+def _finding(
+    lint_id: str,
+    severity: str,
+    path: Path,
+    message: str,
+    hint: str,
+    *,
+    line: Optional[int] = None,
+    code: Optional[str] = None,
+    skill: Optional[str] = None,
+) -> LintFinding:
+    return LintFinding(
+        id=lint_id,
+        severity=severity,
+        file=str(path),
+        line=line,
+        message=message,
+        hint=hint,
+        code=code,
+        skill=skill,
+    )

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -201,7 +201,7 @@ def output_ok(
             recovery_category=recovery_category,
             suggested_skill=suggested_skill,
         )
-        print(json.dumps(payload))
+        print(json.dumps(payload), flush=True)
     else:
         _render_table(data)
     if exit_code != 0:

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -147,14 +147,61 @@ def output(data: Any, fmt: Optional[str]) -> None:
         _render_table(data)
 
 
-def output_ok(data: Any, exit_code: int = 0) -> None:
-    """Print command success output."""
+def _add_agent_envelope_fields(
+    payload: dict,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> dict:
+    if code is not None:
+        payload["code"] = code
+    if message is not None:
+        payload["message"] = message
+    if hint is not None:
+        payload["hint"] = hint
+    if recovery_category is not None:
+        payload["recovery_category"] = recovery_category
+    if suggested_skill is not None:
+        payload["suggested_skill"] = suggested_skill
+    return payload
+
+
+def output_ok(
+    data: Any,
+    exit_code: int = 0,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> None:
+    """Print command success output.
+
+    code/message/hint/recovery fields are emitted in JSON/JSONL modes only;
+    human mode renders command data.
+    """
     if _is_jsonl_mode():
-        output_jsonl_event(
-            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True}
+        payload = _add_agent_envelope_fields(
+            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
         )
+        output_jsonl_event(payload)
     elif _is_json_mode():
-        print(json.dumps({"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data}))
+        payload = _add_agent_envelope_fields(
+            {"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        print(json.dumps(payload))
     else:
         _render_table(data)
     if exit_code != 0:
@@ -167,6 +214,8 @@ def output_error(
     hint: str = None,
     data: Any = None,
     detail: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
     **kwargs,
 ) -> None:
     """Print an error from ERROR_REGISTRY and exit. Never returns."""
@@ -187,9 +236,15 @@ def output_error(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
+            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
         if data is not None:
             payload["data"] = data
         if _is_jsonl_mode():
@@ -224,8 +279,16 @@ def output_error_message(
     fmt: Optional[str] = None,
     exit_code: int = 1,
     detail: str = None,
+    data: Any = None,
+    include_data: bool = False,
+    recovery_category: str = None,
+    suggested_skill: str = None,
 ) -> None:
-    """Print an explicit error message/hint pair and exit. Never returns."""
+    """Print an explicit error message/hint pair and exit. Never returns.
+
+    In machine modes, data is omitted when data is None unless include_data=True.
+    This lets callers distinguish an absent data field from an explicit JSON null.
+    """
     resolved_hint = hint or ""
     if detail:
         message = f"{message} \u2014 {detail}"
@@ -236,9 +299,17 @@ def output_error_message(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
+            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        if include_data or data is not None:
+            payload["data"] = data
         if jsonl_mode:
             payload["event"] = "terminal"
             payload["terminal"] = True

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -201,7 +201,7 @@ def output_ok(
             recovery_category=recovery_category,
             suggested_skill=suggested_skill,
         )
-        print(json.dumps(payload), flush=True)
+        print(json.dumps(payload))
     else:
         _render_table(data)
     if exit_code != 0:
@@ -236,7 +236,6 @@ def output_error(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }
@@ -299,7 +298,6 @@ def output_error_message(
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "code": error_code,
             "message": message,
             "hint": resolved_hint,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "versioneer"]
+requires = ["setuptools>=61.0", "wheel", "versioneer", "PyYAML>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ tmp_job_template_folder = "./nvflare/tool/job/templates"
 copy_package(src_dir="job_templates", dst_dir=tmp_job_template_folder)
 job_templates = package_files(root="nvflare/tool/job", starting="templates")
 deploy_templates = package_files(root="nvflare/tool/deploy", starting="templates")
+agent_skill_package_data = ["manifest.json", "*", "*/*", "*/*/*", "*/*/*/*", "*/*/*/*/*"]
 
 cmdclass = versioneer.get_cmdclass()
 _base_build_py = cmdclass["build_py"]
@@ -136,7 +137,7 @@ setup(
         "nvflare.dashboard.application": extra_files,
         "nvflare.tool.job": job_templates,
         "nvflare.tool.deploy": deploy_templates,
-        "nvflare.tool.agent.bundled_skills": ["manifest.json", "**/*"],
+        "nvflare.tool.agent.bundled_skills": agent_skill_package_data,
     },
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ import shutil
 
 from setuptools import find_packages, setup
 
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__)) if "__file__" in globals() else os.getcwd()
+
 
 def load_local_versioneer():
-    root = os.path.abspath(os.path.dirname(__file__)) if "__file__" in globals() else os.getcwd()
-    versioneer_path = os.path.join(root, "versioneer.py")
+    versioneer_path = os.path.join(ROOT_DIR, "versioneer.py")
     spec = importlib.util.spec_from_file_location("nvflare_local_versioneer", versioneer_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Failed to load versioneer from {versioneer_path}")
@@ -31,7 +32,19 @@ def load_local_versioneer():
     return module
 
 
+def load_local_module(module_name, module_path):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 versioneer = load_local_versioneer()
+agent_skill_manifest = load_local_module(
+    "nvflare_agent_skill_manifest", os.path.join(ROOT_DIR, "nvflare", "tool", "agent", "skill_manifest.py")
+)
 
 # read the contents of your README file
 
@@ -89,11 +102,27 @@ copy_package(src_dir="job_templates", dst_dir=tmp_job_template_folder)
 job_templates = package_files(root="nvflare/tool/job", starting="templates")
 deploy_templates = package_files(root="nvflare/tool/deploy", starting="templates")
 
+cmdclass = versioneer.get_cmdclass()
+_base_build_py = cmdclass["build_py"]
+
+
+class AgentSkillsBuildPy(_base_build_py):
+    def run(self):
+        super().run()
+        agent_skill_manifest.copy_released_skills_to_bundle(
+            os.path.join(ROOT_DIR, "skills"),
+            os.path.join(self.build_lib, "nvflare", "tool", "agent", "bundled_skills"),
+            nvflare_version=version,
+        )
+
+
+cmdclass["build_py"] = AgentSkillsBuildPy
+
 
 setup(
     name=package_name,
     version=version,
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclass,
     package_dir={"nvflare": "nvflare"},
     packages=find_packages(
         where=".",
@@ -107,6 +136,7 @@ setup(
         "nvflare.dashboard.application": extra_files,
         "nvflare.tool.job": job_templates,
         "nvflare.tool.deploy": deploy_templates,
+        "nvflare.tool.agent.bundled_skills": ["manifest.json", "**/*"],
     },
     include_package_data=True,
 )

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# NVFLARE Agent Skills
+
+This directory is the source root for NVFLARE-owned agent skills.
+
+V1 skill directories should follow the guide-compatible shape:
+
+```text
+skills/
+  nvflare-example-skill/
+    SKILL.md
+    references/
+    evals/
+      evals.json
+      files/
+    BENCHMARK.md
+```
+
+Milestone 1 establishes the source root and minimal frontmatter validation.
+Public skill content, runtime evals, packaging, and native install/list commands
+land in later milestones.
+
+Required `SKILL.md` frontmatter fields for V1:
+
+```yaml
+---
+name: nvflare-example-skill
+description: Short trigger-oriented description.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+```
+
+`blast_radius` must be one of:
+
+- `read_only`
+- `edits_files`
+- `runs_simulator`
+- `submits_poc`
+- `submits_production`

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ V1 skill directories should follow the guide-compatible shape:
 
 ```text
 skills/
-  nvflare-example-skill/
+  nvflare-your-skill/
     SKILL.md
     references/
     evals/
@@ -23,12 +23,15 @@ Required `SKILL.md` frontmatter fields for V1:
 
 ```yaml
 ---
-name: nvflare-example-skill
+name: nvflare-your-skill
 description: Short trigger-oriented description.
 min_flare_version: "2.8.0"
 blast_radius: read_only
 ---
 ```
+
+The skill name above is illustrative; released skill content lands in later
+milestones.
 
 `blast_radius` must be one of:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,9 @@
 # NVFLARE Agent Skills
 
-This directory is the source root for NVFLARE-owned agent skills.
+This directory contains NVFLARE-owned agent skills for supported coding agents.
 
-V1 skill directories should follow the guide-compatible shape:
+Each skill lives in its own directory with a `SKILL.md` file. Skills may also
+include supporting references, evaluation fixtures, and benchmark notes:
 
 ```text
 skills/
@@ -15,11 +16,7 @@ skills/
     BENCHMARK.md
 ```
 
-Milestone 1 establishes the source root and minimal frontmatter validation.
-Public skill content, runtime evals, packaging, and native install/list commands
-land in later milestones.
-
-Required `SKILL.md` frontmatter fields for V1:
+Required `SKILL.md` frontmatter fields:
 
 ```yaml
 ---
@@ -30,8 +27,8 @@ blast_radius: read_only
 ---
 ```
 
-The skill name above is illustrative; released skill content lands in later
-milestones.
+The skill name above is illustrative; actual skill directories use their
+published skill names.
 
 `blast_radius` must be one of:
 

--- a/tests/unit_test/tool/agent/__init__.py
+++ b/tests/unit_test/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -503,7 +503,10 @@ def test_agent_doctor_json_reports_local_readiness(capsys, monkeypatch, tmp_path
 
 def test_agent_doctor_human_output_is_summarized(capsys, monkeypatch, tmp_path):
     home = tmp_path / "home"
+    poc_workspace = tmp_path / "poc"
+    poc_workspace.mkdir()
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(poc_workspace))
     monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
 
     exit_code = _run_main(["nvflare", "agent", "doctor"])

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.tool import cli_output
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_output_state(monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "txt")
+    monkeypatch.setattr(cli_output, "_connect_timeout", 5.0)
+
+
+def _run_main(argv):
+    from nvflare import cli
+
+    with patch("sys.argv", argv), patch("nvflare.cli.version_check"):
+        try:
+            cli.main()
+        except SystemExit as e:
+            return e.code
+    return 0
+
+
+def _parse_for_agent_parser():
+    from nvflare import cli
+
+    with patch("sys.argv", ["nvflare", "agent", "--schema"]):
+        _prog_parser, args, sub_cmd_parsers = cli.parse_args("nvflare")
+
+    assert args.sub_command == "agent"
+    assert "agent" in sub_cmd_parsers
+    return sub_cmd_parsers["agent"]
+
+
+def _subparser_choices(parser):
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action.choices
+    return {}
+
+
+def _required_operational_args(parser):
+    required_args = []
+    for action in parser._actions:
+        if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
+            continue
+        if action.dest == "schema" or action.help == argparse.SUPPRESS:
+            continue
+        positional_required = not action.option_strings and action.nargs not in (
+            argparse.OPTIONAL,
+            argparse.ZERO_OR_MORE,
+        )
+        optional_required = bool(getattr(action, "required", False) or getattr(action, "schema_required", False))
+        if positional_required or optional_required:
+            required_args.append(action.dest)
+    return required_args
+
+
+def _minimal_agent_command():
+    agent_parser = _parse_for_agent_parser()
+    choices = _subparser_choices(agent_parser)
+    assert choices, "PR1 should register at least one minimal nvflare agent subcommand"
+
+    for name, parser in choices.items():
+        if _required_operational_args(parser):
+            continue
+        return name, parser
+
+    assert False, "PR1 should expose a read-only nvflare agent subcommand that needs no operational arguments"
+
+
+def _load_single_stdout_json(captured):
+    stdout = captured.out.strip()
+    assert stdout
+    assert len(stdout.splitlines()) == 1
+    return json.loads(stdout)
+
+
+def _assert_envelope_shape(payload, expected_status, require_data=True):
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == expected_status
+    assert "message" in payload
+    assert "hint" in payload
+    if require_data:
+        assert "data" in payload
+    if "code" in payload:
+        assert payload["code"]
+    else:
+        assert payload["error_code"]
+
+
+def test_agent_command_parser_is_registered(monkeypatch):
+    from nvflare import cli
+
+    command_name, _parser = _minimal_agent_command()
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["nvflare", "agent", command_name, "--format", "json"],
+    )
+
+    _prog_parser, args, _sub_cmd_parsers = cli.parse_args("nvflare")
+    assert args.sub_command == "agent"
+
+
+def test_agent_success_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    cli_output.output_ok(
+        {"ready": True},
+        code="AGENT_OK",
+        message="Agent command completed.",
+        hint="",
+        recovery_category="FIXABLE_BY_CONFIG",
+        suggested_skill="agent",
+    )
+
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "ok"
+    assert payload["code"] == "AGENT_OK"
+    assert payload["message"] == "Agent command completed."
+    assert payload["hint"] == ""
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+    assert payload["data"] == {"ready": True}
+
+
+def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_output.output_error_message(
+            "AGENT_ERROR",
+            "Agent command failed.",
+            hint="Use a valid agent command.",
+            exit_code=4,
+            recovery_category="FIXABLE_BY_CONFIG",
+            suggested_skill="agent",
+        )
+
+    assert exc_info.value.code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "error"
+    assert payload["code"] == "AGENT_ERROR"
+    assert payload["error_code"] == "AGENT_ERROR"
+    assert payload["message"] == "Agent command failed."
+    assert payload["hint"] == "Use a valid agent command."
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+
+
+def test_agent_schema_exits_zero_and_emits_raw_schema_json(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"].startswith("nvflare agent")
+    assert "status" not in schema
+    assert "args" in schema
+    assert "examples" in schema
+
+
+def test_agent_minimal_subcommand_schema_does_not_require_operational_args(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"] == f"nvflare agent {command_name}"
+    assert "status" not in schema
+    assert schema["output_modes"] == ["json"]
+    assert schema["streaming"] is False
+    assert schema["mutating"] is False
+    assert schema["idempotent"] is True
+
+
+def test_agent_minimal_subcommand_json_success_is_single_stdout_envelope(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "ok")
+
+
+def test_agent_human_output_stays_off_stdout_in_json_mode(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    assert payload["status"] == "ok"
+
+
+def test_agent_missing_subcommand_json_error_is_non_interactive(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert payload["data"] is None
+    assert captured.err == ""
+
+
+def test_agent_missing_subcommand_stops_when_error_helper_is_mocked():
+    from nvflare.tool.agent.agent_cli import handle_agent_cmd
+
+    with patch("sys.argv", ["nvflare", "agent"]), patch("nvflare.tool.cli_output.output_error_message") as output_error:
+        handle_agent_cmd(SimpleNamespace(agent_sub_cmd=None))
+
+    output_error.assert_called_once()
+
+
+def test_agent_invalid_subcommand_json_error_is_structured(capsys):
+    exit_code = _run_main(["nvflare", "agent", "not-a-pr1-command", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert "event" not in payload
+    assert "terminal" not in payload
+    assert "not-a-pr1-command" in payload["message"]
+    assert captured.err == ""

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -501,6 +501,25 @@ def test_agent_doctor_json_reports_local_readiness(capsys, monkeypatch, tmp_path
     assert not home.joinpath(".nvflare", "config.conf").exists()
 
 
+def test_agent_doctor_human_output_is_summarized(capsys, monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    exit_code = _run_main(["nvflare", "agent", "doctor"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "NVFLARE Agent Doctor" in captured.out
+    assert "status: attention" in captured.out
+    assert "startup kits: 0/0 valid (active: none)" in captured.out
+    assert "findings (1):" in captured.out
+    assert "STARTUP_KIT_NOT_CONFIGURED" in captured.out
+    assert "startup_kits:" not in captured.out
+    assert "{'import_ok':" not in captured.out
+
+
 def test_agent_doctor_schema_exits_zero(capsys):
     exit_code = _run_main(["nvflare", "agent", "doctor", "--schema"])
 

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -77,14 +77,14 @@ def _required_operational_args(parser):
 def _minimal_agent_command():
     agent_parser = _parse_for_agent_parser()
     choices = _subparser_choices(agent_parser)
-    assert choices, "PR1 should register at least one minimal nvflare agent subcommand"
+    assert choices, "nvflare agent should register at least one read-only subcommand"
 
     for name, parser in choices.items():
         if _required_operational_args(parser):
             continue
         return name, parser
 
-    assert False, "PR1 should expose a read-only nvflare agent subcommand that needs no operational arguments"
+    assert False, "nvflare agent should expose a read-only subcommand that needs no operational arguments"
 
 
 def _load_single_stdout_json(captured):

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 import pytest
 
 from nvflare.tool import cli_output
+from nvflare.tool.agent.skill_manager import SkillSource
+from nvflare.tool.agent.skill_manifest import build_skill_manifest
 
 
 @pytest.fixture(autouse=True)
@@ -255,3 +257,143 @@ def test_agent_invalid_subcommand_json_error_is_structured(capsys):
     assert "terminal" not in payload
     assert "not-a-pr1-command" in payload["message"]
     assert captured.err == ""
+
+
+def test_agent_skills_install_dry_run_json_uses_native_source(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["applied"] is False
+    assert payload["data"]["source"]["type"] == "editable"
+    assert payload["data"]["skills"][0]["name"] == "nvflare-test-skill"
+    assert not target.exists()
+
+
+def test_agent_skills_install_and_list_json(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    install_exit = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--format",
+            "json",
+        ]
+    )
+    install_payload = _load_single_stdout_json(capsys.readouterr())
+    assert install_exit == 0
+    assert install_payload["data"]["applied"] is True
+    assert target.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+    list_exit = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "list",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--format",
+            "json",
+        ]
+    )
+    list_payload = _load_single_stdout_json(capsys.readouterr())
+    assert list_exit == 0
+    assert list_payload["data"]["available"][0]["name"] == "nvflare-test-skill"
+    assert list_payload["data"]["installed"][0]["name"] == "nvflare-test-skill"
+
+
+def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(tmp_path / "target"),
+            "--skill",
+            "nvflare-missing",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["code"] == "AGENT_SKILL_NOT_FOUND"
+    assert payload["data"]["missing"] == ["nvflare-missing"]
+
+
+def test_agent_skills_install_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "skills", "install", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent skills install"
+    assert schema["mutating"] is True
+    assert schema["output_modes"] == ["json"]
+
+
+def _patch_skill_source(monkeypatch, tmp_path):
+    from nvflare.tool.agent import skill_manager
+
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    monkeypatch.setattr(skill_manager, "find_skill_source", lambda: source)
+    return source
+
+
+def _write_skill(root, name):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -448,6 +448,70 @@ def test_agent_skills_install_schema_exits_zero(capsys):
     assert schema["output_modes"] == ["json"]
 
 
+def test_agent_inspect_json_reports_static_framework_evidence(capsys, tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text("import torch\n\ndef train():\n    return None\n", encoding="utf-8")
+
+    exit_code = _run_main(["nvflare", "agent", "inspect", str(script), "--format", "json"])
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["static_only"] is True
+    assert payload["data"]["frameworks"][0]["name"] == "pytorch"
+    assert payload["data"]["conversion_state"] == "not_converted"
+    assert payload["data"]["skill_selection"]["recommended_skills"] == ["nvflare-convert-pytorch"]
+
+
+def test_agent_inspect_missing_path_is_structured_json_error(capsys, tmp_path):
+    exit_code = _run_main(["nvflare", "agent", "inspect", str(tmp_path / "missing"), "--format", "json"])
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_INSPECT_PATH_NOT_FOUND"
+    assert payload["data"] is None
+
+
+def test_agent_inspect_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "inspect", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent inspect"
+    assert schema["mutating"] is False
+    assert schema["output_modes"] == ["json"]
+    path_arg = next(arg for arg in schema["args"] if arg["name"] == "path")
+    assert path_arg["required"] is True
+
+
+def test_agent_doctor_json_reports_local_readiness(capsys, monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    exit_code = _run_main(["nvflare", "agent", "doctor", "--format", "json"])
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["nvflare"]["import_ok"] is True
+    assert payload["data"]["online"] == {"enabled": False, "status": "not_requested"}
+    assert any(finding["code"] == "STARTUP_KIT_NOT_CONFIGURED" for finding in payload["data"]["findings"])
+    assert not home.joinpath(".nvflare", "config.conf").exists()
+
+
+def test_agent_doctor_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "doctor", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent doctor"
+    assert schema["mutating"] is False
+    assert schema["output_modes"] == ["json"]
+    assert any(arg["name"] == "--online" for arg in schema["args"])
+
+
 def _patch_skill_source(monkeypatch, tmp_path):
     from nvflare.tool.agent import skill_manager
 

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -354,7 +354,8 @@ def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monke
     assert exit_code == 4
     payload = _load_single_stdout_json(capsys.readouterr())
     _assert_envelope_shape(payload, "error")
-    assert payload["code"] == "AGENT_SKILL_NOT_FOUND"
+    assert payload["error_code"] == "AGENT_SKILL_NOT_FOUND"
+    assert "code" not in payload
     assert payload["data"]["missing"] == ["nvflare-missing"]
 
 
@@ -397,7 +398,8 @@ def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypat
     assert exit_code == 1
     payload = _load_single_stdout_json(capsys.readouterr())
     _assert_envelope_shape(payload, "error")
-    assert payload["code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert payload["error_code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert "code" not in payload
     assert payload["recovery_category"] == "FIXABLE_BY_ENV"
     assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
 

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -162,8 +162,8 @@ def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
     payload = _load_single_stdout_json(capsys.readouterr())
     assert payload["schema_version"] == "1"
     assert payload["status"] == "error"
-    assert payload["code"] == "AGENT_ERROR"
     assert payload["error_code"] == "AGENT_ERROR"
+    assert "code" not in payload
     assert payload["message"] == "Agent command failed."
     assert payload["hint"] == "Use a valid agent command."
     assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -358,6 +358,50 @@ def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monke
     assert payload["data"]["missing"] == ["nvflare-missing"]
 
 
+def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    from nvflare.tool.agent import skill_manager
+
+    monkeypatch.setattr(
+        skill_manager,
+        "install_skills",
+        lambda **_kwargs: {
+            "agent": "codex",
+            "target_path": str(tmp_path / "target"),
+            "requested_skill": None,
+            "source": {},
+            "available": [],
+            "skills": [],
+            "conflicts": [],
+            "errors": [{"skill": "nvflare-test-skill", "code": "skill_install_failed", "message": "disk full"}],
+            "deprecated_skills_skipped": [],
+            "missing": [],
+            "applied": False,
+        },
+    )
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(tmp_path / "target"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert payload["recovery_category"] == "FIXABLE_BY_ENV"
+    assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
+
+
 def test_agent_skills_install_schema_exits_zero(capsys):
     exit_code = _run_main(["nvflare", "agent", "skills", "install", "--schema"])
 

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -14,6 +14,7 @@
 
 import argparse
 import json
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -402,6 +403,38 @@ def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypat
     assert "code" not in payload
     assert payload["recovery_category"] == "FIXABLE_BY_ENV"
     assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_agent_skills_target_symlink_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    actual_target = tmp_path / "actual-target"
+    actual_target.mkdir()
+    link_target = tmp_path / "link-target"
+    link_target.symlink_to(actual_target, target_is_directory=True)
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(link_target),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_SKILL_TARGET_INVALID"
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["data"]["target"] == str(link_target)
 
 
 def test_agent_skills_install_schema_exits_zero(capsys):

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -434,6 +434,7 @@ def test_agent_skills_target_symlink_is_structured_json_error(capsys, monkeypatc
     _assert_envelope_shape(payload, "error")
     assert payload["error_code"] == "AGENT_SKILL_TARGET_INVALID"
     assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert "/private/tmp" in payload["hint"]
     assert payload["data"]["target"] == str(link_target)
 
 

--- a/tests/unit_test/tool/agent/agent_doctor_test.py
+++ b/tests/unit_test/tool/agent/agent_doctor_test.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from nvflare.tool.agent.doctor import doctor_environment
+
+
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    transfer_dir = admin_dir / "transfer"
+    startup_dir.mkdir(parents=True)
+    transfer_dir.mkdir()
+    (startup_dir / "fed_admin.json").write_text(
+        '{"admin": {"username": "admin@nvidia.com", "download_dir": "transfer"}}',
+        encoding="utf-8",
+    )
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
+def test_doctor_local_readiness_does_not_create_config(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    data = doctor_environment()
+
+    assert data["nvflare"]["import_ok"] is True
+    assert data["online"] == {"enabled": False, "status": "not_requested"}
+    assert data["startup_kits"]["active_id"] is None
+    assert any(finding["code"] == "STARTUP_KIT_NOT_CONFIGURED" for finding in data["findings"])
+    assert not home.joinpath(".nvflare", "config.conf").exists()
+
+
+def test_doctor_poc_config_tolerates_missing_pyhocon(monkeypatch, tmp_path):
+    from nvflare.tool.poc import poc_commands
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    monkeypatch.setattr(poc_commands, "DEFAULT_WORKSPACE", str(tmp_path / "missing-poc"))
+    original_import = builtins.__import__
+
+    def import_without_pyhocon(name, *args, **kwargs):
+        if name == "pyhocon":
+            raise ImportError("pyhocon unavailable")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=import_without_pyhocon):
+        data = doctor_environment()
+
+    assert data["poc"]["status"] == "missing"
+    assert any(finding["code"] == "POC_WORKSPACE_MISSING" for finding in data["findings"])
+
+
+def test_doctor_online_uses_read_only_status_check(monkeypatch, tmp_path):
+    _configure_active_startup_kit(tmp_path, monkeypatch)
+
+    class FakeSession:
+        def __init__(self):
+            self.closed = False
+
+        def check_status(self, target_type, client_names):
+            assert target_type == "all"
+            assert client_names is None
+            return {
+                "server_status": "running",
+                "clients": [{"client_name": "site-1"}],
+                "client_status": [],
+                "jobs": [],
+            }
+
+        def close(self):
+            self.closed = True
+
+    fake_session = FakeSession()
+    with patch("nvflare.tool.cli_session.new_cli_session_for_args", return_value=fake_session):
+        data = doctor_environment(online=True, args=SimpleNamespace(kit_id=None, startup_kit=None))
+
+    assert data["online"]["status"] == "ok"
+    assert data["online"]["server_status"] == "running"
+    assert data["online"]["clients"] == [{"client_name": "site-1"}]
+    assert fake_session.closed is True
+
+
+def test_doctor_online_skips_when_session_would_create_download_dir(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text(
+        '{"admin": {"username": "admin@nvidia.com", "download_dir": "missing-transfer"}}',
+        encoding="utf-8",
+    )
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    with patch("nvflare.tool.cli_session.new_cli_session_for_args") as new_session:
+        data = doctor_environment(online=True, args=SimpleNamespace(kit_id=None, startup_kit=None))
+
+    assert data["online"]["status"] == "skipped"
+    assert data["online"]["findings"][0]["code"] == "ONLINE_CHECK_WOULD_CREATE_DOWNLOAD_DIR"
+    new_session.assert_not_called()

--- a/tests/unit_test/tool/agent/agent_inspector_test.py
+++ b/tests/unit_test/tool/agent/agent_inspector_test.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent.inspector import inspect_path
+
+
+def test_inspect_static_only_does_not_execute_user_module(tmp_path):
+    marker = tmp_path / "import_side_effect"
+    script = tmp_path / "train.py"
+    script.write_text(
+        "import pathlib\n"
+        "import torch\n"
+        f"pathlib.Path({str(marker)!r}).write_text('executed')\n"
+        "\n"
+        "def train():\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+
+    assert not marker.exists()
+    assert data["target_type"] == "single_training_script"
+    assert data["conversion_state"] == "not_converted"
+    assert data["frameworks"][0]["name"] == "pytorch"
+    assert data["skill_selection"]["recommended_skills"] == ["nvflare-convert-pytorch"]
+
+
+def test_inspect_redacts_secret_literals_and_absolute_paths_by_default(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text(
+        "API_TOKEN = 'super-secret-value'\n" "DATA_ROOT = '/Users/alice/private/data'\n" "import tensorflow as tf\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+    dumped = json.dumps(data)
+
+    assert "super-secret-value" not in dumped
+    assert "/Users/alice/private/data" not in dumped
+    assert "<REDACTED>" in dumped
+    assert "<REDACTED_PATH>" in dumped
+    assert data["frameworks"][0]["name"] == "tensorflow"
+    assert {finding["code"] for finding in data["findings"]} == {"SECRET_LITERAL_REDACTED"}
+    assert data["patterns"]["absolute_data_paths"][0]["code"] == "ABSOLUTE_DATA_PATH"
+
+
+def test_inspect_redaction_can_be_disabled_for_local_debugging(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text("PASSWORD = 'local-debug-secret'\nDATA_ROOT = '/opt/data'\n", encoding="utf-8")
+
+    data = inspect_path(script, redact=False)
+    dumped = json.dumps(data)
+
+    assert "local-debug-secret" in dumped
+    assert "/opt/data" in dumped
+
+
+def test_inspect_skips_symlink_without_scanning_target(tmp_path):
+    target = tmp_path / "outside.py"
+    target.write_text("import tensorflow\n", encoding="utf-8")
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "linked.py").symlink_to(target)
+    (root / "train.py").write_text("import torch\n", encoding="utf-8")
+
+    data = inspect_path(root)
+
+    assert [framework["name"] for framework in data["frameworks"]] == ["pytorch"]
+    assert data["scan"]["files_skipped"][0]["code"] == "SYMLINK_SKIPPED"
+
+
+def test_inspect_classifies_flare_job_source(tmp_path):
+    job_py = tmp_path / "job.py"
+    job_py.write_text(
+        "from nvflare.recipe import SimEnv\n"
+        "\n"
+        "def main():\n"
+        "    env = SimEnv(num_clients=2)\n"
+        "    recipe.export('/tmp/job')\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(tmp_path)
+
+    assert data["target_type"] == "flare_job_source"
+    assert data["conversion_state"] == "flare_job"
+    assert data["job"]["job_py"] == "job.py"
+    assert data["job"]["sim_env_used"] is True
+    assert data["job"]["export_support"] is True
+
+
+def test_inspect_does_not_treat_pytorch_to_call_as_export_support(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text(
+        "import torch\n" "\n" "def train(tensor):\n" "    return tensor.to('cpu')\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+
+    assert data["job"]["export_support"] is False
+    assert "python job.py --export --export-dir <job-dir>" not in data["recommended_next_commands"]
+
+
+def test_inspect_stops_and_caps_skips_after_file_limit(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    for index in range(20):
+        (root / f"train_{index:02d}.py").write_text("import torch\n", encoding="utf-8")
+
+    data = inspect_path(root, max_files=3)
+
+    assert data["scan"]["files_considered"] == 3
+    assert data["scan"]["files_scanned"] == 3
+    assert data["scan"]["files_skipped_count"] == 1
+    assert data["scan"]["files_skipped_truncated"] is False
+    assert data["scan"]["files_skipped"] == [
+        {"code": "FILE_LIMIT_REACHED", "path": "train_03.py", "message": "file scan limit reached"}
+    ]

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -575,7 +575,7 @@ def test_install_skills_reports_installed_skill_root_symlink_conflict(tmp_path):
     assert plan["conflicts"][0]["symlink_path"] == str(installed_skill)
 
 
-def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):
+def test_list_skills_reports_available_installed_and_ignores_unrelated_external_skills(tmp_path):
     source = _skill_source(tmp_path)
     target = tmp_path / "target"
     install_skills(agent="codex", target_dir=target, source=source)
@@ -585,7 +585,27 @@ def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path
 
     assert data["available"][0]["name"] == "nvflare-test-skill"
     assert data["installed"][0]["name"] == "nvflare-test-skill"
-    assert data["conflicts"][0]["skill"] == "external-skill"
+    assert data["conflicts"] == []
+
+
+def test_list_skills_flags_name_overlap_external_skill_as_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    external = target / "nvflare-test-skill"
+    external.mkdir(parents=True)
+    external.joinpath("SKILL.md").write_text("external content\n", encoding="utf-8")
+
+    data = list_skills(agent="codex", target_dir=target, source=source)
+
+    assert data["installed"] == []
+    assert data["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "external_install_detected",
+            "message": "target skill directory is not managed by nvflare",
+            "target_path": str(external),
+        }
+    ]
 
 
 def test_conflict_falls_back_to_code_for_unknown_conflict(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -14,6 +14,7 @@
 
 import json
 import shutil
+from pathlib import Path
 
 from nvflare.tool.agent import skill_manager
 from nvflare.tool.agent.skill_manager import (
@@ -228,6 +229,52 @@ def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, t
     ]
     assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
     assert not (target / ".nvflare_bak").exists()
+
+
+def test_install_skills_replace_reports_publish_error_when_recovery_fails(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    real_move = shutil.move
+
+    def publish_with_failure(src, dst):
+        raise OSError("publish failed")
+
+    def move_with_recovery_failure(src, dst, *args, **kwargs):
+        if ".nvflare_bak" in Path(src).parts:
+            raise OSError("restore failed")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(skill_manager, "_publish_staged_skill", publish_with_failure)
+    monkeypatch.setattr(skill_manager.shutil, "move", move_with_recovery_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "publish failed",
+            "recovery_error": {"type": "OSError", "message": "restore failed"},
+        }
+    ]
+    assert not (target / "nvflare-test-skill").exists()
+    assert any((target / ".nvflare_bak").iterdir())
 
 
 def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -241,6 +241,13 @@ def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path
     assert data["conflicts"][0]["skill"] == "external-skill"
 
 
+def test_conflict_falls_back_to_code_for_unknown_conflict(tmp_path):
+    conflict = skill_manager._conflict("nvflare-test-skill", "future_conflict", tmp_path / "target")
+
+    assert conflict["code"] == "future_conflict"
+    assert conflict["message"] == "future_conflict"
+
+
 def _skill_source(tmp_path):
     root = tmp_path / "skills"
     _write_skill(root, "nvflare-test-skill")

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 import json
+import shutil
 
+from nvflare.tool.agent import skill_manager
 from nvflare.tool.agent.skill_manager import (
     INSTALL_MANIFEST_FILE_NAME,
     SkillSource,
+    find_skill_source,
     install_skills,
     list_skills,
     resolve_agent_target_dir,
 )
-from nvflare.tool.agent.skill_manifest import build_skill_manifest
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, write_manifest
 
 
 def test_resolve_codex_target_uses_codex_home(tmp_path):
@@ -36,6 +39,48 @@ def test_resolve_claude_target_uses_home(monkeypatch, tmp_path):
     target = resolve_agent_target_dir("claude")
 
     assert target == tmp_path / ".claude" / "skills"
+
+
+def test_resolve_target_override_skips_agent_home_resolution(tmp_path):
+    target = resolve_agent_target_dir("codex", target_dir=tmp_path / "custom-target", env={"CODEX_HOME": "ignored"})
+
+    assert target == tmp_path / "custom-target"
+
+
+def test_resolve_unsupported_agent_raises_value_error():
+    try:
+        resolve_agent_target_dir("unsupported")
+    except ValueError as e:
+        assert "unsupported agent target" in str(e)
+    else:
+        assert False, "unsupported agent target should raise ValueError"
+
+
+def test_find_skill_source_does_not_misclassify_site_packages_skills(monkeypatch, tmp_path):
+    fake_site_packages = tmp_path / "site-packages"
+    fake_module = fake_site_packages / "nvflare" / "tool" / "agent" / "skill_manager.py"
+    fake_module.parent.mkdir(parents=True)
+    fake_module.write_text("# fake installed module\n", encoding="utf-8")
+    _write_skill(fake_site_packages / "skills", "unrelated-skill")
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    write_manifest(
+        {
+            "schema_version": "1",
+            "source_type": "wheel",
+            "nvflare_version": "2.8.0",
+            "skills": [],
+            "findings": [],
+        },
+        bundle_root / "manifest.json",
+    )
+    monkeypatch.setattr(skill_manager, "__file__", str(fake_module))
+    monkeypatch.setattr(skill_manager.resources, "files", lambda _package: bundle_root)
+
+    source = find_skill_source()
+
+    assert source.source_type == "wheel"
+    assert source.root == bundle_root
 
 
 def test_install_skills_dry_run_reports_plan_without_copying(tmp_path):
@@ -145,6 +190,42 @@ def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path
     assert len(backup_runs) == 1
     backup_file = backup_runs[0] / "nvflare-test-skill" / "SKILL.md"
     assert "First Skill" in backup_file.read_text(encoding="utf-8")
+
+
+def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-a-skill")
+    _write_skill(root, "nvflare-failing-skill")
+    _write_skill(root, "nvflare-z-skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    real_copytree = shutil.copytree
+
+    def copytree_with_failure(src, dst, *args, **kwargs):
+        if src.name == "nvflare-failing-skill":
+            raise OSError("disk full")
+        return real_copytree(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(skill_manager.shutil, "copytree", copytree_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-failing-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "disk full",
+        }
+    ]
+    assert (target / "nvflare-a-skill" / "SKILL.md").is_file()
+    assert not (target / "nvflare-failing-skill").exists()
+    assert (target / "nvflare-z-skill" / "SKILL.md").is_file()
 
 
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent.skill_manager import (
+    INSTALL_MANIFEST_FILE_NAME,
+    SkillSource,
+    install_skills,
+    list_skills,
+    resolve_agent_target_dir,
+)
+from nvflare.tool.agent.skill_manifest import build_skill_manifest
+
+
+def test_resolve_codex_target_uses_codex_home(tmp_path):
+    target = resolve_agent_target_dir("codex", env={"CODEX_HOME": str(tmp_path / "codex-home")})
+
+    assert target == tmp_path / "codex-home" / "skills"
+
+
+def test_resolve_claude_target_uses_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    target = resolve_agent_target_dir("claude")
+
+    assert target == tmp_path / ".claude" / "skills"
+
+
+def test_install_skills_dry_run_reports_plan_without_copying(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", dry_run=True, target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["skills"][0]["action"] == "copy"
+    assert plan["skills"][0]["files"]
+    assert not target.exists()
+
+
+def test_install_skills_installs_all_by_default(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    skill_dir = target / "nvflare-test-skill"
+    assert plan["applied"] is True
+    assert skill_dir.joinpath("SKILL.md").is_file()
+    install_manifest = json.loads(skill_dir.joinpath(INSTALL_MANIFEST_FILE_NAME).read_text(encoding="utf-8"))
+    assert install_manifest["managed_by"] == "nvflare"
+    assert install_manifest["name"] == "nvflare-test-skill"
+
+
+def test_install_skills_reports_missing_named_skill(tmp_path):
+    source = _skill_source(tmp_path)
+
+    plan = install_skills(agent="codex", skill_name="nvflare-missing", target_dir=tmp_path / "target", source=source)
+
+    assert plan["applied"] is False
+    assert plan["missing"] == ["nvflare-missing"]
+    assert plan["skills"] == []
+
+
+def test_install_skills_preserves_external_target_directory(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    external = target / "nvflare-test-skill"
+    external.mkdir(parents=True)
+    external.joinpath("SKILL.md").write_text("external content\n", encoding="utf-8")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["conflicts"][0]["code"] == "external_install_detected"
+    assert external.joinpath("SKILL.md").read_text(encoding="utf-8") == "external content\n"
+
+
+def test_install_skills_is_idempotent_for_same_managed_version(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["reason"] == "already_installed"
+
+
+def test_install_skills_preserves_modified_managed_install(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    skill_file = target / "nvflare-test-skill" / "SKILL.md"
+    skill_file.write_text(skill_file.read_text(encoding="utf-8") + "\n# User Edit\n", encoding="utf-8")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "local_modifications_detected"
+    assert plan["conflicts"][0]["code"] == "local_modifications_detected"
+    assert "# User Edit" in skill_file.read_text(encoding="utf-8")
+
+
+def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    skill_plan = plan["skills"][0]
+    assert skill_plan["action"] == "replace"
+    assert skill_plan["status"] == "replaced"
+    assert skill_plan["version_delta"] == "update"
+    assert "Second Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    backup_runs = list((target / ".nvflare_bak").iterdir())
+    assert len(backup_runs) == 1
+    backup_file = backup_runs[0] / "nvflare-test-skill" / "SKILL.md"
+    assert "First Skill" in backup_file.read_text(encoding="utf-8")
+
+
+def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    (target / "external-skill").mkdir()
+
+    data = list_skills(agent="codex", target_dir=target, source=source)
+
+    assert data["available"][0]["name"] == "nvflare-test-skill"
+    assert data["installed"][0]["name"] == "nvflare-test-skill"
+    assert data["conflicts"][0]["skill"] == "external-skill"
+
+
+def _skill_source(tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill")
+    return SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+
+def _write_skill(root, name, heading="Test Skill"):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        f"# {heading}\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -192,6 +192,44 @@ def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path
     assert "First Skill" in backup_file.read_text(encoding="utf-8")
 
 
+def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+    def copytree_with_failure(src, dst, *args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(skill_manager.shutil, "copytree", copytree_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "disk full",
+        }
+    ]
+    assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert not (target / ".nvflare_bak").exists()
+
+
 def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
     root = tmp_path / "skills"
     _write_skill(root, "nvflare-a-skill")

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -378,7 +378,7 @@ def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
-def test_install_skills_rejects_source_symlink_before_copytree(tmp_path):
+def test_install_skills_dry_run_reports_source_symlink_conflict(tmp_path):
     root = tmp_path / "skills"
     skill_dir = _write_skill(root, "nvflare-test-skill")
     outside_file = tmp_path / "outside.txt"
@@ -402,13 +402,82 @@ def test_install_skills_rejects_source_symlink_before_copytree(tmp_path):
             "findings": [],
         },
     )
+    target = tmp_path / "target"
 
-    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source)
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
 
     assert plan["applied"] is False
-    assert plan["errors"][0]["type"] == "ValueError"
-    assert "skill source must not contain symlinks" in plan["errors"][0]["message"]
-    assert not (tmp_path / "target" / "nvflare-test-skill").exists()
+    assert plan["errors"] == []
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "source_symlink_detected"
+    assert plan["skills"][0]["files"] == []
+    assert plan["skills"][0]["source_issue"]["symlink_path"] == str(skill_dir / "outside-link.txt")
+    assert plan["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "source_symlink_detected",
+            "message": "source skill directory contains a symlink",
+            "source_path": str(skill_dir),
+            "symlink_path": str(skill_dir / "outside-link.txt"),
+        }
+    ]
+    assert not (target / "nvflare-test-skill").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_skips_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["errors"] == []
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["status"] == "skipped"
+    assert plan["conflicts"][0]["code"] == "source_symlink_detected"
+    assert not (target / "nvflare-test-skill").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_stage_skill_rejects_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(source_type="editable", root=root, manifest={})
+
+    with pytest.raises(ValueError, match="skill source must not contain symlinks"):
+        skill_manager._stage_skill(
+            skill_dir,
+            tmp_path / "staged",
+            {"name": "nvflare-test-skill", "source_hash": "fake-source-hash"},
+            source,
+            installed_path=tmp_path / "target" / "nvflare-test-skill",
+        )
 
 
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -480,6 +480,101 @@ def test_stage_skill_rejects_source_symlink_before_copytree(tmp_path):
         )
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_source_symlink_root_conflict(tmp_path):
+    actual_root = tmp_path / "actual-skills"
+    skill_dir = _write_skill(actual_root, "nvflare-test-skill")
+    root = tmp_path / "skills"
+    root.mkdir()
+    source_link = root / "nvflare-test-skill"
+    source_link.symlink_to(skill_dir, target_is_directory=True)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+
+    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "source_symlink_detected"
+    assert plan["conflicts"][0]["symlink_path"] == str(source_link)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_stage_skill_rejects_source_symlink_root(tmp_path):
+    actual_root = tmp_path / "actual-skills"
+    skill_dir = _write_skill(actual_root, "nvflare-test-skill")
+    source_link = tmp_path / "nvflare-test-skill"
+    source_link.symlink_to(skill_dir, target_is_directory=True)
+    source = SkillSource(source_type="editable", root=tmp_path, manifest={})
+
+    with pytest.raises(ValueError, match="skill source must not contain symlinks"):
+        skill_manager._stage_skill(
+            source_link,
+            tmp_path / "staged",
+            {"name": "nvflare-test-skill", "source_hash": "fake-source-hash"},
+            source,
+            installed_path=tmp_path / "target" / "nvflare-test-skill",
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_installed_skill_nested_symlink_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    symlink = target / "nvflare-test-skill" / "outside-link.txt"
+    symlink.symlink_to(outside_file)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "target_symlink_detected"
+    assert plan["skills"][0]["target_issue"]["symlink_path"] == str(symlink)
+    assert plan["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "target_symlink_detected",
+            "message": "target skill directory contains a symlink",
+            "target_path": str(target / "nvflare-test-skill"),
+            "symlink_path": str(symlink),
+        }
+    ]
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_installed_skill_root_symlink_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    installed_skill = target / "nvflare-test-skill"
+    actual_skill = tmp_path / "actual-installed-skill"
+    shutil.move(installed_skill, actual_skill)
+    installed_skill.symlink_to(actual_skill, target_is_directory=True)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "target_symlink_detected"
+    assert plan["conflicts"][0]["symlink_path"] == str(installed_skill)
+
+
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):
     source = _skill_source(tmp_path)
     target = tmp_path / "target"

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import json
+import os
 import shutil
 from pathlib import Path
+
+import pytest
 
 from nvflare.tool.agent import skill_manager
 from nvflare.tool.agent.skill_manager import (
@@ -46,6 +49,28 @@ def test_resolve_target_override_skips_agent_home_resolution(tmp_path):
     target = resolve_agent_target_dir("codex", target_dir=tmp_path / "custom-target", env={"CODEX_HOME": "ignored"})
 
     assert target == tmp_path / "custom-target"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_resolve_target_override_rejects_symlink_target(tmp_path):
+    actual_target = tmp_path / "actual-target"
+    actual_target.mkdir()
+    link_target = tmp_path / "link-target"
+    link_target.symlink_to(actual_target, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink components"):
+        resolve_agent_target_dir("codex", target_dir=link_target)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_resolve_target_override_rejects_symlink_parent(tmp_path):
+    actual_parent = tmp_path / "actual-parent"
+    actual_parent.mkdir()
+    link_parent = tmp_path / "link-parent"
+    link_parent.symlink_to(actual_parent, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink components"):
+        resolve_agent_target_dir("codex", target_dir=link_parent / "skills")
 
 
 def test_resolve_unsupported_agent_raises_value_error():
@@ -350,6 +375,40 @@ def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
     assert (target / "nvflare-a-skill" / "SKILL.md").is_file()
     assert not (target / "nvflare-failing-skill").exists()
     assert (target / "nvflare-z-skill" / "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_rejects_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+
+    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source)
+
+    assert plan["applied"] is False
+    assert plan["errors"][0]["type"] == "ValueError"
+    assert "skill source must not contain symlinks" in plan["errors"][0]["message"]
+    assert not (tmp_path / "target" / "nvflare-test-skill").exists()
 
 
 def test_list_skills_reports_available_installed_and_external_conflicts(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -231,6 +231,45 @@ def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, t
     assert not (target / ".nvflare_bak").exists()
 
 
+def test_install_skills_replace_publish_error_restores_existing_install(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+    def publish_with_failure(src, dst):
+        raise OSError("publish failed")
+
+    monkeypatch.setattr(skill_manager, "_publish_staged_skill", publish_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "publish failed",
+        }
+    ]
+    assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Second Skill" not in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert not any((target / ".nvflare_bak").iterdir())
+
+
 def test_install_skills_replace_reports_publish_error_when_recovery_fails(monkeypatch, tmp_path):
     root = tmp_path / "skills"
     _write_skill(root, "nvflare-test-skill", heading="First Skill")

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from importlib import resources
+
+from nvflare.tool.agent import bundled_skills
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, copy_released_skills_to_bundle, skill_tree_hash
+
+
+def test_build_skill_manifest_includes_valid_skill(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["schema_version"] == "1"
+    assert manifest["source_type"] == "editable"
+    assert manifest["nvflare_version"] == "2.8.0"
+    assert manifest["findings"] == []
+    assert manifest["skills"] == [
+        {
+            "name": "nvflare-test-skill",
+            "skill_version": "0.0.0",
+            "min_flare_version": "2.8.0",
+            "max_flare_version": None,
+            "blast_radius": "read_only",
+            "source_hash": skill_tree_hash(skill_dir),
+            "relative_path": "nvflare-test-skill",
+        }
+    ]
+
+
+def test_skill_tree_hash_changes_when_skill_content_changes(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    first_hash = skill_tree_hash(skill_dir)
+
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "notes.md").write_text("new reference\n", encoding="utf-8")
+
+    assert skill_tree_hash(skill_dir) != first_hash
+
+
+def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    _write_skill(source_root, "nvflare-test-skill")
+
+    manifest = copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("manifest.json").is_file()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+    saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert saved_manifest == manifest
+    assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+
+
+def test_bundled_skill_manifest_resource_exists():
+    manifest = resources.files(bundled_skills).joinpath("manifest.json")
+
+    assert manifest.is_file()
+    assert json.loads(manifest.read_text(encoding="utf-8"))["schema_version"] == "1"
+
+
+def _write_skill(root, name):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -95,6 +95,16 @@ def test_skill_tree_hash_rejects_skill_symlinks(tmp_path):
         skill_tree_hash(skill_dir)
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_skill_tree_hash_rejects_symlink_skill_root(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    link_dir = tmp_path / "nvflare-link-skill"
+    link_dir.symlink_to(skill_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        skill_tree_hash(link_dir)
+
+
 def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
     first_hash = skill_tree_hash(skill_dir)

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -51,6 +51,32 @@ def test_skill_tree_hash_changes_when_skill_content_changes(tmp_path):
     assert skill_tree_hash(skill_dir) != first_hash
 
 
+def test_build_skill_manifest_reports_invalid_skill_findings(tmp_path):
+    skill_dir = tmp_path / "nvflare-invalid-skill"
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n" "name: nvflare-invalid-skill\n" "description: Missing required fields.\n" "---\n",
+        encoding="utf-8",
+    )
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["skills"] == []
+    assert manifest["findings"][0]["skill_dir"] == "nvflare-invalid-skill"
+    assert manifest["findings"][0]["issues"][0]["code"] == "skill-frontmatter-field-required"
+
+
+def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    first_hash = skill_tree_hash(skill_dir)
+    cache_dir = skill_dir / "__pycache__"
+    cache_dir.mkdir()
+    cache_dir.joinpath("SKILL.cpython-310.pyc").write_bytes(b"compiled cache")
+    skill_dir.joinpath("cache.pyo").write_bytes(b"optimized cache")
+
+    assert skill_tree_hash(skill_dir) == first_hash
+
+
 def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
     source_root = tmp_path / "skills"
     bundle_root = tmp_path / "bundle"
@@ -63,6 +89,25 @@ def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
     saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
     assert saved_manifest == manifest
     assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+
+
+def test_copy_released_skills_to_bundle_cleans_existing_bundle_content(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    bundle_root.joinpath("__init__.py").write_text("# keep package marker\n", encoding="utf-8")
+    bundle_root.joinpath("stale.txt").write_text("stale\n", encoding="utf-8")
+    stale_dir = bundle_root / "stale-skill"
+    stale_dir.mkdir()
+    stale_dir.joinpath("SKILL.md").write_text("stale\n", encoding="utf-8")
+    _write_skill(source_root, "nvflare-test-skill")
+
+    copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("__init__.py").is_file()
+    assert not bundle_root.joinpath("stale.txt").exists()
+    assert not stale_dir.exists()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
 
 
 def test_bundled_skill_manifest_resource_exists():

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import json
+import os
 from importlib import resources
+
+import pytest
 
 from nvflare.tool.agent import bundled_skills
 from nvflare.tool.agent.skill_manifest import build_skill_manifest, copy_released_skills_to_bundle, skill_tree_hash
@@ -66,6 +69,32 @@ def test_build_skill_manifest_reports_invalid_skill_findings(tmp_path):
     assert manifest["findings"][0]["issues"][0]["code"] == "skill-frontmatter-field-required"
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_build_skill_manifest_rejects_skill_symlinks(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "outside-link.txt").symlink_to(outside_file)
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["skills"] == []
+    assert manifest["findings"][0]["skill_dir"] == "nvflare-test-skill"
+    assert manifest["findings"][0]["issues"][0]["code"] == "skill-symlink-not-allowed"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_skill_tree_hash_rejects_skill_symlinks(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        skill_tree_hash(skill_dir)
+
+
 def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
     first_hash = skill_tree_hash(skill_dir)
@@ -107,6 +136,23 @@ def test_copy_released_skills_to_bundle_cleans_existing_bundle_content(tmp_path)
     assert bundle_root.joinpath("__init__.py").is_file()
     assert not bundle_root.joinpath("stale.txt").exists()
     assert not stale_dir.exists()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_copy_released_skills_to_bundle_unlinks_stale_bundle_symlink(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    stale_target = tmp_path / "stale-target"
+    stale_target.mkdir()
+    bundle_root.joinpath("stale-link").symlink_to(stale_target, target_is_directory=True)
+    _write_skill(source_root, "nvflare-test-skill")
+
+    copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert not bundle_root.joinpath("stale-link").exists()
+    assert stale_target.is_dir()
     assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
 
 

--- a/tests/unit_test/tool/agent_skill_checks/__init__.py
+++ b/tests/unit_test/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent_skill_checks/cli_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/cli_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent_skill_checks import cli
+
+
+def test_agent_skill_checks_cli_emits_json_and_nonzero_on_findings(tmp_path, capsys):
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+
+    exit_code = cli.main(["--skills-root", str(skills_root / "missing"), "--format", "json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is False
+    assert payload["summary"]["error_count"] == 1
+    assert payload["findings"][0]["id"] == "skill-frontmatter-lint"
+
+
+def test_agent_skill_checks_cli_emits_text(capsys, tmp_path):
+    exit_code = cli.main(["--skills-root", str(tmp_path / "missing")])
+
+    assert exit_code == 1
+    assert "agent skill checks:" in capsys.readouterr().out

--- a/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
+++ b/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: nvflare-example-skill
+description: Example fixture skill used by frontmatter validator tests.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+
+# Example Skill
+
+This file exists only as a validator fixture.

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -70,6 +70,15 @@ def test_validate_skill_dir_requires_directory_name_to_match_frontmatter(tmp_pat
     assert _issue_codes(result) == {"skill-name-directory-mismatch"}
 
 
+def test_validate_skill_dir_allows_name_prefix_for_visibility_aware_lint(tmp_path):
+    skill_dir = _write_skill(tmp_path, "example-skill")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert result.ok
+    assert result.metadata["name"] == "example-skill"
+
+
 def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
     skill_dir = tmp_path / "nvflare-missing-fields"
     skill_dir.mkdir()

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from nvflare.tool.agent_skill_checks.frontmatter import (
+    SkillFrontmatterError,
+    parse_skill_frontmatter,
+    validate_skill_dir,
+    validate_skills_root,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parse_skill_frontmatter_reads_required_fields():
+    metadata = parse_skill_frontmatter(FIXTURES / "valid" / "nvflare-example-skill" / "SKILL.md")
+
+    assert metadata["name"] == "nvflare-example-skill"
+    assert metadata["description"] == "Example fixture skill used by frontmatter validator tests."
+    assert metadata["min_flare_version"] == "2.8.0"
+    assert metadata["blast_radius"] == "read_only"
+
+
+def test_validate_skill_dir_accepts_fixture_skill():
+    result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
+
+    assert result.ok
+    assert result.metadata["name"] == "nvflare-example-skill"
+    assert result.issues == ()
+
+
+def test_validate_skill_dir_requires_directory_name_to_match_frontmatter(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-other-name", name="nvflare-example-skill")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-name-directory-mismatch"}
+
+
+def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-fields"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-missing-fields\n"
+        "description: Missing two required fields.\n"
+        "---\n"
+        "\n"
+        "# Missing Fields\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-required"}
+    assert len(result.issues) == 2
+
+
+def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-blast-radius-invalid"}
+
+
+def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("name: nvflare-no-frontmatter\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must start"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-skill-md"
+    skill_dir.mkdir()
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-md-missing"}
+
+
+def test_validate_skills_root_skips_non_skill_files(tmp_path):
+    _write_skill(tmp_path, "nvflare-valid-one")
+    (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+
+    results = validate_skills_root(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].ok
+    assert results[0].metadata["name"] == "nvflare-valid-one"
+
+
+def test_validate_skills_root_reports_missing_root(tmp_path):
+    results = validate_skills_root(tmp_path / "missing")
+
+    assert len(results) == 1
+    assert not results[0].ok
+    assert _issue_codes(results[0]) == {"skills-root-missing"}
+
+
+def _write_skill(tmp_path, skill_name, *, name=None, blast_radius="read_only"):
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name or skill_name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        f"blast_radius: {blast_radius}\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _issue_codes(result):
+    return {issue.code for issue in result.issues}

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -35,6 +35,24 @@ def test_parse_skill_frontmatter_reads_required_fields():
     assert metadata["blast_radius"] == "read_only"
 
 
+def test_parse_skill_frontmatter_accepts_utf8_bom(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_bytes(
+        b"\xef\xbb\xbf---\n"
+        b"name: nvflare-bom-skill\n"
+        b"description: Test skill fixture.\n"
+        b'min_flare_version: "2.8.0"\n'
+        b"blast_radius: read_only\n"
+        b"---\n"
+        b"\n"
+        b"# Test Skill\n"
+    )
+
+    metadata = parse_skill_frontmatter(skill_file)
+
+    assert metadata["name"] == "nvflare-bom-skill"
+
+
 def test_validate_skill_dir_accepts_fixture_skill():
     result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
 
@@ -72,6 +90,29 @@ def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
     assert len(result.issues) == 2
 
 
+def test_validate_skill_dir_reports_wrong_type_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-wrong-type"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-wrong-type\n"
+        "description: Wrong type fixture.\n"
+        "min_flare_version: 2.8\n"
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Wrong Type\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-type"}
+    assert "min_flare_version" in result.issues[0].message
+    assert "float=2.8" in result.issues[0].message
+
+
 def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
     skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
 
@@ -89,6 +130,40 @@ def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
         parse_skill_frontmatter(skill_file)
 
 
+def test_parse_skill_frontmatter_requires_closing_delimiter(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "---\n" "name: nvflare-no-closing-delimiter\n" "description: Missing closing delimiter.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillFrontmatterError, match="must end"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_malformed_yaml(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\nname: [unclosed\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="failed to parse YAML"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_non_mapping(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\n- name\n- description\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must be a mapping"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_directory(tmp_path):
+    result = validate_skill_dir(tmp_path / "nvflare-missing-directory")
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-dir-missing"}
+
+
 def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
     skill_dir = tmp_path / "nvflare-missing-skill-md"
     skill_dir.mkdir()
@@ -102,6 +177,7 @@ def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
 def test_validate_skills_root_skips_non_skill_files(tmp_path):
     _write_skill(tmp_path, "nvflare-valid-one")
     (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+    (tmp_path / ".hidden-dir").mkdir()
 
     results = validate_skills_root(tmp_path)
 

--- a/tests/unit_test/tool/agent_skill_checks/lints_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/lints_test.py
@@ -1,0 +1,405 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent_skill_checks.lints import V1_LINT_IDS, run_v1_lints, validate_skills
+
+LINT_SKILL_FRONTMATTER = "skill-frontmatter-lint"
+LINT_SKILL_MD_SIZE = "skill-md-size-lint"
+LINT_SKILL_TRIGGER = "skill-trigger-lint"
+LINT_SKILL_TRIGGER_OVERLAP = "skill-trigger-overlap-lint"
+LINT_SKILL_CATALOG_CATEGORY = "skill-catalog-category-lint"
+LINT_SKILL_GLOBAL_NEGATIVE = "skill-global-negative-lint"
+LINT_SKILL_POLICY_COVERAGE = "skill-policy-coverage-lint"
+LINT_SKILL_COMMAND_DRIFT = "skill-command-drift-lint"
+LINT_SKILL_HELPER_SCRIPT = "skill-helper-script-lint"
+LINT_SKILL_FIXTURE = "skill-fixture-lint"
+LINT_AGENT_DOC_CROSSLINK = "agent-doc-crosslink-lint"
+REQUIRED_FINDING_FIELDS = {"id", "severity", "file", "message", "hint"}
+
+
+def test_run_v1_lints_passes_complete_skill(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+    assert result["summary"]["error_count"] == 0
+    assert set(result["checks"]) == {
+        LINT_SKILL_FRONTMATTER,
+        LINT_SKILL_MD_SIZE,
+        LINT_SKILL_TRIGGER,
+        LINT_SKILL_TRIGGER_OVERLAP,
+        LINT_SKILL_CATALOG_CATEGORY,
+        LINT_SKILL_GLOBAL_NEGATIVE,
+        LINT_SKILL_POLICY_COVERAGE,
+        LINT_SKILL_COMMAND_DRIFT,
+        LINT_SKILL_HELPER_SCRIPT,
+        LINT_SKILL_FIXTURE,
+        LINT_AGENT_DOC_CROSSLINK,
+    }
+
+
+def test_run_v1_lints_reports_frontmatter_prefix(tmp_path):
+    _write_skill(tmp_path / "skills", "example-skill")
+    docs_root = _write_design_docs(tmp_path, ["example-skill"], category="Orient")
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_FRONTMATTER, "skill-name-prefix-required")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_allows_internal_skill_without_nvflare_prefix(tmp_path):
+    _write_skill(tmp_path / "skills", "example-skill", status="internal")
+    docs_root = _write_design_docs(tmp_path, ["example-skill"], category="Orient")
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FRONTMATTER])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_run_v1_lints_reports_skill_md_size(tmp_path):
+    body = "\n".join(f"line {i}" for i in range(205))
+    _write_skill(tmp_path / "skills", "nvflare-large-skill", body=body)
+    docs_root = _write_design_docs(tmp_path, ["nvflare-large-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_MD_SIZE, "skill-md-too-large")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_missing_trigger_evals(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-trigger-skill", evals={"evals": []})
+    docs_root = _write_design_docs(tmp_path, ["nvflare-trigger-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_TRIGGER, "skill-positive-trigger-eval-missing")
+    assert _has_finding(result, LINT_SKILL_TRIGGER, "skill-adjacent-negative-eval-missing")
+    assert _has_finding(result, LINT_SKILL_GLOBAL_NEGATIVE, "skill-global-negative-eval-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_missing_catalog_entry(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-one-skill")
+    _write_skill(tmp_path / "skills", "nvflare-two-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-one-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_CATALOG_CATEGORY, "skill-catalog-entry-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_trigger_overlap_without_negative_boundary(tmp_path):
+    evals_one = _default_evals("nvflare-one-skill", adjacent_negative=False)
+    evals_two = _default_evals("nvflare-two-skill", adjacent_negative=False)
+    _write_skill(
+        tmp_path / "skills",
+        "nvflare-one-skill",
+        description="Convert PyTorch training code to FLARE.",
+        body="Use when converting PyTorch training code.\n",
+        evals=evals_one,
+    )
+    _write_skill(
+        tmp_path / "skills",
+        "nvflare-two-skill",
+        description="Convert PyTorch training code to FLARE.",
+        body="Use when converting PyTorch training code.\n",
+        evals=evals_two,
+    )
+    docs_root = _write_design_docs(tmp_path, ["nvflare-one-skill", "nvflare-two-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_TRIGGER_OVERLAP, "skill-trigger-overlap")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_policy_without_behavior_ids(tmp_path):
+    evals = _default_evals("nvflare-policy-skill", include_behavior_ids=False)
+    _write_skill(
+        tmp_path / "skills", "nvflare-policy-skill", body="The agent must validate before submit.\n", evals=evals
+    )
+    docs_root = _write_design_docs(tmp_path, ["nvflare-policy-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_POLICY_COVERAGE, "skill-policy-coverage-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_unknown_nvflare_command(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-command-skill", body="Run `nvflare unknown --format json`.\n")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-command-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    finding = _finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    assert isinstance(finding["line"], int)
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_helper_script_without_test(tmp_path):
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-helper-skill")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    scripts_dir.joinpath("helper.py").write_text("print('{}')\n", encoding="utf-8")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-helper-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_HELPER_SCRIPT, "skill-helper-tests-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_missing_fixture_file(tmp_path):
+    evals = _default_evals("nvflare-fixture-skill")
+    evals["evals"][0]["files"] = ["evals/files/missing.py"]
+    _write_skill(tmp_path / "skills", "nvflare-fixture-skill", evals=evals, write_fixture=False)
+    docs_root = _write_design_docs(tmp_path, ["nvflare-fixture-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_FIXTURE, "skill-fixture-file-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_broken_doc_crosslink(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-doc-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-doc-skill"])
+    docs_root.joinpath("agent_integration.md").write_text(
+        docs_root.joinpath("agent_integration.md").read_text(encoding="utf-8")
+        + "\n[missing](missing.md)\n[bad anchor](agent_integration.md#nope)\n",
+        encoding="utf-8",
+    )
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_AGENT_DOC_CROSSLINK, "agent-doc-link-missing")
+    assert _has_finding(result, LINT_AGENT_DOC_CROSSLINK, "agent-doc-anchor-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_supports_check_selection(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    _write_skill(tmp_path / "skills", "nvflare-other-skill", evals={"evals": []})
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill", "nvflare-other-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FRONTMATTER])
+
+    assert result["status"] == "ok"
+    assert result["checks"] == [LINT_SKILL_FRONTMATTER]
+    assert result["summary"]["skill_count"] == 2
+
+
+def test_run_v1_lints_records_doc_dependent_overlap_skip(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+
+    result = run_v1_lints(tmp_path / "skills", checks=[LINT_SKILL_TRIGGER_OVERLAP])
+
+    assert result["status"] == "ok"
+    assert result["skipped_checks"] == [{"id": LINT_SKILL_TRIGGER_OVERLAP, "reason": "docs root is not available"}]
+
+
+def test_validate_skills_filters_summary_to_requested_skill(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    _write_skill(tmp_path / "skills", "nvflare-other-skill", evals={"evals": []})
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill", "nvflare-other-skill"])
+
+    result = validate_skills(tmp_path / "skills", skill_name="nvflare-valid-skill", docs_root=docs_root)
+
+    assert result["status"] == "ok"
+    assert result["requested_skill"] == "nvflare-valid-skill"
+    assert result["summary"]["skill_count"] == 1
+    assert result["findings"] == []
+
+
+def test_validate_skills_uses_requested_size_limit_without_mutating_default(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+
+    limited = validate_skills(
+        tmp_path / "skills",
+        skill_name="nvflare-valid-skill",
+        docs_root=docs_root,
+        max_skill_md_lines=2,
+    )
+    default = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_MD_SIZE])
+
+    assert _has_finding(limited, LINT_SKILL_MD_SIZE, "skill-md-too-large")
+    assert default["status"] == "ok"
+    assert default["findings"] == []
+
+
+def _write_skill(
+    root,
+    name,
+    *,
+    description="Convert PyTorch training code into a FLARE job.",
+    body="Use when converting PyTorch training code.\nDo not use for Kubernetes deployment.\n",
+    evals=None,
+    category="conversion",
+    write_fixture=True,
+    status=None,
+):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    status_line = f"status: {status}\n" if status else ""
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: edits_files\n"
+        f"{status_line}"
+        "---\n"
+        "\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    if write_fixture:
+        files_dir = evals_dir / "files"
+        files_dir.mkdir()
+        files_dir.joinpath("input.py").write_text("print('hello')\n", encoding="utf-8")
+        files_dir.joinpath("README.md").write_text(
+            "Source: synthetic fixture for deterministic agent skill lint tests.\n",
+            encoding="utf-8",
+        )
+    evals_dir.joinpath("evals.json").write_text(
+        json.dumps(evals if evals is not None else _default_evals(name, category=category), indent=2),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_design_docs(tmp_path, skills, *, category="Conversion", tier="bundle"):
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir(exist_ok=True)
+    catalog_rows = "\n".join(f"| {category} | `{skill}` | {tier} | Test skill. |" for skill in skills)
+    conversion_rows = "\n".join(f"| PyTorch | `{skill}` | Test scope. | Test fixture. | {tier} |" for skill in skills)
+    lint_rows = "\n".join(f"| `{lint_id}` | Test lint definition. |" for lint_id in V1_LINT_IDS)
+
+    docs_root.joinpath("agent_integration.md").write_text(
+        "# Agent Integration\n\n"
+        "## Product Skill Catalog\n\n"
+        "| Category | Skill | Tier | Purpose |\n"
+        "| --- | --- | --- | --- |\n"
+        f"{catalog_rows}\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_skill_authoring.md").write_text(
+        "# Agent Skill Authoring\n\n"
+        "## Conversion Skill Families\n\n"
+        "| Code Family | Skill | Scope | Current Repo Evidence | Tier |\n"
+        "| --- | --- | --- | --- | --- |\n"
+        f"{conversion_rows}\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_skill_evaluation.md").write_text(
+        "# Agent Skill Evaluation\n\n"
+        "## V1 Engineering Lints\n\n"
+        "| Check | Definition |\n"
+        "| --- | --- |\n"
+        f"{lint_rows}\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_implementation_plan.md").write_text(
+        "# Agent Implementation Plan\n\n" "[V1 Engineering Lints](agent_skill_evaluation.md#v1-engineering-lints)\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_skills_deferred_roadmap.md").write_text(
+        "# Agent Skills Deferred Roadmap\n",
+        encoding="utf-8",
+    )
+    return docs_root
+
+
+def _default_evals(name, *, category="conversion", adjacent_negative=True, include_behavior_ids=True):
+    data = {
+        "skill_name": name,
+        "evals": [
+            {
+                "id": "positive",
+                "prompt": "Convert PyTorch training code into a FLARE job.",
+                "expected_output": "A validated FLARE job.",
+                "files": ["evals/files/input.py"],
+                "assertions": ["Uses the expected skill."],
+                "nvflare": {"expected_skill": name},
+            },
+            {
+                "id": "global-negative",
+                "prompt": "Deploy a React application.",
+                "expected_output": "No FLARE skill should trigger.",
+                "files": [],
+                "assertions": ["No FLARE skill is selected."],
+                "nvflare": {"expected_skill": "no_skill", "global_negative": True},
+            },
+        ],
+    }
+    if category is not None:
+        data["nvflare"] = {"category": category}
+    if adjacent_negative:
+        data["evals"].append(
+            {
+                "id": "adjacent-negative",
+                "prompt": "Deploy a FLARE startup kit to Kubernetes.",
+                "expected_output": "A deployment skill should trigger.",
+                "files": [],
+                "assertions": ["Conversion skill is not selected."],
+                "nvflare": {"expected_skill": "nvflare-deploy-k8s", "negative_for": name},
+            }
+        )
+    if include_behavior_ids:
+        data["evals"][0]["nvflare"].update(
+            {
+                "mandatory_behavior": [{"id": "inspect-first", "description": "runs inspect before editing"}],
+                "prohibited_behavior": [{"id": "no-production-submit", "description": "does not submit"}],
+                "optional_behavior": [{"id": "summarize", "description": "summarizes result"}],
+            }
+        )
+    return data
+
+
+def _has_finding(result, lint_id, code):
+    return any(finding["id"] == lint_id and finding.get("code") == code for finding in result["findings"])
+
+
+def _finding(result, lint_id, code):
+    matches = [finding for finding in result["findings"] if finding["id"] == lint_id and finding.get("code") == code]
+    assert matches, f"expected finding id={lint_id!r} code={code!r}; got {result['findings']!r}"
+    return matches[0]
+
+
+def _assert_structured_findings(result):
+    assert result["findings"]
+    for finding in result["findings"]:
+        assert REQUIRED_FINDING_FIELDS.issubset(finding), finding
+        assert finding["severity"] in {"error", "warning", "info"}
+        assert finding["file"]
+        assert finding["message"]
+        assert finding["hint"]
+        if "line" in finding:
+            assert isinstance(finding["line"], int)
+            assert finding["line"] > 0
+    json.dumps(result["findings"])

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,7 +58,7 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
-    assert payload["code"] == "INVALID_ARGS"
+    assert "code" not in payload
     assert "event" not in payload
     assert "terminal" not in payload
     assert "usage" in payload["data"]
@@ -109,7 +109,7 @@ def test_jsonl_rejected_for_non_streaming_command(capsys, monkeypatch):
     assert exc_info.value.code == 4
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["event"] == "terminal"
-    assert payload["terminal"] is True
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert payload["error_code"] == "INVALID_ARGS"
     assert "nvflare job monitor" in payload["message"]

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,6 +58,9 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
+    assert payload["code"] == "INVALID_ARGS"
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert "usage" in payload["data"]
     assert "list" in payload["data"]["choices"]
 

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -201,6 +201,15 @@ class TestOutputOk:
         mock_print.assert_called_once()
         assert mock_print.call_args.kwargs["flush"] is True
 
+    def test_json_mode_output_ok_flushes_stdout(self, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with patch("builtins.print") as mock_print:
+            output_ok({"key": "value"})
+
+        mock_print.assert_called_once()
+        assert mock_print.call_args.kwargs["flush"] is True
+
     def test_human_mode_dict_renders_as_table(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "txt")
         output_ok({"status": "running", "id": "abc"})

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -382,6 +382,23 @@ class TestOutputError:
         assert "message" in envelope
         assert "hint" in envelope
 
+    def test_error_envelope_supports_agent_fields(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with pytest.raises(SystemExit) as exc_info:
+            output_error(
+                "CONNECTION_FAILED",
+                recovery_category="RETRYABLE",
+                suggested_skill="nvflare-diagnose-job",
+            )
+
+        assert exc_info.value.code == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["error_code"] == "CONNECTION_FAILED"
+        assert envelope["code"] == "CONNECTION_FAILED"
+        assert envelope["recovery_category"] == "RETRYABLE"
+        assert envelope["suggested_skill"] == "nvflare-diagnose-job"
+
     def test_custom_exit_code(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "json")
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -201,15 +201,6 @@ class TestOutputOk:
         mock_print.assert_called_once()
         assert mock_print.call_args.kwargs["flush"] is True
 
-    def test_json_mode_output_ok_flushes_stdout(self, monkeypatch):
-        monkeypatch.setattr(cli_output, "_output_format", "json")
-
-        with patch("builtins.print") as mock_print:
-            output_ok({"key": "value"})
-
-        mock_print.assert_called_once()
-        assert mock_print.call_args.kwargs["flush"] is True
-
     def test_human_mode_dict_renders_as_table(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "txt")
         output_ok({"status": "running", "id": "abc"})
@@ -404,7 +395,7 @@ class TestOutputError:
         assert exc_info.value.code == 1
         envelope = json.loads(capsys.readouterr().out)
         assert envelope["error_code"] == "CONNECTION_FAILED"
-        assert envelope["code"] == "CONNECTION_FAILED"
+        assert "code" not in envelope
         assert envelope["recovery_category"] == "RETRYABLE"
         assert envelope["suggested_skill"] == "nvflare-diagnose-job"
 


### PR DESCRIPTION
## Summary
- add a developer admission-gate entry point with `python -m nvflare.tool.agent_skill_checks`
- implement deterministic Milestone 5 v1 lint checks and structured findings
- enforce `nvflare-` public skill name prefix in skill frontmatter validation
- add unit coverage for the lint runner, CLI wrapper, and prefix validation

## Stack note
This PR is stacked on #4705 (`agent-skills-pr4-inspect-doctor`). GitHub requires the base branch to exist in `NVIDIA/NVFlare`, so this PR targets `main`; until #4705 lands/rebases, the visible diff may include earlier agent-skill implementation commits.

## Notes
- this intentionally does not add a public `nvflare agent skills lint` command; the lint gate remains engineering/admission infrastructure
- category and doc crosslink checks run when a docs root is available

## Tests
- `python -m pytest tests/unit_test/tool/agent tests/unit_test/tool/agent_skill_checks`
- `python -m nvflare.tool.agent_skill_checks --skills-root skills --docs-root /Users/chesterc/projects/NVFlare/docs/design --format json`
- `python -m black --check nvflare/tool/agent_skill_checks tests/unit_test/tool/agent_skill_checks`
- `python -m isort --check-only nvflare/tool/agent_skill_checks tests/unit_test/tool/agent_skill_checks`
- `python -m flake8 nvflare/tool/agent_skill_checks tests/unit_test/tool/agent_skill_checks`
- `git diff --check`
- `./runtest.sh -s`
