### PR TITLE
Add recipe metadata helper

### DIFF
--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -169,6 +169,73 @@ workflow reports round-level aggregation metrics. See
 :ref:`recipe_metrics_artifacts` for the schema, security behavior, and artifact
 discovery contract.
 
+Recipe Metadata
+---------------
+
+Use ``set_recipe_meta`` to add generated job metadata from a recipe without
+mutating ``recipe.job.job.meta_props`` directly. The helper sets one
+``JobMetaKey`` metadata entry at a time:
+
+.. code-block:: python
+
+   from nvflare.apis.job_def import JobMetaKey
+   from nvflare.recipe import set_recipe_meta
+
+   set_recipe_meta(
+       recipe,
+       JobMetaKey.STUDY,
+       "default",
+   )
+   set_recipe_meta(
+       recipe,
+       JobMetaKey.RESOURCE_SPEC,
+       {
+           "site-1": {"num_of_gpus": 1, "mem_per_gpu_in_GiB": 4},
+           "site-2": {"num_of_gpus": 1, "mem_per_gpu_in_GiB": 2},
+       },
+   )
+   set_recipe_meta(
+       recipe,
+       JobMetaKey.JOB_LAUNCHER_SPEC,
+       {
+           "site-1": {"docker": {"image": "nvflare-site1:latest"}},
+           "site-2": {"docker": {"image": "nvflare-site2:latest"}},
+       },
+   )
+   set_recipe_meta(
+       recipe,
+       JobMetaKey.MANDATORY_CLIENTS,
+       ["site-1", "site-2"],
+   )
+
+Common metadata fields include:
+
+* ``resource_spec``: per-site resource requirements for generated
+  ``meta.json``.
+* ``launcher_spec``: per-site launcher requirements for generated
+  ``meta.json``.
+* ``mandatory_clients``: required client names, if supported by the workflow.
+* ``scope``: job scope metadata.
+* ``custom_props``: nested custom metadata.
+* ``study``: job study metadata.
+
+The key must be a ``JobMetaKey`` enum member. Raw strings are not accepted. The
+value must be a number, a string, a dictionary, or a list. The helper writes
+the key/value pair through ``meta_props`` and does not mutate dedicated recipe
+or ``FedJobConfig`` fields such as ``min_clients``. If the generated
+``meta.json`` also contains that key, the ``meta_props`` value is written last
+by the job generator.
+
+``JobMetaKey.DEPLOY_MAP`` is generated from the recipe's deployment map and
+cannot be set through this helper.
+
+If the same key already exists in ``meta_props``, ``set_recipe_meta`` replaces
+that value.
+
+The helper does not validate runtime resource availability, production
+enrollment, or whether sites named in metadata are present for a run. The
+execution environment and deployment still determine which sites are present.
+
 Execution Environments
 ----------------------
 

--- a/nvflare/recipe/__init__.py
+++ b/nvflare/recipe/__init__.py
@@ -18,7 +18,7 @@ from .poc_env import PocEnv
 from .prod_env import ProdEnv
 from .run import Run
 from .sim_env import SimEnv
-from .utils import add_cross_site_evaluation, add_experiment_tracking
+from .utils import add_cross_site_evaluation, add_experiment_tracking, set_recipe_meta
 
 __all__ = [
     "SimEnv",
@@ -27,6 +27,7 @@ __all__ = [
     "Run",
     "add_experiment_tracking",
     "add_cross_site_evaluation",
+    "set_recipe_meta",
     "FedAvgRecipe",
     "FedTaskRecipe",
 ]

--- a/nvflare/recipe/utils.py
+++ b/nvflare/recipe/utils.py
@@ -15,9 +15,11 @@
 import copy
 import importlib
 import os
+from numbers import Number
 from typing import Any, Dict, List, Optional
 
 from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.fuel.utils.import_utils import optional_import
 from nvflare.job_config.api import FedJob
 from nvflare.recipe.spec import Recipe
@@ -57,6 +59,50 @@ MODEL_LOCATOR_REGISTRY = {
         "persistor_param": "tf_persistor_id",
     },
 }
