### PR TITLE
[2.8] Prevent corrupt client API models from incomplete downloads

### DIFF
--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -346,6 +346,23 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 f"Set peer_read_timeout >= {per_req}s in job config.",
             )
 
+        if configured_per_req is not None and self.heartbeat_timeout is None:
+            self.heartbeat_timeout = per_req
+            self.log_warning(
+                fl_ctx,
+                "Timeout inconsistency: heartbeat_timeout is not set after applying job-config overrides. "
+                "The CJ/subprocess pipe may miss liveness detection while large payloads are downloading. "
+                f"Using {per_req}s for this run. Set heartbeat_timeout >= {per_req}s in job config.",
+            )
+        elif configured_per_req is not None and self.heartbeat_timeout < per_req:
+            self.log_warning(
+                fl_ctx,
+                f"Timeout inconsistency: heartbeat_timeout ({self.heartbeat_timeout}s) < "
+                f"{prefix}streaming_per_request_timeout ({per_req}s). "
+                "The CJ/subprocess pipe may be marked unhealthy while a large payload is still downloading. "
+                f"Set heartbeat_timeout >= {per_req}s in job config.",
+            )
+
         if configured_per_req is not None and self._download_complete_timeout < per_req:
             self.log_warning(
                 fl_ctx,

--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -248,9 +248,9 @@ class ExProcessClientAPI(APISpec):
             raise e
 
     def receive(self, timeout: Optional[float] = None) -> Optional[FLModel]:
-        result = self.__receive()
-        self.receive_called = True
+        result = self.__receive(timeout)
         if result is not None:
+            self.receive_called = True
             self._mem_round = result.current_round
             self._mem_site = self.get_site_name()
             log_rss(f"CA s={self._mem_site} r={result.current_round} recv")

--- a/nvflare/client/in_process/api.py
+++ b/nvflare/client/in_process/api.py
@@ -114,25 +114,32 @@ class InProcessClientAPI(APISpec):
             self.logger.info(f"Memory management enabled: cleanup every {gc_rounds} round(s)")
 
     def receive(self, timeout: Optional[float] = None) -> Optional[FLModel]:
-        result = self.__receive()
-        self.receive_called = True
+        result = self.__receive(timeout)
         if result is not None:
+            self.receive_called = True
             self._mem_round = result.current_round
             self._mem_site = self.get_site_name()
             log_rss(f"CA s={self._mem_site} r={result.current_round} recv")
         return result
 
-    def __receive(self) -> Optional[FLModel]:
+    def __receive(self, timeout: Optional[float] = None) -> Optional[FLModel]:
         if self.fl_model:
             return self.fl_model
 
+        start_time = time.monotonic()
         while True:
             if not self.__continue_job():
                 break
 
             if self.fl_model is None:
-                self.logger.debug(f"no result global message available, sleep {self.result_check_interval} sec")
-                time.sleep(self.result_check_interval)
+                sleep_time = self.result_check_interval
+                if timeout is not None:
+                    remaining = timeout - (time.monotonic() - start_time)
+                    if remaining <= 0:
+                        break
+                    sleep_time = min(sleep_time, remaining)
+                self.logger.debug(f"no result global message available, sleep {sleep_time} sec")
+                time.sleep(sleep_time)
             else:
                 break
 
@@ -221,6 +228,7 @@ class InProcessClientAPI(APISpec):
 
     def clear(self):
         self.fl_model = None
+        self.receive_called = False
 
     def _prepare_param_diff(self, model: FLModel) -> FLModel:
         exchange_format = self.client_config.get_exchange_format()

--- a/nvflare/client/task_registry.py
+++ b/nvflare/client/task_registry.py
@@ -48,7 +48,7 @@ class TaskRegistry:
         """Whether this is the rank 0 process."""
         return self.rank is None or self.rank == "0"
 
-    def _receive(self, timeout: Optional[float] = None) -> Task:
+    def _receive(self, timeout: Optional[float] = None) -> Optional[Task]:
         """Receives a task using flare agent.
 
         This is only called on rank0.
@@ -59,7 +59,7 @@ class TaskRegistry:
         task = self.flare_agent.get_task(timeout)
 
         if task is None:
-            raise RuntimeError(f"no received task within timeout: {timeout}")
+            return None
 
         if task.data is None:
             raise RuntimeError("no received task.data")
@@ -83,7 +83,8 @@ class TaskRegistry:
         """
         if self.is_rank0 and not self.cache_loaded:
             task = self._receive(timeout)
-            self._set_task(task)
+            if task is not None:
+                self._set_task(task)
         return self.received_task
 
     def get_sys_info(self) -> Dict:

--- a/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
+++ b/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
@@ -547,6 +547,10 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
             )
             return lazy
 
