### PR TITLE
Add recipe metrics artifacts writer

### DIFF
--- a/docs/design/recipe_metrics_artifacts_design.md
+++ b/docs/design/recipe_metrics_artifacts_design.md
@@ -1,0 +1,454 @@
+# Recipe Metrics Artifacts Design
+
+## Summary
+
+NVFlare aggregation and training job recipes should persist a standard, machine-readable metrics artifact when they report aggregated round metrics. Today the final aggregated metric values are generally visible only in server logs or experiment tracking backends. This makes automated benchmarking and reporting harder than necessary.
+
+This design proposes a common server-side metrics writer that records:
+
+- final aggregated metrics from the last completed round
+- best metrics published by existing model-selection logic, when available
+- per-site client-reported metrics for each round
+- aggregation weights and provenance when available
+- skipped metrics and skip reasons for unsupported or unsafe metric values
+
+The writer must be generic across aggregation and training recipes and metric names. Metric names such as `auroc`, `accuracy`, `loss`, `dice`, `rmse`, or `f1` are user/client supplied keys, not hard-coded schema fields.
+
+The writer is intentionally an artifact layer over existing workflow outputs. It should consume metrics that recipes and controllers already produce, such as aggregated `FLModel.metrics`, `AGGREGATION_RESULT` payloads, existing contribution weight metadata, and best-selection metadata from model selectors. It should not introduce a parallel aggregation path or best-round selection path.
+
+## Current State
+
+The current recipe surface does not persist a standalone `final_metrics.json` or `metrics.json` from normal training aggregation.
+
+Relevant implementation points:
+
+- `nvflare/job_config/base_fed_job.py` installs `ValidationJsonGenerator` and `IntimeModelSelector` in the shared `BaseFedJob` path.
+- `nvflare/app_common/widgets/intime_model_selector.py` computes and logs a selected validation metric for best-model selection.
+- `nvflare/app_common/widgets/validation_json_generator.py` writes `cross_site_val/cross_val_results.json`, but only for cross-site validation result events.
+- `nvflare/app_common/workflows/fedavg.py` computes weighted aggregated `FLModel.metrics` for rounds in the InTime FedAvg path, but those metrics are not persisted as a metrics artifact.
+- `nvflare/app_common/workflows/base_fedavg.py` fires `AppEventType.AFTER_AGGREGATION` with `AppConstants.AGGREGATION_RESULT` in the non-streaming BaseFedAvg path.
+
+One important detail is that `IntimeModelSelector` and FedAvg round aggregation may not use identical weighting today. `IntimeModelSelector` defaults to equal client weights unless configured with `weigh_by_local_iter=True`; FedAvg's aggregated round metrics use `NUM_STEPS_CURRENT_ROUND` and optional site aggregation weights. The artifact should preserve the provenance of each reported value instead of pretending these streams are identical.
+
+## Goals
+
+- Provide a standard metrics artifact contract for aggregation and training recipes that already produce metrics.
+- Preserve final aggregated metric values and official best metric values when existing selectors or workflows publish them.
+- Preserve per-site client-reported metrics for every completed round.
+- Keep the schema metric-agnostic.
+- Avoid recipe-specific log scraping.
+- Make the writer safe when metric names and values are provided by untrusted clients.
+- Allow benchmarking/reporting tools to consume a stable JSON format.
+
+## Non-Goals
+
+- Do not recompute nonlinear metrics such as AUROC from pooled predictions.
+- Do not require clients to report a specific metric name.
+- Do not force recipes without metrics to invent placeholder metric values.
+- Do not replace TensorBoard, MLflow, W&B, or existing analytics streaming.
+- Do not change model aggregation semantics.
+- Do not reimplement aggregation algorithms that already exist in controllers, aggregators, selectors, or workflow helpers.
+- Do not infer best-round policy or select best rounds in the writer.
+- Do not add metrics artifacts to no-aggregation workflows such as PSI or stats recipes.
+- Do not merge cross-site validation into this artifact contract; it remains a separate workflow with its existing `cross_val_results.json` artifact.
+
+## Proposed Artifacts
+
+The writer should create a dedicated metrics directory under the server run directory:
+
+```text
+metrics/
+  metrics_summary.json
+  round_metrics.jsonl
+```
+
+`metrics_summary.json` is compact and intended for dashboards, benchmark reports, and quick inspection.
+
+`round_metrics.jsonl` is append-friendly and stores one JSON object per completed round.
+
+Round values are recorded verbatim from NVFlare workflow metadata, such as `AppConstants.CURRENT_ROUND` or `FLModel.current_round`. They are 0-based by default and honor nonzero `start_round`; the artifact does not renumber rounds.
+
+No artifact is required for workflows that do not perform training aggregation or do not produce aggregation metrics. This includes PSI, stats-only jobs, and cross-site validation. For an aggregation workflow where the writer is installed but no metrics are reported, the writer should remain quiet or emit a bounded debug log rather than creating a synthetic metrics file.
+
+## Schema: metrics_summary.json
+
+Use arrays for dynamic metric names rather than JSON object keys. This avoids problems in downstream JavaScript tooling with special keys such as `__proto__`, `constructor`, or deeply nested object paths.
+
+Example:
+
+```json
+{
+  "schema_version": "1",
+  "job_name": "ames_fedavg",
+  "algorithm": "FedAvg",
+  "status": "metrics_reported",
+  "metric_source": "client_reported_flmodel_metrics",
+  "metric_split": "validation",
+  "key_metric": {
+    "name": "auroc",
+    "mode": "max",
+    "mode_source": "IntimeModelSelector.negate_key_metric"
+  },
+  "final_round": 2,
+  "final_aggregated_metrics": [
+    {
+      "name": "auroc",
+      "value": 0.7421
+    },
+    {
+      "name": "train_loss",
+      "value": 0.492
+    }
+  ],
+  "best_round": 0,
+  "best_metrics": [
+    {
+      "name": "auroc",
+      "value": 0.7500010132169
+    }
+  ],
+  "best_metric_source": "IntimeModelSelector",
+  "best_metric_detail_source": "initial_metrics",
+  "aggregation": {
+    "method": "weighted_average",
+    "weight_key": "NUM_STEPS_CURRENT_ROUND",
+    "metric_policy": "finite_numeric_metrics_only_per_key_denominator"
+  },
+  "round_metrics_file": "round_metrics.jsonl",
+  "notes": [
+    "Aggregated metrics are weighted averages of client-reported metric values.",
+    "Nonlinear metrics are not recomputed from pooled predictions."
+  ]
+}
+```
+
+`key_metric.name` is published by existing recipe, selector, stop-condition, or workflow logic. It is not a fixed schema field.
+
+`key_metric.mode` is also published by existing logic, not registered separately by users. Examples:
+
+- `IntimeModelSelector` normally implies `max`; if `negate_key_metric=True`, raw metric selection is `min`.
+- FedAvg `stop_cond` operators such as `>` or `>=` imply `max`; `<` or `<=` imply `min`.
+- Custom workflows may expose their comparator or selected best-round metadata through the same event contract.
+
+The writer records best fields only when an existing selector or workflow publishes explicit best-selection metadata. If no such metadata is available, the writer still records final metrics and round metrics but omits `best_round`, `best_metrics`, and `best_aggregated_metrics`.
+
+## Schema: round_metrics.jsonl
+
+Each line is a full JSON object for one completed round.
+
+Example:
+
+```json
+{
+  "round": 0,
+  "aggregated_metrics": [
+    {
+      "name": "auroc",
+      "value": 0.7500010132169
+    },
+    {
+      "name": "train_loss",
+      "value": 0.4855
+    }
+  ],
+  "sites": [
+    {
+      "name": "site-1",
+      "metrics": [
+        {
+          "name": "train_loss",
+          "value": 0.4707
+        },
+        {
+          "name": "auroc",
+          "value": 0.7380791446479046
+        }
+      ],
+      "weight": 2911,
+      "weight_key": "NUM_STEPS_CURRENT_ROUND"
+    },
+    {
+      "name": "site-2",
+      "metrics": [
+        {
+          "name": "train_loss",
+          "value": 0.5003
+        },
+        {
+          "name": "auroc",
+          "value": 0.7619228817858955
+        }
+      ],
+      "weight": 2911,
+      "weight_key": "NUM_STEPS_CURRENT_ROUND"
+    }
+  ],
+  "aggregation": {
+    "method": "weighted_average",
+    "weight_key": "NUM_STEPS_CURRENT_ROUND",
+    "metric_policy": "finite_numeric_metrics_only_per_key_denominator"
+  },
+  "key_metric": {
+    "name": "auroc",
+    "mode": "max",
+    "mode_source": "IntimeModelSelector.negate_key_metric"
+  },
+  "skipped_metrics": [
+    {
+      "site": "site-1",
+      "name": "debug_blob",
+      "reason": "unsupported_type"
+    }
+  ]
+}
+```
+
+The `metrics` arrays preserve client-reported metric names and values after safe normalization. `aggregated_metrics` contains official workflow/controller aggregated metrics after safe normalization; it is not recomputed by the writer from site records.
+
+## Event Contract
+
+The writer should be one common server-side component, for example `MetricsArtifactWriter`, installed by aggregation recipe setup paths where practical. Its responsibility is artifact recording: final metrics, official best metrics, per-round client metrics, provenance, and skipped values. Existing aggregators and best-model selectors remain responsible for computing aggregates and deciding which model is best.
+
+`Widget` is a reasonable implementation base because it is already an event-driven `FLComponent` pattern used by components such as `ValidationJsonGenerator`. The public contract should be "server-side metrics artifact component" rather than "user must register a widget." If `Widget` later proves too narrow, the implementation can use `FLComponent` directly without changing the schema or event contract.
+
+To avoid recipe-specific parsing, workflows should expose consistent events:
+
+1. Per-client contribution accepted
+
+   The writer needs the current round, client identity, client metrics, and contribution weight. Existing events such as `AppEventType.BEFORE_CONTRIBUTION_ACCEPT` can provide this in some workflows, but not all workflows expose a normalized `FLModel` result at this point.
+
+2. Round aggregation completed
+
+   Workflows should fire:
+
+   ```python
+   fire_event_with_data(
+       AppEventType.AFTER_AGGREGATION,
+       fl_ctx,
+       AppConstants.AGGREGATION_RESULT,
+       aggr_result,
+   )
+   ```
+
+   where `aggr_result` is an `FLModel` or an equivalent object with a normalized metrics dictionary and round metadata.
+
+3. Run ended
+
+   On `EventType.END_RUN`, the writer finalizes `metrics_summary.json`.
+
+4. Best model selected
+
+   Model selectors that decide a new global best model should continue firing their existing best-model event and may attach explicit metrics metadata:
+
+   ```python
+   fl_ctx.set_prop(
+       AppConstants.METRICS_SELECTION_INFO,
+       {
+           "source": "IntimeModelSelector",
+           "metric_source": "initial_metrics",
+           "key_metric": {
+               "name": "auroc",
+               "mode": "max",
+               "mode_source": "IntimeModelSelector.negate_key_metric",
+           },
+           "best_round": current_round,
+           "best_metrics": {"auroc": 0.7500010132169},
+       },
+       private=True,
+       sticky=False,
+   )
+   fire_event(AppEventType.GLOBAL_BEST_MODEL_AVAILABLE, fl_ctx)
+   ```
+
+   The writer records this metadata without comparing metric values.
+
+The existing non-streaming `BaseFedAvg` path already fires `AFTER_AGGREGATION` with `AGGREGATION_RESULT`. The InTime FedAvg path should be aligned so that the same writer can consume the same event.
+
+For custom aggregators, the recommended contract is event-based rather than a new mandatory aggregator base interface. Controllers should fire the standard aggregation event with the `FLModel` returned by the aggregator. The easy user path is: custom aggregators return `FLModel(metrics=...)` as they do today. If they have custom metric weights or provenance, they may optionally attach bounded metadata to `FLModel.meta`, for example under a new key such as `metrics_aggregation_info`. Built-in controllers can then pass that through the same event. Lower-level custom workflows can use a helper such as `fire_metrics_aggregation_event(fl_ctx, aggr_result, contributions=None)` instead of hand-building event payloads.
+
+## Cross-Recipe Behavior
+
+The feature should apply to aggregation and training recipes that expose round-level aggregated metrics:
+
+- FedAvg recipes for PyTorch, TensorFlow, NumPy, and sklearn
+- FedOpt recipes
+- Scaffold recipes
+- FedAvg with HE
+- LR FedAvg
+- XGBoost recipes
+- Swarm and cyclic recipes where aggregation metrics are available
+- Flower recipes when metrics are bridged through NVFlare analytics or normalized workflow events
+
+Recipes that do not perform aggregation or do not produce aggregation metrics should remain valid and should not be forced to create metrics artifacts.
+
+## Best Metric Selection
+
+Best metric selection is not a writer responsibility. It belongs to existing model selectors, controllers, or workflows that already own comparison policy and model persistence.
+
+Existing model selectors such as `IntimeModelSelector` can continue to select and persist best models. When they expose `METRICS_SELECTION_INFO`, the writer records:
+
+- `key_metric`
+- `best_round`
+- `best_metrics`
+- optional `best_aggregated_metrics`
+- source/provenance fields
+
+If a selector or workflow does not expose compatible metadata, the artifact omits best fields rather than inferring a policy.
+
+## Aggregation Policy
+
+The writer should not invent aggregation semantics. Its primary job is to persist what existing recipes, controllers, aggregators, and selectors already compute. `aggregated_metrics` should come from the workflow's own `AGGREGATION_RESULT` or equivalent normalized controller output.
+
+Per-site records should include all safely normalized scalar metrics, including bool metrics. Site weights should be recorded as provenance when available, but they should not be used by the writer to compute a synthetic aggregate.
+
+For nonlinear metrics, record a note that aggregated values are weighted averages of client-reported values, not pooled metric computations.
+
+## Security Model
+
+Clients are untrusted metric producers. The metrics writer is a server-side sink for untrusted data and must not interpret metric content as executable code, configuration, or filesystem paths.
+
+Threats to consider:
+
+- code execution through unsafe deserialization or dynamic evaluation
+- path traversal through client-provided names
+- resource exhaustion through huge metric payloads
+- JSON poisoning for downstream JavaScript consumers
+- invalid numeric values such as `NaN` and `Infinity`
+- object side effects through `__str__`, `__repr__`, or custom serialization hooks
+
+Required protections:
+
+- Do not use `eval`, `exec`, dynamic imports, class loading, `pickle`, `yaml.load`, or shell commands.
+- Do not call `str(value)` or `repr(value)` on arbitrary client-provided metric values.
+- Serialize only explicitly normalized JSON-safe values.
+- Use fixed output filenames.
+- Never use metric names, site names, job names, or other client-controlled metadata as path components.
+- Resolve output paths under the server run directory with `resolve_path_under_root`.
+- Use `json.dump(..., allow_nan=False)`.
+- Accept finite numeric values and bool values for official aggregated metrics.
+- Bound metric name length, number of metrics per client, number of sites, skipped metric records, and JSON line size.
+- Store dynamic metric names as values in arrays, not as object keys.
+- Record skipped metrics by name and reason only after safe name normalization.
+
+Suggested default limits:
+
+```text
+max_metric_name_length = 256
+max_metrics_per_site_per_round = 512
+max_sites_per_round = 10000
+max_skipped_metrics_per_round = 1024
+max_round_record_bytes = 1048576
+max_summary_bytes = 1048576
+```
+
+Metric name normalization:
+
+- accept only strings
+- truncate to the configured maximum length
+- reject or replace control characters
+- do not interpret separators such as `.`, `/`, `[`, or `]`
+
+Metric value normalization:
+
+- accept `int`, `float`, bool, and bounded strings for raw per-site metric records
+- convert numeric and bool values to plain Python JSON scalars
+- reject non-finite numbers
+- record only finite numeric values and bool values for official aggregated metrics
+- skip dicts, lists, sets, tuples, objects, tensors, arrays, bytes, and oversized strings unless future support is explicitly designed and bounded
+
+## Failure Behavior
+
+The writer should not fail the job for bad metric payloads. It should:
+
+- skip invalid metrics
+- record skip reasons in the round record
+- log bounded warnings
+- continue writing valid metrics
+
+The writer may fail closed only for local server-side errors such as inability to resolve a safe output path. In that case, it should log an error and avoid writing outside the run directory.
+
+## Implementation Sketch
+
+Add a common server-side metrics artifact component. The first implementation can subclass `Widget` because the component is event-driven, but the design only requires `FLComponent` behavior:
+
+```python
+class MetricsArtifactWriter(Widget):  # or FLComponent if no Widget-specific behavior is needed
+    def __init__(
+        self,
+        results_dir="metrics",
+        summary_file_name="metrics_summary.json",
+        round_file_name="round_metrics.jsonl",
+        limits=None,
+    ):
+        ...
+```
+
+Behavior:
+
+- On `EventType.START_RUN`, reset in-memory summary state.
+- On contribution events, capture normalized per-site metrics and weights for the current round.
+- On `AppEventType.AFTER_AGGREGATION`, capture normalized aggregated metrics and append one JSONL record for the current round.
+- On `AppEventType.GLOBAL_BEST_MODEL_AVAILABLE`, capture normalized `METRICS_SELECTION_INFO` if the selector published it.
+- Optionally read bounded `metrics_aggregation_info` metadata from `FLModel.meta` for custom aggregator provenance.
+- On `EventType.END_RUN`, write `metrics_summary.json`.
+
+State to keep in memory:
+
+- current round per-site metrics until the round aggregate is known
+- final round number and final aggregated metrics
+- official best-selection metadata, when published by a selector or workflow
+- skip counters and bounded skipped metric records
+
+The writer should stream `round_metrics.jsonl` as rounds complete rather than keeping all rounds in memory.
+
+## Recipe Integration
+
+Short term:
+
+- Add the writer to `BaseFedJob` so the recipes already using this path get the artifact.
+- Add the writer to standalone aggregation recipe setup paths that do not use `BaseFedJob`.
+- Align InTime FedAvg to fire `AFTER_AGGREGATION` with `AGGREGATION_RESULT`.
+
+Medium term:
+
+- If standalone recipe builders continue to duplicate writer setup, factor that internal wiring into a shared helper used by NVFlare recipe implementations. Users should not need to call this helper.
+- Standardize event payloads for non-FedAvg workflows.
+- Add recipe parameters to disable or configure the writer when needed.
+
+Long term:
+
+- Document the artifact contract as part of the recipe API.
+- Expose artifact discovery through run/result APIs if useful for benchmark tooling.
+
+## Tests
+
+Unit tests should cover:
+
+- summary file with final metrics
+- official best-selection metadata passthrough
+- JSONL file with one line per round
+- dynamic metric names
+- no hard-coded metric names
+- no writer-side best-round selection or policy inference
+- absent metrics in an aggregation workflow
+- missing key metric
+- partial metric coverage across sites
+- skipped unsupported metric types
+- bool metrics in raw records
+- `NaN` and `Infinity` rejection
+- metric names such as `__proto__`, `constructor`, paths, and control characters
+- output path containment using `resolve_path_under_root`
+- file size and per-round limit enforcement
+
+Integration tests should cover:
+
+- FedAvg recipe
+- one FedOpt or Scaffold recipe
+- one LR or XGBoost recipe if its workflow exposes metrics
+- a PSI or cross-site validation recipe to verify no metrics artifact is produced
+
+## Resolved Design Choices
+
+- Metrics artifact writing is a recorder concern. Aggregation, key-metric policy, and best-round selection remain owned by workflows, aggregators, and model selectors.
+- Bool metrics should be recorded. In per-site records they remain bool values; in aggregated metrics they preserve the official workflow-provided value.
+- Custom aggregators should not be forced into a new mandatory interface. The common contract is the controller-fired aggregation event. Custom aggregators can return `FLModel(metrics=...)` and optionally attach bounded `metrics_aggregation_info` metadata for weights and provenance.

