### PR TITLE
Bind CellNet mTLS endpoint identity

### DIFF
--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -624,6 +624,7 @@ class RunnerTask:
 
 class ConnPropKey:
     FQCN = "fqcn"
+    IDENTITY = "identity"
     URL = "url"
     SCHEME = "scheme"
     ADDRESS = "address"

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -39,6 +39,12 @@ from nvflare.fuel.f3.cellnet.defs import (
     ServiceUnavailable,
 )
 from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo, same_family
+from nvflare.fuel.f3.cellnet.identity import (
+    CellIdentityResolver,
+    get_cert_common_name_from_file,
+    get_param,
+    is_mtls_config,
+)
 from nvflare.fuel.f3.cellnet.registry import Callback, Registry
 from nvflare.fuel.f3.cellnet.utils import decode_payload, encode_payload, format_log_message, make_reply
 from nvflare.fuel.f3.comm_config import CommConfigurator
@@ -288,6 +294,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         bulk_check_interval=0.5,
         bulk_process_interval=0.5,
         max_bulk_size=100,
+        auth_identity: str = None,
+        auth_identity_map: dict = None,
     ):
         """
 
@@ -300,6 +308,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             create_internal_listener: whether to create an internal listener for child cells
             parent_url: url for connecting to parent cell
             parent_resources: extra resources for making connection to parent
+            auth_identity: authenticated identity of this cell's local certificate
+            auth_identity_map: FQCN prefix to expected certificate identity map for mTLS peers
 
         FQCN is the names of all ancestor, concatenated with dots.
 
@@ -395,6 +405,20 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             enhance_credential_info(credentials)
             self.update_fobs_context({FOBSContextKey.SEC_CREDS: credentials})
 
+        local_auth_identity = auth_identity if auth_identity else self._get_auth_identity_from_credentials(credentials)
+        prefix_identity_map = dict(auth_identity_map) if auth_identity_map else {}
+        exact_identity_map = {}
+        if local_auth_identity:
+            exact_identity_map[self.my_info.fqcn] = local_auth_identity
+            if self.my_info.is_on_server:
+                prefix_identity_map[FQCN.ROOT_SERVER] = local_auth_identity
+
+        self.identity_resolver = CellIdentityResolver(
+            local_fqcn=self.my_info.fqcn,
+            prefix_identity_map=prefix_identity_map,
+            exact_identity_map=exact_identity_map,
+        )
+
         ep = Endpoint(
             name=fqcn,
             conn_props=credentials,
@@ -403,7 +427,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             },
         )
 
-        self.communicator = Communicator(local_endpoint=ep)
+        self.communicator = Communicator(local_endpoint=ep, identity_resolver=self.identity_resolver)
 
         self.endpoint = ep
         self.connector_manager = ConnectorManager(
@@ -505,8 +529,22 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         )
         self.ALL_CELLS[fqcn] = self
 
-        self.credential_manager = CredentialManager(self.endpoint)
+        self.credential_manager = CredentialManager(
+            self.endpoint,
+            identity_resolver=self.identity_resolver,
+            enforce_identity=is_mtls_config(credentials, secure),
+        )
         self.cert_ex = CertificateExchanger(self, self.credential_manager)
+
+    @staticmethod
+    def _get_auth_identity_from_credentials(credentials: dict):
+        if not credentials:
+            return None
+
+        cert_path = get_param(credentials, DriverParams.SERVER_CERT)
+        if not cert_path:
+            cert_path = get_param(credentials, DriverParams.CLIENT_CERT)
+        return get_cert_common_name_from_file(cert_path)
 
     def update_fobs_context(self, props: dict):
         if not isinstance(props, dict):

--- a/nvflare/fuel/f3/cellnet/credential_manager.py
+++ b/nvflare/fuel/f3/cellnet/credential_manager.py
@@ -21,6 +21,7 @@ from cryptography.x509 import Certificate
 
 from nvflare.fuel.f3.cellnet.cell_cipher import SimpleCellCipher
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver, get_cert_common_name_from_pem
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message
@@ -38,11 +39,18 @@ CERT_REQ_TIMEOUT = 10
 class CredentialManager:
     """Helper class for secure message. It holds the local credentials and certificate cache"""
 
-    def __init__(self, local_endpoint: Endpoint):
+    def __init__(
+        self,
+        local_endpoint: Endpoint,
+        identity_resolver: CellIdentityResolver = None,
+        enforce_identity: bool = False,
+    ):
 
         self.local_endpoint = local_endpoint
         self.cert_cache = {}
         self.lock = threading.Lock()
+        self.identity_resolver = identity_resolver if identity_resolver else CellIdentityResolver(local_endpoint.name)
+        self.enforce_identity = enforce_identity
 
         conn_props = self.local_endpoint.conn_props
         ca_cert_path = conn_props.get(DriverParams.CA_CERT)
@@ -99,6 +107,19 @@ class CredentialManager:
 
         return req
 
+    def _cache_cert(self, fqcn: str, cert: bytes):
+        if not cert:
+            raise RuntimeError(f"missing certificate for {fqcn}")
+
+        if self.enforce_identity:
+            cn = get_cert_common_name_from_pem(cert)
+            try:
+                self.identity_resolver.require_match(fqcn, cn, f"certificate for {fqcn}")
+            except ValueError as ex:
+                raise RuntimeError(str(ex))
+
+        self.cert_cache[fqcn] = cert
+
     def process_request(self, request: Message) -> dict:
         origin = request.get_header(MessageHeaderKey.ORIGIN)
         target = request.get_header(MessageHeaderKey.DESTINATION)
@@ -110,7 +131,7 @@ class CredentialManager:
             cert = payload.get(CERT_CONTENT)
 
             # Save cert from requester in the cache
-            self.cert_cache[origin] = cert
+            self._cache_cert(origin, cert)
 
             reply[CERT_CONTENT] = self.local_cert
             reply[CERT_CA_CONTENT] = self.ca_cert
@@ -125,7 +146,7 @@ class CredentialManager:
             raise RuntimeError(f"Request to get certificate from {origin} failed: {error}")
 
         cert = reply.get(CERT_CONTENT)
-        self.cert_cache[origin] = cert
+        self._cache_cert(origin, cert)
         return cert
 
     def get_local_cert(self) -> Certificate:

--- a/nvflare/fuel/f3/cellnet/identity.py
+++ b/nvflare/fuel/f3/cellnet/identity.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+from nvflare.fuel.f3.drivers.net_utils import SECURE_SCHEMES
+from nvflare.fuel.utils.argument_utils import str2bool
+
+
+def get_param(params: dict, key: DriverParams, default=None):
+    if not params:
+        return default
+
+    value = params.get(key.value, None)
+    if value is None:
+        value = params.get(key, default)
+    return value
+
+
+def is_mtls_connection(params: dict) -> bool:
+    if not params:
+        return False
+
+    scheme = get_param(params, DriverParams.SCHEME)
+    secure = str2bool(get_param(params, DriverParams.SECURE, False))
+    if scheme not in SECURE_SCHEMES and not secure:
+        return False
+
+    conn_security = get_param(params, DriverParams.CONNECTION_SECURITY, ConnectionSecurity.MTLS)
+    return conn_security == ConnectionSecurity.MTLS
+
+
+def is_mtls_config(credentials: dict, secure: bool) -> bool:
+    if not secure:
+        return False
+
+    conn_security = get_param(credentials, DriverParams.CONNECTION_SECURITY, ConnectionSecurity.MTLS)
+    return conn_security == ConnectionSecurity.MTLS
+
+
+def get_cert_common_name(cert: x509.Certificate) -> Optional[str]:
+    attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    return attrs[0].value if attrs else None
+
+
+def get_cert_common_name_from_pem(cert_bytes: bytes) -> Optional[str]:
+    if not cert_bytes:
+        return None
+
+    cert = x509.load_pem_x509_certificate(cert_bytes)
+    return get_cert_common_name(cert)
+
+
+def get_cert_common_name_from_file(cert_path: str) -> Optional[str]:
+    if not cert_path:
+        return None
+
+    with open(cert_path, "rb") as f:
+        return get_cert_common_name_from_pem(f.read())
+
+
+class CellIdentityResolver:
+    def __init__(self, local_fqcn: str = "", prefix_identity_map: dict = None, exact_identity_map: dict = None):
+        self.local_fqcn = FQCN.normalize(local_fqcn) if local_fqcn else ""
+        self.prefix_identity_map = self._normalize_map(prefix_identity_map)
+        self.exact_identity_map = self._normalize_map(exact_identity_map)
+
+    @staticmethod
+    def _normalize_map(identity_map: dict = None):
+        result = {}
+        if not identity_map:
+            return result
+
+        for fqcn, identity in identity_map.items():
+            if fqcn and identity:
+                result[FQCN.normalize(fqcn)] = identity
+        return result
+
+    @staticmethod
+    def _is_descendant(fqcn: str, prefix: str) -> bool:
+        return fqcn.startswith(prefix + ".")
+
+    def _resolve_local_child_identity(self, fqcn: str) -> Optional[str]:
+        if not self.local_fqcn or not self._is_descendant(fqcn, self.local_fqcn):
+            return None
+
+        # A child connected through this local cell normally authenticates with
+        # the next FQCN segment's certificate. Example: relay-a.site-1 -> site-1.
+        child_suffix = fqcn[len(self.local_fqcn) + 1 :]
+        parts = FQCN.split(child_suffix)
+        return parts[0] if parts else None
+
+    def resolve(self, fqcn: str) -> Optional[str]:
+        if not fqcn:
+            return None
+
+        fqcn = FQCN.normalize(fqcn)
+        identity = self.exact_identity_map.get(fqcn)
+        if identity:
+            return identity
+
+        parts = FQCN.split(fqcn)
+        for i in range(len(parts), 0, -1):
+            prefix = FQCN.join(parts[:i])
+            identity = self.prefix_identity_map.get(prefix)
+            if identity:
+                return identity
+
+        identity = self._resolve_local_child_identity(fqcn)
+        if identity:
+            return identity
+
+        return parts[0] if parts else fqcn
+
+    def require_match(self, fqcn: str, peer_cn: str, peer_desc: str):
+        expected_cn = self.resolve(fqcn)
+        if not peer_cn or peer_cn == "N/A":
+            raise ValueError(f"{peer_desc} does not have an authenticated mTLS peer common name")
+
+        if peer_cn != expected_cn:
+            raise ValueError(
+                f"{peer_desc} authenticated as '{peer_cn}' but claimed endpoint '{fqcn}' "
+                f"requires identity '{expected_cn}'"
+            )

--- a/nvflare/fuel/f3/communicator.py
+++ b/nvflare/fuel/f3/communicator.py
@@ -19,6 +19,7 @@ import weakref
 from typing import Optional
 
 from nvflare.fuel.f3 import drivers
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver
 from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.drivers.driver import Driver
@@ -56,10 +57,10 @@ def load_comm_drivers():
 class Communicator:
     """FCI (Flare Communication Interface) main communication API"""
 
-    def __init__(self, local_endpoint: Endpoint):
+    def __init__(self, local_endpoint: Endpoint, identity_resolver: CellIdentityResolver = None):
         self.local_endpoint = local_endpoint
         self.monitors = []
-        self.conn_manager = ConnManager(local_endpoint)
+        self.conn_manager = ConnManager(local_endpoint, identity_resolver)
         self.stopped = False
 
     def start(self):

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 
 import msgpack
 
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver, get_param, is_mtls_connection
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.connection import BytesAlike, Connection, ConnState, FrameReceiver
 from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
@@ -63,8 +64,9 @@ class ConnManager(ConnMonitor):
     The class is responsible for maintaining state of SFM connections and pumping data through them
     """
 
