### PR TITLE
[2.8] Preserve BYOC metadata when cloning jobs

### DIFF
--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -24,6 +24,7 @@ from typing import Dict, List, Optional, Set
 from zipfile import BadZipFile, ZipFile
 
 import nvflare.fuel.hci.file_transfer_defs as ftd
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import (
     SUBMIT_TOKEN_CONFLICT_STATUS,
@@ -97,6 +98,7 @@ CLONED_META_KEYS = {
     JobMetaKey.MANDATORY_CLIENTS.value,
     JobMetaKey.DATA_STORAGE_FORMAT.value,
     JobMetaKey.STUDY.value,
+    AppValidationKey.BYOC,
 }
 
 JSON_LOG_FILE_NAME = "log.json"

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -21,6 +21,7 @@ from zipfile import ZipFile
 
 import pytest
 
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import (
     SUBMIT_TOKEN_JOB_DELETED_STATUS,
@@ -1121,6 +1122,35 @@ def test_clone_job_preserves_source_study(monkeypatch):
 
     assert conn.errors == []
     assert engine.job_def_manager.cloned_meta[JobMetaKey.STUDY.value] == "cancer-research"
+
+
+def test_clone_job_preserves_byoc_flag(monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", object)
+    monkeypatch.setattr(job_cmds_module, "JobDefManagerSpec", object)
+
+    source_job = _FakeListedJob(
+        {
+            JobMetaKey.JOB_ID.value: "source-job",
+            JobMetaKey.JOB_NAME.value: "source",
+            AppValidationKey.BYOC: True,
+        }
+    )
+    engine = _FakeEngine()
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={
+            JobCommandModule.JOB: source_job,
+            JobCommandModule.JOB_ID: "source-job",
+            ConnProps.USER_NAME: "submitter",
+            ConnProps.USER_ORG: "org",
+            ConnProps.USER_ROLE: "role",
+        },
+    )
+
+    JobCommandModule().clone_job(conn, ["clone_job", "source-job"])
+
+    assert conn.errors == []
+    assert engine.job_def_manager.cloned_meta[AppValidationKey.BYOC] is True
 
 
 def test_list_jobs_filters_legacy_jobs_into_default_study(monkeypatch):


### PR DESCRIPTION
## Summary
- Preserve the validated `byoc` app-validation flag when `clone_job` rebuilds cloned job metadata.
- Add a regression test that verifies BYOC metadata survives cloning.

## Root Cause
`clone_job` copies the source job content, including any `custom/` folder, but rebuilds metadata from `CLONED_META_KEYS`. The BYOC flag is derived during submission by app validation and was not included in that whitelist, so cloned BYOC jobs could be treated as non-BYOC at runtime and fail component authorization.

## Validation
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/private/fed/server/job_cmds_test.py`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m black --check nvflare/private/fed/server/job_cmds.py tests/unit_test/private/fed/server/job_cmds_test.py`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m isort --check-only nvflare/private/fed/server/job_cmds.py tests/unit_test/private/fed/server/job_cmds_test.py`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m flake8 nvflare/private/fed/server/job_cmds.py tests/unit_test/private/fed/server/job_cmds_test.py`