### PR TITLE
Add NVFLARE agent CLI

### DIFF
--- a/docs/design/agent_implementation_plan.md
+++ b/docs/design/agent_implementation_plan.md
@@ -1,0 +1,564 @@
+# NVFLARE Agent Skills Initial Implementation Plan
+
+## Document Control
+
+| Field | Value |
+| --- | --- |
+| Created date | 2026-05-26 |
+| Updated date | 2026-06-04 |
+| Status | Ready for Implementation |
+| Sources | [Agent Integration](agent_integration.md), [Agent Skill Authoring](agent_skill_authoring.md), [Agent Skill Evaluation](agent_skill_evaluation.md), and the temporary deferred-roadmap planning note |
+| Scope | First implementation cut for native NVFLARE agent skills |
+| Out of scope | Public NVIDIA skills catalog mechanics, public scoreboard ownership, Node/npm/npx installer dependency, Auto-FL product roadmap, and deferred roadmap items |
+
+## Intent
+
+This plan implements the simplified initial design. Deferred mechanisms such as
+receipts, provenance, durable workflow state, transcript replay, workspace
+cleanup, full lifecycle commands, compatibility shims, PR-bot automation, and
+the large policy catalog are intentionally not part of this plan. They live in
+the temporary deferred-roadmap planning note.
+
+The core test split is:
+
+- Engineering correctness: unit, CLI, package, helper-script, lint, and release
+  tests that can block NVFLARE CI/release.
+- Runtime agent performance: trigger correctness, instruction following,
+  prohibited-action avoidance, task validation, and benchmark notes that can
+  block public skill promotion.
+
+Do not report normal engineering tests as runtime skill-performance metrics.
+
+## First Implementation Cut
+
+The first useful slice is:
+
+- `nvflare agent skills install --agent codex|claude [--skill <name>]
+  [--dry-run] [--format json]`;
+- `nvflare agent skills list --agent codex|claude --format json`;
+- packaged skills copied from repo-root `skills/` into the NVFLARE wheel;
+- minimal released-skill manifest with name, version/source hash, and
+  FLARE-version compatibility;
+- `nvflare agent inspect <path> --format json`;
+- `nvflare agent doctor [--online] --format json`;
+- guide-compatible skill layout under `skills/<skill>/`;
+- initial lints for frontmatter, size, trigger boundaries, trigger overlap,
+  catalog category, global negatives, policy coverage, command drift, helper
+  scripts, fixtures, and doc crosslinks;
+- at least one public-candidate skill, preferably `nvflare-orient` or
+  `nvflare-convert-pytorch`, with `evals/evals.json` and a short
+  `BENCHMARK.md`.
+
+## Milestone Summary
+
+| Milestone | Theme | Blocks Native Package Mechanics | Required Before First Agent-Skills Release |
+| --- | --- | --- | --- |
+| 0 | CLI envelope and `nvflare agent` command group | Yes | Yes |
+| 1 | Skill source layout and minimal frontmatter validator | Yes | Yes |
+| 2 | Wheel manifest and packaging | Yes | Yes |
+| 3 | Native skill install/list | Yes | Yes |
+| 4 | Read-only inspect and doctor | Yes | Yes |
+| 5 | Initial skill lint and admission gate | Yes | Yes |
+| 6 | Seed skill bundle | Yes | Yes |
+| 7 | Skill benchmark reporting and optional Auto-FL research runs | Internal skill-quality gate, not NVFLARE package mechanics | Yes |
+| 8 | Customer lifecycle skill wave | No | Yes |
+| 9 | Framework conversion skill wave | No | Yes |
+| 10 | Specialized workflow skill wave | No | Yes |
+| 11 | PET and security skill wave | No | Yes |
+| 12 | Export/manifest and publication handoff | Yes | Yes; final handoff gate |
+
+The first native agent-skills release is not complete until skill benchmark
+reporting and follow-on skill waves are done. Benchmark evidence follows the
+seed bundle and gates later skill waves so one or a small number of skills can
+be corrected before the same mistakes are copied across the catalog. It is an
+internal quality gate, not an external publication step. Export manifest,
+manifest-aware consumers, and publication handoff are combined in Milestone 12
+because they package and validate the reviewed release artifacts.
+
+## Initial PR Sequence
+
+The first implementation PRs should stay small and map directly to the
+milestones:
+
+1. `nvflare/tool/agent/` skeleton plus reusable JSON envelope helper.
+2. Repo-root `skills/` directory plus minimal `SKILL.md` frontmatter validator.
+3. Wheel skill manifest plus packaging changes that include released skills in
+   the built wheel.
+4. Native `nvflare agent skills install/list` for `codex` and `claude`.
+5. Read-only `nvflare agent inspect` and `nvflare agent doctor`.
+
+This sequence combines the milestone breakdown with the review recommendation
+to avoid bundling source layout, validation, manifest generation, and wheel
+packaging into one large PR.
+
+Benchmark performance reporting is not part of the public `nvflare agent`
+command surface. Runtime evidence summaries and benchmark drafts belong to the
+benchmark tooling until there is enough evidence and UX clarity to promote a
+separate supported CLI contract.
+
+## Milestone 0: CLI Envelope
+
+Deliverables:
+
+- Add `nvflare agent` command registration.
+- Add shared JSON envelope helper with `schema_version`, `status`, `code`,
+  `message`, `hint`, optional `recovery_category`, optional `suggested_skill`,
+  and command-specific `data`.
+- Define initial agent error codes: `INVALID_ARGS`, `CASE_REQUIRED`,
+  `UNKNOWN_SKILL`, `UNKNOWN_CASE`, `EVIDENCE_REQUIRED`,
+  `CHECKLIST_SCHEMA_INVALID`, `CHECKLIST_MISMATCH`, `INVALID_BEHAVIOR_ID`,
+  `INVALID_STATUS`, `CONFLICTING_EVIDENCE`, `ARTIFACT_NOT_FOUND`,
+  `RECORD_WRITE_FAILED`, and `UNSUPPORTED_SCHEMA_VERSION`.
+- Add `--format json`, `--format jsonl` for streaming commands where needed,
+  and `--schema` conventions for agent-facing commands.
+
+Engineering tests:
+
+- JSON success/error envelope tests.
+- stdout/stderr separation tests.
+- `--schema` tests that do not require operational arguments.
+- non-interactive command tests.
+
+## Milestone 1: Skill Source and Frontmatter
+
+Deliverables:
+
+- Add repo-root `skills/` with guide-compatible structure.
+- Add minimal frontmatter validation for `name`, `description`,
+  `min_flare_version`, and `blast_radius`.
+- Add at least one fixture skill for validator tests.
+
+Engineering tests:
+
+- frontmatter parsing;
+- directory-name and skill-name matching;
+- required-field failures;
+- invalid `blast_radius` fixture.
+
+## Milestone 2: Wheel Manifest and Packaging
+
+Deliverables:
+
+- Add a minimal released-skill manifest with skill name, source hash or version,
+  and FLARE-version compatibility.
+- Define the source-hash contract for released skills: lowercase hex-encoded
+  SHA-256 over sorted files under `skills/<skill>/`. For each included file,
+  feed the UTF-8 relative path, a NUL byte, file contents, and a NUL byte into
+  the single running SHA-256 state. Exclude `__pycache__`, `.pyc`, and `.pyo`
+  files, and reject symlinks rather than following them.
+- Update the active build backend configuration, such as `pyproject.toml`,
+  `setup.py`, or package-data rules, so the wheel actually includes released
+  skill files and the manifest.
+- Support a build-time no-skills control wheel for A/B evaluation by honoring
+  `NVFLARE_PACKAGE_AGENT_SKILLS=0`. The default remains skill bundling enabled;
+  the disabled build should add a `no_skills` wheel build tag, such as
+  `1no_skills`, and write an empty bundled-skill manifest rather than omitting
+  the bundle package.
+
+Engineering tests:
+
+- source-vs-wheel manifest checks;
+- source hash/manifest validation;
+- package contents check.
+- empty bundle manifest and stale bundled-content cleanup when skill packaging
+  is disabled.
+- no-skills wheel filename includes the `no_skills` build tag when the wheel
+  command is available.
+
+## Milestone 3: Native Install/List
+
+Deliverables:
+
+- Implement `nvflare agent skills install --agent codex|claude`.
+- Implement `--skill`, `--dry-run`, `--format json`, and conflict reporting.
+- Resolve `codex` to `$CODEX_HOME/skills` or `~/.codex/skills`.
+- Resolve `claude` to `~/.claude/skills`.
+- If `$CODEX_HOME` is set but the path does not exist, create only the
+  `$CODEX_HOME/skills` path needed for installation after normal dry-run and
+  conflict checks; report the resolved path in JSON output.
+- Implement `nvflare agent skills list --agent codex|claude --format json`.
+- Limit `skills list` conflicts to name-overlap conflicts with available
+  NVFLARE-source skills or managed NVFLARE installs. Unrelated third-party
+  skills already present in the target directory must not appear as conflicts.
+- Ensure install does not require Node.js, npm, npx, network access, or an
+  external skill CLI.
+
+Engineering tests:
+
+- `native-skill-install-no-node`;
+- `skill-install-codex-claude-targets`;
+- `skill-install-all-by-default`;
+- `skill-install-safe-overwrite`;
+- `skill-install-no-third-party-download`;
+- `skill-list-ignores-unrelated-third-party-skills`;
+- `skill-list-flags-name-overlap-external-skill`.
+
+## Milestone 4: Inspect and Doctor
+
+Deliverables:
+
+- Implement read-only `nvflare agent inspect <path> --format json`.
+- Implement static framework and FLARE-integration detection without importing
+  or executing user code.
+- Implement read-only `nvflare agent doctor --format json`.
+- Add optional `doctor --online` bounded read-only checks through the active
+  startup-kit context.
+
+Engineering tests:
+
+- static-only inspect fixtures with import side effects;
+- redaction fixtures for secrets and sensitive paths;
+- symlink and traversal cap fixtures;
+- doctor read-only before/after checks.
+
+## Milestone 5: Initial Lints and Admission Gate
+
+Deliverables:
+
+- Add `tools/agent_skill_checks/` or equivalent local entry point.
+- Implement lints:
+  `skill-frontmatter-lint`, `skill-md-size-lint`, `skill-trigger-lint`,
+  `skill-trigger-overlap-lint`, `skill-catalog-category-lint`,
+  `skill-global-negative-lint`, `skill-policy-coverage-lint`,
+  `skill-command-drift-lint`, `skill-helper-script-lint`,
+  `skill-fixture-lint`, and `agent-doc-crosslink-lint`.
+- Add the shared global negative prompt bank at
+  `skills/_shared/global_negative_prompts.json` with `schema_version: "1"` and
+  `prompts` entries containing `id`, `prompt`, and `description`.
+- Treat [Agent Skill Evaluation](agent_skill_evaluation.md#engineering-lints)
+  as the canonical lint behavior definition; the implementation plan should not
+  restate each lint's inputs and pass/fail semantics.
+- Implement release checklist coverage only from machine-readable
+  `evals/release_checklist.json`; prose-only checklist mentions do not satisfy
+  policy coverage lint.
+- Implement command-drift lint by parsing `nvflare` snippets from skill docs and
+  checking commands/flags against the installed CLI parser or exported command
+  schema in the same checkout or wheel.
+- Keep `evals/evals.json` guide-compatible and put FLARE-specific IDs under
+  `nvflare.mandatory_behavior`, `nvflare.optional_behavior`, and
+  `nvflare.prohibited_behavior`.
+- Follow the example and behavior-ID pass/fail semantics in
+  [Agent Skill Evaluation](agent_skill_evaluation.md#guide-compatible-eval-structure):
+  mandatory IDs require evidence, prohibited IDs fail when observed, and
+  optional IDs are recorded but non-blocking.
+- Treat the 200-line `SKILL.md` limit as the hard initial lint. The roughly
+  2,000-token target is advisory and can be reported with a simple
+  whitespace-based estimate unless a tokenizer is standardized later.
+- Emit lint findings with a shared shape: `id`, `severity`, `file`, `line`
+  when available, `message`, and `hint`.
+
+Engineering tests:
+
+- lint fixtures for pass/fail cases;
+- trigger-overlap lint fixtures with same-category overlap, adjacent-negative
+  coverage, and unrelated-category non-overlap cases;
+- CLI command-schema drift fixtures;
+- global negative bank schema fixtures and per-skill global-negative coverage
+  fixtures;
+- doc crosslink fixtures for valid links, stale anchors, stale lint IDs, and
+  stale command names.
+
+## Milestone 6: Seed Skill Bundle
+
+Deliverables:
+
+- Add the first hand-vetted public-candidate skills.
+- Keep each `SKILL.md` under the 200-line or roughly 2,000-token target.
+- Move long content into `references/`.
+- Add `evals/evals.json`, minimal `evals/files/` when needed, and a
+  hand-authored `BENCHMARK.md` summarizing manual trigger checks, mandatory
+  behavior checks, prohibited behavior checks, and known gaps.
+- Do not add public `agent skills performance` or `agent skills benchmark`
+  subcommands. Packaged `evals/evals.json`
+  describes what benchmark tooling may measure, but it is not useful runtime
+  performance evidence by itself.
+
+Recommended first skills:
+
+- `nvflare-orient`;
+- `nvflare-convert-pytorch`;
+- `nvflare-diagnose-job`.
+
+Exit criteria:
+
+- each public-candidate skill passes the initial admission gate;
+- commands referenced by skills match the installed CLI;
+- each skill has at least one positive trigger eval and one adjacent negative
+  trigger case;
+- public-candidate skills pass global negative trigger checks.
+- `BENCHMARK.md` clearly states whether the skill is public-ready based on
+  manual initial checks or still draft/internal pending Milestone 7 evaluation.
+- `nvflare agent info`, `doctor`, and command schemas do not advertise
+  `agent skills performance`, `agent skills benchmark`, or
+  `agent skills evaluate`.
+
+## Milestone 7: Skill Benchmark Reporting and Auto-FL Research
+
+Deliverables:
+
+- Do not add a runtime skill evaluator, an eval-on switch, or a
+  `skills evaluate` command. Packaged skills must not instruct agents to create
+  evaluator-only artifacts before the final response.
+- Preserve `skills/<skill>/evals/evals.json` as non-runtime skill metadata for
+  trigger coverage, behavior IDs, fixtures, and benchmark/reporting context.
+  This metadata is useful for authoring and benchmark analysis, but it does not
+  imply that agents should run an evaluator during normal skill use.
+- Keep user-facing evidence requirements in each skill's workflow,
+  requirements, and output sections. Agents should collect only evidence needed
+  to complete and explain the user's task.
+- Keep performance records as explicit inputs produced by benchmark harnesses,
+  reviewer workflows, or other external measurement systems. Benchmark
+  reporting may summarize fields that are present, but it must not synthesize
+  missing correctness fields or infer token usage from transcript text.
+- Keep benchmark summaries and generated benchmark drafts in
+  `assist_tools/skills_benchmark` or another explicitly internal benchmark
+  tool. Do not expose them as `agent skills performance` or
+  `agent skills benchmark` until the benchmark workflow itself is
+  stable and the command value is clear without prior hidden setup.
+- Use internal benchmark tooling to upgrade `BENCHMARK.md` from manual initial
+  summaries to benchmark summaries when automated or repeated evidence exists.
+  The rendered file is a publication/review draft; runtime records remain the
+  raw evidence.
+- Measure positive trigger, negative trigger, mandatory behavior,
+  prohibited behavior, and task validation for the seed skills before expanding
+  to additional skill waves.
+- Reuse Auto-FL research workflows as advisory evaluation scenarios after the
+  relevant skills exist.
+
+Engineering tests:
+
+- `agent info` and `agent skills --schema` do not advertise `skills evaluate`,
+  `skills performance`, or `skills benchmark` commands;
+- invoking the removed `agent skills evaluate`, `agent skills performance`, or
+  `agent skills benchmark` command forms returns a structured invalid-args
+  error and lists only supported skills subcommands;
+- packaged `SKILL.md` files contain no runtime evaluator hook, eval-on switch,
+  or evaluator command instruction;
+- the v1 lint id set uses process-metric coverage, not evaluator coverage;
+- benchmark tooling consumes supplied records without creating or modifying
+  them and keeps any report-generation commands outside the public
+  `nvflare agent` CLI surface.
+
+This milestone evaluates the seed skill set before additional skill waves are
+implemented. Benchmark evidence is required before a skill is used as a template
+for broader catalog expansion. It does not perform external publication or
+handoff. Auto-FL remains an advisory research test case: run
+existing Auto-FL tasks without skills, with skills available, and optionally
+with a skill forced to isolate skill content.
+
+## Milestone 8: Customer Lifecycle Skill Wave
+
+The seed bundle plus benchmark reporting prove the package, install, lint,
+authoring, and measurement mechanics. The rest of the skill roadmap should be
+implemented as follow-on skill-development waves, not left as an unowned
+candidate list. Every new skill in these waves must use the authoring and
+benchmark contract:
+
+- `SKILL.md` with required frontmatter, trigger boundaries, negative trigger
+  guidance, approval checkpoints, and validation checklist;
+- `references/` for long examples, framework details, diagnosis patterns, and
+  command walkthroughs;
+- optional `scripts/` only for deterministic JSON-producing helpers that are
+  candidates for later promotion into `nvflare agent` commands;
+- `evals/evals.json`, fixtures under `evals/files/` when needed, and
+  `BENCHMARK.md` with trigger checks, mandatory behavior checks, prohibited
+  behavior checks, and known gaps;
+- admission through the initial skill lints, command-drift checks, trigger
+  overlap checks, global negative checks, and doc crosslink checks.
+
+Each wave must include benchmark or reviewer evidence for each new public skill
+before that wave is considered complete. A wave can carry a documented
+draft/internal exception, but that skill cannot be used as a template for later
+waves or included in publication handoff until Milestone 7 benchmark evidence is
+available for that skill.
+
+Deliverables:
+
+- Add `nvflare-setup-local`, `nvflare-poc-workflow`, and
+  `nvflare-job-lifecycle`.
+- Cover local readiness, POC lifecycle, job validation, submission, monitoring,
+  log/stat download, identity/config checks, and production approval boundaries.
+
+Skill coverage:
+
+- `nvflare-setup-local`
+  - Covers optional local bootstrap and readiness. Use it when the user wants to
+    prepare or repair the local FLARE environment itself, or when another
+    workflow detects that FLARE readiness is missing or broken before it can
+    continue.
+  - Covers fresh-machine or container bootstrap, editable or wheel installation
+    guidance, Python and virtual-environment sanity, optional dependency
+    guidance, CLI availability for `nvflare`, `nvflare agent`,
+    `nvflare recipe`, `nvflare job`, and `nvflare poc`, bundled-skill
+    install/list readiness, and final verification through
+    `nvflare agent doctor`.
+  - Does not cover POC prepare/start/stop/cleanup, POC or production job
+    submission, framework conversion edits, generated job source, or routine
+    validation that a conversion skill can do for its own output.
+  - Does not cover cloud, Kubernetes, Docker production deployment,
+    firewall/security-group setup, cert distribution, or multi-machine
+    provisioning. Route those to later deployment or provisioning workflows.
+
+- `nvflare-poc-workflow`
+  - Covers local POC system lifecycle: prepare, start, verify server/client
+    readiness, report current POC workspace and kit state, stop, cleanup, and
+    restore the previous kit/config when supported by the CLI.
+  - Covers readiness handoff into `nvflare-job-lifecycle` once a local POC
+    system is running and the user wants to submit or monitor a job.
+  - Does not cover installing FLARE, converting training code, generating job
+    source, selecting framework recipes, submitting or monitoring jobs as the
+    lead workflow, production startup-kit operation, or cloud/multi-machine
+    deployment.
+
+- `nvflare-job-lifecycle`
+  - Covers job operations against an already running FLARE system, including POC
+    and production/startup-kit based systems: validate an existing or exported
+    job before submit, submit, monitor, inspect metadata, collect logs and
+    stats, download outputs, summarize metrics/results, and report evidence.
+  - Covers SimEnv and exported-job validation only for existing jobs or as an
+    independent pre-submit pass. Framework conversion skills own the first local
+    validation for jobs they generated.
+  - Covers startup-kit identity/config checks, selected server/user/site
+    context, explicit production approval prompts, and bounded submit summaries
+    before production submission.
+  - Does not cover local environment bootstrap, POC prepare/start/stop/cleanup,
+    framework conversion edits, recipe-specific generated source, cloud or
+    Kubernetes deployment, deep failure diagnosis, or bypassing approval gates
+    for production submit/shutdown/delete/restart flows.
+
+Framework conversion skills own generated `job.py`, client code, recipe
+selection, SimEnv execution, and export for their framework-specific conversion
+requests. For example, a PyTorch request that asks for SCAFFOLD should route to
+`nvflare-convert-pytorch`, use `nvflare recipe list` and
+`nvflare recipe show scaffold-pt` to select the PyTorch SCAFFOLD recipe, and
+generate the converted PyTorch job there. This is the same ownership pattern
+already used by `nvflare-convert-pytorch` for FedAvg: the framework conversion
+skill discovers the recipe, explains the selection when needed, creates
+`client.py` and `job.py`, validates with `python job.py`, and exports with
+`python job.py --export --export-dir /tmp/nvflare/job_config/<job_name>`.
+TensorFlow SCAFFOLD should route to `nvflare-convert-tensorflow` and use the
+TensorFlow recipe.
+
+Do not add standalone `nvflare-local-validation`,
+`nvflare-identity-and-config`, or `nvflare-production-submit` public skills in
+this milestone. Local validation should be shared guidance used by conversion
+skills and `nvflare-job-lifecycle`. Identity/config checks and production-submit
+approval are safety gates inside `nvflare-job-lifecycle`, not separate skills,
+until those workflows grow enough distinct evidence, files, approval records, or
+policy checks to justify their own skill.
+
+## Milestone 9: Framework Conversion Skill Wave
+
+Deliverables:
+
+- Add `nvflare-convert-lightning`, `nvflare-convert-tensorflow`,
+  `nvflare-convert-huggingface`, `nvflare-convert-xgboost`,
+  `nvflare-convert-sklearn`, and `nvflare-convert-survival-analysis`.
+- Scope each skill to the framework-specific edit pattern, examples, recipes,
+  validation commands, and negative triggers defined in the authoring design's
+  conversion table.
+
+## Milestone 10: Specialized Workflow Skill Wave
+
+Deliverables:
+
+- Add `nvflare-experiment-tracking`, `nvflare-site-specific-training`, and
+  `nvflare-collaborative-etl`.
+- Cover TensorBoard/MLflow instrumentation, heterogeneous site scripts or
+  app/config folders, federated ETL, preprocessing, feature validation,
+  data-quality checks, and safe handoff into training or statistics workflows.
+
+## Milestone 11: PET and Security Skill Wave
+
+Deliverables:
+
+- Start with `nvflare-run-private-set-intersection` for PSI/private set
+  intersection.
+- Add DP, HE, and privacy-policy-filter skills only after their evidence,
+  validation fixtures, approval checkpoints, and production safety contracts are
+  ready.
+
+Each wave should update the product skill catalog in
+[Agent Integration](agent_integration.md#product-skill-catalog), the source
+tables in [Agent Skill Authoring](agent_skill_authoring.md), and any deferred
+roadmap entries that are promoted into current scope. A skill is not considered
+implemented just because its name appears in the catalog; implementation means
+the full authoring package, engineering lint coverage, and evaluation evidence
+exist in the repo.
+
+## Milestone 12: Export/Manifest and Publication Handoff
+
+Deliverables:
+
+- Add `_export_manifest.json` to exported job folders with required files,
+  source path/hash, timestamp, NVFLARE version, exporter, and validation status.
+- Add a nested `fingerprint` section in `_export_manifest.json` with FLARE,
+  Python, recipe, framework dependency, and source-hash metadata.
+- Prefer one manifest file with a nested fingerprint unless separate consumers
+  need a separate `job_fingerprint.json`.
+- Make `nvflare agent inspect` consume `_export_manifest.json` and nested
+  fingerprint metadata when present.
+- Keep `nvflare agent inspect` compatible with current exported jobs that lack
+  the manifest.
+- Make future submit preflight consume the same manifest/fingerprint contract
+  when that submit-preflight surface is promoted into current scope.
+- Tie released skill content to the NVFLARE release that ships it.
+- Provide guide-compatible skill files and initial evaluation evidence.
+- Use the [Agent Skill Publication Handoff Checklist](agent_publication_handoff_checklist.md)
+  when preparing an external catalog handoff.
+- Keep external catalog registration, signing, public installer metadata, and
+  public scoreboard mechanics outside this implementation plan.
+- Do not hand off a skill as public-ready until Milestone 7 runtime evaluation
+  passes for that skill.
+
+Engineering tests:
+
+- exported job manifest content and schema tests;
+- manifest source-hash and required-file validation tests;
+- backward-compatible export tests for jobs that do not request manifest-aware
+  behavior;
+- inspect tests for exported jobs with and without `_export_manifest.json`;
+- stale manifest, missing required file, and source-hash mismatch fixtures;
+- preflight compatibility tests when submit preflight is implemented;
+- publication handoff checks that released skill content is tied to the NVFLARE
+  release and has runtime evaluation evidence.
+
+## Agent Benchmark Harness Architecture Catch-Up
+
+The benchmark harness design is ahead of the current implementation. Before a
+second agent adapter is added or the harness is treated as production benchmark
+infrastructure, complete these catch-up items:
+
+- move Codex-specific home, model, auth, launch, and compatibility behavior out
+  of shared host/container modules and into a `CodexAdapter`;
+- replace structural adapter typing with the documented abstract base class and
+  registration validation;
+- implement `harness/scenarios.py` so direct CLI runs and scenario YAMLs compile
+  into one validated `run_plan.json`;
+- implement replay mode for record/report development without live agent
+  invocation;
+- extract container progress and skill-exposure setup into
+  `container/progress.py` and `container/skills.py`;
+- implement `reports/structure_tree.py` or keep `structure_quality_signal`
+  explicitly unavailable until it exists;
+- make flat harness modules explicit re-export shims or remove them;
+- surface `prompt_hash`, stable failure categories, and
+  unavailable `structure_quality_signal` in run summaries;
+- add `KNOWN_PENDING_BENCHMARK_AGENTS` behavior for planned but unsupported
+  adapters;
+- add a named display-record limit and total/displayed counts for skill
+  benchmark summaries.
+
+## Deferred Work
+
+Do not implement these in the initial implementation unless a separate scope decision promotes them:
+
+- receipts, provenance, and durable workflow state;
+- transcript record/replay;
+- workspace cleanup;
+- full lifecycle commands beyond install/list;
+- compatibility shims, `obsoletes`, and changelog commands;
+- PR-bot automation;
+- large policy catalog;
+- full paired harness, instruction-monitor service, and cost-accounting system;
+- public scoreboard mechanics.

--- a/docs/design/agent_integration.md
+++ b/docs/design/agent_integration.md
@@ -1,0 +1,1150 @@
+# NVFLARE Agent Integration Design
+
+## Document Control
+
+| Field | Value |
+| --- | --- |
+| Created date | 2026-05-25 |
+| Current design date | 2026-05-26 |
+| Status | Ready for Implementation |
+| Supersedes | `nvflare_agent_consumer_readiness.md`, `nvflare_agent_foundation.md`, `nvflare_agent_foundation_implementation_plan.md` for current agent-integration decisions |
+| Current owner | NVFLARE product/docs maintainers |
+| Review scope | Runtime integration, packaged install, CLI contracts, generated-code policy, initial skill scope, safety boundaries, and links to authoring/evaluation specs |
+
+## Table of Contents
+
+- [Document Control](#document-control)
+- [Related Specifications](#related-specifications)
+- [Source Inputs](#source-inputs)
+- [Problem Statement](#problem-statement)
+- [Goals](#goals)
+- [Non-Goals](#non-goals)
+- [Key Decisions](#key-decisions)
+- [Agent Readiness Scope](#agent-readiness-scope)
+- [Product Skill Catalog](#product-skill-catalog)
+- [Initial Seed Bundle](#initial-seed-bundle)
+- [Skill File Requirements](#skill-file-requirements)
+- [Skill Evaluation](#skill-evaluation)
+- [Publication Handoff Boundary](#publication-handoff-boundary)
+- [Command Surfaces](#command-surfaces)
+- [Example and Scaffold Conventions](#example-and-scaffold-conventions)
+- [Notebook-Safe Path](#notebook-safe-path)
+- [Production Safety](#production-safety)
+- [Auto-Research Evaluation](#auto-research-evaluation)
+- [Workstreams and Deliverables](#workstreams-and-deliverables)
+- [Publication Handoff Artifacts](#publication-handoff-artifacts)
+- [Success Criteria](#success-criteria)
+- [Open Questions and Deferred Decisions](#open-questions-and-deferred-decisions)
+
+## Related Specifications
+
+- [Agent Skill Authoring](agent_skill_authoring.md) owns skill-writing rules,
+  helper scripts, minimal metadata, examples, eval input files, and maintenance
+  policy.
+- [Agent Skill Evaluation](agent_skill_evaluation.md) owns measurement,
+  the initial admission gate, runtime skill-performance checks, Auto-FL research
+  evaluation conventions, and publication handoff artifacts.
+- Deferred roadmap notes own future mechanisms such as durable workflow state,
+  receipts, provenance, transcript replay, workspace cleanup, full lifecycle
+  commands, compatibility shims, PR-bot automation, and the large policy
+  catalog.
+
+## Source Inputs
+
+This document consolidates current decisions and reviews these historical inputs
+for still-relevant gaps:
+
+- NVIDIA Agent Skills publishing guidance for externally published product skills.
+- `nvflare_agent_consumer_readiness.md`.
+- `nvflare_agent_foundation.md`.
+- `nvflare_agent_foundation_implementation_plan.md`.
+
+The company-level publishing guidance is the governing source for how NVIDIA
+skills are validated, signed, licensed, and published externally. This design
+set is the current NVFLARE source for FLARE-specific agent workflows, commands,
+examples, and product behavior; the historical docs are used only to recover
+still-relevant gaps.
+
+## Problem Statement
+
+NVFLARE is increasingly used through coding agents such as Codex, Claude Code,
+Cursor, Windsurf, and similar developer-side automation tools. In this design,
+the agent is not a FLARE runtime participant. The agent is a developer tool that
+can inspect local training code, modify user files, generate a FLARE job, run
+local validation, submit through the CLI, inspect logs, and help the user
+iterate.
+
+The current CLI work makes FLARE more scriptable, but agent readiness requires
+more than command availability. Agents need:
+
+- discoverable product-specific skills;
+- stable CLI JSON, schema, and error contracts;
+- deterministic local inspection and readiness checks;
+- examples and scaffolds that can be copied safely;
+- explicit production approval boundaries;
+- diagnosis workflows that do not depend on scraping human-only output;
+- a publication handoff model that keeps FLARE skills aligned with FLARE
+  releases while leaving external catalog registration and sync to the
+  NVIDIA skills publication process.
+
+## Goals
+
+- Define how NVFLARE should be made ready for external coding agents.
+- Separate company-level skill publishing from FLARE product-level skill
+  ownership.
+- Define the command, skill, example, and validation surfaces for agent
+  readiness.
+- Preserve the CLI as the baseline execution contract.
+- Use Auto-FL research as a separate benchmark and research consumer for the
+  FLARE skills, measuring whether skills improve accuracy, cost, efficiency,
+  and reproducibility compared with direct agent use without skills.
+- Keep Auto-FL orchestration, retry, routing, and persistence separate from
+  FLARE reasoning skills.
+- Keep the first implementation intentionally small. Deferred mechanics should
+  stay outside this design set until a concrete failure mode or product
+  requirement justifies promotion.
+- Keep security boundaries explicit for production systems, startup kits,
+  private keys, and site-local data.
+
+## Non-Goals
+
+- Make FLARE server or client processes an agentic runtime.
+- Replace Client API, Recipe API, FedJob, SimEnv, or Session APIs.
+- Build a fully automatic converter for arbitrary ML code without user review.
+- Create a separate FLARE-only public skill marketplace that competes with
+  github.com/NVIDIA/skills.
+- Require agents to clone the NVFLARE GitHub repository to use released FLARE.
+- Let agents bypass authorization, handle private keys unsafely, or approve
+  production-impacting actions automatically.
+
+## Key Decisions
+
+### 1. FLARE Needs Product-Owned Skills, But Not a Separate Public Catalog
+
+NVIDIA's public skills catalog and private NVCARPS pipeline are the external
+publication and trust path. FLARE still needs a product-owned way to author,
+validate, version, package, and prepare FLARE-specific skills for that
+publication handoff.
+
+The split is:
+
+| Layer | Owner | Purpose |
+| --- | --- | --- |
+| FLARE product source | NVFLARE repo | Source of truth for FLARE-specific skills, examples, tests, release compatibility, and product workflow ownership |
+| NVIDIA public skills catalog | `github.com/NVIDIA/skills`, public Apache-2.0 repo | Public catalog registration, external discovery, signed skill sync target, and user installation |
+| NVIDIA private validation and signing pipeline | NVCARPS/NV-BASE CI/backend | Internal NVIDIA validation, scanning, signing, skill-card generation, and trust metadata |
+| Optional wheel/package distribution | NVFLARE package | Convenience path for users who install `nvflare` and want matching skills without separately browsing the catalog |
+| Internal-only contributor skills | NVFLARE repo, not catalog synced | Contributor workflows such as CI debug, code review, or repo maintenance that should not publish externally |
+
+This means FLARE should prepare skills from the product repo for the public
+NVIDIA skills catalog and rely on the private NVIDIA pipeline for validation
+and signing when external publication is requested. The product repo is the
+source of truth; the public catalog is the distribution layer; the private
+pipeline is the trust and release-gate layer. Catalog registration, sync, and
+public installer metadata are separate `github.com/NVIDIA/skills` integration
+work, not part of the native NVFLARE installer design.
+
+### 2. The Canonical Skill Source Should Be Repo-Root `skills/`
+
+For external product skills, use the company-standard layout:
+
+```text
+skills/
+  nvflare-orient/
+    SKILL.md
+    references/
+    evals/
+      evals.json
+      files/
+    BENCHMARK.md
+  nvflare-convert-pytorch/
+    SKILL.md
+    references/
+    scripts/
+    evals/
+      evals.json
+      files/
+    BENCHMARK.md
+```
+
+Rules:
+
+- The directory name must match the `name` field in `SKILL.md` frontmatter.
+- Skill names should be lowercase, hyphenated, product-scoped, and CLI-safe.
+- FLARE product skills should use the `nvflare-` prefix to avoid collisions.
+- Do not use `.claude/skills`, `.codex/skills`, or `.cursor/skills` as the
+  primary source.
+- Agents that expect a repo-local `.agents/skills` discovery path should resolve
+  it through a symlink to `../skills`; do not maintain a parallel skill tree.
+- Internal-only contributor skills should live outside the catalog-sync path,
+  for example `.agents/contributor-skills/`.
+
+Released customer-facing skills should be bundled inside the Python wheel so a
+user who installs NVFLARE can install matching skills without cloning the
+NVFLARE source repo. The bundled copy should be generated from the same
+repo-root `skills/` source. There should not be a second hand-maintained skill
+tree under `nvflare/agent/skills/`.
+The wheel should include a minimal released-skill manifest with skill names,
+versions, hashes, and FLARE-version compatibility. Native install-all uses this
+manifest rather than scanning arbitrary package files. Rich catalog versioning,
+changelogs, compatibility shims, and migration metadata are deferred roadmap
+items.
+
+Skill bundling is the default wheel behavior. Benchmark and CI flows that need a
+no-skills control package may build the wheel with
+`NVFLARE_PACKAGE_AGENT_SKILLS=0`. A disabled-skill wheel should add a wheel
+build tag containing `no_skills`, such as `1no_skills`, so the control wheel is
+easy to identify and does not overwrite the default wheel in the same output
+directory. The wheel should still include an empty released-skill manifest so
+`nvflare agent skills list/install` can report that no bundled skills are
+available instead of failing on a missing package resource.
+
+### 3. Support Packaged, Repo-Local, and Catalog Skill Use
+
+Installing NVFLARE-owned skills should not require users to install Node.js,
+`npm`, `npx`, or an external skills CLI. The primary package UX should stay in
+the Python/NVFLARE toolchain:
+
+```bash
+python3 -m pip install nvflare
+nvflare agent skills install --agent codex
+nvflare agent skills install --agent claude
+```
+
+For installing only one skill:
+
+```bash
+nvflare agent skills install --agent codex --skill <nvflare-skill-name>
+```
+
+This command is intentionally narrower than a general skills marketplace. It
+should copy NVFLARE-owned skills from the installed package by default, or from
+repo-root `skills/` when running from an editable/source checkout. It should
+support a small explicit set of agent targets, starting with `codex` and
+`claude`, plus clear dry-run output and safe overwrite behavior. When `--skill`
+is omitted, it should install all compatible released NVFLARE skills bundled
+with the package or present in the selected source. It should not download
+third-party skills, validate catalog signatures, or own the public NVIDIA
+skills publication flow.
+
+`--dry-run --format json` should use the same envelope as a real install with
+`data.applied: false`. The `data` object should include source type, skill
+versions, files to copy, target paths, conflicts found, backups planned,
+deprecated skills skipped, and version deltas. A real install should report the
+same plan with `data.applied: true` after changes are written.
+
+Published skills should still appear in the public NVIDIA skills catalog after
+catalog sync and NVCARPS validation. If users already have a public skills
+installer, that installer may provide an alternate catalog install path, but
+its exact syntax is owned by that ecosystem and is not part of the NVFLARE
+contract. It is not a dependency for installing skills shipped with NVFLARE.
+Integration details with `github.com/NVIDIA/skills`, including any stable
+metadata exposed by future catalog installers, are separate publication work and
+are not part of the native NVFLARE installer contract.
+External catalog sync should follow the FLARE release that contains the matching
+skills; users should not rely on catalog HEAD being newer than their installed
+NVFLARE package.
+
+FLARE should also support pre-publication and developer use directly from the
+NVFLARE product repo without adding a Node dependency. For branch-specific
+testing, users should install NVFLARE from that branch or work from an editable
+clone, then use the same native command:
+
+```bash
+python3 -m pip install -e .
+nvflare agent skills install --agent codex --skill <nvflare-skill-name>
+```
+
+If the public skills ecosystem later supports direct repo sources, it may
+provide an additional path for release-candidate testing or for users who
+intentionally want skills matching a specific NVFLARE branch or commit. Those
+paths are not required for NVFLARE package usage, and they are not the external
+trust path; catalog publication with NVCARPS validation, skill card, and
+signature remains required for official release.
+
+For a local NVFLARE clone, agents should discover skills from the checked-out
+repo when working in that repo:
+
+```text
+NVFlare/
+  skills/
+    nvflare-orient/
+      SKILL.md
+  .agents/
+    skills -> ../skills
+```
+
+`nvflare agent skills list` should report which FLARE skills are present and
+compatible with the installed package. If the public `skills` installer
+later gains first-class local-source support, `nvflare agent skills install`
+may optionally delegate to it only when that dependency is already available or
+explicitly requested. The default NVFLARE path should remain native Python
+package behavior.
+
+The implemented native skill-management and evaluation surface through
+Milestone 7 is intentionally small:
+
+- `nvflare agent skills install --agent codex|claude [--skill <name>]
+  [--dry-run] [--format json]` copies NVFLARE-owned skills from the installed
+  package or editable checkout into the selected agent's skill directory.
+- `nvflare agent skills list --agent codex|claude --format json` reports the
+  installed managed skills for that target and the released skills available
+  from the current NVFLARE package or editable checkout.
+  Its `conflicts` field is limited to target directories whose names overlap
+  with NVFLARE-source skills and are not managed by NVFLARE, or managed
+  NVFLARE installs with local edit/version conflicts. Existing third-party
+  agent skills with unrelated names are ignored by default.
+- Public `agent skills performance` and `agent skills benchmark` subcommands
+  are not supported. Benchmark
+  evidence and report generation remain internal benchmark-tool concerns until
+  the benchmark workflow itself is stable enough to justify a public CLI
+  contract.
+- `nvflare agent skills install --target <dir>` may be supported for explicit
+  custom or project-local installation when named agent shortcuts are not
+  enough.
+- `nvflare agent skills install --local --skill <name> <path>` may be supported
+  as a documented user-side workaround for a critical skill issue before an
+  official NVFLARE patch release.
+
+Full lifecycle commands such as catalog browsing, explain/audit, validate,
+skills doctor, compatibility reports, changelog, uninstall, revert, report-bug,
+feedback, transcript replay, and workspace cleanup are deferred to
+the future roadmap. They should not be required for the first implementation.
+
+Runtime skill-performance evidence is produced by benchmark harnesses, research
+workflows, or reviewer processes that run normal agent tasks and record bounded
+evidence. Installed skills do not activate a separate evaluator mode and do not
+create evaluator-only artifacts during normal use.
+
+Installer authority rules:
+
+- The native `nvflare agent skills install` command is authoritative for
+  wheel-bundled NVFLARE skills. External catalog installers are alternate
+  ecosystem paths, not dependencies of the native path.
+- Native installs are pinned to the installed NVFLARE package or the explicit
+  editable/local source selected by the user. They do not follow public catalog
+  HEAD automatically.
+- Named targets initially resolve as follows: `codex` resolves to
+  `$CODEX_HOME/skills` or `~/.codex/skills` when `CODEX_HOME` is unset; `claude`
+  resolves to `~/.claude/skills`. `--target <dir>` overrides named resolution.
+- If an external catalog installer uses the same directories, native conflict
+  detection applies. If it uses a different directory, `nvflare agent skills
+  list` may report it only when that location is discoverable; the native
+  installer still manages only its selected `--agent` or `--target` directory.
+  The native installer should not rely on external catalog metadata to classify
+  unmanaged directories.
+- Every native install writes a management manifest, for example
+  `.nvflare_skill_install.json`, with skill name, skill version, NVFLARE
+  version, source type (`wheel`, `editable`, or `local_override`), source hash,
+  installed paths, and `managed_by: nvflare`.
+- Reinstalling the same managed version is idempotent. Reinstalling a newer
+  managed version backs up the old managed copy, then replaces it.
+- If the target skill directory already exists without the NVFLARE management
+  manifest, the native installer treats it as external or user-managed and
+  skips it with a structured conflict finding. It does not overwrite catalog,
+  `npx`, or hand-edited installs by default.
+- If a managed skill's content hash differs from the manifest, reinstall skips
+  by default and reports `local_modifications_detected`; the user must pass
+  `--overwrite-managed` to replace it after backup.
+- Adopting an external install into NVFLARE management should require an
+  explicit `--adopt-external` flag; the default is to skip external
+  directories.
+- For wheel-bundled initial skills, `min_flare_version` is primarily lint and
+  documentation metadata because the skills ship with the NVFLARE version that
+  installed them. Local or editable overrides may warn when their declared
+  bounds do not match the running NVFLARE package. `skills install` and
+  `skills list` should surface non-blocking compatibility warnings for local,
+  editable, or externally managed skill content whose declared bounds do not
+  match the running NVFLARE package.
+- Deprecated-skill lifecycle behavior is deferred with the broader lifecycle
+  command set.
+
+### 4. CLI Is the Execution Contract
+
+Agents should drive FLARE administrative workflows through the CLI:
+
+- `nvflare config` for startup kit registration and active identity selection;
+- `nvflare poc` for local proof-of-concept systems;
+- `nvflare job` for submit, list, wait, monitor, logs, stats, download, abort,
+  clone, and delete;
+- `nvflare system` for status, resources, version, restart, and shutdown;
+- `nvflare study` for multi-study workflows;
+- `nvflare recipe` for recipe discovery.
+
+Agent-used commands must support:
+
+- `--format json` with exactly one JSON envelope on stdout;
+- `--format jsonl` for streaming commands, where each line is one complete JSON
+  event envelope;
+- `--schema` without required operational arguments;
+- stable error codes and exit codes;
+- schema metadata for `streaming`, `output_modes`, `idempotent`, and
+  `idempotency_key_supported` when applicable;
+- no required prompts on automation paths;
+- human progress and diagnostics on stderr in JSON mode.
+
+The JSON envelope should use a stable top-level shape:
+
+```json
+{
+  "schema_version": "1",
+  "status": "error",
+  "code": "JOB_FOLDER_NOT_FOUND",
+  "message": "Job folder './jobs/hello-pt' not found.",
+  "hint": "Run python job.py --export --export-dir first.",
+  "recovery_category": "FIXABLE_BY_CODE",
+  "suggested_skill": "nvflare-diagnose-job",
+  "data": null
+}
+```
+
+Successful commands should use the same top-level fields with `status: "ok"`
+and command-specific content under `data`.
+Per-command `data` schemas are defined by each command's `--schema` output.
+
+### 4.1 Error Recovery Contract
+
+Multi-step agent workflows need stable recovery categories so agents know when
+to retry, edit code, switch scoped identity, ask for approval, or stop. JSON
+error envelopes for agent-used commands should include `recovery_category` and,
+when useful, `suggested_skill` in addition to `code`, `message`, and `hint`.
+
+| Recovery Category | Meaning | Default Agent Action |
+| --- | --- | --- |
+| `RETRYABLE` | Transient timeout, dropped connection, or temporary server unavailability | Retry with bounded backoff, then re-run `nvflare agent doctor --online --format json` |
+| `FIXABLE_BY_CONFIG` | Wrong identity, stale startup kit, wrong study, missing local config | Adjust scoped identity/config or ask the user, then re-check |
+| `FIXABLE_BY_CODE` | Bad generated code, missing import, wrong data path, invalid job folder | Re-inspect, patch or regenerate affected files, and validate again |
+| `REQUIRES_USER_APPROVAL` | Production action, irreversible action, key generation, distributed approval | Surface an approval checkpoint and wait |
+| `ENVIRONMENT_FAILURE` | POC partially started, port conflict, GPU unavailable, disk/resource failure | Stop and report environment remediation steps |
+| `UNKNOWN` | Error does not match a known category | Collect diagnosis data and ask for human review |
+
+Contract tests should verify that every public error code used by agent
+workflows maps to a recovery category.
+
+### 5. Skill Authoring Rules Live in the Authoring Guide
+
+Detailed guidance for skill playbooks, granularity, naming, public frontmatter,
+product sidecar metadata, helper scripts, `SKILL.md` structure, examples,
+eval input files, and maintenance policy lives in
+[Agent Skill Authoring](agent_skill_authoring.md). This document keeps the
+runtime, package, command, catalog, and safety integration decisions.
+
+### 6. How Skills Are Triggered and Used
+
+Skills are loaded and selected by the coding agent, not by the FLARE runtime.
+There is no expectation that a user runs a command such as `nvflare skill run`.
+The user either asks a normal task question or explicitly asks the agent to use
+a named skill. The agent then uses the installed skill catalog to decide which
+skill content to load.
+
+The intended flow is:
+
+1. The user makes FLARE skills available through the NVIDIA catalog, direct
+   NVFLARE repo install, or repo-local discovery from a cloned checkout.
+2. The agent indexes the skill `name` and `description` frontmatter. It should
+   not load every full `SKILL.md` and reference file at startup.
+3. The user asks a task, such as "convert this PyTorch training script to
+   FLARE", "run this exported job", or "diagnose why this job failed".
+4. The agent selects a lead skill from the frontmatter match. Explicit user
+   naming wins, for example "use `nvflare-diagnose-job`".
+5. If the task is ambiguous, the agent uses `nvflare-orient` as the routing
+   skill. `nvflare-orient` should call deterministic discovery commands such as
+   `nvflare agent inspect <path> --format json` and, when environment readiness
+   matters, `nvflare agent doctor --format json`.
+6. The command outputs provide evidence, such as detected framework,
+   conversion state, exported job status, active startup kit, server
+   reachability, or authorization findings.
+7. The agent loads the lead skill and only the references needed for the
+   detected workflow. It may also load supporting skills when they represent a
+   distinct sub-workflow, such as local validation, job lifecycle, or production
+   submit approval.
+8. The skill tells the agent what files are safe to edit, which CLI commands or
+   helper scripts to run, which artifacts to produce, and where approval is
+   required.
+9. The agent executes the workflow through CLI commands, scripts, and scoped
+   file edits. The skill should not rely on hidden actions outside the trace.
+10. The workflow produces command logs, generated artifacts, validation output,
+    and a final user-facing answer. The initial eval gate can check these visible
+    outputs against the skill's mandatory and prohibited behavior IDs.
+
+The initial handoff contract is deliberately lightweight. The active agent session
+keeps conversational context, and each skill should make artifacts visible in
+normal command output and the final user-facing summary. Skills that edit files
+must report what they changed, which validation commands ran, and where any
+generated job or support bundle was written.
+
+Durable cross-session workflow state, `_receipt.json`, `_provenance.json`,
+transcript replay, and workspace cleanup are deferred roadmap items. They
+should be added only if real multi-skill or support workflows need a stable
+machine-readable handoff record.
+
+Trigger sources should be explicit:
+
+| Trigger Source | Example | Expected Result |
+| --- | --- | --- |
+| Direct user naming | "Use `nvflare-diagnose-job` on job abc" | Load that skill unless it is clearly unsafe or irrelevant |
+| Prompt semantic match | "Convert this PyTorch script to federated learning" | Load `nvflare-convert-pytorch` after confirming the target path |
+| Routing skill decision | "Help me use FLARE on this repo" | Load `nvflare-orient`, run inspect/doctor as needed, then route to a specific workflow skill |
+| `agent inspect` evidence | framework=`tensorflow`, conversion_state=`not_converted` | Use `nvflare-convert-tensorflow`, not PyTorch or generic conversion guidance |
+| `agent doctor` evidence | no active startup kit | Use setup/config guidance before job submission or production operations |
+| Negative trigger evidence | task is Kubernetes deployment | Do not trigger `nvflare-convert-pytorch` even if PyTorch appears in unrelated docs |
+
+Skill use should have one lead skill and a small number of supporting skills.
+For example:
+
+- "Convert this PyTorch training script to FLARE and run locally" should use
+  `nvflare-convert-pytorch` as the lead skill. The conversion skill owns its
+  first local validation pass.
+- "Submit this exported job to my production system" should use
+  `nvflare-job-lifecycle` as the lead skill, with production identity/config
+  checks and explicit approval gates before submit.
+- "Why did this job fail?" should use `nvflare-diagnose-job` as the lead skill
+  and should collect evidence through `nvflare job meta`, `nvflare job logs`,
+  `nvflare job stats`, `nvflare system status`, and `nvflare system resources`.
+
+`nvflare-orient`, `nvflare agent inspect`, and `nvflare agent doctor` have
+different roles in this trigger path:
+
+- `nvflare-orient` is a routing skill. It interprets user intent, checks
+  current context, calls inspect/doctor when needed, and routes to the right
+  workflow. It is not the long-form conceptual explanation source for all FLARE
+  concepts; conceptual background should live in docs and concise references
+  loaded only when needed.
+- `nvflare agent inspect` is a deterministic CLI command. It classifies local
+  code, scripts, job source, or exported job folders.
+- `nvflare agent doctor` is a deterministic CLI command. It checks local and
+  optionally online environment readiness.
+
+Skill descriptions and negative examples must be precise enough that adjacent
+skills do not steal each other's prompts. Trigger evaluation should include
+customer-like prompts, explicit skill-name prompts, ambiguous prompts that
+should route through `nvflare-orient`, and negative prompts that should trigger
+another FLARE skill or no FLARE skill.
+
+## Agent Readiness Scope
+
+Agent readiness includes:
+
+- FLARE-specific published skills under repo-root `skills/`.
+- Stable CLI contracts for the agent-used command set.
+- `nvflare agent inspect <path>` for read-only static inspection of local user
+  code, job source, and exported job folders.
+- `nvflare agent doctor` for local readiness checks.
+- `nvflare agent doctor --online` for a bounded read-only environment snapshot.
+- Standard job generation and export conventions.
+- Product examples and scaffolds that agents can safely copy.
+- Diagnosis skills using job metadata, logs, stats, downloads, and system state.
+- Explicit production approval checkpoints in skills.
+- Evaluation loops, including Auto-FL research benchmarks, that measure whether
+  skills improve real agent performance.
+
+This design does not require:
+
+- a generic automatic converter for all ML code;
+- a production experiment registry;
+- agent-managed production authorization.
+
+## Product Skill Catalog
+
+The FLARE skill catalog should be workflow-oriented and grouped by customer
+intent. This table is a roadmap view, not the initial implementation scope. The
+`Tier` column is the release-grouping source for this design: `seed` means the
+first implementation seed, `next` means follow-on customer-journey skills, and
+`later` means later catalog expansion. The `Category` column is also the initial
+source for same-category trigger-overlap lint unless a later metadata schema
+adds category directly to skills. Any change to category names or skill-category
+assignment must update the evaluation lint expectations in the same PR.
+Framework conversion scope, repo evidence, and tier are canonical in
+[Agent Skill Authoring](agent_skill_authoring.md#skill-granularity-and-naming).
+This catalog table is a product overview and should not redefine conversion
+scope.
+
+| Category | Skill | Tier | Purpose |
+| --- | --- | --- | --- |
+| Orientation | `nvflare-orient` | seed | Route ambiguous requests using inspect/doctor evidence and choose the next workflow skill |
+| Setup | `nvflare-setup-local` | next | Install and verify local FLARE, check dependencies, and report readiness |
+| Conversion | `nvflare-convert-pytorch` | seed | PyTorch-specific state dict, checkpoint, metrics, and recipe patterns |
+| Conversion | `nvflare-convert-lightning` | next | PyTorch Lightning Trainer, LightningModule, logging, checkpoint, and multi-GPU patterns |
+| Conversion | `nvflare-convert-huggingface` | next | Hugging Face Trainer, datasets, tokenizers, PEFT/LoRA, LLM, and VLM workflows |
+| Conversion | `nvflare-convert-tensorflow` | next | TensorFlow/Keras model weight, metric, and recipe patterns |
+| Conversion | `nvflare-convert-xgboost` | next | XGBoost horizontal and vertical/federated tree workflows |
+| Conversion | `nvflare-convert-sklearn` | next | scikit-learn estimators and pipelines, including logistic regression, SVM, and k-means |
+| Conversion | `nvflare-convert-survival-analysis` | next | Kaplan-Meier and time-to-event analytics workflows |
+| Conversion | `nvflare-convert-monai` | later | MONAI medical imaging training workflows |
+| Conversion | `nvflare-convert-jax` | later | JAX training workflows |
+| Conversion | `nvflare-integrate-flower` | later | Interoperate with existing Flower applications |
+| Conversion | `nvflare-convert-gnn` | later | Graph neural network workflows |
+| Conversion | `nvflare-convert-numpy` | later | NumPy or custom training loops when no stronger framework-specific path applies |
+| Job creation | `nvflare-site-specific-training` | next | Configure jobs where sites use different training scripts, data loaders, training parameters, or app folders while preserving a common FLARE task contract |
+| Local runtime | `nvflare-poc-workflow` | next | Prepare, start, verify, stop, and clean local POC systems |
+| Operations | `nvflare-job-lifecycle` | next | Validate, submit, monitor, inspect, download, collect job outputs, and enforce identity/config plus production approval gates |
+| Observability | `nvflare-experiment-tracking` | next | Add, validate, and interpret TensorBoard or MLflow experiment tracking for FLARE jobs without owning an external tracking service |
+| Operations | `nvflare-system-operations` | later | Inspect and manage FLARE system state with explicit safety gates |
+| Operations | `nvflare-study-workflow` | later | Work with study-scoped job routing, authorization, and data isolation |
+| Deployment | `nvflare-deploy-multimachine` | later | Plan and validate multi-machine server/client/admin deployments |
+| Deployment | `nvflare-deploy-docker` | later | Run FLARE components with containers and mounted startup kits |
+| Deployment | `nvflare-deploy-k8s` | later | Validate Kubernetes deployment artifacts and readiness |
+| Deployment | `nvflare-deploy-cloud` | later | Map FLARE deployment guidance to provider-specific cloud environments |
+| Data discovery | `nvflare-federated-statistics` | later | Generate, run, and interpret federated statistics jobs before training |
+| Data engineering | `nvflare-collaborative-etl` | next | Orchestrate federated/collaborative ETL, preprocessing, feature validation, and data-quality tasks without centralizing site-local data |
+| Privacy/security | `nvflare-privacy-security` | later | Choose the right PET, policy, and security approach for the workflow |
+| Privacy/security | `nvflare-add-differential-privacy` | later | Add DP to supported model training and report privacy budget |
+| Privacy/security | `nvflare-add-homomorphic-encryption` | later | Add HE or secure aggregation to supported FLARE workflows |
+| Privacy/security | `nvflare-run-private-set-intersection` | next | Run PSI (private set intersection) to privately match records before vertical FL or split learning |
+| Privacy/security | `nvflare-privacy-policy-filters` | later | Configure or validate site/job privacy filters and policy scopes |
+| Troubleshooting | `nvflare-diagnose-job` | seed | Collect evidence and map common failures to recovery categories |
+| Troubleshooting | `nvflare-extract-local-debug-script` | later | Extract a non-federated local training/debug script from a FLARE job when diagnosing conversion or convergence issues |
+| Provisioning | `nvflare-distributed-provisioning` | later | Guide request, approval, package, and startup-kit handling workflows |
+
+Skill naming convention:
+
+- Use `nvflare-convert-<framework>` when the workflow is primarily adapting a
+  framework family, such as PyTorch, TensorFlow, XGBoost, sklearn, or JAX.
+- Use `nvflare-convert-<domain-workflow>` when the workflow is described by the
+  customer's domain task and has distinct data/evaluation semantics, such as
+  survival analysis.
+- Use `nvflare-integrate-<external-system>` when the task is interoperability
+  with another FL framework or tool, such as Flower.
+- Use `nvflare-<workflow>` for operational, validation, setup, diagnosis, PET,
+  production-safety, or provisioning workflows.
+
+`nvflare-setup-local` is not a wrapper around `nvflare agent doctor` and it
+does not own POC lifecycle. Doctor is read-only readiness inspection. The setup
+skill may guide installation and dependency remediation, then call doctor to
+verify state. `nvflare-poc-workflow` owns POC prepare, start, verify, stop, and
+cleanup.
+
+`nvflare-site-specific-training` is the follow-on skill for heterogeneous site
+workflows. It should guide agents when sites need different training scripts,
+data loaders, hyperparameters, local preprocessing, or site-specific app/config
+folders while still sharing a compatible task contract and aggregation path.
+This is different from a normal framework-conversion skill, which assumes one
+training pattern can be adapted for all sites.
+
+`nvflare-collaborative-etl` is the follow-on skill for collaborative computing
+tasks that are not model training: ETL, preprocessing, feature validation,
+data-quality checks, local artifact generation, and handoff into later FLARE
+training or statistics workflows. It should keep raw data local and make clear
+which outputs are safe to aggregate or share.
+
+`nvflare-experiment-tracking` is the follow-on skill for tracking and
+observability. It should guide agents to use FLARE-supported tracking paths,
+such as Recipe API `add_experiment_tracking`, `nvflare.client.tracking`
+writers, TensorBoard analytics receivers, MLflow writers, and generated
+tracking instructions. It should not become a production experiment registry or
+provision/manage external TensorBoard or MLflow services; those remain user
+environment concerns.
+
+Auto-FL research is a separate research project, not part of the product
+readiness surface. FLARE skills should be usable by that project as an
+experimental treatment: compare Auto-FL runs with no skills, with relevant
+skills available, and with specific skills forced when appropriate. Use the
+results to measure whether skills improve research-task accuracy, cost,
+efficiency, instruction adherence, reproducibility, and diagnosis quality.
+
+### Auto-FL Orchestration Boundary
+
+Auto-FL can benefit from a Codex workflow-engine-style layer, including
+JavaScript-generated or JavaScript-executed workflows, but that layer should own
+control-plane behavior rather than FLARE reasoning. The workflow layer should
+handle:
+
+- task polling, queueing, routing, and concurrency;
+- retry/backoff policy and failed-run recovery;
+- workspace naming, run IDs, manifests, and persistence;
+- model/agent selection and skill availability per run;
+- hooks around setup, validation, artifact collection, and cleanup;
+- cost, token, runtime, and outcome ledgers.
+
+FLARE skills should remain the reasoning layer. They should define when to use
+FLARE, which integration path to choose, what safety boundaries apply, what CLI
+commands and helper scripts to run, and how to interpret validation or failure
+evidence. Deterministic product behavior should stay in the `nvflare` CLI or
+skill-local helper scripts.
+
+This keeps orchestration reusable across research tasks while keeping
+FLARE-specific decisions versioned with the skills and package. The
+Codex workflow engine should be an Auto-FL research dependency,
+not a dependency for the customer path of installing NVFLARE or NVFLARE skills.
+
+### Privacy-Enhancing Technology Skills
+
+PET skills are deferred from the initial seed. They remain important catalog candidates. PSI
+should be an explicit follow-on skill because NVFLARE already has PSI support
+and examples, but DP, HE, PSI, and privacy policy filters require stronger
+evidence contracts, approval guidance, dependency checks, and validation
+artifacts than the first seed skills.
+
+When PET skills are promoted, their design should define:
+
+- the PET decision boundaries across DP, HE, PSI, privacy filters, secure
+  provisioning, authorization, and communication security;
+- the evidence required before the skill can claim a privacy/security workflow
+  was configured or verified;
+- role boundaries for researcher, project admin, org admin, and site operator;
+- whether a PET-specific evidence artifact such as `_pet_report.json` is
+  required.
+
+The PET evidence artifact is deferred with the other durable workflow artifacts.
+It should land when PET skills land, not in the initial seed scope.
+
+## Initial Seed Bundle
+
+The first implementation should ship a small seed bundle rather than the whole
+catalog. The seed should prove the install path, trigger quality, inspect/doctor
+handoff, conversion guidance, and diagnosis guidance before expanding into the
+full customer journey.
+
+Recommended initial seed skills:
+
+| Category | Skill | Why It Is Useful to Customers |
+| --- | --- | --- |
+| Orientation | `nvflare-orient` | Routes ambiguous requests to setup, conversion, validation, POC, production, recipe-based, or diagnosis workflows without loading all FLARE docs |
+| Conversion | `nvflare-convert-pytorch` | Covers the first high-value path for turning existing PyTorch training code into a FLARE federated workflow |
+| Troubleshooting | `nvflare-diagnose-job` | Turns job/system evidence into likely failure causes and recovery categories |
+
+For a general customer request such as "convert my training code to FLARE",
+the agent should first use `nvflare-orient` and `nvflare agent inspect` to
+identify the framework and conversion state. If PyTorch is detected,
+`nvflare-convert-pytorch` owns the conversion workflow. A broad conversion skill
+should not be added until it has a clear fallback scope that does not overlap
+with framework-specific skills.
+
+Publication sequencing should be driven by evidence, not by whether a skill is
+considered core. The follow-on customer-journey bundle can add setup, job
+generation, site-specific training, collaborative ETL, local validation, POC,
+identity/config, job lifecycle, experiment tracking, and production-submit
+skills after the seed proves the authoring, install, and eval contracts.
+Framework, PET, deployment, and advanced operations skills should follow the
+tiering in the product catalog.
+
+Helper-script authoring and promotion rules live in
+[Agent Skill Authoring](agent_skill_authoring.md#initial-customer-helper-scripts).
+
+## Skill File Requirements
+
+Skill file structure, `SKILL.md` size limits, licensing, example/eval-input
+relationships, and maintenance policy live in
+[Agent Skill Authoring](agent_skill_authoring.md#skill-file-requirements).
+
+## Skill Evaluation
+
+The initial evaluation gate lives in
+[Agent Skill Evaluation](agent_skill_evaluation.md). It separates normal
+engineering tests from runtime agent-performance measurements. The required initial
+runtime measurements are trigger correctness, negative trigger correctness,
+mandatory-instruction coverage, prohibited-action avoidance, and task success
+for the skill's guide-compatible eval cases.
+
+Large policy catalogs, paired live-agent harnesses, separate instruction
+monitor services, transcript replay, cost accounting, and PR-bot automation are
+deferred roadmap items.
+
+## Publication Handoff Boundary
+
+Publication integration with `github.com/NVIDIA/skills` is separate work. This
+design owns the FLARE side of the handoff: skill source, wheel packaging,
+install behavior, command contracts, and evaluation evidence. The concrete
+handoff checklist lives in
+[Agent Skill Publication Handoff Checklist](agent_publication_handoff_checklist.md).
+Catalog registration, sync, public installer metadata, and public scoreboard
+mechanics belong to the NVIDIA skills publication process.
+
+The FLARE release process must still check that skill command examples match
+the installed CLI for that release before handoff. Skill drift is a product
+responsibility, not something the external publication process can fully
+detect.
+When external catalog publication is requested, catalog sync should happen as
+part of the FLARE release handoff rather than as an independent skill-catalog
+cadence.
+
+## Command Surfaces
+
+This section is the canonical contract for agent-facing `nvflare agent`
+commands. Earlier sections may mention these commands as examples or trigger
+sources, but command names, safety boundaries, and output expectations should
+be updated here first.
+
+### `nvflare agent inspect`
+
+`nvflare agent inspect <path> --format json` is a read-only static inspection
+command. It inspects the user-supplied local path, not the installed NVFLARE
+package and not GitHub content.
+
+It should classify:
+
+- training repository;
+- single training script;
+- FLARE job source;
+- exported submit-ready FLARE job;
+- mixed workspace;
+- unknown target.
+
+It should report:
+
+- ranked framework evidence with numeric confidence, supporting evidence, and
+  contradicting evidence;
+- likely entry points;
+- whether FLARE integration usage is present;
+- whether the code is `not_converted`, `partial_client_api`,
+  `client_api_converted`, `flare_job`, `exported_job`, or `unknown`;
+- whether `job.py` exists;
+- whether SimEnv is used;
+- whether export support exists;
+- recipe fit as `compatible`, `requires_fedjob`, or `uncertain`;
+- distributed or multi-GPU patterns such as DDP, DataParallel, FSDP,
+  `torch.distributed`, `accelerate.Accelerator`, and gradient accumulation
+  boundaries;
+- dynamic framework-resolution findings such as Hydra/OmegaConf, dynamic
+  imports, `getattr` dispatch, external training functions, and `torch.compile`;
+- hardcoded absolute data path findings;
+- skipped symlink findings;
+- skill-selection evidence for the agent, such as detected framework,
+  conversion state, exported-job state, and safety findings;
+- recommended next commands.
+
+Inspection must be static only. It may parse files and use AST-based checks, but
+it must not import or execute user modules. It must not scan arbitrary
+home-directory content unless explicitly pointed there, read private key
+contents, modify code, generate files, submit jobs, or start/stop systems.
+
+Inspection output must avoid leaking user source or secrets:
+
+- never include raw file contents in JSON output.
+- report structural facts, symbols, imports, call patterns, capped evidence,
+  and sanitized snippets only.
+- skip `.git`, virtual environments, caches, build outputs, and hidden
+  directories unless the target itself is hidden.
+- cap traversal and evidence volume, for example file count, individual file
+  size, and evidence strings per category.
+- do not follow symlinks by default; report `SYMLINK_SKIPPED` with sanitized
+  target and action.
+- redact secret-like literals, credentials, tokens, connection strings, cloud
+  keys, private endpoints, and sensitive absolute paths by default.
+- support explicit `--redact on|off`; redaction remains on by default and
+  `--redact off` is for local debugging only.
+- report `ABSOLUTE_DATA_PATH` with file/line and pattern type rather than full
+  sensitive values when redaction is on.
+
+### `nvflare agent doctor`
+
+`nvflare agent doctor --format json` is a local readiness command. It should
+check:
+
+- NVFLARE import and version;
+- command registry and schemas;
+- active startup kit config;
+- stale or invalid startup kit paths;
+- optional dependency summary;
+- packaged or installed skill availability;
+- POC workspace state.
+
+`nvflare agent doctor --online --format json` adds a bounded read-only server
+snapshot through the active startup kit or per-command startup-kit selector. It
+should include:
+
+- active startup kit identity;
+- server connection and authentication status;
+- server status;
+- server and client versions;
+- connected clients;
+- resource summary when authorized;
+- job summary when authorized;
+- study summary and submit capability when authorized;
+- startup-kit certificate expiration and renewal hint when supported;
+- packaged skill availability summary;
+- snapshot timestamp and recommended TTL for using the readiness result in
+  follow-on decisions;
+- findings and next steps.
+
+It must not submit, abort, delete, download, restart, shut down, switch
+identity, modify config, or read private key contents.
+
+### Native Skill Commands
+
+`nvflare agent skills install --agent codex|claude [--skill <name>]
+[--dry-run] [--format json]` is the initial management command. It copies
+NVFLARE-owned skills from the installed package or editable checkout to the
+selected agent target. It does not download third-party skills or depend on
+Node.js, `npm`, `npx`, or an external skills CLI.
+
+`nvflare agent skills list --agent codex|claude --format json` reports managed
+installed skills for that target and the compatible released skills available
+from the current NVFLARE package or editable checkout. It is a simple install
+aid, not a public catalog browser. Its `conflicts` field must only describe
+name-overlap conflicts with NVFLARE-source skills or managed NVFLARE installs;
+unrelated third-party skills already present in the agent target directory are
+ignored by default.
+
+Installed skills collect normal task evidence for user-facing results. Runtime
+skill-performance evidence is recorded by benchmark harnesses, research
+workflows, or reviewer processes outside the normal skill path. This is an
+agent/harness convention, not a public `nvflare agent` CLI contract.
+environment switch.
+
+Full discovery, audit, validation, compatibility, transcript, feedback,
+approval-list, revert, uninstall, and cleanup commands are deferred to
+the future roadmap.
+
+### Generated Code API Selection
+
+When an agent generates Python, it should choose the highest-level FLARE API
+that can express the user's intent. The persona and task should drive the API
+choice:
+
+| User intent | Preferred generated code | Avoid |
+| --- | --- | --- |
+| Applied data scientist adapting a known workflow to a domain | Job Recipe API in `job.py`, plus minimal Client API changes in the training script when needed | Custom controllers/executors for standard FedAvg, FedOpt, Scaffold, XGBoost, sklearn, statistics, or similar recipe-covered workflows |
+| Researcher trying variants of an existing algorithm | Recipe API first; FedJob API when the recipe needs unsupported composition or custom components | Rewriting FLARE internals or hand-editing generated config JSON when Python APIs can express the job |
+| Researcher inventing a new algorithm or communication pattern | FedJob API for job assembly; ModelController API for server-side algorithm logic; Client API and `FLModel` for client training/evaluation exchange | Dropping to low-level Controller/Executor APIs before ModelController/FedJob options are exhausted |
+| Platform/admin/operator task | `nvflare` CLI with `--format json` where available | Generated Python that wraps provision, config, package, submit, monitor, system, or study operations |
+
+The default path for applied users should be Recipe API plus Client API because
+that keeps the generated code close to the user's ML code and hides controller,
+executor, and config wiring. The agent should use framework-specific recipes
+when available, such as PyTorch/TensorFlow FedAvg recipes, XGBoost recipes,
+sklearn recipes, federated statistics recipes, PSI recipes, or other product
+recipes that match the detected workflow.
+
+The default path for researchers should still start as high-level as possible.
+If the research question is "try a different aggregation rule," prefer a recipe
+extension point or FedJob component composition before writing a new workflow.
+If the research question is "invent a new server-client algorithm," generate a
+ModelController-based workflow and wire it with FedJob. Drop to lower-level
+Controller or Executor classes only when the algorithm requires FLARE behavior
+that ModelController, Client API, and FedJob cannot represent.
+
+Generated Python should not become operational glue for actions already owned
+by the CLI. Running POC, submitting a job, monitoring logs/stats, registering
+startup kits, packaging, provisioning, and system operations should stay as
+traceable `nvflare` commands. If generated Python is only wrapping a CLI call or
+scraping human output, add or use JSON CLI output, a tested helper script, or a
+missing product command instead.
+
+The Python escape hatch is for job logic, local algorithm research, notebooks,
+and library-first workflows where generated code is the artifact the user wants
+to inspect and keep. It is not for hiding administrative side effects. Skills
+may offer a Python-only path when the host agent cannot run shell commands, but
+that path must state which CLI validation or submission steps the user still
+needs to run outside the agent.
+
+### Job Generation and Export
+
+Agent-generated `job.py` should follow a standard convention:
+
+```bash
+python job.py
+python job.py --export --export-dir <job_folder>
+nvflare job submit -j <job_folder>/<job_name> --format json
+```
+
+`python job.py` should use SimEnv for local validation. POC and production
+submission should go through the CLI, not through generated Python admin glue.
+
+Export should be atomic: write to a temporary directory and move into place only
+after required files are complete. As a follow-on core CLI enhancement, exported
+job folders should eventually include:
+
+- `_export_manifest.json` with required files, source path, source hash,
+  timestamp, NVFLARE version, exporter, `poc_validated`, `poc_validation`, and
+  a nested `fingerprint` section containing FLARE, Python, recipe, framework
+  dependency, and source-hash metadata. Use one manifest file unless a separate
+  consumer explicitly needs a standalone `job_fingerprint.json`.
+
+`nvflare agent inspect` should classify current exported job folders as
+`exported_job` even when these future manifest files are absent. When the
+manifest/fingerprint files exist, inspect and submit preflight should use them
+for stronger completeness, freshness, and validation checks.
+
+Generated examples should make the FL ordering constraint visible: receive the
+global model, apply received weights, train locally, then send the updated model
+and metrics. When practical, generated jobs should write `metrics_summary.json`
+with enough round-start and round-end metrics for conversion and job-lifecycle
+skills to
+detect semantic mistakes such as ignoring the received global model.
+
+Conversion skills and `nvflare-job-lifecycle` must document SimEnv limitations:
+no TLS/auth, no startup-kit validation, no network latency or timeout coverage,
+no real site-local data separation unless the job explicitly models it, and no
+guarantee that per-site resource limits match production. POC validation is
+required before production submission unless the user explicitly accepts the
+risk. POC workflows should record the previous kit identity before prepare and
+use `nvflare poc stop --restore-kit --format json` after validation when that
+restore path is available.
+
+### Diagnosis
+
+The initial diagnosis workflow can be skill-driven. `nvflare-diagnose-job`
+should collect:
+
+```bash
+nvflare job meta <job_id> --format json
+nvflare job logs <job_id> --site all --tail 200 --format json
+nvflare job stats <job_id> --format json
+nvflare system status --format json
+nvflare system resources --format json
+```
+
+Diagnosis must keep evidence bounded and source-aware:
+
+- request bounded logs with `--tail`, `--since`, or `--max-bytes` where
+  available.
+- treat `logs_truncated: true` as a finding when more context may be needed.
+- report `PARTIAL_LOG_VISIBILITY` when per-site logs are unavailable or
+  permission-denied.
+- use log source markers when available: `[USER_CODE_EXCEPTION]` for user
+  training code, `[FLARE]` for framework/runtime code, and `unknown` when no
+  marker exists.
+- match a packaged failure-pattern catalog before asking an LLM to interpret
+  raw logs.
+- avoid confident root-cause claims when required site evidence is missing.
+
+The first `nvflare-diagnose-job` release should include at least 12 packaged
+failure patterns across user-code exceptions, missing imports, data-path
+failures, CUDA/resource exhaustion, auth/startup-kit issues, connection
+timeouts, partial log visibility, export/package mistakes, and site
+authorization failures. Auto-FL and customer support feedback should grow this
+catalog over time.
+
+The skill should map common findings to recovery categories:
+
+| Pattern | Evidence | Recovery Category |
+| --- | --- | --- |
+| `CUDA_OOM` | CUDA out of memory in logs | `FIXABLE_BY_CODE` |
+| `AUTH_FAILURE` | certificate or authentication rejection | `FIXABLE_BY_CONFIG` |
+| `ROUND_TIMEOUT` | round timeout or no client response | `ENVIRONMENT_FAILURE` |
+| `IMPORT_ERROR` | `ModuleNotFoundError` or import failure | `FIXABLE_BY_CODE` |
+| `ABSOLUTE_DATA_PATH` | local absolute path used remotely | `FIXABLE_BY_CODE` |
+| `STARTUP_KIT_EXPIRED` | certificate validity failure | `FIXABLE_BY_CONFIG` |
+
+A later `nvflare job diagnose <job_id> --format json` command can formalize the
+same evidence collection once the patterns are stable.
+
+## Example and Scaffold Conventions
+
+Example layout, README expectations, eval-input source-of-truth rules, and
+recipe-to-skill scaffold guidance live in
+[Agent Skill Authoring](agent_skill_authoring.md#example-and-scaffold-conventions).
+
+## Notebook-Safe Path
+
+Many applied users will run NVFLARE from notebooks while an agent edits files or
+drives shell commands. Notebook workflows need extra guardrails because kernels
+hide global state and long blocking commands can make recovery harder.
+
+Notebook guidance:
+
+- avoid changing the global active startup kit inside notebooks; prefer
+  per-command `--kit-id` or `--startup-kit` selectors.
+- verify that the notebook kernel and shell commands use the same NVFLARE
+  installation with `nvflare --version`.
+- use polling commands such as `nvflare job meta <job_id> --format json` or
+  bounded monitor intervals instead of blocking the kernel indefinitely.
+- after kernel restart, run `nvflare agent doctor --online --format json`
+  before preparing POC again, switching identity, or submitting jobs.
+- after kernel restart, rediscover artifact state with bounded inspect/doctor
+  commands instead of relying on hidden notebook state.
+- provide a notebook example that demonstrates safe POC validation, scoped
+  startup-kit selection, export, submit, bounded monitoring, logs, download, and
+  cleanup.
+
+Notebook guidance is not a separate public skill in the initial catalog. It
+belongs in `nvflare-job-lifecycle`, conversion skills, and concise notebook
+references. A future
+`nvflare-notebook-workflow` skill should be added only if notebook use develops
+distinct triggers, artifacts, safety boundaries, and eval inputs/assertions that would
+overlap poorly with those existing skills.
+
+## Production Safety
+
+Agent workflows must preserve FLARE's security boundaries:
+
+- use `nvflare config add`, `nvflare config use`, `nvflare config inspect`, and
+  per-command `--kit-id` or `--startup-kit` selectors for startup kit identity;
+- do not copy private keys into generated artifacts;
+- redact secrets from logs and JSON outputs;
+- require explicit user approval for production submit, shutdown, delete,
+  restart, distributed approval, and key generation flows;
+- treat generated job code as user-reviewable source;
+- keep site-local data paths local and never assume globally visible data.
+
+High-risk skill actions should include approval checkpoints. For production job
+submit, the checkpoint should show at least:
+
+- job folder;
+- server;
+- study;
+- active identity;
+- whether the action is reversible;
+- risk level;
+- required confirmation phrase.
+
+For the initial implementation, approval is an in-conversation checkpoint: the agent surfaces the
+fields above, waits for the user to type the required confirmation phrase, and
+only then runs the high-risk command. The approval event should be visible in
+the conversation and command trace. A durable approval log, receipt linkage, and
+project-level approval audit command are deferred roadmap items.
+
+## Auto-Research Evaluation
+
+Auto-FL and auto-research evaluation conventions live in
+[Agent Skill Evaluation](agent_skill_evaluation.md#auto-fl-research-evaluation).
+This integration doc only defines the boundary: Auto-FL can consume FLARE
+skills, but orchestration, retry, routing, and persistence remain outside the
+customer skill install path.
+
+## Workstreams and Deliverables
+
+The implementation work spans the three documents:
+
+| Workstream | Owning Spec | Scope |
+| --- | --- | --- |
+| Runtime commands | This document | `nvflare agent inspect`, `doctor`, native skill install/list, CLI JSON/jsonl contracts, and generated-code API policy |
+| Skill source and authoring | [Agent Skill Authoring](agent_skill_authoring.md) | repo-root `skills/`, `SKILL.md`, `references/`, helper scripts, examples, eval input files, minimal metadata, and maintenance policy |
+| Skill evaluation and admission | [Agent Skill Evaluation](agent_skill_evaluation.md) | guide-compatible trigger/task evals, initial admission gate, engineering-vs-runtime test split, and Auto-FL research evaluation conventions |
+| Publication handoff artifacts | [Agent Skill Evaluation](agent_skill_evaluation.md#publication-handoff-boundary) | FLARE skill content, benchmark evidence, and handoff artifacts consumed by the NVIDIA skills publication process |
+| Diagnosis productization | This document plus [Agent Skill Authoring](agent_skill_authoring.md#initial-customer-helper-scripts) | `nvflare-diagnose-job`, bounded evidence collection, failure-pattern catalog, helper scripts, and later promotion to `nvflare job diagnose` |
+| Deferred roadmap | Future roadmap notes | receipts, provenance, workflow state, transcript replay, workspace cleanup, full lifecycle commands, compatibility shims, PR bot, and large policy catalog |
+
+## Publication Handoff Artifacts
+
+Skill content, initial evaluation evidence, benchmark summaries, and publication
+handoff artifact requirements live in
+[Agent Skill Evaluation](agent_skill_evaluation.md#publication-handoff-boundary).
+Public scoreboards and external skill-card mechanics belong to the
+company-wide NVIDIA skills publication process, not FLARE agent integration.
+
+## Success Criteria
+
+Agent readiness is successful when:
+
+- A user can install NVFLARE and obtain FLARE-specific skills from the wheel
+  without needing a separate NVFLARE source checkout.
+- A developer can test FLARE skills from the public NVFLARE GitHub repo or a
+  local NVFLARE clone before the skills are synced into the public catalog.
+- FLARE skills pass the initial evaluation gate before external publication handoff.
+- FLARE handoff artifacts are ready for the NVIDIA skills publication process
+  when external catalog publication is requested.
+- An agent can inspect a simple PyTorch training repo, select the right FLARE
+  skill, apply the appropriate FLARE integration pattern, generate `job.py`, run
+  SimEnv, export a job folder, and submit through `nvflare job submit`.
+- An agent can prepare POC, wait for readiness, submit an exported job, monitor
+  it, collect logs and results, and diagnose a deliberate failure.
+- Production submission requires explicit user approval and reports the active
+  startup kit identity before submission.
+- Skill examples remain aligned with the installed CLI for the corresponding
+  FLARE release.
+
+## Open Questions and Deferred Decisions
+
+No known blocker remains for the first implementation pass. Deferred roadmap
+items are tracked separately, including durable handoff artifacts, transcript
+replay, workspace cleanup, full lifecycle commands, compatibility shims, PR-bot
+automation, and the large policy catalog.
+
+Open non-blocking decisions:
+
+- which additional agent targets beyond `codex` and `claude` should be added
+  after their skill locations, capability model, and trace capture are known;
+- how many diagnosis patterns are required for each later release after Auto-FL
+  and customer feedback produce real failure data.

--- a/docs/design/agent_publication_handoff_checklist.md
+++ b/docs/design/agent_publication_handoff_checklist.md
@@ -1,0 +1,78 @@
+# Agent Skill Publication Handoff Checklist
+
+This document defines the FLARE-owned handoff package for external NVIDIA
+skills publication. It is a checklist for artifacts produced in the NVFLARE
+repository before catalog sync, NVCARPS validation, signing, or public
+scoreboard publication.
+
+External catalog registration, signing infrastructure, public installer
+metadata, and public scoreboard mechanics are owned by the NVIDIA skills
+publication process. FLARE owns the source, release compatibility, and evidence
+bundle that the publication process consumes.
+
+## Handoff Inputs
+
+Each public FLARE skill submitted for external publication should provide:
+
+- skill source directory under `skills/<skill>/`;
+- valid `SKILL.md` frontmatter with `name`, `description`,
+  `min_flare_version`, and `blast_radius`;
+- `references/`, `scripts/`, `assets/`, and `evals/files/` needed by the skill;
+- `evals/evals.json` with `schema_version`, positive trigger cases, adjacent
+  negative trigger cases, mandatory behavior IDs, prohibited behavior IDs, and
+  process metric contracts;
+- `BENCHMARK.md` or an explicit draft/internal marker when runtime evidence is
+  not yet publication-grade;
+- source hash, skill version when present, and target NVFLARE release version;
+- command-drift lint output for every referenced `nvflare` command and flag;
+- helper-script test output when the skill ships scripts;
+- runtime evidence summaries from the agent benchmark harness, research
+  workflow, or reviewer process when available.
+
+## Evidence Mapping
+
+| Publication Question | FLARE Artifact |
+| --- | --- |
+| What is the skill and when should it trigger? | `SKILL.md` frontmatter and trigger/use-boundary text |
+| Which FLARE release supports it? | `min_flare_version`, target release notes, bundled wheel metadata |
+| What source content is being published? | source hash, packaged file manifest, skill directory |
+| Does the skill reference valid product commands? | command-drift lint output and CLI `--schema` checks |
+| Does it avoid adjacent or unrelated prompts? | `negative_trigger_cases`, global negative coverage, runtime trigger evidence when available |
+| Does it follow required workflow rules? | `nvflare.mandatory_behavior` IDs and runtime evidence records |
+| Does it avoid prohibited actions? | `nvflare.prohibited_behavior` IDs and runtime evidence records |
+| Does it improve agent behavior? | `BENCHMARK.md`, benchmark records, process metric summaries |
+| Are helper scripts safe and tested? | helper-script tests and static inspection results |
+
+## Handoff Output
+
+The FLARE release handoff should produce a compact bundle or manifest that
+names:
+
+- skill names and versions included in the handoff;
+- target NVFLARE release and commit;
+- source hashes for each skill;
+- lint/test command summaries;
+- runtime evidence record locations or summaries;
+- generated `BENCHMARK.md` paths;
+- known limitations or publication-blocking gaps.
+
+NVCARPS or the external catalog pipeline may transform these inputs into a skill
+card, signed manifest, catalog entry, public installer metadata, or scoreboard
+entry. Those transformed artifacts are not the source of truth inside NVFLARE.
+
+## Publication Gates
+
+A skill should not be handed off for public catalog publication when:
+
+- required frontmatter is missing or invalid;
+- `evals/evals.json` is missing, has an unsupported `schema_version`, or lacks
+  positive and adjacent negative trigger coverage;
+- referenced `nvflare` commands drift from the target release CLI schema;
+- helper scripts are untested or violate JSON stdout/stderr conventions;
+- runtime evidence shows unresolved significant safety or artifact-ownership
+  violations;
+- the target NVFLARE release does not satisfy the skill compatibility metadata.
+
+Runtime benchmark absence can be accepted only with an explicit draft/internal
+marker or release-owner approval that documents why publication is still
+appropriate.

--- a/nvflare/cli.py
+++ b/nvflare/cli.py
@@ -28,6 +28,7 @@ from nvflare.fuel.hci.tools.authz_preview import define_authz_preview_parser, ru
 from nvflare.lighter.provision import define_provision_parser, handle_provision
 from nvflare.private.fed.app.simulator.simulator import define_simulator_parser, run_simulator
 from nvflare.private.fed.app.utils import version_check
+from nvflare.tool.agent.agent_cli import def_agent_cli_parser, handle_agent_cmd
 from nvflare.tool.cert.cert_cli import def_cert_cli_parser, handle_cert_cmd
 from nvflare.tool.deploy.deploy_cli import def_deploy_cli_parser, handle_deploy_cmd
 from nvflare.tool.job.job_cli import def_job_cli_parser, handle_job_cli_cmd
@@ -65,6 +66,7 @@ CMD_PACKAGE = "package"
 CMD_DEPLOY = "deploy"
 CMD_SYSTEM = "system"
 CMD_STUDY = "study"
+CMD_AGENT = "agent"
 
 _JSONL_COMMANDS = {
     (CMD_JOB, "monitor"),
@@ -306,8 +308,6 @@ def _emit_argparse_error_json(parser, message):
     # command handler runs and therefore sit outside the normal command data envelope.
     payload = {
         "schema_version": SCHEMA_VERSION,
-        "event": "terminal",
-        "terminal": True,
         "status": "error",
         "exit_code": 4,
         "error_code": "INVALID_ARGS",
@@ -466,6 +466,7 @@ def parse_args(prog_name: str):
     sub_cmd_parsers.update(def_package_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_deploy_cli_parser(sub_cmd))
     sub_cmd_parsers.update(def_study_cli_parser(sub_cmd))
+    sub_cmd_parsers.update(def_agent_cli_parser(sub_cmd))
     system_parser = sub_cmd.add_parser(CMD_SYSTEM, help="FL system operations (status, shutdown, version, ...)")
     sub_cmd_parsers.update({CMD_SYSTEM: system_parser})
     def_system_cli_parser(system_parser)
@@ -499,7 +500,7 @@ def parse_args(prog_name: str):
         ns.cert_sub_command = sub_sub
         ns.recipe_sub_cmd = sub_sub or "list"
         ns.deploy_sub_cmd = sub_sub
-        ns.deploy_k8_sub_cmd = positionals[2] if len(positionals) > 2 else None
+        ns.agent_sub_cmd = sub_sub
         ns.format = global_args.format
         ns.connect_timeout = global_args.connect_timeout
         ns.version = global_args.version
@@ -544,6 +545,7 @@ handlers = {
     CMD_DEPLOY: handle_deploy_cmd,
     CMD_STUDY: handle_study_cmd,
     CMD_SYSTEM: handle_system_cmd,
+    CMD_AGENT: handle_agent_cmd,
 }
 
 

--- a/nvflare/tool/agent/agent_cli.py
+++ b/nvflare/tool/agent/agent_cli.py
@@ -1,0 +1,626 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-facing CLI command group."""
+
+import argparse
+import sys
+from typing import Optional
+
+import nvflare
+from nvflare.cli_unknown_cmd_exception import CLIUnknownCmdException
+from nvflare.tool.agent.command_registry import agent_commands
+
+CMD_AGENT_INFO = "info"
+CMD_AGENT_INSPECT = "inspect"
+CMD_AGENT_DOCTOR = "doctor"
+CMD_AGENT_SKILLS = "skills"
+CMD_AGENT_SKILLS_INSTALL = "install"
+CMD_AGENT_SKILLS_LIST = "list"
+
+_AGENT_OUTPUT_MODES = ["json"]
+_AGENT_EXAMPLES = [
+    "nvflare agent info --format json",
+    "nvflare agent inspect ./train.py --format json",
+    "nvflare agent doctor --format json",
+    "nvflare agent doctor --online --format json",
+    "nvflare agent skills install --agent codex --dry-run --format json",
+    "nvflare agent skills list --agent claude --format json",
+    "nvflare agent info --schema",
+]
+_AGENT_SKILLS_EXAMPLES = [
+    "nvflare agent skills install --agent codex --dry-run --format json",
+    "nvflare agent skills install --agent claude --skill nvflare-orient --format json",
+    "nvflare agent skills list --agent codex --format json",
+]
+_agent_parser: Optional[argparse.ArgumentParser] = None
+_agent_sub_cmd_parsers = {}
+_agent_skills_sub_cmd_parsers = {}
+_AGENT_SKILLS_SCHEMA_VALUE_OPTIONS = {"--agent", "--format", "--skill", "--target"}
+_AGENT_SKILLS_SCHEMA_FLAG_OPTIONS = {"--dry-run", "--schema"}
+
+
+def def_agent_cli_parser(sub_cmd) -> dict:
+    """Register the top-level `nvflare agent` command group."""
+    global _agent_parser
+
+    parser = sub_cmd.add_parser(
+        "agent",
+        description="Agent-facing NVFLARE command surface.",
+        help="Agent-facing NVFLARE helpers.",
+    )
+    parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    agent_subparser = parser.add_subparsers(title="agent subcommands", metavar="", dest="agent_sub_cmd")
+
+    info_parser = agent_subparser.add_parser(
+        CMD_AGENT_INFO,
+        description="Show the available NVFLARE agent command surface.",
+        help="show agent command surface metadata",
+    )
+    info_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    _agent_sub_cmd_parsers[CMD_AGENT_INFO] = info_parser
+
+    inspect_parser = agent_subparser.add_parser(
+        CMD_AGENT_INSPECT,
+        description="Statically inspect local code or FLARE job artifacts for agent routing.",
+        help="statically inspect local code or FLARE job artifacts",
+    )
+    inspect_parser.add_argument("path", help="local file or directory to inspect without executing user code")
+    inspect_parser.add_argument(
+        "--redact",
+        choices=["on", "off"],
+        default="on",
+        help="redact secret-like literals and sensitive absolute paths (default: on)",
+    )
+    inspect_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    doctor_parser = agent_subparser.add_parser(
+        CMD_AGENT_DOCTOR,
+        description="Check local NVFLARE agent readiness without modifying state.",
+        help="check local NVFLARE agent readiness",
+    )
+    doctor_parser.add_argument(
+        "--online",
+        action="store_true",
+        help="also run a bounded read-only status check through the selected startup kit",
+    )
+    _add_startup_kit_selection_args(doctor_parser)
+    doctor_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    skills_parser = agent_subparser.add_parser(
+        CMD_AGENT_SKILLS,
+        description="Install and list NVFLARE-owned agent skills.",
+        help="install and list NVFLARE-owned agent skills",
+    )
+    skills_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+    skills_subparser = skills_parser.add_subparsers(
+        title="agent skills subcommands", metavar="", dest="agent_skills_sub_cmd"
+    )
+    install_parser = skills_subparser.add_parser(
+        CMD_AGENT_SKILLS_INSTALL,
+        description="Install NVFLARE-owned skills into a local agent skill directory.",
+        help="install NVFLARE-owned skills",
+    )
+    _add_agent_target_args(install_parser)
+    install_parser.add_argument("--skill", help="install one skill by name; omit to install all available skills")
+    install_parser.add_argument("--dry-run", action="store_true", help="show the install plan without copying files")
+    install_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    list_parser = skills_subparser.add_parser(
+        CMD_AGENT_SKILLS_LIST,
+        description="List available and installed NVFLARE-owned skills for an agent target.",
+        help="list NVFLARE-owned skills",
+    )
+    _add_agent_target_args(list_parser)
+    list_parser.add_argument("--schema", action="store_true", help="print command schema as JSON and exit")
+
+    _agent_sub_cmd_parsers[CMD_AGENT_INSPECT] = inspect_parser
+    _agent_sub_cmd_parsers[CMD_AGENT_DOCTOR] = doctor_parser
+    _agent_sub_cmd_parsers[CMD_AGENT_SKILLS] = skills_parser
+    _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL] = install_parser
+    _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST] = list_parser
+
+    _agent_parser = parser
+    return {"agent": parser}
+
+
+def _add_agent_target_args(parser) -> None:
+    from nvflare.tool.agent.skill_manager import SUPPORTED_AGENT_TARGETS
+
+    parser.add_argument(
+        "--agent", choices=list(SUPPORTED_AGENT_TARGETS), required=True, help="agent skill target to manage"
+    )
+    parser.add_argument("--target", help="override the resolved agent skill directory")
+
+
+def _add_startup_kit_selection_args(parser) -> None:
+    from nvflare.tool.cli_session import add_startup_kit_selection_args
+
+    add_startup_kit_selection_args(parser)
+
+
+def _agent_info_data() -> dict:
+    return {
+        "nvflare_version": nvflare.__version__,
+        "commands": agent_commands(),
+    }
+
+
+def handle_agent_cmd(args) -> None:
+    from nvflare.tool.cli_output import output_error_message, output_ok
+    from nvflare.tool.cli_schema import handle_schema_flag
+
+    sub_cmd = getattr(args, "agent_sub_cmd", None)
+
+    if sub_cmd is None:
+        handle_schema_flag(
+            _agent_parser,
+            "nvflare agent",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SUBCOMMAND_REQUIRED",
+            "Agent subcommand required.",
+            "Run 'nvflare agent --help' or 'nvflare agent info --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if sub_cmd == CMD_AGENT_INFO:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_INFO],
+            "nvflare agent info",
+            _AGENT_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_ok(
+            _agent_info_data(),
+            code="OK",
+            message="NVFLARE agent command surface is available.",
+            hint="Use --schema on agent-facing commands to inspect argument contracts.",
+        )
+        return
+
+    if sub_cmd == CMD_AGENT_INSPECT:
+        _handle_agent_inspect_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
+    if sub_cmd == CMD_AGENT_DOCTOR:
+        _handle_agent_doctor_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
+    if sub_cmd == CMD_AGENT_SKILLS:
+        _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok)
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent subcommand: {sub_cmd}")
+
+
+def _handle_agent_inspect_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.inspector import inspect_path
+
+    handle_schema_flag(
+        _agent_sub_cmd_parsers[CMD_AGENT_INSPECT],
+        "nvflare agent inspect",
+        _AGENT_EXAMPLES,
+        sys.argv[1:],
+        streaming=False,
+        output_modes=_AGENT_OUTPUT_MODES,
+        mutating=False,
+        idempotent=True,
+    )
+    try:
+        data = inspect_path(args.path, redact=getattr(args, "redact", "on") != "off")
+    except FileNotFoundError as e:
+        output_error_message(
+            "AGENT_INSPECT_PATH_NOT_FOUND",
+            str(e),
+            "Pass an existing local file or directory to inspect.",
+            exit_code=4,
+            include_data=True,
+            recovery_category="FIXABLE_BY_CONFIG",
+        )
+        return
+    except Exception as e:
+        output_error_message(
+            "AGENT_INSPECT_FAILED",
+            "Static inspection failed.",
+            "Check file permissions or reduce the inspected path scope.",
+            exit_code=1,
+            detail=str(e),
+            include_data=True,
+            recovery_category="ENVIRONMENT_FAILURE",
+        )
+        return
+
+    output_ok(
+        data,
+        code="OK",
+        message="NVFLARE agent inspect completed.",
+        hint="Use the framework and conversion_state fields to choose the next skill.",
+    )
+
+
+def _handle_agent_doctor_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.doctor import doctor_environment, format_doctor_human
+    from nvflare.tool.cli_output import is_json_mode, is_jsonl_mode, print_human
+
+    handle_schema_flag(
+        _agent_sub_cmd_parsers[CMD_AGENT_DOCTOR],
+        "nvflare agent doctor",
+        _AGENT_EXAMPLES,
+        sys.argv[1:],
+        streaming=False,
+        output_modes=_AGENT_OUTPUT_MODES,
+        mutating=False,
+        idempotent=True,
+    )
+    try:
+        data = doctor_environment(online=getattr(args, "online", False), args=args)
+    except Exception as e:
+        output_error_message(
+            "AGENT_DOCTOR_FAILED",
+            "NVFLARE agent doctor failed.",
+            "Review local NVFLARE installation and startup-kit configuration.",
+            exit_code=1,
+            detail=str(e),
+            include_data=True,
+            recovery_category="ENVIRONMENT_FAILURE",
+        )
+        return
+
+    if not is_json_mode() and not is_jsonl_mode():
+        print_human(format_doctor_human(data))
+        return
+
+    output_ok(
+        data,
+        code="OK",
+        message="NVFLARE agent doctor completed.",
+        hint="Resolve warning/error findings before production or online workflows.",
+    )
+
+
+def _handle_agent_skills_cmd(args, handle_schema_flag, output_error_message, output_ok) -> None:
+    from nvflare.tool.agent.skill_manager import SUPPORTED_AGENT_TARGETS, install_skills, list_skills
+    from nvflare.tool.cli_output import is_json_mode, is_jsonl_mode, print_human
+
+    skills_sub_cmd = getattr(args, "agent_skills_sub_cmd", None)
+    argv = getattr(args, "_argv", sys.argv[1:])
+    raw_schema_sub_cmd = _raw_schema_agent_skills_sub_cmd(argv)
+    schema_sub_cmd = raw_schema_sub_cmd if raw_schema_sub_cmd in _agent_skills_sub_cmd_parsers else None
+
+    if skills_sub_cmd is None and schema_sub_cmd in _agent_skills_sub_cmd_parsers:
+        skills_sub_cmd = schema_sub_cmd
+
+    if skills_sub_cmd is None and raw_schema_sub_cmd:
+        output_error_message(
+            "INVALID_ARGS",
+            "Invalid agent skills subcommand.",
+            "Supported agent skills subcommands: install, list.",
+            exit_code=4,
+            data={"choices": sorted(_agent_skills_sub_cmd_parsers)},
+            recovery_category="FIXABLE_BY_CONFIG",
+        )
+        return
+
+    if skills_sub_cmd is None:
+        handle_schema_flag(
+            _agent_sub_cmd_parsers[CMD_AGENT_SKILLS],
+            "nvflare agent skills",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        output_error_message(
+            "AGENT_SKILLS_SUBCOMMAND_REQUIRED",
+            "Agent skills subcommand required.",
+            "Run 'nvflare agent skills --help' or 'nvflare agent skills list --agent codex --format json'.",
+            exit_code=4,
+            include_data=True,
+        )
+        return
+
+    if skills_sub_cmd == CMD_AGENT_SKILLS_INSTALL:
+        handle_schema_flag(
+            _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_INSTALL],
+            "nvflare agent skills install",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=True,
+            idempotent=True,
+        )
+        try:
+            plan = install_skills(
+                agent=args.agent,
+                skill_name=getattr(args, "skill", None),
+                dry_run=getattr(args, "dry_run", False),
+                target_dir=getattr(args, "target", None),
+            )
+        except ValueError as e:
+            _output_agent_skill_target_error(output_error_message, getattr(args, "target", None), e)
+            return
+        if plan["missing"]:
+            output_error_message(
+                "AGENT_SKILL_NOT_FOUND",
+                f"NVFLARE skill not found: {', '.join(plan['missing'])}.",
+                "Run 'nvflare agent skills list --agent <codex|claude> --format json' to inspect available skills.",
+                exit_code=4,
+                data=plan,
+                recovery_category="FIXABLE_BY_CONFIG",
+            )
+            return
+        if plan["errors"]:
+            output_error_message(
+                "AGENT_SKILL_INSTALL_FAILED",
+                "One or more NVFLARE skills failed to install.",
+                "Review data.errors and rerun the install after fixing the reported filesystem issue.",
+                exit_code=1,
+                data=plan,
+                recovery_category="FIXABLE_BY_ENV",
+            )
+            return
+        if not is_json_mode() and not is_jsonl_mode():
+            print_human(_format_agent_skills_install_human(plan))
+            return
+        output_ok(
+            plan,
+            code="OK",
+            message=(
+                "NVFLARE agent skills install plan completed."
+                if plan["applied"]
+                else "NVFLARE agent skills install dry run completed."
+            ),
+            hint="Review conflicts before relying on skipped skills." if plan["conflicts"] else "",
+        )
+        return
+
+    if skills_sub_cmd == CMD_AGENT_SKILLS_LIST:
+        handle_schema_flag(
+            _agent_skills_sub_cmd_parsers[CMD_AGENT_SKILLS_LIST],
+            "nvflare agent skills list",
+            _AGENT_SKILLS_EXAMPLES,
+            sys.argv[1:],
+            streaming=False,
+            output_modes=_AGENT_OUTPUT_MODES,
+            mutating=False,
+            idempotent=True,
+        )
+        try:
+            data = list_skills(agent=args.agent, target_dir=getattr(args, "target", None))
+        except ValueError as e:
+            _output_agent_skill_target_error(output_error_message, getattr(args, "target", None), e)
+            return
+        if not is_json_mode() and not is_jsonl_mode():
+            print_human(_format_agent_skills_list_human(data))
+            return
+        output_ok(
+            data,
+            code="OK",
+            message="NVFLARE agent skills listed.",
+            hint=f"Supported agent targets: {', '.join(SUPPORTED_AGENT_TARGETS)}.",
+        )
+        return
+
+    raise CLIUnknownCmdException(f"unknown agent skills subcommand: {skills_sub_cmd}")
+
+
+def _format_agent_skills_install_human(plan: dict) -> str:
+    skills = plan.get("skills") or []
+    counts = {
+        "installed": 0,
+        "replaced": 0,
+        "skipped": 0,
+        "planned": 0,
+        "failed": 0,
+    }
+    for skill in skills:
+        state = skill.get("status") or skill.get("action") or "unknown"
+        if state in ("installed", "copy"):
+            counts["installed" if skill.get("status") else "planned"] += 1
+        elif state in ("replaced", "replace"):
+            counts["replaced" if skill.get("status") else "planned"] += 1
+        elif state == "failed":
+            counts["failed"] += 1
+        else:
+            counts["skipped"] += 1
+
+    lines = [
+        "NVFLARE Agent Skills Install",
+        f"agent: {plan.get('agent', '')}",
+        f"target: {plan.get('target_path', '')}",
+    ]
+    requested_skill = plan.get("requested_skill")
+    if requested_skill:
+        lines.append(f"requested skill: {requested_skill}")
+    source = plan.get("source") or {}
+    if source:
+        lines.append(
+            "source: "
+            f"{source.get('type', 'unknown')} "
+            f"({source.get('skill_count', 0)} available, root: {source.get('root', '')})"
+        )
+    lines.extend(
+        [
+            f"mode: {'applied' if plan.get('applied') else 'dry-run'}",
+            "summary: "
+            f"installed {counts['installed']}, "
+            f"replaced {counts['replaced']}, "
+            f"planned {counts['planned']}, "
+            f"skipped {counts['skipped']}, "
+            f"conflicts {len(plan.get('conflicts') or [])}, "
+            f"errors {len(plan.get('errors') or [])}",
+        ]
+    )
+
+    _append_install_skill_rows(lines, skills)
+    _append_conflict_rows(lines, plan.get("conflicts") or [])
+    if plan.get("missing"):
+        lines.append("")
+        lines.append("missing:")
+        for name in plan["missing"]:
+            lines.append(f"  - {name}")
+    lines.append("")
+    lines.append("Use --format json for the full machine-readable install plan.")
+    return "\n".join(lines)
+
+
+def _append_install_skill_rows(lines: list[str], skills: list[dict]) -> None:
+    lines.append("")
+    lines.append("skills:")
+    if not skills:
+        lines.append("  none")
+        return
+
+    for skill in skills:
+        state = skill.get("status") or skill.get("action") or "unknown"
+        detail_parts = []
+        if skill.get("skill_version"):
+            detail_parts.append(f"version {skill['skill_version']}")
+        if skill.get("version_delta"):
+            detail_parts.append(f"delta {skill['version_delta']}")
+        if skill.get("reason"):
+            detail_parts.append(skill["reason"])
+        if skill.get("conflict"):
+            detail_parts.append(f"conflict {skill['conflict']}")
+        if skill.get("backup_path"):
+            detail_parts.append(f"backup {skill['backup_path']}")
+        detail = f" ({', '.join(detail_parts)})" if detail_parts else ""
+        lines.append(f"  - {skill.get('name', '<unknown>')}: {state}{detail}")
+
+
+def _format_agent_skills_list_human(data: dict) -> str:
+    lines = [
+        "NVFLARE Agent Skills",
+        f"agent: {data.get('agent', '')}",
+        f"target: {data.get('target_path', '')}",
+    ]
+    source = data.get("source") or {}
+    if source:
+        lines.append(
+            "source: "
+            f"{source.get('type', 'unknown')} "
+            f"({source.get('skill_count', 0)} available, root: {source.get('root', '')})"
+        )
+
+    _append_skill_rows(lines, "available", data.get("available") or [])
+    _append_skill_rows(lines, "installed", data.get("installed") or [])
+    _append_conflict_rows(lines, data.get("conflicts") or [])
+    return "\n".join(lines)
+
+
+def _append_skill_rows(lines: list[str], title: str, skills: list[dict]) -> None:
+    lines.append("")
+    lines.append(f"{title}:")
+    if not skills:
+        lines.append("  none")
+        return
+
+    for skill in skills:
+        detail_parts = []
+        if skill.get("skill_version"):
+            detail_parts.append(f"version {skill['skill_version']}")
+        if skill.get("blast_radius"):
+            detail_parts.append(f"blast_radius {skill['blast_radius']}")
+        if skill.get("target_path"):
+            detail_parts.append(f"target {skill['target_path']}")
+        elif skill.get("relative_path"):
+            detail_parts.append(f"path {skill['relative_path']}")
+        detail = f" ({', '.join(detail_parts)})" if detail_parts else ""
+        lines.append(f"  - {skill.get('name', '<unknown>')}{detail}")
+
+
+def _append_conflict_rows(lines: list[str], conflicts: list[dict]) -> None:
+    lines.append("")
+    lines.append("conflicts:")
+    if not conflicts:
+        lines.append("  none")
+        return
+
+    for conflict in conflicts:
+        lines.append(
+            "  - "
+            f"{conflict.get('skill', '<unknown>')}: "
+            f"{conflict.get('code', '<unknown>')} - "
+            f"{conflict.get('message', '')}"
+        )
+
+
+def _output_agent_skill_target_error(output_error_message, target, error: ValueError) -> None:
+    output_error_message(
+        "AGENT_SKILL_TARGET_INVALID",
+        "Invalid agent skill target.",
+        "Choose a target directory without user-created symlink components. OS temp aliases such as /tmp are "
+        "normalized automatically.",
+        exit_code=4,
+        detail=str(error),
+        data={"target": target},
+        recovery_category="FIXABLE_BY_CONFIG",
+    )
+
+
+def _schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:
+    token = _raw_schema_agent_skills_sub_cmd(argv)
+    return token if token in _agent_skills_sub_cmd_parsers else None
+
+
+def _raw_schema_agent_skills_sub_cmd(argv: list[str]) -> Optional[str]:
+    # The top-level CLI bypasses nested argparse parsing for --schema, so infer
+    # the third-level agent skills command until that parser path is generalized.
+    # While scanning, skip known option values so e.g. `--skill install` is not
+    # treated as the `install` subcommand.
+    if "--schema" not in argv or CMD_AGENT_SKILLS not in argv:
+        return None
+    skills_index = None
+    for token_index, token in enumerate(argv):
+        if token != CMD_AGENT_SKILLS:
+            continue
+        if token_index > 0 and argv[token_index - 1].startswith("-"):
+            continue
+        skills_index = token_index
+        break
+    if skills_index is None:
+        return None
+    index = skills_index + 1
+    while index < len(argv):
+        token = argv[index]
+        if token in _agent_skills_sub_cmd_parsers:
+            return token
+        option = token.split("=", 1)[0]
+        if option in _AGENT_SKILLS_SCHEMA_FLAG_OPTIONS:
+            index += 1
+            continue
+        if option in _AGENT_SKILLS_SCHEMA_VALUE_OPTIONS:
+            index += 1 if "=" in token else 2
+            continue
+        if token.startswith("-"):
+            index += 2
+            continue
+        return token
+    return None

--- a/nvflare/tool/agent/command_registry.py
+++ b/nvflare/tool/agent/command_registry.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared metadata for the agent-facing command surface."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+AGENT_COMMANDS = (
+    {
+        "name": "info",
+        "command": "nvflare agent info",
+        "status": "available",
+        "mutating": False,
+        "streaming": False,
+    },
+    {
+        "name": "inspect",
+        "command": "nvflare agent inspect",
+        "status": "available",
+        "mutating": False,
+        "streaming": False,
+    },
+    {
+        "name": "doctor",
+        "command": "nvflare agent doctor",
+        "status": "available",
+        "mutating": False,
+        "streaming": False,
+    },
+    {
+        "name": "skills install",
+        "command": "nvflare agent skills install",
+        "status": "available",
+        "mutating": True,
+        "streaming": False,
+    },
+    {
+        "name": "skills list",
+        "command": "nvflare agent skills list",
+        "status": "available",
+        "mutating": False,
+        "streaming": False,
+    },
+)
+
+
+def agent_commands() -> list[dict]:
+    return deepcopy(list(AGENT_COMMANDS))
+
+
+def agent_command_registry() -> dict:
+    return {"status": "ok", "commands": agent_commands()}

--- a/nvflare/tool/agent/doctor.py
+++ b/nvflare/tool/agent/doctor.py
@@ -1,0 +1,383 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read-only agent environment readiness checks."""
+
+import importlib.util
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import nvflare
+from nvflare.tool.agent.command_registry import agent_command_registry
+from nvflare.tool.agent.skill_manager import find_skill_source
+
+OPTIONAL_DEPENDENCIES = ("torch", "tensorflow", "sklearn", "xgboost", "jax", "flwr")
+
+
+def doctor_environment(*, online: bool = False, args=None) -> dict:
+    """Return a read-only local readiness snapshot, optionally with a bounded online check."""
+    data = {
+        "schema_version": "1",
+        "timestamp": _now_utc(),
+        "nvflare": {"import_ok": True, "version": nvflare.__version__},
+        "commands": _command_registry(),
+        "startup_kits": _startup_kit_summary(),
+        "optional_dependencies": _optional_dependency_summary(),
+        "skills": _skills_summary(),
+        "poc": _poc_summary(),
+        "online": {"enabled": False, "status": "not_requested"},
+        "findings": [],
+    }
+    data["findings"].extend(data["startup_kits"].get("findings", []))
+    data["findings"].extend(data["skills"].get("findings", []))
+    data["findings"].extend(data["poc"].get("findings", []))
+
+    if online:
+        data["online"] = _online_summary(args)
+        data["findings"].extend(data["online"].get("findings", []))
+
+    data["status"] = "attention" if data["findings"] else "ok"
+    return data
+
+
+def _command_registry() -> dict:
+    return agent_command_registry()
+
+
+def _startup_kit_summary() -> dict:
+    from nvflare.tool.kit.kit_config import (
+        StartupKitConfigError,
+        get_active_startup_kit_id,
+        get_cli_config_path,
+        get_startup_kit_entries,
+        get_startup_kit_status,
+        load_cli_config,
+    )
+
+    config_file = str(get_cli_config_path())
+    try:
+        config = load_cli_config()
+        active = get_active_startup_kit_id(config)
+        entries = get_startup_kit_entries(config)
+    except StartupKitConfigError as e:
+        return {
+            "config_file": config_file,
+            "active_id": None,
+            "entries": [],
+            "findings": [_finding("STARTUP_KIT_CONFIG_INVALID", "error", str(e), getattr(e, "hint", None))],
+        }
+
+    findings = []
+    if not active:
+        findings.append(
+            _finding(
+                "STARTUP_KIT_NOT_CONFIGURED",
+                "warning",
+                "No active startup kit is configured.",
+                "Run nvflare config list and nvflare config use <id>, or pass --startup-kit for online checks.",
+            )
+        )
+
+    entry_rows = []
+    for kit_id, path in sorted(entries.items()):
+        status, normalized_path, metadata = get_startup_kit_status(path)
+        entry_rows.append(
+            {
+                "id": kit_id,
+                "path": path,
+                "normalized_path": normalized_path,
+                "active": kit_id == active,
+                "status": status,
+                "metadata": metadata,
+            }
+        )
+        for finding in metadata.get("findings", []):
+            finding = dict(finding)
+            finding["startup_kit_id"] = kit_id
+            findings.append(finding)
+
+    return {
+        "config_file": config_file,
+        "active_id": active,
+        "entries": entry_rows,
+        "findings": findings,
+    }
+
+
+def _optional_dependency_summary() -> list[dict]:
+    return [{"name": name, "available": importlib.util.find_spec(name) is not None} for name in OPTIONAL_DEPENDENCIES]
+
+
+def _skills_summary() -> dict:
+    try:
+        source = find_skill_source()
+    except Exception as e:
+        return {
+            "status": "error",
+            "source": None,
+            "available_count": 0,
+            "findings": [_finding("AGENT_SKILL_SOURCE_UNAVAILABLE", "error", str(e))],
+        }
+
+    manifest = source.manifest or {}
+    return {
+        "status": "ok",
+        "source": {
+            "type": source.source_type,
+            "root": str(source.root),
+            "manifest_schema_version": manifest.get("schema_version"),
+            "nvflare_version": manifest.get("nvflare_version"),
+        },
+        "available_count": len(manifest.get("skills", [])),
+        "available": manifest.get("skills", []),
+        "findings": manifest.get("findings", []),
+    }
+
+
+def _poc_summary() -> dict:
+    from nvflare.tool.poc.poc_commands import DEFAULT_WORKSPACE
+
+    workspace = os.getenv("NVFLARE_POC_WORKSPACE") or _configured_poc_workspace() or DEFAULT_WORKSPACE
+    workspace_path = Path(workspace).expanduser()
+    findings = []
+    status = "present" if workspace_path.exists() else "missing"
+    if status == "missing":
+        findings.append(
+            _finding(
+                "POC_WORKSPACE_MISSING",
+                "info",
+                f"POC workspace does not exist: {workspace}",
+                "Run nvflare poc prepare when local POC execution is needed.",
+            )
+        )
+    return {
+        "workspace": str(workspace_path),
+        "status": status,
+        "startup_dir_exists": (workspace_path / "startup").is_dir(),
+        "local_dir_exists": (workspace_path / "local").is_dir(),
+        "findings": findings,
+    }
+
+
+def _configured_poc_workspace() -> str | None:
+    from nvflare.tool.kit.kit_config import get_cli_config_path
+
+    try:
+        from pyhocon import ConfigFactory as CF
+    except ImportError:
+        return None
+
+    config_path = get_cli_config_path()
+    if not config_path.is_file():
+        return None
+    try:
+        config = CF.parse_file(str(config_path))
+    except Exception:
+        return None
+    return config.get("poc.workspace", None) or config.get("poc_workspace.path", None)
+
+
+def _online_summary(args) -> dict:
+    from nvflare.fuel.flare_api.api_spec import AuthenticationError, NoConnection
+    from nvflare.tool.cli_output import get_connect_timeout
+    from nvflare.tool.cli_session import new_cli_session_for_args, resolve_startup_kit_info_for_args
+    from nvflare.tool.kit.kit_config import StartupKitConfigError
+
+    try:
+        startup_kit = resolve_startup_kit_info_for_args(args)
+    except StartupKitConfigError as e:
+        return {
+            "enabled": True,
+            "status": "skipped",
+            "startup_kit": None,
+            "recommended_ttl_seconds": 0,
+            "findings": [_finding("STARTUP_KIT_NOT_READY", "warning", str(e), getattr(e, "hint", None))],
+        }
+
+    read_only_finding = _online_read_only_preflight(startup_kit)
+    if read_only_finding:
+        return {
+            "enabled": True,
+            "status": "skipped",
+            "startup_kit": startup_kit,
+            "recommended_ttl_seconds": 0,
+            "findings": [read_only_finding],
+        }
+
+    session = None
+    try:
+        session = new_cli_session_for_args(args=args, timeout=get_connect_timeout())
+        status = session.check_status("all", None)
+        return {
+            "enabled": True,
+            "status": "ok",
+            "startup_kit": startup_kit,
+            "server_status": status.get("server_status"),
+            "server_start_time": status.get("server_start_time"),
+            "clients": status.get("clients", []),
+            "client_status": status.get("client_status", []),
+            "jobs": status.get("jobs", []),
+            "recommended_ttl_seconds": 30,
+            "findings": [],
+        }
+    except AuthenticationError as e:
+        return _online_error("AUTHENTICATION_FAILED", "authentication_failed", str(e), startup_kit)
+    except NoConnection as e:
+        return _online_error("CONNECTION_FAILED", "connection_failed", str(e), startup_kit)
+    except TimeoutError as e:
+        return _online_error("ONLINE_CHECK_TIMEOUT", "timeout", str(e), startup_kit)
+    except Exception as e:
+        return _online_error(f"ONLINE_CHECK_FAILED_{type(e).__name__.upper()}", "error", str(e), startup_kit)
+    finally:
+        if session is not None:
+            session.close()
+
+
+def _online_error(code: str, status: str, message: str, startup_kit: dict) -> dict:
+    return {
+        "enabled": True,
+        "status": status,
+        "startup_kit": startup_kit,
+        "recommended_ttl_seconds": 0,
+        "findings": [_finding(code, "warning", message)],
+    }
+
+
+def format_doctor_human(data: dict) -> str:
+    """Render a concise human-readable doctor summary."""
+    lines = ["NVFLARE Agent Doctor", f"status: {data.get('status', 'unknown')}", ""]
+
+    nvflare_info = data.get("nvflare") or {}
+    nvflare_status = "import ok" if nvflare_info.get("import_ok") else "import failed"
+    lines.append(f"nvflare: {nvflare_info.get('version', 'unknown')} ({nvflare_status})")
+
+    commands = data.get("commands") or {}
+    lines.append(f"commands: {commands.get('status', 'unknown')} ({len(commands.get('commands', []))} registered)")
+
+    startup_kits = data.get("startup_kits") or {}
+    startup_entries = startup_kits.get("entries", [])
+    valid_startup_count = sum(1 for entry in startup_entries if entry.get("status") == "valid")
+    active_id = startup_kits.get("active_id") or "none"
+    lines.append(f"startup kits: {valid_startup_count}/{len(startup_entries)} valid (active: {active_id})")
+
+    skills = data.get("skills") or {}
+    source = skills.get("source")
+    if source:
+        lines.append(
+            f"skills: {skills.get('available_count', 0)} available "
+            f"({source.get('type', 'unknown')}: {source.get('root', 'unknown')})"
+        )
+    else:
+        lines.append(f"skills: {skills.get('status', 'unknown')}")
+
+    optional_dependencies = data.get("optional_dependencies", [])
+    available_deps = [dep["name"] for dep in optional_dependencies if dep.get("available")]
+    missing_deps = [dep["name"] for dep in optional_dependencies if not dep.get("available")]
+    lines.append(f"optional dependencies: available {_join_names(available_deps)}; missing {_join_names(missing_deps)}")
+
+    poc = data.get("poc") or {}
+    lines.append(f"poc: {poc.get('status', 'unknown')} (workspace: {poc.get('workspace', 'unknown')})")
+
+    online = data.get("online") or {}
+    if online.get("enabled"):
+        online_line = f"online: {online.get('status', 'unknown')}"
+        first_online_finding = _first_finding(online.get("findings", []))
+        if first_online_finding:
+            online_line += f" ({first_online_finding})"
+        lines.append(online_line)
+    else:
+        lines.append(f"online: {online.get('status', 'not_requested')}")
+
+    findings = data.get("findings", [])
+    if findings:
+        lines.append("")
+        lines.append(f"findings ({len(findings)}):")
+        for finding in findings:
+            lines.extend(_format_finding(finding))
+    else:
+        lines.append("")
+        lines.append("findings: none")
+
+    return "\n".join(lines)
+
+
+def _join_names(names: list[str]) -> str:
+    return ", ".join(names) if names else "none"
+
+
+def _first_finding(findings: list[dict]) -> str | None:
+    if not findings:
+        return None
+    finding = findings[0]
+    return f"{finding.get('severity', 'info')} {finding.get('code', 'UNKNOWN')}"
+
+
+def _format_finding(finding: dict) -> list[str]:
+    severity = finding.get("severity", "info")
+    code = finding.get("code", "UNKNOWN")
+    message = str(finding.get("message", "")).splitlines() or [""]
+    lines = [f"- {severity} {code}: {message[0]}"]
+    lines.extend(f"  {line}" for line in message[1:])
+    if finding.get("hint"):
+        lines.append(f"  hint: {finding['hint']}")
+    return lines
+
+
+def _online_read_only_preflight(startup_kit: dict) -> dict | None:
+    """Skip online checks when the existing session API would create local directories."""
+    kit_path = Path(startup_kit["path"])
+    admin_config_path = kit_path / "startup" / "fed_admin.json"
+    try:
+        config = json.loads(admin_config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return _finding(
+            "ONLINE_CHECK_ADMIN_CONFIG_UNREADABLE",
+            "warning",
+            "Online check skipped because fed_admin.json could not be read before guarded session creation.",
+        )
+
+    admin = config.get("admin") if isinstance(config, dict) else None
+    download_dir = admin.get("download_dir") if isinstance(admin, dict) else None
+    if not download_dir:
+        return _finding(
+            "ONLINE_CHECK_REQUIRES_DOWNLOAD_DIR",
+            "warning",
+            "Online check skipped because the active admin config has no pre-existing download_dir.",
+            "Create the startup kit transfer directory or use nvflare system status for the normal CLI path.",
+        )
+
+    download_path = Path(download_dir)
+    if not download_path.is_absolute():
+        download_path = kit_path / download_path
+    if not download_path.is_dir():
+        return _finding(
+            "ONLINE_CHECK_WOULD_CREATE_DOWNLOAD_DIR",
+            "warning",
+            "Online check skipped because the normal session path would create download_dir.",
+            "Create the configured download_dir first or use nvflare system status for the normal CLI path.",
+        )
+    return None
+
+
+def _finding(code: str, severity: str, message: str, hint: str = None) -> dict:
+    result = {"code": code, "severity": severity, "message": message}
+    if hint:
+        result["hint"] = hint
+    return result
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/nvflare/tool/agent/inspector.py
+++ b/nvflare/tool/agent/inspector.py
@@ -1,0 +1,571 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static read-only inspection for agent workflows."""
+
+import ast
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import nvflare
+
+DEFAULT_MAX_FILES = 250
+DEFAULT_MAX_FILE_BYTES = 512 * 1024
+MAX_EVIDENCE_PER_BUCKET = 12
+
+PYTHON_SUFFIXES = {".py"}
+SKIPPED_DIR_NAMES = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "env",
+    "node_modules",
+    "venv",
+}
+SENSITIVE_FILE_SUFFIXES = {".key", ".pem", ".p12", ".pfx"}
+SENSITIVE_FILE_NAMES = {"id_rsa", "id_dsa", "id_ecdsa", "id_ed25519"}
+SECRET_NAME_PATTERN = re.compile(r"(api[_-]?key|secret|token|password|passwd|credential|access[_-]?key)", re.I)
+
+FRAMEWORK_IMPORTS = {
+    "torch": "pytorch",
+    "torchvision": "pytorch",
+    "torchaudio": "pytorch",
+    "pytorch_lightning": "pytorch_lightning",
+    "lightning": "pytorch_lightning",
+    "tensorflow": "tensorflow",
+    "keras": "tensorflow",
+    "xgboost": "xgboost",
+    "sklearn": "sklearn",
+    "jax": "jax",
+    "flax": "jax",
+    "optax": "jax",
+    "numpy": "numpy",
+}
+FRAMEWORK_SKILLS = {
+    "pytorch": "nvflare-convert-pytorch",
+    "pytorch_lightning": "nvflare-convert-lightning",
+    "tensorflow": "nvflare-convert-tensorflow",
+    "xgboost": "nvflare-convert-xgboost",
+    "sklearn": "nvflare-convert-sklearn",
+    "jax": "nvflare-convert-jax",
+    "numpy": "nvflare-convert-numpy",
+}
+
+
+@dataclass
+class InspectState:
+    root: Path
+    redact: bool
+    entries_visited: int = 0
+    files_considered: int = 0
+    files_scanned: int = 0
+    bytes_scanned: int = 0
+    files_skipped_count: int = 0
+    files_skipped: list[dict] = field(default_factory=list)
+    findings: list[dict] = field(default_factory=list)
+    framework_evidence: dict[str, list[dict]] = field(default_factory=dict)
+    flare_imports: list[dict] = field(default_factory=list)
+    flare_calls: set[str] = field(default_factory=set)
+    entry_points: list[dict] = field(default_factory=list)
+    job_py: Optional[str] = None
+    sim_env_used: bool = False
+    export_support: bool = False
+    exported_job_markers: list[str] = field(default_factory=list)
+    distributed_patterns: list[dict] = field(default_factory=list)
+    dynamic_patterns: list[dict] = field(default_factory=list)
+    absolute_path_findings: list[dict] = field(default_factory=list)
+
+
+def inspect_path(
+    path: Path | str,
+    *,
+    redact: bool = True,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+) -> dict:
+    """Inspect a path without importing or executing user code."""
+    target = Path(path).expanduser()
+    state = InspectState(root=target, redact=redact)
+
+    if not target.exists():
+        raise FileNotFoundError(f"inspect path does not exist: {path}")
+
+    if target.is_symlink():
+        _record_symlink_skip(target, state)
+    elif target.is_file():
+        _inspect_file(target, state, max_file_bytes)
+    else:
+        _inspect_dir(target, state, max_files=max_files, max_file_bytes=max_file_bytes)
+
+    frameworks = _rank_frameworks(state)
+    detected_framework = frameworks[0]["name"] if frameworks else None
+    conversion_state = _conversion_state(state, detected_framework)
+    target_type = _target_type(target, state, detected_framework, conversion_state)
+
+    return {
+        "schema_version": "1",
+        "nvflare_version": nvflare.__version__,
+        "path": _display_path(target, target, redact=False),
+        "target_type": target_type,
+        "static_only": True,
+        "redaction": "on" if redact else "off",
+        "limits": {
+            "max_files": max_files,
+            "max_file_bytes": max_file_bytes,
+            "max_evidence_per_bucket": MAX_EVIDENCE_PER_BUCKET,
+        },
+        "scan": {
+            "entries_visited": state.entries_visited,
+            "files_considered": state.files_considered,
+            "files_scanned": state.files_scanned,
+            "bytes_scanned": state.bytes_scanned,
+            "files_skipped_count": state.files_skipped_count,
+            "files_skipped_truncated": state.files_skipped_count > len(state.files_skipped),
+            "files_skipped": state.files_skipped,
+        },
+        "frameworks": frameworks,
+        "entry_points": state.entry_points[:MAX_EVIDENCE_PER_BUCKET],
+        "flare_integration": {
+            "present": bool(state.flare_imports or state.flare_calls),
+            "imports": state.flare_imports[:MAX_EVIDENCE_PER_BUCKET],
+            "calls": sorted(state.flare_calls),
+        },
+        "conversion_state": conversion_state,
+        "job": {
+            "job_py": state.job_py,
+            "sim_env_used": state.sim_env_used,
+            "export_support": state.export_support,
+            "exported_job_markers": state.exported_job_markers[:MAX_EVIDENCE_PER_BUCKET],
+        },
+        "patterns": {
+            "distributed": state.distributed_patterns[:MAX_EVIDENCE_PER_BUCKET],
+            "dynamic": state.dynamic_patterns[:MAX_EVIDENCE_PER_BUCKET],
+            "absolute_data_paths": state.absolute_path_findings[:MAX_EVIDENCE_PER_BUCKET],
+        },
+        "findings": state.findings[:MAX_EVIDENCE_PER_BUCKET],
+        "skill_selection": _skill_selection(detected_framework, conversion_state, state),
+        "recommended_next_commands": _recommended_next_commands(detected_framework, conversion_state, state),
+    }
+
+
+def _inspect_dir(root: Path, state: InspectState, *, max_files: int, max_file_bytes: int) -> None:
+    stack = [root]
+    while stack:
+        directory = stack.pop()
+        try:
+            children = sorted(directory.iterdir(), key=lambda p: p.name)
+        except OSError as e:
+            _add_skip(state, _skip_entry(directory, state, "UNREADABLE_DIRECTORY", "could not read directory", e))
+            continue
+
+        for child in children:
+            if child.is_symlink():
+                _record_symlink_skip(child, state)
+                continue
+            if child.is_dir():
+                if _should_skip_dir(child, root):
+                    _add_skip(state, _skip_entry(child, state, "DIRECTORY_SKIPPED", "directory skipped"))
+                    continue
+                stack.append(child)
+                continue
+            if state.entries_visited >= max_files:
+                _add_skip(state, _skip_entry(child, state, "FILE_LIMIT_REACHED", "file scan limit reached"))
+                return
+            state.entries_visited += 1
+            if not child.is_file():
+                continue
+            _inspect_file(child, state, max_file_bytes)
+
+
+def _inspect_file(path: Path, state: InspectState, max_file_bytes: int) -> None:
+    state.files_considered += 1
+    rel_path = _display_path(path, state.root, state.redact)
+    if _is_sensitive_file(path):
+        _add_skip(state, _skip_entry(path, state, "SENSITIVE_FILE_SKIPPED", "sensitive file skipped"))
+        return
+    if _is_exported_job_marker(path):
+        state.exported_job_markers.append(rel_path)
+    if path.suffix not in PYTHON_SUFFIXES:
+        return
+
+    try:
+        size = path.stat().st_size
+    except OSError as e:
+        _add_skip(state, _skip_entry(path, state, "UNREADABLE_FILE", "could not stat file", e))
+        return
+    if size > max_file_bytes:
+        _add_skip(state, _skip_entry(path, state, "FILE_TOO_LARGE", "file exceeds static inspection cap"))
+        return
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        _add_skip(state, _skip_entry(path, state, "NON_UTF8_FILE", "file is not UTF-8 text"))
+        return
+    except OSError as e:
+        _add_skip(state, _skip_entry(path, state, "UNREADABLE_FILE", "could not read file", e))
+        return
+
+    state.files_scanned += 1
+    state.bytes_scanned += size
+    if path.name == "job.py":
+        state.job_py = rel_path
+
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError as e:
+        state.findings.append(
+            {
+                "code": "PYTHON_PARSE_ERROR",
+                "severity": "warning",
+                "file": rel_path,
+                "line": e.lineno,
+                "message": "Python file could not be parsed statically.",
+            }
+        )
+        return
+
+    visitor = _PythonInspector(path, rel_path, state)
+    visitor.visit(tree)
+    _add_entry_point(path, rel_path, tree, state)
+
+
+class _PythonInspector(ast.NodeVisitor):
+    def __init__(self, path: Path, rel_path: str, state: InspectState):
+        self.path = path
+        self.rel_path = rel_path
+        self.state = state
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._record_import(alias.name, node.lineno)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        self._record_import(module, node.lineno)
+        for alias in node.names:
+            if alias.name in {"FedJob", "FLModel", "SimEnv"}:
+                self.state.flare_imports.append(
+                    _evidence(self.rel_path, node.lineno, "from_import", f"{module}.{alias.name}")
+                )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_name = _call_name(node.func)
+        if call_name:
+            self._record_call(call_name, node.lineno)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self._inspect_secret_assignment(node.targets, node.value, getattr(node, "lineno", None))
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._inspect_secret_assignment([node.target], node.value, getattr(node, "lineno", None))
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str):
+            self._inspect_string_literal(node.value, getattr(node, "lineno", None))
+        self.generic_visit(node)
+
+    def _record_import(self, module: str, lineno: int) -> None:
+        if not module:
+            return
+        framework = _framework_for_import(module)
+        if framework:
+            _append_capped(
+                self.state.framework_evidence,
+                framework,
+                _evidence(self.rel_path, lineno, "import", module),
+            )
+        if module == "nvflare" or module.startswith("nvflare."):
+            self.state.flare_imports.append(_evidence(self.rel_path, lineno, "import", module))
+        if module in {"hydra", "omegaconf"} or module.startswith(("hydra.", "omegaconf.")):
+            self.state.dynamic_patterns.append(_evidence(self.rel_path, lineno, "dynamic_config", module))
+        if module == "torch.distributed" or module.startswith("torch.distributed."):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "distributed_import", module))
+        if module == "accelerate" or module.startswith("accelerate."):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "accelerate_import", module))
+
+    def _record_call(self, call_name: str, lineno: int) -> None:
+        if call_name.startswith("flare.") or call_name.startswith("nvflare."):
+            self.state.flare_calls.add(call_name)
+        if call_name in {"FedJob", "FLModel", "SimEnv"}:
+            self.state.flare_calls.add(call_name)
+        if call_name == "SimEnv" or call_name.endswith(".SimEnv"):
+            self.state.sim_env_used = True
+        if call_name.endswith(".export"):
+            self.state.export_support = True
+        if call_name in {"importlib.import_module", "__import__", "getattr"}:
+            self.state.dynamic_patterns.append(_evidence(self.rel_path, lineno, "dynamic_dispatch", call_name))
+        if call_name == "torch.compile":
+            self.state.dynamic_patterns.append(_evidence(self.rel_path, lineno, "torch_compile", call_name))
+        if call_name.endswith("DistributedDataParallel") or call_name.endswith("DataParallel"):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "distributed_call", call_name))
+        if call_name.endswith("FSDP") or call_name.endswith("Accelerator"):
+            self.state.distributed_patterns.append(_evidence(self.rel_path, lineno, "distributed_call", call_name))
+
+    def _inspect_secret_assignment(self, targets: list[ast.AST], value: ast.AST, lineno: Optional[int]) -> None:
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            return
+        for target in targets:
+            name = _target_name(target)
+            if name and SECRET_NAME_PATTERN.search(name):
+                self.state.findings.append(
+                    {
+                        "code": "SECRET_LITERAL_REDACTED",
+                        "severity": "warning",
+                        "file": self.rel_path,
+                        "line": lineno,
+                        "name": name,
+                        "value": "<REDACTED>" if self.state.redact else value.value,
+                    }
+                )
+
+    def _inspect_string_literal(self, value: str, lineno: Optional[int]) -> None:
+        if _looks_like_absolute_path(value):
+            self.state.absolute_path_findings.append(
+                {
+                    "code": "ABSOLUTE_DATA_PATH",
+                    "severity": "warning",
+                    "file": self.rel_path,
+                    "line": lineno,
+                    "pattern_type": "absolute_path_literal",
+                    "value": _redact_literal(value, self.state.redact),
+                }
+            )
+
+
+def _framework_for_import(module: str) -> Optional[str]:
+    parts = module.split(".")
+    if not parts:
+        return None
+    first = parts[0]
+    if first == "lightning" and len(parts) > 1 and parts[1] == "pytorch":
+        return "pytorch_lightning"
+    if first == "sklearn":
+        return "sklearn"
+    return FRAMEWORK_IMPORTS.get(first)
+
+
+def _rank_frameworks(state: InspectState) -> list[dict]:
+    total = sum(len(evidence) for evidence in state.framework_evidence.values())
+    ranked = []
+    for framework, evidence in state.framework_evidence.items():
+        count = len(evidence)
+        confidence = 0.0
+        if total:
+            # Any static import evidence should register clearly, but cap below
+            # certainty because import presence alone does not prove active use.
+            confidence = min(0.99, 0.45 + (count / total) * 0.5)
+        ranked.append(
+            {
+                "name": framework,
+                "confidence": round(confidence, 2),
+                "evidence": evidence[:MAX_EVIDENCE_PER_BUCKET],
+                "contradicting_evidence": [],
+            }
+        )
+    return sorted(ranked, key=lambda item: (-item["confidence"], item["name"]))
+
+
+def _conversion_state(state: InspectState, detected_framework: Optional[str]) -> str:
+    if state.exported_job_markers:
+        return "exported_job"
+    if state.job_py or state.sim_env_used:
+        return "flare_job"
+    if {"flare.receive", "flare.send"} <= state.flare_calls or "FLModel" in state.flare_calls:
+        return "client_api_converted"
+    if state.flare_imports or state.flare_calls:
+        return "partial_client_api"
+    if detected_framework:
+        return "not_converted"
+    return "unknown"
+
+
+def _target_type(path: Path, state: InspectState, detected_framework: Optional[str], conversion_state: str) -> str:
+    if path.is_file():
+        return "single_training_script" if path.suffix == ".py" else "unknown_target"
+    if conversion_state == "exported_job":
+        return "exported_submit_ready_flare_job"
+    if conversion_state == "flare_job":
+        return "flare_job_source"
+    if detected_framework and conversion_state in {"partial_client_api", "client_api_converted"}:
+        return "mixed_workspace"
+    if detected_framework:
+        return "training_repository"
+    return "unknown_target"
+
+
+def _add_entry_point(path: Path, rel_path: str, tree: ast.Module, state: InspectState) -> None:
+    functions = [node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    main_guard = any(_is_main_guard(node) for node in tree.body if isinstance(node, ast.If))
+    likely = path.name in {"client.py", "server.py", "train.py", "trainer.py", "main.py", "job.py"} or main_guard
+    if likely or any(name in {"main", "train", "fit", "evaluate"} for name in functions):
+        state.entry_points.append(
+            {
+                "path": rel_path,
+                "kind": "python_script",
+                "functions": functions[:MAX_EVIDENCE_PER_BUCKET],
+                "main_guard": main_guard,
+            }
+        )
+
+
+def _is_main_guard(node: ast.If) -> bool:
+    left = getattr(node.test, "left", None)
+    comparators = getattr(node.test, "comparators", [])
+    if not isinstance(left, ast.Name) or left.id != "__name__" or not comparators:
+        return False
+    value = comparators[0]
+    return isinstance(value, ast.Constant) and value.value == "__main__"
+
+
+def _skill_selection(detected_framework: Optional[str], conversion_state: str, state: InspectState) -> dict:
+    recommended = []
+    if conversion_state == "exported_job":
+        recommended.append("nvflare-job-lifecycle")
+    elif detected_framework and conversion_state == "not_converted":
+        skill = FRAMEWORK_SKILLS.get(detected_framework)
+        if skill:
+            recommended.append(skill)
+    if state.findings or state.files_skipped:
+        recommended.append("nvflare-orient")
+
+    return {
+        "detected_framework": detected_framework,
+        "conversion_state": conversion_state,
+        "exported_job": conversion_state == "exported_job",
+        "recommended_skills": recommended,
+        "safety_findings": [finding["code"] for finding in state.findings[:MAX_EVIDENCE_PER_BUCKET]],
+    }
+
+
+def _recommended_next_commands(
+    detected_framework: Optional[str], conversion_state: str, state: InspectState
+) -> list[str]:
+    commands = ["nvflare agent doctor --format json"]
+    if conversion_state == "exported_job":
+        commands.append("nvflare job submit <job-folder> --format json")
+    elif state.job_py and state.export_support:
+        commands.append("python job.py --export --export-dir <job-dir>")
+    elif detected_framework and conversion_state == "not_converted":
+        commands.append("Use the matching nvflare-convert-* skill before editing.")
+    return commands
+
+
+def _record_symlink_skip(path: Path, state: InspectState) -> None:
+    try:
+        target = os.readlink(path)
+    except OSError:
+        target = ""
+    _add_skip(
+        state,
+        {
+            "code": "SYMLINK_SKIPPED",
+            "path": _display_path(path, state.root, state.redact),
+            "target": _redact_literal(target, state.redact),
+            "message": "symlink was not followed during static inspection",
+        },
+    )
+
+
+def _add_skip(state: InspectState, entry: dict) -> None:
+    state.files_skipped_count += 1
+    if len(state.files_skipped) < MAX_EVIDENCE_PER_BUCKET:
+        state.files_skipped.append(entry)
+
+
+def _skip_entry(path: Path, state: InspectState, code: str, message: str, error: Exception = None) -> dict:
+    result = {"code": code, "path": _display_path(path, state.root, state.redact), "message": message}
+    if error is not None:
+        result["error_type"] = type(error).__name__
+    return result
+
+
+def _should_skip_dir(path: Path, root: Path) -> bool:
+    if path == root:
+        return False
+    return path.name in SKIPPED_DIR_NAMES or path.name.startswith(".")
+
+
+def _is_sensitive_file(path: Path) -> bool:
+    return path.name in SENSITIVE_FILE_NAMES or path.suffix.lower() in SENSITIVE_FILE_SUFFIXES
+
+
+def _is_exported_job_marker(path: Path) -> bool:
+    return path.name in {"meta.json", "config_fed_server.json", "config_fed_client.json"}
+
+
+def _display_path(path: Path, root: Path, redact: bool) -> str:
+    base = root if root.is_dir() else root.parent
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError:
+        if redact and path.is_absolute():
+            return f"<REDACTED_PATH>/{path.name}"
+        return str(path)
+
+
+def _redact_literal(value: str, redact: bool) -> str:
+    if not redact:
+        return value
+    if _looks_like_absolute_path(value):
+        return "<REDACTED_PATH>"
+    if SECRET_NAME_PATTERN.search(value):
+        return "<REDACTED>"
+    return value
+
+
+def _looks_like_absolute_path(value: str) -> bool:
+    return value.startswith(("/", "~")) or bool(re.match(r"^[A-Za-z]:[\\/]", value))
+
+
+def _evidence(file_path: str, line: Optional[int], kind: str, value: str) -> dict:
+    return {"file": file_path, "line": line, "kind": kind, "value": value}
+
+
+def _append_capped(target: dict[str, list[dict]], key: str, value: dict) -> None:
+    bucket = target.setdefault(key, [])
+    if len(bucket) < MAX_EVIDENCE_PER_BUCKET:
+        bucket.append(value)
+
+
+def _call_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def _target_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None

--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -1,0 +1,615 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native install/list support for NVFLARE-owned agent skills."""
+
+import json
+import os
+import shutil
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import resources, util
+from pathlib import Path
+from typing import Optional
+
+import nvflare
+from nvflare.tool.agent.skill_manifest import (
+    IGNORED_SKILL_FILE_NAMES,
+    MANIFEST_FILE_NAME,
+    SHARED_SKILL_REFERENCE_DIR,
+    build_skill_manifest,
+    load_manifest,
+    skill_tree_hash,
+)
+
+INSTALL_MANIFEST_FILE_NAME = ".nvflare_skill_install.json"
+SUPPORTED_AGENT_TARGETS = ("codex", "claude")
+BUNDLED_SKILLS_PACKAGE = "nvflare.tool.agent.bundled_skills"
+DEFAULT_INSTALL_LOCK_TTL_SECONDS = 300
+INSTALL_LOCK_TIMESTAMP_FILE_NAME = "created_at_ns"
+
+
+@dataclass(frozen=True)
+class SkillSource:
+    source_type: str
+    root: Path
+    manifest: dict
+
+
+def resolve_agent_target_dir(
+    agent: str, *, target_dir: Optional[Path | str] = None, env: Optional[dict] = None
+) -> Path:
+    """Resolve a named agent target to its skill installation directory."""
+    if target_dir:
+        return _resolve_target_override(target_dir)
+
+    env_map = env or os.environ
+    if agent == "codex":
+        codex_home = env_map.get("CODEX_HOME")
+        if codex_home:
+            return Path(codex_home).expanduser() / "skills"
+        return Path.home() / ".codex" / "skills"
+    if agent == "claude":
+        return Path.home() / ".claude" / "skills"
+    raise ValueError(f"unsupported agent target: {agent}")
+
+
+def find_skill_source() -> SkillSource:
+    """Find skills from an editable/source checkout first, then from the installed package bundle."""
+    source_root = _source_checkout_root()
+    if source_root:
+        return SkillSource(
+            source_type="editable",
+            root=source_root,
+            manifest=build_skill_manifest(source_root, source_type="editable", nvflare_version=nvflare.__version__),
+        )
+
+    bundle_root = Path(str(resources.files(BUNDLED_SKILLS_PACKAGE)))
+    manifest_path = bundle_root / MANIFEST_FILE_NAME
+    manifest = (
+        load_manifest(manifest_path)
+        if manifest_path.is_file()
+        else build_skill_manifest(bundle_root, source_type="wheel")
+    )
+    return SkillSource(source_type="wheel", root=bundle_root, manifest=manifest)
+
+
+def install_skills(
+    *,
+    agent: str,
+    skill_name: Optional[str] = None,
+    dry_run: bool = False,
+    target_dir: Optional[Path | str] = None,
+    source: Optional[SkillSource] = None,
+) -> dict:
+    """Plan or apply a native NVFLARE skill installation."""
+    source = source or find_skill_source()
+    target = resolve_agent_target_dir(agent, target_dir=target_dir)
+    selected, missing = _select_skills(source.manifest, skill_name)
+    plan = _install_plan(source, selected, target, agent=agent, requested_skill=skill_name)
+    plan["missing"] = missing
+    plan["applied"] = False
+
+    if dry_run or missing:
+        return plan
+
+    target.mkdir(parents=True, exist_ok=True)
+    try:
+        _sync_shared_references(source, target)
+    except Exception as e:
+        error = _install_error(SHARED_SKILL_REFERENCE_DIR, e)
+        plan["errors"].append(error)
+        plan["applied"] = False
+        return plan
+    for entry in plan["skills"]:
+        try:
+            if entry["action"] == "copy":
+                _copy_skill(source.root / entry["relative_path"], Path(entry["target_path"]), entry, source)
+                entry["status"] = "installed"
+            elif entry["action"] == "replace":
+                _replace_skill(
+                    source.root / entry["relative_path"],
+                    Path(entry["target_path"]),
+                    Path(entry["backup_path"]),
+                    entry,
+                    source,
+                )
+                entry["status"] = "replaced"
+            else:
+                entry["status"] = "skipped"
+        except Exception as e:
+            error = _install_error(entry["name"], e)
+            entry["status"] = "failed"
+            entry["error"] = error
+            plan["errors"].append(error)
+    plan["applied"] = not plan["errors"]
+    return plan
+
+
+def list_skills(*, agent: str, target_dir: Optional[Path | str] = None, source: Optional[SkillSource] = None) -> dict:
+    """List available packaged skills and installed managed skills for an agent target."""
+    source = source or find_skill_source()
+    target = resolve_agent_target_dir(agent, target_dir=target_dir)
+    installed = []
+    conflicts = []
+    available = source.manifest.get("skills", [])
+    available_names = {skill["name"] for skill in available}
+
+    if target.is_dir():
+        for child in sorted(target.iterdir(), key=lambda p: p.name):
+            if child.name.startswith(".") or not child.is_dir():
+                continue
+            install_manifest = _read_install_manifest(child)
+            if install_manifest and install_manifest.get("managed_by") == "nvflare":
+                installed.append(
+                    {
+                        "name": install_manifest.get("name", child.name),
+                        "skill_version": install_manifest.get("skill_version"),
+                        "source_hash": install_manifest.get("source_hash"),
+                        "target_path": str(child),
+                        "source_type": install_manifest.get("source_type"),
+                    }
+                )
+            elif child.name in available_names:
+                conflicts.append(
+                    {
+                        "skill": child.name,
+                        "code": "external_install_detected",
+                        "message": "target skill directory is not managed by nvflare",
+                        "target_path": str(child),
+                    }
+                )
+
+    return {
+        "agent": agent,
+        "target_path": str(target),
+        "source": _source_summary(source),
+        "available": available,
+        "installed": installed,
+        "conflicts": conflicts,
+    }
+
+
+def _install_plan(
+    source: SkillSource, skills: list[dict], target: Path, *, agent: str, requested_skill: Optional[str]
+) -> dict:
+    planned_skills = []
+    conflicts = []
+    for skill in skills:
+        source_skill_dir = source.root / skill["relative_path"]
+        target_skill_dir = target / skill["name"]
+        source_symlink = _first_symlink_in_tree(source_skill_dir)
+        # The dry-run plan is advisory: source symlinks are checked again in
+        # _stage_skill because the source tree could change before apply.
+        # version_delta: new, unknown external state, blocked local edit, same, or update.
+        entry = {
+            "name": skill["name"],
+            "skill_version": skill.get("skill_version"),
+            "source_hash": skill["source_hash"],
+            "relative_path": skill["relative_path"],
+            "target_path": str(target_skill_dir),
+            "files": [] if source_symlink else _files_to_copy(source_skill_dir, target_skill_dir),
+            "version_delta": "new",
+        }
+        if source_symlink:
+            entry["action"] = "skip"
+            entry["conflict"] = "source_symlink_detected"
+            entry["version_delta"] = "blocked"
+            entry["source_issue"] = {
+                "code": "source_symlink_detected",
+                "message": "source skill directory contains a symlink",
+                "source_path": str(source_skill_dir),
+                "symlink_path": str(source_symlink),
+            }
+            conflicts.append(_source_conflict(skill["name"], source_skill_dir, source_symlink))
+        elif not target_skill_dir.exists():
+            entry["action"] = "copy"
+        else:
+            target_symlink = _first_symlink_in_tree(target_skill_dir)
+            if target_symlink:
+                entry["action"] = "skip"
+                entry["conflict"] = "target_symlink_detected"
+                entry["version_delta"] = "blocked"
+                entry["target_issue"] = {
+                    "code": "target_symlink_detected",
+                    "message": "target skill directory contains a symlink",
+                    "target_path": str(target_skill_dir),
+                    "symlink_path": str(target_symlink),
+                }
+                conflicts.append(_target_symlink_conflict(skill["name"], target_skill_dir, target_symlink))
+            else:
+                install_manifest = _read_install_manifest(target_skill_dir)
+                if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+                    entry["action"] = "skip"
+                    entry["conflict"] = "external_install_detected"
+                    entry["version_delta"] = "unknown"
+                    conflicts.append(_conflict(skill["name"], "external_install_detected", target_skill_dir))
+                else:
+                    try:
+                        installed_source_hash = skill_tree_hash(
+                            target_skill_dir, exclude_names={INSTALL_MANIFEST_FILE_NAME}
+                        )
+                    except ValueError as e:
+                        installed_source_hash = None
+                        entry["target_issue"] = {
+                            "code": "local_modifications_detected",
+                            "message": str(e),
+                            "target_path": str(target_skill_dir),
+                        }
+                    if installed_source_hash != install_manifest.get("source_hash"):
+                        entry["action"] = "skip"
+                        entry["conflict"] = "local_modifications_detected"
+                        entry["version_delta"] = "blocked"
+                        conflicts.append(_conflict(skill["name"], "local_modifications_detected", target_skill_dir))
+                    elif install_manifest.get("source_hash") == skill["source_hash"]:
+                        entry["action"] = "skip"
+                        entry["reason"] = "already_installed"
+                        entry["version_delta"] = "same"
+                    else:
+                        backup_path = _backup_path(target, skill["name"])
+                        entry["action"] = "replace"
+                        entry["backup_path"] = str(backup_path)
+                        entry["version_delta"] = "update"
+        planned_skills.append(entry)
+
+    return {
+        "agent": agent,
+        "target_path": str(target),
+        "requested_skill": requested_skill,
+        "source": _source_summary(source),
+        "available": source.manifest.get("skills", []),
+        "skills": planned_skills,
+        "conflicts": conflicts,
+        "errors": [],
+        "deprecated_skills_skipped": [],
+    }
+
+
+def _copy_skill(source_dir: Path, target_dir: Path, plan_entry: dict, source: SkillSource) -> None:
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    with _skill_install_lock(target_dir):
+        with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
+            temp_skill_dir = Path(temp_root) / target_dir.name
+            _stage_skill(source_dir, temp_skill_dir, plan_entry, source, installed_path=target_dir)
+            _publish_staged_skill(temp_skill_dir, target_dir)
+
+
+def _replace_skill(
+    source_dir: Path, target_dir: Path, backup_path: Path, plan_entry: dict, source: SkillSource
+) -> None:
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    with _skill_install_lock(target_dir):
+        with tempfile.TemporaryDirectory(prefix=f".{target_dir.name}.", dir=target_dir.parent) as temp_root:
+            temp_skill_dir = Path(temp_root) / target_dir.name
+            _stage_skill(source_dir, temp_skill_dir, plan_entry, source, installed_path=target_dir)
+            if not target_dir.exists():
+                raise FileNotFoundError(f"target skill directory no longer exists: {target_dir}")
+            if backup_path.exists():
+                raise FileExistsError(f"backup skill directory already exists: {backup_path}")
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(target_dir, backup_path)
+            try:
+                _publish_staged_skill(temp_skill_dir, target_dir)
+            except Exception as publish_error:
+                if not target_dir.exists() and backup_path.exists():
+                    try:
+                        shutil.move(backup_path, target_dir)
+                        _remove_empty_dir(backup_path.parent)
+                    except Exception as recovery_error:
+                        publish_error.recovery_error = recovery_error
+                raise
+
+
+def _sync_shared_references(source: SkillSource, target: Path) -> None:
+    source_shared = source.root / SHARED_SKILL_REFERENCE_DIR
+    if not source_shared.is_dir():
+        return
+    source_hash = skill_tree_hash(source_shared)
+    target_shared = target / SHARED_SKILL_REFERENCE_DIR
+    plan_entry = {"name": SHARED_SKILL_REFERENCE_DIR, "source_hash": source_hash}
+    if not target_shared.exists():
+        _copy_skill(source_shared, target_shared, plan_entry, source)
+        return
+    if target_shared.is_symlink():
+        raise ValueError(f"shared reference target must not be a symlink: {target_shared}")
+    install_manifest = _read_install_manifest(target_shared)
+    if not install_manifest or install_manifest.get("managed_by") != "nvflare":
+        raise FileExistsError(f"shared reference target is not managed by nvflare: {target_shared}")
+    installed_source_hash = skill_tree_hash(target_shared, exclude_names={INSTALL_MANIFEST_FILE_NAME})
+    if installed_source_hash == source_hash and install_manifest.get("source_hash") == source_hash:
+        return
+    backup_path = _backup_path(target, target_shared.name)
+    _replace_skill(source_shared, target_shared, backup_path, plan_entry, source)
+
+
+def _backup_path(target: Path, skill_name: str) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    return target / ".nvflare_bak" / f"{timestamp}-{time.time_ns()}" / skill_name
+
+
+@contextmanager
+def _skill_install_lock(target_dir: Path):
+    lock_dir = target_dir.parent / f".{target_dir.name}.install.lock"
+    try:
+        _create_lock_dir(lock_dir)
+    except FileExistsError as e:
+        if _lock_dir_is_stale(lock_dir):
+            shutil.rmtree(lock_dir)
+            try:
+                _create_lock_dir(lock_dir)
+            except FileExistsError as retry_error:
+                raise FileExistsError(
+                    f"target skill directory is already being installed: {target_dir}"
+                ) from retry_error
+        else:
+            raise FileExistsError(f"target skill directory is already being installed: {target_dir}") from e
+    try:
+        yield
+    finally:
+        shutil.rmtree(lock_dir, ignore_errors=True)
+
+
+def _lock_ttl_seconds() -> int:
+    value = os.environ.get("NVFLARE_AGENT_SKILL_INSTALL_LOCK_TTL_SECONDS")
+    if value is None:
+        return DEFAULT_INSTALL_LOCK_TTL_SECONDS
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return DEFAULT_INSTALL_LOCK_TTL_SECONDS
+
+
+def _lock_dir_is_stale(lock_dir: Path) -> bool:
+    if lock_dir.is_symlink() or not lock_dir.is_dir():
+        return False
+    ttl_seconds = _lock_ttl_seconds()
+    if ttl_seconds <= 0:
+        return False
+    lock_started_at = _read_lock_started_at(lock_dir)
+    if lock_started_at is not None:
+        return time.time() - lock_started_at > ttl_seconds
+    try:
+        age_seconds = time.time() - lock_dir.stat().st_mtime
+    except OSError:
+        return False
+    return age_seconds > ttl_seconds
+
+
+def _write_lock_timestamp(lock_dir: Path) -> None:
+    (lock_dir / INSTALL_LOCK_TIMESTAMP_FILE_NAME).write_text(str(time.time_ns()), encoding="utf-8")
+
+
+def _create_lock_dir(lock_dir: Path) -> None:
+    lock_dir.mkdir()
+    try:
+        _write_lock_timestamp(lock_dir)
+    except Exception:
+        shutil.rmtree(lock_dir, ignore_errors=True)
+        raise
+
+
+def _read_lock_started_at(lock_dir: Path) -> float | None:
+    timestamp_path = lock_dir / INSTALL_LOCK_TIMESTAMP_FILE_NAME
+    try:
+        text = timestamp_path.read_text(encoding="utf-8").strip()
+        return int(text) / 1_000_000_000
+    except (OSError, ValueError):
+        return None
+
+
+def _remove_empty_dir(path: Path) -> None:
+    try:
+        path.rmdir()
+    except OSError:
+        pass
+
+
+def _install_error(skill_name: str, error: Exception) -> dict:
+    result = {
+        "skill": skill_name,
+        "code": "skill_install_failed",
+        "type": type(error).__name__,
+        "message": str(error),
+    }
+    recovery_error = getattr(error, "recovery_error", None)
+    if recovery_error is not None:
+        result["recovery_error"] = {
+            "type": type(recovery_error).__name__,
+            "message": str(recovery_error),
+        }
+    return result
+
+
+def _publish_staged_skill(staged_dir: Path, target_dir: Path) -> None:
+    if target_dir.exists():
+        raise FileExistsError(f"target skill directory already exists: {target_dir}")
+    os.rename(staged_dir, target_dir)
+
+
+def _stage_skill(
+    source_dir: Path, staged_dir: Path, plan_entry: dict, source: SkillSource, *, installed_path: Path
+) -> None:
+    symlink = _first_symlink_in_tree(source_dir)
+    if symlink:
+        raise ValueError(f"skill source must not contain symlinks: {symlink.relative_to(source_dir).as_posix()}")
+    shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+    manifest = {
+        "schema_version": "1",
+        "managed_by": "nvflare",
+        "name": plan_entry["name"],
+        "skill_version": plan_entry.get("skill_version"),
+        "nvflare_version": nvflare.__version__,
+        "source_type": source.source_type,
+        "source_hash": plan_entry["source_hash"],
+        "installed_paths": [str(installed_path)],
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (staged_dir / INSTALL_MANIFEST_FILE_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _select_skills(manifest: dict, skill_name: Optional[str]) -> tuple[list[dict], list[str]]:
+    skills = manifest.get("skills", [])
+    if not skill_name:
+        return skills, []
+    selected = [skill for skill in skills if skill.get("name") == skill_name]
+    return selected, [] if selected else [skill_name]
+
+
+def _source_summary(source: SkillSource) -> dict:
+    return {
+        "type": source.source_type,
+        "root": str(source.root),
+        "nvflare_version": source.manifest.get("nvflare_version"),
+        "manifest_schema_version": source.manifest.get("schema_version"),
+        "skill_count": len(source.manifest.get("skills", [])),
+        "findings": source.manifest.get("findings", []),
+    }
+
+
+def _resolve_target_override(target_dir: Path | str) -> Path:
+    target = Path(target_dir).expanduser()
+    if any(part == ".." for part in target.parts):
+        raise ValueError(f"agent skill target must not contain parent directory traversal: {target}")
+    logical = Path(os.path.abspath(os.path.normpath(str(target))))
+    symlink = _first_disallowed_target_symlink_component(logical)
+    if symlink is not None:
+        raise ValueError(f"agent skill target must not contain symlink components: {symlink}")
+    return target.resolve(strict=False)
+
+
+def _target_system_symlink_aliases() -> tuple[Path, ...]:
+    aliases = {Path("/tmp")}
+    for value in (os.environ.get("TMPDIR"), tempfile.gettempdir()):
+        if value:
+            aliases.add(Path(os.path.abspath(os.path.normpath(value))))
+    return tuple(sorted(aliases, key=lambda item: str(item)))
+
+
+def _is_allowed_system_target_symlink(path: Path) -> bool:
+    for alias in _target_system_symlink_aliases():
+        try:
+            alias.relative_to(path)
+            return True
+        except ValueError:
+            pass
+    return False
+
+
+def _first_disallowed_target_symlink_component(path: Path) -> Optional[Path]:
+    absolute = path if path.is_absolute() else Path.cwd() / path
+    current = Path(absolute.anchor)
+    parts = absolute.parts[1:]
+    for part in parts:
+        if part in ("", "."):
+            continue
+        current = current / part
+        if current.is_symlink():
+            if _is_allowed_system_target_symlink(current):
+                continue
+            return current
+    return None
+
+
+def _first_symlink_in_tree(root_dir: Path) -> Optional[Path]:
+    if root_dir.is_symlink():
+        return root_dir
+    for root, dir_names, file_names in os.walk(root_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        for name in dir_names + file_names:
+            path = root_path / name
+            if path.is_symlink():
+                return path
+        dir_names[:] = [name for name in dir_names if not (root_path / name).is_symlink()]
+    return None
+
+
+def _files_to_copy(source_dir: Path, target_dir: Path) -> list[dict]:
+    files = []
+    for root, dir_names, file_names in os.walk(source_dir, topdown=True, followlinks=False):
+        root_path = Path(root)
+        dir_names.sort()
+        file_names.sort()
+        dir_names[:] = [name for name in dir_names if name != "__pycache__" and not (root_path / name).is_symlink()]
+        for file_name in file_names:
+            file_path = root_path / file_name
+            if file_path.is_symlink():
+                continue
+            if file_path.suffix in {".pyc", ".pyo"}:
+                continue
+            if not file_path.is_file():
+                continue
+            rel_path = file_path.relative_to(source_dir)
+            files.append({"source": str(file_path), "target": str(target_dir / rel_path)})
+    return files
+
+
+def _read_install_manifest(skill_dir: Path) -> Optional[dict]:
+    manifest_path = skill_dir / INSTALL_MANIFEST_FILE_NAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _conflict(skill_name: str, code: str, target_path: Path) -> dict:
+    messages = {
+        "external_install_detected": "target skill directory is not managed by nvflare",
+        "local_modifications_detected": "managed skill content differs from its install manifest",
+    }
+    return {
+        "skill": skill_name,
+        "code": code,
+        "message": messages.get(code, code),
+        "target_path": str(target_path),
+    }
+
+
+def _source_conflict(skill_name: str, source_path: Path, symlink_path: Path) -> dict:
+    return {
+        "skill": skill_name,
+        "code": "source_symlink_detected",
+        "message": "source skill directory contains a symlink",
+        "source_path": str(source_path),
+        "symlink_path": str(symlink_path),
+    }
+
+
+def _target_symlink_conflict(skill_name: str, target_path: Path, symlink_path: Path) -> dict:
+    return {
+        "skill": skill_name,
+        "code": "target_symlink_detected",
+        "message": "target skill directory contains a symlink",
+        "target_path": str(target_path),
+        "symlink_path": str(symlink_path),
+    }
+
+
+def _source_checkout_root() -> Optional[Path]:
+    spec = util.find_spec("nvflare")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    repo_root = Path(next(iter(spec.submodule_search_locations))).resolve().parent
+    source_root = repo_root / "skills"
+    if source_root.is_dir() and (repo_root / "pyproject.toml").is_file():
+        return source_root
+    return None

--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -37,51 +37,12 @@ Exceptions (plain text, outside the JSON contract):
 
 import json
 import logging
-import re
 import sys
 from typing import Any, Optional
 
 from nvflare.tool.cli_contract import SCHEMA_VERSION
 
 logger = logging.getLogger(__name__)
-
-_REDACTED = "<redacted>"
-_SENSITIVE_KEY_PARTS = {
-    "password",
-    "passwd",
-    "passphrase",
-}
-_SENSITIVE_KEY_NAMES = {
-    "access_key",
-    "access_token",
-    "api_key",
-    "apikey",
-    "auth_token",
-    "bearer_token",
-    "client_secret",
-    "credential",
-    "credentials",
-    "id_token",
-    "private_key",
-    "privatekey",
-    "refresh_token",
-    "secret_key",
-    "session_token",
-}
-_SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
-    r"(?i)\b("
-    r"password|passwd|passphrase|credential|credentials|"
-    r"access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token|session[-_ ]?token|auth[-_ ]?token|"
-    r"api[-_ ]?key|private[-_ ]?key|secret[-_ ]?key|client[-_ ]?secret"
-    r")(\s*[:=]\s*)([\"']?)([^\"'\s,;]+)([\"']?)"
-)
-_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(authorization\s*:\s*bearer\s+)([A-Za-z0-9._~+/=-]+)")
-_AUTH_VALUE_PATTERN = re.compile(r"(?i)\b(authorization\s*[:=]\s*)(?!bearer\s+)([\"']?)([^\"'\s,;]+)([\"']?)")
-_PEM_PRIVATE_KEY_PATTERN = re.compile(
-    r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
-    re.DOTALL,
-)
-_URL_PASSWORD_PATTERN = re.compile(r"\b([a-zA-Z][a-zA-Z0-9+.-]*://[^/\s:@]+:)([^@\s/]+)(@)")
 
 # Module-level CLI state. This process is single-command/single-process, so a pair of globals is
 # sufficient here, but they are intentionally process-global and not thread-safe.
@@ -113,7 +74,7 @@ def set_connect_timeout(value: float) -> None:
     try:
         _connect_timeout = float(value)
     except (TypeError, ValueError):
-        logger.warning("invalid CLI connection timeout; using default 5.0 seconds")
+        logger.warning("invalid CLI connection timeout %r; using default 5.0 seconds", value)
         _connect_timeout = 5.0
 
 
@@ -147,117 +108,102 @@ def _human_stream():
     return sys.stderr if _is_machine_mode() else sys.stdout
 
 
-def _normalize_key(key: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", str(key).lower()).strip("_")
-
-
-def _is_sensitive_key(key: Any) -> bool:
-    normalized = _normalize_key(key)
-    if normalized in _SENSITIVE_KEY_NAMES:
-        return True
-
-    key_parts = set(normalized.split("_"))
-    return bool(key_parts & _SENSITIVE_KEY_PARTS)
-
-
-def _redact_sensitive_text(text: str) -> str:
-    redacted = _PEM_PRIVATE_KEY_PATTERN.sub(_REDACTED, text)
-    redacted = _BEARER_TOKEN_PATTERN.sub(r"\1" + _REDACTED, redacted)
-    redacted = _AUTH_VALUE_PATTERN.sub(r"\1\2" + _REDACTED + r"\4", redacted)
-    redacted = _URL_PASSWORD_PATTERN.sub(r"\1" + _REDACTED + r"\3", redacted)
-    return _SENSITIVE_ASSIGNMENT_PATTERN.sub(r"\1\2\3" + _REDACTED + r"\5", redacted)
-
-
-def _sanitize_for_cli_output(value: Any, key: Any = None) -> Any:
-    if key is not None and _is_sensitive_key(key):
-        return _REDACTED
-
-    if isinstance(value, dict):
-        return {k: _sanitize_for_cli_output(v, k) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_sanitize_for_cli_output(v) for v in value]
-    if isinstance(value, tuple):
-        return tuple(_sanitize_for_cli_output(v) for v in value)
-    if isinstance(value, str):
-        return _redact_sensitive_text(value)
-    return value
-
-
 def _render_table(data: Any) -> None:
-    safe_table_data = _sanitize_for_cli_output(data)
-    if isinstance(safe_table_data, dict):
-        for table_key, safe_table_value in safe_table_data.items():
-            print(f"{table_key}: {safe_table_value}")
-    elif isinstance(safe_table_data, list):
-        if not safe_table_data:
+    if isinstance(data, dict):
+        for k, v in data.items():
+            print(f"{k}: {v}")
+    elif isinstance(data, list):
+        if not data:
             return
-        if isinstance(safe_table_data[0], dict):
-            keys = list(safe_table_data[0].keys())
-            widths = [max(len(k), max(len(str(r.get(k, ""))) for r in safe_table_data)) for k in keys]
+        if isinstance(data[0], dict):
+            keys = list(data[0].keys())
+            widths = [max(len(k), max(len(str(r.get(k, ""))) for r in data)) for k in keys]
             header = "  ".join(k.ljust(w) for k, w in zip(keys, widths))
             print(header)
             print("-" * len(header))
-            for safe_table_row in safe_table_data:
-                print("  ".join(str(safe_table_row.get(k, "")).ljust(w) for k, w in zip(keys, widths)))
+            for row in data:
+                print("  ".join(str(row.get(k, "")).ljust(w) for k, w in zip(keys, widths)))
         else:
-            for safe_table_item in safe_table_data:
-                print(safe_table_item)
+            for item in data:
+                print(item)
     else:
-        print(str(safe_table_data))
+        print(str(data))
 
 
 def output(data: Any, fmt: Optional[str]) -> None:
     """Legacy output helper used by older cert/package command paths."""
-    safe_output_data = _sanitize_for_cli_output(data)
     if fmt is None and _is_json_mode():
         fmt = "json"
     if fmt == "json":
-        safe_output_payload = {
-            "schema_version": SCHEMA_VERSION,
-            "status": "ok",
-            "exit_code": 0,
-            "data": safe_output_data,
-        }
-        print(json.dumps(safe_output_payload))
+        print(json.dumps({"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": 0, "data": data}))
     elif fmt == "quiet":
-        if isinstance(safe_output_data, dict):
-            safe_quiet_value = next(iter(safe_output_data.values()), "")
-            print(safe_quiet_value)
-        elif isinstance(safe_output_data, list):
-            safe_quiet_value = safe_output_data[0] if safe_output_data else ""
-            print(safe_quiet_value)
+        if isinstance(data, dict):
+            print(next(iter(data.values()), ""))
+        elif isinstance(data, list):
+            print(data[0] if data else "")
         else:
-            print(str(safe_output_data))
+            print(str(data))
     else:
-        _render_table(safe_output_data)
+        _render_table(data)
 
 
-def output_ok(data: Any, exit_code: int = 0) -> None:
-    """Print command success output."""
-    safe_output_data = _sanitize_for_cli_output(data)
+def _add_agent_envelope_fields(
+    payload: dict,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> dict:
+    if code is not None:
+        payload["code"] = code
+    if message is not None:
+        payload["message"] = message
+    if hint is not None:
+        payload["hint"] = hint
+    if recovery_category is not None:
+        payload["recovery_category"] = recovery_category
+    if suggested_skill is not None:
+        payload["suggested_skill"] = suggested_skill
+    return payload
+
+
+def output_ok(
+    data: Any,
+    exit_code: int = 0,
+    code: str = None,
+    message: str = None,
+    hint: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
+) -> None:
+    """Print command success output.
+
+    code/message/hint/recovery fields are emitted in JSON/JSONL modes only;
+    human mode renders command data.
+    """
     if _is_jsonl_mode():
-        output_jsonl_event(
-            {
-                "event": "terminal",
-                "status": "ok",
-                "exit_code": exit_code,
-                "data": safe_output_data,
-                "terminal": True,
-            }
+        payload = _add_agent_envelope_fields(
+            {"event": "terminal", "status": "ok", "exit_code": exit_code, "data": data, "terminal": True},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
         )
+        output_jsonl_event(payload)
     elif _is_json_mode():
-        print(
-            json.dumps(
-                {
-                    "schema_version": SCHEMA_VERSION,
-                    "status": "ok",
-                    "exit_code": exit_code,
-                    "data": safe_output_data,
-                }
-            )
+        payload = _add_agent_envelope_fields(
+            {"schema_version": SCHEMA_VERSION, "status": "ok", "exit_code": exit_code, "data": data},
+            code=code,
+            message=message,
+            hint=hint,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
         )
+        print(json.dumps(payload))
     else:
-        _render_table(safe_output_data)
+        _render_table(data)
     if exit_code != 0:
         sys.exit(exit_code)
 
@@ -268,6 +214,8 @@ def output_error(
     hint: str = None,
     data: Any = None,
     detail: str = None,
+    recovery_category: str = None,
+    suggested_skill: str = None,
     **kwargs,
 ) -> None:
     """Print an error from ERROR_REGISTRY and exit. Never returns."""
@@ -277,37 +225,39 @@ def output_error(
     try:
         message = entry["message"].format_map(kwargs) if kwargs else entry["message"]
     except KeyError:
-        logger.warning("Missing format key for error %s", error_code)
+        logger.warning("Missing format key for error %s: %s", error_code, entry["message"])
         message = entry["message"]
     if detail:
         message = f"{message} \u2014 {detail}"
     resolved_hint = hint if hint is not None else entry["hint"]
-    safe_error_message = _sanitize_for_cli_output(message)
-    safe_error_hint = _sanitize_for_cli_output(resolved_hint)
-    safe_error_data = _sanitize_for_cli_output(data)
     if _is_machine_mode():
-        safe_error_payload = {
+        payload = {
             "schema_version": SCHEMA_VERSION,
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "message": safe_error_message,
-            "hint": safe_error_hint,
+            "message": message,
+            "hint": resolved_hint,
         }
-        if safe_error_data is not None:
-            safe_error_payload["data"] = safe_error_data
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        if data is not None:
+            payload["data"] = data
         if _is_jsonl_mode():
-            safe_error_payload["event"] = "terminal"
-            safe_error_payload["terminal"] = True
-            print(json.dumps(safe_error_payload), flush=True)
+            payload["event"] = "terminal"
+            payload["terminal"] = True
+            print(json.dumps(payload), flush=True)
         else:
-            print(json.dumps(safe_error_payload))
+            print(json.dumps(payload))
     else:
-        if safe_error_data is not None:
-            _render_table(safe_error_data)
-        print(safe_error_message, file=sys.stderr)
-        if safe_error_hint:
-            print(f"Hint: {safe_error_hint}", file=sys.stderr)
+        if data is not None:
+            _render_table(data)
+        print(message, file=sys.stderr)
+        if resolved_hint:
+            print(f"Hint: {resolved_hint}", file=sys.stderr)
         print(f"Code: {error_code} (exit {exit_code})", file=sys.stderr)
     sys.exit(exit_code)
 
@@ -316,10 +266,9 @@ def output_jsonl_event(event: Any) -> None:
     """Print one JSONL event for streaming command output."""
     if not isinstance(event, dict):
         event = {"event": event}
-    safe_event = _sanitize_for_cli_output(event)
-    safe_jsonl_payload = {"schema_version": SCHEMA_VERSION}
-    safe_jsonl_payload.update(safe_event)
-    print(json.dumps(safe_jsonl_payload), flush=True)
+    payload = {"schema_version": SCHEMA_VERSION}
+    payload.update(event)
+    print(json.dumps(payload), flush=True)
 
 
 def output_error_message(
@@ -329,33 +278,46 @@ def output_error_message(
     fmt: Optional[str] = None,
     exit_code: int = 1,
     detail: str = None,
+    data: Any = None,
+    include_data: bool = False,
+    recovery_category: str = None,
+    suggested_skill: str = None,
 ) -> None:
-    """Print an explicit error message/hint pair and exit. Never returns."""
+    """Print an explicit error message/hint pair and exit. Never returns.
+
+    In machine modes, data is omitted when data is None unless include_data=True.
+    This lets callers distinguish an absent data field from an explicit JSON null.
+    """
     resolved_hint = hint or ""
     if detail:
         message = f"{message} \u2014 {detail}"
-    safe_error_message = _sanitize_for_cli_output(message)
-    safe_error_hint = _sanitize_for_cli_output(resolved_hint)
     jsonl_mode = fmt == "jsonl" or (fmt is None and _is_jsonl_mode())
     if fmt in {"json", "jsonl"} or (fmt is None and _is_machine_mode()):
-        safe_error_payload = {
+        payload = {
             "schema_version": SCHEMA_VERSION,
             "status": "error",
             "exit_code": exit_code,
             "error_code": error_code,
-            "message": safe_error_message,
-            "hint": safe_error_hint,
+            "message": message,
+            "hint": resolved_hint,
         }
+        _add_agent_envelope_fields(
+            payload,
+            recovery_category=recovery_category,
+            suggested_skill=suggested_skill,
+        )
+        if include_data or data is not None:
+            payload["data"] = data
         if jsonl_mode:
-            safe_error_payload["event"] = "terminal"
-            safe_error_payload["terminal"] = True
-            print(json.dumps(safe_error_payload), flush=True)
+            payload["event"] = "terminal"
+            payload["terminal"] = True
+            print(json.dumps(payload), flush=True)
         else:
-            print(json.dumps(safe_error_payload))
+            print(json.dumps(payload))
     else:
-        print(safe_error_message, file=sys.stderr)
-        if safe_error_hint:
-            print(f"Hint: {safe_error_hint}", file=sys.stderr)
+        print(message, file=sys.stderr)
+        if resolved_hint:
+            print(f"Hint: {resolved_hint}", file=sys.stderr)
         print(f"Code: {error_code} (exit {exit_code})", file=sys.stderr)
     sys.exit(exit_code)
 
@@ -383,8 +345,7 @@ def print_human(*args, **kwargs):
     Usage: print_human("Starting shutdown of NVFLARE")
     """
     kwargs.setdefault("file", _human_stream())
-    safe_args = tuple(_sanitize_for_cli_output(arg) for arg in args)
-    print(*safe_args, **kwargs)
+    print(*args, **kwargs)
 
 
 def prompt_yn(question: str, default_no: bool = True) -> bool:
@@ -405,8 +366,7 @@ def prompt_yn(question: str, default_no: bool = True) -> bool:
     """
     suffix = " [y/N] " if default_no else " [Y/n] "
     stream = _human_stream()
-    safe_question = _sanitize_for_cli_output(question)
-    stream.write(safe_question + suffix)
+    stream.write(question + suffix)
     stream.flush()
     answer = sys.stdin.readline().strip().upper()
     return answer == "Y"

--- a/nvflare/tool/cli_schema.py
+++ b/nvflare/tool/cli_schema.py
@@ -52,10 +52,12 @@ def parser_to_schema(
     mutating: Optional[bool] = None,
     idempotent: Optional[bool] = None,
     retry_token: Optional[dict] = None,
+    schema_required: Optional[set[str]] = None,
 ) -> dict:
     """Serialize an argparse parser to a JSON-compatible schema dict."""
     # argparse exposes parser structure via the private _actions list; this is the standard
     # introspection hook available for building a schema from parser definitions.
+    schema_required = schema_required or set()
     args = []
     for action in parser._actions:
         if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
@@ -69,7 +71,11 @@ def parser_to_schema(
             required = action.nargs not in (argparse.OPTIONAL, argparse.ZERO_OR_MORE)
         else:
             name = max(action.option_strings, key=len)
-            required = bool(getattr(action, "required", False) or getattr(action, "schema_required", False))
+            required = bool(
+                getattr(action, "required", False)
+                or action.dest in schema_required
+                or getattr(action, "schema_required", False)
+            )
 
         entry = {
             "name": name,
@@ -129,6 +135,7 @@ def handle_schema_flag(
     mutating: Optional[bool] = None,
     idempotent: Optional[bool] = None,
     retry_token: Optional[dict] = None,
+    schema_required: Optional[set[str]] = None,
 ) -> None:
     """Handle the pre-parse --schema fast path.
 
@@ -168,6 +175,7 @@ def handle_schema_flag(
                 mutating=mutating,
                 idempotent=idempotent,
                 retry_token=retry_token,
+                schema_required=schema_required,
             )
         # --schema intentionally bypasses the normal command-output envelope so agent/tool callers
         # always get the raw schema document.

--- a/tests/unit_test/tool/agent/agent_cli_test.py
+++ b/tests/unit_test/tool/agent/agent_cli_test.py
@@ -1,0 +1,808 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.tool import cli_output
+from nvflare.tool.agent.skill_manager import SkillSource
+from nvflare.tool.agent.skill_manifest import build_skill_manifest
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_output_state(monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "txt")
+    monkeypatch.setattr(cli_output, "_connect_timeout", 5.0)
+
+
+def _run_main(argv):
+    from nvflare import cli
+
+    with patch("sys.argv", argv), patch("nvflare.cli.version_check"):
+        try:
+            cli.main()
+        except SystemExit as e:
+            return e.code
+    return 0
+
+
+def _parse_for_agent_parser():
+    from nvflare import cli
+
+    with patch("sys.argv", ["nvflare", "agent", "--schema"]):
+        _prog_parser, args, sub_cmd_parsers = cli.parse_args("nvflare")
+
+    assert args.sub_command == "agent"
+    assert "agent" in sub_cmd_parsers
+    return sub_cmd_parsers["agent"]
+
+
+def _subparser_choices(parser):
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action.choices
+    return {}
+
+
+def _required_operational_args(parser):
+    required_args = []
+    for action in parser._actions:
+        if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
+            continue
+        if action.dest == "schema" or action.help == argparse.SUPPRESS:
+            continue
+        positional_required = not action.option_strings and action.nargs not in (
+            argparse.OPTIONAL,
+            argparse.ZERO_OR_MORE,
+        )
+        optional_required = bool(getattr(action, "required", False))
+        if positional_required or optional_required:
+            required_args.append(action.dest)
+    return required_args
+
+
+def _minimal_agent_command():
+    agent_parser = _parse_for_agent_parser()
+    choices = _subparser_choices(agent_parser)
+    assert choices, "nvflare agent should register at least one read-only subcommand"
+
+    for name, parser in choices.items():
+        if _required_operational_args(parser):
+            continue
+        return name, parser
+
+    assert False, "nvflare agent should expose a read-only subcommand that needs no operational arguments"
+
+
+def _load_single_stdout_json(captured):
+    stdout = captured.out.strip()
+    assert stdout
+    assert len(stdout.splitlines()) == 1
+    return json.loads(stdout)
+
+
+def _assert_envelope_shape(payload, expected_status, require_data=True):
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == expected_status
+    assert "message" in payload
+    assert "hint" in payload
+    if require_data:
+        assert "data" in payload
+    if "code" in payload:
+        assert payload["code"]
+    else:
+        assert payload["error_code"]
+
+
+def test_agent_command_parser_is_registered(monkeypatch):
+    from nvflare import cli
+
+    command_name, _parser = _minimal_agent_command()
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["nvflare", "agent", command_name, "--format", "json"],
+    )
+
+    _prog_parser, args, _sub_cmd_parsers = cli.parse_args("nvflare")
+    assert args.sub_command == "agent"
+
+
+def test_agent_success_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    cli_output.output_ok(
+        {"ready": True},
+        code="AGENT_OK",
+        message="Agent command completed.",
+        hint="",
+        recovery_category="FIXABLE_BY_CONFIG",
+        suggested_skill="agent",
+    )
+
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "ok"
+    assert payload["code"] == "AGENT_OK"
+    assert payload["message"] == "Agent command completed."
+    assert payload["hint"] == ""
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+    assert payload["data"] == {"ready": True}
+
+
+def test_agent_error_envelope_fields_are_supported(capsys, monkeypatch):
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_output.output_error_message(
+            "AGENT_ERROR",
+            "Agent command failed.",
+            hint="Use a valid agent command.",
+            exit_code=4,
+            recovery_category="FIXABLE_BY_CONFIG",
+            suggested_skill="agent",
+        )
+
+    assert exc_info.value.code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    assert payload["schema_version"] == "1"
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "AGENT_ERROR"
+    assert "code" not in payload
+    assert payload["message"] == "Agent command failed."
+    assert payload["hint"] == "Use a valid agent command."
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert payload["suggested_skill"] == "agent"
+
+
+def test_agent_schema_exits_zero_and_emits_raw_schema_json(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"].startswith("nvflare agent")
+    assert "status" not in schema
+    assert "args" in schema
+    assert "examples" in schema
+
+
+def test_agent_minimal_subcommand_schema_does_not_require_operational_args(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--schema"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert captured.err == ""
+    assert schema["schema_version"] == "1"
+    assert schema["command"] == f"nvflare agent {command_name}"
+    assert "status" not in schema
+    assert schema["output_modes"] == ["json"]
+    assert schema["streaming"] is False
+    assert schema["mutating"] is False
+    assert schema["idempotent"] is True
+
+
+def test_agent_minimal_subcommand_json_success_is_single_stdout_envelope(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "ok")
+
+
+def test_agent_human_output_stays_off_stdout_in_json_mode(capsys):
+    command_name, _parser = _minimal_agent_command()
+
+    exit_code = _run_main(["nvflare", "agent", command_name, "--format", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    assert payload["status"] == "ok"
+
+
+def test_agent_missing_subcommand_json_error_is_non_interactive(capsys):
+    exit_code = _run_main(["nvflare", "agent", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert payload["data"] is None
+    assert captured.err == ""
+
+
+def test_agent_missing_subcommand_stops_when_error_helper_is_mocked():
+    from nvflare.tool.agent.agent_cli import handle_agent_cmd
+
+    with patch("sys.argv", ["nvflare", "agent"]), patch("nvflare.tool.cli_output.output_error_message") as output_error:
+        handle_agent_cmd(SimpleNamespace(agent_sub_cmd=None))
+
+    output_error.assert_called_once()
+
+
+def test_agent_invalid_subcommand_json_error_is_structured(capsys):
+    exit_code = _run_main(["nvflare", "agent", "not-a-pr1-command", "--format", "json"])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    payload = _load_single_stdout_json(captured)
+    _assert_envelope_shape(payload, "error")
+    assert "event" not in payload
+    assert "terminal" not in payload
+    assert "not-a-pr1-command" in payload["message"]
+    assert captured.err == ""
+
+
+def test_agent_skills_install_dry_run_json_uses_native_source(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["applied"] is False
+    assert payload["data"]["source"]["type"] == "editable"
+    assert payload["data"]["skills"][0]["name"] == "nvflare-test-skill"
+    assert not target.exists()
+
+
+def test_agent_skills_install_accepts_system_temp_alias_target(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = os.path.join(tempfile.gettempdir(), f"nvflare-skill-target-{tmp_path.name}")
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            target,
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["target_path"] == str(Path(target).resolve(strict=False))
+    assert payload["data"]["applied"] is False
+
+
+def test_agent_skills_install_and_list_json(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    install_exit = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--format",
+            "json",
+        ]
+    )
+    install_payload = _load_single_stdout_json(capsys.readouterr())
+    assert install_exit == 0
+    assert install_payload["data"]["applied"] is True
+    assert target.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+
+    list_exit = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "list",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+            "--format",
+            "json",
+        ]
+    )
+    list_payload = _load_single_stdout_json(capsys.readouterr())
+    assert list_exit == 0
+    assert list_payload["data"]["available"][0]["name"] == "nvflare-test-skill"
+    assert list_payload["data"]["installed"][0]["name"] == "nvflare-test-skill"
+
+
+def test_agent_skills_install_human_output_is_summarized(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "NVFLARE Agent Skills Install" in captured.out
+    assert "agent: codex" in captured.out
+    assert "mode: applied" in captured.out
+    assert "summary: installed 1" in captured.out
+    assert "skills:" in captured.out
+    assert "- nvflare-test-skill: installed" in captured.out
+    assert "Use --format json for the full machine-readable install plan." in captured.out
+    assert "'files':" not in captured.out
+    assert "[{'name':" not in captured.out
+
+
+def test_agent_skills_list_human_output_is_summarized(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    target = tmp_path / "target"
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "list",
+            "--agent",
+            "codex",
+            "--target",
+            str(target),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "NVFLARE Agent Skills" in captured.out
+    assert "agent: codex" in captured.out
+    assert "available:" in captured.out
+    assert "installed:" in captured.out
+    assert "conflicts:" in captured.out
+    assert "- nvflare-test-skill" in captured.out
+    assert "[{'name':" not in captured.out
+
+
+def test_removed_agent_skill_report_commands_are_not_advertised(capsys):
+    exit_code = _run_main(["nvflare", "agent", "info", "--format", "json"])
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    commands = {item["command"] for item in payload["data"]["commands"]}
+    assert "nvflare agent skills evaluate" not in commands
+    assert "nvflare agent skills performance" not in commands
+    assert "nvflare agent skills benchmark" not in commands
+
+
+@pytest.mark.parametrize("subcommand", ["evaluate", "performance", "benchmark"])
+def test_unsupported_agent_skills_commands_are_rejected(capsys, subcommand):
+    exit_code = _run_main(["nvflare", "agent", "skills", subcommand, "--format", "json"])
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "INVALID_ARGS"
+    assert payload["data"]["choices"] == ["install", "list"]
+
+
+@pytest.mark.parametrize("subcommand", ["performance", "benchmark"])
+def test_removed_agent_skills_command_schema_is_rejected(capsys, subcommand):
+    exit_code = _run_main(["nvflare", "agent", "skills", subcommand, "--schema", "--format", "json"])
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "INVALID_ARGS"
+    assert payload["data"]["choices"] == ["install", "list"]
+
+
+def test_agent_skills_missing_subcommand_json_error_is_non_interactive(capsys):
+    exit_code = _run_main(["nvflare", "agent", "skills", "--format", "json"])
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_SKILLS_SUBCOMMAND_REQUIRED"
+    assert payload["data"] is None
+
+
+def test_agent_skills_schema_subcommand_does_not_scan_option_values():
+    from nvflare.tool.agent.agent_cli import _schema_agent_skills_sub_cmd
+
+    _parse_for_agent_parser()
+
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "list", "--schema"]) == "list"
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "--schema", "install"]) == "install"
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "--schema", "--format", "json", "install"]) == "install"
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "--schema", "--format=json", "list"]) == "list"
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "benchmark", "--schema"]) is None
+    assert _schema_agent_skills_sub_cmd(["agent", "--target", "skills", "skills", "install", "--schema"]) == "install"
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "--skill", "benchmark", "--schema"]) is None
+    assert _schema_agent_skills_sub_cmd(["agent", "skills", "--schema", "--skill", "install"]) is None
+
+
+def test_agent_skills_missing_named_skill_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(tmp_path / "target"),
+            "--skill",
+            "nvflare-missing",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_SKILL_NOT_FOUND"
+    assert "code" not in payload
+    assert payload["data"]["missing"] == ["nvflare-missing"]
+
+
+def test_agent_skills_install_failure_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    from nvflare.tool.agent import skill_manager
+
+    monkeypatch.setattr(
+        skill_manager,
+        "install_skills",
+        lambda **_kwargs: {
+            "agent": "codex",
+            "target_path": str(tmp_path / "target"),
+            "requested_skill": None,
+            "source": {},
+            "available": [],
+            "skills": [],
+            "conflicts": [],
+            "errors": [{"skill": "nvflare-test-skill", "code": "skill_install_failed", "message": "disk full"}],
+            "deprecated_skills_skipped": [],
+            "missing": [],
+            "applied": False,
+        },
+    )
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(tmp_path / "target"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_SKILL_INSTALL_FAILED"
+    assert "code" not in payload
+    assert payload["recovery_category"] == "FIXABLE_BY_ENV"
+    assert payload["data"]["errors"][0]["code"] == "skill_install_failed"
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_agent_skills_target_symlink_is_structured_json_error(capsys, monkeypatch, tmp_path):
+    _patch_skill_source(monkeypatch, tmp_path)
+    actual_target = tmp_path / "actual-target"
+    actual_target.mkdir()
+    link_target = tmp_path / "link-target"
+    link_target.symlink_to(actual_target, target_is_directory=True)
+
+    exit_code = _run_main(
+        [
+            "nvflare",
+            "agent",
+            "skills",
+            "install",
+            "--agent",
+            "codex",
+            "--target",
+            str(link_target),
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_SKILL_TARGET_INVALID"
+    assert payload["recovery_category"] == "FIXABLE_BY_CONFIG"
+    assert "user-created symlink" in payload["hint"]
+    assert payload["data"]["target"] == str(link_target)
+
+
+def test_agent_skills_install_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "skills", "install", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent skills install"
+    assert schema["mutating"] is True
+    assert schema["output_modes"] == ["json"]
+    args_by_name = {arg["name"]: arg for arg in schema["args"]}
+    assert args_by_name["--skill"]["required"] is False
+
+
+def test_agent_inspect_json_reports_static_framework_evidence(capsys, tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text("import torch\n\ndef train():\n    return None\n", encoding="utf-8")
+
+    exit_code = _run_main(["nvflare", "agent", "inspect", str(script), "--format", "json"])
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["static_only"] is True
+    assert payload["data"]["frameworks"][0]["name"] == "pytorch"
+    assert payload["data"]["conversion_state"] == "not_converted"
+    assert payload["data"]["skill_selection"]["recommended_skills"] == ["nvflare-convert-pytorch"]
+
+
+def test_agent_inspect_missing_path_is_structured_json_error(capsys, tmp_path):
+    exit_code = _run_main(["nvflare", "agent", "inspect", str(tmp_path / "missing"), "--format", "json"])
+
+    assert exit_code == 4
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "error")
+    assert payload["error_code"] == "AGENT_INSPECT_PATH_NOT_FOUND"
+    assert payload["data"] is None
+
+
+def test_agent_inspect_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "inspect", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent inspect"
+    assert schema["mutating"] is False
+    assert schema["output_modes"] == ["json"]
+    path_arg = next(arg for arg in schema["args"] if arg["name"] == "path")
+    assert path_arg["required"] is True
+
+
+def test_agent_doctor_json_reports_local_readiness(capsys, monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    exit_code = _run_main(["nvflare", "agent", "doctor", "--format", "json"])
+
+    assert exit_code == 0
+    payload = _load_single_stdout_json(capsys.readouterr())
+    _assert_envelope_shape(payload, "ok")
+    assert payload["data"]["nvflare"]["import_ok"] is True
+    assert payload["data"]["online"] == {"enabled": False, "status": "not_requested"}
+    assert any(finding["code"] == "STARTUP_KIT_NOT_CONFIGURED" for finding in payload["data"]["findings"])
+    assert not home.joinpath(".nvflare", "config.conf").exists()
+
+
+def test_agent_doctor_human_output_is_summarized(capsys, monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    poc_workspace = tmp_path / "poc"
+    poc_workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(poc_workspace))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    exit_code = _run_main(["nvflare", "agent", "doctor"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "NVFLARE Agent Doctor" in captured.out
+    assert "status: attention" in captured.out
+    assert "startup kits: 0/0 valid (active: none)" in captured.out
+    assert "findings (1):" in captured.out
+    assert "STARTUP_KIT_NOT_CONFIGURED" in captured.out
+    assert "startup_kits:" not in captured.out
+    assert "{'import_ok':" not in captured.out
+
+
+def test_agent_doctor_schema_exits_zero(capsys):
+    exit_code = _run_main(["nvflare", "agent", "doctor", "--schema"])
+
+    assert exit_code == 0
+    schema = json.loads(capsys.readouterr().out)
+    assert schema["command"] == "nvflare agent doctor"
+    assert schema["mutating"] is False
+    assert schema["output_modes"] == ["json"]
+    assert any(arg["name"] == "--online" for arg in schema["args"])
+
+
+def _patch_skill_source(
+    monkeypatch, tmp_path, *, with_behavior=False, with_compound_trigger=False, with_no_skill_trigger=False
+):
+    from nvflare.tool.agent import skill_manager
+
+    root = tmp_path / "skills"
+    _write_skill(
+        root,
+        "nvflare-test-skill",
+        with_behavior=with_behavior,
+        with_compound_trigger=with_compound_trigger,
+        with_no_skill_trigger=with_no_skill_trigger,
+    )
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    monkeypatch.setattr(skill_manager, "find_skill_source", lambda: source)
+    return source
+
+
+def _write_skill(root, name, *, with_behavior=False, with_compound_trigger=False, with_no_skill_trigger=False):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n",
+        encoding="utf-8",
+    )
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    nvflare = {
+        "expected_skill": name,
+        "process_metrics": [
+            {
+                "id": "elapsed_seconds",
+                "description": "time used for the conversion",
+            },
+            {
+                "id": "token_count",
+                "description": "total conversation token count when available",
+            },
+            {
+                "id": "user_correction_count",
+                "description": "number of user corrections",
+            },
+            {
+                "id": "missed_instruction_count",
+                "description": "number of applicable explicit instructions the agent missed",
+            },
+            {
+                "id": "conversion_quality",
+                "description": "reviewer-rated conversion quality",
+            },
+        ],
+    }
+    if with_behavior:
+        nvflare.update(
+            {
+                "mandatory_behavior": [{"id": "inspect-first", "description": "inspect local code before editing"}],
+                "prohibited_behavior": [{"id": "no-production-submit", "description": "do not submit to production"}],
+            }
+        )
+    eval_cases = [
+        {
+            "id": "test-conversion",
+            "prompt": "Convert this training code.",
+            "expected_output": "A validated conversion.",
+            "nvflare": nvflare,
+        }
+    ]
+    if with_compound_trigger:
+        eval_cases.extend(
+            [
+                {
+                    "id": "compound-trigger",
+                    "prompt": "Route this to the test skill and not the other skill.",
+                    "expected_output": "The selected skill is nvflare-test-skill.",
+                    "nvflare": {
+                        "expected_skill": name,
+                        "negative_for": "nvflare-other-skill",
+                    },
+                },
+                {
+                    "id": "invalid-compound-trigger",
+                    "prompt": "Invalid trigger fixture.",
+                    "expected_output": "This fixture is invalid by design.",
+                    "nvflare": {
+                        "expected_skill": name,
+                        "negative_for": name,
+                    },
+                },
+            ]
+        )
+    if with_no_skill_trigger:
+        eval_cases.append(
+            {
+                "id": "global-negative",
+                "prompt": "A non-FLARE task should not trigger this skill.",
+                "expected_output": "No FLARE skill is selected.",
+                "nvflare": {
+                    "expected_skill": None,
+                    "negative_for": "*",
+                },
+            }
+        )
+    evals_dir.joinpath("evals.json").write_text(
+        json.dumps(
+            {
+                "skill_name": name,
+                "evals": eval_cases,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/agent/agent_doctor_test.py
+++ b/tests/unit_test/tool/agent/agent_doctor_test.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from nvflare.tool.agent.doctor import doctor_environment
+
+
+def _configure_active_startup_kit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    transfer_dir = admin_dir / "transfer"
+    startup_dir.mkdir(parents=True)
+    transfer_dir.mkdir()
+    (startup_dir / "fed_admin.json").write_text(
+        '{"admin": {"username": "admin@nvidia.com", "download_dir": "transfer"}}',
+        encoding="utf-8",
+    )
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    return admin_dir
+
+
+def test_doctor_local_readiness_does_not_create_config(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    data = doctor_environment()
+
+    assert data["nvflare"]["import_ok"] is True
+    assert data["online"] == {"enabled": False, "status": "not_requested"}
+    assert data["startup_kits"]["active_id"] is None
+    assert any(finding["code"] == "STARTUP_KIT_NOT_CONFIGURED" for finding in data["findings"])
+    assert not home.joinpath(".nvflare", "config.conf").exists()
+
+
+def test_doctor_command_registry_matches_agent_command_surface(monkeypatch, tmp_path):
+    from nvflare.tool.agent.command_registry import agent_commands
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    data = doctor_environment()
+
+    commands = data["commands"]["commands"]
+    command_names = {item["command"] for item in commands}
+    assert commands == agent_commands()
+    assert "nvflare agent skills install" in command_names
+    assert "nvflare agent skills list" in command_names
+    assert "nvflare agent skills performance" not in command_names
+    assert "nvflare agent skills benchmark" not in command_names
+    assert "nvflare agent skills evaluate" not in command_names
+
+
+def test_doctor_poc_config_tolerates_missing_pyhocon(monkeypatch, tmp_path):
+    from nvflare.tool.poc import poc_commands
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+    monkeypatch.setattr(poc_commands, "DEFAULT_WORKSPACE", str(tmp_path / "missing-poc"))
+    original_import = builtins.__import__
+
+    def import_without_pyhocon(name, *args, **kwargs):
+        if name == "pyhocon":
+            raise ImportError("pyhocon unavailable")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=import_without_pyhocon):
+        data = doctor_environment()
+
+    assert data["poc"]["status"] == "missing"
+    assert any(finding["code"] == "POC_WORKSPACE_MISSING" for finding in data["findings"])
+
+
+def test_doctor_online_uses_read_only_status_check(monkeypatch, tmp_path):
+    _configure_active_startup_kit(tmp_path, monkeypatch)
+
+    class FakeSession:
+        def __init__(self):
+            self.closed = False
+
+        def check_status(self, target_type, client_names):
+            assert target_type == "all"
+            assert client_names is None
+            return {
+                "server_status": "running",
+                "clients": [{"client_name": "site-1"}],
+                "client_status": [],
+                "jobs": [],
+            }
+
+        def close(self):
+            self.closed = True
+
+    fake_session = FakeSession()
+    with patch("nvflare.tool.cli_session.new_cli_session_for_args", return_value=fake_session):
+        data = doctor_environment(online=True, args=SimpleNamespace(kit_id=None, startup_kit=None))
+
+    assert data["online"]["status"] == "ok"
+    assert data["online"]["server_status"] == "running"
+    assert data["online"]["clients"] == [{"client_name": "site-1"}]
+    assert fake_session.closed is True
+
+
+def test_doctor_online_reports_timeout_separately(monkeypatch, tmp_path):
+    _configure_active_startup_kit(tmp_path, monkeypatch)
+
+    class FakeSession:
+        def check_status(self, target_type, client_names):
+            raise TimeoutError("status timed out")
+
+        def close(self):
+            return None
+
+    with patch("nvflare.tool.cli_session.new_cli_session_for_args", return_value=FakeSession()):
+        data = doctor_environment(online=True, args=SimpleNamespace(kit_id=None, startup_kit=None))
+
+    assert data["online"]["status"] == "timeout"
+    assert data["online"]["findings"][0]["code"] == "ONLINE_CHECK_TIMEOUT"
+
+
+def test_doctor_online_generic_error_includes_exception_type(monkeypatch, tmp_path):
+    _configure_active_startup_kit(tmp_path, monkeypatch)
+
+    class FakeSession:
+        def check_status(self, target_type, client_names):
+            raise RuntimeError("unexpected")
+
+        def close(self):
+            return None
+
+    with patch("nvflare.tool.cli_session.new_cli_session_for_args", return_value=FakeSession()):
+        data = doctor_environment(online=True, args=SimpleNamespace(kit_id=None, startup_kit=None))
+
+    assert data["online"]["status"] == "error"
+    assert data["online"]["findings"][0]["code"] == "ONLINE_CHECK_FAILED_RUNTIMEERROR"
+
+
+def test_doctor_online_skips_when_session_would_create_download_dir(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    admin_dir = tmp_path / "active-admin"
+    startup_dir = admin_dir / "startup"
+    startup_dir.mkdir(parents=True)
+    (startup_dir / "fed_admin.json").write_text(
+        '{"admin": {"username": "admin@nvidia.com", "download_dir": "missing-transfer"}}',
+        encoding="utf-8",
+    )
+    (startup_dir / "client.crt").write_text("cert", encoding="utf-8")
+    (startup_dir / "rootCA.pem").write_text("root", encoding="utf-8")
+    config_dir = home / ".nvflare"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.conf").write_text(
+        f"""
+        version = 2
+        startup_kits {{
+          active = "admin@nvidia.com"
+          entries {{
+            "admin@nvidia.com" = "{admin_dir}"
+          }}
+        }}
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("NVFLARE_STARTUP_KIT_DIR", raising=False)
+
+    with patch("nvflare.tool.cli_session.new_cli_session_for_args") as new_session:
+        data = doctor_environment(online=True, args=SimpleNamespace(kit_id=None, startup_kit=None))
+
+    assert data["online"]["status"] == "skipped"
+    assert data["online"]["findings"][0]["code"] == "ONLINE_CHECK_WOULD_CREATE_DOWNLOAD_DIR"
+    new_session.assert_not_called()

--- a/tests/unit_test/tool/agent/agent_inspector_test.py
+++ b/tests/unit_test/tool/agent/agent_inspector_test.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nvflare.tool.agent.inspector import inspect_path
+
+
+def test_inspect_static_only_does_not_execute_user_module(tmp_path):
+    marker = tmp_path / "import_side_effect"
+    script = tmp_path / "train.py"
+    script.write_text(
+        "import pathlib\n"
+        "import torch\n"
+        f"pathlib.Path({str(marker)!r}).write_text('executed')\n"
+        "\n"
+        "def train():\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+
+    assert not marker.exists()
+    assert data["target_type"] == "single_training_script"
+    assert data["conversion_state"] == "not_converted"
+    assert data["frameworks"][0]["name"] == "pytorch"
+    assert data["skill_selection"]["recommended_skills"] == ["nvflare-convert-pytorch"]
+
+
+def test_inspect_redacts_secret_literals_and_absolute_paths_by_default(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text(
+        "API_TOKEN = 'super-secret-value'\n" "DATA_ROOT = '/Users/alice/private/data'\n" "import tensorflow as tf\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+    dumped = json.dumps(data)
+
+    assert "super-secret-value" not in dumped
+    assert "/Users/alice/private/data" not in dumped
+    assert "<REDACTED>" in dumped
+    assert "<REDACTED_PATH>" in dumped
+    assert data["frameworks"][0]["name"] == "tensorflow"
+    assert {finding["code"] for finding in data["findings"]} == {"SECRET_LITERAL_REDACTED"}
+    assert data["patterns"]["absolute_data_paths"][0]["code"] == "ABSOLUTE_DATA_PATH"
+
+
+def test_inspect_redaction_can_be_disabled_for_local_debugging(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text("PASSWORD = 'local-debug-secret'\nDATA_ROOT = '/opt/data'\n", encoding="utf-8")
+
+    data = inspect_path(script, redact=False)
+    dumped = json.dumps(data)
+
+    assert "local-debug-secret" in dumped
+    assert "/opt/data" in dumped
+
+
+def test_inspect_skips_symlink_without_scanning_target(tmp_path):
+    target = tmp_path / "outside.py"
+    target.write_text("import tensorflow\n", encoding="utf-8")
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "linked.py").symlink_to(target)
+    (root / "train.py").write_text("import torch\n", encoding="utf-8")
+
+    data = inspect_path(root)
+
+    assert [framework["name"] for framework in data["frameworks"]] == ["pytorch"]
+    assert data["scan"]["files_skipped"][0]["code"] == "SYMLINK_SKIPPED"
+
+
+def test_inspect_classifies_flare_job_source(tmp_path):
+    job_py = tmp_path / "job.py"
+    job_py.write_text(
+        "from nvflare.recipe import SimEnv\n"
+        "\n"
+        "def main():\n"
+        "    env = SimEnv(num_clients=2)\n"
+        "    recipe.export('/tmp/job')\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(tmp_path)
+
+    assert data["target_type"] == "flare_job_source"
+    assert data["conversion_state"] == "flare_job"
+    assert data["job"]["job_py"] == "job.py"
+    assert data["job"]["sim_env_used"] is True
+    assert data["job"]["export_support"] is True
+
+
+def test_inspect_does_not_treat_pytorch_to_call_as_export_support(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text(
+        "import torch\n" "\n" "def train(tensor):\n" "    return tensor.to('cpu')\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+
+    assert data["job"]["export_support"] is False
+    assert "python job.py --export --export-dir <job-dir>" not in data["recommended_next_commands"]
+
+
+def test_inspect_does_not_treat_builtin_compile_as_torch_compile(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text(
+        "import torch\n" "\n" "def build_code():\n" "    return compile('x = 1', '<inline>', 'exec')\n",
+        encoding="utf-8",
+    )
+
+    data = inspect_path(script)
+
+    assert data["frameworks"][0]["name"] == "pytorch"
+    assert not any(item["kind"] == "torch_compile" for item in data["patterns"]["dynamic"])
+
+
+def test_inspect_stops_and_caps_skips_after_file_limit(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    for index in range(20):
+        (root / f"train_{index:02d}.py").write_text("import torch\n", encoding="utf-8")
+
+    data = inspect_path(root, max_files=3)
+
+    assert data["scan"]["entries_visited"] == 3
+    assert data["scan"]["files_considered"] == 3
+    assert data["scan"]["files_scanned"] == 3
+    assert data["scan"]["files_skipped_count"] == 1
+    assert data["scan"]["files_skipped_truncated"] is False
+    assert data["scan"]["files_skipped"] == [
+        {"code": "FILE_LIMIT_REACHED", "path": "train_03.py", "message": "file scan limit reached"}
+    ]
+
+
+def test_inspect_file_limit_counts_non_python_entries(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    for index in range(5):
+        (root / f"metadata_{index:02d}.json").write_text("{}\n", encoding="utf-8")
+    (root / "train.py").write_text("import torch\n", encoding="utf-8")
+
+    data = inspect_path(root, max_files=3)
+
+    assert data["scan"]["entries_visited"] == 3
+    assert data["scan"]["files_considered"] == 3
+    assert data["scan"]["files_scanned"] == 0
+    assert data["scan"]["files_skipped"] == [
+        {"code": "FILE_LIMIT_REACHED", "path": "metadata_03.json", "message": "file scan limit reached"}
+    ]

--- a/tests/unit_test/tool/agent/agent_skill_checks_test.py
+++ b/tests/unit_test/tool/agent/agent_skill_checks_test.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+from nvflare.tool.agent_skill_checks.lints import run_v1_lints, validate_skills
+
+
+def test_process_metric_lint_requires_process_metrics(tmp_path):
+    _write_skill(
+        tmp_path,
+        "nvflare-test-skill",
+        {
+            "skill_name": "nvflare-test-skill",
+            "evals": [
+                {
+                    "id": "test-positive",
+                    "prompt": "Use this test skill.",
+                    "expected_output": "The skill runs.",
+                    "files": [],
+                    "assertions": ["The skill runs."],
+                    "nvflare": {
+                        "expected_skill": "nvflare-test-skill",
+                        "mandatory_behavior": [{"id": "run-test", "description": "runs the test workflow"}],
+                    },
+                }
+            ],
+        },
+    )
+
+    result = run_v1_lints(tmp_path, checks=["skill-process-metric-lint"])
+
+    assert result["status"] == "failed"
+    assert result["findings"][0]["code"] == "skill-process-metric-missing"
+
+
+def test_process_metric_lint_accepts_process_metrics(tmp_path):
+    _write_skill(
+        tmp_path,
+        "nvflare-test-skill",
+        {
+            "skill_name": "nvflare-test-skill",
+            "evals": [
+                {
+                    "id": "test-positive",
+                    "prompt": "Use this test skill.",
+                    "expected_output": "The skill runs.",
+                    "files": [],
+                    "assertions": ["The skill runs."],
+                    "nvflare": {
+                        "expected_skill": "nvflare-test-skill",
+                        "mandatory_behavior": [{"id": "run-test", "description": "runs the test workflow"}],
+                        "process_metrics": [
+                            {
+                                "id": "turns_to_acceptable",
+                                "description": "number of turns before the result is acceptable",
+                            }
+                        ],
+                    },
+                }
+            ],
+        },
+    )
+
+    result = run_v1_lints(tmp_path, checks=["skill-process-metric-lint"])
+
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+def test_helper_script_json_warning_applies_only_to_python_helpers(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "nvflare-test-skill",
+        {
+            "skill_name": "nvflare-test-skill",
+            "evals": [],
+        },
+    )
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    scripts_dir.joinpath("emit_json.sh").write_text("#!/bin/sh\njq . input.json\n", encoding="utf-8")
+    tests_dir = skill_dir / "tests"
+    tests_dir.mkdir()
+    tests_dir.joinpath("emit_json_test.txt").write_text("shell helper test placeholder\n", encoding="utf-8")
+
+    result = run_v1_lints(tmp_path, checks=["skill-helper-script-lint"])
+
+    assert not any(finding.get("code") == "skill-helper-json-unclear" for finding in result["findings"])
+
+
+def test_helper_script_json_warning_ignores_python_json_reader(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "nvflare-test-skill",
+        {
+            "skill_name": "nvflare-test-skill",
+            "evals": [],
+        },
+    )
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    scripts_dir.joinpath("read_json.py").write_text(
+        "import json\n"
+        "with open('input.json') as f:\n"
+        "    data = json.load(f)\n"
+        "print(data.get('name', 'missing'))\n",
+        encoding="utf-8",
+    )
+    tests_dir = skill_dir / "tests"
+    tests_dir.mkdir()
+    tests_dir.joinpath("read_json_test.txt").write_text("python helper test placeholder\n", encoding="utf-8")
+
+    result = run_v1_lints(tmp_path, checks=["skill-helper-script-lint"])
+
+    assert not any(finding.get("code") == "skill-helper-json-unclear" for finding in result["findings"])
+
+
+def test_trigger_overlap_limit_uses_current_environment(tmp_path, monkeypatch):
+    _write_skill(tmp_path, "nvflare-left", {"skill_name": "nvflare-left", "evals": []})
+    _write_skill(tmp_path, "nvflare-right", {"skill_name": "nvflare-right", "evals": []})
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+    docs_root.joinpath("agent_integration.md").write_text(
+        "| Category | Skill | Tier | Purpose |\n"
+        "| --- | --- | --- | --- |\n"
+        "| Conversion | `nvflare-left` | Seed | Test fixture. |\n"
+        "| Conversion | `nvflare-right` | Seed | Test fixture. |\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NVFLARE_AGENT_MAX_TRIGGER_OVERLAP_SKILLS", "1")
+
+    result = run_v1_lints(tmp_path, docs_root=docs_root, checks=["skill-trigger-overlap-lint"])
+
+    assert result["skipped_checks"][0]["id"] == "skill-trigger-overlap-lint"
+    assert "limit is 1" in result["skipped_checks"][0]["reason"]
+
+
+def test_iter_skill_text_files_skips_oversized_references(tmp_path):
+    from nvflare.tool.agent_skill_checks import lints
+
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill", {"skill_name": "nvflare-test-skill", "evals": []})
+    references_dir = skill_dir / "references"
+    references_dir.mkdir()
+    references_dir.joinpath("large.md").write_text("x" * (lints.MAX_SKILL_TEXT_FILE_BYTES + 1), encoding="utf-8")
+    references_dir.joinpath("small.md").write_text("small reference\n", encoding="utf-8")
+
+    files = [path.name for path, _text in lints._iter_skill_text_files(skill_dir)]
+
+    assert "large.md" not in files
+    assert "small.md" in files
+
+
+def test_doc_crosslink_lint_reads_each_doc_once(tmp_path, monkeypatch):
+    from nvflare.tool.agent_skill_checks import lints
+
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+    docs_root.joinpath("agent_integration.md").write_text("# Integration\n", encoding="utf-8")
+    docs_root.joinpath("agent_skill_evaluation.md").write_text(
+        "# Evaluation\n" + "\n".join(f"`{lint_id}`" for lint_id in lints.V1_LINT_IDS),
+        encoding="utf-8",
+    )
+    read_counts: dict[Path, int] = {}
+    original_read_text = Path.read_text
+
+    def counting_read_text(path, *args, **kwargs):
+        if docs_root in path.parents:
+            read_counts[path] = read_counts.get(path, 0) + 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+    result = run_v1_lints(skills_root, docs_root=docs_root, checks=["agent-doc-crosslink-lint"])
+
+    assert result["status"] == "ok"
+    assert read_counts == {
+        docs_root / "agent_integration.md": 1,
+        docs_root / "agent_skill_evaluation.md": 1,
+    }
+
+
+def test_doc_crosslink_lint_accepts_anchor_in_linked_markdown_outside_canonical_docs(tmp_path):
+    from nvflare.tool.agent_skill_checks import lints
+
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+    docs_root.joinpath("agent_integration.md").write_text("[README usage](README.md#usage)\n", encoding="utf-8")
+    docs_root.joinpath("agent_skill_evaluation.md").write_text(
+        "# Evaluation\n" + "\n".join(f"`{lint_id}`" for lint_id in lints.V1_LINT_IDS),
+        encoding="utf-8",
+    )
+    docs_root.joinpath("README.md").write_text("# Usage\n", encoding="utf-8")
+
+    result = run_v1_lints(skills_root, docs_root=docs_root, checks=["agent-doc-crosslink-lint"])
+
+    assert result["status"] == "ok"
+    assert not any(finding.get("code") == "agent-doc-anchor-missing" for finding in result["findings"])
+
+
+def test_validate_skills_reuses_loaded_skill_records(tmp_path, monkeypatch):
+    from nvflare.tool.agent_skill_checks import lints
+
+    _write_skill(tmp_path, "nvflare-test-skill", {"skill_name": "nvflare-test-skill", "evals": []})
+    load_count = 0
+    original_load = lints._load_skill_records
+
+    def counting_load(*args, **kwargs):
+        nonlocal load_count
+        load_count += 1
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(lints, "_load_skill_records", counting_load)
+
+    result = validate_skills(tmp_path, skill_name="nvflare-test-skill")
+
+    assert result["requested_skill"] == "nvflare-test-skill"
+    assert load_count == 1
+
+
+def _write_skill(root, name, evals):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n"
+        "\n"
+        "## Use When\n"
+        "\n"
+        "Use when testing skill process metrics.\n",
+        encoding="utf-8",
+    )
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    evals_dir.joinpath("evals.json").write_text(json.dumps(evals), encoding="utf-8")
+    return skill_dir

--- a/tests/unit_test/tool/agent/seed_skill_packaging_test.py
+++ b/tests/unit_test/tool/agent/seed_skill_packaging_test.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from nvflare.tool.agent.skill_manager import SkillSource, install_skills, list_skills
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, copy_released_skills_to_bundle
+
+SEED_SKILLS = {
+    "nvflare-orient",
+    "nvflare-convert-pytorch",
+    "nvflare-diagnose-job",
+}
+
+
+def test_seed_skill_manifest_includes_public_skills_and_skips_shared_references():
+    skills_root = _repo_root() / "skills"
+
+    manifest = build_skill_manifest(skills_root, source_type="editable", nvflare_version="2.8.0")
+
+    names = {skill["name"] for skill in manifest["skills"]}
+    assert manifest["findings"] == []
+    assert SEED_SKILLS.issubset(names)
+    assert "_shared" not in names
+    assert all(skill["relative_path"] != "_shared" for skill in manifest["skills"])
+
+
+def test_convert_pytorch_eval_requires_declared_primary_metric_alignment():
+    evals_path = _repo_root() / "skills" / "nvflare-convert-pytorch" / "evals" / "evals.json"
+    data = json.loads(evals_path.read_text(encoding="utf-8"))
+    case = next(item for item in data["evals"] if item["id"] == "pytorch-convert-basic")
+    behaviors = {
+        item["id"]: item["description"] for item in case["nvflare"]["mandatory_behavior"] if isinstance(item, dict)
+    }
+
+    description = behaviors["align-primary-metric"]
+    assert "job documentation, task guidance, or source project guidance" in description
+    assert "FL recipe/global metric" in description
+    assert "FLModel.metrics" in description
+    assert "reports that scalar as validation evidence" in description
+
+
+def test_seed_bundle_copy_includes_references_evals_and_log_fixtures(tmp_path):
+    skills_root = _repo_root() / "skills"
+    bundle_root = tmp_path / "bundle"
+
+    manifest = copy_released_skills_to_bundle(skills_root, bundle_root, nvflare_version="2.8.0")
+
+    names = {skill["name"] for skill in manifest["skills"]}
+    assert SEED_SKILLS.issubset(names)
+    assert (bundle_root / "_shared" / "nvflare-job-lifecycle.md").is_file()
+    _assert_convert_pytorch_payload(bundle_root / "nvflare-convert-pytorch")
+    _assert_diagnose_payload(bundle_root / "nvflare-diagnose-job")
+
+
+def test_seed_skills_install_into_codex_and_claude_temp_targets(tmp_path):
+    source = _seed_skill_source()
+    codex_target = tmp_path / "codex-home" / "skills"
+    claude_target = tmp_path / "home" / ".claude" / "skills"
+
+    codex_plan = install_skills(agent="codex", target_dir=codex_target, source=source)
+    claude_plan = install_skills(agent="claude", target_dir=claude_target, source=source)
+
+    assert codex_plan["applied"] is True
+    assert claude_plan["applied"] is True
+    assert SEED_SKILLS.issubset({entry["name"] for entry in codex_plan["skills"]})
+    assert SEED_SKILLS.issubset({entry["name"] for entry in claude_plan["skills"]})
+    assert codex_target.joinpath("_shared", "nvflare-job-lifecycle.md").is_file()
+    assert claude_target.joinpath("_shared", "nvflare-job-lifecycle.md").is_file()
+    _assert_convert_pytorch_payload(codex_target / "nvflare-convert-pytorch")
+    _assert_convert_pytorch_payload(claude_target / "nvflare-convert-pytorch")
+    _assert_diagnose_payload(codex_target / "nvflare-diagnose-job")
+    _assert_diagnose_payload(claude_target / "nvflare-diagnose-job")
+
+    codex_list = list_skills(agent="codex", target_dir=codex_target, source=source)
+    claude_list = list_skills(agent="claude", target_dir=claude_target, source=source)
+    assert SEED_SKILLS.issubset({skill["name"] for skill in codex_list["installed"]})
+    assert SEED_SKILLS.issubset({skill["name"] for skill in claude_list["installed"]})
+
+
+def test_seed_skills_dry_run_selects_all_seed_skills_without_copying(tmp_path):
+    source = _seed_skill_source()
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["applied"] is False
+    assert SEED_SKILLS.issubset({entry["name"] for entry in plan["skills"]})
+    assert any(
+        Path(file_plan["source"]).name == "transfer_progress_timeout.log"
+        for entry in plan["skills"]
+        if entry["name"] == "nvflare-diagnose-job"
+        for file_plan in entry["files"]
+    )
+    assert not target.exists()
+
+
+def test_setup_build_py_can_disable_packaged_agent_skills(tmp_path):
+    repo_root = _repo_root()
+    build_lib = tmp_path / "build_lib"
+    env = os.environ.copy()
+    env["NVFLARE_PACKAGE_AGENT_SKILLS"] = "0"
+
+    result = subprocess.run(
+        [sys.executable, "setup.py", "build_py", "--build-lib", str(build_lib)],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    bundle_root = build_lib / "nvflare" / "tool" / "agent" / "bundled_skills"
+    manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert bundle_root.joinpath("__init__.py").is_file()
+    assert manifest["source_type"] == "wheel"
+    assert manifest["skills"] == []
+    assert manifest["findings"] == []
+    for skill_name in SEED_SKILLS:
+        assert not bundle_root.joinpath(skill_name).exists()
+
+
+def test_setup_bdist_wheel_no_skills_build_has_distinct_filename(tmp_path):
+    if not _bdist_wheel_available():
+        pytest.skip("bdist_wheel command is not installed in this test environment")
+
+    repo_root = _repo_root()
+    dist_dir = tmp_path / "dist"
+    env = os.environ.copy()
+    env["NVFLARE_PACKAGE_AGENT_SKILLS"] = "0"
+
+    result = subprocess.run(
+        [sys.executable, "setup.py", "bdist_wheel", "--dist-dir", str(dist_dir)],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    wheels = list(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    assert "-1no_skills-" in wheels[0].name
+    with zipfile.ZipFile(wheels[0]) as wheel_file:
+        names = set(wheel_file.namelist())
+        manifest_name = "nvflare/tool/agent/bundled_skills/manifest.json"
+        assert manifest_name in names
+        manifest = json.loads(wheel_file.read(manifest_name).decode("utf-8"))
+        assert manifest["skills"] == []
+        for skill_name in SEED_SKILLS:
+            assert f"nvflare/tool/agent/bundled_skills/{skill_name}/SKILL.md" not in names
+
+
+def _seed_skill_source() -> SkillSource:
+    skills_root = _repo_root() / "skills"
+    return SkillSource(
+        source_type="editable",
+        root=skills_root,
+        manifest=build_skill_manifest(skills_root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+
+def _bdist_wheel_available() -> bool:
+    for module_name in ("setuptools.command.bdist_wheel", "wheel.bdist_wheel"):
+        try:
+            if importlib.util.find_spec(module_name) is not None:
+                return True
+        except ModuleNotFoundError:
+            continue
+    return False
+
+
+def _assert_convert_pytorch_payload(skill_dir: Path) -> None:
+    assert skill_dir.joinpath("SKILL.md").is_file()
+    assert skill_dir.joinpath("references", "job-validation.md").is_file()
+    assert skill_dir.joinpath("references", "pytorch-client-api-conversion.md").is_file()
+    assert skill_dir.joinpath("references", "recipe-selection.md").is_file()
+
+    packaged_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in [
+            skill_dir / "SKILL.md",
+            skill_dir / "references" / "job-validation.md",
+            skill_dir / "references" / "pytorch-client-api-conversion.md",
+        ]
+    )
+    assert "nvflare-job-lifecycle.md" in packaged_text
+    assert "Must not require `rg` to be installed" in packaged_text
+
+
+def _assert_diagnose_payload(skill_dir: Path) -> None:
+    assert skill_dir.joinpath("SKILL.md").is_file()
+    assert skill_dir.joinpath("references", "evidence-collection.md").is_file()
+    assert skill_dir.joinpath("references", "failure-patterns.md").is_file()
+    assert skill_dir.joinpath("evals", "evals.json").is_file()
+    assert skill_dir.joinpath("evals", "files", "poc_component_not_authorized.log").is_file()
+    assert skill_dir.joinpath("evals", "files", "simulation_import_error.log").is_file()
+    assert skill_dir.joinpath("evals", "files", "transfer_progress_timeout.log").is_file()
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -1,0 +1,727 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nvflare.tool.agent import skill_manager
+from nvflare.tool.agent.skill_manager import (
+    INSTALL_LOCK_TIMESTAMP_FILE_NAME,
+    INSTALL_MANIFEST_FILE_NAME,
+    SkillSource,
+    find_skill_source,
+    install_skills,
+    list_skills,
+    resolve_agent_target_dir,
+)
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, write_manifest
+
+
+def test_resolve_codex_target_uses_codex_home(tmp_path):
+    target = resolve_agent_target_dir("codex", env={"CODEX_HOME": str(tmp_path / "codex-home")})
+
+    assert target == tmp_path / "codex-home" / "skills"
+
+
+def test_resolve_claude_target_uses_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    target = resolve_agent_target_dir("claude")
+
+    assert target == tmp_path / ".claude" / "skills"
+
+
+def test_resolve_target_override_skips_agent_home_resolution(tmp_path):
+    target = resolve_agent_target_dir("codex", target_dir=tmp_path / "custom-target", env={"CODEX_HOME": "ignored"})
+
+    assert target == tmp_path / "custom-target"
+
+
+def test_resolve_target_override_accepts_system_temp_alias(tmp_path):
+    target = Path(tempfile.gettempdir()) / f"nvflare-skill-target-{tmp_path.name}"
+
+    resolved = resolve_agent_target_dir("codex", target_dir=target, env={"CODEX_HOME": "ignored"})
+
+    assert resolved == target.resolve(strict=False)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_resolve_target_override_rejects_symlink_target(tmp_path):
+    actual_target = tmp_path / "actual-target"
+    actual_target.mkdir()
+    link_target = tmp_path / "link-target"
+    link_target.symlink_to(actual_target, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink components"):
+        resolve_agent_target_dir("codex", target_dir=link_target)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_resolve_target_override_rejects_symlink_parent(tmp_path):
+    actual_parent = tmp_path / "actual-parent"
+    actual_parent.mkdir()
+    link_parent = tmp_path / "link-parent"
+    link_parent.symlink_to(actual_parent, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink components"):
+        resolve_agent_target_dir("codex", target_dir=link_parent / "skills")
+
+
+def test_resolve_target_override_rejects_parent_traversal(tmp_path):
+    with pytest.raises(ValueError, match="parent directory traversal"):
+        resolve_agent_target_dir("codex", target_dir=tmp_path / "target" / ".." / "skills")
+
+
+def test_resolve_unsupported_agent_raises_value_error():
+    try:
+        resolve_agent_target_dir("unsupported")
+    except ValueError as e:
+        assert "unsupported agent target" in str(e)
+    else:
+        assert False, "unsupported agent target should raise ValueError"
+
+
+def test_find_skill_source_does_not_misclassify_site_packages_skills(monkeypatch, tmp_path):
+    fake_site_packages = tmp_path / "site-packages"
+    fake_package = fake_site_packages / "nvflare"
+    fake_package.mkdir(parents=True)
+    _write_skill(fake_site_packages / "skills", "unrelated-skill")
+    bundle_root = tmp_path / "bundle"
+    bundle_root.mkdir()
+    write_manifest(
+        {
+            "schema_version": "1",
+            "source_type": "wheel",
+            "nvflare_version": "2.8.0",
+            "skills": [],
+            "findings": [],
+        },
+        bundle_root / "manifest.json",
+    )
+    monkeypatch.setattr(
+        skill_manager.util,
+        "find_spec",
+        lambda _name: type("Spec", (), {"submodule_search_locations": [str(fake_package)]})(),
+    )
+    monkeypatch.setattr(skill_manager.resources, "files", lambda _package: bundle_root)
+
+    source = find_skill_source()
+
+    assert source.source_type == "wheel"
+    assert source.root == bundle_root
+
+
+def test_find_skill_source_accepts_pyproject_checkout_without_setup_py(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    fake_package = repo_root / "nvflare"
+    fake_package.mkdir(parents=True)
+    repo_root.joinpath("pyproject.toml").write_text("[project]\nname='nvflare'\n", encoding="utf-8")
+    _write_skill(repo_root / "skills", "nvflare-test-skill")
+    monkeypatch.setattr(
+        skill_manager.util,
+        "find_spec",
+        lambda _name: type("Spec", (), {"submodule_search_locations": [str(fake_package)]})(),
+    )
+
+    source = find_skill_source()
+
+    assert source.source_type == "editable"
+    assert source.root == repo_root / "skills"
+
+
+def test_install_skills_dry_run_reports_plan_without_copying(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", dry_run=True, target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["skills"][0]["action"] == "copy"
+    assert plan["skills"][0]["files"]
+    assert not target.exists()
+
+
+def test_install_skills_installs_all_by_default(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    skill_dir = target / "nvflare-test-skill"
+    assert plan["applied"] is True
+    assert skill_dir.joinpath("SKILL.md").is_file()
+    install_manifest = json.loads(skill_dir.joinpath(INSTALL_MANIFEST_FILE_NAME).read_text(encoding="utf-8"))
+    assert install_manifest["managed_by"] == "nvflare"
+    assert install_manifest["name"] == "nvflare-test-skill"
+
+
+def test_install_skills_reports_missing_named_skill(tmp_path):
+    source = _skill_source(tmp_path)
+
+    plan = install_skills(agent="codex", skill_name="nvflare-missing", target_dir=tmp_path / "target", source=source)
+
+    assert plan["applied"] is False
+    assert plan["missing"] == ["nvflare-missing"]
+    assert plan["skills"] == []
+
+
+def test_install_skills_preserves_external_target_directory(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    external = target / "nvflare-test-skill"
+    external.mkdir(parents=True)
+    external.joinpath("SKILL.md").write_text("external content\n", encoding="utf-8")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["conflicts"][0]["code"] == "external_install_detected"
+    assert external.joinpath("SKILL.md").read_text(encoding="utf-8") == "external content\n"
+
+
+def test_install_skills_is_idempotent_for_same_managed_version(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["reason"] == "already_installed"
+
+
+def test_install_skills_preserves_modified_managed_install(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    skill_file = target / "nvflare-test-skill" / "SKILL.md"
+    skill_file.write_text(skill_file.read_text(encoding="utf-8") + "\n# User Edit\n", encoding="utf-8")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "local_modifications_detected"
+    assert plan["conflicts"][0]["code"] == "local_modifications_detected"
+    assert "# User Edit" in skill_file.read_text(encoding="utf-8")
+
+
+def test_install_skills_replaces_unmodified_managed_install_with_backup(tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    skill_plan = plan["skills"][0]
+    assert skill_plan["action"] == "replace"
+    assert skill_plan["status"] == "replaced"
+    assert skill_plan["version_delta"] == "update"
+    assert "Second Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    backup_runs = list((target / ".nvflare_bak").iterdir())
+    assert len(backup_runs) == 1
+    backup_file = backup_runs[0] / "nvflare-test-skill" / "SKILL.md"
+    assert "First Skill" in backup_file.read_text(encoding="utf-8")
+
+
+def test_install_skills_replace_copy_error_keeps_existing_install(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+    def copytree_with_failure(src, dst, *args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(skill_manager.shutil, "copytree", copytree_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "disk full",
+        }
+    ]
+    assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert not (target / ".nvflare_bak").exists()
+
+
+def test_install_skills_replace_publish_error_restores_existing_install(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+    def publish_with_failure(src, dst):
+        raise OSError("publish failed")
+
+    monkeypatch.setattr(skill_manager, "_publish_staged_skill", publish_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "publish failed",
+        }
+    ]
+    assert "First Skill" in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Second Skill" not in (target / "nvflare-test-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert not any((target / ".nvflare_bak").iterdir())
+
+
+def test_install_skills_replace_reports_publish_error_when_recovery_fails(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill", heading="First Skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+
+    _write_skill(root, "nvflare-test-skill", heading="Second Skill")
+    updated_source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    real_move = shutil.move
+
+    def publish_with_failure(src, dst):
+        raise OSError("publish failed")
+
+    def move_with_recovery_failure(src, dst, *args, **kwargs):
+        if ".nvflare_bak" in Path(src).parts:
+            raise OSError("restore failed")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(skill_manager, "_publish_staged_skill", publish_with_failure)
+    monkeypatch.setattr(skill_manager.shutil, "move", move_with_recovery_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=updated_source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "publish failed",
+            "recovery_error": {"type": "OSError", "message": "restore failed"},
+        }
+    ]
+    assert not (target / "nvflare-test-skill").exists()
+    assert any((target / ".nvflare_bak").iterdir())
+
+
+def test_install_skills_reports_copy_error_and_continues(monkeypatch, tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-a-skill")
+    _write_skill(root, "nvflare-failing-skill")
+    _write_skill(root, "nvflare-z-skill")
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+    real_copytree = shutil.copytree
+
+    def copytree_with_failure(src, dst, *args, **kwargs):
+        if src.name == "nvflare-failing-skill":
+            raise OSError("disk full")
+        return real_copytree(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(skill_manager.shutil, "copytree", copytree_with_failure)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == [
+        {
+            "skill": "nvflare-failing-skill",
+            "code": "skill_install_failed",
+            "type": "OSError",
+            "message": "disk full",
+        }
+    ]
+    assert (target / "nvflare-a-skill" / "SKILL.md").is_file()
+    assert not (target / "nvflare-failing-skill").exists()
+    assert (target / "nvflare-z-skill" / "SKILL.md").is_file()
+
+
+def test_install_skills_fails_when_same_skill_install_lock_exists(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / ".nvflare-test-skill.install.lock").mkdir()
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is False
+    assert plan["errors"][0]["type"] == "FileExistsError"
+    assert "already being installed" in plan["errors"][0]["message"]
+    assert not (target / "nvflare-test-skill").exists()
+
+
+def test_install_skills_recovers_stale_install_lock(monkeypatch, tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+    lock = target / ".nvflare-test-skill.install.lock"
+    lock.mkdir()
+    stale_time = 1_000_000
+    os.utime(lock, (stale_time, stale_time))
+    monkeypatch.setenv("NVFLARE_AGENT_SKILL_INSTALL_LOCK_TTL_SECONDS", "1")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["status"] == "installed"
+    assert (target / "nvflare-test-skill" / "SKILL.md").is_file()
+    assert not lock.exists()
+
+
+def test_install_skills_recovers_stale_install_lock_from_timestamp(monkeypatch, tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+    lock = target / ".nvflare-test-skill.install.lock"
+    lock.mkdir()
+    lock.joinpath(INSTALL_LOCK_TIMESTAMP_FILE_NAME).write_text("0", encoding="utf-8")
+    monkeypatch.setenv("NVFLARE_AGENT_SKILL_INSTALL_LOCK_TTL_SECONDS", "1")
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["skills"][0]["status"] == "installed"
+    assert (target / "nvflare-test-skill" / "SKILL.md").is_file()
+    assert not lock.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_dry_run_reports_source_symlink_conflict(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["applied"] is False
+    assert plan["errors"] == []
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "source_symlink_detected"
+    assert plan["skills"][0]["files"] == []
+    assert plan["skills"][0]["source_issue"]["symlink_path"] == str(skill_dir / "outside-link.txt")
+    assert plan["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "source_symlink_detected",
+            "message": "source skill directory contains a symlink",
+            "source_path": str(skill_dir),
+            "symlink_path": str(skill_dir / "outside-link.txt"),
+        }
+    ]
+    assert not (target / "nvflare-test-skill").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_skips_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert plan["errors"] == []
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["status"] == "skipped"
+    assert plan["conflicts"][0]["code"] == "source_symlink_detected"
+    assert not (target / "nvflare-test-skill").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_stage_skill_rejects_source_symlink_before_copytree(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    skill_dir.joinpath("outside-link.txt").symlink_to(outside_file)
+    source = SkillSource(source_type="editable", root=root, manifest={})
+
+    with pytest.raises(ValueError, match="skill source must not contain symlinks"):
+        skill_manager._stage_skill(
+            skill_dir,
+            tmp_path / "staged",
+            {"name": "nvflare-test-skill", "source_hash": "fake-source-hash"},
+            source,
+            installed_path=tmp_path / "target" / "nvflare-test-skill",
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_source_symlink_root_conflict(tmp_path):
+    actual_root = tmp_path / "actual-skills"
+    skill_dir = _write_skill(actual_root, "nvflare-test-skill")
+    root = tmp_path / "skills"
+    root.mkdir()
+    source_link = root / "nvflare-test-skill"
+    source_link.symlink_to(skill_dir, target_is_directory=True)
+    source = SkillSource(
+        source_type="editable",
+        root=root,
+        manifest={
+            "schema_version": "1",
+            "source_type": "editable",
+            "nvflare_version": "2.8.0",
+            "skills": [
+                {
+                    "name": "nvflare-test-skill",
+                    "skill_version": "0.0.0",
+                    "source_hash": "fake-source-hash",
+                    "relative_path": "nvflare-test-skill",
+                }
+            ],
+            "findings": [],
+        },
+    )
+
+    plan = install_skills(agent="codex", target_dir=tmp_path / "target", source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "source_symlink_detected"
+    assert plan["conflicts"][0]["symlink_path"] == str(source_link)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_stage_skill_rejects_source_symlink_root(tmp_path):
+    actual_root = tmp_path / "actual-skills"
+    skill_dir = _write_skill(actual_root, "nvflare-test-skill")
+    source_link = tmp_path / "nvflare-test-skill"
+    source_link.symlink_to(skill_dir, target_is_directory=True)
+    source = SkillSource(source_type="editable", root=tmp_path, manifest={})
+
+    with pytest.raises(ValueError, match="skill source must not contain symlinks"):
+        skill_manager._stage_skill(
+            source_link,
+            tmp_path / "staged",
+            {"name": "nvflare-test-skill", "source_hash": "fake-source-hash"},
+            source,
+            installed_path=tmp_path / "target" / "nvflare-test-skill",
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_installed_skill_nested_symlink_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content\n", encoding="utf-8")
+    symlink = target / "nvflare-test-skill" / "outside-link.txt"
+    symlink.symlink_to(outside_file)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "target_symlink_detected"
+    assert plan["skills"][0]["target_issue"]["symlink_path"] == str(symlink)
+    assert plan["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "target_symlink_detected",
+            "message": "target skill directory contains a symlink",
+            "target_path": str(target / "nvflare-test-skill"),
+            "symlink_path": str(symlink),
+        }
+    ]
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are not supported on this platform")
+def test_install_skills_reports_installed_skill_root_symlink_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    installed_skill = target / "nvflare-test-skill"
+    actual_skill = tmp_path / "actual-installed-skill"
+    shutil.move(installed_skill, actual_skill)
+    installed_skill.symlink_to(actual_skill, target_is_directory=True)
+
+    plan = install_skills(agent="codex", target_dir=target, source=source, dry_run=True)
+
+    assert plan["skills"][0]["action"] == "skip"
+    assert plan["skills"][0]["conflict"] == "target_symlink_detected"
+    assert plan["conflicts"][0]["symlink_path"] == str(installed_skill)
+
+
+def test_list_skills_reports_available_installed_and_ignores_unrelated_external_skills(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    install_skills(agent="codex", target_dir=target, source=source)
+    (target / "external-skill").mkdir()
+
+    data = list_skills(agent="codex", target_dir=target, source=source)
+
+    assert data["available"][0]["name"] == "nvflare-test-skill"
+    assert data["installed"][0]["name"] == "nvflare-test-skill"
+    assert data["conflicts"] == []
+
+
+def test_list_skills_flags_name_overlap_external_skill_as_conflict(tmp_path):
+    source = _skill_source(tmp_path)
+    target = tmp_path / "target"
+    external = target / "nvflare-test-skill"
+    external.mkdir(parents=True)
+    external.joinpath("SKILL.md").write_text("external content\n", encoding="utf-8")
+
+    data = list_skills(agent="codex", target_dir=target, source=source)
+
+    assert data["installed"] == []
+    assert data["conflicts"] == [
+        {
+            "skill": "nvflare-test-skill",
+            "code": "external_install_detected",
+            "message": "target skill directory is not managed by nvflare",
+            "target_path": str(external),
+        }
+    ]
+
+
+def test_conflict_falls_back_to_code_for_unknown_conflict(tmp_path):
+    conflict = skill_manager._conflict("nvflare-test-skill", "future_conflict", tmp_path / "target")
+
+    assert conflict["code"] == "future_conflict"
+    assert conflict["message"] == "future_conflict"
+
+
+def _skill_source(tmp_path):
+    root = tmp_path / "skills"
+    _write_skill(root, "nvflare-test-skill")
+    return SkillSource(
+        source_type="editable",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="editable", nvflare_version="2.8.0"),
+    )
+
+
+def _write_skill(root, name, heading="Test Skill"):
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill fixture.\n"
+        'min_flare_version: "2.8.0"\n'
+        "blast_radius: read_only\n"
+        "---\n"
+        "\n"
+        f"# {heading}\n",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/tests/unit_test/tool/cli_invalid_args_json_test.py
+++ b/tests/unit_test/tool/cli_invalid_args_json_test.py
@@ -58,6 +58,9 @@ def test_invalid_subcommand_json_error(capsys, monkeypatch):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload["error_code"] == "INVALID_ARGS"
+    assert "code" not in payload
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert "usage" in payload["data"]
     assert "list" in payload["data"]["choices"]
 
@@ -106,7 +109,7 @@ def test_jsonl_rejected_for_non_streaming_command(capsys, monkeypatch):
     assert exc_info.value.code == 4
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["event"] == "terminal"
-    assert payload["terminal"] is True
+    assert "event" not in payload
+    assert "terminal" not in payload
     assert payload["error_code"] == "INVALID_ARGS"
     assert "nvflare job monitor" in payload["message"]

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -218,27 +218,6 @@ class TestOutputOk:
         except (json.JSONDecodeError, ValueError):
             pass
 
-    def test_json_mode_redacts_sensitive_data(self, capsys, monkeypatch):
-        monkeypatch.setattr(cli_output, "_output_format", "json")
-        output_ok(
-            {
-                "user": "admin",
-                "password": "pw123",
-                "nested": {"api_key": "api-secret"},
-                "message": "Authorization: Bearer bearer-secret",
-                "retry_token": {"supported": False},
-                "credential_revoked": False,
-            }
-        )
-        captured = capsys.readouterr()
-        envelope = json.loads(captured.out)
-        assert envelope["data"]["user"] == "admin"
-        assert envelope["data"]["password"] == "<redacted>"
-        assert envelope["data"]["nested"]["api_key"] == "<redacted>"
-        assert envelope["data"]["message"] == "Authorization: Bearer <redacted>"
-        assert envelope["data"]["retry_token"] == {"supported": False}
-        assert envelope["data"]["credential_revoked"] is False
-
 
 # --- output_error_message() tests: explicit message/hint/fmt) ---
 
@@ -306,21 +285,6 @@ class TestOutputErrorCertPackage:
         assert result["status"] == "error"
         assert result["terminal"] is True
         assert result["error_code"] == "MY_CODE"
-
-    def test_error_message_redacts_sensitive_detail_text(self, capsys):
-        with pytest.raises(SystemExit):
-            output_error_message("MY_CODE", "Request failed", None, None, detail="password=secret")
-        captured = capsys.readouterr()
-        assert "password=<redacted>" in captured.err
-        assert "secret" not in captured.err
-
-    def test_error_message_json_redacts_private_key_block(self, capsys):
-        private_key = "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"
-        with pytest.raises(SystemExit):
-            output_error_message("MY_CODE", private_key, None, "json")
-        captured = capsys.readouterr()
-        payload = json.loads(captured.out)
-        assert payload["message"] == "<redacted>"
 
 
 class TestOutputUsageError:
@@ -398,28 +362,6 @@ class TestOutputErrorWithData:
             output_error_message("MY_CODE", "msg", "hint", "json")
         assert exc_info.value.code == 1
 
-    def test_json_error_redacts_sensitive_data_and_detail(self, capsys, monkeypatch):
-        monkeypatch.setattr(cli_output, "_output_format", "json")
-        with pytest.raises(SystemExit):
-            output_error(
-                "INTERNAL_ERROR",
-                detail="access_token=token-secret",
-                data={"session_token": "session-secret", "job_id": "abc123"},
-            )
-        payload = json.loads(capsys.readouterr().out)
-        assert "access_token=<redacted>" in payload["message"]
-        assert "token-secret" not in payload["message"]
-        assert payload["data"] == {"session_token": "<redacted>", "job_id": "abc123"}
-
-    def test_human_error_redacts_sensitive_data(self, capsys, monkeypatch):
-        monkeypatch.setattr(cli_output, "_output_format", "txt")
-        with pytest.raises(SystemExit):
-            output_error("INTERNAL_ERROR", data={"password": "pw123", "job_id": "abc123"})
-        captured = capsys.readouterr()
-        assert "password: <redacted>" in captured.out
-        assert "pw123" not in captured.out
-        assert "job_id: abc123" in captured.out
-
 
 # --- output_error() tests: Phase 0+1 pattern (ERROR_REGISTRY lookup) ---
 
@@ -439,6 +381,23 @@ class TestOutputError:
         assert envelope["error_code"] == "CONNECTION_FAILED"
         assert "message" in envelope
         assert "hint" in envelope
+
+    def test_error_envelope_supports_agent_fields(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli_output, "_output_format", "json")
+
+        with pytest.raises(SystemExit) as exc_info:
+            output_error(
+                "CONNECTION_FAILED",
+                recovery_category="RETRYABLE",
+                suggested_skill="nvflare-diagnose-job",
+            )
+
+        assert exc_info.value.code == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["error_code"] == "CONNECTION_FAILED"
+        assert "code" not in envelope
+        assert envelope["recovery_category"] == "RETRYABLE"
+        assert envelope["suggested_skill"] == "nvflare-diagnose-job"
 
     def test_custom_exit_code(self, capsys, monkeypatch):
         monkeypatch.setattr(cli_output, "_output_format", "json")
@@ -510,21 +469,3 @@ class TestOutputError:
         captured = capsys.readouterr()
         assert "TIMEOUT" in captured.err
         assert captured.out == ""
-
-
-class TestSensitiveOutputRedaction:
-    def test_output_json_redacts_sensitive_fields(self, capsys):
-        output({"credential": "cred-secret", "status": "ok"}, "json")
-        payload = json.loads(capsys.readouterr().out)
-        assert payload["data"] == {"credential": "<redacted>", "status": "ok"}
-
-    def test_jsonl_event_redacts_sensitive_fields(self, capsys):
-        output_jsonl_event({"event": "progress", "private_key": "key-secret"})
-        payload = json.loads(capsys.readouterr().out)
-        assert payload["private_key"] == "<redacted>"
-
-    def test_print_human_redacts_sensitive_inline_text(self, capsys):
-        print_human("failed with api_key=api-secret")
-        captured = capsys.readouterr()
-        assert "api_key=<redacted>" in captured.out
-        assert "api-secret" not in captured.out


### PR DESCRIPTION
## Summary

Adds the public NVFLARE agent CLI surface on top of the bundled agent skills, including schema handling, command registration, skill lifecycle commands, and command-level tests.

## Key Scope

- Add the `nvflare agent` command group and `nvflare agent skills` subcommands.
- Add skill discovery/list/install/export behavior through the CLI.
- Add CLI schema behavior for supported commands without exposing removed benchmark/performance commands.
- Add command-level unit tests for the agent CLI contract and error handling.
- Update design/implementation docs for the supported CLI surface.

## Review Notes

This PR depends on the agent skills/checks foundation from PR #4787. It intentionally does not include benchmark Docker/runtime/reporting code; the benchmark harness is split into PRs 3-5.

## Stack

This is PR 2 of 5. It is based on `flare-agent-split/01-agent-skills` / PR #4787.

## Full Split Plan

| PR | Title | Branch | Base | Non-Test Files | Test Files | Non-Test Lines | Test Lines | Total Lines |
|---:|---|---|---|---:|---:|---:|---:|---:|
| 1 | Agent Skills + Checks | `flare-agent-split/01-agent-skills` | `main` | 41 | 8 | 5,397 | 1,321 | 6,718 |
| 2 | Agent CLI | `flare-agent-split/02-agent-cli` | PR 1 | 11 | 8 | 4,362 | 2,488 | 6,850 |
| 3 | Benchmark Docker Setup | `flare-agent-split/03-benchmark-docker-setup` | PR 2 | 29 | 3 | 4,015 | 1,417 | 5,432 |
| 4 | Skill Benchmark Runtime | `flare-agent-split/04-benchmark-runtime` | PR 3 | 25 | 5 | 9,927 | 3,654 | 13,581 |
| 5 | Benchmark Reporting | `flare-agent-split/05-benchmark-reporting` | PR 4 | 3 | 1 | 2,016 | 1,037 | 3,053 |

## Validation

- `python -m pytest tests/unit_test/tool/agent tests/unit_test/tool/agent_skill_checks tests/unit_test/skills_benchmark`
- `./runtest.sh -s`