### PR TITLE
Drop duplicate task submissions after cleanup

### DIFF
--- a/nvflare/apis/impl/wf_comm_server.py
+++ b/nvflare/apis/impl/wf_comm_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import threading
 import time
+from collections import OrderedDict
 from threading import Lock
 from typing import List, Optional, Tuple, Union
 
@@ -40,6 +41,7 @@ from .task_manager import TaskCheckStatus, TaskManager
 _TASK_KEY_ENGINE = "___engine"
 _TASK_KEY_MANAGER = "___mgr"
 _TASK_KEY_DONE = "___done"
+_COMPLETED_CLIENT_TASK_CACHE_SIZE = 10000
 
 
 def _check_positive_int(name, value):
@@ -80,6 +82,12 @@ class _DeadClientStatus:
         self.disconnect_time = None
 
 
+class _CompletedClientTaskInfo:
+    def __init__(self, client_name: str, task_name: str):
+        self.client_name = client_name
+        self.task_name = task_name
+
+
 class WFCommServer(FLComponent, WFCommSpec):
     def __init__(self, task_check_period=0.2):
         """Manage life cycles of tasks and their destinations.
@@ -92,6 +100,7 @@ class WFCommServer(FLComponent, WFCommSpec):
         self._engine = None
         self._tasks = []  # list of standing tasks
         self._client_task_map = {}  # client_task_id => client_task
+        self._completed_client_task_map = OrderedDict()  # client_task_id => _CompletedClientTaskInfo
         self._all_done = False
         self._task_lock = Lock()
         self._task_monitor = threading.Thread(target=self._monitor_tasks, args=(), name="wf_task", daemon=True)
@@ -385,6 +394,23 @@ class WFCommServer(FLComponent, WFCommSpec):
             # task_id is the uuid associated with the client_task
             return self._client_task_map.get(task_id, None)
 
+    def _remember_completed_client_task(self, client_task: ClientTask):
+        if client_task.result_received_time is None:
+            return
+
+        self._completed_client_task_map[client_task.id] = _CompletedClientTaskInfo(
+            client_name=client_task.client.name, task_name=client_task.task.name
+        )
+        self._completed_client_task_map.move_to_end(client_task.id)
+        while len(self._completed_client_task_map) > _COMPLETED_CLIENT_TASK_CACHE_SIZE:
+            self._completed_client_task_map.popitem(last=False)
+
+    def _get_completed_client_task_info(self, task_id: str):
+        completed_client_task = self._completed_client_task_map.get(task_id)
+        if completed_client_task:
+            self._completed_client_task_map.move_to_end(task_id)
+        return completed_client_task
+
     def process_submission(self, client: Client, task_name: str, task_id: str, result: Shareable, fl_ctx: FLContext):
         """Called to process a submission from one client.
 
@@ -422,9 +448,18 @@ class WFCommServer(FLComponent, WFCommSpec):
         with self._task_lock:
             # task_id is the uuid associated with the client_task
             client_task = self._client_task_map.get(task_id, None)
+            completed_client_task = self._get_completed_client_task_info(task_id) if client_task is None else None
             self.log_debug(fl_ctx, "Get submission from client task={} id={}".format(client_task, task_id))
 
         if client_task is None:
+            if (
+                completed_client_task
+                and completed_client_task.client_name == client.name
+                and completed_client_task.task_name == task_name
+            ):
+                self.log_info(fl_ctx, "client task result is already received - submission dropped")
+                return
+
             # cannot find a standing task for the submission
             self.log_debug(fl_ctx, "no standing task found for {}:{}".format(task_name, task_id))
 
@@ -836,6 +871,7 @@ class WFCommServer(FLComponent, WFCommSpec):
             exit_tasks = list(self._tasks)
             self._tasks.clear()
             self._client_task_map.clear()
+            self._completed_client_task_map.clear()
 
         for task in exit_tasks:
             if task.completion_status is None:
@@ -1069,6 +1105,7 @@ class WFCommServer(FLComponent, WFCommSpec):
                 self._tasks.remove(exit_task)
                 for client_task in exit_task.client_tasks:
                     self.logger.debug("Removing client_task with id={}".format(client_task.id))
