### PR TITLE
Harden built-in artifact writer paths

### DIFF
--- a/nvflare/app_common/ccwf/comps/np_file_model_persistor.py
+++ b/nvflare/app_common/ccwf/comps/np_file_model_persistor.py
@@ -25,6 +25,7 @@ from nvflare.app_common.app_event_type import AppEventType
 from nvflare.app_common.model_desc import ModelDescriptor
 from nvflare.app_common.np.constants import NPConstants
 from nvflare.app_common.np.utils import load_numpy_model
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.security.logging import secure_format_exception
 
 
@@ -70,7 +71,7 @@ class NPFileModelPersistor(ModelPersistor):
 
     def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
         run_dir = _get_run_dir(fl_ctx)
-        model_path = os.path.join(run_dir, self.model_dir, self.model_file_name)
+        model_path = resolve_path_under_root(run_dir, os.path.join(self.model_dir, self.model_file_name), "model path")
 
         data = load_numpy_model(
             fl_ctx=fl_ctx,
@@ -89,11 +90,11 @@ class NPFileModelPersistor(ModelPersistor):
 
     def _save(self, fl_ctx: FLContext, model_learnable: ModelLearnable, file_name: str):
         run_dir = _get_run_dir(fl_ctx)
-        model_root_dir = os.path.join(run_dir, self.model_dir)
+        model_path = resolve_path_under_root(run_dir, os.path.join(self.model_dir, file_name), "model path")
+        model_root_dir = os.path.dirname(model_path)
         if not os.path.exists(model_root_dir):
             os.makedirs(model_root_dir)
 
-        model_path = os.path.join(model_root_dir, file_name)
         np.save(model_path, model_learnable[ModelLearnableKey.WEIGHTS][NPConstants.NUMPY_KEY])
         self.log_info(fl_ctx, f"Saved numpy model to: {model_path}")
         self.log_info(fl_ctx, f"Model: {model_learnable}")
@@ -106,8 +107,7 @@ class NPFileModelPersistor(ModelPersistor):
 
     def _model_file_path(self, fl_ctx: FLContext, file_name):
         run_dir = _get_run_dir(fl_ctx)
-        model_root_dir = os.path.join(run_dir, self.model_dir)
-        return os.path.join(model_root_dir, file_name)
+        return resolve_path_under_root(run_dir, os.path.join(self.model_dir, file_name), "model path")
 
     def _add_to_inventory(self, inventory: dict, fl_ctx: FLContext, file_name: str):
         location = self._model_file_path(fl_ctx, file_name)

--- a/nvflare/app_common/ccwf/comps/np_trainer.py
+++ b/nvflare/app_common/ccwf/comps/np_trainer.py
@@ -28,6 +28,7 @@ from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.model import ModelLearnable
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.np.constants import NPConstants
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.security.logging import secure_format_exception
 
 
@@ -221,9 +222,9 @@ class NPTrainer(Executor):
         engine = fl_ctx.get_engine()
         job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
         run_dir = engine.get_workspace().get_run_dir(job_id)
-        model_path = os.path.join(run_dir, self._model_dir)
-
-        model_load_path = os.path.join(model_path, self._model_name)
+        model_load_path = resolve_path_under_root(
+            run_dir, os.path.join(self._model_dir, self._model_name), "model path"
+        )
         try:
             np_data = np.load(model_load_path, allow_pickle=False)
         except Exception as e:
@@ -240,10 +241,12 @@ class NPTrainer(Executor):
         engine = fl_ctx.get_engine()
         job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
         run_dir = engine.get_workspace().get_run_dir(job_id)
-        model_path = os.path.join(run_dir, self._model_dir)
+        model_save_path = resolve_path_under_root(
+            run_dir, os.path.join(self._model_dir, self._model_name), "model path"
+        )
+        model_path = os.path.dirname(model_save_path)
         if not os.path.exists(model_path):
             os.makedirs(model_path)
 
-        model_save_path = os.path.join(model_path, self._model_name)
         np.save(model_save_path, model[NPConstants.NUMPY_KEY])
         self.log_info(fl_ctx, f"Saved numpy model to: {model_save_path}")

--- a/nvflare/app_common/np/np_model_persistor.py
+++ b/nvflare/app_common/np/np_model_persistor.py
@@ -20,6 +20,7 @@ import numpy as np
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.abstract.model import ModelLearnable, ModelLearnableKey, make_model_learnable
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 
 from .constants import NPConstants
 from .utils import load_numpy_model
@@ -84,7 +85,7 @@ class NPModelPersistor(ModelPersistor):
 
     def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
         run_dir = _get_run_dir(fl_ctx)
-        model_path = os.path.join(run_dir, self.model_dir, self.model_name)
+        model_path = resolve_path_under_root(run_dir, os.path.join(self.model_dir, self.model_name), "model path")
 
         data = load_numpy_model(
             fl_ctx=fl_ctx,
@@ -102,10 +103,12 @@ class NPModelPersistor(ModelPersistor):
     def save_model(self, model_learnable: ModelLearnable, fl_ctx: FLContext):
         workspace = fl_ctx.get_workspace()
         job_id = fl_ctx.get_job_id()
-        model_root_dir = os.path.join(workspace.get_result_root(job_id), self.model_dir)
+        model_path = resolve_path_under_root(
+            workspace.get_result_root(job_id), os.path.join(self.model_dir, self.model_name), "model path"
+        )
+        model_root_dir = os.path.dirname(model_path)
         if not os.path.exists(model_root_dir):
             os.makedirs(model_root_dir)
 
-        model_path = os.path.join(model_root_dir, self.model_name)
         np.save(model_path, model_learnable[ModelLearnableKey.WEIGHTS][NPConstants.NUMPY_KEY])
         self.log_info(fl_ctx, f"Saved numpy model to: {model_path}")

--- a/nvflare/app_common/np/np_trainer.py
+++ b/nvflare/app_common/np/np_trainer.py
@@ -25,6 +25,7 @@ from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.model import ModelLearnable
 from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.security.logging import secure_format_exception
 
 from .constants import NPConstants
@@ -196,9 +197,9 @@ class NPTrainer(Executor):
         engine = fl_ctx.get_engine()
         job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
         run_dir = engine.get_workspace().get_run_dir(job_id)
-        model_path = os.path.join(run_dir, self._model_dir)
-
-        model_load_path = os.path.join(model_path, self._model_name)
+        model_load_path = resolve_path_under_root(
+            run_dir, os.path.join(self._model_dir, self._model_name), "model path"
+        )
         try:
             np_data = np.load(model_load_path, allow_pickle=False)
         except Exception as e:
@@ -215,10 +216,12 @@ class NPTrainer(Executor):
         engine = fl_ctx.get_engine()
         job_id = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
         data_dir = engine.get_workspace().get_result_root(job_id)
-        model_path = os.path.join(data_dir, self._model_dir)
+        model_save_path = resolve_path_under_root(
+            data_dir, os.path.join(self._model_dir, self._model_name), "model path"
+        )
+        model_path = os.path.dirname(model_save_path)
         if not os.path.exists(model_path):
             os.makedirs(model_path)
 
-        model_save_path = os.path.join(model_path, self._model_name)
         np.save(model_save_path, model[NPConstants.NUMPY_KEY])
         self.log_info(fl_ctx, f"Saved numpy model to: {model_save_path}")

--- a/nvflare/app_common/psi/file_psi_writer.py
+++ b/nvflare/app_common/psi/file_psi_writer.py
@@ -19,6 +19,7 @@ from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.storage import StorageException
 from nvflare.app_common.psi.psi_spec import PSIWriter
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 
 
 def _validate_directory(full_path: str):
@@ -61,4 +62,5 @@ class FilePSIWriter(PSIWriter):
     def get_output_path(self, fl_ctx: FLContext) -> str:
         job_dir = os.path.dirname(os.path.abspath(fl_ctx.get_prop(FLContextKey.APP_ROOT)))
         self.log_info(fl_ctx, "job dir = " + job_dir)
-        return os.path.join(job_dir, fl_ctx.get_identity_name(), self.output_path)
+        site_job_dir = os.path.join(job_dir, fl_ctx.get_identity_name())
+        return resolve_path_under_root(site_job_dir, self.output_path, "output_path")

--- a/nvflare/app_common/statistics/json_stats_file_persistor.py
+++ b/nvflare/app_common/statistics/json_stats_file_persistor.py
@@ -14,6 +14,7 @@
 import json
 import os
 
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.storage import StorageException
@@ -21,20 +22,22 @@ from nvflare.app_common.abstract.statistics_writer import StatisticsWriter
 from nvflare.app_common.utils.json_utils import ObjectEncoder
 from nvflare.fuel.utils.class_loader import load_class
 
+OBJECT_ENCODER_PATH = "nvflare.app_common.utils.json_utils.ObjectEncoder"
+_BUILT_IN_JSON_ENCODER_PATHS = {"", OBJECT_ENCODER_PATH}
+
 
 class JsonStatsFileWriter(StatisticsWriter):
     def __init__(self, output_path: str, json_encoder_path: str = ""):
         super().__init__()
         self.job_dir = None
+        self.json_encoder_class = None
         if len(output_path) == 0:
             raise ValueError(f"output_path {output_path} is empty string")
+        if not isinstance(json_encoder_path, str):
+            raise TypeError(f"json_encoder_path must be str but got {type(json_encoder_path)}")
 
         self.output_path = output_path
-        if json_encoder_path == "":
-            self.json_encoder_class = ObjectEncoder
-        else:
-            self.json_encoder_path = json_encoder_path
-            self.json_encoder_class = load_class(json_encoder_path)
+        self.json_encoder_path = json_encoder_path
 
     def save(
         self,
@@ -44,24 +47,23 @@ class JsonStatsFileWriter(StatisticsWriter):
     ):
 
         full_uri = self.get_output_path(fl_ctx)
+        content = json.dumps(data, cls=self._get_json_encoder_class(fl_ctx))
         self._validate_directory(full_uri)
 
-        data_exists = os.path.isfile(full_uri)
-        if data_exists and not overwrite_existing:
-            raise StorageException("object {} already exists and overwrite_existing is False".format(full_uri))
-
-        content = json.dumps(data, cls=self.json_encoder_class)
-
         self.log_info(fl_ctx, f"trying to save data to {full_uri}")
-        with open(full_uri, "w") as outfile:
+        with self._open_output_file(full_uri, overwrite_existing) as outfile:
             outfile.write(content)
 
         self.log_info(fl_ctx, f"file {full_uri} saved")
 
     def get_output_path(self, fl_ctx: FLContext) -> str:
-        self.job_dir = os.path.dirname(os.path.abspath(fl_ctx.get_prop(FLContextKey.APP_ROOT)))
+        app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+        if not app_root:
+            raise ValueError(f"missing {FLContextKey.APP_ROOT} in fl_ctx")
+
+        self.job_dir = os.path.realpath(os.path.dirname(os.path.abspath(app_root)))
         self.log_info(fl_ctx, "job dir = " + self.job_dir)
-        return os.path.join(self.job_dir, self.output_path)
+        return self._resolve_output_path(self.job_dir)
 
     def _validate_directory(self, full_path: str):
         if not os.path.isabs(full_path):
@@ -70,4 +72,54 @@ class JsonStatsFileWriter(StatisticsWriter):
         if os.path.exists(parent_dir) and not os.path.isdir(parent_dir):
             raise ValueError(f"directory {parent_dir} exists but is not a directory.")
         if not os.path.exists(parent_dir):
-            os.makedirs(parent_dir, exist_ok=False)
+            os.makedirs(parent_dir, mode=0o700, exist_ok=False)
+
+    @staticmethod
+    def _open_output_file(full_path: str, overwrite_existing: bool):
+        flags = os.O_WRONLY | os.O_CREAT
+        if overwrite_existing:
+            flags |= os.O_TRUNC
+        else:
+            flags |= os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            # POSIX-only defense in depth; it protects the final path component.
+            # Existing intermediate symlink escapes are rejected by realpath/commonpath before this open.
+            flags |= os.O_NOFOLLOW
+
+        try:
+            fd = os.open(full_path, flags, 0o600)
+        except FileExistsError as ex:
+            raise StorageException(f"object {full_path} already exists and overwrite_existing is False") from ex
+        return os.fdopen(fd, "w", encoding="utf-8")
+
+    def _resolve_output_path(self, job_dir: str) -> str:
+        if os.path.isabs(self.output_path):
+            raise ValueError(f"output_path {self.output_path} must be relative to the job directory.")
+
+        full_path = os.path.realpath(os.path.join(job_dir, self.output_path))
+        if os.path.commonpath([job_dir, full_path]) != job_dir:
+            raise ValueError(f"output_path {self.output_path} must stay inside the job directory.")
+
+        return full_path
+
+    def _get_json_encoder_class(self, fl_ctx: FLContext):
+        if self.json_encoder_path in _BUILT_IN_JSON_ENCODER_PATHS:
+            return ObjectEncoder
+
+        if not self._job_has_byoc(fl_ctx):
+            raise ValueError("custom json_encoder_path is only allowed for BYOC jobs.")
+
+        if self.json_encoder_class is None:
+            json_encoder_class = load_class(self.json_encoder_path)
+            if not issubclass(json_encoder_class, json.JSONEncoder):
+                raise TypeError(f"json_encoder_path {self.json_encoder_path} must be a JSONEncoder class.")
+            self.json_encoder_class = json_encoder_class
+
+        return self.json_encoder_class
+
+    @staticmethod
+    def _job_has_byoc(fl_ctx: FLContext) -> bool:
+        job_meta = fl_ctx.get_prop(FLContextKey.JOB_META)
+        if not isinstance(job_meta, dict):
+            return False
+        return bool(job_meta.get(AppValidationKey.BYOC))

--- a/nvflare/app_common/utils/file_utils.py
+++ b/nvflare/app_common/utils/file_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pathlib
 from typing import Optional
 
@@ -36,3 +37,18 @@ def get_file_ext(input_path: str) -> Optional[str]:
         return ext[1:]
     else:
         return ext
+
+
+def resolve_path_under_root(root_dir: str, relative_path: str, path_name: str = "path") -> str:
+    if not isinstance(root_dir, str):
+        raise TypeError(f"root_dir must be str but got {type(root_dir)}")
+    if not isinstance(relative_path, str):
+        raise TypeError(f"{path_name} must be str but got {type(relative_path)}")
+    if os.path.isabs(relative_path):
+        raise ValueError(f"{path_name} {relative_path} must be relative to {root_dir}.")
+
+    root_real = os.path.realpath(root_dir)
+    full_path = os.path.realpath(os.path.join(root_real, relative_path))
+    if os.path.commonpath([root_real, full_path]) != root_real:
+        raise ValueError(f"{path_name} {relative_path} must stay inside {root_real}.")
+    return full_path

--- a/nvflare/app_common/widgets/validation_json_generator.py
+++ b/nvflare/app_common/widgets/validation_json_generator.py
@@ -23,6 +23,7 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.widgets.widget import Widget
 
 
@@ -99,10 +100,11 @@ class ValidationJsonGenerator(Widget):
                 self.log_error(fl_ctx, "Validation result not found.", fire_event=False)
         elif event_type == EventType.END_RUN:
             run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
-            cross_val_res_dir = os.path.join(run_dir, self._results_dir)
+            res_file_path = resolve_path_under_root(
+                run_dir, os.path.join(self._results_dir, self._json_file_name), "results path"
+            )
+            cross_val_res_dir = os.path.dirname(res_file_path)
             if not os.path.exists(cross_val_res_dir):
                 os.makedirs(cross_val_res_dir)
-
-            res_file_path = os.path.join(cross_val_res_dir, self._json_file_name)
             with open(res_file_path, "w") as f:
                 json.dump(self._val_results, f, default=to_serializable)

--- a/nvflare/app_common/workflows/cross_site_model_eval.py
+++ b/nvflare/app_common/workflows/cross_site_model_eval.py
@@ -30,6 +30,7 @@ from nvflare.app_common.abstract.formatter import Formatter
 from nvflare.app_common.abstract.model_locator import ModelLocator
 from nvflare.app_common.app_constant import AppConstants, ModelName
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
@@ -132,7 +133,7 @@ class CrossSiteModelEval(Controller):
         # Create shareable dirs for models and results
         workspace: Workspace = self._engine.get_workspace()
         run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
-        cross_val_path = os.path.join(run_dir, self._cross_val_dir)
+        cross_val_path = resolve_path_under_root(run_dir, self._cross_val_dir, "cross_val_dir")
         self._cross_val_models_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_MODEL_DIR_NAME)
         self._cross_val_results_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_RESULTS_DIR_NAME)
 

