### PR TITLE
Bind CellNet mTLS endpoint identity

### DIFF
--- a/docs/user_guide/nvflare_cli/distributed_provisioning.rst
+++ b/docs/user_guide/nvflare_cli/distributed_provisioning.rst
@@ -167,6 +167,23 @@ certificate identity. Do not edit the generated ``startup/fed_client.json`` or
 ``startup/signature.json``; regenerate the request, approval, and package so
 the signature covers the final configuration.
 
+.. important::
+
+   Endpoint-to-CN binding is enforced when an mTLS transport exposes the
+   authenticated peer CN. Some active-side gRPC connections do not expose the
+   peer CN to the Python driver, so NVFlare accepts those active connections and
+   relies on passive-side endpoint validation plus the normal application-layer
+   authentication checks.
+
+   Admin console cells use per-session endpoint names and authenticate the admin
+   user by certificate/user identity on the admin listener. Keep admin
+   application-layer authentication configured and protected.
+
+   ``auth_identity`` is loaded when a FLARE process starts. After rotating site
+   certificates or changing certificate CNs, regenerate the startup kits as
+   needed and restart the affected FLARE processes so the in-memory identity
+   resolver uses the new certificate identity.
+
 User example:
 
 .. code-block:: yaml

--- a/docs/user_guide/nvflare_cli/distributed_provisioning.rst
+++ b/docs/user_guide/nvflare_cli/distributed_provisioning.rst
@@ -144,6 +144,29 @@ Client site example:
        type: client
        org: hospital_alpha
 
+If the participant's certificate common name (CN) intentionally differs from
+the FLARE site name, include ``auth_identity`` in the participant definition
+before creating the certificate request. For example, a site named
+``hospital-a`` that authenticates with certificate CN
+``hospital-a.example.com`` should request:
+
+.. code-block:: yaml
+
+   name: hospital_federation
+   description: Site A - Hospital Alpha
+
+   participants:
+     - name: hospital-a
+       type: client
+       org: hospital_alpha
+       auth_identity: hospital-a.example.com
+
+This lets the generated startup kit map the endpoint/FQCN to the expected mTLS
+certificate identity. Do not edit the generated ``startup/fed_client.json`` or
+``startup/fed_server.json`` after packaging if the startup kit contains
+``startup/signature.json``; regenerate the request, approval, and package so
+the signature covers the final configuration.
+
 User example:
 
 .. code-block:: yaml
@@ -628,6 +651,9 @@ Notes
   NVFlare runtime.
 - Standard distributed provisioning does not generate ``signature.json``.
   Trust is anchored in the signed participant certificate and ``rootCA.pem``.
+  If a custom builder or alternate provisioning mode does generate
+  ``startup/signature.json``, do not modify startup JSON files after packaging;
+  regenerate the kit instead.
 - Custom builders are not part of the approval chain. Any ``builders:`` block
   in the local participant definition is applied at package time on the
   requester's machine. Features requiring coordinated builder configuration

--- a/docs/user_guide/nvflare_cli/provision_command.rst
+++ b/docs/user_guide/nvflare_cli/provision_command.rst
@@ -40,6 +40,39 @@ section includes structured guidance such as:
 This keeps JSON output machine-readable while still carrying follow-up
 instructions.
 
+Certificate Identity Overrides
+==============================
+
+For mTLS deployments, each CellNet endpoint is authenticated against the peer
+certificate common name (CN). By default, the expected certificate identity is
+derived from the participant name or FQCN. If a participant intentionally uses a
+certificate CN that differs from its FLARE site name, set ``auth_identity`` in
+``project.yml`` before provisioning.
+
+For example, if the FLARE site is named ``site-1`` but its certificate CN is
+``server.example.com``:
+
+.. code-block:: yaml
+
+   participants:
+     - name: site-1
+       type: client
+       org: nvidia
+       auth_identity: server.example.com
+
+Provisioning uses this value to generate the corresponding startup-kit
+configuration, including peer identity mappings needed by the server and by job
+cells. A job cell such as ``site-1.<job_id>`` still authenticates with the
+parent site's configured certificate identity.
+
+.. warning::
+
+   Do not edit ``startup/fed_client.json`` or ``startup/fed_server.json`` by
+   hand in a signed startup kit. If ``startup/signature.json`` is present, the
+   startup configuration is covered by the signature and manual edits invalidate
+   that signature. Change ``project.yml`` and re-run provisioning so the startup
+   configuration and signature are generated together.
+
 .. _dynamic_provisioning_cli:
 
 Dynamic Provisioning

--- a/docs/user_guide/nvflare_cli/provision_command.rst
+++ b/docs/user_guide/nvflare_cli/provision_command.rst
@@ -65,6 +65,23 @@ configuration, including peer identity mappings needed by the server and by job
 cells. A job cell such as ``site-1.<job_id>`` still authenticates with the
 parent site's configured certificate identity.
 
+.. important::
+
+   Endpoint-to-CN binding is enforced when an mTLS transport exposes the
+   authenticated peer CN. Some active-side gRPC connections do not expose the
+   peer CN to the Python driver, so NVFlare accepts those active connections and
+   relies on passive-side endpoint validation plus the normal application-layer
+   authentication checks.
+
+   Admin console cells use per-session endpoint names and authenticate the admin
+   user by certificate/user identity on the admin listener. Keep admin
+   application-layer authentication configured and protected.
+
+   ``auth_identity`` is loaded when a FLARE process starts. After rotating site
+   certificates or changing certificate CNs, regenerate the startup kits as
+   needed and restart the affected FLARE processes so the in-memory identity
+   resolver uses the new certificate identity.
+
 .. warning::
 
    Do not edit ``startup/fed_client.json`` or ``startup/fed_server.json`` by

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -624,6 +624,7 @@ class RunnerTask:
 
 class ConnPropKey:
     FQCN = "fqcn"
+    IDENTITY = "identity"
     URL = "url"
     SCHEME = "scheme"
     ADDRESS = "address"

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -625,6 +625,8 @@ class RunnerTask:
 class ConnPropKey:
     FQCN = "fqcn"
     IDENTITY = "identity"
+    AUTH_IDENTITY = "auth_identity"
+    AUTH_IDENTITY_MAP = "auth_identity_map"
     URL = "url"
     SCHEME = "scheme"
     ADDRESS = "address"

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -220,6 +220,17 @@ def _validate_url(url: str) -> bool:
     return True
 
 
+def _is_failed_cert_exchange(channel: str, topic: str, reply: Message) -> bool:
+    if not reply:
+        return False
+
+    return (
+        channel == _SM_CHANNEL
+        and topic == _SM_TOPIC
+        and reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.PROCESS_EXCEPTION
+    )
+
+
 class _CounterName:
 
     LATE = "late"
@@ -2021,6 +2032,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             channel = message.get_header(MessageHeaderKey.CHANNEL, "")
             topic = message.get_header(MessageHeaderKey.TOPIC, "")
             reply = self._process_request(origin, message)