+
+_RECIPE_META_UNSUPPORTED_KEYS = {
+    JobMetaKey.DEPLOY_MAP,
+}
+
+
+def _normalize_recipe_meta_key(key: Any) -> str:
+    if not isinstance(key, JobMetaKey):
+        raise TypeError(f"recipe meta key must be a JobMetaKey, got {type(key).__name__}")
+    if key in _RECIPE_META_UNSUPPORTED_KEYS:
+        raise ValueError(
+            f"recipe meta key {key.value!r} is generated from the recipe deployment map and "
+            "cannot be set through set_recipe_meta"
+        )
+    return key.value
+
+
+def _validate_recipe_meta_value(key: str, value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, (Number, str, dict, list)):
+        allowed_types = "number, str, dict, or list"
+        raise TypeError(f"recipe meta value for key {key!r} must be a {allowed_types}; got {type(value).__name__}")
+
+
+def _get_recipe_job_config(recipe: Recipe):
+    job = getattr(recipe, "job", None)
+    job_config = getattr(job, "job", None)
+    if job_config is None:
+        raise TypeError("recipe must provide a FedJob through recipe.job")
+    return job_config
+
+
+def set_recipe_meta(recipe: Recipe, key: JobMetaKey, value: Any) -> None:
+    """Set one generated job metadata value through ``meta_props``.
+
+    The key must be a ``JobMetaKey`` enum member. The value is stored in
+    ``meta_props`` and replaces any existing ``meta_props`` value for that key.
+    """
+    key = _normalize_recipe_meta_key(key)
+    _validate_recipe_meta_value(key, value)
+    job_config = _get_recipe_job_config(recipe)
+
+    meta_props = copy.deepcopy(job_config.meta_props) or {}
+    meta_props[key] = copy.deepcopy(value)
+    job_config.meta_props = meta_props
 
 
 def _has_cross_site_eval_workflow(job: FedJob) -> bool:

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -22,9 +22,10 @@ import tempfile
 
 import pytest
 
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.job_config.api import FedApp, FedJob
 from nvflare.job_config.fed_app_config import ClientAppConfig
-from nvflare.recipe.utils import collect_non_local_scripts
+from nvflare.recipe.utils import collect_non_local_scripts, set_recipe_meta
 
 
 class TestCollectNonLocalScriptsUtility:
@@ -404,6 +405,171 @@ class TestRecipeConfigMethods:
         assert captured["server_kwargs"] == {"id": "decomposer_reg"}
         assert captured["client_kwargs"] == {"id": "decomposer_reg"}
         assert captured["server_obj"] is not captured["client_obj"]