--- a/nvflare/app_opt/tracking/tb/tb_receiver.py
+++ b/nvflare/app_opt/tracking/tb/tb_receiver.py
@@ -19,6 +19,7 @@ from nvflare.apis.analytix import AnalyticsData, AnalyticsDataType
 from nvflare.apis.dxo import from_shareable
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_opt.tracking.tb.tb_event_writer import TensorBoardEventWriter
 
@@ -74,7 +75,7 @@ class TBAnalyticsReceiver(AnalyticsReceiver):
     def initialize(self, fl_ctx: FLContext):
         workspace = fl_ctx.get_engine().get_workspace()
         run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
-        root_log_dir = os.path.join(run_dir, self.tb_folder)
+        root_log_dir = resolve_path_under_root(run_dir, self.tb_folder, "tb_folder")
         os.makedirs(root_log_dir, exist_ok=True)
         self.root_log_dir = root_log_dir
         self.log_info(

--- a/nvflare/app_opt/tracking/tb/tb_receiver.py
+++ b/nvflare/app_opt/tracking/tb/tb_receiver.py
@@ -112,7 +112,7 @@ class TBAnalyticsReceiver(AnalyticsReceiver):
 
         writer = self.writers_table.get(record_origin)
         if writer is None:
-            peer_log_dir = os.path.join(self.root_log_dir, record_origin)
+            peer_log_dir = resolve_path_under_root(self.root_log_dir, record_origin, "record_origin")
             writer = TensorBoardEventWriter(log_dir=peer_log_dir)
             self.writers_table[record_origin] = writer
 

--- a/nvflare/app_opt/xgboost/histogram_based/executor.py
+++ b/nvflare/app_opt/xgboost/histogram_based/executor.py
@@ -27,6 +27,7 @@ from nvflare.apis.signal import Signal
 from nvflare.apis.workspace import Workspace
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.tracking.log_writer import LogWriter
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.app_opt.xgboost.data_loader import XGBDataLoader
 from nvflare.app_opt.xgboost.histogram_based.constants import XGB_TRAIN_TASK, XGBShareableHeader
 from nvflare.app_opt.xgboost.metrics_cb import MetricsCallback
@@ -110,6 +111,9 @@ class FedXGBHistogramExecutor(Executor):
 
         self._metrics_writer_id = metrics_writer_id
         self._metrics_writer = None
+
+    def _get_model_path(self, run_dir: str) -> str:
+        return resolve_path_under_root(run_dir, self.model_file_name, "model_file_name")
 
     def initialize(self, fl_ctx):
         self.client_id = fl_ctx.get_identity_name()
@@ -283,7 +287,7 @@ class FedXGBHistogramExecutor(Executor):
                 workspace = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
                 run_number = fl_ctx.get_prop(FLContextKey.CURRENT_RUN)
                 run_dir = workspace.get_run_dir(run_number)
-                bst.save_model(os.path.join(run_dir, self.model_file_name))
+                bst.save_model(self._get_model_path(run_dir))
                 xgb.collective.communicator_print("Finished training\n")
         except Exception as e:
             secure_log_traceback()

--- a/nvflare/app_opt/xgboost/histogram_based_v2/runners/xgb_client_runner.py
+++ b/nvflare/app_opt/xgboost/histogram_based_v2/runners/xgb_client_runner.py
@@ -22,6 +22,7 @@ from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_constant import FLContextKey, SystemConfigs
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.tracking.log_writer import LogWriter
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 from nvflare.app_opt.xgboost.data_loader import XGBDataLoader
 from nvflare.app_opt.xgboost.histogram_based_v2.defs import Constant
 from nvflare.app_opt.xgboost.histogram_based_v2.runners.xgb_runner import AppRunner
@@ -90,6 +91,9 @@ class XGBClientRunner(AppRunner, FLComponent):
             self._metrics_writer = engine.get_component(self._metrics_writer_id)
             if not isinstance(self._metrics_writer, LogWriter):
                 self.system_panic("writer should be type LogWriter", fl_ctx)
+
+    def _get_model_path(self) -> str:
+        return resolve_path_under_root(self._model_dir, self.model_file_name, "model_file_name")
 
     def _xgb_train(self, num_rounds, xgb_params: dict, xgb_options: dict, train_data, val_data) -> xgb.core.Booster:
         """XGBoost training logic.
@@ -219,7 +223,7 @@ class XGBClientRunner(AppRunner, FLComponent):
             bst = self._xgb_train(self._num_rounds, self._xgb_params, self._xgb_options, train_data, val_data)
 
             # Save the model.
-            bst.save_model(os.path.join(self._model_dir, self.model_file_name))
+            bst.save_model(self._get_model_path())
             xgb.collective.communicator_print("Finished training\n")
 
             enable_explainability = self._xgb_options.get("enable_explainability", True)

--- a/nvflare/app_opt/xgboost/tree_based/model_persistor.py
+++ b/nvflare/app_opt/xgboost/tree_based/model_persistor.py
@@ -21,6 +21,7 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.abstract.model import ModelLearnable, ModelLearnableKey, make_model_learnable
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
 
 
 class XGBModelPersistor(ModelPersistor):
@@ -33,7 +34,7 @@ class XGBModelPersistor(ModelPersistor):
         # get save path from FLContext
         app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
         self.log_dir = app_root
-        self.save_path = os.path.join(self.log_dir, self.save_name)
+        self.save_path = resolve_path_under_root(self.log_dir, self.save_name, "save_name")
         if not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir)
         fl_ctx.sync_sticky()

--- a/tests/integration_test/data/test_configs/standalone_job/image_stats.yml
+++ b/tests/integration_test/data/test_configs/standalone_job/image_stats.yml
@@ -29,3 +29,10 @@ tests:
   - python ../../examples/advanced/federated-statistics/image_stats/prepare_data.py --input_dir /tmp/nvflare/image_stats/data --output_dir /tmp/nvflare/image_stats/data
   - rm -f ../../examples/advanced/federated-statistics/image_stats/temp_requirements.txt
   test_name: Test example image_stats.
+  validators:
+  - path: tests.integration_test.src.validators.json_stats_result_validator.JsonStatsResultValidator
+    args:
+      relative_path: statistics/image_statistics.json
+      required_paths:
+      - intensity.count
+      - intensity.histogram

--- a/tests/integration_test/src/validators/json_stats_result_validator.py
+++ b/tests/integration_test/src/validators/json_stats_result_validator.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from typing import Optional
+
+from .job_result_validator import FinishJobResultValidator
+
+
+class JsonStatsResultValidator(FinishJobResultValidator):
+    def __init__(self, relative_path: str, required_paths: Optional[list[str]] = None):
+        super().__init__()
+        self.relative_path = relative_path
+        self.required_paths = required_paths or []
+
+    def validate_finished_results(self, job_result, client_props) -> bool:
+        stats_file = self._find_stats_file(job_result["workspace_root"])
+        if not stats_file:
+            self.logger.error(f"stats file {self.relative_path} doesn't exist.")
+            return False
+
+        try:
+            with open(stats_file, "r", encoding="utf-8") as f:
+                stats = json.load(f)
+        except Exception as ex:
+            self.logger.error(f"failed to load stats file {stats_file}: {ex}")
+            return False
+
+        if not stats:
+            self.logger.error(f"stats file {stats_file} is empty.")
+            return False
+
+        for required_path in self.required_paths:
+            if not self._has_path(stats, required_path):
+                self.logger.error(f"stats file {stats_file} is missing required path {required_path}.")
+                return False
+
+        return True
+
+    def _find_stats_file(self, workspace_root: str):
+        normalized_suffix = os.path.normpath(self.relative_path)
+        if os.path.isabs(normalized_suffix) or normalized_suffix == os.pardir:
+            return None
+        if normalized_suffix.startswith(os.pardir + os.sep):
+            return None
+
+        stats_file = os.path.join(workspace_root, normalized_suffix)
+        if os.path.isfile(stats_file):
+            return stats_file
+
+        # The downloaded job-result layout can include an extra workspace/app level;
+        # keep the validator stable across those layouts.
+        for root, _, files in os.walk(workspace_root):
+            for file_name in files:
+                candidate = os.path.join(root, file_name)
+                candidate_rel = os.path.normpath(os.path.relpath(candidate, workspace_root))
+                if candidate_rel == normalized_suffix or candidate_rel.endswith(os.sep + normalized_suffix):
+                    return candidate
+
+        return None
+
+    @staticmethod
+    def _has_path(stats: dict, required_path: str):
+        current = stats
+        for part in required_path.split("."):
+            if not isinstance(current, dict) or part not in current:
+                return False
+            current = current[part]
+        return True

--- a/tests/unit_test/app_common/np/np_persistor_test.py
+++ b/tests/unit_test/app_common/np/np_persistor_test.py
@@ -12,7 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for NPModelPersistor source_ckpt_file_full_name support."""
+"""Unit tests for numpy model persistors."""
+
+import os
+
+import numpy as np
+import pytest
+
+from nvflare.apis.fl_constant import FLContextKey, ReservedKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.workspace import Workspace
+from nvflare.app_common.abstract.model import ModelLearnableKey, make_model_learnable
+from nvflare.app_common.ccwf.comps.np_trainer import NPTrainer as CCWFNPTrainer
+from nvflare.app_common.np.constants import NPConstants
+from nvflare.app_common.np.np_trainer import NPTrainer
+
+
+class _Engine:
+    def __init__(self, workspace):
+        self._workspace = workspace
+
+    def get_workspace(self):
+        return self._workspace
+
+
+def _make_fl_ctx(tmp_path):
+    (tmp_path / "startup").mkdir()
+    (tmp_path / "local").mkdir()
+    workspace = Workspace(root_dir=str(tmp_path), site_name="site-1")
+    fl_ctx = FLContext()
+    fl_ctx.put(key=ReservedKey.ENGINE, value=_Engine(workspace), private=True, sticky=False)
+    fl_ctx.put(key=ReservedKey.RUN_NUM, value="job-1", private=False, sticky=True)
+    fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, private=True, sticky=False)
+    fl_ctx.set_prop(FLContextKey.CURRENT_RUN, "job-1", private=False, sticky=True)
+    return fl_ctx
+
+
+def _model_learnable():
+    return make_model_learnable(
+        weights={NPConstants.NUMPY_KEY: np.array([[1, 2], [3, 4]], dtype=np.float32)}, meta_props={}
+    )
 
 
 class TestNPModelPersistorInit:
