### PR TITLE
[2.8] Confine built-in artifact writer paths to the job directory

### DIFF
--- a/nvflare/app_common/widgets/validation_json_generator.py
+++ b/nvflare/app_common/widgets/validation_json_generator.py
@@ -23,6 +23,7 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.widgets.widget import Widget
 
 
@@ -99,10 +100,11 @@ class ValidationJsonGenerator(Widget):
                 self.log_error(fl_ctx, "Validation result not found.", fire_event=False)
         elif event_type == EventType.END_RUN:
             run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
-            cross_val_res_dir = os.path.join(run_dir, self._results_dir)
+            res_file_path = resolve_path_under_root(
+                run_dir, os.path.join(self._results_dir, self._json_file_name), "results path"
+            )
+            cross_val_res_dir = os.path.dirname(res_file_path)
             if not os.path.exists(cross_val_res_dir):
                 os.makedirs(cross_val_res_dir)
-
-            res_file_path = os.path.join(cross_val_res_dir, self._json_file_name)
             with open(res_file_path, "w") as f:
                 json.dump(self._val_results, f, default=to_serializable)

--- a/nvflare/app_common/workflows/cross_site_model_eval.py
+++ b/nvflare/app_common/workflows/cross_site_model_eval.py
@@ -30,6 +30,7 @@ from nvflare.app_common.abstract.formatter import Formatter
 from nvflare.app_common.abstract.model_locator import ModelLocator
 from nvflare.app_common.app_constant import AppConstants, ModelName
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
@@ -132,7 +133,7 @@ class CrossSiteModelEval(Controller):
         # Create shareable dirs for models and results
         workspace: Workspace = self._engine.get_workspace()
         run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
-        cross_val_path = os.path.join(run_dir, self._cross_val_dir)
+        cross_val_path = resolve_path_under_root(run_dir, self._cross_val_dir, "cross_val_dir")
         self._cross_val_models_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_MODEL_DIR_NAME)
         self._cross_val_results_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_RESULTS_DIR_NAME)
 

--- a/nvflare/app_opt/tracking/tb/tb_receiver.py
+++ b/nvflare/app_opt/tracking/tb/tb_receiver.py
@@ -19,6 +19,7 @@ from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
 from nvflare.apis.dxo import from_shareable
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_opt.tracking.tb.tb_event_writer import TensorBoardEventWriter
 
@@ -74,7 +75,7 @@ class TBAnalyticsReceiver(AnalyticsReceiver):
     def initialize(self, fl_ctx: FLContext):
         workspace = fl_ctx.get_engine().get_workspace()
         run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
-        root_log_dir = os.path.join(run_dir, self.tb_folder)
+        root_log_dir = resolve_path_under_root(run_dir, self.tb_folder, "tb_folder")
         os.makedirs(root_log_dir, exist_ok=True)
         self.root_log_dir = root_log_dir
         self.log_info(

--- a/nvflare/app_opt/tracking/tb/tb_receiver.py
+++ b/nvflare/app_opt/tracking/tb/tb_receiver.py
@@ -112,7 +112,7 @@ class TBAnalyticsReceiver(AnalyticsReceiver):
 
         writer = self.writers_table.get(record_origin)
         if writer is None:
-            peer_log_dir = os.path.join(self.root_log_dir, record_origin)
+            peer_log_dir = resolve_path_under_root(self.root_log_dir, record_origin, "record_origin")
             writer = TensorBoardEventWriter(log_dir=peer_log_dir)
             self.writers_table[record_origin] = writer
 

--- a/tests/unit_test/app_common/widgets/validation_json_generator_test.py
+++ b/tests/unit_test/app_common/widgets/validation_json_generator_test.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
+
+
+def _make_fl_ctx(run_dir):
+    workspace = Mock()
+    workspace.get_run_dir.return_value = str(run_dir)
+    engine = Mock()
+    engine.get_workspace.return_value = workspace
+
+    fl_ctx = FLContext()
+    fl_ctx.get_engine = Mock(return_value=engine)
+    fl_ctx.get_job_id = Mock(return_value="job-1")
+    return fl_ctx
+
+
+class TestValidationJsonGeneratorPaths:
+    def test_end_run_writes_results_under_run_dir(self, tmp_path):
+        generator = ValidationJsonGenerator()
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        generator.handle_event(EventType.END_RUN, fl_ctx)
+
+        out = os.path.join(
+            os.path.realpath(str(tmp_path / "run")), AppConstants.CROSS_VAL_DIR, "cross_val_results.json"
+        )
+        assert os.path.isfile(out)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"results_dir": "/tmp/outside_val"},
+            {"results_dir": "../outside_val"},
+            {"json_file_name": "/tmp/outside.json"},
+        ],
+    )
+    def test_end_run_rejects_escaping_paths(self, tmp_path, kwargs):
+        generator = ValidationJsonGenerator(**kwargs)
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            generator.handle_event(EventType.END_RUN, fl_ctx)

