### PR TITLE
Use Node 22 for web deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: '22.12'
           cache: npm
           cache-dependency-path: "${{ env.site_path }}/package-lock.json"
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,9 @@
         "flowbite": "^2.3.0",
         "prismjs": "^1.30.0",
         "tailwindcss": "^3.3.5"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6868,20 +6871,6 @@
       "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
       "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
       "license": "MIT"
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     },
     "node_modules/typescript-auto-import-cache": {
       "version": "0.3.6",

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "version": "0.0.2",
   "private": true,
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
## Summary

- Update the GitHub Pages deploy workflow from Node 20 to Node 22.
- Add a `web/package.json` engine declaration for Node `>=22.12.0` and mirror it in the lockfile.

## Root cause

PR #4764 fixed the Astro 6 / `@astrojs/tailwind` peer dependency resolution issue, but the next deploy run still failed at `npm install` because `@astrojs/mdx@5.0.6` requires Node `>=22.12.0` while the deploy workflow was still installing Node 20.

Because this PR also changes `web/package.json`, the existing `web/**` deploy path filter should trigger the Pages deployment when merged.

## Validation

- `npm install` from `web/` with local Node v24.4.1
- `npm run build` from `web/`
- Confirmed `web/dist/webinars/index.html` contains the Q2 webinar title and YouTube embed URL