@@ -48,6 +87,33 @@ class TestNPModelPersistorInit:
         assert persistor.model == [[1, 2], [3, 4]]
         assert persistor.source_ckpt_file_full_name == "/data/pretrained/model.npy"
 
+    def test_save_model_accepts_relative_model_path(self, tmp_path):
+        from nvflare.app_common.np.np_model_persistor import NPModelPersistor
+
+        fl_ctx = _make_fl_ctx(tmp_path)
+        persistor = NPModelPersistor(model_dir="models", model_name="server.npy")
+        persistor.save_model(_model_learnable(), fl_ctx)
+
+        result_root = fl_ctx.get_workspace().get_result_root(fl_ctx.get_job_id())
+        assert os.path.isfile(os.path.join(result_root, "models", "server.npy"))
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"model_dir": "../outside"},
+            {"model_name": "../../outside.npy"},
+            {"model_dir": "/tmp/outside"},
+        ],
+    )
+    def test_save_model_rejects_escaping_model_path(self, tmp_path, kwargs):
+        from nvflare.app_common.np.np_model_persistor import NPModelPersistor
+
+        fl_ctx = _make_fl_ctx(tmp_path)
+        persistor = NPModelPersistor(**kwargs)
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            persistor.save_model(_model_learnable(), fl_ctx)
+
 
 class TestNPFileModelPersistorInit:
     """Tests for NPFileModelPersistor initialization with source_ckpt_file_full_name."""