--- a/docs/design/recipe_metrics_artifacts_design.md
+++ b/docs/design/recipe_metrics_artifacts_design.md
@@ -209,9 +209,9 @@ The `metrics` arrays preserve client-reported metric names and values after safe
 
 The writer should be one common server-side component, for example `MetricsArtifactWriter`, installed by aggregation recipe setup paths where practical. Its responsibility is artifact recording: final metrics, official best metrics, per-round client metrics, provenance, and skipped values. Existing aggregators and best-model selectors remain responsible for computing aggregates and deciding which model is best.
 
-`Widget` is a reasonable implementation base because it is already an event-driven `FLComponent` pattern used by components such as `ValidationJsonGenerator`. The public contract should be "server-side metrics artifact component" rather than "user must register a widget." If `Widget` later proves too narrow, the implementation can use `FLComponent` directly without changing the schema or event contract.
+`Widget` is a reasonable implementation base because it is already an event-driven `FLComponent` pattern used by components such as `ValidationJsonGenerator`. The public contract is "server-side metrics artifact component" rather than "user must register a widget."
 
-To avoid recipe-specific parsing, workflows should expose consistent events:
+To avoid recipe-specific parsing, the writer consumes these consistent events:
 
 1. Per-client contribution accepted
 
@@ -262,22 +262,18 @@ To avoid recipe-specific parsing, workflows should expose consistent events:
 
    The writer records this metadata without comparing metric values.
 
-Built-in aggregation workflows should publish the same event contract when they have official round-level aggregated metrics. This includes FedAvg-derived workflows and non-FedAvg aggregation workflows that already return an `FLModel` or `Shareable` aggregation result. The writer may normalize both payload shapes, but it must not synthesize aggregate metrics from analytics logs or per-site records.
+Built-in aggregation workflows publish the same event contract when they have official round-level aggregated metrics. This includes FedAvg-derived workflows and non-FedAvg aggregation workflows that return an `FLModel` or `Shareable` aggregation result. The writer normalizes both payload shapes, but it does not synthesize aggregate metrics from analytics logs or per-site records.
 
-For custom aggregators, the recommended contract is event-based rather than a new mandatory aggregator base interface. Controllers should fire the standard aggregation event with the `FLModel` returned by the aggregator. The easy user path is: custom aggregators return `FLModel(metrics=...)` as they do today. If they have custom metric weights or provenance, they may optionally attach bounded metadata to `FLModel.meta`, for example under a new key such as `metrics_aggregation_info`. Built-in controllers can then pass that through the same event. Lower-level custom workflows can use a helper such as `fire_metrics_aggregation_event(fl_ctx, aggr_result, contributions=None)` instead of hand-building event payloads.
+For custom aggregators, the contract is event-based rather than a new mandatory aggregator base interface. Controllers fire the standard aggregation event with the `FLModel` returned by the aggregator. The easy user path is: custom aggregators return `FLModel(metrics=...)` as they do today. If they have custom metric weights or provenance, they can attach bounded metadata to `FLModel.meta`, for example under `metrics_aggregation_info`.
 
-## Cross-Recipe Behavior
+## Recipe Coverage
 
-The feature should apply to aggregation and training recipes that expose round-level aggregated metrics:
+This PR installs the writer in these recipe setup paths:
 
-- FedAvg recipes for PyTorch, TensorFlow, NumPy, and sklearn
-- FedOpt recipes
-- Scaffold recipes
-- FedAvg with HE
+- `BaseFedJob`, covering recipe paths built on the shared BaseFedJob configuration such as FedAvg, FedOpt, Scaffold, FedAvg with HE, and PyTorch, TensorFlow, NumPy, and sklearn variants
 - LR FedAvg
-- XGBoost recipes
-- Swarm and cyclic recipes where aggregation metrics are available
-- Flower recipes when metrics are bridged through NVFlare analytics or normalized workflow events
+- standalone XGBoost recipes
+- Edge SAGE setup
 
 Recipes that do not perform aggregation or do not produce aggregation metrics should remain valid and should not be forced to create metrics artifacts.
 
@@ -354,7 +350,7 @@ Metric value normalization:
 - convert numeric and bool values to plain Python JSON scalars
 - reject non-finite numbers
 - record only finite numeric values and bool values for official aggregated metrics
-- skip dicts, lists, sets, tuples, objects, tensors, arrays, bytes, and oversized strings unless future support is explicitly designed and bounded
+- skip dicts, lists, sets, tuples, objects, tensors, arrays, bytes, and oversized strings
 
 ## Failure Behavior
 
@@ -409,20 +405,11 @@ Current PR scope:
 - Add the writer to standalone aggregation recipe setup paths that do not use `BaseFedJob` and have a standard aggregation workflow.
 - Standardize built-in aggregation workflows on `AFTER_AGGREGATION` with `AGGREGATION_RESULT` for official round metrics, accepting both `FLModel` and compatible `Shareable` payloads.
 - Document the artifact contract as part of the user-facing recipe documentation.
-- Expose discovered metrics artifacts through the existing `nvflare job download --format json` `artifacts` map.
+- Include metrics artifacts in normal job result downloads when they exist, and report their local paths through the existing `nvflare job download --format json` `artifacts` map.
 
-Medium term:
+## Test Coverage
 
-- If standalone recipe builders continue to duplicate writer setup, factor that internal wiring into a shared NVFlare-internal helper used by recipe implementations. Users should not need to call this helper.
-- Bridge additional built-in workflows that currently report metrics only through analytics/event streams once they expose official aggregated metric payloads.
-
-Long term:
-
-- Expose artifact discovery through server-side run/result APIs if benchmark tooling needs to find result artifacts before or without downloading the run directory.
-
-## Tests
-
-Unit tests should cover:
+Unit tests cover:
 
 - summary file with final metrics
 - official best-selection metadata passthrough
@@ -439,13 +426,6 @@ Unit tests should cover:
 - metric names such as `__proto__`, `constructor`, paths, and control characters
 - output path containment using `resolve_path_under_root`
 - file size and per-round limit enforcement
-
-Integration tests should cover:
-
-- FedAvg recipe
-- one FedOpt or Scaffold recipe
-- one LR or XGBoost recipe if its workflow exposes metrics
-- a PSI or cross-site validation recipe to verify no metrics artifact is produced
 
 ## Resolved Design Choices
 

--- a/docs/design/recipe_metrics_artifacts_design.md
+++ b/docs/design/recipe_metrics_artifacts_design.md
@@ -262,7 +262,7 @@ To avoid recipe-specific parsing, workflows should expose consistent events:
 
    The writer records this metadata without comparing metric values.
 
-The existing non-streaming `BaseFedAvg` path already fires `AFTER_AGGREGATION` with `AGGREGATION_RESULT`. The InTime FedAvg path should be aligned so that the same writer can consume the same event.
+Built-in aggregation workflows should publish the same event contract when they have official round-level aggregated metrics. This includes FedAvg-derived workflows and non-FedAvg aggregation workflows that already return an `FLModel` or `Shareable` aggregation result. The writer may normalize both payload shapes, but it must not synthesize aggregate metrics from analytics logs or per-site records.
 
 For custom aggregators, the recommended contract is event-based rather than a new mandatory aggregator base interface. Controllers should fire the standard aggregation event with the `FLModel` returned by the aggregator. The easy user path is: custom aggregators return `FLModel(metrics=...)` as they do today. If they have custom metric weights or provenance, they may optionally attach bounded metadata to `FLModel.meta`, for example under a new key such as `metrics_aggregation_info`. Built-in controllers can then pass that through the same event. Lower-level custom workflows can use a helper such as `fire_metrics_aggregation_event(fl_ctx, aggr_result, contributions=None)` instead of hand-building event payloads.
 
@@ -403,22 +403,22 @@ The writer should stream `round_metrics.jsonl` as rounds complete rather than ke
 
 ## Recipe Integration
 
-Short term:
+Current PR scope:
 
 - Add the writer to `BaseFedJob` so the recipes already using this path get the artifact.
-- Add the writer to standalone aggregation recipe setup paths that do not use `BaseFedJob`.
-- Align InTime FedAvg to fire `AFTER_AGGREGATION` with `AGGREGATION_RESULT`.
+- Add the writer to standalone aggregation recipe setup paths that do not use `BaseFedJob` and have a standard aggregation workflow.
+- Standardize built-in aggregation workflows on `AFTER_AGGREGATION` with `AGGREGATION_RESULT` for official round metrics, accepting both `FLModel` and compatible `Shareable` payloads.
+- Document the artifact contract as part of the user-facing recipe documentation.
+- Expose discovered metrics artifacts through the existing `nvflare job download --format json` `artifacts` map.
 
 Medium term:
 
-- If standalone recipe builders continue to duplicate writer setup, factor that internal wiring into a shared helper used by NVFlare recipe implementations. Users should not need to call this helper.
-- Standardize event payloads for non-FedAvg workflows.
-- Add recipe parameters to disable or configure the writer when needed.
+- If standalone recipe builders continue to duplicate writer setup, factor that internal wiring into a shared NVFlare-internal helper used by recipe implementations. Users should not need to call this helper.
+- Bridge additional built-in workflows that currently report metrics only through analytics/event streams once they expose official aggregated metric payloads.
 
 Long term:
 
-- Document the artifact contract as part of the recipe API.
-- Expose artifact discovery through run/result APIs if useful for benchmark tooling.
+- Expose artifact discovery through server-side run/result APIs if benchmark tooling needs to find result artifacts before or without downloading the run directory.
 
 ## Tests
 

--- a/docs/design/recipe_metrics_artifacts_design.md
+++ b/docs/design/recipe_metrics_artifacts_design.md
@@ -276,6 +276,11 @@ This PR installs the writer in these recipe setup paths:
 
 Recipes that do not perform aggregation or do not produce aggregation metrics should remain valid and should not be forced to create metrics artifacts.
 
+Supported built-in training aggregation recipes install the writer automatically.
+Users do not need to opt in to get the artifact, and this PR does not add a
+recipe-level disable flag. Custom jobs that should not write these artifacts can
+omit the metrics artifact writer from their server configuration.
+
 ## Best Metric Selection
 
 Best metric selection is not a writer responsibility. It belongs to existing model selectors, controllers, or workflows that already own comparison policy and model persistence.

--- a/docs/design/recipe_metrics_artifacts_design.md
+++ b/docs/design/recipe_metrics_artifacts_design.md
@@ -83,7 +83,6 @@ Example:
   "algorithm": "FedAvg",
   "status": "metrics_reported",
   "metric_source": "client_reported_flmodel_metrics",
-  "metric_split": "validation",
   "key_metric": {
     "name": "auroc",
     "mode": "max",

--- a/docs/user_guide/data_scientist_guide/index.rst
+++ b/docs/user_guide/data_scientist_guide/index.rst
@@ -12,6 +12,7 @@ Data Scientist Guide
    client_api_usage
    job_recipe
    available_recipes
+   recipe_metrics_artifacts
    ../timeout_troubleshooting
    flare_api
    poc

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -161,6 +161,14 @@ We use our existing training network under ``../hello-world/hello-pt/model.py`` 
    print(f"Min clients: {recipe.min_clients}")
    print(f"Number of rounds: {recipe.num_rounds}")
 
+Metrics Artifacts
+-----------------
+
+Training aggregation recipes write standard metrics artifacts when their server
+workflow reports round-level aggregation metrics. See
+:ref:`recipe_metrics_artifacts` for the schema, security behavior, and artifact
+discovery contract.
+
 Execution Environments
 ----------------------
 

--- a/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
@@ -21,6 +21,18 @@ to create these files. This includes PSI, stats-only jobs, and standalone
 cross-site validation. Cross-site validation continues to use its existing
 ``cross_site_val/cross_val_results.json`` output.
 
+Recipe Behavior
+---------------
+
+Users do not need to select this writer for supported built-in training
+aggregation recipes. The recipe setup installs it as part of the server
+configuration, and it writes files only when the workflow reports aggregation
+metrics.
+
+This release does not expose a recipe argument to disable metrics artifacts. For
+custom jobs that should not write these artifacts, omit the metrics artifact
+writer from the server configuration.
+
 Recorder Semantics
 ------------------
 

--- a/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
@@ -1,0 +1,221 @@
+.. _recipe_metrics_artifacts:
+
+Recipe Metrics Artifacts
+========================
+
+Built-in training aggregation recipes write standard metrics artifacts when the
+server workflow reports round-level aggregation metrics. These files make recipe
+results easier to consume from benchmark, reporting, and agent tooling without
+scraping server logs.
+
+The artifacts are written under the server run directory:
+
+.. code-block:: text
+
+   metrics/
+     metrics_summary.json
+     round_metrics.jsonl
+
+Recipes or workflows that do not report training aggregation metrics do not need
+to create these files. This includes PSI, stats-only jobs, and standalone
+cross-site validation. Cross-site validation continues to use its existing
+``cross_site_val/cross_val_results.json`` output.
+
+Recorder Semantics
+------------------
+
+The metrics artifact writer is a recorder. It persists metrics and metadata that
+workflows, aggregators, and model selectors already produce:
+
+* official aggregated metrics from the round aggregation result
+* per-site metrics received from clients for each round
+* official best metric metadata published by model-selection logic
+* aggregation provenance, weights, and skipped values when available
+
+It does not recompute metrics, select a best round, infer max/min policy, parse
+logs, or compute nonlinear metrics such as AUROC from pooled predictions.
+
+Metric names are dynamic. Names such as ``auroc``, ``accuracy``, ``loss``,
+``dice``, ``rmse``, or ``f1`` are client or workflow metric keys, not hard-coded
+schema fields.
+
+Round numbers are recorded as provided by workflow metadata such as
+``AppConstants.CURRENT_ROUND`` or ``FLModel.current_round``. They are 0-based by
+default and are not renumbered by the writer.
+
+``metrics_summary.json``
+------------------------
+
+``metrics_summary.json`` contains the final aggregated metrics from the last
+completed metrics round and, when available, official best metric metadata from
+the model selector.
+
+Example:
+
+.. code-block:: json
+
+   {
+     "schema_version": "1",
+     "status": "metrics_reported",
+     "job_name": "ames_fedavg",
+     "metric_source": "client_reported_flmodel_metrics",
+     "metric_split": "validation",
+     "key_metric": {
+       "name": "auroc",
+       "mode": "max",
+       "mode_source": "IntimeModelSelector.negate_key_metric"
+     },
+     "final_round": 2,
+     "final_aggregated_metrics": [
+       {
+         "name": "auroc",
+         "value": 0.7421
+       },
+       {
+         "name": "train_loss",
+         "value": 0.492
+       }
+     ],
+     "best_round": 0,
+     "best_metrics": [
+       {
+         "name": "auroc",
+         "value": 0.7500010132169
+       }
+     ],
+     "best_metric_source": "IntimeModelSelector",
+     "best_metric_detail_source": "initial_metrics",
+     "aggregation": {
+       "method": "weighted_average",
+       "weight_key": "NUM_STEPS_CURRENT_ROUND",
+       "metric_policy": "finite_numeric_metrics_only_per_key_denominator"
+     },
+     "round_metrics_file": "round_metrics.jsonl",
+     "notes": [
+       "Aggregated metrics are weighted averages of client-reported metric values.",
+       "Nonlinear metrics are not recomputed from pooled predictions."
+     ]
+   }
+
+Best metric fields are optional. They are present only when a selector or
+workflow publishes explicit best-selection metadata. The writer does not infer a
+best round from metric values.
+
+``round_metrics.jsonl``
+-----------------------
+
+``round_metrics.jsonl`` contains one JSON object per completed metrics round.
+Each line records official aggregated metrics, per-site client metrics, optional
+aggregation metadata, and skipped metric values.
+
+Example line:
+
+.. code-block:: json
+
+   {
+     "round": 0,
+     "aggregated_metrics": [
+       {
+         "name": "auroc",
+         "value": 0.7500010132169
+       },
+       {
+         "name": "train_loss",
+         "value": 0.4855
+       }
+     ],
+     "sites": [
+       {
+         "name": "site-1",
+         "metrics": [
+           {
+             "name": "train_loss",
+             "value": 0.4707
+           },
+           {
+             "name": "auroc",
+             "value": 0.7380791446479046
+           }
+         ],
+         "weight": 2911,
+         "weight_key": "NUM_STEPS_CURRENT_ROUND"
+       },
+       {
+         "name": "site-2",
+         "metrics": [
+           {
+             "name": "train_loss",
+             "value": 0.5003
+           },
+           {
+             "name": "auroc",
+             "value": 0.7619228817858955
+           }
+         ],
+         "weight": 2911,
+         "weight_key": "NUM_STEPS_CURRENT_ROUND"
+       }
+     ],
+     "aggregation": {
+       "method": "weighted_average",
+       "weight_key": "NUM_STEPS_CURRENT_ROUND",
+       "metric_policy": "finite_numeric_metrics_only_per_key_denominator"
+     },
+     "skipped_metrics": [
+       {
+         "site": "site-1",
+         "name": "debug_blob",
+         "reason": "unsupported_type"
+       }
+     ]
+   }
+
+Dynamic metric names are stored as ``name`` values in arrays rather than as JSON
+object keys. This avoids treating client-provided names as object structure in
+downstream tools.
+
+Safe Metric Values
+------------------
+
+Clients are untrusted metric producers. The writer serializes only normalized
+JSON-safe scalar values and writes to fixed filenames under the server run
+directory.
+
+Official aggregated metrics accept finite numeric values and bool values.
+Per-site metrics accept finite numeric values, bool values, and bounded string
+values. Unsupported objects, tensors, arrays, nested containers, oversized
+values, ``NaN``, and ``Infinity`` are skipped and reported in
+``skipped_metrics`` with a bounded reason record.
+
+Finding Artifacts
+-----------------
+
+For automation, use the job download JSON output instead of constructing paths
+from the workspace layout:
+
+.. code-block:: shell
+
+   nvflare job download <job_id> -o ./downloads --format json
+
+Example response excerpt:
+
+.. code-block:: json
+
+   {
+     "schema_version": "1",
+     "status": "ok",
+     "data": {
+       "download_path": "/abs/path/downloads/abc123",
+       "artifact_discovery": "completed",
+       "artifacts": {
+         "metrics_summary": "/abs/path/downloads/abc123/workspace/metrics/metrics_summary.json",
+         "round_metrics": "/abs/path/downloads/abc123/workspace/metrics/round_metrics.jsonl"
+       },
+       "missing_artifacts": []
+     }
+   }
+
+``round_metrics`` is optional because older jobs and jobs without aggregation
+metrics do not create a per-round metrics file. A future server-side run/result
+API could expose the same artifact metadata before download, but benchmark
+tooling can consume the downloaded artifacts through this JSON map today.

--- a/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
@@ -187,11 +187,12 @@ values. Unsupported objects, tensors, arrays, nested containers, oversized
 values, ``NaN``, and ``Infinity`` are skipped and reported in
 ``skipped_metrics`` with a bounded reason record.
 
-Finding Artifacts
------------------
+Downloaded Artifacts
+--------------------
 
-For automation, use the job download JSON output instead of constructing paths
-from the workspace layout:
+Metrics files are part of the normal downloaded job result when they exist. For
+automation, use the job download JSON output to find the downloaded local paths
+instead of constructing paths from the workspace layout:
 
 .. code-block:: shell
 
@@ -215,7 +216,6 @@ Example response excerpt:
      }
    }
 