+            should_close_connection = _is_failed_cert_exchange(channel, topic, reply)
 
             if not reply:
                 self.received_msg_counter_pool.increment(
@@ -2037,6 +2049,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                 self.received_msg_counter_pool.increment(
                     category=self._stats_category(message), counter_name=_CounterName.REPLY_NOT_EXPECTED
                 )
+                if should_close_connection and connection:
+                    connection.close()
                 return
 
             # send the reply back
@@ -2074,6 +2088,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                         reply = r
                         break
             self._send_reply(reply, endpoint)
+            if should_close_connection and connection:
+                connection.close()
         else:
             # the message is either a reply or a return for a previous request: handle replies
             self._process_reply(origin, message, msg_type)

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -39,6 +39,12 @@ from nvflare.fuel.f3.cellnet.defs import (
     ServiceUnavailable,
 )
 from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo, same_family
+from nvflare.fuel.f3.cellnet.identity import (
+    CellIdentityResolver,
+    get_cert_common_name_from_file,
+    get_param,
+    is_mtls_config,
+)
 from nvflare.fuel.f3.cellnet.registry import Callback, Registry
 from nvflare.fuel.f3.cellnet.utils import decode_payload, encode_payload, format_log_message, make_reply
 from nvflare.fuel.f3.comm_config import CommConfigurator
@@ -288,6 +294,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         bulk_check_interval=0.5,
         bulk_process_interval=0.5,
         max_bulk_size=100,
+        auth_identity: str = None,
+        auth_identity_map: dict = None,
     ):
         """
 
@@ -300,6 +308,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             create_internal_listener: whether to create an internal listener for child cells
             parent_url: url for connecting to parent cell
             parent_resources: extra resources for making connection to parent
+            auth_identity: authenticated identity of this cell's local certificate
+            auth_identity_map: FQCN prefix to expected certificate identity map for mTLS peers
 
         FQCN is the names of all ancestor, concatenated with dots.
 
@@ -395,6 +405,20 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             enhance_credential_info(credentials)
             self.update_fobs_context({FOBSContextKey.SEC_CREDS: credentials})
 
+        local_auth_identity = auth_identity if auth_identity else self._get_auth_identity_from_credentials(credentials)
+        prefix_identity_map = dict(auth_identity_map) if auth_identity_map else {}
+        exact_identity_map = {}
+        if local_auth_identity:
+            exact_identity_map[self.my_info.fqcn] = local_auth_identity
+            if self.my_info.is_on_server:
+                prefix_identity_map[FQCN.ROOT_SERVER] = local_auth_identity
+
+        self.identity_resolver = CellIdentityResolver(
+            local_fqcn=self.my_info.fqcn,
+            prefix_identity_map=prefix_identity_map,
+            exact_identity_map=exact_identity_map,
+        )
+
         ep = Endpoint(
             name=fqcn,
             conn_props=credentials,
@@ -403,7 +427,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             },
         )
 
-        self.communicator = Communicator(local_endpoint=ep)
+        self.communicator = Communicator(local_endpoint=ep, identity_resolver=self.identity_resolver)
 
         self.endpoint = ep
         self.connector_manager = ConnectorManager(
@@ -505,8 +529,22 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         )
         self.ALL_CELLS[fqcn] = self
 
-        self.credential_manager = CredentialManager(self.endpoint)
+        self.credential_manager = CredentialManager(
+            self.endpoint,
+            identity_resolver=self.identity_resolver,
+            enforce_identity=is_mtls_config(credentials, secure),
+        )
         self.cert_ex = CertificateExchanger(self, self.credential_manager)
+
+    @staticmethod
+    def _get_auth_identity_from_credentials(credentials: dict):
+        if not credentials:
+            return None
+
+        cert_path = get_param(credentials, DriverParams.SERVER_CERT)
+        if not cert_path:
+            cert_path = get_param(credentials, DriverParams.CLIENT_CERT)
+        return get_cert_common_name_from_file(cert_path)
 
     def update_fobs_context(self, props: dict):
         if not isinstance(props, dict):

--- a/nvflare/fuel/f3/cellnet/credential_manager.py
+++ b/nvflare/fuel/f3/cellnet/credential_manager.py
@@ -21,6 +21,7 @@ from cryptography.x509 import Certificate
 
 from nvflare.fuel.f3.cellnet.cell_cipher import SimpleCellCipher
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver, get_cert_common_name_from_pem
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message
@@ -38,11 +39,18 @@ CERT_REQ_TIMEOUT = 10
 class CredentialManager:
     """Helper class for secure message. It holds the local credentials and certificate cache"""
 
-    def __init__(self, local_endpoint: Endpoint):
+    def __init__(
+        self,
+        local_endpoint: Endpoint,
+        identity_resolver: CellIdentityResolver = None,
+        enforce_identity: bool = False,
+    ):
 
         self.local_endpoint = local_endpoint
         self.cert_cache = {}
         self.lock = threading.Lock()
+        self.identity_resolver = identity_resolver if identity_resolver else CellIdentityResolver(local_endpoint.name)
+        self.enforce_identity = enforce_identity
 
         conn_props = self.local_endpoint.conn_props
         ca_cert_path = conn_props.get(DriverParams.CA_CERT)
@@ -99,6 +107,19 @@ class CredentialManager:
 
         return req
 
+    def _cache_cert(self, fqcn: str, cert: bytes):
+        if not cert:
+            raise RuntimeError(f"missing certificate for {fqcn}")
+
+        if self.enforce_identity:
+            cn = get_cert_common_name_from_pem(cert)
+            try:
+                self.identity_resolver.require_match(fqcn, cn, f"certificate for {fqcn}")
+            except ValueError as ex:
+                raise RuntimeError(str(ex))
+
+        self.cert_cache[fqcn] = cert
+
     def process_request(self, request: Message) -> dict:
         origin = request.get_header(MessageHeaderKey.ORIGIN)
         target = request.get_header(MessageHeaderKey.DESTINATION)
@@ -110,7 +131,7 @@ class CredentialManager:
             cert = payload.get(CERT_CONTENT)
 
             # Save cert from requester in the cache
-            self.cert_cache[origin] = cert
+            self._cache_cert(origin, cert)
 
             reply[CERT_CONTENT] = self.local_cert
             reply[CERT_CA_CONTENT] = self.ca_cert
@@ -125,7 +146,7 @@ class CredentialManager:
             raise RuntimeError(f"Request to get certificate from {origin} failed: {error}")
 
         cert = reply.get(CERT_CONTENT)
-        self.cert_cache[origin] = cert
+        self._cache_cert(origin, cert)
         return cert
 
     def get_local_cert(self) -> Certificate:

--- a/nvflare/fuel/f3/cellnet/credential_manager.py
+++ b/nvflare/fuel/f3/cellnet/credential_manager.py
@@ -97,7 +97,8 @@ class CredentialManager:
     def get_certificate(self, fqcn: str) -> bytes:
         if not self.cell_cipher:
             raise RuntimeError("This cell doesn't support certificate exchange, not running in secure mode")
-        return self.cert_cache.get(fqcn)
+        with self.lock:
+            return self.cert_cache.get(fqcn)
 
     def create_request(self) -> dict:
         req = {
@@ -118,7 +119,8 @@ class CredentialManager:
             except ValueError as ex:
                 raise RuntimeError(str(ex))
 
-        self.cert_cache[fqcn] = cert
+        with self.lock:
+            self.cert_cache[fqcn] = cert
 
     def process_request(self, request: Message) -> dict:
         origin = request.get_header(MessageHeaderKey.ORIGIN)

--- a/nvflare/fuel/f3/cellnet/identity.py
+++ b/nvflare/fuel/f3/cellnet/identity.py
@@ -97,6 +97,13 @@ class CellIdentityResolver:
     def _is_descendant(fqcn: str, prefix: str) -> bool:
         return fqcn.startswith(prefix + ".")
 
+    def _is_local_descendant_with_ancestor_prefix(self, fqcn: str, prefix: str) -> bool:
+        return (
+            self.local_fqcn
+            and self._is_descendant(fqcn, self.local_fqcn)
+            and self._is_descendant(self.local_fqcn, prefix)
+        )
+
     def _resolve_local_child_identity(self, fqcn: str) -> Optional[str]:
         if not self.local_fqcn or not self._is_descendant(fqcn, self.local_fqcn):
             return None
@@ -119,6 +126,9 @@ class CellIdentityResolver:
         parts = FQCN.split(fqcn)
         for i in range(len(parts), 0, -1):
             prefix = FQCN.join(parts[:i])
+            if self._is_local_descendant_with_ancestor_prefix(fqcn, prefix):
+                continue
+
             identity = self.prefix_identity_map.get(prefix)
             if identity:
                 return identity

--- a/nvflare/fuel/f3/cellnet/identity.py
+++ b/nvflare/fuel/f3/cellnet/identity.py
@@ -131,6 +131,9 @@ class CellIdentityResolver:
 
     def require_match(self, fqcn: str, peer_cn: str, peer_desc: str):
         expected_cn = self.resolve(fqcn)
+        if not expected_cn:
+            raise ValueError(f"{peer_desc} claimed endpoint '{fqcn}' does not resolve to an expected identity")
+
         if not peer_cn or peer_cn == "N/A":
             raise ValueError(f"{peer_desc} does not have an authenticated mTLS peer common name")
 

--- a/nvflare/fuel/f3/cellnet/identity.py
+++ b/nvflare/fuel/f3/cellnet/identity.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+from nvflare.fuel.f3.drivers.net_utils import SECURE_SCHEMES
+from nvflare.fuel.utils.argument_utils import str2bool
+
+
+def get_param(params: dict, key: DriverParams, default=None):
+    if not params:
+        return default
+
+    value = params.get(key.value, None)
+    if value is None:
+        value = params.get(key, default)
+    return value
+
+
+def is_mtls_connection(params: dict) -> bool:
+    if not params:
+        return False
+
+    scheme = get_param(params, DriverParams.SCHEME)
+    secure = str2bool(get_param(params, DriverParams.SECURE, False))
+    if scheme not in SECURE_SCHEMES and not secure:
+        return False
+
+    conn_security = get_param(params, DriverParams.CONNECTION_SECURITY, ConnectionSecurity.MTLS)
+    return conn_security == ConnectionSecurity.MTLS
+
+
+def is_mtls_config(credentials: dict, secure: bool) -> bool:
+    if not secure:
+        return False
+
+    conn_security = get_param(credentials, DriverParams.CONNECTION_SECURITY, ConnectionSecurity.MTLS)
+    return conn_security == ConnectionSecurity.MTLS
+
+
+def get_cert_common_name(cert: x509.Certificate) -> Optional[str]:
+    attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    return attrs[0].value if attrs else None
+
+
+def get_cert_common_name_from_pem(cert_bytes: bytes) -> Optional[str]:
+    if not cert_bytes:
+        return None
+
+    cert = x509.load_pem_x509_certificate(cert_bytes)
+    return get_cert_common_name(cert)
+
+
+def get_cert_common_name_from_file(cert_path: str) -> Optional[str]:
+    if not cert_path:
+        return None
+
+    with open(cert_path, "rb") as f:
+        return get_cert_common_name_from_pem(f.read())
+
+
+class CellIdentityResolver:
+    def __init__(self, local_fqcn: str = "", prefix_identity_map: dict = None, exact_identity_map: dict = None):
+        self.local_fqcn = FQCN.normalize(local_fqcn) if local_fqcn else ""
+        self.prefix_identity_map = self._normalize_map(prefix_identity_map)
+        self.exact_identity_map = self._normalize_map(exact_identity_map)
+
+    @staticmethod
+    def _normalize_map(identity_map: dict = None):
+        result = {}
+        if not identity_map:
+            return result
+
+        for fqcn, identity in identity_map.items():
+            if fqcn and identity:
+                result[FQCN.normalize(fqcn)] = identity
+        return result
+
+    @staticmethod
+    def _is_descendant(fqcn: str, prefix: str) -> bool:
+        return fqcn.startswith(prefix + ".")
+
+    def _resolve_local_child_identity(self, fqcn: str) -> Optional[str]:
+        if not self.local_fqcn or not self._is_descendant(fqcn, self.local_fqcn):
+            return None
+
+        # A child connected through this local cell normally authenticates with
+        # the next FQCN segment's certificate. Example: relay-a.site-1 -> site-1.
+        child_suffix = fqcn[len(self.local_fqcn) + 1 :]
+        parts = FQCN.split(child_suffix)
+        return parts[0] if parts else None
+
+    def resolve(self, fqcn: str) -> Optional[str]:
+        if not fqcn:
+            return None
+
+        fqcn = FQCN.normalize(fqcn)
+        identity = self.exact_identity_map.get(fqcn)
+        if identity:
+            return identity
+
+        parts = FQCN.split(fqcn)
+        for i in range(len(parts), 0, -1):
+            prefix = FQCN.join(parts[:i])
+            identity = self.prefix_identity_map.get(prefix)
+            if identity:
+                return identity
+
+        identity = self._resolve_local_child_identity(fqcn)
+        if identity:
+            return identity
+
+        return parts[0] if parts else fqcn
+
+    def require_match(self, fqcn: str, peer_cn: str, peer_desc: str):
+        expected_cn = self.resolve(fqcn)
+        if not peer_cn or peer_cn == "N/A":
+            raise ValueError(f"{peer_desc} does not have an authenticated mTLS peer common name")
+
+        if peer_cn != expected_cn:
+            raise ValueError(
+                f"{peer_desc} authenticated as '{peer_cn}' but claimed endpoint '{fqcn}' "
+                f"requires identity '{expected_cn}'"
+            )

--- a/nvflare/fuel/f3/cellnet/identity.py
+++ b/nvflare/fuel/f3/cellnet/identity.py
@@ -21,6 +21,7 @@ from nvflare.apis.fl_constant import ConnectionSecurity
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.drivers.net_utils import SECURE_SCHEMES
+from nvflare.fuel.utils.admin_name_utils import is_valid_admin_client_name
 from nvflare.fuel.utils.argument_utils import str2bool
 
 
@@ -146,6 +147,10 @@ class CellIdentityResolver:
 
         if not peer_cn or peer_cn == "N/A":
             raise ValueError(f"{peer_desc} does not have an authenticated mTLS peer common name")
+
+        # Admin client cell names are per-session random IDs; the authenticated user is the cert CN.
+        if is_valid_admin_client_name(fqcn):
+            return
 
         if peer_cn != expected_cn:
             raise ValueError(

--- a/nvflare/fuel/f3/cellnet/identity.py
+++ b/nvflare/fuel/f3/cellnet/identity.py
@@ -24,6 +24,8 @@ from nvflare.fuel.f3.drivers.net_utils import SECURE_SCHEMES
 from nvflare.fuel.utils.admin_name_utils import is_valid_admin_client_name
 from nvflare.fuel.utils.argument_utils import str2bool
 
+ADMIN_LISTENER_KEY = "admin_listener"
+
 
 def get_param(params: dict, key: DriverParams, default=None):
     if not params:
@@ -54,6 +56,13 @@ def is_mtls_config(credentials: dict, secure: bool) -> bool:
 
     conn_security = get_param(credentials, DriverParams.CONNECTION_SECURITY, ConnectionSecurity.MTLS)
     return conn_security == ConnectionSecurity.MTLS
+
+
+def is_admin_listener(params: dict) -> bool:
+    if not params:
+        return False
+
+    return str2bool(params.get(ADMIN_LISTENER_KEY, False))
 
 
 def get_cert_common_name(cert: x509.Certificate) -> Optional[str]:

--- a/nvflare/fuel/f3/communicator.py
+++ b/nvflare/fuel/f3/communicator.py
@@ -19,6 +19,7 @@ import weakref
 from typing import Optional
 
 from nvflare.fuel.f3 import drivers
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver
 from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.drivers.driver import Driver
@@ -56,10 +57,10 @@ def load_comm_drivers():
 class Communicator:
     """FCI (Flare Communication Interface) main communication API"""
 
-    def __init__(self, local_endpoint: Endpoint):
+    def __init__(self, local_endpoint: Endpoint, identity_resolver: CellIdentityResolver = None):
         self.local_endpoint = local_endpoint
         self.monitors = []
-        self.conn_manager = ConnManager(local_endpoint)
+        self.conn_manager = ConnManager(local_endpoint, identity_resolver)
         self.stopped = False
 
     def start(self):

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 
 import msgpack
 
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver, get_param, is_mtls_connection
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.connection import BytesAlike, Connection, ConnState, FrameReceiver
 from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
@@ -63,8 +64,9 @@ class ConnManager(ConnMonitor):
     The class is responsible for maintaining state of SFM connections and pumping data through them
     """
 
-    def __init__(self, local_endpoint: Endpoint):
+    def __init__(self, local_endpoint: Endpoint, identity_resolver: CellIdentityResolver = None):
         self.local_endpoint = local_endpoint
+        self.identity_resolver = identity_resolver if identity_resolver else CellIdentityResolver(local_endpoint.name)
 
         # Active connectors
         self.connectors: Dict[str, ConnectorInfo] = {}
@@ -404,9 +406,17 @@ class ConnManager(ConnMonitor):
                 CommError.BAD_DATA, f"Duplicate endpoint name {endpoint_name} for connection {sfm_conn.get_name()}"
             )
 
+        conn_props = sfm_conn.conn.get_conn_properties()
+        if is_mtls_connection(sfm_conn.conn.connector.params):
+            peer_cn = get_param(conn_props, DriverParams.PEER_CN)
+            try:
+                self.identity_resolver.require_match(endpoint_name, peer_cn, f"connection {sfm_conn.get_name()}")
+            except ValueError as ex:
+                sfm_conn.conn.close()
+                raise CommError(CommError.BAD_DATA, str(ex))
+
         endpoint = Endpoint(endpoint_name, data)
         endpoint.state = EndpointState.READY
-        conn_props = sfm_conn.conn.get_conn_properties()
         if conn_props:
             endpoint.conn_props.update(conn_props)
 

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -20,7 +20,8 @@ from typing import Dict, List, Optional
 
 import msgpack
 
-from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver, get_param, is_mtls_connection
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver, get_param, is_admin_listener, is_mtls_connection
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.connection import BytesAlike, Connection, ConnState, FrameReceiver
 from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
@@ -35,6 +36,7 @@ from nvflare.fuel.f3.sfm.prefix import PREFIX_LEN, Prefix
 from nvflare.fuel.f3.sfm.sfm_conn import SfmConnection
 from nvflare.fuel.f3.sfm.sfm_endpoint import SfmEndpoint
 from nvflare.fuel.f3.stats_pool import StatsPoolManager
+from nvflare.fuel.utils.admin_name_utils import is_valid_admin_client_name
 from nvflare.fuel.utils.buffer_list import BufferList
 from nvflare.security.logging import secure_format_exception, secure_format_traceback
 
@@ -401,6 +403,15 @@ class ConnManager(ConnMonitor):
         if not endpoint_name:
             raise CommError(CommError.BAD_DATA, f"Handshake without endpoint name for connection {sfm_conn.get_name()}")
 
