### PR TITLE
Add skills benchmark reporting

### DIFF
--- a/assist_tools/skills_benchmark/skills/harness/host/runner.py
+++ b/assist_tools/skills_benchmark/skills/harness/host/runner.py
@@ -30,6 +30,7 @@ from typing import Iterable
 from ..agents.registry import DEFAULT_BENCHMARK_AGENT, load_agent_adapter
 from ..common import load_json, write_json
 from ..modes import PAIR_RUNS, mode_spec
+from ..reports import benchmark_insights, metrics_report
 from ..scenarios import (
     ScenarioCompilation,
     ScenarioValidationError,
@@ -85,6 +86,7 @@ STALE_RESULT_DIRS = (
     "with_skills_eval_off",
     "with_skills_eval_on",
 )
+BENCHMARK_METRICS_TITLE = "Agent Skills Benchmark Metrics"
 
 
 @dataclass(frozen=True)
@@ -736,11 +738,67 @@ def replay_result_root(result_root: Path, *, logs: Iterable[Path] = ()) -> dict[
     return write_scenario_summaries(result_root, statuses)
 
 
-def write_host_report_status(result_root: Path) -> None:
+def write_report_generator_status(result_root: Path, statuses: dict[str, int]) -> None:
+    write_json(
+        result_root / "report_generator_status.json",
+        {
+            "status": "ok" if all(status == 0 for status in statuses.values()) else "failed",
+            "exit_codes": statuses,
+        },
+    )
+
+
+def write_benchmark_reports(result_root: Path, *, logs: Iterable[Path] = ()) -> dict[str, int]:
+    statuses: dict[str, int] = {}
+    try:
+        metrics_report.write_reports(result_root, BENCHMARK_METRICS_TITLE)
+    except Exception as exc:
+        write_host_error(result_root / "metrics_report_error.json", exc)
+        emit(f"Metrics report failed: {type(exc).__name__}: {exc}", logs=logs, stderr=True)
+        statuses["metrics_report"] = 1
+    else:
+        statuses["metrics_report"] = 0
+
+    try:
+        runs = benchmark_insights.collect_benchmark_runs(result_root)
+        (result_root / "benchmark_insights.md").write_text(
+            benchmark_insights.benchmark_report(result_root, runs),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        write_host_error(result_root / "benchmark_insights_error.json", exc)
+        emit(f"Benchmark insights report failed: {type(exc).__name__}: {exc}", logs=logs, stderr=True)
+        statuses["benchmark_insights"] = 1
+    else:
+        statuses["benchmark_insights"] = 0
+
+    write_report_generator_status(result_root, statuses)
+    return statuses
+
+
+def emit_benchmark_report_paths(result_root: Path, *, logs: Iterable[Path] = ()) -> None:
+    emit(f"Benchmark insights: {result_root / 'benchmark_insights.md'}", logs=logs)
+    emit(f"Metrics report: {result_root / 'metrics_report.md'}", logs=logs)
+    emit(f"Metrics HTML: {result_root / 'metrics_report.html'}", logs=logs)
+
+
+def write_host_report_status(result_root: Path, report_generator_statuses: dict[str, int] | None = None) -> None:
+    report_generator_statuses = report_generator_statuses or {}
     scenario_report = result_root / "reports" / "scenario_report.md"
+    benchmark_report = result_root / "benchmark_insights.md"
+    metrics_report_path = result_root / "metrics_report.md"
+    benchmark_reports_expected = bool(report_generator_statuses)
+    all_reports_ok = (
+        scenario_report.is_file()
+        and all(status == 0 for status in report_generator_statuses.values())
+        and (not benchmark_reports_expected or (benchmark_report.is_file() and metrics_report_path.is_file()))
+    )
     payload = {
-        "status": "ok" if scenario_report.is_file() else "missing_report",
+        "status": "ok" if all_reports_ok else "missing_report",
         "scenario_report": str(scenario_report),
+        "benchmark_insights": str(benchmark_report),
+        "metrics_report": str(metrics_report_path),
+        "report_generators": report_generator_statuses,
     }
     write_json(
         result_root / "host_report_status.json",
@@ -796,11 +854,14 @@ def run_pair(argv: list[str]) -> int:
 
     emit(f"Scenario summary: {result_root / 'scenario_summary.json'}", logs=logs)
     emit(f"Scenario report: {result_root / 'reports' / 'scenario_report.md'}", logs=logs)
-    write_host_report_status(result_root)
+    report_statuses = write_benchmark_reports(result_root, logs=logs)
+    emit_benchmark_report_paths(result_root, logs=logs)
+    write_host_report_status(result_root, report_statuses)
     return (
         1
         if any(status != 0 for status in run_statuses.values())
         or scenario_summary.get("status") in {"degraded", "failed"}
+        or any(status != 0 for status in report_statuses.values())
         else 0
     )
 
@@ -851,10 +912,16 @@ def run_replay(argv: list[str]) -> int:
     summary = replay_result_root(options.result_root, logs=logs)
     emit(f"Scenario summary: {options.result_root / 'scenario_summary.json'}", logs=logs)
     emit(f"Scenario report: {options.result_root / 'reports' / 'scenario_report.md'}", logs=logs)
-    write_host_report_status(options.result_root)
+    report_statuses = write_benchmark_reports(options.result_root, logs=logs)
+    emit_benchmark_report_paths(options.result_root, logs=logs)
+    write_host_report_status(options.result_root, report_statuses)
     # Replay regenerates artifacts from an existing result tree; it preserves
     # degraded benchmark status instead of re-asserting pass/fail.
-    return 0 if summary.get("status") in {"passed", "degraded"} else 1
+    return (
+        0
+        if summary.get("status") in {"passed", "degraded"} and all(status == 0 for status in report_statuses.values())
+        else 1
+    )
 
 
 def run_interactive(argv: list[str]) -> int:

--- a/assist_tools/skills_benchmark/skills/harness/reports/benchmark_insights.py
+++ b/assist_tools/skills_benchmark/skills/harness/reports/benchmark_insights.py
@@ -1,0 +1,1701 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Record-driven benchmark insight report."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from ..common import load_json
+from ..modes import BENCHMARK_RUNS, mode_names
+from ..quality_signals import (
+    canonical_metric_name,
+    is_fl_summary_metric_label,
+    is_numeric_metric_value,
+    metric_value_entries,
+    reported_metric_payload,
+)
+
+MODE_LABELS = {spec.mode: spec.label for spec in BENCHMARK_RUNS}
+REQUIRED_STRUCTURE_FILES = ("client.py", "model.py", "job.py")
+OPTIONAL_STRUCTURE_FILES = ("prepare_data.py", "download_data.py")
+CONFIG_STRUCTURE_SUFFIXES = (".cfg", ".ini", ".json", ".toml", ".yaml", ".yml")
+TREE_SOURCE_SUFFIXES = (".py",)
+TREE_RUNTIME_SUFFIXES = (".py",) + CONFIG_STRUCTURE_SUFFIXES
+OBSERVED_METRIC_NAMES = ("AUROC", "accuracy", "loss", "f1")
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+MAX_AGENT_EVENTS_TEXT_BYTES = 20 * 1024 * 1024
+
+
+def read_text(path: Path, *, max_bytes: int | None = None) -> str:
+    try:
+        if max_bytes is None:
+            return path.read_text(encoding="utf-8", errors="replace")
+        with path.open("rb") as stream:
+            return stream.read(max_bytes).decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def markdown_cell(value: Any) -> str:
+    text = "NA" if value is None or value == "" else str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def fmt_number(value: Any) -> str:
+    if isinstance(value, bool) or value is None:
+        return "NA"
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.4f}"
+
+
+def as_number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def fmt_short(value: Any) -> str:
+    number = as_number(value)
+    if number is None:
+        return "NA"
+    abs_value = abs(number)
+    sign = "-" if number < 0 else ""
+    if abs_value >= 1_000_000:
+        return f"{sign}{abs_value / 1_000_000:.1f}M"
+    if abs_value >= 1_000:
+        return f"{sign}{abs_value / 1_000:.1f}k"
+    return str(int(number)) if number.is_integer() else f"{number:.1f}"
+
+
+def fmt_percent(value: Any) -> str:
+    number = as_number(value)
+    if number is None:
+        return "NA"
+    return f"{number * 100:.0f}%"
+
+
+def truncate(value: Any, limit: int = 180) -> str:
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def mode_dir_for_benchmark(root: Path, mode: str) -> Path:
+    legacy = root / mode
+    if legacy.exists():
+        return legacy
+
+    run_plan = load_json(root / "run_plan.json", {}) or {}
+    entries = (
+        run_plan.get("entries") if isinstance(run_plan, dict) and isinstance(run_plan.get("entries"), list) else []
+    )
+    for entry in entries:
+        if not isinstance(entry, dict) or str(entry.get("mode")) != mode:
+            continue
+        record_dir = entry.get("record_dir")
+        if not record_dir:
+            continue
+        candidate = root / str(record_dir)
+        if candidate.exists():
+            return candidate
+
+    records_root = root / "records"
+    if records_root.exists():
+        matches = sorted(records_root.glob(f"**/mode={mode}"))
+        if matches:
+            return matches[0]
+    return legacy
+
+
+def final_record_path(root: Path, mode: str) -> Path:
+    mode_dir = mode_dir_for_benchmark(root, mode)
+    benchmark_record = mode_dir / "benchmark_record.json"
+    if benchmark_record.exists():
+        return benchmark_record
+    return mode_dir / "records" / f"{mode}_record.json"
+
+
+def validation_metric_from_record(record: dict[str, Any]) -> dict[str, Any]:
+    metric = record.get("reported_validation_metric")
+    if isinstance(metric, dict) and metric.get("name"):
+        return metric
+    quality = record.get("quality_signals")
+    if isinstance(quality, dict):
+        signal = quality.get("job_guidance_primary_validation_metric") or quality.get(
+            "readme_primary_validation_metric"
+        )
+        if isinstance(signal, dict):
+            metric = signal.get("reported_validation_metric")
+            if isinstance(metric, dict) and metric.get("name"):
+                return metric
+    return {}
+
+
+def filter_mode_console(console_text: str, mode: str) -> str:
+    if not console_text:
+        return ""
+    prefix = f"[{mode}] "
+    lines = []
+    for line in console_text.splitlines():
+        if line.startswith(prefix):
+            lines.append(line[len(prefix) :])
+    return "\n".join(lines)
+
+
+def collect_benchmark_runs(root: Path) -> dict[str, dict[str, Any]]:
+    console_text = read_text(root / "console_output.log")
+    runs: dict[str, dict[str, Any]] = {}
+    for spec in BENCHMARK_RUNS:
+        mode = spec.mode
+        mode_dir = mode_dir_for_benchmark(root, mode)
+        mode_console_text = read_text(root / f"{mode}.console.log") or filter_mode_console(console_text, mode)
+        summary = load_json(mode_dir / "run_summary.json", {}) if mode_dir.exists() else {}
+        record = load_json(final_record_path(root, mode), {}) if mode_dir.exists() else {}
+        if not isinstance(summary, dict):
+            summary = {}
+        if not isinstance(record, dict):
+            record = {}
+        runs[mode] = {
+            "available": mode_dir.exists(),
+            "mode": mode,
+            "label": spec.label,
+            "skills": "with skills" if spec.skills_enabled else "without skills",
+            "run": summary,
+            "record": record,
+            "container_exit": load_json(mode_dir / "container_exit_code.json", {}) if mode_dir.exists() else {},
+            "usage": load_json(mode_dir / "agent_usage.json", {}) if mode_dir.exists() else {},
+            "activity": load_json(mode_dir / "agent_activity.json", {}) if mode_dir.exists() else {},
+            "workspace_delta": load_json(mode_dir / "workspace_delta_manifest.json", {}) if mode_dir.exists() else {},
+            "runtime_image": load_json(mode_dir / "runtime_image.json", {}) if mode_dir.exists() else {},
+            "agent_last_message": read_text(mode_dir / "agent_last_message.txt") if mode_dir.exists() else "",
+            "agent_stderr": read_text(mode_dir / "agent_stderr.txt") if mode_dir.exists() else "",
+            "agent_events_text": (
+                read_text(mode_dir / "agent_events.jsonl", max_bytes=MAX_AGENT_EVENTS_TEXT_BYTES)
+                if mode_dir.exists()
+                else ""
+            ),
+            "console_text": mode_console_text,
+            "validation_metric": validation_metric_from_record(record),
+        }
+    return runs
+
+
+def exit_code(run: dict[str, Any]) -> int | None:
+    summary = run.get("run") if isinstance(run.get("run"), dict) else {}
+    container_exit = run.get("container_exit") if isinstance(run.get("container_exit"), dict) else {}
+    for value in (
+        summary.get("final_container_exit_code"),
+        summary.get("report_inclusive_exit_code"),
+        summary.get("agent_exit_code"),
+        container_exit.get("exit_code"),
+    ):
+        if isinstance(value, bool) or value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def unsupported_model_message(text: str) -> str:
+    match = re.search(r"The '[^']+' model is not supported[^.\n]*(?:\.[^\n]*)?", text)
+    return match.group(0).strip() if match else ""
+
+
+def combined_text(run: dict[str, Any]) -> str:
+    return "\n".join(
+        str(run.get(key) or "") for key in ("agent_events_text", "agent_stderr", "agent_last_message", "console_text")
+    )
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE_PATTERN.sub("", text)
+
+
+def agent_command_events(run: dict[str, Any]) -> list[dict[str, Any]]:
+    events = []
+    for line in str(run.get("agent_events_text") or "").splitlines():
+        try:
+            payload = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        item = payload.get("item")
+        if not isinstance(item, dict) or item.get("type") != "command_execution":
+            continue
+        command = str(item.get("command") or "")
+        if not command:
+            continue
+        events.append(
+            {
+                "command": command,
+                "exit_code": item.get("exit_code"),
+                "id": item.get("id"),
+                "index": len(events),
+                "output": strip_ansi(str(item.get("aggregated_output") or "")),
+                "status": str(item.get("status") or ""),
+            }
+        )
+    return events
+
+
+def command_failed(event: dict[str, Any]) -> bool:
+    exit_value = event.get("exit_code")
+    if isinstance(exit_value, bool):
+        return False
+    if exit_value not in (None, 0):
+        return True
+    return str(event.get("status") or "") == "failed"
+
+
+def command_succeeded(event: dict[str, Any]) -> bool:
+    return event.get("exit_code") == 0 and str(event.get("status") or "") == "completed"
+
+
+def command_recovery_key(command: str) -> str:
+    command = str(command)
+    if re.search(r"\bpip\s+install\b", command):
+        requirements = re.search(r"-r\s+([A-Za-z0-9_./-]*requirements[A-Za-z0-9_.-]*\.txt)", command)
+        return f"pip install {Path(requirements.group(1)).name}" if requirements else "pip install"
+    script = re.search(r"\bpython(?:3)?\s+([A-Za-z0-9_./-]+\.py)\b", command)
+    if script:
+        role = "export" if "--export" in command else "run"
+        return f"python {Path(script.group(1)).name} {role}"
+    first_word = re.search(r"(?:^|['\"])([A-Za-z0-9_./-]+)", command)
+    return first_word.group(1) if first_word else command[:80]
+
+
+def is_simulation_or_job_command(command: str) -> bool:
+    return bool(re.search(r"\bpython(?:3)?\s+[A-Za-z0-9_./-]*job[A-Za-z0-9_./-]*\.py\b", str(command)))
+
+
+def is_material_failed_command(event: dict[str, Any]) -> bool:
+    command = str(event.get("command") or "")
+    output = str(event.get("output") or "")
+    if is_simulation_or_job_command(command):
+        return True
+    if re.search(r"\bpip\s+install\b", command):
+        return True
+    return bool(
+        re.search(
+            r"Traceback|RuntimeError|ConfigError|ModuleNotFoundError|No module named|Simulator run failed",
+            output,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def command_error_summary(output: str) -> str:
+    text = strip_ansi(output)
+    patterns = (
+        r"TypeError: [^\n]+",
+        r"ConfigError: [^\n]+",
+        r"RuntimeError: [^\n]+",
+        r"ModuleNotFoundError: [^\n]+",
+        r"No module named [^\n]+",
+        r"sed: can't read [^\n]+",
+        r"ERROR - [^\n]+",
+        r"Error processing [^\n]+",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            return truncate(match.group(0), 320)
+    for line in text.splitlines():
+        lowered = line.lower()
+        if any(token in lowered for token in ("error", "failed", "traceback", "missing", "not found")):
+            return truncate(line, 320)
+    return truncate(text, 320) if text.strip() else "no command output captured"
+
+
+def recovered_by_later_success(event: dict[str, Any], events: list[dict[str, Any]]) -> bool:
+    key = command_recovery_key(str(event.get("command") or ""))
+    index = int(event.get("index") or 0)
+    for candidate in events:
+        if int(candidate.get("index") or 0) <= index:
+            continue
+        if command_recovery_key(str(candidate.get("command") or "")) == key and command_succeeded(candidate):
+            return True
+    return False
+
+
+def metric_log_lines(output: str, limit: int = 4) -> list[str]:
+    lines = []
+    for line in strip_ansi(output).splitlines():
+        clean = re.sub(r"^\d{4}-\d{2}-\d{2}[^-]*-\s+(?:INFO|WARNING|ERROR)\s+-\s+", "", line).strip()
+        if re.search(r"\b(?:valid|validation|test|train)_[A-Za-z0-9_/-]+\s*=\s*[0-9]+\.[0-9]+", clean):
+            lines.append(clean)
+        elif re.search(r"\b(?:best\s+)?(?:aggregated|global|server)\s+validation\b", clean, flags=re.IGNORECASE):
+            lines.append(clean)
+        if len(lines) >= limit:
+            break
+    return lines
+
+
+def last_successful_job_event(run: dict[str, Any]) -> dict[str, Any] | None:
+    for event in reversed(agent_command_events(run)):
+        if command_succeeded(event) and is_simulation_or_job_command(str(event.get("command") or "")):
+            command = str(event.get("command") or "")
+            if "--help" not in command and "--export" not in command:
+                return event
+    return None
+
+
+def command_failure_diagnostics(run: dict[str, Any], limit: int = 3) -> list[str]:
+    events = agent_command_events(run)
+    failed_events = [event for event in events if command_failed(event)]
+    material_events = [event for event in failed_events if is_material_failed_command(event)]
+    selected_events = material_events or [
+        event
+        for event in failed_events
+        if "git status" not in str(event.get("command") or "")
+        and "rg: command not found" not in str(event.get("output") or "")
+    ]
+    diagnostics = []
+    for event in selected_events:
+        command = str(event.get("command") or "")
+        output = str(event.get("output") or "")
+        recovery = (
+            "recovered by a later successful similar command"
+            if recovered_by_later_success(event, events)
+            else "not recovered in this run"
+        )
+        diagnostics.append(
+            f"Command `{truncate(command, 160)}` failed with exit {event.get('exit_code')}; "
+            f"{recovery}. Root cause evidence: {command_error_summary(output)}"
+        )
+        if len(diagnostics) >= limit:
+            break
+    return diagnostics
+
+
+def successful_job_evidence(run: dict[str, Any]) -> str:
+    event = last_successful_job_event(run)
+    if not event:
+        return ""
+    output = str(event.get("output") or "")
+    parts = ["a later simulator/job command exited 0"]
+    if "Finished" in output:
+        parts.append("the FL workflow reached a Finished state")
+    workspace = re.search(r"Result workspace:\s*([^\n]+)", output)
+    if workspace:
+        parts.append(f"result workspace `{workspace.group(1).strip()}`")
+    metric_lines = metric_log_lines(output)
+    if metric_lines:
+        parts.append("log metrics: " + "; ".join(metric_lines))
+    return "; ".join(parts)
+
+
+def metric_reporting_gap_evidence(run: dict[str, Any]) -> str:
+    issues = run_quality_issues(run)
+    if not issues:
+        return ""
+    record = run.get("record") if isinstance(run.get("record"), dict) else {}
+    expected = quality_signal(record).get("expected_primary_metric") or "target metric"
+    success = successful_job_evidence(run)
+    if success and metric_value(run, canonical_metric_name(expected)) is None:
+        return (
+            f"Metric reporting gap: {success}, but the final response/benchmark record did not include one "
+            f"aggregate `{expected}` scalar for comparison."
+        )
+    return ""
+
+
+def referenced_requirements_files(text: str) -> list[str]:
+    names = []
+    for match in re.finditer(r"\bpip\s+install\s+-r\s+([A-Za-z0-9_./-]*requirements[A-Za-z0-9_.-]*\.txt)\b", text):
+        name = Path(match.group(1)).name
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def path_list_contains_filename(items: Any, filename: str) -> bool:
+    if not isinstance(items, list):
+        return False
+    for item in items:
+        if isinstance(item, dict) and Path(str(item.get("path") or "")).name == filename:
+            return True
+    return False
+
+
+def dependency_file_origin(run: dict[str, Any], filename: str) -> str:
+    source_delta = run_source_input_delta(run)
+    workspace_delta = run_workspace_delta(run)
+    if path_list_contains_filename(source_delta.get("final_files"), filename):
+        return "original input file"
+    for key, label in (
+        ("workspace_added_files", "agent-generated file"),
+        ("changed_files", "agent-created or modified file"),
+        ("workspace_modified_files", "agent-modified original file"),
+    ):
+        if path_list_contains_filename(workspace_delta.get(key), filename):
+            return label
+    if path_list_contains_filename(workspace_delta.get("final_files"), filename):
+        return "present in final agent workspace"
+    return "not found in captured input or workspace manifests"
+
+
+def dependency_reference_notes(run: dict[str, Any]) -> list[str]:
+    notes = []
+    for filename in referenced_requirements_files(combined_text(run)):
+        notes.append(f"`{filename}` provenance: {dependency_file_origin(run, filename)}.")
+    return notes
+
+
+def metric_mismatch_with_reported_scalar(run: dict[str, Any]) -> bool:
+    record = run.get("record") if isinstance(run.get("record"), dict) else {}
+    signal = quality_signal(record)
+    if not signal.get("mismatch"):
+        return False
+    metric = run.get("validation_metric") if isinstance(run.get("validation_metric"), dict) else {}
+    actual_name = canonical_metric_name(metric.get("name"))
+    return bool(actual_name) and metric_value(run, actual_name) is not None
+
+
+def metric_mismatch_issue(run: dict[str, Any]) -> str:
+    record = run.get("record") if isinstance(run.get("record"), dict) else {}
+    signal = quality_signal(record)
+    expected = signal.get("expected_primary_metric") or "target metric"
+    metric = run.get("validation_metric") if isinstance(run.get("validation_metric"), dict) else {}
+    actual_name = canonical_metric_name(metric.get("name"))
+    actual = metric_display(run, actual_name or None)
+    return f"Metric mismatch `primary_metric_reporting`: expected `{expected}`, reported {actual}."
+
+
+def failure_evidence(run: dict[str, Any]) -> str:
+    text = combined_text(run)
+    model_error = unsupported_model_message(text)
+    if model_error:
+        return model_error
+    for line in text.splitlines():
+        lowered = line.lower()
+        if any(token in lowered for token in ("error", "failed", "pull access denied", "not supported")):
+            return line.strip()[:500]
+    return ""
+
+
+def failure_root_cause(run: dict[str, Any]) -> str:
+    record = run.get("record") if isinstance(run.get("record"), dict) else {}
+    exit_summary = record.get("agent_exit_summary") if isinstance(record.get("agent_exit_summary"), dict) else {}
+    failure_category = record.get("failure_category") or exit_summary.get("failure_category")
+    if failure_category:
+        return f"Agent failure category: {failure_category}"
+    text = combined_text(run)
+    model_error = unsupported_model_message(text)
+    if model_error:
+        return f"Agent model selection failed: {model_error}"
+    lowered = text.lower()
+    if "pull access denied" in lowered or "unable to find image" in lowered:
+        return "Docker image unavailable: build the benchmark Docker images before running."
+    error = record.get("harness_error") if isinstance(record.get("harness_error"), dict) else {}
+    if error.get("message"):
+        return f"Harness failure: {error['message']}"
+    evidence = failure_evidence(run)
+    if evidence:
+        return evidence
+    code = exit_code(run)
+    if code not in (None, 0):
+        return f"Agent container failed with exit code {code}."
+    return "No failure detected."
+
+
+def run_quality_issues(run: dict[str, Any]) -> list[str]:
+    issues = []
+    record = run.get("record") if isinstance(run.get("record"), dict) else {}
+    signal = quality_signal(record)
+    expected = signal.get("expected_primary_metric")
+    signal_status = str(signal.get("status") or "")
+    if signal_status in {"fail", "missing"}:
+        if metric_mismatch_with_reported_scalar(run):
+            issues.append(metric_mismatch_issue(run))
+        else:
+            evidence = signal.get("evidence") or "final response did not satisfy the expected validation metric signal"
+            issues.append(f"Failed check `primary_metric_reporting`: {evidence}")
+    metric = run.get("validation_metric") if isinstance(run.get("validation_metric"), dict) else {}
+    metric_name = canonical_metric_name(metric.get("name") or expected)
+    if expected and metric_value(run, metric_name) is None:
+        issues.append(
+            f"Failed check `fl_metric_scalar`: no FL-level scalar value was found for expected metric `{expected}`."
+        )
+    delta = record.get("workspace_delta") if isinstance(record.get("workspace_delta"), dict) else {}
+    changed_count = delta.get("changed_file_count")
+    if changed_count == 0:
+        issues.append("Failed check `workspace_delta`: no generated or modified workspace files were captured.")
+    return issues
+
+
+def run_status_kind(run: dict[str, Any]) -> str:
+    if not run.get("available"):
+        return "missing"
+    code = exit_code(run)
+    if code not in (None, 0):
+        return "failed"
+    if run_quality_issues(run):
+        return "needs review"
+    return "passed"
+
+
+def human_readable_status(run: dict[str, Any]) -> str:
+    if not run.get("available"):
+        return "missing"
+    code = exit_code(run)
+    if code == 0:
+        issues = run_quality_issues(run)
+        if issues:
+            if metric_mismatch_with_reported_scalar(run):
+                return f"completed with metric mismatch ({issues[0]})"
+            return f"needs review ({issues[0]})"
+        return "passed"
+    detail = "unknown exit" if code is None else f"container exit {code}"
+    return f"failed ({detail}; {failure_root_cause(run)})"
+
+
+def run_analysis(run: dict[str, Any]) -> str:
+    if not run.get("available"):
+        return "Run artifacts are missing."
+    issues = run_quality_issues(run)
+    if exit_code(run) == 0 and issues:
+        return issues[0]
+    if exit_code(run) == 0:
+        return "No failure detected."
+    return failure_root_cause(run)
+
+
+def status_summary(runs: dict[str, dict[str, Any]], modes: list[str] | None = None) -> str:
+    modes = modes or mode_names(BENCHMARK_RUNS)
+    parts = []
+    for mode in modes:
+        run = runs.get(mode, {"available": False, "label": MODE_LABELS.get(mode, mode)})
+        parts.append(f"{run.get('label') or MODE_LABELS.get(mode, mode)}: {human_readable_status(run)}")
+    return "; ".join(parts)
+
+
+def metric_name_for_runs(runs: dict[str, dict[str, Any]]) -> str:
+    common_name = comparable_metric_name(runs)
+    if common_name:
+        return common_name
+    if metric_names_for_runs(runs):
+        return "mixed validation metrics"
+    return "result"
+
+
+def metric_names_for_runs(runs: dict[str, dict[str, Any]]) -> list[str]:
+    names = []
+    for run in runs.values():
+        metric = run.get("validation_metric")
+        if isinstance(metric, dict) and metric.get("name"):
+            name = canonical_metric_name(metric["name"])
+            if name and name not in names:
+                names.append(name)
+    return names
+
+
+def comparable_metric_name(runs: dict[str, dict[str, Any]]) -> str | None:
+    names = metric_names_for_runs(runs)
+    return names[0] if len(names) == 1 else None
+
+
+def metric_value(run: dict[str, Any], metric_name: str | None = None) -> Any:
+    metric = run.get("validation_metric")
+    if not isinstance(metric, dict):
+        return None
+    if metric_name is not None and canonical_metric_name(metric.get("name")) != canonical_metric_name(metric_name):
+        return None
+    value = metric.get("value")
+    if is_numeric_metric_value(value):
+        return value
+    for entry in reversed(metric.get("reported_value_entries") or []):
+        if not isinstance(entry, dict):
+            continue
+        value = entry.get("value")
+        label = entry.get("label")
+        if is_numeric_metric_value(value) and is_fl_summary_metric_label(label):
+            return value
+    return None
+
+
+def metric_value_label(run: dict[str, Any], metric_name: str | None = None) -> str:
+    metric = run.get("validation_metric")
+    if not isinstance(metric, dict):
+        return ""
+    if metric_name is not None and canonical_metric_name(metric.get("name")) != canonical_metric_name(metric_name):
+        return ""
+    if metric.get("summary_value_label"):
+        return str(metric["summary_value_label"])
+    if is_numeric_metric_value(metric.get("value")):
+        return str(metric.get("value_scope") or "reported scalar")
+    for entry in reversed(metric.get("reported_value_entries") or []):
+        if not isinstance(entry, dict):
+            continue
+        if is_numeric_metric_value(entry.get("value")) and is_fl_summary_metric_label(entry.get("label")):
+            return str(entry.get("label") or "")
+    return ""
+
+
+def metric_display(run: dict[str, Any], metric_name: str | None) -> str:
+    metric = run.get("validation_metric")
+    actual_name = None
+    if isinstance(metric, dict) and metric.get("name"):
+        actual_name = canonical_metric_name(metric["name"])
+    display_name = actual_name if metric_name is None else metric_name
+    if not display_name:
+        record = run.get("record") if isinstance(run.get("record"), dict) else {}
+        display_name = quality_signal(record).get("expected_primary_metric")
+    if not display_name:
+        display_name = "result"
+    value = metric_value(run, metric_name)
+    if value is None:
+        return f"{display_name} NA"
+    return f"{display_name} {fmt_number(value)}"
+
+
+def metric_reported_value_count(metric: dict[str, Any] | None) -> int:
+    if not isinstance(metric, dict):
+        return 0
+    values = metric.get("reported_values")
+    if not isinstance(values, list):
+        values = metric.get("site_values")
+    if not isinstance(values, list):
+        return 0
+    return sum(1 for value in values if is_numeric_metric_value(value))
+
+
+def additional_metric_values_display(run: dict[str, Any], metric_name: str | None = None) -> str:
+    metric = run.get("validation_metric")
+    if not isinstance(metric, dict):
+        return "NA"
+    if metric_name is not None and canonical_metric_name(metric.get("name")) != canonical_metric_name(metric_name):
+        return "NA"
+    values = metric.get("reported_values")
+    labels = metric.get("reported_value_labels")
+    if not isinstance(values, list):
+        values = metric.get("site_values")
+    if not isinstance(labels, list):
+        labels = metric.get("site_value_labels")
+    if not isinstance(values, list):
+        return "NA"
+    entries = []
+    for index, value in enumerate(values):
+        if not is_numeric_metric_value(value):
+            continue
+        label = labels[index] if isinstance(labels, list) and index < len(labels) else None
+        label_text = str(label).strip() if label else f"value-{index + 1}"
+        entries.append(f"{label_text}={fmt_number(value)}")
+    if len(entries) <= 1:
+        return "NA"
+    return ", ".join(entries[:8]) + (f", +{len(entries) - 8} more" if len(entries) > 8 else "")
+
+
+def metric_payload_display(payload: dict[str, Any]) -> str:
+    name = canonical_metric_name(payload.get("name"))
+    if not name:
+        return "NA"
+    value = payload.get("value")
+    if is_numeric_metric_value(value):
+        return f"{name} {fmt_number(value)}"
+    values = payload.get("reported_values")
+    if isinstance(values, list):
+        numeric_values = [item for item in values if is_numeric_metric_value(item)]
+        if numeric_values:
+            rendered = ", ".join(fmt_number(item) for item in numeric_values[:4])
+            suffix = f", +{len(numeric_values) - 4} more" if len(numeric_values) > 4 else ""
+            return f"{name} values: {rendered}{suffix}"
+    return f"{name} mentioned without numeric value"
+
+
+def observed_metric_payloads(run: dict[str, Any]) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    metric = run.get("validation_metric")
+    if isinstance(metric, dict) and metric.get("name"):
+        name = canonical_metric_name(metric.get("name"))
+        if name:
+            payloads.append(metric)
+            seen.add(name)
+    text = str(run.get("agent_last_message") or "")
+    for name in OBSERVED_METRIC_NAMES:
+        canonical_name = canonical_metric_name(name)
+        if canonical_name in seen:
+            continue
+        entries = metric_value_entries(name, text)
+        if not entries:
+            continue
+        payload = reported_metric_payload(name, entries)
+        if payload.get("reported_values"):
+            payloads.append(payload)
+            seen.add(canonical_name)
+    return payloads
+
+
+def observed_metric_evidence_display(run: dict[str, Any]) -> str:
+    payloads = observed_metric_payloads(run)
+    if not payloads:
+        return "none"
+    return "; ".join(metric_payload_display(payload) for payload in payloads)
+
+
+def additional_or_observed_metric_values_display(run: dict[str, Any], metric_name: str | None = None) -> str:
+    additional = additional_metric_values_display(run, metric_name)
+    if additional != "NA":
+        return additional
+    observed = observed_metric_evidence_display(run)
+    if observed != "none":
+        return observed
+    metric_lines = metric_log_lines(str((last_successful_job_event(run) or {}).get("output") or ""))
+    if metric_lines:
+        return "Final site metrics=NA; log/per-site evidence: " + "; ".join(metric_lines)
+    return "NA"
+
+
+def run_result_metric_status(run: dict[str, Any]) -> str:
+    metric = run.get("validation_metric")
+    if not isinstance(metric, dict) or not metric.get("name"):
+        return "missing"
+    value = metric_value(run, canonical_metric_name(metric.get("name")))
+    if value is not None:
+        label = metric_value_label(run, canonical_metric_name(metric.get("name")))
+        suffix = f" ({label})" if label else ""
+        return f"{canonical_metric_name(metric.get('name'))} {fmt_number(value)}{suffix}"
+    count = metric_reported_value_count(metric)
+    if count:
+        return f"partial: {count} reported values, no FL-level scalar"
+    return f"missing scalar: {canonical_metric_name(metric.get('name'))} mentioned without value"
+
+
+def benchmark_outcome(run: dict[str, Any]) -> str:
+    if not run.get("available"):
+        return "fail: run artifacts missing"
+    code = exit_code(run)
+    if code not in (None, 0):
+        return f"fail: container exit {code}"
+    issues = run_quality_issues(run)
+    if issues:
+        if metric_mismatch_with_reported_scalar(run):
+            return "warn: scalar metric reported, but it does not match the target metric instruction"
+        return "fail: " + issues[0]
+    return "pass: scalar FL result metric available"
+
+
+def quality_signal(record: dict[str, Any]) -> dict[str, Any]:
+    quality = record.get("quality_signals")
+    if not isinstance(quality, dict):
+        return {}
+    signal = quality.get("job_guidance_primary_validation_metric") or quality.get("readme_primary_validation_metric")
+    return signal if isinstance(signal, dict) else {}
+
+
+def quality_signal_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    lines = [
+        "| Run | Expected metric | Reported result | Status | Evidence |",
+        "|---|---|---|---|---|",
+    ]
+    comparable_name = comparable_metric_name(runs)
+    for mode in modes:
+        run = runs[mode]
+        signal = quality_signal(run.get("record") if isinstance(run.get("record"), dict) else {})
+        metric = run.get("validation_metric") if isinstance(run.get("validation_metric"), dict) else {}
+        expected = signal.get("expected_primary_metric") or metric.get("name")
+        result = metric_display(run, comparable_name)
+        label = metric_value_label(run, comparable_name)
+        if label:
+            result = f"{result} ({label})"
+        evidence = signal.get("evidence") or "NA"
+        lines.append(
+            f"| {markdown_cell(run['label'])} | {markdown_cell(expected)} | {markdown_cell(result)} | "
+            f"{markdown_cell(signal.get('status') or 'NA')} | {markdown_cell(evidence)} |"
+        )
+    return "\n".join(lines)
+
+
+def output_changes_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    lines = [
+        "| Run | Changed files | Added | Modified | Notable files |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for mode in modes:
+        run = runs[mode]
+        record = run.get("record") if isinstance(run.get("record"), dict) else {}
+        delta = record.get("workspace_delta") if isinstance(record.get("workspace_delta"), dict) else {}
+        if not delta:
+            delta = run.get("workspace_delta") if isinstance(run.get("workspace_delta"), dict) else {}
+        changed_files = delta.get("changed_files") if isinstance(delta.get("changed_files"), list) else []
+        changed_count = delta.get("changed_file_count")
+        added = delta.get("workspace_added_file_count")
+        modified = delta.get("workspace_modified_file_count")
+        names = []
+        for item in changed_files[:8]:
+            if isinstance(item, dict) and item.get("path"):
+                names.append(str(item["path"]))
+        suffix = "" if len(changed_files) <= 8 else f"; +{len(changed_files) - 8} more"
+        lines.append(
+            f"| {markdown_cell(run['label'])} | {fmt_number(changed_count)} | {fmt_number(added)} | "
+            f"{fmt_number(modified)} | {markdown_cell('; '.join(names) + suffix if names else 'NA')} |"
+        )
+    return "\n".join(lines)
+
+
+def run_summary(run: dict[str, Any]) -> dict[str, Any]:
+    summary = run.get("run")
+    return summary if isinstance(summary, dict) else {}
+
+
+def run_activity(run: dict[str, Any]) -> dict[str, Any]:
+    activity = run.get("activity")
+    return activity if isinstance(activity, dict) else {}
+
+
+def run_record(run: dict[str, Any]) -> dict[str, Any]:
+    record = run.get("record")
+    return record if isinstance(record, dict) else {}
+
+
+def run_workspace_delta(run: dict[str, Any]) -> dict[str, Any]:
+    record = run_record(run)
+    delta = record.get("workspace_delta") if isinstance(record.get("workspace_delta"), dict) else None
+    if isinstance(delta, dict):
+        return delta
+    delta = run.get("workspace_delta")
+    return delta if isinstance(delta, dict) else {}
+
+
+def run_source_input_delta(run: dict[str, Any]) -> dict[str, Any]:
+    record = run_record(run)
+    delta = record.get("source_input_delta") if isinstance(record.get("source_input_delta"), dict) else None
+    return delta if isinstance(delta, dict) else {}
+
+
+def artifact_summary(run: dict[str, Any]) -> str:
+    delta = run_workspace_delta(run)
+    changed = delta.get("changed_file_count")
+    runtime = delta.get("runtime_artifact_count")
+    copied = delta.get("copied_file_count")
+    parts = []
+    if changed is not None:
+        parts.append(f"{fmt_number(changed)} changed/generated files")
+    if runtime is not None:
+        parts.append(f"{fmt_number(runtime)} runtime artifacts")
+    if copied is not None:
+        parts.append(f"{fmt_number(copied)} copied artifacts")
+    return ", ".join(parts) if parts else "not captured"
+
+
+def workspace_change_display(run: dict[str, Any]) -> str:
+    delta = run_workspace_delta(run)
+    changed = delta.get("changed_file_count")
+    added = delta.get("workspace_added_file_count")
+    modified = delta.get("workspace_modified_file_count")
+    deleted = delta.get("workspace_deleted_baseline_file_count")
+    if changed is None:
+        return "not captured"
+    parts = [f"{fmt_number(changed)} changed"]
+    if added is not None:
+        parts.append(f"{fmt_number(added)} added")
+    if modified is not None:
+        parts.append(f"{fmt_number(modified)} modified")
+    if deleted:
+        parts.append(f"{fmt_number(deleted)} deleted")
+    return ", ".join(parts)
+
+
+def source_input_protection_display(run: dict[str, Any]) -> str:
+    record = run_record(run)
+    policy = record.get("source_input_immutable_policy")
+    if isinstance(policy, dict) and policy.get("status"):
+        status = str(policy["status"])
+        reason = policy.get("reason")
+        return f"{status}: {reason}" if reason else status
+    delta = run_source_input_delta(run)
+    if not delta:
+        return "not captured"
+    changed = delta.get("changed_file_count")
+    deleted = delta.get("deleted_file_count")
+    if changed == 0 and deleted == 0:
+        return "pass: immutable input snapshot unchanged"
+    return f"fail: input snapshot changed={fmt_number(changed)}, deleted={fmt_number(deleted)}"
+
+
+def manifest_paths(run: dict[str, Any], key: str) -> list[str]:
+    delta = run_workspace_delta(run)
+    values = delta.get(key)
+    paths = []
+    if isinstance(values, list):
+        for item in values:
+            if isinstance(item, dict) and item.get("path"):
+                paths.append(str(item["path"]))
+    return paths
+
+
+def unique_paths(paths: list[str]) -> list[str]:
+    result = []
+    seen = set()
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            result.append(path)
+    return result
+
+
+def basename_count_display(paths: list[str], limit: int = 6) -> str:
+    if not paths:
+        return "none"
+    counts: dict[str, int] = {}
+    for path in paths:
+        name = Path(path).name
+        counts[name] = counts.get(name, 0) + 1
+    entries = []
+    for name in sorted(counts)[:limit]:
+        count = counts[name]
+        entries.append(name if count == 1 else f"{name} ({count} paths)")
+    if len(counts) > limit:
+        entries.append(f"+{len(counts) - limit} more")
+    return ", ".join(entries)
+
+
+def structure_file_matches(run: dict[str, Any], filename: str) -> list[str]:
+    paths = unique_paths(manifest_paths(run, "final_structure_files") + manifest_paths(run, "runtime_artifacts"))
+    return [path for path in paths if Path(path).name == filename]
+
+
+def structure_score(run: dict[str, Any]) -> float | None:
+    if not run.get("available"):
+        return None
+    present = sum(1 for filename in REQUIRED_STRUCTURE_FILES if structure_file_matches(run, filename))
+    return present / len(REQUIRED_STRUCTURE_FILES)
+
+
+def structure_required_display(run: dict[str, Any]) -> str:
+    score = structure_score(run)
+    if score is None:
+        return "not captured"
+    present = [filename for filename in REQUIRED_STRUCTURE_FILES if structure_file_matches(run, filename)]
+    missing = [filename for filename in REQUIRED_STRUCTURE_FILES if filename not in present]
+    text = f"{len(present)}/{len(REQUIRED_STRUCTURE_FILES)} present"
+    if missing:
+        text += "; missing " + ", ".join(missing)
+    return text
+
+
+def structure_optional_display(run: dict[str, Any]) -> str:
+    if structure_score(run) is None:
+        return "not captured"
+    present = [filename for filename in OPTIONAL_STRUCTURE_FILES if structure_file_matches(run, filename)]
+    return ", ".join(present) if present else "none"
+
+
+def structure_inventory_display(run: dict[str, Any], key: str, suffixes: tuple[str, ...]) -> str:
+    paths = [path for path in manifest_paths(run, key) if Path(path).suffix in suffixes]
+    return basename_count_display(paths)
+
+
+def tree_from_paths(paths: list[str], *, max_paths: int = 80) -> str:
+    sorted_paths = sorted(unique_paths(paths))
+    truncated = len(sorted_paths) > max_paths
+    paths = sorted_paths[:max_paths]
+    if not paths:
+        return "none"
+    tree: dict[str, Any] = {}
+    for path in paths:
+        node = tree
+        for part in Path(path).parts:
+            if not part or part == ".":
+                continue
+            node = node.setdefault(part, {})
+
+    lines = ["."]
+
+    def render(node: dict[str, Any], prefix: str = "") -> None:
+        entries = sorted(node)
+        for index, name in enumerate(entries):
+            connector = "`-- " if index == len(entries) - 1 else "|-- "
+            lines.append(f"{prefix}{connector}{name}")
+            child = node[name]
+            if child:
+                extension = "    " if index == len(entries) - 1 else "|   "
+                render(child, prefix + extension)
+
+    render(tree)
+    if truncated:
+        lines.append(f"... {len(sorted_paths) - max_paths} more paths not shown")
+    return "\n".join(lines)
+
+
+def tree_paths_for_keys(
+    run: dict[str, Any],
+    keys: tuple[str, ...],
+    *,
+    suffixes: tuple[str, ...] | None = None,
+) -> list[str]:
+    paths = []
+    for key in keys:
+        for path in manifest_paths(run, key):
+            if suffixes is not None and Path(path).suffix not in suffixes:
+                continue
+            paths.append(path)
+    return unique_paths(paths)
+
+
+def structure_correctness_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    rows = [
+        ("Required converted files", structure_required_display),
+        ("Optional helper files", structure_optional_display),
+        ("Final workspace Python inventory", lambda run: structure_inventory_display(run, "final_files", (".py",))),
+        (
+            "Changed/generated Python inventory",
+            lambda run: structure_inventory_display(run, "changed_files", (".py",)),
+        ),
+        (
+            "Runtime artifact config inventory",
+            lambda run: structure_inventory_display(run, "runtime_artifacts", CONFIG_STRUCTURE_SUFFIXES),
+        ),
+    ]
+    lines = [
+        "| Structure signal | " + " | ".join(MODE_LABELS.get(mode, mode) for mode in modes) + " |",
+        "|---|" + "|".join("---" for _ in modes) + "|",
+    ]
+    for label, getter in rows:
+        lines.append(
+            f"| {markdown_cell(label)} | " + " | ".join(markdown_cell(getter(runs[mode])) for mode in modes) + " |"
+        )
+    return "\n".join(lines)
+
+
+def structure_trees_section(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    lines = [
+        "### Captured Structure Trees",
+        "",
+        "Trees are rendered from captured artifact manifests in tree-command format.",
+    ]
+    for mode in modes:
+        run = runs[mode]
+        lines.append("")
+        lines.append(f"#### {run.get('label') or mode}")
+        lines.append("")
+        final_paths = tree_paths_for_keys(run, ("final_files",)) or tree_paths_for_keys(
+            run,
+            ("final_structure_files", "runtime_artifacts"),
+            suffixes=TREE_RUNTIME_SUFFIXES,
+        )
+        changed_paths = tree_paths_for_keys(run, ("changed_files", "runtime_artifacts"))
+        lines.append("Final workspace:")
+        lines.append("")
+        lines.append("```text")
+        lines.append(tree_from_paths(final_paths))
+        lines.append("```")
+        lines.append("")
+        lines.append("Changed/generated files:")
+        lines.append("")
+        lines.append("```text")
+        lines.append(tree_from_paths(changed_paths))
+        lines.append("```")
+    return "\n".join(lines)
+
+
+def count_map(run: dict[str, Any], key: str) -> dict[str, Any]:
+    activity = run_activity(run)
+    value = activity.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def hint_count(run: dict[str, Any], key: str) -> int:
+    value = count_map(run, "hint_counts").get(key, 0)
+    number = as_number(value)
+    return int(number) if number is not None else 0
+
+
+def event_type_count(run: dict[str, Any], key: str) -> int:
+    value = count_map(run, "event_types").get(key, 0)
+    number = as_number(value)
+    return int(number) if number is not None else 0
+
+
+def commands_for_run(run: dict[str, Any]) -> list[str]:
+    commands = run_activity(run).get("commands")
+    return [str(command) for command in commands] if isinstance(commands, list) else []
+
+
+def dependency_install_attempted(run: dict[str, Any]) -> bool:
+    for command in commands_for_run(run):
+        lowered = command.lower()
+        if "pip install" in lowered or "uv pip install" in lowered or "python -m pip" in lowered:
+            return True
+    return False
+
+
+def missing_result_metrics_section(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    issue_modes = [mode for mode in modes if run_quality_issues(runs[mode])]
+    if not issue_modes:
+        return ""
+    lines = [
+        "## Missing, Partial, Or Mismatched Result Metrics",
+        "",
+        "A run can complete at the agent/container level and still need review when it omits the requested FL-level validation metric, reports only partial values, or reports a different metric than the job guidance requested.",
+        "",
+        "| Run | Result metric status | Final response metric evidence | Why results are missing, partial, or mismatched | Report action |",
+        "|---|---|---|---|---|",
+    ]
+    for mode in issue_modes:
+        run = runs[mode]
+        issues = run_quality_issues(run)
+        observed_metrics = observed_metric_evidence_display(run)
+        action = "Require the final message or benchmark record to include one aggregate FL validation metric."
+        if metric_mismatch_with_reported_scalar(run):
+            action = (
+                "Treat the run as completed with a reported scalar metric, but flag that it did not follow the target "
+                "metric instruction."
+            )
+        if not metric_names_for_runs({mode: run}) and observed_metrics == "none":
+            action = "Inspect the final message and generated job logs; no parseable validation metric was reported."
+            if successful_job_evidence(run):
+                action = (
+                    "Simulator/job logs contain metric evidence, but the final response or benchmark record did not "
+                    "report one aggregate FL validation metric."
+                )
+        lines.append(
+            f"| {markdown_cell(run.get('label') or mode)} | {markdown_cell(run_result_metric_status(run))} | "
+            f"{markdown_cell(observed_metrics)} | {markdown_cell('; '.join(issues))} | "
+            f"{markdown_cell(action)} |"
+        )
+    return "\n".join(lines)
+
+
+def activity_insights_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    rows = [
+        ("Read commands (`cat`/`sed`/`nl`)", "shell_cat_or_sed", "Direct file-read behavior changed materially."),
+        ("`find` commands", "shell_find", "Filesystem discovery proxy."),
+        ("`rg` commands", "shell_rg", "Search use proxy."),
+        ("Simulation references", "simulation", "Shows validation effort against generated jobs."),
+        ("Python compile checks", "py_compile", "Shows syntax validation effort."),
+        ("Skill reference hits", "skill_references", "Only skills-enabled runs should usually show these."),
+        ("Agent inspect references", "agent_inspect", "Shows use of agent inspection commands."),
+        ("Python job.py references", "python_job_py", "Shows repeated exercise of generated job entry points."),
+    ]
+    lines = [
+        "| Activity signal | " + " | ".join(MODE_LABELS.get(mode, mode) for mode in modes) + " | Interpretation |",
+        "|---|" + "|".join("---:" for _ in modes) + "|---|",
+    ]
+    for label, key, note in rows:
+        lines.append(
+            f"| {markdown_cell(label)} | "
+            + " | ".join(str(hint_count(runs[mode], key)) for mode in modes)
+            + f" | {markdown_cell(note)} |"
+        )
+    return "\n".join(lines)
+
+
+def event_mix_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    keys = sorted({key for mode in modes for key in count_map(runs[mode], "event_types")})
+    if not keys:
+        keys = ["command_execution", "agent_message", "file_change", "todo_list"]
+    lines = [
+        "| Event type | " + " | ".join(MODE_LABELS.get(mode, mode) for mode in modes) + " |",
+        "|---|" + "|".join("---:" for _ in modes) + "|",
+    ]
+    for key in keys:
+        lines.append(
+            f"| `{markdown_cell(key)}` | " + " | ".join(str(event_type_count(runs[mode], key)) for mode in modes) + " |"
+        )
+    return "\n".join(lines)
+
+
+def outcome_details_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    comparable_name = comparable_metric_name(runs)
+    rows = [
+        ("Agent/container outcome", human_readable_status),
+        ("FL result quality gate", benchmark_outcome),
+        ("Reported validation metric", lambda run: metric_display(run, comparable_name)),
+        (
+            "Additional/other validation metric values",
+            lambda run: additional_or_observed_metric_values_display(run, comparable_name),
+        ),
+        ("Source input protection", source_input_protection_display),
+        ("Copied workspace changes", workspace_change_display),
+        ("Captured generated artifacts", artifact_summary),
+        ("Required structure files", structure_required_display),
+        ("Optional structure files", structure_optional_display),
+    ]
+    lines = [
+        "| Signal | " + " | ".join(MODE_LABELS.get(mode, mode) for mode in modes) + " |",
+        "|---|" + "|".join("---" for _ in modes) + "|",
+    ]
+    for label, getter in rows:
+        lines.append(
+            f"| {markdown_cell(label)} | " + " | ".join(markdown_cell(getter(runs[mode])) for mode in modes) + " |"
+        )
+    return "\n".join(lines)
+
+
+def cost_comparison_section(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    if len(modes) != 2:
+        return ""
+    left, right = modes
+    left_run = runs[left]
+    right_run = runs[right]
+    left_summary = run_summary(left_run)
+    right_summary = run_summary(right_run)
+    rows = [
+        ("Elapsed seconds", left_summary.get("elapsed_seconds"), right_summary.get("elapsed_seconds")),
+        ("Total tokens", left_summary.get("token_count"), right_summary.get("token_count")),
+        ("Commands", run_activity(left_run).get("command_count"), run_activity(right_run).get("command_count")),
+        (
+            "Unique commands",
+            run_activity(left_run).get("unique_command_count"),
+            run_activity(right_run).get("unique_command_count"),
+        ),
+        (
+            "Changed/generated files",
+            run_workspace_delta(left_run).get("changed_file_count"),
+            run_workspace_delta(right_run).get("changed_file_count"),
+        ),
+        (
+            "Runtime artifacts",
+            run_workspace_delta(left_run).get("runtime_artifact_count"),
+            run_workspace_delta(right_run).get("runtime_artifact_count"),
+        ),
+    ]
+    lines = [
+        "## Cost And Work Comparison",
+        "",
+        "Cost numbers are descriptive only. Quality gates decide whether a cost comparison is meaningful.",
+        "",
+        f"| Signal | {markdown_cell(left_run.get('label') or left)} | {markdown_cell(right_run.get('label') or right)} | Delta right-left |",
+        "|---|---:|---:|---:|",
+    ]
+    for label, left_value, right_value in rows:
+        left_num = as_number(left_value)
+        right_num = as_number(right_value)
+        delta = right_num - left_num if left_num is not None and right_num is not None else None
+        formatter = fmt_short if label == "Total tokens" else fmt_number
+        lines.append(
+            f"| {markdown_cell(label)} | {formatter(left_value)} | {formatter(right_value)} | {formatter(delta)} |"
+        )
+    return "\n".join(lines)
+
+
+def interpretation_section(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    failed_quality = [runs[mode].get("label") or mode for mode in modes if run_quality_issues(runs[mode])]
+    metric_name = comparable_metric_name(runs) or metric_name_for_runs(runs)
+    lines = [
+        "## Interpretation",
+        "",
+    ]
+    if failed_quality:
+        lines.append(
+            "Quality comparison is incomplete because these runs failed a benchmark quality gate: "
+            + ", ".join(failed_quality)
+            + "."
+        )
+        lines.append(
+            f"For this artifact, the missing/partial signal is `{metric_name}` reporting, not necessarily a Docker or Python execution crash."
+        )
+    else:
+        lines.append("All available runs passed the benchmark quality gates captured by this report.")
+    if len(modes) == 2:
+        left, right = modes
+        left_time = as_number(run_summary(runs[left]).get("elapsed_seconds"))
+        right_time = as_number(run_summary(runs[right]).get("elapsed_seconds"))
+        left_tokens = as_number(run_summary(runs[left]).get("token_count"))
+        right_tokens = as_number(run_summary(runs[right]).get("token_count"))
+        if left_time is not None and right_time is not None:
+            faster = runs[left].get("label") if left_time <= right_time else runs[right].get("label")
+            lines.append(f"Runtime winner by wall-clock seconds: {faster}.")
+        if left_tokens is not None and right_tokens is not None:
+            cheaper = runs[left].get("label") if left_tokens <= right_tokens else runs[right].get("label")
+            lines.append(f"Token-use winner: {cheaper}.")
+    lines.append(
+        "Read cost winners only after checking the quality gates; a cheaper run that does not report the requested FL result is not a successful benchmark winner."
+    )
+    return "\n".join(lines)
+
+
+def mixed_metric_note(runs: dict[str, dict[str, Any]]) -> str:
+    parts = []
+    for run in runs.values():
+        metric = run.get("validation_metric")
+        name = canonical_metric_name(metric.get("name")) if isinstance(metric, dict) else ""
+        if name:
+            parts.append(f"{run.get('label') or run.get('mode')}: {name}")
+    return "; ".join(parts)
+
+
+def chart_number(value: Any, kind: str) -> float | None:
+    number = as_number(value)
+    if number is None:
+        return None
+    if kind == "percent":
+        return max(0.0, min(1.0, number))
+    return max(0.0, number)
+
+
+def chart_value_display(value: Any, kind: str) -> str:
+    if value is None:
+        return "NA"
+    if kind == "short":
+        return fmt_short(value)
+    if kind == "percent":
+        number = as_number(value)
+        return "NA" if number is None else f"{number * 100:.0f}%"
+    return fmt_number(value)
+
+
+def benchmark_chart_metrics(runs: dict[str, dict[str, Any]], metric_name: str | None) -> list[dict[str, Any]]:
+    return [
+        {
+            "label": "Runtime seconds",
+            "kind": "number",
+            "value": lambda run: run_summary(run).get("elapsed_seconds"),
+        },
+        {
+            "label": "Total tokens",
+            "kind": "short",
+            "value": lambda run: run_summary(run).get("token_count"),
+        },
+        {
+            "label": "Commands",
+            "kind": "number",
+            "value": lambda run: run_activity(run).get("command_count"),
+        },
+        {
+            "label": "Structure score",
+            "kind": "percent",
+            "value": structure_score,
+        },
+        {
+            "label": f"Metrics ({metric_name or 'result'})",
+            "kind": "number",
+            "value": lambda run: metric_value(run, metric_name),
+        },
+    ]
+
+
+def chart_mode_label(mode: str, run: dict[str, Any]) -> str:
+    if mode == "without_skills":
+        return "No skills"
+    if mode == "with_skills":
+        return "With skills"
+    return str(run.get("label") or MODE_LABELS.get(mode, mode))
+
+
+def embedded_bar_chart(runs: dict[str, dict[str, Any]]) -> str:
+    metric_name = comparable_metric_name(runs)
+    if metric_name is None and metric_names_for_runs(runs):
+        note = markdown_cell(mixed_metric_note(runs))
+        return f"<section><h3>Metrics (mixed validation metrics)</h3><p>Not comparable: {note}</p></section>"
+    modes = list(runs)
+    metrics = benchmark_chart_metrics(runs, metric_name)
+    width = 1180
+    height = 430
+    margin_x = 32
+    top = 104
+    panel_gap = 18
+    panel_w = (width - margin_x * 2 - panel_gap * (len(metrics) - 1)) / len(metrics)
+    axis_y = 328
+    chart_h = 170
+    bar_gap = 24 if len(modes) <= 2 else 12
+    available_bar_w = max(40.0, panel_w - 44)
+    bar_w = max(18.0, min(38.0, (available_bar_w - bar_gap * max(0, len(modes) - 1)) / max(1, len(modes))))
+    colors = {
+        "without_skills": "#16a34a",
+        "with_skills": "#2563eb",
+    }
+    fallback_colors = ("#2563eb", "#16a34a", "#7c3aed", "#f97316")
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        '<text x="32" y="35" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#111827">Run comparison</text>',
+        '<text x="32" y="58" font-family="Arial, sans-serif" font-size="13" fill="#4b5563">Metrics are mode-local. Missing scalar results are shown as NA instead of drawing a numeric bar.</text>',
+    ]
+    for metric_index, item in enumerate(metrics):
+        x0 = margin_x + metric_index * (panel_w + panel_gap)
+        title = html.escape(str(item["label"]))
+        values = [chart_number(item["value"](runs[mode]), item["kind"]) for mode in modes]
+        numeric_values = [value for value in values if value is not None]
+        maximum = max(numeric_values) if numeric_values else 1.0
+        if maximum == 0:
+            maximum = 1.0
+        bar_group_w = len(modes) * bar_w + max(0, len(modes) - 1) * bar_gap
+        bar_start_x = x0 + max(14.0, (panel_w - bar_group_w) / 2)
+        lines.extend(
+            [
+                f'<text x="{x0:.1f}" y="{top:.1f}" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#111827">{title}</text>',
+                f'<line x1="{x0:.1f}" y1="{axis_y}" x2="{x0 + panel_w:.1f}" y2="{axis_y}" stroke="#d1d5db" stroke-width="1"/>',
+                f'<line x1="{x0:.1f}" y1="{axis_y - chart_h}" x2="{x0:.1f}" y2="{axis_y}" stroke="#d1d5db" stroke-width="1"/>',
+            ]
+        )
+        for bar_index, mode in enumerate(modes):
+            run = runs[mode]
+            value = item["value"](run)
+            numeric_value = values[bar_index]
+            bx = bar_start_x + bar_index * (bar_w + bar_gap)
+            run_label = html.escape(chart_mode_label(mode, run))
+            color = colors.get(mode, fallback_colors[bar_index % len(fallback_colors)])
+            if numeric_value is None:
+                lines.extend(
+                    [
+                        f'<rect x="{bx:.1f}" y="{axis_y - 24}" width="{bar_w:.1f}" height="20" fill="#e5e7eb" rx="3"/>',
+                        f'<text x="{bx + bar_w / 2:.1f}" y="{axis_y - 9}" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="700" fill="#4b5563">NA</text>',
+                    ]
+                )
+            else:
+                height_px = max(4.0, numeric_value / maximum * chart_h)
+                by = axis_y - height_px
+                value_text = html.escape(chart_value_display(value, item["kind"]))
+                lines.extend(
+                    [
+                        f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_w:.1f}" height="{height_px:.1f}" fill="{color}" rx="3"/>',
+                        f'<text x="{bx + bar_w / 2:.1f}" y="{by - 7:.1f}" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#111827">{value_text}</text>',
+                    ]
+                )
+            lines.append(
+                f'<text x="{bx + bar_w / 2:.1f}" y="{axis_y + 19}" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#374151">{run_label}</text>'
+            )
+    legend_x = 32
+    legend_y = 392
+    for index, mode in enumerate(modes):
+        run = runs[mode]
+        color = colors.get(mode, fallback_colors[index % len(fallback_colors)])
+        x = legend_x + index * 220
+        label = html.escape(str(run.get("label") or MODE_LABELS.get(mode, mode)))
+        lines.extend(
+            [
+                f'<rect x="{x}" y="{legend_y}" width="14" height="14" fill="{color}" rx="2"/>',
+                f'<text x="{x + 22}" y="{legend_y + 12}" font-family="Arial, sans-serif" font-size="13" fill="#111827">{label}</text>',
+            ]
+        )
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def outcome_metrics_table(runs: dict[str, dict[str, Any]], modes: list[str] | None = None) -> str:
+    modes = modes or mode_names(BENCHMARK_RUNS)
+    comparable_name = comparable_metric_name(runs)
+    metric_name = comparable_name or metric_name_for_runs(runs)
+    labels = [markdown_cell((runs.get(mode) or {}).get("label") or MODE_LABELS.get(mode, mode)) for mode in modes]
+    values = [metric_display(runs.get(mode, {}), comparable_name) for mode in modes]
+    return "\n".join(
+        [
+            "| Metric | " + " | ".join(labels) + " |",
+            "|---|" + "|".join("---" for _ in modes) + "|",
+            f"| Metrics ({markdown_cell(metric_name)}) | "
+            + " | ".join(markdown_cell(value) for value in values)
+            + " |",
+        ]
+    )
+
+
+def status_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    lines = ["| Run | Status | Analysis |", "|---|---|---|"]
+    for mode in modes:
+        run = runs[mode]
+        lines.append(
+            f"| {markdown_cell(run['label'])} | {markdown_cell(human_readable_status(run))} | "
+            f"{markdown_cell(run_analysis(run))} |"
+        )
+    return "\n".join(lines)
+
+
+def failure_analysis_section(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    lines = []
+    for mode in modes:
+        run = runs[mode]
+        label = run.get("label") or mode
+        status_kind = run_status_kind(run)
+        lines.append(f"### {label}")
+        lines.append("")
+        if status_kind == "passed":
+            metric = metric_display(run, comparable_metric_name(runs))
+            label_text = metric_value_label(run, comparable_metric_name(runs))
+            if label_text:
+                metric = f"{metric} ({label_text})"
+            lines.append(f"- Outcome: passed. {metric}.")
+        elif status_kind == "needs review":
+            lines.append(
+                "- Outcome: needs review. The agent process completed, but benchmark quality checks found issues."
+            )
+            for issue in run_quality_issues(run):
+                lines.append(f"- Issue: {issue}")
+        elif status_kind == "failed":
+            lines.append(f"- Outcome: failed. {failure_root_cause(run)}")
+            evidence = failure_evidence(run)
+            if evidence:
+                lines.append(f"- Evidence: {evidence}")
+        else:
+            lines.append("- Outcome: missing. No run artifacts were found for this mode.")
+        record = run.get("record") if isinstance(run.get("record"), dict) else {}
+        signal = quality_signal(record)
+        if signal.get("evidence"):
+            lines.append(f"- Metric evidence: {signal['evidence']}")
+        if status_kind != "passed":
+            for diagnostic in command_failure_diagnostics(run):
+                lines.append(f"- Command evidence: {diagnostic}")
+            success_evidence = successful_job_evidence(run)
+            if success_evidence:
+                lines.append(f"- Recovery evidence: {success_evidence}.")
+            metric_gap = metric_reporting_gap_evidence(run)
+            if metric_gap:
+                lines.append(f"- {metric_gap}")
+        for note in dependency_reference_notes(run):
+            lines.append(f"- Dependency reference: {note}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def runtime_table(runs: dict[str, dict[str, Any]], modes: list[str]) -> str:
+    lines = ["| Run | Elapsed seconds | Tokens | Commands |", "|---|---:|---:|---:|"]
+    for mode in modes:
+        run = runs[mode]
+        summary = run.get("run") if isinstance(run.get("run"), dict) else {}
+        activity = run.get("activity") if isinstance(run.get("activity"), dict) else {}
+        lines.append(
+            f"| {markdown_cell(run['label'])} | {fmt_number(summary.get('elapsed_seconds'))} | "
+            f"{fmt_number(summary.get('token_count'))} | {fmt_number(activity.get('command_count'))} |"
+        )
+    return "\n".join(lines)
+
+
+def benchmark_report(root: Path, runs: dict[str, dict[str, Any]]) -> str:
+    modes = mode_names(BENCHMARK_RUNS)
+    missing_metrics = missing_result_metrics_section(runs, modes)
+    cost_comparison = cost_comparison_section(runs, modes)
+    quality_gate_summary = "; ".join(
+        f"{runs[mode].get('label') or mode}: {benchmark_outcome(runs[mode])}" for mode in modes
+    )
+    missing_metric_summary = "; ".join(
+        f"{runs[mode].get('label') or mode}: {run_result_metric_status(runs[mode])}"
+        for mode in modes
+        if run_quality_issues(runs[mode])
+    )
+    input_protection_summary = "; ".join(
+        f"{runs[mode].get('label') or mode}: {source_input_protection_display(runs[mode])}" for mode in modes
+    )
+    artifact_summary_text = "; ".join(
+        f"{runs[mode].get('label') or mode}: {artifact_summary(runs[mode])}" for mode in modes
+    )
+    lines = [
+        "# Agent Benchmark Insights",
+        "",
+        f"Result root: `{root}`",
+        "",
+        "## Executive Summary",
+        "",
+        "| Signal | Value |",
+        "|---|---|",
+        f"| Status | {markdown_cell(status_summary(runs, modes))} |",
+        f"| FL result quality gate | {markdown_cell(quality_gate_summary)} |",
+        f"| Missing/partial result metrics | {markdown_cell(missing_metric_summary or 'none')} |",
+        f"| Source input protection | {markdown_cell(input_protection_summary)} |",
+        f"| Captured generated artifacts | {markdown_cell(artifact_summary_text)} |",
+        "",
+        "## Status",
+        "",
+        status_table(runs, modes),
+        "",
+        "## Failure Analysis",
+        "",
+        failure_analysis_section(runs, modes),
+        "",
+    ]
+    if missing_metrics:
+        lines.extend([missing_metrics, ""])
+    lines.extend(
+        [
+            "## Metrics",
+            "",
+            embedded_bar_chart({mode: runs[mode] for mode in modes}),
+            "",
+            outcome_metrics_table(runs, modes),
+            "",
+            "## Quality Signals",
+            "",
+            quality_signal_table(runs, modes),
+            "",
+            "## Output Changes",
+            "",
+            output_changes_table(runs, modes),
+            "",
+            "## Outcome Details",
+            "",
+            outcome_details_table(runs, modes),
+            "",
+            "## Structure Correctness",
+            "",
+            "The structure checks look for the core converted source files and captured runtime/export artifacts. They are report signals, not a substitute for running the generated job.",
+            "",
+            structure_correctness_table(runs, modes),
+            "",
+            structure_trees_section(runs, modes),
+            "",
+            "## Activity Insights",
+            "",
+            activity_insights_table(runs, modes),
+            "",
+            "## Event Mix",
+            "",
+            event_mix_table(runs, modes),
+            "",
+        ]
+    )
+    if cost_comparison:
+        lines.extend([cost_comparison, ""])
+    lines.extend(
+        [
+            "## Runtime",
+            "",
+            runtime_table(runs, modes),
+            "",
+            interpretation_section(runs, modes),
+            "",
+            "## Artifacts",
+            "",
+            "- `metrics_report.md`",
+            "- `metrics_report.html`",
+            "- `records/`",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    runs = collect_benchmark_runs(args.root)
+    output = args.output or args.root / "benchmark_insights.md"
+    output.write_text(benchmark_report(args.root, runs), encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/assist_tools/skills_benchmark/skills/harness/reports/metrics_report.py
+++ b/assist_tools/skills_benchmark/skills/harness/reports/metrics_report.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate record-driven benchmark metrics reports."""
+
+from __future__ import annotations
+
+import argparse
+import html
+from pathlib import Path
+from typing import Any
+
+from ..common import flatten_numbers, load_json, write_json
+from ..modes import BENCHMARK_RUNS
+from .benchmark_insights import (
+    collect_benchmark_runs,
+    embedded_bar_chart,
+    final_record_path,
+    human_readable_status,
+    markdown_cell,
+    metric_name_for_runs,
+    mode_dir_for_benchmark,
+    outcome_metrics_table,
+    run_analysis,
+    status_summary,
+)
+
+
+def collect_runs(root: Path) -> list[dict[str, Any]]:
+    runs = []
+    for spec in BENCHMARK_RUNS:
+        mode_dir = mode_dir_for_benchmark(root, spec.mode)
+        summary = load_json(mode_dir / "run_summary.json", {}) if mode_dir.exists() else {}
+        record = load_json(final_record_path(root, spec.mode), {}) if mode_dir.exists() else {}
+        activity = load_json(mode_dir / "agent_activity.json", {}) if mode_dir.exists() else {}
+        usage = load_json(mode_dir / "agent_usage.json", {}) if mode_dir.exists() else {}
+        runtime_image = load_json(mode_dir / "runtime_image.json", {}) if mode_dir.exists() else {}
+        if not isinstance(summary, dict):
+            summary = {}
+        if not isinstance(record, dict):
+            record = {}
+        if not isinstance(activity, dict):
+            activity = {}
+        if not isinstance(usage, dict):
+            usage = {}
+        if not isinstance(runtime_image, dict):
+            runtime_image = {}
+        runs.append(
+            {
+                "mode": spec.mode,
+                "label": spec.label,
+                "available": mode_dir.exists(),
+                "skills_enabled": spec.skills_enabled,
+                "summary": summary,
+                "record": record,
+                "activity": activity,
+                "usage": usage,
+                "runtime_image": runtime_image,
+                "metrics": flatten_numbers(
+                    {"summary": summary, "record": record, "activity": activity, "usage": usage}
+                ),
+            }
+        )
+    return runs
+
+
+def runs_by_mode_for_insights(root: Path, rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    collected = collect_benchmark_runs(root)
+    for row in rows:
+        run = collected.get(row["mode"])
+        if isinstance(run, dict):
+            run["label"] = row["label"]
+    return collected
+
+
+def numeric_comparison(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if len(rows) != 2:
+        return {}
+    without, with_skills = rows
+    result: dict[str, Any] = {}
+    for key in ("elapsed_seconds", "token_count"):
+        left = without["summary"].get(key)
+        right = with_skills["summary"].get(key)
+        if (
+            isinstance(left, (int, float))
+            and not isinstance(left, bool)
+            and isinstance(right, (int, float))
+            and not isinstance(right, bool)
+        ):
+            result[f"{key}_with_skills_minus_without_skills"] = right - left
+    return result
+
+
+def report_summary(
+    root: Path,
+    title: str,
+    rows: list[dict[str, Any]] | None = None,
+    insight_runs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    rows = collect_runs(root) if rows is None else rows
+    insight_runs = runs_by_mode_for_insights(root, rows) if insight_runs is None else insight_runs
+    metric_name = metric_name_for_runs(insight_runs)
+    return {
+        "title": title,
+        "result_root": str(root),
+        "status": status_summary(insight_runs),
+        "metric_name": metric_name,
+        "runs": rows,
+        "comparison": numeric_comparison(rows),
+    }
+
+
+def fmt(value: Any) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def markdown_report(summary: dict[str, Any], insight_runs: dict[str, dict[str, Any]] | None = None) -> str:
+    root = Path(summary["result_root"])
+    insight_runs = runs_by_mode_for_insights(root, summary["runs"]) if insight_runs is None else insight_runs
+    lines = [
+        f"# {summary['title']}",
+        "",
+        f"Result root: `{summary['result_root']}`",
+        "",
+        f"Status: {summary['status']}",
+        "",
+        "## Runs",
+        "",
+        "| Run | Status | Skills | Elapsed seconds | Tokens | Commands | Root cause |",
+        "|---|---|---|---:|---:|---:|---|",
+    ]
+    for row in summary["runs"]:
+        run = insight_runs[row["mode"]]
+        run_summary = row["summary"]
+        activity = row["activity"]
+        root_cause = "NA" if human_readable_status(run) == "passed" else run_analysis(run)
+        lines.append(
+            f"| {markdown_cell(row['label'])} | {markdown_cell(human_readable_status(run))} | "
+            f"{fmt(row['skills_enabled'])} | {fmt(run_summary.get('elapsed_seconds'))} | "
+            f"{fmt(run_summary.get('token_count'))} | {fmt(activity.get('command_count'))} | "
+            f"{markdown_cell(root_cause)} |"
+        )
+    lines.extend(["", "## Metrics", "", embedded_bar_chart(insight_runs), "", outcome_metrics_table(insight_runs)])
+    comparison = summary.get("comparison") or {}
+    if comparison:
+        lines.extend(["", "## Comparison", "", "| Metric | Delta |", "|---|---:|"])
+        for key, value in sorted(comparison.items()):
+            lines.append(f"| {markdown_cell(key)} | {fmt(value)} |")
+    return "\n".join(lines) + "\n"
+
+
+def html_report(summary: dict[str, Any], insight_runs: dict[str, dict[str, Any]] | None = None) -> str:
+    root = Path(summary["result_root"])
+    insight_runs = runs_by_mode_for_insights(root, summary["runs"]) if insight_runs is None else insight_runs
+    rows = []
+    for row in summary["runs"]:
+        run = insight_runs[row["mode"]]
+        run_summary = row["summary"]
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(row['label'])}</td>"
+            f"<td>{html.escape(human_readable_status(run))}</td>"
+            f"<td>{html.escape(fmt(row['skills_enabled']))}</td>"
+            f"<td>{html.escape(fmt(run_summary.get('elapsed_seconds')))}</td>"
+            f"<td>{html.escape(fmt(run_summary.get('token_count')))}</td>"
+            "</tr>"
+        )
+    chart = embedded_bar_chart(insight_runs)
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{html.escape(summary['title'])}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 16px 0; }}
+    th, td {{ border: 1px solid #d9e2ec; padding: 8px; text-align: left; }}
+    th {{ background: #f5f7fa; }}
+    .bar-row {{ display: grid; grid-template-columns: 180px 1fr 80px; gap: 12px; align-items: center; margin: 8px 0; }}
+    .bar-track {{ background: #e4e7eb; height: 14px; position: relative; }}
+    .bar-fill {{ display: block; background: #2f80ed; height: 14px; }}
+  </style>
+</head>
+<body>
+  <h1>{html.escape(summary['title'])}</h1>
+  <p>Result root: <code>{html.escape(summary['result_root'])}</code></p>
+  <p>Status: {html.escape(summary['status'])}</p>
+  <table>
+    <thead><tr><th>Run</th><th>Status</th><th>Skills</th><th>Elapsed seconds</th><th>Tokens</th></tr></thead>
+    <tbody>{''.join(rows)}</tbody>
+  </table>
+  {chart}
+</body>
+</html>
+"""
+
+
+def write_reports(root: Path, title: str) -> dict[str, Any]:
+    rows = collect_runs(root)
+    insight_runs = runs_by_mode_for_insights(root, rows)
+    summary = report_summary(root, title, rows, insight_runs)
+    write_json(root / "metrics_report.json", summary)
+    (root / "metrics_report.md").write_text(markdown_report(summary, insight_runs), encoding="utf-8")
+    (root / "metrics_report.html").write_text(html_report(summary, insight_runs), encoding="utf-8")
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--title", default="Agent Skills Benchmark Metrics")
+    parser.add_argument(
+        "--plots", action="store_true", help="accepted for compatibility; HTML report is always written"
+    )
+    args = parser.parse_args()
+    write_reports(args.root, args.title)
+    print(args.root / "metrics_report.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test/skills_benchmark/skills_benchmark_reporting_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_reporting_test.py
@@ -1,0 +1,1037 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import stat
+import sys
+from pathlib import Path
+
+
+def test_benchmark_insights_explains_docker_image_failures(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        collect_benchmark_runs,
+        failure_root_cause,
+        human_readable_status,
+    )
+
+    mode_dir = tmp_path / NO_SKILLS_MODE
+    mode_dir.mkdir()
+    (mode_dir / "container_exit_code.json").write_text(json.dumps({"exit_code": 1}) + "\n", encoding="utf-8")
+    (tmp_path / "console_output.log").write_text(
+        "[without_skills] Unable to find image 'agent-skills-benchmark:codex-baseline' locally\n"
+        "[without_skills] docker: Error response from daemon: pull access denied for agent-skills-benchmark\n",
+        encoding="utf-8",
+    )
+
+    run = collect_benchmark_runs(tmp_path)[NO_SKILLS_MODE]
+
+    assert run["available"] is True
+    assert "Docker image unavailable" in failure_root_cause(run)
+    assert "container exit 1" in human_readable_status(run)
+
+
+def test_benchmark_insights_scopes_shared_console_evidence_by_mode(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE, WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        collect_benchmark_runs,
+        dependency_reference_notes,
+    )
+
+    for mode in (NO_SKILLS_MODE, WITH_SKILLS_MODE):
+        records_dir = tmp_path / mode / "records"
+        records_dir.mkdir(parents=True)
+        (records_dir / f"{mode}_record.json").write_text(
+            json.dumps(
+                {
+                    "source_input_delta": {"final_files": [{"path": "requirements-train.txt"}]},
+                    "workspace_delta": {
+                        "workspace_added_files": (
+                            [{"path": "requirements-federated.txt"}] if mode == NO_SKILLS_MODE else []
+                        )
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    (tmp_path / "console_output.log").write_text(
+        "[without_skills] python3 -m pip install -r requirements-federated.txt failed\n"
+        "[with_skills] completed without dependency install errors\n",
+        encoding="utf-8",
+    )
+
+    runs = collect_benchmark_runs(tmp_path)
+
+    assert dependency_reference_notes(runs[NO_SKILLS_MODE]) == [
+        "`requirements-federated.txt` provenance: agent-generated file.",
+    ]
+    assert dependency_reference_notes(runs[WITH_SKILLS_MODE]) == []
+
+
+def test_benchmark_insights_caps_agent_events_text(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports import benchmark_insights
+
+    mode_dir = tmp_path / NO_SKILLS_MODE
+    mode_dir.mkdir()
+    (mode_dir / "agent_events.jsonl").write_text("0123456789", encoding="utf-8")
+    monkeypatch.setattr(benchmark_insights, "MAX_AGENT_EVENTS_TEXT_BYTES", 8)
+
+    run = benchmark_insights.collect_benchmark_runs(tmp_path)[NO_SKILLS_MODE]
+
+    assert run["agent_events_text"] == "01234567"
+
+
+def test_benchmark_reports_read_canonical_record_layout(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.common import write_json
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE, WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports import metrics_report
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import collect_benchmark_runs
+
+    entries = []
+    for index, mode in enumerate((NO_SKILLS_MODE, WITH_SKILLS_MODE), start=1):
+        record_dir = (
+            tmp_path
+            / "records"
+            / "agent=codex"
+            / "model=default"
+            / "workflow=default"
+            / "job=ames"
+            / "repeat=01"
+            / f"mode={mode}"
+        )
+        record_dir.mkdir(parents=True)
+        entries.append(
+            {"run_id": f"run_{index:05d}", "mode": mode, "record_dir": str(record_dir.relative_to(tmp_path))}
+        )
+        write_json(
+            record_dir / "run_summary.json",
+            {
+                "mode": mode,
+                "elapsed_seconds": 10 + index,
+                "token_count": 100 + index,
+                "agent_exit_code": 0,
+                "final_container_exit_code": 0,
+            },
+        )
+        write_json(record_dir / "container_exit_code.json", {"exit_code": 0})
+        write_json(record_dir / "agent_activity.json", {"command_count": index})
+        write_json(
+            record_dir / "benchmark_record.json",
+            {
+                "mode": mode,
+                "reported_validation_metric": {"name": "AUROC", "value": 0.7 + index / 100},
+            },
+        )
+    write_json(tmp_path / "run_plan.json", {"entries": entries})
+
+    runs = collect_benchmark_runs(tmp_path)
+    assert runs[NO_SKILLS_MODE]["available"] is True
+    assert runs[WITH_SKILLS_MODE]["record"]["reported_validation_metric"]["name"] == "AUROC"
+
+    metrics_report.write_reports(tmp_path, "Synthetic Metrics")
+
+    assert (tmp_path / "metrics_report.json").is_file()
+    assert "Metrics (AUROC)" in (tmp_path / "metrics_report.md").read_text(encoding="utf-8")
+
+
+def test_numeric_comparison_rejects_bool_values():
+    from assist_tools.skills_benchmark.skills.harness.reports.metrics_report import numeric_comparison
+
+    rows = [
+        {"summary": {"elapsed_seconds": 10, "token_count": 100}},
+        {"summary": {"elapsed_seconds": True, "token_count": False}},
+    ]
+
+    assert numeric_comparison(rows) == {}
+
+
+def test_structure_tree_falls_back_to_final_workspace_when_changed_python_is_empty():
+    from assist_tools.skills_benchmark.skills.harness.modes import WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import structure_trees_section
+
+    report = structure_trees_section(
+        {
+            WITH_SKILLS_MODE: {
+                "available": True,
+                "label": "With skills",
+                "workspace_delta": {
+                    "changed_files": [
+                        {"path": "nvflare_jobs/ames_fedavg/README.md"},
+                        {"path": "nvflare_jobs/ames_fedavg/requirements.txt"},
+                    ],
+                    "final_structure_files": [
+                        {"path": "download_data.py"},
+                        {"path": "model.py"},
+                        {"path": "nvflare_jobs/ames_fedavg/client.py"},
+                        {"path": "nvflare_jobs/ames_fedavg/job.py"},
+                        {"path": "nvflare_jobs/ames_fedavg/model.py"},
+                    ],
+                },
+            }
+        },
+        [WITH_SKILLS_MODE],
+    )
+
+    assert "Final workspace:" in report
+    assert "Changed/generated files:" in report
+    assert "none" not in report
+    assert "nvflare_jobs" in report
+    assert "client.py" in report
+    assert "job.py" in report
+    assert "README.md" in report
+    assert "requirements.txt" in report
+
+
+def test_status_summary_is_human_readable_for_failures():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import status_summary
+
+    runs = {
+        NO_SKILLS_MODE: {
+            "available": True,
+            "container_exit": {"exit_code": 1},
+            "console_text": "docker: Error response from daemon: pull access denied for agent-skills-benchmark",
+            "run": {},
+            "status": "missing",
+            "validation_metric": {},
+        }
+    }
+
+    summary = status_summary(runs, [NO_SKILLS_MODE])
+
+    assert "No skills baseline: failed" in summary
+    assert "container exit 1" in summary
+    assert "Docker image unavailable" in summary
+    assert "exit=1" not in summary
+
+
+def test_failure_analysis_extracts_unsupported_model_message():
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        failure_evidence,
+        failure_root_cause,
+    )
+
+    run = {
+        "available": True,
+        "agent_events_text": "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+        "container_exit": {"exit_code": 1},
+        "run": {"agent_exit_code": 1},
+        "status": "missing",
+        "validation_metric": {},
+    }
+
+    assert failure_root_cause(run) == (
+        "Agent model selection failed: The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."
+    )
+    assert failure_evidence(run) == (
+        "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."
+    )
+
+
+def test_failure_root_cause_prefers_agent_exit_classifier():
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import failure_root_cause
+
+    run = {
+        "available": True,
+        "agent_events_text": "unstructured error text",
+        "record": {"agent_exit_summary": {"failure_category": "agent_auth_failure"}},
+        "run": {"agent_exit_code": 1},
+    }
+
+    assert failure_root_cause(run) == "Agent failure category: agent_auth_failure"
+
+
+def test_failure_analysis_identifies_agent_generated_requirements_file():
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import dependency_reference_notes
+
+    run = {
+        "agent_last_message": "Install with python3 -m pip install -r requirements-federated.txt.",
+        "record": {
+            "source_input_delta": {
+                "final_files": [
+                    {"path": "requirements-train.txt"},
+                ]
+            },
+            "workspace_delta": {
+                "workspace_added_files": [
+                    {"path": "requirements-federated.txt"},
+                ]
+            },
+        },
+    }
+
+    assert dependency_reference_notes(run) == [
+        "`requirements-federated.txt` provenance: agent-generated file.",
+    ]
+
+
+def test_shared_lifecycle_requires_dependency_preflight_before_missing_dependency_blocker():
+    lifecycle = (Path(__file__).resolve().parents[3] / "skills" / "_shared" / "nvflare-job-lifecycle.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "all generated NVFLARE jobs" in lifecycle
+    assert "recipe-, framework-, and algorithm-independent" in lifecycle
+    assert "requirements-train.txt" in lifecycle
+    assert "python -m pip install -r <requirements-file>" in lifecycle
+    assert "dependency or import failures" in lifecycle
+    assert "Report missing dependencies as blockers only when" in lifecycle
+
+
+def test_readme_metric_alignment_uses_aggregated_validation_metric_scalar():
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+
+    signal = metric_signal(
+        None,
+        "AUROC is the main metric.\n",
+        """
+Round 2 validation AUROC by site:
+- `site-1`: `0.7659574468`
+- `site-2`: `0.7554566645`
+- `site-3`: `0.7373779931`
+- aggregated best validation metric: `0.7529307015`
+""",
+    )
+
+    metric = signal["reported_validation_metric"]
+    assert signal["status"] == "pass"
+    assert signal["aligned_with_readme"] is True
+    assert signal["metric_value_available"] is True
+    assert signal["metric_scalar_available"] is True
+    assert metric["name"] == "AUROC"
+    assert metric["value"] == 0.7529307015
+    assert metric["value_scope"] == "fl_summary_metric"
+    assert metric["site_value_count"] == 3
+    assert metric["summary_value_label"] == "aggregated best validation metric"
+
+
+def test_readme_metric_alignment_uses_named_aggregated_metric_scalar():
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+
+    signal = metric_signal(
+        None,
+        "AUROC is the main metric.\n",
+        """
+Validation:
+- Local training AUROC: 0.7531
+- Best aggregated validation AUROC: 0.7623334631865992
+- Final site metrics: site-1 valid AUROC 0.767293, site-2 valid AUROC 0.757374
+""",
+    )
+
+    metric = signal["reported_validation_metric"]
+    assert signal["status"] == "pass"
+    assert signal["metric_scalar_available"] is True
+    assert metric["name"] == "AUROC"
+    assert metric["value"] == 0.7623334631865992
+    assert metric["value_scope"] == "fl_summary_metric"
+    assert metric["summary_value_label"] == "Best aggregated validation AUROC"
+
+
+def test_job_guidance_metric_alignment_uses_non_readme_docs(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+    from assist_tools.skills_benchmark.skills.harness.records import discover_job_guidance
+
+    job = tmp_path / "job"
+    docs = job / "docs"
+    docs.mkdir(parents=True)
+    docs.joinpath("metrics.md").write_text("Target validation metric: accuracy.\n", encoding="utf-8")
+
+    sources, guidance_text = discover_job_guidance(job)
+    signal = metric_signal(
+        sources,
+        guidance_text,
+        "Server best validation metric at round 3: 0.8123 accuracy",
+    )
+
+    assert signal["expected_primary_metric"] == "accuracy"
+    assert signal["aligned_with_job_guidance"] is True
+    assert signal["sources"][0]["path"].endswith("metrics.md")
+    assert signal["reported_validation_metric"]["name"] == "accuracy"
+
+
+def test_job_guidance_skips_symlink_guidance_files(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    job = tmp_path / "job"
+    job.mkdir()
+    job.joinpath("target.md").write_text("Target validation metric: accuracy.\n", encoding="utf-8")
+    left = job / "readme-left.md"
+    right = job / "readme-right.md"
+    try:
+        left.symlink_to("target.md")
+        right.symlink_to("target.md")
+    except (OSError, NotImplementedError):
+        return
+
+    sources, guidance_text = records.discover_job_guidance(job)
+
+    assert sources == []
+    assert guidance_text == ""
+
+
+def test_job_guidance_skips_symlinked_docs_directory(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    job = tmp_path / "job"
+    outside_docs = tmp_path / "outside_docs"
+    job.mkdir()
+    outside_docs.mkdir()
+    outside_docs.joinpath("README.md").write_text("Target validation metric: accuracy.\n", encoding="utf-8")
+    try:
+        job.joinpath("docs").symlink_to(outside_docs, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return
+
+    sources, guidance_text = records.discover_job_guidance(job)
+
+    assert sources == []
+    assert guidance_text == ""
+
+
+def test_job_guidance_skips_oversized_guidance_files(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.records import MAX_GUIDANCE_FILE_BYTES, discover_job_guidance
+
+    job = tmp_path / "job"
+    job.mkdir()
+    with job.joinpath("README.md").open("wb") as stream:
+        stream.truncate(MAX_GUIDANCE_FILE_BYTES + 1)
+
+    sources, guidance_text = discover_job_guidance(job)
+
+    assert sources == []
+    assert guidance_text == ""
+
+
+def test_job_guidance_stops_collecting_after_guidance_file_cap(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness import records
+
+    job = tmp_path / "job"
+    job.mkdir()
+    for index in range(20):
+        job.joinpath(f"readme-{index:02d}.md").write_text("Target validation metric: accuracy.\n", encoding="utf-8")
+    calls = {"count": 0}
+
+    def counted_is_guidance_file(path):
+        calls["count"] += 1
+        return True
+
+    monkeypatch.setattr(records, "MAX_GUIDANCE_FILES", 3)
+    monkeypatch.setattr(records, "is_guidance_file", counted_is_guidance_file)
+
+    sources, _guidance_text = records.discover_job_guidance(job)
+
+    assert len(sources) == 3
+    assert calls["count"] == 3
+
+
+def test_job_guidance_metric_alignment_includes_prompt(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+    from assist_tools.skills_benchmark.skills.harness.records import discover_job_guidance
+
+    job = tmp_path / "job"
+    job.mkdir()
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("Convert this job. Primary validation metric: AUROC.\n", encoding="utf-8")
+
+    sources, guidance_text = discover_job_guidance(job, prompt)
+    signal = metric_signal(
+        sources,
+        guidance_text,
+        "Aggregated best validation metric: 0.7529 AUROC",
+    )
+
+    assert signal["expected_primary_metric"] == "AUROC"
+    assert signal["aligned_with_job_guidance"] is True
+    assert signal["sources"][0]["source_type"] == "prompt"
+
+
+def test_job_guidance_metric_alignment_uses_source_priority(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+    from assist_tools.skills_benchmark.skills.harness.records import discover_job_guidance
+
+    job = tmp_path / "job"
+    job.mkdir()
+    job.joinpath("README.md").write_text("AUROC is the main metric.\n", encoding="utf-8")
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("Convert this job. Primary validation metric: accuracy.\n", encoding="utf-8")
+
+    sources, guidance_text = discover_job_guidance(job, prompt)
+    signal = metric_signal(
+        sources,
+        guidance_text,
+        "Server best validation metric at round 3: 0.8123 accuracy",
+    )
+
+    assert signal["expected_primary_metric"] == "accuracy"
+    assert signal["source"] == str(prompt)
+    assert signal["matched_source"] == {"path": str(prompt), "source_type": "prompt"}
+    assert signal["aligned_with_job_guidance"] is True
+
+
+def test_job_guidance_metric_alignment_reports_matched_doc_source(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+    from assist_tools.skills_benchmark.skills.harness.records import discover_job_guidance
+
+    job = tmp_path / "job"
+    job.mkdir()
+    readme = job / "README.md"
+    readme.write_text("AUROC is the main metric.\n", encoding="utf-8")
+    prompt = tmp_path / "prompt.txt"
+    prompt.write_text("Convert this job with NVFLARE.\n", encoding="utf-8")
+
+    sources, guidance_text = discover_job_guidance(job, prompt)
+    signal = metric_signal(
+        sources,
+        guidance_text,
+        "Aggregated best validation metric: 0.7529 AUROC",
+    )
+
+    assert signal["expected_primary_metric"] == "AUROC"
+    assert signal["source"] == str(readme)
+    assert signal["matched_source"] == {"path": str(readme), "source_type": "job_documentation"}
+    assert signal["sources"][0]["source_type"] == "prompt"
+    assert signal["aligned_with_job_guidance"] is True
+
+
+def test_metric_mismatch_reports_actual_metric_without_marking_missing():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        benchmark_outcome,
+        human_readable_status,
+        missing_result_metrics_section,
+        outcome_metrics_table,
+    )
+
+    signal = metric_signal(
+        None,
+        "AUROC is the main metric.\n",
+        "Best validation accuracy: 0.8123",
+    )
+    run = {
+        "available": True,
+        "label": "No skills baseline",
+        "container_exit": {"exit_code": 0},
+        "run": {"final_container_exit_code": 0},
+        "record": {"quality_signals": {"job_guidance_primary_validation_metric": signal}},
+        "validation_metric": signal["reported_validation_metric"],
+    }
+    runs = {NO_SKILLS_MODE: run}
+
+    assert signal["mismatch"] is True
+    assert signal["reported_validation_metric"]["name"] == "accuracy"
+    assert "completed with metric mismatch" in human_readable_status(run)
+    assert benchmark_outcome(run).startswith("warn:")
+    assert "accuracy 0.8123" in missing_result_metrics_section(runs, [NO_SKILLS_MODE])
+    assert "no parseable validation metric" not in missing_result_metrics_section(runs, [NO_SKILLS_MODE])
+    assert "| Metrics (accuracy) | accuracy 0.8123 |" in outcome_metrics_table(runs, [NO_SKILLS_MODE])
+
+
+def test_metric_mismatch_evidence_includes_integer_metric_value():
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import format_metric_value
+
+    assert format_metric_value(1) == " 1."
+    assert format_metric_value(1.0) == " 1.0000."
+    assert format_metric_value(None) == "."
+
+
+def test_missing_target_metric_section_reports_observed_alternate_metrics():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        additional_or_observed_metric_values_display,
+        missing_result_metrics_section,
+        outcome_details_table,
+    )
+
+    run = {
+        "available": True,
+        "label": "No skills baseline",
+        "container_exit": {"exit_code": 0},
+        "run": {"final_container_exit_code": 0},
+        "record": {
+            "quality_signals": {
+                "job_guidance_primary_validation_metric": {
+                    "status": "missing",
+                    "expected_primary_metric": "AUROC",
+                    "evidence": "Job guidance declares AUROC as the primary metric, but the final response did not report it.",
+                    "reported_validation_metric": {
+                        "name": None,
+                        "value": None,
+                        "reported_values": [],
+                        "reported_value_entries": [],
+                    },
+                }
+            }
+        },
+        "validation_metric": {"name": None, "value": None, "reported_values": [], "reported_value_entries": []},
+        "agent_last_message": "Validation accuracy: 0.8123\nValidation loss: 0.421",
+    }
+
+    section = missing_result_metrics_section({NO_SKILLS_MODE: run}, [NO_SKILLS_MODE])
+
+    assert "accuracy 0.8123" in section
+    assert "loss 0.4210" in section
+    assert "no parseable validation metric" not in section
+    assert additional_or_observed_metric_values_display(run, "AUROC") == "accuracy 0.8123; loss 0.4210"
+    assert "Additional/other validation metric values" in outcome_details_table({NO_SKILLS_MODE: run}, [NO_SKILLS_MODE])
+
+
+def test_failure_analysis_reports_recovered_job_failure_and_metric_gap():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        additional_or_observed_metric_values_display,
+        failure_analysis_section,
+        outcome_details_table,
+    )
+
+    failed_output = (
+        "TypeError: SmilesCNN.__init__() missing 4 required positional arguments: "
+        "'vocab_size', 'embed_dim', 'num_filters', and 'dropout'\n"
+        "RuntimeError: Simulator run failed with exit code 2.\n"
+    )
+    success_output = (
+        "Finished FedAvg.\n"
+        "site-1: round=0 train_loss=0.6275 valid_auroc=0.7049\n"
+        "site-2: round=0 train_loss=0.6259 valid_auroc=0.7342\n"
+        "Result workspace: /tmp/agent_benchmark/ames-smoke\n"
+    )
+    events = [
+        {
+            "item": {
+                "type": "command_execution",
+                "id": "item_1",
+                "command": "python3 fedavg_job.py --n-clients 2",
+                "status": "failed",
+                "exit_code": 1,
+                "aggregated_output": failed_output,
+            }
+        },
+        {
+            "item": {
+                "type": "command_execution",
+                "id": "item_2",
+                "command": "python3 fedavg_job.py --n-clients 2",
+                "status": "completed",
+                "exit_code": 0,
+                "aggregated_output": success_output,
+            }
+        },
+    ]
+    run = {
+        "available": True,
+        "label": "No skills baseline",
+        "container_exit": {"exit_code": 0},
+        "run": {"final_container_exit_code": 0},
+        "record": {
+            "quality_signals": {
+                "job_guidance_primary_validation_metric": {
+                    "status": "missing",
+                    "expected_primary_metric": "AUROC",
+                    "evidence": "Job guidance declares AUROC as the primary metric, but the final response did not report it.",
+                    "reported_validation_metric": {
+                        "name": None,
+                        "value": None,
+                        "reported_values": [],
+                        "reported_value_entries": [],
+                    },
+                }
+            }
+        },
+        "validation_metric": {"name": None, "value": None, "reported_values": [], "reported_value_entries": []},
+        "agent_events_text": "\n".join(json.dumps(event) for event in events),
+    }
+
+    section = failure_analysis_section({NO_SKILLS_MODE: run}, [NO_SKILLS_MODE])
+
+    assert "Command evidence" in section
+    assert "recovered by a later successful similar command" in section
+    assert "SmilesCNN.__init__() missing 4 required positional arguments" in section
+    assert "Recovery evidence" in section
+    assert "a later simulator/job command exited 0" in section
+    assert "valid_auroc=0.7049" in section
+    assert "Metric reporting gap" in section
+    assert "aggregate `AUROC` scalar" in section
+    assert additional_or_observed_metric_values_display(run, "AUROC") == (
+        "Final site metrics=NA; log/per-site evidence: site-1: round=0 train_loss=0.6275 valid_auroc=0.7049; "
+        "site-2: round=0 train_loss=0.6259 valid_auroc=0.7342"
+    )
+    details = outcome_details_table({NO_SKILLS_MODE: run}, [NO_SKILLS_MODE])
+    assert "Reported validation metric | AUROC NA" in details
+    assert "log/per-site evidence" in details
+
+
+def test_readme_metric_alignment_uses_server_best_validation_metric_scalar():
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+
+    signal = metric_signal(
+        None,
+        "Primary validation metric: AUROC.\n",
+        """
+Final round metrics:
+- `site-1`: valid AUROC `0.7696`, test AUROC `0.7331`
+- `site-2`: valid AUROC `0.7148`, test AUROC `0.7771`
+- `site-3`: valid AUROC `0.7708`, test AUROC `0.7352`
+- Server best validation metric at round 2: `0.7517306189541327`
+""",
+    )
+
+    metric = signal["reported_validation_metric"]
+    assert signal["status"] == "pass"
+    assert signal["aligned_with_readme"] is True
+    assert metric["name"] == "AUROC"
+    assert metric["value"] == 0.7517306189541327
+    assert metric["value_scope"] == "fl_summary_metric"
+    assert metric["site_value_count"] == 6
+    assert metric["summary_value_label"] == "Server best validation metric at round 2"
+
+
+def test_readme_metric_alignment_passes_for_site_level_values_without_scalar():
+    from assist_tools.skills_benchmark.skills.harness.quality_signals import metric_signal
+
+    signal = metric_signal(
+        None,
+        "Primary validation metric: AUROC.\n",
+        """
+Final round metrics:
+- `site-1`: valid AUROC `0.7696`
+- `site-2`: valid AUROC `0.7148`
+- `site-3`: valid AUROC `0.7708`
+""",
+    )
+
+    metric = signal["reported_validation_metric"]
+    assert signal["status"] == "pass"
+    assert signal["aligned_with_readme"] is True
+    assert signal["metric_value_available"] is True
+    assert signal["metric_scalar_available"] is False
+    assert signal["mismatch"] is False
+    assert metric["name"] == "AUROC"
+    assert metric["value"] is None
+    assert metric["value_scope"] == "site_values_only"
+
+
+def test_metrics_chart_names_metric_once_in_panel_title():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE, WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        embedded_bar_chart,
+        outcome_metrics_table,
+    )
+
+    def run(label: str, value: float) -> dict:
+        return {
+            "label": label,
+            "available": True,
+            "status": "0",
+            "run": {"elapsed_seconds": 1, "token_count": 1, "agent_exit_code": 0, "final_container_exit_code": 0},
+            "activity": {"command_count": 1},
+            "record": {},
+            "workspace_delta": {},
+            "validation_metric": {"name": "AUROC", "value": value},
+        }
+
+    chart = embedded_bar_chart(
+        {
+            NO_SKILLS_MODE: run("No skills baseline", 0.7562),
+            WITH_SKILLS_MODE: run("With skills", 0.7529),
+        }
+    )
+    table = outcome_metrics_table(
+        {
+            NO_SKILLS_MODE: run("No skills baseline", 0.7562),
+            WITH_SKILLS_MODE: run("With skills", 0.7529),
+        },
+        [NO_SKILLS_MODE, WITH_SKILLS_MODE],
+    )
+
+    assert "Metrics (AUROC)" in chart
+    assert "FL scalar result" not in chart
+    assert "AUROC 0." not in chart
+    assert chart.count("AUROC") == 1
+    assert ">0.7529<" in chart
+    assert "| Metrics (AUROC) | AUROC 0.7562 | AUROC 0.7529 |" in table
+    assert "FL scalar result" not in table
+
+
+def test_metrics_chart_uses_labeled_aggregated_metric_from_legacy_record():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE, WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        embedded_bar_chart,
+        outcome_metrics_table,
+    )
+
+    def run(label: str, metric: dict) -> dict:
+        return {
+            "label": label,
+            "available": True,
+            "run": {"final_container_exit_code": 0},
+            "activity": {},
+            "validation_metric": metric,
+        }
+
+    runs = {
+        NO_SKILLS_MODE: run("No skills baseline", {"name": "AUROC", "value": None, "reported_value_entries": []}),
+        WITH_SKILLS_MODE: run(
+            "With skills",
+            {
+                "name": "AUROC",
+                "value": None,
+                "reported_value_entries": [
+                    {"value": 0.7531},
+                    {"label": "Best aggregated validation AUROC", "value": 0.7623334631865992},
+                    {"label": "Final site metrics", "value": 0.767293},
+                ],
+            },
+        ),
+    }
+
+    chart = embedded_bar_chart(runs)
+    table = outcome_metrics_table(runs, [NO_SKILLS_MODE, WITH_SKILLS_MODE])
+
+    assert ">0.7623<" in chart
+    assert "| Metrics (AUROC) | AUROC NA | AUROC 0.7623 |" in table
+
+
+def test_metrics_chart_marks_mixed_metric_names_non_comparable():
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE, WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import (
+        embedded_bar_chart,
+        outcome_metrics_table,
+    )
+
+    def run(label: str, metric_name: str, value: float) -> dict:
+        return {
+            "label": label,
+            "available": True,
+            "run": {"final_container_exit_code": 0},
+            "activity": {},
+            "validation_metric": {"name": metric_name, "value": value},
+        }
+
+    runs = {
+        NO_SKILLS_MODE: run("No skills baseline", "accuracy", 0.8123),
+        WITH_SKILLS_MODE: run("With skills", "AUROC", 0.7529),
+    }
+
+    chart = embedded_bar_chart(runs)
+    table = outcome_metrics_table(runs, [NO_SKILLS_MODE, WITH_SKILLS_MODE])
+
+    assert "Metrics (mixed validation metrics)" in chart
+    assert "Not comparable" in chart
+    assert "No skills baseline: accuracy" in chart
+    assert "With skills: AUROC" in chart
+    assert "| Metrics (mixed validation metrics) | accuracy 0.8123 | AUROC 0.7529 |" in table
+
+
+def test_structure_tree_renderer_uses_tree_format():
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import tree_from_paths
+
+    tree = tree_from_paths(
+        [
+            "client.py",
+            "runtime_job_config/ames_fedavg/ames_fedavg/app/config/config_fed_client.json",
+            "runtime_job_config/ames_fedavg/ames_fedavg/app/custom/model.py",
+        ]
+    )
+
+    assert tree.startswith(".\n")
+    assert "|-- client.py" in tree
+    assert "`-- runtime_job_config" in tree
+    assert "        `-- ames_fedavg" in tree
+    assert "- runtime_job_config/ames_fedavg" not in tree
+
+
+def test_run_summary_uses_agent_keys_without_codex_aliases(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.records import write_json, write_run_summary
+
+    final_record = tmp_path / "record.json"
+    summary_path = tmp_path / "run_summary.json"
+    write_json(
+        final_record,
+        {
+            "mode": "with_skills",
+            "agent_process_passed": True,
+            "agent_process_exit_code": 0,
+            "codex_process_passed": True,
+            "codex_process_exit_code": 0,
+            "agent_usage": {"total_tokens": 10},
+            "codex_usage": {"total_tokens": 10},
+            "process_metrics": {
+                "agent_exit_code": 0,
+                "codex_exit_code": 0,
+                "elapsed_seconds": 1,
+            },
+        },
+    )
+
+    write_run_summary(final_record, summary_path, print_summary=False)
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["agent_process_passed"] is True
+    assert summary["agent_process_exit_code"] == 0
+    assert summary["agent_exit_code"] == 0
+    assert summary["agent_usage"] == {"total_tokens": 10}
+    assert "codex_process_passed" not in summary
+    assert "codex_process_exit_code" not in summary
+    assert "codex_exit_code" not in summary
+    assert "codex_usage" not in summary
+    assert not any(key.startswith("codex_") for key in summary["all_metrics"])
+
+
+def test_run_summary_ignores_codex_usage_fallback_and_reports_prompt_hash(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.records import write_json, write_run_summary
+
+    final_record = tmp_path / "record.json"
+    summary_path = tmp_path / "run_summary.json"
+    write_json(
+        final_record,
+        {
+            "mode": "with_skills",
+            "codex_usage": {"total_tokens": 10},
+            "process_metrics": {
+                "elapsed_seconds": 3,
+                "agent_elapsed_seconds": 2,
+            },
+        },
+    )
+    write_json(
+        tmp_path / "prompt_metadata.json",
+        {
+            "prompt_sha256": "abc123",
+            "template_path": "/workspace/prompts/prompt.txt",
+        },
+    )
+
+    write_run_summary(final_record, summary_path, print_summary=False)
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["agent_usage"] == {}
+    assert summary["agent_elapsed_seconds"] == 2
+    assert summary["elapsed_seconds"] == 2
+    assert summary["prompt_hash"] == "abc123"
+    assert summary["prompt_source"] == "/workspace/prompts/prompt.txt"
+    assert summary["structure_quality_signal"] == {
+        "status": "unavailable",
+        "reason": "structure quality was not captured for this run",
+    }
+
+
+def test_make_tree_readable_does_not_follow_symlinked_directories(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.common import make_tree_readable
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_file = outside / "secret.txt"
+    outside_file.write_text("keep private\n", encoding="utf-8")
+    outside_file.chmod(0o600)
+    root = tmp_path / "result"
+    root.mkdir()
+    (root / "outside_link").symlink_to(outside, target_is_directory=True)
+
+    make_tree_readable(root)
+
+    assert stat.S_IMODE(outside_file.stat().st_mode) == 0o600
+
+
+def test_scenario_report_escapes_markdown_table_pipes(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.reports.scenario_report import write_scenario_report
+
+    write_scenario_report(
+        tmp_path,
+        {
+            "scenario_name": "pipe scenario",
+            "status": "passed",
+            "completed_run_count": 1,
+            "expanded_case_count": 1,
+            "winner_policy": "quality",
+            "aggregate_results": {
+                "by_label": {
+                    "with|skills": {
+                        "run_count": 1,
+                        "quality_pass_count": 1,
+                        "agent_elapsed_seconds": {"median": 2.5},
+                        "token_count": {"median": 10},
+                    }
+                },
+                "winner": {"label": "with|skills"},
+            },
+        },
+    )
+
+    report = (tmp_path / "reports" / "scenario_report.md").read_text(encoding="utf-8")
+    assert "with\\|skills" in report
+
+
+def test_report_generators_write_two_mode_outputs(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.modes import NO_SKILLS_MODE, WITH_SKILLS_MODE
+    from assist_tools.skills_benchmark.skills.harness.reports import metrics_report
+    from assist_tools.skills_benchmark.skills.harness.reports.benchmark_insights import main as insights_main
+
+    for mode, value in ((NO_SKILLS_MODE, 0.7562), (WITH_SKILLS_MODE, 0.7529)):
+        mode_dir = tmp_path / mode
+        records_dir = mode_dir / "records"
+        records_dir.mkdir(parents=True)
+        (mode_dir / "container_exit_code.json").write_text(json.dumps({"exit_code": 0}) + "\n", encoding="utf-8")
+        (mode_dir / "run_summary.json").write_text(
+            json.dumps(
+                {
+                    "mode": mode,
+                    "elapsed_seconds": 10,
+                    "token_count": 100,
+                    "agent_exit_code": 0,
+                    "final_container_exit_code": 0,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (records_dir / f"{mode}_record.json").write_text(
+            json.dumps(
+                {
+                    "mode": mode,
+                    "reported_validation_metric": {"name": "AUROC", "value": value},
+                    "process_metrics": {"elapsed_seconds": 10, "token_count": 100},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (mode_dir / "agent_activity.json").write_text(json.dumps({"command_count": 3}) + "\n", encoding="utf-8")
+        (mode_dir / "agent_usage.json").write_text(json.dumps({"total_tokens": 100}) + "\n", encoding="utf-8")
+
+    original_collect_benchmark_runs = metrics_report.collect_benchmark_runs
+    collect_calls = {"count": 0}
+
+    def counted_collect_benchmark_runs(root):
+        collect_calls["count"] += 1
+        return original_collect_benchmark_runs(root)
+
+    monkeypatch.setattr(metrics_report, "collect_benchmark_runs", counted_collect_benchmark_runs)
+    metrics_report.write_reports(tmp_path, "Synthetic Metrics")
+    monkeypatch.setattr(sys, "argv", ["benchmark_insights", str(tmp_path)])
+    insights_main()
+
+    assert (tmp_path / "metrics_report.json").is_file()
+    metrics_markdown = (tmp_path / "metrics_report.md").read_text(encoding="utf-8")
+    insights_markdown = (tmp_path / "benchmark_insights.md").read_text(encoding="utf-8")
+    assert "<svg" in metrics_markdown
+    assert "<svg" in insights_markdown
+    assert "Metrics (AUROC)" in metrics_markdown
+    assert "Metrics (AUROC)" in insights_markdown
+    assert "Benchmark Metrics Comparison" not in insights_markdown
+    assert "with_skills_eval" not in insights_markdown
+    assert "Evaluator" not in insights_markdown
+    assert collect_calls["count"] == 1


### PR DESCRIPTION
## Summary

Adds benchmark reporting on top of the normalized runtime evidence: benchmark insights markdown, metrics markdown/html/json, report generation hooks, and reporting tests.

## Key Scope

- Add `benchmark_insights.md` generation from normalized benchmark records.
- Add metrics report generation in markdown, HTML, and JSON forms.
- Add report generation hooks after pair/replay runs complete and evidence is available.
- Add canonical-layout support for reports under `records/.../mode=<mode>/` result directories.
- Add reporting tests for metrics, insights, tree rendering, and generated outputs.

## Review Notes

This PR depends on the runtime/evidence layer from PR #4790. It is intentionally limited to deriving reports from existing benchmark artifacts; it does not change the Docker setup or execution model.

## Stack

This is PR 5 of 5. It is based on `flare-agent-split/04-benchmark-runtime` / PR #4790.

## Full Split Plan

| PR | Title | Branch | Base | Non-Test Files | Test Files | Non-Test Lines | Test Lines | Total Lines |
|---:|---|---|---|---:|---:|---:|---:|---:|
| 1 | Agent Skills + Checks | `flare-agent-split/01-agent-skills` | `main` | 41 | 8 | 5,397 | 1,321 | 6,718 |
| 2 | Agent CLI | `flare-agent-split/02-agent-cli` | PR 1 | 11 | 8 | 4,362 | 2,488 | 6,850 |
| 3 | Benchmark Docker Setup | `flare-agent-split/03-benchmark-docker-setup` | PR 2 | 29 | 3 | 4,015 | 1,417 | 5,432 |
| 4 | Skill Benchmark Runtime | `flare-agent-split/04-benchmark-runtime` | PR 3 | 25 | 5 | 9,927 | 3,654 | 13,581 |
| 5 | Benchmark Reporting | `flare-agent-split/05-benchmark-reporting` | PR 4 | 3 | 1 | 2,016 | 1,037 | 3,053 |

## Validation

- `python -m pytest tests/unit_test/tool/agent tests/unit_test/tool/agent_skill_checks tests/unit_test/skills_benchmark`
- `./runtest.sh -s`