-``round_metrics`` is optional because older jobs and jobs without aggregation
-metrics do not create a per-round metrics file. A future server-side run/result
-API could expose the same artifact metadata before download, but benchmark
-tooling can consume the downloaded artifacts through this JSON map today.
+``metrics_summary`` and ``round_metrics`` are reported only when those files
+exist in the downloaded result. ``round_metrics`` is optional because older jobs
+and jobs without aggregation metrics do not create a per-round metrics file.

--- a/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_metrics_artifacts.rst
@@ -59,7 +59,6 @@ Example:
      "status": "metrics_reported",
      "job_name": "ames_fedavg",
      "metric_source": "client_reported_flmodel_metrics",
-     "metric_split": "validation",
      "key_metric": {
        "name": "auroc",
        "mode": "max",

--- a/docs/user_guide/nvflare_cli/job_cli.rst
+++ b/docs/user_guide/nvflare_cli/job_cli.rst
@@ -363,7 +363,7 @@ exists, the command fails unless ``--force`` is specified. Use ``--force`` only
 when replacing the existing local download is intended.
 
 Human output remains concise and prints only the final download location. Use
-``--format json`` when agents or scripts need artifact discovery fields. The
+``--format json`` when agents or scripts need paths to downloaded artifacts. The
 JSON success response reports local paths on the machine running the CLI:
 
 .. code-block:: json
@@ -392,8 +392,8 @@ JSON success response reports local paths on the machine running the CLI:
 ``download_path`` is the final local directory returned by the download API.
 ``path`` is a backward-compatible alias for ``download_path`` when present.
 
-``artifacts`` contains local paths discovered under ``download_path``. Agents
-and scripts should use ``data.artifacts.*`` as the source of truth for
+``artifacts`` contains local paths for files found under ``download_path``.
+Agents and scripts should use ``data.artifacts.*`` as the source of truth for
 consumable files instead of assuming a server workspace layout or constructing
 paths from ``download_path``. ``missing_artifacts`` lists expected categories,
 such as model, metrics, or client logs, that were not found locally. Missing
@@ -404,8 +404,8 @@ When ``artifact_discovery`` is ``skipped``, the CLI did not have a local
 directory to inspect, so ``artifacts`` and ``missing_artifacts`` are ``null``
 instead of claiming that expected artifacts were verified absent.
 
-The server download protocol is unchanged; artifact discovery is a local CLI
-post-processing step after the result has been downloaded.
+The server download protocol is unchanged; these artifact paths are computed
+locally by the CLI after the result has been downloaded.
 
 Clone an existing job:
 

--- a/docs/user_guide/nvflare_cli/job_cli.rst
+++ b/docs/user_guide/nvflare_cli/job_cli.rst
@@ -379,7 +379,8 @@ JSON success response reports local paths on the machine running the CLI:
        "artifact_discovery": "completed",
        "artifacts": {
          "global_model": "/abs/path/downloads/abc123/workspace/FL_global_model.pt",
-         "metrics_summary": "/abs/path/downloads/abc123/workspace/metrics_summary.json",
+         "metrics_summary": "/abs/path/downloads/abc123/workspace/metrics/metrics_summary.json",
+         "round_metrics": "/abs/path/downloads/abc123/workspace/metrics/round_metrics.jsonl",
          "client_logs": {
            "site-1": "/abs/path/downloads/abc123/workspace/site-1/log.txt"
          }
@@ -397,6 +398,8 @@ consumable files instead of assuming a server workspace layout or constructing
 paths from ``download_path``. ``missing_artifacts`` lists expected categories,
 such as model, metrics, or client logs, that were not found locally. Missing
 artifacts do not make the command fail when the download itself succeeds.
+``round_metrics`` is reported when the per-round JSONL artifact exists; it is
+optional because older jobs and jobs without aggregation metrics do not create it.
 When ``artifact_discovery`` is ``skipped``, the CLI did not have a local
 directory to inspect, so ``artifacts`` and ``missing_artifacts`` are ``null``
 instead of claiming that expected artifacts were verified absent.

--- a/nvflare/app_common/app_constant.py
+++ b/nvflare/app_common/app_constant.py
@@ -76,6 +76,8 @@ class AppConstants(object):
     ROUND = "_round_"
     MODEL_WEIGHTS = "_model_weights_"
     AGGREGATION_RESULT = "_aggregation_result"
+    METRICS_AGGREGATION_INFO = "metrics_aggregation_info"
+    METRICS_SELECTION_INFO = "metrics_selection_info"
     AGGREGATION_TRIGGERED = "_aggregation_triggered"
     AGGREGATION_ACCEPTED = "_aggregation_accepted"
     TRAIN_SHAREABLE = "_train_shareable_"

--- a/nvflare/app_common/np/recipes/lr/fedavg.py
+++ b/nvflare/app_common/np/recipes/lr/fedavg.py
@@ -17,6 +17,7 @@ from typing import Optional
 from pydantic import BaseModel, PositiveInt, field_validator
 
 from nvflare import FedJob
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_common.workflows.lr.fedavg import FedAvgLR
 from nvflare.app_common.workflows.lr.np_persistor import LRModelPersistor
 from nvflare.client.config import ExchangeFormat, TransferType
@@ -141,6 +142,7 @@ class FedAvgLrRecipe(Recipe):
             source_ckpt_file_full_name=ckpt_path,
         )
         persistor_id = job.to_server(persistor, id="lr_persistor")
+        job.to_server(MetricsArtifactWriter(), id="metrics_artifact_writer")
 
         # Send custom controller to server
         controller = FedAvgLR(

--- a/nvflare/app_common/widgets/intime_model_selector.py
+++ b/nvflare/app_common/widgets/intime_model_selector.py
@@ -48,6 +48,7 @@ class IntimeModelSelector(Widget):
         super().__init__()
 
         self.val_metric = self.best_val_metric = -np.inf
+        self.raw_val_metric = self.best_raw_val_metric = None
         self.weigh_by_local_iter = weigh_by_local_iter
         self.validation_metric_name = validation_metric_name
         self.aggregation_weights = aggregation_weights or {}
@@ -72,6 +73,7 @@ class IntimeModelSelector(Widget):
 
     def _reset_stats(self):
         self.validation_metric_weighted_sum = 0
+        self.raw_validation_metric_weighted_sum = 0
         self.validation_metric_sum_of_weights = 0
 
     def _before_accept(self, fl_ctx: FLContext):
@@ -125,6 +127,7 @@ class IntimeModelSelector(Widget):
                 )
                 return False
 
+        raw_validation_metric = validation_metric
         if self.negate_key_metric:
             validation_metric = -1.0 * validation_metric
 
@@ -140,6 +143,7 @@ class IntimeModelSelector(Widget):
 
         weight = n_iter * aggregation_weights
         self.validation_metric_weighted_sum += validation_metric * weight
+        self.raw_validation_metric_weighted_sum += raw_validation_metric * weight
         self.validation_metric_sum_of_weights += weight
         return True
 
@@ -148,18 +152,42 @@ class IntimeModelSelector(Widget):
             self.log_debug(fl_ctx, "nothing accumulated")
             return False
         self.val_metric = self.validation_metric_weighted_sum / self.validation_metric_sum_of_weights
+        self.raw_val_metric = self.raw_validation_metric_weighted_sum / self.validation_metric_sum_of_weights
         self.logger.debug(f"weighted validation metric {self.val_metric}")
         if self.val_metric > self.best_val_metric:
             self.best_val_metric = self.val_metric
+            self.best_raw_val_metric = self.raw_val_metric
             current_round = fl_ctx.get_prop(AppConstants.CURRENT_ROUND)
             self.log_info(fl_ctx, f"new best validation metric at round {current_round}: {self.best_val_metric}")
 
             # Fire event to notify that the current global model is a new best
             fl_ctx.set_prop(AppConstants.VALIDATION_RESULT, self.best_val_metric, private=True, sticky=False)
+            fl_ctx.set_prop(
+                AppConstants.METRICS_SELECTION_INFO,
+                self._make_metrics_selection_info(current_round),
+                private=True,
+                sticky=False,
+            )
             self.fire_event(AppEventType.GLOBAL_BEST_MODEL_AVAILABLE, fl_ctx)
 
         self._reset_stats()
         return True
+
+    def _make_metrics_selection_info(self, current_round):
+        mode = "min" if self.negate_key_metric else "max"
+        return {
+            "source": self.__class__.__name__,
+            "metric_source": self.validation_metric_name,
+            "key_metric": {
+                "name": self.key_metric,
+                "mode": mode,
+                "mode_source": f"{self.__class__.__name__}.negate_key_metric",
+            },
+            "best_round": current_round,
+            "best_metrics": {
+                self.key_metric: self.best_raw_val_metric,
+            },
+        }
 
 
 class IntimeModelSelectionHandler(IntimeModelSelector):

--- a/nvflare/app_common/widgets/metrics_artifact_writer.py
+++ b/nvflare/app_common/widgets/metrics_artifact_writer.py
@@ -22,6 +22,7 @@ import numpy as np
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey, FLMetaKey
 from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
@@ -94,7 +95,8 @@ class MetricsArtifactWriter(Widget):
 
     def _handle_after_aggregation(self, fl_ctx: FLContext):
         aggr_result = fl_ctx.get_prop(AppConstants.AGGREGATION_RESULT, None)
-        if not isinstance(aggr_result, FLModel):
+        aggr_result = self._to_fl_model(aggr_result)
+        if aggr_result is None:
             return
 
         meta = aggr_result.meta or {}
@@ -143,6 +145,17 @@ class MetricsArtifactWriter(Widget):
         self._aggregation = aggregation if aggregation else self._aggregation
         if key_metric:
             self._key_metric = key_metric
+
+    @staticmethod
+    def _to_fl_model(value):
+        if isinstance(value, FLModel):
+            return value
+        if isinstance(value, Shareable):
+            try:
+                return FLModelUtils.from_shareable(value)
+            except Exception:
+                return None
+        return None
 
     def _handle_global_best_model_available(self, fl_ctx: FLContext):
         selection = self._normalize_selection_info(fl_ctx.get_prop(AppConstants.METRICS_SELECTION_INFO, None))

--- a/nvflare/app_common/widgets/metrics_artifact_writer.py
+++ b/nvflare/app_common/widgets/metrics_artifact_writer.py
@@ -435,7 +435,9 @@ class MetricsArtifactWriter(Widget):
             summary["metric_source"] = self._metric_source
         if self._metric_split:
             summary["metric_split"] = self._metric_split
-        if self._key_metric:
+        if self._best_selection and self._best_selection.get("key_metric"):
+            summary["key_metric"] = self._best_selection["key_metric"]
+        elif self._key_metric:
             summary["key_metric"] = self._key_metric
         if self._best_selection:
             for field in (
@@ -553,8 +555,9 @@ class MetricsArtifactWriter(Widget):
         return None
 
     def _get_site_name(self, model, fl_ctx):
+        meta = model.meta or {}
         for key in (FLMetaKey.SITE_NAME, "client_name", "site_name"):
-            value = model.meta.get(key)
+            value = meta.get(key)
             if isinstance(value, str) and value:
                 return value
         peer_ctx = fl_ctx.get_peer_context()

--- a/nvflare/app_common/widgets/metrics_artifact_writer.py
+++ b/nvflare/app_common/widgets/metrics_artifact_writer.py
@@ -214,7 +214,8 @@ class MetricsArtifactWriter(Widget):
             "name": self._sanitize_name(site_name),
             "metrics": metrics,
         }
-        weight = self._safe_weight(model.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND))
+        meta = model.meta or {}
+        weight = self._safe_weight(meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND))
         if weight is not None:
             site["weight"] = weight
             site["weight_key"] = FLMetaKey.NUM_STEPS_CURRENT_ROUND

--- a/nvflare/app_common/widgets/metrics_artifact_writer.py
+++ b/nvflare/app_common/widgets/metrics_artifact_writer.py
@@ -22,6 +22,7 @@ import numpy as np
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey, FLMetaKey
 from nvflare.apis.fl_context import FLContext
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.shareable import Shareable
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.app_constant import AppConstants
@@ -429,7 +430,7 @@ class MetricsArtifactWriter(Widget):
                 "Nonlinear metrics are not recomputed from pooled predictions.",
             ],
         }
-        job_name = self._safe_text(fl_ctx.get_job_id())
+        job_name = self._get_job_name(fl_ctx)
         if job_name:
             summary["job_name"] = job_name
         if self._metric_source:
@@ -553,6 +554,27 @@ class MetricsArtifactWriter(Widget):
         value = fl_ctx.get_prop(AppConstants.CURRENT_ROUND, None)
         if isinstance(value, int) and not isinstance(value, bool):
             return value
+        return None
+
+    def _get_job_name(self, fl_ctx):
+        job_name = self._get_job_name_from_meta(fl_ctx.get_prop(FLContextKey.JOB_META, None))
+        if job_name:
+            return job_name
+
+        return self._safe_text(fl_ctx.get_job_id())
+
+    def _get_job_name_from_meta(self, meta):
+        if not isinstance(meta, dict):
+            return None
+        for key in (
+            JobMetaKey.JOB_NAME.value,
+            JobMetaKey.JOB_NAME,
+            JobMetaKey.JOB_FOLDER_NAME.value,
+            JobMetaKey.JOB_FOLDER_NAME,
+        ):
+            job_name = self._safe_text(meta.get(key))
+            if job_name:
+                return job_name
         return None
 
     def _get_site_name(self, model, fl_ctx):