+        endpoint_name = FQCN.normalize(endpoint_name)
+        err = FQCN.validate(endpoint_name)
+        if err:
+            sfm_conn.conn.close()
+            raise CommError(
+                CommError.BAD_DATA,
+                f"Invalid endpoint name '{endpoint_name}' for connection {sfm_conn.get_name()}: {err}",
+            )
+
         if endpoint_name == self.local_endpoint.name:
             raise CommError(
                 CommError.BAD_DATA, f"Duplicate endpoint name {endpoint_name} for connection {sfm_conn.get_name()}"
@@ -413,6 +424,16 @@ class ConnManager(ConnMonitor):
         if is_mtls_connection(sfm_conn.conn.connector.params):
             peer_cn = get_param(conn_props, DriverParams.PEER_CN)
             if sfm_conn.conn.connector.mode == Mode.PASSIVE or (peer_cn and peer_cn != "N/A"):
+                if (
+                    is_valid_admin_client_name(endpoint_name)
+                    and sfm_conn.conn.connector.mode == Mode.PASSIVE
+                    and not is_admin_listener(sfm_conn.conn.connector.params)
+                ):
+                    sfm_conn.conn.close()
+                    raise CommError(
+                        CommError.BAD_DATA,
+                        f"Admin endpoint '{endpoint_name}' can only connect through an admin listener",
+                    )
                 try:
                     self.identity_resolver.require_match(endpoint_name, peer_cn, f"connection {sfm_conn.get_name()}")
                 except ValueError as ex:

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -407,7 +407,12 @@ class ConnManager(ConnMonitor):
             )
 
         conn_props = sfm_conn.conn.get_conn_properties()
-        if is_mtls_connection(sfm_conn.conn.connector.params):
+        # Only enforce on incoming (passive) connections: the authenticated peer CN is
+        # the connecting peer's identity, which is what could spoof a victim's endpoint_name.
+        # The active side that dials out to a known URL has no authenticated peer CN to bind
+        # against for some drivers (e.g. gRPC sets PEER_CN to "N/A"/None on the client side),
+        # and server impersonation there is already covered by TLS CA validation.
+        if sfm_conn.conn.connector.mode == Mode.PASSIVE and is_mtls_connection(sfm_conn.conn.connector.params):
             peer_cn = get_param(conn_props, DriverParams.PEER_CN)
             try:
                 self.identity_resolver.require_match(endpoint_name, peer_cn, f"connection {sfm_conn.get_name()}")

--- a/nvflare/fuel/f3/sfm/conn_manager.py
+++ b/nvflare/fuel/f3/sfm/conn_manager.py
@@ -407,18 +407,17 @@ class ConnManager(ConnMonitor):
             )
 
         conn_props = sfm_conn.conn.get_conn_properties()
-        # Only enforce on incoming (passive) connections: the authenticated peer CN is
-        # the connecting peer's identity, which is what could spoof a victim's endpoint_name.
-        # The active side that dials out to a known URL has no authenticated peer CN to bind
-        # against for some drivers (e.g. gRPC sets PEER_CN to "N/A"/None on the client side),
-        # and server impersonation there is already covered by TLS CA validation.
-        if sfm_conn.conn.connector.mode == Mode.PASSIVE and is_mtls_connection(sfm_conn.conn.connector.params):
+        # Passive mTLS connections must always present the connecting peer's CN.
+        # Active mTLS connections enforce the same binding when the driver exposes
+        # a real peer CN; gRPC active-side connections may report "N/A"/None.
+        if is_mtls_connection(sfm_conn.conn.connector.params):
             peer_cn = get_param(conn_props, DriverParams.PEER_CN)
-            try:
-                self.identity_resolver.require_match(endpoint_name, peer_cn, f"connection {sfm_conn.get_name()}")
-            except ValueError as ex:
-                sfm_conn.conn.close()
-                raise CommError(CommError.BAD_DATA, str(ex))
+            if sfm_conn.conn.connector.mode == Mode.PASSIVE or (peer_cn and peer_cn != "N/A"):
+                try:
+                    self.identity_resolver.require_match(endpoint_name, peer_cn, f"connection {sfm_conn.get_name()}")
+                except ValueError as ex:
+                    sfm_conn.conn.close()
+                    raise CommError(CommError.BAD_DATA, str(ex))
 
         endpoint = Endpoint(endpoint_name, data)
         endpoint.state = EndpointState.READY

--- a/nvflare/fuel/utils/log_utils.py
+++ b/nvflare/fuel/utils/log_utils.py
@@ -18,6 +18,7 @@ import logging
 import logging.config
 import os
 import re
+import sys
 from logging import Logger
 from logging.handlers import RotatingFileHandler
 from typing import Union
@@ -103,6 +104,11 @@ class ANSIColor:
             color = cls.COLORS.get(color.lower(), cls.COLORS["reset"])
 
         return f"\x1b[{color}m{text}\x1b[{cls.COLORS['reset']}m"
+
+
+def _stdout_supports_color() -> bool:
+    isatty = getattr(sys.stdout, "isatty", None)
+    return bool(isatty and isatty())
 
 
 class BaseFormatter(logging.Formatter):
@@ -192,6 +198,8 @@ class ColorFormatter(BaseFormatter):
 
     def format(self, record):
         record_s = super().format(record)
+        if not _stdout_supports_color():
+            return record_s
 
         # Apply level_colors based on record levelname
         log_color = self.level_colors.get(self.record.levelname, "reset")

--- a/nvflare/lighter/constants.py
+++ b/nvflare/lighter/constants.py
@@ -59,6 +59,7 @@ class PropKey:
     # ever shipped with the previous name.
     ALLOW_LOG_STREAMING = "allow_log_streaming"
     CONN_SECURITY = "connection_security"
+    AUTH_IDENTITY = "auth_identity"
     CUSTOM_CA_CERT = "custom_ca_cert"
     SCHEME = "scheme"
     CAPACITY = "capacity"

--- a/nvflare/lighter/entity.py
+++ b/nvflare/lighter/entity.py
@@ -41,15 +41,22 @@ class ListeningHost:
 
 
 class ConnectTo:
-    def __init__(self, name, host, port, conn_sec):
+    def __init__(self, name, host, port, conn_sec, auth_identity=None):
         self.name = name
         self.host = host
         self.port = port
         self.conn_sec = conn_sec
+        self.auth_identity = auth_identity
 
     def __str__(self):
-        name, host, port, conn_sec = self.name, self.host, self.port, self.conn_sec
-        return f"ConnectTo[{name=} {host=} {port=} {conn_sec=}]"
+        name, host, port, conn_sec, auth_identity = (
+            self.name,
+            self.host,
+            self.port,
+            self.conn_sec,
+            self.auth_identity,
+        )
+        return f"ConnectTo[{name=} {host=} {port=} {conn_sec=} {auth_identity=}]"
 
 
 def _check_host_name(scope: str, prop_key: str, value):
@@ -93,7 +100,8 @@ def parse_connect_to(value, scope=None, prop_key=None) -> ConnectTo:
         host = value.get(PropKey.HOST)
         port = value.get(PropKey.PORT)
         conn_sec = value.get(PropKey.CONN_SECURITY)
-        return ConnectTo(name, host, port, conn_sec)
+        auth_identity = value.get(PropKey.AUTH_IDENTITY)
+        return ConnectTo(name, host, port, conn_sec, auth_identity)
     else:
         raise ValueError(
             f"bad value for {prop_key} '{value}' in {scope}: invalid type {type(value)}; must be str or dict"

--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -130,6 +130,15 @@ class StaticFileBuilder(Builder):
 
         return client.name
 
+    @staticmethod
+    def _resolve_default_auth_identity(fqcn: str, local_fqcn: str = None):
+        parts = fqcn.split(".")
+        if local_fqcn and fqcn.startswith(local_fqcn + "."):
+            child_parts = fqcn[len(local_fqcn) + 1 :].split(".")
+            return child_parts[0] if child_parts else None
+
+        return parts[0] if parts else None
+
     def _build_auth_identity_map(self, project: Project, ctx: ProvisionContext, local_relay: Participant = None):
         result = {}
         local_prefix = local_relay.get_prop(PropKey.FQCN) if local_relay else None
@@ -137,12 +146,16 @@ class StaticFileBuilder(Builder):
         for relay in project.get_relays():
             fqcn = relay.get_prop(PropKey.FQCN)
             if fqcn and (not local_prefix or fqcn.startswith(local_prefix + ".")):
-                result[fqcn] = self._get_auth_identity(relay)
+                auth_identity = self._get_auth_identity(relay)
+                if auth_identity != self._resolve_default_auth_identity(fqcn, local_prefix):
+                    result[fqcn] = auth_identity
 
         for client in project.get_clients():
             fqcn = self._get_client_cell_fqcn(client, ctx)
             if fqcn and (not local_prefix or fqcn.startswith(local_prefix + ".")):
-                result[fqcn] = self._get_auth_identity(client)
+                auth_identity = self._get_auth_identity(client)
+                if auth_identity != self._resolve_default_auth_identity(fqcn, local_prefix):
+                    result[fqcn] = auth_identity
 
         return result
 

--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -114,6 +114,38 @@ class StaticFileBuilder(Builder):
                 scheme = self.scheme
         return scheme
 
+    @staticmethod
+    def _get_auth_identity(participant: Participant):
+        return participant.get_prop(PropKey.AUTH_IDENTITY, participant.name)
+
+    @staticmethod
+    def _get_client_cell_fqcn(client: Participant, ctx: ProvisionContext):
+        ct = client.get_connect_to()
+        if ct and ct.name:
+            relay_map = ctx.get(CtxKey.RELAY_MAP)
+            if relay_map:
+                relay = relay_map.get(ct.name)
+                if relay:
+                    return ".".join([relay.get_prop(PropKey.FQCN), client.name])
+
+        return client.name
+
+    def _build_auth_identity_map(self, project: Project, ctx: ProvisionContext, local_relay: Participant = None):
+        result = {}
+        local_prefix = local_relay.get_prop(PropKey.FQCN) if local_relay else None
+
+        for relay in project.get_relays():
+            fqcn = relay.get_prop(PropKey.FQCN)
+            if fqcn and (not local_prefix or fqcn.startswith(local_prefix + ".")):
+                result[fqcn] = self._get_auth_identity(relay)
+
+        for client in project.get_clients():
+            fqcn = self._get_client_cell_fqcn(client, ctx)
+            if fqcn and (not local_prefix or fqcn.startswith(local_prefix + ".")):
+                result[fqcn] = self._get_auth_identity(client)
+
+        return result
+
     def _build_server(self, server: Participant, ctx: ProvisionContext):
         project = ctx.get_project()
         dest_dir = ctx.get_kit_dir(server)
@@ -134,6 +166,8 @@ class StaticFileBuilder(Builder):
                 "admin_port": admin_port,
                 "scheme": self._determine_scheme(server),
                 "conn_sec": conn_sec,
+                "auth_identity": self._get_auth_identity(server),
+                "auth_identity_map": json.dumps(self._build_auth_identity_map(project, ctx), indent=16),
             },
         )
 
@@ -264,11 +298,13 @@ class StaticFileBuilder(Builder):
             replacement={
                 "scheme": self._determine_scheme(client),
                 "name": project.name,
-                "server_identity": server.name,
+                "server_identity": self._get_auth_identity(server),
                 "target": target,
                 "fqsn": client.get_prop(PropKey.FQSN),
                 "is_leaf": is_leaf,
                 "conn_sec": self._build_conn_properties(client, ctx),
+                "auth_identity": self._get_auth_identity(client),
+                "auth_identity_map": json.dumps(self._build_auth_identity_map(project, ctx), indent=8),
             },
         )
 
