### PR TITLE
[main] Port 2.8 large-model client API fixes

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -34,7 +34,10 @@ job initialization:
   series of replacement download transactions.
 
 If your 2.7.x job explicitly set either value to ``None``, update it before
-running on 2.8.0:
+running on 2.8.0. Recipe-based external-process jobs already serialize the
+default ``max_resends=3`` in executor args, so the following setting is only
+needed when overriding a previous explicit ``None`` or choosing a different
+retry budget:
 
 .. code-block:: python
 

--- a/docs/programming_guide/timeouts.rst
+++ b/docs/programming_guide/timeouts.rst
@@ -257,8 +257,8 @@ FlareAgent for external process integration (flare_agent.py):
    * - max_resends
      - None in raw ``FlareAgent``; 3 through Client API job config
      - Maximum send retries on failure. For ``ClientAPILauncherExecutor`` jobs,
-       use a finite non-negative value; ``None`` is rejected at job initialization.
-       Configurable via ``add_client_config({"max_resends": N})``.
+       the default is the finite value ``3``; ``None`` is rejected at job
+       initialization. Override via ``add_client_config({"max_resends": N})``.
    * - download_complete_timeout
      - 1800.0
      - Time the subprocess waits after result ACK while the server finishes
@@ -268,7 +268,11 @@ FlareAgent for external process integration (flare_agent.py):
 **Note**: Raw ``FlareAgentWithCellPipe`` defaults to 60.0 s for
 ``submit_result_timeout`` and unlimited ``max_resends``. When launched through
 ``ClientAPILauncherExecutor``, the generated Client API config supplies the
-safer job defaults described above.
+safer job defaults described above. Recipe-based external-process jobs also
+serialize ``max_resends=3`` in the executor args, so reloaded jobs do not fall
+back to the raw unlimited retry default. Use
+``recipe.add_client_config({"max_resends": N})`` only when a job needs a
+different finite retry budget.
 
 IPC Agent
 ^^^^^^^^^
@@ -550,8 +554,16 @@ For subprocess-mode Client API jobs with large payloads, FLARE validates the
 following at job start:
 
 - ``download_complete_timeout`` must not be ``None``.
-- ``max_resends`` must be a finite non-negative integer. Use ``0`` to disable
+- ``max_resends`` must be a finite non-negative integer. Recipe-based jobs
+  serialize the default value ``3`` in executor args. Use ``0`` to disable
   retries; do not use ``None`` for unlimited retries.
+
+Values supplied through ``recipe.add_client_config()`` are top-level entries in
+``config_fed_client.json``. For subprocess-mode Client API jobs,
+``ClientAPILauncherExecutor`` applies these overrides before writing the
+subprocess ``client_api_config.json``, so ``submit_result_timeout``,
+``download_complete_timeout``, and ``max_resends`` are seen by both the parent
+client job process and the external training process.
 
 When ``tensor_streaming_per_request_timeout`` or
 ``np_streaming_per_request_timeout`` is explicitly configured, FLARE also warns
@@ -1535,6 +1547,9 @@ subprocess pipe settings:
 - ``download_complete_timeout`` should be at least the configured streaming
   per-request timeout and long enough for the server to pull large tensor
   results from the subprocess after result ACK.
+- ``max_resends`` should stay finite. The recipe default is ``3``; raise it
+  only when the network is expected to recover after a small number of delayed
+  result acknowledgments.
 
 Swarm Learning Large Model Setup
 --------------------------------

--- a/docs/release_notes/flare_280.rst
+++ b/docs/release_notes/flare_280.rst
@@ -287,7 +287,10 @@ unbounded sequence of large download transactions, and
 alive while the server finishes pulling tensors from it. Jobs with explicitly
 configured large streaming request timeouts now receive warnings when related
 pipe/download-completion timeouts are shorter than the configured streaming
-timeout.
+timeout. Recipe-generated external-process jobs serialize the bounded
+``max_resends=3`` default in executor args, and top-level
+``recipe.add_client_config({"max_resends": N})`` overrides are applied before
+the subprocess Client API config is written.
 
 Server Memory: Tensor Disk Offload
 -----------------------------------

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -825,8 +825,9 @@ Decentralized federated learning without a central server.
    - ``pipe_type`` (default ``"cell_pipe"``): set to ``"file_pipe"`` when cell networking
      is unavailable or for third-party subprocess integrations.
    - ``submit_result_timeout``, ``download_complete_timeout``,
-     ``tensor_min_download_timeout``, ``PEER_READ_TIMEOUT``, and finite
-     ``max_resends``: set via ``recipe.add_client_config({...})`` — see
+     ``tensor_min_download_timeout``, and ``PEER_READ_TIMEOUT``: set via
+     ``recipe.add_client_config({...})``. ``max_resends`` defaults to finite
+     value ``3`` and can be overridden the same way — see
      :ref:`timeout_troubleshooting`.
 
 

--- a/docs/user_guide/timeout_troubleshooting.rst
+++ b/docs/user_guide/timeout_troubleshooting.rst
@@ -173,7 +173,10 @@ server to finish pulling tensors from its ``DownloadService`` after result ACK.
    In FLARE 2.8.0, ``ClientAPILauncherExecutor`` rejects
    ``download_complete_timeout=None`` and ``max_resends=None`` at job
    initialization. Use a positive ``download_complete_timeout`` and a finite
-   non-negative ``max_resends`` value.
+   non-negative ``max_resends`` value. Recipe-based external-process jobs
+   serialize the default ``max_resends=3`` in executor args; use
+   ``recipe.add_client_config({"max_resends": N})`` only to override that
+   default.
 
 Swarm Learning P2P Transfer Timeout
 ------------------------------------
@@ -249,7 +252,7 @@ Most Commonly Adjusted Timeouts
      - Keep subprocess alive while the server downloads large tensor results
    * - max_resends (subprocess mode only)
      - 3
-     - Persistent network failures; use a finite non-negative value
+     - Persistent network failures; keep finite; use 0 to disable retries
    * - round_timeout (Swarm Learning only)
      - 3600 s
      - 7B+ model P2P transfers between Swarm peers
@@ -347,6 +350,7 @@ Large Model Training (100M+ parameters)
        "download_complete_timeout": 1800,   # subprocess mode only
        "tensor_min_download_timeout": 300,  # subprocess mode only; use np_min_download_timeout for NumPy
        "PEER_READ_TIMEOUT": 600,            # subprocess mode only
+       "max_resends": 3,                    # subprocess mode only; finite default
    })
 
 

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -25,9 +25,12 @@ from nvflare.client.config import ConfigKey, ExchangeFormat, TransferType, write
 from nvflare.client.constants import CLIENT_API_CONFIG, EXTERNAL_PRE_INIT_TIMEOUT, PEER_READ_TIMEOUT
 from nvflare.fuel.utils.attributes_exportable import ExportMode
 from nvflare.fuel.utils.fobs.decomposers.via_downloader import MIN_DOWNLOAD_TIMEOUT_DEFAULT
+from nvflare.fuel.utils.validation_utils import check_non_negative_int
 from nvflare.utils.configs import get_client_config_value
 
 logger = logging.getLogger(__name__)
+
+_CONFIG_VALUE_MISSING = object()
 
 
 class ClientAPILauncherExecutor(LauncherExecutor):
@@ -58,7 +61,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         memory_gc_rounds: int = 0,
         cuda_empty_cache: bool = False,
         submit_result_timeout: float = 300.0,