--- a/nvflare/app_common/widgets/metrics_artifact_writer.py
+++ b/nvflare/app_common/widgets/metrics_artifact_writer.py
@@ -1,0 +1,638 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import math
+import os
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey, FLMetaKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.abstract.fl_model import FLModel
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
+from nvflare.app_common.utils.fl_model_utils import FLModelUtils
+from nvflare.widgets.widget import Widget
+
+METRICS_AGGREGATION_INFO = AppConstants.METRICS_AGGREGATION_INFO
+
+
+class MetricsArtifactWriter(Widget):
+    """Writes safe, machine-readable round and summary metric artifacts.
+
+    The writer consumes metrics already produced by workflows/controllers. It records
+    dynamic metric names as values instead of object keys so downstream consumers do
+    not need to treat client-provided names as JSON object structure.
+    """
+
+    def __init__(
+        self,
+        results_dir: str = "metrics",
+        summary_file_name: str = "metrics_summary.json",
+        round_file_name: str = "round_metrics.jsonl",
+        limits: Optional[Dict[str, int]] = None,
+    ):
+        super().__init__()
+        self.results_dir = results_dir
+        self.summary_file_name = summary_file_name
+        self.round_file_name = round_file_name
+
+        limits = limits or {}
+        self.max_metric_name_length = limits.get("max_metric_name_length", 256)
+        self.max_string_value_length = limits.get("max_string_value_length", 1024)
+        self.max_metrics_per_site_per_round = limits.get("max_metrics_per_site_per_round", 512)
+        self.max_sites_per_round = limits.get("max_sites_per_round", 10000)
+        self.max_site_metric_records_per_round = limits.get("max_site_metric_records_per_round", 10000)
+        self.max_skipped_metrics_per_round = limits.get("max_skipped_metrics_per_round", 1024)
+        self.max_round_record_bytes = limits.get("max_round_record_bytes", 1048576)
+        self.max_summary_bytes = limits.get("max_summary_bytes", 1048576)
+        self.max_int_bit_length = limits.get("max_int_bit_length", 1023)
+
+        self._reset()
+
+    def _reset(self):
+        self._has_metrics = False
+        self._final_round = None
+        self._final_aggregated_metrics = []
+        self._best_selection = None
+        self._key_metric = None
+        self._aggregation = None
+        self._metric_source = None
+        self._metric_split = None
+        self._round_file_path = None
+        self._summary_file_path = None
+        self._round_sites = {}
+        self._round_skipped = {}
+        self._round_site_metric_counts = {}
+
+    def handle_event(self, event_type: str, fl_ctx: FLContext):
+        if event_type == EventType.START_RUN:
+            self._reset()
+        elif event_type == AppEventType.AFTER_CONTRIBUTION_ACCEPT:
+            self._handle_after_contribution_accept(fl_ctx)
+        elif event_type == AppEventType.AFTER_AGGREGATION:
+            self._handle_after_aggregation(fl_ctx)
+        elif event_type == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE:
+            self._handle_global_best_model_available(fl_ctx)
+        elif event_type == EventType.END_RUN:
+            self._write_summary_if_needed(fl_ctx)
+
+    def _handle_after_aggregation(self, fl_ctx: FLContext):
+        aggr_result = fl_ctx.get_prop(AppConstants.AGGREGATION_RESULT, None)
+        if not isinstance(aggr_result, FLModel):
+            return
+
+        meta = aggr_result.meta or {}
+        info = meta.get(METRICS_AGGREGATION_INFO, {})
+        if not isinstance(info, dict):
+            info = {}
+
+        skipped = []
+        aggregated_metrics = self._normalize_metrics(
+            aggr_result.metrics, site=None, skipped=skipped, for_aggregation=True
+        )
+        current_round = self._get_current_round(aggr_result, fl_ctx)
+        fallback_sites = self._round_sites.pop(current_round, [])
+        fallback_skipped = self._round_skipped.pop(current_round, [])
+        self._round_site_metric_counts.pop(current_round, None)
+        sites = self._normalize_sites(info.get("sites"), skipped)
+        site_weights = self._normalize_site_weights(info.get("site_weights"), skipped)
+        use_contribution_sites = info.get("use_contribution_sites", True) is not False
+        if not sites and use_contribution_sites:
+            sites = fallback_sites
+            self._merge_skipped(skipped, fallback_skipped)
+        self._apply_site_weights(sites, site_weights)
+
+        if not aggregated_metrics and not sites and not skipped:
+            return
+
+        aggregation = self._sanitize_json_object(info.get("aggregation"))
+        key_metric = self._normalize_key_metric(info.get("key_metric"))
+        record = {
+            "round": current_round,
+            "aggregated_metrics": aggregated_metrics,
+            "sites": sites,
+            "skipped_metrics": skipped,
+        }
+        if aggregation:
+            record["aggregation"] = aggregation
+        if key_metric:
+            record["key_metric"] = key_metric
+        self._append_round_record(fl_ctx, record)
+
+        self._has_metrics = True
+        self._final_round = current_round
+        self._final_aggregated_metrics = aggregated_metrics
+        self._metric_source = self._safe_text(info.get("metric_source"))
+        self._metric_split = self._safe_text(info.get("metric_split"))
+        self._aggregation = aggregation if aggregation else self._aggregation
+        if key_metric:
+            self._key_metric = key_metric
+
+    def _handle_global_best_model_available(self, fl_ctx: FLContext):
+        selection = self._normalize_selection_info(fl_ctx.get_prop(AppConstants.METRICS_SELECTION_INFO, None))
+        if not selection:
+            return
+        self._best_selection = selection
+        key_metric = selection.get("key_metric")
+        if key_metric:
+            self._key_metric = key_metric
+
+    def _handle_after_contribution_accept(self, fl_ctx: FLContext):
+        accepted = fl_ctx.get_prop(AppConstants.AGGREGATION_ACCEPTED, True)
+        if accepted is False:
+            return
+
+        result = fl_ctx.get_prop(AppConstants.TRAINING_RESULT, None)
+        if result is None:
+            peer_ctx = fl_ctx.get_peer_context()
+            if peer_ctx:
+                result = peer_ctx.get_prop(FLContextKey.SHAREABLE, None)
+        if result is None:
+            return
+
+        try:
+            model = FLModelUtils.from_shareable(result)
+        except Exception:
+            return
+        if not model.metrics:
+            return
+
+        current_round = self._get_current_round(model, fl_ctx)
+        skipped = []
+        site_name = self._get_site_name(model, fl_ctx)
+        metrics = self._normalize_metrics(model.metrics, site=site_name, skipped=skipped)
+        if skipped:
+            self._extend_round_skipped(current_round, skipped)
+        if not metrics:
+            return
+        sites = self._round_sites.setdefault(current_round, [])
+        if len(sites) >= self.max_sites_per_round:
+            too_many_sites = []
+            self._add_skipped(too_many_sites, site_name, "", "too_many_sites")
+            self._extend_round_skipped(current_round, too_many_sites)
+            return
+        metric_count = self._round_site_metric_counts.get(current_round, 0)
+        if metric_count + len(metrics) > self.max_site_metric_records_per_round:
+            too_many_metrics = []
+            self._add_skipped(too_many_metrics, site_name, "", "too_many_metrics")
+            self._extend_round_skipped(current_round, too_many_metrics)
+            allowed = self.max_site_metric_records_per_round - metric_count
+            if allowed <= 0:
+                return
+            metrics = metrics[:allowed]
+        self._round_site_metric_counts[current_round] = metric_count + len(metrics)
+        site = {
+            "name": self._sanitize_name(site_name),
+            "metrics": metrics,
+        }
+        weight = self._safe_weight(model.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND))
+        if weight is not None:
+            site["weight"] = weight
+            site["weight_key"] = FLMetaKey.NUM_STEPS_CURRENT_ROUND
+        sites.append(site)
+
+    def _normalize_sites(self, sites, skipped):
+        if not isinstance(sites, list):
+            return []
+
+        normalized_sites = []
+        metric_count = 0
+        for site in sites:
+            if not isinstance(site, dict):
+                continue
+            if len(normalized_sites) >= self.max_sites_per_round:
+                self._add_skipped(skipped, site.get("name"), "", "too_many_sites")
+                break
+            metrics = self._normalize_metrics(site.get("metrics"), site=site.get("name"), skipped=skipped)
+            if not metrics:
+                continue
+            if metric_count + len(metrics) > self.max_site_metric_records_per_round:
+                self._add_skipped(skipped, site.get("name"), "", "too_many_metrics")
+                allowed = self.max_site_metric_records_per_round - metric_count
+                if allowed <= 0:
+                    break
+                metrics = metrics[:allowed]
+            metric_count += len(metrics)
+            site_record = {
+                "name": self._sanitize_name(site.get("name", "")),
+                "metrics": metrics,
+            }
+            weight = self._safe_weight(site.get("weight"))
+            if weight is not None:
+                site_record["weight"] = weight
+            weight_key = self._safe_text(site.get("weight_key"))
+            if weight_key:
+                site_record["weight_key"] = weight_key
+            normalized_sites.append(site_record)
+        return normalized_sites
+
+    def _normalize_site_weights(self, site_weights, skipped):
+        if not isinstance(site_weights, list):
+            return {}
+
+        normalized_weights = {}
+        for site_weight in site_weights:
+            if not isinstance(site_weight, dict):
+                continue
+            if len(normalized_weights) >= self.max_sites_per_round:
+                self._add_skipped(skipped, site_weight.get("name"), "", "too_many_sites")
+                break
+            name = self._sanitize_name(site_weight.get("name", ""))
+            if not name:
+                continue
+            record = {}
+            weight = self._safe_weight(site_weight.get("weight"))
+            if weight is not None:
+                record["weight"] = weight
+            weight_key = self._safe_text(site_weight.get("weight_key"))
+            if weight_key:
+                record["weight_key"] = weight_key
+            if record:
+                normalized_weights[name] = record
+        return normalized_weights
+
+    @staticmethod
+    def _apply_site_weights(sites, site_weights):
+        if not site_weights:
+            return
+        for site in sites:
+            weight_info = site_weights.get(site.get("name"))
+            if weight_info:
+                site.update(weight_info)
+
+    def _normalize_metrics(self, metrics, site, skipped, for_aggregation=False):
+        if not isinstance(metrics, dict):
+            return []
+
+        result = []
+        for name, value in metrics.items():
+            if len(result) >= self.max_metrics_per_site_per_round:
+                self._add_skipped(skipped, site, name, "too_many_metrics")
+                break
+
+            if not isinstance(name, str):
+                self._add_skipped(skipped, site, "", "non_string_metric_name")
+                continue
+            metric_name = self._sanitize_name(name)
+            if not metric_name:
+                self._add_skipped(skipped, site, "", "empty_metric_name")
+                continue
+            normalized, reason = self._normalize_metric_value(value, for_aggregation=for_aggregation)
+            if reason:
+                self._add_skipped(skipped, site, metric_name, reason)
+                continue
+            result.append({"name": metric_name, "value": normalized})
+        return result
+
+    def _normalize_metric_value(self, value, for_aggregation=False) -> Tuple[Any, Optional[str]]:
+        value = self._to_python_scalar(value)
+        if isinstance(value, bool):
+            return value, None
+        if isinstance(value, int) and not isinstance(value, bool):
+            if value.bit_length() > self.max_int_bit_length:
+                return None, "number_too_large"
+            return value, None
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                return None, "non_finite_number"
+            return value, None
+        if not for_aggregation and isinstance(value, str):
+            if len(value) > self.max_string_value_length:
+                return None, "string_too_long"
+            return self._strip_control_chars(value), None
+        return None, "unsupported_type"
+
+    def _normalize_key_metric(self, key_metric):
+        if not isinstance(key_metric, dict):
+            return None
+        name = key_metric.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        normalized = {"name": self._sanitize_name(name)}
+        mode = key_metric.get("mode")
+        if mode in ("max", "min"):
+            normalized["mode"] = mode
+        mode_source = self._safe_text(key_metric.get("mode_source"))
+        if mode_source:
+            normalized["mode_source"] = mode_source
+        return normalized
+
+    def _normalize_selection_info(self, selection):
+        if not isinstance(selection, dict):
+            return None
+        normalized = {}
+        best_round = self._safe_round(selection.get("best_round"))
+        if best_round is not None:
+            normalized["best_round"] = best_round
+        best_metrics = self._normalize_metric_collection(selection.get("best_metrics"), for_aggregation=True)
+        if best_metrics:
+            normalized["best_metrics"] = best_metrics
+        best_aggregated_metrics = self._normalize_metric_collection(
+            selection.get("best_aggregated_metrics"), for_aggregation=True
+        )
+        if best_aggregated_metrics:
+            normalized["best_aggregated_metrics"] = best_aggregated_metrics
+        key_metric = self._normalize_key_metric(selection.get("key_metric"))
+        if key_metric:
+            normalized["key_metric"] = key_metric
+        source = self._safe_text(selection.get("source"))
+        if source:
+            normalized["best_metric_source"] = source
+        metric_source = self._safe_text(selection.get("metric_source"))
+        if metric_source:
+            normalized["best_metric_detail_source"] = metric_source
+        return normalized or None
+
+    def _normalize_metric_collection(self, metrics, for_aggregation=False):
+        if isinstance(metrics, dict):
+            return self._normalize_metrics(metrics, site=None, skipped=[], for_aggregation=for_aggregation)
+        if not isinstance(metrics, list):
+            return []
+        result = []
+        for metric in metrics:
+            if len(result) >= self.max_metrics_per_site_per_round:
+                break
+            if not isinstance(metric, dict):
+                continue
+            name = metric.get("name")
+            if not isinstance(name, str):
+                continue
+            metric_name = self._sanitize_name(name)
+            if not metric_name:
+                continue
+            normalized, reason = self._normalize_metric_value(metric.get("value"), for_aggregation=for_aggregation)
+            if reason:
+                continue
+            result.append({"name": metric_name, "value": normalized})
+        return result
+
+    def _append_round_record(self, fl_ctx, record):
+        self._ensure_paths(fl_ctx)
+        os.makedirs(os.path.dirname(self._round_file_path), exist_ok=True)
+        record = self._fit_round_record(record)
+        line = self._safe_json_dumps(record)
+        if line is None:
+            record = self._make_minimal_round_record(record, "serialization_failed")
+            line = self._safe_json_dumps(record)
+        if line is None:
+            return
+        if len(line.encode("utf-8")) > self.max_round_record_bytes:
+            record = self._make_minimal_round_record(record, "round_record_too_large")
+            line = self._safe_json_dumps(record)
+        if line is None or len(line.encode("utf-8")) > self.max_round_record_bytes:
+            return
+        with open(self._round_file_path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    def _write_summary_if_needed(self, fl_ctx):
+        if not self._has_metrics:
+            return
+        self._ensure_paths(fl_ctx)
+        summary = {
+            "schema_version": "1",
+            "status": "metrics_reported",
+            "final_round": self._final_round,
+            "final_aggregated_metrics": self._final_aggregated_metrics,
+            "round_metrics_file": self.round_file_name,
+            "notes": [
+                "Aggregated metrics are weighted averages of client-reported metric values.",
+                "Nonlinear metrics are not recomputed from pooled predictions.",
+            ],
+        }
+        job_name = self._safe_text(fl_ctx.get_job_id())
+        if job_name:
+            summary["job_name"] = job_name
+        if self._metric_source:
+            summary["metric_source"] = self._metric_source
+        if self._metric_split:
+            summary["metric_split"] = self._metric_split
+        if self._key_metric:
+            summary["key_metric"] = self._key_metric
+        if self._best_selection:
+            for field in (
+                "best_round",
+                "best_metrics",
+                "best_aggregated_metrics",
+                "best_metric_source",
+                "best_metric_detail_source",
+            ):
+                if field in self._best_selection:
+                    summary[field] = self._best_selection[field]
+        if self._aggregation:
+            summary["aggregation"] = self._sanitize_json_object(self._aggregation)
+
+        data = self._safe_json_dumps(summary, indent=2)
+        if data is None:
+            return
+        if len(data.encode("utf-8")) > self.max_summary_bytes:
+            summary.pop("notes", None)
+            data = self._safe_json_dumps(summary, indent=2)
+        if data is None or len(data.encode("utf-8")) > self.max_summary_bytes:
+            return
+        os.makedirs(os.path.dirname(self._summary_file_path), exist_ok=True)
+        with open(self._summary_file_path, "w", encoding="utf-8") as f:
+            f.write(data)
+
+    def _fit_round_record(self, record):
+        fitted = {
+            "round": record.get("round"),
+            "aggregated_metrics": self._fit_json_list(
+                record.get("aggregated_metrics", []), self.max_round_record_bytes
+            ),
+            "sites": [],
+            "skipped_metrics": [],
+        }
+        for field in ("aggregation", "key_metric"):
+            if field in record:
+                fitted[field] = record[field]
+        used = len((self._safe_json_dumps(fitted) or "").encode("utf-8"))
+        for field in ("sites", "skipped_metrics"):
+            for item in record.get(field, []):
+                item_json = self._safe_json_dumps(item)
+                if item_json is None:
+                    continue
+                next_size = used + len(item_json.encode("utf-8")) + 2
+                if next_size > self.max_round_record_bytes:
+                    fitted["skipped_metrics"].append({"name": "", "reason": f"{field}_truncated"})
+                    return fitted
+                fitted[field].append(item)
+                used = next_size
+        return fitted
+
+    def _fit_json_list(self, items, max_bytes):
+        result = []
+        used = 0
+        for item in items:
+            item_json = self._safe_json_dumps(item)
+            if item_json is None:
+                continue
+            item_size = len(item_json.encode("utf-8")) + 1
+            if used + item_size > max_bytes:
+                break
+            result.append(item)
+            used += item_size
+        return result
+
+    def _make_minimal_round_record(self, record, reason):
+        return {
+            "round": record.get("round"),
+            "aggregated_metrics": self._fit_json_list(
+                record.get("aggregated_metrics", []), self.max_round_record_bytes
+            ),
+            "sites": [],
+            "skipped_metrics": [{"name": "", "reason": reason}],
+        }
+
+    @staticmethod
+    def _safe_json_dumps(value, indent=None):
+        try:
+            return json.dumps(value, allow_nan=False, indent=indent, separators=None if indent else (",", ":"))
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    def _ensure_paths(self, fl_ctx):
+        if self._summary_file_path and self._round_file_path:
+            return
+        self._validate_file_name(self.summary_file_name, "metrics summary file name")
+        self._validate_file_name(self.round_file_name, "round metrics file name")
+        run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
+        self._summary_file_path = resolve_path_under_root(
+            run_dir, os.path.join(self.results_dir, self.summary_file_name), "metrics summary path"
+        )
+        self._round_file_path = resolve_path_under_root(
+            run_dir, os.path.join(self.results_dir, self.round_file_name), "round metrics path"
+        )
+
+    @staticmethod
+    def _validate_file_name(file_name: str, path_name: str):
+        if not isinstance(file_name, str):
+            raise TypeError(f"{path_name} must be str but got {type(file_name)}")
+        if os.path.basename(file_name) != file_name or file_name in ("", ".", ".."):
+            raise ValueError(f"{path_name} {file_name} must be relative and stay inside the metrics directory.")
+
+    def _get_current_round(self, aggr_result, fl_ctx):
+        if aggr_result.current_round is not None:
+            return aggr_result.current_round
+        meta = aggr_result.meta or {}
+        for key in (AppConstants.CURRENT_ROUND, "current_round"):
+            value = meta.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+        value = fl_ctx.get_prop(AppConstants.CURRENT_ROUND, None)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        return None
+
+    def _get_site_name(self, model, fl_ctx):
+        for key in (FLMetaKey.SITE_NAME, "client_name", "site_name"):
+            value = model.meta.get(key)
+            if isinstance(value, str) and value:
+                return value
+        peer_ctx = fl_ctx.get_peer_context()
+        if peer_ctx:
+            identity = peer_ctx.get_identity_name(default=None)
+            if identity:
+                return identity
+        return AppConstants.CLIENT_UNKNOWN
+
+    @staticmethod
+    def _safe_round(value):
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        return None
+
+    def _safe_number(self, value):
+        value = self._to_python_scalar(value)
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            if value.bit_length() <= self.max_int_bit_length:
+                return value
+            return None
+        if isinstance(value, float) and math.isfinite(value):
+            return value
+        return None
+
+    def _safe_weight(self, value):
+        weight = self._safe_number(value)
+        if weight is None or weight < 0:
+            return None
+        return weight
+
+    @staticmethod
+    def _to_python_scalar(value):
+        if isinstance(value, np.generic):
+            try:
+                return value.item()
+            except (TypeError, ValueError, OverflowError):
+                return value
+        return value
+
+    def _safe_text(self, value):
+        if not isinstance(value, str):
+            return None
+        return self._strip_control_chars(value[: self.max_metric_name_length])
+
+    def _sanitize_name(self, name):
+        if not isinstance(name, str):
+            return ""
+        return self._strip_control_chars(name[: self.max_metric_name_length])
+
+    @staticmethod
+    def _strip_control_chars(value: str):
+        return "".join(ch for ch in value if ord(ch) >= 32 and ch != "\x7f")
+
+    def _add_skipped(self, skipped, site, name, reason):
+        if len(skipped) >= self.max_skipped_metrics_per_round:
+            return
+        record = {"name": self._sanitize_name(name), "reason": reason}
+        if site is not None:
+            record["site"] = self._sanitize_name(site)
+        skipped.append(record)
+
+    def _extend_round_skipped(self, current_round, skipped):
+        if not skipped:
+            return
+        round_skipped = self._round_skipped.setdefault(current_round, [])
+        self._merge_skipped(round_skipped, skipped)
+
+    def _merge_skipped(self, target, skipped):
+        for record in skipped:
+            if len(target) >= self.max_skipped_metrics_per_round:
+                return
+            target.append(record)
+
+    def _sanitize_json_object(self, value):
+        if isinstance(value, dict):
+            result = {}
+            for key, child in value.items():
+                if not isinstance(key, str):
+                    continue
+                child_value = self._sanitize_json_object(child)
+                if child_value is not None:
+                    result[self._sanitize_name(key)] = child_value
+            return result
+        if isinstance(value, list):
+            return [v for v in (self._sanitize_json_object(child) for child in value) if v is not None]
+        normalized, reason = self._normalize_metric_value(value, for_aggregation=False)
+        if reason:
+            return None
+        return normalized

--- a/nvflare/app_common/widgets/metrics_artifact_writer.py
+++ b/nvflare/app_common/widgets/metrics_artifact_writer.py
@@ -590,7 +590,7 @@ class MetricsArtifactWriter(Widget):
 
     def _safe_weight(self, value):
         weight = self._safe_number(value)
-        if weight is None or weight < 0:
+        if weight is None or weight <= 0:
             return None
         return weight
 

--- a/nvflare/app_common/workflows/base_fedavg.py
+++ b/nvflare/app_common/workflows/base_fedavg.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from typing import Any, Dict, List, Optional
 
 from nvflare.apis.fl_constant import FLMetaKey
@@ -81,6 +82,26 @@ def make_key_metric_info_from_stop_condition(stop_cond, stop_condition) -> Optio
     }
 
 