@@ -401,6 +437,7 @@ class StaticFileBuilder(Builder):
             replacement_dict = {
                 "scheme": scheme,
                 "identity": relay.name,
+                "auth_identity": self._get_auth_identity(relay),
                 "address": addr,
                 "fqcn": fqcn,
                 "conn_sec": conn_sec,
@@ -543,7 +580,7 @@ class StaticFileBuilder(Builder):
         replacement_dict = {
             "project_name": project.name,
             "username": "" if provision_mode == ProvisionMode.POC else admin.name,
-            "server_identity": server.name,
+            "server_identity": self._get_auth_identity(server),
             "scheme": self.scheme,
             "conn_sec": conn_sec,
             "host": conn_host,
@@ -587,6 +624,7 @@ class StaticFileBuilder(Builder):
         # default parent is server
         parent_scheme = self.scheme
         parent_identity = server.name
+        parent_auth_identity = self._get_auth_identity(server)
         parent_fqcn = "server"
         parent_host = server.get_default_host()
         parent_port = ctx.get(CtxKey.FED_LEARN_PORT)
@@ -610,6 +648,7 @@ class StaticFileBuilder(Builder):
                     lh = parent_relay.get_listening_host()
                     parent_scheme = lh.scheme
                     parent_fqcn = parent_relay.get_prop(PropKey.FQCN)
+                    parent_auth_identity = self._get_auth_identity(parent_relay)
 
                     # check whether the specified ct.host is available from the parent relay
                     if ct.host:
@@ -624,6 +663,11 @@ class StaticFileBuilder(Builder):
                             # treat it as a hard error since the customer may intentionally connect to
                             # a different host (BYOConn).
                             ctx.warning(f"the connect_to.host '{ct.host}' in relay {relay.name} may be invalid: {err}")
+                else:
+                    parent_auth_identity = self._get_auth_identity(server)
+
+            if ct.auth_identity:
+                parent_auth_identity = ct.auth_identity
 
             # general logic: properties defined in connect_to overrides parent's listening_host.
             if ct.host:
@@ -656,12 +700,15 @@ class StaticFileBuilder(Builder):
         replacement_dict = {
             "project_name": project.name,
             "identity": relay.name,
-            "server_identity": server.name,
+            "auth_identity": self._get_auth_identity(relay),
+            "server_identity": self._get_auth_identity(server),
             "scheme": parent_scheme,
             "parent_identity": parent_identity,
+            "parent_auth_identity": parent_auth_identity,
             "address": parent_addr,
             "fqcn": parent_fqcn,
             "conn_sec": parent_conn_sec,
+            "auth_identity_map": json.dumps(self._build_auth_identity_map(project, ctx, relay), indent=8),
         }
 
         dest_dir = ctx.get_kit_dir(relay)

--- a/nvflare/lighter/impl/static_file.py
+++ b/nvflare/lighter/impl/static_file.py
@@ -119,6 +119,38 @@ class StaticFileBuilder(Builder):
         return participant.get_prop(PropKey.AUTH_IDENTITY, participant.name)
 
     @staticmethod
+    def _build_optional_json_fields(fields: list, indent: int):
+        lines = []
+        line_prefix = " " * indent
+        for key, value in fields:
+            if not value:
+                continue
+
+            value_text = json.dumps(value, indent=2).replace("\n", "\n" + line_prefix)
+            lines.append(f'{line_prefix}"{key}": {value_text}')
+
+        if not lines:
+            return ""
+
+        return ",\n" + ",\n".join(lines)
+
+    def _build_auth_identity_config(
+        self,
+        auth_identity: str,
+        default_identity: str,
+        auth_identity_map: dict = None,
+        indent: int = 6,
+    ):
+        fields = []
+        if auth_identity and auth_identity != default_identity:
+            fields.append((PropKey.AUTH_IDENTITY, auth_identity))
+
+        if auth_identity_map:
+            fields.append(("auth_identity_map", auth_identity_map))
+
+        return self._build_optional_json_fields(fields, indent)
+
+    @staticmethod
     def _get_client_cell_fqcn(client: Participant, ctx: ProvisionContext):
         ct = client.get_connect_to()
         if ct and ct.name:
@@ -167,6 +199,7 @@ class StaticFileBuilder(Builder):
         fed_learn_port = ctx.get(CtxKey.FED_LEARN_PORT)
         target = f"{server.name}:{fed_learn_port}"
         conn_sec = self._build_conn_properties(server, ctx)
+        server_auth_identity = self._get_auth_identity(server)
 
         ctx.build_from_template(
             dest_dir,
@@ -179,8 +212,12 @@ class StaticFileBuilder(Builder):
                 "admin_port": admin_port,
                 "scheme": self._determine_scheme(server),
                 "conn_sec": conn_sec,
-                "auth_identity": self._get_auth_identity(server),
-                "auth_identity_map": json.dumps(self._build_auth_identity_map(project, ctx), indent=16),
+                "auth_identity_config": self._build_auth_identity_config(
+                    auth_identity=server_auth_identity,
+                    default_identity=server.name,
+                    auth_identity_map=self._build_auth_identity_map(project, ctx),
+                    indent=12,
+                ),
             },
         )
 
@@ -303,6 +340,7 @@ class StaticFileBuilder(Builder):
         if conn_port:
             fl_port = conn_port
         target = f"{conn_host}:{fl_port}"
+        client_auth_identity = self._get_auth_identity(client)
 
         ctx.build_from_template(
             dest_dir,
@@ -316,8 +354,12 @@ class StaticFileBuilder(Builder):
                 "fqsn": client.get_prop(PropKey.FQSN),
                 "is_leaf": is_leaf,
                 "conn_sec": self._build_conn_properties(client, ctx),
-                "auth_identity": self._get_auth_identity(client),
-                "auth_identity_map": json.dumps(self._build_auth_identity_map(project, ctx), indent=8),
+                "auth_identity_config": self._build_auth_identity_config(
+                    auth_identity=client_auth_identity,
+                    default_identity=client.name,
+                    auth_identity_map=self._build_auth_identity_map(project, ctx),
+                    indent=6,
+                ),
             },
         )
 
@@ -450,7 +492,11 @@ class StaticFileBuilder(Builder):
             replacement_dict = {
                 "scheme": scheme,
                 "identity": relay.name,
-                "auth_identity": self._get_auth_identity(relay),
+                "auth_identity_config": self._build_auth_identity_config(
+                    auth_identity=self._get_auth_identity(relay),
+                    default_identity=relay.name,
+                    indent=6,
+                ),
                 "address": addr,
                 "fqcn": fqcn,
                 "conn_sec": conn_sec,
@@ -710,18 +756,27 @@ class StaticFileBuilder(Builder):
                     ctx.warning(f"the connect_to.host '{ct.host}' in relay {relay.name} may be invalid: {err}")
 
         parent_addr = f"{parent_host}:{parent_port}"
+        relay_auth_identity = self._get_auth_identity(relay)
         replacement_dict = {
             "project_name": project.name,
             "identity": relay.name,
-            "auth_identity": self._get_auth_identity(relay),
+            "auth_identity_config": self._build_auth_identity_config(
+                auth_identity=relay_auth_identity,
+                default_identity=relay.name,
+                auth_identity_map=self._build_auth_identity_map(project, ctx, relay),
+                indent=4,
+            ),
             "server_identity": self._get_auth_identity(server),
             "scheme": parent_scheme,
             "parent_identity": parent_identity,
-            "parent_auth_identity": parent_auth_identity,
+            "parent_auth_identity_config": self._build_auth_identity_config(
+                auth_identity=parent_auth_identity,
+                default_identity=parent_identity,
+                indent=6,
+            ),
             "address": parent_addr,
             "fqcn": parent_fqcn,
             "conn_sec": parent_conn_sec,
-            "auth_identity_map": json.dumps(self._build_auth_identity_map(project, ctx, relay), indent=8),
         }
 
         dest_dir = ctx.get_kit_dir(relay)

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -203,9 +203,7 @@ fed_client: |
       "ssl_root_cert": "rootCA.pem",
       "fqsn": "{~~fqsn~~}",
       "is_leaf": {~~is_leaf~~},
-      "connection_security": "{~~conn_sec~~}",
-      "auth_identity": "{~~auth_identity~~}",
-      "auth_identity_map": {~~auth_identity_map~~}
+      "connection_security": "{~~conn_sec~~}"{~~auth_identity_config~~}
     }
   }
 
@@ -437,9 +435,7 @@ fed_server: |
             "ssl_private_key": "server.key",
             "ssl_cert": "server.crt",
             "ssl_root_cert": "rootCA.pem",
-            "connection_security": "{~~conn_sec~~}",
-            "auth_identity": "{~~auth_identity~~}",
-            "auth_identity_map": {~~auth_identity_map~~}
+            "connection_security": "{~~conn_sec~~}"{~~auth_identity_config~~}
         }
     ]
   }
@@ -1244,8 +1240,7 @@ relay_resources_json: |
     "format_version": 2,
     "relay_config": {
       "scheme": "{~~scheme~~}",
-      "identity": "{~~identity~~}",
-      "auth_identity": "{~~auth_identity~~}",
+      "identity": "{~~identity~~}"{~~auth_identity_config~~},
       "address": "{~~address~~}",
       "fqcn": "{~~fqcn~~}",
       "connection_security": "{~~conn_sec~~}"
@@ -1256,14 +1251,11 @@ fed_relay: |
   {
     "format_version": 2,
     "project_name": "{~~project_name~~}",
-    "identity": "{~~identity~~}",
-    "auth_identity": "{~~auth_identity~~}",
-    "auth_identity_map": {~~auth_identity_map~~},
+    "identity": "{~~identity~~}"{~~auth_identity_config~~},
     "server_identity": "{~~server_identity~~}",
     "connect_to": {
       "scheme": "{~~scheme~~}",
-      "identity": "{~~parent_identity~~}",
-      "auth_identity": "{~~parent_auth_identity~~}",
+      "identity": "{~~parent_identity~~}"{~~parent_auth_identity_config~~},
       "address": "{~~address~~}",
       "fqcn": "{~~fqcn~~}",
       "connection_security": "{~~conn_sec~~}"

--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -203,7 +203,9 @@ fed_client: |
       "ssl_root_cert": "rootCA.pem",
       "fqsn": "{~~fqsn~~}",
       "is_leaf": {~~is_leaf~~},
-      "connection_security": "{~~conn_sec~~}"
+      "connection_security": "{~~conn_sec~~}",
+      "auth_identity": "{~~auth_identity~~}",
+      "auth_identity_map": {~~auth_identity_map~~}
     }
   }
 
@@ -435,7 +437,9 @@ fed_server: |
             "ssl_private_key": "server.key",
             "ssl_cert": "server.crt",
             "ssl_root_cert": "rootCA.pem",
-            "connection_security": "{~~conn_sec~~}"
+            "connection_security": "{~~conn_sec~~}",
+            "auth_identity": "{~~auth_identity~~}",
+            "auth_identity_map": {~~auth_identity_map~~}
         }
     ]
   }
@@ -1241,6 +1245,7 @@ relay_resources_json: |
     "relay_config": {
       "scheme": "{~~scheme~~}",
       "identity": "{~~identity~~}",
+      "auth_identity": "{~~auth_identity~~}",
       "address": "{~~address~~}",
       "fqcn": "{~~fqcn~~}",
       "connection_security": "{~~conn_sec~~}"
@@ -1252,10 +1257,13 @@ fed_relay: |
     "format_version": 2,
     "project_name": "{~~project_name~~}",
     "identity": "{~~identity~~}",
+    "auth_identity": "{~~auth_identity~~}",
+    "auth_identity_map": {~~auth_identity_map~~},
     "server_identity": "{~~server_identity~~}",
     "connect_to": {
       "scheme": "{~~scheme~~}",
       "identity": "{~~parent_identity~~}",
+      "auth_identity": "{~~parent_auth_identity~~}",
       "address": "{~~address~~}",
       "fqcn": "{~~fqcn~~}",
       "connection_security": "{~~conn_sec~~}"

--- a/nvflare/private/fed/app/fl_conf.py
+++ b/nvflare/private/fed/app/fl_conf.py
@@ -331,23 +331,29 @@ class FLClientStarterConfiger(JsonConfigurator):
         client = self.config_data["client"]
         client_auth_identity = client.get(ConnPropKey.AUTH_IDENTITY, client.get(ConnPropKey.IDENTITY, client_name))
         servers = self.config_data.get("servers", [])
-        server_identity = (
-            servers[0].get(ConnPropKey.AUTH_IDENTITY, servers[0].get(ConnPropKey.IDENTITY)) if servers else None
-        )
+        server = servers[0] if servers else {}
+        server_identity = server.get(ConnPropKey.AUTH_IDENTITY, server.get(ConnPropKey.IDENTITY))
+        service = server.get("service", {})
+        root_conn_security = client.get(ConnPropKey.CONNECTION_SECURITY)
+        root_conn_props = {
+            ConnPropKey.FQCN: FQCN.ROOT_SERVER,
+            ConnPropKey.IDENTITY: server_identity,
+            ConnPropKey.AUTH_IDENTITY: server_identity,
+            ConnPropKey.CONNECTION_SECURITY: root_conn_security,
+        }
+        root_scheme = service.get(ConnPropKey.SCHEME)
+        root_target = service.get("target")
+        if root_scheme and root_target:
+            root_conn_props[ConnPropKey.URL] = make_url(
+                root_scheme, root_target, root_conn_security != ConnectionSecurity.CLEAR
+            )
 
         if hasattr(self.args, "job_id") and self.args.job_id:
             # this is CJ
             sp_scheme = self.args.sp_scheme
             sp_target = self.args.sp_target
             root_url = f"{sp_scheme}://{sp_target}"
-            root_conn_props = {
-                ConnPropKey.FQCN: FQCN.ROOT_SERVER,
-                ConnPropKey.IDENTITY: server_identity,
-                ConnPropKey.AUTH_IDENTITY: server_identity,
-                ConnPropKey.URL: root_url,
-                ConnPropKey.CONNECTION_SECURITY: client.get(ConnPropKey.CONNECTION_SECURITY),
-            }
-            set_scope_property(client_name, ConnPropKey.ROOT_CONN_PROPS, root_conn_props)
+            root_conn_props[ConnPropKey.URL] = root_url
 
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
@@ -363,6 +369,7 @@ class FLClientStarterConfiger(JsonConfigurator):
                 ConnPropKey.IDENTITY: client_name,
                 ConnPropKey.AUTH_IDENTITY: client_auth_identity,
             }
+        set_scope_property(client_name, ConnPropKey.ROOT_CONN_PROPS, root_conn_props)
         set_scope_property(client_name, ConnPropKey.CP_CONN_PROPS, cp_conn_props)
 
     def start_config(self, config_ctx: ConfigContext):

--- a/nvflare/private/fed/app/fl_conf.py
+++ b/nvflare/private/fed/app/fl_conf.py
@@ -299,6 +299,7 @@ class FLClientStarterConfiger(JsonConfigurator):
         if relay_config:
             if relay_config:
                 relay_fqcn = relay_config.get(ConnPropKey.FQCN)
+                relay_identity = relay_config.get(ConnPropKey.IDENTITY)
                 scheme = relay_config.get(ConnPropKey.SCHEME)
                 addr = relay_config.get(ConnPropKey.ADDRESS)
                 relay_conn_security = relay_config.get(ConnPropKey.CONNECTION_SECURITY)
@@ -319,12 +320,15 @@ class FLClientStarterConfiger(JsonConfigurator):
         if relay_fqcn:
             relay_conn_props = {
                 ConnPropKey.FQCN: relay_fqcn,
+                ConnPropKey.IDENTITY: relay_identity,
                 ConnPropKey.URL: relay_url,
                 ConnPropKey.CONNECTION_SECURITY: relay_conn_security,
             }
             set_scope_property(client_name, ConnPropKey.RELAY_CONN_PROPS, relay_conn_props)
 
         client = self.config_data["client"]
+        servers = self.config_data.get("servers", [])
+        server_identity = servers[0].get(ConnPropKey.IDENTITY) if servers else None
 
         if hasattr(self.args, "job_id") and self.args.job_id:
             # this is CJ
@@ -333,6 +337,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             root_url = f"{sp_scheme}://{sp_target}"
             root_conn_props = {
                 ConnPropKey.FQCN: FQCN.ROOT_SERVER,
+                ConnPropKey.IDENTITY: server_identity,
                 ConnPropKey.URL: root_url,
                 ConnPropKey.CONNECTION_SECURITY: client.get(ConnPropKey.CONNECTION_SECURITY),
             }
@@ -340,6 +345,7 @@ class FLClientStarterConfiger(JsonConfigurator):
 
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
+                ConnPropKey.IDENTITY: client_name,
                 ConnPropKey.URL: self.args.parent_url,
                 ConnPropKey.CONNECTION_SECURITY: self.args.parent_conn_sec,
             }
