### PR TITLE
[main] Port 2.8 dashboard container launch fixes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,22 @@ Build from the repository root:
 docker build -f docker/Dockerfile.parent -t nvflare-parent:latest .
 ```
 
+The dashboard can use the same runtime image. If you want a dashboard-specific
+image name, tag the same build with both names:
+
+```bash
+docker build -f docker/Dockerfile.parent \
+  -t nvflare-parent:latest \
+  -t nvflare-dashboard:latest \
+  .
+```
+
+Then start the dashboard with the dashboard tag:
+
+```bash
+nvflare dashboard --start -i nvflare-dashboard:latest --port 8443
+```
+
 Use this image in `docker.yaml` or `k8s.yaml` as the parent image:
 
 ```yaml
@@ -69,6 +85,8 @@ containers include `/etc/pip/constraint.txt` to protect the tested package set.
 ## Choosing an Image
 
 - Use `Dockerfile.parent` for parent server/client processes.
+- Use `Dockerfile.parent` for the dashboard runtime; tag the same build as a
+  dashboard image if you want a dashboard-specific image name.
 - Use `Dockerfile.job` for submitted job containers.
 - Do not rely on a shell being available in the parent image; it is absent by
   design.

--- a/docs/user_guide/admin_guide/deployment/cloud_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/cloud_deployment.rst
@@ -42,8 +42,11 @@ To run NVFlare dashboard on Azure, run:
 
 .. code-block:: shell
 
-    nvflare dashboard --cloud azure -i nvflare/nvflare:<version>
+    nvflare dashboard --cloud azure -i nvflare/nvflare:2.7.2
 
+The ``-i`` value can be any image reference that the cloud VM can pull, including images hosted in Docker Hub,
+NGC, a cloud registry, or another private registry. For example, use
+``registry.example.com/nvflare/nvflare:2.7.2`` when that registry is reachable from the VM.
 
 .. note::
 
@@ -100,7 +103,7 @@ To run NVFlare dashboard on AWS, run:
 
 .. code-block:: shell
 
-    nvflare dashboard --cloud aws -i nvflare/nvflare:<version>
+    nvflare dashboard --cloud aws -i nvflare/nvflare:2.7.2
 
 .. note::
 

--- a/docs/user_guide/admin_guide/deployment/cloud_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/cloud_deployment.rst
@@ -42,7 +42,7 @@ To run NVFlare dashboard on Azure, run:
 
 .. code-block:: shell
 
-    nvflare dashboard --cloud azure
+    nvflare dashboard --cloud azure -i nvflare/nvflare:<version>
 
 
 .. note::
@@ -100,7 +100,7 @@ To run NVFlare dashboard on AWS, run:
 
 .. code-block:: shell
 
-    nvflare dashboard --cloud aws
+    nvflare dashboard --cloud aws -i nvflare/nvflare:<version>
 
 .. note::
 

--- a/docs/user_guide/admin_guide/deployment/overview.rst
+++ b/docs/user_guide/admin_guide/deployment/overview.rst
@@ -108,7 +108,7 @@ administrator to deploy a website to gather information about the sites and dist
 
 Introduction to NVFLARE Dashboard
 ---------------------------------
-You can install and run :ref:`nvflare_dashboard_ui` using the dashboard CLI command, ``nvflare dashboard –start`` (stop with ``nvflare dashboard –stop``).
+You can install and run :ref:`nvflare_dashboard_ui` using the dashboard CLI command, ``nvflare dashboard --start -i nvflare/nvflare:<version>`` (stop with ``nvflare dashboard --stop``).
 
 For details on how to start Dashboard can be found :ref:`here <dashboard_api>`. The usage information for the Dashboard UI can be found :ref:`here <nvflare_dashboard_ui>`.
 

--- a/docs/user_guide/admin_guide/deployment/overview.rst
+++ b/docs/user_guide/admin_guide/deployment/overview.rst
@@ -108,7 +108,10 @@ administrator to deploy a website to gather information about the sites and dist
 
 Introduction to NVFLARE Dashboard
 ---------------------------------
