### PR TITLE
Fix admin CellNet server identity mapping

### DIFF
--- a/nvflare/fuel/hci/client/api.py
+++ b/nvflare/fuel/hci/client/api.py
@@ -412,6 +412,7 @@ class AdminAPI(AdminAPISpec, StreamableEngine):
             credentials=credentials,
             create_internal_listener=False,
             parent_url=None,
+            auth_identity_map={FQCN.ROOT_SERVER: self.server_identity},
         )
 
         self.cell.register_request_cb(

--- a/tests/unit_test/fuel/hci/admin_api_test.py
+++ b/tests/unit_test/fuel/hci/admin_api_test.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+from nvflare.apis.fl_constant import ConnectionSecurity
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.hci.client.api import AdminAPI
+from nvflare.fuel.hci.client.api_spec import AdminConfigKey
+
+
+def test_admin_api_passes_server_identity_to_cell_auth_identity_map():
+    cell_kwargs = {}
+    authenticator_kwargs = {}
+
+    class _FakeCell:
+        def __init__(self, **kwargs):
+            cell_kwargs.update(kwargs)
+            self.core_cell = Mock()
+
+        def register_request_cb(self, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    class _FakeTokenVerifier:
+        pass
+
+    class _FakeAuthenticator:
+        def __init__(self, **kwargs):
+            authenticator_kwargs.update(kwargs)
+
+        def authenticate(self, shared_fl_ctx, abort_signal):
+            return "token", "signature", "ssid", _FakeTokenVerifier()
+
+    admin_config = {
+        AdminConfigKey.CONNECTION_SECURITY: ConnectionSecurity.MTLS,
+        AdminConfigKey.PROJECT_NAME: "project",
+        AdminConfigKey.SERVER_IDENTITY: "gcp-server",
+        AdminConfigKey.CONNECTION_SCHEME: "tcp",
+        AdminConfigKey.CA_CERT: "rootCA.pem",
+        AdminConfigKey.CLIENT_CERT: "client.crt",
+        AdminConfigKey.CLIENT_KEY: "client.key",
+        AdminConfigKey.HOST: "35.192.226.99",
+        AdminConfigKey.PORT: 8003,
+    }
+    api = AdminAPI(user_name="admin@nvidia.com", admin_config=admin_config, cmd_modules=[])
+
+    with (
+        patch("nvflare.fuel.hci.client.api.Authenticator", _FakeAuthenticator),
+        patch("nvflare.fuel.hci.client.api.AuxRunner", Mock()),
+        patch("nvflare.fuel.hci.client.api.Cell", _FakeCell),
+        patch("nvflare.fuel.hci.client.api.NetAgent", Mock()),
+        patch("nvflare.fuel.hci.client.api.ObjectStreamer", Mock()),
+        patch("nvflare.fuel.hci.client.api.TokenVerifier", _FakeTokenVerifier),
+        patch("nvflare.fuel.hci.client.api.set_add_auth_headers_filters"),
+    ):
+        api.connect()
+
+    assert cell_kwargs["auth_identity_map"] == {FQCN.ROOT_SERVER: "gcp-server"}
+    assert authenticator_kwargs["expected_sp_identity"] == "gcp-server"


### PR DESCRIPTION
## Summary

- Pass the configured admin `server_identity` into the admin CellNet `auth_identity_map` for `FQCN.ROOT_SERVER`.
- Add unit coverage for the non-default server certificate CN case that exposed the admin connection failure.

## Root Cause

PR #4759 added stricter CellNet mTLS endpoint-to-certificate identity binding. Regular FL clients already pass root server identity mappings into `Cell`, but `AdminAPI.connect()` only passed `server_identity` to the later HCI authenticator. That let CellNet default the root endpoint `server` to expected cert CN `server`, rejecting valid deployments whose server certificate CN is different, such as `gcp-server`.

## Validation

- `.venv/bin/python -m pytest tests/unit_test/fuel/hci/admin_api_test.py`
- `VIRTUAL_ENV=/Users/pcnudde/.codex/worktrees/4b99/NVFlare/.venv PATH=/Users/pcnudde/.codex/worktrees/4b99/NVFlare/.venv/bin:$PATH UV_CACHE_DIR=/private/tmp/uv-cache ./runtest.sh -s`
- Live all-clouds admin status succeeded with 4 registered clients.