-        max_resends: int = 3,
+        max_resends: Optional[int] = 3,
         download_complete_timeout: float = 1800.0,
     ) -> None:
         """Initializes the ClientAPILauncherExecutor.
@@ -94,16 +97,17 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 pipe message.  With reverse PASS_THROUGH enabled CJ ACKs immediately (LazyDownloadRef creation is
                 microseconds), so 300 s is a very generous allowance.  Without reverse PASS_THROUGH, CJ must
                 download the full result before ACKing; in that case this should be at least as large as the
-                expected transfer time.  Configurable via recipe.add_client_config({"submit_result_timeout": N}).
+                expected transfer time. Recipe-based jobs can override via
+                recipe.add_client_config({"submit_result_timeout": N}).
             max_resends (int): Maximum number of retries after the initial result send if CJ does not ACK within
                 submit_result_timeout. Defaults to 3. Set to a finite non-negative integer; 0 disables retries.
                 None means unlimited retries (unsafe for large models because each retry creates a new download
-                transaction) and is rejected at job initialization. Configurable via
-                recipe.add_client_config({"max_resends": N}).
+                transaction) and is rejected at job initialization. Recipe-based jobs serialize this default in
+                executor args; override per job via recipe.add_client_config({"max_resends": N}).
             download_complete_timeout (float): How long (seconds) the subprocess waits after send_to_peer() ACKs
                 for the server to finish downloading its tensors from the subprocess DownloadService.  Without
                 this gate, the subprocess may exit before the download completes and the server gets
-                "no ref found".  Defaults to 1800 s.  Configurable via
+                missing download refs. Defaults to 1800 s. Recipe-based jobs can override via
                 recipe.add_client_config({"download_complete_timeout": N}).
         """
         LauncherExecutor.__init__(
@@ -126,8 +130,11 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             submit_model_task_name=submit_model_task_name,
             from_nvflare_converter_id=from_nvflare_converter_id,
             to_nvflare_converter_id=to_nvflare_converter_id,
+            max_resends=max_resends,
         )
 
+        # Preserve the bounded retry default across FedJobConfig export/reload.
+        self._always_serialize_args = {"max_resends"}
         self._server_expected_format = server_expected_format
         self._params_exchange_format = params_exchange_format
         self._params_transfer_type = params_transfer_type
@@ -135,11 +142,10 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         self._memory_gc_rounds = memory_gc_rounds
         self._cuda_empty_cache = cuda_empty_cache
         self._submit_result_timeout = submit_result_timeout
-        self._max_resends = max_resends
         self._download_complete_timeout = download_complete_timeout
         self._cj_round_count = 0
 
-        # Allow the subprocess to exit naturally after Fix 16's download_done.wait()
+        # Allow the subprocess to exit naturally after its download-completion wait
         # before stop_task() sends SIGTERM.  Without this, _finalize_external_execution()
         # kills the subprocess immediately, tearing down its cell connection before the
         # server can download tensors from it ("no path" / deadlock).
@@ -159,6 +165,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
         super().finalize(fl_ctx)
 
     def initialize(self, fl_ctx: FLContext) -> None:
+        self._apply_client_config_overrides(fl_ctx)
         self.prepare_config_for_launch(fl_ctx)
         super().initialize(fl_ctx)
 
@@ -194,38 +201,69 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                         f"Receiver-side PASS_THROUGH enabled on CJ cell for channel '{channel_name}'",
                     )
 
-        # Check for top-level config override for external_pre_init_timeout
-        # This allows jobs to configure timeout via add_client_config()
-        config_timeout = get_client_config_value(fl_ctx, EXTERNAL_PRE_INIT_TIMEOUT)
-        if config_timeout is not None:
-            timeout_value = float(config_timeout)
-            if timeout_value <= 0:
-                self.log_error(fl_ctx, f"Invalid EXTERNAL_PRE_INIT_TIMEOUT: {timeout_value}s (must be positive)")
-                raise ValueError(f"EXTERNAL_PRE_INIT_TIMEOUT must be positive, got {timeout_value}")
-            self.log_info(
-                fl_ctx,
-                f"Overriding external_pre_init_timeout from config: {self._external_pre_init_timeout}s -> {timeout_value}s",
-            )
-            self._external_pre_init_timeout = timeout_value
-
-        # Check for top-level config override for peer_read_timeout.
-        # peer_read_timeout (CJ side) and submit_result_timeout (subprocess side) must be
-        # configured together so the system behaves consistently under large-model transfers.
-        # Placing both overrides in config_fed_client.json (via add_client_config()) lets
-        # operators tune them in one place without touching executor component parameters.
-        config_peer_timeout = get_client_config_value(fl_ctx, PEER_READ_TIMEOUT)
-        if config_peer_timeout is not None:
-            peer_timeout_value = float(config_peer_timeout)
-            if peer_timeout_value <= 0:
-                self.log_error(fl_ctx, f"Invalid PEER_READ_TIMEOUT: {peer_timeout_value}s (must be positive)")
-                raise ValueError(f"PEER_READ_TIMEOUT must be positive, got {peer_timeout_value}")
-            self.log_info(
-                fl_ctx,
-                f"Overriding peer_read_timeout from config: {self.peer_read_timeout}s -> {peer_timeout_value}s",
-            )
-            self.peer_read_timeout = peer_timeout_value
-
         self._validate_timeout_config(fl_ctx)
