### PR TITLE
Align FLModel metrics across FL workflows

### DIFF
--- a/nvflare/app_common/workflows/base_fedavg.py
+++ b/nvflare/app_common/workflows/base_fedavg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from nvflare.apis.fl_constant import FLMetaKey
 from nvflare.app_common.abstract.fl_model import FLModel
@@ -29,6 +29,30 @@ from nvflare.fuel.utils.validation_utils import check_non_negative_int
 from nvflare.security.logging import secure_format_exception
 
 from .model_controller import ModelController
+
+
+def _aggregate_fl_model_metrics(results: List[FLModel]) -> Optional[Dict[str, Any]]:
+    """Aggregate FLModel metrics across results with FedAvg-compatible semantics.
+
+    Metrics are weighted averages of client metric values. For non-linear metrics
+    such as AUROC, this is not the same as computing the metric from pooled
+    predictions across all clients.
+    """
+    aggr_metrics_helper = WeightedAggregationHelper()
+    for _result in results:
+        if _result.metrics is None:
+            return None
+        aggregatable = filter_aggregatable_metrics(_result.metrics)
+        if aggregatable:
+            aggr_metrics_helper.add(
+                data=aggregatable,
+                weight=_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
+                contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
+                contribution_round=_result.current_round,
+            )
+
+    aggr_metrics = aggr_metrics_helper.get_result()
+    return aggr_metrics or None
 
 
 class BaseFedAvg(ModelController):
@@ -109,8 +133,6 @@ class BaseFedAvg(ModelController):
             raise ValueError("received empty results for aggregation.")
 
         aggr_helper = WeightedAggregationHelper()
-        aggr_metrics_helper = WeightedAggregationHelper()
-        all_metrics = True
         for _result in results:
             aggr_helper.add(
                 data=_result.params,
@@ -118,21 +140,9 @@ class BaseFedAvg(ModelController):
                 contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
                 contribution_round=_result.current_round,
             )
-            if _result.metrics is None:
-                all_metrics = False
-            if all_metrics:
-                aggregatable = filter_aggregatable_metrics(_result.metrics)
-                if aggregatable:
-                    aggr_metrics_helper.add(
-                        data=aggregatable,
-                        weight=_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
-                        contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
-                        contribution_round=_result.current_round,
-                    )
 
         aggr_params = aggr_helper.get_result()
-        aggr_metrics = aggr_metrics_helper.get_result() if all_metrics else None
-        aggr_metrics = aggr_metrics or None
+        aggr_metrics = _aggregate_fl_model_metrics(results)
 
         aggr_result = FLModel(
             params=aggr_params,

--- a/nvflare/app_common/workflows/lr/fedavg.py
+++ b/nvflare/app_common/workflows/lr/fedavg.py
@@ -25,7 +25,7 @@ from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedA
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.np.constants import NPConstants
 from nvflare.app_common.np.np_model_persistor import NPModelPersistor
-from nvflare.app_common.workflows.base_fedavg import BaseFedAvg
+from nvflare.app_common.workflows.base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics
 from nvflare.app_common.workflows.lr.np_persistor import LRModelPersistor
 
 
@@ -176,6 +176,7 @@ class FedAvgLR(BaseFedAvg):
         aggr_result = FLModel(
             params={"newton_raphson_updates": newton_raphson_updates},
             params_type=results[0].params_type,
+            metrics=_aggregate_fl_model_metrics(results),
             meta={
                 "nr_aggregated": len(results),
                 AppConstants.CURRENT_ROUND: results[0].current_round,

--- a/nvflare/app_common/workflows/scaffold.py
+++ b/nvflare/app_common/workflows/scaffold.py
@@ -22,7 +22,7 @@ from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedAggregationHelper
 from nvflare.app_common.app_constant import AlgorithmConstants, AppConstants
 
-from .base_fedavg import BaseFedAvg
+from .base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics
 
 
 class Scaffold(BaseFedAvg):
@@ -98,22 +98,23 @@ def scaffold_aggregate_fn(results: List[FLModel]) -> FLModel:
     aggregation_helper = WeightedAggregationHelper()
     crtl_aggregation_helper = WeightedAggregationHelper()
     for _result in results:
+        weight = _result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0)
+        contributor_name = _result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN)
         aggregation_helper.add(
             data=_result.params,
-            weight=_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
-            contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
+            weight=weight,
+            contributor_name=contributor_name,
             contribution_round=_result.current_round,
         )
         if AlgorithmConstants.SCAFFOLD_CTRL_DIFF not in _result.meta:
-            client_name = _result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN)
             raise ValueError(
-                f"Client '{client_name}' did not return required "
+                f"Client '{contributor_name}' did not return required "
                 f"FLModel.meta['{AlgorithmConstants.SCAFFOLD_CTRL_DIFF}'] for Scaffold aggregation."
             )
         crtl_aggregation_helper.add(
             data=_result.meta[AlgorithmConstants.SCAFFOLD_CTRL_DIFF],
-            weight=_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
-            contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
+            weight=weight,
+            contributor_name=contributor_name,
             contribution_round=_result.current_round,
         )
 
