### PR TITLE
Accept path alias in recipe model configs

### DIFF
--- a/nvflare/recipe/utils.py
+++ b/nvflare/recipe/utils.py
@@ -550,6 +550,23 @@ def setup_custom_persistor(*, job, model_persistor=None) -> str:
     return extract_persistor_id(job.to_server(model_persistor, id="persistor"))
 
 
+def _resolve_recipe_model_class_path(recipe_model: Dict[str, Any]) -> str:
+    if "class_path" in recipe_model:
+        key = "class_path"
+    elif "path" in recipe_model:
+        key = "path"
+    else:
+        raise ValueError(
+            "Dict model config must have 'class_path' or 'path' key with fully qualified class path. "
+            f"Got: {recipe_model}"
+        )
+
+    class_path = recipe_model[key]
+    if not isinstance(class_path, str):
+        raise ValueError(f"Dict model config '{key}' must be a string, got: {type(class_path)}")
+    return class_path
+
+
 def validate_dict_model_config(model: Any) -> None:
     """Validate recipe dict model config structure.
 
@@ -563,25 +580,7 @@ def validate_dict_model_config(model: Any) -> None:
         ValueError: If dict config is missing 'class_path'/'path' or value is not a string.
     """
     if isinstance(model, dict):
-        class_path = model.get("class_path")
-        key = "class_path"
-        if class_path is None:
-            class_path = model.get("path")
-            key = "path"
-        if class_path is None:
-            raise ValueError(
-                "Dict model config must have 'class_path' or 'path' key with fully qualified class path. "
-                f"Got: {model}"
-            )
-        if not isinstance(class_path, str):
-            raise ValueError(f"Dict model config '{key}' must be a string, got: {type(class_path)}")
-
-
-def _recipe_model_class_path(recipe_model: Dict[str, Any]) -> str:
-    class_path = recipe_model.get("class_path")
-    if class_path is None:
-        class_path = recipe_model.get("path")
-    return class_path
+        _resolve_recipe_model_class_path(model)
 
 
 def recipe_model_to_job_model(recipe_model: Dict[str, Any]) -> Dict[str, Any]:
