### PR TITLE
Add Q2 webinar recording

### DIFF
--- a/web/src/pages/webinars.astro
+++ b/web/src/pages/webinars.astro
@@ -6,6 +6,15 @@ const base_url = import.meta.env.BASE_URL;
 
 const webinars = [
   {
+    quarter: "Q2 2026",
+    title: "Production Federated Learning, Multicloud Deployment, and Agent-Assisted Research",
+    description:
+      "Go beyond slides with demos of NVIDIA FLARE 2.8 capabilities for production federated learning, multicloud Kubernetes deployment, hardened operations, disk offload, and FLARE Auto-FL.",
+    link: "https://www.youtube.com/watch?v=-8kqkMUZs2c",
+    embed_link: "https://www.youtube-nocookie.com/embed/-8kqkMUZs2c?rel=0",
+    cta: "Watch recording",
+  },
+  {
     quarter: "Q1 2026",
     title: "End-to-End Federated AI: From APIs to Multicloud & Edge (with Rhino FCP)",
     description:


### PR DESCRIPTION
## What changed

- Added the May 2026 NVIDIA FLARE webinar recording as the featured webinar on the website.
- Linked the provided YouTube recording and configured the privacy-enhanced embed.
- Summarized the event description around FLARE 2.8, multicloud Kubernetes deployment, hardened operations, disk offload, and FLARE Auto-FL.


## Validation

- `npm run build` from `web/`
- Confirmed the generated `web/dist/webinars/index.html` contains the new title, recording link, and embed URL.
