### PR TITLE
Fix simulator job cell without server config

### DIFF
--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -691,7 +691,7 @@ class FedJob:
         if threads is None:
             threads = n_clients
 
-        self.job.simulator_run(
+        return self.job.simulator_run(
             workspace,
             clients=",".join(self.clients),
             n_clients=n_clients,

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -195,6 +195,7 @@ class FedJobConfig:
                 process = subprocess.Popen(shlex.split(command, True), shell=False, preexec_fn=os.setsid, env=new_env)
 
                 process.wait()
+                return process.returncode
 
             except KeyboardInterrupt:
                 self.logger.info("KeyboardInterrupt, terminate all the child processes.")

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -544,6 +544,7 @@ class FederatedServer(BaseServer):
         )
 
     def create_job_cell(self, job_id, root_url, parent_url, secure_train, server_config) -> Cell:
+        server_config = server_config or {}
         my_fqcn = FQCN.join([FQCN.ROOT_SERVER, job_id])
         if secure_train:
             root_cert = server_config[SecureTrainConst.SSL_ROOT_CERT]

--- a/nvflare/recipe/sim_env.py
+++ b/nvflare/recipe/sim_env.py
@@ -94,7 +94,7 @@ class SimEnv(ExecEnv):
         self.log_config = v.log_config
         self.clients = v.clients
         self.workspace_root = v.workspace_root
-        self.last_run_status = None
+        self.last_run_failed = False
 
     def deploy(self, job: FedJob):
         # Validate scripts exist locally for simulation
@@ -106,7 +106,7 @@ class SimEnv(ExecEnv):
             )
 
         job_id = job.name
-        self.last_run_status = job.simulator_run(
+        run_status = job.simulator_run(
             workspace=os.path.join(self.workspace_root, job.name),
             n_clients=self.num_clients if self.clients is None else None,
             clients=self.clients,
@@ -114,9 +114,10 @@ class SimEnv(ExecEnv):
             gpu=self.gpu_config,
             log_config=self.log_config,
         )
-        if self.last_run_status:
+        self.last_run_failed = run_status not in (None, 0)
+        if self.last_run_failed:
             raise RuntimeError(
-                f"Simulation failed with return code {self.last_run_status}. "
+                f"Simulation failed with return code {run_status}. "
                 f"Logs are in per-site subdirectories under {os.path.join(self.workspace_root, job_id)}, "
                 f"e.g. server/simulate_job/log.txt"
             )

--- a/nvflare/recipe/sim_env.py
+++ b/nvflare/recipe/sim_env.py
@@ -94,6 +94,7 @@ class SimEnv(ExecEnv):
         self.log_config = v.log_config
         self.clients = v.clients
         self.workspace_root = v.workspace_root
+        self.last_run_status = None
 
     def deploy(self, job: FedJob):
         # Validate scripts exist locally for simulation
@@ -104,7 +105,8 @@ class SimEnv(ExecEnv):
                 f"For SimEnv, all scripts must be present on the local machine."
             )
 