@@ -598,5 +597,4 @@ def recipe_model_to_job_model(recipe_model: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         Dict with 'path' and 'args' for use by PTModel, persistors, etc.
     """
-    validate_dict_model_config(recipe_model)
-    return {"path": _recipe_model_class_path(recipe_model), "args": recipe_model.get("args", {})}
+    return {"path": _resolve_recipe_model_class_path(recipe_model), "args": recipe_model.get("args", {})}

--- a/nvflare/recipe/utils.py
+++ b/nvflare/recipe/utils.py
@@ -553,37 +553,50 @@ def setup_custom_persistor(*, job, model_persistor=None) -> str:
 def validate_dict_model_config(model: Any) -> None:
     """Validate recipe dict model config structure.
 
-    Recipes accept model config with ``class_path`` (fully qualified class name).
-    The job/config layer uses ``path``; recipes use ``class_path`` only.
+    Recipes accept model config with ``class_path`` or the ``path`` alias.
+    The job/config layer uses ``path``.
 
     Args:
         model: Model input to validate.
 
     Raises:
-        ValueError: If dict config is missing 'class_path' or value is not a string.
+        ValueError: If dict config is missing 'class_path'/'path' or value is not a string.
     """
     if isinstance(model, dict):
-        if "class_path" not in model:
+        class_path = model.get("class_path")
+        key = "class_path"
+        if class_path is None:
+            class_path = model.get("path")
+            key = "path"
+        if class_path is None:
             raise ValueError(
-                "Dict model config must have 'class_path' key with fully qualified class path. " f"Got: {model}"
+                "Dict model config must have 'class_path' or 'path' key with fully qualified class path. "
+                f"Got: {model}"
             )
-        class_path = model["class_path"]
         if not isinstance(class_path, str):
-            raise ValueError(f"Dict model config 'class_path' must be a string, got: {type(class_path)}")
+            raise ValueError(f"Dict model config '{key}' must be a string, got: {type(class_path)}")
+
+
+def _recipe_model_class_path(recipe_model: Dict[str, Any]) -> str:
+    class_path = recipe_model.get("class_path")
+    if class_path is None:
+        class_path = recipe_model.get("path")
+    return class_path
 
 
 def recipe_model_to_job_model(recipe_model: Dict[str, Any]) -> Dict[str, Any]:
-    """Validate and convert recipe model dict (class_path) to job/config format (path).
+    """Validate and convert recipe model dict to job/config format (path).
 
     Calls :func:`validate_dict_model_config` internally so callers do not need to
-    validate separately. Recipes accept {"class_path": "module.Class", "args": {...}} only.
+    validate separately. Recipes accept {"class_path": "module.Class", "args": {...}}
+    or {"path": "module.Class", "args": {...}}.
     The Job API and config parsing expect {"path": "module.Class", "args": {...}}.
 
     Args:
-        recipe_model: Dict with 'class_path' and optional 'args'.
+        recipe_model: Dict with 'class_path' or 'path' and optional 'args'.
 
     Returns:
         Dict with 'path' and 'args' for use by PTModel, persistors, etc.
     """
     validate_dict_model_config(recipe_model)
-    return {"path": recipe_model["class_path"], "args": recipe_model.get("args", {})}
+    return {"path": _recipe_model_class_path(recipe_model), "args": recipe_model.get("args", {})}

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -576,10 +576,11 @@ def _privacy_compatible(entry: dict, parameters: list, recipe_cls) -> list:
 
 def _client_requirements(entry: dict, parameters: list) -> dict:
     by_name = {p["name"]: p for p in parameters}
+    per_site_config = by_name.get("per_site_config")
     requirements = {
         "state_exchange": entry.get("state_exchange"),
         "requires_training_script": "train_script" in by_name,
-        "requires_per_site_config": "per_site_config" in by_name,
+        "requires_per_site_config": bool(per_site_config and per_site_config["required"]),
         "requires_site_list": "sites" in by_name,
     }
     for name in ("min_clients", "sites", "label_owner", "client_ranks"):

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -765,6 +765,36 @@ class TestFedAvgRecipeInitialCkpt:
         assert recipe.model["path"] == "my_module.models.SimpleNet"
         assert recipe.model["args"] == {"input_size": 10, "output_size": 5}
 
+    def test_dict_model_config_class_path_takes_precedence(self, mock_file_system, base_recipe_params):
+        """Test that class_path is used when both class_path and path are provided."""
+        model_config = {
+            "class_path": "my_module.models.ClassPathNet",
+            "path": "my_module.models.PathNet",
+            "args": {"input_size": 10},
+        }
+        recipe = FedAvgRecipe(
+            name="test_dict_config_class_path_precedence",
+            model=model_config,
+            **base_recipe_params,
+        )
+
+        assert recipe.model["path"] == "my_module.models.ClassPathNet"
+        assert recipe.model["args"] == {"input_size": 10}
+
+    def test_dict_model_config_explicit_none_class_path_raises(self, mock_file_system, base_recipe_params):
+        """Test that explicit class_path=None does not fall through to path alias."""
+        model_config = {
+            "class_path": None,
+            "path": "my_module.models.PathNet",
+            "args": {"input_size": 10},
+        }
+        with pytest.raises(ValueError, match="'class_path' must be a string"):
+            FedAvgRecipe(
+                name="test_dict_config_none_class_path",
+                model=model_config,
+                **base_recipe_params,
+            )
+
     def test_dict_model_config_with_initial_ckpt(self, mock_file_system, base_recipe_params):
         """Test that dict model config (class_path) with initial_ckpt is accepted."""
         model_config = {

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -679,12 +679,12 @@ class TestFedAvgRecipeValidation:
         assert server_app is not None
         assert server_app.app_config.components.get(locator_id) is locator
 
-    def test_dict_config_missing_path_raises_error(self, mock_file_system, base_recipe_params):
-        """Test that dict config without 'class_path' key raises error."""
-        with pytest.raises(ValueError, match="must have 'class_path' key"):
+    def test_dict_config_missing_class_path_or_path_raises_error(self, mock_file_system, base_recipe_params):
+        """Test that dict config without 'class_path' or 'path' key raises error."""
+        with pytest.raises(ValueError, match="must have 'class_path' or 'path' key"):
             FedAvgRecipe(
                 name="test_invalid_dict",
-                model={"args": {"input_size": 10}},  # Missing 'class_path'
+                model={"args": {"input_size": 10}},  # Missing 'class_path'/'path'
                 **base_recipe_params,
             )
 
@@ -743,6 +743,21 @@ class TestFedAvgRecipeInitialCkpt:
         }
         recipe = FedAvgRecipe(
             name="test_dict_config",
+            model=model_config,
+            **base_recipe_params,
+        )
+
+        assert recipe.model["path"] == "my_module.models.SimpleNet"
+        assert recipe.model["args"] == {"input_size": 10, "output_size": 5}
+
+    def test_dict_model_config_path_alias_accepted(self, mock_file_system, base_recipe_params):
+        """Test that dict model config accepts path as an alias for class_path."""
+        model_config = {
+            "path": "my_module.models.SimpleNet",
+            "args": {"input_size": 10, "output_size": 5},
+        }
+        recipe = FedAvgRecipe(
+            name="test_dict_config_path_alias",
             model=model_config,
             **base_recipe_params,
         )

--- a/tests/unit_test/recipe/fedopt_recipe_test.py
+++ b/tests/unit_test/recipe/fedopt_recipe_test.py
@@ -201,14 +201,14 @@ class TestPTFedOptRecipe:
                 **base_recipe_params,
             )
 