+
+    def _get_client_config_override(self, fl_ctx: FLContext, key: str):
+        return get_client_config_value(fl_ctx, key, _CONFIG_VALUE_MISSING)
+
+    def _apply_positive_float_client_config_override(self, fl_ctx: FLContext, key: str, attr_name: str):
+        value = self._get_client_config_override(fl_ctx, key)
+        if value is _CONFIG_VALUE_MISSING:
+            return
+
+        try:
+            timeout_value = float(value)
+        except (TypeError, ValueError) as e:
+            msg = f"{key} must be positive, got {value}"
+            self.log_error(fl_ctx, msg)
+            raise ValueError(msg) from e
+
+        if timeout_value <= 0:
+            self.log_error(fl_ctx, f"Invalid {key}: {timeout_value}s (must be positive)")
+            raise ValueError(f"{key} must be positive, got {timeout_value}")
+
+        old_value = getattr(self, attr_name)
+        self.log_info(fl_ctx, f"Overriding {attr_name} from config: {old_value}s -> {timeout_value}s")
+        setattr(self, attr_name, timeout_value)
+
+    def _apply_max_resends_client_config_override(self, fl_ctx: FLContext):
+        value = self._get_client_config_override(fl_ctx, ConfigKey.MAX_RESENDS)
+        if value is _CONFIG_VALUE_MISSING:
+            return
+
+        # Validate strictly with the same helper the TaskExchanger constructor uses so the
+        # override path cannot silently truncate floats (e.g. 2.9 -> 2) or accept numeric
+        # strings ("3") via int() coercion. bool is an int subclass but is not a valid count.
+        try:
+            if isinstance(value, bool):
+                raise TypeError(f"{ConfigKey.MAX_RESENDS} must be an int, but got {type(value)}.")
+            check_non_negative_int(ConfigKey.MAX_RESENDS, value)
+        except (TypeError, ValueError) as e:
+            msg = f"{ConfigKey.MAX_RESENDS} must be a finite non-negative integer, got {value!r}"
+            self.log_error(fl_ctx, msg)
+            raise ValueError(msg) from e
+
+        self.log_info(fl_ctx, f"Overriding max_resends from config: {self.max_resends} -> {value}")
+        self.max_resends = value
+
+    def _apply_client_config_overrides(self, fl_ctx: FLContext):
+        # Apply top-level config_fed_client.json overrides before writing the
+        # subprocess Client API config so add_client_config() affects both sides.
+        self._apply_positive_float_client_config_override(
+            fl_ctx, EXTERNAL_PRE_INIT_TIMEOUT, "_external_pre_init_timeout"
+        )
+        # peer_read_timeout is enforced on the CJ side, while submit_result_timeout is
+        # enforced by the subprocess. Keep both tunable from add_client_config() so
+        # operators can coordinate large-model transfer timeouts in one place.
+        self._apply_positive_float_client_config_override(fl_ctx, PEER_READ_TIMEOUT, "peer_read_timeout")
+        self._apply_positive_float_client_config_override(
+            fl_ctx, ConfigKey.SUBMIT_RESULT_TIMEOUT, "_submit_result_timeout"
+        )
+        self._apply_max_resends_client_config_override(fl_ctx)
+        self._apply_positive_float_client_config_override(
+            fl_ctx, ConfigKey.DOWNLOAD_COMPLETE_TIMEOUT, "_download_complete_timeout"
+        )
+        self._stop_task_wait_timeout = self._download_complete_timeout
 
     def _decomposer_prefix(self) -> str:
         """Return the config-var prefix for the active decomposer type.
@@ -245,15 +283,16 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             msg = (
                 "download_complete_timeout is None. This timeout is required to keep the subprocess alive while "
                 "the server downloads large tensor results. Set download_complete_timeout to a positive value "
-                "in job config."
+                "in executor config or via recipe.add_client_config()."
             )
             self.log_error(fl_ctx, msg)
             raise ValueError(msg)
 
-        if self._max_resends is None:
+        if self.max_resends is None:
             msg = (
                 "max_resends is None (unbounded). This can turn one delayed large-model transfer into an "
-                "unlimited resend storm. Set max_resends to a finite non-negative integer (e.g. 3) in job config."
+                "unbounded resend loop. Set max_resends to a finite non-negative integer (e.g. 3) in executor "
+                "config or via recipe.add_client_config()."
             )
             self.log_error(fl_ctx, msg)
             raise ValueError(msg)
@@ -313,7 +352,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 f"Timeout inconsistency: download_complete_timeout ({self._download_complete_timeout}s) < "
                 f"{prefix}streaming_per_request_timeout ({per_req}s). "
                 "The subprocess may stop before the server finishes downloading tensor results. "
-                f"Set download_complete_timeout >= {per_req}s in job config.",
+                f"Set download_complete_timeout >= {per_req}s in executor config or via recipe.add_client_config().",
             )
 
         if self._submit_result_timeout > min_dl:
@@ -391,7 +430,7 @@ class ClientAPILauncherExecutor(LauncherExecutor):
             ConfigKey.MEMORY_GC_ROUNDS: self._memory_gc_rounds,
             ConfigKey.CUDA_EMPTY_CACHE: self._cuda_empty_cache,
             ConfigKey.SUBMIT_RESULT_TIMEOUT: self._submit_result_timeout,
-            ConfigKey.MAX_RESENDS: self._max_resends,
+            ConfigKey.MAX_RESENDS: self.max_resends,
             ConfigKey.DOWNLOAD_COMPLETE_TIMEOUT: self._download_complete_timeout,
             ConfigKey.LAUNCH_ONCE: self._resolve_launch_once(fl_ctx),
         }

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -346,6 +346,23 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                 f"Set peer_read_timeout >= {per_req}s in job config.",
             )
 
+        if configured_per_req is not None and self.heartbeat_timeout is None:
+            self.heartbeat_timeout = per_req
+            self.log_warning(
+                fl_ctx,
+                "Timeout inconsistency: heartbeat_timeout is not set after applying job-config overrides. "
+                "The CJ/subprocess pipe may miss liveness detection while large payloads are downloading. "
+                f"Using {per_req}s for this run. Set heartbeat_timeout >= {per_req}s in job config.",
+            )
+        elif configured_per_req is not None and self.heartbeat_timeout < per_req:
+            self.log_warning(
+                fl_ctx,
+                f"Timeout inconsistency: heartbeat_timeout ({self.heartbeat_timeout}s) < "
+                f"{prefix}streaming_per_request_timeout ({per_req}s). "
+                "The CJ/subprocess pipe may be marked unhealthy while a large payload is still downloading. "
+                f"Set heartbeat_timeout >= {per_req}s in job config.",
+            )
+
         if configured_per_req is not None and self._download_complete_timeout < per_req:
             self.log_warning(
                 fl_ctx,

--- a/nvflare/app_common/executors/launcher_executor.py
+++ b/nvflare/app_common/executors/launcher_executor.py
@@ -55,6 +55,7 @@ class LauncherExecutor(TaskExchanger):
         submit_model_task_name: str = AppConstants.TASK_SUBMIT_MODEL,
         from_nvflare_converter_id: Optional[str] = None,
         to_nvflare_converter_id: Optional[str] = None,
+        max_resends: Optional[int] = None,
     ) -> None:
         """Initializes the LauncherExecutor.
 
@@ -80,6 +81,7 @@ class LauncherExecutor(TaskExchanger):
                 Parameter conversion for launcher-based external execution now happens in the subprocess agent.
             to_nvflare_converter_id (Optional[str]): Deprecated in LauncherExecutor path.
                 Parameter conversion for launcher-based external execution now happens in the subprocess agent.
+            max_resends (Optional[int]): Maximum number of retries for pipe sends. None means no limit.
         """
         TaskExchanger.__init__(
             self,
@@ -87,6 +89,7 @@ class LauncherExecutor(TaskExchanger):
             read_interval=read_interval,
             heartbeat_interval=heartbeat_interval,
             heartbeat_timeout=heartbeat_timeout,
+            max_resends=max_resends,
             peer_read_timeout=peer_read_timeout,
             task_wait_time=task_wait_timeout,
         )
@@ -379,7 +382,7 @@ class LauncherExecutor(TaskExchanger):
             and self.launcher.needs_deferred_stop()
             and self._deferred_stop_event.is_set()
         ):
-            # The subprocess may be blocking in download_done.wait() (Fix 16 / DOWNLOAD_COMPLETE_CB)
+            # The subprocess may be blocking in its download-completion wait
             # so the server can pull large tensors directly from its DownloadService.
             # Calling stop_task() here would send SIGTERM and tear down the subprocess cell
             # before the server connects, causing "no path" errors on every retry.

--- a/nvflare/client/config.py
+++ b/nvflare/client/config.py
@@ -174,8 +174,9 @@ class ClientConfig:
         """Return the maximum number of pipe send retries for submitting task results.
 
         None means unlimited; the default of 3 bounds the retry window and prevents
-        unbounded ArrayDownloadable accumulation (Root Cause 6).
-        Set via recipe.add_client_config({"max_resends": N}).
+        unbounded large-result resend transactions. In recipe-based external-process
+        jobs, the parent executor writes this value into the Client API config and
+        applies recipe.add_client_config({"max_resends": N}) as a per-job override.
         """
         value = self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(ConfigKey.MAX_RESENDS, 3)
         if value is None:
@@ -201,6 +202,8 @@ class ClientConfig:
         After send_to_peer() ACKs, the server asynchronously downloads tensors from the subprocess
         DownloadService.  This timeout gates subprocess exit so the process does not disappear before
         the download completes.  Defaults to 1800 s (30 min) for large-model transfers.
+        Recipe-based external-process jobs can override it with
+        recipe.add_client_config({"download_complete_timeout": N}).
         """
         return float(self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(ConfigKey.DOWNLOAD_COMPLETE_TIMEOUT, 1800.0))
 
