### PR TITLE
Add per-site recipe config helper

### DIFF
--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -169,6 +169,58 @@ workflow reports round-level aggregation metrics. See
 :ref:`recipe_metrics_artifacts` for the schema, security behavior, and artifact
 discovery contract.
 
+Per-Site Configuration
+----------------------
+
+Some recipes accept site-keyed configuration so that each site can use different
+arguments, scripts, data loaders, or validators. For recipes that implement this
+helper contract, use ``set_per_site_config`` to attach the site-keyed input after
+creating the recipe:
+
+.. code-block:: python
+
+   from nvflare.recipe import SimEnv, set_per_site_config
+
+   set_per_site_config(
+       recipe,
+       {
+           "site-1": {"train_args": "--data_path xxx --batch_size 4"},
+           "site-2": {"train_args": "--data_path yyy --batch_size 2"},
+       },
+   )
+
+   env = SimEnv(clients=recipe.configured_sites())
+
+``configured_sites()`` returns the top-level site names from
+``set_per_site_config`` when helper-provided configuration exists. Otherwise, for
+backward compatibility, it returns site names from a recipe's constructor
+``per_site_config`` when available. It does not infer sites from recipe metadata
+such as resource specs, launcher specs, or mandatory clients. It also does not
+mean those sites are currently connected, validate production enrollment, or
+replace the execution environment.
+
+``set_per_site_config`` stores the mapping and calls the recipe's per-site
+configuration hook. It does not by itself create client targets or rebuild an
+already generated job. A recipe must implement the hook for helper-provided
+per-site fields to affect generated app configuration, command-line arguments,
+data loaders, validators, or other recipe behavior.
+
+.. important::
+
+   The second argument to ``set_per_site_config`` is recipe-specific. The helper
+   validates only that it is a dictionary whose top-level keys are site names and
+   whose values are dictionaries. Users must ensure each per-site dictionary uses
+   fields that the selected recipe understands and can convert into generated app
+   configuration, command-line arguments, data loaders, validators, or other
+   recipe-specific settings.
+
+   For example, FedAvg's current per-site support is through the legacy
+   ``FedAvgRecipe(per_site_config=...)`` constructor argument. That constructor
+   path understands per-site values such as ``train_args``, ``train_script``,
+   and ``command``. It does not automatically interpret arbitrary keys such as
+   ``data_path`` or ``batch_size``. For FedAvg, pass those values through
+   ``train_args`` unless your recipe explicitly documents another shape.
+
 Execution Environments
 ----------------------
 

--- a/nvflare/recipe/__init__.py
+++ b/nvflare/recipe/__init__.py
@@ -18,7 +18,7 @@ from .poc_env import PocEnv
 from .prod_env import ProdEnv
 from .run import Run
 from .sim_env import SimEnv