@@ -69,3 +135,64 @@ class TestNPFileModelPersistorInit:
         )
 
         assert persistor.source_ckpt_file_full_name == "/data/pretrained/model.npy"
+
+    def test_save_model_accepts_relative_model_path(self, tmp_path):
+        from nvflare.app_common.ccwf.comps.np_file_model_persistor import NPFileModelPersistor
+
+        fl_ctx = _make_fl_ctx(tmp_path)
+        persistor = NPFileModelPersistor(model_dir="models", last_global_model_file_name="last.npy")
+        persistor.save_model(_model_learnable(), fl_ctx)
+
+        run_dir = fl_ctx.get_workspace().get_run_dir(fl_ctx.get_job_id())
+        assert os.path.isfile(os.path.join(run_dir, "models", "last.npy"))
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"model_dir": "../outside"},
+            {"last_global_model_file_name": "../../outside.npy"},
+            {"best_global_model_file_name": "/tmp/outside.npy"},
+        ],
+    )
+    def test_save_model_rejects_escaping_model_path(self, tmp_path, kwargs):
+        from nvflare.app_common.ccwf.comps.np_file_model_persistor import NPFileModelPersistor
+
+        fl_ctx = _make_fl_ctx(tmp_path)
+        persistor = NPFileModelPersistor(**kwargs)
+        model = _model_learnable()
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            if "best_global_model_file_name" in kwargs:
+                persistor._save(fl_ctx, model, persistor.best_global_model_file_name)
+            else:
+                persistor.save_model(model, fl_ctx)
+
+
+@pytest.mark.parametrize(
+    "trainer_cls",
+    [NPTrainer, CCWFNPTrainer],
+)
+def test_np_trainers_accept_relative_model_path(tmp_path, trainer_cls):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    trainer = trainer_cls(model_dir="models", model_name="local.npy")
+    weights = _model_learnable()[ModelLearnableKey.WEIGHTS][NPConstants.NUMPY_KEY]
+
+    trainer._save_local_model(fl_ctx, {NPConstants.NUMPY_KEY: weights})
+
+    expected_root = fl_ctx.get_workspace().get_result_root(fl_ctx.get_job_id())
+    if trainer_cls is CCWFNPTrainer:
+        expected_root = fl_ctx.get_workspace().get_run_dir(fl_ctx.get_job_id())
+    assert os.path.isfile(os.path.join(expected_root, "models", "local.npy"))
+
+
+@pytest.mark.parametrize(
+    "trainer_cls",
+    [NPTrainer, CCWFNPTrainer],
+)
+def test_np_trainers_reject_escaping_model_path(tmp_path, trainer_cls):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    trainer = trainer_cls(model_dir="../outside")
+    weights = _model_learnable()[ModelLearnableKey.WEIGHTS][NPConstants.NUMPY_KEY]
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        trainer._save_local_model(fl_ctx, {NPConstants.NUMPY_KEY: weights})