+def _get_client_name(result: FLModel) -> str:
+    meta = result.meta or {}
+    value = meta.get("client_name", AppConstants.CLIENT_UNKNOWN)
+    return value if isinstance(value, str) and value else AppConstants.CLIENT_UNKNOWN
+
+
+def _get_num_steps_weight(result: FLModel) -> float:
+    meta = result.meta or {}
+    value = meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND)
+    if value is None or isinstance(value, bool):
+        return 1.0
+    try:
+        weight = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return 1.0
+    if not math.isfinite(weight) or weight <= 0:
+        return 1.0
+    return weight
+
+
 def _aggregate_fl_model_metrics(results: List[FLModel]) -> Optional[Dict[str, Any]]:
     """Aggregate FLModel metrics across results with FedAvg-compatible semantics.
 
@@ -96,8 +117,8 @@ def _aggregate_fl_model_metrics(results: List[FLModel]) -> Optional[Dict[str, An
         if aggregatable:
             aggr_metrics_helper.add(
                 data=aggregatable,
-                weight=_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
-                contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
+                weight=_get_num_steps_weight(_result),
+                contributor_name=_get_client_name(_result),
                 contribution_round=_result.current_round,
             )
 
@@ -165,7 +186,7 @@ class BaseFedAvg(ModelController):
         empty_clients = []
         for _result in results:
             if not _result.params:
-                empty_clients.append(_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN))
+                empty_clients.append(_get_client_name(_result))
 
         if len(empty_clients) > 0:
             raise ValueError(f"Result from client(s) {empty_clients} is empty!")
@@ -186,8 +207,8 @@ class BaseFedAvg(ModelController):
         for _result in results:
             aggr_helper.add(
                 data=_result.params,
-                weight=_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
-                contributor_name=_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
+                weight=_get_num_steps_weight(_result),
+                contributor_name=_get_client_name(_result),
                 contribution_round=_result.current_round,
             )
 

--- a/nvflare/app_common/workflows/base_fedavg.py
+++ b/nvflare/app_common/workflows/base_fedavg.py
@@ -31,6 +31,56 @@ from nvflare.security.logging import secure_format_exception
 from .model_controller import ModelController
 
 
+def make_fedavg_metrics_aggregation_info(
+    key_metric: Optional[str] = None,
+    key_metric_mode: Optional[str] = None,
+    key_metric_mode_source: Optional[str] = None,
+    weight_key: str = FLMetaKey.NUM_STEPS_CURRENT_ROUND,
+    weight_formula: Optional[str] = None,
+    site_weights: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    aggregation = {
+        "method": "weighted_average",
+        "weight_key": weight_key,
+        "metric_policy": "finite_numeric_metrics_only_per_key_denominator",
+    }
+    if weight_formula:
+        aggregation["weight_formula"] = weight_formula
+
+    info = {
+        "metric_source": "client_reported_flmodel_metrics",
+        "aggregation": aggregation,
+    }
+    if key_metric and key_metric_mode in ("max", "min"):
+        key_metric_info = {"name": key_metric, "mode": key_metric_mode}
+        if key_metric_mode_source:
+            key_metric_info["mode_source"] = key_metric_mode_source
+        info["key_metric"] = key_metric_info
+    if site_weights:
+        info["site_weights"] = site_weights
+    return info
+
+
+def make_key_metric_info_from_stop_condition(stop_cond, stop_condition) -> Optional[Dict[str, Any]]:
+    if not stop_cond or not stop_condition:
+        return None
+    tokens = stop_cond.split(" ")
+    if len(tokens) != 3:
+        return None
+    op = tokens[1]
+    if op in (">", ">="):
+        mode = "max"
+    elif op in ("<", "<="):
+        mode = "min"
+    else:
+        return None
+    return {
+        "name": stop_condition[0],
+        "mode": mode,
+        "mode_source": "derived_from_stop_condition",
+    }
+
+
 def _aggregate_fl_model_metrics(results: List[FLModel]) -> Optional[Dict[str, Any]]:
     """Aggregate FLModel metrics across results with FedAvg-compatible semantics.
 
@@ -148,7 +198,11 @@ class BaseFedAvg(ModelController):
             params=aggr_params,
             params_type=results[0].params_type,
             metrics=aggr_metrics,
-            meta={"nr_aggregated": len(results), "current_round": results[0].current_round},
+            meta={
+                "nr_aggregated": len(results),
+                "current_round": results[0].current_round,
+                AppConstants.METRICS_AGGREGATION_INFO: make_fedavg_metrics_aggregation_info(),
+            },
         )
         return aggr_result
 
@@ -178,6 +232,7 @@ class BaseFedAvg(ModelController):
             self.panic(error_msg)
             return FLModel()
         self._results = []
+        self._set_metrics_aggregation_info(aggr_result)
 
         self.fire_event_with_data(
             AppEventType.AFTER_AGGREGATION, self.fl_ctx, AppConstants.AGGREGATION_RESULT, aggr_result
@@ -186,6 +241,22 @@ class BaseFedAvg(ModelController):
         self.debug("End aggregation.")
 
         return aggr_result
+
+    def _set_metrics_aggregation_info(self, aggr_result: FLModel):
+        if not isinstance(aggr_result, FLModel):
+            return
+        aggr_result.meta = aggr_result.meta or {}
+        info = aggr_result.meta.get(AppConstants.METRICS_AGGREGATION_INFO)
+        if isinstance(info, dict):
+            info = dict(info)
+        else:
+            info = make_fedavg_metrics_aggregation_info()
+        key_metric_info = make_key_metric_info_from_stop_condition(
+            getattr(self, "stop_cond", None), getattr(self, "stop_condition", None)
+        )
+        if key_metric_info and "key_metric" not in info:
+            info["key_metric"] = key_metric_info
+        aggr_result.meta[AppConstants.METRICS_AGGREGATION_INFO] = info
 
     def update_model(self, model, aggr_result):
         """Called by the `run` routine to update the current global model (self.model) given the aggregated result.

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -35,7 +35,7 @@ from nvflare.app_common.utils.tensor_disk_offload_context import (
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.log_utils import center_message
 
-from .base_fedavg import BaseFedAvg
+from .base_fedavg import BaseFedAvg, make_fedavg_metrics_aggregation_info, make_key_metric_info_from_stop_condition
 
 
 class FedAvg(BaseFedAvg):
@@ -138,6 +138,7 @@ class FedAvg(BaseFedAvg):
         self._received_count: int = 0
         self._expected_count: int = 0
         self._params_type = None  # Only store params_type, not full result
+        self._site_metric_weights: Dict[str, Dict[str, Any]] = {}
 
     def run(self) -> None:
         disk_offload_root_dir = None
@@ -204,6 +205,7 @@ class FedAvg(BaseFedAvg):
                 self._received_count = 0
                 self._expected_count = len(clients)
                 self._params_type = None
+                self._site_metric_weights = {}
 
                 # Non-blocking send with callback for streaming aggregation
                 self.send_model(
@@ -224,6 +226,9 @@ class FedAvg(BaseFedAvg):
 
                 # Get final aggregated result
                 aggregate_results = self._get_aggregated_result()
+                self.fire_event_with_data(
+                    AppEventType.AFTER_AGGREGATION, self.fl_ctx, AppConstants.AGGREGATION_RESULT, aggregate_results
+                )
 
                 model = self.update_model(model, aggregate_results)
 
@@ -290,6 +295,11 @@ class FedAvg(BaseFedAvg):
             if n_iter is None:
                 n_iter = 1.0
             weight = aggregation_weight * float(n_iter)
+            self._site_metric_weights[client_name] = {
+                "name": client_name,
+                "weight": weight,
+                "weight_key": "effective_fedavg_metric_weight",
+            }
 
             self._aggr_helper.add(
                 data=result.params,
@@ -331,6 +341,9 @@ class FedAvg(BaseFedAvg):
             result.meta = result.meta or {}
             result.meta["nr_aggregated"] = self._received_count
             result.meta["current_round"] = self.current_round
+            if result.current_round is None:
+                result.current_round = self.current_round
+            self._set_metrics_aggregation_info(result)
             return result
         else:
             # Use built-in InTime aggregation
@@ -342,8 +355,47 @@ class FedAvg(BaseFedAvg):
                 params=aggr_params,
                 params_type=self._params_type,
                 metrics=aggr_metrics,
-                meta={"nr_aggregated": self._received_count, "current_round": self.current_round},
+                current_round=self.current_round,
+                meta={
+                    "nr_aggregated": self._received_count,
+                    "current_round": self.current_round,
+                    AppConstants.METRICS_AGGREGATION_INFO: self._make_metrics_aggregation_info(),
+                },
             )
+
+    def _make_metrics_aggregation_info(self) -> Dict[str, Any]:
+        key_metric_info = self._make_key_metric_info()
+        site_weights = list(self._site_metric_weights.values()) if self._site_metric_weights else None
+        weight_formula = None
+        if site_weights:
+            weight_formula = "aggregation_weight * NUM_STEPS_CURRENT_ROUND"
+        info = make_fedavg_metrics_aggregation_info(
+            weight_key="effective_fedavg_metric_weight" if site_weights else FLMetaKey.NUM_STEPS_CURRENT_ROUND,
+            weight_formula=weight_formula,
+            site_weights=site_weights,
+        )
+        if key_metric_info:
+            info["key_metric"] = key_metric_info
+        return info
+
+    def _make_key_metric_info(self) -> Optional[Dict[str, Any]]:
+        return make_key_metric_info_from_stop_condition(self.stop_cond, self.stop_condition)
+
+    def _set_metrics_aggregation_info(self, result: FLModel):
+        key_metric_info = self._make_key_metric_info()
+        existing_info = result.meta.get(AppConstants.METRICS_AGGREGATION_INFO)
+        if isinstance(existing_info, dict):
+            merged_info = dict(existing_info)
+            if "key_metric" not in merged_info and key_metric_info:
+                merged_info["key_metric"] = key_metric_info
+            if "sites" not in merged_info and "use_contribution_sites" not in merged_info:
+                merged_info["use_contribution_sites"] = False
+            result.meta[AppConstants.METRICS_AGGREGATION_INFO] = merged_info
+        else:
+            metrics_info = {"metric_source": "custom_aggregator_flmodel_metrics", "use_contribution_sites": False}
+            if key_metric_info:
+                metrics_info["key_metric"] = key_metric_info
+            result.meta[AppConstants.METRICS_AGGREGATION_INFO] = metrics_info
 
     def should_stop(self, metrics: Optional[Dict] = None) -> bool:
         """Checks whether the current FL experiment should stop.

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -35,7 +35,13 @@ from nvflare.app_common.utils.tensor_disk_offload_context import (
 from nvflare.fuel.utils import fobs
 from nvflare.fuel.utils.log_utils import center_message
 
-from .base_fedavg import BaseFedAvg, make_fedavg_metrics_aggregation_info, make_key_metric_info_from_stop_condition
+from .base_fedavg import (
+    BaseFedAvg,
+    _get_client_name,
+    _get_num_steps_weight,
+    make_fedavg_metrics_aggregation_info,
+    make_key_metric_info_from_stop_condition,
+)
 
 
 class FedAvg(BaseFedAvg):
@@ -269,7 +275,7 @@ class FedAvg(BaseFedAvg):
     def _aggregate_one_result(self, result: FLModel) -> None:
         """Callback: aggregate ONE client result immediately (InTime aggregation)."""
         if not result.params:
-            client_name = result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN)
+            client_name = _get_client_name(result)
             self.warning(f"Empty result from client {client_name}, skipping.")
             return
 
@@ -277,7 +283,7 @@ class FedAvg(BaseFedAvg):
         if self._params_type is None:
             self._params_type = result.params_type
 
-        client_name = result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN)
+        client_name = _get_client_name(result)
         if self.aggregator:
             # Use custom aggregator
             self.aggregator.accept_model(result)
@@ -290,11 +296,7 @@ class FedAvg(BaseFedAvg):
             else:
                 aggregation_weight = 1.0
 
-            n_iter = result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, None)
-            # Handle None case (e.g., first round of some algorithms like K-Means)
-            if n_iter is None:
-                n_iter = 1.0
-            weight = aggregation_weight * float(n_iter)
+            weight = aggregation_weight * _get_num_steps_weight(result)
             self._site_metric_weights[client_name] = {
                 "name": client_name,
                 "weight": weight,

--- a/nvflare/app_common/workflows/lr/fedavg.py
+++ b/nvflare/app_common/workflows/lr/fedavg.py
@@ -25,7 +25,11 @@ from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedA
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.np.constants import NPConstants
 from nvflare.app_common.np.np_model_persistor import NPModelPersistor
-from nvflare.app_common.workflows.base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics
+from nvflare.app_common.workflows.base_fedavg import (
+    BaseFedAvg,
+    _aggregate_fl_model_metrics,
+    make_fedavg_metrics_aggregation_info,
+)
 from nvflare.app_common.workflows.lr.np_persistor import LRModelPersistor
 
 
@@ -177,10 +181,12 @@ class FedAvgLR(BaseFedAvg):
             params={"newton_raphson_updates": newton_raphson_updates},
             params_type=results[0].params_type,
             metrics=_aggregate_fl_model_metrics(results),
+            current_round=results[0].current_round,
             meta={
                 "nr_aggregated": len(results),
                 AppConstants.CURRENT_ROUND: results[0].current_round,
                 AppConstants.NUM_ROUNDS: self.num_rounds,
+                AppConstants.METRICS_AGGREGATION_INFO: make_fedavg_metrics_aggregation_info(),
             },
         )
         return aggr_result

--- a/nvflare/app_common/workflows/lr/fedavg.py
+++ b/nvflare/app_common/workflows/lr/fedavg.py
@@ -19,7 +19,6 @@ from typing import List, Optional
 
 import numpy as np
 
-from nvflare.apis.fl_constant import FLMetaKey
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedAggregationHelper
 from nvflare.app_common.app_constant import AppConstants
@@ -28,6 +27,8 @@ from nvflare.app_common.np.np_model_persistor import NPModelPersistor
 from nvflare.app_common.workflows.base_fedavg import (
     BaseFedAvg,
     _aggregate_fl_model_metrics,
+    _get_client_name,
+    _get_num_steps_weight,
     make_fedavg_metrics_aggregation_info,
 )
 from nvflare.app_common.workflows.lr.np_persistor import LRModelPersistor
@@ -155,8 +156,8 @@ class FedAvgLR(BaseFedAvg):
         for curr_result in results:
             self.aggregator.add(
                 data=curr_result.params,
-                weight=curr_result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0),
-                contributor_name=curr_result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN),
+                weight=_get_num_steps_weight(curr_result),
+                contributor_name=_get_client_name(curr_result),
                 contribution_round=curr_result.current_round,
             )
 

--- a/nvflare/app_common/workflows/scaffold.py
+++ b/nvflare/app_common/workflows/scaffold.py
@@ -17,12 +17,17 @@ from typing import List
 
 import numpy as np
 
-from nvflare.apis.fl_constant import FLMetaKey
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedAggregationHelper
 from nvflare.app_common.app_constant import AlgorithmConstants, AppConstants
 
-from .base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics, make_fedavg_metrics_aggregation_info
+from .base_fedavg import (
+    BaseFedAvg,
+    _aggregate_fl_model_metrics,
+    _get_client_name,
+    _get_num_steps_weight,
+    make_fedavg_metrics_aggregation_info,
+)
 
 
 class Scaffold(BaseFedAvg):
@@ -98,8 +103,8 @@ def scaffold_aggregate_fn(results: List[FLModel]) -> FLModel:
     aggregation_helper = WeightedAggregationHelper()
     crtl_aggregation_helper = WeightedAggregationHelper()
     for _result in results:
-        weight = _result.meta.get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0)
-        contributor_name = _result.meta.get("client_name", AppConstants.CLIENT_UNKNOWN)
+        weight = _get_num_steps_weight(_result)
+        contributor_name = _get_client_name(_result)
         aggregation_helper.add(
             data=_result.params,
             weight=weight,

--- a/nvflare/app_common/workflows/scaffold.py
+++ b/nvflare/app_common/workflows/scaffold.py
@@ -22,7 +22,7 @@ from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedAggregationHelper
 from nvflare.app_common.app_constant import AlgorithmConstants, AppConstants
 
-from .base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics
+from .base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics, make_fedavg_metrics_aggregation_info
 
 
 class Scaffold(BaseFedAvg):
@@ -128,6 +128,7 @@ def scaffold_aggregate_fn(results: List[FLModel]) -> FLModel:
             AlgorithmConstants.SCAFFOLD_CTRL_DIFF: crtl_aggregation_helper.get_result(),
             "nr_aggregated": len(results),
             "current_round": results[0].current_round,
+            AppConstants.METRICS_AGGREGATION_INFO: make_fedavg_metrics_aggregation_info(),
         },
     )
 

--- a/nvflare/app_opt/pt/job_config/base_fed_job.py
+++ b/nvflare/app_opt/pt/job_config/base_fed_job.py
@@ -20,6 +20,7 @@ from nvflare.apis.fl_component import FLComponent
 from nvflare.app_common.abstract.model_locator import ModelLocator
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
 from nvflare.job_config.base_fed_job import BaseFedJob as UnifiedBaseFedJob
@@ -68,6 +69,7 @@ class BaseFedJob(UnifiedBaseFedJob):
         model_selector: Optional[FLComponent] = None,
         convert_to_fed_event: Optional[ConvertToFedEvent] = None,
         analytics_receiver: Optional[AnalyticsReceiver] = None,
+        metrics_artifact_writer: Optional[MetricsArtifactWriter] = None,
         model_persistor: Optional[ModelPersistor] = None,
         model_locator: Optional[ModelLocator] = None,
     ):
@@ -81,6 +83,7 @@ class BaseFedJob(UnifiedBaseFedJob):
             model_selector=model_selector,
             convert_to_fed_event=convert_to_fed_event,
             analytics_receiver=analytics_receiver,
+            metrics_artifact_writer=metrics_artifact_writer,
         )
 
         # PyTorch-specific model setup

--- a/nvflare/app_opt/tf/job_config/base_fed_job.py
+++ b/nvflare/app_opt/tf/job_config/base_fed_job.py
@@ -19,6 +19,7 @@ import tensorflow as tf
 from nvflare.apis.fl_component import FLComponent
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
 from nvflare.job_config.base_fed_job import BaseFedJob as UnifiedBaseFedJob
@@ -72,6 +73,7 @@ class BaseFedJob(UnifiedBaseFedJob):
         model_selector: Optional[FLComponent] = None,
         convert_to_fed_event: Optional[ConvertToFedEvent] = None,
         analytics_receiver: Optional[AnalyticsReceiver] = None,
+        metrics_artifact_writer: Optional[MetricsArtifactWriter] = None,
         model_persistor: Optional[ModelPersistor] = None,
     ):
         # Call the unified BaseFedJob
@@ -84,6 +86,7 @@ class BaseFedJob(UnifiedBaseFedJob):
             model_selector=model_selector,
             convert_to_fed_event=convert_to_fed_event,
             analytics_receiver=analytics_receiver,
+            metrics_artifact_writer=metrics_artifact_writer,
         )
 
         # TensorFlow-specific model setup