-from .utils import add_cross_site_evaluation, add_experiment_tracking
+from .utils import add_cross_site_evaluation, add_experiment_tracking, set_per_site_config
 
 __all__ = [
     "SimEnv",
@@ -27,6 +27,7 @@ __all__ = [
     "Run",
     "add_experiment_tracking",
     "add_cross_site_evaluation",
+    "set_per_site_config",
     "FedAvgRecipe",
     "FedTaskRecipe",
 ]

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -164,6 +164,7 @@ class Recipe(ABC):
             job: the job that implements the recipe.
         """
         self.job = job
+        self._helper_per_site_config = None
 
     def process_env(self, env: ExecEnv):
         """Process environment-specific configuration.
@@ -172,6 +173,37 @@ class Recipe(ABC):
         Script validation is handled by each ExecEnv subclass in deploy().
         """
         pass
+
+    def set_per_site_config(self, config: Dict[str, Dict]) -> None:
+        """Set helper-provided per-site configuration for this recipe.
+
+        The generic helper validates only the site-keyed shape. Recipes that
+        need to map fields into generated app config, command arguments, data
+        loaders, or validators should override ``_apply_per_site_config``.
+        """
+        self._helper_per_site_config = dict(config)
+        self._apply_per_site_config(dict(self._helper_per_site_config))
+
+    def _apply_per_site_config(self, config: Dict[str, Dict]) -> None:
+        """Recipe-specific hook for helper-provided per-site configuration."""
+        pass
+
+    def configured_sites(self) -> List[str]:
+        """Return site keys configured through the helper or legacy constructor config.
+
+        This reports configured site names only. It does not infer sites from job
+        metadata, validate production enrollment, or indicate which clients are
+        connected in the execution environment.
+        """
+        helper_per_site_config = getattr(self, "_helper_per_site_config", None)
+        if helper_per_site_config is not None:
+            return list(helper_per_site_config.keys())
+
+        legacy_per_site_config = getattr(self, "per_site_config", None)
+        if isinstance(legacy_per_site_config, dict):
+            return list(legacy_per_site_config.keys())
+
+        return []
 
     def _snapshot_additional_params(self) -> Dict[str, Dict]:
         snapshot = {}

--- a/nvflare/recipe/utils.py
+++ b/nvflare/recipe/utils.py
@@ -59,6 +59,33 @@ MODEL_LOCATOR_REGISTRY = {
 }
 
 
+def _validate_per_site_config_shape(config: Any) -> Dict[str, Dict]:
+    if not isinstance(config, dict):
+        raise TypeError(f"config must be a dict, got {type(config).__name__}")
+
+    for site_name, site_config in config.items():
+        if not isinstance(site_name, str):
+            raise TypeError(f"per-site config key must be a str, got {type(site_name).__name__}")
+        if not isinstance(site_config, dict):
+            raise TypeError(f"per-site config for site {site_name!r} must be a dict, got {type(site_config).__name__}")
+
+    return config
+
+
+def set_per_site_config(recipe: Recipe, config: Dict[str, Dict]) -> None:
+    """Set site-keyed configuration on a recipe.
+
+    The helper only validates the generic shape:
+    - top-level keys are site names
+    - values are recipe-specific dictionaries
+
+    Each recipe is responsible for validating and interpreting the fields inside
+    each site's dictionary. The execution environment still controls which
+    clients are present for a run.
+    """
+    recipe.set_per_site_config(_validate_per_site_config_shape(config))
+
+
 def _has_cross_site_eval_workflow(job: FedJob) -> bool:
     """Check if CrossSiteModelEval workflow is already configured on server."""
     from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -24,7 +24,7 @@ import pytest
 
 from nvflare.job_config.api import FedApp, FedJob
 from nvflare.job_config.fed_app_config import ClientAppConfig
-from nvflare.recipe.utils import collect_non_local_scripts
+from nvflare.recipe.utils import collect_non_local_scripts, set_per_site_config
 
 
 class TestCollectNonLocalScriptsUtility:
@@ -580,3 +580,131 @@ def test_export_processes_falsy_env(tmp_path):
         recipe.export(job_dir=tmpdir, env=_FalsyEnv())
 
     assert "env" in seen
+
+
+class TestRecipePerSiteConfigHelper:
+    """Test generic helper-provided per-site recipe configuration."""
+
+    def test_set_per_site_config_stores_sites_and_calls_recipe_hook(self):
+        from nvflare.recipe.spec import Recipe
+
+        class RecordingRecipe(Recipe):
+            def __init__(self):
+                super().__init__(FedJob(name="test_per_site_config", min_clients=1))
+                self.applied_config = None
+
+            def _apply_per_site_config(self, config):
+                self.applied_config = config
+
+        recipe = RecordingRecipe()
+        config = {
+            "site-1": {"data_path": "xxx", "batch_size": 4, "unknown_to_helper": True},
+            "site-2": {"data_path": "yyy", "batch_size": 2},
+        }
+
+        set_per_site_config(recipe, config)
+
+        assert recipe.configured_sites() == ["site-1", "site-2"]
+        assert recipe.applied_config == config
+        assert recipe.applied_config is not config
+        assert recipe.applied_config["site-1"] is config["site-1"]
+
+    def test_set_per_site_config_hook_mutation_does_not_change_configured_sites(self):
+        from nvflare.recipe.spec import Recipe
+
+        class MutatingRecipe(Recipe):
+            def __init__(self):
+                super().__init__(FedJob(name="test_per_site_config_hook_mutation", min_clients=1))
+
+            def _apply_per_site_config(self, config):
+                del config["site-1"]
+                config["site-2"] = {"rewritten": True}
+                config["site-3"] = {}
+
+        recipe = MutatingRecipe()
+
+        set_per_site_config(recipe, {"site-1": {}, "site-2": {"batch_size": 4}})
+
+        assert recipe.configured_sites() == ["site-1", "site-2"]
+
+    def test_set_per_site_config_does_not_create_client_targets_by_itself(self):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                super().__init__(FedJob(name="test_per_site_no_targets", min_clients=1))
+
+        recipe = BasicRecipe()
+
+        set_per_site_config(recipe, {"site-1": {}, "site-2": {}})
+
+        assert recipe.configured_sites() == ["site-1", "site-2"]
+        assert recipe.job._deploy_map == {}
+
+    def test_configured_sites_prefers_helper_config_over_legacy_constructor_config(self):
+        from nvflare.recipe.spec import Recipe
+
+        class LegacyRecipe(Recipe):
+            def __init__(self):
+                self.per_site_config = {"legacy-1": {}, "legacy-2": {}}
+                super().__init__(FedJob(name="test_legacy_per_site_config", min_clients=1))
+
+        recipe = LegacyRecipe()
+        assert recipe.configured_sites() == ["legacy-1", "legacy-2"]
+
+        set_per_site_config(recipe, {"helper-1": {}})
+
+        assert recipe.configured_sites() == ["helper-1"]
+
+    def test_empty_helper_config_still_overrides_legacy_constructor_config(self):
+        from nvflare.recipe.spec import Recipe
+
+        class LegacyRecipe(Recipe):
+            def __init__(self):
+                self.per_site_config = {"legacy-1": {}}
+                super().__init__(FedJob(name="test_empty_helper_per_site_config", min_clients=1))
+
+        recipe = LegacyRecipe()
+
+        set_per_site_config(recipe, {})
+
+        assert recipe.configured_sites() == []
+
+    def test_configured_sites_does_not_infer_from_job_meta(self):
+        from nvflare.recipe.spec import Recipe
+
+        class MetaRecipe(Recipe):
+            def __init__(self):
+                super().__init__(
+                    FedJob(
+                        name="test_meta_sites_not_configured_sites",
+                        min_clients=1,
+                        mandatory_clients=["site-1"],
+                        meta_props={
+                            "resource_spec": {"site-1": {"num_of_gpus": 1}},
+                            "launcher_spec": {"site-2": {"docker": {"image": "example/image:latest"}}},
+                        },
+                    )
+                )
+
+        recipe = MetaRecipe()
+
+        assert recipe.configured_sites() == []
+
+    @pytest.mark.parametrize(
+        "config, match",
+        [
+            ("not-a-dict", "config must be a dict"),
+            ({1: {}}, "per-site config key must be a str"),
+            ({"site-1": "not-a-dict"}, "per-site config for site 'site-1' must be a dict"),
+        ],
+    )
+    def test_set_per_site_config_validates_generic_shape_only(self, config, match):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                super().__init__(FedJob(name="test_per_site_validation", min_clients=1))
+
+        with pytest.raises(TypeError, match=match):
+            set_per_site_config(BasicRecipe(), config)

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -236,6 +236,12 @@ class TestRecipePackageExports:
 
         assert callable(add_cross_site_evaluation)
 
+    def test_set_per_site_config_importable_from_recipe(self):
+        """set_per_site_config must be importable from the top-level nvflare.recipe package."""
+        from nvflare.recipe import set_per_site_config
+
+        assert callable(set_per_site_config)
+
 
 class TestCrossSiteEvalIdempotency:
     """Tests for resilient idempotency in add_cross_site_evaluation."""


### PR DESCRIPTION
## Summary
- add `set_per_site_config(recipe, config)` and export it from `nvflare.recipe`
- add base `Recipe.configured_sites()` with helper-config precedence and legacy `per_site_config` fallback
- document that per-site config values are recipe-specific and must use fields the selected recipe understands

## Tests
- `python3 -m pytest tests/unit_test/recipe/spec_test.py tests/unit_test/recipe/utils_test.py -q`
- `./runtest.sh -s`