@@ -347,6 +353,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             # this is CP
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
+                ConnPropKey.IDENTITY: client_name,
             }
         set_scope_property(client_name, ConnPropKey.CP_CONN_PROPS, cp_conn_props)
 

--- a/nvflare/private/fed/app/fl_conf.py
+++ b/nvflare/private/fed/app/fl_conf.py
@@ -300,6 +300,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             if relay_config:
                 relay_fqcn = relay_config.get(ConnPropKey.FQCN)
                 relay_identity = relay_config.get(ConnPropKey.IDENTITY)
+                relay_auth_identity = relay_config.get(ConnPropKey.AUTH_IDENTITY, relay_identity)
                 scheme = relay_config.get(ConnPropKey.SCHEME)
                 addr = relay_config.get(ConnPropKey.ADDRESS)
                 relay_conn_security = relay_config.get(ConnPropKey.CONNECTION_SECURITY)
@@ -321,14 +322,18 @@ class FLClientStarterConfiger(JsonConfigurator):
             relay_conn_props = {
                 ConnPropKey.FQCN: relay_fqcn,
                 ConnPropKey.IDENTITY: relay_identity,
+                ConnPropKey.AUTH_IDENTITY: relay_auth_identity,
                 ConnPropKey.URL: relay_url,
                 ConnPropKey.CONNECTION_SECURITY: relay_conn_security,
             }
             set_scope_property(client_name, ConnPropKey.RELAY_CONN_PROPS, relay_conn_props)
 
         client = self.config_data["client"]
+        client_auth_identity = client.get(ConnPropKey.AUTH_IDENTITY, client.get(ConnPropKey.IDENTITY, client_name))
         servers = self.config_data.get("servers", [])
-        server_identity = servers[0].get(ConnPropKey.IDENTITY) if servers else None
+        server_identity = (
+            servers[0].get(ConnPropKey.AUTH_IDENTITY, servers[0].get(ConnPropKey.IDENTITY)) if servers else None
+        )
 
         if hasattr(self.args, "job_id") and self.args.job_id:
             # this is CJ
@@ -338,6 +343,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             root_conn_props = {
                 ConnPropKey.FQCN: FQCN.ROOT_SERVER,
                 ConnPropKey.IDENTITY: server_identity,
+                ConnPropKey.AUTH_IDENTITY: server_identity,
                 ConnPropKey.URL: root_url,
                 ConnPropKey.CONNECTION_SECURITY: client.get(ConnPropKey.CONNECTION_SECURITY),
             }
@@ -346,6 +352,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
                 ConnPropKey.IDENTITY: client_name,
+                ConnPropKey.AUTH_IDENTITY: client_auth_identity,
                 ConnPropKey.URL: self.args.parent_url,
                 ConnPropKey.CONNECTION_SECURITY: self.args.parent_conn_sec,
             }
@@ -354,6 +361,7 @@ class FLClientStarterConfiger(JsonConfigurator):
             cp_conn_props = {
                 ConnPropKey.FQCN: cp_fqcn,
                 ConnPropKey.IDENTITY: client_name,
+                ConnPropKey.AUTH_IDENTITY: client_auth_identity,
             }
         set_scope_property(client_name, ConnPropKey.CP_CONN_PROPS, cp_conn_props)
 

--- a/nvflare/private/fed/app/relay/relay.py
+++ b/nvflare/private/fed/app/relay/relay.py
@@ -118,6 +118,13 @@ def main(args):
     if not parent_fqcn:
         raise RuntimeError(f"invalid relay config file {args.relay_config}: missing parent.fqcn")
 
+    parent_identity = parent.get(_ConfigKey.IDENTITY)
+    if not parent_identity:
+        if parent_fqcn == FQCN.ROOT_SERVER:
+            parent_identity = server_identity
+        else:
+            parent_identity = FQCN.split(parent_fqcn)[-1]
+
     cmd_vars = parse_vars(args.set)
     secure_train = cmd_vars.get("secure_train", False)
     logger.debug(f"{cmd_vars=} {secure_train=}")
@@ -164,6 +171,8 @@ def main(args):
         credentials=credentials,
         create_internal_listener=True,
         parent_url=parent_url,
+        auth_identity=my_identity,
+        auth_identity_map={parent_fqcn: parent_identity},
     )
     NetAgent(cell, agent_closed_cb=monitor.cellnet_stopped)
     cell.start()

--- a/nvflare/private/fed/app/relay/relay.py
+++ b/nvflare/private/fed/app/relay/relay.py
@@ -57,6 +57,8 @@ class _ConfigKey:
     PROJECT_NAME = "project_name"
     SERVER_IDENTITY = "server_identity"
     IDENTITY = "identity"
+    AUTH_IDENTITY = "auth_identity"
+    AUTH_IDENTITY_MAP = "auth_identity_map"
     CONNECT_TO = "connect_to"
 
 
@@ -102,6 +104,8 @@ def main(args):
     if not my_identity:
         raise RuntimeError(f"invalid relay config file {args.relay_config}: missing {_ConfigKey.IDENTITY}")
 
+    my_auth_identity = relay_config.get(_ConfigKey.AUTH_IDENTITY, my_identity)
+
     parent = relay_config.get(_ConfigKey.CONNECT_TO)
     if not parent:
         raise RuntimeError(f"invalid relay config file {args.relay_config}: missing {_ConfigKey.CONNECT_TO}")
@@ -118,12 +122,17 @@ def main(args):
     if not parent_fqcn:
         raise RuntimeError(f"invalid relay config file {args.relay_config}: missing parent.fqcn")
 
-    parent_identity = parent.get(_ConfigKey.IDENTITY)
+    parent_identity = parent.get(_ConfigKey.AUTH_IDENTITY, parent.get(_ConfigKey.IDENTITY))
     if not parent_identity:
         if parent_fqcn == FQCN.ROOT_SERVER:
             parent_identity = server_identity
         else:
             parent_identity = FQCN.split(parent_fqcn)[-1]
+
+    auth_identity_map = {parent_fqcn: parent_identity}
+    configured_identity_map = relay_config.get(_ConfigKey.AUTH_IDENTITY_MAP)
+    if configured_identity_map:
+        auth_identity_map.update(configured_identity_map)
 
     cmd_vars = parse_vars(args.set)
     secure_train = cmd_vars.get("secure_train", False)
@@ -171,8 +180,8 @@ def main(args):
         credentials=credentials,
         create_internal_listener=True,
         parent_url=parent_url,
-        auth_identity=my_identity,
-        auth_identity_map={parent_fqcn: parent_identity},
+        auth_identity=my_auth_identity,
+        auth_identity_map=auth_identity_map,
     )
     NetAgent(cell, agent_closed_cb=monitor.cellnet_stopped)
     cell.start()

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -164,6 +164,16 @@ class FederatedClientBase:
 
         cp_conn_props = get_scope_property(self.client_name, ConnPropKey.CP_CONN_PROPS)
         cp_fqcn = cp_conn_props.get(ConnPropKey.FQCN)
+        auth_identity_map = {cp_fqcn: self.client_name}
+        relay_identity = relay_conn_props.get(ConnPropKey.IDENTITY)
+        if relay_fqcn and relay_identity:
+            auth_identity_map[relay_fqcn] = relay_identity
+
+        root_conn_props = get_scope_property(self.client_name, ConnPropKey.ROOT_CONN_PROPS, {})
+        root_identity = root_conn_props.get(ConnPropKey.IDENTITY)
+        if root_identity:
+            auth_identity_map[FQCN.ROOT_SERVER] = root_identity
+
         parent_resources = None
         if self.args.job_id:
             # I am CJ
@@ -210,6 +220,8 @@ class FederatedClientBase:
             create_internal_listener=create_internal_listener,
             parent_url=parent_url,
             parent_resources=parent_resources,
+            auth_identity=self.client_name,
+            auth_identity_map=auth_identity_map,
         )
         self.cell.start()
         self.communicator.set_cell(self.cell)

--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -164,15 +164,20 @@ class FederatedClientBase:
 
         cp_conn_props = get_scope_property(self.client_name, ConnPropKey.CP_CONN_PROPS)
         cp_fqcn = cp_conn_props.get(ConnPropKey.FQCN)
-        auth_identity_map = {cp_fqcn: self.client_name}
-        relay_identity = relay_conn_props.get(ConnPropKey.IDENTITY)
+        client_auth_identity = cp_conn_props.get(ConnPropKey.AUTH_IDENTITY, self.client_name)
+        auth_identity_map = {cp_fqcn: client_auth_identity}
+        relay_identity = relay_conn_props.get(ConnPropKey.AUTH_IDENTITY, relay_conn_props.get(ConnPropKey.IDENTITY))
         if relay_fqcn and relay_identity:
             auth_identity_map[relay_fqcn] = relay_identity
 
         root_conn_props = get_scope_property(self.client_name, ConnPropKey.ROOT_CONN_PROPS, {})
-        root_identity = root_conn_props.get(ConnPropKey.IDENTITY)
+        root_identity = root_conn_props.get(ConnPropKey.AUTH_IDENTITY, root_conn_props.get(ConnPropKey.IDENTITY))
         if root_identity:
             auth_identity_map[FQCN.ROOT_SERVER] = root_identity
+
+        configured_identity_map = self.client_args.get(ConnPropKey.AUTH_IDENTITY_MAP)
+        if configured_identity_map:
+            auth_identity_map.update(configured_identity_map)
 
         parent_resources = None
         if self.args.job_id:
@@ -220,7 +225,7 @@ class FederatedClientBase:
             create_internal_listener=create_internal_listener,
             parent_url=parent_url,
             parent_resources=parent_resources,
-            auth_identity=self.client_name,
+            auth_identity=client_auth_identity,
             auth_identity_map=auth_identity_map,
         )
         self.cell.start()

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -181,6 +181,8 @@ class BaseServer(ABC):
             root_url.append(f"{scheme}://0:{admin_port}")
 
         my_fqcn = FQCN.ROOT_SERVER
+        auth_identity = grpc_args.get(ConnPropKey.AUTH_IDENTITY)
+        auth_identity_map = grpc_args.get(ConnPropKey.AUTH_IDENTITY_MAP)
         self.cell = Cell(
             fqcn=my_fqcn,
             root_url=root_url,
@@ -188,6 +190,8 @@ class BaseServer(ABC):
             credentials=credentials,
             create_internal_listener=True,
             parent_url=parent_url,
+            auth_identity=auth_identity,
+            auth_identity_map=auth_identity_map,
         )
 
         self.cell.start()
@@ -556,6 +560,8 @@ class FederatedServer(BaseServer):
         else:
             credentials = {}
 
+        auth_identity = server_config.get(ConnPropKey.AUTH_IDENTITY)
+        auth_identity_map = server_config.get(ConnPropKey.AUTH_IDENTITY_MAP)
         cell = Cell(
             fqcn=my_fqcn,
             root_url=root_url,
@@ -563,6 +569,8 @@ class FederatedServer(BaseServer):
             credentials=credentials,
             create_internal_listener=False,
             parent_url=parent_url,
+            auth_identity=auth_identity,
+            auth_identity_map=auth_identity_map,
         )
 
         cell.start()

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -49,6 +49,7 @@ from nvflare.fuel.f3.cellnet.core_cell import make_reply as make_cellnet_reply
 from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, MessageType
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo
+from nvflare.fuel.f3.cellnet.identity import ADMIN_LISTENER_KEY
 from nvflare.fuel.f3.cellnet.net_agent import NetAgent
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
@@ -176,9 +177,10 @@ class BaseServer(ABC):
         # get admin port
         admin_port = int(grpc_args.get("admin_port", fl_port))
 
-        root_url = [f"{scheme}://0:{fl_port}"]
+        admin_url = f"{scheme}://0:{admin_port}?{ADMIN_LISTENER_KEY}=true"
+        root_url = [admin_url if admin_port == fl_port else f"{scheme}://0:{fl_port}"]
         if admin_port != fl_port:
