### PR TITLE
[2.8] Remove edge classes from default class_allow_list

### DIFF
--- a/docs/user_guide/edge_development/edge_devices.rst
+++ b/docs/user_guide/edge_development/edge_devices.rst
@@ -247,7 +247,14 @@ The following is a sample ``simulation_config.json``:
 
 Both ``simulate_rp.sh`` and ``simulate_lcp.sh`` require the ``simulation_config.json`` file.
 
-If you want to install the simulator in LCPs, you need to configure them in ``config_fed_client.json``, as shown in the following example:
+If you want to install the simulator in LCPs manually, you need to configure them in ``config_fed_client.json``,
+as shown in the following example.
+This advanced configuration path uses ``nvflare.edge.*`` components directly.
+Those edge component classes are not included in the provisioned non-BYOC ``class_allow_list``, so jobs that use
+this direct config must go through BYOC authorization and be submitted by users with BYOC permission in
+``authorization.json``.
+For normal job creation, prefer exporting the job with ``EdgeFedBuffRecipe`` or ``ETFedBuffRecipe`` so the job is
+validated through the BYOC workflow before edge components are built.
 
 .. code-block:: json
 
@@ -319,7 +326,8 @@ If you want to install the simulator in LCPs, you need to configure them in ``co
    }
 
 .. note::
-   You do not need to manually create this file. Instead, you should use either the EdgeJob API or EdgeRecipe to create the job configuration.
+   You do not need to manually create this file. Instead, use the EdgeJob API, ``EdgeFedBuffRecipe``, or
+   ``ETFedBuffRecipe`` to create the job configuration, and make sure the submitting role is allowed to submit BYOC jobs.
 
 Model Development
 =================