@@ -212,8 +215,8 @@ class ClientConfig:
         300 s is returned — large enough for a single-chunk ACK with reverse PASS_THROUGH, and
         a reasonable upper bound for direct (non-PASS_THROUGH) transfers at typical throughputs.
 
-        Changing this value via recipe.add_client_config() sets it for a specific job without
-        touching any process-level defaults.
+        Recipe-based external-process jobs can override it with
+        recipe.add_client_config({"submit_result_timeout": N}) without touching process-level defaults.
         """
         return float(self.config.get(ConfigKey.TASK_EXCHANGE, {}).get(ConfigKey.SUBMIT_RESULT_TIMEOUT, 300.0))
 

--- a/nvflare/client/ex_process/api.py
+++ b/nvflare/client/ex_process/api.py
@@ -248,9 +248,9 @@ class ExProcessClientAPI(APISpec):
             raise e
 
     def receive(self, timeout: Optional[float] = None) -> Optional[FLModel]:
-        result = self.__receive()
-        self.receive_called = True
+        result = self.__receive(timeout)
         if result is not None:
+            self.receive_called = True
             self._mem_round = result.current_round
             self._mem_site = self.get_site_name()
             log_rss(f"CA s={self._mem_site} r={result.current_round} recv")

--- a/nvflare/client/in_process/api.py
+++ b/nvflare/client/in_process/api.py
@@ -114,25 +114,32 @@ class InProcessClientAPI(APISpec):
             self.logger.info(f"Memory management enabled: cleanup every {gc_rounds} round(s)")
 
     def receive(self, timeout: Optional[float] = None) -> Optional[FLModel]:
-        result = self.__receive()
-        self.receive_called = True
+        result = self.__receive(timeout)
         if result is not None:
+            self.receive_called = True
             self._mem_round = result.current_round
             self._mem_site = self.get_site_name()
             log_rss(f"CA s={self._mem_site} r={result.current_round} recv")
         return result
 
-    def __receive(self) -> Optional[FLModel]:
+    def __receive(self, timeout: Optional[float] = None) -> Optional[FLModel]:
         if self.fl_model:
             return self.fl_model
 
+        start_time = time.monotonic()
         while True:
             if not self.__continue_job():
                 break
 
             if self.fl_model is None:
-                self.logger.debug(f"no result global message available, sleep {self.result_check_interval} sec")
-                time.sleep(self.result_check_interval)
+                sleep_time = self.result_check_interval
+                if timeout is not None:
+                    remaining = timeout - (time.monotonic() - start_time)
+                    if remaining <= 0:
+                        break
+                    sleep_time = min(sleep_time, remaining)
+                self.logger.debug(f"no result global message available, sleep {sleep_time} sec")
+                time.sleep(sleep_time)
             else:
                 break
 
@@ -221,6 +228,7 @@ class InProcessClientAPI(APISpec):
 
     def clear(self):
         self.fl_model = None
+        self.receive_called = False
 
     def _prepare_param_diff(self, model: FLModel) -> FLModel:
         exchange_format = self.client_config.get_exchange_format()

--- a/nvflare/client/task_registry.py
+++ b/nvflare/client/task_registry.py
@@ -48,7 +48,7 @@ class TaskRegistry:
         """Whether this is the rank 0 process."""
         return self.rank is None or self.rank == "0"
 
-    def _receive(self, timeout: Optional[float] = None) -> Task:
+    def _receive(self, timeout: Optional[float] = None) -> Optional[Task]:
         """Receives a task using flare agent.
 
         This is only called on rank0.
@@ -59,7 +59,7 @@ class TaskRegistry:
         task = self.flare_agent.get_task(timeout)
 
         if task is None:
-            raise RuntimeError(f"no received task within timeout: {timeout}")
+            return None
 
         if task.data is None:
             raise RuntimeError("no received task.data")
@@ -83,7 +83,8 @@ class TaskRegistry:
         """
         if self.is_rank0 and not self.cache_loaded:
             task = self._receive(timeout)
-            self._set_task(task)
+            if task is not None:
+                self._set_task(task)
         return self.received_task
 
     def get_sys_info(self) -> Dict:

--- a/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
+++ b/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
@@ -547,6 +547,10 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
             )
             return lazy
 
+        if items is None:
+            self.logger.error(f"cannot find item {item_id} because no downloaded data is loaded")
+            raise RuntimeError(f"FOBS download data is missing for item {item_id}")
+
         self.logger.debug(f"trying to get item for {item_id=} from {type(items)=}")
 
         make_lazy_ref_fn = getattr(items, "make_lazy_ref", None)
@@ -555,10 +559,20 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
             self.logger.debug(f"{tid=} created lazy ref for {item_id}")
             return item
 
+        get_item_fn = getattr(items, "get", None)
+        if not callable(get_item_fn):
+            self.logger.error(f"downloaded data for {item_id} does not support get(): {type(items)}")
+            raise RuntimeError(f"FOBS download data has invalid type for item {item_id}")
+
+        if hasattr(items, "__contains__") and item_id not in items:
+            self.logger.error(f"cannot find item {item_id} from loaded data")
+            raise RuntimeError(f"FOBS download data is incomplete: item {item_id} is missing")
+
         item = items.get(item_id)
         self.logger.debug(f"{tid=} found item {item_id}: {type(item)}")
         if item is None:
-            self.logger.error(f"cannot find item {item_id} from loaded data")
+            self.logger.error(f"downloaded item {item_id} is None")
+            raise RuntimeError(f"FOBS download data is incomplete: item {item_id} is None")
         return item
 
     def _download_from_remote_cell(self, fobs_ctx: dict, ref: dict):

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -415,6 +415,7 @@ class FedJobConfig:
         if hasattr(component, "__dict__"):
             parameters = get_component_init_parameters(component)
             attrs = component.__dict__
+            always_serialize_args = set(getattr(component, "_always_serialize_args", ()))
 
             for param in parameters:
                 attr_key = param if param in attrs.keys() else "_" + param
@@ -422,7 +423,9 @@ class FedJobConfig:
                 if attr_key in ["args", "kwargs"]:
                     continue
 
-                if attr_key in attrs.keys() and self._values_differ(parameters[param].default, attrs[attr_key]):
+                if attr_key in attrs.keys() and (
+                    param in always_serialize_args or self._values_differ(parameters[param].default, attrs[attr_key])
+                ):
                     if attrs[attr_key] is None or type(attrs[attr_key]).__name__ in dir(builtins):
                         args[param] = attrs[attr_key]
                     elif issubclass(attrs[attr_key].__class__, Enum):

--- a/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
+++ b/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
@@ -976,6 +976,34 @@ def test_timeout_warning_peer_read_less_than_per_req(monkeypatch):
     assert any("peer_read_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
 
 
+def test_timeout_warning_heartbeat_less_than_per_req(monkeypatch):
+    """A warning must fire when heartbeat_timeout is lower than streaming_per_request_timeout."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, heartbeat_timeout=300.0)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert any("heartbeat_timeout" in w and "streaming_per_request_timeout" in w for w in warnings), warnings
+
+
 def test_timeout_warning_peer_read_none_when_per_req_is_configured(monkeypatch):
     """A warning must fire when peer_read_timeout is unset and streaming timeout is configured."""
     import nvflare.fuel.utils.app_config_utils as acu