--- a/tests/unit_test/app_common/psi/file_psi_writer_test.py
+++ b/tests/unit_test/app_common/psi/file_psi_writer_test.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nvflare.apis.fl_constant import FLContextKey, ReservedKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.psi.file_psi_writer import FilePSIWriter
+
+
+def _make_fl_ctx(tmp_path):
+    app_root = tmp_path / "app_site-1"
+    app_root.mkdir()
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.APP_ROOT, str(app_root), private=True, sticky=False)
+    fl_ctx.put(key=ReservedKey.IDENTITY_NAME, value="site-1", private=False, sticky=True)
+    return fl_ctx
+
+
+def test_file_psi_writer_accepts_relative_output_path(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = FilePSIWriter(output_path="psi/intersection.txt")
+
+    writer.save(["a", "b"], overwrite_existing=True, fl_ctx=fl_ctx)
+
+    expected_path = tmp_path / "site-1" / "psi" / "intersection.txt"
+    assert expected_path.read_text() == "a\nb"
+
+
+@pytest.mark.parametrize("output_path", ["/tmp/intersection.txt", "../intersection.txt"])
+def test_file_psi_writer_rejects_escaping_output_path(tmp_path, output_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = FilePSIWriter(output_path=output_path)
+
+    with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+        writer.save(["a"], overwrite_existing=True, fl_ctx=fl_ctx)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink support required")
+def test_file_psi_writer_rejects_symlink_escape(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    outside = tmp_path.parent / f"{tmp_path.name}_outside"
+    outside.mkdir()
+    site_dir = tmp_path / "site-1"
+    site_dir.mkdir()
+    (site_dir / "link").symlink_to(outside, target_is_directory=True)
+    writer = FilePSIWriter(output_path="link/intersection.txt")
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        writer.save(["a"], overwrite_existing=True, fl_ctx=fl_ctx)

--- a/tests/unit_test/app_common/statistics/json_stats_file_persistor_test.py
+++ b/tests/unit_test/app_common/statistics/json_stats_file_persistor_test.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from nvflare.apis.app_validation import AppValidationKey
+from nvflare.apis.fl_constant import FLContextKey, ReservedKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.storage import StorageException
+from nvflare.app_common.app_constant import StatisticsConstants as StC
+from nvflare.app_common.statistics.json_stats_file_persistor import OBJECT_ENCODER_PATH, JsonStatsFileWriter
+from nvflare.app_common.workflows.statistics_controller import StatisticsController
+
+
+class _FakeEngine:
+    def __init__(self, components: dict):
+        self.components = components
+
+    def get_component(self, component_id: str):
+        return self.components[component_id]
+
+
+def _make_fl_ctx(tmp_path, byoc=False):
+    app_root = tmp_path / "job" / "app"
+    app_root.mkdir(parents=True)
+
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.APP_ROOT, str(app_root), private=True, sticky=False)
+    fl_ctx.set_prop(FLContextKey.JOB_META, {AppValidationKey.BYOC: byoc}, private=True, sticky=False)
+    return fl_ctx
+
+
+def test_save_writes_relative_output_inside_job_dir(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = JsonStatsFileWriter(output_path="statistics/result.json")
+
+    writer.save({"count": {"site-1": 1}}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    output_file = tmp_path / "job" / "statistics" / "result.json"
+    assert json.loads(output_file.read_text(encoding="utf-8")) == {"count": {"site-1": 1}}
+
+
+def test_save_accepts_existing_builtin_encoder_path(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = JsonStatsFileWriter(output_path="statistics/result.json", json_encoder_path=OBJECT_ENCODER_PATH)
+
+    writer.save({"count": {"site-1": 1}}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    output_file = tmp_path / "job" / "statistics" / "result.json"
+    assert json.loads(output_file.read_text(encoding="utf-8")) == {"count": {"site-1": 1}}
+
+
+def test_rejects_non_string_json_encoder_path():
+    with pytest.raises(TypeError, match="must be str"):
+        JsonStatsFileWriter(output_path="result.json", json_encoder_path=123)
+
+
+def test_save_rejects_absolute_output_path(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    outside_file = tmp_path / "outside.json"
+    writer = JsonStatsFileWriter(output_path=str(outside_file))
+
+    with pytest.raises(ValueError, match="must be relative"):
+        writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    assert not outside_file.exists()
+
+
+def test_save_rejects_parent_directory_traversal(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    outside_file = tmp_path / "outside.json"
+    writer = JsonStatsFileWriter(output_path="../outside.json")
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    assert not outside_file.exists()
+
+
+def test_save_rejects_symlink_escape(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    link_path = tmp_path / "job" / "link"
+    try:
+        link_path.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as ex:
+        pytest.skip(f"symlink creation is not available: {ex}")
+
+    writer = JsonStatsFileWriter(output_path="link/result.json")
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    assert not (outside_dir / "result.json").exists()
+
+
+def test_save_rejects_missing_app_root():
+    fl_ctx = FLContext()
+    writer = JsonStatsFileWriter(output_path="result.json")
+
+    with pytest.raises(ValueError, match=FLContextKey.APP_ROOT):
+        writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+
+def test_custom_encoder_path_requires_byoc(tmp_path, monkeypatch):
+    fl_ctx = _make_fl_ctx(tmp_path, byoc=False)
+    writer = JsonStatsFileWriter(output_path="statistics/result.json", json_encoder_path="json.JSONEncoder")
+
+    def fail_load_class(_):
+        raise AssertionError("custom encoder should not be loaded for non-BYOC jobs")
+
+    monkeypatch.setattr("nvflare.app_common.statistics.json_stats_file_persistor.load_class", fail_load_class)
+
+    with pytest.raises(ValueError, match="BYOC"):
+        writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    assert not (tmp_path / "job" / "statistics" / "result.json").exists()
+
+
+def test_custom_encoder_path_is_allowed_for_byoc(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path, byoc=True)
+    writer = JsonStatsFileWriter(output_path="statistics/result.json", json_encoder_path="json.JSONEncoder")
+
+    writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    output_file = tmp_path / "job" / "statistics" / "result.json"
+    assert json.loads(output_file.read_text(encoding="utf-8")) == {"count": 1}
+
+
+def test_custom_encoder_must_be_jsonencoder_subclass(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path, byoc=True)
+    writer = JsonStatsFileWriter(output_path="result.json", json_encoder_path="subprocess.Popen")
+
+    with pytest.raises(TypeError, match="JSONEncoder"):
+        writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    assert not (tmp_path / "job" / "result.json").exists()
+
+
+def test_save_respects_overwrite_existing_false(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = JsonStatsFileWriter(output_path="statistics/result.json")
+    writer.save({"count": 1}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    with pytest.raises(StorageException, match="overwrite_existing is False"):
+        writer.save({"count": 2}, overwrite_existing=False, fl_ctx=fl_ctx)
+
+    output_file = tmp_path / "job" / "statistics" / "result.json"
+    assert json.loads(output_file.read_text(encoding="utf-8")) == {"count": 1}
+
+
+def test_save_does_not_create_parent_directory_when_json_serialization_fails(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = JsonStatsFileWriter(output_path="statistics/result.json")
+
+    with pytest.raises(TypeError):
+        writer.save({"bad": object()}, overwrite_existing=True, fl_ctx=fl_ctx)
+
+    assert not (tmp_path / "job" / "statistics").exists()
+
+
+def test_statistics_controller_post_fn_writes_combined_fed_stats(tmp_path):
+    fl_ctx = _make_fl_ctx(tmp_path)
+    writer = JsonStatsFileWriter(output_path="statistics/fed_stats.json", json_encoder_path=OBJECT_ENCODER_PATH)
+    fl_ctx.set_prop(ReservedKey.ENGINE, _FakeEngine({"stats_writer": writer}), private=True, sticky=False)
+
+    controller = StatisticsController(statistic_configs={StC.STATS_COUNT: {}}, writer_id="stats_writer", min_clients=2)
+    controller.client_statistics = {
+        StC.STATS_COUNT: {
+            "site-1": {"train": {"Age": 10}},
+            "site-2": {"train": {"Age": 20}},
+        }
+    }
+    controller.global_statistics = {
+        StC.STATS_COUNT: {
+            "train": {"Age": 30},
+        }
+    }
+
+    controller.post_fn(StC.FED_STATS_TASK, fl_ctx)
+
+    output_file = tmp_path / "job" / "statistics" / "fed_stats.json"
+    result = json.loads(output_file.read_text(encoding="utf-8"))
+    assert result["Age"][StC.STATS_COUNT]["site-1"]["train"] == 10
+    assert result["Age"][StC.STATS_COUNT]["site-2"]["train"] == 20
+    assert result["Age"][StC.STATS_COUNT][StC.GLOBAL]["train"] == 30

--- a/tests/unit_test/app_common/utils/file_utils_test.py
+++ b/tests/unit_test/app_common/utils/file_utils_test.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
+
+
+def test_resolve_path_under_root_accepts_nested_relative_path(tmp_path):
+    assert resolve_path_under_root(str(tmp_path), "models/server.npy") == os.path.realpath(
+        tmp_path / "models" / "server.npy"
+    )
+
+
+def test_resolve_path_under_root_rejects_absolute_path(tmp_path):
+    with pytest.raises(ValueError, match="must be relative"):
+        resolve_path_under_root(str(tmp_path), str(tmp_path / "outside.npy"), "model path")
+
+
+def test_resolve_path_under_root_rejects_parent_traversal(tmp_path):
+    with pytest.raises(ValueError, match="must stay inside"):
+        resolve_path_under_root(str(tmp_path), "../outside.npy", "model path")
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink support required")
+def test_resolve_path_under_root_rejects_symlink_escape(tmp_path):
+    outside = tmp_path.parent / f"{tmp_path.name}_outside"
+    outside.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        resolve_path_under_root(str(tmp_path), "link/outside.npy", "model path")

--- a/tests/unit_test/app_common/widgets/validation_json_generator_test.py
+++ b/tests/unit_test/app_common/widgets/validation_json_generator_test.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
+
+
+def _make_fl_ctx(run_dir):
+    workspace = Mock()
+    workspace.get_run_dir.return_value = str(run_dir)
+    engine = Mock()
+    engine.get_workspace.return_value = workspace
+
+    fl_ctx = FLContext()
+    fl_ctx.get_engine = Mock(return_value=engine)
+    fl_ctx.get_job_id = Mock(return_value="job-1")
+    return fl_ctx
+
+
+class TestValidationJsonGeneratorPaths:
+    def test_end_run_writes_results_under_run_dir(self, tmp_path):
+        generator = ValidationJsonGenerator()
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        generator.handle_event(EventType.END_RUN, fl_ctx)
+
+        out = os.path.join(
+            os.path.realpath(str(tmp_path / "run")), AppConstants.CROSS_VAL_DIR, "cross_val_results.json"
+        )
+        assert os.path.isfile(out)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"results_dir": "/tmp/outside_val"},
+            {"results_dir": "../outside_val"},
+            {"json_file_name": "/tmp/outside.json"},
+        ],
+    )
+    def test_end_run_rejects_escaping_paths(self, tmp_path, kwargs):
+        generator = ValidationJsonGenerator(**kwargs)
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            generator.handle_event(EventType.END_RUN, fl_ctx)

--- a/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
+++ b/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import Mock
 
 import pytest
 
 from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
 
 
@@ -40,3 +42,15 @@ class TestCrossSiteModelEvalPaths:
 
         with pytest.raises(ValueError, match="must (be relative|stay inside)"):
             controller.start_controller(fl_ctx)
+
+    def test_start_controller_accepts_relative_cross_val_dir(self, tmp_path):
+        engine, fl_ctx = _make_engine_and_ctx(tmp_path / "run")
+        controller = CrossSiteModelEval(participating_clients=["site-1"])
+        controller._engine = engine
+        controller.fire_event = Mock()  # event plumbing is not under test
+
+        controller.start_controller(fl_ctx)
+
+        run_dir = os.path.realpath(str(tmp_path / "run"))
+        assert os.path.isdir(os.path.join(run_dir, AppConstants.CROSS_VAL_DIR, AppConstants.CROSS_VAL_MODEL_DIR_NAME))
+        assert os.path.isdir(os.path.join(run_dir, AppConstants.CROSS_VAL_DIR, AppConstants.CROSS_VAL_RESULTS_DIR_NAME))

--- a/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
+++ b/tests/unit_test/app_common/workflow/cross_site_model_eval_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
+
+
+def _make_engine_and_ctx(run_dir):
+    workspace = Mock()
+    workspace.get_run_dir.return_value = str(run_dir)
+    engine = Mock()
+    engine.get_workspace.return_value = workspace
+
+    fl_ctx = FLContext()
+    fl_ctx.get_job_id = Mock(return_value="job-1")
+    return engine, fl_ctx
+
+
+class TestCrossSiteModelEvalPaths:
+    @pytest.mark.parametrize("cross_val_dir", ["/tmp/outside_cse", "../outside_cse"])
+    def test_start_controller_rejects_escaping_cross_val_dir(self, tmp_path, cross_val_dir):
+        engine, fl_ctx = _make_engine_and_ctx(tmp_path / "run")
+        controller = CrossSiteModelEval(cross_val_dir=cross_val_dir, participating_clients=["site-1"])
+        controller._engine = engine
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            controller.start_controller(fl_ctx)

--- a/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
+++ b/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -200,3 +201,21 @@ class TestTBAnalyticsReceiver:
         assert len(recall_events) == 1
         assert recall_events[0].step == 5
         assert recall_events[0].value == pytest.approx(0.7)
+
+    def test_initialize_accepts_relative_tb_folder(self, tmp_path):
+        receiver = TBAnalyticsReceiver(tb_folder="tb_events")
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        receiver.initialize(fl_ctx)
+
+        expected = os.path.realpath(str(tmp_path / "run" / "tb_events"))
+        assert receiver.root_log_dir == expected
+        assert os.path.isdir(expected)
+
+    @pytest.mark.parametrize("tb_folder", ["/tmp/outside_tb_events", "../outside_tb_events"])
+    def test_initialize_rejects_escaping_tb_folder(self, tmp_path, tb_folder):
+        receiver = TBAnalyticsReceiver(tb_folder=tb_folder)
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            receiver.initialize(fl_ctx)

--- a/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
+++ b/tests/unit_test/app_opt/tracking/tb/tb_receiver_test.py
@@ -219,3 +219,16 @@ class TestTBAnalyticsReceiver:
 
         with pytest.raises(ValueError, match="must (be relative|stay inside)"):
             receiver.initialize(fl_ctx)
+
+    @pytest.mark.parametrize("record_origin", ["../outside_peer", "/tmp/outside_peer"])
+    def test_save_rejects_escaping_record_origin(self, tmp_path, record_origin):
+        receiver = TBAnalyticsReceiver(tb_folder="tb_events")
+        fl_ctx = _make_fl_ctx(tmp_path / "run")
+        receiver.initialize(fl_ctx)
+
+        shareable = create_analytic_dxo(
+            tag="loss", value=0.5, data_type=AnalyticsDataType.SCALAR, global_step=0
+        ).to_shareable()
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            receiver.save(fl_ctx, shareable, record_origin)

--- a/tests/unit_test/app_opt/xgboost/histogram_model_path_test.py
+++ b/tests/unit_test/app_opt/xgboost/histogram_model_path_test.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_context import FLContext
+
+xgboost = pytest.importorskip("xgboost")
+
+from nvflare.app_opt.xgboost.histogram_based.executor import FedXGBHistogramExecutor  # noqa: E402
+from nvflare.app_opt.xgboost.histogram_based_v2.runners.xgb_client_runner import XGBClientRunner  # noqa: E402
+from nvflare.app_opt.xgboost.tree_based.model_persistor import XGBModelPersistor  # noqa: E402
+
+
+def test_histogram_executor_accepts_relative_model_file_name(tmp_path):
+    executor = FedXGBHistogramExecutor(
+        num_rounds=1,
+        early_stopping_rounds=1,
+        xgb_params={},
+        data_loader_id="data_loader",
+        model_file_name="models/model.json",
+    )
+
+    assert executor._get_model_path(str(tmp_path)) == os.path.realpath(tmp_path / "models" / "model.json")
+
+
+@pytest.mark.parametrize("model_file_name", ["/tmp/model.json", "../model.json"])
+def test_histogram_executor_rejects_escaping_model_file_name(tmp_path, model_file_name):
+    executor = FedXGBHistogramExecutor(
+        num_rounds=1,
+        early_stopping_rounds=1,
+        xgb_params={},
+        data_loader_id="data_loader",
+        model_file_name=model_file_name,
+    )
+
+    with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+        executor._get_model_path(str(tmp_path))
+
+
+def test_histogram_v2_runner_accepts_relative_model_file_name(tmp_path):
+    runner = XGBClientRunner(data_loader_id="data_loader", model_file_name="models/model.json")
+    runner._model_dir = str(tmp_path)
+
+    assert runner._get_model_path() == os.path.realpath(tmp_path / "models" / "model.json")
+
+
+@pytest.mark.parametrize("model_file_name", ["/tmp/model.json", "../model.json"])
+def test_histogram_v2_runner_rejects_escaping_model_file_name(tmp_path, model_file_name):
+    runner = XGBClientRunner(data_loader_id="data_loader", model_file_name=model_file_name)
+    runner._model_dir = str(tmp_path)
+
+    with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+        runner._get_model_path()
+
+
+def test_tree_based_xgb_persistor_accepts_relative_save_name(tmp_path):
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.APP_ROOT, str(tmp_path / "app"), private=True, sticky=False)
+    persistor = XGBModelPersistor(save_name="models/xgboost_model.json")
+
+    persistor.handle_event(EventType.START_RUN, fl_ctx)
+
+    assert persistor.save_path == os.path.realpath(tmp_path / "app" / "models" / "xgboost_model.json")
+
+
+@pytest.mark.parametrize("save_name", ["/tmp/xgboost_model.json", "../xgboost_model.json"])
+def test_tree_based_xgb_persistor_rejects_escaping_save_name(tmp_path, save_name):
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.APP_ROOT, str(tmp_path / "app"), private=True, sticky=False)
+    persistor = XGBModelPersistor(save_name=save_name)
+
+    with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+        persistor.handle_event(EventType.START_RUN, fl_ctx)

--- a/tests/unit_test/integration_test/validators/json_stats_result_validator_test.py
+++ b/tests/unit_test/integration_test/validators/json_stats_result_validator_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from tests.integration_test.src.validators.json_stats_result_validator import JsonStatsResultValidator
+
+
+def test_json_stats_validator_finds_nested_expected_relative_path(tmp_path):
+    stats_file = tmp_path / "workspace" / "app" / "statistics" / "image_statistics.json"
+    stats_file.parent.mkdir(parents=True)
+    stats_file.write_text(json.dumps({"intensity": {"count": 1}}), encoding="utf-8")
+    validator = JsonStatsResultValidator(
+        relative_path="statistics/image_statistics.json", required_paths=["intensity.count"]
+    )
+
+    assert validator.validate_finished_results({"workspace_root": str(tmp_path / "workspace")}, [])
+
+
+def test_json_stats_validator_rejects_partial_path_suffix_match(tmp_path):
+    stats_file = tmp_path / "workspace" / "more_statistics" / "image_statistics.json"
+    stats_file.parent.mkdir(parents=True)
+    stats_file.write_text(json.dumps({"intensity": {"count": 1}}), encoding="utf-8")
+    validator = JsonStatsResultValidator(
+        relative_path="statistics/image_statistics.json", required_paths=["intensity.count"]
+    )
+
+    assert not validator.validate_finished_results({"workspace_root": str(tmp_path / "workspace")}, [])
+
+
+def test_json_stats_validator_rejects_path_escape(tmp_path):
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_text(json.dumps({"intensity": {"count": 1}}), encoding="utf-8")
+    validator = JsonStatsResultValidator(relative_path="../outside.json", required_paths=["intensity.count"])
+
+    assert not validator.validate_finished_results({"workspace_root": str(tmp_path / "workspace")}, [])


### PR DESCRIPTION
## Summary
- Port PR #4738 code and test changes from `2.8` to `main`, excluding the 2.8 release-note update.
- Cherry-pick PR #4740 follow-up hardening for CrossSiteModelEval, ValidationJsonGenerator, and TBAnalyticsReceiver artifact paths.
- Keep the shared `resolve_path_under_root` helper and coverage needed by both hardening patches.