-    def test_dict_config_missing_path_raises_error(self, mock_file_system, base_recipe_params):
-        """Test that dict config without 'class_path' key raises error."""
+    def test_dict_config_missing_class_path_or_path_raises_error(self, mock_file_system, base_recipe_params):
+        """Test that dict config without 'class_path' or 'path' key raises error."""
         from nvflare.app_opt.pt.recipes.fedopt import FedOptRecipe
 
-        with pytest.raises(ValueError, match="must have 'class_path' key"):
+        with pytest.raises(ValueError, match="must have 'class_path' or 'path' key"):
             FedOptRecipe(
                 name="test_invalid_dict",
-                model={"args": {"input_size": 10}},  # Missing 'class_path'
+                model={"args": {"input_size": 10}},  # Missing 'class_path'/'path'
                 **base_recipe_params,
             )
 

--- a/tests/unit_test/recipe/scaffold_recipe_test.py
+++ b/tests/unit_test/recipe/scaffold_recipe_test.py
@@ -114,14 +114,14 @@ class TestPTScaffoldRecipe:
                 **base_recipe_params,
             )
 
-    def test_dict_config_missing_path_raises_error(self, mock_file_system, base_recipe_params):
-        """Test that dict config without 'path' key raises error."""
+    def test_dict_config_missing_class_path_or_path_raises_error(self, mock_file_system, base_recipe_params):
+        """Test that dict config without 'class_path' or 'path' key raises error."""
         from nvflare.app_opt.pt.recipes.scaffold import ScaffoldRecipe
 
-        with pytest.raises(ValueError, match="must have 'class_path' key"):
+        with pytest.raises(ValueError, match="must have 'class_path' or 'path' key"):
             ScaffoldRecipe(
                 name="test_invalid_dict",
-                model={"args": {"input_size": 10}},  # Missing 'class_path'
+                model={"args": {"input_size": 10}},  # Missing 'class_path'/'path'
                 **base_recipe_params,
             )
 

--- a/tests/unit_test/recipe/swarm_recipe_test.py
+++ b/tests/unit_test/recipe/swarm_recipe_test.py
@@ -148,14 +148,14 @@ class TestSwarmLearningRecipe:
 
         assert recipe.job is not None
 
-    def test_dict_model_missing_path_rejected(self, mock_file_system):
-        """Test that dict model without 'class_path' key is rejected."""
+    def test_dict_model_missing_class_path_or_path_rejected(self, mock_file_system):
+        """Test that dict model without 'class_path' or 'path' key is rejected."""
         from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
 
-        with pytest.raises(ValueError, match="must have 'class_path' key"):
+        with pytest.raises(ValueError, match="must have 'class_path' or 'path' key"):
             SwarmLearningRecipe(
                 name="test_swarm_bad_dict",
-                model={"args": {"in_features": 10}},  # Missing 'path'
+                model={"args": {"in_features": 10}},  # Missing 'class_path'/'path'
                 num_rounds=5,
                 train_script="train.py",
                 min_clients=2,

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -315,6 +315,7 @@ def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
             min_clients: int,
             num_rounds: int = 2,
             train_script: str = "client.py",
+            per_site_config: dict = None,
             secure: bool = False,
         ):
             pass
@@ -352,6 +353,7 @@ def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
     assert data["template_references"] == ["nvflare/agent/templates/fake"]
     assert data["client_requirements"]["min_clients"] == {"required": True, "default": None}
     assert data["client_requirements"]["requires_training_script"] is True
+    assert data["client_requirements"]["requires_per_site_config"] is False
     assert {p["name"]: p for p in data["parameters"]}["num_rounds"]["default"] == 2
 
 


### PR DESCRIPTION
## Summary
- Accept recipe model dicts that use path as an alias for class_path, then normalize to job/config path
- Keep class_path supported as the canonical recipe spelling
- Report requires_per_site_config only when the recipe parameter is actually required

## Tests
- python -m pytest tests/unit_test/recipe/fedavg_recipe_test.py tests/unit_test/recipe/fedopt_recipe_test.py tests/unit_test/recipe/scaffold_recipe_test.py tests/unit_test/recipe/swarm_recipe_test.py tests/unit_test/tool/recipe_cli_test.py
- nvflare recipe show fedavg-pt --format json
- ./runtest.sh -s