### PR TITLE
fixes nightly build: add exact CSE simulator allow list

### DIFF
--- a/tests/integration_test/slow/recipe_system_test.py
+++ b/tests/integration_test/slow/recipe_system_test.py
@@ -61,7 +61,9 @@ def _write_simulator_resources(workspace_root: str, class_allow_list: list[str])
 def _collect_component_paths(element):
     paths = set()
     if isinstance(element, dict):
-        component_path = element.get("path") or element.get("class_path")
+        component_path = element.get("path")
+        if component_path is None:
+            component_path = element.get("class_path")
         if isinstance(component_path, str):
             paths.add(component_path)
         for value in element.values():
@@ -83,7 +85,12 @@ def _assert_allow_list_matches_exported_job(recipe, export_root, job_name: str, 
             with open(os.path.join(root, file_name)) as f:
                 actual_paths.update(_collect_component_paths(json.load(f)))
 
-    assert actual_paths == set(class_allow_list)
+    expected_paths = set(class_allow_list)
+    missing = expected_paths - actual_paths
+    extra = actual_paths - expected_paths
+    assert (
+        actual_paths == expected_paths
+    ), f"Allow-list mismatch for job '{job_name}': missing from config={missing}, extra in config={extra}"
 
 
 class TestRecipeSystemIntegration:

--- a/tests/integration_test/slow/recipe_system_test.py
+++ b/tests/integration_test/slow/recipe_system_test.py
@@ -24,16 +24,66 @@ To run manually:
 TODO: Decide if these should be added to an existing test category or run in a separate suite.
 """
 
+import json
 import os
 
 import numpy as np
 
+from nvflare.apis.fl_constant import WorkspaceConstants
 from nvflare.app_common.np.recipes import NumpyCrossSiteEvalRecipe, NumpyFedAvgRecipe
 from nvflare.recipe import PocEnv, SimEnv
 from nvflare.recipe.utils import add_cross_site_evaluation
 
 INTEGRATION_TEST_ROOT = os.path.dirname(os.path.dirname(__file__))
 REPO_ROOT = os.path.dirname(os.path.dirname(INTEGRATION_TEST_ROOT))
+CSE_ONLY_DUMMY_VALIDATOR_ALLOW_LIST = [
+    "nvflare.app_common.np.np_model_locator.NPModelLocator",
+    "nvflare.app_common.np.np_validator.NPValidator",
+    "nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator",
+    "nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval",
+]
+
+
+def _write_simulator_resources(workspace_root: str, class_allow_list: list[str]):
+    local_dir = os.path.join(workspace_root, WorkspaceConstants.SITE_FOLDER_NAME)
+    os.makedirs(local_dir, exist_ok=True)
+    with open(os.path.join(local_dir, WorkspaceConstants.RESOURCES_CONFIG), "w") as f:
+        json.dump(
+            {
+                "format_version": 2,
+                "class_allow_list": class_allow_list,
+            },
+            f,
+            indent=4,
+        )
+
+
+def _collect_component_paths(element):
+    paths = set()
+    if isinstance(element, dict):
+        component_path = element.get("path") or element.get("class_path")
+        if isinstance(component_path, str):
+            paths.add(component_path)
+        for value in element.values():
+            paths.update(_collect_component_paths(value))
+    elif isinstance(element, list):
+        for value in element:
+            paths.update(_collect_component_paths(value))
+    return paths
+
+
+def _assert_allow_list_matches_exported_job(recipe, export_root, job_name: str, class_allow_list: list[str]):
+    recipe.export(str(export_root))
+    job_root = os.path.join(export_root, job_name)
+    actual_paths = set()
+    for root, _, files in os.walk(job_root):
+        for file_name in files:
+            if file_name not in ("config_fed_server.json", "config_fed_client.json"):
+                continue
+            with open(os.path.join(root, file_name)) as f:
+                actual_paths.update(_collect_component_paths(json.load(f)))
+
+    assert actual_paths == set(class_allow_list)
 
 
 class TestRecipeSystemIntegration:
@@ -110,15 +160,26 @@ class TestRecipeSystemIntegration:
         model_file = tmp_path / "pretrained.npy"
         np.save(str(model_file), np.array([1.0, 2.0, 3.0]))
         workspace_root = str(tmp_path / "cse_only_dummy")
+        job_name = "cse-only-dummy"
+        _write_simulator_resources(
+            os.path.join(workspace_root, job_name),
+            CSE_ONLY_DUMMY_VALIDATOR_ALLOW_LIST,
+        )
         env = SimEnv(num_clients=2, workspace_root=workspace_root)
         recipe = NumpyCrossSiteEvalRecipe(
-            name="cse-only-dummy",
+            name=job_name,
             min_clients=2,
             initial_ckpt=str(model_file),
             # No eval_script -> NPValidator on clients (submit_model returns OK)
         )
+        _assert_allow_list_matches_exported_job(
+            recipe,
+            tmp_path / "cse_only_dummy_export",
+            job_name,
+            CSE_ONLY_DUMMY_VALIDATOR_ALLOW_LIST,
+        )
         run = recipe.execute(env)
-        assert run.get_job_id() == "cse-only-dummy"
+        assert run.get_job_id() == job_name
         result_path = run.get_result()
         expected_result = os.path.join(env.workspace_root, run.get_job_id())
         assert result_path == expected_result


### PR DESCRIPTION
## Summary
- Add an exact `class_allow_list` for the CSE-only `NumpyCrossSiteEvalRecipe` integration test workspace.
- Assert the allow-list exactly matches the generated `config_fed_server.json` and `config_fed_client.json` component paths.
- Keep simulator runtime behavior unchanged; no broad simulator-wide allow-list is introduced.

## Root Cause
`NVFlare-nightly-main` build #489 failed in `integration_test slow` for `TestRecipeSystemIntegration::test_hello_numpy_cross_val_cse_only_dummy_validator` because the generated non-BYOC simulator workspace had no `local/resources.json` or `local/resources.json.default`. `ComponentPathAuthorizer` therefore rejected built-in components such as `CrossSiteModelEval` before the simulator server app could start.

## Validation
- `.venv/bin/python -m pytest tests/integration_test/slow/recipe_system_test.py::TestRecipeSystemIntegration::test_hello_numpy_cross_val_cse_only_dummy_validator -q`
- `.venv/bin/python -m pytest tests/integration_test/slow/recipe_system_test.py -q`
- `PATH=/Users/pcnudde/.codex/worktrees/b702/NVFlare/.venv/bin:$PATH ./runtest.sh --skip-install -s`
- `.venv/bin/python -m black --check tests/integration_test/slow/recipe_system_test.py`
- `.venv/bin/python -m isort --check-only tests/integration_test/slow/recipe_system_test.py`
- `.venv/bin/python -m flake8 tests/integration_test/slow/recipe_system_test.py`
- `git diff --check`