@@ -1002,6 +1030,35 @@ def test_timeout_warning_peer_read_none_when_per_req_is_configured(monkeypatch):
     executor.initialize(fl_ctx)
 
     assert any("peer_read_timeout is not set" in w for w in warnings), warnings
+
+
+def test_heartbeat_timeout_none_is_corrected_when_per_req_is_configured(monkeypatch):
+    """Unset heartbeat_timeout is corrected because PipeHandler requires a numeric value."""
+    import nvflare.fuel.utils.app_config_utils as acu
+    from nvflare.apis.fl_constant import ConfigVarName
+    from nvflare.fuel.utils.config_service import ConfigService
+
+    executor, warnings, _ = _make_validating_executor(monkeypatch, heartbeat_timeout=None)
+    cell = _FakeCell()
+    fl_ctx = _FakeFLContext(cell)
+
+    def _fake_get(name, default):
+        if ConfigVarName.MIN_DOWNLOAD_TIMEOUT in name:
+            return 700.0
+        if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name:
+            return 600.0
+        return default
+
+    monkeypatch.setattr(acu, "get_positive_float_var", _fake_get)
+    monkeypatch.setattr(
+        ConfigService,
+        "get_float_var",
+        lambda name, conf=None, default=None: 600.0 if ConfigVarName.STREAMING_PER_REQUEST_TIMEOUT in name else default,
+    )
+    executor.initialize(fl_ctx)
+
+    assert executor.heartbeat_timeout == 600.0
+    assert any("heartbeat_timeout is not set" in w and "Using 600.0s" in w for w in warnings), warnings
 
 
 def test_default_peer_read_timeout_does_not_warn_without_configured_per_req(monkeypatch):

--- a/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
+++ b/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
@@ -122,6 +122,12 @@ def test_launcher_converter_ids_warn_when_ignored(monkeypatch):
     assert executor._to_nvflare_converter is None
 
 
+def test_launcher_executor_forwards_max_resends_to_task_exchanger():
+    """LauncherExecutor must pass max_resends into its TaskExchanger base."""
+    executor = LauncherExecutor(pipe_id="test_pipe", max_resends=4)
+    assert executor.max_resends == 4
+
+
 # ---------------------------------------------------------------------------
 # Fix 3: submit_result_timeout wiring through executor
 # ---------------------------------------------------------------------------