-You can install and run :ref:`nvflare_dashboard_ui` using the dashboard CLI command, ``nvflare dashboard --start -i nvflare/nvflare:<version>`` (stop with ``nvflare dashboard --stop``).
+You can install and run :ref:`nvflare_dashboard_ui` using the dashboard CLI command,
+``nvflare dashboard --start -i nvflare/nvflare:2.7.2`` (stop with ``nvflare dashboard --stop``).
+The image name can point to any registry that the runtime can pull from, such as
+``registry.example.com/nvflare/nvflare:2.7.2``.
 
 For details on how to start Dashboard can be found :ref:`here <dashboard_api>`. The usage information for the Dashboard UI can be found :ref:`here <nvflare_dashboard_ui>`.
 

--- a/docs/user_guide/nvflare_cli/dashboard_command.rst
+++ b/docs/user_guide/nvflare_cli/dashboard_command.rst
@@ -38,7 +38,8 @@ Running ``nvflare dashboard -h`` shows all available options.
     --cred CRED           set credential directly in the form of
                           USER_EMAIL:PASSWORD
     -i IMAGE, --image IMAGE
-                          set the container image name
+                          set the container image name (required for --start
+                          and --cloud)
     --local               start dashboard locally without docker image
     --vpc-id VPC_ID       VPC id for AWS EC2 instance. Applicable to AWS only.
                           Ignored if subnet-id is not specified.
@@ -48,10 +49,13 @@ Running ``nvflare dashboard -h`` shows all available options.
 
 .. note::
 
+    The ``-i``/``--image`` option is required when starting Dashboard with Docker or launching Dashboard
+    on cloud. It is not required for ``--stop`` or ``--local``.
+
     For AWS cloud launches, specify ``--vpc-id`` and ``--subnet-id`` together.
     If only one of these options is provided, Dashboard ignores it.
 
-To start Dashboard, run ``nvflare dashboard --start``.
+To start Dashboard, run ``nvflare dashboard --start -i nvflare/nvflare:<version>``.
 
 The Dashboard Docker will detect if the database is initialized.  If not, it will ask for the project_admin email address and will generate a random password:
 
@@ -69,13 +73,13 @@ Note that for the first time, it may take a while to download the nvflare image 
 
 .. code-block::
 
-    Pulling nvflare/nvflare, may take some time to finish.
+    Pulling nvflare/nvflare:<version>, may take some time to finish.
 
 After pulling the image, you should see output similar to the following:
 
 .. code-block::
 
-    Launching nvflare/nvflare
+    Launching nvflare/nvflare:<version>
     Dashboard will listen to port 443
     /path_to_folder_for_db on host mounted to /var/tmp/nvflare/dashboard in container
     No additional environment variables set to the launched container.

--- a/docs/user_guide/nvflare_cli/dashboard_command.rst
+++ b/docs/user_guide/nvflare_cli/dashboard_command.rst
@@ -55,7 +55,11 @@ Running ``nvflare dashboard -h`` shows all available options.
     For AWS cloud launches, specify ``--vpc-id`` and ``--subnet-id`` together.
     If only one of these options is provided, Dashboard ignores it.
 
-To start Dashboard, run ``nvflare dashboard --start -i nvflare/nvflare:<version>``.
+To start Dashboard, run ``nvflare dashboard --start -i nvflare/nvflare:2.7.2``.
+The image is a standard container image reference and can come from any registry that the runtime can pull from,
+for example ``nvflare/nvflare:2.7.2``, ``nvcr.io/nvidia/nvflare:2.7.2``, or
+``registry.example.com/nvflare/nvflare:2.7.2``. Different deployments can use image names from different
+registries as long as each Docker host or cloud VM has pull access.
 
 The Dashboard Docker will detect if the database is initialized.  If not, it will ask for the project_admin email address and will generate a random password:
 
@@ -73,13 +77,13 @@ Note that for the first time, it may take a while to download the nvflare image 
 
 .. code-block::
 
-    Pulling nvflare/nvflare:<version>, may take some time to finish.
+    Pulling nvflare/nvflare:2.7.2, may take some time to finish.
 
 After pulling the image, you should see output similar to the following:
 
 .. code-block::
 