-        job.simulator_run(
+        job_id = job.name
+        self.last_run_status = job.simulator_run(
             workspace=os.path.join(self.workspace_root, job.name),
             n_clients=self.num_clients if self.clients is None else None,
             clients=self.clients,
@@ -112,7 +114,12 @@ class SimEnv(ExecEnv):
             gpu=self.gpu_config,
             log_config=self.log_config,
         )
-        return job.name
+        if self.last_run_status:
+            raise RuntimeError(
+                f"Simulation failed with return code {self.last_run_status}. "
+                f"The simulation logs can be found at {os.path.join(self.workspace_root, job_id)}"
+            )
+        return job_id
 
     def get_job_status(self, job_id: str) -> Optional[str]:
         """Get job status - not supported in simulation environment."""

--- a/nvflare/recipe/sim_env.py
+++ b/nvflare/recipe/sim_env.py
@@ -117,7 +117,8 @@ class SimEnv(ExecEnv):
         if self.last_run_status:
             raise RuntimeError(
                 f"Simulation failed with return code {self.last_run_status}. "
-                f"The simulation logs can be found at {os.path.join(self.workspace_root, job_id)}"
+                f"Logs are in per-site subdirectories under {os.path.join(self.workspace_root, job_id)}, "
+                f"e.g. server/simulate_job/log.txt"
             )
         return job_id
 

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 from nvflare.job_config.fed_job_config import FedJobConfig
 
@@ -40,3 +41,14 @@ class TestFedJobConfig:
         assert expected == job_config._trim_whitespace("site-0, site-1")
         assert expected == job_config._trim_whitespace(" site-0,site-1 ")
         assert expected == job_config._trim_whitespace(" site-0, site-1 ")
+
+    def test_simulator_run_returns_process_returncode(self, tmp_path):
+        job_config = FedJobConfig(job_name="test_job", min_clients=1)
+        mock_process = MagicMock()
+        mock_process.returncode = 3
+
+        with patch.object(job_config, "generate_job_config"):
+            with patch("nvflare.job_config.fed_job_config.subprocess.Popen", return_value=mock_process):
+                result = job_config.simulator_run(str(tmp_path), n_clients=1)
+
+        assert result == 3

--- a/tests/unit_test/job_config/fed_job_test.py
+++ b/tests/unit_test/job_config/fed_job_test.py
@@ -313,5 +313,11 @@ class TestSimulatorRunClientValidation:
     def test_clients_only_no_n_clients_passes(self, tmp_path):
         """Providing only clients (no n_clients) should pass."""
         job = self._make_job()
-        with patch.object(job.job, "simulator_run"):
+        with patch.object(job.job, "simulator_run", return_value=0):
             job.simulator_run(str(tmp_path), clients=["site-1", "site-2"])
+
+    def test_simulator_run_returns_process_status(self, tmp_path):
+        """FedJob.simulator_run() should surface the lower simulator status."""
+        job = self._make_job()
+        with patch.object(job.job, "simulator_run", return_value=2):
+            assert job.simulator_run(str(tmp_path), clients=["site-1", "site-2"]) == 2

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nvflare.apis.fl_constant import RunProcessKey
+from nvflare.apis.fl_constant import ConnPropKey, RunProcessKey
 from nvflare.apis.job_def import JobMetaKey, RunStatus
 from nvflare.apis.job_launcher_spec import JobReturnCode
 from nvflare.apis.shareable import Shareable
@@ -40,6 +40,57 @@ class TestFederatedServer:
         server.client_manager.clients = {"token-a": client}
 
         assert server._resolve_client_fqcn_for_auth("site-a", "token-a") == MISSING_CLIENT_FQCN
+
+    def test_create_job_cell_allows_missing_server_config_for_non_secure_cell(self):
+        server = object.__new__(FederatedServer)
+        server.engine = MagicMock()
+
+        with (
+            patch("nvflare.private.fed.server.fed_server.Cell") as cell_cls,
+            patch("nvflare.private.fed.server.fed_server.NetAgent") as net_agent_cls,
+            patch("nvflare.private.fed.server.fed_server.ServerCommandAgent") as command_agent_cls,
+            patch("nvflare.private.fed.server.fed_server.mpm.add_cleanup_cb"),
+        ):
+            cell = MagicMock()
+            cell_cls.return_value = cell
+            net_agent_cls.return_value = MagicMock()
+            command_agent_cls.return_value = MagicMock()
+
+            result = server.create_job_cell("job-1", "tcp://root", "tcp://parent", False, None)
+
+        assert result is cell
+        assert cell_cls.call_args.kwargs["credentials"] == {}
+        assert cell_cls.call_args.kwargs["auth_identity"] is None
+        assert cell_cls.call_args.kwargs["auth_identity_map"] is None
+
+    def test_create_job_cell_uses_auth_identity_from_server_config(self):
+        server = object.__new__(FederatedServer)
+        server.engine = MagicMock()
+        auth_identity_map = {"server": "server-cn"}
+
+        with (
+            patch("nvflare.private.fed.server.fed_server.Cell") as cell_cls,
+            patch("nvflare.private.fed.server.fed_server.NetAgent") as net_agent_cls,
+            patch("nvflare.private.fed.server.fed_server.ServerCommandAgent") as command_agent_cls,
+            patch("nvflare.private.fed.server.fed_server.mpm.add_cleanup_cb"),
+        ):
+            cell_cls.return_value = MagicMock()
+            net_agent_cls.return_value = MagicMock()
+            command_agent_cls.return_value = MagicMock()
+
+            server.create_job_cell(
+                "job-1",
+                "tcp://root",
+                "tcp://parent",
+                False,
+                {
+                    ConnPropKey.AUTH_IDENTITY: "server-cn",
+                    ConnPropKey.AUTH_IDENTITY_MAP: auth_identity_map,
+                },
+            )
+
+        assert cell_cls.call_args.kwargs["auth_identity"] == "server-cn"
+        assert cell_cls.call_args.kwargs["auth_identity_map"] == auth_identity_map
 
     def test_hot_state_defaults_to_non_empty_session_id(self):
         assert HotState().ssid == DEFAULT_SERVICE_SESSION_ID

--- a/tests/unit_test/recipe/sim_env_test.py
+++ b/tests/unit_test/recipe/sim_env_test.py
@@ -52,9 +52,22 @@ def test_sim_env_deploy_with_explicit_clients_does_not_pass_n_clients():
 
     env = SimEnv(clients=["site-1", "site-2"])
     with patch("nvflare.recipe.sim_env.collect_non_local_scripts", return_value=[]):
-        with patch.object(job, "simulator_run") as mock_run:
+        with patch.object(job, "simulator_run", return_value=0) as mock_run:
             env.deploy(job)
 
     _, kwargs = mock_run.call_args
     assert kwargs.get("n_clients") is None
     assert kwargs.get("clients") == ["site-1", "site-2"]
+
+
+def test_sim_env_deploy_raises_on_failed_simulation(tmp_path):
+    job = FedJob(name="test_job")
+    job._deployed = True
+
+    env = SimEnv(num_clients=2, workspace_root=str(tmp_path))
+    with patch("nvflare.recipe.sim_env.collect_non_local_scripts", return_value=[]):
+        with patch.object(job, "simulator_run", return_value=2):
+            with pytest.raises(RuntimeError, match="Simulation failed with return code 2"):
+                env.deploy(job)
+
+    assert env.last_run_status == 2

--- a/tests/unit_test/recipe/sim_env_test.py
+++ b/tests/unit_test/recipe/sim_env_test.py
@@ -58,6 +58,7 @@ def test_sim_env_deploy_with_explicit_clients_does_not_pass_n_clients():
     _, kwargs = mock_run.call_args
     assert kwargs.get("n_clients") is None
     assert kwargs.get("clients") == ["site-1", "site-2"]
+    assert not env.last_run_failed
 
 
 def test_sim_env_deploy_raises_on_failed_simulation(tmp_path):
@@ -70,4 +71,4 @@ def test_sim_env_deploy_raises_on_failed_simulation(tmp_path):
             with pytest.raises(RuntimeError, match="Simulation failed with return code 2"):
                 env.deploy(job)
 
-    assert env.last_run_status == 2
+    assert env.last_run_failed


### PR DESCRIPTION
## Summary
- Default missing `server_config` to an empty dict in `FederatedServer.create_job_cell` so simulator job-cell creation can run with non-secure training.
- Propagate simulator subprocess return codes through `FedJobConfig.simulator_run()`, `FedJob.simulator_run()`, and `SimEnv.deploy()`.
- Raise from `SimEnv.deploy()` on nonzero simulator status so `python job.py` exits nonzero when the simulator fails.
- Improve the simulation failure message to point reviewers/users at the per-site log layout, for example `server/simulate_job/log.txt`.
- Add regression coverage for the simulator-style `server_config=None` call, auth identity propagation, simulator return-code propagation, and the direct subprocess return-code layer.

## Root Cause
`SimulatorRunner.start_server_app` calls `create_job_cell(..., False, None)`. `create_job_cell` only used `server_config` inside the secure credential block before later unconditionally reading auth identity fields with `server_config.get(...)`, causing an `AttributeError` for non-secure simulator jobs.

The simulator process already exits with its run status, but the recipe path discarded that status in the subprocess wrapper and `FedJob.simulator_run()`. As a result, `python job.py` could report the thread failure in logs while the top-level process still exited `0`.

## Validation
- Reproduced the original `hello-pt` failure on `upstream/main` at `26a072e3c`: server thread hit `AttributeError: NoneType object has no attribute get`, while `python job.py` exited `0`.
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/private/fed/server/fed_server_test.py tests/unit_test/private/fed/app/simulator/simulator_runner_test.py tests/unit_test/recipe/sim_env_test.py tests/unit_test/job_config/fed_job_test.py::TestSimulatorRunClientValidation -q`
- `/Users/zhihongz/nvflare-env/3.12/bin/python -m pytest tests/unit_test/job_config/fed_job_config_test.py tests/unit_test/recipe/sim_env_test.py -q`
- `PYTHONPATH=/Users/zhihongz/work/NVFlare /Users/zhihongz/nvflare-env/3.12/bin/python job.py --synthetic_data --train_size 16 --test_size 8 --num_rounds 1 --epochs 1 --batch_size 4 --num_workers 0` from `examples/hello-world/hello-pt`
- Scoped `black --check`, `isort --check-only`, `flake8`, and `git diff --check` on changed files

## Notes
- `PATH=/Users/zhihongz/nvflare-env/3.12/bin:$PATH ./runtest.sh -s` failed before style checks because dependency setup selected Python 3.8 and `versioneer.py` uses `dict[str, str]` syntax.
- `PATH=/Users/zhihongz/nvflare-env/3.12/bin:$PATH ./runtest.sh --skip-install -s` reached Black and failed only on pre-existing vendored `examples/.../node_modules/.../flatted.py` files outside this PR.