@@ -351,26 +357,51 @@ def test_peer_read_timeout_and_external_pre_init_both_overridable(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Fix 10: max_resends wiring
+# max_resends wiring
 # ---------------------------------------------------------------------------
 
 
 def test_max_resends_default_stored():
     """Default max_resends (3) must be stored on the executor."""
     executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
-    assert executor._max_resends == 3
+    assert executor.max_resends == 3
+    assert "_max_resends" not in executor.__dict__
 
 
 def test_max_resends_custom_stored():
     """Custom max_resends must be stored exactly as given."""
     executor = ClientAPILauncherExecutor(pipe_id="test_pipe", max_resends=10)
-    assert executor._max_resends == 10
+    assert executor.max_resends == 10
+    assert "_max_resends" not in executor.__dict__
 
 
 def test_max_resends_none_stored():
     """max_resends=None (unlimited) must be stored as-is."""
     executor = ClientAPILauncherExecutor(pipe_id="test_pipe", max_resends=None)
-    assert executor._max_resends is None
+    assert executor.max_resends is None
+    assert "_max_resends" not in executor.__dict__
+
+
+def test_fed_job_config_serializes_default_max_resends(tmp_path):
+    """Regression: default max_resends must not serialize as null in executor args."""
+    from nvflare.client.config import ConfigKey
+    from nvflare.job_config.fed_job_config import FedJobConfig
+
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
+    args = FedJobConfig(job_name="job", min_clients=1)._get_args(executor, str(tmp_path))
+
+    assert args[ConfigKey.MAX_RESENDS] == 3
+
+
+def test_fed_job_config_serializes_custom_max_resends(tmp_path):
+    """Regression: custom max_resends must serialize from TaskExchanger state."""
+    from nvflare.client.config import ConfigKey
+    from nvflare.job_config.fed_job_config import FedJobConfig
+
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe", max_resends=7)
+    args = FedJobConfig(job_name="job", min_clients=1)._get_args(executor, str(tmp_path))
+
+    assert args[ConfigKey.MAX_RESENDS] == 7
 
 
 def test_prepare_config_includes_max_resends(monkeypatch):
@@ -419,6 +450,105 @@ def test_prepare_config_includes_max_resends(monkeypatch):
     task_exchange = captured.get(ConfigKey.TASK_EXCHANGE, {})
     assert ConfigKey.MAX_RESENDS in task_exchange
     assert task_exchange[ConfigKey.MAX_RESENDS] == 5
+
+
+def test_client_config_overrides_apply_before_subprocess_config_write(monkeypatch):
+    """add_client_config overrides must be reflected in the generated Client API config."""
+    from unittest.mock import MagicMock
+
+    from nvflare.client.config import ConfigKey
+
+    captured = {}
+    monkeypatch.setattr(
+        _GCV_MODULE,
+        _make_gcv_stub(
+            {
+                ConfigKey.SUBMIT_RESULT_TIMEOUT: 650.0,
+                ConfigKey.MAX_RESENDS: 8,
+                ConfigKey.DOWNLOAD_COMPLETE_TIMEOUT: 2400.0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "nvflare.app_common.executors.client_api_launcher_executor.write_config_to_file",
+        lambda config_data, config_file_path: captured.update(config_data),
+    )
+    monkeypatch.setattr(
+        "nvflare.app_common.executors.client_api_launcher_executor.update_export_props",
+        lambda config_data, fl_ctx: None,
+    )
+    monkeypatch.setattr(LauncherExecutor, "initialize", lambda self, fl_ctx: None)
+    monkeypatch.setattr(ClientAPILauncherExecutor, "_validate_timeout_config", lambda self, fl_ctx: None)
+    monkeypatch.setattr(ClientAPILauncherExecutor, "log_info", lambda self, fl_ctx, msg: None)
+
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
+    mock_pipe = MagicMock()
+    mock_pipe.export.return_value = ("nvflare.some.PipeClass", {})
+    executor.pipe = mock_pipe
+    executor.get_pipe_channel_name = lambda: "task"
+
+    fake_workspace = MagicMock()
+    fake_workspace.get_app_config_dir.return_value = "/tmp/fake_dir"
+    fake_engine = MagicMock()
+    fake_engine.get_workspace.return_value = fake_workspace
+    fl_ctx = MagicMock()
+    fl_ctx.get_engine.return_value = fake_engine
+    fl_ctx.get_job_id.return_value = "test_job"
+
+    executor.initialize(fl_ctx)
+
+    task_exchange = captured[ConfigKey.TASK_EXCHANGE]
+    assert task_exchange[ConfigKey.SUBMIT_RESULT_TIMEOUT] == 650.0
+    assert task_exchange[ConfigKey.MAX_RESENDS] == 8
+    assert task_exchange[ConfigKey.DOWNLOAD_COMPLETE_TIMEOUT] == 2400.0
+    assert executor._submit_result_timeout == 650.0
+    assert executor.max_resends == 8
+    assert executor._download_complete_timeout == 2400.0
+    assert executor._stop_task_wait_timeout == 2400.0
+
+
+@pytest.mark.parametrize("value", [-1, None, 2.9, 3.0, "3", True])
+def test_client_config_max_resends_override_rejects_invalid_values(monkeypatch, value):
+    """Invalid top-level max_resends overrides must fail before config generation.
+
+    Floats (even integer-valued like 3.0), numeric strings, bools, negatives, and None must be
+    rejected instead of silently coerced via int() (e.g. 2.9 -> 2)."""
+    from nvflare.client.config import ConfigKey
+
+    errors = []
+    monkeypatch.setattr(_GCV_MODULE, _make_gcv_stub({ConfigKey.MAX_RESENDS: value}))
+    monkeypatch.setattr(ClientAPILauncherExecutor, "prepare_config_for_launch", lambda self, fl_ctx: None)
+    monkeypatch.setattr(LauncherExecutor, "initialize", lambda self, fl_ctx: None)
+    monkeypatch.setattr(ClientAPILauncherExecutor, "log_error", lambda self, fl_ctx, msg: errors.append(msg))
+
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
+
+    with pytest.raises(ValueError, match="max_resends must be a finite non-negative integer"):
+        executor.initialize(_FakeFLContext(_FakeCell()))
+
+    assert any("max_resends" in e for e in errors), errors
+
+
+def test_client_config_float_override_rejects_none(monkeypatch):
+    """Explicit null timeout overrides should fail loudly instead of silently using defaults."""
+    from nvflare.client.config import ConfigKey
+
+    errors = []
+    writes = []
+    monkeypatch.setattr(_GCV_MODULE, _make_gcv_stub({ConfigKey.DOWNLOAD_COMPLETE_TIMEOUT: None}))
+    monkeypatch.setattr(
+        "nvflare.app_common.executors.client_api_launcher_executor.write_config_to_file",
+        lambda config_data, config_file_path: writes.append(config_data),
+    )
+    monkeypatch.setattr(ClientAPILauncherExecutor, "log_error", lambda self, fl_ctx, msg: errors.append(msg))
+
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
+
+    with pytest.raises(ValueError, match="download_complete_timeout must be positive"):
+        executor.initialize(_FakeFLContext(_FakeCell()))
+
+    assert writes == []
+    assert any("download_complete_timeout" in e for e in errors), errors
 
 
 def test_client_config_get_max_resends_default():

--- a/tests/unit_test/app_opt/pt/test_pt_launcher_executor_params.py
+++ b/tests/unit_test/app_opt/pt/test_pt_launcher_executor_params.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for H2 fix: PTClientAPILauncherExecutor must accept and forward
+"""Tests for PTClientAPILauncherExecutor timeout parameter forwarding.
 submit_result_timeout, max_resends, and download_complete_timeout.
 
-Before H2 fix, these three parameters were not in the PT subclass signature.
+These parameters must stay exposed in the PT subclass signature.
 Users configuring the PT executor in JSON/YAML could not set them — the base
 class defaults always won silently.
 """
@@ -24,37 +24,35 @@ import inspect
 
 
 class TestPTClientAPILauncherExecutorParams:
-    """H2 fix: PTClientAPILauncherExecutor must expose and forward new timeout params."""
+    """PTClientAPILauncherExecutor must expose and forward timeout params."""
 
     def test_submit_result_timeout_param_exists(self):
-        """submit_result_timeout must be in PTClientAPILauncherExecutor signature (H2)."""
+        """submit_result_timeout must be in PTClientAPILauncherExecutor signature."""
         from nvflare.app_opt.pt.client_api_launcher_executor import PTClientAPILauncherExecutor
 
         sig = inspect.signature(PTClientAPILauncherExecutor.__init__)
         assert (
             "submit_result_timeout" in sig.parameters
-        ), "submit_result_timeout must be a parameter of PTClientAPILauncherExecutor (H2 fix)"
+        ), "submit_result_timeout must be a parameter of PTClientAPILauncherExecutor"
 
     def test_max_resends_param_exists(self):
-        """max_resends must be in PTClientAPILauncherExecutor signature (H2)."""
+        """max_resends must be in PTClientAPILauncherExecutor signature."""
         from nvflare.app_opt.pt.client_api_launcher_executor import PTClientAPILauncherExecutor
 
         sig = inspect.signature(PTClientAPILauncherExecutor.__init__)
-        assert (
-            "max_resends" in sig.parameters
-        ), "max_resends must be a parameter of PTClientAPILauncherExecutor (H2 fix)"
+        assert "max_resends" in sig.parameters, "max_resends must be a parameter of PTClientAPILauncherExecutor"
 
     def test_download_complete_timeout_param_exists(self):
-        """download_complete_timeout must be in PTClientAPILauncherExecutor signature (H2)."""
+        """download_complete_timeout must be in PTClientAPILauncherExecutor signature."""
         from nvflare.app_opt.pt.client_api_launcher_executor import PTClientAPILauncherExecutor
 
         sig = inspect.signature(PTClientAPILauncherExecutor.__init__)
         assert (
             "download_complete_timeout" in sig.parameters
-        ), "download_complete_timeout must be a parameter of PTClientAPILauncherExecutor (H2 fix)"
+        ), "download_complete_timeout must be a parameter of PTClientAPILauncherExecutor"
 
     def test_defaults_match_base_class(self):
-        """Default values for new params must match ClientAPILauncherExecutor defaults (H2)."""
+        """Default values for timeout params must match ClientAPILauncherExecutor defaults."""
         from nvflare.app_common.executors.client_api_launcher_executor import ClientAPILauncherExecutor
         from nvflare.app_opt.pt.client_api_launcher_executor import PTClientAPILauncherExecutor
 
@@ -66,10 +64,10 @@ class TestPTClientAPILauncherExecutorParams:
             pt_default = pt_sig.parameters[param_name].default
             assert (
                 pt_default == base_default
-            ), f"{param_name}: PT default {pt_default!r} must match base default {base_default!r} (H2 fix)"
+            ), f"{param_name}: PT default {pt_default!r} must match base default {base_default!r}"
 
     def test_new_params_forwarded_to_base(self):
-        """submit_result_timeout/max_resends/download_complete_timeout are forwarded to base __init__ (H2).
+        """submit_result_timeout/max_resends/download_complete_timeout are forwarded to base __init__.
 
         Verifies by patching ClientAPILauncherExecutor.__init__ and checking
         the kwargs it receives.
@@ -98,8 +96,8 @@ class TestPTClientAPILauncherExecutorParams:
 
         assert (
             received_kwargs.get("submit_result_timeout") == 999.0
-        ), "submit_result_timeout must be forwarded to base __init__ (H2 fix)"
-        assert received_kwargs.get("max_resends") == 7, "max_resends must be forwarded to base __init__ (H2 fix)"
+        ), "submit_result_timeout must be forwarded to base __init__"
+        assert received_kwargs.get("max_resends") == 7, "max_resends must be forwarded to base __init__"
         assert (
             received_kwargs.get("download_complete_timeout") == 3600.0
-        ), "download_complete_timeout must be forwarded to base __init__ (H2 fix)"
+        ), "download_complete_timeout must be forwarded to base __init__"

--- a/tests/unit_test/client/ex_process/api_test.py
+++ b/tests/unit_test/client/ex_process/api_test.py
@@ -15,6 +15,9 @@
 import copy
 from unittest.mock import patch
 
+import pytest
+
+from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.abstract.params_converter import ParamsConverter
 from nvflare.client.config import ClientConfig, ConfigKey, ExchangeFormat
 from nvflare.client.converter_utils import create_default_params_converters