-    Launching nvflare/nvflare:<version>
+    Launching nvflare/nvflare:2.7.2
     Dashboard will listen to port 443
     /path_to_folder_for_db on host mounted to /var/tmp/nvflare/dashboard in container
     No additional environment variables set to the launched container.

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.2_provision_via_dashboard/provision_via_dashboard.ipynb
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.2_provision_via_dashboard/provision_via_dashboard.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "### Starting the Dashboard\n",
     "\n",
-    "To start Dashboard, run `nvflare dashboard --start`.\n",
+    "To start Dashboard, run `nvflare dashboard --start -i nvflare/nvflare:<version>`.\n",
     "\n",
     "The Dashboard Docker will detect if the database is initialized. If not, it will ask for the project_admin email address and will generate a random password. You would need to log in with this random password to finish setting up the project in Dashboard once the system is up and running. The project_admin can change his/her password in the Dashboard system after logging in.\n",
     "\n",
@@ -114,7 +114,7 @@
     "Let's first go ahead and start a Dashboard, by typing the following command in a terminal:\n",
     "\n",
     "```bash\n",
-    "nvflare dashboard --start --port 567 --folder ./dashboard-wd --passphrase 12345 \n",
+    "nvflare dashboard --start -i nvflare/nvflare:<version> --port 567 --folder ./dashboard-wd --passphrase 12345 \n",
     "```\n",
     "\n",
     "Here we use the following options to configure the Dashboard start-up:\n",

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.5_deployment_in_aws/deployment_in_aws.ipynb
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.5_deployment_in_aws/deployment_in_aws.ipynb
@@ -20,7 +20,7 @@
     "You can easily deploy your Dashboard in AWS. To do that, simply execute the following command in a terminal:\n",
     "\n",
     "```bash\n",
-    "nvflare dashboard --cloud aws\n",
+    "nvflare dashboard --cloud aws -i nvflare/nvflare:<version>\n",
     "```"
    ]
   },

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.6_deployment_in_azure/deployment_in_azure.ipynb
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.6_deployment_in_azure/deployment_in_azure.ipynb
@@ -20,7 +20,7 @@
     "You can easily deploy your Dashboard in Azure. To do that, simply execute the following command in a terminal:\n",
     "\n",
     "```bash\n",