+
+
+class TestRecipeMetaHelper:
+    """Test generic helper-provided recipe metadata."""
+
+    def test_set_recipe_meta_sets_recognized_top_level_meta_props(self, tmp_path):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                job = FedJob(name="test_recipe_meta", min_clients=1, meta_props={"owner": "alice"})
+                job.to_server({"server_arg": True})
+                super().__init__(job)
+
+        recipe = BasicRecipe()
+        resource_spec = {
+            "site-1": {"num_of_gpus": 1, "mem_per_gpu_in_GiB": 4},
+            "site-2": {"num_of_gpus": 1, "mem_per_gpu_in_GiB": 2},
+        }
+        launcher_spec = {
+            "site-1": {"docker": {"image": "nvflare-site1:latest"}},
+            "site-2": {"docker": {"image": "nvflare-site2:latest"}},
+        }
+        mandatory_clients = ["site-1", "site-2"]
+
+        set_recipe_meta(recipe, JobMetaKey.STUDY, "default")
+        set_recipe_meta(recipe, JobMetaKey.RESOURCE_SPEC, resource_spec)
+        set_recipe_meta(recipe, JobMetaKey.JOB_LAUNCHER_SPEC, launcher_spec)
+        set_recipe_meta(recipe, JobMetaKey.MANDATORY_CLIENTS, mandatory_clients)
+        set_recipe_meta(recipe, JobMetaKey.SCOPE, "private")
+        set_recipe_meta(recipe, JobMetaKey.CUSTOM_PROPS, {"team": "research"})
+
+        job_config = recipe.job.job
+        assert job_config.min_clients == 1
+        assert job_config.mandatory_clients is None
+        assert job_config.resource_specs == {}
+        assert job_config.meta_props == {
+            "owner": "alice",
+            "study": "default",
+            "resource_spec": resource_spec,
+            "launcher_spec": launcher_spec,
+            "mandatory_clients": mandatory_clients,
+            "scope": "private",
+            "custom_props": {"team": "research"},
+        }
+
+        recipe.job.export_job(str(tmp_path))
+        with open(tmp_path / "test_recipe_meta" / "meta.json") as f:
+            exported_meta = json.load(f)
+
+        assert exported_meta["min_clients"] == 1
+        assert exported_meta["mandatory_clients"] == mandatory_clients
+        assert exported_meta["resource_spec"] == resource_spec
+        assert exported_meta["launcher_spec"] == launcher_spec
+        assert exported_meta["scope"] == "private"
+        assert exported_meta["study"] == "default"
+        assert exported_meta["custom_props"] == {"team": "research"}
+        assert exported_meta["owner"] == "alice"
+
+    def test_set_recipe_meta_stores_values_that_differ_from_fed_job_config(self, tmp_path):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                job = FedJob(name="test_recipe_meta_conflict", min_clients=2)
+                job.job.resource_specs = {"base-site": {"num_of_gpus": 0}}
+                job.to_server({"server_arg": True})
+                super().__init__(job)
+
+        recipe = BasicRecipe()
+        resource_spec = {"site-1": {"num_of_gpus": 1}}
+
+        set_recipe_meta(recipe, JobMetaKey.MIN_CLIENTS, 3)
+        set_recipe_meta(recipe, JobMetaKey.RESOURCE_SPEC, resource_spec)
+
+        job_config = recipe.job.job
+        assert job_config.min_clients == 2
+        assert job_config.resource_specs == {"base-site": {"num_of_gpus": 0}}
+        assert job_config.meta_props["min_clients"] == 3
+        assert job_config.meta_props["resource_spec"] == resource_spec
+
+        recipe.job.export_job(str(tmp_path))
+        with open(tmp_path / "test_recipe_meta_conflict" / "meta.json") as f:
+            exported_meta = json.load(f)
+
+        assert exported_meta["min_clients"] == 3
+        assert exported_meta["resource_spec"] == resource_spec
+
+    def test_set_recipe_meta_replaces_different_value_from_existing_meta_props(self):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                super().__init__(
+                    FedJob(name="test_recipe_meta_props_conflict", min_clients=1, meta_props={"study": "a"})
+                )
+
+        recipe = BasicRecipe()
+        set_recipe_meta(recipe, JobMetaKey.STUDY, "b")
+
+        assert recipe.job.job.meta_props["study"] == "b"
+
+    def test_set_recipe_meta_allows_existing_meta_props_that_differ_from_generated_values(self):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                job = FedJob(name="test_recipe_meta_generated_conflict", min_clients=2, meta_props={"min_clients": 5})
+                super().__init__(job)
+
+        recipe = BasicRecipe()
+        set_recipe_meta(recipe, JobMetaKey.STUDY, "default")
+
+        assert recipe.job.job.meta_props["min_clients"] == 5
+        assert recipe.job.job.meta_props["study"] == "default"
+
+    def test_set_recipe_meta_rejects_generated_deploy_map_key(self):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                job = FedJob(name="test_recipe_meta_deploy_map", min_clients=1)
+                job.to_server({"server_arg": True})
+                super().__init__(job)
+
+        with pytest.raises(ValueError, match="deploy_map.*cannot be set through set_recipe_meta"):
+            set_recipe_meta(BasicRecipe(), JobMetaKey.DEPLOY_MAP, {"app": ["server"]})
+
+    def test_set_recipe_meta_deep_copies_user_values(self):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                super().__init__(FedJob(name="test_recipe_meta_copy", min_clients=1))
+
+        recipe = BasicRecipe()
+        launcher_spec = {"site-1": {"docker": {"image": "nvflare:latest"}}}
+        mandatory_clients = ["site-1"]
+
+        set_recipe_meta(recipe, JobMetaKey.JOB_LAUNCHER_SPEC, launcher_spec)
+        set_recipe_meta(recipe, JobMetaKey.MANDATORY_CLIENTS, mandatory_clients)
+        launcher_spec["site-1"]["docker"]["image"] = "changed"
+        mandatory_clients.append("site-2")
+
+        assert recipe.job.job.meta_props["launcher_spec"] == {"site-1": {"docker": {"image": "nvflare:latest"}}}
+        assert recipe.job.job.meta_props["mandatory_clients"] == ["site-1"]
+
+    @pytest.mark.parametrize(
+        "key, value, error_type, match",
+        [
+            (1, "value", TypeError, "key must be a JobMetaKey"),
+            ("study", "default", TypeError, "key must be a JobMetaKey"),
+            (JobMetaKey.STUDY, True, TypeError, "must be a number, str, dict, or list"),
+            (JobMetaKey.STUDY, None, TypeError, "must be a number, str, dict, or list"),
+        ],
+    )
+    def test_set_recipe_meta_validates_key_and_supported_value_types(self, key, value, error_type, match):
+        from nvflare.recipe.spec import Recipe
+
+        class BasicRecipe(Recipe):
+            def __init__(self):
+                super().__init__(FedJob(name="test_recipe_meta_validation", min_clients=1))
+
+        with pytest.raises(error_type, match=match):
+            set_recipe_meta(BasicRecipe(), key, value)
 
 
 class _DummyExecEnv:

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -236,6 +236,12 @@ class TestRecipePackageExports:
 
         assert callable(add_cross_site_evaluation)
 