@@ -177,6 +180,50 @@ def test_ex_process_api_passes_submit_result_timeout_to_agent(monkeypatch):
 
     assert "submit_result_timeout" in captured_kwargs, "submit_result_timeout was not passed to FlareAgentWithFLModel"
     assert captured_kwargs["submit_result_timeout"] == 999.0
+
+
+def test_ex_process_receive_timeout_does_not_arm_send_under_congestion():
+    from unittest.mock import MagicMock
+
+    from nvflare.client.config import ClientConfig
+    from nvflare.client.ex_process.api import ExProcessClientAPI
+    from nvflare.client.model_registry import ModelRegistry
+
+    fake_agent = MagicMock()
+    fake_agent.get_task.return_value = None
+    registry = ModelRegistry(ClientConfig({}), rank="0", flare_agent=fake_agent)
+    api = ExProcessClientAPI(config_file="fake_config.json")
+    api.model_registry = registry
+
+    assert api.receive(timeout=12.5) is None
+    fake_agent.get_task.assert_called_once_with(12.5)
+    assert api.receive_called is False
+    with pytest.raises(RuntimeError, match='"receive" needs to be called'):
+        api.send(FLModel(params={"x": 1}))
+
+
+def test_ex_process_receive_timeout_then_later_task_allows_send():
+    from unittest.mock import MagicMock
+
+    from nvflare.client.config import ClientConfig
+    from nvflare.client.ex_process.api import ExProcessClientAPI
+    from nvflare.client.flare_agent import Task
+    from nvflare.client.model_registry import ModelRegistry
+
+    received_model = FLModel(params={"x": 1})
+    fake_agent = MagicMock()
+    fake_agent.get_task.side_effect = [None, Task(task_name="train", task_id="task-1", data=received_model)]
+    registry = ModelRegistry(ClientConfig({}), rank="0", flare_agent=fake_agent)
+    api = ExProcessClientAPI(config_file="fake_config.json")
+    api.model_registry = registry
+
+    assert api.receive(timeout=0.1) is None
+    assert api.receive_called is False
+
+    assert api.receive(timeout=0.1) is received_model
+    assert api.receive_called is True
+    api.send(FLModel(params={"x": 2}), clear_cache=False)
+    fake_agent.submit_result.assert_called_once()
 
 
 # ── _downgrade_rotating_handlers tests ────────────────────────────────────────

--- a/tests/unit_test/client/in_process/api_test.py
+++ b/tests/unit_test/client/in_process/api_test.py
@@ -262,4 +262,52 @@ class TestInProcessClientAPI(unittest.TestCase):
         self.assertIsNone(output_model.params)
         self.assertEqual(output_model.metrics, {"loss": 0.42})
 
+    def test_receive_timeout_does_not_arm_send_under_congestion(self):
+        """A missing next-round model should time out cleanly and not permit send()."""
+        client_api = InProcessClientAPI(self.task_metadata, result_check_interval=0.001)
+        client_api.init()
+
+        self.assertIsNone(client_api.receive(timeout=0.01))
+        self.assertFalse(client_api.receive_called)
+        with self.assertRaisesRegex(RuntimeError, '"receive" needs to be called'):
+            client_api.send(FLModel(params={"w": 1}))
+
+    def test_receive_timeout_then_later_model_allows_send(self):
+        """A timeout must not poison the next successful receive/send cycle."""
+        import numpy as np
+
+        client_api = InProcessClientAPI(self.task_metadata, result_check_interval=0.001)
+        client_api.init()
+
+        self.assertIsNone(client_api.receive(timeout=0.01))
+        self.assertFalse(client_api.receive_called)
+
+        self._fire_global_model(client_api, {"w": np.ones((10,))})
+        input_model = client_api.receive(timeout=0.01)
+        self.assertIsNotNone(input_model)
+        self.assertIsNotNone(input_model.params)
+        self.assertTrue(client_api.receive_called)
+
+        client_api.send(FLModel(params={"w": np.zeros((10,))}), clear_cache=False)
+        self.assertTrue(client_api.receive_called)
+
+    def test_clear_resets_receive_guard_between_rounds(self):
+        """A prior successful round must not arm send() after a later receive timeout."""
+        import numpy as np
+
+        client_api = InProcessClientAPI(self.task_metadata, result_check_interval=0.001)
+        client_api.init()
+
+        self._fire_global_model(client_api, {"w": np.ones((10,))})
+        self.assertIsNotNone(client_api.receive(timeout=0.01))
+        self.assertTrue(client_api.receive_called)
+
+        client_api.send(FLModel(params={"w": np.zeros((10,))}), clear_cache=True)
+        self.assertFalse(client_api.receive_called)
+
+        self.assertIsNone(client_api.receive(timeout=0.01))
+        self.assertFalse(client_api.receive_called)
+        with self.assertRaisesRegex(RuntimeError, '"receive" needs to be called'):
+            client_api.send(FLModel(params={"w": np.zeros((10,))}))
+
     # Add more test methods for other functionalities in the class

--- a/tests/unit_test/client/test_model_registry.py
+++ b/tests/unit_test/client/test_model_registry.py
@@ -135,6 +135,24 @@ class TestReleaseParamsReceivedModel(unittest.TestCase):
         self.assertIsNone(received.params)
 
 
+class TestGetModelTimeout(unittest.TestCase):
+    def test_returns_none_when_agent_get_task_times_out(self):
+        registry = _make_registry()
+        registry.flare_agent.get_task.return_value = None
+
+        self.assertIsNone(registry.get_model(timeout=12.5))
+        registry.flare_agent.get_task.assert_called_once_with(12.5)
+        self.assertFalse(registry.cache_loaded)
+
+    def test_allows_received_model_with_none_param_values(self):
+        registry = _make_registry()
+        model = FLModel(params={"center": np.ones((2, 2)), "count": None})
+        task = Task(task_name="train", task_id="test-task-1", data=model)
+        registry._set_task(task)
+
+        self.assertIs(registry.get_model(), model)
+
+
 class TestReleaseParamsMemoryRelease(unittest.TestCase):
     """Verify that numpy arrays are actually dereferenced after release_params."""
 

--- a/tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py
+++ b/tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py
@@ -14,6 +14,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from nvflare.fuel.utils.fobs.decomposers.via_downloader import EncKey, EncType, ViaDownloaderDecomposer
 
 
@@ -88,3 +90,24 @@ class TestViaDownloaderRecomposeLazyRefGuard:
 
         result = decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
         assert result == "lazy_T0"
+
+    def test_missing_downloaded_items_raises(self):
+        decomposer = _DummyViaDownloader()
+        manager = SimpleNamespace(fobs_ctx={})
+
+        with pytest.raises(RuntimeError, match="FOBS download data is missing"):
+            decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
+
+    def test_missing_downloaded_item_raises(self):
+        decomposer = _DummyViaDownloader()
+        manager = SimpleNamespace(fobs_ctx={decomposer.items_key: {}})
+
+        with pytest.raises(RuntimeError, match="FOBS download data is incomplete"):
+            decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
+
+    def test_none_downloaded_item_raises(self):
+        decomposer = _DummyViaDownloader()
+        manager = SimpleNamespace(fobs_ctx={decomposer.items_key: {"T0": None}})
+
+        with pytest.raises(RuntimeError, match="item T0 is None"):
+            decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch.nn as nn
@@ -23,9 +24,14 @@ from nvflare.app_common.abstract.model_locator import ModelLocator
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.aggregators.model_aggregator import ModelAggregator
 from nvflare.app_common.app_constant import DefaultCheckpointFileName