-    def __init__(self, local_endpoint: Endpoint):
+    def __init__(self, local_endpoint: Endpoint, identity_resolver: CellIdentityResolver = None):
         self.local_endpoint = local_endpoint
+        self.identity_resolver = identity_resolver if identity_resolver else CellIdentityResolver(local_endpoint.name)
 
         # Active connectors
         self.connectors: Dict[str, ConnectorInfo] = {}
@@ -404,9 +406,17 @@ class ConnManager(ConnMonitor):
                 CommError.BAD_DATA, f"Duplicate endpoint name {endpoint_name} for connection {sfm_conn.get_name()}"
             )
 
+        conn_props = sfm_conn.conn.get_conn_properties()
+        if is_mtls_connection(sfm_conn.conn.connector.params):
+            peer_cn = get_param(conn_props, DriverParams.PEER_CN)
+            try:
+                self.identity_resolver.require_match(endpoint_name, peer_cn, f"connection {sfm_conn.get_name()}")
+            except ValueError as ex:
+                sfm_conn.conn.close()
+                raise CommError(CommError.BAD_DATA, str(ex))
+
         endpoint = Endpoint(endpoint_name, data)
         endpoint.state = EndpointState.READY
-        conn_props = sfm_conn.conn.get_conn_properties()
         if conn_props:
             endpoint.conn_props.update(conn_props)
 