-            root_url.append(f"{scheme}://0:{admin_port}")
+            root_url.append(admin_url)
 
         my_fqcn = FQCN.ROOT_SERVER
         auth_identity = grpc_args.get(ConnPropKey.AUTH_IDENTITY)

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -1645,7 +1645,7 @@ def start_poc(cmd_args):
         output_error_message(
             "SERVICE_FAILED",
             message="POC service failed to start.",
-            hint=("If this was an admin console, start the POC server and clients first with 'nvflare poc start'."),
+            hint="Start the POC server and clients first with 'nvflare poc start'.",
             exit_code=2,
             detail=str(e),
         )
@@ -1898,10 +1898,7 @@ def _ensure_server_running_for_admin_console(project_config: Dict, service_confi
     fed_learn_port, _ = _get_poc_server_ports(project_config, service_config)
     port_available, _ = _is_local_port_available(fed_learn_port)
     if port_available:
-        raise PocServiceStartError(
-            f"server is not running at {POC_LOCAL_HOST}:{fed_learn_port}; "
-            "start server and client services first with 'nvflare poc start'"
-        )
+        raise PocServiceStartError(f"server is not running at {POC_LOCAL_HOST}:{fed_learn_port}")
 
 
 def setup_service_config(poc_workspace) -> Tuple:

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -1009,6 +1009,10 @@ class _PocDynamicProvisionLogger:
         pass
 
 
+class PocServiceStartError(RuntimeError):
+    """Raised when a foreground POC service exits with a failure status."""
+
+
 def _dynamic_poc_project_config(project_config: Dict, participant: Dict) -> Dict:
     dynamic_config = copy.deepcopy(project_config)
     participants = project_config.get("participants", [])
@@ -1637,6 +1641,15 @@ def start_poc(cmd_args):
     try:
         with _quiet_cli_streams(json_mode):
             _start_poc(poc_workspace, gpu_ids, excluded, services_list, study=study)
+    except PocServiceStartError as e:
+        output_error_message(
+            "SERVICE_FAILED",
+            message="POC service failed to start.",
+            hint=("If this was an admin console, start the POC server and clients first with 'nvflare poc start'."),
+            exit_code=2,
+            detail=str(e),
+        )
+        raise SystemExit(2)
     except CLIException as e:
         error_data = _build_poc_port_diagnostics(port_preflight) if json_mode else None
         output_error("INVALID_ARGS", exit_code=4, detail=str(e), data=error_data)
@@ -1844,6 +1857,7 @@ def _start_poc(poc_workspace: str, gpu_ids: List[int], excluded=None, services_l
 
     validate_services(project_config, services_list, excluded)
     validate_poc_workspace(poc_workspace, service_config, project_config)
+    _ensure_server_running_for_admin_console(project_config, service_config, services_list)
     _run_poc(
         SC.CMD_START,
         poc_workspace,
@@ -1866,6 +1880,28 @@ def validate_participants(participant_names, list_participants):
     for p in list_participants:
         if p not in participant_names:
             raise CLIException(f"participant '{p}' is not defined, expecting one of: {participant_names}")
+
+
+def _is_poc_admin_service(service_name: str, service_config: Dict) -> bool:
+    return service_name == service_config.get(SC.FLARE_PROJ_ADMIN) or service_name in service_config.get(
+        SC.FLARE_OTHER_ADMINS, []
+    )
+
+
+def _ensure_server_running_for_admin_console(project_config: Dict, service_config: Dict, services_list: List[str]):
+    if not services_list or not any(_is_poc_admin_service(service, service_config) for service in services_list):
+        return
+
+    if service_config.get(SC.FLARE_SERVER) in services_list:
+        return
+
+    fed_learn_port, _ = _get_poc_server_ports(project_config, service_config)
+    port_available, _ = _is_local_port_available(fed_learn_port)
+    if port_available:
+        raise PocServiceStartError(
+            f"server is not running at {POC_LOCAL_HOST}:{fed_learn_port}; "
+            "start server and client services first with 'nvflare poc start'"
+        )
 
 
 def setup_service_config(poc_workspace) -> Tuple:
@@ -2114,7 +2150,9 @@ def async_process(service_name, cmd_path, gpu_ids: Optional[List[int]], service_
 
 def sync_process(service_name, cmd_path):
     my_env = _env_with_cli_python_path()
-    subprocess.run(cmd_path.split(" "), env=my_env)
+    completed = subprocess.run(cmd_path.split(" "), env=my_env)
+    if completed.returncode != 0:
+        raise PocServiceStartError(f"service '{service_name}' exited with code {completed.returncode}: {cmd_path}")
 
 
 def _run_poc(

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -2050,14 +2050,21 @@ def _build_commands(
     return _sort_service_cmds(cmd_type, service_commands, service_config)
 
 
+def _env_with_cli_python_path() -> Dict[str, str]:
+    my_env = os.environ.copy()
+    python_dir = os.path.dirname(sys.executable)
+    if python_dir:
+        path = my_env.get("PATH", "")
+        my_env["PATH"] = os.pathsep.join([python_dir, path]) if path else python_dir
+    return my_env
+
+
 def prepare_env(service_name, gpu_ids: Optional[List[int]], service_config: Dict):
-    my_env = None
+    my_env = _env_with_cli_python_path()
     if gpu_ids:
-        my_env = os.environ.copy()
         my_env["CUDA_VISIBLE_DEVICES"] = ",".join([str(gid) for gid in gpu_ids])
 
     if service_config.get(SC.IS_DOCKER_RUN):
-        my_env = os.environ.copy() if my_env is None else my_env
         if gpu_ids:
             my_env["GPU2USE"] = f'--gpus="device={my_env["CUDA_VISIBLE_DEVICES"]}"'
 
@@ -2106,7 +2113,7 @@ def async_process(service_name, cmd_path, gpu_ids: Optional[List[int]], service_
 
 
 def sync_process(service_name, cmd_path):
-    my_env = os.environ.copy()
+    my_env = _env_with_cli_python_path()
     subprocess.run(cmd_path.split(" "), env=my_env)
 
 

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -36,11 +36,11 @@ from nvflare.fuel.utils.constants import Mode
 
 
 class _FakeConnection:
-    def __init__(self, peer_cn, conn_security=ConnectionSecurity.MTLS):
+    def __init__(self, peer_cn, conn_security=ConnectionSecurity.MTLS, mode=Mode.PASSIVE):
         self.name = "CN-test"
         self.closed = False
         self.connector = SimpleNamespace(
-            mode=Mode.ACTIVE,
+            mode=mode,
             params={
                 DriverParams.SECURE: True,
                 DriverParams.CONNECTION_SECURITY: conn_security,
@@ -91,6 +91,13 @@ def test_identity_resolver_maps_relay_child_to_child_identity_without_configured
     assert resolver.resolve("relay-1.site-1") == "site-1"
 
 
+def test_identity_resolver_rejects_unresolvable_endpoint_identity():
+    resolver = CellIdentityResolver(local_fqcn="server")
+
+    with pytest.raises(ValueError, match="does not resolve"):
+        resolver.require_match(".", "site-1", "connection test")
+
+
 def test_mtls_handshake_accepts_job_cell_with_parent_cert_identity():
     manager = _conn_manager(identity_map={"site-1": "site-1"})
     conn = _FakeConnection(peer_cn="site-1")
@@ -137,6 +144,22 @@ def test_tls_handshake_does_not_enforce_peer_identity():
     assert not conn.closed
 
 
+@pytest.mark.parametrize("peer_cn", [None, "N/A"])
+def test_mtls_active_connection_without_peer_cn_is_accepted(peer_cn):
+    # On the active (connecting) side, some drivers (e.g. gRPC) do not expose the
+    # peer CN (it is None or "N/A"). Enforcement must be skipped there so the
+    # connecting peer can register the endpoint it dialed out to; otherwise the
+    # default gRPC mTLS client->server handshake would always be rejected.
+    manager = _conn_manager(local_fqcn="site-1", identity_map={"server": "server"})
+    conn = _FakeConnection(peer_cn=peer_cn, mode=Mode.ACTIVE)
+    sfm_conn = SfmConnection(conn, Endpoint("site-1"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "server"})
+
+    assert "server" in manager.sfm_endpoints
+    assert not conn.closed
+
+
 def test_mtls_certificate_cache_rejects_cert_identity_mismatch():
     resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
     manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
@@ -175,3 +198,24 @@ def test_mtls_certificate_cache_accepts_configured_auth_identity_for_site_cert_c
 
     assert manager.process_response(message) == cert
     assert manager.cert_cache["site-1.job-123"] == cert
+
+
+def test_certificate_cache_access_uses_lock():
+    class _TrackingLock:
+        def __init__(self):
+            self.enter_count = 0
+
+        def __enter__(self):
+            self.enter_count += 1
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            pass
+
+    manager = CredentialManager(Endpoint("server"))
+    manager.cell_cipher = object()
+    manager.lock = _TrackingLock()
+    cert = _cert_pem("site-1")
+
+    manager._cache_cert("site-1", cert)
+    assert manager.get_certificate("site-1") == cert
+    assert manager.lock.enter_count == 2

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -197,6 +197,19 @@ def test_mtls_active_connection_without_peer_cn_is_accepted(peer_cn):
     assert not conn.closed
 
 
+def test_mtls_active_connection_with_peer_cn_enforces_endpoint_identity():
+    manager = _conn_manager(local_fqcn="site-1", identity_map={"server": "server"})
+    conn = _FakeConnection(peer_cn="attacker", mode=Mode.ACTIVE)
+    sfm_conn = SfmConnection(conn, Endpoint("site-1"))
+
+    with pytest.raises(CommError) as ex:
+        manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "server"})
+
+    assert ex.value.code == CommError.BAD_DATA
+    assert "server" not in manager.sfm_endpoints
+    assert conn.closed
+
+
 def test_mtls_certificate_cache_rejects_cert_identity_mismatch():
     resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
     manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -119,6 +119,22 @@ def test_identity_resolver_rejects_unresolvable_endpoint_identity():
         resolver.require_match(".", "site-1", "connection test")
 
 
+def test_identity_resolver_accepts_authenticated_admin_client_identity():
+    resolver = CellIdentityResolver(local_fqcn="server")
+
+    resolver.require_match("_admin_9af49fef-235f-41bd-9296-12fd09eacb2a", "admin@nvidia.com", "connection admin")
+
+
+def test_identity_resolver_rejects_admin_like_endpoint_without_authenticated_identity():
+    resolver = CellIdentityResolver(local_fqcn="server")
+
+    with pytest.raises(ValueError, match="authenticated mTLS peer common name"):
+        resolver.require_match("_admin_9af49fef-235f-41bd-9296-12fd09eacb2a", None, "connection admin")
+
+    with pytest.raises(ValueError, match="requires identity"):
+        resolver.require_match("_admin_not-a-uuid", "admin@nvidia.com", "connection admin")
+
+
 def test_mtls_handshake_accepts_job_cell_with_parent_cert_identity():
     manager = _conn_manager(identity_map={"site-1": "site-1"})
     conn = _FakeConnection(peer_cn="site-1")

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -102,6 +102,17 @@ def test_mtls_handshake_accepts_job_cell_with_parent_cert_identity():
     assert not conn.closed
 
 
+def test_mtls_handshake_accepts_configured_auth_identity_for_site_cert_cn_mismatch():
+    manager = _conn_manager(identity_map={"site-1": "custom-site-cn"})
+    conn = _FakeConnection(peer_cn="custom-site-cn")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert "site-1.job-123" in manager.sfm_endpoints
+    assert not conn.closed
+
+
 def test_mtls_handshake_rejects_spoofed_endpoint_identity():
     manager = _conn_manager(identity_map={"site-1": "site-1"})
     conn = _FakeConnection(peer_cn="attacker")
@@ -144,6 +155,19 @@ def test_mtls_certificate_cache_accepts_job_cell_parent_cert_identity():
     resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
     manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
     cert = _cert_pem("site-1")
+    message = Message(
+        headers={MessageHeaderKey.ORIGIN: "site-1.job-123"},
+        payload={CERT_CONTENT: cert},
+    )
+
+    assert manager.process_response(message) == cert
+    assert manager.cert_cache["site-1.job-123"] == cert
+
+
+def test_mtls_certificate_cache_accepts_configured_auth_identity_for_site_cert_cn_mismatch():
+    resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "custom-site-cn"})
+    manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
+    cert = _cert_pem("custom-site-cn")
     message = Message(
         headers={MessageHeaderKey.ORIGIN: "site-1.job-123"},
         payload={CERT_CONTENT: cert},

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -91,6 +91,27 @@ def test_identity_resolver_maps_relay_child_to_child_identity_without_configured
     assert resolver.resolve("relay-1.site-1") == "site-1"
 
 
+def test_identity_resolver_maps_nested_relay_child_to_child_identity_despite_parent_prefix():
+    resolver = CellIdentityResolver(local_fqcn="relay-1.relay-2", prefix_identity_map={"relay-1": "relay-1"})
+
+    assert resolver.resolve("relay-1.relay-2.relay-3") == "relay-3"
+    resolver.require_match("relay-1.relay-2.relay-3", "relay-3", "connection relay-3")
+    with pytest.raises(ValueError, match="relay-1"):
+        resolver.require_match("relay-1.relay-2.relay-3", "relay-1", "connection relay-3")
+
+
+def test_identity_resolver_uses_configured_identity_for_nested_relay_child():
+    resolver = CellIdentityResolver(
+        local_fqcn="relay-1.relay-2",
+        prefix_identity_map={
+            "relay-1": "relay-1",
+            "relay-1.relay-2.relay-3": "custom-relay-3",
+        },
+    )
+
+    assert resolver.resolve("relay-1.relay-2.relay-3") == "custom-relay-3"
+
+
 def test_identity_resolver_rejects_unresolvable_endpoint_identity():
     resolver = CellIdentityResolver(local_fqcn="server")
 

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.fuel.f3.cellnet.credential_manager import CERT_CONTENT, CredentialManager
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
+from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+from nvflare.fuel.f3.endpoint import Endpoint
+from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.sfm.conn_manager import ConnManager
+from nvflare.fuel.f3.sfm.constants import HandshakeKeys
+from nvflare.fuel.f3.sfm.sfm_conn import SfmConnection
+from nvflare.fuel.utils.constants import Mode
+
+
+class _FakeConnection:
+    def __init__(self, peer_cn, conn_security=ConnectionSecurity.MTLS):
+        self.name = "CN-test"
+        self.closed = False
+        self.connector = SimpleNamespace(
+            mode=Mode.ACTIVE,
+            params={
+                DriverParams.SECURE: True,
+                DriverParams.CONNECTION_SECURITY: conn_security,
+            },
+        )
+        self.conn_props = {}
+        if peer_cn is not None:
+            self.conn_props[DriverParams.PEER_CN.value] = peer_cn
+
+    def get_conn_properties(self):
+        return self.conn_props
+
+    def close(self):
+        self.closed = True
+
+
+def _cert_pem(common_name: str):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _conn_manager(local_fqcn="server", identity_map=None):
+    resolver = CellIdentityResolver(local_fqcn=local_fqcn, prefix_identity_map=identity_map)
+    return ConnManager(Endpoint(local_fqcn), identity_resolver=resolver)
+
+
+def test_identity_resolver_maps_job_cell_to_configured_parent_identity():
+    resolver = CellIdentityResolver(local_fqcn="site-1", prefix_identity_map={"site-1": "site-1"})
+
+    assert resolver.resolve("site-1.job-123") == "site-1"
+
+
+def test_identity_resolver_maps_relay_child_to_child_identity_without_configured_prefix():
+    resolver = CellIdentityResolver(local_fqcn="relay-1", exact_identity_map={"relay-1": "relay-1"})
+
+    assert resolver.resolve("relay-1.site-1") == "site-1"
+
+
+def test_mtls_handshake_accepts_job_cell_with_parent_cert_identity():
+    manager = _conn_manager(identity_map={"site-1": "site-1"})
+    conn = _FakeConnection(peer_cn="site-1")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert "site-1.job-123" in manager.sfm_endpoints
+    assert not conn.closed
+
+
+def test_mtls_handshake_rejects_spoofed_endpoint_identity():
+    manager = _conn_manager(identity_map={"site-1": "site-1"})
+    conn = _FakeConnection(peer_cn="attacker")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    with pytest.raises(CommError) as ex:
+        manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert ex.value.code == CommError.BAD_DATA
+    assert "site-1.job-123" not in manager.sfm_endpoints
+    assert conn.closed
+
+
+def test_tls_handshake_does_not_enforce_peer_identity():
+    manager = _conn_manager(identity_map={"site-1": "site-1"})
+    conn = _FakeConnection(peer_cn=None, conn_security=ConnectionSecurity.TLS)
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "site-1.job-123"})
+
+    assert "site-1.job-123" in manager.sfm_endpoints
+    assert not conn.closed
+
+
+def test_mtls_certificate_cache_rejects_cert_identity_mismatch():
+    resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
+    manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
+    message = Message(
+        headers={MessageHeaderKey.ORIGIN: "site-1.job-123"},
+        payload={CERT_CONTENT: _cert_pem("attacker")},
+    )
+
+    with pytest.raises(RuntimeError, match="attacker"):
+        manager.process_response(message)
+
+    assert "site-1.job-123" not in manager.cert_cache
+
+
+def test_mtls_certificate_cache_accepts_job_cell_parent_cert_identity():
+    resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
+    manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
+    cert = _cert_pem("site-1")
+    message = Message(
+        headers={MessageHeaderKey.ORIGIN: "site-1.job-123"},
+        payload={CERT_CONTENT: cert},
+    )
+
+    assert manager.process_response(message) == cert
+    assert manager.cert_cache["site-1.job-123"] == cert

--- a/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/identity_binding_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -22,9 +23,11 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.fuel.f3.cellnet.core_cell import CoreCell
 from nvflare.fuel.f3.cellnet.credential_manager import CERT_CONTENT, CredentialManager
-from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
-from nvflare.fuel.f3.cellnet.identity import CellIdentityResolver
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessageType, ReturnCode
+from nvflare.fuel.f3.cellnet.identity import ADMIN_LISTENER_KEY, CellIdentityResolver
+from nvflare.fuel.f3.cellnet.utils import make_reply
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.endpoint import Endpoint
@@ -36,7 +39,7 @@ from nvflare.fuel.utils.constants import Mode
 
 
 class _FakeConnection:
-    def __init__(self, peer_cn, conn_security=ConnectionSecurity.MTLS, mode=Mode.PASSIVE):
+    def __init__(self, peer_cn, conn_security=ConnectionSecurity.MTLS, mode=Mode.PASSIVE, admin_listener=False):
         self.name = "CN-test"
         self.closed = False
         self.connector = SimpleNamespace(
@@ -46,6 +49,8 @@ class _FakeConnection:
                 DriverParams.CONNECTION_SECURITY: conn_security,
             },
         )
+        if admin_listener:
+            self.connector.params[ADMIN_LISTENER_KEY] = "true"
         self.conn_props = {}
         if peer_cn is not None:
             self.conn_props[DriverParams.PEER_CN.value] = peer_cn
@@ -77,6 +82,36 @@ def _cert_pem(common_name: str):
 def _conn_manager(local_fqcn="server", identity_map=None):
     resolver = CellIdentityResolver(local_fqcn=local_fqcn, prefix_identity_map=identity_map)
     return ConnManager(Endpoint(local_fqcn), identity_resolver=resolver)
+
+
+class _NoOpStats:
+    def increment(self, *args, **kwargs):
+        pass
+
+    def record_value(self, *args, **kwargs):
+        pass
+
+
+class _EmptyRegistry:
+    def find(self, *args, **kwargs):
+        return None
+
+
+def _receive_test_core_cell(reply):
+    cell = CoreCell.__new__(CoreCell)
+    cell.my_info = SimpleNamespace(fqcn="server")
+    cell.logger = logging.getLogger(__name__)
+    cell.received_msg_counter_pool = _NoOpStats()
+    cell.sent_msg_counter_pool = _NoOpStats()
+    cell.received_msg_size_pool = _NoOpStats()
+    cell.msg_travel_stats_pool = _NoOpStats()
+    cell.in_filter_reg = _EmptyRegistry()
+    cell.out_reply_filter_reg = _EmptyRegistry()
+    cell.message_interceptor = None
+    cell.sent_reply = None
+    cell._process_request = lambda origin, message: reply
+    cell._send_reply = lambda reply, endpoint: setattr(cell, "sent_reply", reply)
+    return cell
 
 
 def test_identity_resolver_maps_job_cell_to_configured_parent_identity():
@@ -170,6 +205,43 @@ def test_mtls_handshake_rejects_spoofed_endpoint_identity():
     assert conn.closed
 
 
+def test_mtls_handshake_rejects_invalid_endpoint_fqcn():
+    manager = _conn_manager(identity_map={"server": "server"})
+    conn = _FakeConnection(peer_cn="server")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    with pytest.raises(CommError) as ex:
+        manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "server."})
+
+    assert ex.value.code == CommError.BAD_DATA
+    assert "server." not in manager.sfm_endpoints
+    assert conn.closed
+
+
+def test_mtls_handshake_rejects_admin_endpoint_on_non_admin_listener():
+    manager = _conn_manager()
+    conn = _FakeConnection(peer_cn="admin@nvidia.com")
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    with pytest.raises(CommError) as ex:
+        manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "_admin_9af49fef-235f-41bd-9296-12fd09eacb2a"})
+
+    assert ex.value.code == CommError.BAD_DATA
+    assert "_admin_9af49fef-235f-41bd-9296-12fd09eacb2a" not in manager.sfm_endpoints
+    assert conn.closed
+
+
+def test_mtls_handshake_accepts_admin_endpoint_on_admin_listener():
+    manager = _conn_manager()
+    conn = _FakeConnection(peer_cn="admin@nvidia.com", admin_listener=True)
+    sfm_conn = SfmConnection(conn, Endpoint("server"))
+
+    manager.update_endpoint(sfm_conn, {HandshakeKeys.ENDPOINT_NAME: "_admin_9af49fef-235f-41bd-9296-12fd09eacb2a"})
+
+    assert "_admin_9af49fef-235f-41bd-9296-12fd09eacb2a" in manager.sfm_endpoints
+    assert not conn.closed
+
+
 def test_tls_handshake_does_not_enforce_peer_identity():
     manager = _conn_manager(identity_map={"site-1": "site-1"})
     conn = _FakeConnection(peer_cn=None, conn_security=ConnectionSecurity.TLS)