+                    self._remember_completed_client_task(client_task)
                     self._client_task_map.pop(client_task.id)
 
         # do the task exit processing outside the lock to minimize the locking time

--- a/tests/unit_test/apis/impl/controller_test.py
+++ b/tests/unit_test/apis/impl/controller_test.py
@@ -1202,6 +1202,9 @@ class TestBasic(TestController):
             result=result,
         )
 
+        controller.communicator.check_tasks()
+        assert client_task_id not in controller.communicator._client_task_map
+
         duplicate_result = Shareable()
         duplicate_result["result"] = "duplicate"
         controller.communicator.process_submission(
@@ -1215,6 +1218,58 @@ class TestBasic(TestController):
         client_task = task.last_client_task_map[client.name]
         assert result_count == 1
         assert client_task.result == result
+        launch_thread.join()
+        self.teardown_system(controller, fl_ctx)
+
+    def test_process_submission_completed_task_mismatch_uses_unknown_handler(self):
+        controller, fl_ctx, clients = self.setup_system(num_of_clients=2)
+        assigned_client, other_client = clients
+        task = create_task("__test_task")
+        launch_thread = threading.Thread(
+            target=launch_task,
+            kwargs={
+                "controller": controller,
+                "task": task,
+                "method": "send",
+                "fl_ctx": fl_ctx,
+                "kwargs": {"targets": [assigned_client]},
+            },
+        )
+        get_ready(launch_thread)
+
+        task_name_out, client_task_id, _ = controller.communicator.process_task_request(assigned_client, fl_ctx)
+        assert task_name_out == "__test_task"
+
+        result = Shareable()
+        result["result"] = "result"
+        controller.communicator.process_submission(
+            client=assigned_client,
+            task_name="__test_task",
+            task_id=client_task_id,
+            fl_ctx=fl_ctx,
+            result=result,
+        )
+        controller.communicator.check_tasks()
+        assert client_task_id not in controller.communicator._client_task_map
+
+        with pytest.raises(RuntimeError, match="Unknown task: __test_task from client __test_client1."):
+            controller.communicator.process_submission(
+                client=other_client,
+                task_name="__test_task",
+                task_id=client_task_id,
+                fl_ctx=fl_ctx,
+                result=Shareable(),
+            )
+
+        with pytest.raises(RuntimeError, match="Unknown task: __wrong_task from client __test_client0."):
+            controller.communicator.process_submission(
+                client=assigned_client,
+                task_name="__wrong_task",
+                task_id=client_task_id,
+                fl_ctx=fl_ctx,
+                result=Shareable(),
+            )
+
         launch_thread.join()
         self.teardown_system(controller, fl_ctx)
 


### PR DESCRIPTION
## Summary
- keep a bounded record of completed client task IDs after the task monitor removes them from the active map
- drop only exact duplicate submissions for those completed IDs: same task ID, same client, same task name
- keep mismatched client or task-name submissions on the existing process_result_of_unknown_task path
- make the duplicate-submission regression deterministic and add coverage for completed-task mismatch behavior

## Impact
This changes production behavior only for duplicate result submissions that arrive after the task monitor has already cleaned the active client-task map. Previously those late duplicates could be treated as unknown tasks and call controller overrides of process_result_of_unknown_task. With this change, exact duplicates are logged and ignored, matching the already-existing behavior while the task is still active. Non-duplicates with a retired task ID still use the unknown-task handler.

## Tests
- python -m pytest tests/unit_test/apis/impl/controller_test.py::TestBasic::test_process_submission_drops_duplicate_result tests/unit_test/apis/impl/controller_test.py::TestBasic::test_process_submission_completed_task_mismatch_uses_unknown_handler -q
- python -m pytest tests/unit_test/apis/impl/controller_test.py::TestBasic::test_process_submission_invalid_task tests/unit_test/apis/impl/controller_test.py::TestBasic::test_process_submission_rejects_unassigned_client_task_id tests/unit_test/apis/impl/controller_test.py::TestBasic::test_process_submission -q
- python -m pytest tests/unit_test/apis/impl/controller_test.py -q
- ./runtest.sh -s