### PR TITLE
fix(edge): create Android SGD optimizer once and correct proxy port docs

### DIFF
--- a/examples/advanced/edge/README.md
+++ b/examples/advanced/edge/README.md
@@ -132,7 +132,7 @@ You can get an example app from [nvflare/edge/device](../../../nvflare/edge/devi
 
 It can be installed on your device and started.
 
-You need to configure the server PORT to be the PORT shown in lcp_map.json (for example: 9003).
+You need to configure the server PORT to be the PORT of the routing proxy (4321 by default, as started by `start_rp.sh`). The ports in `lcp_map.json` (e.g. 9003) are the internal leaf-client ports used by the proxy itself and are not directly reachable by mobile devices.
 
 And you can find out the IP address of your machine and fill it there.
 

--- a/nvflare/edge/device/android/sdk/training/ETTrainer.kt
+++ b/nvflare/edge/device/android/sdk/training/ETTrainer.kt
@@ -274,10 +274,14 @@ class ETTrainer(
         val initialParameters: Map<String, Tensor> = model.namedParameters("forward")
         val oldParams = toTensorDictionary(initialParameters)
         Log.d(TAG, "Captured initial parameters with ${oldParams.size} tensors")
-        
+
         // Save initial parameters
         artifactManager.saveModelParameters(initialParameters, "initial_parameters.json", "Initial Model Parameters")
-        
+
+        // Create optimizer once to preserve momentum state across batches.
+        // Recreating it every batch resets the velocity buffer and negates any momentum benefit.
+        val sgd = SGD.create(initialParameters, learningRate.toDouble(), momentum.toDouble(), SGD_WEIGHT_DECAY, 0.0, SGD_NESTEROV)
+
         var totalLoss = 0.0f
         var totalSteps = 0
         
@@ -321,8 +325,6 @@ class ETTrainer(
                 epochSteps++
                 totalSteps++
                 
-                val parameters: Map<String, Tensor> = model.namedParameters("forward")
-                val sgd = SGD.create(parameters, learningRate.toDouble(), momentum.toDouble(), SGD_WEIGHT_DECAY, SGD_WEIGHT_DECAY, SGD_NESTEROV)
                 val gradients: Map<String, Tensor> = model.namedGradients("forward")
                 sgd.step(gradients)
                 


### PR DESCRIPTION
## Summary

Fixes two remaining items from issue #3827 affecting the edge training example.

**1. Android `ETTrainer.kt` — SGD optimizer recreated every batch step**

The `SGD.create(...)` call was inside the inner batch loop, so a brand-new optimizer was constructed on every gradient step. This discarded the velocity buffer between iterations, silently making `momentum=0.9` a no-op. The optimizer is now created once before the training loops so momentum state accumulates correctly across all batches and epochs — the same fix that was already applied to the Python simulation counterpart in commit `823f70c0`.

Also corrected: `dampening` was mistakenly passed as `SGD_WEIGHT_DECAY` (a separate constant) instead of `0.0`.

**2. `examples/advanced/edge/README.md` — wrong port documented for real mobile devices**

Line 135 told users to configure their mobile app's server PORT to the leaf-client port from `lcp_map.json` (e.g. `9003`). Real devices connect to the **routing proxy** started by `start_rp.sh` (port `4321` by default); the `lcp_map.json` ports are the internal ports the proxy uses to reach leaf clients and are not directly reachable from mobile devices.

## Test plan

- [ ] Review `ETTrainer.kt`: confirm `SGD.create` is called once before the `for (epoch in 1..epochs)` loop and the optimizer instance is reused across all batches
- [ ] Review `README.md`: confirm the port instruction now references the routing proxy port (`4321`) rather than a `lcp_map.json` port
- [ ] Build the Android app and run a short training session; verify loss decreases smoothly (momentum now effective)

Closes #3827