### PR TITLE
[main] Cherry-pick FLARE-2976 MPM return-code fix

### DIFF
--- a/nvflare/fuel/f3/mpm.py
+++ b/nvflare/fuel/f3/mpm.py
@@ -180,8 +180,13 @@ class MainProcessMonitor:
         logger.info(f"{cls.name}: Good Bye!")
         if num_active_threads > 0:
             try:
+                # main_func may return None when it completes without an explicit return
+                # statement; coerce any non-int value to 0 so the parent's int() parse of
+                # _process_rc.txt doesn't fail with ValueError and mislog a successful job
+                # as RC=1.
+                rc_to_write = rc if isinstance(rc, int) else 0
                 with open(rc_file, "w") as outfile:
-                    outfile.write(f"{rc}")
+                    outfile.write(f"{rc_to_write}")
 
                 os.kill(os.getpid(), signal.SIGKILL)
             except Exception as ex:

--- a/tests/unit_test/fuel/f3/mpm_test.py
+++ b/tests/unit_test/fuel/f3/mpm_test.py
@@ -51,12 +51,12 @@ class TestMainProcessMonitorReturnCode:
         # still alive at shutdown is what forces the rc-file write + SIGKILL path
         lingering = _fake_thread("cellnet-worker", daemon=False)
 
-        with patch("nvflare.fuel.f3.mpm.threading.current_thread", return_value=main_thread), patch(
-            "nvflare.fuel.f3.mpm.threading.enumerate", return_value=[main_thread, lingering]
-        ), patch.object(MainProcessMonitor, "_start_shutdown"), patch(
-            "nvflare.fuel.f3.mpm.AioContext.close_global_context"
-        ), patch(
-            "nvflare.fuel.f3.mpm.os.kill"
+        with (
+            patch("nvflare.fuel.f3.mpm.threading.current_thread", return_value=main_thread),
+            patch("nvflare.fuel.f3.mpm.threading.enumerate", return_value=[main_thread, lingering]),
+            patch.object(MainProcessMonitor, "_start_shutdown"),
+            patch("nvflare.fuel.f3.mpm.AioContext.close_global_context"),
+            patch("nvflare.fuel.f3.mpm.os.kill"),
         ):
             MainProcessMonitor.run(main_func, run_dir=str(run_dir))
 

--- a/tests/unit_test/fuel/f3/mpm_test.py
+++ b/tests/unit_test/fuel/f3/mpm_test.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from unittest.mock import MagicMock, patch
+
+from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.fuel.f3.mpm import MainProcessMonitor
+
+
+def _fake_thread(name, daemon):
+    t = MagicMock()
+    t.name = name
+    t.daemon = daemon
+    return t
+
+
+class TestMainProcessMonitorReturnCode:
+    """Regression tests for FLARE-2976.
+
+    When an ext_process job's main_func returns implicitly (None) and non-daemon
+    threads are still alive at shutdown, MPM used to write the literal string "None"
+    to _process_rc.txt. The parent then did int("None") -> ValueError and mislogged a
+    successful job as RC=1. The value written must always be an int the parent can parse.
+    """
+
+    def _run_and_read_rc(self, run_dir, main_func):
+        rc_file = os.path.join(str(run_dir), FLMetaKey.PROCESS_RC_FILE)
+
+        main_thread = _fake_thread("MainThread", daemon=False)
+        # a non-daemon, non-MainThread worker (e.g. cellnet conn_mgr / frame_mgr pool)
+        # still alive at shutdown is what forces the rc-file write + SIGKILL path
+        lingering = _fake_thread("cellnet-worker", daemon=False)
+
+        with patch("nvflare.fuel.f3.mpm.threading.current_thread", return_value=main_thread), patch(
+            "nvflare.fuel.f3.mpm.threading.enumerate", return_value=[main_thread, lingering]
+        ), patch.object(MainProcessMonitor, "_start_shutdown"), patch(
+            "nvflare.fuel.f3.mpm.AioContext.close_global_context"
+        ), patch(
+            "nvflare.fuel.f3.mpm.os.kill"
+        ):
+            MainProcessMonitor.run(main_func, run_dir=str(run_dir))
+
+        with open(rc_file) as f:
+            return f.read().strip()
+
+    def test_implicit_none_return_writes_parseable_zero(self, tmp_path):
+        content = self._run_and_read_rc(tmp_path, lambda: None)
+        # must be int-parseable (not "None") and represent success
+        assert int(content) == 0
+
+    def test_int_return_code_is_preserved(self, tmp_path):
+        # a real exit code (e.g. ProcessExitCode.CONFIG_ERROR == 103) must pass through unchanged
+        content = self._run_and_read_rc(tmp_path, lambda: 103)
+        assert int(content) == 103
+
+    def test_non_int_return_is_coerced(self, tmp_path):
+        # any other non-int return value also stays int-parseable
+        content = self._run_and_read_rc(tmp_path, lambda: "done")
+        assert int(content) == 0

--- a/tests/unit_test/fuel/f3/mpm_test.py
+++ b/tests/unit_test/fuel/f3/mpm_test.py
@@ -34,6 +34,15 @@ class TestMainProcessMonitorReturnCode:
     successful job as RC=1. The value written must always be an int the parent can parse.
     """
 
+    def setup_method(self):
+        # run() mutates MainProcessMonitor's class-level state (e.g. sets _stopping=True)
+        # and never resets it; restore defaults before each test so state can't leak
+        # into other tests sharing this pytest session.
+        MainProcessMonitor._stopping = False
+        MainProcessMonitor._cleanup_cbs = []
+        MainProcessMonitor._logger = None
+        MainProcessMonitor._aio_ctx = None
+
     def _run_and_read_rc(self, run_dir, main_func):
         rc_file = os.path.join(str(run_dir), FLMetaKey.PROCESS_RC_FILE)
 


### PR DESCRIPTION
## Summary

- Cherry-picks #4754 from `2.8` to `main`.
- Coerces the MPM return code before writing `_process_rc.txt`.
- Adds unit coverage for numeric and string process return codes, including reset handling for `MainProcessMonitor` class state between tests.

## Validation

- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/f3/mpm_test.py`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/f3`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m black --check nvflare/fuel/f3/mpm.py tests/unit_test/fuel/f3/mpm_test.py`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m isort --check-only nvflare/fuel/f3/mpm.py tests/unit_test/fuel/f3/mpm_test.py`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m flake8 nvflare/fuel/f3/mpm.py tests/unit_test/fuel/f3/mpm_test.py`
- `git diff --check upstream/main..HEAD`
- `./runtest.sh -s nvflare/fuel/f3/mpm.py tests/unit_test/fuel/f3/mpm_test.py`