--- a/nvflare/app_opt/xgboost/recipes/bagging.py
+++ b/nvflare/app_opt/xgboost/recipes/bagging.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_common.workflows.cyclic_ctl import CyclicController
 from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
 from nvflare.app_opt.xgboost.tree_based.bagging_aggregator import XGBBaggingAggregator
@@ -222,6 +223,7 @@ class XGBBaggingRecipe(Recipe):
         """Configure the federated job for XGBoost tree-based training."""
         # Create FedJob
         job = FedJob(name=self.name, min_clients=self.min_clients)
+        job.to_server(MetricsArtifactWriter(), id="metrics_artifact_writer")
 
         # Configure server components
         if self.training_mode == "cyclic":

--- a/nvflare/app_opt/xgboost/recipes/histogram.py
+++ b/nvflare/app_opt/xgboost/recipes/histogram.py
@@ -17,6 +17,7 @@ from typing import Optional
 from pydantic import BaseModel, field_validator
 
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
 from nvflare.app_opt.tracking.tb.tb_writer import TBWriter
 from nvflare.app_opt.xgboost.histogram_based_v2.fed_controller import XGBFedController
@@ -183,6 +184,7 @@ class XGBHorizontalRecipe(Recipe):
         """Configure the federated job for XGBoost histogram-based training."""
         # Create FedJob
         job = FedJob(name=self.name, min_clients=self.min_clients)
+        job.to_server(MetricsArtifactWriter(), id="metrics_artifact_writer")
 
         # Configure controller and executor (histogram-based V2)
         controller_kwargs = {

--- a/nvflare/app_opt/xgboost/recipes/vertical.py
+++ b/nvflare/app_opt/xgboost/recipes/vertical.py
@@ -17,6 +17,7 @@ from typing import Optional
 from pydantic import BaseModel, field_validator
 
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_opt.tracking.tb.tb_receiver import TBAnalyticsReceiver
 from nvflare.app_opt.tracking.tb.tb_writer import TBWriter
 from nvflare.app_opt.xgboost.histogram_based_v2.fed_controller import XGBFedController
@@ -255,6 +256,7 @@ class XGBVerticalRecipe(Recipe):
 
         # Create FedJob
         job = FedJob(name=self.name, min_clients=self.min_clients)
+        job.to_server(MetricsArtifactWriter(), id="metrics_artifact_writer")
 
         # Configure controller for vertical mode
         controller_kwargs = {

--- a/nvflare/edge/tools/edge_job.py
+++ b/nvflare/edge/tools/edge_job.py
@@ -16,6 +16,7 @@ import os.path
 from typing import Optional
 
 from nvflare.apis.app_validation import AppValidationKey
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.edge.assessor import Assessor
 from nvflare.edge.controllers.sage import ScatterAndGatherForEdge
 from nvflare.edge.executors.edge_model_executor import EdgeModelExecutor
@@ -85,6 +86,7 @@ class EdgeJob(FedJob):
         check_str("task_name", task_name)
 
         assessor_id = self.to_server(assessor, id="wf_assessor")
+        self.to_server(MetricsArtifactWriter(), id="metrics_artifact_writer")
 
         controller = ScatterAndGatherForEdge(
             assessor_id=assessor_id,

--- a/nvflare/job_config/base_fed_job.py
+++ b/nvflare/job_config/base_fed_job.py
@@ -17,6 +17,7 @@ from typing import List, Optional
 from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE
 from nvflare.apis.fl_component import FLComponent
 from nvflare.app_common.widgets.convert_to_fed_event import ConvertToFedEvent
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_common.widgets.streaming import AnalyticsReceiver
 from nvflare.app_common.widgets.validation_json_generator import ValidationJsonGenerator
 from nvflare.job_config.api import FedJob, validate_object_for_job
@@ -43,6 +44,7 @@ class BaseFedJob(FedJob):
         model_selector: Optional[FLComponent] = None,
         convert_to_fed_event: Optional[ConvertToFedEvent] = None,
         analytics_receiver: Optional[AnalyticsReceiver] = None,
+        metrics_artifact_writer: Optional[MetricsArtifactWriter] = None,
     ):
         """Unified BaseFedJob for PyTorch, TensorFlow, and Scikit-learn.
 
@@ -73,6 +75,8 @@ class BaseFedJob(FedJob):
                 If not provided, a ConvertToFedEvent object will be created.
             analytics_receiver: Receive analytics. If not provided, framework-specific
                 child classes may provide defaults (e.g., TBAnalyticsReceiver for PT/TF).
+            metrics_artifact_writer: Component for writing server-side metrics artifacts.
+                If not provided, a MetricsArtifactWriter will be configured.
         """
         super().__init__(
             name=name,
@@ -98,6 +102,13 @@ class BaseFedJob(FedJob):
             from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 
             self.to_server(id="model_selector", obj=IntimeModelSelector(key_metric=key_metric))
+
+        # Metrics artifact writer
+        if metrics_artifact_writer is not None:
+            validate_object_for_job("metrics_artifact_writer", metrics_artifact_writer, FLComponent)
+        else:
+            metrics_artifact_writer = MetricsArtifactWriter()
+        self.to_server(id="metrics_artifact_writer", obj=metrics_artifact_writer)
 
         # Convert to fed event
         if convert_to_fed_event:

--- a/nvflare/private/fed/simulator/simulator_server.py
+++ b/nvflare/private/fed/simulator/simulator_server.py
@@ -75,7 +75,7 @@ class SimulatorServerEngine(ServerEngine):
 
 class SimulatorRunManager(RunManager):
     def create_job_processing_context_properties(self, workspace, job_id):
-        return {}
+        return super().create_job_processing_context_properties(workspace, job_id)
 
 
 class SimulatorIdentityAsserter(IdentityAsserter):

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -1185,6 +1185,9 @@ def _discover_job_download_artifacts(download_path: str) -> Tuple[dict, List[str
         elif file_name == "metrics_summary.json" and "metrics_summary" not in artifacts:
             artifacts["metrics_summary"] = file_path
             continue
+        elif file_name == "round_metrics.jsonl" and "round_metrics" not in artifacts:
+            artifacts["round_metrics"] = file_path
+            continue
         elif file_name != "log.txt":
             continue
 

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -88,3 +88,39 @@ class TestInTimeModelSelector:
             handler.handle_event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT, fl_ctx)
         handler.handle_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
         assert (engine.last_event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE) == expected
+
+    def test_model_selection_publishes_metrics_selection_info(self):
+        handler = IntimeModelSelector(key_metric="loss", negate_key_metric=True)
+        engine = MockSimpleEngine()
+        peer_ctx = FLContext()
+        dxo = DXO(
+            DataKind.WEIGHT_DIFF,
+            data=dict(),
+            meta={
+                MetaKey.INITIAL_METRICS: {"loss": 0.2},
+                MetaKey.NUM_STEPS_CURRENT_ROUND: 1,
+            },
+        )
+        shareable = dxo.to_shareable()
+        shareable.add_cookie(AppConstants.CONTRIBUTION_ROUND, 1)
+        peer_ctx.set_prop(FLContextKey.SHAREABLE, shareable, private=True)
+        fl_ctx = engine.fl_ctx_mgr.new_context()
+        fl_ctx.set_prop(AppConstants.CURRENT_ROUND, 1, private=True, sticky=False)
+        fl_ctx.set_peer_context(peer_ctx)
+
+        handler.handle_event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT, fl_ctx)
+        handler.handle_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
+
+        assert engine.last_event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE
+        assert fl_ctx.get_prop(AppConstants.VALIDATION_RESULT) == -0.2
+        assert fl_ctx.get_prop(AppConstants.METRICS_SELECTION_INFO) == {
+            "source": "IntimeModelSelector",
+            "metric_source": MetaKey.INITIAL_METRICS,
+            "key_metric": {
+                "name": "loss",
+                "mode": "min",
+                "mode_source": "IntimeModelSelector.negate_key_metric",
+            },
+            "best_round": 1,
+            "best_metrics": {"loss": 0.2},
+        }

--- a/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
+++ b/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
@@ -424,6 +424,22 @@ class TestMetricsArtifactWriterAggregationEvents:
         assert "weight" not in rounds[0]["sites"][0]
         assert rounds[0]["sites"][1]["weight"] == 1
 
+    def test_zero_weights_are_ignored_without_affecting_official_aggregation(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_contribution(writer, fl_ctx, 1, "site-1", {"score": 0.0}, weight=0)
+        _record_contribution(writer, fl_ctx, 1, "site-2", {"score": 1.0}, weight=1)
+        _record_round(writer, fl_ctx, 1, metrics={"score": 0.5})
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"score": 0.5}
+        assert "weight" not in rounds[0]["sites"][0]
+        assert rounds[0]["sites"][1]["weight"] == 1
+
     def test_numpy_scalar_metrics_are_normalized_to_json_scalars(self, tmp_path):
         writer = MetricsArtifactWriter()
         run_dir = tmp_path / "run"

--- a/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
+++ b/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
@@ -330,6 +330,57 @@ class TestMetricsArtifactWriterAggregationEvents:
         assert summary["best_metric_source"] == "IntimeModelSelector"
         assert summary["best_metric_detail_source"] == "initial_metrics"
 
+    def test_summary_key_metric_prefers_best_selection_metadata(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        selection_key_metric = {"name": "accuracy", "mode": "max", "mode_source": "selector"}
+        aggregation_key_metric = {"name": "loss", "mode": "min", "mode_source": "stop_condition"}
+        _record_best_selection(
+            writer,
+            fl_ctx,
+            {
+                "source": "IntimeModelSelector",
+                "key_metric": selection_key_metric,
+                "best_round": 0,
+                "best_metrics": {"accuracy": 0.9},
+            },
+        )
+        _record_round(writer, fl_ctx, 1, {"loss": 0.4, "accuracy": 0.8}, key_metric=aggregation_key_metric)
+        _finish_run(writer, fl_ctx)
+
+        summary = _read_summary(run_dir)
+        assert summary["key_metric"] == selection_key_metric
+        assert summary["best_round"] == 0
+        assert _metrics_to_dict(summary["best_metrics"]) == {"accuracy": 0.9}
+
+        rounds = _read_rounds(run_dir)
+        assert rounds[0]["key_metric"] == aggregation_key_metric
+
+    def test_contribution_with_none_meta_does_not_crash(self, tmp_path, monkeypatch):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        monkeypatch.setattr(
+            FLModelUtils,
+            "from_shareable",
+            lambda _: FLModel(metrics={"loss": 0.3}, current_round=1, meta=None),
+        )
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        fl_ctx.set_prop(AppConstants.TRAINING_RESULT, object(), private=True, sticky=False)
+        writer.handle_event(AppEventType.AFTER_CONTRIBUTION_ACCEPT, fl_ctx)
+        fl_ctx.set_prop(AppConstants.TRAINING_RESULT, None, private=True, sticky=False)
+        _record_round(writer, fl_ctx, 1, {"loss": 0.3})
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert rounds[0]["sites"][0]["name"] == AppConstants.CLIENT_UNKNOWN
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"loss": 0.3}
+
     def test_bool_site_metrics_are_recorded_without_synthetic_aggregation(self, tmp_path):
         writer = MetricsArtifactWriter()
         run_dir = tmp_path / "run"

--- a/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
+++ b/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
@@ -1,0 +1,656 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import math
+import os
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.abstract.fl_model import FLModel
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.fl_model_utils import FLModelUtils
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
+
+_METRICS_AGGREGATION_INFO = "metrics_aggregation_info"
+_METRICS_DIR = "metrics"
+_SUMMARY_FILE = "metrics_summary.json"
+_ROUND_FILE = "round_metrics.jsonl"
+
+
+class _UnsafeObject:
+    def __repr__(self):
+        raise AssertionError("unsafe metric object should not be stringified")
+
+    def __str__(self):
+        raise AssertionError("unsafe metric object should not be stringified")
+
+
+class generic:
+    __module__ = "numpy"
+
+
+class _SpoofedNumpyScalar(generic):
+    __module__ = "numpy"
+
+    def item(self):
+        raise AssertionError("spoofed metric object should not have item() called")
+
+
+def _make_fl_ctx(run_dir):
+    workspace = Mock()
+    workspace.get_run_dir.return_value = str(run_dir)
+    engine = Mock()
+    engine.get_workspace.return_value = workspace
+
+    fl_ctx = FLContext()
+    fl_ctx.get_engine = Mock(return_value=engine)
+    fl_ctx.get_job_id = Mock(return_value="job-1")
+    return fl_ctx
+
+
+def _artifact_paths(run_dir):
+    metrics_dir = run_dir / _METRICS_DIR
+    return metrics_dir, metrics_dir / _SUMMARY_FILE, metrics_dir / _ROUND_FILE
+
+
+def _aggregation_info(sites=None, key_metric=None, site_weights=None, use_contribution_sites=True):
+    info = {
+        "metric_source": "client_reported_flmodel_metrics",
+        "metric_split": "validation",
+        "aggregation": {
+            "method": "weighted_average",
+            "weight_key": FLMetaKey.NUM_STEPS_CURRENT_ROUND,
+            "metric_policy": "finite_numeric_metrics_only_per_key_denominator",
+        },
+    }
+    if sites is not None:
+        info["sites"] = sites
+    if key_metric is not None:
+        info["key_metric"] = key_metric
+    if site_weights is not None:
+        info["site_weights"] = site_weights
+    if not use_contribution_sites:
+        info["use_contribution_sites"] = False
+    return info
+
+
+def _site(name, metrics, weight=1.0):
+    return {
+        "name": name,
+        "metrics": metrics,
+        "weight": weight,
+        "weight_key": FLMetaKey.NUM_STEPS_CURRENT_ROUND,
+    }
+
+
+def _record_round(
+    writer,
+    fl_ctx,
+    round_num,
+    metrics,
+    sites=None,
+    key_metric=None,
+    site_weights=None,
+    use_contribution_sites=True,
+):
+    aggr_result = FLModel(
+        metrics=metrics,
+        current_round=round_num,
+        meta={
+            AppConstants.CURRENT_ROUND: round_num,
+            _METRICS_AGGREGATION_INFO: _aggregation_info(
+                sites=sites,
+                key_metric=key_metric,
+                site_weights=site_weights,
+                use_contribution_sites=use_contribution_sites,
+            ),
+        },
+    )
+    try:
+        fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, aggr_result, private=True, sticky=False)
+        writer.handle_event(AppEventType.AFTER_AGGREGATION, fl_ctx)
+    finally:
+        fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, None, private=True, sticky=False)
+
+
+def _record_contribution(writer, fl_ctx, round_num, site_name, metrics, weight=1):
+    result = FLModel(
+        metrics=metrics,
+        current_round=round_num,
+        meta={FLMetaKey.SITE_NAME: site_name, FLMetaKey.NUM_STEPS_CURRENT_ROUND: weight},
+    )
+    shareable = FLModelUtils.to_shareable(result)
+    try:
+        fl_ctx.set_prop(AppConstants.TRAINING_RESULT, shareable, private=True, sticky=False)
+        writer.handle_event(AppEventType.AFTER_CONTRIBUTION_ACCEPT, fl_ctx)
+    finally:
+        fl_ctx.set_prop(AppConstants.TRAINING_RESULT, None, private=True, sticky=False)
+
+
+def _finish_run(writer, fl_ctx):
+    writer.handle_event(EventType.END_RUN, fl_ctx)
+
+
+def _record_best_selection(writer, fl_ctx, selection):
+    try:
+        fl_ctx.set_prop(AppConstants.METRICS_SELECTION_INFO, selection, private=True, sticky=False)
+        writer.handle_event(AppEventType.GLOBAL_BEST_MODEL_AVAILABLE, fl_ctx)
+    finally:
+        fl_ctx.set_prop(AppConstants.METRICS_SELECTION_INFO, None, private=True, sticky=False)
+
+
+def _read_summary(run_dir):
+    _, summary_path, _ = _artifact_paths(run_dir)
+    with open(summary_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _read_rounds(run_dir):
+    _, _, round_path = _artifact_paths(run_dir)
+    with open(round_path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _metrics_to_dict(metrics):
+    assert isinstance(metrics, list)
+    return {entry["name"]: entry["value"] for entry in metrics}
+
+
+def _collect_object_keys(value):
+    if isinstance(value, dict):
+        keys = set(value.keys())
+        for child in value.values():
+            keys.update(_collect_object_keys(child))
+        return keys
+    if isinstance(value, list):
+        keys = set()
+        for child in value:
+            keys.update(_collect_object_keys(child))
+        return keys
+    return set()
+
+
+def _collect_metric_names(value):
+    names = set()
+    if isinstance(value, dict):
+        if set(value.keys()) >= {"name", "value"}:
+            names.add(value["name"])
+        for child in value.values():
+            names.update(_collect_metric_names(child))
+    elif isinstance(value, list):
+        for child in value:
+            names.update(_collect_metric_names(child))
+    return names
+
+
+class TestMetricsArtifactWriterAggregationEvents:
+    def test_writes_summary_and_jsonl_from_aggregation_events(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        key_metric = {"name": "accuracy", "mode": "max", "mode_source": "derived_from_existing_selection_logic"}
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            {"accuracy": 0.82, "loss": 0.40},
+            sites=[
+                _site("site-1", {"accuracy": 0.80, "loss": 0.38}, weight=10),
+                _site("site-2", {"accuracy": 0.84, "loss": 0.42}, weight=10),
+            ],
+            key_metric=key_metric,
+        )
+        _record_round(
+            writer,
+            fl_ctx,
+            2,
+            {"accuracy": 0.81, "loss": 0.35},
+            sites=[
+                _site("site-1", {"accuracy": 0.79, "loss": 0.34}, weight=10),
+                _site("site-2", {"accuracy": 0.83, "loss": 0.36}, weight=10),
+            ],
+            key_metric=key_metric,
+        )
+        _finish_run(writer, fl_ctx)
+
+        metrics_dir, summary_path, round_path = _artifact_paths(run_dir)
+        assert metrics_dir.is_dir()
+        assert summary_path.is_file()
+        assert round_path.is_file()
+
+        summary = _read_summary(run_dir)
+        assert summary["status"] == "metrics_reported"
+        assert summary["final_round"] == 2
+        assert _metrics_to_dict(summary["final_aggregated_metrics"]) == {"accuracy": 0.81, "loss": 0.35}
+        assert summary["key_metric"] == key_metric
+        assert summary["round_metrics_file"] == _ROUND_FILE
+        assert "best_round" not in summary
+
+        rounds = _read_rounds(run_dir)
+        assert [record["round"] for record in rounds] == [1, 2]
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"accuracy": 0.82, "loss": 0.40}
+        assert rounds[0]["sites"][0]["name"] == "site-1"
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"accuracy": 0.80, "loss": 0.38}
+        assert rounds[0]["key_metric"] == key_metric
+        assert rounds[0]["aggregation"]["method"] == "weighted_average"
+
+    def test_key_metric_metadata_does_not_make_writer_select_best_round(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        key_metric = {"name": "score", "mode": "max", "mode_source": "workflow_metadata"}
+        for index, value in enumerate([0.70, 0.75, 0.72], start=1):
+            _record_round(writer, fl_ctx, index, {"score": value, "aux": index}, key_metric=key_metric)
+        _finish_run(writer, fl_ctx)
+
+        summary = _read_summary(run_dir)
+        assert summary["key_metric"] == key_metric
+        assert "best_round" not in summary
+        assert "best_metrics" not in summary
+        assert "best_aggregated_metrics" not in summary
+
+    def test_records_official_best_selection_metadata(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(writer, fl_ctx, 1, {"score": 0.3})
+        _record_best_selection(
+            writer,
+            fl_ctx,
+            {
+                "source": "IntimeModelSelector",
+                "metric_source": "initial_metrics",
+                "key_metric": {"name": "score", "mode": "min", "mode_source": "IntimeModelSelector"},
+                "best_round": 1,
+                "best_metrics": {"score": 0.3},
+            },
+        )
+        _finish_run(writer, fl_ctx)
+
+        summary = _read_summary(run_dir)
+        assert summary["key_metric"] == {
+            "name": "score",
+            "mode": "min",
+            "mode_source": "IntimeModelSelector",
+        }
+        assert summary["best_round"] == 1
+        assert _metrics_to_dict(summary["best_metrics"]) == {"score": 0.3}
+        assert summary["best_metric_source"] == "IntimeModelSelector"
+        assert summary["best_metric_detail_source"] == "initial_metrics"
+
+    def test_bool_site_metrics_are_recorded_without_synthetic_aggregation(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            metrics={},
+            sites=[
+                _site("site-1", {"accepted": True}, weight=3),
+                _site("site-2", {"accepted": False}, weight=1),
+            ],
+        )
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"accepted": True}
+        assert _metrics_to_dict(rounds[0]["sites"][1]["metrics"]) == {"accepted": False}
+        assert rounds[0]["aggregated_metrics"] == []
+
+        summary = _read_summary(run_dir)
+        assert summary["final_aggregated_metrics"] == []
+
+    def test_negative_weights_are_ignored_without_affecting_official_aggregation(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_contribution(writer, fl_ctx, 1, "site-1", {"score": -1.0}, weight=-100)
+        _record_contribution(writer, fl_ctx, 1, "site-2", {"score": 1.0}, weight=1)
+        _record_round(writer, fl_ctx, 1, metrics={"score": 0.5})
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"score": 0.5}
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"score": -1.0}
+        assert "weight" not in rounds[0]["sites"][0]
+        assert rounds[0]["sites"][1]["weight"] == 1
+
+    def test_numpy_scalar_metrics_are_normalized_to_json_scalars(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_contribution(
+            writer,
+            fl_ctx,
+            1,
+            "site-1",
+            {"loss": np.float32(0.2), "count": np.int64(3), "accepted": np.bool_(True)},
+            weight=np.int64(5),
+        )
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            {"loss": np.float32(0.2), "count": np.int64(3), "accepted": np.bool_(True)},
+        )
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert rounds[0]["skipped_metrics"] == []
+        site_metrics = _metrics_to_dict(rounds[0]["sites"][0]["metrics"])
+        assert math.isclose(site_metrics["loss"], 0.2, rel_tol=1e-6)
+        assert site_metrics["count"] == 3
+        assert site_metrics["accepted"] is True
+        assert rounds[0]["sites"][0]["weight"] == 5
+
+        summary_metrics = _metrics_to_dict(_read_summary(run_dir)["final_aggregated_metrics"])
+        assert math.isclose(summary_metrics["loss"], 0.2, rel_tol=1e-6)
+        assert summary_metrics["count"] == 3
+        assert summary_metrics["accepted"] is True
+
+    def test_numpy_scalar_normalization_does_not_call_item_on_spoofed_objects(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(writer, fl_ctx, 1, {"loss": _SpoofedNumpyScalar()})
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert rounds[0]["aggregated_metrics"] == []
+        assert rounds[0]["sites"] == []
+        assert rounds[0]["skipped_metrics"] == [{"name": "loss", "reason": "unsupported_type"}]
+
+    def test_dynamic_and_dangerous_metric_names_are_array_values_not_json_keys_or_paths(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+        dangerous_metrics = {
+            "__proto__": 0.1,
+            "constructor": 0.2,
+            "../outside/loss": 0.3,
+            "fold[0].score": 0.4,
+            "line\nbreak\x00metric": 0.5,
+        }
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            dangerous_metrics,
+            sites=[_site("site/../1", dangerous_metrics, weight=1)],
+            key_metric={"name": "__proto__", "mode": "max", "mode_source": "workflow_metadata"},
+        )
+        _finish_run(writer, fl_ctx)
+
+        summary = _read_summary(run_dir)
+        rounds = _read_rounds(run_dir)
+        combined = {"summary": summary, "rounds": rounds}
+        object_keys = _collect_object_keys(combined)
+        for metric_name in dangerous_metrics:
+            assert metric_name not in object_keys
+
+        metric_names = _collect_metric_names(combined)
+        assert {"__proto__", "constructor", "../outside/loss", "fold[0].score"} <= metric_names
+        assert all("\n" not in name and "\x00" not in name for name in metric_names)
+
+        written_files = sorted(p.relative_to(run_dir).as_posix() for p in run_dir.rglob("*") if p.is_file())
+        assert written_files == [f"{_METRICS_DIR}/{_SUMMARY_FILE}", f"{_METRICS_DIR}/{_ROUND_FILE}"]
+
+    def test_invalid_metric_values_are_skipped_with_metadata_without_unsafe_stringification(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+        unsafe_value = _UnsafeObject()
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            {
+                "loss": 0.25,
+                "nan_metric": float("nan"),
+                "inf_metric": float("inf"),
+                "debug_blob": unsafe_value,
+            },
+            sites=[
+                _site(
+                    "site-1",
+                    {
+                        "loss": 0.20,
+                        "nan_metric": float("nan"),
+                        "debug_blob": unsafe_value,
+                        "raw_bytes": b"abc",
+                    },
+                    weight=1,
+                )
+            ],
+        )
+        _finish_run(writer, fl_ctx)
+
+        _, summary_path, round_path = _artifact_paths(run_dir)
+        assert "NaN" not in summary_path.read_text(encoding="utf-8")
+        assert "Infinity" not in summary_path.read_text(encoding="utf-8")
+        assert "NaN" not in round_path.read_text(encoding="utf-8")
+        assert "Infinity" not in round_path.read_text(encoding="utf-8")
+
+        summary = _read_summary(run_dir)
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(summary["final_aggregated_metrics"]) == {"loss": 0.25}
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"loss": 0.25}
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"loss": 0.20}
+
+        skipped = rounds[0]["skipped_metrics"]
+        skipped_names = {entry["name"] for entry in skipped}
+        assert {"nan_metric", "inf_metric", "debug_blob", "raw_bytes"} <= skipped_names
+        assert all(entry.get("reason") for entry in skipped)
+
+    def test_per_site_skipped_metrics_from_contribution_events_are_preserved(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+        unsafe_value = _UnsafeObject()
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_contribution(
+            writer,
+            fl_ctx,
+            1,
+            "site-1",
+            {"loss": 0.2, "bad_object": unsafe_value, "huge_int": 10**400, 2: 0.1},
+            weight=3,
+        )
+        _record_round(writer, fl_ctx, 1, {"loss": 0.2})
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"loss": 0.2}
+        skipped = {(entry.get("site"), entry["name"], entry["reason"]) for entry in rounds[0]["skipped_metrics"]}
+        assert ("site-1", "bad_object", "unsupported_type") in skipped
+        assert ("site-1", "huge_int", "number_too_large") in skipped
+        assert ("site-1", "", "non_string_metric_name") in skipped
+
+    def test_effective_site_weights_are_recorded_without_recomputing_aggregation(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_contribution(writer, fl_ctx, 1, "site-1", {"score": 0.0}, weight=100)
+        _record_contribution(writer, fl_ctx, 1, "site-2", {"score": 1.0}, weight=100)
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            metrics={"score": 0.5},
+            site_weights=[
+                {"name": "site-1", "weight": 1.0, "weight_key": "effective_fedavg_metric_weight"},
+                {"name": "site-2", "weight": 3.0, "weight_key": "effective_fedavg_metric_weight"},
+            ],
+        )
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"score": 0.5}
+        assert [site["weight"] for site in rounds[0]["sites"]] == [1.0, 3.0]
+        assert {site["weight_key"] for site in rounds[0]["sites"]} == {"effective_fedavg_metric_weight"}
+
+    def test_custom_aggregator_metadata_can_disable_contribution_site_fallback(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_contribution(writer, fl_ctx, 1, "site-1", {"score": 0.1}, weight=1)
+        _record_round(writer, fl_ctx, 1, {"score": 0.9}, use_contribution_sites=False)
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"score": 0.9}
+        assert rounds[0]["sites"] == []
+
+    def test_site_and_round_metric_limits_are_enforced(self, tmp_path):
+        writer = MetricsArtifactWriter(limits={"max_sites_per_round": 1, "max_site_metric_records_per_round": 1})
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(
+            writer,
+            fl_ctx,
+            1,
+            metrics={},
+            sites=[
+                _site("site-1", {"m1": 1, "m2": 2}, weight=1),
+                _site("site-2", {"m1": 3}, weight=1),
+            ],
+        )
+        _finish_run(writer, fl_ctx)
+
+        rounds = _read_rounds(run_dir)
+        assert len(rounds[0]["sites"]) == 1
+        assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"m1": 1}
+        skipped_reasons = {entry["reason"] for entry in rounds[0]["skipped_metrics"]}
+        assert {"too_many_metrics", "too_many_sites"} <= skipped_reasons
+
+    def test_oversized_round_record_is_truncated_before_write(self, tmp_path):
+        writer = MetricsArtifactWriter(
+            limits={"max_round_record_bytes": 500, "max_string_value_length": 200, "max_metrics_per_site_per_round": 10}
+        )
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+        large_metrics = {f"metric_{i}": "x" * 100 for i in range(20)}
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(writer, fl_ctx, 1, {"score": 1.0}, sites=[_site("site-1", large_metrics, weight=1)])
+        _finish_run(writer, fl_ctx)
+
+        _, _, round_path = _artifact_paths(run_dir)
+        assert round_path.stat().st_size <= 500
+        rounds = _read_rounds(run_dir)
+        assert rounds[0]["round"] == 1
+
+    @pytest.mark.parametrize(
+        "event_payload",
+        [
+            None,
+            FLModel(metrics=None, current_round=1),
+            FLModel(metrics={}, current_round=1),
+        ],
+    )
+    def test_no_metrics_do_not_create_synthetic_artifacts(self, tmp_path, event_payload):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        writer.handle_event(AppEventType.VALIDATION_RESULT_RECEIVED, fl_ctx)
+        if event_payload is not None:
+            try:
+                fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, event_payload, private=True, sticky=False)
+                writer.handle_event(AppEventType.AFTER_AGGREGATION, fl_ctx)
+            finally:
+                fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, None, private=True, sticky=False)
+        _finish_run(writer, fl_ctx)
+
+        _, summary_path, round_path = _artifact_paths(run_dir)
+        assert not summary_path.exists()
+        assert not round_path.exists()
+
+    def test_best_selection_without_round_metrics_does_not_create_artifacts(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_best_selection(
+            writer,
+            fl_ctx,
+            {
+                "source": "IntimeModelSelector",
+                "key_metric": {"name": "score", "mode": "max"},
+                "best_round": 1,
+                "best_metrics": {"score": 0.8},
+            },
+        )
+        _finish_run(writer, fl_ctx)
+
+        _, summary_path, round_path = _artifact_paths(run_dir)
+        assert not summary_path.exists()
+        assert not round_path.exists()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"results_dir": "../outside_metrics"},
+            {"results_dir": "/tmp/outside_metrics"},
+            {"summary_file_name": "../metrics_summary.json"},
+            {"round_file_name": "/tmp/round_metrics.jsonl"},
+        ],
+    )
+    def test_output_path_is_resolved_under_run_dir(self, tmp_path, kwargs):
+        writer = MetricsArtifactWriter(**kwargs)
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        with pytest.raises(ValueError, match="must (be relative|stay inside)"):
+            writer.handle_event(EventType.START_RUN, fl_ctx)
+            _record_round(writer, fl_ctx, 1, {"accuracy": 0.8})
+            _finish_run(writer, fl_ctx)
+
+        assert not os.path.exists(tmp_path / "outside_metrics")