@@ -413,7 +421,7 @@ An example can be found in the `edge examples <https://github.com/NVIDIA/NVFlare
 
 .. code-block:: python
 
-   recipe = EdgeRecipe(
+   recipe = EdgeFedBuffRecipe(
            job_name=f"pt_job_{fl_mode}{suffix}",
            model=Cifar10ConvNet(),
            model_manager_config=model_manager_config,

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -147,21 +147,7 @@ local_client_resources: |
       "nvflare.app_opt.xgboost.tree_based.bagging_aggregator.XGBBaggingAggregator",
       "nvflare.app_opt.xgboost.tree_based.executor.FedXGBTreeExecutor",
       "nvflare.app_opt.xgboost.tree_based.model_persistor.XGBModelPersistor",
-      "nvflare.app_opt.xgboost.tree_based.shareable_generator.XGBModelShareableGenerator",
-      "nvflare.edge.aggregators.model_update_dxo_factory.ModelUpdateDXOAggrFactory",
-      "nvflare.edge.assessors.buff_device_manager.BuffDeviceManager",
-      "nvflare.edge.assessors.buff_model_manager.BuffModelManager",
-      "nvflare.edge.assessors.model_update.ModelUpdateAssessor",
-      "nvflare.edge.controllers.sage.ScatterAndGatherForEdge",
-      "nvflare.edge.executors.edge_model_executor.EdgeModelExecutor",
-      "nvflare.edge.executors.et_edge_model_executor.ETEdgeModelExecutor",
-      "nvflare.edge.simulation.devices.num.NumProcessor",
-      "nvflare.edge.simulation.devices.tp.TPDeviceFactory",
-      "nvflare.edge.simulation.devices.tp.TPODeviceFactory",
-      "nvflare.edge.simulation.devices.tp.TaskProcessingDevice",
-      "nvflare.edge.updaters.emd.AggregatorFactory",
-      "nvflare.edge.widgets.etr.EdgeTaskReceiver",
-      "nvflare.edge.widgets.tpo_runner.TPORunner"
+      "nvflare.app_opt.xgboost.tree_based.shareable_generator.XGBModelShareableGenerator"
     ],
     "allow_log_streaming": {~~allow_log_streaming~~},
     "client": {
@@ -363,21 +349,7 @@ local_server_resources: |
           "nvflare.app_opt.xgboost.tree_based.bagging_aggregator.XGBBaggingAggregator",
           "nvflare.app_opt.xgboost.tree_based.executor.FedXGBTreeExecutor",
           "nvflare.app_opt.xgboost.tree_based.model_persistor.XGBModelPersistor",
-          "nvflare.app_opt.xgboost.tree_based.shareable_generator.XGBModelShareableGenerator",
-          "nvflare.edge.aggregators.model_update_dxo_factory.ModelUpdateDXOAggrFactory",
-          "nvflare.edge.assessors.buff_device_manager.BuffDeviceManager",
-          "nvflare.edge.assessors.buff_model_manager.BuffModelManager",
-          "nvflare.edge.assessors.model_update.ModelUpdateAssessor",
-          "nvflare.edge.controllers.sage.ScatterAndGatherForEdge",
-          "nvflare.edge.executors.edge_model_executor.EdgeModelExecutor",
-          "nvflare.edge.executors.et_edge_model_executor.ETEdgeModelExecutor",
-          "nvflare.edge.simulation.devices.num.NumProcessor",
-          "nvflare.edge.simulation.devices.tp.TPDeviceFactory",
-          "nvflare.edge.simulation.devices.tp.TPODeviceFactory",
-          "nvflare.edge.simulation.devices.tp.TaskProcessingDevice",
-          "nvflare.edge.updaters.emd.AggregatorFactory",
-          "nvflare.edge.widgets.etr.EdgeTaskReceiver",
-          "nvflare.edge.widgets.tpo_runner.TPORunner"
+          "nvflare.app_opt.xgboost.tree_based.shareable_generator.XGBModelShareableGenerator"
         ],
       "servers": [
           {

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -274,20 +274,6 @@ class TestStaticFileBuilder:
             "nvflare.app_opt.xgboost.tree_based.executor.FedXGBTreeExecutor",
             "nvflare.app_opt.xgboost.tree_based.model_persistor.XGBModelPersistor",
             "nvflare.app_opt.xgboost.tree_based.shareable_generator.XGBModelShareableGenerator",
-            "nvflare.edge.aggregators.model_update_dxo_factory.ModelUpdateDXOAggrFactory",
-            "nvflare.edge.assessors.buff_device_manager.BuffDeviceManager",
-            "nvflare.edge.assessors.buff_model_manager.BuffModelManager",
-            "nvflare.edge.assessors.model_update.ModelUpdateAssessor",
-            "nvflare.edge.controllers.sage.ScatterAndGatherForEdge",
-            "nvflare.edge.executors.edge_model_executor.EdgeModelExecutor",
-            "nvflare.edge.executors.et_edge_model_executor.ETEdgeModelExecutor",
-            "nvflare.edge.simulation.devices.num.NumProcessor",
-            "nvflare.edge.simulation.devices.tp.TPDeviceFactory",
-            "nvflare.edge.simulation.devices.tp.TPODeviceFactory",
-            "nvflare.edge.simulation.devices.tp.TaskProcessingDevice",
-            "nvflare.edge.updaters.emd.AggregatorFactory",
-            "nvflare.edge.widgets.etr.EdgeTaskReceiver",
-            "nvflare.edge.widgets.tpo_runner.TPORunner",
         ]
         for resource_key in ("local_client_resources", "local_server_resources"):
             resource_template = template[resource_key]
@@ -329,12 +315,56 @@ class TestStaticFileBuilder:
                 "explicitly_reviewed_package_prefixes with an in-test explanation."
             )
 
-    def test_master_template_allows_regression_components(self):
+    def test_master_template_class_allow_list_excludes_edge_components(self):
+        """Provisioned non-BYOC resources must not authorize edge components."""
+        import os
+
+        import yaml
+
+        template_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+            "nvflare",
+            "lighter",
+            "templates",
+            "master_template.yml",
+        )
+        with open(template_path, "r") as f:
+            template = yaml.safe_load(f)
+
+        for resource_key in ("local_client_resources", "local_server_resources"):
+            extracted = _extract_class_allow_list(template[resource_key])
+            edge_paths = [p for p in extracted if p.startswith("nvflare.edge.")]
+            assert not edge_paths, f"edge classes should not be in {resource_key}: {edge_paths}"
+
+    def test_master_template_default_authz_grants_submission_byoc_to_lead_and_project_admin(self):
+        """Default authorization grants broad project_admin permissions and lead BYOC submission permission."""
+        import os
+
+        import yaml
+
+        template_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+            "nvflare",
+            "lighter",
+            "templates",
+            "master_template.yml",
+        )
+        with open(template_path, "r") as f:
+            template = yaml.safe_load(f)
+
+        default_authz = yaml.safe_load(template["default_authz"])
+        permissions = default_authz["permissions"]
+
+        assert permissions["project_admin"] == "any"
+        assert permissions["lead"]["byoc"] == "any"
+
+    def test_master_template_allows_non_edge_regression_components(self):
         """Pin the specific paths that regressed in 2.8.0rc4 (PR #4701 fallout).
 
         Non-BYOC jobs that loaded these built-in classes worked on 2.8.0rc3
         and broke on rc4 because they were missing from the provisioned
-        class_allow_list. This test guards against future re-regression.
+        class_allow_list. Edge components are intentionally outside this
+        non-BYOC regression set.
         """
         import os
 
@@ -355,8 +385,6 @@ class TestStaticFileBuilder:
         regression_paths = [
             # PR #4701 regression: NPTrainer was omitted from the curated list.
             "nvflare.app_common.np.np_trainer.NPTrainer",
-            # PR #4701 regression: edge components were entirely absent.
-            "nvflare.edge.executors.edge_model_executor.EdgeModelExecutor",
             # PR #4701 regression: ccwf re-export short paths were not matched
             # because the list only stored the full module path. Configs in
             # the wild reference the package-level alias.

--- a/tests/unit_test/recipe/edge_recipe_test.py
+++ b/tests/unit_test/recipe/edge_recipe_test.py
@@ -15,9 +15,12 @@
 """Tests for Edge FedBuff recipes."""
 
 import importlib.util
+import json
 from unittest.mock import patch
 
 import pytest
+
+from nvflare.recipe.spec import ExecEnv
 
 torch = pytest.importorskip("torch")
 
@@ -41,6 +44,61 @@ def simple_pt_model():
     import torch.nn as nn
 
     return nn.Linear(10, 2)
+
+
+def _iter_component_configs(value):
+    if isinstance(value, dict):
+        if "path" in value or "class_path" in value:
+            yield value
+        for child in value.values():
+            yield from _iter_component_configs(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_component_configs(child)
+
+
+class _AuthorizingExportEnv(ExecEnv):
+    def __init__(self, job_root):
+        super().__init__()
+        self.job_root = job_root
+        self.authorized_paths = []
+        self.meta = {}
+
+    def deploy(self, job):
+        from nvflare.apis.app_validation import AppValidationKey
+        from nvflare.apis.fl_constant import FLContextKey
+        from nvflare.apis.fl_context import FLContext
+        from nvflare.app_common.widgets.component_path_authorizer import ComponentPathAuthorizer
+        from nvflare.fuel.utils.zip_utils import zip_directory_to_bytes
+        from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
+
+        job.export_job(str(self.job_root))
+        job_dir = self.job_root / job.name
+        job_data = zip_directory_to_bytes("", str(job_dir))
+        valid, error, meta = JobMetaValidator().validate(job.name, job_data)
+        assert valid, error
+        assert meta.get(AppValidationKey.BYOC) is True
+        self.meta = meta
+
+        fl_ctx = FLContext()
+        fl_ctx.set_prop(FLContextKey.JOB_META, meta, private=True, sticky=False)
+        authorizer = ComponentPathAuthorizer()
+        for config_path in sorted(job_dir.glob("*/config/config_fed_*.json")):
+            config = json.loads(config_path.read_text())
+            for component_config in _iter_component_configs(config):
+                authorizer.authorize_component_config(component_config, fl_ctx=fl_ctx)
+                self.authorized_paths.append(component_config.get("path") or component_config.get("class_path"))
+
+        return job.name
+
+    def get_job_status(self, job_id: str):
+        return None
+
+    def abort_job(self, job_id: str) -> None:
+        pass
+
+    def get_job_result(self, job_id: str, timeout: float = 0.0):
+        return str(self.job_root / job_id)
 
 
 class TestEdgeFedBuffRecipe:
@@ -131,6 +189,25 @@ class TestEdgeFedBuffRecipe:
         # Verify model is stored as dict
         assert isinstance(recipe.model, dict)
         assert recipe.model["path"] == "torch.nn.Linear"
+
+    def test_run_validates_edge_job_byoc_before_component_authorization(
+        self, tmp_path, model_manager_config, device_manager_config
+    ):
+        """JobMetaValidator must mark exported edge jobs BYOC before ComponentPathAuthorizer sees the configs."""
+        from nvflare.edge.tools.edge_fed_buff_recipe import EdgeFedBuffRecipe
+
+        recipe = EdgeFedBuffRecipe(
+            job_name="test_edge_authorizer_smoke",
+            model={"class_path": "torch.nn.Linear", "args": {"in_features": 10, "out_features": 2}},
+            model_manager_config=model_manager_config,
+            device_manager_config=device_manager_config,
+        )
+        env = _AuthorizingExportEnv(tmp_path)
+
+        run = recipe.run(env)
+
+        assert run.get_job_id() == "test_edge_authorizer_smoke"
+        assert any(path.startswith("nvflare.edge.") for path in env.authorized_paths)
 
     def test_relative_path_accepted_if_exists(
         self, mock_file_system, simple_pt_model, model_manager_config, device_manager_config


### PR DESCRIPTION
## Summary

- remove nvflare.edge component paths from the default client and server class_allow_list entries added in PR #4737
- keep the non-edge class_allow_list fixes from PR #4737 intact
- clarify template tests so default authorization assertions describe only the permissions they check
- add an EdgeFedBuffRecipe.run() smoke test that validates the exported job metadata and passes generated edge configs through ComponentPathAuthorizer
- update edge device docs to call direct edge component configs a BYOC-authorized advanced path and steer normal job creation to EdgeFedBuffRecipe/ETFedBuffRecipe export
- leave simulator behavior unchanged; simulator is not the production BYOC=false path covered by this allow-list change

## Test plan

- python -m pytest tests/unit_test/lighter/static_file_builder_test.py tests/unit_test/recipe/edge_recipe_test.py
- git diff --check
- ./runtest.sh -s