### PR TITLE
[main] Migrate built-in job configs to fully qualified class paths

### DIFF
--- a/job_templates/sag_cse_ccwf_pt/config_fed_client.conf
+++ b/job_templates/sag_cse_ccwf_pt/config_fed_client.conf
@@ -157,7 +157,7 @@
     },
     {
       id = "model_locator"
-      name = "PTFileModelLocator"
+      path = "nvflare.app_opt.pt.file_model_locator.PTFileModelLocator"
       args {
           pt_persistor_id = "persistor"
       }
@@ -172,7 +172,7 @@
     },
     {
       id = "json_generator"
-      name = "ValidationJsonGenerator"
+      path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
       args {}
     }
   ]

--- a/job_templates/sag_cse_pt/config_fed_server.conf
+++ b/job_templates/sag_cse_pt/config_fed_server.conf
@@ -111,7 +111,7 @@
     # used by CrossSiteModelEval to find and locate the models inventory saved during training
     {
       id = "model_locator"
-      name = "PTFileModelLocator"
+      path = "nvflare.app_opt.pt.file_model_locator.PTFileModelLocator"
       args {
           pt_persistor_id = "persistor"
       }
@@ -119,7 +119,7 @@
     # write validation results to json file
     {
       id = "json_generator"
-      name = "ValidationJsonGenerator"
+      path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
       args {}
     }
   ]