+        if items is None:
+            self.logger.error(f"cannot find item {item_id} because no downloaded data is loaded")
+            raise RuntimeError(f"FOBS download data is missing for item {item_id}")
+
         self.logger.debug(f"trying to get item for {item_id=} from {type(items)=}")
 
         make_lazy_ref_fn = getattr(items, "make_lazy_ref", None)
@@ -555,10 +559,20 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
             self.logger.debug(f"{tid=} created lazy ref for {item_id}")
             return item
 
+        get_item_fn = getattr(items, "get", None)
+        if not callable(get_item_fn):
+            self.logger.error(f"downloaded data for {item_id} does not support get(): {type(items)}")
+            raise RuntimeError(f"FOBS download data has invalid type for item {item_id}")
+
+        if hasattr(items, "__contains__") and item_id not in items:
+            self.logger.error(f"cannot find item {item_id} from loaded data")
+            raise RuntimeError(f"FOBS download data is incomplete: item {item_id} is missing")
+
         item = items.get(item_id)
         self.logger.debug(f"{tid=} found item {item_id}: {type(item)}")
         if item is None:
-            self.logger.error(f"cannot find item {item_id} from loaded data")
+            self.logger.error(f"downloaded item {item_id} is None")
+            raise RuntimeError(f"FOBS download data is incomplete: item {item_id} is None")
         return item
 
     def _download_from_remote_cell(self, fobs_ctx: dict, ref: dict):

