### PR TITLE
[2.8] Load job FOBS decomposers from custom dir, gated on BYOC (FLARE-2977)

### DIFF
--- a/nvflare/private/fed/server/job_meta_validator.py
+++ b/nvflare/private/fed/server/job_meta_validator.py
@@ -175,8 +175,11 @@ class JobMetaValidator(JobMetaValidatorSpec):
             if self._entry_exists(zip_file, custom_folder):
                 has_byoc = True
 
+        # BYOC is derived from the submitted app contents, not trusted from user-provided meta.
         if has_byoc:
             meta[AppValidationKey.BYOC] = True
+        else:
+            meta.pop(AppValidationKey.BYOC, None)
 
     @staticmethod
     def _convert_value_to_int(v) -> int:

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -22,7 +22,7 @@ import sys
 import warnings
 from typing import List, Optional, Union
 
-from nvflare.apis.app_validation import AppValidator
+from nvflare.apis.app_validation import AppValidationKey, AppValidator
 from nvflare.apis.client import Client
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLContext
@@ -341,16 +341,28 @@ def fobs_initialize(workspace: Workspace = None, job_id: Optional[str] = None):
 
 def custom_fobs_initialize(workspace: Workspace = None, job_id: Optional[str] = None):
     if workspace:
+        # site-level decomposers are installed by the site admin and always loaded
         site_custom_dir = workspace.get_client_custom_dir()
         decomposer_dir = os.path.join(site_custom_dir, ConfigVarName.DECOMPOSER_MODULE)
         if os.path.exists(decomposer_dir):
             register_custom_folder(decomposer_dir)
 
         if job_id:
-            app_custom_dir = workspace.get_app_config_dir(job_id)
+            # decomposers shipped with the job are custom code: load them only from the job's
+            # custom dir (the BYOC-detected location) and only for BYOC-enabled jobs. Decomposers
+            # placed under the job config dir are intentionally ignored.
+            app_custom_dir = workspace.get_app_custom_dir(job_id)
             decomposer_dir = os.path.join(app_custom_dir, ConfigVarName.DECOMPOSER_MODULE)
-            if os.path.exists(decomposer_dir):
+            if os.path.exists(decomposer_dir) and _job_allows_byoc(workspace, job_id):
                 register_custom_folder(decomposer_dir)
+
+
+def _job_allows_byoc(workspace: Workspace, job_id: str) -> bool:
+    try:
+        job_meta = get_job_meta_from_workspace(workspace, job_id)
+    except Exception:
+        return False
+    return bool(job_meta.get(AppValidationKey.BYOC, False))
 
 
 def nvflare_fobs_initialize():

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -361,6 +361,12 @@ def custom_fobs_initialize(workspace: Workspace = None, job_id: Optional[str] = 
 def _job_allows_byoc(workspace: Workspace, job_id: str) -> bool:
     try:
         job_meta = get_job_meta_from_workspace(workspace, job_id)
+        if not isinstance(job_meta, dict):
+            logging.getLogger(__name__).warning(
+                f"job meta for job '{job_id}' is not a dict (got {type(job_meta)}); treating as non-BYOC"
+            )
+            return False
+        return bool(job_meta.get(AppValidationKey.BYOC, False))
     except Exception as e:
         # fail safe: deny job decomposers, but log so a corrupted/misconfigured deployment
         # can be told apart from a legitimate non-BYOC job
@@ -368,7 +374,6 @@ def _job_allows_byoc(workspace: Workspace, job_id: str) -> bool:
             f"could not read job meta for job '{job_id}'; treating as non-BYOC: {secure_format_exception(e)}"
         )
         return False
