### PR TITLE
Add skills benchmark runtime

### DIFF
--- a/assist_tools/skills_benchmark/README.md
+++ b/assist_tools/skills_benchmark/README.md
@@ -1,0 +1,658 @@
+# Agent Skills Benchmark Harness
+
+This harness runs agent CLIs in Docker and compares the same unstructured
+NVFLARE job-conversion task with and without packaged NVFLARE agent skills.
+
+Current runnable scope:
+
+- Agents: Codex and Claude. Claude requires an explicit `--model`.
+- Modes: `without_skills` and `with_skills`.
+- Job input: a folder containing scripts, data, docs, and any local
+  requirements files.
+- Prompt input: a local prompt file for direct runs, or a scenario prompt file/template.
+- Scenario input: optional YAML compiled into `scenario.json` and
+  `run_plan.json`.
+- Results: written under `assist_tools/skills_benchmark/results/` by default.
+
+There is no runtime evaluator mode. The harness measures what the agent does
+and reports normalized evidence from the run.
+
+## Quick Start
+
+From the NVFLARE checkout:
+
+```bash
+cd assist_tools/skills_benchmark
+./bin/build.sh
+./bin/run.sh pair --prompt /path/to/prompt.txt /path/to/job-folder
+```
+
+The paired run creates a timestamped result directory:
+
+```text
+results/<timestamp>/
+|-- scenario.json
+|-- run_plan.json
+|-- scenario_summary.json
+|-- reports/
+|   |-- scenario_report.json
+|   `-- scenario_report.md
+|-- records/
+|   `-- agent=.../model=.../workflow=.../job=.../mode=.../
+```
+
+Read `reports/scenario_report.md` first. It summarizes scenario status,
+aggregate timing, quality-gate results, and the selected winner policy.
+
+## Prerequisites
+
+Install or configure these on the host:
+
+- Docker.
+- Python 3.
+- `uv`, unless the SDK profile provides existing wheel files.
+- Codex authentication through `~/.codex/auth.json` and
+  `~/.codex/config.toml`, or `OPENAI_API_KEY`.
+
+By default, the harness mounts Codex auth/config files read-only into the
+container. To use an API key instead:
+
+```bash
+OPENAI_API_KEY="$OPENAI_API_KEY" \
+  ./bin/run.sh pair --prompt /path/to/prompt.txt /path/to/job-folder
+```
+
+To use a non-default Codex auth/config directory:
+
+```bash
+./bin/run.sh pair \
+  --agent-home /path/to/codex-home \
+  --prompt /path/to/prompt.txt \
+  /path/to/job-folder
+```
+
+To disable host agent auth/config mounting:
+
+```bash
+./bin/run.sh pair \
+  --no-agent-auth-mount \
+  --prompt /path/to/prompt.txt \
+  /path/to/job-folder
+```
+
+## Build Images
+
+Build the two Docker images:
+
+```bash
+cd assist_tools/skills_benchmark
+./bin/build.sh
+```
+
+The build creates:
+
+- `agent-skills-benchmark:codex-baseline`
+- `agent-skills-benchmark:codex-skills`
+
+Both images install the selected benchmark SDK from the SDK profile. The
+default profile is `nvflare-profile`; the default agent profile is `codex`.
+The baseline image uses the SDK profile's baseline wheel variant; the skills
+image uses the skills wheel variant and runs the profile-declared skills
+setup mode.
+
+Select another supported agent profile:
+
+```bash
+./bin/build.sh --agent-profile claude
+```
+
+Use a custom profile file:
+
+```bash
+./bin/build.sh \
+  --sdk-profile /path/to/sdk-profile.yaml \
+  --agent-profile /path/to/agent-profile.yaml
+```
+
+For a repo-backed SDK build, set the SDK profile source:
+
+```yaml
+source:
+  type: repo
+  path: /path/to/sdk-checkout
+  markers:
+    - pyproject.toml
+build:
+  type: uv_wheel
+```
+
+For wheel-provided SDK images, set `source.type: wheels` and
+`build.type: provided_wheels`. In this mode `build.sh` stages the listed wheels
+and does not need the SDK repo or `uv`:
+
+```yaml
+source:
+  type: wheels
+  wheels:
+    skills: /path/to/sdk-with-skills.whl
+    baseline: /path/to/sdk-baseline.whl
+build:
+  type: provided_wheels
+```
+
+SDK skills setup is explicit in the same profile. Use `command` when the SDK
+has a CLI installer:
+
+```yaml
+skills:
+  setup:
+    type: command
+    install_command: sdk-cli skills install --agent "${BENCHMARK_DOCKER_AGENT}" --target "${BENCHMARK_AGENT_HOME}/skills"
+    list_command: sdk-cli skills list --agent "${BENCHMARK_DOCKER_AGENT}" --target "${BENCHMARK_AGENT_HOME}/skills"
+```
+
+Use `copy` when the SDK provides a skills folder directly. `build.sh` stages
+that folder into the Docker build context, and the image copies it into the
+selected agent profile home under `skills/`:
+
+```yaml
+skills:
+  setup:
+    type: copy
+    source_path: /path/to/sdk/agent-skills
+    expected_source: profile_skills_folder
+```
+
+Agent CLI versions and image names live in the agent profile:
+
+```yaml
+images:
+  skills: agent-skills-benchmark:{agent}-skills
+  baseline: agent-skills-benchmark:{agent}-baseline
+  report: agent-skills-benchmark:{agent}-skills
+
+build:
+  args:
+    BENCHMARK_DOCKER_AGENT: codex
+    BENCHMARK_AGENT_HOME: /workspace/.codex
+    AGENT_CLI_NAME: codex
+    AGENT_INSTALL_COMMAND: npm install -g "@openai/codex@0.137.0"
+    AGENT_VERSION_COMMAND: codex --version
+```
+
+Useful build flags:
+
+```bash
+./bin/build.sh --no-cache
+./bin/build.sh --skip-baseline-image
+./bin/build.sh --skip-skills-image
+./bin/build.sh --node-image node:22.16.0-bookworm-slim
+./bin/build.sh --uv-image ghcr.io/astral-sh/uv:0.11.19
+```
+
+Verify the images exist:
+
+```bash
+docker image ls 'agent-skills-benchmark'
+```
+
+Verify the default NVFlare SDK and packaged skills in the skills image:
+
+```bash
+docker run --rm agent-skills-benchmark:codex-skills \
+  /bin/bash -lc 'nvflare --version; nvflare --format json agent skills list --agent codex'
+```
+
+The images do not install job-specific training dependencies. Installing
+requirements from the job folder is part of the measured agent behavior.
+
+## Add Another SDK
+
+Add one SDK profile file:
+
+```text
+assist_tools/skills_benchmark/config/sdks/<sdk-profile>.yaml
+```
+
+The YAML declares the SDK package/import names, source, skills and baseline
+wheel variants, and `skills.setup`. `build.type: uv_wheel` builds wheels from a
+repo source. `build.type: provided_wheels` stages the exact wheel paths from a
+wheels source and skips SDK building. `skills.setup.type` must be `command`,
+`copy`, or `none`.
+Then build with:
+
+```bash
+./bin/build.sh --sdk-profile <sdk-profile>
+```
+
+Run the benchmark tests after adding the plugin:
+
+```bash
+python -m pytest tests/unit_test/skills_benchmark
+```
+
+## Prompt Inputs
+
+The prompt is not committed to git and is not baked into Docker images. Pass it
+at run time for direct `pair`, `one`, and `interactive` runs:
+
+```bash
+./bin/run.sh pair --prompt ./prompt.txt /path/to/job-folder
+```
+
+Inside the container:
+
+- The job folder is mounted read-only at `/workspace/input`.
+- The prompt file is mounted read-only at
+  `/workspace/prompts/benchmark_prompt.txt`.
+- The result directory is mounted at `/workspace/results`.
+
+The harness copies the prompt verbatim. It does not append mode names, workflow
+instructions, record paths, or skill instructions. The prompt should describe
+the conversion task and ask the agent to report final artifacts, validation
+steps, and any validation metric requested by the job documentation.
+
+Scenario YAML may also use prompt templates:
+
+```yaml
+prompt:
+  path: prompt_template.txt
+  variables:
+    job_name: ames
+```
+
+Only explicitly declared scalar variables are substituted. Missing variables,
+unused variables, attribute/index access, and format conversions fail scenario
+validation. Template variables do not authorize hidden mode, workflow, metric,
+record-path, or skill-hint injection. Compared mode legs receive identical
+rendered prompt bytes, and rendered prompts are materialized under the result
+root, not in the scenario source directory.
+
+Example prompt:
+
+```text
+Convert the training job in /workspace/input into an exportable NVFLARE job.
+Use the workflow requested by the job documentation when it is clear.
+Install job dependencies from requirements files when needed.
+Run cheap validation before full simulation, then report final artifact paths
+and validation metrics.
+```
+
+## Run A Pair
+
+Run both modes sequentially:
+
+```bash
+./bin/run.sh pair --prompt ./prompt.txt /path/to/job-folder
+```
+
+Equivalent explicit job-folder option:
+
+```bash
+./bin/run.sh pair --prompt ./prompt.txt --training-code /path/to/job-folder
+```
+
+Set the parent directory for timestamped results:
+
+```bash
+./bin/run.sh pair \
+  --prompt ./prompt.txt \
+  --results-root /path/to/results \
+  /path/to/job-folder
+```
+
+Write a comparison to an exact directory:
+
+```bash
+./bin/run.sh pair \
+  --prompt ./prompt.txt \
+  --output-dir /path/to/exact-result-dir \
+  /path/to/job-folder
+```
+
+Select a Codex model:
+
+```bash
+./bin/run.sh pair \
+  --model <model-name> \
+  --prompt ./prompt.txt \
+  /path/to/job-folder
+```
+
+Select Claude:
+
+```bash
+./bin/run.sh pair \
+  --agent claude \
+  --model <model-name> \
+  --prompt ./prompt.txt \
+  /path/to/job-folder
+```
+
+`--agent` defaults to `codex`. Known but unimplemented agents such as Hermes
+and OpenClaw fail during build/run preflight.
+
+`pair` is a shortcut over the scenario/run-plan execution path. It writes the
+same canonical scenario records as `scenario`.
+
+## Run A Scenario
+
+Scenario YAML files describe agents, models, workflows, jobs, and comparison
+type. The harness compiles them into `scenario.json` and `run_plan.json`
+before Docker execution:
+
+```bash
+./bin/run.sh scenario /path/to/scenario.yaml --output-dir /path/to/result-root
+```
+
+Minimal skills-vs-baseline scenario:
+
+```yaml
+name: ames mode ablation
+
+prompt: ./prompt.txt
+fail_fast: false
+
+agents:
+  - name: codex
+    models:
+      - "<model-name>"
+
+workflows:
+  - name: fedavg
+
+jobs:
+  - name: ames
+    path: /path/to/job-folder
+    scale: small
+
+comparison:
+  type: mode_ablation
+  modes:
+    - without_skills
+    - with_skills
+```
+
+For Claude, set `agents[0].name` to `claude` and provide a model. For a model
+comparison, keep one agent and use `comparison.type: model_comparison` with a
+`comparison.models` list.
+
+Save the YAML above as a local scenario file, edit `prompt` and `jobs[].path`,
+then pass it to `scenario`.
+
+The scenario command writes:
+
+```text
+result-root/
+|-- scenario.json
+|-- run_plan.json
+|-- scenario_summary.json
+|-- reports/
+|   |-- scenario_report.json
+|   `-- scenario_report.md
+`-- records/
+    `-- agent=<agent>/model=<model>/workflow=<workflow>/job=<job>/mode=<mode>/
+```
+
+Each mode directory contains direct canonical artifacts such as
+`record_summary.json`, `agent_events.jsonl`, `agent_usage.json`,
+`agent_activity.json`, `agent_last_message.txt`, `agent_stderr.txt`,
+`agent_record.json`, and `benchmark_record.json`.
+
+## Replay Captured Results
+
+Use `replay` to regenerate parser artifacts, scenario
+summaries, and scenario reports from an existing result root without invoking a
+live agent or Docker:
+
+```bash
+./bin/run.sh replay /path/to/result-root
+```
+
+Replay requires a `run_plan.json` in the result root and captured
+`agent_events.jsonl` files under the canonical records tree.
+
+## Run One Mode
+
+Use the shortcuts:
+
+```bash
+./bin/run.sh without-skills --prompt ./prompt.txt /path/to/job-folder
+./bin/run.sh with-skills --prompt ./prompt.txt /path/to/job-folder
+```
+
+Or use `one` with an explicit mode:
+
+```bash
+./bin/run.sh one --mode without_skills --prompt ./prompt.txt /path/to/job-folder
+./bin/run.sh one --mode with_skills --prompt ./prompt.txt /path/to/job-folder
+```
+
+For a single run, `--output-dir` maps to the exact mode result directory:
+
+```bash
+./bin/run.sh one \
+  --mode with_skills \
+  --prompt ./prompt.txt \
+  --output-dir /path/to/exact-mode-result \
+  /path/to/job-folder
+```
+
+The harness derives skill exposure from the selected mode.
+
+## Interactive Container
+
+Use `interactive` to inspect the runtime image, auth mounts, or job input:
+
+```bash
+./bin/run.sh interactive --prompt ./prompt.txt /path/to/job-folder
+```
+
+Useful checks inside the container:
+
+```bash
+python --version
+uv --version
+nvflare --version
+nvflare --format json agent skills list --agent codex
+ls -la /workspace/input
+ls -la /workspace/prompts
+```
+
+## Result Layout
+
+Each scenario mode directory contains the normalized run artifacts:
+
+```text
+records/agent=<agent>/model=<model>/workflow=<workflow>/job=<job>/mode=with_skills/
+|-- agent_activity.json
+|-- agent_events.jsonl
+|-- agent_record.json
+|-- agent_last_message.txt
+|-- agent_stderr.txt
+|-- agent_usage.json
+|-- benchmark_record.json
+|-- container_exit_code.json
+|-- prompt.txt
+|-- prompt_metadata.json
+|-- records/
+|   |-- with_skills_agent_record.json
+|   `-- with_skills_record.json
+|-- record_summary.json
+|-- run_summary.json
+|-- timing.json
+|-- workspace_delta/
+`-- workspace_delta_manifest.json
+```
+
+`without_skills` has the same shape with `without_skills` record names.
+
+The paired result root contains canonical scenario files:
+
+```text
+results/<timestamp>/
+|-- console_output.log
+|-- host_report_status.json
+|-- scenario.json
+|-- run_plan.json
+|-- scenario_summary.json
+|-- reports/
+|   |-- scenario_report.json
+|   `-- scenario_report.md
+`-- records/
+```
+
+For Codex compatibility, the harness also writes aliases such as
+`codex_events.jsonl`, `codex_usage.json`, and `codex_last_message.txt`.
+
+## Reading Results
+
+Start with these files:
+
+- `reports/scenario_report.md`: human-readable scenario status, aggregate
+  results, quality-gate status, and winner policy.
+- `scenario_summary.json`: machine-readable scenario, comparison, and aggregate
+  summaries.
+- `records/.../mode=<mode>/record_summary.json`: normalized per-run metrics,
+  exit codes, prompt hash, and quality signals.
+- `records/.../mode=<mode>/agent_last_message.txt`: final agent response.
+- `records/.../mode=<mode>/agent_stderr.txt`: agent stderr.
+- `records/.../mode=<mode>/workspace_delta/`: generated files retained for
+  review.
+- `console_output.log`: complete host-side console log for paired runs.
+
+When a case fails, look for:
+
+- `records/.../mode=<mode>/early_failure.json`
+- `records/.../mode=<mode>/late_harness_failure.json`
+- `records/.../mode=<mode>/container_exit_code.json`
+- `records/.../mode=<mode>/agent_stderr.txt`
+- `records/.../mode=<mode>/agent_last_message.txt`
+
+## Configuration Inputs
+
+Use CLI flags for normal runs:
+
+| Input | Purpose |
+| --- | --- |
+| `--agent` | Agent profile to run. Defaults to `codex`. |
+| `--model` | Agent model to run. Required for agents without a default model. |
+| `--workflow` | Workflow label written into scenario records. Defaults to `default`. |
+| `--job-scale` | Resource policy size for direct `pair`/`one` runs: `small`, `medium`, or `large`. |
+| `--agent-home` | Host auth/config directory for the selected agent. Defaults come from the agent profile. |
+| `--no-agent-auth-mount` | Disable mounting host auth/config files for the selected agent. |
+| `--results-root` | Parent directory for timestamped result directories. |
+| `--output-dir` | Exact output directory for this run or comparison. |
+| `--sdk-profile` | SDK build profile for `bin/build.sh`. Defaults to `nvflare-profile`. |
+| `--agent-profile` | Agent build profile for `bin/build.sh`. Defaults to `codex`. |
+
+Use environment variables only for provider-native credentials or compatibility
+with older scripts:
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENAI_API_KEY` | Optional Codex API key passed through to the container. |
+| `ANTHROPIC_API_KEY` | Optional Claude API key passed through to the container. |
+| `ANTHROPIC_AUTH_TOKEN` | Optional Claude auth token passed through to the container. |
+
+Compatibility fallbacks such as `BENCHMARK_AGENT`, `BENCHMARK_AGENT_MODEL`,
+`MODE`, `JOB_INPUT_DIR`, `TRAINING_CODE`, `RESULT_ROOT`, and `RESULT_DIR` still
+exist for existing automation. Prefer the CLI flags above for new usage.
+New agent profiles should add provider-native credential passthrough names only
+when the agent CLI requires them; they should not introduce new harness
+variables for auth directory or auth mounting.
+
+## Troubleshooting
+
+Missing Docker images:
+
+```text
+Benchmark Docker image(s) are missing locally
+```
+
+Run:
+
+```bash
+./bin/build.sh
+docker image ls 'agent-skills-benchmark'
+```
+
+Prompt missing:
+
+```text
+Prompt file is required
+```
+
+Create a local prompt file and pass `--prompt /path/to/prompt.txt`. The harness
+does not use a repository prompt by default.
+
+Unsupported model:
+
+```text
+The '<model>' model is not supported
+```
+
+Pass `--model` with a model available to the account used by the selected
+agent.
+
+Auth missing:
+
+```text
+Codex auth not mounted
+Codex config not mounted
+```
+
+Check `--agent-home`, `~/.codex/auth.json`, and `~/.codex/config.toml`, or pass
+`OPENAI_API_KEY`. Use `interactive` to inspect the container environment.
+
+No report generated:
+
+Check these files in the result root:
+
+- `host_report_status.json`
+- `console_output.log`
+
+No validation metric in reports:
+
+The report extracts metrics from agent evidence. If the agent final message or
+record does not expose the requested scalar metric, the report shows `NA`
+instead of inventing a value.
+
+Slow skills run:
+
+Compare `phase_seconds.agent_elapsed_seconds`, `activity.command_count`,
+`activity.command_prefix_counts`, and `activity.hint_counts` in each
+`run_summary.json`. Skill installation happens at image-build time, not during
+the measured agent run.
+
+Job dependency failure:
+
+Inspect `records/.../mode=<mode>/agent_last_message.txt`,
+`records/.../mode=<mode>/agent_stderr.txt`, and
+`records/.../mode=<mode>/workspace_delta/`. The prompt should instruct the
+agent to install job dependencies from available requirements files when needed.
+
+## Harness Modules
+
+- `bin/build.sh`: thin wrapper around `assist_tools.skills_benchmark.skills.harness.host.build`.
+- `bin/run.sh`: thin wrapper around `assist_tools.skills_benchmark.skills.harness.host.runner`.
+- `docker/Dockerfile`: runtime image with the selected agent CLI and SDK wheel.
+- `config/agents/`: built-in editable agent CLI configs.
+- `config/sdks/`: built-in editable SDK build/install configs.
+- `skills/harness/scenarios.py`: scenario validation, run-plan expansion, and
+  scenario reports.
+- `skills/harness/host/`: Docker orchestration, path handling, image selection, and
+  scenario execution.
+- `skills/harness/container/`: in-container agent execution and artifact capture.
+- `skills/harness/sdks/`: SDK config loader and adapter interfaces.
+- `skills/harness/artifacts.py`, `events.py`, `records.py`, `timing.py`, and
+  `quality_signals.py`: normalized measurement semantics.
+- `skills/harness/reports/`: scenario report helpers and structure rendering.
+
+## Current Limits
+
+- Codex and Claude adapters are implemented. Hermes and OpenClaw are registered
+  as known-pending adapters.
+- The harness does not require or validate a structured job schema.
+- The harness does not infer a framework or workflow from the job folder. The
+  prompt and job documentation define the requested task.

--- a/assist_tools/skills_benchmark/bin/run.sh
+++ b/assist_tools/skills_benchmark/bin/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [COMMAND] --prompt PATH [--training-code PATH] [--results-root PATH] [PATH]
+
+Commands:
+  pair             Run paired skills/no-skills benchmark cases. This is the default when COMMAND is omitted.
+  one              Run one benchmark case. Use --mode with_skills or without_skills.
+  scenario         Run a compiled scenario YAML.
+  replay           Rebuild parser artifacts and scenario reports from captured results.
+  interactive      Start an interactive benchmark container.
+  with-skills      Shortcut for: one --mode with_skills.
+  without-skills   Shortcut for: one --mode without_skills.
+
+Examples:
+  ./bin/run.sh --prompt /path/to/prompt.txt /path/to/job-folder
+  ./bin/run.sh pair --prompt /path/to/prompt.txt --training-code /path/to/job-folder
+  ./bin/run.sh pair --agent claude --model MODEL --prompt /path/to/prompt.txt /path/to/job-folder
+  ./bin/run.sh pair --agent-home /path/to/agent-home --prompt /path/to/prompt.txt /path/to/job-folder
+  ./bin/run.sh pair --no-agent-auth-mount --prompt /path/to/prompt.txt /path/to/job-folder
+  ./bin/run.sh pair --prompt /path/to/prompt.txt --results-root /path/to/results /path/to/job-folder
+  ./bin/run.sh pair --prompt /path/to/prompt.txt --output-dir /path/to/exact-run-dir /path/to/job-folder
+  ./bin/run.sh scenario /path/to/scenario.yaml --output-dir /path/to/exact-run-dir
+  ./bin/run.sh replay /path/to/existing-run-dir
+  ./bin/run.sh one --mode with_skills --prompt /path/to/prompt.txt /path/to/job-folder
+EOF
+}
+
+if [[ "$#" -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" ]]; then
+  command="$1"
+  shift
+elif [[ "$1" == -* ]]; then
+  command="pair"
+else
+  command="$1"
+  shift
+fi
+
+case "${command}" in
+  one|run-one|single)
+    exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner run-one "$@"
+    ;;
+  pair)
+    exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner pair "$@"
+    ;;
+  scenario)
+    exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner scenario "$@"
+    ;;
+  replay)
+    exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner replay "$@"
+    ;;
+  interactive|shell)
+    exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner interactive "$@"
+    ;;
+  with-skills)
+    MODE=with_skills USE_PREINSTALLED_SKILLS=true exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner run-one "$@"
+    ;;
+  without-skills)
+    MODE=without_skills USE_PREINSTALLED_SKILLS=false exec python3 -m assist_tools.skills_benchmark.skills.harness.host.runner run-one "$@"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: ${command}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/assist_tools/skills_benchmark/skills/harness/agent_run.py
+++ b/assist_tools/skills_benchmark/skills/harness/agent_run.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility entry point for the migrated container runner."""
+
+from __future__ import annotations
+
+from .container.agent_run import main
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/artifacts.py
+++ b/assist_tools/skills_benchmark/skills/harness/artifacts.py
@@ -1,0 +1,421 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Workspace artifact capture and bounded report artifact collection."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Iterable
+
+SOURCE_SUFFIXES = {
+    ".cfg",
+    ".ini",
+    ".json",
+    ".jsonl",
+    ".md",
+    ".py",
+    ".rst",
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+DELTA_SUFFIXES = SOURCE_SUFFIXES | {".log"}
+REPORT_SUFFIXES = DELTA_SUFFIXES
+SOURCE_NAMES = {"dockerfile", "makefile", "requirements.txt"}
+IGNORED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "__pycache__",
+    "data",
+    "env",
+    "node_modules",
+    "outputs",
+    "venv",
+}
+IGNORED_SUFFIXES = {".ckpt", ".npy", ".npz", ".onnx", ".pth", ".pt", ".pkl"}
+GENERATED_REPORT_ARTIFACTS = {
+    "comprehensive_report.json",
+    "comprehensive_report.md",
+    "metrics_plots.svg",
+    "metrics_plots.png",
+    "metrics_report.pdf",
+    "benchmark_insights.md",
+    # Legacy generated report name; keep excluded for older result roots.
+    "direct_report.md",
+}
+STRUCTURE_FILE_NAMES = {"client.py", "model.py", "job.py", "prepare_data.py", "download_data.py"}
+
+WORKSPACE_MAX_FILE_BYTES = 2 * 1024 * 1024
+WORKSPACE_MAX_TOTAL_BYTES = 25 * 1024 * 1024
+WORKSPACE_MAX_FILES = 500
+WORKSPACE_MAX_FINAL_FILES = 500
+REPORT_MAX_FILE_BYTES = 512 * 1024
+REPORT_MAX_TOTAL_BYTES = 10 * 1024 * 1024
+REPORT_MAX_FILES = 500
+
+
+def is_source_like(path: Path, *, include_logs: bool = False) -> bool:
+    suffixes = DELTA_SUFFIXES if include_logs else SOURCE_SUFFIXES
+    lower_name = path.name.lower()
+    return (
+        path.suffix.lower() in suffixes
+        or lower_name in SOURCE_NAMES
+        or lower_name.startswith("readme")
+        or (lower_name.startswith("requirements") and path.suffix.lower() == ".txt")
+    )
+
+
+def should_skip_rel(rel: Path) -> bool:
+    return any(part in IGNORED_DIRS for part in rel.parts) or rel.suffix.lower() in IGNORED_SUFFIXES
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def iter_files_no_symlink_dirs(root: Path) -> Iterable[Path]:
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(dirpath)
+        dirnames[:] = [name for name in dirnames if not (current / name).is_symlink()]
+        for filename in filenames:
+            yield current / filename
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def write_workspace_baseline(workspace_root: Path, out: Path) -> None:
+    files: dict[str, dict[str, Any]] = {}
+    for path in sorted(iter_files_no_symlink_dirs(workspace_root)):
+        if not path.is_file() or path.is_symlink():
+            continue
+        rel_path = path.relative_to(workspace_root)
+        rel = rel_path.as_posix()
+        if should_skip_rel(rel_path) or not is_source_like(path):
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size > WORKSPACE_MAX_FILE_BYTES:
+            continue
+        files[rel] = {"sha256": sha256(path), "size_bytes": size}
+
+    out.write_text(
+        json.dumps(
+            {
+                "root": str(workspace_root),
+                "max_file_bytes": WORKSPACE_MAX_FILE_BYTES,
+                "source_file_count": len(files),
+                "files": files,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def copy_limited(src: Path, dst: Path, copied_state: dict[str, int], skipped: list[dict[str, Any]]) -> int | None:
+    try:
+        size = src.stat().st_size
+    except OSError as exc:
+        skipped.append({"path": str(src), "reason": f"stat_failed:{exc}"})
+        return None
+    if size > WORKSPACE_MAX_FILE_BYTES:
+        skipped.append({"path": str(src), "reason": "file_size_limit", "size_bytes": size})
+        return None
+    if copied_state["files"] >= WORKSPACE_MAX_FILES:
+        skipped.append({"path": str(src), "reason": "file_count_limit", "size_bytes": size})
+        return None
+    if copied_state["bytes"] + size > WORKSPACE_MAX_TOTAL_BYTES:
+        skipped.append({"path": str(src), "reason": "total_size_limit", "size_bytes": size})
+        return None
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    copied_state["files"] += 1
+    copied_state["bytes"] += size
+    return size
+
+
+def capture_workspace_delta(
+    workspace_root: Path,
+    baseline_path: Path,
+    delta_root: Path,
+    manifest_path: Path,
+    runtime_artifact_root: Path,
+    *,
+    delta_scope: str = "workspace",
+    include_runtime_artifacts: bool = True,
+) -> None:
+    baseline = load_json(baseline_path)
+    baseline_files = baseline.get("files") if isinstance(baseline.get("files"), dict) else {}
+    delta_root.mkdir(parents=True, exist_ok=True)
+    changed_root = delta_root / "changed_files"
+    runtime_root = delta_root / "runtime_artifacts"
+    copied_state = {"files": 0, "bytes": 0}
+
+    changed_files: list[dict[str, Any]] = []
+    deleted_files: list[dict[str, Any]] = []
+    skipped_files: list[dict[str, Any]] = []
+    current_files: dict[str, dict[str, Any]] = {}
+    modified_files: list[dict[str, Any]] = []
+    added_files: list[dict[str, Any]] = []
+
+    for path in sorted(iter_files_no_symlink_dirs(workspace_root)):
+        if not path.is_file() or path.is_symlink():
+            continue
+        rel_path = path.relative_to(workspace_root)
+        rel = rel_path.as_posix()
+        if should_skip_rel(rel_path) or not is_source_like(path, include_logs=True):
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            skipped_files.append({"path": rel, "reason": f"stat_failed:{exc}"})
+            continue
+        if size > WORKSPACE_MAX_FILE_BYTES:
+            skipped_files.append({"path": rel, "reason": "file_size_limit", "size_bytes": size})
+            continue
+        file_hash = sha256(path)
+        current_files[rel] = {"sha256": file_hash, "size_bytes": size}
+        before = baseline_files.get(rel)
+        if before and before.get("sha256") == file_hash:
+            continue
+        status = "modified" if before else "added"
+        copied_size = copy_limited(path, changed_root / rel_path, copied_state, skipped_files)
+        if copied_size is not None:
+            entry = {
+                "path": rel,
+                "status": status,
+                "size_bytes": copied_size,
+                "sha256": file_hash,
+                "artifact_path": (changed_root / rel_path).relative_to(delta_root).as_posix(),
+            }
+            changed_files.append(entry)
+            if status == "modified":
+                modified_files.append(entry)
+            else:
+                added_files.append(entry)
+
+    for rel in sorted(set(baseline_files) - set(current_files)):
+        deleted_files.append({"path": rel, "status": "deleted"})
+
+    workspace_changes = [*added_files, *modified_files, *deleted_files]
+
+    runtime_artifacts: list[dict[str, Any]] = []
+    if include_runtime_artifacts:
+        runtime_sources = [
+            ("runtime_job_config", runtime_artifact_root / "job_config"),
+        ]
+        for label, root in runtime_sources:
+            if not root.is_dir():
+                continue
+            for path in sorted(iter_files_no_symlink_dirs(root)):
+                if not path.is_file() or path.is_symlink():
+                    continue
+                rel_path = path.relative_to(root)
+                rel = rel_path.as_posix()
+                if should_skip_rel(rel_path) or not is_source_like(path, include_logs=True):
+                    continue
+                dst = runtime_root / label / rel_path
+                copied_size = copy_limited(path, dst, copied_state, skipped_files)
+                if copied_size is not None:
+                    runtime_artifacts.append(
+                        {
+                            "path": f"{label}/{rel}",
+                            "source_path": str(path),
+                            "size_bytes": copied_size,
+                            "artifact_path": dst.relative_to(delta_root).as_posix(),
+                        }
+                    )
+
+    final_files: list[dict[str, Any]] = []
+    final_structure_files: list[dict[str, Any]] = []
+    for rel, meta in sorted(current_files.items()):
+        entry = {"path": rel, "size_bytes": meta.get("size_bytes"), "sha256": meta.get("sha256")}
+        if len(final_files) < WORKSPACE_MAX_FINAL_FILES:
+            final_files.append(entry)
+        if Path(rel).name.lower() in STRUCTURE_FILE_NAMES:
+            final_structure_files.append(entry)
+    manifest = {
+        "schema_version": "2",
+        "delta_scope": delta_scope,
+        "workspace_root": str(workspace_root),
+        "delta_dir": str(delta_root),
+        "changed_files_dir": str(changed_root),
+        "runtime_artifacts_dir": str(runtime_root),
+        "limits": {
+            "max_file_bytes": WORKSPACE_MAX_FILE_BYTES,
+            "max_total_bytes": WORKSPACE_MAX_TOTAL_BYTES,
+            "max_files": WORKSPACE_MAX_FILES,
+            "max_final_files": WORKSPACE_MAX_FINAL_FILES,
+        },
+        "initial_source_file_count": len(baseline_files),
+        "final_source_file_count": len(current_files),
+        "changed_file_count": len(changed_files),
+        "deleted_file_count": len(deleted_files),
+        "workspace_added_file_count": len(added_files),
+        "workspace_modified_file_count": len(modified_files),
+        "workspace_deleted_baseline_file_count": len(deleted_files),
+        "workspace_change_count": len(workspace_changes),
+        "workspace_changes_allowed": delta_scope == "agent_workspace",
+        "legacy_compat": {
+            "input_mutation_fields_removed": True,
+            "source_input_policy_manifest": "input_delta_manifest.json",
+        },
+        "runtime_artifact_count": len(runtime_artifacts),
+        "copied_file_count": copied_state["files"],
+        "copied_bytes": copied_state["bytes"],
+        "final_file_manifest_count": len(final_files),
+        "final_files_truncated": len(current_files) > len(final_files),
+        "final_structure_file_count": len(final_structure_files),
+        "final_structure_files": final_structure_files,
+        "final_files": final_files,
+        "changed_files": changed_files,
+        "deleted_files": deleted_files,
+        "workspace_added_files": added_files,
+        "workspace_modified_files": modified_files,
+        "workspace_deleted_baseline_files": deleted_files,
+        "workspace_changes": workspace_changes,
+        "runtime_artifacts": runtime_artifacts,
+        "skipped_files": skipped_files,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def collect_report_artifacts(root: Path) -> list[dict[str, Any]]:
+    artifacts: list[dict[str, Any]] = []
+    total_bytes = 0
+    for path in sorted(iter_files_no_symlink_dirs(root)):
+        if len(artifacts) >= REPORT_MAX_FILES:
+            break
+        if not path.is_file() or path.is_symlink():
+            continue
+        rel_path = path.relative_to(root)
+        rel = rel_path.as_posix()
+        if rel in GENERATED_REPORT_ARTIFACTS or should_skip_rel(rel_path):
+            continue
+        suffix = path.suffix.lower()
+        if suffix not in REPORT_SUFFIXES:
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if total_bytes >= REPORT_MAX_TOTAL_BYTES:
+            break
+        read_limit = min(size, REPORT_MAX_FILE_BYTES, REPORT_MAX_TOTAL_BYTES - total_bytes)
+        try:
+            with path.open("rb") as stream:
+                raw = stream.read(read_limit)
+        except OSError as exc:
+            artifacts.append(
+                {
+                    "relative_path": rel,
+                    "size_bytes": size,
+                    "captured_bytes": 0,
+                    "truncated": False,
+                    "line_count": 0,
+                    "kind": suffix.lstrip("."),
+                    "content": "",
+                    "read_error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+            continue
+        total_bytes += len(raw)
+        text = raw.decode("utf-8", errors="replace")
+        truncated = size > read_limit
+        entry: dict[str, Any] = {
+            "relative_path": rel,
+            "size_bytes": size,
+            "captured_bytes": len(raw),
+            "truncated": truncated,
+            "line_count": 0 if text == "" else text.count("\n") + (0 if text.endswith("\n") else 1),
+            "kind": suffix.lstrip("."),
+            "content": text,
+        }
+
+        if not truncated and suffix == ".json":
+            try:
+                entry["json"] = json.loads(text)
+            except json.JSONDecodeError as exc:
+                entry["json_parse_error"] = str(exc)
+        elif suffix == ".jsonl":
+            record_count = 0
+            parse_errors = 0
+            for line in text.splitlines():
+                if not line.strip():
+                    continue
+                record_count += 1
+                try:
+                    json.loads(line)
+                except json.JSONDecodeError:
+                    parse_errors += 1
+            entry["jsonl_record_count"] = record_count
+            entry["jsonl_parse_errors"] = parse_errors
+
+        artifacts.append(entry)
+    return artifacts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    baseline = subparsers.add_parser("baseline")
+    baseline.add_argument("workspace_root", type=Path)
+    baseline.add_argument("out", type=Path)
+
+    delta = subparsers.add_parser("delta")
+    delta.add_argument("workspace_root", type=Path)
+    delta.add_argument("baseline_path", type=Path)
+    delta.add_argument("delta_root", type=Path)
+    delta.add_argument("manifest_path", type=Path)
+    delta.add_argument("runtime_artifact_root", type=Path)
+
+    args = parser.parse_args()
+    if args.command == "baseline":
+        write_workspace_baseline(args.workspace_root, args.out)
+    elif args.command == "delta":
+        capture_workspace_delta(
+            args.workspace_root,
+            args.baseline_path,
+            args.delta_root,
+            args.manifest_path,
+            args.runtime_artifact_root,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/container/agent_run.py
+++ b/assist_tools/skills_benchmark/skills/harness/container/agent_run.py
@@ -1,0 +1,1249 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-container agent benchmark lifecycle runner."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from contextlib import nullcontext, suppress
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..agents.base import (
+    AgentAdapter,
+    AgentLaunchContext,
+    AgentLaunchSpec,
+    FinalMessageSource,
+    SkillExposureContext,
+    SkillExposureResult,
+)
+from ..agents.registry import load_agent_adapter
+from ..artifacts import capture_workspace_delta, write_workspace_baseline
+from ..common import bool_from_text, load_json, make_tree_readable, write_json
+from ..modes import mode_spec
+from ..records import AgentRecordSynthesisInputs, merge_record, synthesize_agent_record, write_run_summary
+from ..timing import LifecycleEpochs, finalize_timing
+from .progress import ProgressWriter
+from .skills import apply_skill_exposure
+from .skills import copy_optional_metadata_files as _copy_optional_metadata_files
+
+DEFAULT_CONTAINER_VENV_DIR = "/workspace/venv"
+RUNTIME_ARTIFACT_ROOT = Path("/tmp/agent_benchmark")
+AGENT_TIMEOUT_EXIT_CODE = 124
+AGENT_TERMINATE_GRACE_SECONDS = 10
+MAX_STDOUT_TAIL_LINES = 1000
+MAX_STDOUT_TAIL_LINE_BYTES = 4096
+STDOUT_TAIL_TRUNCATED_MARKER = "...[truncated]"
+
+
+def epoch_seconds() -> int:
+    return int(time.time())
+
+
+def epoch_nanoseconds() -> int:
+    return time.time_ns()
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def required_bool(name: str, value: str) -> bool:
+    if value not in {"true", "false"}:
+        raise SystemExit(f"{name} must be true or false; got {value}")
+    return bool_from_text(value)
+
+
+@dataclass(frozen=True)
+class AgentRunConfig:
+    mode: str
+    use_preinstalled_skills: bool
+    job_input_dir: Path
+    result_dir: Path
+    records_dir: Path
+    run_root: Path
+    prompt_source: Path
+    progress_interval_seconds: int
+    sdk_image_kind: str
+    agent: str
+    agent_model: str
+    agent_home: Path
+    agent_model_was_explicit: bool
+    agent_timeout_seconds: int | None = None
+
+    @property
+    def skill_run_mode(self) -> str:
+        return self.mode
+
+    @property
+    def run_input_dir(self) -> Path:
+        return self.run_root / "input"
+
+    @property
+    def run_workspace_dir(self) -> Path:
+        return self.run_root / "workspace"
+
+    @property
+    def agent_record_path(self) -> Path:
+        return self.records_dir / f"{self.mode}_agent_record.json"
+
+    @property
+    def final_record_path(self) -> Path:
+        return self.records_dir / f"{self.mode}_record.json"
+
+    @property
+    def agent_events_path(self) -> Path:
+        return self.result_dir / "agent_events.jsonl"
+
+    @property
+    def agent_usage_path(self) -> Path:
+        return self.result_dir / "agent_usage.json"
+
+    @property
+    def agent_activity_path(self) -> Path:
+        return self.result_dir / "agent_activity.json"
+
+    @property
+    def agent_last_message_path(self) -> Path:
+        return self.result_dir / "agent_last_message.txt"
+
+    @property
+    def agent_stderr_path(self) -> Path:
+        return self.result_dir / "agent_stderr.txt"
+
+    @property
+    def prompt_file_path(self) -> Path:
+        return self.result_dir / "prompt.txt"
+
+    @property
+    def progress_log_path(self) -> Path:
+        return self.result_dir / "progress.jsonl"
+
+    @classmethod
+    def from_env(cls) -> "AgentRunConfig":
+        env = os.environ
+        mode = env.get("MODE", "with_skills")
+        try:
+            spec = mode_spec(mode)
+        except ValueError as exc:
+            raise SystemExit(str(exc).replace("Unknown mode", "Unknown MODE")) from exc
+        use_preinstalled = env.get("USE_PREINSTALLED_SKILLS")
+        if use_preinstalled is None:
+            use_preinstalled = "true" if spec.skills_enabled else "false"
+        use_preinstalled_skills = required_bool("USE_PREINSTALLED_SKILLS", use_preinstalled)
+        if use_preinstalled_skills != spec.skills_enabled:
+            expected = "true" if spec.skills_enabled else "false"
+            raise SystemExit(
+                f"USE_PREINSTALLED_SKILLS={use_preinstalled} conflicts with MODE={mode}; expected {expected}."
+            )
+        job_input = env.get("JOB_INPUT_DIR") or env.get("TRAINING_CODE") or "/workspace/input"
+        result_dir = env.get("RESULT_DIR", "/workspace/results")
+        agent_name = env.get("BENCHMARK_AGENT")
+        if not agent_name:
+            raise SystemExit("BENCHMARK_AGENT is required inside the benchmark container.")
+        adapter = load_agent_adapter(agent_name)
+        agent_model = adapter.model_from_env(env)
+        agent_home = Path(env.get("BENCHMARK_AGENT_HOME") or env.get(adapter.agent_home_env, adapter.container_home))
+        agent_timeout_seconds = optional_positive_int_env("AGENT_TIMEOUT_SECONDS", env.get("AGENT_TIMEOUT_SECONDS"))
+        progress_interval_seconds = (
+            optional_positive_int_env("PROGRESS_INTERVAL_SECONDS", env.get("PROGRESS_INTERVAL_SECONDS")) or 60
+        )
+        return cls(
+            mode=mode,
+            use_preinstalled_skills=use_preinstalled_skills,
+            job_input_dir=Path(job_input),
+            result_dir=Path(result_dir),
+            records_dir=Path(env.get("RECORDS_DIR", str(Path(result_dir) / "records"))),
+            run_root=Path(env.get("RUN_ROOT", f"/workspace/run/{mode}")),
+            prompt_source=Path(env.get("PROMPT_SOURCE", "/workspace/prompts/benchmark_prompt.txt")),
+            progress_interval_seconds=progress_interval_seconds,
+            sdk_image_kind=env.get("SDK_IMAGE_KIND", "unknown"),
+            agent=adapter.name,
+            agent_model=agent_model,
+            agent_home=agent_home,
+            agent_model_was_explicit=adapter.model_was_explicit(env),
+            agent_timeout_seconds=agent_timeout_seconds,
+        )
+
+
+def command_output(command: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
+    except Exception:
+        return None
+
+
+def optional_positive_int_env(name: str, value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer; got {value}") from exc
+    if parsed <= 0:
+        raise SystemExit(f"{name} must be positive; got {value}")
+    return parsed
+
+
+def login_shell_runtime_probe() -> dict[str, Any]:
+    sdk_import_name = os.environ.get("SDK_IMPORT_NAME", "")
+    sdk_version_command = os.environ.get("SDK_VERSION_COMMAND", "")
+    sdk_import_probe = (
+        "python -c 'import importlib, os; "
+        'name=os.environ.get("SDK_IMPORT_NAME", ""); '
+        "module=importlib.import_module(name) if name else None; "
+        'print("sdk_import_name=" + name); '
+        'print("sdk_import_version=" + (getattr(module, "__version__", "unknown") if module else ""))'
+        "'"
+    )
+    script = "\n".join(
+        [
+            "printf 'PATH=%s\\n' \"$PATH\"",
+            "printf 'python=%s\\n' \"$(command -v python)\"",
+            sdk_import_probe,
+        ]
+    )
+    command = ["/bin/bash", "-lc", script]
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError as exc:
+        return {
+            "command": command,
+            "exit_code": 127,
+            "output": f"{type(exc).__name__}: {exc}",
+            "ok": False,
+            "reason": "failed_to_start_login_shell_probe",
+        }
+
+    sdk_version_output = None
+    sdk_version_exit_code = None
+    sdk_version_error = None
+    if sdk_version_command:
+        try:
+            sdk_version_argv = shlex.split(sdk_version_command)
+        except ValueError as exc:
+            sdk_version_error = f"failed_to_parse_sdk_version_command: {exc}"
+        else:
+            if not sdk_version_argv:
+                sdk_version_error = "empty_sdk_version_command"
+            else:
+                try:
+                    sdk_version_result = subprocess.run(
+                        sdk_version_argv,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                    )
+                except OSError as exc:
+                    sdk_version_exit_code = 127
+                    sdk_version_error = f"{type(exc).__name__}: {exc}"
+                else:
+                    sdk_version_exit_code = sdk_version_result.returncode
+                    sdk_version_output = sdk_version_result.stdout.strip()
+
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    expected_venv = os.environ.get("BENCHMARK_CONTAINER_VENV_DIR") or os.environ.get(
+        "VIRTUAL_ENV", DEFAULT_CONTAINER_VENV_DIR
+    )
+    expected_python = str(Path(expected_venv) / "bin" / "python")
+    ok = result.returncode == 0 and values.get("python") == expected_python
+    reason = "ok"
+    if result.returncode != 0:
+        reason = f"probe_exit_code_{result.returncode}"
+    elif values.get("python") != expected_python:
+        reason = f"python_resolved_to_{values.get('python') or 'missing'}"
+    return {
+        "command": command,
+        "exit_code": result.returncode,
+        "output": result.stdout,
+        "path": values.get("PATH"),
+        "python": values.get("python"),
+        "sdk_import_name": sdk_import_name,
+        "sdk_import_version": values.get("sdk_import_version"),
+        "sdk_version_command": sdk_version_command,
+        "sdk_version_exit_code": sdk_version_exit_code,
+        "sdk_version_output": sdk_version_output,
+        "sdk_version_error": sdk_version_error,
+        "expected_python": expected_python,
+        "ok": ok,
+        "reason": reason,
+    }
+
+
+def agent_launch_context(config: AgentRunConfig) -> AgentLaunchContext:
+    return AgentLaunchContext(
+        workspace_dir=config.run_workspace_dir,
+        prompt_file=config.prompt_file_path,
+        result_dir=config.result_dir,
+        events_dest=config.agent_events_path,
+        stderr_dest=config.agent_stderr_path,
+        final_message_dest=config.agent_last_message_path,
+        model=config.agent_model,
+        model_was_explicit=config.agent_model_was_explicit,
+        timeout_seconds=config.agent_timeout_seconds,
+    )
+
+
+def build_agent_launch(config: AgentRunConfig) -> AgentLaunchSpec:
+    adapter = load_agent_adapter(config.agent)
+    return adapter.launch_spec(agent_launch_context(config))
+
+
+def launch_subprocess_argv(argv: list[str], *, login_shell: bool) -> list[str]:
+    if not login_shell:
+        return list(argv)
+    return ["/bin/bash", "--login", "-c", "exec " + shlex.join(argv)]
+
+
+def persist_container_runtime_metadata(config: AgentRunConfig, launch: AgentLaunchSpec | None = None) -> None:
+    build_metadata = load_json(config.agent_home / "build_metadata.json", {}) or {}
+    sdk_wheel_metadata = load_json(config.agent_home / "sdk_wheel_metadata.json", {}) or {}
+    if build_metadata:
+        write_json(config.result_dir / "image_build_metadata.json", build_metadata)
+    if sdk_wheel_metadata:
+        write_json(config.result_dir / "sdk_wheel_metadata.json", sdk_wheel_metadata)
+
+    runtime_path = config.result_dir / "runtime_image.json"
+    runtime_metadata = load_json(runtime_path, {}) or {}
+    launch = launch or build_agent_launch(config)
+    probe = (
+        login_shell_runtime_probe()
+        if launch.login_shell
+        else {
+            "ok": True,
+            "reason": "skipped_adapter_does_not_use_login_shell",
+            "required": False,
+        }
+    )
+    runtime_metadata.update(
+        {
+            "container_python_executable": sys.executable,
+            "container_python_version": sys.version.split()[0],
+            "container_virtual_env": os.environ.get("VIRTUAL_ENV"),
+            "container_path_prefix": os.environ.get("PATH", "").split(":")[:3],
+            "container_pip_version": command_output([sys.executable, "-m", "pip", "--version"]),
+            "container_uv_version": command_output(["uv", "--version"]),
+            "login_shell_required": launch.login_shell,
+            "login_shell_runtime_probe": probe,
+            "image_build_metadata": build_metadata,
+            "sdk_wheel_metadata": sdk_wheel_metadata,
+        }
+    )
+    write_json(runtime_path, runtime_metadata)
+    if launch.login_shell and not probe.get("ok"):
+        raise RuntimeError(f"Login-shell runtime probe failed: {probe.get('reason')}")
+
+
+def run_agent_availability_probe(config: AgentRunConfig) -> None:
+    adapter = load_agent_adapter(config.agent)
+    command = adapter.availability_probe()
+    if not command:
+        write_json(
+            config.result_dir / "agent_availability_probe.json",
+            {"status": "skipped", "reason": "adapter did not define an availability probe"},
+        )
+        return
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=agent_subprocess_env(adapter.runtime_env(config), adapter),
+        )
+    except OSError as exc:
+        write_json(
+            config.result_dir / "agent_availability_probe.json",
+            {
+                "status": "failed",
+                "command": command,
+                "exit_code": 127,
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+        )
+        raise RuntimeError(f"Agent availability probe failed to start: {type(exc).__name__}: {exc}") from exc
+    write_json(
+        config.result_dir / "agent_availability_probe.json",
+        {
+            "status": "passed" if result.returncode == 0 else "failed",
+            "command": command,
+            "exit_code": result.returncode,
+            "output": result.stdout,
+        },
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Agent availability probe failed with exit code {result.returncode}: {command}")
+
+
+def setup_skill_availability(config: AgentRunConfig) -> tuple[int, int, SkillExposureResult]:
+    start = epoch_seconds()
+    adapter = load_agent_adapter(config.agent)
+    spec = adapter.skill_exposure(
+        SkillExposureContext(
+            result_dir=config.result_dir,
+            container_home=config.agent_home,
+            mode=config.mode,
+            skills_enabled=config.use_preinstalled_skills,
+            sdk_image_kind=config.sdk_image_kind,
+        )
+    )
+    result = apply_skill_exposure(
+        spec=spec,
+        skills_enabled=config.use_preinstalled_skills,
+        result_dir=config.result_dir,
+        sdk_image_kind=config.sdk_image_kind,
+    )
+    write_json(config.result_dir / "skills_exposure_result.json", asdict(result))
+    return start, epoch_seconds(), result
+
+
+def copy_optional_metadata_files(source_dir: Path, result_dir: Path, names: tuple[str, ...]) -> dict[str, Any]:
+    return _copy_optional_metadata_files(source_dir, result_dir, names)
+
+
+def validate_input_symlinks(input_dir: Path) -> None:
+    root = input_dir.resolve()
+    for dirpath, dirnames, filenames in os.walk(input_dir, followlinks=False):
+        current = Path(dirpath)
+        for name in [*dirnames, *filenames]:
+            path = current / name
+            if not path.is_symlink():
+                continue
+            target = path.readlink()
+            resolved_target = (target if target.is_absolute() else path.parent / target).resolve(strict=False)
+            if not resolved_target.is_relative_to(root):
+                rel = path.relative_to(input_dir)
+                raise RuntimeError(f"Job input symlink escapes input directory: {rel} -> {target}")
+
+
+def prepare_input_workspace(config: AgentRunConfig) -> tuple[int, int]:
+    start = epoch_seconds()
+    config.run_root.mkdir(parents=True, exist_ok=True)
+    for name in ("input", "generated", "job_config", "workspace"):
+        shutil.rmtree(config.run_root / name, ignore_errors=True)
+    validate_input_symlinks(config.job_input_dir)
+    shutil.copytree(config.job_input_dir, config.run_input_dir, symlinks=True)
+    shutil.copytree(config.run_input_dir, config.run_workspace_dir, symlinks=True)
+    for name in ("generated", "job_config"):
+        (config.run_root / name).mkdir(parents=True, exist_ok=True)
+    return start, epoch_seconds()
+
+
+def prepare_prompt(config: AgentRunConfig) -> tuple[int, int]:
+    start = epoch_seconds()
+    shutil.copy2(config.prompt_source, config.prompt_file_path)
+    prompt_bytes = config.prompt_file_path.read_bytes()
+    write_json(
+        config.result_dir / "prompt_metadata.json",
+        {
+            "template_path": str(config.prompt_source),
+            "prompt_path": str(config.prompt_file_path),
+            "template_sha256": hashlib.sha256(prompt_bytes).hexdigest(),
+            "prompt_sha256": hashlib.sha256(prompt_bytes).hexdigest(),
+            "template_bytes": len(prompt_bytes),
+            "prompt_bytes": len(prompt_bytes),
+            "verbatim_copy": True,
+            "harness_prompt_injection": False,
+            "note": "The harness copies the mounted prompt file verbatim and does not append mode, path, or skill instructions.",
+        },
+    )
+    return start, epoch_seconds()
+
+
+def write_agent_compatibility_copies(config: AgentRunConfig) -> None:
+    # Use file copies rather than symlinks because benchmark results may live on
+    # Docker volume mounts where symlink behavior varies by host platform.
+    adapter = load_agent_adapter(config.agent)
+    suffixes = {
+        "events": config.agent_events_path,
+        "usage": config.agent_usage_path,
+        "activity": config.agent_activity_path,
+        "last_message": config.agent_last_message_path,
+        "stderr": config.agent_stderr_path,
+    }
+    for prefix in adapter.artifact_alias_prefixes():
+        for suffix, source in suffixes.items():
+            target = (
+                config.result_dir
+                / f"{prefix}_{suffix}.{'jsonl' if suffix == 'events' else 'json' if suffix in {'usage', 'activity'} else 'txt'}"
+            )
+            if source.exists() and source != target:
+                shutil.copy2(source, target)
+
+
+AGENT_ENV_DENYLIST = {
+    "MODE",
+    "USE_PREINSTALLED_SKILLS",
+    "SDK_IMAGE_KIND",
+    "RESULT_DIR",
+    "RECORDS_DIR",
+    "SDK_AGENT_RECORD",
+    "RUN_ROOT",
+    "PROMPT_SOURCE",
+    "JOB_INPUT_DIR",
+    "TRAINING_CODE",
+    "PROGRESS_INTERVAL_SECONDS",
+    "BENCHMARK_AGENT",
+    "BENCHMARK_AGENT_MODEL",
+    "BENCHMARK_AGENT_HOME",
+    "AGENT_TIMEOUT_SECONDS",
+}
+
+
+def agent_subprocess_env(launch_env: dict[str, str], adapter=None) -> dict[str, str]:
+    denied = set(AGENT_ENV_DENYLIST)
+    if adapter is not None:
+        denied.update(str(item) for item in adapter.model_env_names())
+    env = {key: value for key, value in os.environ.items() if key not in denied}
+    env.update(launch_env)
+    return env
+
+
+def raw_tail_text(lines: deque[str], tail_bytes: int | None) -> str:
+    text = "".join(lines)
+    if not tail_bytes or tail_bytes <= 0:
+        return text
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= tail_bytes:
+        return text
+    return encoded[-tail_bytes:].decode("utf-8", errors="replace")
+
+
+def truncate_stdout_tail_line(line: str) -> str:
+    encoded = line.encode("utf-8", errors="replace")
+    if len(encoded) <= MAX_STDOUT_TAIL_LINE_BYTES:
+        return line
+    marker = f"{STDOUT_TAIL_TRUNCATED_MARKER}\n" if line.endswith("\n") else STDOUT_TAIL_TRUNCATED_MARKER
+    marker_bytes = marker.encode("utf-8")
+    head = encoded[: max(0, MAX_STDOUT_TAIL_LINE_BYTES - len(marker_bytes))]
+    return head.decode("utf-8", errors="replace") + marker
+
+
+def event_matches_selector(event: dict[str, Any], selector: dict[str, Any] | None) -> bool:
+    if not selector:
+        return True
+    return all(event.get(key) == value for key, value in selector.items())
+
+
+def event_message_text(event: dict[str, Any]) -> str:
+    for key in ("final_message", "message", "content", "text", "output", "value"):
+        if key not in event:
+            continue
+        value = event[key]
+        return value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+    return json.dumps(event, sort_keys=True)
+
+
+def final_message_metadata(
+    source: FinalMessageSource, status: str, *, message: str = "", stdout_tail_truncated: bool = False
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "source_type": source.source_type,
+        "source_path": str(source.path) if source.path else None,
+        "event_selector": source.event_selector,
+        "tail_bytes": source.tail_bytes,
+        "parser": source.parser,
+        "parser_warnings": source.parser_warnings,
+        "stdout_tail_truncated": stdout_tail_truncated,
+        "message": message,
+    }
+
+
+def materialize_structured_event_message(config: AgentRunConfig, source: FinalMessageSource) -> str | None:
+    selected: dict[str, Any] | None = None
+    try:
+        with config.agent_events_path.open("r", encoding="utf-8") as stream:
+            for line in stream:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict) and event_matches_selector(event, source.event_selector):
+                    selected = event
+    except OSError:
+        return None
+    return event_message_text(selected) if selected else None
+
+
+def materialize_final_message(
+    config: AgentRunConfig,
+    adapter: AgentAdapter,
+    stdout_tail_lines: deque[str],
+    *,
+    stdout_tail_truncated: bool = False,
+) -> None:
+    source = adapter.final_message_source(config.result_dir)
+    destination = config.agent_last_message_path
+    if source.source_type == "file":
+        if source.path and source.path.is_file():
+            if source.path.resolve(strict=False) != destination.resolve(strict=False):
+                shutil.copy2(source.path, destination)
+            write_json(
+                config.result_dir / "final_message_source.json",
+                final_message_metadata(source, "materialized", stdout_tail_truncated=stdout_tail_truncated),
+            )
+            return
+        destination.write_text("", encoding="utf-8")
+        write_json(
+            config.result_dir / "final_message_source.json",
+            final_message_metadata(
+                source,
+                "missing",
+                message="configured final message file was not written",
+                stdout_tail_truncated=stdout_tail_truncated,
+            ),
+        )
+        return
+    if source.source_type == "stdout_tail":
+        destination.write_text(raw_tail_text(stdout_tail_lines, source.tail_bytes), encoding="utf-8")
+        write_json(
+            config.result_dir / "final_message_source.json",
+            final_message_metadata(source, "materialized", stdout_tail_truncated=stdout_tail_truncated),
+        )
+        return
+    if source.source_type == "structured_event":
+        if stdout_tail_truncated:
+            destination.write_text("", encoding="utf-8")
+            write_json(
+                config.result_dir / "final_message_source.json",
+                final_message_metadata(
+                    source,
+                    "missing",
+                    message="stdout reader was still active; structured event final message was not read",
+                    stdout_tail_truncated=stdout_tail_truncated,
+                ),
+            )
+            return
+        text = materialize_structured_event_message(config, source)
+        destination.write_text(text or "", encoding="utf-8")
+        write_json(
+            config.result_dir / "final_message_source.json",
+            final_message_metadata(
+                source,
+                "materialized" if text is not None else "missing",
+                message="" if text is not None else "no matching structured event found",
+                stdout_tail_truncated=stdout_tail_truncated,
+            ),
+        )
+        return
+    if source.source_type == "not_available":
+        destination.write_text("", encoding="utf-8")
+        write_json(
+            config.result_dir / "final_message_source.json",
+            final_message_metadata(source, "skipped", stdout_tail_truncated=stdout_tail_truncated),
+        )
+        return
+    raise ValueError(f"Unsupported final message source_type: {source.source_type}")
+
+
+def write_launch_spec_metadata(
+    config: AgentRunConfig,
+    launch_argv: list[str],
+    launch_env: dict[str, str],
+    launch: AgentLaunchSpec,
+    skill_exposure: SkillExposureResult | None,
+) -> None:
+    write_json(
+        config.result_dir / "launch_spec_metadata.json",
+        {
+            "agent": config.agent,
+            "agent_model": config.agent_model,
+            "agent_model_explicit": config.agent_model_was_explicit,
+            "argv": launch_argv,
+            "cwd": str(launch.cwd),
+            "prompt_input_mode": launch.prompt_input_mode,
+            "stdout_events_dest": str(launch.stdout_events_dest),
+            "stderr_dest": str(launch.stderr_dest),
+            "final_message_dest": str(launch.final_message_dest) if launch.final_message_dest else None,
+            "login_shell": launch.login_shell,
+            "approval_flags": launch.approval_flags,
+            "sandbox_flags": launch.sandbox_flags,
+            "bypass_reason": launch.bypass_reason,
+            "launch_timeout": launch.launch_timeout,
+            "environment_keys": sorted(launch_env),
+            "skill_launch_args": skill_exposure.launch_args if skill_exposure else [],
+            "skill_environment_keys": sorted(skill_exposure.environment) if skill_exposure else [],
+        },
+    )
+
+
+def terminate_timed_out_process(process: subprocess.Popen, stderr, timeout: int | None) -> None:
+    message = f"Agent command timed out after {timeout} seconds; terminating process.\n"
+    stderr.write(message.encode("utf-8", errors="replace"))
+    stderr.flush()
+    process.terminate()
+    try:
+        process.wait(timeout=AGENT_TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        stderr.write(b"Agent process did not terminate; killing process.\n")
+        stderr.flush()
+        process.kill()
+        process.wait()
+
+
+def run_agent(
+    config: AgentRunConfig,
+    progress: ProgressWriter,
+    skill_exposure: SkillExposureResult | None = None,
+    launch: AgentLaunchSpec | None = None,
+) -> tuple[int, int, int]:
+    start = epoch_seconds()
+    config.progress_log_path.write_text("", encoding="utf-8")
+    progress.write("agent_exec", "start", start)
+    progress.start_heartbeat("agent_exec", config.progress_interval_seconds)
+    agent_exit = 127
+    launch_error: OSError | None = None
+    stdout_tail_lines: deque[str] = deque(maxlen=MAX_STDOUT_TAIL_LINES)
+    stdout_tail_lock = threading.Lock()
+    adapter = load_agent_adapter(config.agent)
+    launch = launch or build_agent_launch(config)
+    launch_argv = list(launch.argv)
+    launch_env = dict(launch.environment)
+    if config.use_preinstalled_skills and skill_exposure is not None:
+        launch_argv.extend(skill_exposure.launch_args)
+        launch_env.update(skill_exposure.environment)
+    process_argv = launch_subprocess_argv(launch_argv, login_shell=launch.login_shell)
+    write_launch_spec_metadata(config, process_argv, launch_env, launch, skill_exposure)
+
+    try:
+        try:
+            prompt_stdin_context = (
+                launch.prompt_file.open("rb") if launch.prompt_input_mode == "stdin" else nullcontext(None)
+            )
+            with (
+                prompt_stdin_context as prompt_stdin,
+                launch.stdout_events_dest.open("w", encoding="utf-8") as events_out,
+                launch.stderr_dest.open("wb") as stderr,
+            ):
+                stdin = prompt_stdin if launch.prompt_input_mode == "stdin" else subprocess.DEVNULL
+                try:
+                    process = subprocess.Popen(
+                        process_argv,
+                        cwd=launch.cwd,
+                        stdin=stdin,
+                        stdout=subprocess.PIPE,
+                        stderr=stderr,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        env=agent_subprocess_env(launch_env, adapter),
+                    )
+                except OSError as exc:
+                    launch_error = exc
+                    message = f"Failed to start agent command: {type(exc).__name__}: {exc}\n"
+                    stderr.write(message.encode("utf-8", errors="replace"))
+                    print(message.rstrip(), file=sys.stderr)
+                else:
+                    if process.stdout is None:
+                        raise RuntimeError("Agent stdout pipe was not created")
+                    reader_error: list[BaseException] = []
+                    reader_stop = threading.Event()
+                    events_write_lock = threading.Lock()
+
+                    def stream_stdout() -> None:
+                        try:
+                            for line in process.stdout:
+                                if reader_stop.is_set():
+                                    break
+                                with stdout_tail_lock:
+                                    stdout_tail_lines.append(truncate_stdout_tail_line(line))
+                                event = adapter.normalize_event(line)
+                                normalized = (
+                                    json.dumps(event, sort_keys=True, separators=(",", ":"))
+                                    if event is not None
+                                    else None
+                                )
+                                if normalized:
+                                    with events_write_lock:
+                                        if reader_stop.is_set():
+                                            break
+                                        events_out.write(normalized + "\n")
+                                        events_out.flush()
+                        except BaseException as exc:
+                            if not reader_stop.is_set():
+                                reader_error.append(exc)
+
+                    reader = threading.Thread(target=stream_stdout, daemon=True)
+                    reader.start()
+                    try:
+                        agent_exit = process.wait(timeout=launch.launch_timeout)
+                    except subprocess.TimeoutExpired:
+                        terminate_timed_out_process(process, stderr, launch.launch_timeout)
+                        agent_exit = AGENT_TIMEOUT_EXIT_CODE
+                    reader.join(timeout=AGENT_TERMINATE_GRACE_SECONDS)
+                    stdout_tail_truncated = reader.is_alive()
+                    if stdout_tail_truncated:
+                        reader_stop.set()
+                        with suppress(OSError, ValueError):
+                            process.stdout.close()
+                        reader.join(timeout=AGENT_TERMINATE_GRACE_SECONDS)
+                        # Closing stdout can make the reader observe ValueError; reader_stop makes that non-fatal.
+                        with events_write_lock:
+                            pass
+                        stderr.write(
+                            "Agent stdout reader did not finish within "
+                            f"{AGENT_TERMINATE_GRACE_SECONDS} seconds after process exit.\n".encode("utf-8")
+                        )
+                    with stdout_tail_lock:
+                        stdout_tail_snapshot = deque(stdout_tail_lines, maxlen=stdout_tail_lines.maxlen)
+                    materialize_final_message(
+                        config,
+                        adapter,
+                        stdout_tail_snapshot,
+                        stdout_tail_truncated=stdout_tail_truncated,
+                    )
+                    if reader_error:
+                        raise RuntimeError(f"Failed to read agent stdout: {reader_error[0]}")
+        except OSError as exc:
+            launch_error = exc
+            print(f"Failed to prepare agent command streams: {type(exc).__name__}: {exc}", file=sys.stderr)
+    finally:
+        progress.stop_heartbeat()
+
+    end = epoch_seconds()
+    progress.write("agent_exec", "failed_to_start" if launch_error is not None else "finished", end)
+    if launch_error is not None and not config.agent_last_message_path.exists():
+        config.agent_last_message_path.write_text("", encoding="utf-8")
+    return start, end, agent_exit
+
+
+def post_process(
+    config: AgentRunConfig, elapsed_seconds: int, agent_exit: int, run_start_time_ns: int
+) -> tuple[int, int]:
+    start = epoch_seconds()
+    input_delta_manifest = config.result_dir / "input_delta_manifest.json"
+    capture_workspace_delta(
+        config.run_input_dir,
+        config.result_dir / "input_baseline_manifest.json",
+        config.result_dir / "input_delta",
+        input_delta_manifest,
+        RUNTIME_ARTIFACT_ROOT,
+        delta_scope="input_snapshot",
+        include_runtime_artifacts=False,
+    )
+    workspace_delta_manifest = config.result_dir / "workspace_delta_manifest.json"
+    capture_workspace_delta(
+        config.run_workspace_dir,
+        config.result_dir / "workspace_baseline_manifest.json",
+        config.result_dir / "workspace_delta",
+        workspace_delta_manifest,
+        RUNTIME_ARTIFACT_ROOT,
+        delta_scope="agent_workspace",
+    )
+    adapter = load_agent_adapter(config.agent)
+    exit_summary = adapter.exit_summary(agent_exit, config.agent_stderr_path)
+    write_json(config.agent_usage_path, adapter.parse_usage(config.agent_events_path))
+    write_json(config.agent_activity_path, adapter.parse_activity(config.agent_events_path))
+    write_json(config.result_dir / "agent_exit_summary.json", exit_summary)
+    write_agent_compatibility_copies(config)
+    synthesize_agent_record(
+        AgentRecordSynthesisInputs(
+            agent_record_path=config.agent_record_path,
+            records_dir=config.records_dir,
+            events_path=config.agent_events_path,
+            usage_path=config.agent_usage_path,
+            activity_path=config.agent_activity_path,
+            last_message_path=config.agent_last_message_path,
+            input_dir=config.run_input_dir,
+            mode=config.mode,
+            elapsed_seconds=elapsed_seconds,
+            agent_exit=agent_exit,
+            skills_enabled=config.use_preinstalled_skills,
+            skill_run_mode=config.skill_run_mode,
+            agent=config.agent,
+            agent_model=config.agent_model,
+            run_start_time_ns=run_start_time_ns,
+            workspace_delta_manifest_path=workspace_delta_manifest,
+            input_delta_manifest_path=input_delta_manifest,
+            prompt_path=config.prompt_file_path,
+        )
+    )
+    merge_record(
+        agent_record_path=config.agent_record_path,
+        final_record_path=config.final_record_path,
+        usage_path=config.agent_usage_path,
+        mode=config.mode,
+        elapsed_seconds=elapsed_seconds,
+        agent_exit=agent_exit,
+        skills_enabled=config.use_preinstalled_skills,
+        skill_run_mode=config.skill_run_mode,
+        agent=config.agent,
+        agent_model=config.agent_model,
+    )
+    record = load_json(config.final_record_path, {}) or {}
+    if isinstance(record, dict):
+        record["agent_exit_summary"] = exit_summary
+        if exit_summary.get("failure_category"):
+            record["failure_category"] = exit_summary.get("failure_category")
+            record["failure_root_cause"] = exit_summary.get("failure_category")
+        metrics = record.setdefault("process_metrics", {})
+        if isinstance(metrics, dict):
+            metrics["agent_exit_classifier"] = exit_summary.get("classifier")
+        write_json(config.final_record_path, record)
+    write_run_summary(config.final_record_path, config.result_dir / "run_summary.json", print_summary=False)
+    return start, epoch_seconds()
+
+
+def report_exit_status(command_statuses: dict[str, int]) -> int:
+    return 1 if any(status != 0 for status in command_statuses.values()) else 0
+
+
+def record_has_policy_failure(record: dict[str, Any]) -> bool:
+    metrics = record.get("process_metrics")
+    if isinstance(metrics, dict) and metrics.get("source_input_immutable_violation"):
+        return True
+    violation = record.get("source_input_immutable_violation")
+    return isinstance(violation, dict) and violation.get("status") == "fail"
+
+
+def final_container_exit_status(agent_exit: int, report_statuses: dict[str, int], *, policy_failed: bool) -> int:
+    if agent_exit != 0:
+        return agent_exit
+    if policy_failed:
+        return 1
+    return report_exit_status(report_statuses)
+
+
+def write_report_outcome(config: AgentRunConfig, agent_exit: int, report_statuses: dict[str, int]) -> int:
+    report_exit = report_exit_status(report_statuses)
+    record = load_json(config.final_record_path, {}) or {}
+    if not isinstance(record, dict):
+        record = {}
+    policy_failed = record_has_policy_failure(record)
+    final_exit = final_container_exit_status(agent_exit, report_statuses, policy_failed=policy_failed)
+    record["agent_report_exit_codes"] = report_statuses
+    record["agent_report_exit_code"] = report_exit
+    record["agent_report_failed"] = report_exit != 0
+    record["harness_policy_failed"] = policy_failed
+    record["final_container_exit_code"] = final_exit
+    record["report_inclusive_exit_code"] = final_exit
+    metrics = record.setdefault("process_metrics", {})
+    if isinstance(metrics, dict):
+        metrics["agent_report_exit_code"] = report_exit
+        metrics["agent_report_failed"] = 1 if report_exit else 0
+        metrics["harness_policy_failed"] = 1 if policy_failed else 0
+        metrics["final_container_exit_code"] = final_exit
+        metrics["report_inclusive_exit_code"] = final_exit
+    write_json(config.final_record_path, record)
+    write_run_summary(config.final_record_path, config.result_dir / "run_summary.json", print_summary=False)
+    return final_exit
+
+
+def exit_code_from_exception(exc: BaseException, default: int = 1) -> int:
+    if isinstance(exc, SystemExit) and isinstance(exc.code, int):
+        return exc.code
+    return default
+
+
+def harness_error_payload(exc: BaseException, exit_code: int, phase: str) -> dict[str, Any]:
+    return {
+        "timestamp": utc_timestamp(),
+        "phase": phase,
+        "exit_code": exit_code,
+        "error_type": type(exc).__name__,
+        "message": str(exc),
+    }
+
+
+def write_failure_record(
+    *,
+    result_dir: Path,
+    records_dir: Path,
+    mode: str,
+    exit_code: int,
+    error_type: str,
+    message: str,
+    phase: str,
+    agent: str = "unknown",
+    agent_model: str = "unspecified_default",
+    skills_enabled: bool | None = None,
+) -> int:
+    result_dir.mkdir(parents=True, exist_ok=True)
+    records_dir.mkdir(parents=True, exist_ok=True)
+    error = {
+        "timestamp": utc_timestamp(),
+        "phase": phase,
+        "exit_code": exit_code,
+        "error_type": error_type,
+        "message": message,
+    }
+    record = {
+        "schema_version": "1",
+        "mode": mode,
+        "run_mode": "unknown" if skills_enabled is None else "with_skills" if skills_enabled else "without_skills",
+        "agent": agent,
+        "source": "agent_benchmark_harness",
+        "agent_process_passed": False,
+        "agent_process_exit_code": exit_code,
+        "agent_elapsed_seconds": 0,
+        "elapsed_seconds": 0,
+        "agent_model": agent_model,
+        "skills_enabled": skills_enabled,
+        "timestamp": error["timestamp"],
+        "agent_record_present": False,
+        "agent_record_valid": False,
+        "harness_failure": True,
+        "harness_error": error,
+        "harness_errors": [error],
+        "agent_report_exit_codes": {},
+        "agent_report_exit_code": 0,
+        "agent_report_failed": False,
+        "final_container_exit_code": exit_code,
+        "report_inclusive_exit_code": exit_code,
+        "process_metrics": {
+            "elapsed_seconds": 0,
+            "agent_elapsed_seconds": 0,
+            "token_count": None,
+            "agent_exit_code": exit_code,
+            "agent_process_passed": 0,
+            "harness_failure": 1,
+            "agent_report_exit_code": 0,
+            "agent_report_failed": 0,
+            "final_container_exit_code": exit_code,
+            "report_inclusive_exit_code": exit_code,
+        },
+    }
+    final_record_path = records_dir / f"{mode}_record.json"
+    write_json(final_record_path, record)
+    write_json(
+        result_dir / "early_failure.json",
+        {
+            **error,
+            "record_path": str(final_record_path),
+        },
+    )
+    write_run_summary(final_record_path, result_dir / "run_summary.json", print_summary=False)
+    make_tree_readable(result_dir)
+    return exit_code
+
+
+def merge_harness_failure(config: AgentRunConfig, exc: BaseException, exit_code: int, phase: str) -> int | None:
+    record = load_json(config.final_record_path, {}) or {}
+    if not isinstance(record, dict) or not record:
+        return None
+    error = harness_error_payload(exc, exit_code, phase)
+    record["harness_failure"] = True
+    record["agent"] = record.get("agent") or config.agent
+    record["agent_model"] = record.get("agent_model") or config.agent_model
+    record["harness_error"] = error
+    errors = record.get("harness_errors")
+    if not isinstance(errors, list):
+        errors = []
+    errors.append(error)
+    record["harness_errors"] = errors
+    record["final_container_exit_code"] = exit_code
+    record["harness_failure_exit_code"] = exit_code
+    metrics = record.setdefault("process_metrics", {})
+    if isinstance(metrics, dict):
+        metrics["harness_failure"] = 1
+        metrics["harness_failure_exit_code"] = exit_code
+        metrics["final_container_exit_code"] = exit_code
+    write_json(config.final_record_path, record)
+    write_json(
+        config.result_dir / "late_harness_failure.json",
+        {
+            **error,
+            "record_path": str(config.final_record_path),
+            "preserved_existing_record": True,
+        },
+    )
+    write_run_summary(config.final_record_path, config.result_dir / "run_summary.json", print_summary=False)
+    make_tree_readable(config.result_dir)
+    return exit_code
+
+
+def write_failure_record_from_env(exc: BaseException, exit_code: int, phase: str) -> int:
+    env = os.environ
+    result_dir = Path(env.get("RESULT_DIR", "/workspace/results"))
+    records_dir = Path(env.get("RECORDS_DIR", str(result_dir / "records")))
+    agent = env.get("BENCHMARK_AGENT", "unknown")
+    try:
+        agent_model = load_agent_adapter(agent).model_from_env(env)
+    except Exception:
+        agent_model = env.get("BENCHMARK_AGENT_MODEL", "unspecified_default")
+    return write_failure_record(
+        result_dir=result_dir,
+        records_dir=records_dir,
+        mode=env.get("MODE", "unknown"),
+        exit_code=exit_code,
+        error_type=type(exc).__name__,
+        message=str(exc),
+        phase=phase,
+        agent=agent,
+        agent_model=agent_model,
+    )
+
+
+def write_configured_failure(
+    config: AgentRunConfig,
+    exc: BaseException,
+    exit_code: int,
+    phase: str,
+    *,
+    preserve_existing_record: bool = False,
+) -> int:
+    if preserve_existing_record:
+        merged_exit = merge_harness_failure(config, exc, exit_code, phase)
+        if merged_exit is not None:
+            return merged_exit
+    return write_failure_record(
+        result_dir=config.result_dir,
+        records_dir=config.records_dir,
+        mode=config.mode,
+        exit_code=exit_code,
+        error_type=type(exc).__name__,
+        message=str(exc),
+        phase=phase,
+        agent=config.agent,
+        agent_model=config.agent_model,
+        skills_enabled=config.use_preinstalled_skills,
+    )
+
+
+def run_agent_benchmark() -> int:
+    try:
+        config = AgentRunConfig.from_env()
+    except BaseException as exc:
+        if isinstance(exc, KeyboardInterrupt):
+            raise
+        return write_failure_record_from_env(exc, exit_code_from_exception(exc, 2), "config")
+
+    phase = "input_validation"
+    normal_record_written = False
+    try:
+        if not config.prompt_source.is_file():
+            message = (
+                f"Prompt file is not mounted or does not exist: {config.prompt_source}. "
+                "Mount a prompt file to /workspace/prompts/benchmark_prompt.txt or pass --prompt through the host wrapper scripts."
+            )
+            print(message, file=sys.stderr)
+            return write_configured_failure(config, RuntimeError(message), 2, phase)
+        if not config.job_input_dir.is_dir():
+            message = f"Job input folder does not exist: {config.job_input_dir}"
+            print(message, file=sys.stderr)
+            return write_configured_failure(config, RuntimeError(message), 2, phase)
+
+        config.result_dir.mkdir(parents=True, exist_ok=True)
+        config.records_dir.mkdir(parents=True, exist_ok=True)
+        config.run_root.mkdir(parents=True, exist_ok=True)
+        phase = "runtime_metadata_probe"
+        agent_launch = build_agent_launch(config)
+        persist_container_runtime_metadata(config, agent_launch)
+        phase = "agent_availability_probe"
+        run_agent_availability_probe(config)
+
+        script_start = epoch_seconds()
+        script_start_ns = epoch_nanoseconds()
+        phase = "skill_availability_setup"
+        skill_start, skill_end, skill_exposure = setup_skill_availability(config)
+        phase = "input_copy"
+        input_start, input_end = prepare_input_workspace(config)
+        write_workspace_baseline(config.run_input_dir, config.result_dir / "input_baseline_manifest.json")
+        write_workspace_baseline(config.run_workspace_dir, config.result_dir / "workspace_baseline_manifest.json")
+        phase = "prompt_prepare"
+        prompt_start, prompt_end = prepare_prompt(config)
+
+        phase = "agent_exec"
+        progress = ProgressWriter(config.mode, script_start, config.progress_log_path)
+        agent_start, agent_end, agent_exit = run_agent(config, progress, skill_exposure, agent_launch)
+        elapsed_seconds = agent_end - agent_start
+        phase = "post_process"
+        post_start, post_end = post_process(config, elapsed_seconds, agent_exit, script_start_ns)
+        normal_record_written = True
+        phase = "report_outcome"
+        report_start = epoch_seconds()
+        report_statuses: dict[str, int] = {}
+        final_exit = write_report_outcome(config, agent_exit, report_statuses)
+        report_end = epoch_seconds()
+
+        script_end = epoch_seconds()
+        phase = "finalize_timing"
+        finalize_timing(
+            config.result_dir / "run_summary.json",
+            config.final_record_path,
+            config.result_dir / "timing.json",
+            config.agent_activity_path,
+            LifecycleEpochs(
+                script_start=script_start,
+                skill_availability_start=skill_start,
+                skill_availability_end=skill_end,
+                input_copy_start=input_start,
+                input_copy_end=input_end,
+                prompt_prep_start=prompt_start,
+                prompt_prep_end=prompt_end,
+                agent_start=agent_start,
+                agent_end=agent_end,
+                post_process_start=post_start,
+                post_process_end=post_end,
+                report_outcome_start=report_start,
+                report_outcome_end=report_end,
+                script_end=script_end,
+            ),
+        )
+        print(
+            "Benchmark run complete: "
+            f"mode={config.mode}; elapsed_seconds={script_end - script_start}; "
+            f"agent_elapsed_seconds={elapsed_seconds}; final_exit={final_exit}; result_dir={config.result_dir}",
+            flush=True,
+        )
+        return final_exit
+    except BaseException as exc:
+        if isinstance(exc, KeyboardInterrupt):
+            raise
+        return write_configured_failure(
+            config,
+            exc,
+            exit_code_from_exception(exc),
+            phase,
+            preserve_existing_record=normal_record_written,
+        )
+    finally:
+        make_tree_readable(config.result_dir)
+
+
+def main() -> None:
+    raise SystemExit(run_agent_benchmark())
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/container/progress.py
+++ b/assist_tools/skills_benchmark/skills/harness/container/progress.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Progress heartbeat writer for in-container benchmark runs."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def epoch_seconds() -> int:
+    return int(time.time())
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+class ProgressWriter:
+    def __init__(self, mode: str, script_start_epoch: int, progress_log: Path):
+        self.mode = mode
+        self.script_start_epoch = script_start_epoch
+        self.progress_log = progress_log
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+
+    def write(self, phase: str, status: str, epoch: int | None = None) -> None:
+        epoch = epoch_seconds() if epoch is None else epoch
+        elapsed = epoch - self.script_start_epoch
+        timestamp = utc_timestamp()
+        print(
+            f"[{timestamp}] benchmark progress: mode={self.mode} phase={phase} "
+            f"status={status} elapsed_seconds={elapsed}",
+            file=sys.stderr,
+            flush=True,
+        )
+        with self._lock:
+            with self.progress_log.open("a", encoding="utf-8") as stream:
+                stream.write(
+                    json.dumps(
+                        {
+                            "timestamp": timestamp,
+                            "mode": self.mode,
+                            "phase": phase,
+                            "status": status,
+                            "elapsed_seconds": elapsed,
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+
+    def start_heartbeat(self, phase: str, interval_seconds: int) -> None:
+        if interval_seconds <= 0:
+            return
+
+        def loop() -> None:
+            while not self._stop.wait(interval_seconds):
+                self.write(phase, "running")
+
+        self._thread = threading.Thread(target=loop, daemon=True)
+        self._thread.start()
+
+    def stop_heartbeat(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None

--- a/assist_tools/skills_benchmark/skills/harness/container/skills.py
+++ b/assist_tools/skills_benchmark/skills/harness/container/skills.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Container-side skill visibility setup for benchmark runs."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+from ..agents.base import SkillExposureResult, SkillExposureSpec
+from ..common import write_json
+
+EXPOSURE_ACTION_TIMEOUT_SECONDS = 300
+
+
+def discover_bundled_skills_root() -> str | None:
+    value = os.environ.get("SDK_PACKAGED_SKILLS_ROOT", "")
+    return value or None
+
+
+def copy_optional_metadata_files(source_dir: Path, result_dir: Path, names: tuple[str, ...]) -> dict[str, Any]:
+    copied = []
+    missing = []
+    for name in names:
+        if Path(name).name != name:
+            raise ValueError(f"metadata file name must not contain path separators: {name}")
+        source = source_dir / name
+        if source.is_file():
+            shutil.copy2(source, result_dir / name)
+            copied.append({"source": str(source), "target": str(result_dir / name)})
+        else:
+            missing.append(str(source))
+    payload = {"copied": copied, "missing": missing}
+    if missing:
+        write_json(result_dir / "skills_metadata_missing.json", payload)
+    return payload
+
+
+def copy_metadata_paths(paths: list[Path], result_dir: Path, container_home: Path | None) -> list[dict[str, str]]:
+    copied = []
+    missing = []
+    for source in paths:
+        if container_home is None or not is_within_path(source, container_home):
+            write_json(
+                result_dir / "skills_state.json",
+                {
+                    "status": "error",
+                    "reason": "metadata_file_outside_container_home",
+                    "metadata_file": str(source),
+                    "container_home": str(container_home) if container_home else None,
+                },
+            )
+            raise SystemExit(2)
+        if source.is_file():
+            target = result_dir / source.name
+            shutil.copy2(source, target)
+            copied.append({"source": str(source), "target": str(target)})
+        else:
+            missing.append(str(source))
+    if missing:
+        write_json(result_dir / "skills_metadata_missing.json", {"copied": copied, "missing": missing})
+    return copied
+
+
+def remove_directory_contents(root: Path) -> list[str]:
+    disabled = []
+    root.mkdir(parents=True, exist_ok=True)
+    for child in list(root.iterdir()):
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink(missing_ok=True)
+        disabled.append(str(child))
+    return disabled
+
+
+def resolved(path: Path) -> Path:
+    return path.resolve(strict=False)
+
+
+def is_within_path(path: Path, root: Path) -> bool:
+    try:
+        resolved(path).relative_to(resolved(root))
+    except ValueError:
+        return False
+    return True
+
+
+def validate_skill_root_scope(spec: SkillExposureSpec, result_dir: Path) -> None:
+    if spec.skill_root is None:
+        return
+    if spec.container_home is None:
+        write_json(
+            result_dir / "skills_state.json",
+            {
+                "status": "error",
+                "reason": "container_home_required_for_skill_root",
+                "mechanism_type": spec.mechanism_type,
+                "skill_root": str(spec.skill_root),
+            },
+        )
+        raise SystemExit(2)
+    if is_within_path(spec.skill_root, spec.container_home):
+        return
+    write_json(
+        result_dir / "skills_state.json",
+        {
+            "status": "error",
+            "reason": "skill_root_outside_container_home",
+            "mechanism_type": spec.mechanism_type,
+            "skill_root": str(spec.skill_root),
+            "container_home": str(spec.container_home),
+        },
+    )
+    raise SystemExit(2)
+
+
+def skill_root_has_installed_skills(spec: SkillExposureSpec, result_dir: Path) -> bool:
+    if spec.skill_root is None:
+        return True
+    try:
+        return spec.skill_root.is_dir() and any(path.is_dir() for path in spec.skill_root.iterdir())
+    except OSError as exc:
+        write_json(
+            result_dir / "skills_state.json",
+            {
+                "status": "error",
+                "reason": "skill_root_unreadable",
+                "mechanism_type": spec.mechanism_type,
+                "skill_root": str(spec.skill_root),
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+        )
+        raise SystemExit(2) from exc
+
+
+def timeout_output_text(exc: subprocess.TimeoutExpired) -> str:
+    output = exc.output if exc.output is not None else getattr(exc, "stdout", None)
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    if isinstance(output, str):
+        return output
+    return ""
+
+
+def run_exposure_action(
+    action: list[str],
+    result_dir: Path,
+    name: str,
+    env: dict[str, str],
+    *,
+    timeout_seconds: int = EXPOSURE_ACTION_TIMEOUT_SECONDS,
+) -> tuple[str, str | None]:
+    if not action:
+        return "skipped", None
+    output_path = result_dir / f"skills_{name}_output.txt"
+    try:
+        result = subprocess.run(
+            action,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env={**os.environ, **env},
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output_path.write_text(timeout_output_text(exc), encoding="utf-8")
+        write_json(
+            result_dir / "skills_state.json",
+            {
+                "status": "error",
+                "reason": "action_timeout",
+                "action_name": name,
+                "timeout_seconds": timeout_seconds,
+                "mechanism_type": "action",
+                "command": action,
+                "output_ref": str(output_path),
+            },
+        )
+        raise SystemExit(2) from exc
+    output_path.write_text(result.stdout or "", encoding="utf-8")
+    if result.returncode != 0:
+        write_json(
+            result_dir / "skills_state.json",
+            {
+                "status": "error",
+                "reason": f"{name}_action_failed",
+                "exit_code": result.returncode,
+                "mechanism_type": "action",
+                "command": action,
+                "output_ref": str(output_path),
+            },
+        )
+        raise SystemExit(2)
+    return "passed", str(output_path)
+
+
+def apply_skill_exposure(
+    *,
+    spec: SkillExposureSpec,
+    skills_enabled: bool,
+    result_dir: Path,
+    sdk_image_kind: str,
+    bundled_skills_root: Callable[[], str | None] = discover_bundled_skills_root,
+) -> SkillExposureResult:
+    validate_skill_root_scope(spec, result_dir)
+    if spec.mechanism_type == "none":
+        result = SkillExposureResult(status="skipped", mechanism_type=spec.mechanism_type)
+        write_json(
+            result_dir / "skills_state.json",
+            {
+                "status": result.status,
+                "skills_enabled": skills_enabled,
+                "mechanism_type": spec.mechanism_type,
+                "source": sdk_image_kind,
+            },
+        )
+        return result
+
+    if skills_enabled:
+        setup_status, setup_output_ref = run_exposure_action(
+            spec.setup_action, result_dir, "setup_action", spec.environment
+        )
+        if not skill_root_has_installed_skills(spec, result_dir):
+            write_json(
+                result_dir / "skills_state.json",
+                {
+                    "status": "error",
+                    "reason": f"preinstalled skills are missing from {spec.skill_root}",
+                    "mechanism_type": spec.mechanism_type,
+                },
+            )
+            raise SystemExit(2)
+        metadata_files = copy_metadata_paths(spec.metadata_files, result_dir, spec.container_home)
+        probe_status, probe_output_ref = run_exposure_action(
+            spec.probe_action, result_dir, "probe_action", spec.environment
+        )
+        write_json(
+            result_dir / "skills_state.json",
+            {
+                "status": "prepared",
+                "source": sdk_image_kind,
+                "skills_enabled": True,
+                "mechanism_type": spec.mechanism_type,
+                "setup_status": setup_status,
+                "setup_output_ref": setup_output_ref,
+                "probe_status": probe_status,
+                "probe_output_ref": probe_output_ref,
+            },
+        )
+        return SkillExposureResult(
+            status="prepared",
+            mechanism_type=spec.mechanism_type,
+            installed_paths=[str(spec.skill_root)] if spec.skill_root else [],
+            launch_args=list(spec.launch_args),
+            environment=dict(spec.environment),
+            probe_status=probe_status,
+            probe_output_ref=probe_output_ref,
+            metadata_files=metadata_files,
+        )
+
+    disable_status, disable_output_ref = run_exposure_action(
+        spec.disable_action, result_dir, "disable_action", spec.environment
+    )
+    disabled_paths = remove_directory_contents(spec.skill_root) if spec.skill_root else []
+    parser_warnings = []
+    if not spec.skill_root:
+        parser_warnings.append("no skill_root configured for disabled skill exposure")
+    bundled_root = bundled_skills_root() if spec.disable_packaged_source else None
+    removed_packaged_source = False
+    if bundled_root:
+        path = Path(bundled_root)
+        if not is_within_path(path, Path("/workspace")):
+            write_json(
+                result_dir / "skills_state.json",
+                {
+                    "status": "error",
+                    "reason": "bundled_skill_source_outside_workspace",
+                    "mechanism_type": spec.mechanism_type,
+                    "bundled_skill_source_path": str(path),
+                },
+            )
+            raise SystemExit(2)
+        if path.is_dir():
+            shutil.rmtree(path)
+            removed_packaged_source = True
+            disabled_paths.append(str(path))
+
+    write_json(
+        result_dir / "skills_state.json",
+        {
+            "status": "disabled",
+            "source": sdk_image_kind,
+            "skills_enabled": False,
+            "image_kind": sdk_image_kind,
+            "mechanism_type": spec.mechanism_type,
+            "disabled_paths": disabled_paths,
+            "disable_status": disable_status,
+            "disable_output_ref": disable_output_ref,
+            "note": parser_warnings[0] if parser_warnings else "",
+            "packaged_skill_source_removed_during_agent": removed_packaged_source,
+            "packaged_skill_source_path": bundled_root,
+            "reporting_note": (
+                "Wrapper-side reports run from the skills image so benchmark contracts are available "
+                "outside the measured agent container."
+            ),
+        },
+    )
+    write_json(
+        result_dir / "skills_list.json",
+        {"status": "skipped", "installed": [], "reason": "skills intentionally removed for baseline run"},
+    )
+    return SkillExposureResult(
+        status="disabled",
+        mechanism_type=spec.mechanism_type,
+        disabled_paths=disabled_paths,
+        parser_warnings=parser_warnings,
+    )

--- a/assist_tools/skills_benchmark/skills/harness/events.py
+++ b/assist_tools/skills_benchmark/skills/harness/events.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent event parsing for usage and activity metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+MAX_ACTIVITY_COMMANDS = 200
+MAX_TRACKED_EVENT_TYPES = 500
+MAX_TRACKED_COMMAND_PREFIXES = 500
+MAX_TRACKED_UNIQUE_COMMANDS = 10000
+
+
+def walk(obj: Any, depth: int = 20) -> Iterable[dict[str, Any]]:
+    if depth < 0:
+        return
+    if isinstance(obj, dict):
+        yield obj
+        for value in obj.values():
+            yield from walk(value, depth - 1)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from walk(value, depth - 1)
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def normalize_command(value: Any) -> str | None:
+    if isinstance(value, list):
+        return " ".join(str(item) for item in value)
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def increment_bounded_counter(counter: Counter[str], key: str, max_keys: int) -> bool:
+    if key in counter or len(counter) < max_keys:
+        counter[key] += 1
+        return False
+    return True
+
+
+def parse_usage_and_activity_data(events_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    # Usage and activity are derived in one pass so large event streams are only
+    # decoded once; keep output-specific normalization below clearly separated.
+    last_total_tokens: float | None = None
+    max_total_tokens: float | None = None
+    last_input_tokens: float | None = None
+    last_output_tokens: float | None = None
+    max_input_tokens: float | None = None
+    max_output_tokens: float | None = None
+    raw_usage_object_count = 0
+    token_parser_warnings: list[str] = []
+    event_count = 0
+    decode_errors = 0
+    event_types: Counter[str] = Counter()
+    command_prefixes: Counter[str] = Counter()
+    commands: list[str] = []
+    unique_commands_seen: set[str] = set()
+    command_count = 0
+    commands_truncated = False
+    unique_commands_truncated = False
+    event_types_truncated = False
+    command_prefixes_truncated = False
+    hint_counts: Counter[str] = Counter()
+    first_event_dt = None
+    first_event_timestamp = None
+    last_event_dt = None
+    last_event_timestamp = None
+    previous_event_dt = None
+    max_inter_event_gap_seconds = None
+
+    hints = {
+        "skill_md": ["skill.md"],
+        "skill_references": ["/references/", " references/"],
+        "skill_metadata": ["evals/evals.json", "/evals/"],
+        "benchmark_md": ["benchmark.md"],
+        "agent_inspect": ["agent inspect"],
+        "agent_skill_setup": ["skills install", "skills list"],
+        "py_compile": ["py_compile"],
+        "python_job_py": ["python job.py", "python3 job.py"],
+        "simulation": ["simulator", "simulate", "--workspace-root"],
+        "shell_find": ["find "],
+        "shell_rg": ["rg "],
+        "shell_cat_or_sed": ["cat ", "sed ", "nl -ba"],
+    }
+
+    def maybe_add_command(key: str, value: Any) -> None:
+        nonlocal command_count, command_prefixes_truncated, commands_truncated, unique_commands_truncated
+        if str(key).lower() not in {"cmd", "command", "shell_command"}:
+            return
+        command = normalize_command(value)
+        if not command:
+            return
+        command = command.strip()
+        if not command:
+            return
+        command_count += 1
+        if command in unique_commands_seen or len(unique_commands_seen) < MAX_TRACKED_UNIQUE_COMMANDS:
+            unique_commands_seen.add(command)
+        else:
+            unique_commands_truncated = True
+        if len(commands) < MAX_ACTIVITY_COMMANDS:
+            commands.append(command)
+        else:
+            commands_truncated = True
+        if increment_bounded_counter(command_prefixes, command.split()[0], MAX_TRACKED_COMMAND_PREFIXES):
+            command_prefixes_truncated = True
+
+    def add_text_hints(text: str) -> None:
+        lowered = text.lower()
+        for name, needles in hints.items():
+            if any(needle in lowered for needle in needles):
+                hint_counts[name] += 1
+
+    if events_path.exists():
+        with events_path.open("r", encoding="utf-8", errors="replace") as events:
+            for line in events:
+                line = line.rstrip("\n")
+                if not line.strip():
+                    continue
+                add_text_hints(line)
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    decode_errors += 1
+                    continue
+                event_count += 1
+                if isinstance(event, dict):
+                    event_timestamp = event.get("harness_timestamp") or event.get("timestamp")
+                    event_dt = parse_timestamp(event_timestamp)
+                    if event_dt is not None:
+                        if first_event_dt is None:
+                            first_event_dt = event_dt
+                            first_event_timestamp = event_timestamp
+                        if previous_event_dt is not None:
+                            gap = (event_dt - previous_event_dt).total_seconds()
+                            if gap >= 0 and (max_inter_event_gap_seconds is None or gap > max_inter_event_gap_seconds):
+                                max_inter_event_gap_seconds = gap
+                        previous_event_dt = event_dt
+                        last_event_dt = event_dt
+                        last_event_timestamp = event_timestamp
+                    for key in ("type", "event", "name"):
+                        value = event.get(key)
+                        if isinstance(value, str):
+                            if increment_bounded_counter(event_types, value, MAX_TRACKED_EVENT_TYPES):
+                                event_types_truncated = True
+                    for container_key in ("msg", "item", "delta"):
+                        container = event.get(container_key)
+                        if isinstance(container, dict):
+                            value = container.get("type") or container.get("name")
+                            if isinstance(value, str):
+                                if increment_bounded_counter(event_types, value, MAX_TRACKED_EVENT_TYPES):
+                                    event_types_truncated = True
+                for item in walk(event):
+                    lowered = {str(k).lower(): v for k, v in item.items()}
+                    if any(k in lowered for k in ("usage", "token_usage")):
+                        raw_usage_object_count += 1
+                    for key, value in item.items():
+                        maybe_add_command(key, value)
+                    for key, value in lowered.items():
+                        if not isinstance(value, (int, float)) or isinstance(value, bool):
+                            continue
+                        normalized = key.replace("-", "_")
+                        if normalized in {"total_tokens", "total_token_count", "total_used_tokens"}:
+                            last_total_tokens = value
+                            max_total_tokens = value if max_total_tokens is None else max(max_total_tokens, value)
+                        elif normalized in {"input_tokens", "prompt_tokens", "input_token_count"}:
+                            max_input_tokens = value if max_input_tokens is None else max(max_input_tokens, value)
+                            last_input_tokens = value
+                        elif normalized in {"output_tokens", "completion_tokens", "output_token_count"}:
+                            max_output_tokens = value if max_output_tokens is None else max(max_output_tokens, value)
+                            last_output_tokens = value
+
+    total_tokens = last_total_tokens
+    fallback_total = None
+    if last_input_tokens is not None or last_output_tokens is not None:
+        fallback_total = (last_input_tokens or 0) + (last_output_tokens or 0)
+    if total_tokens is None and fallback_total is not None:
+        total_tokens = fallback_total
+        token_parser_warnings.append(
+            "No cumulative total_tokens field was found; total_tokens uses last input_tokens plus last output_tokens."
+        )
+    if total_tokens is not None and fallback_total is not None and total_tokens < fallback_total:
+        token_parser_warnings.append(
+            "Last cumulative total_tokens is smaller than last input_tokens plus last output_tokens; token fields may not share the same semantics."
+        )
+
+    usage = {
+        "total_tokens": total_tokens,
+        "max_input_tokens": max_input_tokens,
+        "max_output_tokens": max_output_tokens,
+        "last_input_tokens": last_input_tokens,
+        "last_output_tokens": last_output_tokens,
+        "max_total_tokens_seen": max_total_tokens,
+        "token_parser": "last cumulative total_tokens from agent JSON events; fallback is last input_tokens plus last output_tokens",
+        "token_parser_warnings": token_parser_warnings,
+        "usage_objects_seen": raw_usage_object_count,
+    }
+    activity = {
+        "event_count": event_count,
+        "json_decode_errors": decode_errors,
+        "timestamp_field": "harness_timestamp",
+        "first_event_timestamp": first_event_timestamp,
+        "last_event_timestamp": last_event_timestamp,
+        "event_span_seconds": (
+            round((last_event_dt - first_event_dt).total_seconds(), 3)
+            if first_event_dt is not None and last_event_dt is not None
+            else None
+        ),
+        "max_inter_event_gap_seconds": (
+            round(max_inter_event_gap_seconds, 3) if max_inter_event_gap_seconds is not None else None
+        ),
+        "event_types": dict(event_types.most_common()),
+        "event_types_truncated": event_types_truncated,
+        "command_count": command_count,
+        "unique_command_count": len(unique_commands_seen),
+        "unique_commands_truncated": unique_commands_truncated,
+        "command_prefix_counts": dict(command_prefixes.most_common()),
+        "command_prefix_counts_truncated": command_prefixes_truncated,
+        "hint_counts": dict(hint_counts.most_common()),
+        "commands": commands,
+        "commands_truncated": commands_truncated,
+    }
+    return usage, activity
+
+
+def parse_usage_and_activity(events_path: Path, usage_out: Path, activity_out: Path) -> None:
+    usage, activity = parse_usage_and_activity_data(events_path)
+    usage_out.write_text(json.dumps(usage, indent=2, sort_keys=True), encoding="utf-8")
+    activity_out.write_text(json.dumps(activity, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("parse",))
+    parser.add_argument("events_path", type=Path)
+    parser.add_argument("usage_out", type=Path)
+    parser.add_argument("activity_out", type=Path)
+    args = parser.parse_args()
+    parse_usage_and_activity(args.events_path, args.usage_out, args.activity_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/host/runner.py
+++ b/assist_tools/skills_benchmark/skills/harness/host/runner.py
@@ -1,0 +1,965 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host-side benchmark orchestration CLI."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import traceback
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterable
+
+from ..agents.registry import DEFAULT_BENCHMARK_AGENT, load_agent_adapter
+from ..common import load_json, write_json
+from ..modes import PAIR_RUNS, mode_spec
+from ..scenarios import (
+    ScenarioCompilation,
+    ScenarioValidationError,
+    compile_scenario,
+    compile_scenario_file,
+    slugify,
+    validate_path_budget,
+    write_scenario_summaries,
+)
+from .common import (
+    CONTAINER_PROMPT_PATH,
+    CaseConfig,
+    ImageConfig,
+    absolute_path,
+    add_agent_auth_mounts,
+    add_agent_passthrough_env,
+    default_results_root,
+    docker_args_for_case,
+    docker_env,
+    emit,
+    parse_host_cli_options,
+    stream_command,
+    timestamp_slug,
+    write_runtime_image,
+)
+
+STALE_RESULT_FILES = (
+    "comprehensive_report.json",
+    "comprehensive_report.md",
+    "metrics_plots.png",
+    "metrics_plots.svg",
+    "metrics_summary.json",
+    "metrics_report.html",
+    "metrics_report.json",
+    "metrics_report.md",
+    "benchmark_insights.md",
+    "pair_summary.json",
+    "process_eval_ablation_summary.json",
+    "report_generator_status.json",
+    "skill_benchmark.json",
+    "skill_benchmark.md",
+    "skill_performance.json",
+    "skill_performance.txt",
+    "skill_report_status.json",
+    "scenario.json",
+    "run_plan.json",
+    "scenario_summary.json",
+)
+STALE_RESULT_DIRS = (
+    "process_eval_runs",
+    "records",
+    "reports",
+    "with_skills_eval_off",
+    "with_skills_eval_on",
+)
+
+
+@dataclass(frozen=True)
+class InteractiveRuntimeConfig:
+    agent: str
+    agent_model: str
+    model_was_explicit: bool
+
+
+@dataclass(frozen=True)
+class ScenarioCliOptions:
+    scenario_path: Path
+    results_root: Path | None = None
+    result_root: Path | None = None
+    agent_home: Path | None = None
+    mount_agent_auth: bool | None = None
+
+
+@dataclass(frozen=True)
+class ReplayCliOptions:
+    result_root: Path
+
+
+@dataclass(frozen=True)
+class RuntimeAuthOptions:
+    agent_home: Path | None = None
+    mount_agent_auth: bool | None = None
+
+    @property
+    def has_overrides(self) -> bool:
+        return self.agent_home is not None or self.mount_agent_auth is not None
+
+
+def run_one_case(config: CaseConfig, *, logs: Iterable[Path] = (), prefix: str | None = None) -> int:
+    config.result_dir.mkdir(parents=True, exist_ok=True)
+    emit(f"Running mode={config.mode} with runtime image: {config.run_image}", logs=logs, prefix=prefix)
+    emit(f"Report image: {config.images.report_image_name}", logs=logs, prefix=prefix)
+    emit(f"Job folder: {config.job_input_dir} -> /workspace/input", logs=logs, prefix=prefix)
+    emit(f"Prompt file: {config.prompt_path} -> {CONTAINER_PROMPT_PATH}", logs=logs, prefix=prefix)
+    write_runtime_image(config)
+    status = stream_command(
+        docker_args_for_case(config, logs=logs, prefix=prefix),
+        logs=logs,
+        prefix=prefix,
+        timeout_seconds=config.container_timeout_seconds,
+    )
+    write_json(config.result_dir / "container_exit_code.json", {"exit_code": status})
+    if enforce_result_size_budget(config, logs=logs, prefix=prefix):
+        return 1
+    return combined_exit_status({config.mode: status})
+
+
+def directory_size_bytes(path: Path) -> int:
+    total = 0
+    for dirpath, dirnames, filenames in os.walk(path, followlinks=False):
+        dirnames[:] = [name for name in dirnames if not (Path(dirpath) / name).is_symlink()]
+        for name in filenames:
+            item = Path(dirpath) / name
+            try:
+                if item.is_symlink() or not item.is_file():
+                    continue
+                total += item.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def enforce_result_size_budget(config: CaseConfig, *, logs: Iterable[Path] = (), prefix: str | None = None) -> bool:
+    budget = config.result_size_budget_bytes
+    if budget is None:
+        return False
+    used = directory_size_bytes(config.result_dir)
+    failed = used > budget
+    write_json(
+        config.result_dir / "result_size_budget.json",
+        {
+            "status": "fail" if failed else "pass",
+            "result_size_bytes": used,
+            "budget_bytes": budget,
+        },
+    )
+    if failed:
+        emit(
+            f"Result size budget exceeded: {used} bytes > {budget} bytes.",
+            logs=logs,
+            prefix=prefix,
+            stderr=True,
+        )
+    return failed
+
+
+def write_host_error(path: Path, exc: BaseException) -> None:
+    write_json(
+        path,
+        {
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+            "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        },
+    )
+
+
+def run_case_safely(config: CaseConfig, *, logs: Iterable[Path] = (), prefix: str | None = None) -> int:
+    try:
+        return run_one_case(config, logs=logs, prefix=prefix)
+    except Exception as exc:
+        config.result_dir.mkdir(parents=True, exist_ok=True)
+        write_host_error(config.result_dir / "host_case_error.json", exc)
+        emit(
+            f"Case failed before completion: {type(exc).__name__}: {exc}",
+            logs=logs,
+            prefix=prefix,
+            stderr=True,
+        )
+        return 1
+
+
+def run_one(argv: list[str]) -> int:
+    options = parse_host_cli_options(argv, "run-one")
+    try:
+        adapter = agent_adapter_from_options(options)
+        images = image_config_from_adapter(adapter)
+        compilation = one_compilation_from_options(options)
+    except ScenarioValidationError as exc:
+        return emit_scenario_validation_error(exc)
+    mode = str(compilation.run_plan["entries"][0]["mode"])
+    result_root = single_result_dir(options, mode)
+    result_root.mkdir(parents=True, exist_ok=True)
+    clean_pair_result_root(result_root)
+    console_log = result_root / "console_output.log"
+    console_log.write_text("", encoding="utf-8")
+    logs = (console_log,)
+
+    emit(f"Result root: {result_root}", logs=logs)
+    emit(f"Console log: {console_log}", logs=logs)
+    emit(f"Runtime image: {images.image_name}", logs=logs)
+    emit(f"Report image: {images.report_image_name}", logs=logs)
+    emit(f"Job folder: {options.job_input}", logs=logs)
+    emit(f"Prompt file: {options.prompt_path} -> {CONTAINER_PROMPT_PATH}", logs=logs)
+
+    try:
+        run_statuses, scenario_summary = execute_run_plan(
+            compilation,
+            result_root=result_root,
+            logs=logs,
+            **execute_auth_kwargs(options),
+        )
+    except ScenarioValidationError as exc:
+        status = emit_scenario_validation_error(exc, logs=logs)
+        write_host_report_status(result_root)
+        return status
+
+    emit(f"Scenario summary: {result_root / 'scenario_summary.json'}", logs=logs)
+    emit(f"Scenario report: {result_root / 'reports' / 'scenario_report.md'}", logs=logs)
+    write_host_report_status(result_root)
+    return (
+        1
+        if any(status != 0 for status in run_statuses.values())
+        or scenario_summary.get("status") in {"degraded", "failed"}
+        else 0
+    )
+
+
+def single_result_dir(options, mode: str) -> Path:
+    if options.result_dir is not None:
+        return options.result_dir
+    if options.results_root is not None:
+        return options.results_root / "single" / f"{timestamp_slug()}_{mode}"
+    return absolute_path(
+        os.environ.get("RESULT_DIR", str(default_results_root() / "single" / f"{timestamp_slug()}_{mode}"))
+    )
+
+
+def comparison_result_root(options, *, default_prefix: str | None = None) -> Path:
+    if options.result_root is not None:
+        return options.result_root
+    timestamp = timestamp_slug()
+    default_name = f"{default_prefix}_{timestamp}" if default_prefix else timestamp
+    if options.results_root is not None:
+        return options.results_root / default_name
+    return absolute_path(os.environ.get("RESULT_ROOT", str(default_results_root() / default_name)))
+
+
+def scenario_result_root(options: ScenarioCliOptions, compilation: ScenarioCompilation) -> Path:
+    if options.result_root is not None:
+        return options.result_root
+    slug = compilation.scenario.get("scenario_slug") or slugify(str(compilation.scenario.get("name") or "scenario"))
+    default_name = f"{slug}_{timestamp_slug()}"
+    if options.results_root is not None:
+        return options.results_root / default_name
+    return absolute_path(os.environ.get("RESULT_ROOT", str(default_results_root() / default_name)))
+
+
+def parse_scenario_cli_options(argv: list[str]) -> ScenarioCliOptions:
+    scenario_path: Path | None = None
+    results_root: Path | None = None
+    result_root: Path | None = None
+    agent_home: Path | None = None
+    mount_agent_auth: bool | None = None
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--results-root" or arg.startswith("--results-root="):
+            value, index = _scenario_option_value(argv, index, "--results-root")
+            if results_root is not None:
+                raise SystemExit("Expected only one --results-root")
+            results_root = absolute_path(value)
+        elif (
+            arg in {"--output-dir", "--result-root"}
+            or arg.startswith("--output-dir=")
+            or arg.startswith("--result-root=")
+        ):
+            option = "--output-dir" if arg.startswith("--output-dir") else "--result-root"
+            value, index = _scenario_option_value(argv, index, option)
+            if result_root is not None:
+                raise SystemExit("Expected only one exact output directory")
+            result_root = absolute_path(value)
+        elif arg == "--agent-home" or arg.startswith("--agent-home="):
+            value, index = _scenario_option_value(argv, index, "--agent-home")
+            if agent_home is not None:
+                raise SystemExit("Expected only one --agent-home")
+            agent_home = absolute_path(value)
+        elif arg == "--no-agent-auth-mount":
+            if mount_agent_auth is False:
+                raise SystemExit("Expected only one --no-agent-auth-mount")
+            mount_agent_auth = False
+            index += 1
+        elif arg in {"-h", "--help"}:
+            print(
+                "Usage: run.sh scenario SCENARIO.yaml "
+                "[--results-root PATH|--output-dir PATH] [--agent-home PATH] [--no-agent-auth-mount]"
+            )
+            raise SystemExit(0)
+        elif arg.startswith("-"):
+            raise SystemExit(f"Unknown scenario option: {arg}")
+        else:
+            if scenario_path is not None:
+                raise SystemExit("Expected only one scenario YAML file")
+            scenario_path = absolute_path(arg)
+            index += 1
+    if scenario_path is None:
+        raise SystemExit("Scenario YAML file is required.")
+    if not scenario_path.is_file():
+        raise SystemExit(f"Scenario YAML file must exist: {scenario_path}")
+    if results_root is not None and result_root is not None:
+        raise SystemExit("Use --results-root or --output-dir, not both.")
+    return ScenarioCliOptions(
+        scenario_path=scenario_path,
+        results_root=results_root,
+        result_root=result_root,
+        agent_home=agent_home,
+        mount_agent_auth=mount_agent_auth,
+    )
+
+
+def parse_replay_cli_options(argv: list[str]) -> ReplayCliOptions:
+    result_root: Path | None = None
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if (
+            arg in {"--result-root", "--output-dir"}
+            or arg.startswith("--result-root=")
+            or arg.startswith("--output-dir=")
+        ):
+            option = "--result-root" if arg.startswith("--result-root") else "--output-dir"
+            value, index = _scenario_option_value(argv, index, option)
+            if result_root is not None:
+                raise SystemExit("Expected only one replay result root")
+            result_root = absolute_path(value)
+        elif arg in {"-h", "--help"}:
+            print("Usage: run.sh replay RESULT_ROOT")
+            raise SystemExit(0)
+        elif arg.startswith("-"):
+            raise SystemExit(f"Unknown replay option: {arg}")
+        else:
+            if result_root is not None:
+                raise SystemExit("Expected only one replay result root")
+            result_root = absolute_path(arg)
+            index += 1
+    if result_root is None:
+        raise SystemExit("Replay result root is required.")
+    if not (result_root / "run_plan.json").is_file():
+        raise SystemExit(f"Replay result root must contain run_plan.json: {result_root}")
+    return ReplayCliOptions(result_root=result_root)
+
+
+def _scenario_option_value(argv: list[str], index: int, option: str) -> tuple[str, int]:
+    arg = argv[index]
+    if arg.startswith(f"{option}="):
+        return arg.split("=", 1)[1], index + 1
+    if index + 1 >= len(argv):
+        raise SystemExit(f"{option} requires a path")
+    return argv[index + 1], index + 2
+
+
+def checked_bool_override(name: str, expected: bool, mode: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return expected
+    if value not in {"true", "false"}:
+        raise SystemExit(f"{name} must be true or false; got {value}")
+    actual = value == "true"
+    if actual != expected:
+        expected_text = "true" if expected else "false"
+        raise SystemExit(f"{name}={value} conflicts with MODE={mode}; expected {expected_text}.")
+    return actual
+
+
+def reject_parallel_comparison_runs(command: str) -> None:
+    parallel = os.environ.get("PARALLEL_CASES", "false").strip().lower()
+    if parallel not in {"", "0", "false", "no", "off"}:
+        raise SystemExit(
+            f"PARALLEL_CASES is no longer supported for benchmark comparisons; {command} runs sequentially."
+        )
+
+
+def clean_pair_result_root(result_root: Path) -> None:
+    """Remove generated artifacts from older harness layouts before a fresh pair run."""
+
+    for spec in PAIR_RUNS:
+        path = result_root / spec.mode
+        if path.exists():
+            shutil.rmtree(path)
+    for name in STALE_RESULT_DIRS:
+        path = result_root / name
+        if path.exists():
+            shutil.rmtree(path)
+    for name in STALE_RESULT_FILES:
+        path = result_root / name
+        if path.exists() and path.is_file():
+            path.unlink()
+
+
+def pair_compilation_from_options(options) -> ScenarioCompilation:
+    adapter = agent_adapter_from_options(options)
+    agent_model, model_was_explicit = agent_model_from_options(adapter, options)
+    agent_entry: dict[str, object] = {"name": adapter.name}
+    if model_was_explicit:
+        agent_entry["models"] = [agent_model]
+    raw = {
+        "name": f"pair {adapter.name} {options.job_input.name}",
+        "prompt": str(options.prompt_path),
+        "agents": [agent_entry],
+        "comparison": {"type": "mode_ablation", "modes": [spec.mode for spec in PAIR_RUNS]},
+        "workflows": [{"name": options.workflow or os.environ.get("BENCHMARK_WORKFLOW", "default")}],
+        "jobs": [
+            {
+                "name": options.job_input.name,
+                "path": str(options.job_input),
+                "scale": options.job_scale
+                or os.environ.get("BENCHMARK_JOB_SCALE", os.environ.get("JOB_SCALE", "small")),
+            }
+        ],
+    }
+    return compile_scenario(raw, base_dir=Path.cwd(), allow_external_prompt=True)
+
+
+def one_compilation_from_options(options) -> ScenarioCompilation:
+    adapter = agent_adapter_from_options(options)
+    mode = options.mode or os.environ.get("MODE", "with_skills")
+    try:
+        spec = mode_spec(mode)
+    except ValueError as exc:
+        raise ScenarioValidationError(str(exc).replace("Unknown mode", "Unknown MODE")) from exc
+    checked_bool_override(
+        "USE_PREINSTALLED_SKILLS",
+        spec.skills_enabled,
+        mode,
+    )
+    agent_model, model_was_explicit = agent_model_from_options(adapter, options)
+    agent_entry: dict[str, object] = {"name": adapter.name}
+    if model_was_explicit:
+        agent_entry["models"] = [agent_model]
+    raw = {
+        "name": f"one {adapter.name} {mode} {options.job_input.name}",
+        "prompt": str(options.prompt_path),
+        "agents": [agent_entry],
+        "comparison": {"type": "one", "mode": mode},
+        "workflows": [{"name": options.workflow or os.environ.get("BENCHMARK_WORKFLOW", "default")}],
+        "jobs": [
+            {
+                "name": options.job_input.name,
+                "path": str(options.job_input),
+                "scale": options.job_scale
+                or os.environ.get("BENCHMARK_JOB_SCALE", os.environ.get("JOB_SCALE", "small")),
+            }
+        ],
+    }
+    return compile_scenario(raw, base_dir=Path.cwd(), allow_external_prompt=True)
+
+
+def image_config_for_agent(agent: str) -> ImageConfig:
+    return image_config_from_adapter(load_agent_adapter(agent))
+
+
+def image_config_from_adapter(adapter) -> ImageConfig:
+    try:
+        return ImageConfig.for_adapter(adapter)
+    except ValueError as exc:
+        raise ScenarioValidationError(str(exc)) from exc
+
+
+def model_was_explicit_for_entry(entry: dict[str, object]) -> bool:
+    return str(entry.get("model_source") or "") != "adapter_default"
+
+
+def positive_int_resource_value(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
+
+
+def case_config_for_entry(
+    entry: dict[str, object],
+    result_root: Path,
+    runtime_auth_options: RuntimeAuthOptions | None = None,
+) -> CaseConfig:
+    adapter = load_agent_adapter(str(entry["agent"]))
+    resource_policy = entry.get("resource_policy") if isinstance(entry.get("resource_policy"), dict) else {}
+    runtime_auth_options = runtime_auth_options or RuntimeAuthOptions()
+    host_agent_home = runtime_auth_options.agent_home or absolute_path(str(adapter.host_home_from_env(os.environ)))
+    mount_host_agent_auth = (
+        runtime_auth_options.mount_agent_auth
+        if runtime_auth_options.mount_agent_auth is not None
+        else adapter.mount_auth_from_env(os.environ)
+    )
+    return CaseConfig(
+        mode=str(entry["mode"]),
+        use_preinstalled_skills=bool(entry["skills_enabled"]),
+        job_input_dir=Path(str(entry["job_path"])),
+        result_dir=result_root / str(entry["record_dir"]),
+        prompt_path=Path(str(entry["prompt_source"])),
+        images=image_config_for_agent(adapter.name),
+        progress_interval_seconds=os.environ.get("PROGRESS_INTERVAL_SECONDS", "60"),
+        agent=adapter.name,
+        agent_model=str(entry["agent_model"]),
+        model_was_explicit=model_was_explicit_for_entry(entry),
+        adapter=adapter,
+        host_agent_home=host_agent_home,
+        mount_host_agent_auth=mount_host_agent_auth,
+        agent_timeout_seconds=positive_int_resource_value(resource_policy.get("agent_timeout_seconds")),
+        container_timeout_seconds=positive_int_resource_value(resource_policy.get("container_timeout_seconds")),
+        result_size_budget_bytes=positive_int_resource_value(resource_policy.get("result_size_budget_bytes")),
+    )
+
+
+def inspect_docker_image(image: str) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", image],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except OSError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return result.returncode == 0, result.stderr.strip()
+
+
+def preflight_docker_images(
+    entries: Iterable[dict[str, object]],
+    *,
+    result_root: Path,
+    logs: Iterable[Path] = (),
+    runtime_auth_options: RuntimeAuthOptions | None = None,
+) -> None:
+    images_by_run: dict[str, list[str]] = {}
+    inspect_results: dict[str, dict[str, object]] = {}
+    for entry in entries:
+        config = case_config_for_entry(entry, result_root, runtime_auth_options)
+        images_by_run.setdefault(config.run_image, []).append(str(entry.get("run_id")))
+    for image in sorted(images_by_run):
+        available, detail = inspect_docker_image(image)
+        inspect_results[image] = {
+            "available": available,
+            "detail": detail,
+            "run_ids": images_by_run[image],
+        }
+    missing = [image for image, result in inspect_results.items() if not result["available"]]
+    payload = {
+        "status": "fail" if missing else "pass",
+        "images": inspect_results,
+        "missing_images": missing,
+    }
+    write_json(result_root / "docker_image_preflight.json", payload)
+    if not missing:
+        return
+    message = (
+        "Benchmark Docker image(s) are missing locally: "
+        + ", ".join(missing)
+        + ". Run ./bin/build.sh from assist_tools/skills_benchmark before running the benchmark."
+    )
+    emit(message, logs=logs, stderr=True)
+    raise ScenarioValidationError(message)
+
+
+def copy_file_if_present(source: Path, target: Path) -> bool:
+    if not source.is_file():
+        return False
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if source.resolve() != target.resolve():
+        shutil.copy2(source, target)
+    return True
+
+
+def canonicalize_entry_artifacts(result_root: Path, entry: dict[str, object], status: int | None) -> None:
+    record_dir = result_root / str(entry["record_dir"])
+    mode = str(entry["mode"])
+    record_dir.mkdir(parents=True, exist_ok=True)
+    write_json(record_dir / "run_plan_entry.json", entry)
+    copy_file_if_present(record_dir / "records" / f"{mode}_agent_record.json", record_dir / "agent_record.json")
+    copy_file_if_present(record_dir / "records" / f"{mode}_record.json", record_dir / "benchmark_record.json")
+    copy_file_if_present(record_dir / "run_summary.json", record_dir / "record_summary.json")
+    summary = load_json(record_dir / "record_summary.json", {}) or {}
+    if not isinstance(summary, dict):
+        summary = {}
+    runtime_image = load_json(record_dir / "runtime_image.json", {}) or {}
+    if not isinstance(runtime_image, dict):
+        runtime_image = {}
+    activity = load_json(record_dir / "agent_activity.json", {}) or {}
+    if not isinstance(activity, dict):
+        activity = {}
+    summary.update(
+        {
+            key: entry.get(key)
+            for key in (
+                "run_id",
+                "scenario_name",
+                "comparison_type",
+                "comparison_group_id",
+                "agent",
+                "agent_model",
+                "workflow",
+                "job_name",
+                "job_slug",
+                "job_path",
+                "job_scale",
+                "mode",
+                "skills_enabled",
+                "prompt_hash",
+                "prompt_source",
+            )
+        }
+    )
+    summary["host_status"] = status
+    summary["artifact_paths"] = entry.get("artifact_paths") or {}
+    summary.setdefault("runtime_image", runtime_image.get("runtime_image"))
+    summary.setdefault("wheel_variant", runtime_image.get("sdk_image_kind"))
+    summary.setdefault("command_count", activity.get("command_count"))
+    write_json(record_dir / "record_summary.json", summary)
+
+
+def execute_run_plan(
+    compilation: ScenarioCompilation,
+    *,
+    result_root: Path,
+    logs: Iterable[Path] = (),
+    runtime_auth_options: RuntimeAuthOptions | None = None,
+) -> tuple[dict[str, int], dict[str, object]]:
+    path_budget = compilation.scenario.get("path_budget")
+    if isinstance(path_budget, int):
+        validate_path_budget(
+            str(compilation.scenario.get("name") or compilation.run_plan.get("scenario_name")),
+            compilation.run_plan.get("entries") if isinstance(compilation.run_plan.get("entries"), list) else [],
+            path_budget,
+            result_root,
+        )
+    execution = compilation.write(result_root)
+    run_plan = execution.run_plan
+    entries = run_plan.get("entries") if isinstance(run_plan.get("entries"), list) else []
+    try:
+        preflight_docker_images(
+            entries,
+            result_root=result_root,
+            logs=logs,
+            runtime_auth_options=runtime_auth_options,
+        )
+    except ScenarioValidationError as exc:
+        write_scenario_summaries(
+            result_root,
+            {},
+            harness_failure={
+                "status": "failed",
+                "failure_category": "harness_preflight_failure",
+                "message": str(exc),
+            },
+        )
+        raise
+    statuses: dict[str, int] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        prefix = str(entry["run_id"])
+        emit(
+            "Starting run_id={} agent={} model={} mode={} record_dir={}".format(
+                entry["run_id"],
+                entry["agent"],
+                entry["agent_model"],
+                entry["mode"],
+                entry["record_dir"],
+            ),
+            logs=logs,
+            prefix=prefix,
+        )
+        config = case_config_for_entry(entry, result_root, runtime_auth_options)
+        status = run_case_safely(config, logs=logs, prefix=prefix)
+        statuses[str(entry["run_id"])] = status
+        canonicalize_entry_artifacts(result_root, entry, status)
+        emit(f"Finished run_id={entry['run_id']} status={status}", logs=logs, prefix=prefix)
+        if status != 0 and run_plan.get("fail_fast"):
+            emit("Stopping scenario early because fail_fast=true.", logs=logs, stderr=True)
+            break
+    summary = write_scenario_summaries(result_root, statuses)
+    return statuses, summary
+
+
+def replay_result_root(result_root: Path, *, logs: Iterable[Path] = ()) -> dict[str, object]:
+    replay_metadata = {
+        "schema_version": "1",
+        "replayed": True,
+        "agent_invocation": "replayed",
+        "replayed_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_result_root": str(result_root.resolve()),
+        "note": "Replay regenerates parser/report artifacts from captured records and does not execute Docker.",
+    }
+    write_json(result_root / "replay_metadata.json", replay_metadata)
+    run_plan = load_json(result_root / "run_plan.json", {}) or {}
+    entries = run_plan.get("entries") if isinstance(run_plan.get("entries"), list) else []
+    statuses: dict[str, int] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        record_dir = result_root / str(entry["record_dir"])
+        events_path = record_dir / "agent_events.jsonl"
+        if events_path.is_file():
+            adapter = load_agent_adapter(str(entry["agent"]))
+            write_json(record_dir / "agent_usage.json", adapter.parse_usage(events_path))
+            write_json(record_dir / "agent_activity.json", adapter.parse_activity(events_path))
+            emit(f"Replayed parsers for {entry['run_id']}: {events_path}", logs=logs)
+        container_exit = load_json(record_dir / "container_exit_code.json", {}) or {}
+        if isinstance(container_exit, dict) and isinstance(container_exit.get("exit_code"), int):
+            statuses[str(entry["run_id"])] = int(container_exit["exit_code"])
+        canonicalize_entry_artifacts(result_root, entry, statuses.get(str(entry["run_id"])))
+    return write_scenario_summaries(result_root, statuses)
+
+
+def write_host_report_status(result_root: Path) -> None:
+    scenario_report = result_root / "reports" / "scenario_report.md"
+    payload = {
+        "status": "ok" if scenario_report.is_file() else "missing_report",
+        "scenario_report": str(scenario_report),
+    }
+    write_json(
+        result_root / "host_report_status.json",
+        payload,
+    )
+
+
+def combined_exit_status(case_statuses: dict[str, int], report_statuses: dict[str, int] | None = None) -> int:
+    report_statuses = report_statuses or {}
+    return 1 if any(status != 0 for status in [*case_statuses.values(), *report_statuses.values()]) else 0
+
+
+def emit_scenario_validation_error(exc: ScenarioValidationError, *, logs: Iterable[Path] = ()) -> int:
+    emit(f"Scenario validation failed: {exc}", logs=logs, stderr=True)
+    return 1
+
+
+def run_pair(argv: list[str]) -> int:
+    reject_parallel_comparison_runs("pair")
+    options = parse_host_cli_options(argv, "pair")
+    result_root = comparison_result_root(options)
+    result_root.mkdir(parents=True, exist_ok=True)
+    clean_pair_result_root(result_root)
+    console_log = result_root / "console_output.log"
+    console_log.write_text("", encoding="utf-8")
+    logs = (console_log,)
+    try:
+        adapter = agent_adapter_from_options(options)
+        compilation = pair_compilation_from_options(options)
+        images = image_config_from_adapter(adapter)
+    except ScenarioValidationError as exc:
+        return emit_scenario_validation_error(exc, logs=logs)
+
+    emit(f"Result root: {result_root}", logs=logs)
+    emit(f"Console log: {console_log}", logs=logs)
+    emit(f"Skills image: {images.image_name}", logs=logs)
+    emit(f"Baseline image: {images.baseline_image_name}", logs=logs)
+    emit(f"Report image: {images.report_image_name}", logs=logs)
+    emit(f"Job folder: {options.job_input}", logs=logs)
+    emit(f"Prompt file: {options.prompt_path} -> {CONTAINER_PROMPT_PATH}", logs=logs)
+
+    try:
+        run_statuses, scenario_summary = execute_run_plan(
+            compilation,
+            result_root=result_root,
+            logs=logs,
+            **execute_auth_kwargs(options),
+        )
+    except ScenarioValidationError as exc:
+        status = emit_scenario_validation_error(exc, logs=logs)
+        write_host_report_status(result_root)
+        return status
+
+    emit(f"Scenario summary: {result_root / 'scenario_summary.json'}", logs=logs)
+    emit(f"Scenario report: {result_root / 'reports' / 'scenario_report.md'}", logs=logs)
+    write_host_report_status(result_root)
+    return (
+        1
+        if any(status != 0 for status in run_statuses.values())
+        or scenario_summary.get("status") in {"degraded", "failed"}
+        else 0
+    )
+
+
+def run_scenario(argv: list[str]) -> int:
+    reject_parallel_comparison_runs("scenario")
+    options = parse_scenario_cli_options(argv)
+    try:
+        compilation = compile_scenario_file(options.scenario_path)
+    except ScenarioValidationError as exc:
+        return emit_scenario_validation_error(exc)
+    result_root = scenario_result_root(options, compilation)
+    result_root.mkdir(parents=True, exist_ok=True)
+    console_log = result_root / "console_output.log"
+    console_log.write_text("", encoding="utf-8")
+    logs = (console_log,)
+
+    emit(f"Result root: {result_root}", logs=logs)
+    emit(f"Console log: {console_log}", logs=logs)
+    emit(f"Scenario file: {options.scenario_path}", logs=logs)
+    emit(f"Run count: {compilation.run_plan.get('run_count')}", logs=logs)
+
+    try:
+        statuses, summary = execute_run_plan(
+            compilation,
+            result_root=result_root,
+            logs=logs,
+            **execute_auth_kwargs(options),
+        )
+    except ScenarioValidationError as exc:
+        status = emit_scenario_validation_error(exc, logs=logs)
+        write_host_report_status(result_root)
+        return status
+    emit(f"Scenario summary: {result_root / 'scenario_summary.json'}", logs=logs)
+    emit(f"Scenario report: {result_root / 'reports' / 'scenario_report.md'}", logs=logs)
+    write_host_report_status(result_root)
+    return (
+        1 if any(status != 0 for status in statuses.values()) or summary.get("status") in {"degraded", "failed"} else 0
+    )
+
+
+def run_replay(argv: list[str]) -> int:
+    options = parse_replay_cli_options(argv)
+    console_log = options.result_root / "replay_console_output.log"
+    console_log.write_text("", encoding="utf-8")
+    logs = (console_log,)
+    emit(f"Replay result root: {options.result_root}", logs=logs)
+    summary = replay_result_root(options.result_root, logs=logs)
+    emit(f"Scenario summary: {options.result_root / 'scenario_summary.json'}", logs=logs)
+    emit(f"Scenario report: {options.result_root / 'reports' / 'scenario_report.md'}", logs=logs)
+    write_host_report_status(options.result_root)
+    # Replay regenerates artifacts from an existing result tree; it preserves
+    # degraded benchmark status instead of re-asserting pass/fail.
+    return 0 if summary.get("status") in {"passed", "degraded"} else 1
+
+
+def run_interactive(argv: list[str]) -> int:
+    options = parse_host_cli_options(argv, "interactive")
+    try:
+        adapter = agent_adapter_from_options(options)
+        agent_model, model_was_explicit = agent_model_from_options(adapter, options)
+        images = image_config_from_adapter(adapter)
+    except ScenarioValidationError as exc:
+        return emit_scenario_validation_error(exc)
+    runtime_auth_options = runtime_auth_options_from_host_cli(options)
+    host_agent_home = runtime_auth_options.agent_home or absolute_path(str(adapter.host_home_from_env(os.environ)))
+    mount_agent_auth = (
+        runtime_auth_options.mount_agent_auth
+        if runtime_auth_options.mount_agent_auth is not None
+        else adapter.mount_auth_from_env(os.environ)
+    )
+    container_records = os.environ.get("CONTAINER_RECORDS", "/tmp/agent_benchmark/records")
+    args = [
+        "docker",
+        "run",
+        "--rm",
+        "-it",
+        "-v",
+        f"{options.job_input}:/workspace/input",
+        "-v",
+        f"{options.prompt_path}:{CONTAINER_PROMPT_PATH}:ro",
+        *docker_env("JOB_INPUT_DIR", "/workspace/input"),
+        *docker_env("TRAINING_CODE", "/workspace/input"),
+        *docker_env("PROMPT_SOURCE", CONTAINER_PROMPT_PATH),
+        *docker_env("RECORDS_DIR", container_records),
+    ]
+    for name, value in sorted(
+        adapter.runtime_env(
+            InteractiveRuntimeConfig(
+                agent=adapter.name,
+                agent_model=agent_model,
+                model_was_explicit=model_was_explicit,
+            )
+        ).items()
+    ):
+        args.extend(docker_env(name, value))
+    add_agent_passthrough_env(args, adapter)
+    if mount_agent_auth:
+        interactive_config = SimpleNamespace(host_agent_home=host_agent_home)
+        add_agent_auth_mounts(args, mounts=adapter.auth_mounts(interactive_config))
+    emit(f"Mounting job folder: {options.job_input} -> /workspace/input")
+    emit(f"Using prompt file: {options.prompt_path} -> {CONTAINER_PROMPT_PATH}")
+    try:
+        return subprocess.call([*args, images.image_name, "bash"])
+    except OSError as exc:
+        emit(f"Failed to start interactive container: {type(exc).__name__}: {exc}", stderr=True)
+        return 127
+
+
+def agent_adapter_from_options(options):
+    agent_name = getattr(options, "agent", None) or os.environ.get("BENCHMARK_AGENT", DEFAULT_BENCHMARK_AGENT)
+    try:
+        return load_agent_adapter(agent_name)
+    except ValueError as exc:
+        raise ScenarioValidationError(str(exc)) from exc
+
+
+def runtime_auth_options_from_host_cli(options) -> RuntimeAuthOptions:
+    return RuntimeAuthOptions(
+        agent_home=getattr(options, "agent_home", None),
+        mount_agent_auth=getattr(options, "mount_agent_auth", None),
+    )
+
+
+def execute_auth_kwargs(options) -> dict[str, RuntimeAuthOptions]:
+    runtime_auth_options = runtime_auth_options_from_host_cli(options)
+    return {"runtime_auth_options": runtime_auth_options} if runtime_auth_options.has_overrides else {}
+
+
+def agent_model_from_options(adapter, options) -> tuple[str, bool]:
+    env = os.environ if not getattr(options, "model", None) else {**os.environ, "BENCHMARK_AGENT_MODEL": options.model}
+    try:
+        return adapter.model_from_env(env), adapter.model_was_explicit(env)
+    except ValueError as exc:
+        raise ScenarioValidationError(str(exc)) from exc
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] in {"-h", "--help"}:
+        print(
+            "Usage: python -m assist_tools.skills_benchmark.skills.harness.host.runner {run-one,pair,scenario,replay,interactive} "
+            "--prompt PATH [--training-code PATH] [--results-root PATH] [PATH]"
+        )
+        raise SystemExit(0 if len(sys.argv) >= 2 else 2)
+    command, argv = sys.argv[1], sys.argv[2:]
+    if command == "run-one":
+        status = run_one(argv)
+    elif command == "pair":
+        status = run_pair(argv)
+    elif command == "scenario":
+        status = run_scenario(argv)
+    elif command == "replay":
+        status = run_replay(argv)
+    elif command == "interactive":
+        status = run_interactive(argv)
+    else:
+        raise SystemExit(f"Unknown command: {command}")
+    raise SystemExit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/host_runner.py
+++ b/assist_tools/skills_benchmark/skills/harness/host_runner.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility entry point for the migrated host runner."""
+
+from __future__ import annotations
+
+from .host.runner import main
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/modes.py
+++ b/assist_tools/skills_benchmark/skills/harness/modes.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run-mode definitions shared by wrappers and reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ModeSpec:
+    label: str
+    mode: str
+    skills_enabled: bool
+
+
+BENCHMARK_RUNS: tuple[ModeSpec, ...] = (
+    ModeSpec("No skills baseline", "without_skills", False),
+    ModeSpec("With skills", "with_skills", True),
+)
+
+# These aliases intentionally share the same tuple. They preserve wrapper/report
+# vocabulary while the benchmark has one canonical two-mode run set.
+PAIR_RUNS: tuple[ModeSpec, ...] = BENCHMARK_RUNS
+
+KNOWN_RUNS: tuple[ModeSpec, ...] = BENCHMARK_RUNS
+KNOWN_RUN_BY_MODE: dict[str, ModeSpec] = {item.mode: item for item in KNOWN_RUNS}
+
+
+def mode_records(runs: Iterable[ModeSpec]) -> list[dict[str, object]]:
+    return [asdict(item) for item in runs]
+
+
+def mode_names(runs: Iterable[ModeSpec]) -> list[str]:
+    return [item.mode for item in runs]
+
+
+def mode_spec(mode: str) -> ModeSpec:
+    try:
+        return KNOWN_RUN_BY_MODE[mode]
+    except KeyError as exc:
+        valid_modes = ", ".join(KNOWN_RUN_BY_MODE)
+        raise ValueError(f"Unknown mode {mode}; expected one of: {valid_modes}") from exc
+
+
+def mode_shell_rows(runs: Iterable[ModeSpec]) -> list[str]:
+    rows = []
+    for item in runs:
+        rows.append("|".join([item.mode, "true" if item.skills_enabled else "false"]))
+    return rows
+
+
+def select_mode(
+    runs: Iterable[ModeSpec],
+    *,
+    skills_enabled: bool | None = None,
+) -> str:
+    for item in runs:
+        if skills_enabled is not None and item.skills_enabled != skills_enabled:
+            continue
+        return item.mode
+    raise RuntimeError("no benchmark mode matches the requested role")
+
+
+BENCHMARK_MODE_NAMES = mode_names(BENCHMARK_RUNS)
+PAIR_MODE_NAMES = mode_names(PAIR_RUNS)
+NO_SKILLS_MODE = "without_skills"
+WITH_SKILLS_MODE = "with_skills"
+PAIR_WITHOUT_MODE = NO_SKILLS_MODE
+PAIR_WITH_MODE = WITH_SKILLS_MODE
+
+
+def benchmark_runs() -> list[dict[str, object]]:
+    return mode_records(BENCHMARK_RUNS)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("benchmark-json", "benchmark-shell", "pair-json", "pair-shell"))
+    args = parser.parse_args()
+
+    if args.command == "benchmark-json":
+        print(json.dumps(mode_records(BENCHMARK_RUNS), indent=2, sort_keys=True))
+    elif args.command == "pair-json":
+        print(json.dumps(mode_records(PAIR_RUNS), indent=2, sort_keys=True))
+    else:
+        runs = PAIR_RUNS if args.command == "pair-shell" else BENCHMARK_RUNS
+        for row in mode_shell_rows(runs):
+            print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/quality_signals.py
+++ b/assist_tools/skills_benchmark/skills/harness/quality_signals.py
@@ -1,0 +1,576 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Best-effort quality signals derived from job instructions and final output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+FLOAT_PATTERN = r"(?<![A-Za-z0-9_])([0-9]+\.[0-9]+)(?![A-Za-z0-9_])"
+GENERIC_VALIDATION_METRIC_PATTERN = (
+    r"\b(?:"
+    r"(?:(?:aggregated|aggregate|global|server)\s+)?(?:best\s+)?validation\s+(?:metric|[A-Za-z0-9_/-]+)"
+    r"|(?:best\s+)?(?:aggregated|aggregate|global|server)\s+validation\s+(?:metric|[A-Za-z0-9_/-]+)"
+    r")\b"
+)
+METRIC_ALIAS_PATTERNS = {
+    "AUROC": r"\b(?:AUROC|AUC)\b|\b(?:valid|validation)[_-]?auroc\b",
+    "accuracy": r"\baccuracy\b|\b(?:valid|validation)[_-]?accuracy\b|\bacc\b",
+    "loss": r"\b(?:loss|valid[_-]?loss|validation[_-]?loss|train[_-]?loss)\b",
+    "f1": r"\b(?:f1|f1[_-]?score|valid[_-]?f1|validation[_-]?f1)\b",
+}
+
+
+def canonical_metric_name(name: Any) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", str(name or "").strip()).strip("_")
+    aliases = {
+        "auroc": "AUROC",
+        "auc": "AUROC",
+        "valid_auroc": "AUROC",
+        "validation_auroc": "AUROC",
+        "accuracy": "accuracy",
+        "acc": "accuracy",
+        "valid_accuracy": "accuracy",
+        "validation_accuracy": "accuracy",
+        "loss": "loss",
+        "valid_loss": "loss",
+        "validation_loss": "loss",
+        "train_loss": "loss",
+        "f1": "f1",
+        "f1_score": "f1",
+        "valid_f1": "f1",
+        "validation_f1": "f1",
+    }
+    return aliases.get(normalized.lower(), normalized)
+
+
+def first_float(pattern: str, text: str) -> float | None:
+    match = re.search(pattern, text, flags=re.IGNORECASE)
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_numeric_metric_value(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def format_metric_value(value: Any) -> str:
+    if isinstance(value, float):
+        return f" {value:.4f}."
+    if isinstance(value, int) and not isinstance(value, bool):
+        return f" {value}."
+    return "."
+
+
+def line_value_after_metric(line: str, match: re.Match[str]) -> float | None:
+    tail = line[match.end() :]
+    delimiter = re.search(r"[,;]", tail)
+    if delimiter:
+        tail = tail[: delimiter.start()]
+    value_match = re.search(FLOAT_PATTERN, tail)
+    return parse_float(value_match.group(1)) if value_match else None
+
+
+def label_from_metric_line(line: str) -> str | None:
+    match = re.match(r"\s*[-*]?\s*`?([^`:]+?)`?\s*:", line)
+    if not match:
+        return None
+    label = match.group(1).strip("` ")
+    return label or None
+
+
+def metric_value_entry(value: float, label: str | None = None) -> dict[str, Any]:
+    entry: dict[str, Any] = {"value": value}
+    if label:
+        entry["label"] = label
+    return entry
+
+
+def following_line_values(lines: list[str], start_index: int, metric_pattern: str, limit: int = 8) -> list[float]:
+    entries, _consumed = following_line_value_entries(lines, start_index, metric_pattern, limit)
+    return [entry["value"] for entry in entries]
+
+
+def line_metric_entries(line: str, metric_pattern: str) -> list[dict[str, Any]]:
+    label = label_from_metric_line(line)
+    entries: list[dict[str, Any]] = []
+    for match in re.finditer(metric_pattern, line, flags=re.IGNORECASE):
+        value = line_value_after_metric(line, match)
+        if value is not None:
+            entries.append(metric_value_entry(value, label))
+    return entries
+
+
+def single_unlabeled_metric_entry(line: str) -> dict[str, Any] | None:
+    label = label_from_metric_line(line)
+    matches = list(re.finditer(FLOAT_PATTERN, line))
+    if len(matches) != 1:
+        return None
+    value = parse_float(matches[0].group(1))
+    return metric_value_entry(value, label) if value is not None else None
+
+
+def following_line_value_entries(
+    lines: list[str],
+    start_index: int,
+    metric_pattern: str,
+    limit: int = 8,
+) -> tuple[list[dict[str, Any]], set[int]]:
+    entries: list[dict[str, Any]] = []
+    consumed: set[int] = set()
+    for index in range(start_index + 1, min(len(lines), start_index + 1 + limit)):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped:
+            if entries:
+                break
+            continue
+        if entries and not stripped.startswith(("-", "*", "`")) and ":" not in stripped:
+            break
+        line_entries = line_metric_entries(line, metric_pattern)
+        if not line_entries:
+            entry = single_unlabeled_metric_entry(line)
+            line_entries = [entry] if entry else []
+        if line_entries:
+            entries.extend(line_entries)
+            consumed.add(index)
+        if entries and not stripped.startswith(("-", "*", "`")):
+            break
+    return entries, consumed
+
+
+def metric_values(metric_name: str, text: str) -> list[float]:
+    return [entry["value"] for entry in metric_value_entries(metric_name, text)]
+
+
+def metric_value_entries(metric_name: str, text: str) -> list[dict[str, Any]]:
+    canonical = canonical_metric_name(metric_name)
+    pattern = METRIC_ALIAS_PATTERNS.get(canonical)
+    if not pattern:
+        pattern = rf"\b{re.escape(canonical)}\b"
+    lines = text.splitlines()
+    entries: list[dict[str, Any]] = []
+    consumed_lines: set[int] = set()
+    for index, line in enumerate(lines):
+        if index in consumed_lines:
+            continue
+        matches = list(re.finditer(pattern, line, flags=re.IGNORECASE))
+        if not matches:
+            continue
+        line_entries = line_metric_entries(line, pattern)
+        if line_entries:
+            entries.extend(line_entries)
+            continue
+        following_entries, consumed = following_line_value_entries(lines, index, pattern)
+        entries.extend(following_entries)
+        consumed_lines.update(consumed)
+    return entries
+
+
+def metric_mentioned(metric_name: str, text: str) -> bool:
+    canonical = canonical_metric_name(metric_name)
+    pattern = METRIC_ALIAS_PATTERNS.get(canonical, rf"\b{re.escape(canonical)}\b")
+    return re.search(pattern, text, flags=re.IGNORECASE) is not None
+
+
+def is_site_label(label: Any) -> bool:
+    return re.search(r"\bsite[-_ ]?\d+\b", str(label or ""), flags=re.IGNORECASE) is not None
+
+
+def is_fl_summary_metric_label(label: Any) -> bool:
+    text = str(label or "")
+    return (
+        not is_site_label(text) and re.search(GENERIC_VALIDATION_METRIC_PATTERN, text, flags=re.IGNORECASE) is not None
+    )
+
+
+def generic_validation_metric_entries(text: str) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        label = label_from_metric_line(line)
+        for match in re.finditer(GENERIC_VALIDATION_METRIC_PATTERN, line, flags=re.IGNORECASE):
+            value = line_value_after_metric(line, match)
+            if value is None:
+                continue
+            entries.append(metric_value_entry(value, label or match.group(0).strip()))
+    return entries
+
+
+def merge_metric_entries(*entry_groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    seen: set[tuple[str, float]] = set()
+    for entries in entry_groups:
+        for entry in entries:
+            value = entry.get("value")
+            if not is_numeric_metric_value(value):
+                continue
+            key = (str(entry.get("label") or "").strip().lower(), float(value))
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(entry)
+    return merged
+
+
+def fl_summary_metric_entry(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for entry in reversed(entries):
+        value = entry.get("value")
+        if is_numeric_metric_value(value) and is_fl_summary_metric_label(entry.get("label")):
+            return entry
+    return None
+
+
+def reported_metric_payload(name: str, entries: list[dict[str, Any]]) -> dict[str, Any]:
+    values = [entry["value"] for entry in entries if is_numeric_metric_value(entry.get("value"))]
+    labels = [entry.get("label") for entry in entries]
+    site_entries = [
+        entry for entry in entries if is_numeric_metric_value(entry.get("value")) and is_site_label(entry.get("label"))
+    ]
+    summary_entry = fl_summary_metric_entry(entries)
+    has_single_value = len(values) == 1
+    has_site_labels = bool(values) and len(site_entries) == len(values)
+    if summary_entry:
+        value = summary_entry["value"]
+        value_scope = "fl_summary_metric"
+    elif has_single_value:
+        value = values[0]
+        value_scope = "reported_scalar"
+    elif has_site_labels:
+        value = None
+        value_scope = "site_values_only"
+    elif values:
+        value = None
+        value_scope = "reported_values_only"
+    else:
+        value = None
+        value_scope = "not_available"
+    return {
+        "name": canonical_metric_name(name),
+        "value": value,
+        "reported_values": values,
+        "reported_value_labels": labels,
+        "reported_value_entries": entries,
+        "site_values": [entry["value"] for entry in site_entries],
+        "site_value_labels": [entry.get("label") for entry in site_entries],
+        "site_value_count": len(site_entries),
+        "summary_value_label": summary_entry.get("label") if summary_entry else None,
+        "value_scope": value_scope,
+        "source": "agent_last_message",
+    }
+
+
+PRIMARY_METRIC_PATTERNS = (
+    r"^\s*[-*]?\s*([A-Za-z][A-Za-z0-9_./ -]{0,40}?)\s+is\s+the\s+main\s+metric\b",
+    r"\bmain\s+metric\s*(?:to\s+watch\s+)?(?:is|:)\s*([A-Za-z][A-Za-z0-9_./ -]{0,40})",
+    r"\bprimary\s+(?:validation\s+)?metric\s*(?:is|:)\s*([A-Za-z][A-Za-z0-9_./ -]{0,40})",
+    r"\btarget\s+(?:validation\s+)?metric\s*(?:is|:)\s*([A-Za-z][A-Za-z0-9_./ -]{0,40})",
+)
+
+
+def primary_metric_from_guidance(guidance_text: str) -> str | None:
+    metric, _source = primary_metric_from_guidance_sources(
+        [{"source_type": "job_guidance", "text": guidance_text}],
+        guidance_text,
+    )
+    return metric
+
+
+def primary_metric_from_text(guidance_text: str) -> str | None:
+    for pattern in PRIMARY_METRIC_PATTERNS:
+        match = re.search(pattern, guidance_text, flags=re.IGNORECASE | re.MULTILINE)
+        if match:
+            metric = re.split(r"[,.;\n]", match.group(1).strip(), maxsplit=1)[0].strip()
+            metric = canonical_metric_name(metric)
+            if metric:
+                return metric
+    return None
+
+
+def primary_metric_from_readme(readme_text: str) -> str | None:
+    return primary_metric_from_guidance(readme_text)
+
+
+def guidance_source_payload(source: Any) -> tuple[str | None, list[dict[str, Any]]]:
+    if source is None:
+        return None, []
+    if isinstance(source, Path):
+        path = str(source)
+        return path, [{"path": path, "source_type": "job_guidance"}]
+    if isinstance(source, list):
+        sources = []
+        for item in source:
+            if isinstance(item, dict):
+                path = item.get("path")
+                if path:
+                    sources.append(
+                        {
+                            "path": str(path),
+                            "source_type": str(item.get("source_type") or "job_guidance"),
+                        }
+                    )
+            elif item:
+                sources.append({"path": str(item), "source_type": "job_guidance"})
+        primary = sources[0]["path"] if sources else None
+        return primary, sources
+    path = str(source)
+    return path, [{"path": path, "source_type": "job_guidance"}]
+
+
+def guidance_source_entries(source: Any, guidance_text: str) -> list[dict[str, Any]]:
+    if isinstance(source, list):
+        entries = []
+        for item in source:
+            if isinstance(item, dict):
+                entries.append(
+                    {
+                        "path": str(item.get("path") or ""),
+                        "source_type": str(item.get("source_type") or "job_guidance"),
+                        "text": str(item.get("text") or ""),
+                    }
+                )
+            elif item:
+                entries.append({"path": str(item), "source_type": "job_guidance", "text": ""})
+        if any(entry["text"] for entry in entries):
+            return entries
+
+    primary_source, sources = guidance_source_payload(source)
+    if sources:
+        return [
+            {
+                "path": str(sources[0].get("path") or primary_source or ""),
+                "source_type": str(sources[0].get("source_type") or "job_guidance"),
+                "text": guidance_text,
+            }
+        ]
+    return [{"path": "", "source_type": "job_guidance", "text": guidance_text}]
+
+
+def public_guidance_source(entry: dict[str, Any]) -> dict[str, Any]:
+    result = {
+        "source_type": str(entry.get("source_type") or "job_guidance"),
+    }
+    if entry.get("path"):
+        result["path"] = str(entry["path"])
+    return result
+
+
+def primary_metric_from_guidance_sources(
+    guidance_sources: list[dict[str, Any]], guidance_text: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    entries = guidance_sources or [{"source_type": "job_guidance", "text": guidance_text}]
+    for entry in entries:
+        metric = primary_metric_from_text(str(entry.get("text") or ""))
+        if metric:
+            return metric, entry
+    if not any(entry.get("text") for entry in entries):
+        metric = primary_metric_from_text(guidance_text)
+        if metric:
+            return metric, entries[0] if entries else None
+    return None, None
+
+
+def reported_validation_metric(last_message: str, expected_metric: str | None) -> dict[str, Any]:
+    detected = []
+    generic_entries = generic_validation_metric_entries(last_message)
+    for name in ("AUROC", "accuracy", "loss", "f1"):
+        entries = metric_value_entries(name, last_message)
+        if entries or metric_mentioned(name, last_message):
+            detected.append(reported_metric_payload(name, entries))
+    if generic_entries:
+        detected.append(reported_metric_payload("validation metric", generic_entries))
+    if expected_metric and metric_mentioned(expected_metric, last_message):
+        entries = merge_metric_entries(metric_value_entries(expected_metric, last_message), generic_entries)
+        return reported_metric_payload(expected_metric, entries)
+    if detected:
+        return detected[0]
+    return {
+        "name": None,
+        "value": None,
+        "reported_values": [],
+        "reported_value_labels": [],
+        "reported_value_entries": [],
+        "site_values": [],
+        "site_value_labels": [],
+        "site_value_count": 0,
+        "value_scope": "not_available",
+        "source": "agent_last_message",
+    }
+
+
+def required_validation_metric_status(signal: Mapping[str, Any] | None) -> str:
+    if not isinstance(signal, dict) or not signal.get("expected_primary_metric"):
+        return "not_required"
+    if signal.get("metric_value_available"):
+        return "present"
+    metric = signal.get("reported_validation_metric")
+    if isinstance(metric, dict):
+        value = metric.get("value")
+        values = metric.get("reported_values")
+        if is_numeric_metric_value(value):
+            return "present"
+        if isinstance(values, list) and any(is_numeric_metric_value(item) for item in values):
+            return "present"
+    return "missing"
+
+
+def critical_quality_checks_failed(*sources: Mapping[str, Any] | None) -> bool:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        checks = source.get("quality_checks")
+        if not isinstance(checks, list):
+            continue
+        for check in checks:
+            if not isinstance(check, dict):
+                continue
+            severity = str(check.get("severity") or "").lower()
+            status = str(check.get("status") or "").lower()
+            if severity == "critical" and (check.get("passed") is False or status in {"fail", "failed", "error"}):
+                return True
+    return False
+
+
+def metric_signal(guidance_source: Any, guidance_text: str, final_message: str) -> dict[str, Any]:
+    guidance_entries = guidance_source_entries(guidance_source, guidance_text)
+    expected, matched_source = primary_metric_from_guidance_sources(guidance_entries, guidance_text)
+    reported = reported_validation_metric(final_message, expected)
+    _primary_source, sources = guidance_source_payload(guidance_source)
+    if not sources and guidance_entries:
+        sources = [public_guidance_source(entry) for entry in guidance_entries if entry.get("path")]
+    matched_public_source = public_guidance_source(matched_source) if matched_source else {}
+    primary_source = matched_public_source.get("path") or (sources[0]["path"] if sources else None)
+    signal: dict[str, Any] = {
+        "source": primary_source,
+        "matched_source": matched_public_source or None,
+        "sources": sources,
+        "source_type": "job_guidance",
+        "expected_primary_metric": expected,
+        "reported_validation_metric": reported,
+        "available": bool(expected),
+    }
+    if not expected:
+        signal["status"] = "not_available"
+        return signal
+
+    value = reported.get("value")
+    reported_values = reported.get("reported_values")
+    if not isinstance(reported_values, list):
+        reported_values = []
+    site_values = reported.get("site_values")
+    if not isinstance(site_values, list):
+        site_values = []
+    has_value = is_numeric_metric_value(value)
+    numeric_reported_values = [
+        reported_value for reported_value in reported_values if is_numeric_metric_value(reported_value)
+    ]
+    has_reported_numeric = has_value or bool(numeric_reported_values)
+    reported_name = canonical_metric_name(reported.get("name"))
+    expected_name = canonical_metric_name(expected)
+    names_match = bool(reported.get("name")) and reported_name == expected_name
+    aligned = names_match and has_reported_numeric
+    mismatch = bool(reported.get("name")) and not names_match
+    if aligned:
+        status = "pass"
+        if has_value:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, and the final response reported "
+                f"{reported.get('name')} {value:.4f}."
+            )
+        elif site_values:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, and the final response reported "
+                f"{len(site_values)} site-level {reported.get('name')} values."
+            )
+        else:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, and the final response reported "
+                f"{len(numeric_reported_values)} {reported.get('name')} values."
+            )
+    elif mismatch:
+        status = "fail"
+        if has_value:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, but the final response reported "
+                f"{reported.get('name')}" + format_metric_value(value)
+            )
+        else:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, but the final response reported "
+                f"{reported.get('name')}."
+            )
+    elif reported.get("name"):
+        status = "missing"
+        if site_values:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, and the final response reported "
+                f"{len(site_values)} site-level {reported.get('name')} values but no single FL-level value."
+            )
+        elif reported_values:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, and the final response reported "
+                f"{len(reported_values)} {reported.get('name')} values but no single FL-level value."
+            )
+        else:
+            evidence = (
+                f"Job guidance declares {expected} as the primary metric, and the final response mentioned "
+                f"{reported.get('name')} but did not report a numeric value."
+            )
+    else:
+        status = "missing"
+        evidence = f"Job guidance declares {expected} as the primary metric, but the final response did not report it."
+
+    signal.update(
+        {
+            "status": status,
+            "evidence": evidence,
+            "metric_value_available": has_reported_numeric,
+            "metric_scalar_available": has_value,
+            "aligned_with_job_guidance": aligned,
+            "aligned_with_readme": aligned,
+            "mismatch": mismatch,
+        }
+    )
+    return signal
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("readme", type=Path)
+    parser.add_argument("final_message", type=Path)
+    args = parser.parse_args()
+    readme_text = args.readme.read_text(encoding="utf-8", errors="replace") if args.readme.is_file() else ""
+    final_text = (
+        args.final_message.read_text(encoding="utf-8", errors="replace") if args.final_message.is_file() else ""
+    )
+    print(json.dumps(metric_signal(args.readme if args.readme.is_file() else None, readme_text, final_text), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/record_identity.py
+++ b/assist_tools/skills_benchmark/skills/harness/record_identity.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for extracting benchmark record identity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def record_skill(record: dict[str, Any]) -> Any:
+    discovery = record.get("skill_discovery")
+    if not isinstance(discovery, dict):
+        discovery = {}
+    return record.get("skill") or record.get("skill_name") or discovery.get("selected_skill")
+
+
+def record_case(record: dict[str, Any]) -> Any:
+    discovery = record.get("skill_discovery")
+    if not isinstance(discovery, dict):
+        discovery = {}
+    return record.get("case_id") or discovery.get("selected_case_id")

--- a/assist_tools/skills_benchmark/skills/harness/records.py
+++ b/assist_tools/skills_benchmark/skills/harness/records.py
@@ -1,0 +1,1074 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark-record synthesis and normalization helpers."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from .common import bool_from_text, flatten_numbers, load_json, write_json
+from .quality_signals import critical_quality_checks_failed, metric_signal, required_validation_metric_status
+from .record_identity import record_case, record_skill
+from .timing import LifecycleEpochs, finalize_timing
+
+ALLOWED_BEHAVIOR_STATUSES = {"pass", "fail", "missing", "not_applicable", "non_scoring_note"}
+MAX_JSON_RECORD_FILES = 10000
+MAX_JSON_RECORD_FILE_BYTES = 5 * 1024 * 1024
+MAX_EVENTS_TEXT_BYTES = 20 * 1024 * 1024
+MAX_EVALS_FILE_BYTES = 512 * 1024
+UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL = {
+    "status": "unavailable",
+    "reason": "structure quality was not captured for this run",
+}
+
+
+@dataclass(frozen=True)
+class AgentRecordSynthesisInputs:
+    agent_record_path: Path
+    records_dir: Path
+    events_path: Path
+    usage_path: Path
+    activity_path: Path
+    last_message_path: Path
+    input_dir: Path
+    mode: str
+    elapsed_seconds: int
+    agent_exit: int
+    skills_enabled: bool
+    skill_run_mode: str
+    agent: str
+    agent_model: str
+    run_start_time_ns: int
+    workspace_delta_manifest_path: Path
+    input_delta_manifest_path: Path | None = None
+    prompt_path: Path | None = None
+
+
+def apply_record_runtime_fields(
+    record: dict[str, Any],
+    *,
+    usage: dict[str, Any],
+    mode: str,
+    elapsed_seconds: int,
+    agent_exit: int,
+    skills_enabled: bool,
+    skill_run_mode: str,
+    agent: str,
+    agent_model: str,
+    agent_record_present: bool | None = None,
+    agent_record_valid: bool | None = None,
+) -> dict[str, Any]:
+    """Mutate ``record`` in place and return its ``process_metrics`` mapping."""
+
+    record["schema_version"] = "1"
+    record["run_mode"] = record.get("run_mode") or skill_run_mode
+    record["agent"] = record.get("agent") or agent
+    record["mode"] = mode
+    record["source"] = "agent_benchmark_harness"
+    record["agent_model"] = record.get("agent_model") or agent_model
+    record["skills_enabled"] = skills_enabled
+    record["agent_process_passed"] = agent_exit == 0
+    record["agent_process_exit_code"] = agent_exit
+    record["agent_elapsed_seconds"] = elapsed_seconds
+    record["elapsed_seconds"] = elapsed_seconds
+    record["timestamp"] = record.get("timestamp") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if agent_record_present is not None:
+        record["agent_record_present"] = agent_record_present
+    if agent_record_valid is not None:
+        record["agent_record_valid"] = agent_record_valid
+
+    metrics = record.get("process_metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+        record["process_metrics"] = metrics
+    metrics.update(
+        {
+            "elapsed_seconds": elapsed_seconds,
+            "agent_elapsed_seconds": elapsed_seconds,
+            "token_count": usage.get("total_tokens"),
+            "cache_tokens": usage.get("cache_tokens"),
+            "cost": usage.get("cost"),
+            "agent_exit_code": agent_exit,
+            "agent_process_passed": 1 if agent_exit == 0 else 0,
+            "token_parser": usage.get("token_parser"),
+        }
+    )
+    parser_warnings = usage.get("parser_warnings") or usage.get("token_parser_warnings")
+    if parser_warnings:
+        metrics["token_parser_warning_count"] = len(parser_warnings)
+    if agent_record_present is not None:
+        metrics["agent_record_present"] = 1 if agent_record_present else 0
+    if agent_record_valid is not None:
+        metrics["agent_record_valid"] = 1 if agent_record_valid else 0
+    return metrics
+
+
+def same_path(left: str | Path, right: str | Path) -> bool:
+    try:
+        return Path(left).resolve() == Path(right).resolve()
+    except Exception:
+        return False
+
+
+def record_is_candidate(record: Any) -> bool:
+    return isinstance(record, dict) and (record_skill(record) or record_case(record))
+
+
+def load_text(path: Path, *, max_bytes: int | None = None) -> str:
+    try:
+        if max_bytes is not None:
+            if max_bytes <= 0:
+                return ""
+            with path.open("rb") as stream:
+                return stream.read(max_bytes).decode("utf-8", errors="replace")
+        return path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def iter_json_records(root: Path, agent_record_path: Path | None = None) -> Iterable[tuple[Path, dict[str, Any]]]:
+    scanned = 0
+    record_paths = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(dirpath)
+        dirnames[:] = [name for name in dirnames if not (current / name).is_symlink()]
+        record_paths.extend(current / filename for filename in filenames if filename.endswith(".json"))
+    for path in sorted(record_paths):
+        if not path.is_file() or path.is_symlink():
+            continue
+        if agent_record_path is not None and same_path(path, agent_record_path):
+            continue
+        if path.name.endswith("_agent_record.json") or path.name.endswith("_record.json"):
+            continue
+        try:
+            if path.stat().st_size > MAX_JSON_RECORD_FILE_BYTES:
+                continue
+        except OSError:
+            continue
+        scanned += 1
+        if scanned > MAX_JSON_RECORD_FILES:
+            break
+        data = load_json(path)
+        if isinstance(data, dict):
+            yield path, data
+        elif isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    yield path, item
+
+
+def path_is_current_run(path: Path, run_start_time_ns: int) -> bool:
+    try:
+        return path.stat().st_mtime_ns >= max(0, run_start_time_ns)
+    except OSError:
+        return False
+
+
+GUIDANCE_FILE_STEMS = {
+    "readme",
+    "task",
+    "tasks",
+    "instruction",
+    "instructions",
+    "guidance",
+    "metric",
+    "metrics",
+    "source",
+    "notes",
+}
+GUIDANCE_SUFFIXES = {".md", ".rst", ".txt"}
+MAX_GUIDANCE_FILES = 12
+MAX_GUIDANCE_FILE_BYTES = 512 * 1024
+
+
+def guidance_priority(path: Path) -> tuple[int, str]:
+    name = path.name.lower()
+    stem = path.stem.lower()
+    if name == "prompt.txt":
+        return (0, name)
+    if name == "readme.md":
+        return (1, name)
+    if stem == "readme":
+        return (2, name)
+    if stem in GUIDANCE_FILE_STEMS:
+        return (3, name)
+    return (4, name)
+
+
+def is_guidance_file(path: Path) -> bool:
+    if not path.is_file() or path.suffix.lower() not in GUIDANCE_SUFFIXES:
+        return False
+    stem = path.stem.lower()
+    return stem in GUIDANCE_FILE_STEMS or path.name.lower().startswith("readme")
+
+
+def guidance_identity(path: Path) -> tuple:
+    try:
+        return ("resolved", str(path.resolve()))
+    except OSError:
+        pass
+    if path.is_symlink():
+        try:
+            target = path.readlink()
+            if not target.is_absolute():
+                target = path.parent / target
+            return ("symlink_target", str(target))
+        except OSError:
+            pass
+    try:
+        stat_result = path.stat()
+        return ("inode", stat_result.st_dev, stat_result.st_ino)
+    except OSError:
+        return ("path", str(path))
+
+
+def discover_job_guidance(input_root: Path, prompt_path: Path | None = None) -> tuple[list[dict[str, str]], str]:
+    if not input_root.is_dir():
+        return [], ""
+    candidates = []
+    if prompt_path is not None and prompt_path.is_file():
+        candidates.append((prompt_path, "prompt"))
+    for path in input_root.iterdir():
+        if path.is_symlink():
+            continue
+        if is_guidance_file(path):
+            candidates.append((path, "job_documentation"))
+            if len(candidates) >= MAX_GUIDANCE_FILES:
+                break
+    docs_dir = input_root / "docs"
+    if len(candidates) < MAX_GUIDANCE_FILES and docs_dir.is_dir() and not docs_dir.is_symlink():
+        for path in docs_dir.iterdir():
+            if path.is_symlink():
+                continue
+            if is_guidance_file(path):
+                candidates.append((path, "job_documentation"))
+                if len(candidates) >= MAX_GUIDANCE_FILES:
+                    break
+    if not candidates:
+        return [], ""
+    candidates.sort(key=lambda item: guidance_priority(item[0]))
+    sources = []
+    chunks = []
+    seen = set()
+    for path, source_type in candidates[:MAX_GUIDANCE_FILES]:
+        identity = guidance_identity(path)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        try:
+            if path.stat().st_size > MAX_GUIDANCE_FILE_BYTES:
+                continue
+        except OSError:
+            continue
+        text = load_text(path)
+        if not text:
+            continue
+        sources.append({"path": str(path), "source_type": source_type, "text": text})
+        chunks.append(f"\n\n# {source_type}: {path}\n{text}")
+    return sources, "".join(chunks)
+
+
+def discover_readme(input_root: Path) -> tuple[Path | None, str]:
+    sources, guidance_text = discover_job_guidance(input_root)
+    if not sources:
+        return None, ""
+    return Path(sources[0]["path"]), guidance_text
+
+
+def agent_home_from_env() -> Path:
+    return Path(os.environ.get("BENCHMARK_AGENT_HOME", "/workspace/agent-home"))
+
+
+def available_skill_names() -> set[str]:
+    names = set()
+    skills_root = agent_home_from_env() / "skills"
+    if skills_root.is_dir():
+        for path in skills_root.iterdir():
+            if path.is_symlink():
+                continue
+            if path.is_dir() and not path.name.startswith("."):
+                names.add(path.name)
+    return names
+
+
+def eval_case_ids_for_skill(skill_name: str) -> list[str]:
+    evals_path = agent_home_from_env() / "skills" / skill_name / "evals" / "evals.json"
+    try:
+        if not evals_path.is_file() or evals_path.stat().st_size > MAX_EVALS_FILE_BYTES:
+            return []
+    except OSError:
+        return []
+    data = load_json(evals_path)
+    if not isinstance(data, dict):
+        return []
+    case_ids = []
+    for item in data.get("evals") or []:
+        if isinstance(item, dict) and item.get("id"):
+            case_ids.append(str(item["id"]))
+    return case_ids
+
+
+IDENTITY_PLACEHOLDERS = {
+    "CASE",
+    "CASE_ID",
+    "EVAL_ID",
+    "SKILL",
+    "SKILL_NAME",
+    "<case>",
+    "<case_id>",
+    "<skill>",
+    "<skill_name>",
+}
+
+
+def valid_identity_token(value: str) -> bool:
+    normalized = value.strip()
+    return (
+        bool(normalized) and normalized not in IDENTITY_PLACEHOLDERS and normalized.upper() not in IDENTITY_PLACEHOLDERS
+    )
+
+
+def identity_occurrence_count(text: str, candidate: str) -> int:
+    pattern = re.compile(rf"(?<![A-Za-z0-9_.-]){re.escape(candidate)}(?![A-Za-z0-9_.-])")
+    return sum(1 for _match in pattern.finditer(text))
+
+
+def infer_from_events(events_text: str) -> dict[str, Any]:
+    scores: dict[str, int] = {}
+    source: dict[str, str] = {}
+
+    def add(name: str, points: int, reason: str) -> None:
+        if not valid_identity_token(name):
+            return
+        scores[name] = scores.get(name, 0) + points
+        source.setdefault(name, reason)
+
+    for match in re.finditer(r"/[^\s\"']+/skills/([^/\s\"']+)", events_text):
+        add(match.group(1), 50, "agent_skill_path")
+
+    for match in re.finditer(r"(?:^|\s)--skill(?:=|\s+)([A-Za-z0-9_.-]+)", events_text):
+        add(match.group(1), 100, "agent_skill_arg")
+
+    skill_names = sorted(
+        (name for name in available_skill_names() if valid_identity_token(name)), key=len, reverse=True
+    )
+    if skill_names:
+        skill_pattern = re.compile("|".join(re.escape(name) for name in skill_names))
+        for name, occurrences in Counter(match.group(0) for match in skill_pattern.finditer(events_text)).items():
+            add(name, occurrences, "installed_skill_name_seen_in_events")
+
+    skill = ""
+    if scores:
+        skill = sorted(scores.items(), key=lambda item: (item[1], item[0]), reverse=True)[0][0]
+
+    case_id = ""
+    case_source = ""
+    case_match = re.search(r"(?:^|\s)--case(?:=|\s+)([A-Za-z0-9_.-]+)", events_text)
+    if case_match and valid_identity_token(case_match.group(1)):
+        case_id = case_match.group(1)
+        case_source = "agent_skill_arg"
+    elif skill:
+        case_scores = {}
+        candidates = sorted(
+            (candidate for candidate in eval_case_ids_for_skill(skill) if valid_identity_token(candidate)),
+            key=len,
+            reverse=True,
+        )
+        for candidate in candidates:
+            count = identity_occurrence_count(events_text, candidate)
+            if count:
+                case_scores[candidate] = count
+        if case_scores:
+            case_id = sorted(case_scores.items(), key=lambda item: (item[1], item[0]), reverse=True)[0][0]
+            case_source = "installed_skill_case_seen_in_events"
+    return {
+        "skill": skill,
+        "case_id": case_id,
+        "skill_source": source.get(skill, "") if skill else "",
+        "case_source": case_source,
+        "skill_scores": dict(sorted(scores.items(), key=lambda item: (-item[1], item[0]))[:5]),
+        "used_as_fallback": False,
+    }
+
+
+def record_score(path: Path, record: dict[str, Any]) -> tuple[int, int, str]:
+    score = 0
+    if record_skill(record):
+        score += 2
+    if record_case(record):
+        score += 2
+    if isinstance(record.get("mandatory_behavior"), dict) and record["mandatory_behavior"]:
+        score += 1
+    if isinstance(record.get("prohibited_behavior"), dict) and record["prohibited_behavior"]:
+        score += 1
+    try:
+        mtime = path.stat().st_mtime_ns
+    except OSError:
+        mtime = 0
+    return score, mtime, str(path)
+
+
+def choose_source_record(
+    candidates: list[tuple[Path, dict[str, Any]]],
+    *,
+    expected_skill: str = "",
+    expected_case: str = "",
+) -> tuple[Path | None, dict[str, Any] | None, dict[str, Any]]:
+    audit: dict[str, Any] = {
+        "candidate_count": len(candidates),
+        "expected_skill": expected_skill or None,
+        "expected_case": expected_case or None,
+        "selection_reason": "",
+        "selected_path": None,
+        "selected_skill": None,
+        "selected_case": None,
+    }
+    explicit_candidates = [
+        (path, record) for path, record in candidates if record_skill(record) and record_case(record)
+    ]
+    audit["explicit_identity_candidate_count"] = len(explicit_candidates)
+    if not explicit_candidates:
+        audit["selection_reason"] = "no_explicit_identity_candidates"
+        return None, None, audit
+
+    filtered = explicit_candidates
+    if expected_skill:
+        filtered = [(path, record) for path, record in filtered if str(record_skill(record)) == str(expected_skill)]
+    if expected_case:
+        filtered = [(path, record) for path, record in filtered if str(record_case(record)) == str(expected_case)]
+    audit["identity_matched_candidate_count"] = len(filtered)
+    if (expected_skill or expected_case) and not filtered:
+        audit["selection_reason"] = "no_candidate_matched_expected_identity"
+        return None, None, audit
+
+    identities = sorted({(str(record_skill(record)), str(record_case(record))) for _path, record in filtered})
+    audit["candidate_identities"] = [{"skill": skill, "case": case} for skill, case in identities]
+    if not expected_skill and not expected_case and len(identities) != 1:
+        audit["selection_reason"] = "ambiguous_identity_without_expected_filter"
+        return None, None, audit
+
+    scored = []
+    for path, record in filtered:
+        score, mtime, path_text = record_score(path, record)
+        scored.append((score, mtime, path_text, path, record))
+    if not scored:
+        audit["selection_reason"] = "no_scored_candidates"
+        return None, None, audit
+    scored.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
+    selected_path = scored[0][3]
+    selected_record = scored[0][4]
+    audit["selection_reason"] = "selected_explicit_identity_record"
+    audit["selected_path"] = str(selected_path)
+    audit["selected_skill"] = str(record_skill(selected_record))
+    audit["selected_case"] = str(record_case(selected_record))
+    audit["selected_score"] = scored[0][0]
+    return selected_path, selected_record, audit
+
+
+def synthesize_agent_record(inputs: AgentRecordSynthesisInputs) -> None:
+    agent_record_path = inputs.agent_record_path
+    records_dir = inputs.records_dir
+    events_path = inputs.events_path
+    usage_path = inputs.usage_path
+    activity_path = inputs.activity_path
+    last_message_path = inputs.last_message_path
+    input_dir = inputs.input_dir
+    mode = inputs.mode
+    elapsed_seconds = inputs.elapsed_seconds
+    agent_exit = inputs.agent_exit
+    skills_enabled = inputs.skills_enabled
+    skill_run_mode = inputs.skill_run_mode
+    agent = inputs.agent
+    agent_model = inputs.agent_model
+    run_start_time_ns = inputs.run_start_time_ns
+    workspace_delta_manifest_path = inputs.workspace_delta_manifest_path
+    input_delta_manifest_path = inputs.input_delta_manifest_path
+    prompt_path = inputs.prompt_path
+    records_dir.mkdir(parents=True, exist_ok=True)
+    existing_agent_record = load_json(agent_record_path)
+    usage = load_json(usage_path, {}) or {}
+    activity = load_json(activity_path, {}) or {}
+    workspace_delta = load_json(workspace_delta_manifest_path, {}) or {}
+    input_delta: dict[str, Any] | None = None
+    input_delta_not_captured_reason = "input_delta_manifest was not provided"
+    if input_delta_manifest_path is not None:
+        loaded_input_delta = load_json(input_delta_manifest_path)
+        if isinstance(loaded_input_delta, dict) and loaded_input_delta.get("delta_scope") == "input_snapshot":
+            input_delta = loaded_input_delta
+        elif isinstance(loaded_input_delta, dict) and loaded_input_delta:
+            input_delta_not_captured_reason = (
+                f"input_delta_manifest had unexpected delta_scope={loaded_input_delta.get('delta_scope')!r}"
+            )
+        else:
+            input_delta_not_captured_reason = "input_delta_manifest was missing, empty, or unreadable"
+    events_text = load_text(events_path, max_bytes=MAX_EVENTS_TEXT_BYTES)
+    last_message = load_text(last_message_path)
+    guidance_sources, guidance_text = discover_job_guidance(input_dir, prompt_path)
+    event_identity = infer_from_events(events_text)
+    job_guidance_metric_signal = metric_signal(guidance_sources, guidance_text, last_message)
+    existing_skill = str(record_skill(existing_agent_record) or "") if isinstance(existing_agent_record, dict) else ""
+    existing_case = str(record_case(existing_agent_record) or "") if isinstance(existing_agent_record, dict) else ""
+    if not valid_identity_token(existing_skill):
+        existing_skill = ""
+    if not valid_identity_token(existing_case):
+        existing_case = ""
+
+    candidates = [
+        (path, record)
+        for path, record in iter_json_records(records_dir, agent_record_path)
+        if path_is_current_run(path, run_start_time_ns)
+        and record_is_candidate(record)
+        and record_skill(record)
+        and record_case(record)
+    ]
+    source_path, source_record, source_audit = choose_source_record(
+        candidates,
+        expected_skill=existing_skill,
+        expected_case=existing_case,
+    )
+
+    base: dict[str, Any] = {}
+    record_source = "harness_synthesized"
+    if isinstance(source_record, dict):
+        base = copy.deepcopy(source_record)
+        record_source = "agent_runtime_evidence_record"
+    elif isinstance(existing_agent_record, dict):
+        base = copy.deepcopy(existing_agent_record)
+        record_source = "existing_mode_agent_record"
+
+    skill = record_skill(base)
+    case_id = record_case(base)
+    event_skill = event_identity.get("skill") if isinstance(event_identity, dict) else ""
+    event_case = event_identity.get("case_id") if isinstance(event_identity, dict) else ""
+    if not skill and event_skill:
+        skill = event_skill
+        event_identity["used_as_fallback"] = True
+    if not case_id and event_case:
+        case_id = event_case
+        event_identity["used_as_fallback"] = True
+    if event_identity.get("used_as_fallback"):
+        print(
+            "warning: benchmark record identity inferred from agent event text "
+            f"(skill={skill or 'unknown'}, case_id={case_id or 'unknown'})",
+            file=sys.stderr,
+        )
+
+    record = base if isinstance(base, dict) else {}
+    metrics = apply_record_runtime_fields(
+        record,
+        usage=usage,
+        mode=mode,
+        elapsed_seconds=elapsed_seconds,
+        agent_exit=agent_exit,
+        skills_enabled=skills_enabled,
+        skill_run_mode=skill_run_mode,
+        agent=agent,
+        agent_model=agent_model,
+    )
+    record["agent_record_generated_by_harness"] = True
+    record["agent_record_source"] = record_source
+    if source_path is not None:
+        record["agent_record_source_path"] = str(source_path)
+    record["agent_record_source_audit"] = source_audit
+    record["event_identity_inference"] = event_identity
+
+    if skill:
+        record["skill"] = skill
+        record["skill_name"] = skill
+    if case_id:
+        record["case_id"] = case_id
+
+    discovery = record.get("skill_discovery")
+    if not isinstance(discovery, dict):
+        discovery = {}
+    if skill and not discovery.get("selected_skill"):
+        discovery["selected_skill"] = skill
+    if case_id and not discovery.get("selected_case_id"):
+        discovery["selected_case_id"] = case_id
+    if discovery:
+        discovery.setdefault(
+            "source",
+            "harness_explicit_record" if not event_identity.get("used_as_fallback") else "harness_event_log_fallback",
+        )
+        record["skill_discovery"] = discovery
+
+    for category in ("mandatory_behavior", "prohibited_behavior", "optional_behavior"):
+        if record.get(category) is None:
+            record[category] = {}
+
+    metrics["event_count"] = activity.get("event_count")
+    metrics["command_count"] = activity.get("command_count")
+    metrics["unique_command_count"] = activity.get("unique_command_count")
+    if isinstance(workspace_delta, dict):
+        record["workspace_delta"] = workspace_delta
+        for key in (
+            "changed_file_count",
+            "deleted_file_count",
+            "workspace_added_file_count",
+            "workspace_modified_file_count",
+            "workspace_deleted_baseline_file_count",
+            "workspace_change_count",
+            "runtime_artifact_count",
+            "copied_file_count",
+            "copied_bytes",
+        ):
+            if isinstance(workspace_delta.get(key), (int, float)) and not isinstance(workspace_delta.get(key), bool):
+                metrics[f"workspace_delta_{key}"] = workspace_delta[key]
+
+    if isinstance(input_delta, dict):
+        record["source_input_delta"] = input_delta
+        input_delta_aliases = {
+            "workspace_added_file_count": "added_file_count",
+            "workspace_modified_file_count": "modified_file_count",
+            "workspace_deleted_baseline_file_count": "deleted_baseline_file_count",
+            "workspace_change_count": "change_count",
+        }
+        for key in (
+            "changed_file_count",
+            "deleted_file_count",
+            "workspace_added_file_count",
+            "workspace_modified_file_count",
+            "workspace_deleted_baseline_file_count",
+            "workspace_change_count",
+            "copied_file_count",
+            "copied_bytes",
+        ):
+            if isinstance(input_delta.get(key), (int, float)) and not isinstance(input_delta.get(key), bool):
+                metrics[f"source_input_delta_{key}"] = input_delta[key]
+                if key in input_delta_aliases:
+                    metrics[f"source_input_delta_{input_delta_aliases[key]}"] = input_delta[key]
+        source_input_violation = bool(input_delta.get("changed_file_count") or input_delta.get("deleted_file_count"))
+        metrics["source_input_immutable_violation"] = 1 if source_input_violation else 0
+        record["source_input_immutable_policy"] = {
+            "status": "fail" if source_input_violation else "pass",
+            "reason": (
+                "The immutable input snapshot changed during the agent run."
+                if source_input_violation
+                else "The immutable input snapshot was unchanged; conversion output is captured separately from the writable workspace."
+            ),
+            "scope": str(input_delta.get("workspace_root") or ""),
+            "changed_files": input_delta.get("changed_files") or [],
+            "deleted_files": input_delta.get("deleted_files") or [],
+        }
+        if source_input_violation:
+            record["source_input_immutable_violation"] = {
+                "status": "fail",
+                "reason": "Agent or runtime changed files inside the immutable input snapshot.",
+                "changed_files": input_delta.get("changed_files") or [],
+                "deleted_files": input_delta.get("deleted_files") or [],
+            }
+    else:
+        record["source_input_immutable_policy"] = {
+            "status": "not_captured",
+            "reason": input_delta_not_captured_reason,
+            "scope": "",
+            "changed_files": [],
+            "deleted_files": [],
+        }
+        metrics["source_input_immutable_violation"] = 0
+
+    quality_signals = record.get("quality_signals")
+    if not isinstance(quality_signals, dict):
+        quality_signals = {}
+    quality_signals["job_guidance_primary_validation_metric"] = job_guidance_metric_signal
+    record["quality_signals"] = quality_signals
+    record["required_validation_metric_status"] = required_validation_metric_status(job_guidance_metric_signal)
+    record["critical_quality_checks_failed"] = bool(
+        record.get("critical_quality_checks_failed") or critical_quality_checks_failed(record)
+    )
+    if job_guidance_metric_signal.get("expected_primary_metric"):
+        record["validation_metric_policy"] = {
+            "source": job_guidance_metric_signal.get("source"),
+            "sources": job_guidance_metric_signal.get("sources"),
+            "expected_primary_metric": job_guidance_metric_signal.get("expected_primary_metric"),
+            "scoring_note": "Measured as a benchmark quality signal from the final message and job documentation.",
+        }
+        validation_metric = job_guidance_metric_signal.get("reported_validation_metric")
+        record["reported_validation_metric"] = validation_metric
+        metrics["validation_metric_policy_available"] = 1
+        metrics["validation_metric_value_available"] = (
+            1 if job_guidance_metric_signal.get("metric_value_available") else 0
+        )
+        metrics["validation_metric_aligned_with_job_guidance"] = (
+            1 if job_guidance_metric_signal.get("aligned_with_job_guidance") else 0
+        )
+        metrics["validation_metric_aligned_with_readme"] = (
+            1 if job_guidance_metric_signal.get("aligned_with_readme") else 0
+        )
+        metrics["validation_metric_mismatch"] = 1 if job_guidance_metric_signal.get("mismatch") else 0
+    else:
+        validation_metric = job_guidance_metric_signal.get("reported_validation_metric")
+        if isinstance(validation_metric, dict) and validation_metric.get("name"):
+            record["reported_validation_metric"] = validation_metric
+        metrics["validation_metric_policy_available"] = 0
+
+    record["process_metrics"] = metrics
+    record["agent_usage"] = usage
+
+    notes = record.get("notes")
+    note = "Mode-specific benchmark record was synthesized by the benchmark harness, not requested through prompt text."
+    if isinstance(notes, list):
+        if note not in notes:
+            notes.append(note)
+    elif isinstance(notes, str) and notes:
+        record["notes"] = [notes, note] if notes != note else [notes]
+    else:
+        record["notes"] = [note]
+
+    write_json(agent_record_path, record)
+
+
+def as_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_behavior_map(record: dict[str, Any], category: str) -> dict[str, dict[str, str]]:
+    raw = record.get(category)
+    if not isinstance(raw, dict):
+        raw = {}
+    normalized = {}
+    for behavior_id, entry in raw.items():
+        if not isinstance(entry, dict):
+            entry = {}
+        status = entry.get("status")
+        if status not in ALLOWED_BEHAVIOR_STATUSES:
+            status = "missing"
+        normalized[str(behavior_id)] = {
+            "status": status,
+            "evidence": str(entry.get("evidence") or "No evidence supplied by agent."),
+        }
+    record[category] = normalized
+    return normalized
+
+
+def status_counts(behavior_map: dict[str, dict[str, str]]) -> dict[str, int]:
+    counts = {status: 0 for status in sorted(ALLOWED_BEHAVIOR_STATUSES)}
+    for entry in behavior_map.values():
+        status = entry.get("status")
+        if status in counts:
+            counts[status] += 1
+    return counts
+
+
+def pass_rate(behavior_map: dict[str, dict[str, str]]) -> float | None:
+    total = len(behavior_map)
+    if total == 0:
+        return None
+    return round(sum(1 for entry in behavior_map.values() if entry.get("status") == "pass") / total, 3)
+
+
+def merge_record(
+    agent_record_path: Path,
+    final_record_path: Path,
+    usage_path: Path,
+    mode: str,
+    elapsed_seconds: int,
+    agent_exit: int,
+    skills_enabled: bool,
+    skill_run_mode: str,
+    agent: str,
+    agent_model: str,
+) -> None:
+    record: dict[str, Any] = {}
+    agent_record_present = agent_record_path.exists()
+    agent_record_valid = False
+    if agent_record_present:
+        try:
+            data = json.loads(agent_record_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                record = data
+                agent_record_valid = True
+        except Exception as exc:
+            record = {"notes": f"agent record was not valid JSON: {exc}"}
+
+    if not isinstance(record, dict):
+        record = {"notes": "agent record was not a JSON object"}
+
+    usage = load_json(usage_path, {}) or {}
+    metrics = apply_record_runtime_fields(
+        record,
+        usage=usage,
+        mode=mode,
+        elapsed_seconds=elapsed_seconds,
+        agent_exit=agent_exit,
+        skills_enabled=skills_enabled,
+        skill_run_mode=skill_run_mode,
+        agent=agent,
+        agent_model=agent_model,
+        agent_record_present=agent_record_present,
+        agent_record_valid=agent_record_valid,
+    )
+    if "user_correction_count" not in metrics and "correction_count" in metrics:
+        metrics["user_correction_count"] = metrics.get("correction_count")
+    if "first_pass_accepted" not in metrics:
+        corrections = as_float(metrics.get("user_correction_count"))
+        if corrections is not None and agent_exit == 0:
+            metrics["first_pass_accepted"] = 1 if corrections == 0 else 0
+
+    mandatory_behavior = normalize_behavior_map(record, "mandatory_behavior")
+    prohibited_behavior = normalize_behavior_map(record, "prohibited_behavior")
+    optional_behavior = normalize_behavior_map(record, "optional_behavior")
+    mandatory_count = len(mandatory_behavior)
+    prohibited_count = len(prohibited_behavior)
+    required_count = mandatory_count + prohibited_count
+    required_pass_count = sum(1 for entry in mandatory_behavior.values() if entry.get("status") == "pass") + sum(
+        1 for entry in prohibited_behavior.values() if entry.get("status") == "pass"
+    )
+    instruction_compliance = {
+        "mandatory_behavior": {
+            "total": mandatory_count,
+            "pass_rate": pass_rate(mandatory_behavior),
+            "status_counts": status_counts(mandatory_behavior),
+        },
+        "prohibited_behavior": {
+            "total": prohibited_count,
+            "avoidance_rate": pass_rate(prohibited_behavior),
+            "status_counts": status_counts(prohibited_behavior),
+        },
+        "optional_behavior": {
+            "total": len(optional_behavior),
+            "coverage_rate": pass_rate(optional_behavior),
+            "status_counts": status_counts(optional_behavior),
+        },
+        "required_behavior": {
+            "total": required_count,
+            "pass_rate": round(required_pass_count / required_count, 3) if required_count else None,
+            "pass_count": required_pass_count,
+        },
+    }
+    reported_instruction_compliance = record.get("instruction_compliance")
+    if (
+        mandatory_behavior
+        or prohibited_behavior
+        or optional_behavior
+        or not isinstance(reported_instruction_compliance, dict)
+    ):
+        record["instruction_compliance"] = instruction_compliance
+    else:
+        instruction_compliance = reported_instruction_compliance
+    required_behavior = instruction_compliance.get("required_behavior") or {}
+    mandatory_behavior_summary = instruction_compliance.get("mandatory_behavior") or {}
+    prohibited_behavior_summary = instruction_compliance.get("prohibited_behavior") or {}
+    metrics["instruction_required_pass_rate"] = required_behavior.get("pass_rate")
+    metrics["instruction_mandatory_pass_rate"] = mandatory_behavior_summary.get("pass_rate")
+    metrics["instruction_prohibited_avoidance_rate"] = prohibited_behavior_summary.get("avoidance_rate")
+    required_pass_rate = required_behavior.get("pass_rate")
+    if required_pass_rate is not None:
+        metrics["instruction_required_passed"] = 1 if required_pass_rate >= 1.0 else 0
+    record["agent_usage"] = usage
+    write_json(final_record_path, record)
+
+
+def write_run_summary(final_record_path: Path, summary_path: Path, *, print_summary: bool = True) -> None:
+    record = load_json(final_record_path, {}) or {}
+    metrics = record.get("process_metrics") or {}
+    prompt_metadata = load_json(summary_path.parent / "prompt_metadata.json", {}) or {}
+    if not isinstance(prompt_metadata, dict):
+        prompt_metadata = {}
+    runtime_metadata = load_json(summary_path.parent / "runtime_image.json", {}) or {}
+    if not isinstance(runtime_metadata, dict):
+        runtime_metadata = {}
+    activity = metrics.get("activity") if isinstance(metrics.get("activity"), dict) else {}
+    skill_discovery = record.get("skill_discovery") if isinstance(record.get("skill_discovery"), dict) else {}
+    quality_signals = record.get("quality_signals") if isinstance(record.get("quality_signals"), dict) else {}
+    validation_signal = quality_signals.get("job_guidance_primary_validation_metric")
+    validation_metric = record.get("reported_validation_metric")
+    if validation_metric is None and isinstance(validation_signal, dict):
+        validation_metric = validation_signal.get("reported_validation_metric")
+    agent_elapsed = metrics.get("agent_elapsed_seconds")
+    if agent_elapsed is None:
+        agent_elapsed = record.get("agent_elapsed_seconds")
+    if agent_elapsed is None:
+        agent_elapsed = metrics.get("elapsed_seconds")
+    summary = {
+        "mode": record.get("mode"),
+        "run_mode": record.get("run_mode"),
+        "skill": record.get("skill"),
+        "skill_name": record.get("skill_name"),
+        "observed_skill_name": skill_discovery.get("selected_skill") or record.get("skill") or record.get("skill_name"),
+        "skill_name_source": skill_discovery.get("source") or record.get("agent_record_source"),
+        "case_id": record.get("case_id"),
+        "agent_elapsed_seconds": agent_elapsed,
+        "elapsed_seconds": agent_elapsed,
+        "phase_seconds": metrics.get("phase_seconds"),
+        "prompt_hash": prompt_metadata.get("prompt_sha256"),
+        "prompt_source": prompt_metadata.get("template_path"),
+        "token_count": metrics.get("token_count"),
+        "command_count": metrics.get("command_count") or activity.get("command_count"),
+        "cache_tokens": metrics.get("cache_tokens"),
+        "cost": metrics.get("cost"),
+        "runtime_image": runtime_metadata.get("runtime_image"),
+        "wheel_variant": runtime_metadata.get("sdk_image_kind"),
+        "conversion_quality": metrics.get("conversion_quality"),
+        "correction_count": metrics.get("correction_count"),
+        "command_failures": metrics.get("command_failures"),
+        "agent_process_passed": record.get("agent_process_passed"),
+        "agent_process_exit_code": record.get("agent_process_exit_code"),
+        "agent_exit_code": metrics.get("agent_exit_code"),
+        "agent_report_exit_codes": record.get("agent_report_exit_codes") or {},
+        "agent_report_exit_code": record.get("agent_report_exit_code"),
+        "agent_report_failed": record.get("agent_report_failed"),
+        "final_container_exit_code": record.get("final_container_exit_code"),
+        "report_inclusive_exit_code": record.get("report_inclusive_exit_code"),
+        "harness_failure": record.get("harness_failure") or metrics.get("harness_failure"),
+        "harness_error": record.get("harness_error") or {},
+        "harness_errors": record.get("harness_errors") or [],
+        "failure_root_cause": record.get("failure_root_cause") or record.get("failure_category"),
+        "validation_metric": validation_metric,
+        "validation_metric_status": record.get("required_validation_metric_status"),
+        "required_validation_metric_status": record.get("required_validation_metric_status"),
+        "structure_quality_signal": record.get("structure_quality_signal") or UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL,
+        "skills_enabled": record.get("skills_enabled"),
+        "agent": record.get("agent"),
+        "agent_model": record.get("agent_model"),
+        "agent_record_present": record.get("agent_record_present"),
+        "agent_record_valid": record.get("agent_record_valid"),
+        "process_metrics": metrics,
+        "instruction_compliance": record.get("instruction_compliance") or {},
+        "mandatory_behavior": record.get("mandatory_behavior") or {},
+        "prohibited_behavior": record.get("prohibited_behavior") or {},
+        "optional_behavior": record.get("optional_behavior") or {},
+        "skill_discovery": record.get("skill_discovery") or {},
+        "agent_usage": record.get("agent_usage") or {},
+        "workspace_delta": record.get("workspace_delta") or {},
+        "source_input_delta": record.get("source_input_delta") or {},
+        "source_input_immutable_policy": record.get("source_input_immutable_policy") or {},
+    }
+    summary["all_metrics"] = flatten_numbers(summary)
+    write_json(summary_path, summary)
+    if print_summary:
+        elapsed = metrics.get("elapsed_seconds")
+        elapsed_text = (
+            f"{elapsed:.1f}s" if isinstance(elapsed, (int, float)) and not isinstance(elapsed, bool) else "NA"
+        )
+        print(
+            "Run summary written: "
+            f"{summary_path}; mode={summary.get('mode') or 'unknown'}; "
+            f"elapsed={elapsed_text}; final_exit={summary.get('final_container_exit_code')}",
+            flush=True,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    synth = subparsers.add_parser("synthesize")
+    synth.add_argument("agent_record", type=Path)
+    synth.add_argument("records_dir", type=Path)
+    synth.add_argument("events_path", type=Path)
+    synth.add_argument("usage_path", type=Path)
+    synth.add_argument("activity_path", type=Path)
+    synth.add_argument("last_message_path", type=Path)
+    synth.add_argument("input_dir", type=Path)
+    synth.add_argument("mode")
+    synth.add_argument("elapsed_seconds", type=int)
+    synth.add_argument("agent_exit", type=int)
+    synth.add_argument("skills_enabled")
+    synth.add_argument("skill_run_mode")
+    synth.add_argument("agent_model")
+    synth.add_argument("run_start_time_ns", type=int)
+    synth.add_argument("workspace_delta_manifest", type=Path)
+    synth.add_argument("input_delta_manifest", nargs="?", type=Path)
+    synth.add_argument("--agent", default=os.environ.get("BENCHMARK_AGENT", "unknown"))
+
+    merge = subparsers.add_parser("merge")
+    merge.add_argument("agent_record", type=Path)
+    merge.add_argument("final_record", type=Path)
+    merge.add_argument("usage_path", type=Path)
+    merge.add_argument("mode")
+    merge.add_argument("elapsed_seconds", type=int)
+    merge.add_argument("agent_exit", type=int)
+    merge.add_argument("skills_enabled")
+    merge.add_argument("skill_run_mode")
+    merge.add_argument("agent_model")
+    merge.add_argument("--agent", default=os.environ.get("BENCHMARK_AGENT", "unknown"))
+
+    summary = subparsers.add_parser("summary")
+    summary.add_argument("final_record", type=Path)
+    summary.add_argument("summary_path", type=Path)
+
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("summary_path", type=Path)
+    finalize.add_argument("record_path", type=Path)
+    finalize.add_argument("timing_path", type=Path)
+    finalize.add_argument("activity_path", type=Path)
+    finalize.add_argument("epochs", nargs=14, type=int)
+
+    args = parser.parse_args()
+    if args.command == "synthesize":
+        synthesize_agent_record(
+            AgentRecordSynthesisInputs(
+                agent_record_path=args.agent_record,
+                records_dir=args.records_dir,
+                events_path=args.events_path,
+                usage_path=args.usage_path,
+                activity_path=args.activity_path,
+                last_message_path=args.last_message_path,
+                input_dir=args.input_dir,
+                mode=args.mode,
+                elapsed_seconds=args.elapsed_seconds,
+                agent_exit=args.agent_exit,
+                skills_enabled=bool_from_text(args.skills_enabled),
+                skill_run_mode=args.skill_run_mode,
+                agent=args.agent,
+                agent_model=args.agent_model,
+                run_start_time_ns=args.run_start_time_ns,
+                workspace_delta_manifest_path=args.workspace_delta_manifest,
+                input_delta_manifest_path=args.input_delta_manifest,
+            )
+        )
+    elif args.command == "merge":
+        merge_record(
+            args.agent_record,
+            args.final_record,
+            args.usage_path,
+            args.mode,
+            args.elapsed_seconds,
+            args.agent_exit,
+            bool_from_text(args.skills_enabled),
+            args.skill_run_mode,
+            args.agent,
+            args.agent_model,
+        )
+    elif args.command == "summary":
+        write_run_summary(args.final_record, args.summary_path)
+    elif args.command == "finalize":
+        finalize_timing(
+            args.summary_path,
+            args.record_path,
+            args.timing_path,
+            args.activity_path,
+            LifecycleEpochs.from_sequence(args.epochs),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/reports/__init__.py
+++ b/assist_tools/skills_benchmark/skills/harness/reports/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/assist_tools/skills_benchmark/skills/harness/reports/scenario_report.py
+++ b/assist_tools/skills_benchmark/skills/harness/reports/scenario_report.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario-level benchmark report rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..common import write_json
+
+
+def markdown_cell(value: Any) -> str:
+    text = "NA" if value is None or value == "" else str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def write_scenario_report(result_root: Path, summary: Mapping[str, Any]) -> None:
+    reports_dir = result_root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    write_json(reports_dir / "scenario_report.json", dict(summary))
+    lines = [
+        f"# Scenario Report: {summary.get('scenario_name')}",
+        "",
+        f"Result root: `{result_root}`",
+        f"Status: `{summary.get('status')}`",
+        f"Agent invocation: `{summary.get('agent_invocation') or 'live'}`",
+        f"Runs: {summary.get('completed_run_count')}/{summary.get('expanded_case_count')} completed",
+    ]
+    replay = summary.get("replay") if isinstance(summary.get("replay"), Mapping) else {}
+    if replay.get("replayed"):
+        lines.extend(
+            [
+                "",
+                "Replay: `true`",
+                f"Replayed at: `{replay.get('replayed_at')}`",
+                "This report was regenerated from captured artifacts; no agent or Docker run was executed.",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## Aggregate Results",
+            "",
+            "| Label | Runs | Quality pass | Median agent seconds | Median tokens |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    aggregates = (summary.get("aggregate_results") or {}).get("by_label") or {}
+    for label, data in sorted(aggregates.items()):
+        elapsed = data.get("agent_elapsed_seconds", {}).get("median")
+        tokens = data.get("token_count", {}).get("median")
+        lines.append(
+            f"| {markdown_cell(label)} | {markdown_cell(data.get('run_count'))} | "
+            f"{markdown_cell(data.get('quality_pass_count'))} | {markdown_cell(elapsed)} | {markdown_cell(tokens)} |"
+        )
+    winner = (summary.get("aggregate_results") or {}).get("winner")
+    lines.extend(["", "## Winner Policy", "", f"`{summary.get('winner_policy')}`"])
+    if winner:
+        lines.append(f"\nSelected winner: `{winner.get('label')}`.")
+    else:
+        lines.append("\nNo winner selected because no compared label passed the quality gate with timing data.")
+    (reports_dir / "scenario_report.md").write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/assist_tools/skills_benchmark/skills/harness/scenario_common.py
+++ b/assist_tools/skills_benchmark/skills/harness/scenario_common.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared scenario constants, errors, and validation helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+SCHEMA_VERSION = "1"
+COMPARISON_MODE_ABLATION = "mode_ablation"
+COMPARISON_AGENT = "agent_comparison"
+COMPARISON_MODEL = "model_comparison"
+COMPARISON_ONE = "one"
+COMPARISON_TYPES = {COMPARISON_MODE_ABLATION, COMPARISON_AGENT, COMPARISON_MODEL, COMPARISON_ONE}
+JOB_SCALES = {"small", "medium", "large"}
+DEFAULT_PATH_BUDGET = 240
+SLUG_VISIBLE_LENGTH = 48
+
+DEFAULT_RESOURCE_POLICIES: dict[str, dict[str, int]] = {
+    "small": {
+        "agent_timeout_seconds": 30 * 60,
+        "container_timeout_seconds": 40 * 60,
+        "result_size_budget_bytes": 1 * 1024 * 1024 * 1024,
+    },
+    "medium": {
+        "agent_timeout_seconds": 90 * 60,
+        "container_timeout_seconds": 120 * 60,
+        "result_size_budget_bytes": 5 * 1024 * 1024 * 1024,
+    },
+    "large": {
+        "agent_timeout_seconds": 240 * 60,
+        "container_timeout_seconds": 300 * 60,
+        "result_size_budget_bytes": 20 * 1024 * 1024 * 1024,
+    },
+}
+
+DEFAULT_QUALITY_GATE = {
+    "agent_process_passed": True,
+    "final_container_exit_code": 0,
+    "source_input_modified": False,
+    "required_validation_metric_status": ["present", "not_required"],
+    "critical_quality_checks_failed": False,
+}
+QUALITY_GATE_KEYS = set(DEFAULT_QUALITY_GATE)
+REQUIRED_VALIDATION_METRIC_STATUSES = {"present", "not_required", "missing"}
+DEFAULT_WINNER_POLICY = "median_agent_elapsed_seconds_then_tokens_with_quality_gate"
+UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL = {
+    "status": "unavailable",
+    "reason": "structure quality was not captured for this run",
+}
+SUMMARY_RUN_FIELDS = (
+    "run_id",
+    "sequence",
+    "scenario_name",
+    "comparison_type",
+    "comparison_group_id",
+    "agent",
+    "agent_model",
+    "workflow",
+    "job_name",
+    "job_slug",
+    "job_path",
+    "job_scale",
+    "mode",
+    "skills_enabled",
+    "prompt_hash",
+    "record_dir",
+)
+
+
+class ScenarioValidationError(ValueError):
+    """Raised when a scenario cannot produce a valid run plan."""
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def stable_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+
+
+def slug_base(value: str) -> tuple[str, bool]:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+    return normalized[:SLUG_VISIBLE_LENGTH].rstrip("_"), len(normalized) > SLUG_VISIBLE_LENGTH
+
+
+def slugify(value: str, *, force_hash: bool = False) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+    hash_input = str(value) or "empty"
+    suffix = stable_hash(hash_input)
+    if not normalized:
+        return f"item_{suffix}"
+    visible = normalized[:SLUG_VISIBLE_LENGTH].rstrip("_")
+    if force_hash or len(normalized) > SLUG_VISIBLE_LENGTH:
+        return f"{visible}_{suffix}"
+    return visible
+
+
+def unique_slug_map(values: Iterable[str]) -> dict[str, str]:
+    ordered = list(dict.fromkeys(str(value) for value in values))
+    bases: dict[str, list[str]] = {}
+    truncated: dict[str, bool] = {}
+    for value in ordered:
+        base, was_truncated = slug_base(value)
+        base = base or "item"
+        bases.setdefault(base, []).append(value)
+        truncated[value] = was_truncated
+    result = {}
+    for value in ordered:
+        base, _was_truncated = slug_base(value)
+        base = base or "item"
+        result[value] = slugify(value, force_hash=truncated[value] or len(bases[base]) > 1)
+    return result
+
+
+def require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ScenarioValidationError(f"{label} must be a mapping")
+    return value
+
+
+def require_non_empty_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ScenarioValidationError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def as_list(value: Any, label: str) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    raise ScenarioValidationError(f"{label} must be a list")
+
+
+def model_list(value: Any, label: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        items = [value]
+    elif isinstance(value, list):
+        items = value
+    else:
+        raise ScenarioValidationError(f"{label} must be a string or list of strings")
+    models = tuple(require_non_empty_string(item, label) for item in items)
+    if len(set(models)) != len(models):
+        raise ScenarioValidationError(f"{label} contains duplicate model names")
+    return models
+
+
+def resolve_path(value: str, base_dir: Path) -> Path:
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else base_dir / path
+
+
+def load_yaml_file(path: str | Path) -> dict[str, Any]:
+    scenario_path = Path(path)
+    try:
+        raw = yaml.safe_load(scenario_path.read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        raise ScenarioValidationError(f"Could not read scenario file {scenario_path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ScenarioValidationError(f"Scenario file {scenario_path} must contain a YAML object")
+    return raw

--- a/assist_tools/skills_benchmark/skills/harness/scenario_prompt.py
+++ b/assist_tools/skills_benchmark/skills/harness/scenario_prompt.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prompt path, template, and materialization helpers for benchmark scenarios."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import string
+from pathlib import Path
+from typing import Any, Mapping
+
+from .scenario_common import ScenarioValidationError, require_non_empty_string, resolve_path, slugify
+
+MAX_PROMPT_BYTES = 4 * 1024 * 1024
+GENERATED_PROMPT_DIR = ".agent_benchmark/rendered_prompts"
+PROMPT_TEMPLATE_VARIABLE_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+PROMPT_TEMPLATE_SCALAR_TYPES = (str, int, float, bool)
+PROMPT_TEMPLATE_LITERAL_BRACE_HINT = "Use '{{' and '}}' for literal braces in prompt templates."
+
+
+def prompt_template_fields(template_text: str) -> set[str]:
+    fields = set()
+    try:
+        parsed = list(string.Formatter().parse(template_text))
+    except ValueError as exc:
+        raise ScenarioValidationError(
+            f"Prompt template is invalid: {exc}. {PROMPT_TEMPLATE_LITERAL_BRACE_HINT}"
+        ) from exc
+    for _literal, field_name, format_spec, conversion in parsed:
+        if field_name is None:
+            continue
+        if field_name == "":
+            raise ScenarioValidationError(
+                f"Prompt templates must not use positional '{{}}' placeholders. {PROMPT_TEMPLATE_LITERAL_BRACE_HINT}"
+            )
+        if "." in field_name or "[" in field_name or "]" in field_name:
+            raise ScenarioValidationError("Prompt templates must not use attribute or index access")
+        if not PROMPT_TEMPLATE_VARIABLE_PATTERN.match(field_name):
+            raise ScenarioValidationError(
+                f"Prompt template placeholder has an unsafe name: {field_name}. "
+                f"{PROMPT_TEMPLATE_LITERAL_BRACE_HINT}"
+            )
+        if format_spec or conversion:
+            raise ScenarioValidationError(
+                f"Prompt templates must not use format specifiers or conversions. "
+                f"{PROMPT_TEMPLATE_LITERAL_BRACE_HINT}"
+            )
+        fields.add(field_name)
+    return fields
+
+
+def prompt_template_variables(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ScenarioValidationError("prompt.variables must be a mapping")
+    variables: dict[str, str] = {}
+    for key, raw_value in value.items():
+        name = require_non_empty_string(key, "prompt variable name")
+        if not PROMPT_TEMPLATE_VARIABLE_PATTERN.match(name):
+            raise ScenarioValidationError(f"prompt.variables.{name} has an unsafe variable name")
+        if raw_value is None or not isinstance(raw_value, PROMPT_TEMPLATE_SCALAR_TYPES):
+            raise ScenarioValidationError(f"prompt.variables.{name} must be a scalar string, number, or boolean")
+        variables[name] = str(raw_value)
+    return variables
+
+
+def render_prompt_template(template_text: str, variables: Mapping[str, str]) -> str:
+    fields = prompt_template_fields(template_text)
+    missing = fields.difference(variables)
+    if missing:
+        raise ScenarioValidationError(
+            f"Prompt template missing variable(s): {', '.join(sorted(missing))}. "
+            f"{PROMPT_TEMPLATE_LITERAL_BRACE_HINT}"
+        )
+    unused = set(variables).difference(fields)
+    if unused:
+        raise ScenarioValidationError(f"prompt.variables contains unused variable(s): {', '.join(sorted(unused))}")
+    try:
+        return template_text.format(**variables)
+    except (KeyError, IndexError, ValueError) as exc:
+        raise ScenarioValidationError(
+            f"Prompt template could not be rendered: {exc}. {PROMPT_TEMPLATE_LITERAL_BRACE_HINT}"
+        ) from exc
+
+
+def read_prompt_bytes(prompt_path: Path) -> bytes:
+    try:
+        prompt_bytes = prompt_path.read_bytes()
+    except OSError as exc:
+        raise ScenarioValidationError(f"Could not read prompt file {prompt_path}: {exc}") from exc
+    if len(prompt_bytes) > MAX_PROMPT_BYTES:
+        raise ScenarioValidationError(
+            f"Prompt file exceeds max size {MAX_PROMPT_BYTES} bytes: {prompt_path} ({len(prompt_bytes)} bytes)"
+        )
+    return prompt_bytes
+
+
+def resolve_prompt_path(prompt_text: str, base_dir: Path, *, allow_external_prompt: bool) -> Path:
+    prompt_path = resolve_path(prompt_text, base_dir)
+    base_root = base_dir.resolve()
+    resolved_prompt_path = prompt_path.resolve()
+    if not allow_external_prompt and not resolved_prompt_path.is_relative_to(base_root):
+        raise ScenarioValidationError(f"Prompt file must stay within scenario directory {base_root}: {prompt_path}")
+    if not prompt_path.is_file():
+        raise ScenarioValidationError(f"Prompt file must exist: {prompt_path}")
+    return resolved_prompt_path
+
+
+def rendered_prompt_filename(source_path: Path, rendered_bytes: bytes) -> str:
+    rendered_hash = hashlib.sha256(rendered_bytes).hexdigest()
+    return f"{slugify(source_path.stem)}_{rendered_hash[:12]}.txt"
+
+
+def contains_inline_template_placeholder(value: str) -> bool:
+    try:
+        return any(
+            field_name is not None and PROMPT_TEMPLATE_VARIABLE_PATTERN.match(field_name)
+            for _literal, field_name, _format_spec, _conversion in string.Formatter().parse(value)
+        )
+    except ValueError:
+        return False
+
+
+def materialize_prompt_for_output(scenario: dict[str, Any], run_plan: dict[str, Any], output_dir: Path) -> None:
+    prompt = scenario.get("prompt")
+    if not isinstance(prompt, dict) or prompt.get("source_type") != "template":
+        return
+    rendered_text = prompt.pop("_rendered_text", None)
+    filename = prompt.pop("_rendered_filename", None)
+    if not isinstance(rendered_text, str) or not isinstance(filename, str):
+        return
+    rendered_bytes = rendered_text.encode("utf-8")
+    prompt_dir = output_dir / GENERATED_PROMPT_DIR
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    rendered_path = (prompt_dir / filename).resolve()
+    rendered_path.write_bytes(rendered_bytes)
+    prompt["path"] = str(rendered_path)
+    prompt["rendered_path"] = str(rendered_path)
+    for entry in run_plan.get("entries") or []:
+        if isinstance(entry, dict):
+            entry["prompt_source"] = str(rendered_path)
+
+
+def resolve_prompt(raw: Mapping[str, Any], base_dir: Path, *, allow_external_prompt: bool = False) -> dict[str, Any]:
+    value = raw.get("prompt_path") or raw.get("prompt_file") or raw.get("prompt")
+    source_type = "file"
+    variables: dict[str, str] = {}
+    if isinstance(value, dict):
+        prompt_mapping = value
+        variables = prompt_template_variables(prompt_mapping.get("variables"))
+        if prompt_mapping.get("template") and prompt_mapping.get("path"):
+            raise ScenarioValidationError("prompt must not set both template and path")
+        if prompt_mapping.get("template"):
+            source_type = "template"
+            value = prompt_mapping.get("template")
+        elif prompt_mapping.get("path"):
+            value = prompt_mapping.get("path")
+            source_type = "template" if variables else "file"
+        else:
+            raise ScenarioValidationError("prompt mapping must contain path or template")
+    prompt_text = require_non_empty_string(value, "prompt path")
+    if source_type == "file" and contains_inline_template_placeholder(prompt_text):
+        raise ScenarioValidationError(
+            "prompt must be a file path, not an inline template string. "
+            "Use a prompt template file with prompt.template or prompt.path plus prompt.variables."
+        )
+    resolved_prompt_path = resolve_prompt_path(prompt_text, base_dir, allow_external_prompt=allow_external_prompt)
+    source_bytes = read_prompt_bytes(resolved_prompt_path)
+    prompt_bytes = source_bytes
+    prompt_path = resolved_prompt_path
+    if source_type == "template":
+        try:
+            template_text = source_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ScenarioValidationError(f"Prompt template must be UTF-8 text: {resolved_prompt_path}") from exc
+        rendered_text = render_prompt_template(template_text, variables)
+        prompt_bytes = rendered_text.encode("utf-8")
+        if len(prompt_bytes) > MAX_PROMPT_BYTES:
+            raise ScenarioValidationError(
+                f"Rendered prompt exceeds max size {MAX_PROMPT_BYTES} bytes: "
+                f"{resolved_prompt_path} ({len(prompt_bytes)} bytes)"
+            )
+    prompt_sha = hashlib.sha256(prompt_bytes).hexdigest()
+    source_sha = hashlib.sha256(source_bytes).hexdigest()
+    prompt = {
+        "path": str(prompt_path),
+        "source_path": str(resolved_prompt_path),
+        "source_type": source_type,
+        "sha256": prompt_sha,
+        "bytes": len(prompt_bytes),
+        "rendered_sha256": prompt_sha,
+        "rendered_bytes": len(prompt_bytes),
+        "source_sha256": source_sha,
+        "source_bytes": len(source_bytes),
+    }
+    if source_type == "template":
+        prompt["_rendered_text"] = prompt_bytes.decode("utf-8")
+        prompt["_rendered_filename"] = rendered_prompt_filename(resolved_prompt_path, prompt_bytes)
+    return prompt

--- a/assist_tools/skills_benchmark/skills/harness/scenario_run_plan.py
+++ b/assist_tools/skills_benchmark/skills/harness/scenario_run_plan.py
@@ -1,0 +1,764 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario validation and run-plan expansion."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .agents.registry import load_agent_adapter
+from .common import write_json
+from .modes import mode_spec
+from .scenario_common import (
+    COMPARISON_AGENT,
+    COMPARISON_MODE_ABLATION,
+    COMPARISON_MODEL,
+    COMPARISON_ONE,
+    COMPARISON_TYPES,
+    DEFAULT_PATH_BUDGET,
+    DEFAULT_QUALITY_GATE,
+    DEFAULT_RESOURCE_POLICIES,
+    DEFAULT_WINNER_POLICY,
+    JOB_SCALES,
+    QUALITY_GATE_KEYS,
+    REQUIRED_VALIDATION_METRIC_STATUSES,
+    SCHEMA_VERSION,
+    ScenarioValidationError,
+    as_list,
+    load_yaml_file,
+    model_list,
+    require_mapping,
+    require_non_empty_string,
+    resolve_path,
+    slugify,
+    unique_slug_map,
+    utc_timestamp,
+)
+from .scenario_prompt import materialize_prompt_for_output, resolve_prompt
+
+
+@dataclass(frozen=True)
+class ScenarioCompilation:
+    scenario: dict[str, Any]
+    run_plan: dict[str, Any]
+
+    def materialized(self, output_dir: str | Path) -> "ScenarioCompilation":
+        scenario = copy.deepcopy(self.scenario)
+        run_plan = copy.deepcopy(self.run_plan)
+        materialize_prompt_for_output(scenario, run_plan, Path(output_dir))
+        return ScenarioCompilation(scenario=scenario, run_plan=run_plan)
+
+    def write(self, output_dir: str | Path) -> "ScenarioCompilation":
+        path = Path(output_dir)
+        path.mkdir(parents=True, exist_ok=True)
+        materialized = self.materialized(path)
+        write_json(path / "scenario.json", materialized.scenario)
+        write_json(path / "run_plan.json", materialized.run_plan)
+        return materialized
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    name: str
+    models: tuple[str, ...]
+    default_model: str
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    name: str
+    source: str
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    name: str
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    path: Path
+    name: str
+    scale: str
+    resource_policy: dict[str, int]
+
+
+def resolve_agents(raw: Mapping[str, Any]) -> tuple[dict[str, AgentSpec], list[dict[str, Any]]]:
+    agents_raw = as_list(raw.get("agents"), "agents")
+    if not agents_raw:
+        raise ScenarioValidationError("agents must contain at least one agent")
+    agents: dict[str, AgentSpec] = {}
+    resolved = []
+    for index, item in enumerate(agents_raw):
+        if isinstance(item, str):
+            name = item
+            models = ()
+        else:
+            data = require_mapping(item, f"agents[{index}]")
+            name = require_non_empty_string(data.get("name"), f"agents[{index}].name")
+            models = model_list(data.get("models", data.get("model")), f"agents[{index}].models")
+        if name in agents:
+            raise ScenarioValidationError(f"Duplicate agent entry: {name}")
+        try:
+            adapter = load_agent_adapter(name)
+        except ValueError as exc:
+            raise ScenarioValidationError(str(exc)) from exc
+        try:
+            default_model = adapter.default_model if models else adapter.model_from_env({})
+        except ValueError as exc:
+            raise ScenarioValidationError(str(exc)) from exc
+        spec = AgentSpec(name=name, models=models, default_model=default_model)
+        agents[name] = spec
+        resolved.append(
+            {
+                "name": name,
+                "models": list(models),
+                "default_model": default_model,
+                "model_source_when_unspecified": "adapter_default",
+            }
+        )
+    return agents, resolved
+
+
+def resolve_workflows(raw: Mapping[str, Any]) -> tuple[list[WorkflowSpec], list[dict[str, Any]]]:
+    workflows_raw = as_list(raw.get("workflows"), "workflows")
+    if not workflows_raw:
+        raise ScenarioValidationError("workflows must contain at least one workflow")
+    workflows = []
+    for index, item in enumerate(workflows_raw):
+        if isinstance(item, str):
+            name = item
+        else:
+            data = require_mapping(item, f"workflows[{index}]")
+            name = data.get("name")
+        workflows.append(WorkflowSpec(require_non_empty_string(name, f"workflows[{index}].name")))
+    if len({item.name for item in workflows}) != len(workflows):
+        raise ScenarioValidationError("workflows contains duplicate names")
+    return workflows, [{"name": item.name} for item in workflows]
+
+
+def _integer_policy_overrides(raw: Mapping[str, Any], field_path: str) -> dict[str, int]:
+    overrides = {}
+    for key, value in raw.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ScenarioValidationError(f"{field_path}.{key} must be an integer greater than 0; got {value!r}")
+        overrides[str(key)] = value
+    return overrides
+
+
+def resource_policy_for(
+    scale: str, scenario_raw: Mapping[str, Any], job_raw: Mapping[str, Any], job_policy_path: str
+) -> dict[str, int]:
+    policy = dict(DEFAULT_RESOURCE_POLICIES[scale])
+    scenario_policy = scenario_raw.get("resource_policy") or {}
+    if isinstance(scenario_policy, dict):
+        global_overrides = scenario_policy.get(scale) or {}
+        if isinstance(global_overrides, dict):
+            policy.update(_integer_policy_overrides(global_overrides, f"resource_policy.{scale}"))
+    job_policy = job_raw.get("resource_policy") or {}
+    if isinstance(job_policy, dict):
+        policy.update(_integer_policy_overrides(job_policy, job_policy_path))
+    return policy
+
+
+def resolve_jobs(raw: Mapping[str, Any], base_dir: Path) -> tuple[list[JobSpec], list[dict[str, Any]]]:
+    jobs_raw = as_list(raw.get("jobs"), "jobs")
+    if not jobs_raw:
+        raise ScenarioValidationError("jobs must contain at least one job")
+    jobs = []
+    resolved = []
+    for index, item in enumerate(jobs_raw):
+        data = require_mapping(item, f"jobs[{index}]")
+        path_value = require_non_empty_string(data.get("path"), f"jobs[{index}].path")
+        path = resolve_path(path_value, base_dir).resolve()
+        if not path.is_dir():
+            raise ScenarioValidationError(f"Job path must be an existing directory: {path}")
+        scale = data.get("scale", data.get("job_scale"))
+        scale = require_non_empty_string(scale, f"jobs[{index}].scale")
+        if scale not in JOB_SCALES:
+            raise ScenarioValidationError(f"jobs[{index}].scale must be one of: {', '.join(sorted(JOB_SCALES))}")
+        name = require_non_empty_string(data.get("name") or path.name, f"jobs[{index}].name")
+        policy = resource_policy_for(scale, raw, data, f"jobs[{index}].resource_policy")
+        jobs.append(JobSpec(path=path, name=name, scale=scale, resource_policy=policy))
+        resolved.append({"name": name, "path": str(path), "scale": scale, "resource_policy": policy})
+    return jobs, resolved
+
+
+def resolve_fail_fast(raw: Mapping[str, Any]) -> bool:
+    value = raw.get("fail_fast", False)
+    if not isinstance(value, bool):
+        raise ScenarioValidationError(f"fail_fast must be a boolean; got {value!r}")
+    return value
+
+
+def resolve_quality_gate(raw: Mapping[str, Any]) -> dict[str, Any]:
+    override = raw.get("quality_gate")
+    gate = {
+        "agent_process_passed": DEFAULT_QUALITY_GATE["agent_process_passed"],
+        "final_container_exit_code": DEFAULT_QUALITY_GATE["final_container_exit_code"],
+        "source_input_modified": DEFAULT_QUALITY_GATE["source_input_modified"],
+        "required_validation_metric_status": list(DEFAULT_QUALITY_GATE["required_validation_metric_status"]),
+        "critical_quality_checks_failed": DEFAULT_QUALITY_GATE["critical_quality_checks_failed"],
+    }
+    if override is None:
+        return gate
+    if not isinstance(override, dict):
+        raise ScenarioValidationError("quality_gate must be a mapping")
+    for key, value in override.items():
+        if key not in QUALITY_GATE_KEYS:
+            raise ScenarioValidationError(
+                f"quality_gate.{key} is not supported; expected one of: {', '.join(sorted(QUALITY_GATE_KEYS))}"
+            )
+        if key in {"agent_process_passed", "source_input_modified", "critical_quality_checks_failed"}:
+            if not isinstance(value, bool):
+                raise ScenarioValidationError(f"quality_gate.{key} must be a boolean")
+            gate[key] = value
+        elif key == "final_container_exit_code":
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ScenarioValidationError("quality_gate.final_container_exit_code must be an integer")
+            gate[key] = value
+        elif key == "required_validation_metric_status":
+            statuses = model_list(value, "quality_gate.required_validation_metric_status")
+            if not statuses:
+                raise ScenarioValidationError("quality_gate.required_validation_metric_status must not be empty")
+            unknown = [status for status in statuses if status not in REQUIRED_VALIDATION_METRIC_STATUSES]
+            if unknown:
+                raise ScenarioValidationError(
+                    "quality_gate.required_validation_metric_status contains unsupported value(s): "
+                    + ", ".join(unknown)
+                )
+            gate[key] = list(statuses)
+    return gate
+
+
+def resolve_path_budget(raw: Mapping[str, Any]) -> int:
+    value = raw.get("path_budget", DEFAULT_PATH_BUDGET)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 80:
+        raise ScenarioValidationError("path_budget must be an integer >= 80")
+    return value
+
+
+def validate_mode(mode: Any, label: str) -> str:
+    mode_name = require_non_empty_string(mode, label)
+    try:
+        mode_spec(mode_name)
+    except ValueError as exc:
+        raise ScenarioValidationError(str(exc)) from exc
+    return mode_name
+
+
+def validate_comparison(raw: Mapping[str, Any], agents: Mapping[str, AgentSpec]) -> dict[str, Any]:
+    comparison = require_mapping(raw.get("comparison"), "comparison")
+    comparison_type = require_non_empty_string(comparison.get("type"), "comparison.type")
+    if comparison_type not in COMPARISON_TYPES:
+        raise ScenarioValidationError(
+            f"comparison.type must be one of: {', '.join(sorted(COMPARISON_TYPES))}; got {comparison_type}"
+        )
+    resolved = dict(comparison)
+    if comparison_type == COMPARISON_MODE_ABLATION:
+        modes = [
+            validate_mode(item, "comparison.modes[]") for item in as_list(comparison.get("modes"), "comparison.modes")
+        ]
+        if not modes:
+            raise ScenarioValidationError("comparison.modes must contain at least one mode")
+        if len(set(modes)) != len(modes):
+            raise ScenarioValidationError("comparison.modes contains duplicate modes")
+        resolved["modes"] = modes
+    elif comparison_type == COMPARISON_ONE:
+        resolved["mode"] = validate_mode(comparison.get("mode"), "comparison.mode")
+    elif comparison_type == COMPARISON_AGENT:
+        resolved["mode"] = validate_mode(comparison.get("mode"), "comparison.mode")
+        compared_agents = [
+            item if isinstance(item, str) else require_mapping(item, "comparison.agents[]").get("name")
+            for item in as_list(comparison.get("agents"), "comparison.agents")
+        ]
+        compared_agents = [require_non_empty_string(item, "comparison.agents[]") for item in compared_agents]
+        if not compared_agents:
+            raise ScenarioValidationError("comparison.agents must contain at least one agent")
+        if len(set(compared_agents)) != len(compared_agents):
+            raise ScenarioValidationError("comparison.agents contains duplicate agents")
+        for agent in compared_agents:
+            if agent not in agents:
+                raise ScenarioValidationError(f"comparison.agents includes {agent!r}, but agents does not define it")
+        resolved["agents"] = compared_agents
+    elif comparison_type == COMPARISON_MODEL:
+        agent = require_non_empty_string(comparison.get("agent"), "comparison.agent")
+        if agent not in agents:
+            raise ScenarioValidationError(f"comparison.agent {agent!r} is not listed in agents")
+        resolved["agent"] = agent
+        resolved["mode"] = validate_mode(comparison.get("mode"), "comparison.mode")
+        models = model_list(comparison.get("models"), "comparison.models")
+        if not models:
+            raise ScenarioValidationError("comparison.models must contain at least one model")
+        resolved["models"] = list(models)
+    return resolved
+
+
+def agent_model_options(agent: AgentSpec) -> list[ModelSpec]:
+    if agent.models:
+        return [ModelSpec(name=model, source="scenario") for model in agent.models]
+    return [ModelSpec(name=agent.default_model, source="adapter_default")]
+
+
+def resolve_agent_comparison_models(
+    comparison: Mapping[str, Any], agents: Mapping[str, AgentSpec]
+) -> dict[str, ModelSpec]:
+    explicit = comparison.get("models_by_agent") or {}
+    if explicit and not isinstance(explicit, dict):
+        raise ScenarioValidationError("comparison.models_by_agent must be a mapping")
+    resolved = {}
+    for agent_name in comparison["agents"]:
+        if agent_name in explicit:
+            models = model_list(explicit[agent_name], f"comparison.models_by_agent.{agent_name}")
+            if len(models) != 1:
+                raise ScenarioValidationError(
+                    f"comparison.models_by_agent.{agent_name} must resolve to exactly one model"
+                )
+            resolved[agent_name] = ModelSpec(models[0], "comparison.models_by_agent")
+            continue
+        agent = agents[agent_name]
+        if len(agent.models) > 1:
+            raise ScenarioValidationError(
+                f"agent_comparison model selection is ambiguous for {agent_name}; "
+                "use comparison.models_by_agent or configure exactly one top-level model"
+            )
+        if len(agent.models) == 1:
+            resolved[agent_name] = ModelSpec(agent.models[0], "scenario")
+        else:
+            resolved[agent_name] = ModelSpec(agent.default_model, "adapter_default")
+    return resolved
+
+
+def artifact_paths(record_dir: str) -> dict[str, str]:
+    return {
+        "record_dir": record_dir,
+        "record_summary": f"{record_dir}/record_summary.json",
+        "agent_events": f"{record_dir}/agent_events.jsonl",
+        "agent_usage": f"{record_dir}/agent_usage.json",
+        "agent_activity": f"{record_dir}/agent_activity.json",
+        "agent_last_message": f"{record_dir}/agent_last_message.txt",
+        "agent_stderr": f"{record_dir}/agent_stderr.txt",
+        "agent_record": f"{record_dir}/agent_record.json",
+        "benchmark_record": f"{record_dir}/benchmark_record.json",
+        "input_delta_manifest": f"{record_dir}/input_delta_manifest.json",
+        "workspace_delta_manifest": f"{record_dir}/workspace_delta_manifest.json",
+    }
+
+
+def record_dir_for(
+    *,
+    agent_slug: str,
+    model_slug: str,
+    workflow_slug: str,
+    job_slug: str,
+    mode: str,
+) -> str:
+    return f"records/agent={agent_slug}/model={model_slug}/workflow={workflow_slug}/job={job_slug}/mode={mode}"
+
+
+def model_slug_for(slugs: Mapping[str, Mapping[str, str]], agent_name: str, model_name: str) -> str:
+    return slugs["models"].get(model_slug_key(agent_name, model_name)) or slugify(model_name)
+
+
+def model_slug_key(agent_name: str, model_name: str) -> str:
+    return json.dumps([agent_name, model_name], ensure_ascii=False, separators=(",", ":"))
+
+
+def build_run_entry(
+    *,
+    scenario_name: str,
+    comparison_type: str,
+    comparison_group_id: str,
+    sequence: int,
+    agent: AgentSpec,
+    model: ModelSpec,
+    workflow: WorkflowSpec,
+    job: JobSpec,
+    mode: str,
+    prompt: Mapping[str, Any],
+    slugs: Mapping[str, Mapping[str, str]],
+) -> dict[str, Any]:
+    spec = mode_spec(mode)
+    agent_slug = slugs["agents"][agent.name]
+    model_slug = model_slug_for(slugs, agent.name, model.name)
+    workflow_slug = slugs["workflows"][workflow.name]
+    job_slug = slugs["jobs"][job.name]
+    record_dir = record_dir_for(
+        agent_slug=agent_slug,
+        model_slug=model_slug,
+        workflow_slug=workflow_slug,
+        job_slug=job_slug,
+        mode=mode,
+    )
+    return {
+        "run_id": f"run_{sequence:05d}",
+        "sequence": sequence,
+        "scenario_name": scenario_name,
+        "comparison_type": comparison_type,
+        "comparison_group_id": comparison_group_id,
+        "agent": agent.name,
+        "agent_slug": agent_slug,
+        "agent_model": model.name,
+        "agent_model_slug": model_slug,
+        "model_source": model.source,
+        "workflow": workflow.name,
+        "workflow_slug": workflow_slug,
+        "job_name": job.name,
+        "job_slug": job_slug,
+        "job_path": str(job.path),
+        "job_scale": job.scale,
+        "resource_policy": job.resource_policy,
+        "mode": mode,
+        "mode_label": spec.label,
+        "skills_enabled": spec.skills_enabled,
+        "prompt_source": prompt["path"],
+        "prompt_hash": prompt["sha256"],
+        "prompt_bytes": prompt["bytes"],
+        "record_dir": record_dir,
+        "artifact_paths": artifact_paths(record_dir),
+    }
+
+
+def slug_context(
+    agents: Mapping[str, AgentSpec],
+    workflows: list[WorkflowSpec],
+    jobs: list[JobSpec],
+    comparison: Mapping[str, Any],
+) -> dict[str, dict[str, str]]:
+    model_values_by_agent: dict[str, list[str]] = {}
+
+    def append_model(agent_name: str, model_name: str) -> None:
+        values = model_values_by_agent.setdefault(agent_name, [])
+        if model_name not in values:
+            values.append(model_name)
+
+    for agent in agents.values():
+        for model in agent.models or (agent.default_model,):
+            append_model(agent.name, model)
+    if comparison.get("type") == COMPARISON_MODEL:
+        agent_name = str(comparison["agent"])
+        for model in comparison["models"]:
+            append_model(agent_name, str(model))
+    if comparison.get("type") == COMPARISON_AGENT and isinstance(comparison.get("models_by_agent"), dict):
+        for agent_name, value in comparison["models_by_agent"].items():
+            for model in model_list(value, f"comparison.models_by_agent.{agent_name}"):
+                append_model(str(agent_name), model)
+    model_slugs = {}
+    for agent_name, values in model_values_by_agent.items():
+        per_agent = unique_slug_map(values)
+        for value, slug in per_agent.items():
+            model_slugs[model_slug_key(agent_name, value)] = slug
+    return {
+        "agents": unique_slug_map(agent.name for agent in agents.values()),
+        "models": model_slugs,
+        "workflows": unique_slug_map(workflow.name for workflow in workflows),
+        "jobs": unique_slug_map(job.name for job in jobs),
+    }
+
+
+def append_group(
+    *,
+    groups: list[dict[str, Any]],
+    entries: list[dict[str, Any]],
+    group_index: int,
+    group_axes: dict[str, Any],
+    compared_entries: list[dict[str, Any]],
+    comparison_type: str,
+) -> None:
+    group_id = f"group_{group_index:05d}"
+    for entry in compared_entries:
+        entry["comparison_group_id"] = group_id
+        entries.append(entry)
+    groups.append(
+        {
+            "comparison_group_id": group_id,
+            "comparison_type": comparison_type,
+            "group_axes": group_axes,
+            "compared_run_ids": [entry["run_id"] for entry in compared_entries],
+        }
+    )
+
+
+def expand_run_plan(
+    *,
+    scenario_name: str,
+    comparison: Mapping[str, Any],
+    agents: Mapping[str, AgentSpec],
+    workflows: list[WorkflowSpec],
+    jobs: list[JobSpec],
+    prompt: Mapping[str, Any],
+    path_budget: int,
+    quality_gate: Mapping[str, Any],
+    winner_policy: str = DEFAULT_WINNER_POLICY,
+) -> dict[str, Any]:
+    comparison_type = str(comparison["type"])
+    slugs = slug_context(agents, workflows, jobs, comparison)
+    entries: list[dict[str, Any]] = []
+    groups: list[dict[str, Any]] = []
+    sequence = 0
+    group_index = 0
+
+    def next_entry(**kwargs: Any) -> dict[str, Any]:
+        nonlocal sequence
+        sequence += 1
+        return build_run_entry(
+            scenario_name=scenario_name,
+            comparison_type=comparison_type,
+            sequence=sequence,
+            prompt=prompt,
+            slugs=slugs,
+            **kwargs,
+        )
+
+    if comparison_type in {COMPARISON_MODE_ABLATION, COMPARISON_ONE}:
+        modes = comparison.get("modes") if comparison_type == COMPARISON_MODE_ABLATION else [comparison["mode"]]
+        for agent in agents.values():
+            for model in agent_model_options(agent):
+                for workflow in workflows:
+                    for job in jobs:
+                        group_index += 1
+                        compared = [
+                            next_entry(
+                                comparison_group_id="",
+                                agent=agent,
+                                model=model,
+                                workflow=workflow,
+                                job=job,
+                                mode=mode,
+                            )
+                            for mode in modes
+                        ]
+                        append_group(
+                            groups=groups,
+                            entries=entries,
+                            group_index=group_index,
+                            group_axes={
+                                "agent": agent.name,
+                                "agent_model": model.name,
+                                "workflow": workflow.name,
+                                "job_slug": slugs["jobs"][job.name],
+                            },
+                            compared_entries=compared,
+                            comparison_type=comparison_type,
+                        )
+    elif comparison_type == COMPARISON_AGENT:
+        model_by_agent = resolve_agent_comparison_models(comparison, agents)
+        mode = str(comparison["mode"])
+        for workflow in workflows:
+            for job in jobs:
+                group_index += 1
+                compared = [
+                    next_entry(
+                        comparison_group_id="",
+                        agent=agents[agent_name],
+                        model=model_by_agent[agent_name],
+                        workflow=workflow,
+                        job=job,
+                        mode=mode,
+                    )
+                    for agent_name in comparison["agents"]
+                ]
+                append_group(
+                    groups=groups,
+                    entries=entries,
+                    group_index=group_index,
+                    group_axes={
+                        "mode": mode,
+                        "workflow": workflow.name,
+                        "job_slug": slugs["jobs"][job.name],
+                    },
+                    compared_entries=compared,
+                    comparison_type=comparison_type,
+                )
+    elif comparison_type == COMPARISON_MODEL:
+        agent = agents[str(comparison["agent"])]
+        mode = str(comparison["mode"])
+        models = [ModelSpec(str(model), "comparison") for model in comparison["models"]]
+        for workflow in workflows:
+            for job in jobs:
+                group_index += 1
+                compared = [
+                    next_entry(
+                        comparison_group_id="",
+                        agent=agent,
+                        model=model,
+                        workflow=workflow,
+                        job=job,
+                        mode=mode,
+                    )
+                    for model in models
+                ]
+                append_group(
+                    groups=groups,
+                    entries=entries,
+                    group_index=group_index,
+                    group_axes={
+                        "agent": agent.name,
+                        "mode": mode,
+                        "workflow": workflow.name,
+                        "job_slug": slugs["jobs"][job.name],
+                    },
+                    compared_entries=compared,
+                    comparison_type=comparison_type,
+                )
+
+    # Compile-time check uses a root-agnostic proxy; execution revalidates with the actual result root.
+    validate_path_budget(scenario_name, entries, path_budget)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scenario_name": scenario_name,
+        "generated_at": utc_timestamp(),
+        "comparison_type": comparison_type,
+        "run_count": len(entries),
+        "comparison_group_count": len(groups),
+        "execution": {"parallelism": 1},
+        "quality_gate": dict(quality_gate),
+        "winner_policy": winner_policy,
+        "entries": entries,
+        "comparison_groups": groups,
+    }
+
+
+def scenario_reproducibility_metadata(
+    *,
+    agents: Mapping[str, AgentSpec],
+    prompt: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+    jobs: list[JobSpec],
+) -> dict[str, Any]:
+    agent_metadata = {}
+    image_targets = {}
+    build_args = {}
+    agent_versions = {}
+    for agent_name in sorted(agents):
+        adapter = load_agent_adapter(agent_name)
+        targets = adapter.image_targets()
+        args = adapter.build_args()
+        agent_metadata[agent_name] = adapter.metadata()
+        image_targets[agent_name] = {
+            "skills": targets.skills,
+            "baseline": targets.baseline,
+            "report": targets.report,
+        }
+        build_args[agent_name] = args
+        agent_versions[agent_name] = {
+            key: value
+            for key, value in sorted(args.items())
+            if key in {"AGENT_CLI_NAME", "AGENT_INSTALL_COMMAND", "AGENT_VERSION_COMMAND"}
+        }
+    modes = []
+    comparison_type = comparison.get("type")
+    if comparison_type == COMPARISON_MODE_ABLATION:
+        modes = list(comparison.get("modes") or [])
+    elif comparison_type in {COMPARISON_AGENT, COMPARISON_MODEL, COMPARISON_ONE}:
+        modes = [str(comparison.get("mode"))]
+    wheel_variants = sorted(
+        {
+            (
+                "local_wheel_with_preinstalled_skills"
+                if mode_spec(str(mode)).skills_enabled
+                else "local_wheel_without_packaged_skills"
+            )
+            for mode in modes
+        }
+    )
+    return {
+        "compiled_at": utc_timestamp(),
+        "prompt_hash": prompt.get("sha256"),
+        "prompt_bytes": prompt.get("bytes"),
+        "agent_adapters": agent_metadata,
+        "agent_versions": agent_versions,
+        "image_targets": image_targets,
+        "build_args": build_args,
+        "wheel_variants": wheel_variants,
+        "job_paths": {job.name: str(job.path) for job in jobs},
+    }
+
+
+def validate_path_budget(
+    scenario_name: str, entries: list[dict[str, Any]], path_budget: int, result_root: str | Path | None = None
+) -> None:
+    prefix = Path(result_root) if result_root is not None else Path("results") / slugify(scenario_name)
+    for entry in entries:
+        longest = max((str(Path(path)) for path in entry["artifact_paths"].values()), key=len)
+        candidate = prefix / longest
+        if len(str(candidate)) > path_budget:
+            raise ScenarioValidationError(f"Expanded artifact path exceeds path_budget={path_budget}: {candidate}")
+
+
+def compile_scenario(
+    raw: Mapping[str, Any],
+    *,
+    base_dir: str | Path,
+    source_path: str | Path | None = None,
+    allow_external_prompt: bool = False,
+) -> ScenarioCompilation:
+    base_path = Path(base_dir)
+    name = require_non_empty_string(raw.get("name"), "name")
+    prompt = resolve_prompt(raw, base_path, allow_external_prompt=allow_external_prompt)
+    agents, resolved_agents = resolve_agents(raw)
+    workflows, resolved_workflows = resolve_workflows(raw)
+    jobs, resolved_jobs = resolve_jobs(raw, base_path)
+    path_budget = resolve_path_budget(raw)
+    comparison = validate_comparison(raw, agents)
+    fail_fast = resolve_fail_fast(raw)
+    quality_gate = resolve_quality_gate(raw)
+
+    scenario = {
+        "schema_version": SCHEMA_VERSION,
+        "name": name,
+        "scenario_slug": slugify(name),
+        "source_path": str(Path(source_path).resolve()) if source_path else None,
+        "prompt": prompt,
+        "agents": resolved_agents,
+        "workflows": resolved_workflows,
+        "jobs": resolved_jobs,
+        "comparison": comparison,
+        "fail_fast": fail_fast,
+        "quality_gate": quality_gate,
+        "winner_policy": DEFAULT_WINNER_POLICY,
+        "path_budget": path_budget,
+        "resource_policy_defaults": DEFAULT_RESOURCE_POLICIES,
+    }
+    scenario["reproducibility"] = scenario_reproducibility_metadata(
+        agents=agents,
+        prompt=prompt,
+        comparison=comparison,
+        jobs=jobs,
+    )
+    run_plan = expand_run_plan(
+        scenario_name=name,
+        comparison=comparison,
+        agents=agents,
+        workflows=workflows,
+        jobs=jobs,
+        prompt=prompt,
+        path_budget=path_budget,
+        quality_gate=quality_gate,
+        winner_policy=DEFAULT_WINNER_POLICY,
+    )
+    run_plan["source_path"] = scenario["source_path"]
+    run_plan["fail_fast"] = fail_fast
+    return ScenarioCompilation(scenario=scenario, run_plan=run_plan)
+
+
+def compile_scenario_file(path: str | Path) -> ScenarioCompilation:
+    scenario_path = Path(path)
+    raw = load_yaml_file(scenario_path)
+    return compile_scenario(raw, base_dir=scenario_path.parent, source_path=scenario_path)

--- a/assist_tools/skills_benchmark/skills/harness/scenario_summaries.py
+++ b/assist_tools/skills_benchmark/skills/harness/scenario_summaries.py
@@ -1,0 +1,503 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario summary aggregation and report status helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from pathlib import Path
+from typing import Any, Mapping
+
+from .common import load_json
+from .quality_signals import critical_quality_checks_failed, required_validation_metric_status
+from .reports.scenario_report import write_scenario_report
+from .scenario_common import (
+    COMPARISON_AGENT,
+    COMPARISON_MODE_ABLATION,
+    COMPARISON_MODEL,
+    DEFAULT_QUALITY_GATE,
+    DEFAULT_WINNER_POLICY,
+    SCHEMA_VERSION,
+    SUMMARY_RUN_FIELDS,
+    UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL,
+)
+
+
+def is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def number_or_none(value: Any) -> float | None:
+    return float(value) if is_number(value) else None
+
+
+def number_or_zero(value: Any) -> float:
+    return float(value) if is_number(value) else 0.0
+
+
+def optional_number_sort_value(value: Any) -> tuple[int, float]:
+    return (0, float(value)) if is_number(value) else (1, 0.0)
+
+
+def stats_for_values(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"count": 0, "median": None, "mean": None, "min": None, "max": None, "stddev": None}
+    return {
+        "count": len(values),
+        "median": statistics.median(values),
+        "mean": statistics.mean(values),
+        "min": min(values),
+        "max": max(values),
+        "stddev": statistics.stdev(values) if len(values) >= 2 else None,
+    }
+
+
+def record_dir_path(result_root: Path, entry: Mapping[str, Any]) -> Path:
+    return result_root / str(entry["record_dir"])
+
+
+def benchmark_record_path(record_dir: Path, mode: str) -> Path:
+    direct = record_dir / "benchmark_record.json"
+    if direct.is_file():
+        return direct
+    return record_dir / "records" / f"{mode}_record.json"
+
+
+def agent_record_path(record_dir: Path, mode: str) -> Path:
+    direct = record_dir / "agent_record.json"
+    if direct.is_file():
+        return direct
+    return record_dir / "records" / f"{mode}_agent_record.json"
+
+
+def read_entry_artifacts(result_root: Path, entry: Mapping[str, Any]) -> dict[str, Any]:
+    record_dir = record_dir_path(result_root, entry)
+    mode = str(entry["mode"])
+    summary = load_json(record_dir / "record_summary.json", None)
+    if not isinstance(summary, dict):
+        summary = load_json(record_dir / "run_summary.json", {}) or {}
+    record = load_json(benchmark_record_path(record_dir, mode), {}) or {}
+    container_exit = load_json(record_dir / "container_exit_code.json", {}) or {}
+    return {
+        "record_dir": record_dir,
+        "summary": summary if isinstance(summary, dict) else {},
+        "record": record if isinstance(record, dict) else {},
+        "container_exit": container_exit if isinstance(container_exit, dict) else {},
+    }
+
+
+def quality_gate_failures(
+    summary: Mapping[str, Any],
+    record: Mapping[str, Any],
+    status: int | None,
+    quality_gate: Mapping[str, Any] | None = None,
+) -> list[str]:
+    gate = quality_gate or DEFAULT_QUALITY_GATE
+    failures = []
+    if status not in (0, None):
+        failures.append(f"host_status={status}")
+    agent_passed = summary.get("agent_process_passed", record.get("agent_process_passed"))
+    expected_agent_passed = gate.get("agent_process_passed", True)
+    if agent_passed != expected_agent_passed:
+        failures.append(
+            "agent_process_passed" if expected_agent_passed is True else f"agent_process_passed={agent_passed}"
+        )
+    final_exit = summary.get("final_container_exit_code", record.get("final_container_exit_code"))
+    expected_final_exit = gate.get("final_container_exit_code", 0)
+    if final_exit is None:
+        failures.append("final_container_exit_code=not_recorded")
+    elif final_exit != expected_final_exit:
+        failures.append(f"final_container_exit_code={final_exit}")
+    policy = summary.get("source_input_immutable_policy")
+    if not isinstance(policy, dict):
+        policy = (
+            record.get("source_input_immutable_policy")
+            if isinstance(record.get("source_input_immutable_policy"), dict)
+            else {}
+        )
+    source_input_modified = policy.get("status") == "fail"
+    expected_source_input_modified = gate.get("source_input_modified", False)
+    if source_input_modified != expected_source_input_modified:
+        failures.append(
+            "source_input_modified"
+            if expected_source_input_modified is False
+            else f"source_input_modified={source_input_modified}"
+        )
+    metric_status = (
+        record.get("required_validation_metric_status")
+        or summary.get("required_validation_metric_status")
+        or required_validation_metric_status_from_artifacts(summary, record)
+    )
+    allowed_metric_statuses = set(gate.get("required_validation_metric_status") or ())
+    if metric_status and metric_status not in allowed_metric_statuses:
+        failures.append(f"required_validation_metric_status={metric_status}")
+    critical_checks_failed = bool(
+        record.get("critical_quality_checks_failed")
+        or summary.get("critical_quality_checks_failed")
+        or critical_quality_checks_failed(summary, record)
+    )
+    expected_critical_failed = gate.get("critical_quality_checks_failed", False)
+    if critical_checks_failed != expected_critical_failed:
+        failures.append(
+            "critical_quality_checks_failed"
+            if expected_critical_failed is False
+            else f"critical_quality_checks_failed={critical_checks_failed}"
+        )
+    if not summary and not record:
+        failures.append("missing_record_summary")
+    return failures
+
+
+def required_validation_metric_status_from_artifacts(summary: Mapping[str, Any], record: Mapping[str, Any]) -> str:
+    for artifact in (record, summary):
+        quality = artifact.get("quality_signals") if isinstance(artifact, Mapping) else None
+        if isinstance(quality, Mapping):
+            signal = quality.get("job_guidance_primary_validation_metric") or quality.get(
+                "readme_primary_validation_metric"
+            )
+            status = required_validation_metric_status(signal if isinstance(signal, Mapping) else None)
+            if status != "not_required":
+                return status
+    return "not_required"
+
+
+def run_summary_for_entry(
+    result_root: Path,
+    entry: Mapping[str, Any],
+    statuses: Mapping[str, int],
+    quality_gate: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    artifacts = read_entry_artifacts(result_root, entry)
+    summary = artifacts["summary"]
+    record = artifacts["record"]
+    container_exit = artifacts["container_exit"]
+    status = statuses.get(str(entry["run_id"]))
+    if status is None:
+        status = statuses.get(str(entry["mode"]))
+    final_exit = summary.get("final_container_exit_code", record.get("final_container_exit_code"))
+    if final_exit is None:
+        final_exit = container_exit.get("exit_code")
+    effective_quality_gate = quality_gate or DEFAULT_QUALITY_GATE
+    failures = quality_gate_failures(summary, record, status, effective_quality_gate)
+    required_metric_status = (
+        record.get("required_validation_metric_status")
+        or summary.get("required_validation_metric_status")
+        or required_validation_metric_status_from_artifacts(summary, record)
+    )
+    critical_checks_failed = bool(
+        record.get("critical_quality_checks_failed")
+        or summary.get("critical_quality_checks_failed")
+        or critical_quality_checks_failed(summary, record)
+    )
+    process_metrics = record.get("process_metrics") if isinstance(record.get("process_metrics"), dict) else {}
+    agent_elapsed = summary.get("agent_elapsed_seconds")
+    if agent_elapsed is None:
+        agent_elapsed = process_metrics.get("agent_elapsed_seconds")
+    token_count = summary.get("token_count")
+    if token_count is None:
+        token_count = process_metrics.get("token_count")
+    payload = {key: entry.get(key) for key in SUMMARY_RUN_FIELDS}
+    payload.update(
+        {
+            "status": "passed" if not failures else "failed",
+            "host_status": status,
+            "quality_gate_passed": not failures,
+            "quality_gate_failures": failures,
+            "quality_gate": dict(effective_quality_gate),
+            "required_validation_metric_status": required_metric_status,
+            "validation_metric_status": required_metric_status,
+            "critical_quality_checks_failed": critical_checks_failed,
+            "agent_elapsed_seconds": agent_elapsed,
+            "elapsed_seconds": (
+                agent_elapsed
+                if agent_elapsed is not None
+                else summary.get("elapsed_seconds", process_metrics.get("elapsed_seconds"))
+            ),
+            "phase_seconds": summary.get("phase_seconds", process_metrics.get("phase_seconds")),
+            "token_count": token_count,
+            "command_count": summary.get("command_count", process_metrics.get("command_count")),
+            "cost": summary.get("cost", process_metrics.get("cost")),
+            "agent_process_passed": summary.get("agent_process_passed", record.get("agent_process_passed")),
+            "agent_exit_code": summary.get("agent_exit_code", process_metrics.get("agent_exit_code")),
+            "final_container_exit_code": final_exit,
+            "failure_root_cause": record.get("failure_root_cause") or record.get("failure_category"),
+            "observed_skill_name": summary.get("observed_skill_name")
+            or record.get("skill")
+            or record.get("skill_name"),
+            "skill_name_source": summary.get("skill_name_source") or record.get("agent_record_source"),
+            "validation_metric": summary.get("validation_metric") or record.get("reported_validation_metric"),
+            "structure_quality_signal": summary.get("structure_quality_signal")
+            or record.get("structure_quality_signal")
+            or UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL,
+            "artifact_paths": entry.get("artifact_paths") or {},
+        }
+    )
+    return payload
+
+
+def failed_run_summary_for_entry(
+    entry: Mapping[str, Any],
+    statuses: Mapping[str, int],
+    exc: Exception,
+    *,
+    quality_gate: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    effective_quality_gate = quality_gate or DEFAULT_QUALITY_GATE
+    status = statuses.get(str(entry.get("run_id")))
+    if status is None:
+        status = statuses.get(str(entry.get("mode")))
+    payload = {key: entry.get(key) for key in SUMMARY_RUN_FIELDS}
+    payload.update(
+        {
+            "status": "failed",
+            "host_status": status,
+            "quality_gate_passed": False,
+            "quality_gate_failures": ["run_summary_generation_failed"],
+            "quality_gate": dict(effective_quality_gate),
+            "required_validation_metric_status": "unknown",
+            "validation_metric_status": "unknown",
+            "critical_quality_checks_failed": True,
+            "agent_elapsed_seconds": None,
+            "elapsed_seconds": None,
+            "phase_seconds": None,
+            "token_count": None,
+            "command_count": None,
+            "cost": None,
+            "agent_process_passed": False,
+            "agent_exit_code": None,
+            "final_container_exit_code": None,
+            "failure_root_cause": "run_summary_generation_failed",
+            "observed_skill_name": None,
+            "skill_name_source": None,
+            "validation_metric": None,
+            "structure_quality_signal": UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL,
+            "artifact_paths": entry.get("artifact_paths") or {},
+            "summary_generation_error": {
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+        }
+    )
+    return payload
+
+
+def comparison_label(entry: Mapping[str, Any]) -> str:
+    comparison_type = str(entry.get("comparison_type") or "")
+    if comparison_type == COMPARISON_MODE_ABLATION:
+        return str(entry.get("mode"))
+    if comparison_type == COMPARISON_AGENT:
+        return str(entry.get("agent"))
+    if comparison_type == COMPARISON_MODEL:
+        return str(entry.get("agent_model"))
+    return str(entry.get("mode") or entry.get("run_id"))
+
+
+def comparison_group_summary(
+    group: Mapping[str, Any],
+    runs_by_id: Mapping[str, dict[str, Any]],
+    quality_gate: Mapping[str, Any] | None = None,
+    winner_policy: str = DEFAULT_WINNER_POLICY,
+) -> dict[str, Any]:
+    effective_quality_gate = quality_gate or DEFAULT_QUALITY_GATE
+    compared = [runs_by_id[run_id] for run_id in group.get("compared_run_ids", []) if run_id in runs_by_id]
+    winner = None
+    candidates = [
+        run for run in compared if run.get("quality_gate_passed") and is_number(run.get("agent_elapsed_seconds"))
+    ]
+    if candidates:
+        winner_run = min(
+            candidates, key=lambda item: (float(item["agent_elapsed_seconds"]), number_or_zero(item.get("token_count")))
+        )
+        winner = {
+            "run_id": winner_run["run_id"],
+            "label": comparison_label(winner_run),
+            "agent_elapsed_seconds": winner_run.get("agent_elapsed_seconds"),
+            "token_count": winner_run.get("token_count"),
+        }
+    return {
+        "comparison_group_id": group.get("comparison_group_id"),
+        "comparison_type": group.get("comparison_type"),
+        "group_axes": group.get("group_axes") or {},
+        "compared_runs": compared,
+        "compared_records": compared,
+        "aggregate_results": aggregate_results(compared, winner_policy=winner_policy),
+        "winner_policy": winner_policy,
+        "quality_gate": dict(effective_quality_gate),
+        "winner": winner,
+        "status": "passed" if compared and all(run.get("quality_gate_passed") for run in compared) else "degraded",
+    }
+
+
+def aggregate_results(runs: list[dict[str, Any]], winner_policy: str = DEFAULT_WINNER_POLICY) -> dict[str, Any]:
+    by_label: dict[str, list[dict[str, Any]]] = {}
+    for run in runs:
+        by_label.setdefault(comparison_label(run), []).append(run)
+    aggregate = {}
+    for label, items in sorted(by_label.items()):
+        elapsed_values = [
+            float(item["agent_elapsed_seconds"]) for item in items if is_number(item.get("agent_elapsed_seconds"))
+        ]
+        token_values = [float(item["token_count"]) for item in items if is_number(item.get("token_count"))]
+        aggregate[label] = {
+            "run_count": len(items),
+            "quality_pass_count": sum(1 for item in items if item.get("quality_gate_passed")),
+            "quality_fail_count": sum(1 for item in items if not item.get("quality_gate_passed")),
+            "agent_elapsed_seconds": stats_for_values(elapsed_values),
+            "token_count": stats_for_values(token_values),
+        }
+    candidates = [
+        (label, data)
+        for label, data in aggregate.items()
+        if data["quality_pass_count"] > 0 and data["agent_elapsed_seconds"]["median"] is not None
+    ]
+    winner = None
+    if candidates:
+        label, data = min(
+            candidates,
+            key=lambda item: (
+                float(item[1]["agent_elapsed_seconds"]["median"]),
+                optional_number_sort_value(item[1]["token_count"]["median"]),
+            ),
+        )
+        winner = {
+            "label": label,
+            "median_agent_elapsed_seconds": data["agent_elapsed_seconds"]["median"],
+            "median_token_count": data["token_count"]["median"],
+        }
+    effective_policy = winner_policy if winner else "no_quality_qualified_winner"
+    return {"by_label": aggregate, "winner": winner, "winner_policy": effective_policy}
+
+
+def write_json_atomic(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp_path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def scenario_status(
+    *,
+    runs: list[dict[str, Any]],
+    completed: int,
+    failed: int,
+    harness_failure: Mapping[str, Any] | None = None,
+    report_generation_failed: bool = False,
+) -> str:
+    if harness_failure or report_generation_failed:
+        return "failed"
+    if not runs:
+        return "not_run"
+    if completed == 0:
+        return "not_run"
+    if failed == 0:
+        return "passed"
+    if completed == len(runs) and failed == len(runs):
+        return "failed"
+    return "degraded"
+
+
+def write_scenario_summaries(
+    result_root: str | Path,
+    statuses: Mapping[str, int] | None = None,
+    *,
+    harness_failure: Mapping[str, Any] | None = None,
+    report_writer: Any = None,
+) -> dict[str, Any]:
+    root = Path(result_root)
+    if report_writer is None:
+        report_writer = write_scenario_report
+    statuses = statuses or {}
+    run_plan = load_json(root / "run_plan.json", {}) or {}
+    scenario = load_json(root / "scenario.json", {}) or {}
+    replay_metadata = load_json(root / "replay_metadata.json", {}) or {}
+    if not isinstance(replay_metadata, dict):
+        replay_metadata = {}
+    entries = run_plan.get("entries") if isinstance(run_plan.get("entries"), list) else []
+    quality_gate = (
+        run_plan.get("quality_gate") if isinstance(run_plan.get("quality_gate"), dict) else DEFAULT_QUALITY_GATE
+    )
+    winner_policy = str(run_plan.get("winner_policy") or DEFAULT_WINNER_POLICY)
+    runs = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            runs.append(run_summary_for_entry(root, entry, statuses, quality_gate))
+        except Exception as exc:
+            runs.append(failed_run_summary_for_entry(entry, statuses, exc, quality_gate=quality_gate))
+    runs_by_id = {str(run["run_id"]): run for run in runs if run.get("run_id") is not None}
+    comparison_groups = [
+        comparison_group_summary(group, runs_by_id, quality_gate, winner_policy)
+        for group in run_plan.get("comparison_groups", [])
+        if isinstance(group, dict)
+    ]
+    aggregate = aggregate_results(runs, winner_policy=winner_policy)
+    completed = sum(
+        1 for run in runs if run.get("host_status") is not None or run.get("final_container_exit_code") is not None
+    )
+    failed = sum(1 for run in runs if not run.get("quality_gate_passed"))
+    status = scenario_status(runs=runs, completed=completed, failed=failed, harness_failure=harness_failure)
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "scenario_name": run_plan.get("scenario_name") or scenario.get("name"),
+        "comparison_type": run_plan.get("comparison_type"),
+        "expanded_case_count": len(entries),
+        "completed_run_count": completed,
+        "failed_run_count": failed,
+        "status": status,
+        "quality_gate": quality_gate,
+        "winner_policy": winner_policy,
+        "reproducibility": scenario.get("reproducibility") if isinstance(scenario, dict) else {},
+        "replay": replay_metadata,
+        "is_replay": bool(replay_metadata.get("replayed")),
+        "agent_invocation": "replayed" if replay_metadata.get("replayed") else "live",
+        "runs": runs,
+        "comparison_groups": comparison_groups,
+        "aggregate_results": aggregate,
+        "aggregate_metrics": aggregate,
+    }
+    if harness_failure:
+        summary["harness_failure"] = dict(harness_failure)
+        summary["failure_root_cause"] = harness_failure.get("failure_category") or harness_failure.get("message")
+    summary["report_generation_status"] = {"status": "pending"}
+    try:
+        report_writer(root, summary)
+    except Exception as exc:
+        summary["status"] = scenario_status(
+            runs=runs,
+            completed=completed,
+            failed=failed,
+            harness_failure=harness_failure,
+            report_generation_failed=True,
+        )
+        summary["report_generation_status"] = {
+            "status": "failed",
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+        write_json_atomic(root / "scenario_summary.json", summary)
+    else:
+        summary["report_generation_status"] = {"status": "ok"}
+        write_json_atomic(root / "scenario_summary.json", summary)
+    return summary

--- a/assist_tools/skills_benchmark/skills/harness/scenarios.py
+++ b/assist_tools/skills_benchmark/skills/harness/scenarios.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Scenario public API for benchmark scenario compilation and summaries."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Mapping
+
+from .reports.scenario_report import write_scenario_report
+from .scenario_common import (
+    COMPARISON_AGENT,
+    COMPARISON_MODE_ABLATION,
+    COMPARISON_MODEL,
+    COMPARISON_ONE,
+    COMPARISON_TYPES,
+    DEFAULT_PATH_BUDGET,
+    DEFAULT_QUALITY_GATE,
+    DEFAULT_RESOURCE_POLICIES,
+    DEFAULT_WINNER_POLICY,
+    JOB_SCALES,
+    QUALITY_GATE_KEYS,
+    REQUIRED_VALIDATION_METRIC_STATUSES,
+    SCHEMA_VERSION,
+    SLUG_VISIBLE_LENGTH,
+    SUMMARY_RUN_FIELDS,
+    UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL,
+    ScenarioValidationError,
+    as_list,
+    load_yaml_file,
+    model_list,
+    require_mapping,
+    require_non_empty_string,
+    resolve_path,
+    slug_base,
+    slugify,
+    stable_hash,
+    unique_slug_map,
+    utc_timestamp,
+)
+from .scenario_prompt import (
+    GENERATED_PROMPT_DIR,
+    MAX_PROMPT_BYTES,
+    PROMPT_TEMPLATE_LITERAL_BRACE_HINT,
+    PROMPT_TEMPLATE_SCALAR_TYPES,
+    PROMPT_TEMPLATE_VARIABLE_PATTERN,
+    materialize_prompt_for_output,
+    prompt_template_fields,
+    prompt_template_variables,
+    read_prompt_bytes,
+    render_prompt_template,
+    rendered_prompt_filename,
+    resolve_prompt,
+    resolve_prompt_path,
+)
+from .scenario_run_plan import (
+    AgentSpec,
+    JobSpec,
+    ModelSpec,
+    ScenarioCompilation,
+    WorkflowSpec,
+    agent_model_options,
+    append_group,
+    artifact_paths,
+    build_run_entry,
+    compile_scenario,
+    compile_scenario_file,
+    expand_run_plan,
+    model_slug_for,
+    model_slug_key,
+    record_dir_for,
+    resolve_agent_comparison_models,
+    resolve_agents,
+    resolve_fail_fast,
+    resolve_jobs,
+    resolve_path_budget,
+    resolve_quality_gate,
+    resolve_workflows,
+    scenario_reproducibility_metadata,
+    slug_context,
+    validate_comparison,
+    validate_mode,
+    validate_path_budget,
+)
+from .scenario_summaries import (
+    agent_record_path,
+    aggregate_results,
+    benchmark_record_path,
+    comparison_group_summary,
+    comparison_label,
+    is_number,
+    number_or_none,
+    number_or_zero,
+    quality_gate_failures,
+    read_entry_artifacts,
+    record_dir_path,
+    required_validation_metric_status_from_artifacts,
+    run_summary_for_entry,
+    scenario_status,
+    stats_for_values,
+    write_json_atomic,
+)
+from .scenario_summaries import write_scenario_summaries as _write_scenario_summaries
+
+__all__ = (
+    "AgentSpec",
+    "COMPARISON_AGENT",
+    "COMPARISON_MODE_ABLATION",
+    "COMPARISON_MODEL",
+    "COMPARISON_ONE",
+    "COMPARISON_TYPES",
+    "DEFAULT_PATH_BUDGET",
+    "DEFAULT_QUALITY_GATE",
+    "DEFAULT_RESOURCE_POLICIES",
+    "DEFAULT_WINNER_POLICY",
+    "GENERATED_PROMPT_DIR",
+    "JOB_SCALES",
+    "JobSpec",
+    "MAX_PROMPT_BYTES",
+    "ModelSpec",
+    "PROMPT_TEMPLATE_LITERAL_BRACE_HINT",
+    "PROMPT_TEMPLATE_SCALAR_TYPES",
+    "PROMPT_TEMPLATE_VARIABLE_PATTERN",
+    "QUALITY_GATE_KEYS",
+    "REQUIRED_VALIDATION_METRIC_STATUSES",
+    "SCHEMA_VERSION",
+    "SLUG_VISIBLE_LENGTH",
+    "SUMMARY_RUN_FIELDS",
+    "ScenarioCompilation",
+    "ScenarioValidationError",
+    "UNAVAILABLE_STRUCTURE_QUALITY_SIGNAL",
+    "WorkflowSpec",
+    "agent_model_options",
+    "agent_record_path",
+    "aggregate_results",
+    "append_group",
+    "artifact_paths",
+    "as_list",
+    "benchmark_record_path",
+    "build_run_entry",
+    "compile_scenario",
+    "compile_scenario_file",
+    "comparison_group_summary",
+    "comparison_label",
+    "expand_run_plan",
+    "is_number",
+    "load_yaml_file",
+    "materialize_prompt_for_output",
+    "model_list",
+    "model_slug_for",
+    "model_slug_key",
+    "number_or_none",
+    "number_or_zero",
+    "prompt_template_fields",
+    "prompt_template_variables",
+    "quality_gate_failures",
+    "read_entry_artifacts",
+    "read_prompt_bytes",
+    "record_dir_for",
+    "record_dir_path",
+    "render_prompt_template",
+    "rendered_prompt_filename",
+    "require_mapping",
+    "require_non_empty_string",
+    "required_validation_metric_status_from_artifacts",
+    "resolve_agent_comparison_models",
+    "resolve_agents",
+    "resolve_fail_fast",
+    "resolve_jobs",
+    "resolve_path",
+    "resolve_path_budget",
+    "resolve_prompt",
+    "resolve_prompt_path",
+    "resolve_quality_gate",
+    "resolve_workflows",
+    "run_summary_for_entry",
+    "scenario_reproducibility_metadata",
+    "scenario_status",
+    "slug_base",
+    "slug_context",
+    "slugify",
+    "stable_hash",
+    "stats_for_values",
+    "unique_slug_map",
+    "utc_timestamp",
+    "validate_comparison",
+    "validate_mode",
+    "validate_path_budget",
+    "write_json_atomic",
+    "write_scenario_report",
+    "write_scenario_summaries",
+)
+
+
+def write_scenario_summaries(
+    result_root: str | Path,
+    statuses: Mapping[str, int] | None = None,
+    *,
+    harness_failure: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _write_scenario_summaries(
+        result_root,
+        statuses,
+        harness_failure=harness_failure,
+        report_writer=write_scenario_report,
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Compile an agent benchmark scenario into scenario.json/run_plan.json."
+    )
+    parser.add_argument("scenario", help="Scenario YAML file")
+    parser.add_argument(
+        "--output-dir", required=True, help="Directory where scenario.json and run_plan.json are written"
+    )
+    args = parser.parse_args(argv)
+    compilation = compile_scenario_file(args.scenario)
+    compilation.write(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/timing.py
+++ b/assist_tools/skills_benchmark/skills/harness/timing.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Timing finalization for benchmark records and summaries."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .common import flatten_numbers, load_json
+
+
+@dataclass(frozen=True)
+class LifecycleEpochs:
+    script_start: int
+    skill_availability_start: int
+    skill_availability_end: int
+    input_copy_start: int
+    input_copy_end: int
+    prompt_prep_start: int
+    prompt_prep_end: int
+    agent_start: int
+    agent_end: int
+    post_process_start: int
+    post_process_end: int
+    report_outcome_start: int
+    report_outcome_end: int
+    script_end: int
+
+    @classmethod
+    def from_sequence(cls, values: list[int]) -> "LifecycleEpochs":
+        if len(values) != 14:
+            raise ValueError(f"expected 14 lifecycle epoch values; got {len(values)}")
+        return cls(*values)
+
+
+def _write_json_files_atomic(payloads: dict[Path, Any]) -> None:
+    staged_paths: list[tuple[Path, Path]] = []
+    try:
+        for path, value in payloads.items():
+            with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as stream:
+                temp_path = Path(stream.name)
+                staged_paths.append((temp_path, path))
+                json.dump(value, stream, indent=2, sort_keys=True)
+        for temp_path, path in staged_paths:
+            os.replace(temp_path, path)
+        staged_paths.clear()
+    finally:
+        for temp_path, _path in staged_paths:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+
+def finalize_timing(
+    summary_path: Path,
+    record_path: Path,
+    timing_path: Path,
+    activity_path: Path,
+    epochs: LifecycleEpochs,
+) -> None:
+    setup_elapsed = epochs.agent_start - epochs.script_start
+    agent_elapsed = epochs.agent_end - epochs.agent_start
+    phase_seconds = {
+        "container_elapsed_seconds": epochs.script_end - epochs.script_start,
+        "setup_elapsed_seconds": setup_elapsed,
+        "skill_exposure_elapsed_seconds": epochs.skill_availability_end - epochs.skill_availability_start,
+        "input_copy_elapsed_seconds": epochs.input_copy_end - epochs.input_copy_start,
+        "prompt_prepare_elapsed_seconds": epochs.prompt_prep_end - epochs.prompt_prep_start,
+        "agent_elapsed_seconds": agent_elapsed,
+        "post_process_elapsed_seconds": epochs.post_process_end - epochs.post_process_start,
+        "report_elapsed_seconds": epochs.report_outcome_end - epochs.report_outcome_start,
+    }
+    timing = {
+        "epoch_seconds": {
+            "script_start": epochs.script_start,
+            "agent_start": epochs.agent_start,
+            "agent_end": epochs.agent_end,
+            "script_end": epochs.script_end,
+        },
+        "phase_seconds": phase_seconds,
+    }
+    summary = load_json(summary_path, {}) or {}
+    record = load_json(record_path, {}) or {}
+    activity = load_json(activity_path, {}) or {}
+    summary["phase_seconds"] = phase_seconds
+    if summary.get("agent_elapsed_seconds") is None:
+        summary["agent_elapsed_seconds"] = agent_elapsed
+    summary["activity"] = {
+        "event_count": activity.get("event_count"),
+        "first_event_timestamp": activity.get("first_event_timestamp"),
+        "last_event_timestamp": activity.get("last_event_timestamp"),
+        "event_span_seconds": activity.get("event_span_seconds"),
+        "max_inter_event_gap_seconds": activity.get("max_inter_event_gap_seconds"),
+        "command_count": activity.get("command_count"),
+        "unique_command_count": activity.get("unique_command_count"),
+        "command_prefix_counts": activity.get("command_prefix_counts"),
+        "hint_counts": activity.get("hint_counts"),
+    }
+    metrics = record.setdefault("process_metrics", {})
+    if isinstance(metrics, dict):
+        metrics["phase_seconds"] = phase_seconds
+        metrics["activity"] = summary["activity"]
+        if metrics.get("agent_elapsed_seconds") is None:
+            metrics["agent_elapsed_seconds"] = agent_elapsed
+    summary["process_metrics"] = (
+        record.get("process_metrics")
+        if isinstance(record.get("process_metrics"), dict)
+        else summary.get("process_metrics", {})
+    )
+    summary["all_metrics"] = flatten_numbers(summary)
+    _write_json_files_atomic({timing_path: timing, summary_path: summary, record_path: record})

--- a/docs/design/agent_benchmark_harness.md
+++ b/docs/design/agent_benchmark_harness.md
@@ -1,0 +1,1608 @@
+# Agent Benchmark Harness Architecture
+
+This document defines the intended architecture for the NVFLARE agent benchmark
+harness. The harness measures how agent-accessible NVFLARE skills affect applied
+conversion and diagnosis tasks. It is benchmark infrastructure, not product API.
+
+The benchmark input is intentionally loose: a job is a folder containing scripts,
+data, configuration, and human documentation. The harness must not require a job
+schema or perform the agent's conversion work. The harness mounts an explicit
+benchmark prompt and execution environment, then measures the agent's behavior
+and produced artifacts.
+
+The architecture supports multiple agents through adapters. Codex is the
+supported adapter until another agent has a defined installation,
+configuration, authentication, invocation, event, usage, and final-message
+contract. Unsupported agents fail during preflight.
+
+## System Boundary
+
+The benchmark system has five external inputs:
+
+- a job folder;
+- a prompt file or rendered prompt;
+- a scenario definition or direct run arguments;
+- an agent and model selection;
+- a skill-exposure mode.
+
+It produces one result tree containing normalized agent artifacts, records,
+workspace-delta manifests, metrics, and reports.
+
+The harness compares skill exposure, not evaluator behavior. The only benchmark
+modes are:
+
+```text
+without_skills
+with_skills
+```
+
+There is no evaluator axis, no `eval=on` mode, and no runtime skill evaluator in
+the benchmark architecture. Correctness and quality are derived from measured
+agent output, generated artifacts, validation evidence, source immutability, and
+failure analysis.
+
+## Architecture Overview
+
+```text
+CLI / Scenario
+    |
+    v
+Host runner and scenario expander
+    |
+    | builds/selects images, validates inputs, mounts job/prompt/results
+    v
+Docker runtime
+    |
+    v
+Container runtime environment
+    |
+    | provides Python/uv/pip, selected NVFLARE wheel/skill visibility, agent CLI, mounted prompt/job/results, progress/timing capture
+    v
+Agent adapter
+    |
+    | starts the specified agent CLI, does not modify the prompt, and normalizes agent-specific events
+    v
+Artifact, record, and report pipeline
+```
+
+The host side owns Docker orchestration and run planning. The container runtime
+environment provides the neutral infrastructure for one measured run: Python,
+uv/pip, NVFLARE, the selected agent CLI, the explicit prompt, the job mount, the
+result mount, selected skill visibility, and bounded observation artifacts. Agent adapters own
+agent-specific installation metadata, authentication, configuration, invocation,
+and parsing. Measurement semantics live in shared artifact, record, event,
+timing, quality-signal, and report modules.
+
+## Repository Layout
+
+The target benchmark harness layout lives under `assist_tools/skills_benchmark/`:
+
+```text
+assist_tools/skills_benchmark/
+|-- README.md
+|-- bin/
+|   |-- build.sh
+|   `-- run.sh
+|-- config/
+|   |-- agents/
+|   |   |-- codex.yaml
+|   |   `-- claude.yaml
+|   `-- sdks/
+|       `-- nvflare-profile.yaml
+|-- docker/
+|   |-- Dockerfile
+|   `-- build_context.dockerignore
+`-- skills/
+    `-- harness/
+        |-- __init__.py
+        |-- common.py
+        |-- modes.py
+        |-- artifacts.py
+        |-- events.py
+        |-- quality_signals.py
+        |-- scenarios.py
+        |-- timing.py
+        |-- records.py
+        |-- record_identity.py
+        |-- host/
+        |   |-- build.py
+        |   |-- common.py
+        |   `-- runner.py
+        |-- container/
+        |   |-- agent_run.py
+        |   |-- progress.py
+        |   `-- skills.py
+        |-- agents/
+        |   |-- base.py
+        |   |-- config.py
+        |   |-- registry.py
+        |   |-- parsers.py
+        |   `-- classifiers.py
+        |-- sdks/
+        |   |-- base.py
+        |   |-- config.py
+        |   `-- registry.py
+        `-- reports/
+            |-- scenario_report.py
+            `-- structure_tree.py
+```
+
+This location keeps the harness outside `nvflare/` product packages while
+making it an importable assist-tool package. Unit tests for the harness live
+under `tests/unit_test/skills_benchmark/`. Integration tests that validate
+Docker execution live under `tests/integration_test/skills_benchmark/`.
+
+`docs/design/agent_benchmark_harness.md` is the architecture document. The
+harness-local README explains how to build and run the tool.
+
+The nested `skills/harness/host/`,
+`skills/harness/container/`, `skills/harness/agents/`, and
+`skills/harness/reports/` packages are the canonical implementation
+locations. Flat compatibility modules such as
+`skills/harness/host_runner.py` or
+`skills/harness/agent_run.py` may exist only as explicit re-export shims
+with deprecation comments. They must not own independent logic.
+The layout is normative for the target architecture. Modules listed here are
+the canonical destinations for the corresponding responsibilities; runnable
+scenario YAML support requires `skills/harness/scenarios.py` to compile
+the YAML into `run_plan.json` before any Docker execution.
+Future supported agents add an agent config file under
+`config/agents/`, for example
+`config/agents/<agent>.yaml`. They do not add a per-agent adapter
+subclass when existing launch, skill-exposure, event-parser, usage-parser,
+final-message, and exit-classifier registries cover the agent.
+
+## Component Ownership
+
+### CLI Wrappers
+
+`bin/build.sh` and `bin/run.sh` are thin entry points. They translate shell usage
+into Python module invocations and do not own benchmark semantics.
+
+### Host Runner
+
+`harness/host/` owns host-side orchestration:
+
+- direct CLI argument parsing;
+- scenario file loading and run-plan expansion;
+- preflight validation;
+- Docker image selection and build invocation;
+- explicit Docker context and mount construction;
+- result-root creation;
+- sequential execution of run-plan entries;
+- host-side report orchestration.
+
+The host runner does not parse agent event streams, infer task success from raw
+logs, derive skill identity from workflow names, or mutate job input folders.
+
+### Record Identity
+
+`harness/record_identity.py` owns stable identifiers used in run plans, result
+paths, and aggregation keys: slugs, collision handling, prompt hashes, job
+hashes, and comparison group IDs. Reports consume these identifiers from
+scenario/run-plan metadata rather than reconstructing them from directory names.
+
+### Scenario Engine
+
+`harness/scenarios.py` owns scenario parsing, validation, and expansion. A
+scenario expands into a concrete `run_plan.json` before the first Docker run
+starts. The run plan is the source of truth for execution order and comparison
+grouping.
+
+Every benchmark entry point compiles into this same run-plan model. Direct
+commands create a single-case scenario and run plan; they do not bypass
+scenario validation, result identity, record synthesis, or report aggregation.
+Scenario YAML files are runnable inputs only when they are consumed by
+`harness/scenarios.py` and produce `run_plan.json`. Scenario examples or YAMLs
+without that compiled run plan are design fixtures, not an alternate execution
+path.
+
+Preflight validation covers:
+
+- supported agent names;
+- unambiguous agent/model selection;
+- valid comparison type and mode names;
+- job paths that exist and are directories;
+- explicit `job_scale` for every scenario job;
+- prompt path existence or renderability;
+- Docker image availability or build inputs;
+- explicit Docker context allowlisting;
+- estimated run count and result-tree size.
+
+Execution is sequential by default. Parallelism is a separate scenario field and
+must be explicit because concurrent agent runs affect timing, resource
+contention, and result interpretation.
+
+Parallelism applies to independent run-plan entries only. A single run-plan
+entry owns one container, one result directory, and one runtime staging root. No
+two concurrent entries may share `/tmp/agent_benchmark`, a workspace copy, a
+record directory, or an agent auth/config write location.
+Isolation is container-boundary isolation. A fixed path such as `/tmp/agent_benchmark`
+is safe only because each benchmark run gets its own container; if a container
+is reused for multiple concurrent run-plan entries, each entry must receive a
+unique runtime artifact root.
+
+### Docker Build And Runtime
+
+The Docker layer provides isolated, repeatable execution. The local SDK
+checkout is build input only. Runtime images receive the selected SDK through
+built wheels and explicit metadata, not by copying the working tree into the
+image.
+
+Image identity is resolved from `(sdk profile, agent profile, variant)`. The
+current default SDK profile is `nvflare-profile` and the default agent profile
+is `codex`, so the default image names remain:
+
+```text
+agent-skills-benchmark:<agent>-baseline
+agent-skills-benchmark:<agent>-skills
+```
+
+SDK-specific build behavior is pluggable through `harness/sdks/`. An SDK
+profile declares:
+
+```text
+source.type = repo with source.path and markers, or wheels with exact wheel paths
+build.type = uv_wheel for repo builds, or provided_wheels for prebuilt wheels
+skills and baseline wheel variants
+optional build-env toggle used while building each wheel
+skills.setup.type = command, copy, or none
+Docker build args for package name, import name, version check, and skills setup metadata
+metadata files emitted by the SDK setup step
+```
+
+For NVFlare, `config/sdks/nvflare-profile.yaml` declares the existing wheel split:
+
+```text
+skills wheel     NVFLARE_PACKAGE_AGENT_SKILLS=1
+baseline wheel   NVFLARE_PACKAGE_AGENT_SKILLS=0
+```
+
+Those wheels are reused across agent images. Agent profiles own agent CLI
+installation, version commands, auth-home defaults, optional native
+dependencies, and CLI availability probes. The shared builder resolves the
+selected `(sdk, agent, variant)` image inputs and passes SDK build arguments
+from the SDK adapter plus agent build arguments from the agent adapter.
+
+The Docker convention is one shared Dockerfile with generic `base`, `skills`,
+and `baseline` stages. The Dockerfile must not branch on agent names or encode
+Codex-specific assumptions such as `CODEX_HOME`, Codex auth file names, or
+`codex exec`. It must also not hardcode NVFlare-specific wheel names or skill
+install commands. The shared stages expose the configured SDK, Python, the
+benchmark harness, prompt mounts, job mounts, result mounts, and generic
+benchmark environment. Agent profiles provide commands such as
+`AGENT_INSTALL_COMMAND` and `AGENT_VERSION_COMMAND` to add the selected agent
+runtime.
+
+### Container Runtime Environment
+
+`harness/container/agent_run.py` is the container-side runtime setup and
+observation wrapper for one measured run:
+
+- validate mounted input, prompt, and result directories;
+- provide the configured Python, uv/pip, NVFLARE, and agent CLI environment;
+- provide a container-local workspace copy from the mounted job folder;
+- apply the selected packaged-skill visibility mode;
+- copy the prompt verbatim and write prompt metadata into the record directory;
+- establish workspace baselines for delta capture;
+- hand the prompt and workspace to the selected agent adapter;
+- preserve agent stdout, stderr, events, and final message;
+- synthesize fallback records on failure;
+- run artifact capture and report commands;
+- write final run status.
+
+The container runtime environment does not instruct the agent, construct
+agent-specific commands, or parse raw agent events. It also does not own report
+meaning, quality-gate policy, skill identity trust decisions, or timing
+semantics beyond calling the timing module at defined measurement boundaries.
+Workflow names, mode names, record paths, result paths, and metric expectations
+remain harness metadata unless they are present in the explicit benchmark
+prompt selected by the scenario.
+
+### Timing Boundaries
+
+The container runtime environment records timing marks. Adapters do not decide
+when a benchmark timer starts or stops.
+
+The headline comparison metric is `agent_elapsed_seconds`. It starts
+immediately before the adapter launches the agent process described by
+`AgentLaunchSpec`. It stops when that process exits, or when launch fails and
+the runtime environment records the launch failure. It excludes Docker image build,
+container startup, mounted-input validation, prompt staging, skill exposure,
+workspace baseline capture, artifact capture, record synthesis, and report
+generation.
+
+The run summary also records phase timings:
+
+```text
+container_elapsed_seconds
+setup_elapsed_seconds
+skill_exposure_elapsed_seconds
+agent_elapsed_seconds
+post_process_elapsed_seconds
+report_elapsed_seconds
+```
+
+Skill exposure, agent CLI installation, auth mounting, and configuration setup
+are environment preparation. They are recorded separately and are not eligible
+for the cost/performance winner metric unless a scenario explicitly declares a
+setup-cost experiment.
+
+### Agent Adapter Registry
+
+The harness has a single adapter registry. The registry is the only place that
+maps an agent name to agent-specific behavior. Adding a supported agent requires
+registering one agent config and one install surface; it must not require
+changes to record schemas, report code, mode definitions, quality gates, metric
+extraction, workspace-delta capture, timing, or scenario comparison semantics.
+
+Registration validates the complete adapter contract before an agent can be
+used. A supported adapter must provide all required launch, skill-exposure,
+event, usage, final-message, metadata, and failure-classification behavior at
+registration time; missing methods or unsupported capabilities fail preflight,
+not an in-progress benchmark run.
+The adapter base must be an abstract base class with explicit abstract methods.
+Registration may add additional semantic validation, but structural typing alone
+is not the architecture contract.
+
+The registry supports three categories:
+
+| Category | Meaning |
+| --- | --- |
+| `supported` | The adapter has implementation, Docker image support, contract tests, and can run benchmarks. |
+| `known_pending` | The agent is named in design or docs, but intentionally fails preflight with a clear unsupported message. |
+| `unknown` | The harness rejects the name as invalid input. |
+
+This keeps future names such as `hermes` or `openclaw` visible without allowing
+partially implemented agents to run.
+
+The initial registry state is `codex` and `claude` as `supported`; names such as
+`hermes` or `openclaw` may be registered as `known_pending` only when the design
+and user-facing error message intentionally identify them as planned but not
+runnable.
+
+### Agent Adapters
+
+An agent adapter owns only the agent-specific mechanics required to start and
+parse one agent surface. It translates the specified agent name and model into
+provider-specific CLI, auth, environment, launch, and parsing details. It must
+not add prompt text, task hints, benchmark expectations, metric names, record
+paths, workflow instructions, or other context beyond the explicit benchmark
+prompt selected by the scenario.
+
+If an adapter cannot provide a stable, benchmark-owned default model, it must
+require an explicit model from direct CLI `--model` or scenario configuration.
+A supported adapter must not let the underlying agent CLI select an implicit
+default model for measured runs.
+
+```python
+class AgentAdapter:
+    name: str
+    display_name: str
+    default_model: str
+    agent_home_env: str
+    container_home: str
+
+    def model_from_env(self, env: Mapping[str, str]) -> str: ...
+    def build_args(self) -> dict[str, str]: ...
+    def image_targets(self) -> AgentImageTargets: ...
+    def auth_mounts(self, host_config) -> list[DockerMount]: ...
+    def runtime_env(self, config) -> dict[str, str]: ...
+    def launch_spec(self, config) -> AgentLaunchSpec: ...
+    def skill_exposure(self, config) -> SkillExposureSpec: ...
+    def availability_probe(self) -> list[str]: ...
+    def normalize_event(self, raw_line: str) -> dict | None: ...
+    def parse_usage(self, events_path: Path) -> dict: ...
+    def parse_activity(self, events_path: Path) -> dict: ...
+    def final_message_source(self, result_dir: Path) -> FinalMessageSource: ...
+    def metadata(self) -> dict: ...
+    def exit_summary(self, exit_code: int, stderr_path: Path) -> dict: ...
+```
+
+The adapter contract covers:
+
+- CLI installation and version metadata;
+- host and container auth/config locations;
+- runtime environment variables;
+- model selection;
+- launch working directory, delivery of the explicit prompt without modification,
+  stdout/stderr/event stream routing, shell/login behavior, approval and
+  sandbox flags, and launch-failure handling;
+- skill-exposure mechanism, setup action, probe action, and metadata locations;
+- final assistant message capture;
+- raw event normalization;
+- token and activity extraction;
+- CLI availability checks;
+- exit-code interpretation;
+- agent-specific parser warnings.
+
+`AgentLaunchSpec` has six required fields with no defaults:
+
+| Field | Meaning |
+| --- | --- |
+| `argv` | Agent CLI argv excluding shell interpolation. |
+| `cwd` | Working directory for the measured agent process. |
+| `prompt_file` | Path to the already-rendered benchmark prompt. |
+| `prompt_input_mode` | How exact prompt bytes are delivered: `stdin` or `file_arg`. |
+| `stdout_events_dest` | File path where stdout or structured event stream is captured. |
+| `stderr_dest` | File path where stderr is captured. |
+
+Optional fields have explicit defaults:
+
+| Field | Default |
+| --- | --- |
+| `final_message_dest` | `none` |
+| `environment` | `{}` |
+| `login_shell` | `false` |
+| `approval_flags` | `[]` |
+| `sandbox_flags` | `[]` |
+| `bypass_reason` | `none` |
+| `launch_timeout` | job-scale policy |
+| `extra_artifact_paths` | `[]` |
+
+The container runtime needs the required fields to start and observe the
+process.
+Optional fields describe agent-specific launch behavior, but missing optional
+fields must not prevent a supported adapter from running.
+`sandbox_flags` and `approval_flags` are audit metadata recorded in
+`launch_spec_metadata.json`; any flag that must affect the measured agent
+process must also be present in the adapter's `argv` template. `bypass_reason`
+must explain why these flags are acceptable inside the isolated benchmark
+container.
+
+`prompt_file` is the path to the already-rendered benchmark prompt. If
+`prompt_input_mode` is `stdin`, the runtime streams the exact file bytes to the
+agent process. If it is `file_arg`, the adapter argv may reference
+`{prompt_file}`. Adapter configs must not use `{prompt_text}` or any other
+template that injects prompt content into argv, environment variables, or
+adapter-owned files.
+
+If an argv template references `{final_message_dest}`, the renderer must provide
+a concrete path and set `final_message_dest` to that same path. If no concrete
+final-message path is available, rendering fails preflight or the template must
+omit the flag pair. It must not substitute the literal value `none`.
+`bypass_reason` is required whenever `approval_flags` or `sandbox_flags` disable
+interactive approval or sandbox checks; it is recorded in runtime metadata.
+
+`SkillExposureSpec` is mechanism-typed rather than command-shaped:
+
+```text
+mechanism_type = cli_install | launch_flag | directory_mount | config_file | preinstalled_home | none
+skill_root
+source_paths
+setup_action
+probe_action
+disable_action
+launch_args
+environment
+metadata_files
+expected_post_setup_state
+```
+
+Only fields that make sense for the mechanism are populated. For example, a
+Codex-style adapter can use `cli_install`, while an agent that exposes skills
+through an added directory can use `launch_flag` or `directory_mount`. The
+container runtime requests the adapter's skill exposure spec and records the
+returned `SkillExposureSpec`; it does not branch on agent names or
+provider-specific paths.
+
+`harness/container/skills.py` is the only component that executes
+`SkillExposureSpec` actions. It validates scoped paths, applies `setup_action`
+for `with_skills`, applies `disable_action` for `without_skills`, runs
+`probe_action` when present, captures declared `metadata_files`, and writes
+`SkillExposureResult`. The adapter returns data; it does not execute the setup,
+probe, or disable action itself.
+
+`SkillExposureResult` is written by the container runtime after applying the
+spec:
+
+```text
+status = prepared | disabled | skipped | failed
+mechanism_type
+installed_paths
+disabled_paths
+probe_status
+probe_output_ref
+metadata_files
+parser_warnings
+```
+
+In `with_skills` mode, the container runtime applies the spec's setup action
+unless the mechanism is already prepared. In `without_skills` mode, the
+container runtime applies the spec's disable action. If the no-skills image or launch path
+already guarantees no packaged skills are visible, the adapter returns
+`mechanism_type: none`; the container runtime records `status: skipped` and
+performs no file operation.
+Setup, probe, and disable actions are scoped to benchmark-owned container paths
+such as the benchmark agent home, skill root, workspace config path, or result
+directory. They must not operate on the host user's real agent home, global
+skill catalog, or unrelated agent configuration. Broad operations such as
+`--all` are allowed only when the target root is explicitly the benchmark-owned
+agent home or skill root.
+
+`FinalMessageSource` is also typed:
+
+```text
+source_type = file | structured_event | stdout_tail | not_available
+path
+event_selector
+tail_bytes
+parser_warnings
+```
+
+The container runtime always materializes `agent_last_message.txt` as the
+normalized artifact. Adapters that cannot ask the CLI to write a final-message
+file must extract the final message from structured events or bounded stdout
+and record parser warnings when fidelity is lower.
+
+Benchmark launches are non-interactive. If an agent normally asks for approval,
+uses an interactive sandbox, or blocks tool execution by default, its adapter
+must declare the explicit CLI flags or configuration that make benchmark runs
+fully automated inside the isolated container. The adapter metadata must record
+those flags and why they are safe in the benchmark context. The shared
+runtime layer must not hard-code a provider-specific bypass flag.
+
+The agent process receives a sanitized environment assembled from the adapter's
+runtime requirements. Benchmark control variables such as mode, result paths,
+record paths, and skill-exposure bookkeeping remain harness-internal state and
+are not exposed as task instructions. If a scenario intentionally
+exposes a benchmark variable to the agent, that exposure is part of the
+experimental condition and must be recorded in prompt or run metadata.
+
+The run plan selects whether the measured run is `with_skills` or
+`without_skills`. The container runtime applies that already-selected
+visibility mode before the measured agent process starts. The adapter owns the
+mechanics for the selected agent: where skills live, how they are installed or
+hidden, how availability is probed, and where skill metadata is recorded.
+`container/skills.py` applies the adapter-provided spec and records the
+outcome; adapters must not directly remove, overwrite, or publish benchmark
+skill files as a side effect of constructing the spec.
+
+Adapters may expose observations such as model name, CLI version, raw usage,
+raw activity, tool-call summaries, and agent-reported skill identity. They must
+not decide benchmark meaning. Timing boundaries, workspace artifacts, process
+records, report filters, source immutability policy, pass/fail normalization,
+metric validity, skill-identity trust decisions, and failure-root
+classification belong to the harness runtime, record layer, and report layer.
+
+Direct CLI commands select agents and models with `--agent` and `--model`.
+Scenario YAML selects them with `agents[].name` and `agents[].models`.
+After run-plan expansion, shared host and container modules use generic
+benchmark runtime names:
+
+```text
+BENCHMARK_AGENT
+BENCHMARK_AGENT_MODEL
+BENCHMARK_AGENT_HOME
+BENCHMARK_AGENT_CONFIG_DIR
+```
+
+Agent-specific variables such as `CODEX_HOME` or `CLAUDE_CONFIG_DIR` are
+translated by the adapter at the host boundary. They
+must not become required inputs for shared records, reports, modes, or quality
+checks. Shared host, container, record, and report code must not branch on
+provider-specific names except through the adapter registry.
+
+Event normalization is agent-specific but emits an agent-neutral event schema.
+The container runtime calls the selected adapter directly:
+
+```python
+adapter.normalize_event(raw_line: str) -> dict | None
+```
+
+If a module-level helper exists, it is only a thin registry wrapper around the
+selected adapter method, not a second dispatch model.
+
+`harness/events.py` owns neutral event helpers and common counters.
+`harness/agents/config.py`, `harness/agents/parsers.py`, and
+`harness/agents/classifiers.py` own raw event normalization, usage parsing,
+activity parsing, final-message discovery, exit classification, and CLI
+metadata selected by each agent config.
+
+If an agent exposes lower-fidelity output than Codex, the adapter still writes
+the neutral artifacts and records parser warnings. Missing token usage, missing
+structured tool-call events, or an approximate final-message source are
+recorded as limitations; they do not change the benchmark schema.
+
+### Neutral Event And Usage Contracts
+
+Adapters normalize raw agent output into the shared `agent_events.jsonl`,
+`agent_usage.json`, `agent_activity.json`, `agent_last_message.txt`, and
+`agent_stderr.txt` artifacts.
+
+Normalized shell and tool events use agent-neutral fields:
+
+```text
+schema_version
+event_type
+agent
+timestamp
+tool_kind
+command_text
+command_argv
+cwd
+status
+exit_code
+started_at
+ended_at
+output_ref
+truncated
+redacted
+parser_warnings
+```
+
+The adapter may omit fields that the agent CLI does not expose, but omitted or
+approximated fields must be declared in `parser_warnings`. Reports consume this
+neutral event schema rather than provider-specific envelopes such as Codex item
+types.
+
+Usage artifacts declare their semantics:
+
+```text
+schema_version
+source
+usage_fidelity
+is_cumulative
+input_tokens
+output_tokens
+reasoning_tokens
+cache_tokens
+tool_tokens
+total_tokens
+cost
+parser_warnings
+```
+
+The shared harness may aggregate normalized usage fields. It must not scrape
+arbitrary provider raw JSON as the primary usage contract.
+
+Allowed `usage_fidelity` values are:
+
+| Fidelity | Meaning |
+| --- | --- |
+| `exact` | Reported directly by the agent CLI or provider metadata with documented semantics. |
+| `parsed` | Derived from structured agent events with stable parser logic. |
+| `approximate` | Estimated from partial, lossy, or text-derived evidence. |
+| `unavailable` | The adapter could not provide the field. |
+
+Reports may compare elapsed time across all completed runs because timing
+boundaries are harness-defined. Token and cost comparisons require comparable usage sources:
+`exact` may be compared with `exact`, and `parsed` may be compared with
+`parsed` from the same adapter parser version. Mixed-fidelity comparisons remain
+visible in tables but cannot be used as winner-policy tiebreakers unless the
+scenario explicitly opts into approximate cost comparison.
+
+### Failure Classification Contract
+
+Adapters normalize provider-specific failures into shared categories:
+
+```text
+agent_cli_missing
+agent_auth_failure
+agent_model_unsupported
+agent_rate_limited
+agent_context_limit
+agent_sandbox_or_approval_failure
+agent_internal_error
+agent_unknown_failure
+harness_preflight_failure
+harness_execution_skipped
+harness_execution_error
+```
+
+The report layer renders these categories and combines them with shared
+benchmark evidence. It must not hard-code provider-specific diagnoses such as
+Codex model-selection failures outside the adapter layer.
+The harness runtime, not the adapter, writes `harness_preflight_failure`,
+`harness_execution_skipped`, and `harness_execution_error` when the failure is
+clearly caused by run-plan validation, skipped execution policy, Docker/runtime
+or artifact/report pipeline failure rather than the agent CLI.
+
+### Shared Benchmark Core
+
+The shared benchmark core is agent-neutral. It owns:
+
+- prompt staging;
+- job-folder mounting;
+- skill-exposure modes;
+- workspace baseline and delta capture;
+- source-input immutability checks;
+- lifecycle timing;
+- normalized record synthesis;
+- metric extraction and quality signals;
+- failure analysis;
+- report rendering;
+- scenario expansion and comparison grouping.
+
+The shared core must not know how an agent authenticates, where its home
+directory is located, which CLI flags select a model, how its raw events are
+shaped, or how it writes a final assistant response. Those are adapter
+responsibilities.
+
+Adding a new supported agent should be localized to:
+
+- `config/agents/<agent>.yaml`;
+- the agent install descriptor in that config;
+- adapter registry configuration;
+- auth/config README entries;
+- sample event fixtures and adapter contract tests.
+
+If the new agent requires a parser or classifier that does not exist, add that
+implementation to the shared parser/classifier registry and reference its ID
+from the YAML config. Do not add a per-agent adapter subclass.
+
+If adding an agent requires editing reports, records, modes, metric extraction,
+or failure-analysis logic, the adapter boundary is too weak.
+
+### Codex Agent Config
+
+The Codex agent config defines:
+
+- CLI command: `codex exec --json ...`;
+- model input: direct-run `--model` or scenario `agents[].models`;
+- auth/config mounts: `CODEX_HOME`, host `.codex/auth.json`, and
+  `.codex/config.toml`;
+- JSONL event normalization;
+- cumulative token usage parsing;
+- final message path for `--output-last-message`.
+
+### Non-Codex Agent Configs
+
+A non-Codex agent config is supported only when these contracts are known:
+
+- installation and version pinning;
+- auth and config mount locations;
+- model selection;
+- structured event availability;
+- final assistant response source;
+- token usage source;
+- tool-call and shell-command representation;
+- exit-code semantics.
+
+If an agent does not expose Codex-like structured events, its adapter still
+emits the neutral event contract with lower-fidelity activity fields and parser
+warnings in `agent_usage.json` or `agent_activity.json`.
+
+Non-Codex adapters must not introduce new benchmark modes or report sections.
+For example, Claude, Hermes, or OpenClaw compare against Codex through the same
+`without_skills` and `with_skills` modes, the same result schema, the same
+quality gates, and the same reports. Agent-specific sections are allowed only
+for raw metadata that does not change benchmark interpretation.
+
+### Agent Adapter Examples
+
+Most adapter behavior is data: CLI argv templates, auth paths,
+skill-exposure mechanism, event parser ID, usage parser ID, final-message
+source, and exit-classifier ID. `ConfigurableAgentAdapter` is the concrete
+adapter class. It reads an agent config file and implements `AgentAdapter`
+methods from that config. Adding an agent is config-only when existing
+mechanism and parser registry entries cover that agent.
+
+Module ownership:
+
+- `harness/agents/base.py` owns the `AgentAdapter` abstract base class and typed
+  specs such as `AgentLaunchSpec`, `SkillExposureSpec`,
+  `SkillExposureResult`, and `FinalMessageSource`.
+- `harness/agents/config.py` owns `AgentConfig`, YAML validation, template
+  rendering, config-driven image/auth/runtime helpers, and
+  `ConfigurableAgentAdapter`.
+- `harness/agents/registry.py` owns supported/known-pending/unknown agent
+  registration and maps an agent name to a loaded `ConfigurableAgentAdapter`.
+- `harness/agents/parsers.py` owns parser registries and helpers such as
+  `parse_usage_from_events`, `parse_activity_from_events`, and
+  `normalize_event_with_parser`.
+- `harness/agents/classifiers.py` owns exit-code and failure-classifier
+  registries, including `classify_exit`.
+
+Neutral event schema utilities remain in `harness/events.py`.
+If a new agent exposes a raw event format that no existing parser supports, the
+new code belongs in the shared parser registry under a named parser ID, not in a
+per-agent adapter subclass.
+
+#### Generic Configurable Adapter
+
+```python
+class ConfigurableAgentAdapter(AgentAdapter):
+    """Implements adapter methods that can be safely driven by YAML config.
+
+    Agents are registered by loading YAML configs. Provider-specific parsers and
+    classifiers are selected by ID from registries.
+    """
+
+    def __init__(self, config_path: Path) -> None:
+        self._cfg = AgentConfig.load(config_path)
+
+    @property
+    def name(self) -> str: return self._cfg.name
+    @property
+    def display_name(self) -> str: return self._cfg.display_name
+    @property
+    def default_model(self) -> str: return self._cfg.default_model
+    @property
+    def agent_home_env(self) -> str: return self._cfg.agent_home_env
+    @property
+    def container_home(self) -> str: return self._cfg.container_home
+
+    def launch_spec(self, config) -> AgentLaunchSpec:
+        argv = self._cfg.launch.render_argv(config)
+        return AgentLaunchSpec(
+            argv=argv,
+            cwd=config.workspace_dir,
+            prompt_file=config.prompt_file,
+            prompt_input_mode=self._cfg.launch.prompt_input_mode,
+            stdout_events_dest=config.events_dest,
+            stderr_dest=config.stderr_dest,
+            launch_timeout=config.timeout_seconds,
+            bypass_reason=self._cfg.launch.bypass_reason,
+        )
+
+    def skill_exposure(self, config) -> SkillExposureSpec:
+        return self._cfg.skill_exposure.render(config)
+
+    def final_message_source(self, result_dir: Path) -> FinalMessageSource:
+        return self._cfg.final_message.render(result_dir)
+
+    def parse_usage(self, events_path: Path) -> dict:
+        return parse_usage_from_events(events_path, self._cfg.usage)
+
+    def parse_activity(self, events_path: Path) -> dict:
+        return parse_activity_from_events(events_path, self._cfg.activity)
+
+    def normalize_event(self, raw_line: str) -> dict | None:
+        return normalize_event_with_parser(raw_line, self._cfg.events.parser)
+
+    def exit_summary(self, exit_code: int, stderr_path: Path) -> dict:
+        return classify_exit(exit_code, stderr_path, self._cfg.exit.classifier)
+
+    def metadata(self) -> dict:
+        return {"agent": self.name, "config": str(self._cfg.source_path)}
+```
+
+This sketch omits straightforward accessors such as `model_from_env`,
+`auth_mounts`, `runtime_env`, image target resolution, and availability probes;
+those are still part of the formal `AgentAdapter` contract.
+
+#### Agent Config Files
+
+Each agent ships one YAML config file. Mechanical differences between agents
+live here. Provider-specific event, usage, activity, final-message, and
+exit-code behavior is selected through named parser or classifier IDs in the
+config.
+
+```yaml
+# config/agents/codex.yaml
+name: codex
+display_name: OpenAI Codex CLI
+default_model: o3
+agent_home_env: CODEX_HOME
+container_home: /workspace/.codex
+
+launch:
+  prompt_input_mode: stdin
+  argv: ["codex", "exec", "--json",
+         "--output-last-message", "{final_message_dest}",
+         "--dangerously-bypass-approvals-and-sandbox",
+         "--model", "{model}"]
+  bypass_reason: "isolated container; no persistent side effects outside workspace"
+
+skill_exposure:
+  mechanism_type: cli_install
+  setup_action: ["codex", "skills", "install", "--path", "{skills_dir}"]
+  probe_action:  ["codex", "skills", "list"]
+  # Scoped to the benchmark-owned agent home, never the host user's skill state.
+  disable_action: ["codex", "skills", "uninstall", "--root", "{container_home}", "--all"]
+  metadata_files: ["~/.codex/skills.json"]
+
+final_message:
+  source_type: file
+  path: "{result_dir}/agent_last_message.txt"
+
+events:
+  parser: codex_jsonl
+  format: jsonl
+
+usage:
+  parser: codex_cumulative_usage
+  fidelity: parsed
+  is_cumulative: true
+
+activity:
+  parser: codex_jsonl_activity
+
+exit:
+  classifier: stderr_patterns
+  rules:
+    - category: agent_cli_missing
+      exit_codes: [127]
+    - category: agent_auth_failure
+      any: [auth, "api key", login]
+```
+
+```yaml
+# config/agents/claude.yaml
+name: claude
+display_name: Anthropic Claude Code CLI
+default_model: unspecified_default
+requires_explicit_model: true
+agent_home_env: CLAUDE_CONFIG_DIR
+container_home: /workspace/.claude
+
+build:
+  args:
+    BENCHMARK_DOCKER_AGENT: claude
+    BENCHMARK_AGENT_HOME: /workspace/.claude
+    AGENT_CLI_NAME: claude
+    AGENT_INSTALL_COMMAND: npm install -g "@anthropic-ai/claude-code@latest"
+    AGENT_VERSION_COMMAND: claude --version
+
+runtime_env:
+  CLAUDE_CONFIG_DIR: "{container_home}"
+
+launch:
+  prompt_input_mode: stdin
+  argv: ["claude", "--dangerously-skip-permissions",
+         "--output-format", "stream-json",
+         "--verbose", "--model", "{model}", "--print"]
+  sandbox_flags: ["--dangerously-skip-permissions"]
+  bypass_reason: "isolated benchmark container; writable state is limited to mounted result/workspace paths"
+
+skill_exposure:
+  mechanism_type: launch_flag
+  skill_root: "{container_home}/skills"
+  launch_args: ["--add-dir", "{skills_dir}"]
+
+final_message:
+  source_type: structured_event
+  event_selector: {type: result, subtype: success}
+  parser: generic_structured_event_message
+  parser_warnings:
+    - "final message from last result event; may be truncated at context limit"
+
+events:
+  parser: claude_stream_json
+  format: stream-json
+
+usage:
+  parser: claude_stream_usage
+  fidelity: parsed
+  is_cumulative: false
+
+activity:
+  parser: claude_stream_activity
+
+exit:
+  classifier: stderr_patterns
+  rules:
+    - category: agent_cli_missing
+      exit_codes: [127]
+    - category: agent_sandbox_or_approval_failure
+      any: [permission, approval]
+```
+
+```yaml
+# config/agents/hermes.yaml  (illustrative)
+name: hermes
+display_name: Hermes Agent CLI
+default_model: hermes-3
+agent_home_env: HERMES_HOME
+container_home: /workspace/.hermes
+
+launch:
+  prompt_input_mode: file_arg
+  argv: ["hermes", "run", "--no-confirm",
+         "--model", "{model}", "--prompt-file", "{prompt_file}"]
+  bypass_reason: "--no-confirm disables interactive approval in headless runs"
+
+skill_exposure:
+  mechanism_type: config_file
+  setup_action:   ["hermes", "skills", "write-config",
+                   "--skills-dir", "{skills_dir}", "--output", "{config_path}"]
+  disable_action: ["hermes", "skills", "clear-config", "--config", "{config_path}"]
+  probe_action:   ["hermes", "skills", "verify",       "--config", "{config_path}"]
+  config_path: "{workspace_dir}/.hermes/hermes.yaml"
+  metadata_files: ["{config_path}"]
+
+final_message:
+  source_type: stdout_tail
+  tail_bytes: 8192
+  parser_warnings:
+    - "Hermes does not emit a structured final-message event; stdout tail used"
+
+events:
+  parser: generic_partial_json
+  format: partial-json
+
+usage:
+  parser: unavailable
+  fidelity: unavailable
+  parser_warnings:
+    - "Hermes CLI does not report token usage"
+
+activity:
+  parser: generic_command_activity
+
+exit:
+  classifier: generic_cli
+```
+
+```yaml
+# config/agents/openclaw.yaml  (illustrative)
+name: openclaw
+display_name: OpenClaw Agent
+default_model: claw-2
+agent_home_env: OPENCLAW_HOME
+container_home: /workspace/.openclaw
+
+launch:
+  prompt_input_mode: file_arg
+  argv: ["openclaw", "exec", "--batch",
+         "--model", "{model}", "--input", "{prompt_file}"]
+  bypass_reason: "--batch enables non-interactive execution"
+
+skill_exposure:
+  # skills baked into the image; mode difference is entirely in image selection
+  mechanism_type: preinstalled_home
+  skill_root: /workspace/.openclaw/skills
+  probe_action: ["openclaw", "skills", "list"]
+  metadata_files: ["/workspace/.openclaw/skills/manifest.json"]
+
+final_message:
+  source_type: file
+  path: "{result_dir}/openclaw_response.txt"
+
+events:
+  parser: generic_jsonl
+  format: jsonl
+
+usage:
+  parser: openclaw_exact_usage
+  fidelity: exact
+  is_cumulative: true
+
+activity:
+  parser: generic_jsonl_activity
+
+exit:
+  classifier: generic_cli
+```
+
+#### Parser And Classifier Registries
+
+Agent configs select parser and classifier behavior by ID. The registry maps
+IDs such as `codex_jsonl`, `claude_stream_json`, `generic_jsonl`, or
+`generic_cli` to shared parser functions. Adding a new agent should not create a
+new adapter subclass. If the agent needs a new raw event parser, usage parser,
+activity parser, final-message extractor, or exit classifier, that code is
+added to the shared registry under a named ID and then referenced from the YAML
+config.
+Event, usage, activity, and final-message parser IDs are registered in
+`harness/agents/parsers.py`. Exit and failure classifier IDs are registered in
+`harness/agents/classifiers.py`. `harness/agents/registry.py` validates at
+preflight that every parser or classifier ID referenced by an agent YAML exists.
+
+#### Key Differences Across Agent Configs
+
+| Adapter | `mechanism_type` | bypass flag | events format | `usage_fidelity` | final message |
+| --- | --- | --- | --- | --- | --- |
+| Codex | `cli_install` | `--dangerously-bypass-approvals-and-sandbox` | `jsonl` | `parsed` | `file` |
+| Claude | `launch_flag` | `--dangerously-skip-permissions` | `stream-json` | `parsed` | `structured_event` |
+| Hermes | `config_file` | `--no-confirm` | `partial-json` | `unavailable` | `stdout_tail` |
+| OpenClaw | `preinstalled_home` | `--batch` | `jsonl` | `exact` | `file` |
+
+For `preinstalled_home` agents such as OpenClaw, the `with_skills` vs
+`without_skills` difference is entirely in the Docker image layer. The
+container runtime still calls `skill_exposure()` to record the spec;
+`setup_action` and `disable_action` are absent and the container runtime skips
+execution.
+
+The design vocabulary includes `cli_install`, `launch_flag`,
+`directory_mount`, `config_file`, `preinstalled_home`, and `none`. The current
+runtime implementation supports `launch_flag`, `preinstalled_home`, and `none`.
+Adapter configs that use other mechanism types fail validation until the
+corresponding container-side execution logic is implemented.
+
+### Artifact Layer
+
+`harness/artifacts.py` owns bounded artifact capture:
+
+- workspace baseline manifests;
+- post-run workspace delta manifests;
+- source-input immutability checks;
+- generated-file structure summaries;
+- safe references to large or sensitive artifacts.
+
+The artifact layer records what changed. It does not decide whether a change is
+scientifically correct or whether the agent chose the right workflow.
+
+The protected input surface is the original job folder mounted into the
+container. It is mounted read-only. The agent works in a container-local
+workspace copy. Before the agent starts, the artifact layer captures hash
+manifests for both the read-only input mount and the workspace copy. After the
+agent exits, it captures the same manifests again and computes:
+
+```text
+input_delta_manifest.json
+workspace_delta_manifest.json
+```
+
+The manifest comparison is content based: stable relative path, file type, size,
+and SHA-256 for regular files. Symlinks are recorded but not followed. Large
+files may be represented by bounded metadata plus an explicit truncation flag
+when hashing would exceed configured artifact limits.
+
+`source_input_modified` is true only when the original input mount's manifest
+changes or the harness detects an attempted write against the protected input
+surface. Generated files in the workspace copy are expected and are reported in
+`workspace_delta_manifest.json`; they do not by themselves mean the original
+source input was modified.
+
+### Record Layer
+
+`harness/records.py` owns normalized records. Records combine:
+
+- run identity;
+- agent identity;
+- mode and skill exposure;
+- Docker image and wheel metadata;
+- timing;
+- token and activity counters;
+- final agent message references;
+- process metrics;
+- validation metrics extracted from generated output;
+- quality-signal observations;
+- failure-root classification.
+
+Records are generated from observed artifacts. They do not depend on a runtime
+evaluator record, evaluator pass/fail, or evaluator score.
+
+### Report Layer
+
+`harness/reports/` owns report generation. Reports consume normalized records,
+run summaries, scenario metadata, and artifact manifests. They do not parse raw
+agent logs when a normalized source exists.
+
+Reports show:
+
+- scenario and comparison identity;
+- agent, model, mode, image, and wheel variant;
+- human-readable run status;
+- failure analysis and likely root cause for failed runs;
+- scalar validation metrics when extractable;
+- source immutability and structure checks;
+- token, command, timing, and cost-related measurements;
+- comparison summaries across modes, agents, models, workflows, and jobs.
+
+Metric sections should be named by metric family, for example
+`Metrics (AUROC)` or `Metrics (valid_loss)`. Plot legends should identify the
+compared run leg rather than repeating the metric name in every bar label.
+If structure-tree analysis is unavailable for a run, reports and summaries
+should include `structure_quality_signal` with an explicit unavailable/null
+state rather than omitting the field.
+
+## Mode Model
+
+Modes describe skill exposure only:
+
+```text
+without_skills
+with_skills
+```
+
+Agent selection is orthogonal:
+
+```text
+agent = codex | claude | ...
+mode = without_skills | with_skills
+job = /path/to/job-folder
+```
+
+This supports comparisons such as:
+
+```text
+codex / without_skills
+codex / with_skills
+claude / without_skills
+claude / with_skills
+```
+
+The architecture has no `with_skills_eval_on`, `with_skills_eval_off`,
+`PROCESS_EVAL`, `NVFLARE_SKILL_EVAL`, or skill-evaluator mode.
+
+`with_skills` means packaged NVFLARE agent skills are made available through the
+selected agent's supported skill or instruction mechanism. `without_skills`
+means those packaged NVFLARE skills are absent. The mode meaning is shared
+across agents; the adapter only supplies the mechanics needed to expose or hide
+the same NVFLARE skill content for that agent.
+
+Skill installation, agent CLI installation, authentication setup, and agent
+configuration setup are environment preparation. They happen before the measured
+agent process starts and are recorded as runtime metadata, not as agent task
+work.
+
+## Scenario Model
+
+A scenario defines a matrix across these axes:
+
+| Axis | Meaning |
+| --- | --- |
+| `agent` | Agent surface such as `codex` or `claude` |
+| `agent_model` | Model name within the selected agent |
+| `workflow` | Requested NVFLARE workflow such as FedAvg or SCAFFOLD |
+| `comparison` | Explicit comparison object |
+| `job` | Unstructured input job folder |
+| `job_scale` | Scenario-provided scale annotation: `small`, `medium`, `large` |
+Important boundaries:
+
+- `agent` and `agent_model` are separate axes.
+- `workflow` is separate from the job folder.
+- `workflow` does not imply framework or skill package.
+- `workflow` is scenario metadata and comparison identity; it is not a hidden
+  instruction. If the agent should perform a specific workflow, that request
+  must appear in the explicit benchmark prompt.
+- `job` remains an unstructured folder.
+- `job_scale` controls timeout and resource policy; it is not inferred by
+  default.
+- `comparison` is explicit and must not be overloaded by shorthand names.
+
+Scenario validation rejects job entries without an explicit `job_scale`. Direct
+CLI runs must also produce a run-plan entry with an explicit `job_scale`, either
+from a CLI argument or a named direct-run default recorded in the run plan. The
+harness must not infer scale from file count, data size, README text, or runtime
+duration.
+
+Default resource policy:
+
+| `job_scale` | `agent_elapsed_seconds` timeout | Container timeout | Result-size budget |
+| --- | ---: | ---: | ---: |
+| `small` | 30 minutes | 40 minutes | 1 GB |
+| `medium` | 90 minutes | 120 minutes | 5 GB |
+| `large` | 240 minutes | 300 minutes | 20 GB |
+
+Scenarios may override these values explicitly. CPU, memory, and GPU limits are
+scenario fields, not inferred from `job_scale`, because agent CLIs and training
+dependencies have different resource profiles.
+
+Comparison examples:
+
+```yaml
+comparison:
+  type: mode_ablation
+  modes: [without_skills, with_skills]
+```
+
+```yaml
+comparison:
+  type: agent_comparison
+  mode: with_skills
+  agents: [codex, claude]
+```
+
+```yaml
+comparison:
+  type: model_comparison
+  agent: codex
+  mode: with_skills
+  models: ["<codex-model-a>", "<codex-model-b>"]
+```
+
+```yaml
+comparison:
+  type: one
+  mode: with_skills
+```
+
+Expansion rules:
+
+- `mode_ablation` and `one` create one comparison group per
+  `(agent, model, workflow, job)` combination.
+- `agent_comparison` varies the agent axis. Each compared agent resolves to one
+  model. Ambiguous model selection is a validation error.
+- `model_comparison` varies the model axis for one explicit agent.
+- Workflows and jobs expand outside the compared axis.
+
+For `agent_comparison`, each compared agent must resolve to exactly one model
+through one of these sources, in order: an explicit `models_by_agent` entry in
+the comparison object, a single model in that agent's top-level scenario entry,
+or the adapter's declared default model. If more than one model remains
+possible, preflight fails. If an adapter default is used, the run plan records
+`model_source: adapter_default`.
+
+## Prompt Model
+
+The prompt is an explicit benchmark input and is the only task instruction the
+harness gives the agent. A direct run passes a prompt file. A scenario may
+select a prompt file or a declared prompt template, but every rendered byte is
+part of the benchmark prompt and is copied into each record directory as
+`prompt.txt` with hash metadata.
+
+The harness must not append hidden text to the prompt. It must not add mode
+names, workflow instructions, skill hints, record paths, metric expectations,
+output-format requirements, or evaluator/reporting instructions unless those
+words are already present in the explicit prompt source selected by the
+scenario. This is the benchmark bias boundary: skill availability is the
+experimental variable, not extra harness guidance.
+
+Prompt templates use a strict variable renderer: every placeholder must have a
+value, unknown placeholders fail preflight, and rendered prompts are plain text.
+Template variables are substitutions only. They do not authorize the harness to
+auto-inject job metadata, workflow text, mode names, or output expectations.
+Direct prompt files are treated as already rendered prompts. Rendered scenario
+templates are materialized under the result root during scenario write/execution
+so scenario compilation does not mutate the scenario source directory.
+
+For skill-ablation comparisons such as `without_skills` versus `with_skills`,
+compared mode legs must receive identical prompt bytes unless the scenario is
+explicitly labeled as a prompt-ablation experiment. The prompt hash is the
+audit mechanism for this rule.
+
+The harness must not rely on prompt text for mode names, record paths, report
+filters, or evaluator behavior. Those are harness-supplied configuration values
+kept outside the agent prompt.
+The prompt hash is computed over the rendered prompt bytes and recorded as a
+top-level record-summary field so prompt variation is visible in every
+comparison.
+
+## Skill Identity
+
+The harness does not infer skill identity from workflow names, framework names,
+or job folders. Skill identity is an observed output, not scenario input.
+
+Accepted evidence sources include:
+
+- structured agent records;
+- structured benchmark records;
+- explicit structured metadata written by the agent or validation workflow.
+
+Reports should include:
+
+```text
+observed_skill_name
+skill_name_source = agent_record | benchmark_record | structured_metadata | unknown
+```
+
+If no trustworthy skill identity is discovered, reports use `unknown`. The
+report layer decides whether the evidence is trustworthy enough to describe as
+observed skill identity; it does not infer identity from workflow or job names.
+
+## Result Directory Layout
+
+The result path encodes the axes needed for aggregation and debugging:
+
+```text
+results/
+`-- <scenario_name>/
+    |-- scenario.json
+    |-- run_plan.json
+    |-- scenario_summary.json
+    |-- reports/
+    |   |-- scenario_report.md
+    |   `-- scenario_report.json
+    `-- records/
+        `-- agent=<agent>/
+            `-- model=<model_slug>/
+                `-- workflow=<workflow_slug>/
+                    `-- job=<job_slug>/
+                        `-- mode=<mode>/
+                            |-- record_summary.json
+                            |-- agent_events.jsonl
+                            |-- agent_usage.json
+                            |-- agent_activity.json
+                            |-- agent_last_message.txt
+                            |-- agent_stderr.txt
+                            |-- agent_record.json
+                            |-- benchmark_record.json
+                            |-- input_delta_manifest.json
+                            `-- workspace_delta_manifest.json
+```
+
+Slugs are filesystem-safe and stable: lowercase, replace every non-alphanumeric
+sequence with `_`, trim leading/trailing `_`, truncate the visible part to 48
+characters, and append an 8-character stable hash when truncation or collision
+handling is needed. The hash input is the full untruncated source string after
+normalization, not only the visible prefix. Empty slugs become `item_<hash>`.
+Collision detection runs while expanding the run plan. If two normalized names
+would produce the same slug within the same axis and parent path, both slugs get
+hash suffixes derived from their full normalized source strings.
+
+Preflight checks the maximum expanded artifact path length before execution.
+The default path budget is 240 characters for host-visible paths. Scenarios may
+set a shorter result root or an explicit path budget, but they must fail
+preflight rather than produce paths that are likely to break on the host or
+Docker volume mount.
+
+`scenario.json` stores the resolved scenario, including job paths, prompt
+hashes, wheel metadata, image tags, and agent versions. `run_plan.json` stores
+expanded record entries in execution order. Reports aggregate by reading
+scenario metadata and normalized records, not by guessing from directory names
+alone.
+
+The normalized `agent_*` artifacts are the source of truth. Provider-specific
+files such as `codex_*`, `claude_*`, `hermes_*`, or `openclaw_*` may exist only
+as debug or compatibility artifacts; reports must not require them.
+
+Each run-plan entry executes once. If a run fails, the failure is benchmark
+evidence and the harness preserves the artifacts needed to diagnose it. A user
+may rerun the scenario into a new result root when they want another sample, but
+the harness does not create additional executions for a failed run.
+
+## Summary Schema
+
+Every record summary includes:
+
+```text
+scenario_name
+comparison_type
+agent
+agent_model
+prompt_hash
+prompt_source
+workflow
+observed_skill_name
+skill_name_source
+job_slug
+job_path
+job_scale
+mode
+skills_enabled
+runtime_image
+wheel_variant
+elapsed_seconds
+agent_elapsed_seconds
+phase_seconds
+token_count
+command_count
+agent_exit_code
+final_container_exit_code
+agent_process_passed
+failure_root_cause
+validation_metric
+validation_metric_status
+structure_quality_signal
+artifact_paths
+```
+
+`elapsed_seconds`, when present for compatibility, is an alias for
+`agent_elapsed_seconds`. Full setup, post-processing, and report timings live in
+`phase_seconds`.
+
+`phase_seconds` uses the same keys as the timing boundary contract:
+
+```text
+container_elapsed_seconds
+setup_elapsed_seconds
+skill_exposure_elapsed_seconds
+agent_elapsed_seconds
+post_process_elapsed_seconds
+report_elapsed_seconds
+```
+
+Every comparison summary includes:
+
+```text
+comparison_type
+group_axes
+compared_records[]
+aggregate_results{}
+winner_policy
+quality_gate
+```
+
+`winner_policy` describes how the report selected or refused to select a winner,
+for example `median_agent_elapsed_seconds_then_tokens_with_quality_gate` or
+`no_single_cost_winner`.
+
+`quality_gate` describes the minimum correctness criteria applied before a cost
+winner is considered meaningful. The harness must not invent correctness from
+cost metrics.
+
+The default quality gate is:
+
+```text
+agent_process_passed == true
+final_container_exit_code == 0
+source_input_modified == false
+required_validation_metric_status in {present, not_required}
+critical_quality_checks_failed == false
+```
+
+Scenarios may override the implemented gate fields shown above, and every
+override is recorded in `quality_gate`. The current implementation does not yet
+support the broader design vocabulary for named required checks or required
+metric families. Unsupported quality-gate fields fail validation instead of
+silently changing comparison semantics. A run that does not meet the gate can
+still appear in reports, but it is not eligible to win a cost/performance
+comparison.
+
+The default winner policy is
+`median_agent_elapsed_seconds_then_tokens_with_quality_gate`:
+
+1. Exclude compared records that do not satisfy the quality gate.
+2. If no compared record satisfies the gate, set winner policy to
+   `no_quality_qualified_winner`.
+3. Compare `agent_elapsed_seconds` across compared records.
+4. Break ties with `token_count`.
+5. If both values tie or required values are missing, report
+   `no_single_cost_winner`.
+
+Reports may also show aggregate statistics when a scenario contains multiple
+records for the same comparison label.
+
+Scenario execution continues after individual run failures unless the scenario
+sets `fail_fast: true`. Scenario summaries report partial results and mark the
+scenario as `degraded` when at least one run failed, was skipped, or lacked a
+quality-qualified record. A scenario is `failed` when preflight fails before a
+run plan is executable, all run-plan entries fail, or a required report cannot
+be generated. A fully executed scenario with all required records satisfying
+the quality gate is `passed`.
+
+## CI And Test Boundaries
+
+CI exercises harness health, not the full benchmark matrix. A CI scenario uses:
+
+- one supported agent;
+- one model;
+- one small synthetic job folder;
+- one workflow;
+- one explicit comparison object;
+
+CI verifies that Docker build/run works, records are produced, reports render,
+skill exposure modes behave correctly, and parser assumptions remain valid.
+
+Unit tests cover pure behavior:
+
+- scenario expansion and slugging;
+- event normalization;
+- token parsing;
+- record normalization;
+- metric extraction;
+- structure-tree rendering;
+- report rendering helpers.
+
+Adapter contract tests validate that sample agent outputs map into the neutral
+event, usage, final-message, skill-exposure, and failure-classification
+contracts. A new agent config is not `supported` until it has:
+
+- sample raw event fixtures;
+- usage fixtures with declared token semantics;
+- final-message fixtures;
+- launch dry-run or preflight coverage;
+- skill-exposure probe coverage;
+- Docker build metadata coverage;
+- a static check that provider-specific names appear only in agent config,
+  parser/classifier registry, Docker install, auth README, or declared
+  debug/compatibility artifacts.
+
+Integration smoke tests run a tiny synthetic job and verify normalized records
+and reports. Long agent runs are opt-in.
+
+## Replay Mode
+
+The harness supports analysis development without live agent credentials through
+a replay mode. Replay mode consumes captured neutral artifacts, such as
+`agent_events.jsonl`, `agent_usage.json`, `agent_activity.json`,
+`agent_last_message.txt`, workspace-delta manifests, and benchmark records, then
+runs record synthesis, quality-signal extraction, aggregation, and report
+generation without invoking an agent CLI.
+
+Replay mode is for parser, record, and report development. It must not claim to
+measure fresh agent performance, mutate the original job input, or refresh
+token/cost data. Replay reports must identify their source run and mark
+`agent_invocation` as `replayed`.
+
+## Reporting Language
+
+Reports use agent-neutral labels:
+
+- `Agent events`;
+- `Agent runtime`;
+- `Agent usage`;
+- `Agent final message`;
+- `Agent status`;
+- `Agent failure analysis`.
+
+Reports always show agent name, model, CLI version when known, runtime image,
+wheel variant, skill exposure mode, workflow, job metadata, and prompt hash.
+
+Report code derives mode order and compared records from `scenario.json` and
+comparison summaries. It must not hard-code a fixed three-mode ablation order or
+evaluator-specific sections.

--- a/docs/design/skill_benchmark_harness_architecture.md
+++ b/docs/design/skill_benchmark_harness_architecture.md
@@ -1,0 +1,302 @@
+# Skill Benchmark Harness Architecture
+
+This document describes the implemented skill benchmark harness under
+`assist_tools/skills_benchmark`. The harness measures how agent-accessible
+NVFLARE skills affect applied conversion and diagnosis tasks.
+
+The harness is not an agent runtime and it is not an NVFLARE training workflow.
+It is a controlled runner that executes the same prompt and input folder with
+and without packaged NVFLARE skills, then normalizes the evidence for review.
+The skill packaging and install architecture is documented separately in
+[skills_architecture.md](skills_architecture.md).
+
+## Major Components
+
+| Component | Main files | Responsibility |
+| --- | --- | --- |
+| CLI wrappers | `bin/build.sh`, `bin/run.sh` | Thin shell entry points. They set `PYTHONPATH` and dispatch to Python host modules. |
+| SDK profile | `config/sdks/*.yaml`, `sdks/base.py`, `sdks/config.py`, `sdks/registry.py` | Describes the SDK under test: checkout markers, package/import names, wheel variants, build environment, Docker build args, and skill install/list commands. The current default profile is `nvflare-profile`, which describes the NVFLARE SDK. |
+| Agent plugin | `config/agents/*.yaml`, `agents/base.py`, `agents/config.py`, `agents/registry.py` | Describes an agent CLI: image names, auth mounts, model argument mapping, launch command, skill exposure mechanism, event parser, usage parser, final-message source, and exit classifier. Codex and Claude are implemented; Hermes and OpenClaw are registered as known pending agents. |
+| Host runner | `skills/harness/host/build.py`, `skills/harness/host/runner.py`, `scenarios.py`, `record_identity.py` | Runs on the host. It builds/stages SDK wheels, builds/selects Docker images, expands scenario YAML into `run_plan.json`, validates inputs, mounts job/prompt/result directories, and starts one container per run-plan entry. |
+| Docker setup | `docker/Dockerfile`, `docker/build_context.dockerignore` | Creates shared runtime images from local SDK wheels. The skills image installs the skills wheel and preinstalls agent skills; the baseline image installs the no-skills wheel and records that skills are intentionally absent. |
+| Container runner | `skills/harness/container/agent_run.py`, `container/skills.py`, `container/progress.py` | Runs inside each benchmark container. It copies the input job to an isolated workspace, applies `with_skills` or `without_skills`, launches the selected agent plugin, captures progress, and writes normalized run artifacts. |
+| Evidence and records | `artifacts.py`, `events.py`, `records.py`, `timing.py`, `quality_signals.py` | Normalizes raw run evidence into workspace deltas, event streams, usage/activity summaries, agent records, benchmark records, timing summaries, and quality signals. |
+| Reporting | `skills/harness/reports/` | Rebuilds scenario reports, benchmark insights, and metrics reports from captured records. Reporting can run through `replay` without launching Docker or an agent. |
+
+## Harness Component Flow
+
+```mermaid
+flowchart TD
+    CLI["Benchmark CLI"] --> Host["Host runner"]
+    Host --> SDK["SDK profile"]
+    Host --> AgentPlugin["Agent plugin"]
+    SDK --> WheelBuild["SDK wheel build"]
+    AgentPlugin --> ImageConfig["Agent image config"]
+    WheelBuild --> DockerBuild["Docker build"]
+    ImageConfig --> DockerBuild
+    DockerBuild --> SkillsImage["Skills image"]
+    DockerBuild --> BaselineImage["Baseline image"]
+    Host --> Scenario["Scenario engine"]
+    Scenario --> RunPlan["Run plan"]
+    RunPlan --> DockerRun["Docker run"]
+    SkillsImage --> DockerRun
+    BaselineImage --> DockerRun
+    AgentPlugin --> DockerRun
+    DockerRun --> Container["Container runner"]
+    Container --> AgentRun["Agent CLI run"]
+    Container --> SkillMode["Skill exposure mode"]
+    AgentRun --> Evidence["Run evidence"]
+    Evidence --> Records["Normalized records"]
+    Records --> Reports["Reports"]
+```
+
+## SDK And Docker Setup
+
+```mermaid
+flowchart TD
+    SDKYaml["SDK profile YAML"] --> SDKAdapter["Configurable SDK adapter"]
+    SDKAdapter --> Repo["SDK checkout or wheel source"]
+    Repo --> SkillsWheel["Skills wheel variant"]
+    Repo --> BaselineWheel["Baseline wheel variant"]
+    SkillsWheel --> BuildContext["Minimal Docker build context"]
+    BaselineWheel --> BuildContext
+    SDKAdapter --> BuildArgs["SDK Docker build args"]
+    BuildArgs --> Dockerfile["Shared Dockerfile"]
+    BuildContext --> Dockerfile
+    Dockerfile --> SkillsImage["agent skills image"]
+    Dockerfile --> BaselineImage["agent baseline image"]
+    SkillsImage --> Preinstall["SDK declared skills install and list commands"]
+    BaselineImage --> NoSkills["No skills installed"]
+```
+
+The SDK profile owns SDK-specific package details. For NVFLARE, the profile
+builds two local wheels from the checkout:
+
+- skills variant: `NVFLARE_PACKAGE_AGENT_SKILLS=1`
+- baseline variant: `NVFLARE_PACKAGE_AGENT_SKILLS=0`
+
+The Docker image build consumes only staged wheel artifacts and a copied harness
+package. It does not copy the SDK working tree into the runtime image. This
+keeps the measured container closer to a user-installed SDK package.
+
+## Agent Plugin Flow
+
+```mermaid
+flowchart TD
+    AgentYaml["Agent YAML"] --> AgentAdapter["Configurable agent adapter"]
+    AgentAdapter --> Auth["Auth mounts"]
+    AgentAdapter --> Launch["Launch command"]
+    AgentAdapter --> Exposure["Skill exposure"]
+    AgentAdapter --> Parsers["Event and usage parsers"]
+    Auth --> HostRunner["Host runner"]
+    Launch --> ContainerRunner["Container runner"]
+    Exposure --> ContainerRunner
+    Parsers --> Replay["Replay and reports"]
+    ContainerRunner --> AgentCLI["Codex or Claude CLI"]
+    AgentCLI --> Events["agent events"]
+    Events --> Parsers
+```
+
+The agent plugin is data-driven. The YAML config tells the harness how to run
+the agent; it does not add benchmark instructions to the prompt. The prompt is
+copied verbatim into the container and delivered according to the plugin's
+launch configuration.
+
+Codex uses a preinstalled-home skill exposure mechanism: the skills image
+installs skills into the configured `CODEX_HOME` skill directory, and the
+baseline path removes packaged skill visibility.
+
+Claude uses a launch-flag skill exposure mechanism: the plugin passes the
+configured skills directory through the agent launch args for the skills run.
+
+## Container Run Artifacts
+
+```mermaid
+flowchart TD
+    Prompt["prompt.txt"] --> AgentRun["Agent CLI run"]
+    Input["input job copy"] --> Workspace["isolated workspace"]
+    Workspace --> AgentRun
+    SkillState["skills_state.json"] --> AgentRun
+    AgentRun --> Events["agent_events.jsonl"]
+    AgentRun --> Stderr["agent_stderr.txt"]
+    AgentRun --> LastMessage["agent_last_message.txt"]
+    AgentRun --> Usage["agent_usage.json"]
+    AgentRun --> Activity["agent_activity.json"]
+    Workspace --> Delta["workspace_delta_manifest.json"]
+    Events --> AgentRecord["agent_record.json"]
+    Usage --> AgentRecord
+    Activity --> AgentRecord
+    Delta --> AgentRecord
+    AgentRecord --> RunSummary["run_summary.json"]
+```
+
+Each run-plan entry owns its own container, result directory, workspace copy,
+agent home, prompt copy, event stream, and records. `with_skills` and
+`without_skills` receive the same prompt and input folder; the only intended
+behavioral difference is skill visibility.
+
+## Reporting Overview
+
+```mermaid
+flowchart TD
+    RunPlan["run_plan.json"] --> ScenarioSummary["scenario_summary.json"]
+    Records["benchmark records and run summaries"] --> ScenarioSummary
+    Records --> QualitySignals["quality signals"]
+    Records --> Timing["timing and usage summaries"]
+
+    ScenarioSummary --> ScenarioReport["reports/scenario_report.md and json"]
+    QualitySignals --> BenchmarkInsights["benchmark_insights.md"]
+    Timing --> MetricsReports["metrics_report.md, json, html"]
+
+    ScenarioReport --> Review["human review and skill iteration"]
+    BenchmarkInsights --> Review
+    MetricsReports --> Review
+```
+
+## Reporting Architecture
+
+Benchmark reporting is a separate read-side pipeline over captured run
+artifacts. It does not launch an agent, change prompt content, install skills,
+or mutate benchmark inputs. The same reporting path runs after live benchmark
+execution and during `replay`.
+
+```mermaid
+flowchart TD
+    ResultRoot["result root"] --> RunPlanFile["run_plan.json"]
+    ResultRoot --> ScenarioFile["scenario.json"]
+    ResultRoot --> RecordDirs["records per run"]
+
+    RecordDirs --> Canonical["canonicalized run artifacts"]
+    Canonical --> AgentEvents["agent_events.jsonl"]
+    Canonical --> UsageFile["agent_usage.json"]
+    Canonical --> ActivityFile["agent_activity.json"]
+    Canonical --> RunSummaryFile["run_summary.json"]
+    Canonical --> BenchmarkRecord["benchmark_record.json"]
+    Canonical --> WorkspaceDelta["workspace_delta_manifest.json"]
+
+    AgentEvents --> ReplayParsers["agent plugin parsers"]
+    ReplayParsers --> UsageFile
+    ReplayParsers --> ActivityFile
+
+    RunPlanFile --> ScenarioSummaryBuild["write_scenario_summaries"]
+    ScenarioFile --> ScenarioSummaryBuild
+    RunSummaryFile --> ScenarioSummaryBuild
+    BenchmarkRecord --> ScenarioSummaryBuild
+    WorkspaceDelta --> ScenarioSummaryBuild
+
+    ScenarioSummaryBuild --> ScenarioSummaryFile["scenario_summary.json"]
+    ScenarioSummaryFile --> ScenarioReport["reports/scenario_report.md and json"]
+
+    BenchmarkRecord --> Insights["benchmark_insights.md"]
+    RunSummaryFile --> MetricsReport["metrics_report.md json html"]
+    UsageFile --> MetricsReport
+    ActivityFile --> MetricsReport
+```
+
+The reporting pipeline has these implemented responsibilities:
+
+| Stage | Main implementation | Output |
+| --- | --- | --- |
+| Per-run canonicalization | `host/runner.py::canonicalize_entry_artifacts` | Copies mode-specific records into stable names such as `agent_record.json`, `benchmark_record.json`, and `record_summary.json`. |
+| Replay parsing | `host/runner.py::replay_result_root` plus the selected agent plugin parsers | Rebuilds `agent_usage.json` and `agent_activity.json` from `agent_events.jsonl` without running Docker or the agent. |
+| Scenario summary | `scenarios.py::write_scenario_summaries` | Writes `scenario_summary.json`, repeat summaries, comparison groups, aggregate results, quality gate status, winner policy, replay metadata, and report generation status. |
+| Scenario report | `reports/scenario_report.py` | Writes `reports/scenario_report.json` and `reports/scenario_report.md` from `scenario_summary.json`. |
+| Benchmark insights | `reports/benchmark_insights.py` | Writes a review-oriented `benchmark_insights.md` with quality gate interpretation, root-cause hints, command evidence, metric-reporting gaps, and run comparison guidance. |
+| Metrics report | `reports/metrics_report.py` | Writes `metrics_report.json`, `metrics_report.md`, and `metrics_report.html` with status, elapsed time, token usage, command counts, and numeric comparisons. |
+| Host report status | `host/runner.py::write_host_report_status` | Writes `host_report_status.json` so automation can quickly detect whether the scenario report exists. |
+
+The main reporting inputs are the normalized run artifacts, not raw console
+logs. Raw `agent_events.jsonl`, `agent_stderr.txt`, `agent_last_message.txt`,
+and `console_output.log` are kept as evidence, while reports consume normalized
+records whenever possible.
+
+`replay` is the reporting-only mode. It expects an existing result root with
+`run_plan.json` and captured run directories, regenerates parser outputs and
+reports, writes `replay_metadata.json`, and marks the scenario summary with
+`agent_invocation: replayed`.
+
+## Final Benchmark Report Structure
+
+The final benchmark report is the human-facing rollup over the generated
+scenario report, benchmark insights, metrics report, and raw evidence. It
+should start with conclusions and then provide enough per-task evidence for
+debugging and skill iteration.
+
+```mermaid
+flowchart TD
+    FinalReport["Final benchmark report"]
+
+    FinalReport --> ExecutiveSummary["Executive summary"]
+    FinalReport --> Scope["Benchmark scope"]
+    FinalReport --> Environment["Environment"]
+    FinalReport --> AgentSkillConfig["Agent and skill configuration"]
+    FinalReport --> TaskSuite["Task suite summary"]
+    FinalReport --> OverallResults["Overall results"]
+    FinalReport --> PerTaskResults["Per-task results"]
+    FinalReport --> SkillComparison["With-skills vs without-skills comparison"]
+    FinalReport --> FailureAnalysis["Failure analysis"]
+    FinalReport --> EvidenceArtifacts["Evidence and artifacts"]
+    FinalReport --> ReportingMetrics["Reporting metrics"]
+    FinalReport --> Trends["Regression and trend view"]
+    FinalReport --> Recommendations["Recommendations"]
+    FinalReport --> Appendix["Appendix"]
+
+    ScenarioReport["scenario_report.md/json"] --> ExecutiveSummary
+    ScenarioReport --> TaskSuite
+    ScenarioReport --> OverallResults
+    ScenarioReport --> PerTaskResults
+
+    BenchmarkInsights["benchmark_insights.md"] --> FailureAnalysis
+    BenchmarkInsights --> Recommendations
+
+    MetricsReport["metrics_report.md/json/html"] --> ReportingMetrics
+    MetricsReport --> SkillComparison
+    MetricsReport --> Trends
+
+    RawEvidence["raw run artifacts"] --> EvidenceArtifacts
+    RawEvidence --> Appendix
+```
+
+The recommended sections are:
+
+| Section | Purpose | Primary inputs |
+| --- | --- | --- |
+| Executive summary | State overall pass rate, skill impact, biggest wins, regressions, and blockers. | `scenario_summary.json`, `scenario_report.md`, `benchmark_insights.md` |
+| Benchmark scope | Identify benchmark run ID, date, agent, skill profile, task suite version, and SDK or repo version. | `run_plan.json`, `scenario.json`, `replay_metadata.json`, host metadata |
+| Environment | Capture host OS, Docker image, SDK commit/version, Python version, important environment variables, and setup deviations. | Host build metadata, Docker labels, run records |
+| Agent and skill configuration | Record the agent plugin, enabled skills, skill source/version, launch configuration, timeout, and retry settings. | Agent YAML, SDK profile YAML, `skills_state.json`, run plan entries |
+| Task suite summary | Summarize task count, categories, difficulty labels, expected outputs, and scoring mode. | `scenario.json`, `run_plan.json` |
+| Overall results | Show pass/fail/skip counts, success rate, average runtime, average command or tool usage, and category-level failure rate. | `scenario_summary.json`, `metrics_report.json` |
+| Per-task results | List task status, score, runtime, agent, skill mode, triggered skills, key artifacts, and failure reason. | `run_summary.json`, `benchmark_record.json`, `agent_record.json` |
+| With-skills vs without-skills comparison | Compare pass rate, runtime, command count, quality score, tasks helped by skills, and tasks hurt or unchanged. | Repeat summaries, comparison groups, `metrics_report.json` |
+| Failure analysis | Group failures by missing skill coverage, tool/runtime issue, incorrect implementation, incomplete validation, environment issue, or timeout. | `benchmark_insights.md`, quality signals, agent activity |
+| Evidence and artifacts | Link to raw logs, event streams, workspace deltas, generated outputs, and container logs. | `agent_events.jsonl`, `agent_stderr.txt`, `workspace_delta_manifest.json`, console logs |
+| Reporting metrics | Present pass rate, completion time, retry count, tool-call count, file-change count, validation rate, and token/cost metrics when available. | `metrics_report.json`, `agent_usage.json`, `agent_activity.json` |
+| Regression and trend view | Compare against previous benchmark runs, including new failures, fixed failures, and performance changes. | Previous result roots, current `scenario_summary.json`, current metrics report |
+| Recommendations | Prioritize skill improvements, harness gaps, task coverage gaps, and product or documentation issues found by the benchmark. | `benchmark_insights.md`, failure analysis, reviewer notes |
+| Appendix | Preserve raw schemas, scoring rules, task manifest details, full per-task metadata, and reproduction commands. | `scenario.json`, records, raw artifacts |
+
+The report should be readable in this order:
+
+```mermaid
+flowchart LR
+    Conclusions["Conclusions"] --> ScopeContext["Scope and context"]
+    ScopeContext --> AggregateResults["Aggregate results"]
+    AggregateResults --> TaskEvidence["Per-task evidence"]
+    TaskEvidence --> RootCause["Failure analysis"]
+    RootCause --> ActionItems["Recommendations"]
+    ActionItems --> RawAppendix["Raw appendix"]
+```
+
+## Key Implementation Points
+
+- Harness root: `/Users/chesterc/projects/NVFlare/assist_tools/skills_benchmark`
+- Harness core: `/Users/chesterc/projects/NVFlare/assist_tools/skills_benchmark/skills/harness`
+- Harness SDK profiles: `/Users/chesterc/projects/NVFlare/assist_tools/skills_benchmark/config/sdks`
+- Harness agent plugins: `/Users/chesterc/projects/NVFlare/assist_tools/skills_benchmark/config/agents`
+- Harness Docker setup: `/Users/chesterc/projects/NVFlare/assist_tools/skills_benchmark/docker/Dockerfile`
+- Harness reporting: `/Users/chesterc/projects/NVFlare/assist_tools/skills_benchmark/skills/harness/reports`
+
+The important boundary: the harness starts external agent CLIs inside Docker
+and normalizes the resulting evidence. The agent remains the component that
+reads the prompt and uses the installed skills.

--- a/setup.cfg
+++ b/setup.cfg
@@ -172,7 +172,7 @@ ignore =
     W503,
     W504
 per_file_ignores = __init__.py: F401
-exclude = *.pyi,.git,.eggs,nvflare/_version.py,versioneer.py,venv,.venv,_version.py,*grpc.py,*_pb2.py
+exclude = *.pyi,.git,.eggs,nvflare/_version.py,versioneer.py,venv,.venv,_version.py,*grpc.py,*_pb2.py,tests/agent_benchmark/results
 
 [pydocstyle]
 convention = google

--- a/tests/unit_test/skills_benchmark/skills_benchmark_build_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_build_test.py
@@ -61,13 +61,7 @@ def test_prepare_build_context_stages_assist_tools_for_docker_copy(tmp_path, mon
         assert (context / "assist_tools" / "skills_benchmark" / "__init__.py").is_file()
         assert (context / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml").is_file()
         assert (
-            context
-            / "assist_tools"
-            / "skills_benchmark"
-            / "skills"
-            / "harness"
-            / "container"
-            / "sdk_skills_setup.py"
+            context / "assist_tools" / "skills_benchmark" / "skills" / "harness" / "container" / "agent_run.py"
         ).is_file()
         dockerignore = (context / ".dockerignore").read_text(encoding="utf-8")
         assert "!assist_tools/" in dockerignore

--- a/tests/unit_test/skills_benchmark/skills_benchmark_container_runtime_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_container_runtime_test.py
@@ -1,0 +1,599 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+from pathlib import Path
+
+
+def test_agent_config_rejects_prompt_text_placeholder(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    config_path = tmp_path / "unsafe.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "unsafe",
+                "display_name": "Unsafe Agent",
+                "default_model": "default",
+                "agent_home_env": "UNSAFE_HOME",
+                "container_home": "/workspace/.unsafe",
+                "launch": {"argv": ["unsafe", "run", "{prompt_text}"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "must not use {prompt_text}" in str(exc)
+    else:
+        raise AssertionError("agent adapter config must reject prompt_text injection paths")
+
+
+def test_agent_config_rejects_file_arg_without_prompt_file_placeholder(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    config_path = tmp_path / "missing_prompt_file.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "unsafe",
+                "display_name": "Unsafe Agent",
+                "default_model": "default",
+                "agent_home_env": "UNSAFE_HOME",
+                "container_home": "/workspace/.unsafe",
+                "launch": {"argv": ["unsafe", "run"], "prompt_input_mode": "file_arg"},
+                "skill_exposure": {"mechanism_type": "none"},
+                "final_message": {"source_type": "not_available"},
+                "events": {"parser": "generic_jsonl"},
+                "usage": {"parser": "generic_cli_usage"},
+                "activity": {"parser": "generic_jsonl_activity"},
+                "exit": {"classifier": "generic_cli"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "must include {prompt_file}" in str(exc)
+    else:
+        raise AssertionError("file_arg prompt delivery must include the prompt file in argv")
+
+
+def test_codex_adapter_launch_spec_uses_prompt_file_without_prompt_text(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchContext
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    result_dir = tmp_path / "results"
+    workspace_dir = tmp_path / "workspace"
+    prompt_file = tmp_path / "prompt.txt"
+    result_dir.mkdir()
+    workspace_dir.mkdir()
+    prompt_file.write_text("Convert this job. Do not leak prompt text into argv.\n", encoding="utf-8")
+    config = AgentLaunchContext(
+        model="test-model",
+        model_was_explicit=True,
+        result_dir=result_dir,
+        workspace_dir=workspace_dir,
+        prompt_file=prompt_file,
+        events_dest=result_dir / "agent_events.jsonl",
+        stderr_dest=result_dir / "agent_stderr.txt",
+        final_message_dest=result_dir / "agent_last_message.txt",
+    )
+
+    spec = load_agent_adapter("codex").launch_spec(config)
+
+    rendered_argv = " ".join(spec.argv)
+    assert spec.prompt_file == prompt_file
+    assert spec.prompt_input_mode == "stdin"
+    assert spec.final_message_dest == result_dir / "agent_last_message.txt"
+    assert "{prompt_text}" not in rendered_argv
+    assert "Convert this job" not in rendered_argv
+    assert spec.argv[-1] == "-"
+    assert spec.argv[-3:] == ["-m", "test-model", "-"]
+    assert "--dangerously-bypass-approvals-and-sandbox" in spec.sandbox_flags
+    assert spec.bypass_reason
+
+
+def test_codex_adapter_runtime_env_sets_generic_agent_model_and_home(tmp_path):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    agent_home = tmp_path / ".codex"
+    env = load_agent_adapter("codex").runtime_env(
+        SimpleNamespace(
+            agent_model="test-model",
+            agent_home=agent_home,
+            model_was_explicit=True,
+        )
+    )
+
+    assert env["BENCHMARK_AGENT"] == "codex"
+    assert env["BENCHMARK_AGENT_MODEL"] == "test-model"
+    assert env["CODEX_HOME"] == "/workspace/.codex"
+
+
+def test_container_config_uses_generic_agent_model_and_home(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig
+
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setenv("BENCHMARK_AGENT", "codex")
+    monkeypatch.setenv("BENCHMARK_AGENT_MODEL", "generic-model")
+    monkeypatch.setenv("BENCHMARK_AGENT_HOME", "/workspace/agent-home")
+
+    config = AgentRunConfig.from_env()
+
+    assert config.agent_model == "generic-model"
+    assert config.agent_home == Path("/workspace/agent-home")
+    assert not hasattr(config, "codex_home")
+
+
+def test_container_config_requires_benchmark_agent(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig
+
+    monkeypatch.delenv("BENCHMARK_AGENT", raising=False)
+
+    try:
+        AgentRunConfig.from_env()
+    except SystemExit as exc:
+        assert "BENCHMARK_AGENT is required" in str(exc)
+    else:
+        raise AssertionError("in-container config should require explicit BENCHMARK_AGENT")
+
+
+def test_container_config_rejects_invalid_progress_interval(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig
+
+    monkeypatch.setenv("BENCHMARK_AGENT", "codex")
+    monkeypatch.setenv("PROGRESS_INTERVAL_SECONDS", "fast")
+
+    try:
+        AgentRunConfig.from_env()
+    except SystemExit as exc:
+        assert "PROGRESS_INTERVAL_SECONDS must be an integer" in str(exc)
+    else:
+        raise AssertionError("invalid progress interval should fail with a clean config error")
+
+
+def test_agent_subprocess_env_hides_harness_controls_and_adapter_model_env(monkeypatch):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import agent_subprocess_env
+
+    adapter = SimpleNamespace(model_env_names=lambda: ("CUSTOM_AGENT_MODEL",))
+    monkeypatch.setenv("MODE", "with_skills")
+    monkeypatch.setenv("JOB_INPUT_DIR", "/workspace/input")
+    monkeypatch.setenv("BENCHMARK_AGENT", "codex")
+    monkeypatch.setenv("BENCHMARK_AGENT_MODEL", "generic-model")
+    monkeypatch.setenv("CUSTOM_AGENT_MODEL", "custom-model")
+    monkeypatch.setenv("AGENT_TIMEOUT_SECONDS", "120")
+    monkeypatch.setenv("OPENAI_API_KEY", "kept-for-agent-auth")
+
+    env = agent_subprocess_env({"CODEX_HOME": "/workspace/.codex"}, adapter)
+
+    assert "MODE" not in env
+    assert "JOB_INPUT_DIR" not in env
+    assert "BENCHMARK_AGENT" not in env
+    assert "BENCHMARK_AGENT_MODEL" not in env
+    assert "CUSTOM_AGENT_MODEL" not in env
+    assert "AGENT_TIMEOUT_SECONDS" not in env
+    assert env["OPENAI_API_KEY"] == "kept-for-agent-auth"
+    assert env["CODEX_HOME"] == "/workspace/.codex"
+
+
+def test_progress_writer_serializes_concurrent_file_writes(tmp_path):
+    import threading
+
+    from assist_tools.skills_benchmark.skills.harness.container.progress import ProgressWriter
+
+    writer = ProgressWriter("with_skills", 0, tmp_path / "progress.jsonl")
+    threads = [threading.Thread(target=writer.write, args=(f"phase-{index}", "running", index)) for index in range(20)]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    rows = [json.loads(line) for line in (tmp_path / "progress.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 20
+    assert {row["phase"] for row in rows} == {f"phase-{index}" for index in range(20)}
+
+
+def test_launch_subprocess_argv_wraps_login_shell_command():
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import launch_subprocess_argv
+
+    argv = launch_subprocess_argv(["agent", "run", "prompt with spaces"], login_shell=True)
+
+    assert argv[:3] == ["/bin/bash", "--login", "-c"]
+    assert argv[3].startswith("exec agent run")
+    assert "'prompt with spaces'" in argv[3]
+
+
+def test_run_agent_enforces_launch_timeout(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchSpec, FinalMessageSource
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AGENT_TIMEOUT_EXIT_CODE,
+        AgentRunConfig,
+        ProgressWriter,
+        run_agent,
+    )
+
+    class TimeoutAdapter:
+        def launch_spec(self, config):
+            return AgentLaunchSpec(
+                argv=[sys.executable, "-c", "import time; time.sleep(5)"],
+                cwd=config.workspace_dir,
+                prompt_file=config.prompt_file,
+                prompt_input_mode="stdin",
+                stdout_events_dest=config.events_dest,
+                stderr_dest=config.stderr_dest,
+                final_message_dest=config.final_message_dest,
+                launch_timeout=1,
+            )
+
+        def normalize_event(self, raw_line):
+            return None
+
+        def final_message_source(self, result_dir):
+            return FinalMessageSource(source_type="not_available")
+
+        def model_env_names(self):
+            return ()
+
+    result_dir = tmp_path / "results"
+    run_root = tmp_path / "run"
+    workspace = run_root / "workspace"
+    result_dir.mkdir()
+    workspace.mkdir(parents=True)
+    prompt = result_dir / "prompt.txt"
+    prompt.write_text("prompt\n", encoding="utf-8")
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=run_root,
+        prompt_source=prompt,
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+    monkeypatch.setattr(agent_run, "load_agent_adapter", lambda _agent: TimeoutAdapter())
+
+    _start, _end, exit_code = run_agent(config, ProgressWriter(config.mode, 0, config.progress_log_path))
+
+    assert exit_code == AGENT_TIMEOUT_EXIT_CODE
+    assert "timed out after 1 seconds" in config.agent_stderr_path.read_text(encoding="utf-8")
+
+
+def test_run_agent_stops_stdout_reader_before_events_file_closes(tmp_path, monkeypatch):
+    import threading
+    import time
+
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchSpec, FinalMessageSource
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        ProgressWriter,
+        run_agent,
+    )
+
+    class GuardedEventsDest:
+        def __init__(self):
+            self.closed = False
+            self.write_after_close = False
+            self.writes: list[str] = []
+
+        def __str__(self):
+            return "guarded-agent-events.jsonl"
+
+        def open(self, *args, **kwargs):
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.closed = True
+            return False
+
+        def write(self, value):
+            if self.closed:
+                self.write_after_close = True
+            self.writes.append(value)
+
+        def flush(self):
+            return None
+
+    normalize_started = threading.Event()
+    release_normalize = threading.Event()
+    guarded_events = GuardedEventsDest()
+
+    class SlowNormalizeAdapter:
+        def launch_spec(self, config):
+            return AgentLaunchSpec(
+                argv=[sys.executable, "-c", 'print(\'{"type":"event"}\')'],
+                cwd=config.workspace_dir,
+                prompt_file=config.prompt_file,
+                prompt_input_mode="stdin",
+                stdout_events_dest=guarded_events,
+                stderr_dest=config.stderr_dest,
+                final_message_dest=config.final_message_dest,
+            )
+
+        def normalize_event(self, raw_line):
+            normalize_started.set()
+            release_normalize.wait(timeout=2)
+            return {"type": "event"}
+
+        def final_message_source(self, result_dir):
+            return FinalMessageSource(source_type="not_available")
+
+        def model_env_names(self):
+            return ()
+
+    result_dir = tmp_path / "results"
+    run_root = tmp_path / "run"
+    result_dir.mkdir()
+    (run_root / "workspace").mkdir(parents=True)
+    prompt = result_dir / "prompt.txt"
+    prompt.write_text("prompt\n", encoding="utf-8")
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=run_root,
+        prompt_source=prompt,
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+    monkeypatch.setattr(agent_run, "AGENT_TERMINATE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(agent_run, "load_agent_adapter", lambda _agent: SlowNormalizeAdapter())
+
+    _start, _end, exit_code = run_agent(config, ProgressWriter(config.mode, 0, config.progress_log_path))
+    assert normalize_started.is_set()
+    assert exit_code == 0
+
+    release_normalize.set()
+    time.sleep(0.1)
+
+    assert guarded_events.closed is True
+    assert guarded_events.write_after_close is False
+
+
+def test_run_agent_closes_stdout_pipe_when_reader_is_blocked(tmp_path, monkeypatch):
+    import threading
+
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchSpec, FinalMessageSource
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        ProgressWriter,
+        run_agent,
+    )
+
+    class BlockingStdout:
+        def __init__(self):
+            self.closed = False
+            self.close_event = threading.Event()
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.close_event.wait(timeout=2)
+            raise StopIteration
+
+        def close(self):
+            self.closed = True
+            self.close_event.set()
+
+    blocked_stdout = BlockingStdout()
+
+    class FakeProcess:
+        stdout = blocked_stdout
+
+        def wait(self, timeout=None):
+            return 0
+
+    class BlockedReaderAdapter:
+        def launch_spec(self, config):
+            return AgentLaunchSpec(
+                argv=[sys.executable, "-c", "pass"],
+                cwd=config.workspace_dir,
+                prompt_file=config.prompt_file,
+                prompt_input_mode="stdin",
+                stdout_events_dest=config.events_dest,
+                stderr_dest=config.stderr_dest,
+                final_message_dest=config.final_message_dest,
+            )
+
+        def normalize_event(self, raw_line):
+            return {"type": "event"}
+
+        def final_message_source(self, result_dir):
+            return FinalMessageSource(source_type="not_available")
+
+        def model_env_names(self):
+            return ()
+
+    result_dir = tmp_path / "results"
+    run_root = tmp_path / "run"
+    result_dir.mkdir()
+    (run_root / "workspace").mkdir(parents=True)
+    prompt = result_dir / "prompt.txt"
+    prompt.write_text("prompt\n", encoding="utf-8")
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=run_root,
+        prompt_source=prompt,
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+    monkeypatch.setattr(agent_run, "AGENT_TERMINATE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(agent_run, "load_agent_adapter", lambda _agent: BlockedReaderAdapter())
+    monkeypatch.setattr(agent_run.subprocess, "Popen", lambda *args, **kwargs: FakeProcess())
+
+    _start, _end, exit_code = run_agent(config, ProgressWriter(config.mode, 0, config.progress_log_path))
+
+    assert exit_code == 0
+    assert blocked_stdout.closed is True
+
+
+def test_run_agent_materializes_final_message_before_reader_error(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchSpec, FinalMessageSource
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        ProgressWriter,
+        run_agent,
+    )
+
+    class ReaderErrorAdapter:
+        def launch_spec(self, config):
+            return AgentLaunchSpec(
+                argv=[sys.executable, "-c", "print('partial final message')"],
+                cwd=config.workspace_dir,
+                prompt_file=config.prompt_file,
+                prompt_input_mode="stdin",
+                stdout_events_dest=config.events_dest,
+                stderr_dest=config.stderr_dest,
+                final_message_dest=config.final_message_dest,
+            )
+
+        def normalize_event(self, raw_line):
+            raise ValueError("bad event")
+
+        def final_message_source(self, result_dir):
+            return FinalMessageSource(source_type="stdout_tail", tail_bytes=100, parser="generic_stdout_last_message")
+
+        def model_env_names(self):
+            return ()
+
+    result_dir = tmp_path / "results"
+    run_root = tmp_path / "run"
+    result_dir.mkdir()
+    (run_root / "workspace").mkdir(parents=True)
+    prompt = result_dir / "prompt.txt"
+    prompt.write_text("prompt\n", encoding="utf-8")
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=run_root,
+        prompt_source=prompt,
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+    monkeypatch.setattr(agent_run, "load_agent_adapter", lambda _agent: ReaderErrorAdapter())
+
+    try:
+        run_agent(config, ProgressWriter(config.mode, 0, config.progress_log_path))
+    except RuntimeError as exc:
+        assert "Failed to read agent stdout" in str(exc)
+    else:
+        raise AssertionError("reader errors should still propagate after final message materialization")
+
+    assert config.agent_last_message_path.read_text(encoding="utf-8") == "partial final message\n"
+
+
+def test_materialize_final_message_from_stdout_tail(tmp_path):
+    from collections import deque
+
+    from assist_tools.skills_benchmark.skills.harness.agents.base import FinalMessageSource
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        materialize_final_message,
+    )
+
+    class StdoutAdapter:
+        def final_message_source(self, result_dir):
+            return FinalMessageSource(source_type="stdout_tail", tail_bytes=12, parser="generic_stdout_last_message")
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+
+    materialize_final_message(
+        config,
+        StdoutAdapter(),
+        deque(["first line\n", "final message\n"]),
+        stdout_tail_truncated=True,
+    )
+
+    assert config.agent_last_message_path.read_text(encoding="utf-8") == "nal message\n"
+    metadata = json.loads((result_dir / "final_message_source.json").read_text(encoding="utf-8"))
+    assert metadata["source_type"] == "stdout_tail"
+    assert metadata["status"] == "materialized"
+    assert metadata["stdout_tail_truncated"] is True
+
+
+def test_stdout_tail_line_is_bounded_by_bytes():
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        MAX_STDOUT_TAIL_LINE_BYTES,
+        STDOUT_TAIL_TRUNCATED_MARKER,
+        truncate_stdout_tail_line,
+    )
+
+    line = ("a" * (MAX_STDOUT_TAIL_LINE_BYTES + 100)) + "\n"
+
+    truncated = truncate_stdout_tail_line(line)
+
+    assert len(truncated.encode("utf-8")) <= MAX_STDOUT_TAIL_LINE_BYTES
+    assert STDOUT_TAIL_TRUNCATED_MARKER in truncated
+    assert truncated.endswith("\n")

--- a/tests/unit_test/skills_benchmark/skills_benchmark_host_runner_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_host_runner_test.py
@@ -1,0 +1,794 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_sh_defaults_to_pair_when_first_arg_is_option(tmp_path):
+    script = Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "bin" / "run.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    recorder = tmp_path / "python_args.txt"
+    fake_python = fake_bin / "python3"
+    fake_python.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$RECORD_PATH"\n', encoding="utf-8")
+    fake_python.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["RECORD_PATH"] = str(recorder)
+
+    result = subprocess.run(
+        [str(script), "--prompt", "prompt.txt", "job"],
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert recorder.read_text(encoding="utf-8").splitlines() == [
+        "-m",
+        "assist_tools.skills_benchmark.skills.harness.host.runner",
+        "pair",
+        "--prompt",
+        "prompt.txt",
+        "job",
+    ]
+
+
+def test_expand_home_path_uses_pathlib_expanduser():
+    from assist_tools.skills_benchmark.skills.harness.host.common import expand_home_path
+
+    assert expand_home_path("~/nvflare") == str(Path.home() / "nvflare")
+    assert expand_home_path("/workspace/input") == "/workspace/input"
+
+
+def test_agent_availability_probe_records_missing_cli(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        run_agent_availability_probe,
+    )
+
+    class MissingProbeAdapter:
+        def availability_probe(self):
+            return ["/definitely/missing/agent-cli"]
+
+        def runtime_env(self, config):
+            return {}
+
+        def model_env_names(self):
+            return ()
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+    monkeypatch.setattr(agent_run, "load_agent_adapter", lambda _agent: MissingProbeAdapter())
+
+    try:
+        run_agent_availability_probe(config)
+    except RuntimeError as exc:
+        assert "Agent availability probe failed to start" in str(exc)
+    else:
+        raise AssertionError("missing agent CLI should fail availability probe")
+
+    probe = json.loads((result_dir / "agent_availability_probe.json").read_text(encoding="utf-8"))
+    assert probe["status"] == "failed"
+    assert probe["exit_code"] == 127
+
+
+def test_host_image_config_rejects_unsupported_agent(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host.common import ImageConfig
+
+    monkeypatch.setenv("BENCHMARK_AGENT", "hermes")
+
+    try:
+        ImageConfig.from_env()
+    except SystemExit as exc:
+        assert "BENCHMARK_AGENT='hermes'" in str(exc)
+        assert "known but not implemented" in str(exc)
+    else:
+        raise AssertionError("unsupported benchmark agent should fail before image selection")
+
+
+def test_host_docker_args_use_migrated_container_entrypoint(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+    from assist_tools.skills_benchmark.skills.harness.host.common import (
+        CONTAINER_PROMPT_PATH,
+        CaseConfig,
+        ImageConfig,
+        docker_args_for_case,
+    )
+
+    job_input = tmp_path / "job"
+    prompt_dir = tmp_path / "prompts"
+    result_dir = tmp_path / "results"
+    agent_home = tmp_path / ".codex"
+    job_input.mkdir()
+    prompt_dir.mkdir()
+    prompt_path = prompt_dir / "benchmark_prompt.txt"
+    prompt_path.write_text("convert this job\n", encoding="utf-8")
+
+    config = CaseConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=job_input,
+        result_dir=result_dir,
+        prompt_path=prompt_path,
+        images=ImageConfig(
+            image_name="agent-skills-benchmark:codex-skills",
+            baseline_image_name="agent-skills-benchmark:codex-baseline",
+            report_image_name="agent-skills-benchmark:codex-skills",
+        ),
+        progress_interval_seconds="0",
+        agent="codex",
+        agent_model="unspecified_default",
+        model_was_explicit=False,
+        adapter=load_agent_adapter("codex"),
+        host_agent_home=agent_home,
+        mount_host_agent_auth=False,
+    )
+
+    args = docker_args_for_case(config)
+
+    assert "-m" in args
+    module_index = args.index("-m") + 1
+    assert args[module_index] == "assist_tools.skills_benchmark.skills.harness.container.agent_run"
+    assert f"{prompt_path}:{CONTAINER_PROMPT_PATH}:ro" in args
+    assert f"PROMPT_SOURCE={CONTAINER_PROMPT_PATH}" in args
+    assert "RECORDS_DIR=/workspace/results/records" in args
+
+
+def test_enforce_result_size_budget_reports_oversized_results(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+    from assist_tools.skills_benchmark.skills.harness.host.common import CaseConfig, ImageConfig
+    from assist_tools.skills_benchmark.skills.harness.host.runner import enforce_result_size_budget
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    result_dir.joinpath("large.txt").write_text("too large\n", encoding="utf-8")
+    config = CaseConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        prompt_path=tmp_path / "prompt.txt",
+        images=ImageConfig(
+            image_name="agent-skills-benchmark:codex-skills",
+            baseline_image_name="agent-skills-benchmark:codex-baseline",
+            report_image_name="agent-skills-benchmark:codex-skills",
+        ),
+        progress_interval_seconds="0",
+        agent="codex",
+        agent_model="unspecified_default",
+        model_was_explicit=False,
+        adapter=load_agent_adapter("codex"),
+        host_agent_home=tmp_path / ".codex",
+        mount_host_agent_auth=False,
+        result_size_budget_bytes=1,
+    )
+
+    assert enforce_result_size_budget(config) is True
+    payload = json.loads((result_dir / "result_size_budget.json").read_text(encoding="utf-8"))
+    assert payload["status"] == "fail"
+    assert payload["budget_bytes"] == 1
+
+
+def test_directory_size_bytes_does_not_traverse_symlinked_directories(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.runner import directory_size_bytes
+
+    result_dir = tmp_path / "results"
+    outside = tmp_path / "outside"
+    result_dir.mkdir()
+    outside.mkdir()
+    (result_dir / "small.txt").write_text("ok", encoding="utf-8")
+    (outside / "large.txt").write_text("x" * 1000, encoding="utf-8")
+    os.symlink(outside, result_dir / "outside_link")
+
+    assert directory_size_bytes(result_dir) == 2
+
+
+def test_case_config_for_entry_applies_resource_policy(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+
+    entry = {
+        "agent": "codex",
+        "mode": "with_skills",
+        "skills_enabled": True,
+        "job_path": str(tmp_path / "job"),
+        "record_dir": "records/run",
+        "prompt_source": str(tmp_path / "prompt.txt"),
+        "agent_model": "unspecified_default",
+        "model_source": "adapter_default",
+        "resource_policy": {
+            "agent_timeout_seconds": 11,
+            "container_timeout_seconds": 22,
+            "result_size_budget_bytes": 33,
+        },
+    }
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+
+    config = runner.case_config_for_entry(entry, tmp_path / "results")
+
+    assert config.agent_timeout_seconds == 11
+    assert config.container_timeout_seconds == 22
+    assert config.result_size_budget_bytes == 33
+
+
+def test_positive_int_resource_value_accepts_float_values():
+    from assist_tools.skills_benchmark.skills.harness.host.runner import positive_int_resource_value
+
+    assert positive_int_resource_value(1800.0) == 1800
+    assert positive_int_resource_value(0.5) is None
+    assert positive_int_resource_value(0.0) is None
+    assert positive_int_resource_value(True) is None
+
+
+def test_stream_command_warns_when_reader_thread_stays_alive(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import common
+
+    class FakeStdout:
+        def close(self):
+            return None
+
+    class FakeProcess:
+        stdout = FakeStdout()
+
+        def wait(self, timeout=None):
+            return 0
+
+    class StuckThread:
+        def __init__(self, target, daemon):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            return None
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(common.subprocess, "Popen", lambda *args, **kwargs: FakeProcess())
+    monkeypatch.setattr(common.threading, "Thread", StuckThread)
+    log = tmp_path / "console.log"
+
+    status = common.stream_command(["docker", "run"], logs=(log,), prefix="run_00001")
+
+    assert status == 0
+    assert "[run_00001] Output reader thread did not stop within 2 seconds." in log.read_text(encoding="utf-8")
+
+
+def test_host_cli_accepts_results_root(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    results_root = tmp_path / "bench-results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+
+    options = parse_host_cli_options(
+        ["--prompt", str(prompt), "--results-root", str(results_root), "--training-code", str(job_input)],
+        "pair",
+    )
+
+    assert options.job_input == job_input
+    assert options.prompt_path == prompt
+    assert options.results_root == results_root
+    assert options.result_root is None
+    assert options.result_dir is None
+
+
+def test_host_cli_accepts_direct_run_selection_flags(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    agent_home = tmp_path / "agent-home"
+    job_input.mkdir()
+    agent_home.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+
+    options = parse_host_cli_options(
+        [
+            "--prompt",
+            str(prompt),
+            "--agent",
+            "claude",
+            "--model",
+            "claude-test",
+            "--mode",
+            "without_skills",
+            "--workflow",
+            "fedavg",
+            "--job-scale",
+            "medium",
+            "--agent-home",
+            str(agent_home),
+            "--no-agent-auth-mount",
+            str(job_input),
+        ],
+        "run-one",
+    )
+
+    assert options.agent == "claude"
+    assert options.model == "claude-test"
+    assert options.mode == "without_skills"
+    assert options.workflow == "fedavg"
+    assert options.job_scale == "medium"
+    assert options.agent_home == agent_home
+    assert options.mount_agent_auth is False
+
+
+def test_scenario_cli_accepts_generic_auth_flags(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.runner import parse_scenario_cli_options
+
+    scenario = tmp_path / "scenario.yaml"
+    output_dir = tmp_path / "results"
+    agent_home = tmp_path / "agent-home"
+    scenario.write_text("name: test\n", encoding="utf-8")
+    agent_home.mkdir()
+
+    options = parse_scenario_cli_options(
+        [
+            str(scenario),
+            "--output-dir",
+            str(output_dir),
+            "--agent-home",
+            str(agent_home),
+            "--no-agent-auth-mount",
+        ]
+    )
+
+    assert options.scenario_path == scenario
+    assert options.result_root == output_dir
+    assert options.agent_home == agent_home
+    assert options.mount_agent_auth is False
+
+
+def test_run_scenario_passes_generic_auth_flags_to_execution(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    scenario = tmp_path / "scenario.yaml"
+    output_dir = tmp_path / "results"
+    agent_home = tmp_path / "agent-home"
+    job_input.mkdir()
+    agent_home.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    scenario.write_text(
+        "\n".join(
+            [
+                "name: scenario auth",
+                f"prompt: {prompt}",
+                "agents:",
+                "  - name: codex",
+                "    models: [codex-test]",
+                "workflows:",
+                "  - name: default",
+                "jobs:",
+                "  - name: job",
+                f"    path: {job_input}",
+                "    scale: small",
+                "comparison:",
+                "  type: one",
+                "  mode: with_skills",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    captured = {}
+
+    def fake_execute(compilation, *, result_root, logs=(), runtime_auth_options=None):
+        captured["result_root"] = result_root
+        captured["runtime_auth_options"] = runtime_auth_options
+        return {"run_00001": 0}, {"status": "passed"}
+
+    monkeypatch.setattr(runner, "execute_run_plan", fake_execute)
+
+    status = runner.run_scenario(
+        [
+            str(scenario),
+            "--output-dir",
+            str(output_dir),
+            "--agent-home",
+            str(agent_home),
+            "--no-agent-auth-mount",
+        ]
+    )
+
+    assert status == 0
+    assert captured["result_root"] == output_dir
+    assert captured["runtime_auth_options"].agent_home == agent_home
+    assert captured["runtime_auth_options"].mount_agent_auth is False
+
+
+def test_host_cli_rejects_mode_for_pair(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+
+    try:
+        parse_host_cli_options(["--prompt", str(prompt), "--mode", "with_skills", str(job_input)], "pair")
+    except SystemExit as exc:
+        assert "--mode is only supported for run-one" in str(exc)
+    else:
+        raise AssertionError("--mode should be rejected for pair")
+
+
+def test_default_results_root_uses_codex_compat_alias(monkeypatch, tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import default_results_root
+
+    compat_root = tmp_path / "compat-results"
+    monkeypatch.delenv("AGENT_BENCHMARK_RESULTS_ROOT", raising=False)
+    monkeypatch.setenv("CODEX_DOCKER_RESULTS_ROOT", str(compat_root))
+
+    assert default_results_root() == compat_root
+
+
+def test_pair_compilation_accepts_explicit_absolute_prompt_path(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+    from assist_tools.skills_benchmark.skills.harness.host.runner import pair_compilation_from_options
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    results_root = tmp_path / "bench-results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    options = parse_host_cli_options(
+        ["--prompt", str(prompt), "--results-root", str(results_root), "--training-code", str(job_input)],
+        "pair",
+    )
+
+    compilation = pair_compilation_from_options(options)
+
+    assert compilation.scenario["prompt"]["path"] == str(prompt.resolve())
+
+
+def test_pair_compilation_uses_direct_run_selection_flags(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+    from assist_tools.skills_benchmark.skills.harness.host.runner import pair_compilation_from_options
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    monkeypatch.delenv("BENCHMARK_AGENT", raising=False)
+    monkeypatch.delenv("BENCHMARK_AGENT_MODEL", raising=False)
+
+    options = parse_host_cli_options(
+        [
+            "--prompt",
+            str(prompt),
+            "--agent",
+            "codex",
+            "--model",
+            "codex-test",
+            "--workflow",
+            "fedavg",
+            "--job-scale",
+            "medium",
+            str(job_input),
+        ],
+        "pair",
+    )
+
+    compilation = pair_compilation_from_options(options)
+    entries = compilation.run_plan["entries"]
+
+    assert entries
+    assert {entry["agent"] for entry in entries} == {"codex"}
+    assert {entry["agent_model"] for entry in entries} == {"codex-test"}
+    assert {entry["workflow"] for entry in entries} == {"fedavg"}
+    assert {entry["job_scale"] for entry in entries} == {"medium"}
+
+
+def test_case_config_uses_generic_runtime_auth_overrides(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+    from assist_tools.skills_benchmark.skills.harness.host.runner import (
+        RuntimeAuthOptions,
+        case_config_for_entry,
+        pair_compilation_from_options,
+    )
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    agent_home = tmp_path / "custom-agent-home"
+    result_root = tmp_path / "results"
+    job_input.mkdir()
+    agent_home.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    monkeypatch.delenv("BENCHMARK_AGENT", raising=False)
+    monkeypatch.delenv("BENCHMARK_AGENT_MODEL", raising=False)
+
+    options = parse_host_cli_options(
+        ["--prompt", str(prompt), "--agent", "codex", "--model", "codex-test", str(job_input)],
+        "pair",
+    )
+    compilation = pair_compilation_from_options(options)
+    entry = compilation.run_plan["entries"][0]
+
+    config = case_config_for_entry(
+        entry,
+        result_root,
+        RuntimeAuthOptions(agent_home=agent_home, mount_agent_auth=False),
+    )
+
+    assert config.host_agent_home == agent_home
+    assert config.mount_host_agent_auth is False
+
+
+def test_run_one_executes_compiled_one_scenario(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    result_root = tmp_path / "results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    captured = {}
+    monkeypatch.setenv("MODE", "with_skills")
+    monkeypatch.setattr(
+        runner.ImageConfig,
+        "for_adapter",
+        classmethod(
+            lambda cls, _adapter: SimpleNamespace(
+                image_name="skills-image",
+                baseline_image_name="baseline-image",
+                report_image_name="report-image",
+            )
+        ),
+    )
+
+    def fake_execute(compilation, *, result_root, logs=()):
+        captured["compilation"] = compilation
+        captured["result_root"] = result_root
+        return {"run_00001": 0}, {"status": "passed"}
+
+    monkeypatch.setattr(runner, "execute_run_plan", fake_execute)
+
+    status = runner.run_one(["--prompt", str(prompt), "--output-dir", str(result_root), str(job_input)])
+
+    assert status == 0
+    assert captured["result_root"] == result_root
+    run_plan = captured["compilation"].run_plan
+    assert run_plan["comparison_type"] == "one"
+    assert run_plan["run_count"] == 1
+    assert run_plan["entries"][0]["mode"] == "with_skills"
+    assert run_plan["entries"][0]["record_dir"].startswith("records/")
+
+
+def test_run_one_reports_image_config_validation_without_traceback(tmp_path, monkeypatch, capsys):
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    result_root = tmp_path / "results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    monkeypatch.setenv("MODE", "with_skills")
+    monkeypatch.setattr(
+        runner.ImageConfig,
+        "for_adapter",
+        classmethod(lambda cls, _adapter: (_ for _ in ()).throw(ValueError("bad image template"))),
+    )
+
+    status = runner.run_one(["--prompt", str(prompt), "--output-dir", str(result_root), str(job_input)])
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "Scenario validation failed: bad image template" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_run_pair_returns_failure_for_any_run_id_status(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    result_root = tmp_path / "results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner.ImageConfig,
+        "for_adapter",
+        classmethod(
+            lambda cls, _adapter: SimpleNamespace(
+                image_name="skills-image",
+                baseline_image_name="baseline-image",
+                report_image_name="report-image",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "execute_run_plan",
+        lambda *args, **kwargs: ({"run_00001": 1, "run_00002": 0}, {"status": "ok"}),
+    )
+
+    status = runner.run_pair(["--prompt", str(prompt), "--output-dir", str(result_root), str(job_input)])
+
+    assert status == 1
+
+
+def test_run_pair_reports_scenario_validation_without_traceback(tmp_path, monkeypatch, capsys):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    result_root = tmp_path / "results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner.ImageConfig,
+        "for_adapter",
+        classmethod(
+            lambda cls, _adapter: SimpleNamespace(
+                image_name="skills-image",
+                baseline_image_name="baseline-image",
+                report_image_name="report-image",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "execute_run_plan",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ScenarioValidationError("expanded path too long")),
+    )
+
+    status = runner.run_pair(["--prompt", str(prompt), "--output-dir", str(result_root), str(job_input)])
+
+    assert status == 1
+    captured = capsys.readouterr()
+    assert "Scenario validation failed: expanded path too long" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_run_pair_writes_host_report_status_after_preflight_report(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    result_root = tmp_path / "results"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner.ImageConfig,
+        "for_adapter",
+        classmethod(
+            lambda cls, _adapter: SimpleNamespace(
+                image_name="skills-image",
+                baseline_image_name="baseline-image",
+                report_image_name="report-image",
+            )
+        ),
+    )
+
+    def fail_after_report(_compilation, *, result_root, logs=()):
+        reports_dir = result_root / "reports"
+        reports_dir.mkdir(parents=True)
+        reports_dir.joinpath("scenario_report.md").write_text("preflight report\n", encoding="utf-8")
+        raise ScenarioValidationError("preflight failed")
+
+    monkeypatch.setattr(runner, "execute_run_plan", fail_after_report)
+
+    status = runner.run_pair(["--prompt", str(prompt), "--output-dir", str(result_root), str(job_input)])
+
+    assert status == 1
+    host_status = json.loads((result_root / "host_report_status.json").read_text(encoding="utf-8"))
+    assert host_status["status"] == "ok"
+    assert host_status["scenario_report"] == str(result_root / "reports" / "scenario_report.md")
+
+
+def test_host_cli_output_dir_maps_to_exact_result_location(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+
+    job_input = tmp_path / "job"
+    prompt = tmp_path / "prompt.txt"
+    output_dir = tmp_path / "exact-output"
+    job_input.mkdir()
+    prompt.write_text("convert this job\n", encoding="utf-8")
+
+    comparison_options = parse_host_cli_options(
+        ["--prompt", str(prompt), "--output-dir", str(output_dir), str(job_input)],
+        "pair",
+    )
+    single_options = parse_host_cli_options(
+        ["--prompt", str(prompt), "--output-dir", str(output_dir), str(job_input)],
+        "run-one",
+    )
+
+    assert comparison_options.result_root == output_dir
+    assert comparison_options.result_dir is None
+    assert single_options.result_dir == output_dir
+    assert single_options.result_root is None
+
+
+def test_host_cli_requires_prompt_path(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.common import parse_host_cli_options
+
+    job_input = tmp_path / "job"
+    job_input.mkdir()
+
+    try:
+        parse_host_cli_options([str(job_input)], "pair")
+    except SystemExit as exc:
+        assert "Prompt file is required" in str(exc)
+    else:
+        raise AssertionError("parse_host_cli_options should require --prompt")
+
+
+def test_container_config_rejects_unknown_mode(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig
+
+    monkeypatch.setenv("MODE", "with_skill_typo")
+
+    try:
+        AgentRunConfig.from_env()
+    except SystemExit as exc:
+        assert "Unknown MODE with_skill_typo" in str(exc)
+        assert "without_skills" in str(exc)
+        assert "with_skills" in str(exc)
+    else:
+        raise AssertionError("unknown MODE should fail before skill defaulting")
+
+
+def test_container_config_rejects_mode_skill_flag_conflict(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig
+
+    monkeypatch.setenv("MODE", "without_skills")
+    monkeypatch.setenv("USE_PREINSTALLED_SKILLS", "true")
+
+    try:
+        AgentRunConfig.from_env()
+    except SystemExit as exc:
+        assert "conflicts with MODE=without_skills" in str(exc)
+        assert "expected false" in str(exc)
+    else:
+        raise AssertionError("MODE and USE_PREINSTALLED_SKILLS disagreement should fail fast")

--- a/tests/unit_test/skills_benchmark/skills_benchmark_records_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_records_test.py
@@ -1,0 +1,1063 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+def test_record_identity_prefers_direct_skill_and_case():
+    from assist_tools.skills_benchmark.skills.harness.record_identity import record_case, record_skill
+
+    record = {
+        "skill": "direct-skill",
+        "case_id": "direct-case",
+        "skill_discovery": {"selected_skill": "fallback-skill", "selected_case_id": "fallback-case"},
+    }
+
+    assert record_skill(record) == "direct-skill"
+    assert record_case(record) == "direct-case"
+
+
+def test_record_identity_falls_back_to_skill_discovery():
+    from assist_tools.skills_benchmark.skills.harness.record_identity import record_case, record_skill
+
+    record = {"skill_discovery": {"selected_skill": "fallback-skill", "selected_case_id": "fallback-case"}}
+
+    assert record_skill(record) == "fallback-skill"
+    assert record_case(record) == "fallback-case"
+
+
+def test_collect_report_artifacts_skips_symlinks(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.artifacts import collect_report_artifacts
+
+    root = tmp_path / "results"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    root.joinpath("leak.txt").symlink_to(outside)
+    root.joinpath("kept.txt").write_text("normal\n", encoding="utf-8")
+
+    artifacts = collect_report_artifacts(root)
+
+    assert {item["relative_path"] for item in artifacts} == {"kept.txt"}
+
+
+def test_collect_report_artifacts_does_not_traverse_symlinked_directories(tmp_path):
+    if not hasattr(os, "symlink"):
+        return
+    from assist_tools.skills_benchmark.skills.harness.artifacts import collect_report_artifacts
+
+    root = tmp_path / "results"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside.joinpath("leak.txt").write_text("secret\n", encoding="utf-8")
+    root.joinpath("linked").symlink_to(outside, target_is_directory=True)
+    root.joinpath("kept.txt").write_text("normal\n", encoding="utf-8")
+
+    artifacts = collect_report_artifacts(root)
+
+    assert {item["relative_path"] for item in artifacts} == {"kept.txt"}
+
+
+def test_workspace_artifact_capture_does_not_traverse_symlinked_directories(tmp_path):
+    if not hasattr(os, "symlink"):
+        return
+    from assist_tools.skills_benchmark.skills.harness.artifacts import capture_workspace_delta, write_workspace_baseline
+
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    workspace.joinpath("kept.py").write_text("print('kept')\n", encoding="utf-8")
+    outside.joinpath("leak.py").write_text("print('secret')\n", encoding="utf-8")
+    workspace.joinpath("linked").symlink_to(outside, target_is_directory=True)
+    baseline_path = tmp_path / "baseline.json"
+
+    write_workspace_baseline(workspace, baseline_path)
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    capture_workspace_delta(
+        workspace,
+        tmp_path / "empty_baseline.json",
+        tmp_path / "delta",
+        tmp_path / "delta_manifest.json",
+        tmp_path / "nvflare",
+        include_runtime_artifacts=False,
+    )
+    manifest = json.loads((tmp_path / "delta_manifest.json").read_text(encoding="utf-8"))
+
+    assert set(baseline["files"]) == {"kept.py"}
+    assert {item["path"] for item in manifest["final_files"]} == {"kept.py"}
+    assert {item["path"] for item in manifest["changed_files"]} == {"kept.py"}
+
+
+def test_parse_usage_activity_scans_hints_from_raw_line_without_json_reserialize(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import events
+
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text(json.dumps({"type": "turn", "message": "read SKILL.md"}) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(events.json, "dumps", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unused")))
+
+    _usage, activity = events.parse_usage_and_activity_data(events_path)
+
+    assert activity["hint_counts"]["skill_md"] == 1
+
+
+def test_parse_usage_activity_caps_command_list(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness import events
+
+    events_path = tmp_path / "events.jsonl"
+    with events_path.open("w", encoding="utf-8") as stream:
+        for index in range(events.MAX_ACTIVITY_COMMANDS + 3):
+            stream.write(json.dumps({"type": "turn", "cmd": f"python job.py --round {index}"}) + "\n")
+
+    _usage, activity = events.parse_usage_and_activity_data(events_path)
+
+    assert activity["command_count"] == events.MAX_ACTIVITY_COMMANDS + 3
+    assert len(activity["commands"]) == events.MAX_ACTIVITY_COMMANDS
+    assert activity["unique_command_count"] == events.MAX_ACTIVITY_COMMANDS + 3
+    assert activity["commands_truncated"] is True
+
+
+def test_parse_usage_activity_counts_usage_objects_without_retaining_them(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness import events
+
+    events_path = tmp_path / "events.jsonl"
+    with events_path.open("w", encoding="utf-8") as stream:
+        for index in range(1205):
+            stream.write(json.dumps({"type": "turn", "usage": {"total_tokens": index}}) + "\n")
+
+    usage, _activity = events.parse_usage_and_activity_data(events_path)
+
+    assert usage["usage_objects_seen"] == 1205
+
+
+def test_parse_usage_activity_bounds_distinct_tracking_structures(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import events
+
+    monkeypatch.setattr(events, "MAX_TRACKED_EVENT_TYPES", 2)
+    monkeypatch.setattr(events, "MAX_TRACKED_COMMAND_PREFIXES", 2)
+    monkeypatch.setattr(events, "MAX_TRACKED_UNIQUE_COMMANDS", 2)
+    events_path = tmp_path / "events.jsonl"
+    with events_path.open("w", encoding="utf-8") as stream:
+        for index in range(5):
+            stream.write(
+                json.dumps(
+                    {
+                        "type": f"event-{index}",
+                        "cmd": f"tool-{index} --arg",
+                        "input_tokens": index,
+                        "output_tokens": index + 10,
+                    }
+                )
+                + "\n"
+            )
+
+    usage, activity = events.parse_usage_and_activity_data(events_path)
+
+    assert usage["max_input_tokens"] == 4
+    assert usage["max_output_tokens"] == 14
+    assert len(activity["event_types"]) == 2
+    assert activity["event_types_truncated"] is True
+    assert len(activity["command_prefix_counts"]) == 2
+    assert activity["command_prefix_counts_truncated"] is True
+    assert activity["unique_command_count"] == 2
+    assert activity["unique_commands_truncated"] is True
+
+
+def test_prepare_input_workspace_rejects_symlink_escaping_input(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig, prepare_input_workspace
+
+    job = tmp_path / "job"
+    job.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    job.joinpath("escape.txt").symlink_to(outside)
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=job,
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+
+    try:
+        prepare_input_workspace(config)
+    except RuntimeError as exc:
+        assert "symlink escapes input directory" in str(exc)
+    else:
+        raise AssertionError("job input symlinks that escape the input directory should be rejected")
+
+
+def test_validate_input_symlinks_does_not_traverse_symlinked_directory_loop(tmp_path):
+    if not hasattr(os, "symlink"):
+        return
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import validate_input_symlinks
+
+    job = tmp_path / "job"
+    job.mkdir()
+    job.joinpath("loop").symlink_to(job, target_is_directory=True)
+
+    validate_input_symlinks(job)
+
+
+def test_prepare_prompt_hashes_copied_prompt_file(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig, prepare_prompt
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("convert this job\n", encoding="utf-8")
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=prompt,
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=tmp_path / ".agent",
+        agent_model_was_explicit=False,
+    )
+
+    prepare_prompt(config)
+
+    copied = config.prompt_file_path.read_bytes()
+    metadata = json.loads((result_dir / "prompt_metadata.json").read_text(encoding="utf-8"))
+    expected_hash = hashlib.sha256(copied).hexdigest()
+    assert metadata["template_sha256"] == expected_hash
+    assert metadata["prompt_sha256"] == expected_hash
+    assert metadata["template_bytes"] == len(copied)
+    assert metadata["prompt_bytes"] == len(copied)
+    assert metadata["verbatim_copy"] is True
+
+
+def test_setup_skill_availability_allows_missing_optional_metadata(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        setup_skill_availability,
+    )
+
+    codex_home = tmp_path / ".codex"
+    result_dir = tmp_path / "results"
+    skill_dir = codex_home / "skills" / "nvflare-convert-pytorch"
+    skill_dir.mkdir(parents=True)
+    result_dir.mkdir()
+
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="codex",
+        agent_model="test-model",
+        agent_home=codex_home,
+        agent_model_was_explicit=True,
+    )
+
+    setup_skill_availability(config)
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    missing = json.loads((result_dir / "skills_metadata_missing.json").read_text(encoding="utf-8"))
+    assert state["status"] == "prepared"
+    assert state["skills_enabled"] is True
+    assert sorted(Path(item).name for item in missing["missing"]) == [
+        "skills_build_install.json",
+        "skills_list.json",
+    ]
+    assert not (result_dir / "skills_build_install.json").exists()
+
+
+def test_skill_exposure_carries_launch_args_and_environment(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import SkillExposureSpec
+    from assist_tools.skills_benchmark.skills.harness.container.skills import apply_skill_exposure
+
+    skill_root = tmp_path / "skills"
+    (skill_root / "nvflare-convert-pytorch").mkdir(parents=True)
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+
+    result = apply_skill_exposure(
+        spec=SkillExposureSpec(
+            mechanism_type="launch_flag",
+            container_home=tmp_path,
+            skill_root=skill_root,
+            launch_args=["--add-dir", str(skill_root)],
+            environment={"AGENT_SKILLS_DIR": str(skill_root)},
+        ),
+        skills_enabled=True,
+        result_dir=result_dir,
+        sdk_image_kind="test-skills",
+    )
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "prepared"
+    assert result.status == "prepared"
+    assert result.launch_args == ["--add-dir", str(skill_root)]
+    assert result.environment == {"AGENT_SKILLS_DIR": str(skill_root)}
+
+
+def test_skill_exposure_action_timeout_writes_failure_state(tmp_path, monkeypatch):
+    import subprocess
+
+    from assist_tools.skills_benchmark.skills.harness.container import skills
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"], output="partial output\n")
+
+    monkeypatch.setattr(skills.subprocess, "run", timeout_run)
+
+    try:
+        skills.run_exposure_action(["agent", "skills", "install"], result_dir, "setup_action", {})
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("timed out exposure action should abort skill exposure")
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    output = (result_dir / "skills_setup_action_output.txt").read_text(encoding="utf-8")
+    assert state["reason"] == "action_timeout"
+    assert state["action_name"] == "setup_action"
+    assert state["timeout_seconds"] == skills.EXPOSURE_ACTION_TIMEOUT_SECONDS
+    assert state["output_ref"].endswith("skills_setup_action_output.txt")
+    assert output == "partial output\n"
+
+
+def test_skill_exposure_rejects_skill_root_outside_container_home(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import SkillExposureSpec
+    from assist_tools.skills_benchmark.skills.harness.container.skills import apply_skill_exposure
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    outside = tmp_path / "outside"
+
+    try:
+        apply_skill_exposure(
+            spec=SkillExposureSpec(
+                mechanism_type="preinstalled_home",
+                container_home=tmp_path / "agent_home",
+                skill_root=outside,
+            ),
+            skills_enabled=False,
+            result_dir=result_dir,
+            sdk_image_kind="test-baseline",
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("out-of-scope skill_root should fail before removal")
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    assert state["reason"] == "skill_root_outside_container_home"
+    assert state["skill_root"] == str(outside)
+
+
+def test_skill_exposure_rejects_metadata_file_outside_container_home(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import SkillExposureSpec
+    from assist_tools.skills_benchmark.skills.harness.container.skills import apply_skill_exposure
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    container_home = tmp_path / "agent_home"
+    skill_root = container_home / "skills"
+    (skill_root / "nvflare-convert-pytorch").mkdir(parents=True)
+    outside_metadata = tmp_path / "outside.json"
+    outside_metadata.write_text("{}\n", encoding="utf-8")
+
+    try:
+        apply_skill_exposure(
+            spec=SkillExposureSpec(
+                mechanism_type="preinstalled_home",
+                container_home=container_home,
+                skill_root=skill_root,
+                metadata_files=[outside_metadata],
+            ),
+            skills_enabled=True,
+            result_dir=result_dir,
+            sdk_image_kind="test-skills",
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("metadata files outside container_home should not be copied to results")
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    assert state["reason"] == "metadata_file_outside_container_home"
+    assert state["metadata_file"] == str(outside_metadata)
+
+
+def test_skill_exposure_requires_container_home_when_skill_root_is_configured(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import SkillExposureSpec
+    from assist_tools.skills_benchmark.skills.harness.container.skills import apply_skill_exposure
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    skill_root = tmp_path / "skills"
+
+    try:
+        apply_skill_exposure(
+            spec=SkillExposureSpec(mechanism_type="preinstalled_home", skill_root=skill_root),
+            skills_enabled=False,
+            result_dir=result_dir,
+            sdk_image_kind="test-baseline",
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("configured skill_root without container_home should fail before removal")
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    assert state["reason"] == "container_home_required_for_skill_root"
+
+
+def test_skill_exposure_rejects_bundled_root_outside_workspace(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import SkillExposureSpec
+    from assist_tools.skills_benchmark.skills.harness.container.skills import apply_skill_exposure
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    container_home = tmp_path / "home"
+    skill_root = container_home / "skills"
+
+    try:
+        apply_skill_exposure(
+            spec=SkillExposureSpec(
+                mechanism_type="preinstalled_home",
+                container_home=container_home,
+                skill_root=skill_root,
+                disable_packaged_source=True,
+            ),
+            skills_enabled=False,
+            result_dir=result_dir,
+            sdk_image_kind="test-baseline",
+            bundled_skills_root=lambda: str(tmp_path / "unsafe-bundled-source"),
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("out-of-scope bundled skill root should fail before removal")
+
+    state = json.loads((result_dir / "skills_state.json").read_text(encoding="utf-8"))
+    assert state["reason"] == "bundled_skill_source_outside_workspace"
+
+
+def test_copy_optional_metadata_files_preserves_generic_names(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import copy_optional_metadata_files
+
+    source_dir = tmp_path / "source"
+    result_dir = tmp_path / "results"
+    source_dir.mkdir()
+    result_dir.mkdir()
+    (source_dir / "skills_list.json").write_text('{"installed": []}\n', encoding="utf-8")
+
+    payload = copy_optional_metadata_files(
+        source_dir,
+        result_dir,
+        ("skills_list.json", "skills_build_install.json"),
+    )
+
+    assert (result_dir / "skills_list.json").read_text(encoding="utf-8") == '{"installed": []}\n'
+    assert payload["copied"] == [
+        {
+            "source": str(source_dir / "skills_list.json"),
+            "target": str(result_dir / "skills_list.json"),
+        }
+    ]
+    assert payload["missing"] == [str(source_dir / "skills_build_install.json")]
+
+
+def test_copy_optional_metadata_files_rejects_path_traversal(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import copy_optional_metadata_files
+
+    source_dir = tmp_path / "source"
+    result_dir = tmp_path / "results"
+    source_dir.mkdir()
+    result_dir.mkdir()
+
+    try:
+        copy_optional_metadata_files(source_dir, result_dir, ("../unsafe.json",))
+    except ValueError as exc:
+        assert "path separators" in str(exc)
+    else:
+        raise AssertionError("metadata file names must not traverse outside the source dir")
+
+
+def test_available_skill_names_skips_symlinked_skill_directories(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    agent_home = tmp_path / "agent-home"
+    skills_root = agent_home / "skills"
+    outside = tmp_path / "outside-skills"
+    skills_root.mkdir(parents=True)
+    outside.mkdir()
+    (skills_root / "nvflare-real").mkdir()
+    try:
+        (skills_root / "nvflare-linked").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return
+    monkeypatch.setenv("BENCHMARK_AGENT_HOME", str(agent_home))
+
+    assert records.available_skill_names() == {"nvflare-real"}
+
+
+def test_infer_from_events_scores_installed_skill_names_in_single_pass(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    monkeypatch.setattr(records, "available_skill_names", lambda: {"nvflare-a", "nvflare-b"})
+
+    inferred = records.infer_from_events("nvflare-a did work. nvflare-b helped. nvflare-b finished.")
+
+    assert inferred["skill"] == "nvflare-b"
+    assert inferred["skill_source"] == "installed_skill_name_seen_in_events"
+
+
+def test_infer_from_events_uses_case_id_boundaries(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    monkeypatch.setattr(records, "available_skill_names", lambda: {"nvflare-a"})
+    monkeypatch.setattr(records, "eval_case_ids_for_skill", lambda _skill: ["basic", "basic-v2"])
+
+    inferred = records.infer_from_events("nvflare-a ran case basic-v2 successfully.")
+
+    assert inferred["case_id"] == "basic-v2"
+
+
+def test_eval_case_ids_for_skill_skips_oversized_evals_json(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    agent_home = tmp_path / "agent-home"
+    evals_dir = agent_home / "skills" / "nvflare-a" / "evals"
+    evals_dir.mkdir(parents=True)
+    with evals_dir.joinpath("evals.json").open("wb") as stream:
+        stream.truncate(records.MAX_EVALS_FILE_BYTES + 1)
+    monkeypatch.setenv("BENCHMARK_AGENT_HOME", str(agent_home))
+    monkeypatch.setattr(
+        records,
+        "load_json",
+        lambda _path, default=None: (_ for _ in ()).throw(AssertionError("oversized evals should not load")),
+    )
+
+    assert records.eval_case_ids_for_skill("nvflare-a") == []
+
+
+def test_load_text_caps_bytes(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.records import load_text
+
+    path = tmp_path / "events.jsonl"
+    path.write_bytes(b"abcdef")
+
+    assert load_text(path, max_bytes=3) == "abc"
+
+
+def test_synthesize_agent_record_caps_event_text_for_identity(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    monkeypatch.setattr(records, "MAX_EVENTS_TEXT_BYTES", 8)
+    monkeypatch.setattr(records, "available_skill_names", lambda: {"nvflare-large"})
+    monkeypatch.setattr(records, "eval_case_ids_for_skill", lambda _skill: [])
+    records_dir = tmp_path / "records"
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    usage_path = tmp_path / "usage.json"
+    activity_path = tmp_path / "activity.json"
+    events_path = tmp_path / "agent_events.jsonl"
+    last_message_path = tmp_path / "agent_last_message.txt"
+    workspace_delta_path = tmp_path / "workspace_delta_manifest.json"
+    usage_path.write_text("{}\n", encoding="utf-8")
+    activity_path.write_text("{}\n", encoding="utf-8")
+    events_path.write_text("prefixxx nvflare-large should not be read\n", encoding="utf-8")
+    last_message_path.write_text("done\n", encoding="utf-8")
+    workspace_delta_path.write_text("{}\n", encoding="utf-8")
+    agent_record_path = records_dir / "with_skills_agent_record.json"
+
+    records.synthesize_agent_record(
+        records.AgentRecordSynthesisInputs(
+            agent_record_path=agent_record_path,
+            records_dir=records_dir,
+            events_path=events_path,
+            usage_path=usage_path,
+            activity_path=activity_path,
+            last_message_path=last_message_path,
+            input_dir=input_dir,
+            mode="with_skills",
+            elapsed_seconds=1,
+            agent_exit=0,
+            skills_enabled=True,
+            skill_run_mode="with_skills",
+            agent="codex",
+            agent_model="test-model",
+            run_start_time_ns=0,
+            workspace_delta_manifest_path=workspace_delta_path,
+        )
+    )
+
+    record = json.loads(agent_record_path.read_text(encoding="utf-8"))
+    assert "skill" not in record
+    assert record["event_identity_inference"]["skill"] == ""
+
+
+def test_iter_json_records_enforces_file_count_limit(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    for index in range(3):
+        (tmp_path / f"record-{index}.json").write_text(
+            json.dumps({"skill": "nvflare-test", "case_id": f"case-{index}"}),
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(records, "MAX_JSON_RECORD_FILES", 1)
+
+    loaded = list(records.iter_json_records(tmp_path))
+
+    assert len(loaded) == 1
+
+
+def test_iter_json_records_skips_oversized_json_files(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    small = tmp_path / "small.json"
+    small.write_text(json.dumps({"skill": "nvflare-test"}), encoding="utf-8")
+    (tmp_path / "large.json").write_text(
+        json.dumps({"skill": "nvflare-large-value-that-exceeds-the-limit"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(records, "MAX_JSON_RECORD_FILE_BYTES", small.stat().st_size)
+
+    loaded = list(records.iter_json_records(tmp_path))
+
+    assert [record["skill"] for _path, record in loaded] == ["nvflare-test"]
+
+
+def test_iter_json_records_file_count_limit_ignores_oversized_skips(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    small = tmp_path / "small.json"
+    small.write_text(json.dumps({"skill": "nvflare-test"}), encoding="utf-8")
+    oversized = tmp_path / "oversized.json"
+    oversized.write_text(json.dumps({"skill": "nvflare-oversized", "payload": "too-large"}), encoding="utf-8")
+    monkeypatch.setattr(records, "MAX_JSON_RECORD_FILES", 1)
+    monkeypatch.setattr(records, "MAX_JSON_RECORD_FILE_BYTES", small.stat().st_size)
+
+    loaded = list(records.iter_json_records(tmp_path))
+
+    assert [record["skill"] for _path, record in loaded] == ["nvflare-test"]
+
+
+def test_iter_json_records_does_not_traverse_symlinked_directories(tmp_path):
+    if not hasattr(os, "symlink"):
+        return
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside.joinpath("external.json").write_text(json.dumps({"skill": "external"}), encoding="utf-8")
+    records_root = tmp_path / "records"
+    records_root.mkdir()
+    records_root.joinpath("local.json").write_text(json.dumps({"skill": "local"}), encoding="utf-8")
+    records_root.joinpath("linked").symlink_to(outside, target_is_directory=True)
+
+    loaded = list(records.iter_json_records(records_root))
+
+    assert [record["skill"] for _path, record in loaded] == ["local"]
+
+
+def test_login_shell_runtime_probe_uses_configured_venv_path(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+
+    class ProbeResult:
+        returncode = 0
+        stdout = "\n".join(
+            [
+                "PATH=/custom/venv/bin:/usr/bin",
+                "python=/custom/venv/bin/python",
+                "sdk_import_name=example_sdk",
+                "sdk_import_version=9.9",
+            ]
+        )
+
+    class VersionResult:
+        returncode = 0
+        stdout = "Example SDK 9.9\n"
+
+    calls = []
+
+    def fake_run(command, *args, **kwargs):
+        calls.append(command)
+        return ProbeResult() if len(calls) == 1 else VersionResult()
+
+    monkeypatch.setenv("BENCHMARK_CONTAINER_VENV_DIR", "/custom/venv")
+    monkeypatch.setenv("SDK_IMPORT_NAME", "example_sdk")
+    monkeypatch.setenv("SDK_VERSION_COMMAND", "example-sdk --version")
+    monkeypatch.setattr(agent_run.subprocess, "run", fake_run)
+
+    probe = agent_run.login_shell_runtime_probe()
+
+    assert probe["ok"] is True
+    assert probe["expected_python"] == "/custom/venv/bin/python"
+    assert probe["sdk_import_name"] == "example_sdk"
+    assert probe["sdk_import_version"] == "9.9"
+    assert calls[1] == ["example-sdk", "--version"]
+    assert probe["sdk_version_exit_code"] == 0
+    assert probe["sdk_version_output"] == "Example SDK 9.9"
+
+
+def test_login_shell_runtime_probe_does_not_shell_interpolate_sdk_version_command(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+
+    class ProbeResult:
+        returncode = 0
+        stdout = "\n".join(["PATH=/custom/venv/bin:/usr/bin", "python=/custom/venv/bin/python"])
+
+    class VersionResult:
+        returncode = 0
+        stdout = "version output\n"
+
+    calls = []
+
+    def fake_run(command, *args, **kwargs):
+        calls.append(command)
+        return ProbeResult() if len(calls) == 1 else VersionResult()
+
+    monkeypatch.setenv("BENCHMARK_CONTAINER_VENV_DIR", "/custom/venv")
+    monkeypatch.setenv("SDK_VERSION_COMMAND", "example-sdk --version; rm -rf /workspace")
+    monkeypatch.setattr(agent_run.subprocess, "run", fake_run)
+
+    probe = agent_run.login_shell_runtime_probe()
+
+    assert calls[0] == ["/bin/bash", "-lc", calls[0][2]]
+    assert "rm -rf" not in calls[0][2]
+    assert calls[1] == ["example-sdk", "--version;", "rm", "-rf", "/workspace"]
+    assert probe["sdk_version_output"] == "version output"
+
+
+def test_runtime_metadata_skips_login_shell_probe_when_launch_does_not_require_it(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchSpec
+    from assist_tools.skills_benchmark.skills.harness.container import agent_run
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        persist_container_runtime_metadata,
+    )
+
+    result_dir = tmp_path / "results"
+    agent_home = tmp_path / ".agent"
+    result_dir.mkdir()
+    agent_home.mkdir()
+    (agent_home / "sdk_wheel_metadata.json").write_text(
+        json.dumps({"sdk_name": "example", "variant": "skills"}, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="test",
+        agent_model="test-model",
+        agent_home=agent_home,
+        agent_model_was_explicit=False,
+    )
+    launch = AgentLaunchSpec(
+        argv=["agent", "run"],
+        cwd=tmp_path,
+        prompt_file=tmp_path / "prompt.txt",
+        prompt_input_mode="stdin",
+        stdout_events_dest=result_dir / "agent_events.jsonl",
+        stderr_dest=result_dir / "agent_stderr.txt",
+        final_message_dest=result_dir / "agent_last_message.txt",
+        login_shell=False,
+    )
+    monkeypatch.setattr(agent_run, "command_output", lambda _command: None)
+
+    def fail_probe():
+        raise AssertionError("login shell probe should be skipped")
+
+    monkeypatch.setattr(agent_run, "login_shell_runtime_probe", fail_probe)
+
+    persist_container_runtime_metadata(config, launch)
+
+    metadata = json.loads((result_dir / "runtime_image.json").read_text(encoding="utf-8"))
+    assert metadata["login_shell_required"] is False
+    assert metadata["login_shell_runtime_probe"]["reason"] == "skipped_adapter_does_not_use_login_shell"
+    assert metadata["sdk_wheel_metadata"]["sdk_name"] == "example"
+    assert (result_dir / "sdk_wheel_metadata.json").is_file()
+
+
+def test_finalize_timing_uses_named_lifecycle_epochs(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.timing import LifecycleEpochs, finalize_timing
+
+    summary_path = tmp_path / "run_summary.json"
+    record_path = tmp_path / "record.json"
+    activity_path = tmp_path / "agent_activity.json"
+    timing_path = tmp_path / "timing.json"
+    write_json(summary_path, {"process_metrics": {}})
+    write_json(record_path, {"process_metrics": {}})
+    write_json(activity_path, {"event_count": 3, "command_count": 2})
+
+    finalize_timing(
+        summary_path,
+        record_path,
+        timing_path,
+        activity_path,
+        LifecycleEpochs(
+            script_start=10,
+            skill_availability_start=11,
+            skill_availability_end=13,
+            input_copy_start=13,
+            input_copy_end=17,
+            prompt_prep_start=18,
+            prompt_prep_end=20,
+            agent_start=21,
+            agent_end=31,
+            post_process_start=31,
+            post_process_end=35,
+            report_outcome_start=36,
+            report_outcome_end=37,
+            script_end=40,
+        ),
+    )
+
+    timing = json.loads(timing_path.read_text(encoding="utf-8"))
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert timing["phase_seconds"] == {
+        "container_elapsed_seconds": 30,
+        "setup_elapsed_seconds": 11,
+        "skill_exposure_elapsed_seconds": 2,
+        "input_copy_elapsed_seconds": 4,
+        "prompt_prepare_elapsed_seconds": 2,
+        "agent_elapsed_seconds": 10,
+        "post_process_elapsed_seconds": 4,
+        "report_elapsed_seconds": 1,
+    }
+    assert summary["activity"]["event_count"] == 3
+    assert summary["activity"]["command_count"] == 2
+    assert record["process_metrics"]["phase_seconds"]["agent_elapsed_seconds"] == 10
+
+
+def test_finalize_timing_does_not_partially_replace_when_staging_fails(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.timing import LifecycleEpochs, finalize_timing
+
+    summary_path = tmp_path / "run_summary.json"
+    timing_path = tmp_path / "timing.json"
+    activity_path = tmp_path / "agent_activity.json"
+    record_path = tmp_path / "missing_parent" / "record.json"
+    summary_text = '{"old_summary": true}\n'
+    timing_text = '{"old_timing": true}\n'
+    summary_path.write_text(summary_text, encoding="utf-8")
+    timing_path.write_text(timing_text, encoding="utf-8")
+    activity_path.write_text("{}\n", encoding="utf-8")
+
+    try:
+        finalize_timing(
+            summary_path,
+            record_path,
+            timing_path,
+            activity_path,
+            LifecycleEpochs(
+                script_start=10,
+                skill_availability_start=11,
+                skill_availability_end=13,
+                input_copy_start=13,
+                input_copy_end=17,
+                prompt_prep_start=18,
+                prompt_prep_end=20,
+                agent_start=21,
+                agent_end=31,
+                post_process_start=31,
+                post_process_end=35,
+                report_outcome_start=36,
+                report_outcome_end=37,
+                script_end=40,
+            ),
+        )
+    except OSError:
+        pass
+    else:
+        raise AssertionError("missing record parent should fail before replacing timing artifacts")
+
+    assert summary_path.read_text(encoding="utf-8") == summary_text
+    assert timing_path.read_text(encoding="utf-8") == timing_text
+
+
+def test_atomic_json_writer_cleans_staged_temp_file_when_dump_fails(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import timing
+
+    def fail_json_dump(*_args, **_kwargs):
+        raise TypeError("cannot serialize")
+
+    monkeypatch.setattr(timing.json, "dump", fail_json_dump)
+
+    try:
+        timing._write_json_files_atomic({tmp_path / "out.json": {"bad": object()}})
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("json dump failure should propagate")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_failure_record_outputs_early_failure_artifacts(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import write_failure_record
+
+    result_dir = tmp_path / "results"
+    records_dir = result_dir / "records"
+
+    exit_code = write_failure_record(
+        result_dir=result_dir,
+        records_dir=records_dir,
+        mode="with_skills",
+        exit_code=2,
+        error_type="RuntimeError",
+        message="prompt missing",
+        phase="input_validation",
+        agent="codex",
+        agent_model="test-model",
+        skills_enabled=True,
+    )
+
+    record = json.loads((records_dir / "with_skills_record.json").read_text(encoding="utf-8"))
+    early = json.loads((result_dir / "early_failure.json").read_text(encoding="utf-8"))
+    summary = json.loads((result_dir / "run_summary.json").read_text(encoding="utf-8"))
+    assert exit_code == 2
+    assert record["harness_failure"] is True
+    assert record["harness_error"]["phase"] == "input_validation"
+    assert record["final_container_exit_code"] == 2
+    assert early["record_path"] == str(records_dir / "with_skills_record.json")
+    assert summary["harness_failure"] is True
+    assert summary["final_container_exit_code"] == 2
+
+
+def test_write_failure_record_defaults_to_unknown_agent(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import write_failure_record
+
+    result_dir = tmp_path / "results"
+    records_dir = result_dir / "records"
+
+    write_failure_record(
+        result_dir=result_dir,
+        records_dir=records_dir,
+        mode="with_skills",
+        exit_code=2,
+        error_type="RuntimeError",
+        message="config failed",
+        phase="config",
+    )
+
+    record = json.loads((records_dir / "with_skills_record.json").read_text(encoding="utf-8"))
+    assert record["agent"] == "unknown"
+    assert record["process_metrics"]["agent_elapsed_seconds"] == 0
+
+
+def test_merge_harness_failure_preserves_existing_record(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import AgentRunConfig, merge_harness_failure
+
+    result_dir = tmp_path / "results"
+    records_dir = result_dir / "records"
+    records_dir.mkdir(parents=True)
+    final_record = records_dir / "with_skills_record.json"
+    write_json(
+        final_record,
+        {
+            "mode": "with_skills",
+            "agent_process_passed": True,
+            "agent_process_exit_code": 0,
+            "process_metrics": {"elapsed_seconds": 12},
+        },
+    )
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=records_dir,
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="codex",
+        agent_model="test-model",
+        agent_home=tmp_path / ".codex",
+        agent_model_was_explicit=True,
+    )
+
+    exit_code = merge_harness_failure(config, RuntimeError("post process failed"), 1, "post_process")
+
+    record = json.loads(final_record.read_text(encoding="utf-8"))
+    late = json.loads((result_dir / "late_harness_failure.json").read_text(encoding="utf-8"))
+    summary = json.loads((result_dir / "run_summary.json").read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert record["agent_process_passed"] is True
+    assert record["process_metrics"]["elapsed_seconds"] == 12
+    assert record["harness_error"]["phase"] == "post_process"
+    assert record["harness_errors"][0]["message"] == "post process failed"
+    assert late["preserved_existing_record"] is True
+    assert summary["harness_failure"] is True
+    assert summary["harness_errors"][0]["phase"] == "post_process"
+
+
+def test_pair_result_root_cleanup_removes_legacy_eval_artifacts(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host.runner import clean_pair_result_root
+
+    result_root = tmp_path / "result"
+    result_root.mkdir()
+    for name in ("with_skills_eval_on", "with_skills_eval_off", "process_eval_runs", "without_skills", "with_skills"):
+        path = result_root / name
+        path.mkdir()
+        path.joinpath("old.txt").write_text("stale\n", encoding="utf-8")
+    result_root.joinpath("comprehensive_report.md").write_text("Benchmark Metrics Comparison\n", encoding="utf-8")
+    result_root.joinpath("metrics_summary.json").write_text("{}\n", encoding="utf-8")
+    result_root.joinpath("user_note.txt").write_text("keep\n", encoding="utf-8")
+
+    clean_pair_result_root(result_root)
+
+    assert not result_root.joinpath("with_skills_eval_on").exists()
+    assert not result_root.joinpath("with_skills_eval_off").exists()
+    assert not result_root.joinpath("process_eval_runs").exists()
+    assert not result_root.joinpath("without_skills").exists()
+    assert not result_root.joinpath("with_skills").exists()
+    assert not result_root.joinpath("comprehensive_report.md").exists()
+    assert not result_root.joinpath("metrics_summary.json").exists()
+    assert result_root.joinpath("user_note.txt").read_text(encoding="utf-8") == "keep\n"

--- a/tests/unit_test/skills_benchmark/skills_benchmark_scenarios_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_scenarios_test.py
@@ -1,0 +1,1190 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+from pathlib import Path
+
+import yaml
+
+
+def write_prompt_and_job(tmp_path: Path) -> tuple[Path, Path]:
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("Convert this job with the workflow named in the benchmark prompt.\n", encoding="utf-8")
+    job = tmp_path / "ames"
+    job.mkdir(exist_ok=True)
+    job.joinpath("README.md").write_text("Synthetic job fixture.\n", encoding="utf-8")
+    return prompt, job
+
+
+def base_scenario(tmp_path: Path) -> dict:
+    prompt, job = write_prompt_and_job(tmp_path)
+    return {
+        "name": "ci smoke scaffold",
+        "prompt": prompt.name,
+        "agents": [{"name": "codex", "models": ["gpt-test"]}],
+        "comparison": {"type": "mode_ablation", "modes": ["without_skills", "with_skills"]},
+        "workflows": [{"name": "SCAFFOLD"}],
+        "jobs": [{"path": job.name, "scale": "small"}],
+    }
+
+
+def test_mode_ablation_expands_modes_and_target_record_paths(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+    scenario = compilation.scenario
+    run_plan = compilation.run_plan
+    entries = run_plan["entries"]
+
+    expected_prompt_hash = hashlib.sha256((tmp_path / "prompt.txt").read_bytes()).hexdigest()
+    assert scenario["name"] == "ci smoke scaffold"
+    assert scenario["prompt"]["sha256"] == expected_prompt_hash
+    assert scenario["reproducibility"]["prompt_hash"] == expected_prompt_hash
+    assert scenario["reproducibility"]["image_targets"]["codex"]["skills"] == "agent-skills-benchmark:codex-skills"
+    assert scenario["reproducibility"]["agent_versions"]["codex"]["AGENT_CLI_NAME"] == "codex"
+    assert scenario["reproducibility"]["agent_versions"]["codex"]["AGENT_VERSION_COMMAND"] == "codex --version"
+    assert scenario["reproducibility"]["wheel_variants"] == [
+        "local_wheel_with_preinstalled_skills",
+        "local_wheel_without_packaged_skills",
+    ]
+    assert run_plan["run_count"] == 2
+    assert run_plan["comparison_group_count"] == 1
+    assert [entry["mode"] for entry in entries] == [
+        "without_skills",
+        "with_skills",
+    ]
+    assert {entry["prompt_hash"] for entry in entries} == {expected_prompt_hash}
+    assert entries[0]["record_dir"] == (
+        "records/agent=codex/model=gpt_test/workflow=scaffold/job=ames/mode=without_skills"
+    )
+    assert entries[1]["skills_enabled"] is True
+    assert run_plan["comparison_groups"][0]["compared_run_ids"] == ["run_00001", "run_00002"]
+
+
+def test_compile_scenario_file_writes_scenario_and_run_plan(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario_file
+
+    raw = base_scenario(tmp_path)
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    output_dir = tmp_path / "compiled"
+
+    compilation = compile_scenario_file(scenario_path)
+    compilation.write(output_dir)
+
+    scenario_json = json.loads((output_dir / "scenario.json").read_text(encoding="utf-8"))
+    run_plan_json = json.loads((output_dir / "run_plan.json").read_text(encoding="utf-8"))
+    assert scenario_json["source_path"] == str(scenario_path.resolve())
+    assert run_plan_json["source_path"] == str(scenario_path.resolve())
+    assert run_plan_json["run_count"] == 2
+
+
+def test_scenario_reproducibility_records_profile_image_targets(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    scenario = compile_scenario(base_scenario(tmp_path), base_dir=tmp_path).scenario
+
+    assert scenario["reproducibility"]["image_targets"]["codex"] == {
+        "skills": "agent-skills-benchmark:codex-skills",
+        "baseline": "agent-skills-benchmark:codex-baseline",
+        "report": "agent-skills-benchmark:codex-skills",
+    }
+
+
+def test_prompt_path_must_stay_inside_scenario_directory(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    base_dir = tmp_path / "scenario"
+    base_dir.mkdir()
+    raw = base_scenario(base_dir)
+    outside_prompt = tmp_path / "outside_prompt.txt"
+    outside_prompt.write_text("secret prompt\n", encoding="utf-8")
+    raw["prompt"] = str(outside_prompt)
+
+    try:
+        compile_scenario(raw, base_dir=base_dir)
+    except ScenarioValidationError as exc:
+        assert "Prompt file must stay within scenario directory" in str(exc)
+    else:
+        raise AssertionError("absolute prompt paths outside the scenario directory should be rejected")
+
+
+def test_prompt_template_renders_only_explicit_variables(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    template = tmp_path / "prompt_template.txt"
+    template.write_text("Convert {job_name} with metric {metric}.\n", encoding="utf-8")
+    raw["prompt"] = {
+        "template": template.name,
+        "variables": {"job_name": "ames", "metric": "AUROC"},
+    }
+
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+    prompt = compilation.scenario["prompt"]
+    rendered_bytes = b"Convert ames with metric AUROC.\n"
+    expected_hash = hashlib.sha256(rendered_bytes).hexdigest()
+
+    assert prompt["source_type"] == "template"
+    assert prompt["source_path"] == str(template.resolve())
+    assert prompt["sha256"] == expected_hash
+    assert prompt["rendered_sha256"] == expected_hash
+    assert prompt["bytes"] == len(rendered_bytes)
+    assert prompt["path"] == str(template.resolve())
+    assert not (tmp_path / ".agent_benchmark").exists()
+    assert {entry["prompt_hash"] for entry in compilation.run_plan["entries"]} == {expected_hash}
+
+    result_root = tmp_path / "results"
+    materialized = compilation.write(result_root)
+    written_scenario = json.loads((result_root / "scenario.json").read_text(encoding="utf-8"))
+    written_run_plan = json.loads((result_root / "run_plan.json").read_text(encoding="utf-8"))
+    rendered_path = Path(written_scenario["prompt"]["path"])
+
+    assert rendered_path.is_relative_to((result_root / ".agent_benchmark" / "rendered_prompts").resolve())
+    assert rendered_path.read_bytes() == rendered_bytes
+    assert "_rendered_text" not in written_scenario["prompt"]
+    assert {entry["prompt_source"] for entry in written_run_plan["entries"]} == {str(rendered_path)}
+    assert {entry["prompt_source"] for entry in materialized.run_plan["entries"]} == {str(rendered_path)}
+
+
+def test_prompt_path_with_variables_is_rendered_as_template(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("Convert {job_name}.\n", encoding="utf-8")
+    raw["prompt"] = {"path": prompt.name, "variables": {"job_name": "ames"}}
+
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+
+    assert compilation.scenario["prompt"]["source_type"] == "template"
+    assert compilation.scenario["prompt"]["path"] == str(prompt.resolve())
+    materialized = compilation.write(tmp_path / "results")
+    assert Path(materialized.scenario["prompt"]["path"]).read_text(encoding="utf-8") == "Convert ames.\n"
+
+
+def test_inline_prompt_template_string_is_rejected(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["prompt"] = "Convert {job_name}."
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "prompt must be a file path, not an inline template string" in str(exc)
+        assert "prompt.template" in str(exc)
+    else:
+        raise AssertionError("inline prompt template strings should be rejected with a targeted error")
+
+
+def test_execute_run_plan_materializes_template_prompt_under_result_root(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    raw["path_budget"] = 400
+    template = tmp_path / "prompt_template.txt"
+    template.write_text("Convert {job_name}.\n", encoding="utf-8")
+    raw["prompt"] = {"template": template.name, "variables": {"job_name": "ames"}}
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+    result_root = tmp_path / "results"
+    observed_prompt_paths = []
+
+    def fake_run_case(config, *, logs=(), prefix=None):
+        observed_prompt_paths.append(config.prompt_path)
+        records_dir = config.result_dir / "records"
+        records_dir.mkdir(parents=True, exist_ok=True)
+        write_json(
+            config.result_dir / "run_summary.json",
+            {
+                "agent_process_passed": True,
+                "final_container_exit_code": 0,
+                "source_input_immutable_policy": {"status": "pass"},
+                "required_validation_metric_status": "not_required",
+            },
+        )
+        write_json(config.result_dir / "container_exit_code.json", {"exit_code": 0})
+        write_json(
+            records_dir / f"{config.mode}_record.json",
+            {
+                "agent_process_passed": True,
+                "final_container_exit_code": 0,
+                "source_input_immutable_policy": {"status": "pass"},
+                "process_metrics": {"agent_elapsed_seconds": 1},
+            },
+        )
+        return 0
+
+    monkeypatch.setattr(runner, "run_case_safely", fake_run_case)
+    monkeypatch.setattr(runner, "inspect_docker_image", lambda image: (True, ""))
+
+    runner.execute_run_plan(compilation, result_root=result_root)
+
+    assert not (tmp_path / ".agent_benchmark").exists()
+    assert len(observed_prompt_paths) == 1
+    rendered_prompt = observed_prompt_paths[0]
+    assert rendered_prompt.is_relative_to((result_root / ".agent_benchmark" / "rendered_prompts").resolve())
+    assert rendered_prompt.read_text(encoding="utf-8") == "Convert ames.\n"
+    run_plan = json.loads((result_root / "run_plan.json").read_text(encoding="utf-8"))
+    assert run_plan["entries"][0]["prompt_source"] == str(rendered_prompt)
+
+
+def test_prompt_template_rejects_missing_unsafe_and_non_scalar_variables(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    template = tmp_path / "prompt_template.txt"
+    template.write_text("Convert {job.name} with {metric}.\n", encoding="utf-8")
+    raw = base_scenario(tmp_path)
+    raw["prompt"] = {"template": template.name, "variables": {"metric": "AUROC"}}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "attribute or index access" in str(exc)
+    else:
+        raise AssertionError("prompt templates should reject attribute access")
+
+    template.write_text("Convert {job_name} with {metric}.\n", encoding="utf-8")
+    raw["prompt"] = {"template": template.name, "variables": {"job_name": "ames"}}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "missing variable" in str(exc)
+        assert "metric" in str(exc)
+    else:
+        raise AssertionError("prompt templates should reject missing variables")
+
+    raw["prompt"] = {"template": template.name, "variables": {"job_name": "ames", "metric": ["AUROC"]}}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "prompt.variables.metric" in str(exc)
+        assert "scalar" in str(exc)
+    else:
+        raise AssertionError("prompt templates should reject non-scalar variables")
+
+
+def test_prompt_template_literal_brace_errors_explain_escaping(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    template = tmp_path / "prompt_template.txt"
+    template.write_text('Return JSON like {"metric": "AUROC"}.\n', encoding="utf-8")
+    raw["prompt"] = {"template": template.name}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        message = str(exc)
+        assert "literal braces" in message
+        assert "{{" in message
+        assert "}}" in message
+    else:
+        raise AssertionError("prompt templates should explain literal brace escaping")
+
+    template.write_text('Return JSON like {{"metric": "AUROC"}} for {job_name}.\n', encoding="utf-8")
+    raw["prompt"] = {"template": template.name, "variables": {"job_name": "ames"}}
+
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+
+    assert compilation.scenario["prompt"]["_rendered_text"] == 'Return JSON like {"metric": "AUROC"} for ames.\n'
+
+
+def test_model_comparison_expands_comparison_models(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "codex"}]
+    raw["comparison"] = {
+        "type": "model_comparison",
+        "agent": "codex",
+        "mode": "with_skills",
+        "models": ["gpt-a", "gpt-b"],
+    }
+    run_plan = compile_scenario(raw, base_dir=tmp_path).run_plan
+
+    assert run_plan["run_count"] == 2
+    assert run_plan["comparison_group_count"] == 1
+    assert [entry["agent_model"] for entry in run_plan["entries"]] == ["gpt-a", "gpt-b"]
+    assert [entry["model_source"] for entry in run_plan["entries"]] == ["comparison", "comparison"]
+    assert "model=gpt_a" in run_plan["entries"][0]["record_dir"]
+    assert "model=gpt_b" in run_plan["entries"][1]["record_dir"]
+
+
+def test_model_comparison_dedupes_overlapping_top_level_models(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "codex", "models": ["gpt-a", "gpt-b"]}]
+    raw["comparison"] = {
+        "type": "model_comparison",
+        "agent": "codex",
+        "mode": "with_skills",
+        "models": ["gpt-a", "gpt-b"],
+    }
+    run_plan = compile_scenario(raw, base_dir=tmp_path).run_plan
+
+    assert "model=gpt_a/" in run_plan["entries"][0]["record_dir"]
+    assert "model=gpt_b/" in run_plan["entries"][1]["record_dir"]
+
+
+def test_model_slug_fallback_avoids_unhandled_missing_key():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import model_slug_for
+
+    assert model_slug_for({"models": {}}, "codex", "gpt-test") == "gpt_test"
+
+
+def test_model_slug_key_is_visible_and_agent_scoped():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import model_slug_for, model_slug_key
+
+    codex_key = model_slug_key("codex", "shared/model")
+    claude_key = model_slug_key("claude", "shared/model")
+    slugs = {"models": {codex_key: "shared_model_codex", claude_key: "shared_model_claude"}}
+
+    assert "\0" not in codex_key
+    assert model_slug_for(slugs, "codex", "shared/model") == "shared_model_codex"
+    assert model_slug_for(slugs, "claude", "shared/model") == "shared_model_claude"
+
+
+def test_slug_collisions_hash_original_values(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    job_a = tmp_path / "my-job"
+    job_b = tmp_path / "my job"
+    job_a.mkdir()
+    job_b.mkdir()
+    raw["jobs"] = [
+        {"name": "my-job", "path": job_a.name, "scale": "small"},
+        {"name": "my job", "path": job_b.name, "scale": "small"},
+    ]
+    entries = compile_scenario(raw, base_dir=tmp_path).run_plan["entries"]
+    job_slugs = {entry["job_slug"] for entry in entries}
+
+    assert len(job_slugs) == 2
+    assert all(job_slug.startswith("my_job_") for job_slug in job_slugs)
+    assert len({entry["record_dir"] for entry in entries}) == len(entries)
+
+
+def test_missing_job_scale_is_rejected(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["jobs"][0].pop("scale")
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "jobs[0].scale" in str(exc)
+    else:
+        raise AssertionError("scenario validation must require explicit job scale")
+
+
+def test_fail_fast_requires_boolean(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["fail_fast"] = "false"
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "fail_fast must be a boolean" in str(exc)
+    else:
+        raise AssertionError("scenario validation must reject string fail_fast values")
+
+
+def test_quality_gate_override_is_recorded_and_applied(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario, quality_gate_failures
+
+    raw = base_scenario(tmp_path)
+    raw["quality_gate"] = {"required_validation_metric_status": ["present"]}
+
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+
+    assert compilation.scenario["quality_gate"]["required_validation_metric_status"] == ["present"]
+    assert compilation.run_plan["quality_gate"]["required_validation_metric_status"] == ["present"]
+    failures = quality_gate_failures(
+        {
+            "agent_process_passed": True,
+            "final_container_exit_code": 0,
+            "source_input_immutable_policy": {"status": "pass"},
+            "required_validation_metric_status": "not_required",
+        },
+        {},
+        0,
+        compilation.run_plan["quality_gate"],
+    )
+    assert "required_validation_metric_status=not_required" in failures
+
+
+def test_quality_gate_rejects_unknown_fields(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["quality_gate"] = {"unknown_check": True}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "quality_gate.unknown_check" in str(exc)
+    else:
+        raise AssertionError("unknown scenario quality-gate fields should fail validation")
+
+
+def test_resource_policy_non_integer_values_are_validation_errors(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["resource_policy"] = {"small": {"agent_timeout_seconds": "fast"}}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "resource_policy.small.agent_timeout_seconds" in str(exc)
+        assert "must be an integer greater than 0" in str(exc)
+    else:
+        raise AssertionError("non-integer scenario resource policy values should fail validation")
+
+    job_policy_case = tmp_path / "job-policy"
+    job_policy_case.mkdir()
+    raw = base_scenario(job_policy_case)
+    raw["jobs"][0]["resource_policy"] = {"agent_timeout_seconds": None}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "jobs[0].resource_policy.agent_timeout_seconds" in str(exc)
+        assert "must be an integer greater than 0" in str(exc)
+    else:
+        raise AssertionError("non-integer job resource policy values should fail validation")
+
+
+def test_resource_policy_rejects_bool_and_non_positive_values(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["resource_policy"] = {"small": {"agent_timeout_seconds": False}}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "resource_policy.small.agent_timeout_seconds" in str(exc)
+        assert "must be an integer greater than 0" in str(exc)
+    else:
+        raise AssertionError("boolean resource policy values should fail validation")
+
+    zero_case = tmp_path / "zero-policy"
+    zero_case.mkdir()
+    raw = base_scenario(zero_case)
+    raw["jobs"][0]["resource_policy"] = {"container_timeout_seconds": 0}
+
+    try:
+        compile_scenario(raw, base_dir=zero_case)
+    except ScenarioValidationError as exc:
+        assert "jobs[0].resource_policy.container_timeout_seconds" in str(exc)
+        assert "must be an integer greater than 0" in str(exc)
+    else:
+        raise AssertionError("zero resource policy values should fail validation")
+
+
+def test_prompt_file_size_guard_rejects_large_prompt(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import (
+        MAX_PROMPT_BYTES,
+        ScenarioValidationError,
+        compile_scenario,
+    )
+
+    raw = base_scenario(tmp_path)
+    prompt_path = tmp_path / raw["prompt"]
+    with prompt_path.open("wb") as stream:
+        stream.truncate(MAX_PROMPT_BYTES + 1)
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "Prompt file exceeds max size" in str(exc)
+    else:
+        raise AssertionError("scenario prompt files should be size-limited before read_bytes")
+
+
+def test_prompt_file_size_guard_uses_read_bytes_length(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import (
+        MAX_PROMPT_BYTES,
+        ScenarioValidationError,
+        compile_scenario,
+    )
+
+    raw = base_scenario(tmp_path)
+    prompt_path = tmp_path / raw["prompt"]
+    original_read_bytes = Path.read_bytes
+
+    def fake_read_bytes(path):
+        if path == prompt_path:
+            return b"x" * (MAX_PROMPT_BYTES + 1)
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "Prompt file exceeds max size" in str(exc)
+    else:
+        raise AssertionError("scenario prompt files should be capped by bytes read, not a stale stat")
+
+
+def test_validate_path_budget_uses_longest_path_not_lexicographic_max():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, validate_path_budget
+
+    short_late_path = "zz"
+    long_early_path = "a" * 80
+    budget = len(str(Path("results") / "path-budget" / short_late_path)) + 1
+
+    try:
+        validate_path_budget(
+            "path budget",
+            [{"artifact_paths": {"short": short_late_path, "long": long_early_path}}],
+            budget,
+        )
+    except ScenarioValidationError as exc:
+        assert long_early_path in str(exc)
+        assert "path_budget" in str(exc)
+    else:
+        raise AssertionError("path budget validation must check the longest rendered artifact path")
+
+
+def test_validate_path_budget_can_use_actual_result_root():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, validate_path_budget
+
+    result_root = Path("r" * 40)
+    artifact_path = "short.txt"
+    synthetic_budget = len(str(Path("results") / "path-budget" / artifact_path)) + 1
+
+    try:
+        validate_path_budget(
+            "path budget",
+            [{"artifact_paths": {"short": artifact_path}}],
+            synthetic_budget,
+            result_root=result_root,
+        )
+    except ScenarioValidationError as exc:
+        assert str(result_root) in str(exc)
+    else:
+        raise AssertionError("path budget validation should include the actual result root when provided")
+
+
+def test_quality_gate_failures_reports_missing_final_exit_as_not_recorded():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import quality_gate_failures
+
+    failures = quality_gate_failures(
+        {"agent_process_passed": True, "source_input_immutable_policy": {"status": "pass"}},
+        {},
+        0,
+    )
+
+    assert "final_container_exit_code=not_recorded" in failures
+    assert "final_container_exit_code=None" not in failures
+
+
+def test_quality_gate_failures_derives_missing_required_validation_metric():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import quality_gate_failures
+
+    record = {
+        "agent_process_passed": True,
+        "final_container_exit_code": 0,
+        "source_input_immutable_policy": {"status": "pass"},
+        "quality_signals": {
+            "job_guidance_primary_validation_metric": {
+                "expected_primary_metric": "AUROC",
+                "metric_value_available": False,
+                "reported_validation_metric": {"name": None, "value": None, "reported_values": []},
+            }
+        },
+    }
+
+    failures = quality_gate_failures({}, record, 0)
+
+    assert "required_validation_metric_status=missing" in failures
+
+
+def test_quality_gate_failures_derives_critical_quality_check_failure():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import quality_gate_failures
+
+    record = {
+        "agent_process_passed": True,
+        "final_container_exit_code": 0,
+        "source_input_immutable_policy": {"status": "pass"},
+        "quality_checks": [{"severity": "critical", "status": "fail"}],
+    }
+
+    failures = quality_gate_failures({}, record, 0)
+
+    assert "critical_quality_checks_failed" in failures
+
+
+def test_known_pending_agent_is_rejected(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "hermes"}]
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "BENCHMARK_AGENT='hermes'" in str(exc)
+        assert "known but not implemented" in str(exc)
+    else:
+        raise AssertionError("known-pending agents should fail preflight")
+
+
+def test_claude_scenario_requires_explicit_model(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "claude"}]
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "requires an explicit benchmark model" in str(exc)
+        assert "BENCHMARK_AGENT_MODEL" in str(exc)
+    else:
+        raise AssertionError("Claude scenarios must require an explicit model")
+
+
+def test_agent_comparison_requires_unambiguous_model_selection(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "codex", "models": ["gpt-a", "gpt-b"]}]
+    raw["comparison"] = {"type": "agent_comparison", "mode": "with_skills", "agents": ["codex"]}
+
+    try:
+        compile_scenario(raw, base_dir=tmp_path)
+    except ScenarioValidationError as exc:
+        assert "ambiguous" in str(exc)
+        assert "models_by_agent" in str(exc)
+    else:
+        raise AssertionError("agent comparison must reject ambiguous model selection")
+
+
+def test_agent_comparison_models_by_agent_resolves_single_model(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "codex", "models": ["gpt-a", "gpt-b"]}]
+    raw["comparison"] = {
+        "type": "agent_comparison",
+        "mode": "with_skills",
+        "agents": ["codex"],
+        "models_by_agent": {"codex": "gpt-b"},
+    }
+    run_plan = compile_scenario(raw, base_dir=tmp_path).run_plan
+
+    assert run_plan["run_count"] == 1
+    assert run_plan["entries"][0]["agent_model"] == "gpt-b"
+    assert run_plan["entries"][0]["model_source"] == "comparison.models_by_agent"
+
+
+def test_execute_run_plan_writes_canonical_records_and_scenario_summary(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["path_budget"] = 400
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+    result_root = tmp_path / "results"
+
+    def fake_run_case(config, *, logs=(), prefix=None):
+        records_dir = config.result_dir / "records"
+        records_dir.mkdir(parents=True, exist_ok=True)
+        write_json(
+            config.result_dir / "run_summary.json",
+            {
+                "mode": config.mode,
+                "agent": config.agent,
+                "agent_model": config.agent_model,
+                "skills_enabled": config.use_preinstalled_skills,
+                "agent_elapsed_seconds": 2 if config.use_preinstalled_skills else 3,
+                "token_count": 10,
+                "agent_process_passed": True,
+                "final_container_exit_code": 0,
+                "source_input_immutable_policy": {"status": "pass"},
+                "validation_metric_status": "not_required",
+                "required_validation_metric_status": "not_required",
+            },
+        )
+        write_json(config.result_dir / "container_exit_code.json", {"exit_code": 0})
+        write_json(
+            config.result_dir / "runtime_image.json",
+            {
+                "runtime_image": "runtime-image",
+                "sdk_image_kind": "skills" if config.use_preinstalled_skills else "baseline",
+            },
+        )
+        write_json(config.result_dir / "agent_activity.json", {"command_count": 2})
+        write_json(records_dir / f"{config.mode}_agent_record.json", {"mode": config.mode})
+        write_json(
+            records_dir / f"{config.mode}_record.json",
+            {
+                "mode": config.mode,
+                "agent": config.agent,
+                "agent_model": config.agent_model,
+                "agent_process_passed": True,
+                "final_container_exit_code": 0,
+                "source_input_immutable_policy": {"status": "pass"},
+                "process_metrics": {
+                    "agent_elapsed_seconds": 2 if config.use_preinstalled_skills else 3,
+                    "elapsed_seconds": 2 if config.use_preinstalled_skills else 3,
+                    "token_count": 10,
+                    "agent_exit_code": 0,
+                },
+            },
+        )
+        return 0
+
+    monkeypatch.setattr(runner, "run_case_safely", fake_run_case)
+    monkeypatch.setattr(runner, "inspect_docker_image", lambda image: (True, ""))
+
+    statuses, summary = runner.execute_run_plan(compilation, result_root=result_root)
+
+    first_record_dir = result_root / compilation.run_plan["entries"][0]["record_dir"]
+    assert statuses == {"run_00001": 0, "run_00002": 0}
+    assert (result_root / "scenario.json").is_file()
+    assert (result_root / "run_plan.json").is_file()
+    assert json.loads((result_root / "docker_image_preflight.json").read_text(encoding="utf-8"))["status"] == "pass"
+    assert (first_record_dir / "record_summary.json").is_file()
+    assert (first_record_dir / "benchmark_record.json").is_file()
+    assert not (result_root / "without_skills").exists()
+    assert summary["status"] == "passed"
+    assert "aggregate_metrics" in summary
+    assert summary["aggregate_results"]["winner"]["label"] == "with_skills"
+    first_record_summary = json.loads((first_record_dir / "record_summary.json").read_text(encoding="utf-8"))
+    assert first_record_summary["scenario_name"] == raw["name"]
+    assert first_record_summary["runtime_image"] == "runtime-image"
+    assert first_record_summary["wheel_variant"] == "baseline"
+    assert first_record_summary["command_count"] == 2
+    assert "validation_metric_status" in first_record_summary
+    assert (result_root / "reports" / "scenario_report.md").is_file()
+
+
+def test_execute_run_plan_fails_preflight_before_missing_docker_image(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import runner
+    from assist_tools.skills_benchmark.skills.harness.scenarios import ScenarioValidationError, compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    raw["path_budget"] = 400
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+    result_root = tmp_path / "results"
+    called = {"run_case": False}
+
+    monkeypatch.setattr(runner, "inspect_docker_image", lambda image: (False, "image not found"))
+
+    def fake_run_case(*args, **kwargs):
+        called["run_case"] = True
+        return 0
+
+    monkeypatch.setattr(runner, "run_case_safely", fake_run_case)
+
+    try:
+        runner.execute_run_plan(compilation, result_root=result_root)
+    except ScenarioValidationError as exc:
+        assert "Benchmark Docker image(s) are missing locally" in str(exc)
+    else:
+        raise AssertionError("missing Docker images should fail before any benchmark run starts")
+
+    assert called["run_case"] is False
+    preflight = json.loads((result_root / "docker_image_preflight.json").read_text(encoding="utf-8"))
+    assert preflight["status"] == "fail"
+    assert preflight["missing_images"] == ["agent-skills-benchmark:codex-skills"]
+    summary = json.loads((result_root / "scenario_summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "failed"
+    assert summary["harness_failure"]["failure_category"] == "harness_preflight_failure"
+    assert (result_root / "reports" / "scenario_report.json").is_file()
+
+
+def test_scenario_summary_failed_when_all_runs_fail_quality_gate(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario, write_scenario_summaries
+
+    raw = base_scenario(tmp_path)
+    raw["path_budget"] = 400
+    compilation = compile_scenario(raw, base_dir=tmp_path).write(tmp_path / "results")
+    result_root = tmp_path / "results"
+    statuses = {}
+    for entry in compilation.run_plan["entries"]:
+        record_dir = result_root / entry["record_dir"]
+        record_dir.mkdir(parents=True)
+        statuses[entry["run_id"]] = 1
+        write_json(record_dir / "container_exit_code.json", {"exit_code": 1})
+        write_json(record_dir / "record_summary.json", {"agent_process_passed": False, "final_container_exit_code": 1})
+
+    summary = write_scenario_summaries(result_root, statuses)
+
+    assert summary["status"] == "failed"
+    assert summary["failed_run_count"] == 2
+
+
+def test_scenario_summary_degraded_when_fail_fast_leaves_runs_unexecuted(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario, write_scenario_summaries
+
+    raw = base_scenario(tmp_path)
+    raw["fail_fast"] = True
+    raw["path_budget"] = 400
+    compilation = compile_scenario(raw, base_dir=tmp_path).write(tmp_path / "results")
+    result_root = tmp_path / "results"
+    first_entry = compilation.run_plan["entries"][0]
+    record_dir = result_root / first_entry["record_dir"]
+    record_dir.mkdir(parents=True)
+    write_json(record_dir / "container_exit_code.json", {"exit_code": 1})
+    write_json(record_dir / "record_summary.json", {"agent_process_passed": False, "final_container_exit_code": 1})
+
+    summary = write_scenario_summaries(result_root, {first_entry["run_id"]: 1})
+
+    assert summary["status"] == "degraded"
+    assert summary["completed_run_count"] == 1
+    assert summary["failed_run_count"] == 2
+
+
+def test_scenario_summary_failed_when_report_generation_fails(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import scenarios
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+
+    raw = base_scenario(tmp_path)
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    compilation = scenarios.compile_scenario(raw, base_dir=tmp_path).write(tmp_path / "results")
+    result_root = tmp_path / "results"
+    entry = compilation.run_plan["entries"][0]
+    record_dir = result_root / entry["record_dir"]
+    record_dir.mkdir(parents=True)
+    write_json(record_dir / "container_exit_code.json", {"exit_code": 0})
+    write_json(
+        record_dir / "record_summary.json",
+        {
+            "agent_process_passed": True,
+            "final_container_exit_code": 0,
+            "source_input_immutable_policy": {"status": "pass"},
+            "required_validation_metric_status": "not_required",
+        },
+    )
+    monkeypatch.setattr(
+        scenarios,
+        "write_scenario_report",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("render failed")),
+    )
+
+    summary = scenarios.write_scenario_summaries(result_root, {entry["run_id"]: 0})
+
+    assert summary["status"] == "failed"
+    assert summary["report_generation_status"]["status"] == "failed"
+    assert "render failed" in summary["report_generation_status"]["message"]
+
+
+def test_scenario_summary_keeps_report_generation_pending_in_memory_only(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import scenarios
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+
+    raw = base_scenario(tmp_path)
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    compilation = scenarios.compile_scenario(raw, base_dir=tmp_path).write(tmp_path / "results")
+    result_root = tmp_path / "results"
+    entry = compilation.run_plan["entries"][0]
+    record_dir = result_root / entry["record_dir"]
+    record_dir.mkdir(parents=True)
+    write_json(record_dir / "container_exit_code.json", {"exit_code": 0})
+    write_json(
+        record_dir / "record_summary.json",
+        {
+            "agent_process_passed": True,
+            "final_container_exit_code": 0,
+            "source_input_immutable_policy": {"status": "pass"},
+            "required_validation_metric_status": "not_required",
+        },
+    )
+
+    def assert_pending_report_status(root, _summary):
+        assert _summary["report_generation_status"]["status"] == "pending"
+        assert not (root / "scenario_summary.json").exists()
+
+    monkeypatch.setattr(scenarios, "write_scenario_report", assert_pending_report_status)
+
+    summary = scenarios.write_scenario_summaries(result_root, {entry["run_id"]: 0})
+
+    assert summary["report_generation_status"]["status"] == "ok"
+    saved = json.loads((result_root / "scenario_summary.json").read_text(encoding="utf-8"))
+    assert saved["report_generation_status"]["status"] == "ok"
+
+
+def test_scenario_summary_replaces_stale_summary_atomically(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import scenarios
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+
+    raw = base_scenario(tmp_path)
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    compilation = scenarios.compile_scenario(raw, base_dir=tmp_path).write(tmp_path / "results")
+    result_root = tmp_path / "results"
+    (result_root / "scenario_summary.json").write_text('{"status": "stale"}', encoding="utf-8")
+    entry = compilation.run_plan["entries"][0]
+    record_dir = result_root / entry["record_dir"]
+    record_dir.mkdir(parents=True)
+    write_json(record_dir / "container_exit_code.json", {"exit_code": 0})
+    write_json(
+        record_dir / "record_summary.json",
+        {
+            "agent_process_passed": True,
+            "final_container_exit_code": 0,
+            "source_input_immutable_policy": {"status": "pass"},
+            "required_validation_metric_status": "not_required",
+        },
+    )
+
+    summary = scenarios.write_scenario_summaries(result_root, {entry["run_id"]: 0})
+
+    saved = json.loads((result_root / "scenario_summary.json").read_text(encoding="utf-8"))
+    assert saved["status"] == summary["status"]
+    assert saved["status"] != "stale"
+    assert saved["report_generation_status"]["status"] == "ok"
+    assert not (result_root / ".scenario_summary.json.tmp").exists()
+
+
+def test_scenario_summary_records_per_entry_summary_exception(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import scenario_summaries, scenarios
+
+    raw = base_scenario(tmp_path)
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    raw["quality_gate"] = {"required_validation_metric_status": ["present"]}
+    compilation = scenarios.compile_scenario(raw, base_dir=tmp_path).write(tmp_path / "results")
+    result_root = tmp_path / "results"
+    entry = compilation.run_plan["entries"][0]
+
+    def fail_run_summary(*_args, **_kwargs):
+        raise RuntimeError("bad record payload")
+
+    monkeypatch.setattr(scenario_summaries, "run_summary_for_entry", fail_run_summary)
+
+    summary = scenario_summaries.write_scenario_summaries(
+        result_root,
+        {entry["run_id"]: 1},
+        report_writer=lambda *_args, **_kwargs: None,
+    )
+
+    saved = json.loads((result_root / "scenario_summary.json").read_text(encoding="utf-8"))
+    run = summary["runs"][0]
+    assert saved["runs"][0]["status"] == "failed"
+    assert run["quality_gate_failures"] == ["run_summary_generation_failed"]
+    assert run["quality_gate"]["final_container_exit_code"] == 0
+    assert run["quality_gate"]["required_validation_metric_status"] == ["present"]
+    assert run["summary_generation_error"]["error_type"] == "RuntimeError"
+    assert "bad record payload" in run["summary_generation_error"]["message"]
+
+
+def test_scenario_summary_ignores_missing_run_id_when_indexing_runs(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import scenario_summaries
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+
+    result_root = tmp_path / "results"
+    result_root.mkdir()
+    run_plan = {
+        "schema_version": "1",
+        "scenario_name": "missing run id",
+        "comparison_type": "mode_ablation",
+        "quality_gate": {"final_container_exit_code": 0},
+        "entries": [
+            {"mode": "without_skills", "record_dir": "records/missing"},
+            {"run_id": "run_00001", "mode": "with_skills", "record_dir": "records/valid"},
+        ],
+        "comparison_groups": [
+            {
+                "comparison_group_id": "group_001",
+                "comparison_type": "mode_ablation",
+                "compared_run_ids": ["None", "run_00001"],
+            }
+        ],
+    }
+    write_json(result_root / "run_plan.json", run_plan)
+    write_json(result_root / "scenario.json", {"name": "missing run id"})
+
+    def fake_run_summary(_root, entry, _statuses, _quality_gate):
+        return {
+            "run_id": entry.get("run_id"),
+            "mode": entry["mode"],
+            "record_dir": entry["record_dir"],
+            "quality_gate_passed": entry.get("run_id") == "run_00001",
+            "agent_elapsed_seconds": 1.0 if entry.get("run_id") == "run_00001" else None,
+        }
+
+    monkeypatch.setattr(scenario_summaries, "run_summary_for_entry", fake_run_summary)
+
+    summary = scenario_summaries.write_scenario_summaries(
+        result_root,
+        {"run_00001": 0},
+        report_writer=lambda *_args, **_kwargs: None,
+    )
+
+    compared = summary["comparison_groups"][0]["compared_runs"]
+    assert [run["run_id"] for run in compared] == ["run_00001"]
+
+
+def test_write_json_atomic_removes_temp_file_when_write_fails(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.scenario_summaries import write_json_atomic
+
+    target = tmp_path / "scenario_summary.json"
+    tmp_file = tmp_path / ".scenario_summary.json.tmp"
+    original_write_text = Path.write_text
+
+    def fail_after_partial_write(self, data, *args, **kwargs):
+        if self == tmp_file:
+            original_write_text(self, "partial", encoding="utf-8")
+            raise OSError("disk full")
+        return original_write_text(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_after_partial_write)
+
+    try:
+        write_json_atomic(target, {"status": "ok"})
+    except OSError as exc:
+        assert "disk full" in str(exc)
+    else:
+        raise AssertionError("partial temp write failure should propagate")
+
+    assert not tmp_file.exists()
+    assert not target.exists()
+
+
+def test_comparison_group_summary_ignores_non_numeric_token_count():
+    from assist_tools.skills_benchmark.skills.harness.scenarios import comparison_group_summary
+
+    group = {
+        "comparison_group_id": "group_001",
+        "comparison_type": "mode_ablation",
+        "compared_run_ids": ["run_00001", "run_00002"],
+    }
+    runs_by_id = {
+        "run_00001": {
+            "run_id": "run_00001",
+            "mode": "without_skills",
+            "quality_gate_passed": True,
+            "agent_elapsed_seconds": 2,
+            "token_count": {"bad": "shape"},
+        },
+        "run_00002": {
+            "run_id": "run_00002",
+            "mode": "with_skills",
+            "quality_gate_passed": True,
+            "agent_elapsed_seconds": 3,
+            "token_count": 1,
+        },
+    }
+
+    summary = comparison_group_summary(group, runs_by_id)
+
+    assert summary["winner"]["run_id"] == "run_00001"
+
+
+def test_aggregate_results_sorts_missing_token_median_last():
+    from assist_tools.skills_benchmark.skills.harness.scenario_summaries import aggregate_results
+
+    summary = aggregate_results(
+        [
+            {
+                "mode": "without_skills",
+                "quality_gate_passed": True,
+                "agent_elapsed_seconds": 2,
+                "token_count": None,
+            },
+            {
+                "mode": "with_skills",
+                "quality_gate_passed": True,
+                "agent_elapsed_seconds": 2,
+                "token_count": 5,
+            },
+        ]
+    )
+
+    assert summary["winner"]["label"] == "with_skills"
+
+
+def test_replay_result_root_regenerates_agent_parser_artifacts(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.host.runner import replay_result_root
+    from assist_tools.skills_benchmark.skills.harness.scenarios import compile_scenario
+
+    raw = base_scenario(tmp_path)
+    raw["agents"] = [{"name": "claude", "models": ["claude-test"]}]
+    raw["comparison"] = {"type": "one", "mode": "with_skills"}
+    compilation = compile_scenario(raw, base_dir=tmp_path)
+    result_root = tmp_path / "captured"
+    compilation.write(result_root)
+    entry = compilation.run_plan["entries"][0]
+    record_dir = result_root / entry["record_dir"]
+    record_dir.mkdir(parents=True)
+    adapter = load_agent_adapter("claude")
+    raw_events = [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "name": "Bash", "input": {"command": "python job.py"}}],
+                "usage": {"input_tokens": 1, "output_tokens": 2},
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "usage": {"input_tokens": 4, "output_tokens": 5},
+            "total_cost_usd": 0.01,
+        },
+    ]
+    with (record_dir / "agent_events.jsonl").open("w", encoding="utf-8") as stream:
+        for event in raw_events:
+            stream.write(json.dumps(adapter.normalize_event(json.dumps(event))) + "\n")
+    write_json(record_dir / "run_summary.json", {"agent_process_passed": True, "final_container_exit_code": 0})
+    write_json(record_dir / "container_exit_code.json", {"exit_code": 0})
+    records_dir = record_dir / "records"
+    records_dir.mkdir()
+    write_json(records_dir / "with_skills_record.json", {"agent_process_passed": True, "final_container_exit_code": 0})
+
+    summary = replay_result_root(result_root)
+
+    usage = json.loads((record_dir / "agent_usage.json").read_text(encoding="utf-8"))
+    activity = json.loads((record_dir / "agent_activity.json").read_text(encoding="utf-8"))
+    replay_metadata = json.loads((result_root / "replay_metadata.json").read_text(encoding="utf-8"))
+    assert usage["total_tokens"] == 9
+    assert usage["cost"] == 0.01
+    assert activity["commands"] == ["python job.py"]
+    assert replay_metadata["replayed"] is True
+    assert replay_metadata["agent_invocation"] == "replayed"
+    assert summary["is_replay"] is True
+    assert summary["agent_invocation"] == "replayed"
+    assert summary["replay"]["source_result_root"] == str(result_root.resolve())
+    assert (record_dir / "record_summary.json").is_file()
+    assert summary["completed_run_count"] == 1
+    report_json = json.loads((result_root / "reports" / "scenario_report.json").read_text(encoding="utf-8"))
+    report_markdown = (result_root / "reports" / "scenario_report.md").read_text(encoding="utf-8")
+    assert report_json["agent_invocation"] == "replayed"
+    assert "Replay: `true`" in report_markdown
+    assert "Agent invocation: `replayed`" in report_markdown


### PR DESCRIPTION
## Summary

Adds the skills benchmark runtime: host entrypoints, pair/replay/scenario execution, scenario compilation, canonical result records, quality gates, and runtime tests.

## Key Scope

- Add `bin/run.sh` host entrypoint and pair/replay/scenario command handling.
- Add host/container execution flow and canonical result layout under benchmark result roots.
- Add scenario compilation, prompt materialization, run-plan expansion, repeat handling, and scenario summaries.
- Add artifact capture, record normalization, benchmark records, and quality gate support.
- Add runtime, host runner, records, and scenario tests split by functionality.

## Review Notes

This PR depends on the Docker/profile setup from PR #4789. It intentionally stops at producing normalized evidence and canonical records; report generation is isolated in PR #5.

## Stack

This is PR 4 of 5. It is based on `flare-agent-split/03-benchmark-docker-setup` / PR #4789.

## Full Split Plan

| PR | Title | Branch | Base | Non-Test Files | Test Files | Non-Test Lines | Test Lines | Total Lines |
|---:|---|---|---|---:|---:|---:|---:|---:|
| 1 | Agent Skills + Checks | `flare-agent-split/01-agent-skills` | `main` | 41 | 8 | 5,397 | 1,321 | 6,718 |
| 2 | Agent CLI | `flare-agent-split/02-agent-cli` | PR 1 | 11 | 8 | 4,362 | 2,488 | 6,850 |
| 3 | Benchmark Docker Setup | `flare-agent-split/03-benchmark-docker-setup` | PR 2 | 29 | 3 | 4,015 | 1,417 | 5,432 |
| 4 | Skill Benchmark Runtime | `flare-agent-split/04-benchmark-runtime` | PR 3 | 25 | 5 | 9,927 | 3,654 | 13,581 |
| 5 | Benchmark Reporting | `flare-agent-split/05-benchmark-reporting` | PR 4 | 3 | 1 | 2,016 | 1,037 | 3,053 |

## Validation

- `python -m pytest tests/unit_test/tool/agent tests/unit_test/tool/agent_skill_checks tests/unit_test/skills_benchmark`
- `./runtest.sh -s`