--- a/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
+++ b/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
@@ -976,6 +976,34 @@ def test_timeout_warning_peer_read_less_than_per_req(monkeypatch):
     assert any("peer_read_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
 
 
+def test_timeout_warning_heartbeat_less_than_per_req(monkeypatch):
+    """A warning must fire when heartbeat_timeout is lower than streaming_per_request_timeout."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, heartbeat_timeout=300.0)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert any("heartbeat_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
+
+
 def test_timeout_warning_peer_read_none_when_per_req_is_configured(monkeypatch):
     """A warning must fire when peer_read_timeout is unset and streaming timeout is configured."""
     import nvflare.fuel.utils.app_config_utils as acu
@@ -1002,6 +1030,35 @@ def test_timeout_warning_peer_read_none_when_per_req_is_configured(monkeypatch):
     executor.initialize(fl_ctx)
 
     assert any("peer_read_timeout is not set" in w for w in warnings), warnings
+
+
+def test_heartbeat_timeout_none_is_corrected_when_per_req_is_configured(monkeypatch):
+    """Unset heartbeat_timeout is corrected because PipeHandler requires a numeric value."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, heartbeat_timeout=None)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert executor.heartbeat_timeout == 600.0
+    assert any("heartbeat_timeout is not set" in w and "Using 600.0s" in w for w in warnings), warnings
 
 
 def test_default_peer_read_timeout_does_not_warn_without_configured_per_req(monkeypatch):

--- a/tests/unit_test/client/ex_process/api_test.py
+++ b/tests/unit_test/client/ex_process/api_test.py
@@ -15,6 +15,9 @@
 import copy
 from unittest.mock import patch
 
+import pytest
+
+from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.abstract.params_converter import ParamsConverter
 from nvflare.client.config import ClientConfig, ConfigKey, ExchangeFormat
 from nvflare.client.converter_utils import create_default_params_converters
@@ -177,6 +180,50 @@ def test_ex_process_api_passes_submit_result_timeout_to_agent(monkeypatch):
 
     assert "submit_result_timeout" in captured_kwargs, "submit_result_timeout was not passed to FlareAgentWithFLModel"
     assert captured_kwargs["submit_result_timeout"] == 999.0
+
+
+def test_ex_process_receive_timeout_does_not_arm_send_under_congestion():
+    from unittest.mock import MagicMock
+
+    from nvflare.client.config import ClientConfig
+    from nvflare.client.ex_process.api import ExProcessClientAPI
+    from nvflare.client.model_registry import ModelRegistry
+
+    fake_agent = MagicMock()
+    fake_agent.get_task.return_value = None
+    registry = ModelRegistry(ClientConfig({}), rank="0", flare_agent=fake_agent)
+    api = ExProcessClientAPI(config_file="fake_config.json")
+    api.model_registry = registry
+
+    assert api.receive(timeout=12.5) is None
+    fake_agent.get_task.assert_called_once_with(12.5)
+    assert api.receive_called is False
+    with pytest.raises(RuntimeError, match='"receive" needs to be called'):
+        api.send(FLModel(params={"x": 1}))
+
+
+def test_ex_process_receive_timeout_then_later_task_allows_send():
+    from unittest.mock import MagicMock
+
+    from nvflare.client.config import ClientConfig
+    from nvflare.client.ex_process.api import ExProcessClientAPI
+    from nvflare.client.flare_agent import Task
+    from nvflare.client.model_registry import ModelRegistry
+
+    received_model = FLModel(params={"x": 1})
+    fake_agent = MagicMock()
+    fake_agent.get_task.side_effect = [None, Task(task_name="train", task_id="task-1", data=received_model)]
+    registry = ModelRegistry(ClientConfig({}), rank="0", flare_agent=fake_agent)
+    api = ExProcessClientAPI(config_file="fake_config.json")
+    api.model_registry = registry
+
+    assert api.receive(timeout=0.1) is None
+    assert api.receive_called is False
+
+    assert api.receive(timeout=0.1) is received_model
+    assert api.receive_called is True
+    api.send(FLModel(params={"x": 2}), clear_cache=False)
+    fake_agent.submit_result.assert_called_once()
 
 
 # ── _downgrade_rotating_handlers tests ────────────────────────────────────────

--- a/tests/unit_test/client/in_process/api_test.py
+++ b/tests/unit_test/client/in_process/api_test.py
@@ -262,4 +262,52 @@ class TestInProcessClientAPI(unittest.TestCase):
         self.assertIsNone(output_model.params)
         self.assertEqual(output_model.metrics, {"loss": 0.42})
 
+    def test_receive_timeout_does_not_arm_send_under_congestion(self):
+        """A missing next-round model should time out cleanly and not permit send()."""
+        client_api = InProcessClientAPI(self.task_metadata, result_check_interval=0.001)
+        client_api.init()
+
+        self.assertIsNone(client_api.receive(timeout=0.01))
+        self.assertFalse(client_api.receive_called)
+        with self.assertRaisesRegex(RuntimeError, '"receive" needs to be called'):
+            client_api.send(FLModel(params={"w": 1}))
+
+    def test_receive_timeout_then_later_model_allows_send(self):
+        """A timeout must not poison the next successful receive/send cycle."""
+        import numpy as np
+
+        client_api = InProcessClientAPI(self.task_metadata, result_check_interval=0.001)
+        client_api.init()
+
+        self.assertIsNone(client_api.receive(timeout=0.01))
+        self.assertFalse(client_api.receive_called)
+
+        self._fire_global_model(client_api, {"w": np.ones((10,))})
+        input_model = client_api.receive(timeout=0.01)
+        self.assertIsNotNone(input_model)
+        self.assertIsNotNone(input_model.params)
+        self.assertTrue(client_api.receive_called)
+
+        client_api.send(FLModel(params={"w": np.zeros((10,))}), clear_cache=False)
+        self.assertTrue(client_api.receive_called)
+
+    def test_clear_resets_receive_guard_between_rounds(self):
+        """A prior successful round must not arm send() after a later receive timeout."""
+        import numpy as np
+
+        client_api = InProcessClientAPI(self.task_metadata, result_check_interval=0.001)
+        client_api.init()
+
+        self._fire_global_model(client_api, {"w": np.ones((10,))})
+        self.assertIsNotNone(client_api.receive(timeout=0.01))
+        self.assertTrue(client_api.receive_called)
+
+        client_api.send(FLModel(params={"w": np.zeros((10,))}), clear_cache=True)
+        self.assertFalse(client_api.receive_called)
+
+        self.assertIsNone(client_api.receive(timeout=0.01))
+        self.assertFalse(client_api.receive_called)
+        with self.assertRaisesRegex(RuntimeError, '"receive" needs to be called'):
+            client_api.send(FLModel(params={"w": np.zeros((10,))}))
+
     # Add more test methods for other functionalities in the class

--- a/tests/unit_test/client/test_model_registry.py
+++ b/tests/unit_test/client/test_model_registry.py
@@ -135,6 +135,24 @@ class TestReleaseParamsReceivedModel(unittest.TestCase):
         self.assertIsNone(received.params)
 
 
+class TestGetModelTimeout(unittest.TestCase):
+    def test_returns_none_when_agent_get_task_times_out(self):
+        registry = _make_registry()
+        registry.flare_agent.get_task.return_value = None
+
+        self.assertIsNone(registry.get_model(timeout=12.5))
+        registry.flare_agent.get_task.assert_called_once_with(12.5)
+        self.assertFalse(registry.cache_loaded)
+
+    def test_allows_received_model_with_none_param_values(self):
+        registry = _make_registry()
+        model = FLModel(params={"center": np.ones((2, 2)), "count": None})
+        task = Task(task_name="train", task_id="test-task-1", data=model)
+        registry._set_task(task)
+
+        self.assertIs(registry.get_model(), model)
+
+
 class TestReleaseParamsMemoryRelease(unittest.TestCase):
     """Verify that numpy arrays are actually dereferenced after release_params."""
 

--- a/tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py
+++ b/tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py
@@ -14,6 +14,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from nvflare.fuel.utils.fobs.decomposers.via_downloader import EncKey, EncType, ViaDownloaderDecomposer
 
 
@@ -88,3 +90,24 @@ class TestViaDownloaderRecomposeLazyRefGuard:
 
         result = decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
         assert result == "lazy_T0"
+
+    def test_missing_downloaded_items_raises(self):
+        decomposer = _DummyViaDownloader()
+        manager = SimpleNamespace(fobs_ctx={})
+
+        with pytest.raises(RuntimeError, match="FOBS download data is missing"):
+            decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
+
+    def test_missing_downloaded_item_raises(self):
+        decomposer = _DummyViaDownloader()
+        manager = SimpleNamespace(fobs_ctx={decomposer.items_key: {}})
+
+        with pytest.raises(RuntimeError, match="FOBS download data is incomplete"):
+            decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
+
+    def test_none_downloaded_item_raises(self):
+        decomposer = _DummyViaDownloader()
+        manager = SimpleNamespace(fobs_ctx={decomposer.items_key: {"T0": None}})
+
+        with pytest.raises(RuntimeError, match="item T0 is None"):
+            decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)


### PR DESCRIPTION
## Summary
- fail FOBS recomposition when streamed download items are missing or `None`, preventing incomplete downloads from materializing corrupt model params
- forward `receive(timeout=...)` through the external-process and in-process client API paths so timeout calls return `None` instead of raising or blocking incorrectly
- keep `send()` guarded after timed-out receives, including the in-process multi-round case where `clear()` must reset stale receive state
- warn when `heartbeat_timeout` is shorter than the configured streaming request timeout

## Tests
- `python -m pytest tests/unit_test/client/ex_process/api_test.py tests/unit_test/client/in_process/api_test.py tests/unit_test/client/test_model_registry.py tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py tests/unit_test/app_common/executors/client_api_launcher_executor_test.py`
- `./runtest.sh -s`