--- a/nvflare/private/fed/app/fl_conf.py
+++ b/nvflare/private/fed/app/fl_conf.py
@@ -299,6 +299,7 @@ class FLClientStarterConfiger(JsonConfigurator):
         if relay_config:
             if relay_config:
                 relay_fqcn = relay_config.get(ConnPropKey.FQCN)
+                relay_identity = relay_config.get(ConnPropKey.IDENTITY)
                 scheme = relay_config.get(ConnPropKey.SCHEME)
                 addr = relay_config.get(ConnPropKey.ADDRESS)
                 relay_conn_security = relay_config.get(ConnPropKey.CONNECTION_SECURITY)
@@ -319,12 +320,15 @@ class FLClientStarterConfiger(JsonConfigurator):
         if relay_fqcn:
             relay_conn_props = {
                 ConnPropKey.FQCN: relay_fqcn,
+                ConnPropKey.IDENTITY: relay_identity,
                 ConnPropKey.URL: relay_url,
                 ConnPropKey.CONNECTION_SECURITY: relay_conn_security,
             }
             set_scope_property(client_name, ConnPropKey.RELAY_CONN_PROPS, relay_conn_props)
 
         client = self.config_data["client"]
+        servers = self.config_data.get("servers", [])
+        server_identity = servers[0].get(ConnPropKey.IDENTITY) if servers else None
 
         if hasattr(self.args, "job_id") and self.args.job_id:
             # this is CJ