-    "nvflare dashboard --cloud azure\n",
+    "nvflare dashboard --cloud azure -i nvflare/nvflare:<version>\n",
     "```"
    ]
   },

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -101,7 +101,7 @@ def start(args):
     try:
         container_obj = client.containers.run(
             dashboard_image,
-            entrypoint=["python", "-m", "nvflare.dashboard.wsgi"],
+            entrypoint=["python3", "-m", "nvflare.dashboard.wsgi"],
             detach=True,
             auto_remove=True,
             name="nvflare-dashboard",

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -26,6 +26,20 @@ from nvflare.dashboard.utils import EnvVar
 from nvflare.lighter import tplt_utils, utils
 
 supported_csp = ("azure", "aws")
+_dashboard_parser = None
+
+
+def _require_image(args):
+    if args.image:
+        return
+
+    from nvflare.tool.cli_output import output_usage_error
+
+    output_usage_error(
+        _dashboard_parser,
+        "-i/--image is required when starting dashboard with Docker or launching dashboard on cloud.",
+        exit_code=4,
+    )
 
 
 def start(args):
@@ -220,6 +234,9 @@ def main():
 
 
 def define_dashboard_parser(parser):
+    global _dashboard_parser
+    _dashboard_parser = parser
+
     parser.add_argument(
         "--cloud",
         type=str,
@@ -237,7 +254,7 @@ def define_dashboard_parser(parser):
     )
     parser.add_argument("-e", "--env", action="append", help="additional environment variables: var1=value1")
     parser.add_argument("--cred", help="set credential directly in the form of USER_EMAIL:PASSWORD")
-    parser.add_argument("-i", "--image", help="set the container image name")
+    parser.add_argument("-i", "--image", help="set the container image name (required for --start and --cloud)")
     parser.add_argument("--local", action="store_true", help="start dashboard locally without docker image")
     parser.add_argument(
         "--vpc-id",
@@ -258,9 +275,12 @@ def handle_dashboard(args):
     if args.stop:
         stop()
     elif args.start or args.local:
+        if not args.local:
+            _require_image(args)
         start(args)
     elif args.cloud:
         if args.cloud in supported_csp:
+            _require_image(args)
             cloud(args)
         else:
             print(

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -132,7 +132,7 @@ def _fail_if_container_exited(container_obj):
         exit(1)
 
     status = getattr(container_obj, "status", None)
-    if status not in {"dead", "exited"}:
+    if status not in {"dead", "exited", "removing"}:
         return
 
     print(f"Dashboard container exited immediately with status: {status}")

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -43,6 +43,9 @@ def _require_image(args):
 
 
 def start(args):
+    if not args.local:
+        _require_image(args)
+
     cwd = os.getcwd()
     if not args.folder:
         folder = cwd

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -92,13 +92,12 @@ def start(args):
         print("Unable to communicate to docker daemon/socket.  Please make sure your docker is up and running.")
         exit(0)
     version = nvflare.__version__
-    dashboard_image = f"nvflare/nvflare:{version}"
-    if args.image:
-        if dashboard_image != args.image:
-            print(
-                f"Current dashboard container image is nvflare/nvflare:{version}, but requesting to use {args.image}.  Use it at your own risk."
-            )
-            dashboard_image = args.image
+    expected_image = f"nvflare/nvflare:{version}"
+    dashboard_image = args.image
+    if expected_image != dashboard_image:
+        print(
+            f"Current dashboard container image is {expected_image}, but requesting to use {dashboard_image}.  Use it at your own risk."
+        )
     try:
         print(f"Pulling {dashboard_image}, may take some time to finish.")
         _ = client.images.pull(dashboard_image)
@@ -203,7 +202,7 @@ def cloud(args):
             f"Unable to launching dashboard on cloud with {version}.  Please install official NVFlare release from PyPi."
         )
         exit(0)
-    replacement_dict = {"NVFLARE": f"nvflare=={version}", "START_OPT": f"-i {args.image}" if args.image else ""}
+    replacement_dict = {"NVFLARE": f"nvflare=={version}", "START_OPT": f"-i {args.image}"}
     utils._write(
         dest,
         utils.sh_replace(tplt.get_cloud_script_header() + dsb_start, replacement_dict),

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -17,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 import docker
 import nvflare
@@ -100,12 +101,12 @@ def start(args):
     try:
         container_obj = client.containers.run(
             dashboard_image,
-            entrypoint=["/usr/local/bin/python3", "nvflare/dashboard/wsgi.py"],
+            entrypoint=["python", "-m", "nvflare.dashboard.wsgi"],
             detach=True,
             auto_remove=True,
             name="nvflare-dashboard",
             ports={8443: args.port},
-            volumes={folder: {"bind": "/var/tmp/nvflare/dashboard", "model": "rw"}},
+            volumes={folder: {"bind": "/var/tmp/nvflare/dashboard", "mode": "rw"}},
             environment=environment,
         )
     except docker.errors.APIError as e:
@@ -114,11 +115,37 @@ def start(args):
         print(e)
         exit(1)
     if container_obj:
+        _fail_if_container_exited(container_obj)
         print("Dashboard container started")
         print("Container name nvflare-dashboard")
         print(f"id is {container_obj.id}")
     else:
         print("Container failed to start")
+
+
+def _fail_if_container_exited(container_obj):
+    time.sleep(1)
+    try:
+        container_obj.reload()
+    except docker.errors.NotFound:
+        print("Dashboard container exited immediately and was removed.")
+        exit(1)
+
+    status = getattr(container_obj, "status", None)
+    if status not in {"dead", "exited"}:
+        return
+
+    print(f"Dashboard container exited immediately with status: {status}")
+    try:
+        logs = container_obj.logs(stdout=True, stderr=True, tail=50)
+    except docker.errors.APIError:
+        logs = None
+    if logs:
+        if isinstance(logs, bytes):
+            logs = logs.decode("utf-8", errors="replace")
+        print("Container logs:")
+        print(logs.rstrip())
+    exit(1)
 
 
 def start_local(env):

--- a/nvflare/dashboard/wsgi.py
+++ b/nvflare/dashboard/wsgi.py
@@ -15,8 +15,7 @@
 import os
 import ssl
 
-from application import init_app
-
+from nvflare.dashboard.application import init_app
 from nvflare.dashboard.utils import EnvVar, get_web_root
 
 app = init_app()

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -100,7 +100,7 @@ class TestDashboardCli:
 
         client.containers.run.assert_called_once()
         run_kwargs = client.containers.run.call_args.kwargs
-        assert run_kwargs["entrypoint"] == ["python", "-m", "nvflare.dashboard.wsgi"]
+        assert run_kwargs["entrypoint"] == ["python3", "-m", "nvflare.dashboard.wsgi"]
         assert run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]["mode"] == "rw"
         assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
         assert "Dashboard container started" in capsys.readouterr().out
@@ -129,3 +129,28 @@ class TestDashboardCli:
         assert f"Dashboard container exited immediately with status: {status}" in output
         assert "Container logs:" in output
         assert "can't open file" in output
+
+    def test_start_reports_auto_removed_container_exit(self, capsys):
+        """auto_remove=True often removes the container before reload() returns;
+        that path raises docker.errors.NotFound and must exit 1 with a clear message."""
+        args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+        container = SimpleNamespace(
+            id="container-1",
+            status="running",
+            reload=Mock(side_effect=dashboard_cli.docker.errors.NotFound("gone")),
+            logs=Mock(),
+        )
+        client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+        client.containers.run.return_value = container
+
+        with (
+            patch.object(dashboard_cli.docker, "from_env", return_value=client),
+            patch.object(dashboard_cli.time, "sleep"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            dashboard_cli.start(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Dashboard container exited immediately and was removed." in output
+        container.logs.assert_not_called()

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nvflare.dashboard import cli as dashboard_cli
+from nvflare.tool.cli_output import set_output_format
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_output_format():
+    set_output_format("txt")
+
+
+def _parse_dashboard_args(argv):
+    parser = argparse.ArgumentParser(prog="nvflare dashboard")
+    dashboard_cli.define_dashboard_parser(parser)
+    return parser.parse_args(argv)
+
+
+class TestDashboardCli:
+    def test_start_requires_image(self, capsys):
+        args = _parse_dashboard_args(["--start"])
+
+        with patch.object(dashboard_cli, "start") as start_mock, pytest.raises(SystemExit) as exc_info:
+            dashboard_cli.handle_dashboard(args)
+
+        assert exc_info.value.code == 4
+        assert "-i/--image is required" in capsys.readouterr().err
+        start_mock.assert_not_called()
+
+    def test_cloud_requires_image(self, capsys):
+        args = _parse_dashboard_args(["--cloud", "aws"])
+
+        with patch.object(dashboard_cli, "cloud") as cloud_mock, pytest.raises(SystemExit) as exc_info:
+            dashboard_cli.handle_dashboard(args)
+
+        assert exc_info.value.code == 4
+        assert "-i/--image is required" in capsys.readouterr().err
+        cloud_mock.assert_not_called()
+
+    def test_start_accepts_image(self):
+        args = _parse_dashboard_args(["--start", "-i", "nvflare/nvflare:test"])
+
+        with patch.object(dashboard_cli, "start") as start_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        start_mock.assert_called_once_with(args)
+
+    def test_cloud_accepts_image(self):
+        args = _parse_dashboard_args(["--cloud", "azure", "-i", "nvflare/nvflare:test"])
+
+        with patch.object(dashboard_cli, "cloud") as cloud_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        cloud_mock.assert_called_once_with(args)
+
+    def test_stop_does_not_require_image(self):
+        args = _parse_dashboard_args(["--stop"])
+
+        with patch.object(dashboard_cli, "stop") as stop_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        stop_mock.assert_called_once_with()
+
+    def test_local_does_not_require_image(self):
+        args = _parse_dashboard_args(["--local"])
+
+        with patch.object(dashboard_cli, "start") as start_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        start_mock.assert_called_once_with(args)
+
+    def test_start_uses_installed_package_entrypoint(self, capsys):
+        args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+        container = SimpleNamespace(id="container-1", status="running", reload=Mock(), logs=Mock())
+        client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+        client.containers.run.return_value = container
+
+        with (
+            patch.object(dashboard_cli.docker, "from_env", return_value=client),
+            patch.object(dashboard_cli.time, "sleep"),
+        ):
+            dashboard_cli.start(args)
+
+        client.containers.run.assert_called_once()
+        run_kwargs = client.containers.run.call_args.kwargs
+        assert run_kwargs["entrypoint"] == ["python", "-m", "nvflare.dashboard.wsgi"]
+        assert run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]["mode"] == "rw"
+        assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
+        assert "Dashboard container started" in capsys.readouterr().out
+
+    def test_start_reports_immediate_container_exit(self, capsys):
+        args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
+        container = SimpleNamespace(
+            id="container-1",
+            status="exited",
+            reload=Mock(),
+            logs=Mock(return_value=b"python: can't open file '/app/nvflare/dashboard/wsgi.py'"),
+        )
+        client = SimpleNamespace(images=SimpleNamespace(pull=Mock()), containers=SimpleNamespace(run=Mock()))
+        client.containers.run.return_value = container
+
+        with (
+            patch.object(dashboard_cli.docker, "from_env", return_value=client),
+            patch.object(dashboard_cli.time, "sleep"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            dashboard_cli.start(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Dashboard container exited immediately with status: exited" in output
+        assert "Container logs:" in output
+        assert "can't open file" in output

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -105,11 +105,12 @@ class TestDashboardCli:
         assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
         assert "Dashboard container started" in capsys.readouterr().out
 
-    def test_start_reports_immediate_container_exit(self, capsys):
+    @pytest.mark.parametrize("status", ["exited", "removing"])
+    def test_start_reports_immediate_container_exit(self, capsys, status):
         args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
         container = SimpleNamespace(
             id="container-1",
-            status="exited",
+            status=status,
             reload=Mock(),
             logs=Mock(return_value=b"python: can't open file '/app/nvflare/dashboard/wsgi.py'"),
         )
@@ -125,6 +126,6 @@ class TestDashboardCli:
 
         assert exc_info.value.code == 1
         output = capsys.readouterr().out
-        assert "Dashboard container exited immediately with status: exited" in output
+        assert f"Dashboard container exited immediately with status: {status}" in output
         assert "Container logs:" in output
         assert "can't open file" in output

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -86,6 +86,15 @@ class TestDashboardCli:
 
         start_mock.assert_called_once_with(args)
 
+    def test_start_requires_image_when_called_directly(self, capsys):
+        args = _parse_dashboard_args(["--start"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            dashboard_cli.start(args)
+
+        assert exc_info.value.code == 4
+        assert "-i/--image is required" in capsys.readouterr().err
+
     def test_start_uses_installed_package_entrypoint(self, capsys):
         args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
         container = SimpleNamespace(id="container-1", status="running", reload=Mock(), logs=Mock())
@@ -105,7 +114,7 @@ class TestDashboardCli:
         assert "model" not in run_kwargs["volumes"][str(dashboard_cli.os.getcwd())]
         assert "Dashboard container started" in capsys.readouterr().out
 
-    @pytest.mark.parametrize("status", ["exited", "removing"])
+    @pytest.mark.parametrize("status", ["dead", "exited", "removing"])
     def test_start_reports_immediate_container_exit(self, capsys, status):
         args = _parse_dashboard_args(["--start", "-i", "nvflare-parent:test", "--cred", "admin@example.com:pw:org"])
         container = SimpleNamespace(


### PR DESCRIPTION
## Summary

Ports the recent 2.8 dashboard container fixes to main:

- #4706: require an explicit dashboard container image for Docker/cloud launches
- #4720: launch dashboard from the installed package module, use the python3 entrypoint, and detect immediately removed/exited dashboard containers

The #4720 test coverage depends on #4706, so these are ported together.

## Verification

- `python -m pytest tests/unit_test/dashboard/cli_test.py` -> 10 passed
- `python -m pytest tests/unit_test/dashboard` -> 26 passed
- `./runtest.sh -s` -> passed