--- a/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
+++ b/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
+from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLMetaKey
 from nvflare.apis.fl_context import FLContext
@@ -126,6 +127,16 @@ def _record_round(
     )
     try:
         fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, aggr_result, private=True, sticky=False)
+        writer.handle_event(AppEventType.AFTER_AGGREGATION, fl_ctx)
+    finally:
+        fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, None, private=True, sticky=False)
+
+
+def _record_shareable_round(writer, fl_ctx, round_num, metrics):
+    shareable = DXO(data_kind=DataKind.METRICS, data=metrics).to_shareable()
+    shareable.set_header(AppConstants.CURRENT_ROUND, round_num)
+    try:
+        fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, shareable, private=True, sticky=False)
         writer.handle_event(AppEventType.AFTER_AGGREGATION, fl_ctx)
     finally:
         fl_ctx.set_prop(AppConstants.AGGREGATION_RESULT, None, private=True, sticky=False)
@@ -270,6 +281,23 @@ class TestMetricsArtifactWriterAggregationEvents:
         assert "best_round" not in summary
         assert "best_metrics" not in summary
         assert "best_aggregated_metrics" not in summary
+
+    def test_records_shareable_aggregation_result_metrics(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_shareable_round(writer, fl_ctx, 0, {"accuracy": 0.81, "loss": 0.35})
+        _finish_run(writer, fl_ctx)
+
+        summary = _read_summary(run_dir)
+        assert summary["final_round"] == 0
+        assert _metrics_to_dict(summary["final_aggregated_metrics"]) == {"accuracy": 0.81, "loss": 0.35}
+
+        rounds = _read_rounds(run_dir)
+        assert rounds[0]["round"] == 0
+        assert _metrics_to_dict(rounds[0]["aggregated_metrics"]) == {"accuracy": 0.81, "loss": 0.35}
 
     def test_records_official_best_selection_metadata(self, tmp_path):
         writer = MetricsArtifactWriter()

--- a/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
+++ b/tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py
@@ -22,8 +22,9 @@ import pytest
 
 from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.fl_constant import FLContextKey, FLMetaKey
 from nvflare.apis.fl_context import FLContext
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
@@ -251,6 +252,7 @@ class TestMetricsArtifactWriterAggregationEvents:
 
         summary = _read_summary(run_dir)
         assert summary["status"] == "metrics_reported"
+        assert summary["job_name"] == "job-1"
         assert summary["final_round"] == 2
         assert _metrics_to_dict(summary["final_aggregated_metrics"]) == {"accuracy": 0.81, "loss": 0.35}
         assert summary["key_metric"] == key_metric
@@ -264,6 +266,24 @@ class TestMetricsArtifactWriterAggregationEvents:
         assert _metrics_to_dict(rounds[0]["sites"][0]["metrics"]) == {"accuracy": 0.80, "loss": 0.38}
         assert rounds[0]["key_metric"] == key_metric
         assert rounds[0]["aggregation"]["method"] == "weighted_average"
+
+    def test_summary_job_name_prefers_job_meta_name_over_runtime_id(self, tmp_path):
+        writer = MetricsArtifactWriter()
+        run_dir = tmp_path / "run"
+        fl_ctx = _make_fl_ctx(run_dir)
+        fl_ctx.get_job_id.return_value = "simulate_job"
+        fl_ctx.set_prop(
+            FLContextKey.JOB_META,
+            {JobMetaKey.JOB_NAME.value: "hello-numpy-metrics-e2e"},
+            private=True,
+            sticky=False,
+        )
+
+        writer.handle_event(EventType.START_RUN, fl_ctx)
+        _record_round(writer, fl_ctx, 1, {"accuracy": 0.82})
+        _finish_run(writer, fl_ctx)
+
+        assert _read_summary(run_dir)["job_name"] == "hello-numpy-metrics-e2e"
 
     def test_key_metric_metadata_does_not_make_writer_select_best_round(self, tmp_path):
         writer = MetricsArtifactWriter()

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -65,6 +65,11 @@ class MockModelAggregator(ModelAggregator):
         self.reset_count += 1
 
 
+class _TestBaseFedAvg(BaseFedAvg):
+    def run(self):
+        pass
+
+
 class _FakeTempRef:
     def __init__(self):
         self.cleaned = False
@@ -149,6 +154,41 @@ class TestFedAvgInit:
         assert controller.save_filename == "best_model.pt"
         assert controller.exclude_vars == "bn.*"
         assert controller.aggregation_weights == {"site-1": 2.0, "site-2": 1.0}
+
+
+class TestBaseFedAvgMetricsAggregationInfo:
+    def test_aggregate_adds_key_metric_info_from_existing_stop_condition(self):
+        controller = _TestBaseFedAvg()
+        controller.fl_ctx = FLContext()
+        controller.event = lambda _: None
+        controller.fire_event_with_data = lambda *args, **kwargs: None
+        controller.current_round = 1
+        controller.stop_cond = "score <= 0.2"
+        controller.stop_condition = ("score", 0.2, None)
+
+        aggr_result = controller.aggregate(
+            [
+                FLModel(
+                    params={"w": 1.0},
+                    current_round=1,
+                    metrics={"score": 0.1},
+                    meta={"client_name": "site-1", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 1},
+                ),
+                FLModel(
+                    params={"w": 3.0},
+                    current_round=1,
+                    metrics={"score": 0.3},
+                    meta={"client_name": "site-2", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 1},
+                ),
+            ]
+        )
+
+        metrics_info = aggr_result.meta[AppConstants.METRICS_AGGREGATION_INFO]
+        assert metrics_info["key_metric"] == {
+            "name": "score",
+            "mode": "min",
+            "mode_source": "derived_from_stop_condition",
+        }
 
     def test_stop_condition_parsing(self):
         """Test that stop condition is correctly parsed."""
@@ -1140,6 +1180,9 @@ class TestScaffoldAggregation:
         assert aggr_result.meta[AlgorithmConstants.SCAFFOLD_CTRL_DIFF]["w"] == 3.0
         assert aggr_result.meta["nr_aggregated"] == 2
         assert aggr_result.meta["current_round"] == 0
+        metrics_info = aggr_result.meta[AppConstants.METRICS_AGGREGATION_INFO]
+        assert metrics_info["metric_source"] == "client_reported_flmodel_metrics"
+        assert metrics_info["aggregation"]["method"] == "weighted_average"
 
     def test_scaffold_aggregate_fn_aggregates_generic_numeric_metrics_with_step_weights(self):
         """Test Scaffold aggregates metric keys generically with client local-step weights."""

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -760,6 +760,52 @@ class TestFedAvgAggregation:
             "accuracy": pytest.approx(0.75),
         }
 