--- a/job_templates/sag_pt_executor/config_fed_server.conf
+++ b/job_templates/sag_pt_executor/config_fed_server.conf
@@ -7,7 +7,7 @@ task_result_filters = []
 components = [
     {
         id = "persistor"
-        name = "PTFileModelPersistor"
+        path = "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor"
         args {
             model {
                 # path to defined PyTorch network
@@ -18,45 +18,45 @@ components = [
     }
     {
         id = "shareable_generator"
-        name = "FullModelShareableGenerator"
+        path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
         args {}
     }
     {
         id = "aggregator"
-        name = "InTimeAccumulateWeightedAggregator"
+        path = "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator"
         args {
             expected_data_kind = "WEIGHTS"
         }
     }
     {
         id = "model_selector"
-        name = "IntimeModelSelector"
+        path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
         args {}
     }
     {
         id = "model_locator"
-        name = "PTFileModelLocator"
+        path = "nvflare.app_opt.pt.file_model_locator.PTFileModelLocator"
         args {
             pt_persistor_id = "persistor"
         }
     }
     {
         id = "json_generator"
-        name = "ValidationJsonGenerator"
+        path = "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator"
         args {}
     }
 ]
 workflows = [
     {
         id = "pre_train"
-        name = "InitializeGlobalWeights"
+        path = "nvflare.app_common.workflows.initialize_global_weights.InitializeGlobalWeights"
         args  {
             task_name = "get_weights"
         }
     }
     {
         id = "scatter_gather_ctl"
-        name = "ScatterAndGather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
         args {
             min_clients = 2
             # can adjust number of Scatter-And-Gather rounds
@@ -72,7 +72,7 @@ workflows = [
     }
     {
         id = "cross_site_model_eval"
-        name = "CrossSiteModelEval"
+        path = "nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval"
         args {
             model_locator_id = "model_locator"
             submit_model_timeout = 600

--- a/job_templates/sklearn_kmeans/config_fed_server.conf
+++ b/job_templates/sklearn_kmeans/config_fed_server.conf
@@ -14,7 +14,7 @@
       {
         # 1st workflow"
         id = "scatter_and_gather"
-        name = "ScatterAndGather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
         args {
             # argument of the ScatterAndGather class.
             # min number of clients required for ScatterAndGather controller to move to the next round
@@ -75,7 +75,7 @@
     {
       # This is the generator that convert the model to shareable communication message structure used in workflow
       id = "shareable_generator"
-      name = "FullModelShareableGenerator"
+      path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
       args = {}
     },
     {

--- a/job_templates/sklearn_linear/config_fed_server.conf
+++ b/job_templates/sklearn_linear/config_fed_server.conf
@@ -14,7 +14,7 @@
       {
         # 1st workflow"
         id = "scatter_and_gather"
-        name = "ScatterAndGather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
         args {
             # argument of the ScatterAndGather class.
             # min number of clients required for ScatterAndGather controller to move to the next round
@@ -81,14 +81,14 @@
     {
       # This is the generator that convert the model to shareable communication message structure used in workflow
       id = "shareable_generator"
-      name = "FullModelShareableGenerator"
+      path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
       args = {}
     },
     {
       # This is the aggregator that perform the weighted average aggregation.
       # the aggregation is "in-time", so it doesn't wait for client results, but aggregates as soon as it received the data.
       id = "aggregator"
-      name = "InTimeAccumulateWeightedAggregator"
+      path = "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator"
       args.expected_data_kind = "WEIGHTS"
     }
   ]

--- a/job_templates/sklearn_svm/config_fed_server.conf
+++ b/job_templates/sklearn_svm/config_fed_server.conf
@@ -14,7 +14,7 @@
       {
         # 1st workflow"
         id = "scatter_and_gather"
-        name = "ScatterAndGather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
         args {
             # argument of the ScatterAndGather class.
             # min number of clients required for ScatterAndGather controller to move to the next round
@@ -75,7 +75,7 @@
     {
       # This is the generator that convert the model to shareable communication message structure used in workflow
       id = "shareable_generator"
-      name = "FullModelShareableGenerator"
+      path = "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator"
       args = {}
     },
     {

--- a/job_templates/vertical_xgb/config_fed_client.conf
+++ b/job_templates/vertical_xgb/config_fed_client.conf
@@ -46,7 +46,7 @@ components = [
   }
   {
     id = "event_to_fed"
-    name = "ConvertToFedEvent"
+    path = "nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent"
     args {
       events_to_convert = ["analytix_log_stats"]
       fed_event_prefix = "fed."

--- a/job_templates/xgboost_tree/config_fed_server.conf
+++ b/job_templates/xgboost_tree/config_fed_server.conf
@@ -14,7 +14,7 @@
     {
         # 1st workflow"
         id = "scatter_and_gather"
-        name = "ScatterAndGather"
+        path = "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather"
         args {
             # argument of the ScatterAndGather class.
             # min number of clients required for ScatterAndGather controller to move to the next round

--- a/research/fedhca2/jobs/fedhca2/app/config/config_fed_client.json
+++ b/research/fedhca2/jobs/fedhca2/app/config/config_fed_client.json
@@ -22,12 +22,12 @@
   "components": [
     {
       "id": "analytic_sender",
-      "name": "AnalyticsSender",
+      "path": "nvflare.app_common.widgets.streaming.AnalyticsSender",
       "args": {}
     },
     {
       "id": "event_to_fed",
-      "name": "ConvertToFedEvent",
+      "path": "nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent",
       "args": {
         "events_to_convert": [
           "analytix_log_stats"

--- a/research/fedhca2/jobs/fedhca2/app/config/config_fed_server.json
+++ b/research/fedhca2/jobs/fedhca2/app/config/config_fed_server.json
@@ -8,7 +8,7 @@
   "components": [
     {
       "id": "shareable_generator",
-      "name": "FullModelShareableGenerator",
+      "path": "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator",
       "args": {}
     },
     {
@@ -20,7 +20,7 @@
     },
     {
       "id": "tb_analytics_receiver",
-      "name": "TBAnalyticsReceiver",
+      "path": "nvflare.app_opt.tracking.tb.tb_receiver.TBAnalyticsReceiver",
       "args": {
         "events": [
           "fed.analytix_log_stats"
@@ -31,7 +31,7 @@
   "workflows": [
     {
       "id": "scatter_and_gather",
-      "name": "ScatterAndGather",
+      "path": "nvflare.app_common.workflows.scatter_and_gather.ScatterAndGather",
       "args": {
         "min_clients": 6,
         "num_rounds": 100,


### PR DESCRIPTION
## Summary
- Cherry-pick of #4744 onto `main`.
- Replace legacy `"name": "<ShortName>"` component declarations with `"path": "<fully.qualified.ClassName>"` in 8 `job_templates/` configs and the `research/fedhca2` job.
- The class-path authorizer added in #4684 rejects the legacy `name` form for non-BYOC jobs, so these built-in job templates currently fail to load unless BYOC is enabled.
- No behavioral change; the resolved class is identical, only the declaration form changes.

## Files changed
Job templates (non-BYOC):
- `job_templates/sag_cse_ccwf_pt/config_fed_client.conf`
- `job_templates/sag_cse_pt/config_fed_server.conf`
- `job_templates/sag_pt_executor/config_fed_server.conf`
- `job_templates/sklearn_kmeans/config_fed_server.conf`
- `job_templates/sklearn_linear/config_fed_server.conf`
- `job_templates/sklearn_svm/config_fed_server.conf`
- `job_templates/vertical_xgb/config_fed_client.conf`
- `job_templates/xgboost_tree/config_fed_server.conf`

Research job:
- `research/fedhca2/jobs/fedhca2/app/config/config_fed_client.json`
- `research/fedhca2/jobs/fedhca2/app/config/config_fed_server.json`

## Test plan
- [ ] Run `./runtest.sh -s` to confirm style checks pass.
- [ ] Load each affected job template via the simulator (or job API) and confirm the workflow starts without `UnsafeComponentError`/`ConfigError`.
- [ ] Spot-check `research/fedhca2` job submission to confirm components instantiate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)