@@ -224,6 +296,25 @@ def test_mtls_certificate_cache_rejects_cert_identity_mismatch():
     assert "site-1.job-123" not in manager.cert_cache
 
 
+def test_mtls_certificate_request_rejects_spoofed_origin_identity():
+    resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
+    manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
+    manager.local_cert = _cert_pem("server")
+    manager.ca_cert = manager.local_cert
+    message = Message(
+        headers={
+            MessageHeaderKey.ORIGIN: "site-1.job-123",
+            MessageHeaderKey.DESTINATION: "server",
+        },
+        payload={CERT_CONTENT: _cert_pem("attacker")},
+    )
+
+    with pytest.raises(RuntimeError, match="attacker"):
+        manager.process_request(message)
+
+    assert "site-1.job-123" not in manager.cert_cache
+
+
 def test_mtls_certificate_cache_accepts_job_cell_parent_cert_identity():
     resolver = CellIdentityResolver(local_fqcn="server", prefix_identity_map={"site-1": "site-1"})
     manager = CredentialManager(Endpoint("server"), identity_resolver=resolver, enforce_identity=True)
@@ -269,3 +360,26 @@ def test_certificate_cache_access_uses_lock():
     manager._cache_cert("site-1", cert)
     assert manager.get_certificate("site-1") == cert
     assert manager.lock.enter_count == 2
+
+
+def test_failed_certificate_exchange_request_closes_connection_after_reply():
+    cell = _receive_test_core_cell(make_reply(ReturnCode.PROCESS_EXCEPTION))
+    conn = _FakeConnection(peer_cn="site-1")
+    message = Message(
+        headers={
+            MessageHeaderKey.MSG_TYPE: MessageType.REQ,
+            MessageHeaderKey.ORIGIN: "site-1",
+            MessageHeaderKey.DESTINATION: "server",
+            MessageHeaderKey.FROM_CELL: "site-1",
+            MessageHeaderKey.TO_CELL: "server",
+            MessageHeaderKey.CHANNEL: "credential_manager",
+            MessageHeaderKey.TOPIC: "key_exchange",
+            MessageHeaderKey.REPLY_EXPECTED: True,
+            MessageHeaderKey.REQ_ID: "req-1",
+        }
+    )
+
+    CoreCell._process_received_msg(cell, Endpoint("site-1"), conn, message)
+
+    assert cell.sent_reply is not None
+    assert conn.closed

--- a/tests/unit_test/fuel/f3/communicator_test.py
+++ b/tests/unit_test/fuel/f3/communicator_test.py
@@ -28,8 +28,8 @@ from nvflare.fuel.f3.message import Message, MessageReceiver
 log = logging.getLogger(__name__)
 
 APP_ID = 123
-NODE_A = "Communicator A"
-NODE_B = "Communicator B"
+NODE_A = "communicator-a"
+NODE_B = "communicator-b"
 MESSAGE_FROM_A = "Test message from a"
 MESSAGE_FROM_B = "Test message from b"
 

--- a/tests/unit_test/fuel/log_utils_dynamic_config_test.py
+++ b/tests/unit_test/fuel/log_utils_dynamic_config_test.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import json
+import logging
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -49,6 +52,33 @@ def test_log_modes_preserve_concise_and_add_msg_only():
         "%(asctime)s - %(levelname)s - %(message)s"
     )
     assert logmode_config_dict[LogMode.MSG_ONLY]["formatters"]["consoleFormatter"]["fmt"] == "%(message)s"