+    def test_set_recipe_meta_importable_from_recipe(self):
+        """set_recipe_meta must be importable from the top-level nvflare.recipe package."""
+        from nvflare.recipe import set_recipe_meta
+
+        assert callable(set_recipe_meta)
+
 
 class TestCrossSiteEvalIdempotency:
     """Tests for resilient idempotency in add_cross_site_evaluation."""


### PR DESCRIPTION
## Summary
- add `set_recipe_meta(recipe, key, value)` and export it from `nvflare.recipe`
- require the second argument to be a `JobMetaKey` enum member; raw strings are rejected
- accept number, string, dictionary, or list values, including list-backed metadata such as `JobMetaKey.MANDATORY_CLIENTS`
- write helper-provided metadata through `meta_props`; same-key `meta_props` values are replaced without conflict checks
- reject `JobMetaKey.DEPLOY_MAP` because it is generated dynamically from recipe deployment and must not be snapshotted into `meta_props`
- document recipe metadata helper usage and update agent test-command guidance
- add unit coverage for metadata export, deep-copying, enum/value validation, metadata replacement/override behavior, deploy-map rejection, list-valued metadata, and package export

## Tests
- `source ../.venv/bin/activate && python3 -m pytest tests/unit_test/recipe/spec_test.py tests/unit_test/recipe/utils_test.py -q`
- `source ../.venv/bin/activate && ./runtest.sh -s --skip-install`
- `source ../.venv/bin/activate && ./runtest.sh -u --skip-install`