-    return bool(job_meta.get(AppValidationKey.BYOC, False))
 
 
 def nvflare_fobs_initialize():

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -353,14 +353,20 @@ def custom_fobs_initialize(workspace: Workspace = None, job_id: Optional[str] = 
             # placed under the job config dir are intentionally ignored.
             app_custom_dir = workspace.get_app_custom_dir(job_id)
             decomposer_dir = os.path.join(app_custom_dir, ConfigVarName.DECOMPOSER_MODULE)
-            if os.path.exists(decomposer_dir) and _job_allows_byoc(workspace, job_id):
+            # confirm BYOC before probing the job-controlled path (no filesystem touch otherwise)
+            if _job_allows_byoc(workspace, job_id) and os.path.exists(decomposer_dir):
                 register_custom_folder(decomposer_dir)
 
 
 def _job_allows_byoc(workspace: Workspace, job_id: str) -> bool:
     try:
         job_meta = get_job_meta_from_workspace(workspace, job_id)
-    except Exception:
+    except Exception as e:
+        # fail safe: deny job decomposers, but log so a corrupted/misconfigured deployment
+        # can be told apart from a legitimate non-BYOC job
+        logging.getLogger(__name__).warning(
+            f"could not read job meta for job '{job_id}'; treating as non-BYOC: {secure_format_exception(e)}"
+        )
         return False
     return bool(job_meta.get(AppValidationKey.BYOC, False))
 

--- a/tests/unit_test/private/fed/server/job_meta_validator_test.py
+++ b/tests/unit_test/private/fed/server/job_meta_validator_test.py
@@ -21,6 +21,7 @@ from zipfile import ZipFile
 
 import pytest
 
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.fl_constant import JobConstants
 from nvflare.fuel.utils.zip_utils import get_all_file_paths, normpath_for_zip, split_path
 from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
@@ -169,6 +170,23 @@ class TestJobMetaValidator:
         }}
         """
         self._assert_invalid("valid_job", meta)
+
+    def test_ignores_user_byoc_true_without_custom_folder(self):
+        meta = """
+        {
+            "byoc": true,
+            "name": "sag",
+            "resource_spec": {},
+            "deploy_map": {"sag": ["server", "site-1", "site-2"]}
+        }
+        """
+        data = _zip_job_with_meta("valid_job", meta)
+
+        valid, error, validated_meta = self.validator.validate("valid_job", data)
+
+        assert valid
+        assert error == ""
+        assert AppValidationKey.BYOC not in validated_meta
 
     def _assert_valid(self, job_name: str):
         data = _zip_job_with_meta(job_name, "")

--- a/tests/unit_test/private/fed/utils/fed_utils_test.py
+++ b/tests/unit_test/private/fed/utils/fed_utils_test.py
@@ -17,11 +17,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nvflare.apis.app_validation import AppValidationKey
+from nvflare.apis.fl_constant import ConfigVarName
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.fobs import Decomposer
 from nvflare.fuel.utils.fobs.datum import DatumManager
 from nvflare.fuel.utils.fobs.fobs import register_custom_folder
-from nvflare.private.fed.utils.fed_utils import create_job_processing_context_properties, extract_participants
+from nvflare.private.fed.utils.fed_utils import (
+    create_job_processing_context_properties,
+    custom_fobs_initialize,
+    extract_participants,
+)
 
 
 class ExampleTestClass:
@@ -83,3 +89,64 @@ class TestFedUtils:
         with patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace", return_value=[]):
             with pytest.raises(RuntimeError, match="job_meta must be dict"):
                 create_job_processing_context_properties(workspace, "job-1")
+
+    @staticmethod
+    def _make_workspace():
+        workspace = MagicMock()
+        workspace.get_client_custom_dir.return_value = os.path.join("site", "custom")
+        workspace.get_app_custom_dir.return_value = os.path.join("job", "custom")
+        workspace.get_app_config_dir.return_value = os.path.join("job", "config")
+        return workspace
+
+    @patch("nvflare.private.fed.utils.fed_utils.register_custom_folder")
+    @patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace")
+    @patch("os.path.exists", return_value=True)
+    def test_job_config_decomposers_are_ignored(self, mock_exists, mock_get_meta, mock_register):
+        # even for a BYOC job, decomposers are only loaded from the job custom dir, never from config
+        mock_get_meta.return_value = {AppValidationKey.BYOC: True}
+        workspace = self._make_workspace()
+
+        custom_fobs_initialize(workspace, job_id="job-1")
+
+        registered_dirs = [call.args[0] for call in mock_register.call_args_list]
+        config_decomposer_dir = os.path.join("job", "config", ConfigVarName.DECOMPOSER_MODULE)
+        custom_decomposer_dir = os.path.join("job", "custom", ConfigVarName.DECOMPOSER_MODULE)
+
+        # config-shipped decomposers must never be loaded (FLARE-2977)
+        assert config_decomposer_dir not in registered_dirs
+        # decomposers shipped under the job custom dir are loaded for a BYOC job
+        assert custom_decomposer_dir in registered_dirs
+
+    @patch("nvflare.private.fed.utils.fed_utils.register_custom_folder")
+    @patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace")
+    @patch("os.path.exists", return_value=True)
+    def test_job_custom_decomposers_ignored_when_not_byoc(self, mock_exists, mock_get_meta, mock_register):
+        # job meta without the BYOC flag => job is not allowed to bring custom code
+        mock_get_meta.return_value = {}
+        workspace = self._make_workspace()
+
+        custom_fobs_initialize(workspace, job_id="job-1")
+
+        registered_dirs = [call.args[0] for call in mock_register.call_args_list]
+        custom_decomposer_dir = os.path.join("job", "custom", ConfigVarName.DECOMPOSER_MODULE)
+        site_decomposer_dir = os.path.join("site", "custom", ConfigVarName.DECOMPOSER_MODULE)
+
+        # the job's custom/nvflare_decomposers must be ignored for a non-BYOC job
+        assert custom_decomposer_dir not in registered_dirs
+        # site decomposers are installed by the admin and must still be loaded
+        assert site_decomposer_dir in registered_dirs
+
+    @patch("nvflare.private.fed.utils.fed_utils.register_custom_folder")
+    @patch("nvflare.private.fed.utils.fed_utils.get_job_meta_from_workspace")
+    @patch("os.path.exists", return_value=True)
+    def test_job_decomposers_ignored_when_meta_unavailable(self, mock_exists, mock_get_meta, mock_register):
+        # if the job meta cannot be read, default to not loading the job decomposers
+        mock_get_meta.side_effect = FileNotFoundError("missing job meta")
+        workspace = self._make_workspace()
+
+        custom_fobs_initialize(workspace, job_id="job-1")
+
+        registered_dirs = [call.args[0] for call in mock_register.call_args_list]
+        custom_decomposer_dir = os.path.join("job", "custom", ConfigVarName.DECOMPOSER_MODULE)
+
+        assert custom_decomposer_dir not in registered_dirs


### PR DESCRIPTION
## Summary
Fixes **FLARE-2977** (P0): non-BYOC jobs could execute config-shipped FOBS decomposer Python.

A job app could ship Python at `app_*/config/nvflare_decomposers/*.py`. `custom_fobs_initialize()` loaded the job decomposer folder from the app **config** dir and `register_custom_folder()` appended it to `sys.path` and imported every `.py` (running import-time code and registering any `Decomposer`). Because BYOC detection only looks for a `custom/` folder, such jobs were never flagged BYOC, so the `class_allow_list` / component authorizer never guarded this import path — an RCE bypass for jobs whose BYOC permission is denied.

## Change
In `custom_fobs_initialize()` (`nvflare/private/fed/utils/fed_utils.py`):
- **Load the job's decomposers from the app custom dir** (`get_app_custom_dir(job_id)/nvflare_decomposers`) instead of the config dir. Decomposers now live under `custom/`, which is the **BYOC-detected** location — so a job that ships decomposer code is flagged BYOC and **rejected at submission when BYOC is not authorized**. Decomposers placed under `config/` are no longer loaded at all.
- The job decomposer load **remains gated on the job's BYOC meta flag** (`AppValidationKey.BYOC`) as defense-in-depth; `_job_allows_byoc()` **fails safe** (returns `False`) if the meta can't be read.
- **Site-level** decomposers (`get_client_custom_dir()/nvflare_decomposers`, admin-controlled) continue to load unconditionally.

This addresses the bypass by relocating job decomposers to the BYOC-detected custom dir (intent of recommended fixes **#1/#3**) and retaining the BYOC gate (**#2**).

## Tests
`tests/unit_test/private/fed/utils/fed_utils_test.py`:
- `test_job_config_decomposers_are_ignored` — for a BYOC job, `config/nvflare_decomposers` is **never** loaded; only `custom/nvflare_decomposers` is.
- `test_job_custom_decomposers_ignored_when_not_byoc` — job custom decomposers gated out when `byoc` is false; site decomposers still load.
- `test_job_decomposers_ignored_when_meta_unavailable` — fail-safe when meta can't be read.

All 7 tests in the file pass.

## Not included (follow-ups)
- **#5** Constrain `FedAvg.save_filename` (path traversal) — explicitly independent of this path.

## Behavior-change note
Jobs that currently ship decomposers under `config/nvflare_decomposers` must move them to `custom/nvflare_decomposers` (which makes them proper BYOC jobs) or have the site pre-deploy the decomposers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