--- a/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
+++ b/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import Mock
 
 import pytest
 
 from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
 
 
@@ -40,3 +42,15 @@ class TestCrossSiteModelEvalPaths:
 
         with pytest.raises(ValueError, match="must (be relative|stay inside)"):
             controller.start_controller(fl_ctx)
+
+    def test_start_controller_accepts_relative_cross_val_dir(self, tmp_path):
+        engine, fl_ctx = _make_engine_and_ctx(tmp_path / "run")
+        controller = CrossSiteModelEval(participating_clients=["site-1"])
+        controller._engine = engine
+        controller.fire_event = Mock()  # event plumbing is not under test
+
+        controller.start_controller(fl_ctx)
+
+        run_dir = os.path.realpath(str(tmp_path / "run"))
+        assert os.path.isdir(os.path.join(run_dir, AppConstants.CROSS_VAL_DIR, AppConstants.CROSS_VAL_MODEL_DIR_NAME))
+        assert os.path.isdir(os.path.join(run_dir, AppConstants.CROSS_VAL_DIR, AppConstants.CROSS_VAL_RESULTS_DIR_NAME))

--- a/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
+++ b/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
+
+
+def _make_engine_and_ctx(run_dir):
+    workspace = Mock()
+    workspace.get_run_dir.return_value = str(run_dir)
+    engine = Mock()
+    engine.get_workspace.return_value = workspace
+
+    fl_ctx = FLContext()
+    fl_ctx.get_job_id = Mock(return_value="job-1")
+    return engine, fl_ctx
+
+
+class TestCrossSiteModelEvalPaths:
+    @pytest.mark.parametrize("cross_val_dir", ["/tmp/outside_cse", "../outside_cse"])
+    def test_start_controller_rejects_escaping_cross_val_dir(self, tmp_path, cross_val_dir):
+        engine, fl_ctx = _make_engine_and_ctx(tmp_path / "run")
+        controller = CrossSiteModelEval(cross_val_dir=cross_val_dir, participating_clients=["site-1"])
+        controller._engine = engine
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            controller.start_controller(fl_ctx)

--- a/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
+++ b/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -200,3 +201,21 @@ class TestTBAnalyticsReceiver:
         assert len(recall_events) == 1
         assert recall_events[0].step == 5
         assert recall_events[0].value == pytest.approx(0.7)
+
+    def test_initialize_accepts_relative_tb_folder(self, tmp_path):
+        receiver = TBAnalyticsReceiver(tb_folder="tb_events")
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        receiver.initialize(fl_ctx)
+
+        expected = os.path.realpath(str(tmp_path / "run" / "tb_events"))
+        assert receiver.root_log_dir == expected
+        assert os.path.isdir(expected)
+
+    @pytest.mark.parametrize("tb_folder", ["/tmp/outside_tb_events", "../outside_tb_events"])
+    def test_initialize_rejects_escaping_tb_folder(self, tmp_path, tb_folder):
+        receiver = TBAnalyticsReceiver(tb_folder=tb_folder)
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            receiver.initialize(fl_ctx)

--- a/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
+++ b/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
@@ -219,3 +219,16 @@ class TestTBAnalyticsReceiver:
 
         with pytest.raises(ValueError, match="must (be relative|stay inside)"):
             receiver.initialize(fl_ctx)
+
+    @pytest.mark.parametrize("record_origin", ["../outside_peer", "/tmp/outside_peer"])
+    def test_save_rejects_escaping_record_origin(self, tmp_path, record_origin):
+        receiver = TBAnalyticsReceiver(tb_folder="tb_events")
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+        receiver.initialize(fl_ctx)
+
+        shareable = create_analytic_dxo(
+            tag="loss", value=0.5, data_type=AnalyticsDataType.SCALAR, global_step=0
+        ).to_shareable()
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            receiver.save(fl_ctx, shareable, record_origin)


### PR DESCRIPTION
## Summary

- Several built-in artifact writers/controllers joined config-supplied paths onto the job run directory with no containment, so an absolute path or `..` traversal in their constructor args escaped the job-owned directory:
  - `CrossSiteModelEval` — `cross_val_dir` reaches `shutil.rmtree` + `os.makedirs` (arbitrary directory delete/create).
  - `ValidationJsonGenerator` — `results_dir` / `json_file_name` reach `open(..., "w")` + `json.dump` (arbitrary file write).
  - `TBAnalyticsReceiver` — `tb_folder` reaches `os.makedirs` + TensorBoard event writes (arbitrary directory create).
- Route all three through `file_utils.resolve_path_under_root`, the same containment helper added for the other built-in writers in #4738. Relative paths that stay inside the job directory are unchanged; absolute paths and parent-directory traversal now raise `ValueError`.
- Adds positive and negative unit tests for each of the three classes.

## Context

These are the three sites flagged during review of #4738 that share the same config-path to filesystem-sink pattern but were not converted there. Follow-up to #4738; relevant to the non-BYOC `class_allow_list` hardening in #4701 / #4737.