+
+
+def test_color_formatter_omits_ansi_when_stdout_is_not_tty(monkeypatch):
+    from nvflare.fuel.utils.log_utils import ColorFormatter
+
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    formatter = ColorFormatter("%(message)s")
+    record = logging.LogRecord("nvflare.test", logging.INFO, __file__, 1, "hello", (), None)
+
+    assert formatter.format(record) == "hello"
+
+
+def test_color_formatter_emits_ansi_when_stdout_is_tty(monkeypatch):
+    from nvflare.fuel.utils.log_utils import ColorFormatter
+
+    class TTYStringIO(io.StringIO):
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(sys, "stdout", TTYStringIO())
+    formatter = ColorFormatter("%(message)s")
+    record = logging.LogRecord("nvflare.test", logging.INFO, __file__, 1, "hello", (), None)
+
+    formatted = formatter.format(record)
+    assert formatted.startswith("\x1b[")
+    assert formatted.endswith("\x1b[0m")
+    assert "hello" in formatted
 
 
 def test_validate_site_log_config_accepts_levels_and_modes():

--- a/tests/unit_test/lighter/poc_commands_test.py
+++ b/tests/unit_test/lighter/poc_commands_test.py
@@ -110,6 +110,28 @@ class TestPOCCommands:
 
         assert my_env["PATH"].split(os.pathsep)[0] == os.path.dirname(sys.executable)
 
+    def test_start_poc_admin_only_requires_running_server(self, monkeypatch, tmp_path):
+        project_config = {
+            "participants": [
+                {"name": "server", "type": "server", "fed_learn_port": 8002},
+                {"name": "admin@nvidia.com", "type": "admin"},
+                {"name": "site-1", "type": "client"},
+            ]
+        }
+        service_config = {
+            SC.FLARE_SERVER: "server",
+            SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+            SC.FLARE_OTHER_ADMINS: [],
+            SC.FLARE_CLIENTS: ["site-1"],
+        }
+        monkeypatch.setattr(poc_commands, "setup_service_config", lambda _workspace: (project_config, service_config))
+        monkeypatch.setattr(poc_commands, "validate_poc_workspace", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(poc_commands, "_is_local_port_available", lambda _port: (True, None))
+        monkeypatch.setattr(poc_commands, "_run_poc", lambda *_args, **_kwargs: None)
+
+        with pytest.raises(poc_commands.PocServiceStartError, match="server is not running"):
+            poc_commands._start_poc(str(tmp_path), [], services_list=["admin@nvidia.com"])
+
     def test_get_package_command(self):
         cmd = get_service_command(SC.CMD_START, "/tmp/nvflare/poc", SC.FLARE_SERVER, {})
         assert "/tmp/nvflare/poc/server/startup/start.sh" == cmd

--- a/tests/unit_test/lighter/poc_commands_test.py
+++ b/tests/unit_test/lighter/poc_commands_test.py
@@ -15,6 +15,7 @@ import collections
 import copy
 import json
 import os
+import sys
 
 import pytest
 import yaml
@@ -102,6 +103,12 @@ class TestPOCCommands:
         assert my_env["CUDA_VISIBLE_DEVICES"] == "0"
         assert "GPU2USE" not in my_env
         assert "SVR_NAME" not in my_env
+
+    def test_prepare_env_prefers_cli_python_dir(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/usr/bin")
+        my_env = prepare_env("site-1", [], {})
+
+        assert my_env["PATH"].split(os.pathsep)[0] == os.path.dirname(sys.executable)
 
     def test_get_package_command(self):
         cmd = get_service_command(SC.CMD_START, "/tmp/nvflare/poc", SC.FLARE_SERVER, {})

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -141,6 +141,34 @@ class TestStaticFileBuilder:
         registry_path = tmp_path / server.name / "local" / "study_registry.json"
         assert not registry_path.exists()
 
+    def test_auth_identity_config_omits_default_identity_fields(self):
+        builder = StaticFileBuilder()
+
+        assert builder._build_auth_identity_config(auth_identity="site-1", default_identity="site-1") == ""
+
+    def test_auth_identity_config_emits_custom_identity_fields_as_valid_json(self):
+        builder = StaticFileBuilder()
+
+        fragment = builder._build_auth_identity_config(
+            auth_identity="custom-site-cn",
+            default_identity="site-1",
+            auth_identity_map={"site-2": "custom-site-2-cn"},
+            indent=6,
+        )
+        config_text = "\n".join(
+            [
+                "{",
+                '  "client": {',
+                '      "connection_security": "mtls"' + fragment,
+                "  }",
+                "}",
+            ]
+        )
+        config = json.loads(config_text)
+
+        assert config["client"]["auth_identity"] == "custom-site-cn"
+        assert config["client"]["auth_identity_map"] == {"site-2": "custom-site-2-cn"}
+
     def test_master_template_moves_user_config_runtime_workspace(self):
         """CC startup kits live in plaintext /user_config, so runtime artifacts must not default there."""
         template = _load_master_template()

--- a/tests/unit_test/private/fed/app/fl_conf_test.py
+++ b/tests/unit_test/private/fed/app/fl_conf_test.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from nvflare.apis.fl_constant import ConnectionSecurity, ConnPropKey
+from nvflare.fuel.data_event.data_bus import DataBus
+from nvflare.fuel.data_event.utils import get_scope_property
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.private.fed.app.fl_conf import FLClientStarterConfiger
+
+
+@pytest.fixture(autouse=True)
+def clear_data_bus():
+    DataBus().data_store.clear()
+    yield
+    DataBus().data_store.clear()
+
+
+def test_cp_conn_props_include_root_auth_identity():
+    configer = FLClientStarterConfiger.__new__(FLClientStarterConfiger)
+    configer.args = SimpleNamespace()
+    configer.logger = logging.getLogger(__name__)
+    configer.config_data = {
+        "servers": [
+            {
+                "service": {
+                    "scheme": "grpc",
+                    "target": "server.example.com:8002",
+                },
+                ConnPropKey.IDENTITY: FQCN.ROOT_SERVER,
+                ConnPropKey.AUTH_IDENTITY: "custom-server-cn",
+            }
+        ],
+        "client": {
+            ConnPropKey.IDENTITY: "site-1",
+            ConnPropKey.AUTH_IDENTITY: "custom-site-cn",
+            ConnPropKey.CONNECTION_SECURITY: ConnectionSecurity.MTLS,
+        },
+    }
+
+    configer._determine_conn_props("site-1", configer.config_data)
+
+    root_conn_props = get_scope_property("site-1", ConnPropKey.ROOT_CONN_PROPS)
+    assert root_conn_props == {
+        ConnPropKey.FQCN: FQCN.ROOT_SERVER,
+        ConnPropKey.IDENTITY: "custom-server-cn",
+        ConnPropKey.AUTH_IDENTITY: "custom-server-cn",
+        ConnPropKey.CONNECTION_SECURITY: ConnectionSecurity.MTLS,
+        ConnPropKey.URL: "grpcs://server.example.com:8002",
+    }
+
+    cp_conn_props = get_scope_property("site-1", ConnPropKey.CP_CONN_PROPS)
+    assert cp_conn_props[ConnPropKey.AUTH_IDENTITY] == "custom-site-cn"

--- a/tests/unit_test/tool/package/package_commands_test.py
+++ b/tests/unit_test/tool/package/package_commands_test.py
@@ -1098,6 +1098,8 @@ class TestClientKitAssembly:
         assert cfg["servers"][0]["service"]["scheme"] == "grpc"
         assert cfg["client"]["fqsn"] == "hospital-1"
         assert cfg["servers"][0]["service"]["target"] == "server.example.com:8002"
+        assert "auth_identity" not in cfg["client"]
+        assert "auth_identity_map" not in cfg["client"]
 
     def test_dir_mode_auto_discovery(self, cert_env, tmp_path):
         work = tmp_path / "work"

--- a/tests/unit_test/tool/poc/poc_output_test.py
+++ b/tests/unit_test/tool/poc/poc_output_test.py
@@ -1101,6 +1101,46 @@ class TestPocOutput:
         assert data["exit_code"] == 2
         assert "--no-wait" in data["hint"]
 
+    def test_start_poc_service_failure_exits_service_failed(self, capsys, tmp_path):
+        from nvflare.tool.poc.poc_commands import PocServiceStartError, start_poc
+        from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
+
+        args = MagicMock()
+        args.service = "admin@nvidia.com"
+        args.exclude = ""
+        args.gpu = None
+        args.study = None
+        args.no_wait = False
+
+        project_config = {"participants": [{"name": "server", "type": "server"}, {"name": "site-1", "type": "client"}]}
+        service_config = {
+            SC.FLARE_SERVER: "server",
+            SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+            SC.FLARE_CLIENTS: ["site-1"],
+        }
+
+        with (
+            patch("nvflare.tool.poc.poc_commands.get_poc_workspace", return_value=str(tmp_path)),
+            patch("nvflare.tool.poc.poc_commands.get_service_list", return_value=["admin@nvidia.com"]),
+            patch("nvflare.tool.poc.poc_commands.get_excluded", return_value=[]),
+            patch("nvflare.tool.poc.poc_commands.get_gpis", return_value=[]),
+            patch(
+                "nvflare.tool.poc.poc_commands._start_poc",
+                side_effect=PocServiceStartError("service 'admin@nvidia.com' exited with code 1"),
+            ),
+            patch("nvflare.tool.poc.poc_commands.setup_service_config", return_value=(project_config, service_config)),
+            patch("nvflare.tool.poc.poc_commands._is_local_port_available", return_value=(True, None)),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                start_poc(args)
+
+        assert exc_info.value.code == 2
+        data = json.loads(capsys.readouterr().out)
+        assert data["error_code"] == "SERVICE_FAILED"
+        assert data["exit_code"] == 2
+        assert "nvflare poc start" in data["hint"]
+        assert "admin@nvidia.com" in data["message"]
+
     def test_wait_for_poc_system_ready_wraps_unexpected_wait_errors(self, tmp_path):
         from nvflare.tool.api_utils import SystemStartTimeout
         from nvflare.tool.poc.poc_commands import _wait_for_poc_system_ready


### PR DESCRIPTION
## Summary

Bind CellNet endpoint names to the authenticated mTLS peer certificate identity so a peer cannot claim another `endpoint_name` during SFM handshake or certificate exchange.

This adds a CellNet identity resolver that supports exact FQCN identities, configured prefix identities, local child identity inference, and the job-cell case where the endpoint is `site-1.<job_id>` but the certificate identity remains `site-1`.

It also adds explicit config support for deployments where a site certificate CN intentionally differs from the endpoint/FQCN: use `auth_identity` for the local cert CN and `auth_identity_map` for remote FQCN/prefix to expected cert CN mappings. Existing `identity` values remain the fallback for compatibility. Redundant identity-map entries are omitted when the resolver already derives the same expected CN.

Follow-up POC changes improve local startup behavior: POC services launch with the active `nvflare` CLI Python, optional admin-console startup reports service failures without repeated connection spam, authenticated admin connections are allowed for the console, and redirected service console logs are written without ANSI color control characters.

## Root Cause

The SFM handshake trusted the peer-supplied `endpoint_name` independently of the mTLS certificate common name. Certificate exchange also cached certificates by the claimed origin FQCN without checking that the certificate identity matched that origin.

## Changes

- Enforce endpoint/CN binding in `ConnManager.update_endpoint()` only for mTLS connections.
- Validate cached peer cert identity in `CredentialManager` only when the CellNet config uses mTLS.
- Propagate configured identities through client, job-cell, relay, and root connection properties.
- Add `auth_identity` / `auth_identity_map` runtime config and provisioning template support for cert CNs that differ from endpoint/FQCN.
- Omit redundant auth identity mappings for direct flat sites so package/provision kit parity stays stable.
- Document `auth_identity` configuration and warn users to regenerate signed startup kits instead of editing startup JSON when `startup/signature.json` is present.
- Improve POC startup/admin-console UX by using the CLI Python for launched services, surfacing service startup failures once, and allowing authenticated admin POC connections.
- Keep redirected POC console logs plain by skipping ANSI colors when console output is not attached to a TTY.
- Add job-cell, relay-child, configured-CN, POC startup, and redirected-console-log coverage.

## Validation

- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/tool/package/package_commands_test.py -v` (`226 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/fuel/f3/cellnet/identity_binding_test.py tests/unit_test/lighter/static_file_builder_test.py tests/unit_test/lighter/poc_commands_test.py -v` (`41 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/fuel/f3 -v` (`222 passed`, before the config follow-up; focused identity tests rerun after)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/private/fed/client/communicator_test.py tests/unit_test/private/fed/utils/site_config_test.py -v` (`7 passed`)
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/fuel/log_utils_dynamic_config_test.py -q` (`7 passed`)
- `PATH=/Users/zhihongz/nvflare-env/3.12/bin:$PATH ./runtest.sh --skip-install -s nvflare/fuel/utils/log_utils.py`
- `PATH=/Users/zhihongz/nvflare-env/3.12/bin:$PATH ./runtest.sh --skip-install -s tests/unit_test/fuel/log_utils_dynamic_config_test.py`
- Fresh `nvflare poc start` appended plain server console output with `escape_count 0` and no unexpected control bytes in `/tmp/nvflare/poc/example_project/prod_00/server/poc_console.log`.
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m black --check ...changed files...`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m isort --check ...changed files...`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m flake8 ...changed files... --count --statistics`
- `git diff --check`

## Note

`./runtest.sh -s` was run with `VIRTUAL_ENV=/Users/zhihongz/nvflare-env/3.12` and failed on unrelated vendored files under `examples/.../analytics-dashboard/node_modules/.../flatted/python/flatted.py` that Black would reformat. The scoped style checks above passed for this PR's changed files.