@@ -333,6 +337,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             root_url = f"{sp_scheme}://{sp_target}"
             root_conn_props = {
                 ConnPropKey.FQCN: FQCN.ROOT_SERVER,
+                ConnPropKey.IDENTITY: server_identity,
                 ConnPropKey.URL: root_url,
                 ConnPropKey.CONNECTION_SECURITY: client.get(ConnPropKey.CONNECTION_SECURITY),
             }
@@ -340,6 +345,7 @@ class FLClientStarterConfiger(JsonConfigurator):
 
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
+                ConnPropKey.IDENTITY: client_name,
                 ConnPropKey.URL: self.args.parent_url,
                 ConnPropKey.CONNECTION_SECURITY: self.args.parent_conn_sec,
             }
@@ -347,6 +353,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             # this is CP
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
+                ConnPropKey.IDENTITY: client_name,
             }
         set_scope_property(client_name, ConnPropKey.CP_CONN_PROPS, cp_conn_props)
 

--- a/nvflare/private/fed/app/relay/relay.py
+++ b/nvflare/private/fed/app/relay/relay.py
@@ -118,6 +118,13 @@ def main(args):
     if not parent_fqcn:
         raise RuntimeError(f"invalid relay config file {args.relay_config}: missing parent.fqcn")
 
+    parent_identity = parent.get(_ConfigKey.IDENTITY)
+    if not parent_identity:
+        if parent_fqcn == FQCN.ROOT_SERVER:
+            parent_identity = server_identity
+        else:
+            parent_identity = FQCN.split(parent_fqcn)[-1]
+
     cmd_vars = parse_vars(args.set)
     secure_train = cmd_vars.get("secure_train", False)
     logger.debug(f"{cmd_vars=} {secure_train=}")