@@ -122,6 +123,7 @@ def scaffold_aggregate_fn(results: List[FLModel]) -> FLModel:
     aggr_result = FLModel(
         params=aggregated_dict,
         params_type=results[0].params_type,
+        metrics=_aggregate_fl_model_metrics(results),
         meta={
             AlgorithmConstants.SCAFFOLD_CTRL_DIFF: crtl_aggregation_helper.get_result(),
             "nr_aggregated": len(results),

--- a/nvflare/app_opt/pt/fedopt_ctl.py
+++ b/nvflare/app_opt/pt/fedopt_ctl.py
@@ -171,5 +171,6 @@ class FedOpt(FedAvg):
 
         global_model.params = weights
         global_model.meta = aggr_result.meta
+        global_model.metrics = aggr_result.metrics
 
         return global_model

--- a/nvflare/app_opt/tf/fedopt_ctl.py
+++ b/nvflare/app_opt/tf/fedopt_ctl.py
@@ -177,5 +177,6 @@ class FedOpt(FedAvg):
 
         global_model.params = new_weights
         global_model.meta = aggr_result.meta
+        global_model.metrics = aggr_result.metrics
 
         return global_model

--- a/tests/unit_test/app_common/workflow/fedavg_lr_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_lr_test.py
@@ -199,6 +199,44 @@ class TestNewtonRaphsonAggregatorFunction:
 
         np.testing.assert_allclose(aggr_result.params["newton_raphson_updates"], expected_updates, rtol=1e-6)
 
+    def test_aggregator_aggregates_generic_numeric_metrics(self):
+        """Test aggregation preserves FedAvg-compatible metrics on the Newton-Raphson update."""
+        controller = FedAvgLR(damping_factor=1.0, epsilon=1.0, n_features=1)
+
+        gradient1 = np.array([[1.0], [2.0]])
+        hessian1 = np.array([[4.0, 0.0], [0.0, 4.0]])
+        result1 = FLModel(
+            params={"gradient": gradient1, "hessian": hessian1},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.2, "accuracy": 0.8, "meta": {"site": "site-1"}},
+            current_round=1,
+            meta={
+                "client_name": "site-1",
+                FLMetaKey.NUM_STEPS_CURRENT_ROUND: 2,
+            },
+        )
+
+        gradient2 = np.array([[3.0], [4.0]])
+        hessian2 = np.array([[8.0, 0.0], [0.0, 8.0]])
+        result2 = FLModel(
+            params={"gradient": gradient2, "hessian": hessian2},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.8, "accuracy": 0.2, "meta": {"site": "site-2"}},
+            current_round=1,
+            meta={
+                "client_name": "site-2",
+                FLMetaKey.NUM_STEPS_CURRENT_ROUND: 6,
+            },
+        )
+
+        aggr_result = controller.newton_raphson_aggregator_fn([result1, result2])
+
+        assert aggr_result.metrics == {
+            "loss": pytest.approx(0.65),
+            "accuracy": pytest.approx(0.35),
+        }
+        assert "meta" not in aggr_result.metrics
+
     def test_aggregator_with_regularization(self):
         """Test that epsilon regularization prevents singular matrix issues."""
         controller = FedAvgLR(damping_factor=1.0, epsilon=10.0, n_features=2)

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -14,6 +14,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import nvflare.app_common.workflows.fedavg as fedavg_module
 from nvflare.apis.client import Client
 from nvflare.apis.controller_spec import ClientTask, Task
@@ -662,6 +664,62 @@ class TestFedAvgAggregation:
         assert aggr_result.metrics is not None
         assert aggr_result.metrics["loss"] == 0.6
 
