### PR TITLE
Cherry-pick [2.8]: Make image option of dashboard cli mandatory (#4706)

### DIFF
--- a/docs/user_guide/admin_guide/deployment/cloud_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/cloud_deployment.rst
@@ -42,8 +42,11 @@ To run NVFlare dashboard on Azure, run:
 
 .. code-block:: shell
 
-    nvflare dashboard --cloud azure
+    nvflare dashboard --cloud azure -i nvflare/nvflare:2.7.2
 
+The ``-i`` value can be any image reference that the cloud VM can pull, including images hosted in Docker Hub,
+NGC, a cloud registry, or another private registry. For example, use
+``registry.example.com/nvflare/nvflare:2.7.2`` when that registry is reachable from the VM.
 
 .. note::
 
@@ -100,7 +103,7 @@ To run NVFlare dashboard on AWS, run:
 
 .. code-block:: shell
 
-    nvflare dashboard --cloud aws
+    nvflare dashboard --cloud aws -i nvflare/nvflare:2.7.2
 
 .. note::
 

--- a/docs/user_guide/admin_guide/deployment/overview.rst
+++ b/docs/user_guide/admin_guide/deployment/overview.rst
@@ -108,7 +108,10 @@ administrator to deploy a website to gather information about the sites and dist
 
 Introduction to NVFLARE Dashboard
 ---------------------------------
-You can install and run :ref:`nvflare_dashboard_ui` using the dashboard CLI command, ``nvflare dashboard –start`` (stop with ``nvflare dashboard –stop``).
+You can install and run :ref:`nvflare_dashboard_ui` using the dashboard CLI command,
+``nvflare dashboard --start -i nvflare/nvflare:2.7.2`` (stop with ``nvflare dashboard --stop``).
+The image name can point to any registry that the runtime can pull from, such as
+``registry.example.com/nvflare/nvflare:2.7.2``.
 
 For details on how to start Dashboard can be found :ref:`here <dashboard_api>`. The usage information for the Dashboard UI can be found :ref:`here <nvflare_dashboard_ui>`.
 

--- a/docs/user_guide/nvflare_cli/dashboard_command.rst
+++ b/docs/user_guide/nvflare_cli/dashboard_command.rst
@@ -38,7 +38,8 @@ Running ``nvflare dashboard -h`` shows all available options.
     --cred CRED           set credential directly in the form of
                           USER_EMAIL:PASSWORD
     -i IMAGE, --image IMAGE
-                          set the container image name
+                          set the container image name (required for --start
+                          and --cloud)
     --local               start dashboard locally without docker image
     --vpc-id VPC_ID       VPC id for AWS EC2 instance. Applicable to AWS only.
                           Ignored if subnet-id is not specified.
@@ -48,10 +49,17 @@ Running ``nvflare dashboard -h`` shows all available options.
 
 .. note::
 
+    The ``-i``/``--image`` option is required when starting Dashboard with Docker or launching Dashboard
+    on cloud. It is not required for ``--stop`` or ``--local``.
+
     For AWS cloud launches, specify ``--vpc-id`` and ``--subnet-id`` together.
     If only one of these options is provided, Dashboard ignores it.
 
-To start Dashboard, run ``nvflare dashboard --start``.
+To start Dashboard, run ``nvflare dashboard --start -i nvflare/nvflare:2.7.2``.
+The image is a standard container image reference and can come from any registry that the runtime can pull from,
+for example ``nvflare/nvflare:2.7.2``, ``nvcr.io/nvidia/nvflare:2.7.2``, or
+``registry.example.com/nvflare/nvflare:2.7.2``. Different deployments can use image names from different
+registries as long as each Docker host or cloud VM has pull access.
 
 The Dashboard Docker will detect if the database is initialized.  If not, it will ask for the project_admin email address and will generate a random password:
 
@@ -69,13 +77,13 @@ Note that for the first time, it may take a while to download the nvflare image 
 
 .. code-block::
 
-    Pulling nvflare/nvflare, may take some time to finish.
+    Pulling nvflare/nvflare:2.7.2, may take some time to finish.
 
 After pulling the image, you should see output similar to the following:
 
 .. code-block::
 
-    Launching nvflare/nvflare
+    Launching nvflare/nvflare:2.7.2
     Dashboard will listen to port 443
     /path_to_folder_for_db on host mounted to /var/tmp/nvflare/dashboard in container
     No additional environment variables set to the launched container.

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.2_provision_via_dashboard/provision_via_dashboard.ipynb
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.2_provision_via_dashboard/provision_via_dashboard.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "### Starting the Dashboard\n",
     "\n",
-    "To start Dashboard, run `nvflare dashboard --start`.\n",
+    "To start Dashboard, run `nvflare dashboard --start -i nvflare/nvflare:<version>`.\n",
     "\n",
     "The Dashboard Docker will detect if the database is initialized. If not, it will ask for the project_admin email address and will generate a random password. You would need to log in with this random password to finish setting up the project in Dashboard once the system is up and running. The project_admin can change his/her password in the Dashboard system after logging in.\n",
     "\n",
@@ -114,7 +114,7 @@
     "Let's first go ahead and start a Dashboard, by typing the following command in a terminal:\n",
     "\n",
     "```bash\n",
-    "nvflare dashboard --start --port 567 --folder ./dashboard-wd --passphrase 12345 \n",
+    "nvflare dashboard --start -i nvflare/nvflare:<version> --port 567 --folder ./dashboard-wd --passphrase 12345 \n",
     "```\n",
     "\n",
     "Here we use the following options to configure the Dashboard start-up:\n",

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.5_deployment_in_aws/deployment_in_aws.ipynb
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.5_deployment_in_aws/deployment_in_aws.ipynb
@@ -20,7 +20,7 @@
     "You can easily deploy your Dashboard in AWS. To do that, simply execute the following command in a terminal:\n",
     "\n",
     "```bash\n",
-    "nvflare dashboard --cloud aws\n",
+    "nvflare dashboard --cloud aws -i nvflare/nvflare:<version>\n",
     "```"
    ]
   },

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.6_deployment_in_azure/deployment_in_azure.ipynb
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-4_setup_federated_system/04.6_deployment_in_azure/deployment_in_azure.ipynb
@@ -20,7 +20,7 @@
     "You can easily deploy your Dashboard in Azure. To do that, simply execute the following command in a terminal:\n",
     "\n",
     "```bash\n",