+from nvflare.app_common.executors.client_api_launcher_executor import ClientAPILauncherExecutor
+from nvflare.app_common.executors.launcher_executor import LauncherExecutor
 from nvflare.app_common.np.recipes import NumpyFedAvgRecipe
 from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.client.config import ConfigKey
+from nvflare.client.constants import CLIENT_API_CONFIG
+from nvflare.fuel.utils.class_utils import instantiate_class
 
 
 class SimpleTestModel(nn.Module):
@@ -156,6 +162,49 @@ def get_server_component(recipe, component_id):
 def get_server_controller(recipe):
     server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
     return server_app.app_config.workflows[0].controller
+
+
+def _get_train_executor_config(client_config):
+    for executor_entry in client_config.get("executors", []):
+        executor = executor_entry["executor"]
+        if "ClientAPILauncherExecutor" in executor.get("path", ""):
+            return executor_entry["executor"]
+    raise AssertionError("External-process Client API launcher executor not found in exported client config")
+
+
+def _make_exported_executor_fl_ctx(config_dir, job_id):
+    workspace = MagicMock()
+    workspace.get_app_config_dir.return_value = str(config_dir)
+    engine = MagicMock()
+    engine.get_workspace.return_value = workspace
+    engine.get_component.return_value = None
+    fl_ctx = MagicMock()
+    fl_ctx.get_engine.return_value = engine
+    fl_ctx.get_job_id.return_value = job_id
+    fl_ctx.get_identity_name.return_value = "site-1"
+    return fl_ctx
+
+
+def _run_exported_external_process_executor_startup(executor_config, config_dir, job_id):
+    executor = instantiate_class(executor_config["path"], executor_config.get("args", {}))
+    pipe = MagicMock()
+    pipe.export.return_value = ("nvflare.fuel.utils.pipe.cell_pipe.CellPipe", {})
+    executor.pipe = pipe
+    fl_ctx = _make_exported_executor_fl_ctx(config_dir=config_dir, job_id=job_id)
+
+    with (
+        patch.object(LauncherExecutor, "initialize", lambda self, fl_ctx: None),
+        # Skip only advisory timeout relationship checks; prepare_config_for_launch()
+        # still exercises required startup validation before writing subprocess config.
+        patch.object(ClientAPILauncherExecutor, "_validate_timeout_config", lambda self, fl_ctx: None),
+        patch.object(ClientAPILauncherExecutor, "log_info", lambda self, fl_ctx, msg: None),
+        patch.object(ClientAPILauncherExecutor, "log_error", lambda self, fl_ctx, msg: None),
+    ):
+        executor.initialize(fl_ctx)
+
+    client_api_config_path = config_dir / CLIENT_API_CONFIG
+    with open(client_api_config_path, "r") as f:
+        return json.load(f)
 
 
 class TestFedAvgRecipe:
@@ -826,6 +875,91 @@ class TestFedAvgRecipeDictConfigJobExport:
         # Verify export created the job directory
         assert os.path.exists(job_dir)
         assert os.path.exists(os.path.join(job_dir, "test_dict_ckpt_export"))
+
+
+class TestFedAvgRecipeExternalProcessStartup:
+    """Regression coverage for recipe-based external-process executor startup."""
+
+    @pytest.mark.parametrize("top_level_max_resends,expected_max_resends", [(None, 3), (5, 5)])
+    def test_exported_external_process_executor_startup_uses_bounded_max_resends(
+        self, tmp_path, top_level_max_resends, expected_max_resends
+    ):
+        """Simulate the rc4 failure path: export recipe config, reload executor args, then initialize."""
+        train_script = tmp_path / "train.py"
+        train_script.write_text("# Dummy train script\n")
+        job_name = f"test_external_process_max_resends_{expected_max_resends}"
+
+        recipe = FedAvgRecipe(
+            name=job_name,
+            model={"class_path": "model.SimpleNetwork", "args": {}},
+            train_script=str(train_script),
+            train_args="--epochs 1",
+            min_clients=2,
+            num_rounds=1,
+            launch_external_process=True,
+        )
+        if top_level_max_resends is not None:
+            recipe.add_client_config({ConfigKey.MAX_RESENDS: top_level_max_resends})
+
+        export_dir = tmp_path / "exported_job"
+        recipe.export(job_dir=str(export_dir))
+
+        config_dir = export_dir / job_name / "app" / "config"
+        client_config_path = config_dir / "config_fed_client.json"
+        with open(client_config_path, "r") as f:
+            client_config = json.load(f)
+
+        train_executor = _get_train_executor_config(client_config)
+        train_executor_args = train_executor.get("args", {})
+
+        assert "PTClientAPILauncherExecutor" in train_executor["path"]
+        assert train_executor_args[ConfigKey.MAX_RESENDS] == 3
+        if top_level_max_resends is not None:
+            assert client_config[ConfigKey.MAX_RESENDS] == top_level_max_resends
+
+        client_api_config = _run_exported_external_process_executor_startup(
+            train_executor, config_dir=config_dir, job_id=job_name
+        )
+
+        assert client_api_config[ConfigKey.TASK_EXCHANGE][ConfigKey.MAX_RESENDS] == expected_max_resends
+
+    def test_old_rc4_exported_null_max_resends_still_rejects_at_startup(self, tmp_path):
+        """Old exported configs with executor max_resends: null must fail instead of running unbounded."""
+        train_script = tmp_path / "train.py"
+        train_script.write_text("# Dummy train script\n")
+        job_name = "test_external_process_null_max_resends"
+
+        recipe = FedAvgRecipe(
+            name=job_name,
+            model={"class_path": "model.SimpleNetwork", "args": {}},
+            train_script=str(train_script),
+            train_args="--epochs 1",
+            min_clients=2,
+            num_rounds=1,
+            launch_external_process=True,
+        )
+
+        export_dir = tmp_path / "exported_job"
+        recipe.export(job_dir=str(export_dir))
+
+        config_dir = export_dir / job_name / "app" / "config"
+        client_config_path = config_dir / "config_fed_client.json"
+        with open(client_config_path, "r") as f:
+            client_config = json.load(f)
+
+        train_executor = _get_train_executor_config(client_config)
+        train_executor["args"][ConfigKey.MAX_RESENDS] = None
+        client_config_path.write_text(json.dumps(client_config))
+        with open(client_config_path, "r") as f:
+            reloaded_client_config = json.load(f)
+        reloaded_train_executor = _get_train_executor_config(reloaded_client_config)
+
+        with pytest.raises(ValueError, match="max_resends is None"):
+            _run_exported_external_process_executor_startup(
+                reloaded_train_executor, config_dir=config_dir, job_id=job_name
+            )
+
+        assert not (config_dir / CLIENT_API_CONFIG).exists()
 
 
 class TestNumpyFedAvgRecipeInitialCkpt:


### PR DESCRIPTION
## Summary

Ports the recent 2.8 large-model reliability fixes to main:

- #4724: external process max_resends serialization and coordinated timeout overrides
- #4725: prevent corrupt Client API models from incomplete streamed downloads

Main already contains the earlier related ports for #4708/#4710 and the associated docs/test follow-ups.

## Verification

- `python -m pytest tests/unit_test/app_common/executors/client_api_launcher_executor_test.py tests/unit_test/app_opt/pt/test_pt_launcher_executor_params.py tests/unit_test/recipe/fedavg_recipe_test.py tests/unit_test/client/ex_process/api_test.py tests/unit_test/client/in_process/api_test.py tests/unit_test/client/test_model_registry.py tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py` -> 189 passed
- `./runtest.sh -s` -> passed
