### PR TITLE
fix(dxo_filter): correct error message in DXOFilter.__init__ validation

### DIFF
--- a/nvflare/apis/dxo_filter.py
+++ b/nvflare/apis/dxo_filter.py
@@ -44,7 +44,7 @@ class DXOFilter(Filter, ABC):
 
         if supported_data_kinds and data_kinds_to_filter:
             if not all(dk in supported_data_kinds for dk in data_kinds_to_filter):
-                raise ValueError(f"invalid data kinds: {data_kinds_to_filter}. Only support {data_kinds_to_filter}")
+                raise ValueError(f"invalid data kinds: {data_kinds_to_filter}. Only support {supported_data_kinds}")
 
         if not data_kinds_to_filter:
             data_kinds_to_filter = supported_data_kinds

--- a/tests/unit_test/apis/dxo_filter_test.py
+++ b/tests/unit_test/apis/dxo_filter_test.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nvflare.apis.dxo import DXO, DataKind
+from nvflare.apis.dxo_filter import DXOFilter
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+
+
+class _NoOpDXOFilter(DXOFilter):
+    """Minimal concrete DXOFilter for testing."""
+
+    def process_dxo(self, dxo: DXO, shareable: Shareable, fl_ctx: FLContext):
+        return dxo
+
+
+class TestDXOFilterInit:
+    def test_valid_data_kinds(self):
+        f = _NoOpDXOFilter(
+            supported_data_kinds=[DataKind.WEIGHTS, DataKind.WEIGHT_DIFF],
+            data_kinds_to_filter=[DataKind.WEIGHTS],
+        )
+        assert f.data_kinds == [DataKind.WEIGHTS]
+
+    def test_none_supported_kinds_accepts_all(self):
+        f = _NoOpDXOFilter(supported_data_kinds=None, data_kinds_to_filter=None)
+        assert f.data_kinds is None
+
+    def test_unsupported_kind_raises_with_correct_message(self):
+        """Error message must list supported_data_kinds, not data_kinds_to_filter."""
+        supported = [DataKind.WEIGHTS, DataKind.WEIGHT_DIFF]
+        bad_kinds = [DataKind.METRICS]
+        with pytest.raises(ValueError) as exc_info:
+            _NoOpDXOFilter(supported_data_kinds=supported, data_kinds_to_filter=bad_kinds)
+        msg = str(exc_info.value)
+        # The message must reference the supported kinds, not the invalid ones
+        assert DataKind.WEIGHTS in msg
+        assert DataKind.WEIGHT_DIFF in msg
+        # And it must identify the bad kinds too
+        assert DataKind.METRICS in msg
+
+    def test_supported_kinds_must_be_list(self):
+        with pytest.raises(ValueError, match="supported_data_kinds must be a list"):
+            _NoOpDXOFilter(supported_data_kinds="WEIGHTS", data_kinds_to_filter=None)
+
+    def test_data_kinds_to_filter_must_be_list(self):
+        with pytest.raises(ValueError, match="data_kinds_to_filter must be a list"):
+            _NoOpDXOFilter(supported_data_kinds=[DataKind.WEIGHTS], data_kinds_to_filter="WEIGHTS")
+
+    def test_no_filter_kinds_defaults_to_supported(self):
+        supported = [DataKind.WEIGHTS, DataKind.WEIGHT_DIFF]
+        f = _NoOpDXOFilter(supported_data_kinds=supported, data_kinds_to_filter=None)
+        assert f.data_kinds == supported


### PR DESCRIPTION
## Summary

- Fixes a copy-paste bug in `nvflare/apis/dxo_filter.py` line 47 where the validation error message repeated `data_kinds_to_filter` instead of `supported_data_kinds`.
- Before this fix, when a user passed unsupported `data_kinds_to_filter`, the error message was completely misleading — it appeared to say the invalid kinds _were_ supported.
- Adds `tests/unit_test/apis/dxo_filter_test.py` with 6 unit tests covering all validation branches in `DXOFilter.__init__()`, including a regression test that asserts the error message lists the supported kinds.

**Before:**
```
ValueError: invalid data kinds: ['METRICS']. Only support ['METRICS']
```

**After:**
```
ValueError: invalid data kinds: ['METRICS']. Only support ['WEIGHTS', 'WEIGHT_DIFF']
```

Closes #4774

## Test plan

- [x] `pytest tests/unit_test/apis/dxo_filter_test.py -v` — all 6 tests pass
- [x] `test_unsupported_kind_raises_with_correct_message` specifically validates the fix: the error message contains the supported kinds, not the invalid ones
- [x] Default behaviour (no unsupported kinds) unchanged — other tests confirm the happy path