-    "nvflare dashboard --cloud azure\n",
+    "nvflare dashboard --cloud azure -i nvflare/nvflare:<version>\n",
     "```"
    ]
   },

--- a/nvflare/dashboard/cli.py
+++ b/nvflare/dashboard/cli.py
@@ -25,6 +25,20 @@ from nvflare.dashboard.utils import EnvVar
 from nvflare.lighter import tplt_utils, utils
 
 supported_csp = ("azure", "aws")
+_dashboard_parser = None
+
+
+def _require_image(args):
+    if args.image:
+        return
+
+    from nvflare.tool.cli_output import output_usage_error
+
+    output_usage_error(
+        _dashboard_parser,
+        "-i/--image is required when starting dashboard with Docker or launching dashboard on cloud.",
+        exit_code=4,
+    )
 
 
 def start(args):
@@ -77,13 +91,12 @@ def start(args):
         print("Unable to communicate to docker daemon/socket.  Please make sure your docker is up and running.")
         exit(0)
     version = nvflare.__version__
-    dashboard_image = f"nvflare/nvflare:{version}"
-    if args.image:
-        if dashboard_image != args.image:
-            print(
-                f"Current dashboard container image is nvflare/nvflare:{version}, but requesting to use {args.image}.  Use it at your own risk."
-            )
-            dashboard_image = args.image
+    expected_image = f"nvflare/nvflare:{version}"
+    dashboard_image = args.image
+    if expected_image != dashboard_image:
+        print(
+            f"Current dashboard container image is {expected_image}, but requesting to use {dashboard_image}.  Use it at your own risk."
+        )
     try:
         print(f"Pulling {dashboard_image}, may take some time to finish.")
         _ = client.images.pull(dashboard_image)
@@ -162,7 +175,7 @@ def cloud(args):
             f"Unable to launching dashboard on cloud with {version}.  Please install official NVFlare release from PyPi."
         )
         exit(0)
