### PR TITLE
Add NVFLARE agent skills and checks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include versioneer.py
 include nvflare/_version.py
 include nvflare/libs/*.so
 include nvflare/fuel/utils/*.json
+recursive-include skills *
 recursive-include nvflare/lighter/templates *
 recursive-include nvflare/tool/deploy/templates *

--- a/docs/design/agent_skill_authoring.md
+++ b/docs/design/agent_skill_authoring.md
@@ -1,0 +1,457 @@
+# NVFLARE Agent Skill Authoring Design
+
+## Document Control
+
+| Field | Value |
+| --- | --- |
+| Created date | 2026-05-26 |
+| Status | Ready for Implementation |
+| Parent design | [Agent Integration](agent_integration.md) |
+| Related designs | [Agent Skill Evaluation](agent_skill_evaluation.md), [Agent Skill Publication Handoff Checklist](agent_publication_handoff_checklist.md) |
+| Current owner | NVFLARE product/docs maintainers |
+| Review scope | Skill-writing rules, guide-compatible file structure, minimal metadata, helper scripts, examples, eval input files, and maintenance policy |
+
+## Table of Contents
+
+- [Document Control](#document-control)
+- [Scope](#scope)
+- [Agent Design Principles](#agent-design-principles)
+- [Skills Are Workflow Playbooks, Not Command Wrappers](#skills-are-workflow-playbooks-not-command-wrappers)
+- [Skill Granularity and Naming](#skill-granularity-and-naming)
+- [Frontmatter and Product Metadata](#frontmatter-and-product-metadata)
+- [Trigger and Handoff Contract](#trigger-and-handoff-contract)
+- [Initial Customer Helper Scripts](#initial-customer-helper-scripts)
+- [Skill File Requirements](#skill-file-requirements)
+- [Example and Scaffold Conventions](#example-and-scaffold-conventions)
+- [Authoring Workstreams and Deliverables](#authoring-workstreams-and-deliverables)
+
+## Scope
+
+This document owns how NVFLARE product skills are authored and maintained. The
+runtime command contract, install model, and production safety boundaries live
+in [Agent Integration](agent_integration.md). Evaluation and publication handoff scoring
+live in [Agent Skill Evaluation](agent_skill_evaluation.md).
+
+Authoring rules should not restate runtime contracts differently. When a skill
+needs to know how agents trigger or hand off work in the initial implementation, refer to the
+integration design. Durable workflow state, receipts, provenance, transcript
+replay, workspace cleanup, compatibility shims, and large lifecycle metadata
+are deferred until a concrete product requirement promotes them into scope.
+
+## Agent Design Principles
+
+FLARE agent readiness should treat an LLM as a domain expert, not as a
+deterministic workflow engine. The design should let the model reason about
+ambiguous FLARE choices while code, schemas, tests, and tools enforce mechanical
+constraints.
+
+Principles:
+
+- Let the expert focus on expert work. Skills should ask the LLM to reason
+  about integration lane, failure cause, safety boundary, and user intent.
+  Deterministic work such as command validation, export checks, manifest
+  validation, schema generation, path scanning, and policy gates should live in
+  CLI code or helper tools.
+- Focus attention on what matters. `SKILL.md` should contain only trigger
+  context, decision logic, workflow steps, and safety constraints. Large
+  examples, command details, troubleshooting catalogs, and framework-specific
+  deep dives should live in `references/` and be loaded only when needed.
+- Learn from experience. Each skill should carry evaluation results, known
+  failure cases, and drift notes in `BENCHMARK.md` or references. Repeated
+  failures should become new tests, diagnosis patterns, guardrails, or reference
+  guidance instead of one-off prompt edits.
+- Make work observable and independently checked. Agent workflows should produce
+  command logs, artifact manifests, findings, and benchmark reports. Evaluation
+  should include an independent critique or grading step rather than relying on
+  the same agent run to judge its own output.
+
+Prompt instructions are not enough for production-grade behavior. Any mandatory
+"must do" or "must not do" requirement should have a matching code guardrail,
+test, schema constraint, or approval checkpoint where practical.
+
+## Skills Are Workflow Playbooks, Not Command Wrappers
+
+Skills should teach agents how to combine product surfaces:
+
+- which FLARE integration surface to use for a customer workflow;
+- which files to inspect;
+- which edits are safe;
+- which commands to run;
+- how to validate before submission;
+- how to diagnose common failures;
+- when to stop and ask the user for approval.
+
+Skills should not be one wrapper per CLI command. The CLI schema is the command
+contract; skills are procedural product knowledge. When a sequence is mandatory
+for correctness, prefer bundling the deterministic checks into a CLI command or
+helper tool rather than relying on the LLM to remember every step.
+
+Skills that edit user files must make recovery explicit:
+
+- copy every file to be modified into `.nvflare_bak/<timestamp>/` before the
+  first write.
+- include `backup_path` in the final user-facing summary when files were
+  changed.
+- be idempotent: re-running the skill must not duplicate imports,
+  `flare.init()`, `flare.receive()`, `flare.send()`, or generated config blocks.
+- support a dry-run plan for mutating workflows that lists planned commands,
+  files to create/change, approval checkpoints, mutating steps, and estimated
+  duration.
+- do not delete `.nvflare_bak/<timestamp>/` backups automatically after a
+  successful run.
+
+## Skill Granularity and Naming
+
+FLARE skills should be workflow-oriented and organized by product category.
+They should not be one giant general-purpose FLARE skill, and they should not
+be one skill per CLI command.
+
+The target granularity is an intent-level workflow that an agent can complete
+end to end. Create a separate skill when the workflow has materially different:
+
+- user intent;
+- files to inspect or edit;
+- safety boundary;
+- validation commands;
+- success criteria;
+- evaluation dataset.
+
+Keep commands together when they are steps in one user goal. For example,
+`job submit`, `job monitor`, `job logs`, `job stats`, and `job download` belong
+in `nvflare-job-lifecycle`; they should not become separate command-wrapper
+skills. Conversion skills should be named for the customer's goal or framework,
+not for the internal FLARE API used to implement the conversion. Do not ship a
+broad `nvflare-federate-training-code` skill in the seed bundle if it
+overlaps with framework-specific conversion skills. General routing should live
+in `nvflare-orient`, `nvflare agent inspect`, and conversion reference material.
+Once the framework is known, the framework-specific skill should own the
+workflow. PyTorch is singled out only because it is the first detailed
+framework-specific conversion path; it is not separate from training-code
+conversion conceptually.
+
+A generic conversion skill can be added later only if it has a clear non-overlap
+boundary, such as custom Python, NumPy, or otherwise unrecognized training
+loops. It must include negative trigger evals proving it does not steal PyTorch,
+Lightning, TensorFlow, XGBoost, or sklearn prompts.
+`nvflare-convert-numpy` is the deliberate first fallback for NumPy and simple
+custom loops only. It is not a broad "federate anything" skill, and its negative
+trigger evals must prove that framework-specific prompts route elsewhere.
+
+Conversion skill families should follow the way customers describe their code,
+not FLARE internals. This table is the canonical conversion-skill scope source;
+the product catalog in the integration design is a summary view and should be
+linted against this table or generated from skill metadata. The roadmap should
+be derived from current FLARE examples, recipes, and optional app modules, then
+revisited each release as the examples change.
+
+| Code Family | Skill | Scope | Current Repo Evidence | Tier |
+| --- | --- | --- | --- | --- |
+| PyTorch | `nvflare-convert-pytorch` | `torch.nn.Module`, `state_dict`, PyTorch data loaders, checkpoints, and metrics | `examples/hello-world/hello-pt`, `examples/advanced/cifar10/pt`, `nvflare.app_opt.pt`, recipe metadata | `seed` |
+| PyTorch Lightning | `nvflare-convert-lightning` | `LightningModule`, `Trainer`, callbacks, checkpointing, multi-GPU, and logging patterns | `examples/hello-world/hello-lightning`, `examples/advanced/multi-gpu/lightning` | `next` |
+| TensorFlow/Keras | `nvflare-convert-tensorflow` | `tf.keras`, `model.fit`, weight exchange, callbacks, GPU memory behavior, and saved model patterns | `examples/hello-world/hello-tf`, `examples/hello-world/hello-cyclic`, `examples/advanced/cifar10/tf`, `nvflare.app_opt.tf` | `next` |
+| Hugging Face / LLM / VLM | `nvflare-convert-huggingface` | `Trainer`, `AutoModel`, tokenizers, datasets, PEFT/LoRA, adapter checkpoints, and transformer/VLM fine-tuning | `examples/advanced/llm_hf`, `examples/advanced/medgemma`, `examples/advanced/qwen3-vl`, `research/auto-fl-research/tasks/vlm_med` | `next` |
+| XGBoost | `nvflare-convert-xgboost` | `Booster`, `DMatrix`, horizontal histogram, bagging, vertical XGBoost, and secure variants | `examples/advanced/xgboost`, `nvflare.app_opt.xgboost.recipes`, recipe metadata | `next` |
+| scikit-learn traditional ML | `nvflare-convert-sklearn` | estimators and pipelines such as logistic regression, SVM, k-means, preprocessing, `fit`, `predict`, and metrics | `examples/advanced/sklearn-linear`, `examples/advanced/sklearn-svm`, `examples/advanced/sklearn-kmeans`, `nvflare.app_opt.sklearn.recipes`, recipe metadata | `next` |
+| Survival analysis | `nvflare-convert-survival-analysis` | Kaplan-Meier, Cox-style workflows, censored labels, concordance metrics, time-to-event data, and healthcare validation patterns | `examples/advanced/kaplan-meier-he`, self-paced survival analysis tutorial | `next` |
+| MONAI / medical imaging | `nvflare-convert-monai` | medical image loaders, transforms, segmentation/classification loops, and healthcare evaluation artifacts | `examples/advanced/monai` | `later` |
+| JAX | `nvflare-convert-jax` | JAX/NumPy parameter trees, `.npy` caches, and custom training loops | `examples/hello-world/hello-jax` | `later` |
+| Flower applications | `nvflare-integrate-flower` | Running existing Flower PyTorch apps under FLARE job orchestration and tracking | `examples/hello-world/hello-flower` | `later` |
+| GNN | `nvflare-convert-gnn` | graph data, node/edge task patterns, and GNN-specific model/data exchange | `examples/advanced/gnn` | `later` |
+| NumPy/custom loops | `nvflare-convert-numpy` | custom Python or NumPy training loops when no stronger framework family is detected | `examples/hello-world/hello-numpy`, `examples/hello-world/ml-to-fl/np`, `nvflare.app_common.np`, recipe metadata | `later` |
+
+Do not create one skill per algorithm unless the workflow is genuinely
+different. Logistic regression, SVM, and k-means can start as references under
+`nvflare-convert-sklearn` because their customer workflow is usually "convert my
+sklearn estimator or pipeline." Survival analysis may deserve a separate skill
+because censored labels, evaluation metrics, and clinical data conventions are
+substantially different.
+
+The roadmap should not blindly turn every example directory into a public
+skill. A new conversion skill needs a distinct trigger surface, distinct edit
+pattern, and enough examples or recipes to evaluate it. Otherwise, keep the
+content as references under the closest existing skill.
+
+Each `SKILL.md` should stay concise and trigger-focused:
+
+- when to use;
+- when not to use;
+- decision tree;
+- high-level workflow;
+- approval checkpoints;
+- validation checklist;
+- links to deeper `references/` files.
+
+Detailed examples, command walkthroughs, diagnosis patterns, framework
+conversion details, and evaluation notes should live under `references/` so the
+agent loads them only when needed.
+
+## Frontmatter and Product Metadata
+
+Each published skill must include the agentskills.io required frontmatter:
+
+```yaml
+---
+name: nvflare-convert-pytorch
+description: "Convert PyTorch training code into an NVFLARE federated training job and validate it with SimEnv and exported FLARE jobs."
+min_flare_version: "2.8.0"
+blast_radius: edits_files
+---
+```
+
+`name` and `description` are the public trigger surface. The description should
+say when the skill should trigger and include enough negative boundary language
+that nearby skills do not steal the prompt. FLARE-specific initial metadata should
+stay minimal:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `name` | yes | must match the skill directory |
+| `description` | yes | concise trigger description for the agent |
+| `min_flare_version` | yes | first NVFLARE release that supports the skill; lint/documentation metadata initially because bundled skills ship with FLARE |
+| `blast_radius` | yes | `read_only`, `edits_files`, `runs_simulator`, `submits_poc`, or `submits_production`; informational initially and the hook for future enforcement |
+| `skill_version` | optional | useful for changelog and debugging inside a FLARE release, but not a separate distribution cadence |
+
+Do not add a broad `references/contract.yaml` requirement for the initial implementation. Rich sidecar
+metadata such as allowed tools, allowed commands, compatibility shims, budgets,
+agent profiles, `obsoletes`, lifecycle states, and durable handoff keys is
+deferred to the roadmap.
+
+Shared skill references under `skills/_shared/` are versioned content, not
+untracked include files. Install manifests should record the shared-reference
+hash or version used by an installed skill whenever shared files are copied into
+the target agent skill directory. Updating shared reference content should be
+treated as a behavior-affecting skill change for every public skill that
+consumes it, with release notes or benchmark evidence when the shared guidance
+changes observable agent behavior.
+
+## Trigger and Handoff Contract
+
+The authoritative runtime contract for skill triggering and one-lead plus
+supporting-skill composition lives in
+[Agent Integration](agent_integration.md#6-how-skills-are-triggered-and-used).
+For the initial implementation, skill authors should assume handoff happens through visible command
+outputs, generated artifacts, and the active agent session. Durable handoff
+files, receipts, and provenance sidecars are deferred roadmap items.
+
+## Initial Customer Helper Scripts
+
+Scripts are useful when the work is deterministic and customer-visible, but not
+yet stable enough to be a product CLI command. They should be skill-local,
+JSON-producing helpers under `scripts/` and should be promoted into `nvflare`
+CLI commands once their behavior becomes a product contract.
+
+Recommended initial helper scripts:
+
+| Script | Used By | Purpose | Promotion Path |
+| --- | --- | --- | --- |
+| `scripts/scan_project.py` | `nvflare-orient`, framework conversion skills | Static scan for frameworks, entry points, FLARE integration usage, `job.py`, SimEnv usage, export support, and absolute data paths | `nvflare agent inspect` |
+| `scripts/validate_flare_integration.py` | framework conversion skills | AST-based check for FLARE receive/send patterns, `FLModel`, and incomplete conversion patterns without exposing API details as customer intent | `nvflare agent inspect` or a future conversion lint command |
+| `scripts/validate_exported_job.py` | `nvflare-job-lifecycle`, framework conversion skills | Check required job files and obvious packaging mistakes; use `_export_manifest.json` or fingerprint metadata when the future export API provides them | `nvflare agent inspect` and `nvflare job submit` preflight |
+| `scripts/extract_metrics_summary.py` | `nvflare-job-lifecycle`, framework conversion skills | Collect simple metrics from known JSON artifacts, logs, TensorBoard pointers, or result files so the agent can report training progress | future `nvflare job metrics` |
+| `scripts/collect_job_evidence.py` | `nvflare-diagnose-job` | Run the standard evidence commands and save a support bundle with job meta, logs, stats, system status, and resources | future `nvflare job diagnose` |
+| `scripts/match_failure_patterns.py` | `nvflare-diagnose-job` | Match collected logs and metadata against known patterns such as CUDA OOM, import errors, auth failures, timeouts, and expired startup kits | future `nvflare job diagnose` |
+| `scripts/redact_support_bundle.py` | `nvflare-diagnose-job`, `nvflare-job-lifecycle` | Redact secrets, local usernames, tokens, and private paths before an evidence bundle is shared | future support-bundle command |
+
+Script requirements:
+
+- deterministic behavior only; no hidden LLM calls;
+- one CLI-compatible JSON envelope on stdout and diagnostics on stderr. The
+  envelope should use the same top-level shape as agent-facing CLI commands,
+  including `schema_version`, `status`, `code`, `message`, and `data`;
+- explicit path or job ID arguments; no broad home-directory scanning;
+- no importing or executing user training modules;
+- no reading private key contents;
+- no mutation unless the script name and skill workflow clearly say it writes
+  generated files;
+- stable enough inputs and outputs to be covered by tests;
+- easy removal or promotion when the equivalent product CLI command exists.
+
+When a helper script is promoted to a product CLI command, leave a short
+transition record in the skill reference, for example
+`promoted_to: nvflare job diagnose`, and update skills to call the product
+command before removing the script. Skill lint should fail when a public skill
+continues to call a promoted script after the replacement CLI command is
+available for the target FLARE version.
+
+These scripts should reduce LLM burden. They should not become a second product
+API surface that diverges from the CLI.
+
+
+
+## Skill File Requirements
+
+Each public FLARE skill should include:
+
+- `SKILL.md` with valid frontmatter, an H1 heading, and concise workflow
+  instructions;
+- `evals/evals.json` with guide-compatible prompts, expected outputs, files,
+  and assertions;
+- `evals/files/` for input fixtures or minimized expected artifacts when a
+  deterministic eval needs files;
+- `BENCHMARK.md` as the human-readable benchmark summary generated from, or
+  linked to, guide-compatible benchmark artifacts;
+- `references/` for detailed examples, command contracts, and product-specific
+  guidance that should not bloat `SKILL.md`;
+- `scripts/` and `assets/` only when needed by the stated workflow;
+- publication handoff artifacts or externally generated skill-card/signature
+  artifacts when the separate publication process produces them.
+
+Global-negative evals that expect no FLARE skill to trigger may set
+`nvflare.negative_for` to the literal string `"*"`. Adjacent-negative evals
+against a specific competing skill should name that skill explicitly.
+
+`SKILL.md` should stay compact enough for frequent loading. The initial lint uses
+200 lines as the hard gate. Roughly 2,000 tokens is an advisory authoring
+target, reported as a warning by a simple whitespace-based estimate unless a
+project tokenizer is later standardized. Longer examples, walkthroughs,
+command tables, and troubleshooting catalogs should move to `references/` and
+be loaded only when needed.
+
+Packaged skills must not include runtime-evaluator hooks. `SKILL.md` files
+should not instruct agents to check evaluator environment variables, enable an
+eval-on mode, or run an evaluator command before the final response. Keep
+user-facing evidence requirements in the workflow, requirements, and output
+sections. Preserve non-runtime skill metadata, eval cases, benchmark summaries,
+and read-only performance reporting when they help skill development.
+
+Recommended structure:
+
+```text
+skills/nvflare-convert-pytorch/
+  SKILL.md
+  references/
+    pytorch-client-api-conversion.md
+    job-export-contract.md
+  scripts/
+    validate_exported_job.py
+  evals/
+    evals.json
+    files/
+      hello-pt/
+  BENCHMARK.md
+```
+
+This follows the public skill-guide structure: `SKILL.md` is the portable
+instruction file, `references/`, `scripts/`, and `assets/` are loaded only when
+needed, `evals/evals.json` is the hand-authored eval definition, and generated
+benchmark outputs live in eval workspaces. FLARE-specific requirements should
+be represented as fields, assertions, references, or generated reports inside
+that structure, not as a separate public skill layout.
+
+Copyright and license text must appear below the YAML frontmatter and initial
+H1 heading, not above the frontmatter.
+
+License choice:
+
+- default to dual Apache 2.0 plus CC-BY 4.0 when a skill mixes instructions,
+  examples, helper scripts, or generated-code snippets;
+- use Apache 2.0 only for skills that are primarily executable helper code;
+- use CC-BY 4.0 only for skills that are purely instructional and contain no
+  meaningful executable code snippets or helper scripts.
+
+Examples and skills have separate source-of-truth roles:
+
+- `examples/` remains the source for runnable product examples.
+- skills should reference example paths and may include short snippets, but they
+  should not copy whole examples into `references/`.
+- eval input files may copy a minimized snapshot of an example under
+  `evals/files/` only when needed for deterministic testing; the fixture should
+  record the source example path and source hash.
+- release checks should verify that referenced example paths still exist and
+  that eval input-file hashes are intentionally updated when examples change.
+
+### Skills Maintenance Policy
+
+Packaged skills are part of the NVFLARE user contract and need explicit
+ownership:
+
+- each public skill declares a precise trigger description, minimum FLARE
+  version, and blast radius in frontmatter.
+- public skills may declare `skill_version`; skill changes can follow semantic
+  versioning at the skill level for debugging and review, even when bundled into
+  an NVFLARE release.
+- skill updates are versioned independently with `skill_version`, but official
+  packaged distribution follows the NVFLARE release cycle. Out-of-cycle official
+  skill fixes require an NVFLARE patch release; user-side workarounds can use
+  `nvflare agent skills install --local` until an official release is
+  available. This avoids implying that the native wheel installer fetches
+  out-of-band catalog updates.
+- breaking CLI schema changes require a skill compatibility audit before
+  release.
+- community PRs can add or update framework-specific skills when they include
+  examples, trigger evals, behavior IDs, and the initial checks.
+- community skill contributions follow the same project CLA, code-of-conduct,
+  review, and release rules as other NVFLARE contributions. FLARE maintainers
+  arbitrate trigger overlap, naming conflicts, lifecycle status, and whether a
+  community change can alter an NVIDIA-owned public skill or must ship as a new
+  skill/reference first.
+- breaking changes to NVIDIA-owned public skills require a migration note and
+  benchmark comparison before release; minor community improvements can merge
+  when they preserve trigger boundaries and pass the admission gate.
+- local user overrides are supported through `nvflare agent skills install
+  --local`, but packaged skills remain the release source of truth.
+
+Skill semantic-versioning rules:
+
+| Bump | Triggers |
+| --- | --- |
+| Major | breaking trigger change, removed mandatory step, dropped FLARE version support, or incompatible output expectation |
+| Minor | new optional behavior, new reference, new eval input or expected artifact, or expanded framework scope |
+| Patch | wording, typo, benchmark update, eval input hash refresh, non-behavioral reference cleanup, or metadata correction that does not change routing |
+
+Full deprecation lifecycle behavior, `obsoletes`, changelog commands, and
+catalog migration rules are deferred roadmap items. Until then, removing or
+renaming a shipped skill should require a release-note entry and explicit
+maintainer approval.
+
+
+
+## Example and Scaffold Conventions
+
+New agent-ready examples should use a predictable layout:
+
+```text
+<example_or_job>/
+  README.md
+  job.py
+  client.py
+  model.py
+  prepare_data.py
+  download_data.py
+  requirements.txt
+```
+
+Not every file is required for every example, but these names should be used
+when the concepts exist.
+
+README files should include:
+
+- what the example does;
+- file structure;
+- setup and dependency installation;
+- data preparation;
+- job recipe overview;
+- local SimEnv run command;
+- export command;
+- POC or production submit command;
+- expected outputs and artifact locations;
+- troubleshooting notes.
+
+## Authoring Workstreams and Deliverables
+
+- Add repo-root `skills/` and keep it as the source for public FLARE skills.
+- Add the initial seed skill set defined in the integration design.
+- Keep each `SKILL.md` concise and move deep reference material into
+  `references/`.
+- Add the initial helper scripts that support customer workflows:
+  `scan_project.py`, `validate_flare_integration.py`,
+  `validate_exported_job.py`, `extract_metrics_summary.py`,
+  `collect_job_evidence.py`, `match_failure_patterns.py`, and
+  `redact_support_bundle.py`.
+- Add skill lint checks for name, description, directory matching, command
+  references, script references, release compatibility, prohibited primary
+  paths, trigger overlap, and guide-compatible eval shape.
+- Add script contract tests for JSON-envelope output, explicit arguments, no
+  user-code imports, no secret leakage, and expected failure handling.
+- Package released customer-facing skills in the Python wheel from the same
+  repo-root source.

--- a/docs/design/agent_skill_evaluation.md
+++ b/docs/design/agent_skill_evaluation.md
@@ -1,0 +1,713 @@
+# NVFLARE Agent Skill Evaluation Architecture
+
+## Document Control
+
+| Field | Value |
+| --- | --- |
+| Created date | 2026-05-26 |
+| Updated date | 2026-06-08 |
+| Status | Proposed design |
+| Parent design | [Agent Integration](agent_integration.md) |
+| Related designs | [Agent Skill Authoring](agent_skill_authoring.md), [Agent Skill Publication Handoff Checklist](agent_publication_handoff_checklist.md) |
+| Current owner | NVFLARE product/docs maintainers |
+| Review scope | Skill evaluation gate, guide-compatible eval shape, engineering/runtime test split, runtime evidence without a separate evaluator, Auto-FL research evaluation, and publication handoff artifacts |
+
+## Table of Contents
+
+- [Document Control](#document-control)
+- [Scope](#scope)
+- [Evaluation Principles](#evaluation-principles)
+- [Guide-Compatible Eval Structure](#guide-compatible-eval-structure)
+- [Eval Schema Versioning and Negative Triggers](#eval-schema-versioning-and-negative-triggers)
+- [Skill Admission Gate](#skill-admission-gate)
+- [Engineering Lints](#engineering-lints)
+- [Engineering Correctness Checks](#engineering-correctness-checks)
+- [Runtime Agent-Performance Checks](#runtime-agent-performance-checks)
+- [Runtime Process Evidence](#runtime-process-evidence)
+- [Runtime Evidence Records and Reports](#runtime-evidence-records-and-reports)
+- [Auto-FL Research Evaluation](#auto-fl-research-evaluation)
+- [Publication Handoff Boundary](#publication-handoff-boundary)
+
+## Scope
+
+This document defines the evaluation architecture for public FLARE skills. It
+owns the skill metadata, deterministic lint, runtime evidence, reporting, and
+publication handoff contracts used to judge whether a skill is ready for public
+use.
+
+This document does not define the full agent benchmark harness. The benchmark
+harness architecture is defined in
+[Agent Benchmark Harness Architecture](agent_benchmark_harness.md).
+
+Every public FLARE skill must have enough measurement to answer:
+
+- Did the right prompt trigger the right skill?
+- Did adjacent or unrelated prompts avoid the wrong skill?
+- Did the agent follow mandatory instructions?
+- Did the agent avoid prohibited actions?
+- Did the task produce the expected validation evidence or artifact?
+- Do referenced `nvflare` commands still exist for the target release?
+
+Runtime skill-performance measurement uses normal agent runs. There is no
+runtime evaluator, no `eval=on` switch, and no `NVFLARE_SKILL_EVAL=on`
+activation path.
+
+Authored `evals/evals.json` files remain useful as skill metadata and evidence
+contracts. Runtime skill-performance evidence should come from benchmark
+harnesses, manual review, or research workflows that record what happened during
+normal skill-assisted runs. Reports should summarize observed behavior, process
+metrics, task validation evidence, and known gaps without depending on an
+external pass/fail or 1-5 score.
+
+## Evaluation Principles
+
+Evaluation has two separate layers:
+
+| Layer | Purpose | Examples | Blocks |
+| --- | --- | --- | --- |
+| Engineering correctness | Normal product tests for CLI, package, helper scripts, lints, schemas, and install behavior | unit tests, CLI tests, package tests, static lints | NVFLARE release if the product contract is broken |
+| Runtime agent performance | Measures how well skills help agents choose, follow, and complete workflows | trigger evals, instruction assertions, artifact checks, manual or scripted agent runs | public skill promotion if the skill behavior is poor |
+
+Do not treat engineering tests as runtime skill metrics. For example,
+`native-skill-install-no-node` is a CLI/package test, not evidence that
+`nvflare-convert-pytorch` helps an agent convert code. Conversely, a good
+agent-run benchmark does not excuse a broken installer or command schema.
+
+Every new normative rule in `SKILL.md` or `references/` should have one of:
+
+- a `nvflare.mandatory_behavior`, `nvflare.optional_behavior`, or
+  `nvflare.prohibited_behavior` entry in `evals/evals.json`;
+- a deterministic CLI/helper-script test;
+- a release checklist item with an observable artifact.
+
+If a rule cannot be measured, rewrite it as guidance instead of a requirement.
+
+## Guide-Compatible Eval Structure
+
+FLARE skills should follow the NVIDIA skill-guide structure. Authored evals
+live under the skill:
+
+```text
+skills/<skill>/
+  SKILL.md
+  references/
+  scripts/
+  assets/
+  evals/
+    evals.json
+    files/
+  BENCHMARK.md
+```
+
+`evals/evals.json` should use guide-compatible fields such as `prompt`,
+`expected_output`, `files`, and `assertions`. FLARE-specific behavior IDs live
+inside an `nvflare` extension object rather than in a parallel eval format.
+For FLARE scoring and runtime evidence, `nvflare.mandatory_behavior`,
+`nvflare.prohibited_behavior`, `nvflare.optional_behavior`, and
+`nvflare.process_metrics` are the canonical contract. Free-text `assertions`
+are human-readable guidance and may be generated from, or kept consistent with,
+the structured behavior IDs; reports must not treat free-text assertions as a
+second independent source of truth.
+
+Example:
+
+```json
+{
+  "schema_version": "1",
+  "skill_name": "nvflare-convert-pytorch",
+  "evals": [
+    {
+      "id": "pytorch-convert-basic",
+      "prompt": "Convert this PyTorch training script to a FLARE federated training job and run it locally.",
+      "expected_output": "A FLARE-compatible training integration, a generated or updated job.py, a successful local SimEnv run, and an exported job folder.",
+      "files": ["evals/files/hello-pt/train.py"],
+      "assertions": [
+        "The agent runs nvflare agent inspect before editing.",
+        "The agent edits only training and job files.",
+        "The generated code uses the expected FLARE API surface for this workflow.",
+        "The agent runs python job.py for local validation.",
+        "The agent runs python job.py --export --export-dir to export a job folder.",
+        "The agent does not submit to production without explicit approval."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {"id": "inspect-first", "description": "runs nvflare agent inspect before editing"},
+          {"id": "scoped-edits", "description": "edits only training and job files"},
+          {"id": "use-client-api-for-training-exchange", "description": "uses nvflare.client receive/send and FLModel for training exchange"},
+          {"id": "simenv-run", "description": "runs python job.py"},
+          {"id": "export-job", "description": "runs python job.py --export --export-dir"}
+        ],
+        "prohibited_behavior": [
+          {"id": "no-production-submit", "description": "does not submit to production without explicit approval"},
+          {"id": "no-user-code-import", "description": "does not import or execute user modules during static inspection"},
+          {"id": "no-cli-wrapper-python", "description": "does not generate Python solely to wrap nvflare CLI operations or scrape human CLI output"}
+        ],
+        "optional_behavior": [
+          {"id": "metrics-summary", "description": "summarizes metrics artifacts when available"}
+        ],
+        "process_metrics": [
+          {"id": "turns_to_acceptable", "description": "number of user/agent turns before an acceptable workflow result"},
+          {"id": "user_correction_count", "description": "number of user corrections needed after the first pass"},
+          {"id": "missed_instruction_count", "description": "number of applicable explicit instructions the agent missed"},
+          {"id": "layout_violations", "description": "count of generated layout or artifact-location mistakes found before final acceptance"}
+        ]
+      }
+    }
+  ],
+  "negative_trigger_cases": [
+    {
+      "id": "negative-k8s-deploy",
+      "prompt": "Deploy an existing FLARE startup kit to Kubernetes.",
+      "expected_output": "The PyTorch conversion skill should not trigger.",
+      "files": [],
+      "assertions": [
+        "The selected skill is not nvflare-convert-pytorch."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-deploy-k8s",
+        "negative_for": "nvflare-convert-pytorch"
+      }
+    }
+  ]
+}
+```
+
+Generated benchmark outputs should also follow the guide-style workspace when
+they exist:
+
+```text
+skills/<skill>-workspace/
+  iteration-1/
+    <eval-id>/
+      with_skill/
+        outputs/
+        timing.json
+        evidence.json
+      without_skill/
+        outputs/
+        timing.json
+        evidence.json
+    benchmark.json
+    benchmark.md
+```
+
+FLARE-specific generated reports can be added inside those run directories.
+Generated workspaces are not committed by default.
+The `skills/<skill>-workspace/` layout is for raw benchmark artifacts and
+side-by-side with/without-skill runs. Runtime evidence records are generated
+artifacts owned by the benchmark, research workflow, or reviewer process that
+created them. There is no evaluator-owned default records root.
+
+Behavior ID evaluation semantics:
+
+- `nvflare.mandatory_behavior` entries are required observations. Each ID must
+  be supported by an agent transcript, command log, file diff, generated
+  artifact, deterministic helper output, or manual reviewer checklist item.
+  Missing evidence should be reported as a missing required observation.
+- Explicit user, design, or skill instructions that should be counted as missed
+  instructions must be represented by measurable `nvflare.mandatory_behavior`
+  IDs in the selected eval case. For example, a "do another review" requirement
+  should be represented by a behavior such as `review-after-fix`, and a "use the
+  requested output location without overwriting source files" requirement should
+  be represented by a behavior such as `non-destructive-output-location`.
+  Without such a behavior ID or an explicit harness- or reviewer-supplied count,
+  the report has no ground truth for that instruction and must not infer a miss
+  from vague transcript absence.
+- `nvflare.prohibited_behavior` entries are forbidden observations. If the
+  transcript, command log, file diff, or generated artifact shows the behavior
+  happened, the runtime evidence should report a prohibited-behavior violation.
+- `nvflare.optional_behavior` entries are advisory observations. They can be
+  recorded in benchmark output when present, but missing optional behavior does
+  not fail the eval.
+
+The IDs are stable labels, not metrics by themselves. Behavior IDs are scoped to
+the selected skill and eval case, not globally unique across all skills. The
+benchmark harness, research workflow, or reviewer checklist maps each ID in that
+eval case to concrete evidence and records the observed status.
+The selected case in the skill's `evals/evals.json` is the canonical source of
+behavior IDs. Runtime reports must not rely on a separate hard-coded behavior-ID
+list outside the selected eval case.
+
+Process metrics are also stable labels. They measure how efficiently the skill
+guided the agent, not whether the generated model reached a high accuracy. They
+should live under `nvflare.process_metrics` in at least one eval for every
+public skill. Typical metrics include first-pass acceptance, user correction
+count, agent self-correction count, layout or workflow violations, unwanted
+actions, validation evidence completeness, and turns or tool calls to an
+acceptable result.
+
+Runtime process records are generated artifacts, not packaged skill source.
+Only concise summaries, known gaps, and corrective skill changes should be
+committed to `BENCHMARK.md`.
+
+## Eval Schema Versioning and Negative Triggers
+
+`evals/evals.json` must include a top-level `schema_version`. Version `"1"` uses
+the guide-compatible shape in this document:
+
+```text
+schema_version
+skill_name
+evals[]
+negative_trigger_cases[]
+```
+
+`evals[]` contains positive or task-completion cases where the skill is expected
+to be useful. `negative_trigger_cases[]` contains adjacent or unrelated prompts
+where the skill must not be selected. Negative trigger cases use the same fields
+as normal eval cases, but the `nvflare` extension must include `negative_for`
+and may include `expected_skill` or `expected_no_skill`.
+
+Schema readers and lints must reject unsupported `schema_version` values instead
+of silently interpreting them as the current schema. Backward-compatible
+additive fields may be accepted when the reader preserves unknown fields or
+reports them as ignored. Breaking changes require a new schema version and a
+short migration note in this section.
+
+Schema version `"1"` changelog:
+
+- top-level `schema_version`;
+- guide-compatible `evals[]`;
+- top-level `negative_trigger_cases[]`;
+- FLARE-specific behavior IDs under each case's `nvflare` object;
+- `nvflare.process_metrics` for runtime process-quality contracts.
+
+<a id="initial-evaluation-gate"></a>
+
+## Skill Admission Gate
+
+Adding or publishing a public FLARE skill should fail review unless the PR
+includes:
+
+- `SKILL.md` with valid frontmatter, a precise trigger description, and clear
+  "use / do not use" boundaries.
+- `min_flare_version` and `blast_radius` in frontmatter.
+- at least one positive trigger eval in `evals/evals.json`;
+- at least one adjacent negative trigger case for the nearest competing skill;
+- global negative coverage for prompts that should trigger no FLARE skill;
+- `nvflare.mandatory_behavior` and `nvflare.prohibited_behavior` IDs for every
+  normative workflow rule in the skill;
+- `nvflare.process_metrics` for process quality, correction count, validation
+  evidence, and first-pass workflow quality;
+- deterministic input files under `evals/files/` when file editing or artifact
+  assertions require them;
+- command-drift checks for every referenced `nvflare` command and flag;
+- helper-script tests when the skill ships scripts;
+- a `BENCHMARK.md` summary or an explicit `draft/internal` marker when the
+  skill is not ready for public release.
+
+<a id="initial-engineering-lints"></a>
+
+## Engineering Lints
+
+This table is the canonical lint definition. The authoring guide owns the
+frontmatter schema and metadata semantics; this evaluation spec owns which
+deterministic checks run before a public skill is accepted.
+
+| Check | Failure Condition | Deterministic Inputs | Required Behavior |
+| --- | --- | --- | --- |
+| `skill-frontmatter-lint` | missing required frontmatter, invalid `blast_radius`, name mismatch, or non-`nvflare-` public skill name | `skills/<skill>/SKILL.md` frontmatter, directory name, and the frontmatter schema in [Agent Skill Authoring](agent_skill_authoring.md#frontmatter-and-product-metadata) | Parse frontmatter as YAML, require the authoring-guide required fields, require public skill names to match their directory and start with `nvflare-`, and require `blast_radius` to be an allowed value. |
+| `skill-md-size-lint` | `SKILL.md` exceeds the 200-line hard gate without an approved exception | `skills/<skill>/SKILL.md` | Fail when `SKILL.md` exceeds 200 lines unless an explicit approved exception marker exists. Report the roughly 2,000-token guidance as advisory using a simple whitespace estimate until a tokenizer is standardized. |
+| `skill-trigger-lint` | missing trigger/use-boundary text, missing positive trigger eval, or missing adjacent negative trigger case | `SKILL.md` trigger text and `evals/evals.json` | Require a non-empty trigger/use-boundary description, at least one positive trigger eval, and at least one adjacent negative trigger case in `negative_trigger_cases` for the nearest competing same-category skill. |
+| `skill-trigger-overlap-lint` | same-category public skills have overlapping descriptions or trigger examples without negative trigger cases or documented boundaries | product catalog category, conversion-family table, `SKILL.md` descriptions, and trigger eval prompts | For same-category public skills, flag overlapping descriptions or trigger examples unless the skills include documented use/do-not-use boundaries and adjacent negative trigger cases covering the overlap. The lint uses deterministic text/category checks, not a runtime LLM recommender. |
+| `skill-catalog-category-lint` | category values used for overlap lint drift from the product catalog table or conversion-family table | product catalog table, conversion-family table, and any generated lint category map | Verify every public skill has one canonical category source for overlap checks, and fail if the category map disagrees with the catalog or conversion-family table. |
+| `skill-global-negative-lint` | unrelated global negative prompt coverage is missing or malformed | repo-root `skills/_shared/global_negative_prompts.json` and per-skill `evals/evals.json` | Require coverage for prompts that should trigger no FLARE skill, such as unrelated web, Kubernetes-only, or generic coding tasks. The shared bank should use `schema_version: "1"` and `prompts` entries with `id`, `prompt`, and `description`. The deterministic lint validates that public skills include or reference required global-negative cases. |
+| `skill-policy-coverage-lint` | normative words appear without a nearby measurable behavior ID, deterministic helper test, or checklist item | `SKILL.md`, `references/`, helper tests, and `evals/evals.json` | Flag normative words such as `must`, `must not`, `required`, `prohibited`, and `approval` unless the rule maps to `nvflare.mandatory_behavior`, `nvflare.prohibited_behavior`, a deterministic helper test, or a release checklist item. |
+| `skill-process-metric-lint` | missing process metric contracts for a public skill, or malformed process metric entries | `evals/evals.json` | Require at least one `nvflare.process_metrics` entry for every public skill. Each metric must have a stable `id` and `description` so runtime runs can record first-pass quality, correction count, unwanted actions, validation evidence completeness, and related process outcomes. |
+| `skill-command-drift-lint` | referenced `nvflare` commands, flags, or JSON examples do not match the installed CLI or exported command schema | `SKILL.md`, `references/`, `scripts/`, CLI parser/schema output | Verify each referenced `nvflare` command, flag, and JSON example against the installed CLI or exported `--schema` output so stale commands fail before release. |
+| `skill-helper-script-lint` | helper scripts lack tests or violate JSON stdout/stderr conventions | `skills/<skill>/scripts/` and tests | Require tests for shipped helper scripts, require machine-readable stdout when JSON output is promised, require diagnostics on stderr, and fail when a public skill calls a helper script marked as promoted to a product CLI command. |
+| `skill-fixture-lint` | file-editing evals lack required `evals/files/` inputs or fixture source notes | `evals/evals.json`, `evals/files/`, and fixture notes | Ensure file-editing or artifact-producing evals reference existing deterministic input files under `evals/files/` and include source/provenance notes for fixtures. |
+| `agent-doc-crosslink-lint` | design-doc links, lint IDs, or command references are stale | `docs/design/agent_*.md` and public skill `SKILL.md`, `references/`, `BENCHMARK.md`, and `evals/evals.json` files | Resolve internal markdown links and anchors, verify referenced lint IDs and command names have canonical definitions, and fail on stale cross-document references inside the scoped agent-skill documents. Do not scan unrelated repository docs. |
+
+Release checklist items used as measurement substitutes must be machine-readable
+in `evals/release_checklist.json` with `schema_version: "1"` and entries
+containing `id`, `description`, and `evidence_expected`. Prose-only checklist
+mentions do not satisfy `skill-policy-coverage-lint`.
+
+For `skill-trigger-overlap-lint`, the deterministic algorithm compares only
+skills in the same catalog category, normalizes trigger and
+use/do-not-use text to lowercase tokens, remove stop words, and flag exact or
+substring overlap of skill names, framework names, recipe names, command names,
+or three-token phrases unless both skills have adjacent negative trigger-case coverage
+for the overlap. The lint does not use an LLM or infer semantic similarity
+beyond those deterministic text checks.
+
+For `skill-command-drift-lint`, scan fenced code blocks and inline snippets that
+start with `nvflare`, parse the command and flags against the installed CLI
+parser or exported command schema, and fail on unknown commands or flags. The CI
+environment for this lint must run from the same NVFLARE checkout or installed
+wheel whose CLI is being validated.
+
+Global negative coverage is per public skill: every public skill must either
+include `negative_trigger_cases` entries marked `negative_for: <skill-name>` for each prompt ID in
+`skills/_shared/global_negative_prompts.json`, or reference a shared coverage
+set that expands to those IDs. Deterministic lint only validates coverage
+declarations; benchmark or research runs may execute selected prompts later.
+
+Each lint should emit structured findings with at least `id`, `severity`,
+`file`, `line` when available, `message`, and `hint`. These findings are
+engineering correctness evidence, not runtime skill-performance metrics.
+
+## Engineering Correctness Checks
+
+These checks are ordinary NVFLARE tests. They should live in unit, CLI,
+package, script, lint, or release-test suites and should not be reported as
+runtime skill-performance metrics:
+
+| Area | Check ID | Evidence |
+| --- | --- | --- |
+| Native install | `native-skill-install-no-node` | install test environment and command trace show no Node.js, npm, npx, or external skill CLI dependency |
+| Native install | `skill-install-codex-claude-targets` | dry-run JSON and filesystem assertions prove target resolution |
+| Native install | `skill-install-all-by-default` | dry-run JSON and installed list show all compatible released NVFLARE skills are selected |
+| Native install | `skill-install-safe-overwrite` | target fixture proves existing files are preserved, skipped, or replaced only with explicit overwrite flags |
+| Native install | `skill-install-no-third-party-download` | network-disabled test and command trace prove only NVFLARE-owned skills are copied |
+| Native install/list | `skill-list-ignores-unrelated-third-party-skills` | target fixture with unrelated third-party skills proves `skills list` does not report them as conflicts |
+| Native install/list | `skill-list-flags-name-overlap-external-skill` | target fixture with an unmanaged skill sharing an NVFLARE skill name proves `skills list` reports a name-overlap conflict |
+| CLI contract | `cli-json-single-envelope` | `--format json` emits one JSON object on stdout |
+| CLI contract | `cli-jsonl-streaming-envelope` | streaming commands with `--format jsonl` emit one complete JSON event per line |
+| CLI contract | `cli-schema-no-operational-args` | `--schema` works without runtime inputs |
+| CLI contract | `cli-error-recovery-category` | agent-facing errors include a valid `recovery_category` |
+| Inspect safety | `inspect-static-only` | static inspection does not import or execute user modules |
+| Inspect safety | `inspect-redaction-default` | secret-like literals and sensitive paths are redacted by default |
+| Doctor safety | `doctor-read-only` | doctor does not mutate config, submit jobs, or read private key contents |
+| Helper scripts | `helper-json-stdout` | helper scripts emit one CLI-compatible JSON envelope on stdout and diagnostics on stderr |
+| Helper scripts | `helper-no-user-code-import` | static helper scripts do not import or execute user modules |
+
+## Runtime Agent-Performance Checks
+
+These checks measure the skill's usefulness to an agent and should be reported
+in `BENCHMARK.md` when measured:
+
+| Area | Check ID | Evidence |
+| --- | --- | --- |
+| Triggering | `positive-trigger-correct` | matching prompts activate the expected skill |
+| Triggering | `negative-trigger-correct` | adjacent prompts do not activate the wrong skill |
+| Triggering | `global-negative-no-trigger` | unrelated prompts trigger no FLARE skill |
+| Instruction following | `mandatory-behavior-followed` | observable trace or artifact shows each `nvflare.mandatory_behavior` item was followed |
+| Instruction following | `prohibited-behavior-avoided` | observable trace or artifact shows each `nvflare.prohibited_behavior` item was avoided |
+| Task success | `task-validation-passed` | validation command, generated artifact, or deterministic assertion satisfies the eval |
+| Generated code API choice | `use-recipe-for-applied-workflow` | standard applied workflows use Recipe API when an appropriate recipe exists |
+| Generated code API choice | `use-client-api-for-training-exchange` | training exchange uses Client API and `FLModel` when Client API conversion is required |
+| Generated code API choice | `use-cli-for-operations` | config, provision, submit, monitor, system, and study operations use the CLI rather than generated wrapper Python |
+| Production safety | `approval-before-production-submit` | production submission occurs only after explicit user approval |
+| Production safety | `no-private-key-copy` | generated artifacts do not contain copied private keys |
+
+The check IDs in this table are reporting categories, not canonical behavior
+IDs. Runtime evidence must use behavior IDs from the selected skill's
+`evals/evals.json`, not from this table.
+
+`BENCHMARK.md` should keep the runtime report short:
+
+- skill version or source commit;
+- FLARE version;
+- eval cases run;
+- trigger pass/fail summary;
+- mandatory behavior followed/missed;
+- prohibited behavior violations;
+- task validation result;
+- process metric summary;
+- known failures and next changes.
+
+Cost, repeatability, paired with-skill/without-skill deltas, and independent
+monitor reports belong to the benchmark harness rather than the skill metadata
+contract.
+
+Same-category overlap means skills sharing the `Category` column in the product
+catalog table, with conversion-family refinements from the authoring guide.
+Category is not a required frontmatter field.
+
+<a id="runtime-process-evidence"></a>
+
+## Runtime Process Evidence
+
+Process evidence answers whether the skill reduced repeated correction and
+token-heavy trial-and-error. It is separate from task metrics such as model
+accuracy, AUROC, or loss. For example, a conversion can produce a runnable model
+but still show poor process evidence if it mixes generated files into the source
+root, uses nonstandard names, writes runtime artifacts into the project tree, or
+requires several user correction rounds.
+
+Recommended evidence record shape:
+
+```json
+{
+  "schema_version": "1",
+  "skill": "nvflare-convert-pytorch",
+  "skill_version": "0.1.0",
+  "case_id": "ames-pytorch-fedavg-conversion",
+  "agent": "codex",
+  "run_mode": "with_skill",
+  "source_hash": "cc84428d014be112e254420a92b6497d3b11cbd5a67b263e56ebd0a4df18e00d",
+  "source_commit": null,
+  "prompt_summary": "Convert AMES PyTorch code to FedAvg simulation with 2 sites",
+  "mandatory_behavior": {
+    "inspect-first": {
+      "status": "pass",
+      "evidence": ["tool log shows nvflare agent inspect ran before file edits"],
+      "notes": "Inspection happened before editing."
+    },
+    "use-client-api-for-training-exchange": {
+      "status": "pass",
+      "evidence": ["client.py uses nvflare.client receive/send and FLModel"],
+      "notes": ""
+    }
+  },
+  "prohibited_behavior": {
+    "no-production-submit": {
+      "status": "pass",
+      "evidence": ["command log contains no nvflare job submit command"],
+      "notes": ""
+    }
+  },
+  "optional_behavior": {
+    "metrics-summary": {
+      "status": "missing",
+      "evidence": [],
+      "notes": "No metric artifact was available."
+    }
+  },
+  "first_pass": {
+    "accepted": false,
+    "violations": [
+      "mixed generated FLARE files into original source root",
+      "used fl_train.py instead of client.py",
+      "used fl_job/fl_workspace under project root instead of /tmp/nvflare"
+    ]
+  },
+  "final_result": {
+    "accepted": true,
+    "validation_passed": true,
+    "simulation_passed": true,
+    "failure_root_cause": null
+  },
+  "process_metrics": {
+    "elapsed_seconds": 812,
+    "token_count": 42000,
+    "turns_to_acceptable": 4,
+    "user_correction_count": 3,
+    "agent_self_correction_count": 1,
+    "missed_instruction_count": 2,
+    "layout_violations": 3,
+    "workflow_violations": null,
+    "evidence_gap_violations": null,
+    "validation_commands_run": 5,
+    "unnecessary_files_created": 4
+  },
+  "significant_violations": [],
+  "skill_improvements": [
+    "add generated-job folder rule",
+    "require client.py/job.py/model.py",
+    "keep runtime workspace outside the source tree"
+  ]
+}
+```
+
+`prompt_summary` is optional and should be a short, sanitized description of the
+task, not a copied prompt. `process_metrics.agent_self_correction_count` is the
+count of agent-detected corrections made before the user had to correct the
+workflow.
+
+`process_metrics.missed_instruction_count` counts applicable explicit
+instructions that the agent did not follow. Condition-based instructions count
+only when the condition is satisfied. A missed instruction that is severe enough
+to invalidate safety, artifact ownership, or approval requirements should also
+be recorded in `significant_violations`. When the count is absent or `null`, a
+report may show it as unavailable; it must not infer hidden intent from vague
+transcript absence.
+
+Runtime `process_metrics` fields:
+
+| Field | Type | Nullability and ownership |
+| --- | --- | --- |
+| `elapsed_seconds` | number | `null` when unavailable. Prefer measured harness data from artifacts. |
+| `token_count` | integer | `null` when unavailable. Never infer from transcript text. |
+| `turns_to_acceptable` | integer | `null` when unavailable. Reviewer checklist may supply it. |
+| `user_correction_count` | integer | `null` when unavailable. `0` means no user correction was observed in available evidence. |
+| `agent_self_correction_count` | integer | `null` when unavailable. `0` means no self-correction was observed in available evidence. |
+| `missed_instruction_count` | integer | `null` when unavailable. `0` means no missed instruction was observed in available evidence. |
+| `layout_violations` | integer | `null` when not checked. `0` means checked and none found. |
+| `workflow_violations` | integer | `null` when not checked. `0` means checked and none found. |
+| `evidence_gap_violations` | integer | `null` when not checked. `0` means checked and none found. |
+| `validation_commands_run` | integer | `null` when not applicable or not tracked. |
+| `unnecessary_files_created` | integer | `null` when not checked. |
+
+Additional metrics are allowed only when the selected eval case declares them
+under `nvflare.process_metrics`.
+
+This design does not define a 1-5 process score or a top-level evaluator
+pass/fail. Reports may apply an explicit quality gate for a specific benchmark
+or publication review, but that policy belongs to the benchmark/report layer and
+must be documented with the report.
+
+The feedback loop is:
+
+1. Run a realistic task with the skill enabled.
+2. Record first-pass violations, correction count, validation evidence, and
+   significant blockers.
+3. Compare process metrics and task evidence against the baseline or previous
+   skill version.
+4. Add only the missing guardrails to `SKILL.md`, `references/`, helper scripts,
+   or deterministic lints.
+5. Add or update structured behavior IDs, human-readable assertions, and
+   process metrics together so they do not drift.
+6. Re-run and verify correction count, failure rate, or evidence gaps improve.
+
+<a id="runtime-evaluator-and-records"></a>
+
+## Runtime Evidence Records and Reports
+
+Runtime evidence records are generated by the benchmark harness, research
+workflow, or reviewer process that runs the task. They are normal run artifacts,
+not evaluator outputs. A record must preserve bounded evidence that explains the
+run outcome without copying full transcripts, large command outputs, secrets,
+access tokens, private keys, credentials, or sensitive absolute paths.
+
+The record should use `schema_version` value `"1"` and include:
+
+- `schema_version`, `skill`, `skill_version`, `case_id`, `agent`,
+  `source_hash`, and optional `source_commit`;
+- `run_mode`, normally `with_skill` or `without_skill` when a comparison run is
+  being performed, otherwise `null`;
+- optional `prompt_summary`;
+- `mandatory_behavior`, `prohibited_behavior`, and `optional_behavior` maps
+  keyed by behavior ID from the selected `evals/evals.json` case;
+- `first_pass`, `final_result`, `process_metrics`, `significant_violations`,
+  and `skill_improvements` using the evidence-record shape above.
+
+Allowed behavior `status` values are `pass`, `fail`, `missing`,
+`not_applicable`, and `non_scoring_note`. Aggregation and reporting commands
+must reject unknown status values rather than silently treating them as pass.
+Consumers must also reject or clearly surface records with unsupported
+`schema_version` values instead of silently interpreting them as the current
+schema.
+
+Status meaning depends on behavior category. For mandatory and optional
+behaviors, `pass` means evidence of the expected behavior was observed, `fail`
+means contradictory evidence was observed, and `missing` means requested
+evidence was not found. For prohibited behaviors, `pass` means no evidence of
+the prohibited behavior was observed, and `fail` means the prohibited action was
+detected.
+
+`source_hash` must use the same contract as the released-skill manifest:
+lowercase hex-encoded SHA-256 over the sorted files under `skills/<skill>/`.
+For each included file, feed the UTF-8 relative path, a NUL byte, the file
+contents, and a NUL byte into the single running SHA-256 state. Exclude
+`__pycache__`, `.pyc`, and `.pyo` files, and reject symlinks rather than
+following them.
+
+`skill_version` should come from the packaged manifest when available, otherwise
+from `SKILL.md` frontmatter. If neither source provides it, store `null` and
+keep the record grouped separately from records with a non-null version.
+
+`not_applicable` is not valid for mandatory or prohibited behavior IDs. Use it
+only for optional behavior IDs where the evidence source is genuinely irrelevant
+to the run. A valid `not_applicable` entry is excluded from optional evidence
+summaries and does not count as missing evidence.
+
+`non_scoring_note` is for reviewer or harness observations that should be
+preserved but are not behavior IDs from the selected eval case. It is not valid
+for canonical mandatory or prohibited behavior IDs. Store these notes in the
+record's `optional_behavior` map with `status: "non_scoring_note"` and an ID
+that is not treated as a behavior requirement.
+
+Each evidence string in a runtime record should be at most 512 characters, and
+each behavior entry should include at most 10 evidence strings. Longer evidence
+belongs in the run artifact directory and should be referenced by relative path.
+`notes` fields should be short reviewer summaries, not copied logs.
+`first_pass.violations` and `skill_improvements` should each contain at most 10
+strings, and each string should be at most 512 characters.
+
+`final_result.validation_passed` and `final_result.simulation_passed` are
+case-specific booleans. They should be `true` or `false` only when the selected
+case requires that kind of validation evidence, and `null` when the field is not
+applicable or not tracked for the skill. Non-conversion skills should use
+`final_result.accepted` plus skill-specific mandatory behavior evidence rather
+than forcing simulation-specific fields.
+
+Reports must not invent token usage, infer hidden agent intent, or retroactively
+excuse missing evidence. If token counts are unavailable from the agent runtime,
+the record should store `null` and reports should mark token usage unavailable.
+Likewise, reports must not invent missed-instruction findings for instructions
+that are not represented by selected-case mandatory behavior IDs or an explicit
+structured `process_metrics.missed_instruction_count` supplied by the harness or
+reviewer.
+
+Benchmark reporting is internal tooling, not a public `nvflare agent` command
+surface. The `agent skills performance` and `agent skills benchmark`
+subcommands are not supported. Packaged
+`evals/evals.json` files define what a benchmark harness can measure, but they
+are not performance evidence by themselves.
+
+Internal benchmark reporting should read explicit benchmark or reviewer records,
+aggregate only fields that are present, and preserve unavailable counts for
+missing numeric values. It must not run skills, call an LLM, infer token usage
+from transcript text, synthesize correctness fields, or mutate records. When a
+benchmark report renders a `BENCHMARK.md` draft, the draft is review material;
+runtime records remain the raw evidence.
+
+### Runtime Evidence Retention
+
+Runtime evidence records are user- and workspace-owned artifacts. NVFLARE does
+not delete them automatically because they may be release evidence, publication
+handoff evidence, or regression history. Tools that scan records must bound
+their work with file-count and file-size limits and report when records were
+skipped or unavailable.
+
+The default retention policy is:
+
+- benchmark and reviewer workflows write records under an explicit run or
+  records root;
+- benchmark reporting reads bounded records and never mutates them;
+- users or CI jobs own archival and deletion;
+- publication handoff bundles should copy or reference only the records needed
+  for the release decision;
+- future cleanup commands may provide `archive`, `prune`, or `export` behavior,
+  but those commands must be explicit and must not run as part of read-only
+  reporting.
+
+Reports should show the records root, record count scanned, records skipped by
+limits, and the newest/oldest record timestamp when available.
+
+## Auto-FL Research Evaluation
+
+Auto-FL is a research evaluation consumer, not a release canary. The FLARE
+research team already has Auto-FL workflows. Those workflows should be reused
+as repeatable test cases for whether the new skills improve agent behavior.
+
+Recommended comparison modes:
+
+| Mode | Purpose |
+| --- | --- |
+| `without_skill` | baseline agent behavior with no FLARE skill loaded |
+| `with_skill` | same task with relevant FLARE skills available |
+| `with_skill_forced` | diagnostic mode that names one skill explicitly to isolate skill content from trigger selection |
+
+Auto-FL evaluation should measure task success, validation score, missed
+mandatory behavior, prohibited actions, runtime, tool calls, and token/cost data
+when available. Results should feed skill improvements, helper scripts, and
+future eval cases. They should not block release or publication handoff
+unless a separate release-gate decision is made later.
+
+Auto-FL-specific artifacts should remain in the research project. FLARE skills
+should not define Auto-FL queue state, retry policy, routing, persistence, or
+run resumption.
+
+## Publication Handoff Boundary
+
+External publication is separate `github.com/NVIDIA/skills` integration work.
+This evaluation spec owns the FLARE side of the handoff:
+
+- guide-compatible `SKILL.md`;
+- references, scripts, assets, and eval inputs;
+- lint and engineering-test evidence;
+- runtime skill-performance summary in `BENCHMARK.md` when available;
+- FLARE release and skill source/version information.
+
+The concrete artifact checklist lives in
+[Agent Skill Publication Handoff Checklist](agent_publication_handoff_checklist.md).
+
+The public NVIDIA skill scoreboard, catalog sync, public installer metadata,
+signing, and publication UI are outside this NVFLARE design. FLARE should
+provide artifacts that the company-wide process can consume, but should not own
+the public scoreboard mechanics.

--- a/docs/design/skills_architecture.md
+++ b/docs/design/skills_architecture.md
@@ -1,0 +1,116 @@
+# FLARE Agent Skill Architecture
+
+This is a picture of what is implemented today for the `nvflare agent` skill
+system: the agent-facing CLI, the packaged skills, and the install/list paths.
+The benchmark harness architecture is documented separately in
+[skill_benchmark_harness_architecture.md](skill_benchmark_harness_architecture.md).
+
+## High-Level System View
+
+```mermaid
+flowchart TB
+    Authoring["Skill Authoring Source: skills, references, eval contracts"] --> Lint["Engineering Lint Tool: module CLI plus pytest-covered checks"]
+    Lint --> Package["Python Packaging Hook: setup.py and bundled_skills manifest"]
+    Package --> Install["Skill Install CLI: nvflare agent skills install and list"]
+    Install --> AgentHome["Agent Skill Home: Codex or Claude skill directory"]
+
+    AgentHome --> AgentRuntime["Agent Runtime: Codex or Claude loads SKILL.md"]
+    AgentRuntime --> AgentCLI["Agent-Facing NVFLARE CLI: info, inspect, doctor, skills"]
+    AgentRuntime --> NVFLAREWork["NVFLARE Workflows: recipes, job.py, simulator, job CLI"]
+```
+
+## System Layers
+
+| Layer | Implemented pieces | Purpose |
+| --- | --- | --- |
+| Authoring source | `skills/`, `SKILL.md`, `references/`, `evals/evals.json`, `BENCHMARK.md` | Human-readable skill instructions and supporting evidence. |
+| Engineering lint tool | `nvflare.tool.agent_skill_checks`, `python -m nvflare.tool.agent_skill_checks`, pytest coverage | Deterministic admission checks for frontmatter, triggers, command drift, policy coverage, fixtures, process metrics, and doc links. The check itself is a CLI/library tool; pytest validates the tool behavior. |
+| Python packaging hook | `setup.py`, `nvflare.tool.agent.bundled_skills`, `manifest.json` | Standard wheel-build hook that copies released skills into the NVFLARE package or writes an empty bundle for no-skill builds. |
+| Skill install CLI | `nvflare agent skills install/list`, `skill_manager.py` | CLI copy/install tool that installs managed skills into Codex or Claude target directories with hashes, locks, backups, and symlink checks. |
+| Runtime agent surface | Codex/Claude skill loading, `nvflare agent inspect`, `nvflare agent doctor`, recipe/job CLI | The agent reads skill instructions and uses NVFLARE commands to inspect, convert, validate, or diagnose. |
+| Benchmark harness | [skill_benchmark_harness_architecture.md](skill_benchmark_harness_architecture.md) | Separate architecture for measuring skill impact with Docker, SDK profiles, agent plugins, and reporting. |
+
+## Implemented Architecture
+
+```mermaid
+flowchart LR
+    User["User / Benchmark Prompt"] --> Agent["Codex or Claude CLI"]
+
+    Agent --> InstalledSkills["Agent Skill Directory: Codex CODEX_HOME skills or Claude launch add-dir"]
+
+    NVCLI["nvflare agent CLI"] --> Info["info"]
+    NVCLI --> Inspect["inspect: static AST scan"]
+    NVCLI --> Doctor["doctor: readiness check"]
+    NVCLI --> SkillOps["skills install/list"]
+
+    SkillSource["repo-root skills: editable checkout"] --> SkillOps
+    WheelBundle["nvflare.tool.agent.bundled_skills: wheel package bundle"] --> SkillOps
+    SkillOps --> InstalledSkills
+
+    Agent -->|follows SKILL.md| Inspect
+    Agent -->|readiness| Doctor
+    Agent -->|normal NVFLARE work| Recipes["NVFLARE recipes / job.py / simulator / CLI"]
+
+    Inspect --> Project["Local training code / FLARE job artifacts"]
+    Doctor --> Env["Local NVFLARE install, startup kits, optional deps, POC workspace"]
+```
+
+## Skill Source And Install Flow
+
+```mermaid
+flowchart TD
+    SkillsRoot["repo-root skills/"] --> SkillDirs["nvflare-orient, nvflare-convert-pytorch, nvflare-diagnose-job, shared references"]
+
+    SkillDirs --> ManifestBuild["build_skill_manifest: frontmatter validation and source hash"]
+    ManifestBuild --> Editable["Editable source manifest"]
+
+    SkillsRoot --> SetupPy["setup.py build_py"]
+    SetupPy --> Bundle["wheel bundled_skills + manifest.json"]
+    SetupPy --> EmptyBundle["empty bundled_skills manifest"]
+
+    Editable --> FindSource["find_skill_source"]
+    Bundle --> FindSource
+
+    FindSource --> Install["nvflare agent skills install"]
+    Install --> Target["Agent target skill dir"]
+    Target --> InstallManifest[".nvflare_skill_install.json with managed_by, source_hash, skill_version"]
+
+    Install --> Safety["symlink checks, lock dir, atomic staging, backup on replace, local modification detection"]
+```
+
+## What The Skills Actually Do
+
+```mermaid
+flowchart LR
+    Orient["nvflare-orient: read-only router"] --> InspectCmd["nvflare agent inspect"]
+    Orient --> DoctorCmd["nvflare agent doctor"]
+    Orient --> Recommend["Recommend next skill"]
+
+    Convert["nvflare-convert-pytorch: edits files"] --> InspectCmd
+    Convert --> RecipeList["nvflare recipe list"]
+    Convert --> ClientAPI["Generate client.py/model.py/job.py with FLModel exchange"]
+    Convert --> Validate["python job.py and export job"]
+
+    Diagnose["nvflare-diagnose-job: read-only"] --> InspectCmd
+    Diagnose --> Logs["Bounded logs / job evidence"]
+    Diagnose --> Patterns["Packaged failure-pattern references"]
+    Diagnose --> Cause["Likely cause + next action"]
+```
+
+## Key Implementation Points
+
+- Public skill source: `/Users/chesterc/projects/NVFlare/skills`
+- Implemented skills:
+  - `nvflare-orient`
+  - `nvflare-convert-pytorch`
+  - `nvflare-diagnose-job`
+- Agent-facing CLI: `/Users/chesterc/projects/NVFlare/nvflare/tool/agent/agent_cli.py`
+- Skill install/list logic: `/Users/chesterc/projects/NVFlare/nvflare/tool/agent/skill_manager.py`
+- Static inspection: `/Users/chesterc/projects/NVFlare/nvflare/tool/agent/inspector.py`
+- Readiness checks: `/Users/chesterc/projects/NVFlare/nvflare/tool/agent/doctor.py`
+- Packaging hook: `/Users/chesterc/projects/NVFlare/setup.py:116`
+- Benchmark harness architecture: `/Users/chesterc/projects/NVFlare/docs/design/skill_benchmark_harness_architecture.md`
+
+The important boundary: NVFLARE does not run a custom agent runtime for these
+skills. It packages, installs, validates, and measures skill files that
+Codex/Claude then load through their own skill mechanisms.

--- a/nvflare/tool/agent/__init__.py
+++ b/nvflare/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nvflare/tool/agent/bundled_skills/__init__.py
+++ b/nvflare/tool/agent/bundled_skills/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bundled NVFLARE-owned agent skills and manifest."""

--- a/nvflare/tool/agent/bundled_skills/manifest.json
+++ b/nvflare/tool/agent/bundled_skills/manifest.json
@@ -1,0 +1,7 @@
+{
+  "findings": [],
+  "nvflare_version": "",
+  "schema_version": "1",
+  "skills": [],
+  "source_type": "wheel"
+}

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build and validate the manifest for NVFLARE-owned agent skills."""
+
+import hashlib
+import importlib
+import importlib.util
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+MANIFEST_FILE_NAME = "manifest.json"
+MANIFEST_SCHEMA_VERSION = "1"
+IGNORED_SKILL_FILE_NAMES = {"__pycache__", "*.pyc", "*.pyo"}
+SHARED_SKILL_REFERENCE_DIR = "_shared"
+HASH_READ_CHUNK_BYTES = 1024 * 1024
+
+
+class SkillManifestError(ValueError):
+    """Manifest loading error surfaced through agent CLI structured error handling."""
+
+    def __init__(self, code: str, message: str, hint: str = "", detail: str = ""):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.hint = hint
+        self.detail = detail
+
+
+def skill_tree_hash(skill_dir: Path, *, exclude_names: Optional[set[str]] = None) -> str:
+    """Hash a skill directory by relative paths and file contents."""
+    excluded = {"__pycache__"}
+    if exclude_names:
+        excluded.update(exclude_names)
+    digest = hashlib.sha256()
+    for file_path in _iter_skill_files(skill_dir, exclude_names=excluded):
+        rel_path = file_path.relative_to(skill_dir).as_posix()
+        digest.update(rel_path.encode("utf-8"))
+        digest.update(b"\0")
+        with file_path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(HASH_READ_CHUNK_BYTES), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_version: str = "") -> dict:
+    """Build the released-skill manifest for a skills source root."""
+    root = Path(skills_root)
+    skills = []
+    findings = []
+    if root.is_dir():
+        for child in sorted(root.iterdir(), key=lambda p: p.name):
+            if _should_skip_skill_dir(child):
+                continue
+            result = _validate_skill_dir(child)
+            if not result.ok:
+                findings.append(
+                    {
+                        "skill_dir": child.name,
+                        "issues": [
+                            {"code": issue.code, "message": issue.message, "path": issue.path}
+                            for issue in result.issues
+                        ],
+                    }
+                )
+                continue
+            metadata = dict(result.metadata)
+            skills.append(
+                {
+                    "name": metadata["name"],
+                    "skill_version": metadata.get("skill_version", "0.0.0"),
+                    "min_flare_version": metadata["min_flare_version"],
+                    "max_flare_version": metadata.get("max_flare_version"),
+                    "blast_radius": metadata["blast_radius"],
+                    "source_hash": skill_tree_hash(child),
+                    "relative_path": child.name,
+                }
+            )
+
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "source_type": source_type,
+        "nvflare_version": nvflare_version,
+        "skills": skills,
+        "findings": findings,
+    }
+
+
+def _should_skip_skill_dir(path: Path) -> bool:
+    return path.name.startswith(".") or path.name.startswith("_") or not path.is_dir()
+
+
+def write_manifest(manifest: dict, manifest_path: Path | str) -> None:
+    path = Path(manifest_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_manifest(manifest_path: Path | str) -> dict:
+    path = Path(manifest_path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillManifestError(
+            "AGENT_SKILL_MANIFEST_READ_FAILED",
+            f"Could not read skill manifest: {path}",
+            "Rebuild or reinstall the NVFLARE agent skill bundle.",
+            detail=str(exc),
+        ) from exc
+    try:
+        manifest = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SkillManifestError(
+            "AGENT_SKILL_MANIFEST_INVALID_JSON",
+            f"Skill manifest is not valid JSON: {path}",
+            "Rebuild or reinstall the NVFLARE agent skill bundle.",
+            detail=str(exc),
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise SkillManifestError(
+            "AGENT_SKILL_MANIFEST_INVALID",
+            f"Skill manifest must contain a JSON object: {path}",
+            "Rebuild or reinstall the NVFLARE agent skill bundle.",
+        )
+    return manifest
+
+
+def copy_released_skills_to_bundle(
+    skills_root: Path | str, bundle_root: Path | str, *, nvflare_version: str = ""
+) -> dict:
+    """Copy valid released skills and write their manifest into a package bundle directory."""
+    source_root = Path(skills_root)
+    target_root = Path(bundle_root)
+    _clean_bundle_root(target_root)
+
+    manifest = build_skill_manifest(source_root, source_type="wheel", nvflare_version=nvflare_version)
+    _copy_shared_references_to_bundle(source_root, target_root)
+    for skill in manifest["skills"]:
+        shutil.copytree(
+            source_root / skill["relative_path"],
+            target_root / skill["relative_path"],
+            ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES),
+        )
+    write_manifest(manifest, target_root / MANIFEST_FILE_NAME)
+    return manifest
+
+
+def _copy_shared_references_to_bundle(source_root: Path, target_root: Path) -> None:
+    shared_root = source_root / SHARED_SKILL_REFERENCE_DIR
+    if not shared_root.is_dir():
+        return
+    skill_tree_hash(shared_root)
+    shutil.copytree(
+        shared_root,
+        target_root / SHARED_SKILL_REFERENCE_DIR,
+        ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES),
+    )
+
+
+def write_empty_skill_bundle(bundle_root: Path | str, *, nvflare_version: str = "") -> dict:
+    """Write an empty package skill bundle manifest and remove bundled skill content."""
+    target_root = Path(bundle_root)
+    _clean_bundle_root(target_root)
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "source_type": "wheel",
+        "nvflare_version": nvflare_version,
+        "skills": [],
+        "findings": [],
+    }
+    write_manifest(manifest, target_root / MANIFEST_FILE_NAME)
+    return manifest
+
+
+def _clean_bundle_root(target_root: Path) -> None:
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    for child in list(target_root.iterdir()):
+        if child.name == "__init__.py":
+            continue
+        if child.is_symlink():
+            child.unlink()
+        elif child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
+def _iter_skill_files(skill_dir: Path, *, exclude_names: set[str]) -> Iterable[Path]:
+    if skill_dir.is_symlink():
+        raise ValueError("skill directory contains symlink: .")
+    for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        rel_root = root_path.relative_to(skill_dir)
+        if any(part in exclude_names for part in rel_root.parts):
+            dir_names[:] = []
+            continue
+
+        dir_names.sort()
+        file_names.sort()
+        for dir_name in list(dir_names):
+            dir_path = root_path / dir_name
+            if dir_path.is_symlink():
+                raise ValueError(f"skill directory contains symlink: {dir_path.relative_to(skill_dir).as_posix()}")
+            if dir_name in exclude_names:
+                dir_names.remove(dir_name)
+
+        for file_name in file_names:
+            file_path = root_path / file_name
+            rel_path = file_path.relative_to(skill_dir)
+            if file_path.is_symlink():
+                raise ValueError(f"skill directory contains symlink: {rel_path.as_posix()}")
+            if any(part in exclude_names for part in rel_path.parts):
+                continue
+            if file_path.suffix in {".pyc", ".pyo"}:
+                continue
+            if not file_path.is_file():
+                continue
+            yield file_path
+
+
+def _validate_skill_dir(skill_dir: Path):
+    return _load_frontmatter_module().validate_skill_dir(skill_dir)
+
+
+def _load_frontmatter_module():
+    try:
+        return importlib.import_module("nvflare.tool.agent_skill_checks.frontmatter")
+    except ImportError:
+        pass
+
+    # setup.py loads this file before build isolation has all NVFLARE runtime
+    # dependencies, so fall back to loading the validator file directly.
+    # TODO: remove this direct-loader workaround when skill packaging no longer
+    # imports manifest building from setup.py/build isolation.
+    module_name = "nvflare_agent_skill_frontmatter"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    module_path = Path(__file__).resolve().parents[1] / "agent_skill_checks" / "frontmatter.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load agent skill frontmatter validator from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/nvflare/tool/agent_skill_checks/__init__.py
+++ b/nvflare/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation helpers for NVFLARE agent skill source files."""

--- a/nvflare/tool/agent_skill_checks/__main__.py
+++ b/nvflare/tool/agent_skill_checks/__main__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvflare.tool.agent_skill_checks.cli import main
+
+raise SystemExit(main())

--- a/nvflare/tool/agent_skill_checks/cli.py
+++ b/nvflare/tool/agent_skill_checks/cli.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local admission-gate entry point for NVFLARE agent skills."""
+
+import argparse
+import json
+from pathlib import Path
+
+from nvflare.tool.agent_skill_checks.lints import run_v1_lints
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m nvflare.tool.agent_skill_checks",
+        description="Run deterministic v1 lint checks for NVFLARE agent skills.",
+    )
+    parser.add_argument("--skills-root", default="skills", help="path to the skills source root")
+    parser.add_argument("--docs-root", help="optional docs/design root for cross-document link checks")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="output format")
+    parser.add_argument("--check", action="append", help="run one lint ID; may be repeated")
+    args = parser.parse_args(argv)
+
+    result = run_v1_lints(
+        Path(args.skills_root),
+        docs_root=Path(args.docs_root) if args.docs_root else None,
+        checks=args.check,
+    )
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_text_result(result)
+    return 0 if result["status"] == "ok" else 1
+
+
+def _print_text_result(result: dict) -> None:
+    summary = result["summary"]
+    print(
+        "agent skill checks: "
+        f"{summary.get('error_count', 0)} error(s), "
+        f"{summary.get('warning_count', 0)} warning(s), "
+        f"{summary.get('info_count', 0)} info finding(s)"
+    )
+    for finding in result["findings"]:
+        location = finding["file"]
+        if finding.get("line"):
+            location = f"{location}:{finding['line']}"
+        skill = f" [{finding['skill']}]" if finding.get("skill") else ""
+        print(f"{finding['severity'].upper()} {finding['id']}{skill} {location}: {finding['message']}")
+        if finding.get("hint"):
+            print(f"  hint: {finding['hint']}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nvflare/tool/agent_skill_checks/frontmatter.py
+++ b/nvflare/tool/agent_skill_checks/frontmatter.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation for NVFLARE agent skill frontmatter."""
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import yaml
+
+SKILL_FILE_NAME = "SKILL.md"
+YAML_ANCHOR_OR_ALIAS_RE = re.compile(r"(^|[:\s\[{,])([&*])[A-Za-z0-9_-]+(?=\s|$|[,}\]])")
+REQUIRED_FRONTMATTER_FIELDS = ("name", "description", "min_flare_version", "blast_radius")
+VALID_BLAST_RADIUS = frozenset(
+    {
+        "read_only",
+        "edits_files",
+        "runs_simulator",
+        "submits_poc",
+        "submits_production",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SkillValidationIssue:
+    code: str
+    message: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SkillValidationResult:
+    skill_dir: str
+    metadata: Mapping[str, Any]
+    issues: tuple[SkillValidationIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+class SkillFrontmatterError(ValueError):
+    """Raised when SKILL.md frontmatter cannot be parsed."""
+
+
+def parse_skill_frontmatter(skill_file: Path | str) -> dict[str, Any]:
+    """Parse YAML frontmatter from a SKILL.md file."""
+    path = Path(skill_file)
+    text = path.read_text(encoding="utf-8-sig")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise SkillFrontmatterError("SKILL.md must start with YAML frontmatter delimiter '---'")
+
+    close_index = _find_closing_delimiter(lines)
+    if close_index is None:
+        raise SkillFrontmatterError("SKILL.md frontmatter must end with delimiter '---'")
+
+    raw_frontmatter = "\n".join(lines[1:close_index])
+    if YAML_ANCHOR_OR_ALIAS_RE.search(raw_frontmatter):
+        raise SkillFrontmatterError("SKILL.md frontmatter must not use YAML anchors or aliases")
+    try:
+        metadata = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as e:
+        raise SkillFrontmatterError(f"failed to parse YAML frontmatter: {e}") from e
+
+    if not isinstance(metadata, dict):
+        raise SkillFrontmatterError("SKILL.md frontmatter must be a mapping")
+    return metadata
+
+
+def validate_skill_dir(skill_dir: Path | str) -> SkillValidationResult:
+    """Validate one guide-compatible skill directory."""
+    path = Path(skill_dir)
+    issues: list[SkillValidationIssue] = []
+    metadata: dict[str, Any] = {}
+
+    skill_file = path / SKILL_FILE_NAME
+    if path.is_symlink():
+        issues.append(_issue("skill-symlink-not-allowed", "skill path must not be a symlink", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    if not path.is_dir():
+        issues.append(_issue("skill-dir-missing", "skill path must be a directory", path))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    _validate_no_symlinks(path, issues)
+    if issues:
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+    if not skill_file.is_file():
+        issues.append(_issue("skill-md-missing", "skill directory must contain SKILL.md", skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    try:
+        metadata = parse_skill_frontmatter(skill_file)
+    except SkillFrontmatterError as e:
+        issues.append(_issue("skill-frontmatter-invalid", str(e), skill_file))
+        return SkillValidationResult(str(path), metadata, tuple(issues))
+
+    _validate_required_fields(metadata, skill_file, issues)
+    _validate_name_matches_directory(metadata.get("name"), path, skill_file, issues)
+    _validate_blast_radius(metadata.get("blast_radius"), skill_file, issues)
+
+    return SkillValidationResult(str(path), metadata, tuple(issues))
+
+
+def validate_skills_root(skills_root: Path | str) -> list[SkillValidationResult]:
+    """Validate every skill directory under a skills root."""
+    root = Path(skills_root)
+    if not root.is_dir():
+        return [SkillValidationResult(str(root), {}, (_issue("skills-root-missing", "skills root is missing", root),))]
+
+    results = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if should_skip_skill_dir(child):
+            continue
+        results.append(validate_skill_dir(child))
+    return results
+
+
+def should_skip_skill_dir(path: Path) -> bool:
+    """Return whether a skills-root child is metadata/reference-only."""
+    return path.name.startswith(".") or path.name.startswith("_") or not path.is_dir()
+
+
+def _find_closing_delimiter(lines: list[str]) -> Optional[int]:
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return i
+    return None
+
+
+def _validate_required_fields(
+    metadata: Mapping[str, Any], skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    for field in REQUIRED_FRONTMATTER_FIELDS:
+        value = metadata.get(field)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            issues.append(
+                _issue("skill-frontmatter-field-required", f"frontmatter field '{field}' is required", skill_file)
+            )
+        elif not isinstance(value, str):
+            issues.append(
+                _issue(
+                    "skill-frontmatter-field-type",
+                    f"frontmatter field '{field}' must be a non-empty string; " f"got {type(value).__name__}={value!r}",
+                    skill_file,
+                )
+            )
+
+
+def _validate_name_matches_directory(
+    name: Any, skill_dir: Path, skill_file: Path, issues: list[SkillValidationIssue]
+) -> None:
+    if isinstance(name, str) and name.strip() and name != skill_dir.name:
+        issues.append(
+            _issue(
+                "skill-name-directory-mismatch",
+                f"frontmatter name '{name}' must match directory name '{skill_dir.name}'",
+                skill_file,
+            )
+        )
+
+
+def _validate_blast_radius(radius: Any, skill_file: Path, issues: list[SkillValidationIssue]) -> None:
+    if isinstance(radius, str) and radius.strip() and radius not in VALID_BLAST_RADIUS:
+        issues.append(
+            _issue(
+                "skill-blast-radius-invalid",
+                f"blast_radius must be one of: {', '.join(sorted(VALID_BLAST_RADIUS))}",
+                skill_file,
+            )
+        )
+
+
+def _validate_no_symlinks(skill_dir: Path, issues: list[SkillValidationIssue]) -> None:
+    for root, dir_names, file_names in os.walk(skill_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        for name in dir_names + file_names:
+            path = root_path / name
+            if path.is_symlink():
+                issues.append(_issue("skill-symlink-not-allowed", "skill directories must not contain symlinks", path))
+        dir_names[:] = [name for name in dir_names if not (root_path / name).is_symlink()]
+
+
+def _issue(code: str, message: str, path: Path) -> SkillValidationIssue:
+    return SkillValidationIssue(code=code, message=message, path=str(path))

--- a/nvflare/tool/agent_skill_checks/lints.py
+++ b/nvflare/tool/agent_skill_checks/lints.py
@@ -1,0 +1,1559 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic v1 admission lints for NVFLARE-owned agent skills."""
+
+import json
+import os
+import re
+import shlex
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from nvflare.tool.agent_skill_checks.frontmatter import (
+    SKILL_FILE_NAME,
+    parse_skill_frontmatter,
+    should_skip_skill_dir,
+    validate_skill_dir,
+)
+
+V1_LINT_IDS = (
+    "skill-frontmatter-lint",
+    "skill-md-size-lint",
+    "skill-trigger-lint",
+    "skill-trigger-overlap-lint",
+    "skill-catalog-category-lint",
+    "skill-global-negative-lint",
+    "skill-policy-coverage-lint",
+    "skill-process-metric-lint",
+    "skill-command-drift-lint",
+    "skill-helper-script-lint",
+    "skill-fixture-lint",
+    "agent-doc-crosslink-lint",
+)
+
+LINT_SKILL_FRONTMATTER = "skill-frontmatter-lint"
+LINT_SKILL_MD_SIZE = "skill-md-size-lint"
+LINT_SKILL_TRIGGER = "skill-trigger-lint"
+LINT_SKILL_TRIGGER_OVERLAP = "skill-trigger-overlap-lint"
+LINT_SKILL_CATALOG_CATEGORY = "skill-catalog-category-lint"
+LINT_SKILL_GLOBAL_NEGATIVE = "skill-global-negative-lint"
+LINT_SKILL_POLICY_COVERAGE = "skill-policy-coverage-lint"
+LINT_SKILL_PROCESS_METRIC = "skill-process-metric-lint"
+LINT_SKILL_COMMAND_DRIFT = "skill-command-drift-lint"
+LINT_SKILL_HELPER_SCRIPT = "skill-helper-script-lint"
+LINT_SKILL_FIXTURE = "skill-fixture-lint"
+LINT_AGENT_DOC_CROSSLINK = "agent-doc-crosslink-lint"
+
+FINDING_ERROR = "error"
+FINDING_WARNING = "warning"
+FINDING_INFO = "info"
+SKILL_MD_MAX_LINES = 200
+SKILL_MD_ADVISORY_WORDS = 2000
+MAX_SKILL_TEXT_FILE_BYTES = 512 * 1024
+DEFAULT_MAX_TRIGGER_OVERLAP_SKILLS = 200
+
+_PUBLIC_EXEMPT_STATUS = {"draft", "internal", "private"}
+_SIZE_EXCEPTION_MARKERS = (
+    "nvflare-lint: allow skill-md-size-lint",
+    "skill-md-size-lint: approved-exception",
+)
+_TRIGGER_TERMS = (
+    "trigger",
+    "use when",
+    "when to use",
+    "use this skill",
+    "do not use",
+    "do-not-use",
+    "boundary",
+)
+_BOUNDARY_TERMS = ("do not use", "do-not-use", "use boundary", "boundary", "negative")
+_NORMATIVE_RE = re.compile(r"\b(must|must not|required|prohibited|approval)\b", re.IGNORECASE)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+_BACKTICK_NVFLARE_RE = re.compile(r"`(nvflare(?:\s+[^`]+)?)`")
+_SAFE_COMMAND_TOKEN_RE = re.compile(r"^(?:--?[A-Za-z0-9][\w-]*(?:=[^\s`;&|]+)?|[A-Za-z0-9_./:=+@%,-]+|<[^>\n]+>)$")
+_SIGNIFICANT_TOKEN_RE = re.compile(r"[a-z][a-z0-9_-]{2,}")
+_STOPWORDS = {
+    "and",
+    "for",
+    "the",
+    "this",
+    "that",
+    "with",
+    "into",
+    "from",
+    "using",
+    "when",
+    "skill",
+    "nvflare",
+    "flare",
+    "federated",
+    "workflow",
+}
+_KNOWN_NVFLARE_ROOT_COMMANDS = {
+    "agent",
+    "authz-preview",
+    "cert",
+    "config",
+    "dashboard",
+    "deploy",
+    "job",
+    "package",
+    "poc",
+    "preflight-check",
+    "provision",
+    "recipe",
+    "simulator",
+    "study",
+    "system",
+}
+_KNOWN_AGENT_COMMANDS = {"doctor", "info", "inspect", "skills"}
+_KNOWN_AGENT_SKILLS_COMMANDS = {"install", "list"}
+_PLANNED_AGENT_SKILLS_COMMANDS = set()
+_KNOWN_AGENT_FLAGS = {
+    "agent": {"--format", "--schema"},
+    "agent doctor": {"--format", "--online", "--schema", "--startup-kit", "--project", "--org"},
+    "agent info": {"--format", "--schema"},
+    "agent inspect": {"--format", "--redact", "--schema"},
+    "agent skills": {"--format", "--schema"},
+    "agent skills install": {"--agent", "--dry-run", "--format", "--schema", "--skill", "--target"},
+    "agent skills list": {"--agent", "--format", "--schema", "--target"},
+}
+_DOC_FILES = (
+    "agent_implementation_plan.md",
+    "agent_integration.md",
+    "agent_skill_authoring.md",
+    "agent_skill_evaluation.md",
+    "agent_skills_deferred_roadmap.md",
+)
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    id: str
+    severity: str
+    file: str
+    message: str
+    hint: str
+    line: Optional[int] = None
+    code: Optional[str] = None
+    skill: Optional[str] = None
+    global_finding: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        data = {
+            "id": self.id,
+            "severity": self.severity,
+            "file": self.file,
+            "message": self.message,
+            "hint": self.hint,
+        }
+        if self.line is not None:
+            data["line"] = self.line
+        if self.code is not None:
+            data["code"] = self.code
+        if self.skill is not None:
+            data["skill"] = self.skill
+        if self.global_finding:
+            data["global"] = True
+        return data
+
+
+@dataclass
+class SkillRecord:
+    name: str
+    skill_dir: Path
+    skill_file: Path
+    metadata: dict[str, Any]
+    text: str
+    body: str
+    evals: list[dict[str, Any]]
+    evals_path: Path
+    evals_error: Optional[str]
+
+    @property
+    def public(self) -> bool:
+        status = str(self.metadata.get("status", "public")).strip().lower()
+        return status not in _PUBLIC_EXEMPT_STATUS
+
+
+@dataclass
+class LintContext:
+    skills_root: Path
+    docs_root: Optional[Path]
+    max_skill_md_lines: int
+    records: list[SkillRecord]
+    findings: list[LintFinding]
+    skipped_checks: list[dict[str, str]]
+
+
+def run_v1_lints(
+    skills_root: Path | str = "skills",
+    *,
+    docs_root: Path | str | None = None,
+    checks: Optional[Iterable[str]] = None,
+    max_skill_md_lines: int = SKILL_MD_MAX_LINES,
+) -> dict[str, Any]:
+    """Run deterministic v1 admission lints and return structured findings."""
+    result, _records = _run_v1_lints_with_records(
+        skills_root,
+        docs_root=docs_root,
+        checks=checks,
+        max_skill_md_lines=max_skill_md_lines,
+    )
+    return result
+
+
+def _run_v1_lints_with_records(
+    skills_root: Path | str = "skills",
+    *,
+    docs_root: Path | str | None = None,
+    checks: Optional[Iterable[str]] = None,
+    max_skill_md_lines: int = SKILL_MD_MAX_LINES,
+) -> tuple[dict[str, Any], list[SkillRecord]]:
+    selected = tuple(checks or V1_LINT_IDS)
+    unknown = sorted(set(selected).difference(V1_LINT_IDS))
+    if unknown:
+        raise ValueError(f"unknown agent skill lint check(s): {', '.join(unknown)}")
+
+    root = Path(skills_root)
+    resolved_docs_root = _resolve_docs_root(docs_root)
+    findings: list[LintFinding] = []
+    records = _load_skill_records(root, findings)
+    context = LintContext(
+        skills_root=root,
+        docs_root=resolved_docs_root,
+        max_skill_md_lines=max_skill_md_lines,
+        records=records,
+        findings=findings,
+        skipped_checks=[],
+    )
+
+    lint_functions = {
+        "skill-frontmatter-lint": _lint_frontmatter,
+        "skill-md-size-lint": _lint_md_size,
+        "skill-trigger-lint": _lint_trigger,
+        "skill-trigger-overlap-lint": _lint_trigger_overlap,
+        "skill-catalog-category-lint": _lint_catalog_category,
+        "skill-global-negative-lint": _lint_global_negative,
+        "skill-policy-coverage-lint": _lint_policy_coverage,
+        "skill-process-metric-lint": _lint_process_metrics,
+        "skill-command-drift-lint": _lint_command_drift,
+        "skill-helper-script-lint": _lint_helper_scripts,
+        "skill-fixture-lint": _lint_fixtures,
+        "agent-doc-crosslink-lint": _lint_doc_crosslinks,
+    }
+
+    for check in selected:
+        lint_functions[check](context)
+
+    summary = _summary_from_lint_findings(context.findings, len(records))
+    status = "failed" if summary["error_count"] else "ok"
+    return {
+        "schema_version": "1",
+        "status": status,
+        "passed": status == "ok",
+        "skills_root": str(root),
+        "docs_root": str(resolved_docs_root) if resolved_docs_root is not None else None,
+        "checks": list(selected),
+        "skipped_checks": context.skipped_checks,
+        "summary": summary,
+        "findings": [finding.as_dict() for finding in context.findings],
+    }, records
+
+
+def validate_skills(
+    skills_root: Path | str = "skills",
+    *,
+    skill_name: Optional[str] = None,
+    docs_root: Path | str | None = None,
+    max_skill_md_lines: int = SKILL_MD_MAX_LINES,
+) -> dict[str, Any]:
+    """Compatibility wrapper for callers that validate one skill source root."""
+    result, records = _run_v1_lints_with_records(
+        skills_root,
+        docs_root=docs_root,
+        max_skill_md_lines=max_skill_md_lines,
+    )
+
+    if skill_name is not None:
+        result["requested_skill"] = skill_name
+        result["findings"] = [
+            finding for finding in result["findings"] if _finding_matches_requested_skill(finding, skill_name)
+        ]
+        result["summary"] = _summary_from_findings(result["findings"], _matching_skill_count(records, skill_name))
+        result["status"] = "failed" if result["summary"]["error_count"] else "ok"
+        result["passed"] = result["status"] == "ok"
+    else:
+        result["requested_skill"] = None
+    return result
+
+
+def _summary_from_findings(findings: list[dict[str, Any]], skill_count: int) -> dict[str, int]:
+    severity_counts = Counter(finding.get("severity", FINDING_ERROR) for finding in findings)
+    return _summary_from_counts(severity_counts, len(findings), skill_count)
+
+
+def _finding_matches_requested_skill(finding: dict[str, Any], skill_name: str) -> bool:
+    finding_skill = finding.get("skill")
+    return finding_skill == skill_name or (finding_skill is None and finding.get("global") is True)
+
+
+def _summary_from_lint_findings(findings: list[LintFinding], skill_count: int) -> dict[str, int]:
+    severity_counts = Counter(finding.severity for finding in findings)
+    return _summary_from_counts(severity_counts, len(findings), skill_count)
+
+
+def _summary_from_counts(severity_counts: Counter, finding_count: int, skill_count: int) -> dict[str, int]:
+    return {
+        "skill_count": skill_count,
+        "finding_count": finding_count,
+        "error_count": severity_counts.get(FINDING_ERROR, 0),
+        "warning_count": severity_counts.get(FINDING_WARNING, 0),
+        "info_count": severity_counts.get(FINDING_INFO, 0),
+    }
+
+
+def _load_skill_records(skills_root: Path, findings: list[LintFinding]) -> list[SkillRecord]:
+    if not skills_root.exists():
+        findings.append(
+            _finding(
+                "skill-frontmatter-lint",
+                FINDING_ERROR,
+                skills_root,
+                "skills root does not exist",
+                "Pass --skills-root pointing at the repository skills/ directory.",
+                code="skills-root-missing",
+                global_finding=True,
+            )
+        )
+        return []
+    if not skills_root.is_dir():
+        findings.append(
+            _finding(
+                "skill-frontmatter-lint",
+                FINDING_ERROR,
+                skills_root,
+                "skills root is not a directory",
+                "Pass --skills-root pointing at the repository skills/ directory.",
+                code="skills-root-not-directory",
+                global_finding=True,
+            )
+        )
+        return []
+
+    records = []
+    for child in sorted(skills_root.iterdir(), key=lambda p: p.name):
+        if should_skip_skill_dir(child):
+            continue
+        skill_file = child / SKILL_FILE_NAME
+        text = _read_bounded_text(skill_file) if skill_file.is_file() else None
+        metadata = _try_parse_frontmatter(skill_file) if text is not None else {}
+        text = text or ""
+        evals_path = child / "evals" / "evals.json"
+        evals, evals_error = _load_evals(evals_path)
+        records.append(
+            SkillRecord(
+                name=str(metadata.get("name") or child.name),
+                skill_dir=child,
+                skill_file=skill_file,
+                metadata=metadata,
+                text=text,
+                body=_skill_body(text),
+                evals=evals,
+                evals_path=evals_path,
+                evals_error=evals_error,
+            )
+        )
+    return records
+
+
+def _matching_skill_count(records: list[SkillRecord], skill_name: str) -> int:
+    return sum(1 for record in records if record.name == skill_name)
+
+
+def _lint_frontmatter(context: LintContext) -> None:
+    for record in context.records:
+        result = validate_skill_dir(record.skill_dir)
+        for issue in result.issues:
+            context.findings.append(
+                _finding(
+                    "skill-frontmatter-lint",
+                    FINDING_ERROR,
+                    Path(issue.path),
+                    issue.message,
+                    "Fix SKILL.md frontmatter before publishing this skill.",
+                    code=issue.code,
+                    skill=record.name,
+                    line=_line_for_frontmatter_issue(record.skill_file, issue.code, issue.message),
+                )
+            )
+
+        if record.public and _has_valid_name(record.metadata) and not record.name.startswith("nvflare-"):
+            context.findings.append(
+                _finding(
+                    "skill-frontmatter-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"public NVFLARE skill name '{record.name}' must start with 'nvflare-'",
+                    "Rename the skill directory and frontmatter name, or mark the skill draft/internal.",
+                    code="skill-name-prefix-required",
+                    skill=record.name,
+                    line=_line_for_field(record.skill_file, "name"),
+                )
+            )
+
+
+def _has_valid_name(metadata: dict[str, Any]) -> bool:
+    name = metadata.get("name")
+    return isinstance(name, str) and bool(name.strip())
+
+
+def _lint_md_size(context: LintContext) -> None:
+    for record in context.records:
+        if not record.skill_file.is_file():
+            continue
+        if _is_oversized_text_file(record.skill_file):
+            if _has_bounded_size_exception(record.skill_file):
+                continue
+            context.findings.append(
+                _finding(
+                    "skill-md-size-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"SKILL.md exceeds the readable size limit of {MAX_SKILL_TEXT_FILE_BYTES} bytes",
+                    "Move detailed workflow notes into references/ or add an approved exception marker near the top.",
+                    code="skill-md-too-large",
+                    skill=record.name,
+                    line=1,
+                )
+            )
+            continue
+        lines = record.text.splitlines()
+        max_lines = context.max_skill_md_lines
+        if len(lines) > max_lines and not _has_size_exception(record.text):
+            context.findings.append(
+                _finding(
+                    "skill-md-size-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"SKILL.md has {len(lines)} lines; v1 hard limit is {max_lines}",
+                    "Move detailed workflow notes into references/ or add an approved exception marker.",
+                    code="skill-md-too-large",
+                    skill=record.name,
+                    line=max_lines + 1,
+                )
+            )
+        word_count = len(record.text.split())
+        if word_count > SKILL_MD_ADVISORY_WORDS:
+            context.findings.append(
+                _finding(
+                    "skill-md-size-lint",
+                    FINDING_INFO,
+                    record.skill_file,
+                    f"SKILL.md has about {word_count} whitespace-delimited tokens",
+                    "The roughly 2,000-token target is advisory; keep SKILL.md concise when practical.",
+                    code="skill-md-token-advisory",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_trigger(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        searchable = f"{record.metadata.get('description', '')}\n{record.body}".lower()
+        if not any(term in searchable for term in _TRIGGER_TERMS):
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    "skill is missing trigger or use-boundary text",
+                    "Add concise trigger guidance and negative boundary language to SKILL.md.",
+                    code="skill-trigger-text-missing",
+                    skill=record.name,
+                )
+            )
+
+        if record.evals_error:
+            _add_evals_error(context, "skill-trigger-lint", record)
+            continue
+        if not record.evals_path.is_file():
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "evals/evals.json is required for public skill trigger checks",
+                    "Add guide-compatible evals/evals.json with positive and adjacent negative trigger evals.",
+                    code="skill-evals-missing",
+                    skill=record.name,
+                )
+            )
+            continue
+        if not any(_is_positive_eval(item, record.name) for item in record.evals):
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing positive trigger eval for this skill",
+                    "Add an eval whose nvflare.expected_skill matches this skill.",
+                    code="skill-positive-trigger-eval-missing",
+                    skill=record.name,
+                )
+            )
+        if not any(_is_adjacent_negative_eval(item, record.name) for item in record.evals):
+            context.findings.append(
+                _finding(
+                    "skill-trigger-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing adjacent negative trigger eval for this skill",
+                    "Add an eval whose nvflare.negative_for names this skill and expected_skill names the neighbor.",
+                    code="skill-adjacent-negative-eval-missing",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_trigger_overlap(context: LintContext) -> None:
+    if context.docs_root is None or not context.docs_root.is_dir():
+        _skip(context, "skill-trigger-overlap-lint", "docs root is not available")
+        return
+
+    category_map = _category_map(context)
+    if not category_map:
+        _skip(context, "skill-trigger-overlap-lint", "catalog categories are not available")
+        return
+
+    grouped: dict[str, list[SkillRecord]] = defaultdict(list)
+    for record in _public_records(context.records):
+        category = category_map.get(record.name)
+        if category:
+            grouped[category].append(record)
+
+    max_trigger_overlap_skills = _max_trigger_overlap_skills()
+    for category, records in grouped.items():
+        if len(records) > max_trigger_overlap_skills:
+            _skip(
+                context,
+                "skill-trigger-overlap-lint",
+                f"category {category!r} has {len(records)} skills; limit is {max_trigger_overlap_skills}",
+            )
+            continue
+        token_cache = {record.name: _trigger_tokens(record) for record in records}
+        for i, left in enumerate(records):
+            for right in records[i + 1 :]:
+                if not _records_overlap(left, right, token_cache):
+                    continue
+                if _has_boundary_text(left) and _has_boundary_text(right) and _has_adjacent_negative_pair(left, right):
+                    continue
+                context.findings.append(
+                    _finding(
+                        "skill-trigger-overlap-lint",
+                        FINDING_ERROR,
+                        left.skill_file,
+                        f"same-category skills '{left.name}' and '{right.name}' have overlapping trigger language",
+                        "Add use/do-not-use boundaries and adjacent negative evals covering the overlap.",
+                        code="skill-trigger-overlap",
+                        skill=left.name,
+                    )
+                )
+
+
+def _max_trigger_overlap_skills() -> int:
+    value = os.environ.get("NVFLARE_AGENT_MAX_TRIGGER_OVERLAP_SKILLS")
+    if value is None or value == "":
+        return DEFAULT_MAX_TRIGGER_OVERLAP_SKILLS
+    try:
+        parsed = int(value)
+    except ValueError:
+        return DEFAULT_MAX_TRIGGER_OVERLAP_SKILLS
+    return parsed if parsed > 0 else DEFAULT_MAX_TRIGGER_OVERLAP_SKILLS
+
+
+def _lint_catalog_category(context: LintContext) -> None:
+    docs_root = context.docs_root
+    if docs_root is None or not docs_root.is_dir():
+        _skip(context, "skill-catalog-category-lint", "docs root is not available")
+        return
+
+    product = _parse_product_catalog(docs_root / "agent_integration.md")
+    conversion = _parse_conversion_table(docs_root / "agent_skill_authoring.md")
+    if not product:
+        context.findings.append(
+            _finding(
+                "skill-catalog-category-lint",
+                FINDING_ERROR,
+                docs_root / "agent_integration.md",
+                "product skill catalog could not be parsed",
+                "Keep the catalog markdown table headed by Category, Skill, Tier, and Purpose.",
+                code="skill-catalog-unparseable",
+                global_finding=True,
+            )
+        )
+        return
+
+    for record in _public_records(context.records):
+        if record.name not in product:
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    record.skill_file,
+                    f"public skill '{record.name}' is missing from the product skill catalog",
+                    "Add the skill to agent_integration.md or mark it draft/internal.",
+                    code="skill-catalog-entry-missing",
+                    skill=record.name,
+                )
+            )
+
+    for skill, conversion_tier in conversion.items():
+        product_row = product.get(skill)
+        if product_row is None:
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    docs_root / "agent_skill_authoring.md",
+                    f"conversion-family skill '{skill}' is missing from the product catalog",
+                    "Keep conversion-family rows and the product catalog in sync.",
+                    code="conversion-skill-catalog-missing",
+                    skill=skill,
+                )
+            )
+            continue
+        if product_row["category"] != "Conversion":
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    docs_root / "agent_integration.md",
+                    f"conversion-family skill '{skill}' has category '{product_row['category']}'",
+                    "Conversion-family skills should use the Conversion category for overlap checks.",
+                    code="conversion-skill-category-mismatch",
+                    skill=skill,
+                )
+            )
+        product_tier = _strip_backticks(product_row["tier"])
+        conversion_tier = _strip_backticks(conversion_tier)
+        if conversion_tier and product_tier and conversion_tier != product_tier:
+            context.findings.append(
+                _finding(
+                    "skill-catalog-category-lint",
+                    FINDING_ERROR,
+                    docs_root / "agent_integration.md",
+                    f"skill '{skill}' tier differs between catalog and conversion-family table",
+                    "Use one tier consistently across the authoring and integration docs.",
+                    code="skill-catalog-tier-mismatch",
+                    skill=skill,
+                )
+            )
+
+
+def _lint_global_negative(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        if record.evals_error:
+            _add_evals_error(context, "skill-global-negative-lint", record)
+            continue
+        if not record.evals_path.is_file():
+            context.findings.append(
+                _finding(
+                    "skill-global-negative-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "evals/evals.json is required for global negative coverage",
+                    "Add at least one eval representing an unrelated prompt that should trigger no FLARE skill.",
+                    code="skill-evals-missing",
+                    skill=record.name,
+                )
+            )
+            continue
+        if not any(_is_global_negative_eval(item) for item in record.evals):
+            context.findings.append(
+                _finding(
+                    "skill-global-negative-lint",
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing global negative eval",
+                    "Add an eval for an unrelated prompt with nvflare.expected_skill set to null or 'none'.",
+                    code="skill-global-negative-eval-missing",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_policy_coverage(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        has_behavior_ids = any(_behavior_id_count(item) for item in record.evals)
+        has_helper_tests = _skill_has_helper_tests(record.skill_dir)
+        has_checklist = _skill_text_contains(record.skill_dir, "checklist")
+        if has_behavior_ids or has_helper_tests or has_checklist:
+            continue
+
+        for file_path, text in _iter_skill_text_files(record.skill_dir):
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                if _NORMATIVE_RE.search(line):
+                    context.findings.append(
+                        _finding(
+                            "skill-policy-coverage-lint",
+                            FINDING_ERROR,
+                            file_path,
+                            "normative rule has no measurable behavior ID, helper test, or checklist coverage",
+                            "Map required/prohibited behavior to evals/evals.json nvflare behavior IDs or tests.",
+                            code="skill-policy-coverage-missing",
+                            skill=record.name,
+                            line=line_no,
+                        )
+                    )
+                    break
+            else:
+                continue
+            break
+
+
+def _lint_process_metrics(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        if record.evals_error:
+            _add_evals_error(context, LINT_SKILL_PROCESS_METRIC, record)
+            continue
+        if not record.evals_path.is_file():
+            context.findings.append(
+                _finding(
+                    LINT_SKILL_PROCESS_METRIC,
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "evals/evals.json is required for process-metric coverage",
+                    "Add process metric contracts under nvflare.process_metrics.",
+                    code="skill-evals-missing",
+                    skill=record.name,
+                )
+            )
+            continue
+
+        process_metrics = []
+        for item in record.evals:
+            for metric in _process_metrics(item):
+                process_metrics.append((item, metric))
+
+        if not process_metrics:
+            context.findings.append(
+                _finding(
+                    LINT_SKILL_PROCESS_METRIC,
+                    FINDING_ERROR,
+                    record.evals_path,
+                    "missing process metric contracts for this public skill",
+                    "Add nvflare.process_metrics entries for first-pass quality, correction count, unwanted actions, "
+                    "validation evidence, or other skill-process outcomes.",
+                    code="skill-process-metric-missing",
+                    skill=record.name,
+                )
+            )
+            continue
+
+        for item, metric in process_metrics:
+            if not isinstance(metric, dict):
+                context.findings.append(
+                    _finding(
+                        LINT_SKILL_PROCESS_METRIC,
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' process metric must be an object",
+                        "Use objects with at least id and description fields.",
+                        code="skill-process-metric-type",
+                        skill=record.name,
+                    )
+                )
+                continue
+            metric_id = metric.get("id")
+            description = metric.get("description")
+            if not isinstance(metric_id, str) or not metric_id.strip():
+                context.findings.append(
+                    _finding(
+                        LINT_SKILL_PROCESS_METRIC,
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' process metric is missing id",
+                        "Add a stable metric id such as turns_to_acceptable or user_correction_count.",
+                        code="skill-process-metric-id-missing",
+                        skill=record.name,
+                    )
+                )
+            if not isinstance(description, str) or not description.strip():
+                context.findings.append(
+                    _finding(
+                        LINT_SKILL_PROCESS_METRIC,
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' process metric '{metric_id}' is missing description",
+                        "Describe what the metric measures and what evidence records it.",
+                        code="skill-process-metric-description-missing",
+                        skill=record.name,
+                    )
+                )
+
+
+def _lint_command_drift(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        for file_path, text in _iter_skill_text_files(record.skill_dir, include_scripts=True):
+            for line_no, command in _extract_nvflare_commands(text):
+                message = _command_drift_message(command)
+                if message is None:
+                    continue
+                context.findings.append(
+                    _finding(
+                        "skill-command-drift-lint",
+                        FINDING_ERROR,
+                        file_path,
+                        message,
+                        "Update the referenced nvflare command or the CLI command schema before publishing.",
+                        code="skill-command-drift",
+                        skill=record.name,
+                        line=line_no,
+                    )
+                )
+
+
+def _lint_helper_scripts(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        scripts_dir = record.skill_dir / "scripts"
+        if not scripts_dir.is_dir():
+            continue
+        script_files = list(_iter_files_no_follow(scripts_dir))
+        if script_files and not _skill_has_helper_tests(record.skill_dir):
+            context.findings.append(
+                _finding(
+                    "skill-helper-script-lint",
+                    FINDING_ERROR,
+                    scripts_dir,
+                    "helper scripts are shipped without tests",
+                    "Add tests under the skill or repository test tree for each shipped helper script.",
+                    code="skill-helper-tests-missing",
+                    skill=record.name,
+                )
+            )
+
+        for script in script_files:
+            try:
+                if script.stat().st_size > MAX_SKILL_TEXT_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            text = script.read_text(encoding="utf-8", errors="replace")
+            lowered = text.lower()
+            if "promoted_to:" in lowered or "_promoted_to:" in lowered:
+                context.findings.append(
+                    _finding(
+                        "skill-helper-script-lint",
+                        FINDING_ERROR,
+                        script,
+                        "helper script is marked as promoted to a product CLI command",
+                        "Update SKILL.md to call the product CLI command instead of the promoted helper script.",
+                        code="skill-helper-promoted",
+                        skill=record.name,
+                    )
+                )
+            declares_json_output = any(
+                token in lowered for token in ("json output", "stdout json", "json stdout", "jsonl", "machine-readable")
+            )
+            if script.suffix == ".py" and declares_json_output and "json.dumps" not in text and "json.dump" not in text:
+                context.findings.append(
+                    _finding(
+                        "skill-helper-script-lint",
+                        FINDING_WARNING,
+                        script,
+                        "script mentions JSON but does not appear to write JSON with the json module",
+                        "Ensure machine-readable stdout is valid JSON and diagnostics go to stderr.",
+                        code="skill-helper-json-unclear",
+                        skill=record.name,
+                    )
+                )
+
+
+def _lint_fixtures(context: LintContext) -> None:
+    for record in _public_records(context.records):
+        if record.evals_error:
+            _add_evals_error(context, "skill-fixture-lint", record)
+            continue
+        if not record.evals_path.is_file():
+            continue
+
+        for item in record.evals:
+            files = item.get("files", [])
+            if files is None:
+                files = []
+            if not isinstance(files, list):
+                context.findings.append(
+                    _finding(
+                        "skill-fixture-lint",
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' files field must be a list",
+                        "Use guide-compatible files: [...] entries relative to the skill directory.",
+                        code="skill-fixture-files-type",
+                        skill=record.name,
+                    )
+                )
+                continue
+
+            if _eval_mentions_file_editing(item) and not files:
+                context.findings.append(
+                    _finding(
+                        "skill-fixture-lint",
+                        FINDING_ERROR,
+                        record.evals_path,
+                        f"eval '{item.get('id', '<missing>')}' describes file editing without input fixtures",
+                        "Add deterministic input files under evals/files/ and reference them from the eval.",
+                        code="skill-fixture-input-missing",
+                        skill=record.name,
+                    )
+                )
+
+            for rel_path in files:
+                fixture_path = record.skill_dir / str(rel_path)
+                resolved_fixture_path = fixture_path.resolve(strict=False)
+                resolved_skill_dir = record.skill_dir.resolve()
+                if not resolved_fixture_path.is_relative_to(resolved_skill_dir):
+                    context.findings.append(
+                        _finding(
+                            "skill-fixture-lint",
+                            FINDING_ERROR,
+                            record.evals_path,
+                            f"eval fixture path escapes skill directory: {rel_path}",
+                            "Use fixture paths relative to the skill directory.",
+                            code="skill-fixture-path-escape",
+                            skill=record.name,
+                        )
+                    )
+                    continue
+                if not fixture_path.is_file():
+                    context.findings.append(
+                        _finding(
+                            "skill-fixture-lint",
+                            FINDING_ERROR,
+                            record.evals_path,
+                            f"eval fixture does not exist: {rel_path}",
+                            "Place deterministic fixtures under evals/files/ and reference existing files.",
+                            code="skill-fixture-file-missing",
+                            skill=record.name,
+                        )
+                    )
+
+        files_dir = record.skill_dir / "evals" / "files"
+        if _has_files(files_dir) and not _has_fixture_notes(record.skill_dir):
+            context.findings.append(
+                _finding(
+                    "skill-fixture-lint",
+                    FINDING_ERROR,
+                    files_dir,
+                    "eval fixtures are missing source/provenance notes",
+                    "Add evals/README.md, evals/files/README.md, or evals/files/SOURCE.md.",
+                    code="skill-fixture-notes-missing",
+                    skill=record.name,
+                )
+            )
+
+
+def _lint_doc_crosslinks(context: LintContext) -> None:
+    docs_root = context.docs_root
+    if docs_root is None or not docs_root.is_dir():
+        _skip(context, "agent-doc-crosslink-lint", "docs root is not available")
+        return
+
+    text_by_path = {
+        doc_path: text
+        for doc_path in _iter_existing_doc_files(docs_root)
+        if (text := _read_bounded_text(doc_path)) is not None
+    }
+    anchors_by_path = {doc_path.resolve(): _markdown_anchors(text) for doc_path, text in text_by_path.items()}
+
+    def anchors_for_path(path: Path) -> set[str]:
+        resolved = path.resolve()
+        if resolved not in anchors_by_path and path.suffix.lower() in {".md", ".markdown"} and path.is_file():
+            text = _read_bounded_text(path)
+            if text is not None:
+                anchors_by_path[resolved] = _markdown_anchors(text)
+        return anchors_by_path.get(resolved, set())
+
+    for doc_path, text in text_by_path.items():
+        for line_no, href in _iter_markdown_links(text):
+            if href.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _, anchor = href.partition("#")
+            target_path = (doc_path.parent / target).resolve() if target else doc_path.resolve()
+            if target and not target_path.exists():
+                context.findings.append(
+                    _finding(
+                        "agent-doc-crosslink-lint",
+                        FINDING_ERROR,
+                        doc_path,
+                        f"markdown link target does not exist: {href}",
+                        "Update the link or restore the referenced design document.",
+                        code="agent-doc-link-missing",
+                        line=line_no,
+                    )
+                )
+                continue
+            if anchor:
+                if _normalize_anchor(anchor) not in anchors_for_path(target_path):
+                    context.findings.append(
+                        _finding(
+                            "agent-doc-crosslink-lint",
+                            FINDING_ERROR,
+                            doc_path,
+                            f"markdown link anchor does not exist: {href}",
+                            "Update the link anchor to match the target heading.",
+                            code="agent-doc-anchor-missing",
+                            line=line_no,
+                        )
+                    )
+
+    eval_doc = docs_root / "agent_skill_evaluation.md"
+    if eval_doc.is_file():
+        text = text_by_path.get(eval_doc)
+        if text is not None:
+            for lint_id in V1_LINT_IDS:
+                if f"`{lint_id}`" not in text:
+                    context.findings.append(
+                        _finding(
+                            "agent-doc-crosslink-lint",
+                            FINDING_ERROR,
+                            eval_doc,
+                            f"lint id '{lint_id}' is missing from the canonical evaluation doc",
+                            "Keep agent_skill_evaluation.md#v1-engineering-lints as the canonical lint table.",
+                            code="agent-doc-lint-id-missing",
+                        )
+                    )
+
+    for doc_path, text in text_by_path.items():
+        if doc_path.name == "agent_skills_deferred_roadmap.md":
+            continue
+        for line_no, command in _extract_nvflare_commands(text):
+            if not command.startswith("nvflare agent"):
+                continue
+            message = _command_drift_message(command, check_flags=False, allow_planned=True)
+            if message is None:
+                continue
+            context.findings.append(
+                _finding(
+                    "agent-doc-crosslink-lint",
+                    FINDING_ERROR,
+                    doc_path,
+                    f"agent command reference is stale: {message}",
+                    "Update the design doc command reference or the agent CLI command surface.",
+                    code="agent-doc-command-reference-stale",
+                    line=line_no,
+                )
+            )
+
+
+def _resolve_docs_root(docs_root: Path | str | None) -> Optional[Path]:
+    if docs_root is not None:
+        return Path(docs_root)
+    candidate = Path.cwd() / "docs" / "design"
+    return candidate if (candidate / "agent_skill_evaluation.md").is_file() else None
+
+
+def _try_parse_frontmatter(skill_file: Path) -> dict[str, Any]:
+    try:
+        return parse_skill_frontmatter(skill_file)
+    except Exception:
+        return {}
+
+
+def _skill_body(text: str) -> str:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[index + 1 :])
+    return text
+
+
+def _load_evals(evals_path: Path) -> tuple[list[dict[str, Any]], Optional[str]]:
+    if not evals_path.is_file():
+        return [], None
+    if _is_oversized_text_file(evals_path):
+        return [], f"evals/evals.json exceeds size limit ({MAX_SKILL_TEXT_FILE_BYTES} bytes)"
+    try:
+        raw = json.loads(evals_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        return [], f"failed to parse evals/evals.json: {e}"
+    if isinstance(raw, dict):
+        items = raw.get("evals", [])
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return [], "evals/evals.json must be an object with an evals list or a list"
+    if not isinstance(items, list):
+        return [], "evals/evals.json field 'evals' must be a list"
+    evals = [item for item in items if isinstance(item, dict)]
+    if len(evals) != len(items):
+        return evals, "each evals/evals.json entry must be an object"
+    return evals, None
+
+
+def _add_evals_error(context: LintContext, lint_id: str, record: SkillRecord) -> None:
+    context.findings.append(
+        _finding(
+            lint_id,
+            FINDING_ERROR,
+            record.evals_path,
+            record.evals_error or "evals/evals.json is invalid",
+            "Use guide-compatible JSON with an evals list.",
+            code="skill-evals-invalid",
+            skill=record.name,
+        )
+    )
+
+
+def _public_records(records: list[SkillRecord]) -> list[SkillRecord]:
+    return [record for record in records if record.public]
+
+
+def _is_positive_eval(item: dict[str, Any], skill_name: str) -> bool:
+    nvflare = _nvflare_ext(item)
+    if nvflare.get("expected_skill") == skill_name:
+        return True
+    tags = _eval_tags(item)
+    return "positive" in tags or "positive-trigger" in tags
+
+
+def _is_adjacent_negative_eval(item: dict[str, Any], skill_name: str) -> bool:
+    nvflare = _nvflare_ext(item)
+    if nvflare.get("negative_for") == skill_name:
+        return True
+    tags = _eval_tags(item)
+    return "adjacent-negative" in tags or "adjacent_negative" in tags
+
+
+def _is_global_negative_eval(item: dict[str, Any]) -> bool:
+    nvflare = _nvflare_ext(item)
+    expected_skill = nvflare.get("expected_skill")
+    if expected_skill is None and "expected_skill" in nvflare:
+        return True
+    if isinstance(expected_skill, str) and expected_skill.lower() in {"none", "no-skill", "no_skill"}:
+        return True
+    if nvflare.get("negative_for") == "*":
+        return True
+    tags = _eval_tags(item)
+    text = _eval_text(item).lower()
+    return "global-negative" in tags or "global_negative" in tags or "trigger no flare skill" in text
+
+
+def _eval_tags(item: dict[str, Any]) -> set[str]:
+    values = item.get("tags", [])
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return set()
+    return {str(value).strip().lower() for value in values}
+
+
+def _nvflare_ext(item: dict[str, Any]) -> dict[str, Any]:
+    nvflare = item.get("nvflare", {})
+    return nvflare if isinstance(nvflare, dict) else {}
+
+
+def _behavior_id_count(item: dict[str, Any]) -> int:
+    nvflare = _nvflare_ext(item)
+    count = 0
+    for key in ("mandatory_behavior", "optional_behavior", "prohibited_behavior"):
+        values = nvflare.get(key, [])
+        if isinstance(values, list):
+            count += len(values)
+    return count
+
+
+def _process_metrics(item: dict[str, Any]) -> list[Any]:
+    nvflare = _nvflare_ext(item)
+    metrics = nvflare.get("process_metrics", [])
+    return metrics if isinstance(metrics, list) else [metrics]
+
+
+def _eval_text(item: dict[str, Any]) -> str:
+    parts = [str(item.get("id", "")), str(item.get("prompt", "")), str(item.get("expected_output", ""))]
+    assertions = item.get("assertions", [])
+    if isinstance(assertions, list):
+        parts.extend(str(assertion) for assertion in assertions)
+    return "\n".join(parts)
+
+
+def _records_overlap(left: SkillRecord, right: SkillRecord, token_cache: dict[str, set[str]] | None = None) -> bool:
+    token_cache = token_cache or {}
+    left_tokens = token_cache[left.name] if left.name in token_cache else _trigger_tokens(left)
+    right_tokens = token_cache[right.name] if right.name in token_cache else _trigger_tokens(right)
+    if not left_tokens or not right_tokens:
+        return False
+    shared = left_tokens.intersection(right_tokens)
+    smaller = min(len(left_tokens), len(right_tokens))
+    return len(shared) >= 4 and (len(shared) / smaller) >= 0.35
+
+
+def _trigger_tokens(record: SkillRecord) -> set[str]:
+    prompts = "\n".join(str(item.get("prompt", "")) for item in record.evals)
+    text = f"{record.metadata.get('description', '')}\n{prompts}"
+    return {
+        token
+        for token in _SIGNIFICANT_TOKEN_RE.findall(text.lower())
+        if token not in _STOPWORDS and not token.startswith("nvflare")
+    }
+
+
+def _has_boundary_text(record: SkillRecord) -> bool:
+    text = f"{record.metadata.get('description', '')}\n{record.body}".lower()
+    return any(term in text for term in _BOUNDARY_TERMS)
+
+
+def _has_adjacent_negative_pair(left: SkillRecord, right: SkillRecord) -> bool:
+    return any(_negative_for_neighbor(item, left.name, right.name) for item in left.evals) or any(
+        _negative_for_neighbor(item, right.name, left.name) for item in right.evals
+    )
+
+
+def _negative_for_neighbor(item: dict[str, Any], skill_name: str, neighbor_name: str) -> bool:
+    nvflare = _nvflare_ext(item)
+    return nvflare.get("negative_for") == skill_name and nvflare.get("expected_skill") == neighbor_name
+
+
+def _category_map(context: LintContext) -> dict[str, str]:
+    if context.docs_root is None or not context.docs_root.is_dir():
+        return {}
+    product = _parse_product_catalog(context.docs_root / "agent_integration.md")
+    return {skill: row["category"] for skill, row in product.items()}
+
+
+def _parse_product_catalog(path: Path) -> dict[str, dict[str, str]]:
+    text = _read_bounded_text(path)
+    if text is None:
+        return {}
+    rows = {}
+    in_table = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Category | Skill | Tier | Purpose |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            break
+        if set(stripped.replace("|", "").replace("-", "").replace(" ", "")) == set():
+            continue
+        columns = [column.strip() for column in stripped.strip("|").split("|")]
+        if len(columns) < 4 or columns[0] == "Category":
+            continue
+        skill = _strip_backticks(columns[1])
+        if skill:
+            rows[skill] = {"category": columns[0], "tier": columns[2]}
+    return rows
+
+
+def _parse_conversion_table(path: Path) -> dict[str, str]:
+    text = _read_bounded_text(path)
+    if text is None:
+        return {}
+    rows = {}
+    in_table = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Code Family | Skill | Scope | Current Repo Evidence | Tier |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            break
+        columns = [column.strip() for column in stripped.strip("|").split("|")]
+        if len(columns) < 5 or columns[0] == "Code Family" or columns[0].startswith("---"):
+            continue
+        skill = _strip_backticks(columns[1])
+        if skill:
+            rows[skill] = columns[4]
+    return rows
+
+
+def _strip_backticks(value: str) -> str:
+    return value.strip().strip("`")
+
+
+def _extract_nvflare_commands(text: str) -> list[tuple[int, str]]:
+    commands = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        matches = list(_BACKTICK_NVFLARE_RE.finditer(line))
+        if matches:
+            commands.extend((line_no, match.group(1).strip()) for match in matches)
+            continue
+        index = line.find("nvflare ")
+        if index == -1:
+            continue
+        commands.append((line_no, _trim_command(line[index:])))
+    return commands
+
+
+def _trim_command(text: str) -> str:
+    text = text.strip()
+    for separator in ("&&", "|", ";"):
+        if separator in text:
+            text = text.split(separator, 1)[0].strip()
+    return text
+
+
+def _command_drift_message(command: str, *, check_flags: bool = True, allow_planned: bool = False) -> Optional[str]:
+    tokens = _command_tokens(command)
+    if not tokens or tokens[0] != "nvflare":
+        return None
+    positional = [token for token in tokens[1:] if not token.startswith("-") and not _looks_like_value(token)]
+    if not positional:
+        return None
+    root = positional[0]
+    if root not in _KNOWN_NVFLARE_ROOT_COMMANDS:
+        return f"unknown nvflare command root '{root}' in '{command}'"
+    if root != "agent":
+        return None
+
+    if len(positional) >= 2 and positional[1] not in _KNOWN_AGENT_COMMANDS:
+        return f"unknown nvflare agent command '{positional[1]}' in '{command}'"
+    if len(positional) >= 3 and positional[1] == "skills":
+        skills_command = positional[2]
+        if skills_command not in _KNOWN_AGENT_SKILLS_COMMANDS:
+            if not allow_planned or skills_command not in _PLANNED_AGENT_SKILLS_COMMANDS:
+                return f"unknown nvflare agent skills command '{skills_command}' in '{command}'"
+
+    command_key = " ".join(positional[:3] if len(positional) >= 3 and positional[1] == "skills" else positional[:2])
+    allowed_flags = _KNOWN_AGENT_FLAGS.get(command_key, _KNOWN_AGENT_FLAGS.get(root, set()))
+    if check_flags:
+        for token in tokens:
+            if token.startswith("--"):
+                flag = token.split("=", 1)[0]
+                if flag not in allowed_flags:
+                    return f"unknown flag '{flag}' for 'nvflare {command_key}' in '{command}'"
+    return None
+
+
+def _command_tokens(command: str) -> list[str]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return []
+    try:
+        start = tokens.index("nvflare")
+    except ValueError:
+        return []
+    command_tokens = []
+    for token in tokens[start:]:
+        if token in {"&&", "|", ";"}:
+            break
+        if not _safe_command_token(token):
+            break
+        command_tokens.append(token)
+    return command_tokens
+
+
+def _safe_command_token(token: str) -> bool:
+    return bool(_SAFE_COMMAND_TOKEN_RE.match(token))
+
+
+def _looks_like_value(token: str) -> bool:
+    return token.startswith("<") or "/" in token or token in {"on", "off", "json", "jsonl", "human"}
+
+
+def _skill_has_helper_tests(skill_dir: Path) -> bool:
+    tests_dir = skill_dir / "tests"
+    if tests_dir.is_dir() and any(True for _path in _iter_files_no_follow(tests_dir)):
+        return True
+    return any(path.name.endswith(("_test.py", ".test.py")) for path in _iter_files_no_follow(skill_dir))
+
+
+def _skill_text_contains(skill_dir: Path, needle: str) -> bool:
+    needle = needle.lower()
+    return any(needle in text.lower() for _, text in _iter_skill_text_files(skill_dir))
+
+
+def _iter_skill_text_files(skill_dir: Path, *, include_scripts: bool = False) -> Iterable[tuple[Path, str]]:
+    candidates = [skill_dir / SKILL_FILE_NAME]
+    references_dir = skill_dir / "references"
+    if references_dir.is_dir():
+        candidates.extend(
+            path for path in _iter_files_no_follow(references_dir) if path.suffix.lower() in {".md", ".txt"}
+        )
+    if include_scripts:
+        scripts_dir = skill_dir / "scripts"
+        if scripts_dir.is_dir():
+            candidates.extend(_iter_files_no_follow(scripts_dir))
+    for path in candidates:
+        if path.is_file():
+            try:
+                if path.stat().st_size > MAX_SKILL_TEXT_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            yield path, path.read_text(encoding="utf-8", errors="replace")
+
+
+def _eval_mentions_file_editing(item: dict[str, Any]) -> bool:
+    text = _eval_text(item).lower()
+    patterns = (
+        r"\b(?:edit|modify|update|rewrite|write|create|generate|export)s?\s+(?:a\s+|an\s+|the\s+)?file\b",
+        r"\b(?:edit|modify|update|rewrite|write|create|generate|export)s?\s+(?:source|code|artifact)s?\b",
+        r"\b(?:file|artifact)s?\s+(?:is|are|must be|should be)?\s*(?:created|generated|written|exported|modified)\b",
+        r"\boutput\s+(?:file|artifact|directory)\b",
+    )
+    return any(re.search(pattern, text) for pattern in patterns)
+
+
+def _has_files(path: Path) -> bool:
+    return path.is_dir() and any(True for _child in _iter_files_no_follow(path))
+
+
+def _iter_files_no_follow(root: Path) -> Iterable[Path]:
+    if root.is_symlink() or not root.is_dir():
+        return
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = sorted(name for name in dirnames if not (Path(dirpath) / name).is_symlink())
+        for filename in sorted(filenames):
+            path = Path(dirpath) / filename
+            if path.is_file():
+                yield path
+
+
+def _has_fixture_notes(skill_dir: Path) -> bool:
+    note_paths = (
+        skill_dir / "evals" / "README.md",
+        skill_dir / "evals" / "files" / "README.md",
+        skill_dir / "evals" / "files" / "SOURCE.md",
+    )
+    return any(path.is_file() for path in note_paths)
+
+
+def _read_bounded_text(path: Path) -> Optional[str]:
+    if not path.is_file():
+        return None
+    if _is_oversized_text_file(path):
+        return None
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _is_oversized_text_file(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > MAX_SKILL_TEXT_FILE_BYTES
+    except OSError:
+        return False
+
+
+def _has_bounded_size_exception(path: Path) -> bool:
+    try:
+        with path.open("rb") as stream:
+            prefix = stream.read(16 * 1024)
+    except OSError:
+        return False
+    return _has_size_exception(prefix.decode("utf-8", errors="replace"))
+
+
+def _iter_existing_doc_files(docs_root: Path) -> Iterable[Path]:
+    for name in _DOC_FILES:
+        path = docs_root / name
+        if path.is_file():
+            yield path
+
+
+def _iter_markdown_links(text: str) -> Iterable[tuple[int, str]]:
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for match in _MARKDOWN_LINK_RE.finditer(line):
+            yield line_no, match.group(1).strip()
+
+
+def _markdown_anchors(text: str) -> set[str]:
+    anchors = set()
+    for line in text.splitlines():
+        if not line.startswith("#"):
+            continue
+        heading = line.lstrip("#").strip()
+        if heading:
+            anchors.add(_normalize_anchor(heading))
+    return anchors
+
+
+def _normalize_anchor(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"`([^`]+)`", r"\1", value)
+    value = re.sub(r"[^a-z0-9 _-]", "", value)
+    value = value.replace(" ", "-")
+    value = re.sub(r"-+", "-", value)
+    return value.strip("-")
+
+
+def _line_for_frontmatter_issue(skill_file: Path, code: str, message: str) -> Optional[int]:
+    if code == "skill-frontmatter-field-required":
+        match = re.search(r"field '([^']+)'", message)
+        if match:
+            return _line_for_field(skill_file, match.group(1))
+    if code in {"skill-name-directory-mismatch", "skill-blast-radius-invalid", "skill-frontmatter-field-type"}:
+        for field in ("name", "blast_radius", "description", "min_flare_version"):
+            if field in message:
+                return _line_for_field(skill_file, field)
+    return 1 if skill_file.is_file() else None
+
+
+def _line_for_field(skill_file: Path, field: str) -> Optional[int]:
+    if not skill_file.is_file():
+        return None
+    if _is_oversized_text_file(skill_file):
+        return 1
+    prefix = f"{field}:"
+    for line_no, line in enumerate(skill_file.read_text(encoding="utf-8-sig", errors="replace").splitlines(), start=1):
+        if line.strip().startswith(prefix):
+            return line_no
+    return 1
+
+
+def _has_size_exception(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _SIZE_EXCEPTION_MARKERS)
+
+
+def _skip(context: LintContext, check: str, reason: str) -> None:
+    context.skipped_checks.append({"id": check, "reason": reason})
+
+
+def _finding(
+    lint_id: str,
+    severity: str,
+    path: Path,
+    message: str,
+    hint: str,
+    *,
+    line: Optional[int] = None,
+    code: Optional[str] = None,
+    skill: Optional[str] = None,
+    global_finding: bool = False,
+) -> LintFinding:
+    return LintFinding(
+        id=lint_id,
+        severity=severity,
+        file=str(path),
+        line=line,
+        message=message,
+        hint=hint,
+        code=code,
+        skill=skill,
+        global_finding=global_finding,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "versioneer"]
+requires = ["setuptools>=61.0", "wheel", "versioneer", "PyYAML>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]
@@ -8,7 +8,14 @@ profile = "black"
 multi_line_output = 3
 line_length = 120
 skip = [".git", ".eggs", "venv", ".venv", "versioneer.py", "_version.py", "conf.py", "nvflare/__init__.py"]
-skip_glob = [ "*.pyi", "**/*_pb2*" ]
+skip_glob = [
+    "*.pyi",
+    "**/*_pb2*",
+    "tests/agent_benchmark/results/*",
+    "tests/agent_benchmark/results/**",
+    "assist_tools/skills_benchmark/results/*",
+    "assist_tools/skills_benchmark/results/**",
+]
 
 [tool.black]
 line-length = 120
