### PR TITLE
Document Kubernetes API CA validation

### DIFF
--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -40,6 +40,9 @@ Before you start, make sure you have:
 * NVIDIA GPU Operator or NVIDIA device plugin installed on clusters that will
   run jobs with ``resource_spec[site].num_of_gpus``. See
   `Cloud GPU Setup References`_.
+* For Kubernetes job launching, a Kubernetes API-server CA chain that passes
+  Python 3.13+ strict X.509 validation. CA certificates must include required
+  RFC 5280 extensions such as ``keyUsage`` with certificate signing allowed.
 
 The generated charts do not install a Kubernetes cluster, storage class, GPU
 device plugin, ingress controller, or registry credentials.
@@ -975,6 +978,15 @@ Check the parent logs for Kubernetes import or authorization failures:
 
 If the logs show that the ``kubernetes`` Python package is missing, rebuild the
 parent image with the NVFlare ``K8S`` extra or ``pip install kubernetes``.
+
+If the logs show ``SSLCertVerificationError`` with
+``CA cert does not include key usage extension``, the parent Kubernetes client
+is rejecting the cluster API-server CA. This is known to affect some MicroK8s
+CA certificates that omit the X.509 ``keyUsage`` extension. Regenerate or
+replace the cluster CA with an RFC 5280-compliant CA. As a temporary
+compatibility workaround for development clusters, use a custom parent image
+based on Python 3.12 or earlier. Do not disable Kubernetes API TLS verification
+in production.
 
 Job pod stays ``Pending`` or ``Unknown``
 ----------------------------------------

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -982,11 +982,12 @@ parent image with the NVFlare ``K8S`` extra or ``pip install kubernetes``.
 If the logs show ``SSLCertVerificationError`` with
 ``CA cert does not include key usage extension``, the parent Kubernetes client
 is rejecting the cluster API-server CA. This is known to affect some MicroK8s
-CA certificates that omit the X.509 ``keyUsage`` extension. Regenerate or
-replace the cluster CA with an RFC 5280-compliant CA. As a temporary
-compatibility workaround for development clusters, use a custom parent image
-based on Python 3.12 or earlier. Do not disable Kubernetes API TLS verification
-in production.
+CA certificates that omit the X.509 ``keyUsage`` extension; see
+`canonical/microk8s#4864 <https://github.com/canonical/microk8s/issues/4864>`__.
+Regenerate or replace the cluster CA with an RFC 5280-compliant CA. As a
+temporary compatibility workaround for development clusters, use a custom
+parent image based on Python 3.12 or earlier. Do not disable Kubernetes API TLS
+verification in production.
 
 Job pod stays ``Pending`` or ``Unknown``
 ----------------------------------------


### PR DESCRIPTION
## What changed

Adds Kubernetes deployment documentation for Python 3.13+ strict X.509 validation of the Kubernetes API-server CA chain.

## Why

The parent pod runs the Kubernetes job launcher. With the Python 3.14 parent image, API calls can fail on clusters whose API-server CA omits required RFC 5280 extensions such as `keyUsage`, which can prevent job pods from being created.

## Impact

Operators get a prerequisite note and a troubleshooting path for `SSLCertVerificationError: CA cert does not include key usage extension`, including MicroK8s context and guidance to fix the cluster CA rather than disabling TLS verification.