-    replacement_dict = {"NVFLARE": f"nvflare=={version}", "START_OPT": f"-i {args.image}" if args.image else ""}
+    replacement_dict = {"NVFLARE": f"nvflare=={version}", "START_OPT": f"-i {args.image}"}
     utils._write(
         dest,
         utils.sh_replace(tplt.get_cloud_script_header() + dsb_start, replacement_dict),
@@ -193,6 +206,9 @@ def main():
 
 
 def define_dashboard_parser(parser):
+    global _dashboard_parser
+    _dashboard_parser = parser
+
     parser.add_argument(
         "--cloud",
         type=str,
@@ -210,7 +226,7 @@ def define_dashboard_parser(parser):
     )
     parser.add_argument("-e", "--env", action="append", help="additional environment variables: var1=value1")
     parser.add_argument("--cred", help="set credential directly in the form of USER_EMAIL:PASSWORD")
-    parser.add_argument("-i", "--image", help="set the container image name")
+    parser.add_argument("-i", "--image", help="set the container image name (required for --start and --cloud)")
     parser.add_argument("--local", action="store_true", help="start dashboard locally without docker image")
     parser.add_argument(
         "--vpc-id",
@@ -231,9 +247,12 @@ def handle_dashboard(args):
     if args.stop:
         stop()
     elif args.start or args.local:
+        if not args.local:
+            _require_image(args)
         start(args)
     elif args.cloud:
         if args.cloud in supported_csp:
+            _require_image(args)
             cloud(args)
         else:
             print(

--- a/tests/unit_test/dashboard/cli_test.py
+++ b/tests/unit_test/dashboard/cli_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.dashboard import cli as dashboard_cli
+from nvflare.tool.cli_output import set_output_format
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_output_format():
+    set_output_format("txt")
+
+
+def _parse_dashboard_args(argv):
+    parser = argparse.ArgumentParser(prog="nvflare dashboard")
+    dashboard_cli.define_dashboard_parser(parser)
+    return parser.parse_args(argv)
+
+
+class TestDashboardCli:
+    def test_start_requires_image(self, capsys):
+        args = _parse_dashboard_args(["--start"])
+
+        with patch.object(dashboard_cli, "start") as start_mock, pytest.raises(SystemExit) as exc_info:
+            dashboard_cli.handle_dashboard(args)
+
+        assert exc_info.value.code == 4
+        assert "-i/--image is required" in capsys.readouterr().err
+        start_mock.assert_not_called()
+
+    def test_cloud_requires_image(self, capsys):
+        args = _parse_dashboard_args(["--cloud", "aws"])
+
+        with patch.object(dashboard_cli, "cloud") as cloud_mock, pytest.raises(SystemExit) as exc_info:
+            dashboard_cli.handle_dashboard(args)
+
+        assert exc_info.value.code == 4
+        assert "-i/--image is required" in capsys.readouterr().err
+        cloud_mock.assert_not_called()
+
+    def test_start_accepts_image(self):
+        args = _parse_dashboard_args(["--start", "-i", "nvflare/nvflare:test"])
+
+        with patch.object(dashboard_cli, "start") as start_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        start_mock.assert_called_once_with(args)
+
+    def test_cloud_accepts_image(self):
+        args = _parse_dashboard_args(["--cloud", "azure", "-i", "nvflare/nvflare:test"])
+
+        with patch.object(dashboard_cli, "cloud") as cloud_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        cloud_mock.assert_called_once_with(args)
+
+    def test_stop_does_not_require_image(self):
+        args = _parse_dashboard_args(["--stop"])
+
+        with patch.object(dashboard_cli, "stop") as stop_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        stop_mock.assert_called_once_with()
+
+    def test_local_does_not_require_image(self):
+        args = _parse_dashboard_args(["--local"])
+
+        with patch.object(dashboard_cli, "start") as start_mock:
+            dashboard_cli.handle_dashboard(args)
+
+        start_mock.assert_called_once_with(args)


### PR DESCRIPTION
### Description

Forward-port 2.8 commit `39dcf5e5666a987578cb43cf851b530af513b513` to `main`.

This makes the dashboard CLI Docker image option mandatory, updates related docs/notebooks, and adds unit tests for the CLI validation behavior.

### Types of changes
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.

### Verification

- `PYENV_VERSION=3.10.13 python3 -m pytest -q tests/unit_test/dashboard/cli_test.py`
- `PYENV_VERSION=3.10.13 ./runtest.sh -s`