@@ -164,6 +171,8 @@ def main(args):
         credentials=credentials,
         create_internal_listener=True,
         parent_url=parent_url,
+        auth_identity=my_identity,
+        auth_identity_map={parent_fqcn: parent_identity},
     )
     NetAgent(cell, agent_closed_cb=monitor.cellnet_stopped)
     cell.start()

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -164,6 +164,16 @@ class FederatedClientBase:
 
         cp_conn_props = get_scope_property(self.client_name, ConnPropKey.CP_CONN_PROPS)
         cp_fqcn = cp_conn_props.get(ConnPropKey.FQCN)
+        auth_identity_map = {cp_fqcn: self.client_name}
+        relay_identity = relay_conn_props.get(ConnPropKey.IDENTITY)
+        if relay_fqcn and relay_identity:
+            auth_identity_map[relay_fqcn] = relay_identity
+
+        root_conn_props = get_scope_property(self.client_name, ConnPropKey.ROOT_CONN_PROPS, {})
+        root_identity = root_conn_props.get(ConnPropKey.IDENTITY)
+        if root_identity:
+            auth_identity_map[FQCN.ROOT_SERVER] = root_identity
+
         parent_resources = None
         if self.args.job_id:
             # I am CJ
@@ -210,6 +220,8 @@ class FederatedClientBase:
             create_internal_listener=create_internal_listener,
             parent_url=parent_url,
             parent_resources=parent_resources,