+    def test_aggregate_fl_model_metrics_empty_metrics_keep_round_enabled(self):
+        """Test the shared metric helper treats empty metrics as present."""
+        from nvflare.app_common.workflows.base_fedavg import _aggregate_fl_model_metrics
+
+        result1 = FLModel(
+            params={"w": 1.0},
+            params_type=ParamsType.FULL,
+            metrics={},
+            meta={"client_name": "site-1", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 4},
+        )
+        result2 = FLModel(
+            params={"w": 3.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.6},
+            meta={"client_name": "site-2", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 6},
+        )
+        result1.current_round = 0
+        result2.current_round = 0
+
+        aggr_metrics = _aggregate_fl_model_metrics([result1, result2])
+
+        assert aggr_metrics == {"loss": pytest.approx(0.6)}
+
+    def test_aggregate_fl_model_metrics_uses_per_key_denominators(self):
+        """Test missing metric keys do not dilute keys contributed by other clients."""
+        from nvflare.app_common.workflows.base_fedavg import _aggregate_fl_model_metrics
+
+        result1 = FLModel(
+            params={"w": 1.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.2},
+            meta={"client_name": "site-1", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 2},
+        )
+        result2 = FLModel(
+            params={"w": 3.0},
+            params_type=ParamsType.FULL,
+            metrics={"accuracy": 0.9},
+            meta={"client_name": "site-2", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 6},
+        )
+        result3 = FLModel(
+            params={"w": 5.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.6, "accuracy": 0.3},
+            meta={"client_name": "site-3", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 2},
+        )
+        result1.current_round = 0
+        result2.current_round = 0
+        result3.current_round = 0
+
+        aggr_metrics = _aggregate_fl_model_metrics([result1, result2, result3])
+
+        assert aggr_metrics == {
+            "loss": pytest.approx(0.4),
+            "accuracy": pytest.approx(0.75),
+        }
+
     def test_base_fedavg_aggregate_fn_returns_none_when_all_metrics_filtered(self):
         """Test BaseFedAvg.aggregate_fn returns None when all metrics are non-aggregatable."""
         result1 = FLModel(
@@ -1009,6 +1067,22 @@ class TestFedAvgWorkflowEvents:
 class TestScaffoldAggregation:
     """Test Scaffold aggregation behavior."""
 
+    @staticmethod
+    def _scaffold_result(client_name, params, ctrl_diff, metrics, num_steps):
+        from nvflare.app_common.app_constant import AlgorithmConstants
+
+        return FLModel(
+            params=params,
+            params_type=ParamsType.FULL,
+            metrics=metrics,
+            current_round=0,
+            meta={
+                "client_name": client_name,
+                FLMetaKey.NUM_STEPS_CURRENT_ROUND: num_steps,
+                AlgorithmConstants.SCAFFOLD_CTRL_DIFF: ctrl_diff,
+            },
+        )
+
     def test_missing_scaffold_ctrl_diff_raises_clear_error(self):
         """Test missing scaffold control diff raises a clear, framework-neutral error."""
         import re
@@ -1066,6 +1140,85 @@ class TestScaffoldAggregation:
         assert aggr_result.meta[AlgorithmConstants.SCAFFOLD_CTRL_DIFF]["w"] == 3.0
         assert aggr_result.meta["nr_aggregated"] == 2
         assert aggr_result.meta["current_round"] == 0
+
+    def test_scaffold_aggregate_fn_aggregates_generic_numeric_metrics_with_step_weights(self):
+        """Test Scaffold aggregates metric keys generically with client local-step weights."""
+        from nvflare.app_common.app_constant import AlgorithmConstants
+        from nvflare.app_common.workflows.scaffold import scaffold_aggregate_fn
+
+        result1 = self._scaffold_result(
+            client_name="site-1",
+            params={"w": 1.0},
+            ctrl_diff={"w": 2.0},
+            metrics={"loss": 0.2, "accuracy": 0.8},
+            num_steps=2,
+        )
+        result2 = self._scaffold_result(
+            client_name="site-2",
+            params={"w": 5.0},
+            ctrl_diff={"w": 6.0},
+            metrics={"loss": 0.8, "accuracy": 0.2},
+            num_steps=6,
+        )
+
+        aggr_result = scaffold_aggregate_fn([result1, result2])
+
+        assert aggr_result.params["w"] == pytest.approx(4.0)
+        assert aggr_result.meta[AlgorithmConstants.SCAFFOLD_CTRL_DIFF]["w"] == pytest.approx(5.0)
+        assert aggr_result.metrics == {
+            "loss": pytest.approx(0.65),
+            "accuracy": pytest.approx(0.35),
+        }
+
+    def test_scaffold_aggregate_fn_filters_non_aggregatable_metrics(self):
+        """Test Scaffold skips unsupported metric values while preserving numeric metrics."""
+        from nvflare.app_common.workflows.scaffold import scaffold_aggregate_fn
+
+        result1 = self._scaffold_result(
+            client_name="site-1",
+            params={"w": 1.0},
+            ctrl_diff={"w": 2.0},
+            metrics={"loss": 0.2, "meta": {"site": "site-1"}, "tags": ["a"], "run_name": "r1"},
+            num_steps=1,
+        )
+        result2 = self._scaffold_result(
+            client_name="site-2",
+            params={"w": 3.0},
+            ctrl_diff={"w": 4.0},
+            metrics={"loss": 0.6, "meta": {"site": "site-2"}, "tags": ["b"], "run_name": "r2"},
+            num_steps=1,
+        )
+
+        aggr_result = scaffold_aggregate_fn([result1, result2])
+
+        assert aggr_result.metrics is not None
+        assert aggr_result.metrics["loss"] == pytest.approx(0.4)
+        assert "meta" not in aggr_result.metrics
+        assert "tags" not in aggr_result.metrics
+        assert "run_name" not in aggr_result.metrics
+
+    def test_scaffold_aggregate_fn_none_metrics_disable_round_metrics(self):
+        """Test Scaffold matches BaseFedAvg when any client returns metrics=None."""
+        from nvflare.app_common.workflows.scaffold import scaffold_aggregate_fn
+
+        result1 = self._scaffold_result(
+            client_name="site-1",
+            params={"w": 1.0},
+            ctrl_diff={"w": 2.0},
+            metrics=None,
+            num_steps=1,
+        )
+        result2 = self._scaffold_result(
+            client_name="site-2",
+            params={"w": 3.0},
+            ctrl_diff={"w": 4.0},
+            metrics={"loss": 0.6},
+            num_steps=1,
+        )
+
+        aggr_result = scaffold_aggregate_fn([result1, result2])
+
+        assert aggr_result.metrics is None
 
 
 class TestFedAvgAggregationWeights:

--- a/tests/unit_test/app_opt/pt/pt_fedopt_ctl_test.py
+++ b/tests/unit_test/app_opt/pt/pt_fedopt_ctl_test.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+from nvflare.app_common.abstract.fl_model import FLModel
+
+_MODULE_NAME = "_nvflare_pt_fedopt_ctl_for_test"
+
+
+class _FakeTorchWeight:
+    def __init__(self, value):
+        self.value = value
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.value
+
+
+class _FakeOptimizer:
+    param_groups = [{"lr": 0.1}]
+
+
+class _FakeLRScheduler:
+    pass
+
+
+def _load_pt_fedopt_ctl(monkeypatch):
+    """Load PT fedopt_ctl.py directly so the test does not require importing the whole PT package."""
+    if "torch" not in sys.modules:
+        fake_torch = ModuleType("torch")
+        fake_torch.nn = SimpleNamespace(Module=object)
+        fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
+        fake_torch.device = lambda device: device
+        fake_torch.tensor = lambda value: value
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    module_path = Path(__file__).parents[4] / "nvflare" / "app_opt" / "pt" / "fedopt_ctl.py"
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(_MODULE_NAME, None)
+        raise
+
+    return module
+
+
+def test_pt_fedopt_update_model_preserves_aggregated_metrics(monkeypatch):
+    module = _load_pt_fedopt_ctl(monkeypatch)
+
+    try:
+        controller = object.__new__(module.FedOpt)
+        controller.current_round = 3
+        controller.device = "cpu"
+        controller.optimizer = _FakeOptimizer()
+        controller.lr_scheduler = _FakeLRScheduler()
+        controller.info = MagicMock()
+        controller.optimizer_update = MagicMock(
+            side_effect=lambda model_diff: ({"trainable": _FakeTorchWeight(1.5)}, ["trainable"])
+        )
+
+        global_model = FLModel(
+            params={"trainable": 1.0, "batch_norm": 10.0},
+            metrics={"old_metric": -1.0},
+            meta={"old_meta": "before"},
+        )
+        aggr_result = FLModel(
+            params={"trainable": 0.5, "batch_norm": 2.0},
+            metrics={"loss": 0.25, "accuracy": 0.75},
+            meta={"nr_aggregated": 2},
+        )
+
+        updated = controller.update_model(global_model, aggr_result)
+
+        assert updated.params["trainable"] == 1.5
+        assert updated.params["batch_norm"] == 12.0
+        assert updated.meta == aggr_result.meta
+        assert updated.metrics == aggr_result.metrics
+
+        clear_metrics_result = FLModel(
+            params={"trainable": 0.5, "batch_norm": 2.0},
+            metrics=None,
+            meta={"nr_aggregated": 2},
+        )
+
+        updated = controller.update_model(global_model, clear_metrics_result)
+
+        assert updated.metrics is None
+    finally:
+        sys.modules.pop(_MODULE_NAME, None)

--- a/tests/unit_test/app_opt/tf/tf_fedopt_ctl_test.py
+++ b/tests/unit_test/app_opt/tf/tf_fedopt_ctl_test.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+
+_MODULE_NAME = "_nvflare_tf_fedopt_ctl_for_test"
+
+
+class _FakeWeight:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _FakeKerasModel:
+    trainable_weights = [_FakeWeight((1,))]
+
+    def get_weights(self):
+        return [np.array([1.5])]
+
+
+class _FakeLearningRate:
+    def numpy(self):
+        return 0.1
+
+
+class _FakeOptimizer:
+    def __init__(self):
+        self.learning_rate = _FakeLearningRate()
+        self.applied_gradients = None
+
+    def apply_gradients(self, gradients):
+        self.applied_gradients = list(gradients)
+
+
+class _FakeLRScheduler:
+    pass
+
+
+def _load_tf_fedopt_ctl(monkeypatch):
+    """Load TF fedopt_ctl.py directly so TensorFlow is not required for this unit test."""
+    if "tensorflow" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "tensorflow", ModuleType("tensorflow"))
+
+    module_path = Path(__file__).parents[4] / "nvflare" / "app_opt" / "tf" / "fedopt_ctl.py"
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(_MODULE_NAME, None)
+        raise
+
+    return module
+
+
+def test_tf_fedopt_update_model_preserves_aggregated_metrics(monkeypatch):
+    module = _load_tf_fedopt_ctl(monkeypatch)
+
+    try:
+        controller = object.__new__(module.FedOpt)
+        controller.current_round = 3
+        controller.persistor = SimpleNamespace(model=_FakeKerasModel())
+        controller.optimizer = _FakeOptimizer()
+        controller.lr_scheduler = _FakeLRScheduler()
+        controller.info = MagicMock()
+        controller._to_tf_params_list = MagicMock(return_value=["gradient"])
+
+        global_model = FLModel(
+            params={
+                "trainable": np.array([1.0]),
+                "batch_norm": np.array([10.0]),
+            },
+            metrics={"old_metric": -1.0},
+            meta={"old_meta": "before"},
+        )
+        aggr_result = FLModel(
+            params={
+                "trainable": np.array([1.25]),
+                "batch_norm": np.array([12.0]),
+            },
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.25, "accuracy": 0.75},
+            meta={"nr_aggregated": 2},
+        )
+
+        updated = controller.update_model(global_model, aggr_result)
+
+        np.testing.assert_array_equal(updated.params["trainable"], np.array([1.5]))
+        np.testing.assert_array_equal(updated.params["batch_norm"], np.array([12.0]))
+        assert updated.meta == aggr_result.meta
+        assert updated.metrics == aggr_result.metrics
+
+        clear_metrics_result = FLModel(
+            params={
+                "trainable": np.array([1.25]),
+                "batch_norm": np.array([12.0]),
+            },
+            params_type=ParamsType.FULL,
+            metrics=None,
+            meta={"nr_aggregated": 2},
+        )
+
+        updated = controller.update_model(global_model, clear_metrics_result)
+
+        assert updated.metrics is None
+    finally:
+        sys.modules.pop(_MODULE_NAME, None)


### PR DESCRIPTION
## Summary
- Add shared FedAvg-compatible aggregation for generic `FLModel.metrics`.
- Use the shared metric aggregation in SCAFFOLD and LR FedAvg custom aggregation paths.
- Preserve aggregated metrics through PT/TF FedOpt controller `update_model()` overrides.
- Add focused tests for SCAFFOLD metric aggregation, LR FedAvg metric aggregation, and PT/TF FedOpt metric preservation/clearing.

## Scope
This PR is limited to FLModel-based workflow parity. It does not change legacy DXO/ScatterAndGather metric collection semantics, including recipe paths that use explicit `DataKind.METRICS` wiring.

Metrics remain generic: no metric key is hardcoded. Values that cannot be aggregated are filtered using the existing FedAvg helper behavior. Aggregated AUROC-like metrics are weighted averages of client metric values, not pooled/global metrics.

## Testing
- `python -m pytest tests/unit_test/app_common/workflow/fedavg_test.py tests/unit_test/app_common/workflow/fedavg_lr_test.py tests/unit_test/app_opt/pt/pt_fedopt_ctl_test.py tests/unit_test/app_opt/tf/tf_fedopt_ctl_test.py -q`
- `./runtest.sh -s`