@@ -29,6 +36,8 @@ exclude = '''
     | buck-out
     | build
     | dist
+    | tests/agent_benchmark/results
+    | assist_tools/skills_benchmark/results
   )/
   | .pb2.
   | _version.py

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ import shutil
 
 from setuptools import find_packages, setup
 
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__)) if "__file__" in globals() else os.getcwd()
+
 
 def load_local_versioneer():
-    root = os.path.abspath(os.path.dirname(__file__)) if "__file__" in globals() else os.getcwd()
-    versioneer_path = os.path.join(root, "versioneer.py")
+    versioneer_path = os.path.join(ROOT_DIR, "versioneer.py")
     spec = importlib.util.spec_from_file_location("nvflare_local_versioneer", versioneer_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Failed to load versioneer from {versioneer_path}")
@@ -31,7 +32,19 @@ def load_local_versioneer():
     return module
 
 
+def load_local_module(module_name, module_path):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 versioneer = load_local_versioneer()
+agent_skill_manifest = load_local_module(
+    "nvflare_agent_skill_manifest", os.path.join(ROOT_DIR, "nvflare", "tool", "agent", "skill_manifest.py")
+)
 
 # read the contents of your README file
 
@@ -83,17 +96,73 @@ def remove_dir(target_path):
         shutil.rmtree(target_path)
 
 
+def _package_agent_skills_enabled():
+    value = os.environ.get("NVFLARE_PACKAGE_AGENT_SKILLS", "1").strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _no_skills_wheel_build_tag():
+    return os.environ.get("NVFLARE_NO_SKILLS_WHEEL_BUILD_TAG", "1no_skills").strip()
+
+
 extra_files = package_files(root="nvflare/dashboard/application", starting="static")
 tmp_job_template_folder = "./nvflare/tool/job/templates"
 copy_package(src_dir="job_templates", dst_dir=tmp_job_template_folder)
 job_templates = package_files(root="nvflare/tool/job", starting="templates")
 deploy_templates = package_files(root="nvflare/tool/deploy", starting="templates")
+agent_skill_package_data = ["manifest.json", "*", "*/*", "*/*/*", "*/*/*/*", "*/*/*/*/*"]
+
+cmdclass = versioneer.get_cmdclass()
+_base_build_py = cmdclass["build_py"]
+
+
+class AgentSkillsBuildPy(_base_build_py):
+    def run(self):
+        super().run()
+        bundle_root = os.path.join(self.build_lib, "nvflare", "tool", "agent", "bundled_skills")
+        if _package_agent_skills_enabled():
+            agent_skill_manifest.copy_released_skills_to_bundle(
+                os.path.join(ROOT_DIR, "skills"),
+                bundle_root,
+                nvflare_version=version,
+            )
+        else:
+            agent_skill_manifest.write_empty_skill_bundle(
+                bundle_root,
+                nvflare_version=version,
+            )
+
+
+cmdclass["build_py"] = AgentSkillsBuildPy
+
+
+def _agent_skills_bdist_wheel_cmd():
+    try:
+        from setuptools.command.bdist_wheel import bdist_wheel
+    except ImportError:
+        try:
+            from wheel.bdist_wheel import bdist_wheel
+        except ImportError:
+            return None
+
+    class AgentSkillsBdistWheel(bdist_wheel):
+        def finalize_options(self):
+            if not _package_agent_skills_enabled() and not self.build_number:
+                self.build_number = _no_skills_wheel_build_tag()
+            super().finalize_options()
+
+    return AgentSkillsBdistWheel
+
+
+_bdist_wheel_cmd = _agent_skills_bdist_wheel_cmd()
+if _bdist_wheel_cmd is not None:
+    cmdclass["bdist_wheel"] = _bdist_wheel_cmd
 
 
 setup(
     name=package_name,
     version=version,
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclass,
     package_dir={"nvflare": "nvflare"},
     packages=find_packages(
         where=".",
@@ -107,6 +176,7 @@ setup(
         "nvflare.dashboard.application": extra_files,
         "nvflare.tool.job": job_templates,
         "nvflare.tool.deploy": deploy_templates,
+        "nvflare.tool.agent.bundled_skills": agent_skill_package_data,
     },
     include_package_data=True,
 )

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,42 @@
+# NVFLARE Agent Skills
+
+This directory contains NVFLARE-owned agent skills for supported coding agents.
+
+Each skill lives in its own directory with a `SKILL.md` file. Skills may also
+include supporting references, evaluation fixtures, and benchmark notes:
+
+```text
+skills/
+  nvflare-your-skill/
+    SKILL.md
+    references/
+    evals/
+      evals.json
+      files/
+    BENCHMARK.md
+```
+
+Directories whose names start with `_`, such as `_shared/`, are reference-only
+support content. They are not installable skills and do not contain `SKILL.md`.
+
+Required `SKILL.md` frontmatter fields:
+
+```yaml
+---
+name: nvflare-your-skill
+description: Short trigger-oriented description.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+```
+
+The skill name above is illustrative; actual skill directories use their
+published skill names.
+
+`blast_radius` must be one of:
+
+- `read_only`
+- `edits_files`
+- `runs_simulator`
+- `submits_poc`
+- `submits_production`

--- a/skills/_shared/nvflare-experiment-workflows.md
+++ b/skills/_shared/nvflare-experiment-workflows.md
@@ -1,0 +1,113 @@
+# Shared NVFLARE Experiment Workflow Guidance
+
+Use this reference for framework-agnostic reruns, recipe comparisons, data
+replacement, data distribution, synthetic data, and site heterogeneity requests.
+
+## Iterative Reruns
+
+When the user asks to change batch size, train args, number of rounds,
+`min_clients`, site count, or recipe, update only the affected training args or
+job configuration. For recipe changes, rerun
+`nvflare recipe show <recipe-name> --format json` and verify the new recipe's
+parameters before editing.
+
+After each change, rerun local validation when possible. If an exported job was
+previously produced and export remains in scope, export again so the job folder
+matches the updated source.
+
+## Recipe Search And Accuracy Comparison
+
+When the user asks for the best recipe or best accuracy, first define the target
+metric, validation split, maximum run budget, and compatible recipe set. Do not
+promise that one recipe is best without measured evidence from comparable runs.
+
+Keep dataset split, number of sites, rounds, epochs, seed, and evaluation metric
+comparable unless the user asks to tune them. Report a small results table with
+recipe, settings, metric value, command, status, and result path. If a candidate
+cannot run, report the blocker instead of silently dropping it.
+
+## Data Distribution Experiments
+
+When the user asks to compare IID and heterogeneous data splits, define the split
+strategy before editing. Examples include equal random IID shards, label-skewed
+non-IID shards, quantity-skewed shards, or user-provided per-site partitions.
+
+Keep recipe, rounds, epochs, batch size, seed, and metric comparable unless the
+user asks to tune them. Do not copy private data into generated artifacts; prefer
+split indices, deterministic samplers, or site-local path arguments.
+
+Report split strategy, per-site sample counts or label summary when available,
+metric value, command, status, and result path.
+
+## Dataset Replacement Experiments
+
+When the user provides a dataset URL and asks to repeat an experiment, record
+the URL, dataset name when known, version or timestamp when available, expected
+download size if known, license or access constraints when visible, and local
+cache/path used for validation.
+
+Do not hide download, preprocessing, schema, or label-mapping assumptions. Keep
+recipe, site count, rounds, epochs, batch size, seed, split policy, and metric
+comparable unless the user asks to tune them. If the new dataset requires a data
+loader or preprocessing change, keep it scoped and report the changed files.
+
+Follow the project's existing data-prep structure. If it already has
+`download_data.py`, `prepare_data.py`, `prepare_data.sh`, or equivalent helpers,
+extend those rather than creating a parallel structure. If no helper exists and
+a new one is needed, use the established NVFLARE example convention of separate
+download and prepare/split steps, and keep download paths, cache paths, and
+per-site output directories explicit.
+
+Use hello-world examples as the first convention reference for new helpers:
+`examples/hello-world/hello-lr/download_data.py`,
+`examples/hello-world/hello-lr/prepare_data.py`,
+`examples/hello-world/hello-jax/prepare_data.py`, and shell-based examples such
+as `examples/hello-world/hello-cyclic/prepare_data.sh`.
+
+## Synthetic Per-Site Data
+
+When the user asks for synthetic data per site, add a deterministic data
+generation step only after the expected data schema is clear from the model
+input, transforms, loss function, and data loader, or from a user-provided data
+generation spec.
+
+If modality, schema, label semantics, target distribution, missingness/noise,
+site heterogeneity, expected metric, or generation library is not clear, ask the
+user for a data generation spec or an approved generator/library before creating
+data. The spec should name modality, shape or columns, label or target
+definition, class balance or value distributions, missing-data and noise
+assumptions, per-site distribution differences, sample counts, seed, and
+expected metric interpretation.
+
+Do not invent labels, features, class balance, missingness, site skew, or
+expected accuracy. If the user supplies a generator or domain-specific synthetic
+data tool, wire it into the existing data-prep flow and record the tool, version
+or command, seed, and parameters used.
+
+Prefer extending existing `prepare_data.py`, `prepare_data.sh`, or equivalent
+helpers. If a separate generator is needed, keep it under the same data-prep
+structure and call it from the prepare step.
+
+Generated site data should be written to explicit per-site outputs that the job
+can pass as site-specific data paths. Treat synthetic validation as a smoke test
+of wiring and training execution unless the user provides a synthetic data spec
+with meaningful expected metrics.
+
+## Site-Specific Training Heterogeneity
+
+When the user asks to simulate different site speeds or training
+hyperparameters, prefer per-site arguments or per-site config in `job.py`.
+Examples include per-site learning rate, batch size, local epochs, sleep/delay
+for speed simulation, dataset shard, or workload size.
+
+Only create site-specific training scripts when arguments/config cannot express
+the requested behavior. If scripts are split, keep shared model and training
+helpers common and report why script splitting was necessary. Report each
+site's settings, command, status, metric, and result path.
+
+## Common Gaps To Report
+
+- The source training script has side effects at import time.
+- The model has non-serializable state outside framework-native model state.
+- The dataset path is site-specific and cannot be validated locally.
+- The job file has no export path yet.

--- a/skills/_shared/nvflare-job-lifecycle.md
+++ b/skills/_shared/nvflare-job-lifecycle.md
@@ -1,0 +1,138 @@
+# Shared NVFLARE Job Lifecycle Guidance
+
+Use this reference for framework-agnostic conversion, validation, export, and
+POC handoff behavior. Framework skills should combine it with framework-specific
+model, training-loop, and aggregation guidance.
+
+## Natural Request Parsing
+
+Users may describe work in product terms, for example: "Here is my training
+code. Convert it to FLARE FL code, run it with 3 simulated sites on this
+dataset, split the dataset evenly, use FedAvg, and train for 3 rounds."
+
+Extract recipe intent, site count, rounds, dataset path, split policy, training
+arguments, validation intent, and approval boundaries before asking follow-up
+questions. Ask only when a missing value changes the generated job or runtime
+behavior.
+
+## Generated Job Layout
+
+Create generated FLARE source in a separate job folder unless the user asks for
+in-place conversion. Prefer `<project>/nvflare_jobs/<job_name>/` for source
+files and standard names such as `client.py`, `job.py`, `model.py`,
+`requirements.txt`, and small config files. Preserve the original training
+files as references instead of renaming or overwriting them.
+
+Do not put exported jobs, simulation workspaces, generated model artifacts, or
+temporary vocab/cache files in the original source root by default. Use explicit
+runtime locations under `/tmp/nvflare/` unless the user provides another path:
+
+- exported job config: `/tmp/nvflare/job_config/<job_name>/`;
+- simulation workspace: `/tmp/nvflare/workspaces/<job_name>/`;
+- generated validation outputs or evaluation records:
+  `/tmp/nvflare/results/<job_name>/`.
+
+## Local Validation
+
+- Use `python job.py` for local recipe or SimEnv validation when the generated
+  job file supports direct execution.
+- Prefer synthetic data flags or small fixtures when the original dataset is
+  unavailable.
+- Dependency installation is recipe-, framework-, and algorithm-independent and
+  applies to all generated NVFLARE jobs.
+- Before treating dependency or import failures as blockers, discover
+  source-provided dependency files such as `requirements.txt`,
+  `requirements-train.txt`, or other `requirements*.txt` files needed by the
+  training code. Install the applicable files into the active validation
+  environment with
+  `python -m pip install -r <requirements-file>` or the repository's documented
+  equivalent, then rerun the failed compile, import, export, or simulation
+  check.
+- Report missing dependencies as blockers only when no applicable dependency
+  file exists, dependency installation fails, the requirement needs unavailable
+  system/GPU resources, or user approval/network access is required and not
+  available.
+- Report command, status, result directory, and dependency or data blockers.
+
+## Preflight Before Full Simulation
+
+Before `python job.py`, run cheap checks first:
+
+- Install applicable source-provided Python requirement files for the training
+  code before running import-sensitive checks.
+- Compile generated Python files.
+- Construct the recipe and export to a temporary directory.
+- Inspect exported server config for model path and constructor args.
+- Verify `app/custom` includes files imported by server and client code; add
+  explicit file packaging only when export misses a required file.
+- Check server/client model `state_dict` compatibility.
+
+Use preflight results to fix packaging, config, or model-state issues before
+spending time on full simulation.
+
+## Export
+
+- Use `python job.py --export --export-dir <dir>` to export a generated job.
+  These are NVFLARE job system arguments across recipes, algorithms, and
+  frameworks. Do not declare them as generated job-local arguments.
+- If a generated `job.py` defines local command-line options, its local parser
+  must tolerate NVFLARE system arguments such as `--export` and `--export-dir`.
+  With `argparse`, use `parse_known_args()` or an equivalent approach. Do not
+  add local `--export` or `--export-dir` arguments, and do not let local parsing
+  reject or consume them before the NVFLARE job/export layer handles export.
+  Treat this as a generation-time requirement; validation should confirm the
+  behavior rather than discovering it through a failed export.
+- Default `<dir>` to `/tmp/nvflare/job_config/<job_name>` unless the user
+  provides an export directory.
+- If writing explicit Job API code without a recipe execution helper, call
+  `job.export_job(<dir>)` directly when needed.
+- Inspect the exported folder for server/client app folders and expected config
+  files before recommending submission.
+
+## Validation Evidence
+
+Before calling a generated job correct, report:
+
+- selected recipe and the `nvflare recipe show` command used to inspect it;
+- changed files and why they were changed;
+- local validation command and pass/fail status;
+- export command, export directory, and exported folder inspection result when
+  export is in scope;
+- metric values or a clear explanation that metrics were unavailable;
+- exact result paths, including simulation workspace, generated result files,
+  logs, and global-model artifact paths used as evidence;
+- unresolved blockers such as unavailable data, missing dependencies, or
+  required user approval.
+
+If `python job.py` cannot run, the conversion may still be saved as a draft, but
+report it as unvalidated and name the concrete blocker.
+
+## POC Handoff
+
+Users may approve a runtime handoff after simulation, for example: "Simulation
+looks good. Start POC and submit the exported job" or "I have a POC workspace
+here; submit the job to it."
+
+Treat this as explicit POC approval. Validate the exported job folder first,
+then use the supplied POC workspace or start POC as requested, submit the job,
+and wait or monitor if requested.
+
+Report the POC workspace, submitted job folder, job ID, final status or current
+status, command evidence, and log/result paths. If the POC run fails, record the
+failure as evaluation evidence.
+
+## Approval Boundary
+
+POC or production submission is outside a conversion skill's default action.
+Ask for explicit user approval before using submit or runtime-start commands.
+
+## Evaluation Records
+
+When a generated job does not run as expected, keep the failure as evaluation
+evidence instead of treating it as a one-off note. Record the user request,
+selected recipe, files changed, validation command, failure output summary,
+root-cause hypothesis, and follow-up fix or blocker.
+
+If the failure represents a repeatable skill gap, add or update an eval case,
+benchmark gap, fixture, or reference note so future skill runs are tested
+against the same scenario.

--- a/skills/nvflare-convert-pytorch/BENCHMARK.md
+++ b/skills/nvflare-convert-pytorch/BENCHMARK.md
@@ -1,0 +1,40 @@
+# Benchmark Summary
+
+Status: draft/internal pending Milestone 11 runtime evaluation.
+
+Skill version: 0.1.0
+FLARE version: 2.8.0 minimum
+
+## Initial Checks
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Positive trigger | Draft | `pytorch-convert-basic` covers natural PyTorch-to-FL conversion with FedAvg simulation settings. |
+| POC handoff trigger | Draft | `pytorch-approved-poc-handoff` covers explicit post-simulation POC approval with a provided workspace. |
+| Iterative rerun trigger | Draft | `pytorch-iterative-rerun` covers scoped hyperparameter and recipe changes followed by validation. |
+| Recipe search trigger | Draft | `pytorch-recipe-search` covers bounded recipe comparison without unmeasured best-recipe claims. |
+| Data distribution trigger | Draft | `pytorch-data-distribution-rerun` covers IID/non-IID split experiments with comparable result reporting. |
+| Dataset URL rerun trigger | Draft | `pytorch-dataset-url-rerun` covers repeating experiments with a user-provided dataset URL. |
+| Synthetic data trigger | Draft | `pytorch-synthetic-site-data` covers deterministic synthetic per-site generation and validation. |
+| Site heterogeneity trigger | Draft | `pytorch-site-specific-training` covers per-site speed and hyperparameter simulation. |
+| Adjacent negative trigger | Draft | Lightning prompt routes away from this skill. |
+| Global negative trigger | Draft | Kubernetes deployment prompt routes away from this skill. |
+| Mandatory behavior | Draft | Behavior IDs cover inspect-first, model constructor argument auditing, natural request parsing, recipe discovery, recipe selection from FL intent, scoped edits, standard generated layout, `/tmp/nvflare` runtime outputs, Client API exchange, local validation, validation evidence reporting, and failed-validation eval records. |
+| Prohibited behavior | Draft | Behavior IDs prohibit production submit, private data copying, and CLI-wrapper Python. |
+| Process metrics | Draft | Metrics cover first-pass acceptance, turns to acceptable, user correction count, layout violations, and validation evidence completeness. |
+
+## Observed Process Runs
+
+| Case | Status | Process Observation | Notes |
+| --- | --- | --- | --- |
+| AMES PyTorch FedAvg conversion | Informal/ad hoc | Required user correction | Functional conversion and simulation completed, but first pass used `fl_train.py` instead of `client.py`, wrote export/workspace artifacts under the project root, and required user correction. The skill was updated to add standard-layout, `/tmp/nvflare` output, and result-evidence guardrails. |
+
+## Known Gaps
+
+- Repeated runtime agent-performance measurement has not been run yet.
+- The AMES row above is an informal process observation from a real conversion
+  exercise, not a formal score.
+- The seed skill targets standard PyTorch loops only, not Lightning,
+  Hugging Face Trainer, TensorFlow, XGBoost, sklearn, or custom NumPy loops.
+- Export validation uses NVFLARE job system arguments; no job-local export argument
+  definition is required.

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: nvflare-convert-pytorch
+description: "Convert existing PyTorch training code into an NVFLARE federated job using Client API model exchange, local validation, and job export; do not use for other frameworks or deployment-only tasks."
+min_flare_version: "2.8.0"
+blast_radius: edits_files
+skill_version: "0.1.0"
+---
+
+# NVFLARE Convert PyTorch
+
+## Use When
+
+Use when the user asks to convert an existing PyTorch training script,
+`torch.nn.Module`, `state_dict` workflow, data loader, checkpoint, or metric
+loop into an NVFLARE federated training job.
+
+## Do Not Use When
+
+Do not use for PyTorch Lightning, Hugging Face Trainer, TensorFlow, XGBoost,
+scikit-learn, Kubernetes deployment, production submission, or generic PyTorch
+debugging that does not ask for FLARE conversion.
+
+## Workflow
+
+1. Run `nvflare agent inspect <path> --format json` before editing.
+2. Identify the model definition, required `nn.Module.__init__` arguments,
+   training loop, data loading, metrics, and checkpoint behavior. Determine the
+   concrete constructor values that server and client models must share before
+   creating `job.py`.
+3. Run `nvflare recipe list --framework pytorch --format json` and select the
+   recipe from the requested FL workflow, not from PyTorch alone. Use FedAvg
+   only for standard horizontal model-parameter aggregation.
+   For standard FedAvg, use the portable fast path in
+   `references/recipe-selection.md`; do not add per-site recipe config unless
+   the sites actually need different training scripts, arguments, or launch
+   settings.
+4. Use the user-requested target location for the converted FLARE job source.
+5. Use the standard generated source names `client.py`, `job.py`, and `model.py`
+   when model code is copied or wrapped. Keep original files such as `train.py`
+   as source references unless the user explicitly asks to rewrite them.
+6. Convert training exchange to the FLARE Client API: initialize FLARE, receive
+   an `FLModel`, load `params` into the PyTorch model, train or evaluate, and
+   send an `FLModel` with updated `params`, metrics, and useful metadata.
+7. Add or update a `job.py` that uses the selected PyTorch recipe or job API
+   path for local simulation and export. Follow the shared job lifecycle
+   guidance for generated job layout, validation, and export system arguments.
+8. Validate locally with `python job.py` and export with
+   `python job.py --export --export-dir /tmp/nvflare/job_config/<job_name>`
+   using NVFLARE job system arguments. Keep simulation workspaces and generated
+   runtime outputs under `/tmp/nvflare/` unless the user provides another path.
+
+## Requirements
+
+- Must keep edits scoped to training, model, job, and small config files.
+- Must audit model constructor arguments before writing `job.py`. If the model
+  has required non-default `__init__` parameters, generate explicit recipe model
+  config with `path` or `class_path` and `args`, then verify recipe
+  construction and export preserve those arguments.
+- Must preserve user data paths and require user confirmation before changing
+  them.
+- Must translate natural user requests into concrete recipe, site-count,
+  dataset, split, training, validation, and export settings.
+- Must prefer synthetic or fixture data for validation when the original dataset is
+  unavailable.
+- Must report recipe choice, validation commands, export status, and remaining
+  blockers before calling the conversion complete.
+- Must report metric values or explain why metrics are unavailable, including
+  the exact simulation workspace, result file, log, or global-model path used as
+  evidence.
+- Must not submit to POC or production without explicit user approval.
+- Must not generate Python solely to wrap `nvflare` CLI commands or scrape
+  human CLI output.
+- Must not require `rg` to be installed. Use `rg` when available; otherwise use
+  `nvflare agent inspect`, `find`, `git ls-files`, or a small Python search.
+
+## Agent Responsibilities
+
+- Run project inspection and recipe discovery before selecting a recipe.
+- Explain the selected recipe when the user's algorithm intent is ambiguous.
+- Convert PyTorch Client API model exchange and generate or update `job.py`.
+- Keep validation, export, reruns, recipe comparisons, data-prep experiments,
+  synthetic data decisions, POC handoff, and evaluation records within the
+  instructions in this skill and its `references/` files.
+- Report PyTorch-specific blockers such as non-`state_dict` model state,
+  incompatible checkpoint loading, unsupported metric serialization, or data
+  loaders that cannot be parameterized per site.
+
+## User Input And Approval
+
+- Ask the user to clarify FL workflow intent when recipe selection is uncertain.
+- Ask before changing private data paths, replacing dataset access, or using
+  non-fixture data for validation.
+- Ask before POC, production, or startup-kit based runtime submission.
+
+Load `../_shared/nvflare-job-lifecycle.md` and
+`references/recipe-selection.md` before creating `job.py`,
+`references/pytorch-client-api-conversion.md` for conversion details, and
+`references/job-validation.md` for PyTorch-specific validation notes. Do not
+depend on NVFLARE repository examples being present in the user's environment.

--- a/skills/nvflare-convert-pytorch/evals/evals.json
+++ b/skills/nvflare-convert-pytorch/evals/evals.json
@@ -1,0 +1,432 @@
+{
+  "skill_name": "nvflare-convert-pytorch",
+  "evals": [
+    {
+      "id": "pytorch-convert-basic",
+      "prompt": "Here is my PyTorch training code. Convert it to FLARE FL code, run the converted job with 3 simulated sites using this dataset, split the dataset evenly for the 3 sites, use FedAvg, and train for 3 rounds.",
+      "expected_output": "A FLARE-compatible PyTorch Client API training integration with standard client.py/job.py/model.py layout, a runnable job.py using FedAvg with 3 simulated sites and 3 rounds, local validation evidence, result or metric evidence, and an export attempt under /tmp/nvflare/job_config when supported.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect before editing.",
+        "The agent edits only training, model, job, or small config files.",
+        "The agent audits required model constructor arguments before writing job.py and uses explicit path or class_path plus args when needed.",
+        "The agent translates the natural request into recipe, site-count, dataset, split, training, validation, and export settings.",
+        "The agent checks nvflare recipe list --framework pytorch --format json before selecting the job recipe.",
+        "The agent selects FedAvg only when the requested workflow is standard horizontal model-parameter aggregation.",
+        "The generated source uses standard names such as client.py, job.py, and model.py instead of ad hoc names such as fl_train.py.",
+        "The generated training code uses nvflare.client receive/send and FLModel for model exchange.",
+        "The agent keeps simulation workspaces, exported job folders, and generated runtime outputs under /tmp/nvflare unless the user gives another location.",
+        "The agent runs python job.py for local validation when dependencies are available.",
+        "When job documentation, task guidance, or source project guidance declares a primary or target validation metric, the agent configures the FL recipe/global metric to that metric and reports that scalar.",
+        "The agent reports recipe choice, validation status, export status, metric or result evidence, exact result paths, and remaining blockers.",
+        "The agent records failed generated-job validation as evaluation evidence when the job does not run as expected.",
+        "The agent does not submit to POC or production without explicit approval."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "inspect-first",
+            "description": "runs nvflare agent inspect before editing"
+          },
+          {
+            "id": "scoped-edits",
+            "description": "edits only training, model, job, or small config files"
+          },
+          {
+            "id": "audit-model-constructor-args",
+            "description": "audits required model constructor arguments before writing job.py and uses explicit path or class_path plus args when needed"
+          },
+          {
+            "id": "derive-config-from-natural-request",
+            "description": "translates natural user requests into recipe, site-count, dataset, split, training, validation, and export settings"
+          },
+          {
+            "id": "discover-pytorch-recipes",
+            "description": "checks nvflare recipe list --framework pytorch --format json before selecting the job recipe"
+          },
+          {
+            "id": "select-recipe-from-fl-intent",
+            "description": "selects the PyTorch recipe from the requested FL workflow instead of assuming every PyTorch job is FedAvg"
+          },
+          {
+            "id": "standard-generated-layout",
+            "description": "uses standard generated file names such as client.py, job.py, and model.py"
+          },
+          {
+            "id": "tmp-runtime-outputs",
+            "description": "uses /tmp/nvflare locations for exported jobs, simulation workspaces, and generated validation outputs unless overridden by the user"
+          },
+          {
+            "id": "use-client-api-for-training-exchange",
+            "description": "uses nvflare.client receive/send and FLModel for training exchange"
+          },
+          {
+            "id": "local-validation",
+            "description": "runs local job validation when dependencies are available"
+          },
+          {
+            "id": "align-primary-metric",
+            "description": "when job documentation, task guidance, or source project guidance declares a primary or target validation metric, configures the FL recipe/global metric to that metric key, returns that numeric scalar in FLModel.metrics, and reports that scalar as validation evidence"
+          },
+          {
+            "id": "report-validation-evidence",
+            "description": "reports recipe choice, validation command status, export status, metric or result evidence, exact result paths, and remaining blockers"
+          },
+          {
+            "id": "record-validation-failures",
+            "description": "records failed generated-job validation as evaluation evidence when the job does not run as expected"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-production-submit",
+            "description": "does not submit to POC or production without explicit approval"
+          },
+          {
+            "id": "no-user-data-copy",
+            "description": "does not copy private site data into generated artifacts"
+          },
+          {
+            "id": "no-cli-wrapper-python",
+            "description": "does not generate Python solely to wrap NVFLARE CLI operations or scrape human CLI output"
+          }
+        ],
+        "optional_behavior": [
+          {
+            "id": "export-job",
+            "description": "exports the job folder with NVFLARE job system arguments when export is requested"
+          },
+          {
+            "id": "approved-poc-submit",
+            "description": "submits the exported job to POC only when the user explicitly approves POC or provides a POC workspace and asks for submission"
+          }
+        ],
+        "process_metrics": [
+          {
+            "id": "first_pass_accepted",
+            "description": "whether the first generated conversion satisfies layout, recipe, validation, and evidence requirements without user correction"
+          },
+          {
+            "id": "turns_to_acceptable",
+            "description": "number of user/agent turns before the conversion is accepted as structurally correct and validated or explicitly blocked"
+          },
+          {
+            "id": "user_correction_count",
+            "description": "number of user corrections needed for workflow, layout, validation, evidence, or artifact-location mistakes"
+          },
+          {
+            "id": "missed_instruction_count",
+            "description": "number of applicable user, design, or skill instructions missed during conversion, such as requested output locations, non-destructive edits, or requested review passes"
+          },
+          {
+            "id": "layout_violations",
+            "description": "count of generated source layout, file naming, or runtime artifact placement violations found before final acceptance"
+          },
+          {
+            "id": "validation_evidence_completeness",
+            "description": "whether the final answer reports validation commands, statuses, the declared primary/global metric scalar when applicable, result evidence, and exact artifact paths"
+          },
+          {
+            "id": "elapsed_seconds",
+            "description": "wall-clock time used for the conversion workflow from first skill-guided action to final reported result"
+          },
+          {
+            "id": "token_count",
+            "description": "total conversation token count for the conversion run when supplied by the evaluation runner"
+          },
+          {
+            "id": "conversion_quality",
+            "description": "reviewer-rated 1-5 quality of the converted FLARE job, considering structure, API choices, validation evidence, and artifact placement"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-approved-poc-handoff",
+      "prompt": "Simulation looks good. I have a POC workspace at /tmp/nvflare/poc_workspace. Submit the exported job to it and wait for the result.",
+      "expected_output": "The agent treats this as explicit POC approval, validates the exported job folder, uses the supplied POC workspace, submits the job, waits or monitors as requested, and reports job ID, status, result paths, and failure evidence if any.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent treats the request as explicit POC approval.",
+        "The agent validates the exported job folder before submission.",
+        "The agent uses the supplied POC workspace instead of guessing a production environment.",
+        "The agent reports job ID, status, result paths, and failure evidence if any."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "optional_behavior": [
+          {
+            "id": "approved-poc-submit",
+            "description": "submits the exported job to POC only when explicitly approved"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-production-submit",
+            "description": "does not submit to production when the user asked for POC"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-iterative-rerun",
+      "prompt": "Change the batch size to 64, increase the training to 5 rounds, switch from FedAvg to SCAFFOLD, and run it again.",
+      "expected_output": "The agent treats this as a scoped update to an existing generated PyTorch FL job, inspects the SCAFFOLD recipe metadata, updates only affected job or training arguments, reruns local validation, exports again if export remains in scope, and reports updated settings and validation evidence.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent treats hyperparameter and recipe changes as scoped updates.",
+        "The agent runs nvflare recipe show scaffold-pt --format json before switching recipes.",
+        "The agent updates only affected job or training arguments.",
+        "The agent reruns local validation and reports updated settings and evidence."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "iterative-job-update",
+            "description": "applies requested hyperparameter, round-count, min-client, site-count, or recipe changes to the existing generated job"
+          },
+          {
+            "id": "recipe-change-show",
+            "description": "runs nvflare recipe show for the target recipe before switching recipes"
+          },
+          {
+            "id": "local-validation",
+            "description": "reruns local validation after the scoped job update when dependencies are available"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-recipe-search",
+      "prompt": "Find the best recipe among the available PyTorch recipes and give me the best accuracy for this training code.",
+      "expected_output": "The agent treats this as bounded experiment planning, asks for missing metric or run budget when needed, lists compatible PyTorch recipes, inspects selected recipe metadata, runs comparable experiments only when authorized and feasible, and reports measured results without claiming a best recipe without evidence.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent does not claim the best recipe without measured evidence.",
+        "The agent asks for target metric or run budget when missing.",
+        "The agent uses nvflare recipe list --framework pytorch --format json to find candidates.",
+        "The agent keeps dataset split, site count, rounds, and metric comparable across runs."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "bounded-recipe-search",
+            "description": "treats best-recipe requests as bounded experiment planning and execution"
+          },
+          {
+            "id": "no-unmeasured-best-claim",
+            "description": "does not claim a best recipe or best accuracy without measured evidence"
+          },
+          {
+            "id": "comparable-recipe-runs",
+            "description": "keeps dataset split, site count, rounds, and metric comparable across recipe runs"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-data-distribution-rerun",
+      "prompt": "Split the dataset differently to represent IID and heterogeneous non-IID site distributions, train the model again, and show me the result.",
+      "expected_output": "The agent treats this as a data-partition experiment, defines IID and non-IID split strategies, keeps recipe and training budget comparable, avoids copying private data into generated artifacts, reruns validation for each split when feasible, and reports measured metrics, commands, status, and result paths.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent defines concrete IID and non-IID split strategies before editing.",
+        "The agent keeps recipe, rounds, epochs, batch size, seed, and metric comparable unless asked to tune them.",
+        "The agent avoids copying private data into generated artifacts.",
+        "The agent reports measured metrics, commands, status, and result paths for each split."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "define-data-split-strategies",
+            "description": "defines concrete IID and non-IID split strategies before running data-distribution experiments"
+          },
+          {
+            "id": "comparable-data-split-runs",
+            "description": "keeps recipe and training budget comparable across data split experiments"
+          },
+          {
+            "id": "report-distribution-results",
+            "description": "reports metrics, commands, status, and result paths for each data split"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-user-data-copy",
+            "description": "does not copy private site data into generated artifacts"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-dataset-url-rerun",
+      "prompt": "I want to use a different dataset and repeat the experiment. Here is the URL for the dataset: https://example.com/datasets/new-image-data.zip",
+      "expected_output": "The agent treats this as a dataset-replacement experiment, records the dataset URL and source details, validates download and preprocessing assumptions, keeps recipe and training settings comparable unless asked to tune them, reruns validation when feasible, and reports metrics, commands, status, result path, and blockers.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent records dataset URL and source details.",
+        "The agent validates download and preprocessing assumptions before rerunning.",
+        "The agent follows the existing download_data and prepare_data structure instead of inventing a parallel data-prep layout.",
+        "The agent references hello-world data-prep examples when adding new helpers.",
+        "The agent keeps recipe, site count, rounds, split policy, and metric comparable unless asked to tune them.",
+        "The agent reports metrics, commands, status, result path, dataset source, and blockers."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "record-dataset-source",
+            "description": "records dataset URL, source details, local path, and known version or access constraints"
+          },
+          {
+            "id": "validate-dataset-access",
+            "description": "validates dataset download, preprocessing, schema, and label assumptions before rerunning"
+          },
+          {
+            "id": "follow-data-prep-structure",
+            "description": "follows existing download_data and prepare_data helpers or the established NVFLARE separate download/prepare convention"
+          },
+          {
+            "id": "reference-hello-world-data-prep",
+            "description": "uses hello-world data-prep examples as convention references when adding new helpers"
+          },
+          {
+            "id": "comparable-dataset-rerun",
+            "description": "keeps recipe and training settings comparable across dataset replacement experiments unless asked to tune them"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-silent-dataset-substitution",
+            "description": "does not silently substitute a different dataset if the requested URL is unavailable"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-synthetic-site-data",
+      "prompt": "Use synthetic data for each site, generate deterministic data for 3 sites, then run the training again and show the result.",
+      "expected_output": "The agent treats this as a synthetic per-site data generation task, follows existing download_data or prepare_data structure, records seed/schema/site counts/output paths, runs validation when feasible, and reports generation and training evidence.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent creates or extends a deterministic data generation or prepare_data step.",
+        "The agent infers modality, schema, labels, missingness, site distribution, and task type only when clear.",
+        "The agent asks for a generation spec or approved generator/library when modality, task, shape/schema, labels, missingness, site distribution, or expected behavior are unclear.",
+        "The agent follows existing data-prep structure or hello-world conventions.",
+        "The agent writes explicit per-site outputs and reports seed, schema, and site counts.",
+        "The agent treats synthetic validation as a smoke test unless the user provides meaningful expected metrics.",
+        "The agent reruns validation and reports command, status, metric, and result path."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "deterministic-synthetic-data",
+            "description": "generates synthetic site data deterministically with seed, modality/schema, site count, and sample counts"
+          },
+          {
+            "id": "require-synthetic-data-spec",
+            "description": "asks for a data generation spec or approved generator when modality, task, shape/schema, labels, missingness, site distribution, or expected behavior are unclear"
+          },
+          {
+            "id": "follow-data-prep-structure",
+            "description": "follows existing download_data and prepare_data helpers or hello-world data-prep conventions"
+          },
+          {
+            "id": "report-synthetic-data-evidence",
+            "description": "reports generation command, seed, modality/schema, missingness/noise assumptions, per-site counts, validation status, and result path"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-invented-synthetic-schema",
+            "description": "does not invent synthetic labels, features, class balance, missingness, site skew, or expected accuracy when the data schema is unclear"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-site-specific-training",
+      "prompt": "Simulate that sites train at different speeds and use different learning rates and batch sizes. Change the generated job and run it again.",
+      "expected_output": "The agent treats this as site-specific training heterogeneity, prefers per-site args or config over duplicate scripts, reruns validation when feasible, and reports per-site settings, commands, status, metrics, and result paths.",
+      "files": [
+        "evals/files/hello-pt/train.py",
+        "evals/files/hello-pt/model.py"
+      ],
+      "assertions": [
+        "The agent prefers per-site args or config in job.py over copying the training script.",
+        "The agent creates site-specific scripts only when args/config cannot express the behavior.",
+        "The agent keeps shared model and training helpers common if scripts are split.",
+        "The agent reports each site's learning rate, batch size, speed simulation, command, status, metric, and result path."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "prefer-site-specific-args",
+            "description": "uses per-site args or config for site-specific training settings before duplicating scripts"
+          },
+          {
+            "id": "avoid-script-drift",
+            "description": "keeps shared model and training logic common when site-specific scripts are unavoidable"
+          },
+          {
+            "id": "report-site-heterogeneity",
+            "description": "reports per-site settings, commands, status, metrics, and result paths"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pytorch-negative-lightning",
+      "prompt": "Convert my PyTorch Lightning Trainer and LightningModule to an NVFLARE workflow.",
+      "expected_output": "The PyTorch conversion skill should not be the lead; route to the Lightning conversion skill when available.",
+      "files": [],
+      "assertions": [
+        "The selected skill is not nvflare-convert-pytorch."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-lightning",
+        "negative_for": "nvflare-convert-pytorch"
+      }
+    },
+    {
+      "id": "pytorch-global-negative-kubernetes",
+      "prompt": "Deploy an existing FLARE startup kit to Kubernetes.",
+      "expected_output": "No PyTorch conversion skill should trigger.",
+      "files": [],
+      "assertions": [
+        "The selected skill is not nvflare-convert-pytorch."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "*"
+      }
+    }
+  ]
+}

--- a/skills/nvflare-convert-pytorch/evals/files/SOURCE.md
+++ b/skills/nvflare-convert-pytorch/evals/files/SOURCE.md
@@ -1,0 +1,11 @@
+# Fixture Source Notes
+
+The `hello-pt` fixtures are minimized from the NVFLARE repository example:
+
+- Source example: `examples/hello-world/hello-pt`
+- `client.py` source hash: `99e36b5c74b7006640adc979f07bb93a59b0c141fc7d4429154b9809d27332aa`
+- `model.py` source hash: `51f86e25439901191515c853545c5d4e167dce34a40219f9aa63051614c8c6d9`
+- `job.py` source hash: `6b4314c8c0992701e4f0fdfd04e0efe448cc7909f8bab6f43f44550d83ad6bf5`
+
+The fixture intentionally omits data download and full job execution details so
+trigger and behavior evals stay deterministic.

--- a/skills/nvflare-convert-pytorch/evals/files/hello-pt/model.py
+++ b/skills/nvflare-convert-pytorch/evals/files/hello-pt/model.py
@@ -1,0 +1,14 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class SimpleNetwork(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(4, 8)
+        self.fc2 = nn.Linear(8, 2)
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)

--- a/skills/nvflare-convert-pytorch/evals/files/hello-pt/train.py
+++ b/skills/nvflare-convert-pytorch/evals/files/hello-pt/train.py
@@ -1,0 +1,29 @@
+import torch
+from model import SimpleNetwork
+from torch import nn
+from torch.optim import SGD
+
+
+def train_one_epoch(model, loader, optimizer, loss_fn):
+    model.train()
+    for features, labels in loader:
+        optimizer.zero_grad()
+        output = model(features)
+        loss = loss_fn(output, labels)
+        loss.backward()
+        optimizer.step()
+
+
+def main():
+    model = SimpleNetwork()
+    optimizer = SGD(model.parameters(), lr=0.01)
+    loss_fn = nn.CrossEntropyLoss()
+    features = torch.randn(8, 4)
+    labels = torch.randint(0, 2, (8,))
+    loader = [(features, labels)]
+    train_one_epoch(model, loader, optimizer, loss_fn)
+    torch.save(model.state_dict(), "model.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/nvflare-convert-pytorch/references/job-validation.md
+++ b/skills/nvflare-convert-pytorch/references/job-validation.md
@@ -1,0 +1,15 @@
+# PyTorch Job Validation Notes
+
+## PyTorch-Specific Validation
+
+- Validate that received `FLModel.params` load into the PyTorch model through
+  `load_state_dict` or a deliberate compatible mapping.
+- Validate that outbound `FLModel.params` comes from the trained model's
+  `state_dict` and does not include optimizer or dataloader objects.
+- Confirm that checkpoint loading, metric collection, and device placement still
+  work after the Client API conversion.
+- For data-prep changes, confirm the PyTorch `Dataset` or `DataLoader` receives
+  the generated per-site path or arguments rather than hard-coded global paths.
+- Report PyTorch-specific blockers such as non-serializable model state,
+  checkpoint keys that do not match the converted model, transforms that depend
+  on unavailable data, or metrics that cannot be serialized into `FLModel`.

--- a/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
+++ b/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
@@ -1,0 +1,86 @@
+# PyTorch Client API Conversion
+
+This reference covers standard PyTorch training loops that already have a
+`torch.nn.Module`, optimizer, data loaders, and metrics.
+
+## Conversion Pattern
+
+- Import `nvflare.client as flare`.
+- Call `flare.init()` before the training loop that participates in FLARE.
+- Loop while `flare.is_running()`.
+- Call `flare.receive()` to get the incoming `FLModel`.
+- Load `input_model.params` into the PyTorch model with `load_state_dict`.
+- Train or evaluate using the user's existing data loader and optimizer.
+- Send `flare.FLModel(params=model.cpu().state_dict(), metrics=..., meta=...)`
+  with `flare.send(...)`.
+
+## Source Layout
+
+For PyTorch conversions, the job source should normally contain:
+
+- `client.py`: FLARE Client API entry point;
+- `job.py`: recipe or FedJob builder, simulation entry point, and export entry
+  point;
+- `model.py`: copied, wrapped, or imported model definition when needed;
+- `requirements.txt` or a small requirements file only when dependencies differ
+  from the source project.
+
+Avoid names such as `fl_train.py` for the generated FLARE Client API entry
+point unless the user explicitly requests that naming.
+
+For standard FedAvg, package shared generated files for all clients. Do not
+replace all-client deployment with explicit per-site deployment unless the
+conversion has real per-site differences such as different scripts, arguments,
+data-split settings, or launch behavior.
+
+## Model Construction Consistency
+
+The model created by `job.py` for the server-side initial model and the model
+created by `client.py` before `load_state_dict` must have matching constructor
+arguments and state-dict shapes. When the original model needs arguments such as
+input dimension, vocabulary size, number of classes, hidden size, or dropout,
+make those values explicit in both places.
+
+Do not rely on exporting a live `nn.Module` instance when the model constructor
+has required arguments. Derive required constructor values from the source code,
+dataset metadata, vocab/config generation, checkpoint metadata, or CLI args
+before writing `job.py`, then pass them explicitly through the recipe model
+config and the client model construction path.
+
+Acceptable patterns include:
+
+- a shared `model_args` dict imported by both `job.py` and `client.py`;
+- an explicit recipe model config such as
+  `{"path": "model.ModelClass", "args": model_args}` or
+  `{"class_path": "model.ModelClass", "args": model_args}`;
+- a small JSON/config file read by both sides;
+- explicit CLI arguments passed through recipe `train_args` and parsed by
+  `client.py`, with the same values used in `job.py`.
+
+Before simulation, validate the generated model construction path when possible
+by instantiating the server-side and client-side model with the same arguments
+and checking that `load_state_dict` can accept the initial parameters. Treat a
+state-dict key or tensor-shape mismatch as a conversion bug, not as a reason to
+change the model architecture without user approval.
+
+## Evaluation Branch
+
+When the task is evaluation-only, use `flare.is_evaluate()` to send metrics
+without local training.
+
+## Scope Boundaries
+
+- Keep user model architecture and loss function unless the user asks for a
+  change.
+- Keep data loading local to the site and do not add code that copies private
+  data into generated artifacts.
+- For checkpoints, preserve user checkpoint semantics and document what is
+  federated versus site-local.
+- For metrics, send scalar summaries in the `metrics` field and keep rich
+  tracking artifacts in the normal experiment-tracking path.
+
+## Job Pattern Reference
+
+Load `recipe-selection.md` before creating or updating `job.py` so the selected
+recipe matches the user's requested FL workflow. Do not assume NVFLARE
+repository examples are available in the user's environment.

--- a/skills/nvflare-convert-pytorch/references/recipe-selection.md
+++ b/skills/nvflare-convert-pytorch/references/recipe-selection.md
@@ -1,0 +1,170 @@
+# PyTorch Recipe Selection
+
+PyTorch identifies the training framework; it does not determine the federated
+workflow. Choose the recipe from the user's FL intent, topology, and aggregation
+requirements.
+
+## Discover Recipes
+
+Run the local recipe catalog before creating or updating `job.py`:
+
+```bash
+nvflare recipe list --framework pytorch --format json
+```
+
+Use the returned recipe metadata as the source of truth for recipe names,
+modules, classes, algorithms, aggregation mode, state exchange, privacy metadata,
+and optional dependencies.
+
+After selecting a candidate recipe, inspect its parameters:
+
+```bash
+nvflare recipe show <recipe-name> --format json
+```
+
+## Quick Algorithm Guide
+
+If the user does not know which FL algorithm they need, explain the choices in
+plain language before editing `job.py`:
+
+- FedAvg: the default starting point for most horizontal FL jobs. Each site
+  trains locally, sends model weights or updates, and the server averages them.
+  Use this when the user simply asks to federate normal PyTorch training.
+- FedAvg with HE: FedAvg plus homomorphic encryption support for protected
+  aggregation. Use only when the user asks for HE or encrypted aggregation.
+- FedProx: FedAvg-style training with a proximal term in the client loss to
+  improve stability when site data or compute behavior is very different.
+- FedOpt: server-side optimizer variants such as FedAdam, FedYogi, or FedAdagrad.
+  Use when the user wants server optimizer control or better behavior than plain
+  averaging on heterogeneous data.
+- SCAFFOLD: adds control variates to reduce client drift on non-IID data. Use
+  when the user specifically asks for SCAFFOLD or drift mitigation.
+- Cyclic: sends the model through clients sequentially instead of aggregating
+  updates on the server. Use when the requested workflow is client-to-client or
+  cyclic weight transfer.
+- Swarm Learning: peer/client-parent aggregation topology instead of a normal
+  server-centered FedAvg topology. Use when the user asks for swarm learning.
+- FedEval: evaluation-only. Use when the user wants to distribute a checkpoint
+  to sites and collect metrics without federated training updates.
+
+For deeper background, see the algorithm papers for
+[FedAvg](https://proceedings.mlr.press/v54/mcmahan17a.html),
+[FedProx](https://arxiv.org/abs/1812.06127),
+[FedOpt](https://openreview.net/forum?id=LkFG3lB13U5),
+[SCAFFOLD](https://proceedings.mlr.press/v119/karimireddy20a.html), and
+[Swarm Learning](https://www.nature.com/articles/s41586-021-03583-3). For
+Cyclic recipes, use the local catalog and
+`nvflare recipe show cyclic-pt --format json`.
+
+## Selection Rules
+
+- Use `fedavg-pt` for standard horizontal federated training where clients train
+  the same PyTorch model locally and the server aggregates model weights or
+  weight diffs across rounds.
+- Use `fedavg-he-pt` when the user asks for FedAvg with homomorphic encryption.
+- Use `fedprox-pt` when the user asks for FedProx or proximal loss behavior.
+- Use `fedopt-pt` when the user asks for server-side optimizer variants such as
+  FedAdam, FedYogi, or FedAdagrad behavior.
+- Use `scaffold-pt` when the user asks for SCAFFOLD-style control variates or
+  client-drift mitigation.
+- Use `cyclic-pt` when the user asks for sequential client-to-client model
+  transfer rather than server aggregation.
+- Use `swarm-pt` when the user asks for swarm learning or peer/client-parent
+  aggregation topology.
+- Use `fedeval-pt` for evaluation-only jobs that send a checkpoint to sites and
+  collect metrics without local training updates.
+- Ask the user before choosing when the requested FL workflow is not clear.
+
+## Standard FedAvg Fast Path
+
+For a normal PyTorch-to-FedAvg conversion, keep the `job.py` recipe construction
+small and portable:
+
+```python
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe.sim_env import SimEnv
+
+model_args = {"input_size": input_size, "num_classes": num_classes}
+recipe_model = {"path": "model.ModelClass", "args": model_args}
+
+recipe = FedAvgRecipe(
+    name=job_name,
+    min_clients=num_clients,
+    num_rounds=num_rounds,
+    model=recipe_model,
+    train_script="client.py",
+    train_args=train_args,
+)
+
+env = SimEnv(num_clients=num_clients, workspace_root=workspace_root)
+run = recipe.execute(env)
+```
+
+Prefer a recipe model dict with the same constructor arguments used by the
+client-side model:
+
+```python
+model={"path": "model.ModelClass", "args": model_args}
+```
+
+The exported job/config uses `path`. If a local recipe API still requires
+`class_path`, use that key at recipe construction time, but do not prefer it
+when `path` is accepted.
+Some export paths serialize only the class path if given a live model instance,
+which can drop required constructor values. Use explicit model config with
+`path` or `class_path` plus `args`, then verify export preserves the required
+model arguments.
+
+The server-side recipe model and the client-side training model must construct
+the same architecture. If the model constructor needs dimensions, class counts,
+dropout settings, embedding sizes, or other architecture arguments, pass the
+same values on both sides. Prefer a small shared constant, JSON/config file, or
+explicit `train_args` values over hard-coded divergent defaults.
+
+Use these portable imports when writing custom Job API code:
+
+```python
+from nvflare.job_config.api import FedJob
+from nvflare.job_config.script_runner import ScriptRunner
+from nvflare.recipe.sim_env import SimEnv
+```
+
+Do not inspect large NVFLARE modules to recover these imports unless validation
+shows that the installed version differs.
+
+Do not infer that `per_site_config` is required only because recipe metadata
+mentions it. For standard FedAvg with the same `client.py`, `model.py`, and
+training arguments on all clients, leave `per_site_config` unset and let the
+recipe deploy the executor to all clients. Use `per_site_config` only when at
+least one site needs a different `train_script`, `train_args`, command,
+external-process setting, framework/exchange setting, or launch behavior.
+
+For non-FedAvg workflows, use the matching recipe from the catalog and keep the
+PyTorch Client API exchange aligned with that recipe's expected task names,
+metadata, and parameter format.
+
+## Non-FedAvg Recipe Rules
+
+The FedAvg fast path is not a universal PyTorch job template. When the user asks
+for FedOpt, FedProx, SCAFFOLD, Cyclic, Swarm Learning, FedEval, encryption, or a
+topology-specific workflow:
+
+- use `nvflare recipe show <recipe-name> --format json` for the selected recipe;
+- supply parameters marked `"required": true`;
+- leave optional parameters at defaults unless the user request, source code, or
+  validation result requires them;
+- keep generated source names and runtime locations consistent with this skill;
+- keep shared generated files on all clients unless the recipe semantics or user
+  request require site-specific roles, scripts, arguments, or launch settings;
+- ask before choosing when recipe intent or topology is ambiguous.
+
+For recipes with topology roles, such as cyclic ordering, swarm roles, vertical
+data ownership, or label-owner style workflows, do not collapse the topology into
+standard FedAvg. Preserve the selected recipe's required role or site parameters
+and report any missing user input before validation.
+
+## Export Behavior
+
+Export handling is shared across algorithms and frameworks. Follow
+`../../_shared/nvflare-job-lifecycle.md` for `--export`, `--export-dir`, and
+local command-line parser behavior.

--- a/skills/nvflare-diagnose-job/BENCHMARK.md
+++ b/skills/nvflare-diagnose-job/BENCHMARK.md
@@ -1,0 +1,30 @@
+# Benchmark Summary
+
+Status: draft/internal pending Milestone 11 runtime evaluation.
+
+Skill version: 0.1.0
+FLARE version: 2.8.0 minimum
+
+## Initial Checks
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Positive POC/production trigger | Draft | `diagnose-poc-component-not-authorized` covers failed POC job diagnosis. |
+| Positive simulation trigger | Draft | `diagnose-simulation-import-error` covers local `python job.py` failure diagnosis. |
+| Partial evidence trigger | Draft | `diagnose-partial-log-visibility` covers missing or denied site logs. |
+| Retryable transfer trigger | Draft | `diagnose-transfer-progress-timeout` covers peer timeout with active transfer progress. |
+| Adjacent negative trigger | Draft | PyTorch conversion routes to `nvflare-convert-pytorch`. |
+| Job lifecycle negative trigger | Draft | Healthy job monitoring routes away from diagnosis. |
+| Global negative trigger | Draft | Non-FLARE web-app prompt routes to no skill. |
+| Mandatory behavior | Draft | Behavior IDs cover runtime mode selection, mode-specific evidence, bounded logs, pattern matching, partial evidence, retryable transfer timeouts, and recovery reporting. |
+| Prohibited behavior | Draft | Behavior IDs prohibit mutation, private-key reads, unbounded logs, job CLI use for simulation-only failures, and confident causes with missing evidence. |
+| Process evaluation | Draft | Metrics cover first-pass supported diagnosis, turns to supported diagnosis, bounded evidence collection, correction count, and unwanted actions. |
+
+## Known Gaps
+
+- Runtime agent-performance scoring has not been run yet.
+- Runtime process scoring has not been run yet.
+- The pattern catalog is intentionally compact and should grow from support and
+  Auto-FL feedback.
+- No helper scripts are included in the first release; evidence collection is
+  skill-guided through existing CLI and local artifact inspection.

--- a/skills/nvflare-diagnose-job/SKILL.md
+++ b/skills/nvflare-diagnose-job/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: nvflare-diagnose-job
+description: "Diagnose failed, stalled, or suspicious NVFLARE jobs in simulation, POC, or production by collecting bounded evidence and mapping failure patterns to recovery actions."
+min_flare_version: "2.8.0"
+blast_radius: read_only
+skill_version: "0.1.0"
+---
+
+# NVFLARE Diagnose Job
+
+## Use When
+
+Use when the user asks why an NVFLARE job failed, stalled, timed out, ended with
+`EXECUTION_EXCEPTION`, lost clients, produced suspicious logs, or needs failure
+evidence interpreted.
+
+## Do Not Use When
+
+Do not use for creating jobs, converting training code, submitting healthy jobs,
+monitoring a normal run, downloading results, production deployment, or generic
+Python debugging without NVFLARE job context.
+
+## Workflow
+
+1. Determine runtime mode first:
+   - simulation: user provides `job.py`, SimEnv output, local logs, exported job
+     folder, or a failed `python job.py` run;
+   - POC/production: user provides a job ID, startup kit, POC workspace, admin
+     context, or asks about a running FLARE system.
+2. If mode or evidence is ambiguous, ask for the missing mode, job ID, local
+   log path, simulation output path, or startup-kit context before diagnosing.
+3. For simulation mode, inspect local artifacts only. Use
+   `nvflare agent inspect <path> --format json` when a project or job path is
+   available, then read bounded local logs and generated job/config artifacts.
+4. For POC/production mode, collect bounded job and system evidence through the
+   FLARE CLI, using `--tail`, `--since`, or `--max-bytes` for logs.
+5. Match evidence against the packaged failure-pattern catalog before
+   interpreting raw logs.
+6. Report observed status, evidence quality, matched pattern, likely cause,
+   confidence, recovery category, and concrete next action.
+
+## Requirements
+
+- Must keep diagnosis read-only.
+- Must distinguish simulation from POC/production before choosing evidence
+  commands.
+- Must keep log evidence bounded and report truncation or missing site logs.
+- Must avoid confident root-cause claims when required site evidence is missing.
+- Must not read private key contents, mutate jobs/configs/runtime state, or run
+  unbounded scans.
+
+## Output Shape
+
+Report:
+
+- runtime mode and evidence sources;
+- job status or local failure status;
+- matched failure pattern and confidence;
+- recovery category such as `FIXABLE_BY_CODE`, `FIXABLE_BY_CONFIG`,
+  `ENVIRONMENT_FAILURE`, `RETRYABLE`, or `UNKNOWN`;
+- source-aware evidence summary with site/process labels when available;
+- next action and any missing evidence.
+
+Load `references/evidence-collection.md` for mode-specific evidence collection
+and `references/failure-patterns.md` before assigning a likely failure cause.

--- a/skills/nvflare-diagnose-job/evals/evals.json
+++ b/skills/nvflare-diagnose-job/evals/evals.json
@@ -1,0 +1,211 @@
+{
+  "skill_name": "nvflare-diagnose-job",
+  "evals": [
+    {
+      "id": "diagnose-poc-component-not-authorized",
+      "prompt": "My POC job abc123 finished with FINISHED:EXECUTION_EXCEPTION. Diagnose why it failed.",
+      "expected_output": "The agent treats the request as POC/production mode, collects bounded job and system evidence through NVFLARE CLI commands, matches ComponentNotAuthorized to a configuration recovery path, and reports confidence plus next action.",
+      "files": [
+        "evals/files/poc_component_not_authorized.log"
+      ],
+      "assertions": [
+        "The agent identifies POC/production mode from the job ID and POC wording.",
+        "The agent uses bounded nvflare job/system evidence commands.",
+        "The agent matches ComponentNotAuthorized before interpreting the logs.",
+        "The agent reports FIXABLE_BY_CONFIG and a concrete allow-list recovery action.",
+        "The agent does not mutate the job, runtime, or config."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-diagnose-job",
+        "mandatory_behavior": [
+          {
+            "id": "determine-runtime-mode",
+            "description": "distinguishes simulation from POC/production before collecting evidence"
+          },
+          {
+            "id": "collect-mode-specific-evidence",
+            "description": "uses local artifacts for simulation and nvflare job/system CLI for POC or production"
+          },
+          {
+            "id": "bounded-log-evidence",
+            "description": "keeps log collection bounded with tail, since, or max-bytes controls"
+          },
+          {
+            "id": "match-failure-pattern",
+            "description": "matches evidence against the packaged failure-pattern catalog before assigning cause"
+          },
+          {
+            "id": "report-recovery-category",
+            "description": "reports matched pattern, confidence, recovery category, and next action"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-mutation",
+            "description": "does not mutate jobs, configs, runtime systems, or user files during diagnosis"
+          },
+          {
+            "id": "no-private-key-read",
+            "description": "does not read private key contents"
+          },
+          {
+            "id": "no-unbounded-log-dump",
+            "description": "does not request or paste unbounded logs"
+          }
+        ],
+        "process_metrics": [
+          {
+            "id": "first_pass_diagnosis_supported",
+            "description": "whether the first diagnosis maps evidence to a plausible failure pattern without user correction"
+          },
+          {
+            "id": "turns_to_supported_diagnosis",
+            "description": "number of user/agent turns before the diagnosis includes evidence, confidence, recovery category, and next action"
+          },
+          {
+            "id": "evidence_collection_bounded",
+            "description": "whether evidence collection stays bounded by tail, since, max-bytes, local artifact scope, or explicit user-provided logs"
+          },
+          {
+            "id": "user_correction_count",
+            "description": "number of user corrections needed for mode selection, evidence interpretation, recovery category, or overconfident claims"
+          },
+          {
+            "id": "missed_instruction_count",
+            "description": "number of applicable user, design, or skill instructions missed during diagnosis, such as requested review passes, bounded-evidence requirements, or mode-specific triage"
+          },
+          {
+            "id": "unwanted_action_count",
+            "description": "number of mutations, private-key reads, unbounded log dumps, or production actions attempted during diagnosis"
+          }
+        ]
+      }
+    },
+    {
+      "id": "diagnose-simulation-import-error",
+      "prompt": "My simulation run failed when I ran python job.py. Diagnose this local log.",
+      "expected_output": "The agent treats the request as simulation mode, uses local artifacts rather than job/system CLI, matches the import error, and reports the missing dependency as a code/environment packaging issue.",
+      "files": [
+        "evals/files/simulation_import_error.log"
+      ],
+      "assertions": [
+        "The agent identifies simulation mode from python job.py and local log wording.",
+        "The agent does not use nvflare job or nvflare system commands for pure simulation evidence.",
+        "The agent matches ModuleNotFoundError to IMPORT_ERROR.",
+        "The agent reports FIXABLE_BY_CODE and dependency packaging or environment setup as next action."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-diagnose-job",
+        "mandatory_behavior": [
+          {
+            "id": "simulation-local-evidence",
+            "description": "uses local command output, SimEnv artifacts, job.py, generated configs, and local logs for simulation failures"
+          },
+          {
+            "id": "match-failure-pattern",
+            "description": "matches evidence against the packaged failure-pattern catalog before assigning cause"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-job-cli-for-simulation-only",
+            "description": "does not use nvflare job or nvflare system commands for a pure simulation failure"
+          }
+        ]
+      }
+    },
+    {
+      "id": "diagnose-partial-log-visibility",
+      "prompt": "Job abc123 timed out in production, but some client logs are missing or permission denied. Diagnose what you can.",
+      "expected_output": "The agent marks the diagnosis as partial, reports PARTIAL_LOG_VISIBILITY, avoids a confident root-cause claim, and gives bounded follow-up evidence to collect.",
+      "files": [
+        "evals/files/partial_log_visibility.json"
+      ],
+      "assertions": [
+        "The agent reports missing or denied site logs as partial evidence.",
+        "The agent avoids a confident root-cause claim with missing site evidence.",
+        "The agent recommends a bounded next evidence command or site-log collection step."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-diagnose-job",
+        "mandatory_behavior": [
+          {
+            "id": "mark-partial-evidence",
+            "description": "reports partial, truncated, unavailable, or permission-denied evidence"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-confident-cause-with-missing-evidence",
+            "description": "does not claim a confident root cause when required site evidence is missing"
+          }
+        ]
+      }
+    },
+    {
+      "id": "diagnose-transfer-progress-timeout",
+      "prompt": "A production job saw peer_read_timeout while streaming a large model, but later logs still show stream progress and completion. Diagnose the failure category.",
+      "expected_output": "The agent matches the timeout-with-progress case to TRANSFER_PROGRESS_TIMEOUT, reports RETRYABLE rather than ENVIRONMENT_FAILURE, and recommends checking progress-aware streaming evidence before escalating.",
+      "files": [
+        "evals/files/transfer_progress_timeout.log"
+      ],
+      "assertions": [
+        "The agent recognizes peer_read_timeout with active streaming progress as a transient transfer-congestion candidate.",
+        "The agent reports RETRYABLE rather than ENVIRONMENT_FAILURE for the progress-confirmed transfer timeout.",
+        "The agent recommends checking progress-aware streaming evidence and only tuning timeouts if progress stalls."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-diagnose-job",
+        "mandatory_behavior": [
+          {
+            "id": "retryable-transfer-timeout",
+            "description": "classifies timeout evidence with active transfer progress as RETRYABLE instead of environment failure"
+          },
+          {
+            "id": "check-progress-before-escalation",
+            "description": "checks transfer progress evidence before treating peer timeout as a failed peer or environment outage"
+          }
+        ]
+      }
+    },
+    {
+      "id": "diagnose-negative-pytorch-conversion",
+      "prompt": "Convert this PyTorch training script into an NVFLARE federated job and run it locally.",
+      "expected_output": "The diagnosis skill should not be the lead; the PyTorch conversion skill should handle the request.",
+      "files": [],
+      "assertions": [
+        "The selected skill is nvflare-convert-pytorch, not nvflare-diagnose-job."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "negative_for": "nvflare-diagnose-job"
+      }
+    },
+    {
+      "id": "diagnose-negative-healthy-job-lifecycle",
+      "prompt": "Monitor my healthy running job and download the final model when it completes.",
+      "expected_output": "The diagnosis skill should not trigger because the request is normal job lifecycle management, not failure diagnosis.",
+      "files": [],
+      "assertions": [
+        "The selected skill is not nvflare-diagnose-job."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-job-lifecycle",
+        "negative_for": "nvflare-diagnose-job"
+      }
+    },
+    {
+      "id": "diagnose-global-negative-web-app",
+      "prompt": "Build a React dashboard for tracking bakery orders.",
+      "expected_output": "No FLARE diagnosis skill should trigger.",
+      "files": [],
+      "assertions": [
+        "The selected skill is none."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "*"
+      }
+    }
+  ]
+}

--- a/skills/nvflare-diagnose-job/evals/files/SOURCE.md
+++ b/skills/nvflare-diagnose-job/evals/files/SOURCE.md
@@ -1,0 +1,9 @@
+# Diagnosis Eval Fixtures
+
+These fixtures are minimal synthetic log snippets derived from common NVFLARE
+failure shapes. They are not copied from customer jobs and contain no private
+site data.
+
+`transfer_progress_timeout.log` is synthetic evidence for a large-transfer
+timeout warning where later streaming progress indicates a retryable congestion
+case rather than a dead peer.

--- a/skills/nvflare-diagnose-job/evals/files/partial_log_visibility.json
+++ b/skills/nvflare-diagnose-job/evals/files/partial_log_visibility.json
@@ -1,0 +1,8 @@
+{
+  "job_id": "abc123",
+  "logs": {
+    "server": {"status": "ok", "truncated": true, "lines": ["Round 2 timed out waiting for clients"]},
+    "site-1": {"status": "permission_denied"},
+    "site-2": {"status": "missing"}
+  }
+}

--- a/skills/nvflare-diagnose-job/evals/files/poc_component_not_authorized.log
+++ b/skills/nvflare-diagnose-job/evals/files/poc_component_not_authorized.log
@@ -1,0 +1,3 @@
+2026-06-02 11:42:03 - JsonScanner - ERROR - ComponentNotAuthorized
+component not authorized: Component 'custom.trainer.CustomTrainer' at config path 'executors.#0.executor' is not in allow_list
+2026-06-02 11:42:04 - worker_process - ERROR - FL client execution exception: ComponentNotAuthorized

--- a/skills/nvflare-diagnose-job/evals/files/simulation_import_error.log
+++ b/skills/nvflare-diagnose-job/evals/files/simulation_import_error.log
@@ -1,0 +1,5 @@
+2026-06-02 10:15:20 - worker_process - ERROR - FL client execution exception
+[USER_CODE_EXCEPTION] Traceback (most recent call last):
+  File "/workspace/app/custom/train.py", line 8, in <module>
+    import missing_training_lib
+ModuleNotFoundError: No module named 'missing_training_lib'

--- a/skills/nvflare-diagnose-job/evals/files/transfer_progress_timeout.log
+++ b/skills/nvflare-diagnose-job/evals/files/transfer_progress_timeout.log
@@ -1,0 +1,5 @@
+2026-06-02 07:36:10 - client_api_launcher - INFO - Round 0 received 5000 model tensors through streaming
+2026-06-02 07:39:45 - CellPipe - ERROR - failed to send task train: peer_read_timeout=300.0
+2026-06-02 07:39:46 - DownloadService - INFO - stream progress active ref=model-abc bytes_done=3221225472 total_bytes=5368709120
+2026-06-02 07:41:02 - DownloadService - INFO - stream progress active ref=model-abc bytes_done=4831838208 total_bytes=5368709120
+2026-06-02 07:43:11 - client_api_launcher - INFO - model transfer completed after timeout warning

--- a/skills/nvflare-diagnose-job/references/evidence-collection.md
+++ b/skills/nvflare-diagnose-job/references/evidence-collection.md
@@ -1,0 +1,80 @@
+# Evidence Collection
+
+Diagnosis is mode-aware. Simulation failures usually have local artifacts and no
+admin server lifecycle. POC and production failures use the FLARE job/system CLI
+because a server and sites exist.
+
+## Mode Decision
+
+| Mode | Evidence In Prompt | Evidence Source |
+| --- | --- | --- |
+| Simulation | `job.py`, SimEnv, local stdout/stderr, exported job folder, failed `python job.py` | Local files and command output |
+| POC/production | job ID, startup kit, POC workspace, admin context, server/client status | `nvflare job` and `nvflare system` CLI |
+| Ambiguous | "failed job" with no ID/path/logs | Ask for mode plus one concrete evidence source |
+
+Treat POC as production-mode diagnosis because the same server, client, admin,
+job, and log surfaces are used, even when everything runs on localhost.
+
+## Simulation Evidence
+
+Use local evidence only:
+
+- failed command and stdout/stderr, usually `python job.py`;
+- `job.py`, recipe settings, generated config, and exported job folder when
+  available;
+- SimEnv workspace, result directory, and site/server logs produced by the
+  simulation;
+- local dependency, dataset, and path evidence supplied by the user.
+
+Use `nvflare --format json agent inspect <path>` when the user provides a
+project, job, or exported-job path. Do not use `nvflare job` or
+`nvflare system` commands for a pure simulation failure unless the user also
+provides a POC/production job ID or startup-kit context.
+
+## POC And Production Evidence
+
+Use bounded CLI evidence. Prefer JSON envelopes for agent-readable output:
+
+```bash
+nvflare --format json job meta <job_id>
+nvflare --format json job logs <job_id> --site all --tail 200
+nvflare --format json job stats <job_id> --site all
+nvflare --format json system status
+nvflare --format json system resources
+```
+
+When the user supplies a startup kit or registered kit ID, add the matching
+`--startup-kit <path>` or `--kit-id <id>` option to each command that needs
+server access. When logs are large or the failure window is known, prefer
+`--since <timestamp>` or `--max-bytes <bytes>` in addition to or instead of
+`--tail`.
+
+## Evidence Quality
+
+Track whether each evidence source is complete, partial, unavailable, or
+permission-denied. Treat these as findings:
+
+- `PARTIAL_LOG_VISIBILITY`: one or more expected site logs are missing,
+  permission-denied, unavailable, or not streamed to the server.
+- `LOGS_TRUNCATED`: log output reports truncation or the selected bound may
+  omit earlier context.
+- `MODE_AMBIGUOUS`: the prompt does not identify simulation versus
+  POC/production and no concrete evidence path or job ID is available.
+
+Use source labels from the evidence when available: server, site name, client
+name, subprocess, user training code, or FLARE runtime. If markers such as
+`[USER_CODE_EXCEPTION]` or `[FLARE]` are present, preserve them in the evidence
+summary. If no marker or source label is visible, mark the source as `unknown`
+rather than inferring user code or FLARE runtime ownership.
+
+## Diagnosis Report
+
+Report the diagnosis as:
+
+1. mode and evidence collected;
+2. failure status and affected sites;
+3. matched pattern and confidence;
+4. likely cause with source-aware evidence;
+5. recovery category;
+6. concrete next action;
+7. missing evidence or follow-up command when confidence is limited.

--- a/skills/nvflare-diagnose-job/references/failure-patterns.md
+++ b/skills/nvflare-diagnose-job/references/failure-patterns.md
@@ -1,0 +1,34 @@
+# Failure Pattern Catalog
+
+Match these patterns before interpreting raw logs. Use `UNKNOWN` when evidence
+does not match a known pattern or required site evidence is missing.
+
+| Pattern | Modes | Evidence Signals | Recovery Category | Next Action |
+| --- | --- | --- | --- | --- |
+| `USER_CODE_EXCEPTION` | both | `[USER_CODE_EXCEPTION]`, traceback in custom training code, `FINISHED:EXECUTION_EXCEPTION` | `FIXABLE_BY_CODE` | Point to the user-code file/function and rerun validation after the code fix. |
+| `IMPORT_ERROR` | both | `ModuleNotFoundError`, `ImportError`, missing package in site or simulation logs | `FIXABLE_BY_CODE` | Add dependency packaging or environment setup; verify all sites use the dependency. |
+| `DATA_PATH_NOT_FOUND` | both | `FileNotFoundError`, `No such file`, dataset path missing on one site | `FIXABLE_BY_CODE` | Make data paths site-specific and validate each site's path. |
+| `ABSOLUTE_DATA_PATH` | both | hard-coded `/home/...`, `/Users/...`, drive-letter paths, remote site cannot resolve path | `FIXABLE_BY_CODE` | Replace hard-coded local paths with site args/config or prepared site data. |
+| `CUDA_OOM` | both | `CUDA out of memory`, GPU allocation failure, memory exhausted | `FIXABLE_BY_CODE` | Reduce batch/model memory, use gradient accumulation, or adjust resource allocation. |
+| `ROUND_TIMEOUT` | POC/production | round timeout, no client response, task timeout, aggregator waits for clients | `ENVIRONMENT_FAILURE` | Check client liveness, site logs, resource pressure, and timeout configuration. |
+| `TRANSFER_PROGRESS_TIMEOUT` | POC/production | `peer_read_timeout`, `PEER_GONE`, or task timeout appears while logs also show large model/tensor streaming progress, active download, or later successful transfer progress | `RETRYABLE` | Treat as a transient transfer-congestion candidate; check progress-aware streaming evidence, avoid duplicate resends, and retry or tune streaming idle settings only if progress stalls. |
+| `PEER_GONE_OR_TIMEOUT` | POC/production | `PEER_GONE`, `target_unreachable`, `peer_read_timeout`, connection closed, and no evidence of active transfer progress | `ENVIRONMENT_FAILURE` | Check site process health, network reachability, heartbeat/liveness, and whether the peer actually exited. |
+| `AUTH_FAILURE` | POC/production | authentication rejection, certificate verification failure, unauthorized admin/site | `FIXABLE_BY_CONFIG` | Verify startup kit, identity, organization, token, and server trust chain. |
+| `STARTUP_KIT_EXPIRED` | POC/production | certificate validity failure, expired kit, not-before/not-after errors | `FIXABLE_BY_CONFIG` | Re-provision or refresh startup kits and retry with the active kit. |
+| `COMPONENT_NOT_AUTHORIZED` | both | `ComponentNotAuthorized`, component not in `allow_list` | `FIXABLE_BY_CONFIG` | Add the component to the secure-mode allow list or use an authorized component. |
+| `PACKAGE_EXPORT_ERROR` | both | missing app/config files, malformed exported job folder, missing `config_fed_*` | `FIXABLE_BY_CODE` | Re-export the job and inspect required server/client app folders. |
+| `SIMULATION_CONFIG_ERROR` | simulation | bad `job.py` args, recipe parameter mismatch, local config parse failure | `FIXABLE_BY_CODE` | Fix `job.py` or recipe arguments and rerun `python job.py`. |
+| `PARTIAL_LOG_VISIBILITY` | POC/production | site logs unavailable, permission-denied, logs not streamed, truncated evidence | `UNKNOWN` | Collect missing site logs or rerun with better log streaming before assigning root cause. |
+| `SITE_AUTHORIZATION_FAILURE` | POC/production | site rejected, client disabled, missing site authorization, org mismatch | `FIXABLE_BY_CONFIG` | Check site identity, authorization policy, and enabled/disabled client state. |
+
+## Confidence Guidance
+
+- High confidence: one pattern has direct evidence from the affected site or
+  simulation traceback.
+- Medium confidence: pattern signals match, but some site logs or status fields
+  are missing.
+- Low confidence: only terminal status is known, logs are partial, or multiple
+  patterns are plausible.
+
+When confidence is medium or low, name the missing evidence and give the next
+bounded command or local file path to collect.

--- a/skills/nvflare-orient/BENCHMARK.md
+++ b/skills/nvflare-orient/BENCHMARK.md
@@ -1,0 +1,25 @@
+# Benchmark Summary
+
+Status: draft/internal pending Milestone 11 runtime evaluation.
+
+Skill version: 0.1.0
+FLARE version: 2.8.0 minimum
+
+## Initial Checks
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Positive trigger | Draft | `orient-ambiguous-project` defines the initial routing prompt. |
+| Adjacent negative trigger | Draft | PyTorch conversion routes to `nvflare-convert-pytorch`. |
+| Diagnosis handoff trigger | Draft | Failed or suspicious FLARE jobs route to `nvflare-diagnose-job`. |
+| Global negative trigger | Draft | Non-FLARE web-app prompt routes to no skill. |
+| Mandatory behavior | Draft | Behavior IDs cover inspect-first, read-only routing, single lead skill, and diagnosis handoff. |
+| Prohibited behavior | Draft | Behavior IDs prohibit file edits, production actions, and implementing diagnosis during routing. |
+| Process evaluation | Draft | Metrics cover first-pass route correctness, turns to route, unwanted actions, and handoff clarity. |
+
+## Known Gaps
+
+- Runtime agent-performance scoring has not been run yet.
+- Runtime process scoring has not been run yet.
+- Orientation routing will need new adjacent negatives as more workflow skills
+  are added.

--- a/skills/nvflare-orient/SKILL.md
+++ b/skills/nvflare-orient/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: nvflare-orient
+description: "Route ambiguous NVFLARE requests by inspecting the local project, checking readiness, and recommending the next specific FLARE workflow skill without editing files."
+min_flare_version: "2.8.0"
+blast_radius: read_only
+skill_version: "0.1.0"
+---
+
+# NVFLARE Orient
+
+## Use When
+
+Use when the user asks where to start with NVFLARE, how a local project maps to
+FLARE workflows, or which FLARE skill should handle an ambiguous request.
+
+## Do Not Use When
+
+Do not use when the user already names a specific workflow such as PyTorch
+conversion, job submission, production deployment, Kubernetes setup, or log
+diagnosis. Route to the narrower skill instead.
+
+## Workflow
+
+1. Clarify the target path or use the current workspace when the user already
+   gives enough context.
+2. Run `nvflare agent inspect <path> --format json` for static project evidence.
+3. Run `nvflare agent doctor --format json` when the user asks about local
+   readiness or when inspection suggests missing FLARE setup.
+4. Classify the request into one next action: conversion, local validation,
+   POC workflow, production workflow, diagnosis, deployment, or no FLARE skill.
+5. Recommend one lead skill and only mention supporting skills when the next
+   step clearly needs them.
+
+## Requirements
+
+- Must keep the work read-only.
+- Must report the evidence used for routing.
+- Must prefer a specific workflow skill over broad FLARE advice.
+- Must say when no FLARE skill should trigger.
+- Must not edit files, start POC systems, submit jobs, or read private keys.
+
+Load `references/orientation-routing.md` when routing is ambiguous or when the
+inspect output names multiple possible workflow families.

--- a/skills/nvflare-orient/evals/evals.json
+++ b/skills/nvflare-orient/evals/evals.json
@@ -1,0 +1,123 @@
+{
+  "skill_name": "nvflare-orient",
+  "evals": [
+    {
+      "id": "orient-ambiguous-project",
+      "prompt": "I have a local training repo and want to know how to start using NVFLARE.",
+      "expected_output": "The agent inspects the project, checks local readiness when needed, and recommends the next specific NVFLARE workflow skill.",
+      "files": [],
+      "assertions": [
+        "The agent runs nvflare agent inspect before recommending a workflow.",
+        "The agent keeps the routing step read-only.",
+        "The agent recommends one lead skill or says no FLARE skill should trigger."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-orient",
+        "mandatory_behavior": [
+          {
+            "id": "inspect-before-routing",
+            "description": "runs static inspection before routing ambiguous project requests"
+          },
+          {
+            "id": "read-only-routing",
+            "description": "does not mutate files or runtime systems during orientation"
+          },
+          {
+            "id": "single-lead-skill",
+            "description": "recommends one lead skill when a FLARE workflow is appropriate"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-file-edits",
+            "description": "does not edit project files during orientation"
+          },
+          {
+            "id": "no-production-action",
+            "description": "does not submit jobs or start production systems during orientation"
+          }
+        ],
+        "optional_behavior": [
+          {
+            "id": "doctor-readiness",
+            "description": "runs doctor when the prompt asks about local readiness"
+          }
+        ],
+        "process_metrics": [
+          {
+            "id": "first_pass_route_correct",
+            "description": "whether the first routing recommendation names the correct lead skill or no-skill result"
+          },
+          {
+            "id": "turns_to_route",
+            "description": "number of user/agent turns before a concrete lead skill or no-skill route is identified"
+          },
+          {
+            "id": "unwanted_action_count",
+            "description": "number of file edits, runtime commands, or production actions performed during read-only orientation"
+          },
+          {
+            "id": "missed_instruction_count",
+            "description": "number of applicable user, design, or skill instructions missed during orientation, such as requested review passes, read-only constraints, or routing conditions"
+          },
+          {
+            "id": "handoff_clarity",
+            "description": "whether the route includes the next skill, why it applies, and what the agent should do next"
+          }
+        ]
+      }
+    },
+    {
+      "id": "orient-negative-pytorch-conversion",
+      "prompt": "Convert this PyTorch training script into an NVFLARE federated job.",
+      "expected_output": "The orientation skill should not be the lead; the PyTorch conversion skill should handle the request.",
+      "files": [],
+      "assertions": [
+        "The selected skill is nvflare-convert-pytorch, not nvflare-orient."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "negative_for": "nvflare-orient"
+      }
+    },
+    {
+      "id": "orient-diagnosis-handoff",
+      "prompt": "My FLARE job finished with EXECUTION_EXCEPTION and the client logs look suspicious. Which skill should diagnose it?",
+      "expected_output": "The orientation skill routes the request to nvflare-diagnose-job rather than conversion or job generation.",
+      "files": [],
+      "assertions": [
+        "The selected follow-up skill is nvflare-diagnose-job.",
+        "The orientation step stays read-only.",
+        "The agent does not continue into broad generic advice once the diagnosis skill is clear."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-diagnose-job",
+        "mandatory_behavior": [
+          {
+            "id": "diagnosis-handoff",
+            "description": "routes failed or suspicious FLARE jobs to nvflare-diagnose-job"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-diagnosis-implementation-during-routing",
+            "description": "does not perform diagnosis while acting as the orientation router"
+          }
+        ]
+      }
+    },
+    {
+      "id": "orient-global-negative-web-app",
+      "prompt": "Build a React landing page for a bakery.",
+      "expected_output": "No FLARE skill should trigger.",
+      "files": [],
+      "assertions": [
+        "The selected skill is none."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "*"
+      }
+    }
+  ]
+}

--- a/skills/nvflare-orient/references/orientation-routing.md
+++ b/skills/nvflare-orient/references/orientation-routing.md
@@ -1,0 +1,36 @@
+# Orientation Routing Reference
+
+`nvflare-orient` is the lead skill for ambiguous NVFLARE requests. It should
+turn project evidence and user intent into one narrow next action.
+
+## Evidence Sources
+
+- `nvflare agent inspect <path> --format json` for framework, FLARE usage,
+  conversion state, safety findings, and recommended skills.
+- `nvflare agent doctor --format json` for local CLI, skill bundle, startup-kit,
+  POC, and optional online readiness.
+- User-provided target files, job folders, logs, or stated deployment context.
+
+## Routing Rules
+
+- Existing PyTorch training loop needing FLARE conversion:
+  `nvflare-convert-pytorch`.
+- Generic "help me use FLARE here" with no clear workflow: inspect first, then
+  recommend the narrowest skill.
+- Existing FLARE job that fails or produces suspicious logs:
+  `nvflare-diagnose-job`, not conversion.
+- POC startup, production submission, Kubernetes deployment, or identity setup:
+  route to the corresponding operations or deployment skill when available.
+- Non-FLARE Python, web, data science, or generic ML questions: no FLARE skill.
+
+## Output Shape
+
+Summaries should name:
+
+- target path inspected;
+- strongest evidence found;
+- recommended next skill or no-skill decision;
+- validation or approval boundary before any mutating follow-up.
+
+Do not turn routing into implementation. Once the next skill is clear, hand off
+instead of continuing with broad advice.

--- a/tests/unit_test/tool/agent/__init__.py
+++ b/tests/unit_test/tool/agent/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from importlib import resources
+from types import SimpleNamespace
+
+import pytest
+
+from nvflare.tool.agent import bundled_skills, skill_manifest
+from nvflare.tool.agent.skill_manifest import (
+    SkillManifestError,
+    build_skill_manifest,
+    copy_released_skills_to_bundle,
+    load_manifest,
+    skill_tree_hash,
+    write_empty_skill_bundle,
+)
+
+
+def test_build_skill_manifest_includes_valid_skill(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["schema_version"] == "1"
+    assert manifest["source_type"] == "editable"
+    assert manifest["nvflare_version"] == "2.8.0"
+    assert manifest["findings"] == []
+    assert manifest["skills"] == [
+        {
+            "name": "nvflare-test-skill",
+            "skill_version": "0.0.0",
+            "min_flare_version": "2.8.0",
+            "max_flare_version": None,
+            "blast_radius": "read_only",
+            "source_hash": skill_tree_hash(skill_dir),
+            "relative_path": "nvflare-test-skill",
+        }
+    ]
+
+
+def test_skill_tree_hash_changes_when_skill_content_changes(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    first_hash = skill_tree_hash(skill_dir)
+
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "notes.md").write_text("new reference\n", encoding="utf-8")
+
+    assert skill_tree_hash(skill_dir) != first_hash
+
+
+def test_skill_tree_hash_reads_file_contents_in_chunks(tmp_path, monkeypatch):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+
+    def fail_read_bytes(_path):
+        raise AssertionError("skill_tree_hash should not load whole files with read_bytes")
+
+    monkeypatch.setattr(type(skill_dir), "read_bytes", fail_read_bytes)
+
+    assert isinstance(skill_tree_hash(skill_dir), str)
+
+
+def test_build_skill_manifest_reports_invalid_skill_findings(tmp_path):
+    skill_dir = tmp_path / "nvflare-invalid-skill"
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n" "name: nvflare-invalid-skill\n" "description: Missing required fields.\n" "---\n",
+        encoding="utf-8",
+    )
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["skills"] == []
+    assert manifest["findings"][0]["skill_dir"] == "nvflare-invalid-skill"
+    assert manifest["findings"][0]["issues"][0]["code"] == "skill-frontmatter-field-required"
+
+
+def test_build_skill_manifest_skips_shared_reference_dirs(tmp_path):
+    _write_skill(tmp_path, "nvflare-test-skill")
+    shared_dir = tmp_path / "_shared"
+    shared_dir.mkdir()
+    shared_dir.joinpath("reference.md").write_text("shared guidance\n", encoding="utf-8")
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["findings"] == []
+    assert [skill["name"] for skill in manifest["skills"]] == ["nvflare-test-skill"]
+    assert [skill["relative_path"] for skill in manifest["skills"]] == ["nvflare-test-skill"]
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_build_skill_manifest_rejects_skill_symlinks(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "outside-link.txt").symlink_to(outside_file)
+
+    manifest = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+
+    assert manifest["skills"] == []
+    assert manifest["findings"][0]["skill_dir"] == "nvflare-test-skill"
+    assert manifest["findings"][0]["issues"][0]["code"] == "skill-symlink-not-allowed"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_skill_tree_hash_rejects_skill_symlinks(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        skill_tree_hash(skill_dir)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_skill_tree_hash_rejects_symlink_skill_root(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    link_dir = tmp_path / "nvflare-link-skill"
+    link_dir.symlink_to(skill_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        skill_tree_hash(link_dir)
+
+
+def test_skill_tree_hash_ignores_python_cache_files(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    first_hash = skill_tree_hash(skill_dir)
+    cache_dir = skill_dir / "__pycache__"
+    cache_dir.mkdir()
+    cache_dir.joinpath("SKILL.cpython-310.pyc").write_bytes(b"compiled cache")
+    skill_dir.joinpath("cache.pyo").write_bytes(b"optimized cache")
+
+    assert skill_tree_hash(skill_dir) == first_hash
+
+
+def test_validate_skill_dir_uses_current_frontmatter_loader(monkeypatch, tmp_path):
+    first = SimpleNamespace(validate_skill_dir=lambda _path: "first")
+    second = SimpleNamespace(validate_skill_dir=lambda _path: "second")
+
+    monkeypatch.setattr(skill_manifest, "_load_frontmatter_module", lambda: first)
+    assert skill_manifest._validate_skill_dir(tmp_path) == "first"
+
+    monkeypatch.setattr(skill_manifest, "_load_frontmatter_module", lambda: second)
+    assert skill_manifest._validate_skill_dir(tmp_path) == "second"
+
+
+def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    _write_skill(source_root, "nvflare-test-skill")
+
+    manifest = copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("manifest.json").is_file()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+    saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert saved_manifest == manifest
+    assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+
+
+def test_copy_released_skills_to_bundle_cleans_existing_bundle_content(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    bundle_root.joinpath("__init__.py").write_text("# keep package marker\n", encoding="utf-8")
+    bundle_root.joinpath("stale.txt").write_text("stale\n", encoding="utf-8")
+    stale_dir = bundle_root / "stale-skill"
+    stale_dir.mkdir()
+    stale_dir.joinpath("SKILL.md").write_text("stale\n", encoding="utf-8")
+    _write_skill(source_root, "nvflare-test-skill")
+
+    copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("__init__.py").is_file()
+    assert not bundle_root.joinpath("stale.txt").exists()
+    assert not stale_dir.exists()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_copy_released_skills_to_bundle_unlinks_stale_bundle_symlink(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    stale_target = tmp_path / "stale-target"
+    stale_target.mkdir()
+    bundle_root.joinpath("stale-link").symlink_to(stale_target, target_is_directory=True)
+    _write_skill(source_root, "nvflare-test-skill")
+
+    copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert not bundle_root.joinpath("stale-link").exists()
+    assert stale_target.is_dir()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_copy_released_skills_to_bundle_rejects_shared_reference_symlink(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    _write_skill(source_root, "nvflare-test-skill")
+    shared_dir = source_root / "_shared"
+    shared_dir.mkdir()
+    outside_file = tmp_path / "outside.md"
+    outside_file.write_text("external shared content\n", encoding="utf-8")
+    shared_dir.joinpath("outside-link.md").symlink_to(outside_file)
+
+    with pytest.raises(ValueError, match="skill directory contains symlink"):
+        copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
+
+    assert not bundle_root.joinpath("_shared", "outside-link.md").exists()
+
+
+def test_write_empty_skill_bundle_writes_empty_manifest_and_cleans_existing_content(tmp_path):
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    bundle_root.joinpath("__init__.py").write_text("# keep package marker\n", encoding="utf-8")
+    bundle_root.joinpath("stale.txt").write_text("stale\n", encoding="utf-8")
+    stale_skill = bundle_root / "nvflare-stale-skill"
+    stale_skill.mkdir()
+    stale_skill.joinpath("SKILL.md").write_text("stale\n", encoding="utf-8")
+
+    manifest = write_empty_skill_bundle(bundle_root, nvflare_version="2.8.0")
+
+    assert bundle_root.joinpath("__init__.py").is_file()
+    assert not bundle_root.joinpath("stale.txt").exists()
+    assert not stale_skill.exists()
+    assert manifest == {
+        "schema_version": "1",
+        "source_type": "wheel",
+        "nvflare_version": "2.8.0",
+        "skills": [],
+        "findings": [],
+    }
+    assert json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8")) == manifest
+
+
+def test_bundled_skill_manifest_resource_exists():
+    manifest = resources.files(bundled_skills).joinpath("manifest.json")
+
+    assert manifest.is_file()
+    assert json.loads(manifest.read_text(encoding="utf-8"))["schema_version"] == "1"
+
+
+def test_load_manifest_wraps_read_and_json_errors(tmp_path):
+    missing = tmp_path / "missing.json"
+    with pytest.raises(SkillManifestError) as read_exc:
+        load_manifest(missing)
+    assert read_exc.value.code == "AGENT_SKILL_MANIFEST_READ_FAILED"
+
+    corrupt = tmp_path / "manifest.json"
+    corrupt.write_text("{not json\n", encoding="utf-8")
+    with pytest.raises(SkillManifestError) as json_exc:
+        load_manifest(corrupt)
+    assert json_exc.value.code == "AGENT_SKILL_MANIFEST_INVALID_JSON"
+
+    corrupt.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(SkillManifestError) as shape_exc:
+        load_manifest(corrupt)
+    assert shape_exc.value.code == "AGENT_SKILL_MANIFEST_INVALID"
+
+
+def _write_skill(root, name):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent_skill_checks/__init__.py
+++ b/tests/unit_test/tool/agent_skill_checks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/tool/agent_skill_checks/cli_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/cli_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent_skill_checks import cli
+
+
+def test_agent_skill_checks_cli_emits_json_and_nonzero_on_findings(tmp_path, capsys):
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+
+    exit_code = cli.main(["--skills-root", str(skills_root / "missing"), "--format", "json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is False
+    assert payload["summary"]["error_count"] == 1
+    assert payload["findings"][0]["id"] == "skill-frontmatter-lint"
+
+
+def test_agent_skill_checks_cli_emits_text(capsys, tmp_path):
+    exit_code = cli.main(["--skills-root", str(tmp_path / "missing")])
+
+    assert exit_code == 1
+    assert "agent skill checks:" in capsys.readouterr().out

--- a/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
+++ b/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: nvflare-example-skill
+description: Example fixture skill used by frontmatter validator tests.
+min_flare_version: "2.8.0"
+blast_radius: read_only
+---
+
+# Example Skill
+
+This file exists only as a validator fixture.

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from nvflare.tool.agent_skill_checks.frontmatter import (
+    SkillFrontmatterError,
+    parse_skill_frontmatter,
+    validate_skill_dir,
+    validate_skills_root,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_parse_skill_frontmatter_reads_required_fields():
+    metadata = parse_skill_frontmatter(FIXTURES / "valid" / "nvflare-example-skill" / "SKILL.md")
+
+    assert metadata["name"] == "nvflare-example-skill"
+    assert metadata["description"] == "Example fixture skill used by frontmatter validator tests."
+    assert metadata["min_flare_version"] == "2.8.0"
+    assert metadata["blast_radius"] == "read_only"
+
+
+def test_parse_skill_frontmatter_accepts_utf8_bom(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_bytes(
+        b"\xef\xbb\xbf---\n"
+        b"name: nvflare-bom-skill\n"
+        b"description: Test skill fixture.\n"
+        b'min_flare_version: "2.8.0"\n'
+        b"blast_radius: read_only\n"
+        b"---\n"
+        b"\n"
+        b"# Test Skill\n"
+    )
+
+    metadata = parse_skill_frontmatter(skill_file)
+
+    assert metadata["name"] == "nvflare-bom-skill"
+
+
+def test_validate_skill_dir_accepts_fixture_skill():
+    result = validate_skill_dir(FIXTURES / "valid" / "nvflare-example-skill")
+
+    assert result.ok
+    assert result.metadata["name"] == "nvflare-example-skill"
+    assert result.issues == ()
+
+
+def test_validate_skill_dir_requires_directory_name_to_match_frontmatter(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-other-name", name="nvflare-example-skill")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-name-directory-mismatch"}
+
+
+def test_validate_skill_dir_allows_name_prefix_for_visibility_aware_lint(tmp_path):
+    skill_dir = _write_skill(tmp_path, "example-skill")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert result.ok
+    assert result.metadata["name"] == "example-skill"
+
+
+def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-fields"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-missing-fields\n"
+        "description: Missing two required fields.\n"
+        "---\n"
+        "\n"
+        "# Missing Fields\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-required"}
+    assert len(result.issues) == 2
+
+
+def test_validate_skill_dir_reports_wrong_type_fields(tmp_path):
+    skill_dir = tmp_path / "nvflare-wrong-type"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-wrong-type\n"
+        "description: Wrong type fixture.\n"
+        "min_flare_version: 2.8\n"
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Wrong Type\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-type"}
+    assert "min_flare_version" in result.issues[0].message
+    assert "float=2.8" in result.issues[0].message
+
+
+def test_validate_skill_dir_rejects_invalid_blast_radius(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-invalid-radius", blast_radius="global_admin")
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-blast-radius-invalid"}
+
+
+def test_parse_skill_frontmatter_requires_delimiters(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("name: nvflare-no-frontmatter\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must start"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_requires_closing_delimiter(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "---\n" "name: nvflare-no-closing-delimiter\n" "description: Missing closing delimiter.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillFrontmatterError, match="must end"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_malformed_yaml(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\nname: [unclosed\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="failed to parse YAML"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_non_mapping(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("---\n- name\n- description\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillFrontmatterError, match="must be a mapping"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_parse_skill_frontmatter_rejects_yaml_anchors_and_aliases(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "---\n"
+        "name: nvflare-anchor-skill\n"
+        "description: &shared Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: *shared\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillFrontmatterError, match="anchors or aliases"):
+        parse_skill_frontmatter(skill_file)
+
+
+def test_validate_skill_dir_reports_missing_directory(tmp_path):
+    result = validate_skill_dir(tmp_path / "nvflare-missing-directory")
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-dir-missing"}
+
+
+def test_validate_skill_dir_reports_missing_skill_file(tmp_path):
+    skill_dir = tmp_path / "nvflare-missing-skill-md"
+    skill_dir.mkdir()
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-md-missing"}
+
+
+def test_validate_skills_root_skips_non_skill_files(tmp_path):
+    _write_skill(tmp_path, "nvflare-valid-one")
+    (tmp_path / "README.md").write_text("not a skill\n", encoding="utf-8")
+    (tmp_path / ".hidden-dir").mkdir()
+    (tmp_path / "_shared").mkdir()
+
+    results = validate_skills_root(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].ok
+    assert results[0].metadata["name"] == "nvflare-valid-one"
+
+
+def test_validate_skills_root_reports_missing_root(tmp_path):
+    results = validate_skills_root(tmp_path / "missing")
+
+    assert len(results) == 1
+    assert not results[0].ok
+    assert _issue_codes(results[0]) == {"skills-root-missing"}
+
+
+def _write_skill(tmp_path, skill_name, *, name=None, blast_radius="read_only"):
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name or skill_name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        f"blast_radius: {blast_radius}\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _issue_codes(result):
+    return {issue.code for issue in result.issues}

--- a/tests/unit_test/tool/agent_skill_checks/lints_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/lints_test.py
@@ -1,0 +1,688 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from nvflare.tool.agent_skill_checks import lints as lints_module
+from nvflare.tool.agent_skill_checks.lints import (
+    MAX_SKILL_TEXT_FILE_BYTES,
+    V1_LINT_IDS,
+    _parse_conversion_table,
+    _parse_product_catalog,
+    _run_v1_lints_with_records,
+    run_v1_lints,
+    validate_skills,
+)
+
+LINT_SKILL_FRONTMATTER = "skill-frontmatter-lint"
+LINT_SKILL_MD_SIZE = "skill-md-size-lint"
+LINT_SKILL_TRIGGER = "skill-trigger-lint"
+LINT_SKILL_TRIGGER_OVERLAP = "skill-trigger-overlap-lint"
+LINT_SKILL_CATALOG_CATEGORY = "skill-catalog-category-lint"
+LINT_SKILL_GLOBAL_NEGATIVE = "skill-global-negative-lint"
+LINT_SKILL_POLICY_COVERAGE = "skill-policy-coverage-lint"
+LINT_SKILL_PROCESS_METRIC = "skill-process-metric-lint"
+LINT_SKILL_COMMAND_DRIFT = "skill-command-drift-lint"
+LINT_SKILL_HELPER_SCRIPT = "skill-helper-script-lint"
+LINT_SKILL_FIXTURE = "skill-fixture-lint"
+LINT_AGENT_DOC_CROSSLINK = "agent-doc-crosslink-lint"
+REQUIRED_FINDING_FIELDS = {"id", "severity", "file", "message", "hint"}
+
+
+def test_run_v1_lints_passes_complete_skill(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+    assert result["summary"]["error_count"] == 0
+    assert {"error", "warning", "info"}.isdisjoint(result["summary"])
+    assert set(result["checks"]) == {
+        LINT_SKILL_FRONTMATTER,
+        LINT_SKILL_MD_SIZE,
+        LINT_SKILL_TRIGGER,
+        LINT_SKILL_TRIGGER_OVERLAP,
+        LINT_SKILL_CATALOG_CATEGORY,
+        LINT_SKILL_GLOBAL_NEGATIVE,
+        LINT_SKILL_POLICY_COVERAGE,
+        LINT_SKILL_PROCESS_METRIC,
+        LINT_SKILL_COMMAND_DRIFT,
+        LINT_SKILL_HELPER_SCRIPT,
+        LINT_SKILL_FIXTURE,
+        LINT_AGENT_DOC_CROSSLINK,
+    }
+
+
+def test_run_v1_lints_reports_frontmatter_prefix(tmp_path):
+    _write_skill(tmp_path / "skills", "example-skill")
+    docs_root = _write_design_docs(tmp_path, ["example-skill"], category="Orient")
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_FRONTMATTER, "skill-name-prefix-required")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_allows_internal_skill_without_nvflare_prefix(tmp_path):
+    _write_skill(tmp_path / "skills", "example-skill", status="internal")
+    docs_root = _write_design_docs(tmp_path, ["example-skill"], category="Orient")
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FRONTMATTER])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_run_v1_lints_reports_skill_md_size(tmp_path):
+    body = "\n".join(f"line {i}" for i in range(205))
+    _write_skill(tmp_path / "skills", "nvflare-large-skill", body=body)
+    docs_root = _write_design_docs(tmp_path, ["nvflare-large-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_MD_SIZE, "skill-md-too-large")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_does_not_parse_oversized_skill_md(monkeypatch, tmp_path):
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-large-skill")
+    with skill_dir.joinpath("SKILL.md").open("ab") as stream:
+        stream.truncate(MAX_SKILL_TEXT_FILE_BYTES + 1)
+    monkeypatch.setattr(
+        lints_module,
+        "_try_parse_frontmatter",
+        lambda _path: (_ for _ in ()).throw(AssertionError("oversized SKILL.md should not be parsed")),
+    )
+
+    result, records = _run_v1_lints_with_records(tmp_path / "skills", checks=[LINT_SKILL_MD_SIZE])
+
+    assert records[0].metadata == {}
+    assert records[0].text == ""
+    assert records[0].body == ""
+    assert _has_finding(result, LINT_SKILL_MD_SIZE, "skill-md-too-large")
+
+
+def test_load_evals_rejects_oversized_evals_json(tmp_path):
+    evals_path = tmp_path / "evals.json"
+    with evals_path.open("wb") as stream:
+        stream.truncate(MAX_SKILL_TEXT_FILE_BYTES + 1)
+
+    evals, error = lints_module._load_evals(evals_path)
+
+    assert evals == []
+    assert error == f"evals/evals.json exceeds size limit ({MAX_SKILL_TEXT_FILE_BYTES} bytes)"
+
+
+def test_line_for_field_does_not_read_oversized_skill_md(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    with skill_file.open("wb") as stream:
+        stream.truncate(MAX_SKILL_TEXT_FILE_BYTES + 1)
+
+    assert lints_module._line_for_field(skill_file, "name") == 1
+
+
+def test_run_v1_lints_reports_missing_trigger_evals(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-trigger-skill", evals={"evals": []})
+    docs_root = _write_design_docs(tmp_path, ["nvflare-trigger-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_TRIGGER, "skill-positive-trigger-eval-missing")
+    assert _has_finding(result, LINT_SKILL_TRIGGER, "skill-adjacent-negative-eval-missing")
+    assert _has_finding(result, LINT_SKILL_GLOBAL_NEGATIVE, "skill-global-negative-eval-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_missing_catalog_entry(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-one-skill")
+    _write_skill(tmp_path / "skills", "nvflare-two-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-one-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_CATALOG_CATEGORY, "skill-catalog-entry-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_trigger_overlap_without_negative_boundary(tmp_path):
+    evals_one = _default_evals("nvflare-one-skill", adjacent_negative=False)
+    evals_two = _default_evals("nvflare-two-skill", adjacent_negative=False)
+    _write_skill(
+        tmp_path / "skills",
+        "nvflare-one-skill",
+        description="Convert PyTorch training code to FLARE.",
+        body="Use when converting PyTorch training code.\n",
+        evals=evals_one,
+    )
+    _write_skill(
+        tmp_path / "skills",
+        "nvflare-two-skill",
+        description="Convert PyTorch training code to FLARE.",
+        body="Use when converting PyTorch training code.\n",
+        evals=evals_two,
+    )
+    docs_root = _write_design_docs(tmp_path, ["nvflare-one-skill", "nvflare-two-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_TRIGGER_OVERLAP, "skill-trigger-overlap")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_policy_without_behavior_ids(tmp_path):
+    evals = _default_evals("nvflare-policy-skill", include_behavior_ids=False)
+    _write_skill(
+        tmp_path / "skills", "nvflare-policy-skill", body="The agent must validate before submit.\n", evals=evals
+    )
+    docs_root = _write_design_docs(tmp_path, ["nvflare-policy-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_POLICY_COVERAGE, "skill-policy-coverage-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_unknown_nvflare_command(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-command-skill", body="Run `nvflare unknown --format json`.\n")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-command-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    finding = _finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    assert isinstance(finding["line"], int)
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_command_drift_before_unsafe_token(tmp_path):
+    _write_skill(
+        tmp_path / "skills",
+        "nvflare-command-skill",
+        body="Run `nvflare agent unknown $HOME/skills`.\n",
+    )
+    docs_root = _write_design_docs(tmp_path, ["nvflare-command-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_COMMAND_DRIFT])
+
+    assert _has_finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    finding = _finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    assert "unknown nvflare agent command 'unknown'" in finding["message"]
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_parses_quoted_nvflare_command_with_shlex(tmp_path):
+    _write_skill(
+        tmp_path / "skills",
+        "nvflare-command-skill",
+        body='Run `nvflare agent skills install --skill "nvflare-valid-skill" --target /tmp/skills`.\n',
+    )
+    docs_root = _write_design_docs(tmp_path, ["nvflare-command-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_COMMAND_DRIFT])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_run_v1_lints_skips_trigger_overlap_when_skill_count_exceeds_cap(monkeypatch, tmp_path):
+    monkeypatch.setenv("NVFLARE_AGENT_MAX_TRIGGER_OVERLAP_SKILLS", "1")
+    _write_skill(tmp_path / "skills", "nvflare-one-skill")
+    _write_skill(tmp_path / "skills", "nvflare-two-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-one-skill", "nvflare-two-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_TRIGGER_OVERLAP])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+    assert result["skipped_checks"] == [
+        {
+            "id": LINT_SKILL_TRIGGER_OVERLAP,
+            "reason": "category 'Conversion' has 2 skills; limit is 1",
+        }
+    ]
+
+
+def test_run_v1_lints_reports_helper_script_without_test(tmp_path):
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-helper-skill")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    scripts_dir.joinpath("helper.py").write_text("print('{}')\n", encoding="utf-8")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-helper-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_HELPER_SCRIPT, "skill-helper-tests-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_helper_script_ignores_symlink_loop(tmp_path):
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-helper-skill")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    scripts_dir.joinpath("helper.py").write_text("print('{}')\n", encoding="utf-8")
+    _symlink_dir_or_skip(scripts_dir, scripts_dir / "loop")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-helper-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_HELPER_SCRIPT])
+
+    assert _has_finding(result, LINT_SKILL_HELPER_SCRIPT, "skill-helper-tests-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_skips_oversized_helper_script_content_checks(tmp_path):
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-helper-skill")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    helper = scripts_dir / "helper.py"
+    helper.write_text("promoted_to: nvflare agent helper\n", encoding="utf-8")
+    with helper.open("ab") as stream:
+        stream.truncate(MAX_SKILL_TEXT_FILE_BYTES + 1)
+    tests_dir = skill_dir / "tests"
+    tests_dir.mkdir()
+    tests_dir.joinpath("helper_test.txt").write_text("helper test placeholder\n", encoding="utf-8")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-helper-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_HELPER_SCRIPT])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_run_v1_lints_reports_missing_fixture_file(tmp_path):
+    evals = _default_evals("nvflare-fixture-skill")
+    evals["evals"][0]["files"] = ["evals/files/missing.py"]
+    _write_skill(tmp_path / "skills", "nvflare-fixture-skill", evals=evals, write_fixture=False)
+    docs_root = _write_design_docs(tmp_path, ["nvflare-fixture-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_SKILL_FIXTURE, "skill-fixture-file-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_fixture_file_check_ignores_symlink_loop(tmp_path):
+    evals = _default_evals("nvflare-fixture-skill")
+    evals["evals"][0]["files"] = ["evals/files/input.py"]
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-fixture-skill", evals=evals, write_fixture=False)
+    files_dir = skill_dir / "evals" / "files"
+    files_dir.mkdir()
+    files_dir.joinpath("input.py").write_text("print('hello')\n", encoding="utf-8")
+    _symlink_dir_or_skip(files_dir, files_dir / "loop")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-fixture-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FIXTURE])
+
+    assert _has_finding(result, LINT_SKILL_FIXTURE, "skill-fixture-notes-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_does_not_require_fixtures_for_conceptual_file_mentions(tmp_path):
+    evals = {
+        "skill_name": "nvflare-fixture-skill",
+        "evals": [
+            {
+                "id": "conceptual-file-guidance",
+                "prompt": "Explain how to create a dataset file naming convention.",
+                "expected_output": "A written explanation, not edited files.",
+                "files": [],
+                "assertions": ["Mentions file naming without creating artifacts."],
+                "nvflare": {"expected_skill": "nvflare-fixture-skill"},
+            }
+        ],
+        "nvflare": {"category": "conversion"},
+    }
+    _write_skill(tmp_path / "skills", "nvflare-fixture-skill", evals=evals, write_fixture=False)
+    docs_root = _write_design_docs(tmp_path, ["nvflare-fixture-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FIXTURE])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_run_v1_lints_reference_text_scan_ignores_symlink_loop(tmp_path):
+    skill_dir = _write_skill(tmp_path / "skills", "nvflare-command-skill")
+    references_dir = skill_dir / "references"
+    references_dir.mkdir()
+    references_dir.joinpath("guide.md").write_text("Run `nvflare unknown --format json`.\n", encoding="utf-8")
+    _symlink_dir_or_skip(references_dir, references_dir / "loop")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-command-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_COMMAND_DRIFT])
+
+    assert _has_finding(result, LINT_SKILL_COMMAND_DRIFT, "skill-command-drift")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_rejects_fixture_paths_that_escape_skill_dir(tmp_path):
+    evals = _default_evals("nvflare-fixture-skill")
+    evals["evals"][0]["files"] = ["../outside.py"]
+    _write_skill(tmp_path / "skills", "nvflare-fixture-skill", evals=evals)
+    docs_root = _write_design_docs(tmp_path, ["nvflare-fixture-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FIXTURE])
+
+    assert _has_finding(result, LINT_SKILL_FIXTURE, "skill-fixture-path-escape")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_reports_broken_doc_crosslink(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-doc-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-doc-skill"])
+    docs_root.joinpath("agent_integration.md").write_text(
+        docs_root.joinpath("agent_integration.md").read_text(encoding="utf-8")
+        + "\n[missing](missing.md)\n[bad anchor](agent_integration.md#nope)\n",
+        encoding="utf-8",
+    )
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert _has_finding(result, LINT_AGENT_DOC_CROSSLINK, "agent-doc-link-missing")
+    assert _has_finding(result, LINT_AGENT_DOC_CROSSLINK, "agent-doc-anchor-missing")
+    _assert_structured_findings(result)
+
+
+def test_run_v1_lints_supports_check_selection(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    _write_skill(tmp_path / "skills", "nvflare-other-skill", evals={"evals": []})
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill", "nvflare-other-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_FRONTMATTER])
+
+    assert result["status"] == "ok"
+    assert result["checks"] == [LINT_SKILL_FRONTMATTER]
+    assert result["summary"]["skill_count"] == 2
+
+
+def test_run_v1_lints_skips_shared_reference_dirs(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    shared_dir = tmp_path / "skills" / "_shared"
+    shared_dir.mkdir()
+    shared_dir.joinpath("reference.md").write_text("shared guidance\n", encoding="utf-8")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+
+    assert result["status"] == "ok"
+    assert result["summary"]["skill_count"] == 1
+    assert result["findings"] == []
+
+
+def test_run_v1_lints_records_doc_dependent_overlap_skip(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+
+    result = run_v1_lints(
+        tmp_path / "skills",
+        docs_root=tmp_path / "missing-docs",
+        checks=[LINT_SKILL_TRIGGER_OVERLAP],
+    )
+
+    assert result["status"] == "ok"
+    assert result["skipped_checks"] == [{"id": LINT_SKILL_TRIGGER_OVERLAP, "reason": "docs root is not available"}]
+
+
+def test_run_v1_lints_doc_crosslinks_skip_oversized_doc(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+    doc_path = docs_root / "agent_implementation_plan.md"
+    doc_path.write_text("[Broken](missing.md)\n", encoding="utf-8")
+    with doc_path.open("ab") as stream:
+        stream.truncate(MAX_SKILL_TEXT_FILE_BYTES + 1)
+
+    result = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_AGENT_DOC_CROSSLINK])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_catalog_parsers_skip_oversized_docs(tmp_path):
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+    product_doc = docs_root / "agent_integration.md"
+    conversion_doc = docs_root / "agent_skill_authoring.md"
+    for doc_path in (product_doc, conversion_doc):
+        with doc_path.open("ab") as stream:
+            stream.truncate(MAX_SKILL_TEXT_FILE_BYTES + 1)
+
+    assert _parse_product_catalog(product_doc) == {}
+    assert _parse_conversion_table(conversion_doc) == {}
+
+
+def test_validate_skills_filters_summary_to_requested_skill(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    _write_skill(tmp_path / "skills", "nvflare-other-skill", evals={"evals": []})
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill", "nvflare-other-skill"])
+
+    result = validate_skills(tmp_path / "skills", skill_name="nvflare-valid-skill", docs_root=docs_root)
+
+    assert result["status"] == "ok"
+    assert result["requested_skill"] == "nvflare-valid-skill"
+    assert result["summary"]["skill_count"] == 1
+    assert result["findings"] == []
+
+
+def test_validate_skills_excludes_unattributed_doc_findings_for_requested_skill(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+    docs_root.joinpath("agent_implementation_plan.md").write_text(
+        "# Agent Implementation Plan\n\n[Missing](missing.md)\n",
+        encoding="utf-8",
+    )
+
+    all_result = run_v1_lints(tmp_path / "skills", docs_root=docs_root)
+    requested_result = validate_skills(tmp_path / "skills", skill_name="nvflare-valid-skill", docs_root=docs_root)
+
+    assert _has_finding(all_result, LINT_AGENT_DOC_CROSSLINK, "agent-doc-link-missing")
+    assert requested_result["status"] == "ok"
+    assert requested_result["findings"] == []
+
+
+def test_validate_skills_keeps_global_findings_for_requested_skill(tmp_path):
+    result = validate_skills(tmp_path / "missing-skills", skill_name="nvflare-valid-skill", docs_root=tmp_path / "docs")
+
+    assert result["status"] == "failed"
+    assert result["summary"]["error_count"] == 1
+    finding = _finding(result, LINT_SKILL_FRONTMATTER, "skills-root-missing")
+    assert finding["global"] is True
+    assert "skill" not in finding
+
+
+def test_validate_skills_uses_requested_size_limit_without_mutating_default(tmp_path):
+    _write_skill(tmp_path / "skills", "nvflare-valid-skill")
+    docs_root = _write_design_docs(tmp_path, ["nvflare-valid-skill"])
+
+    limited = validate_skills(
+        tmp_path / "skills",
+        skill_name="nvflare-valid-skill",
+        docs_root=docs_root,
+        max_skill_md_lines=2,
+    )
+    default = run_v1_lints(tmp_path / "skills", docs_root=docs_root, checks=[LINT_SKILL_MD_SIZE])
+
+    assert _has_finding(limited, LINT_SKILL_MD_SIZE, "skill-md-too-large")
+    assert default["status"] == "ok"
+    assert default["findings"] == []
+
+
+def _write_skill(
+    root,
+    name,
+    *,
+    description="Convert PyTorch training code into a FLARE job.",
+    body="Use when converting PyTorch training code.\nDo not use for Kubernetes deployment.\n",
+    evals=None,
+    category="conversion",
+    write_fixture=True,
+    status=None,
+):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    status_line = f"status: {status}\n" if status else ""
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: edits_files\n"
+        f"{status_line}"
+        "---\n"
+        "\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    if write_fixture:
+        files_dir = evals_dir / "files"
+        files_dir.mkdir()
+        files_dir.joinpath("input.py").write_text("print('hello')\n", encoding="utf-8")
+        files_dir.joinpath("README.md").write_text(
+            "Source: synthetic fixture for deterministic agent skill lint tests.\n",
+            encoding="utf-8",
+        )
+    evals_dir.joinpath("evals.json").write_text(
+        json.dumps(evals if evals is not None else _default_evals(name, category=category), indent=2),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_design_docs(tmp_path, skills, *, category="Conversion", tier="bundle"):
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir(exist_ok=True)
+    catalog_rows = "\n".join(f"| {category} | `{skill}` | {tier} | Test skill. |" for skill in skills)
+    conversion_rows = "\n".join(f"| PyTorch | `{skill}` | Test scope. | Test fixture. | {tier} |" for skill in skills)
+    lint_rows = "\n".join(f"| `{lint_id}` | Test lint definition. |" for lint_id in V1_LINT_IDS)
+
+    docs_root.joinpath("agent_integration.md").write_text(
+        "# Agent Integration\n\n"
+        "## Product Skill Catalog\n\n"
+        "| Category | Skill | Tier | Purpose |\n"
+        "| --- | --- | --- | --- |\n"
+        f"{catalog_rows}\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_skill_authoring.md").write_text(
+        "# Agent Skill Authoring\n\n"
+        "## Conversion Skill Families\n\n"
+        "| Code Family | Skill | Scope | Current Repo Evidence | Tier |\n"
+        "| --- | --- | --- | --- | --- |\n"
+        f"{conversion_rows}\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_skill_evaluation.md").write_text(
+        "# Agent Skill Evaluation\n\n"
+        "## V1 Engineering Lints\n\n"
+        "| Check | Definition |\n"
+        "| --- | --- |\n"
+        f"{lint_rows}\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_implementation_plan.md").write_text(
+        "# Agent Implementation Plan\n\n" "[V1 Engineering Lints](agent_skill_evaluation.md#v1-engineering-lints)\n",
+        encoding="utf-8",
+    )
+    docs_root.joinpath("agent_skills_deferred_roadmap.md").write_text(
+        "# Agent Skills Deferred Roadmap\n",
+        encoding="utf-8",
+    )
+    return docs_root
+
+
+def _symlink_dir_or_skip(target, link):
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (NotImplementedError, OSError) as e:
+        pytest.skip(f"directory symlink is not available in this environment: {e}")
+
+
+def _default_evals(name, *, category="conversion", adjacent_negative=True, include_behavior_ids=True):
+    data = {
+        "skill_name": name,
+        "evals": [
+            {
+                "id": "positive",
+                "prompt": "Convert PyTorch training code into a FLARE job.",
+                "expected_output": "A validated FLARE job.",
+                "files": ["evals/files/input.py"],
+                "assertions": ["Uses the expected skill."],
+                "nvflare": {
+                    "expected_skill": name,
+                    "process_metrics": [
+                        {
+                            "id": "turns_to_acceptable",
+                            "description": "number of turns before an acceptable result",
+                        }
+                    ],
+                },
+            },
+            {
+                "id": "global-negative",
+                "prompt": "Deploy a React application.",
+                "expected_output": "No FLARE skill should trigger.",
+                "files": [],
+                "assertions": ["No FLARE skill is selected."],
+                "nvflare": {"expected_skill": "no_skill", "global_negative": True},
+            },
+        ],
+    }
+    if category is not None:
+        data["nvflare"] = {"category": category}
+    if adjacent_negative:
+        data["evals"].append(
+            {
+                "id": "adjacent-negative",
+                "prompt": "Deploy a FLARE startup kit to Kubernetes.",
+                "expected_output": "A deployment skill should trigger.",
+                "files": [],
+                "assertions": ["Conversion skill is not selected."],
+                "nvflare": {"expected_skill": "nvflare-deploy-k8s", "negative_for": name},
+            }
+        )
+    if include_behavior_ids:
+        data["evals"][0]["nvflare"].update(
+            {
+                "mandatory_behavior": [{"id": "inspect-first", "description": "runs inspect before editing"}],
+                "prohibited_behavior": [{"id": "no-production-submit", "description": "does not submit"}],
+                "optional_behavior": [{"id": "summarize", "description": "summarizes result"}],
+            }
+        )
+    return data
+
+
+def _has_finding(result, lint_id, code):
+    return any(finding["id"] == lint_id and finding.get("code") == code for finding in result["findings"])
+
+
+def _finding(result, lint_id, code):
+    matches = [finding for finding in result["findings"] if finding["id"] == lint_id and finding.get("code") == code]
+    assert matches, f"expected finding id={lint_id!r} code={code!r}; got {result['findings']!r}"
+    return matches[0]
+
+
+def _assert_structured_findings(result):
+    assert result["findings"]
+    for finding in result["findings"]:
+        assert REQUIRED_FINDING_FIELDS.issubset(finding), finding
+        assert finding["severity"] in {"error", "warning", "info"}
+        assert finding["file"]
+        assert finding["message"]
+        assert finding["hint"]
+        if "line" in finding:
+            assert isinstance(finding["line"], int)
+            assert finding["line"] > 0
+    json.dumps(result["findings"])

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from nvflare.tool.agent_skill_checks.lints import run_v1_lints
+
+
+def test_seed_skills_pass_v1_admission_lints():
+    repo_root = Path(__file__).resolve().parents[4]
+
+    result = run_v1_lints(repo_root / "skills", docs_root=repo_root / "docs" / "design")
+
+    assert result["status"] == "ok"
+    assert result["summary"]["skill_count"] >= 2
+    assert result["findings"] == []


### PR DESCRIPTION
## Summary

Adds the NVFLARE agent skill layer and the local validation checks that make those skills packageable, inspectable, and testable before wiring them into the CLI or benchmark harness.

## Key Scope

- Add the bundled NVFLARE agent skills and their packaging metadata.
- Add skill check utilities for validating skill structure, descriptions, and installability.
- Add focused tests for bundled skill discovery, skill metadata, and packaging smoke coverage.
- Add design/implementation documentation that describes the agent skill responsibilities and boundaries.

## Review Notes

This PR is intentionally limited to the agent skills foundation. It does not add the public `nvflare agent` CLI surface or the benchmark harness; those are split into later PRs to keep this review focused on the reusable skill content and checks.

## Stack

This is PR 1 of 5. It targets `NVIDIA/NVFlare:main`.

## Full Split Plan

| PR | Title | Branch | Base | Non-Test Files | Test Files | Non-Test Lines | Test Lines | Total Lines |
|---:|---|---|---|---:|---:|---:|---:|---:|
| 1 | Agent Skills + Checks | `flare-agent-split/01-agent-skills` | `main` | 41 | 8 | 5,397 | 1,321 | 6,718 |
| 2 | Agent CLI | `flare-agent-split/02-agent-cli` | PR 1 | 11 | 8 | 4,362 | 2,488 | 6,850 |
| 3 | Benchmark Docker Setup | `flare-agent-split/03-benchmark-docker-setup` | PR 2 | 29 | 3 | 4,015 | 1,417 | 5,432 |
| 4 | Skill Benchmark Runtime | `flare-agent-split/04-benchmark-runtime` | PR 3 | 25 | 5 | 9,927 | 3,654 | 13,581 |
| 5 | Benchmark Reporting | `flare-agent-split/05-benchmark-reporting` | PR 4 | 3 | 1 | 2,016 | 1,037 | 3,053 |

## Validation

- `python -m pytest tests/unit_test/tool/agent tests/unit_test/tool/agent_skill_checks tests/unit_test/skills_benchmark`
- `./runtest.sh -s`