+            auth_identity=self.client_name,
+            auth_identity_map=auth_identity_map,
         )
         self.cell.start()
         self.communicator.set_cell(self.cell)

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.fuel.f3.cellnet.credential_manager import CERT_CONTENT, CredentialManager
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+from nvflare.fuel.f3.endpoint import Endpoint
+from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.sfm.conn_manager import ConnManager
+from nvflare.fuel.f3.sfm.constants import HandshakeKeys
+from nvflare.fuel.f3.sfm.sfm_conn import SfmConnection
+from nvflare.fuel.utils.constants import Mode
+
+
+class _FakeConnection:
+    def __init__(self, peer_cn, conn_security=ConnectionSecurity.MTLS):
+        self.name = "CN-test"
+        self.closed = False
+        self.connector = SimpleNamespace(
+            mode=Mode.ACTIVE,
+            params={
+                DriverParams.SECURE: True,
+                DriverParams.CONNECTION_SECURITY: conn_security,
+            },
+        )
+        self.conn_props = {}
+        if peer_cn is not None:
+            self.conn_props[DriverParams.PEER_CN.value] = peer_cn
+
+    def get_conn_properties(self):
+        return self.conn_props
+
+    def close(self):
+        self.closed = True
+
+
+def _cert_pem(common_name: str):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _conn_manager(local_fqcn="server", identity_map=None):
+    resolver = CellIdentityResolver(local_fqcn=local_fqcn, prefix_identity_map=identity_map)
+    return ConnManager(Endpoint(local_fqcn), identity_resolver=resolver)
+
+
+def test_identity_resolver_maps_job_cell_to_configured_parent_identity():
+    resolver = CellIdentityResolver(local_fqcn="site-1", prefix_identity_map={"site-1": "site-1"})
+
+    assert resolver.resolve("site-1.job-123") == "site-1"
+
+
+def test_identity_resolver_maps_relay_child_to_child_identity_without_configured_prefix():
+    resolver = CellIdentityResolver(local_fqcn="relay-1", exact_identity_map={"relay-1": "relay-1"})
+
+    assert resolver.resolve("relay-1.site-1") == "site-1"
+
+
+def test_mtls_handshake_accepts_job_cell_with_parent_cert_identity():
+    manager = _conn_manager(identity_map={"site-1": "site-1"})
+    conn = _FakeConnection(peer_cn="site-1")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert "site-1.job-123" in manager.sfm_endpoints
+    assert not conn.closed
+
+
+def test_mtls_handshake_rejects_spoofed_endpoint_identity():
+    manager = _conn_manager(identity_map={"site-1": "site-1"})
+    conn = _FakeConnection(peer_cn="attacker")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    with pytest.raises(CommError) as ex:
+        manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert ex.value.code == CommError.BAD_DATA
+    assert "site-1.job-123" not in manager.sfm_endpoints
+    assert conn.closed
+
+
+def test_tls_handshake_does_not_enforce_peer_identity():
+    manager = _conn_manager(identity_map={"site-1": "site-1"})
+    conn = _FakeConnection(peer_cn=None, conn_security=ConnectionSecurity.TLS)
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert "site-1.job-123" in manager.sfm_endpoints
+    assert not conn.closed
+
+
+def test_mtls_certificate_cache_rejects_cert_identity_mismatch():
+    resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
+    manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
+    message = Message(
+        headers={MessageHeaderKey.ORIGIN: "site-1.job-123"},
+        payload={CERT_CONTENT: _cert_pem("attacker")},
+    )
+
+    with pytest.raises(RuntimeError, match="attacker"):
+        manager.process_response(message)
+
+    assert "site-1.job-123" not in manager.cert_cache
+
+
+def test_mtls_certificate_cache_accepts_job_cell_parent_cert_identity():
+    resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
+    manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
+    cert = _cert_pem("site-1")
+    message = Message(
+        headers={MessageHeaderKey.ORIGIN: "site-1.job-123"},
+        payload={CERT_CONTENT: cert},
+    )
+
+    assert manager.process_response(message) == cert
+    assert manager.cert_cache["site-1.job-123"] == cert


### PR DESCRIPTION
## Summary

Bind CellNet endpoint names to the authenticated mTLS peer certificate identity so a peer cannot claim another `endpoint_name` during SFM handshake or certificate exchange.

This adds a CellNet identity resolver that supports exact FQCN identities, configured prefix identities, local child identity inference, and the job-cell case where the endpoint is `site-1.<job_id>` but the certificate identity remains `site-1`.

## Root Cause

The SFM handshake trusted the peer-supplied `endpoint_name` independently of the mTLS certificate common name. Certificate exchange also cached certificates by the claimed origin FQCN without checking that the certificate identity matched that origin.

## Changes

- Enforce endpoint/CN binding in `ConnManager.update_endpoint()` only for mTLS connections.
- Validate cached peer cert identity in `CredentialManager` only when the CellNet config uses mTLS.
- Propagate configured identities through client, job-cell, relay, and root connection properties.
- Add job-cell and relay-child identity resolution coverage.

## Validation

- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/fuel/f3/cellnet/identity_binding_test.py -v` (`7 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/fuel/f3 -v` (`222 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/private/fed/client/communicator_test.py -v` (`2 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/private/fed/utils/site_config_test.py -v` (`5 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m black --check ...changed files...`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m isort --check ...changed files...`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m flake8 ...changed files... --count --statistics`
- `git diff --check`

## Note

`./runtest.sh -s` was run with `VIRTUAL_ENV=/Users/zhihongz/nvflare-env/3.12` and failed on unrelated vendored files under `examples/.../analytics-dashboard/node_modules/.../flatted/python/flatted.py` that Black would reformat. The scoped style checks above passed for this PR's changed files.