+    def test_aggregate_fl_model_metrics_sanitizes_invalid_num_steps(self):
+        """Test invalid client step counts do not become negative or non-finite metric weights."""
+        from nvflare.app_common.workflows.base_fedavg import _aggregate_fl_model_metrics
+
+        result1 = FLModel(
+            params={"w": 1.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.2},
+            meta={"client_name": "site-1", FLMetaKey.NUM_STEPS_CURRENT_ROUND: -100},
+        )
+        result2 = FLModel(
+            params={"w": 3.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.6},
+            meta={"client_name": "site-2", FLMetaKey.NUM_STEPS_CURRENT_ROUND: float("inf")},
+        )
+        result3 = FLModel(
+            params={"w": 5.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 1.0},
+            meta={"client_name": "site-3", FLMetaKey.NUM_STEPS_CURRENT_ROUND: "bad"},
+        )
+        result1.current_round = 0
+        result2.current_round = 0
+        result3.current_round = 0
+
+        aggr_metrics = _aggregate_fl_model_metrics([result1, result2, result3])
+
+        assert aggr_metrics == {"loss": pytest.approx(0.6)}
+
+    def test_aggregate_fl_model_metrics_handles_none_meta(self):
+        """Test metrics aggregation falls back safely when client result meta is absent."""
+        from nvflare.app_common.workflows.base_fedavg import _aggregate_fl_model_metrics
+
+        result = FLModel(
+            params={"w": 1.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.2},
+            meta=None,
+        )
+        result.current_round = 0
+
+        aggr_metrics = _aggregate_fl_model_metrics([result])
+
+        assert aggr_metrics == {"loss": pytest.approx(0.2)}
+
     def test_base_fedavg_aggregate_fn_returns_none_when_all_metrics_filtered(self):
         """Test BaseFedAvg.aggregate_fn returns None when all metrics are non-aggregatable."""
         result1 = FLModel(
@@ -1377,6 +1423,46 @@ class TestFedAvgAggregationWeights:
         aggr_result = controller._get_aggregated_result()
         # Weighted average: (2.0*100 + 6.0*300) / (100 + 300) = (200 + 1800) / 400 = 2000/400 = 5.0
         assert aggr_result.params["w"] == 5.0
+
+    def test_streaming_aggregation_sanitizes_invalid_num_steps(self):
+        """Test invalid client step counts cannot become negative streaming aggregation weights."""
+        controller = FedAvg(num_clients=2)
+
+        from nvflare.app_common.aggregators.weighted_aggregation_helper import WeightedAggregationHelper
+
+        controller._aggr_helper = WeightedAggregationHelper()
+        controller._aggr_metrics_helper = WeightedAggregationHelper()
+        controller._all_metrics = True
+        controller._received_count = 0
+        controller._expected_count = 2
+        controller._params_type = None
+        controller._site_metric_weights = {}
+        controller.current_round = 0
+
+        result1 = FLModel(
+            params={"w": 2.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.2},
+            meta={"client_name": "site-1", FLMetaKey.NUM_STEPS_CURRENT_ROUND: -100},
+        )
+        result2 = FLModel(
+            params={"w": 6.0},
+            params_type=ParamsType.FULL,
+            metrics={"loss": 0.6},
+            meta={"client_name": "site-2", FLMetaKey.NUM_STEPS_CURRENT_ROUND: 3},
+        )
+
+        controller._aggregate_one_result(result1)
+        controller._aggregate_one_result(result2)
+
+        aggr_result = controller._get_aggregated_result()
+        assert aggr_result.params["w"] == pytest.approx(5.0)
+        assert aggr_result.metrics == {"loss": pytest.approx(0.5)}
+        site_weights = aggr_result.meta[AppConstants.METRICS_AGGREGATION_INFO]["site_weights"]
+        assert site_weights == [
+            {"name": "site-1", "weight": 1.0, "weight_key": "effective_fedavg_metric_weight"},
+            {"name": "site-2", "weight": 3.0, "weight_key": "effective_fedavg_metric_weight"},
+        ]
 
     def test_aggregation_with_multi_value_state_dict(self):
         """Test aggregation with state dict containing multiple parameters."""

--- a/tests/unit_test/app_opt/xgboost/xgboost_recipe_test.py
+++ b/tests/unit_test/app_opt/xgboost/xgboost_recipe_test.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nvflare.apis.job_def import SERVER_SITE_NAME
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
+
+pytest.importorskip("xgboost")
+
+
+class DummyDataLoader:
+    pass
+
+
+def _per_site_config():
+    return {
+        "site-1": {"data_loader": DummyDataLoader()},
+        "site-2": {"data_loader": DummyDataLoader()},
+    }
+
+
+def _get_metrics_writer(recipe):
+    server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
+    return server_app.app_config.components.get("metrics_artifact_writer")
+
+
+def test_xgb_bagging_recipe_configures_metrics_artifact_writer():
+    from nvflare.app_opt.xgboost.recipes import XGBBaggingRecipe
+
+    recipe = XGBBaggingRecipe(name="xgb_bagging", min_clients=2, per_site_config=_per_site_config())
+
+    assert isinstance(_get_metrics_writer(recipe), MetricsArtifactWriter)
+
+
+def test_xgb_horizontal_recipe_configures_metrics_artifact_writer():
+    from nvflare.app_opt.xgboost.recipes import XGBHorizontalRecipe
+
+    recipe = XGBHorizontalRecipe(name="xgb_horizontal", min_clients=2, num_rounds=1, per_site_config=_per_site_config())
+
+    assert isinstance(_get_metrics_writer(recipe), MetricsArtifactWriter)
+
+
+def test_xgb_vertical_recipe_configures_metrics_artifact_writer():
+    from nvflare.app_opt.xgboost.recipes import XGBVerticalRecipe
+
+    recipe = XGBVerticalRecipe(
+        name="xgb_vertical",
+        min_clients=2,
+        num_rounds=1,
+        label_owner="site-1",
+        per_site_config=_per_site_config(),
+    )
+
+    assert isinstance(_get_metrics_writer(recipe), MetricsArtifactWriter)

--- a/tests/unit_test/private/fed/app/simulator/simulator_runner_test.py
+++ b/tests/unit_test/private/fed/app/simulator/simulator_runner_test.py
@@ -26,6 +26,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from nvflare.apis.fl_constant import FLContextKey, MachineStatus, WorkspaceConstants
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.private.fed.app.simulator.simulator_runner import SimulatorClientRunner, SimulatorRunner
 from nvflare.private.fed.utils.fed_utils import split_gpus
 
@@ -164,6 +165,8 @@ class TestSimulatorRunner:
                     fl_ctx = runner.server.engine.new_context()
                     workspace_obj = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
                     assert workspace_obj.get_root_dir() == os.path.join(workspace, "server")
+                    job_meta = fl_ctx.get_prop(FLContextKey.JOB_META)
+                    assert job_meta[JobMetaKey.JOB_NAME.value] == "sag"
 
                     runner.server.logger = Mock()
                     runner.server.engine.asked_to_stop = True

--- a/tests/unit_test/recipe/edge_recipe_test.py
+++ b/tests/unit_test/recipe/edge_recipe_test.py
@@ -267,6 +267,31 @@ class TestEdgeFedBuffRecipe:
                 return comp
         raise AssertionError("ModelUpdateAssessor not found in server components")
 
+    def _find_metrics_writer(self, job):
+        """Find the MetricsArtifactWriter component in the job's server config."""
+        from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
+
+        server_app = job._deploy_map.get("server")
+        assert server_app is not None, "No server app found in job"
+        metrics_writer = server_app.app_config.components.get("metrics_artifact_writer")
+        assert isinstance(metrics_writer, MetricsArtifactWriter)
+        return metrics_writer
+
+    def test_metrics_artifact_writer_is_configured(
+        self, mock_file_system, simple_pt_model, model_manager_config, device_manager_config
+    ):
+        """Test that EdgeFedBuffRecipe configures the server-side metrics artifact writer."""
+        from nvflare.edge.tools.edge_fed_buff_recipe import EdgeFedBuffRecipe
+
+        recipe = EdgeFedBuffRecipe(
+            job_name="test_metrics_writer",
+            model=simple_pt_model,
+            model_manager_config=model_manager_config,
+            device_manager_config=device_manager_config,
+        )
+
+        self._find_metrics_writer(recipe.job)
+
     def test_device_wait_timeout_default_is_none(
         self, mock_file_system, simple_pt_model, model_manager_config, device_manager_config
     ):

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch.nn as nn
 
+from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.job_def import ALL_SITES, SERVER_SITE_NAME
 from nvflare.app_common.abstract.fl_model import FLModel
 from nvflare.app_common.abstract.model_locator import ModelLocator
@@ -28,10 +29,12 @@ from nvflare.app_common.executors.client_api_launcher_executor import ClientAPIL
 from nvflare.app_common.executors.launcher_executor import LauncherExecutor
 from nvflare.app_common.np.recipes import NumpyFedAvgRecipe
 from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
+from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
 from nvflare.client.config import ConfigKey
 from nvflare.client.constants import CLIENT_API_CONFIG
 from nvflare.fuel.utils.class_utils import instantiate_class
+from nvflare.job_config.base_fed_job import BaseFedJob
 
 
 class SimpleTestModel(nn.Module):
@@ -86,6 +89,12 @@ class InvalidAggregator:
 
     def __init__(self):
         pass
+
+
+class CustomMetricSelector(FLComponent):
+    def __init__(self, key_metric):
+        super().__init__()
+        self.key_metric = key_metric
 
 
 class DummyPersistor(ModelPersistor):
@@ -159,6 +168,11 @@ def get_server_component(recipe, component_id):
     return server_app.app_config.components.get(component_id)
 
 
+def get_server_component_from_job(job, component_id):
+    server_app = job._deploy_map[SERVER_SITE_NAME]
+    return server_app.app_config.components.get(component_id)
+
+
 def get_server_controller(recipe):
     server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
     return server_app.app_config.workflows[0].controller
@@ -228,6 +242,19 @@ class TestFedAvgRecipe:
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == key_metric
+        metrics_writer = get_server_component(recipe, "metrics_artifact_writer")
+        assert isinstance(metrics_writer, MetricsArtifactWriter)
+        assert not hasattr(metrics_writer, "key_metric")
+
+    def test_metrics_writer_does_not_copy_policy_from_custom_selector(self):
+        key_metric = "custom_score"
+        job = BaseFedJob(
+            name="test_custom_selector_policy", min_clients=2, model_selector=CustomMetricSelector(key_metric)
+        )
+
+        metrics_writer = get_server_component_from_job(job, "metrics_artifact_writer")
+        assert isinstance(metrics_writer, MetricsArtifactWriter)
+        assert not hasattr(metrics_writer, "key_metric")
 
     def test_best_model_filename_passthrough_pt(self, mock_file_system, base_recipe_params, simple_model):
         """best_model_filename should configure the generated PT persistor's best model artifact."""

--- a/tests/unit_test/tool/job/job_download_test.py
+++ b/tests/unit_test/tool/job/job_download_test.py
@@ -142,17 +142,21 @@ class TestJobDownload:
         assert envelope["data"]["artifacts"]["global_model"] == str(model_path)
         assert "global_model" not in envelope["data"]["missing_artifacts"]
 
-    def test_download_discovers_metrics_summary_and_client_logs(self, tmp_path, capsys):
-        """metrics_summary.json and client log.txt files are reported from the local download path."""
+    def test_download_discovers_metrics_artifacts_and_client_logs(self, tmp_path, capsys):
+        """metrics artifacts and client log.txt files are reported from the local download path."""
         download_path = tmp_path / "results"
+        metrics_dir = download_path / "metrics"
         site_log_dir = download_path / "site-1"
         server_log_dir = download_path / "server"
+        metrics_dir.mkdir(parents=True)
         site_log_dir.mkdir(parents=True)
         server_log_dir.mkdir()
-        metrics_path = download_path / "metrics_summary.json"
+        metrics_path = metrics_dir / "metrics_summary.json"
+        round_metrics_path = metrics_dir / "round_metrics.jsonl"
         site_log_path = site_log_dir / "log.txt"
         server_log_path = server_log_dir / "log.txt"
         metrics_path.write_text("{}")
+        round_metrics_path.write_text("{}\n")
         site_log_path.write_text("client log")
         server_log_path.write_text("server log")
 
@@ -160,9 +164,11 @@ class TestJobDownload:
 
         artifacts = envelope["data"]["artifacts"]
         assert artifacts["metrics_summary"] == str(metrics_path)
+        assert artifacts["round_metrics"] == str(round_metrics_path)
         assert artifacts["client_logs"] == {"site-1": str(site_log_path)}
         assert str(server_log_path) not in artifacts["client_logs"].values()
         assert "metrics_summary" not in envelope["data"]["missing_artifacts"]
+        assert "round_metrics" not in envelope["data"]["missing_artifacts"]
         assert "client_logs" not in envelope["data"]["missing_artifacts"]
 
     def test_download_client_logs_only_include_log_files(self, tmp_path, capsys):

--- a/tests/unit_test/tool/poc/poc_force_test.py
+++ b/tests/unit_test/tool/poc/poc_force_test.py
@@ -118,6 +118,12 @@ class TestPocForce:
         workspace.mkdir()
         sentinel = workspace / "keep.txt"
         sentinel.write_text("keep me")
+        current_time = -31
+
+        def fake_time():
+            nonlocal current_time
+            current_time += 31
+            return current_time
 
         with (
             patch(
@@ -133,7 +139,7 @@ class TestPocForce:
             patch("nvflare.tool.poc.poc_commands.is_poc_ready", return_value=True),
             patch("nvflare.tool.poc.poc_commands.is_poc_running", return_value=True),
             patch("nvflare.tool.poc.poc_commands._stop_poc"),
-            patch("nvflare.tool.poc.poc_commands.time.time", side_effect=[0, 31]),
+            patch("nvflare.tool.poc.poc_commands.time.time", side_effect=fake_time),
             patch("nvflare.tool.poc.poc_commands.prepare_poc_provision") as mock_prov,
         ):
             with pytest.raises(


### PR DESCRIPTION
## Summary
- add a safe server-side `MetricsArtifactWriter` that persists `metrics/metrics_summary.json` and `metrics/round_metrics.jsonl` from existing workflow outputs
- keep the writer as a recorder: it persists official aggregated metrics, received per-site metrics, provenance, skipped values, and explicit best-selection metadata without recomputing aggregates or selecting best rounds
- support standard aggregation result events with `FLModel` and compatible `Shareable` payloads so non-FedAvg workflows using the existing event contract can be recorded
- wire the writer through `BaseFedJob`, LR, standalone XGBoost recipe setup paths, and Edge SAGE setup without adding artifacts for no-metric runs
- add `METRICS_SELECTION_INFO` so model selectors such as `IntimeModelSelector` can publish best-metric metadata for the writer to record
- document the user-facing recipe metrics artifact contract and report downloaded metrics artifact paths through `nvflare job download --format json`

## Output JSON schemas
The artifacts are metric-agnostic: names such as `auroc`, `loss`, `accuracy`, `dice`, or custom metrics are values in metric arrays, not hard-coded schema fields.

Round values are recorded verbatim from NVFlare workflow metadata, such as `AppConstants.CURRENT_ROUND` or `FLModel.current_round`. They are 0-based by default and honor nonzero `start_round`; the artifact does not renumber rounds.

`metrics/metrics_summary.json`:

```json
{
  "schema_version": "1",
  "status": "metrics_reported",
  "job_name": "ames_fedavg",
  "metric_source": "client_reported_flmodel_metrics",
  "key_metric": {
    "name": "auroc",
    "mode": "max",
    "mode_source": "IntimeModelSelector.negate_key_metric"
  },
  "final_round": 2,
  "final_aggregated_metrics": [
    {
      "name": "auroc",
      "value": 0.7421
    },
    {
      "name": "train_loss",
      "value": 0.492
    }
  ],
  "best_round": 0,
  "best_metrics": [
    {
      "name": "auroc",
      "value": 0.7500010132169
    }
  ],
  "best_metric_source": "IntimeModelSelector",
  "best_metric_detail_source": "initial_metrics",
  "aggregation": {
    "method": "weighted_average",
    "weight_key": "NUM_STEPS_CURRENT_ROUND",
    "metric_policy": "finite_numeric_metrics_only_per_key_denominator"
  },
  "round_metrics_file": "round_metrics.jsonl",
  "notes": [
    "Aggregated metrics are weighted averages of client-reported metric values.",
    "Nonlinear metrics are not recomputed from pooled predictions."
  ]
}
```

`best_round` and `best_metrics` are present only when an existing selector or workflow publishes explicit `METRICS_SELECTION_INFO`. The writer records those values but does not infer policy or compare rounds.

`metrics/round_metrics.jsonl` stores one JSON object per completed round:

```json
{
  "round": 0,
  "aggregated_metrics": [
    {
      "name": "auroc",
      "value": 0.7500010132169
    },
    {
      "name": "train_loss",
      "value": 0.4855
    }
  ],
  "sites": [
    {
      "name": "site-1",
      "metrics": [
        {
          "name": "train_loss",
          "value": 0.4707
        },
        {
          "name": "auroc",
          "value": 0.7380791446479046
        }
      ],
      "weight": 2911,
      "weight_key": "NUM_STEPS_CURRENT_ROUND"
    },
    {
      "name": "site-2",
      "metrics": [
        {
          "name": "train_loss",
          "value": 0.5003
        },
        {
          "name": "auroc",
          "value": 0.7619228817858955
        }
      ],
      "weight": 2911,
      "weight_key": "NUM_STEPS_CURRENT_ROUND"
    }
  ],
  "aggregation": {
    "method": "weighted_average",
    "weight_key": "NUM_STEPS_CURRENT_ROUND",
    "metric_policy": "finite_numeric_metrics_only_per_key_denominator"
  },
  "key_metric": {
    "name": "auroc",
    "mode": "max",
    "mode_source": "IntimeModelSelector.negate_key_metric"
  },
  "skipped_metrics": [
    {
      "site": "site-1",
      "name": "debug_blob",
      "reason": "unsupported_type"
    }
  ]
}
```

No metrics artifact is written for recipes that do not report aggregation, per-site, or skipped metrics. PSI, stats-only jobs, and standalone cross-site validation are intentionally outside this artifact contract.

## Downloaded artifacts
Metrics files are part of the normal downloaded job result when they exist. `nvflare job download --format json` reports their downloaded local paths in the `artifacts` map:

```json
{
  "artifacts": {
    "metrics_summary": "/abs/path/downloads/abc123/workspace/metrics/metrics_summary.json",
    "round_metrics": "/abs/path/downloads/abc123/workspace/metrics/round_metrics.jsonl"
  }
}
```

`metrics_summary` and `round_metrics` are reported only when those files exist in the downloaded result. `round_metrics` is optional for older jobs and jobs without per-round metrics.

## Tests
- `python -m pytest tests/unit_test/app_common/widgets/metrics_artifact_writer_test.py tests/unit_test/tool/job/job_download_test.py tests/unit_test/recipe/fedavg_recipe_test.py tests/unit_test/recipe/edge_recipe_test.py tests/unit_test/app_opt/xgboost/xgboost_recipe_test.py -q`
- `./runtest.sh -s`
