### PR TITLE
Support study-specific K8s job pod templates

### DIFF
--- a/docs/design/job_launcher_and_job_handle.md
+++ b/docs/design/job_launcher_and_job_handle.md
@@ -374,13 +374,14 @@ Constructor parameters:
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
 | `config_file_path` | required | Path to kubeconfig. Loaded lazily on first `launch_job`. |
-| `workspace_pvc` | required | PVC claim name for workspace volume. |
-| `study_data_pvc_file_path` | required | YAML file mapping study/dataset names to PVC claim names. Validated lazily; missing study entries skip data PVC mounts and log a warning. |
+| `study_data_pvc_file_path` | `None` | Optional YAML file mapping study/dataset names to PVC claim names. Validated lazily; missing study entries skip data PVC mounts and log a warning. When this is the only study-specific setting, the launcher uses the built-in pod manifest behavior. |
+| `study_job_spec_file_path` | `None` | Optional YAML file mapping study names to Kubernetes Pod YAML templates. Matching studies use the template with NVFlare-owned job fields overlaid; unmatched studies use the built-in manifest. When this is set without `study_data_pvc_file_path`, no study-data PVC mounts are added. |
 | `timeout` | `None` | Wall-clock seconds for `enter_states([RUNNING])`. |
 | `namespace` | `"default"` | Kubernetes namespace. |
 | `pending_timeout` | `120` | Seconds to wait while the scheduler reports insufficient CPU, memory, or GPU resources. Use `0` to fail fast or `None` to wait indefinitely unless `timeout` is set. Job meta can override with `launcher_spec[site][k8s].pending_timeout`. |
 | `default_python_path` | `"/usr/local/bin/python3"` | Default Python executable in the pod command. Job meta can override with `launcher_spec[site][k8s].python_path`. |
 | `workspace_mount_path` | `"/var/tmp/nvflare/workspace"` | In-container path where job pods mount the transferred job workspace and startup kit. `nvflare deploy prepare` sets this from `parent.workspace_mount_path`. |
+| `image_pull_secrets` | `None` | Optional list of existing Kubernetes Secret names attached to launched job pods as `imagePullSecrets`. |
 | `ephemeral_storage` | `"1Gi"` | Default job pod workspace `emptyDir` size and `ephemeral-storage` request/limit. Job meta can override with `launcher_spec[site][k8s].ephemeral_storage`. |
 
 Launch sequence:
@@ -389,14 +390,24 @@ Launch sequence:
 |------|--------|
 | 0 | Lazy init: load kubeconfig and create `CoreV1Api`. |
 | 1 | Sanitize job ID via `uuid4_to_rfc1123`. Extract `site_name`, `job_image` from `get_job_launcher_spec(job_meta, site_name, "k8s")`. Raise if `WORKSPACE_OBJECT` missing. |
-| 2 | Read `JOB_PROCESS_ARGS`; raise if absent or `EXE_MODULE` missing. Resolve dataset PVC mounts from `study_data_pvc_file_path` when the YAML file contains entries for the job study. |
-| 3 | Build `job_config`: name, image, args from `get_module_args()`. Use `launcher_spec[site][k8s].python_path` for the pod command when present, falling back to `default_python_path`. Mount the job workspace at `workspace_mount_path`, mount the startup-kit Secret at `<workspace_mount_path>/startup`, and set custom-code `PYTHONPATH` under `workspace_mount_path`. Add the workspace `emptyDir.sizeLimit` and `resources.requests/limits["ephemeral-storage"]` from `launcher_spec[site][k8s].ephemeral_storage` when present, falling back to the launcher default. Add K8s CPU and memory limits from `launcher_spec`; add GPU limits from the flat `resource_spec[site].num_of_gpus` GPU resource requirement. Apply `launcher_spec[site][k8s].pending_timeout` when present. Missing study entries skip data PVC mounts and log a warning. |
+| 2 | Read `JOB_PROCESS_ARGS`; raise if absent or `EXE_MODULE` missing. Resolve a pod YAML template from `study_job_spec_file_path` when configured and the job study has an entry. Resolve dataset PVC mounts from `study_data_pvc_file_path` only when that path is configured and the YAML file contains entries for the job study. |
+| 3 | Build `job_config`: name, image, args from `get_module_args()`. Use `launcher_spec[site][k8s].python_path` for the pod command when present, falling back to `default_python_path`. Mount the job workspace at `workspace_mount_path`, mount the startup-kit Secret at `<workspace_mount_path>/startup`, and set custom-code `PYTHONPATH` under `workspace_mount_path`. Add the workspace `emptyDir.sizeLimit` and `resources.requests/limits["ephemeral-storage"]` from `launcher_spec[site][k8s].ephemeral_storage` when present, falling back to the launcher default. Add K8s CPU and memory limits from `launcher_spec`; add GPU limits from the flat `resource_spec[site].num_of_gpus` GPU resource requirement. Apply `launcher_spec[site][k8s].pending_timeout` when present. Missing study entries skip data PVC mounts and log a warning. If a pod template is resolved, preserve template pod fields and sidecars while replacing NVFlare-owned fields such as pod name, job container image/command/args, workspace mounts, transfer env vars, image pull secrets, and resources. |
 | 4 | Create `K8sJobHandle`. |
 | 5 | `core_v1.create_namespaced_pod()`. On any exception: set `terminal_state = TERMINATED`, preserve `EXCEPTION` as the return code, and return handle. |
 | 6 | `job_handle.enter_states([RUNNING])`. On any `BaseException`: `terminate()` then re-raise. |
 | 7 | Return handle. |
 
-The K8s launcher loads `study_data_pvc_file_path` once per launcher instance. Restart the parent site process to pick up hand edits to this runtime file.
+The K8s launcher loads `study_data_pvc_file_path` and
+`study_job_spec_file_path` once per launcher instance. Restart the parent site
+process to pick up hand edits to these runtime files.
+
+Study-specific configuration combinations:
+
+- `study_data_pvc_file_path` only: use the built-in pod manifest and add matching study-data PVC mounts under `/data/<study>/<dataset>`.
+- `study_job_spec_file_path` only: use the matching Pod template and add only the launcher-owned workspace/startup volumes and mounts.
+- Both paths: use the matching Pod template. If `study_data_pvc_file_path` also has entries for the job study, the launcher logs a warning and adds those PVCs as extra volumes and mounts.
+
+When a Pod template is used, `workspace-job` and `startup-kit` remain launcher-owned reserved names. Any same-named template `spec.volumes` or selected job-container `volumeMounts` are replaced by the launcher-generated `emptyDir` workspace and startup-kit Secret mounts. Other named template volumes and mounts are preserved.
 
 **Event registration** — unconditional (site policy, not job config):
 

--- a/docs/design/site_runtime_packaging_design.md
+++ b/docs/design/site_runtime_packaging_design.md
@@ -408,6 +408,24 @@ Supported `job_launcher` keys:
     `imagePullSecrets` to every dynamically launched job pod for this prepared
     site.
 
+- `study_job_spec_file_path`
+  - Required: no
+  - Default: `null`
+  - Description: optional YAML mapping from study name to a Kubernetes Pod YAML
+    template file. When the launched job's study has an entry, `K8sJobLauncher`
+    loads that pod template and overlays NVFlare-owned job fields such as pod
+    name, job container image/command/args, workspace volumes, transfer
+    environment variables, image pull secrets, and resource requests. Relative
+    pod-template paths are resolved from the mapping file directory. Studies
+    without an entry use the built-in pod manifest. If only
+    `study_job_spec_file_path` is set, no study-data PVC mounts are added. If
+    both `study_job_spec_file_path` and `study_data_pvc_file_path` are
+    configured and the job study has entries in both files, the Pod template is
+    used and the study-data PVC entries are added as extra volume mounts with a
+    warning. The launcher always owns the `workspace-job` and `startup-kit`
+    volume names; same-named template volumes and job-container mounts are
+    replaced.
+
 
 ## Docker Runtime Preparation
 

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -273,6 +273,8 @@ The runtime config controls site-level Kubernetes settings:
   to every dynamically launched job pod for this prepared site. Configure this
   during deployment preparation when job images live in a private registry; job
   authors still only specify the job image in ``meta.json``.
+  ``study_job_spec_file_path`` can point to a YAML file that maps study names to
+  Kubernetes Pod template files for dynamically launched job pods.
   ``pending_timeout`` is in seconds. It controls how long a dynamically launched
   job pod can stay in ``Pending`` or ``Unknown`` before the launcher deletes it
   and reports the run as an execution exception. The admin ``list_jobs`` command
@@ -472,6 +474,15 @@ the dataset at ``/data/<study>/<dataset>``, for example
 ``/data/default/data``. ``mode`` must be ``ro`` or ``rw``. Missing
 ``study_data.yaml`` files or missing entries for a job's study mean no
 study-data PVCs are mounted for that job.
+
+When ``study_job_spec_file_path`` is configured, matching jobs use the
+study-specific Pod template. If no ``study_data_pvc_file_path`` is configured,
+the template does not receive additional study-data mounts. If both are
+configured and the job study has matching entries in both files, the template is
+used and the study-data PVCs are added as extra volume mounts; the launcher logs
+a warning for this combination. The launcher always replaces template
+``workspace-job`` and ``startup-kit`` volumes and job-container mounts with its
+generated workspace ``emptyDir`` and startup-kit Secret mounts.
 
 Example ``nvfldata-pvc.yaml``:
 

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -460,6 +460,15 @@ study data mappings in ``local/study_data.yaml`` inside the prepared kit before
 copying ``local/`` into the workspace PVC. If the kit is already staged, edit
 the file on the PVC or restage ``local/``.
 
+``nvflare deploy prepare`` writes the K8s launcher's
+``study_data_pvc_file_path`` as ``<workspace_mount_path>/local/study_data.yaml``
+in the prepared ``local/resources.json.default``. Before staging the prepared
+kit or starting the parent pod, you can edit that launcher config to use a
+different ``study_data_pvc_file_path``, remove it entirely, and/or add
+``study_job_spec_file_path`` for study-specific Pod templates. Any mapping or
+template files referenced by these fields must be staged with ``local/`` or
+otherwise exist at the configured in-pod paths.
+
 Example ``study_data.yaml``:
 
 .. code-block:: yaml

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -484,6 +484,94 @@ a warning for this combination. The launcher always replaces template
 ``workspace-job`` and ``startup-kit`` volumes and job-container mounts with its
 generated workspace ``emptyDir`` and startup-kit Secret mounts.
 
+Minimal Study Job Pod Template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``study_job_spec_file_path`` to point the launcher to a study-to-template
+mapping file:
+
+.. code-block:: yaml
+
+   study-a: pod_specs/default-job-pod.yaml
+
+The following ``pod_specs/default-job-pod.yaml`` starts with the minimal Pod
+template and shows common optional fields, including a node selector for an H100
+node labeled by the NVIDIA GPU Operator or NVIDIA GPU Feature Discovery (GFD).
+Before setting the selector, verify the exact label value in your cluster:
+
+.. code-block:: console
+
+   $ kubectl get nodes -L nvidia.com/gpu.product,nvidia.com/gpu.count,nvidia.com/gpu.present
+
+If you omit the optional fields and keep only the ``nvflare_job`` container, the
+study uses ``study_job_spec_file_path`` while keeping the same effective job pod
+manifest as the built-in launcher behavior:
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     labels:
+       nvflare.io/study: study-a
+       workload: h100-training
+     annotations:
+       nvflare.io/study-owner: research-team-a
+       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+   spec:
+     serviceAccountName: study-a-job
+     nodeSelector:
+       nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+     tolerations:
+       - key: nvidia.com/gpu
+         operator: Exists
+         effect: NoSchedule
+     containers:
+       - name: nvflare_job
+
+At launch time, NVFLARE selects the ``nvflare_job`` container and overlays the
+same launcher-owned fields used by the built-in manifest: pod name, job
+container name, image, command, args, resources, workspace ``emptyDir``,
+startup-kit Secret, volume mounts, transfer environment variables, image pull
+Secrets, and ``restartPolicy: Never``. Add template fields such as
+``serviceAccountName``, ``nodeSelector``, ``affinity``, ``tolerations``, sidecar
+containers, or additional volumes only when the study needs behavior that
+differs from the original launcher manifest.
+
+Use Kubernetes node labels to steer study job pods to specific nodes. On
+clusters with the NVIDIA GPU Operator or GFD, GPU nodes commonly have labels
+such as ``nvidia.com/gpu.product`` and ``nvidia.com/gpu.count``; the H100
+selector above matches the product label value NVIDIA documents for a full H100
+80GB HBM3 node. If the cluster uses MIG, GPU sharing, or a different H100 form
+factor, copy the exact ``nvidia.com/gpu.product`` value from ``kubectl get
+nodes``. For more complex placement rules, such as accepting multiple H100
+product labels, use ``spec.affinity.nodeAffinity`` instead of, or in addition
+to, ``nodeSelector``:
+
+.. code-block:: yaml
+
+   spec:
+     affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+             - matchExpressions:
+                 - key: nvidia.com/gpu.product
+                   operator: In
+                   values:
+                     - NVIDIA-H100-80GB-HBM3
+                     - NVIDIA-H100-NVL
+
+To target one named node, use a label that identifies that node, such as the
+standard ``kubernetes.io/hostname`` label, or add your own operational label and
+select it from the template. Keep in mind that strict node selection can leave a
+job pod ``Pending`` when the selected node has no available capacity.
+Pod annotations in ``metadata.annotations`` are preserved and can be used by
+admission controllers, schedulers, or monitoring integrations, but Kubernetes
+does not select nodes by annotation alone. GPU resource requests and limits are
+still launcher-owned; set them in the submitted job's
+``launcher_spec[site][k8s].num_of_gpus`` rather than in the Pod template.
+
 Example ``nvfldata-pvc.yaml``:
 
 .. code-block:: yaml

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -188,6 +188,15 @@ Top-level keys:
   registry Secret names to ``meta.json``.
 - ``job_pod_security_context``: security context passed to dynamically
   launched job pods.
+- ``study_job_spec_file_path``: optional YAML mapping from study name to
+  Kubernetes Pod template file. Matching studies use the template with
+  launcher-owned fields overlaid. If this is set without a configured
+  ``study_data_pvc_file_path``, no study-data PVC mounts are added. If both are
+  configured and the job study has entries in both files, the template is used
+  and the study-data entries are added as extra volume mounts with a warning.
+  Template volumes or job-container mounts named ``workspace-job`` or
+  ``startup-kit`` are replaced by the launcher-generated workspace and startup
+  mounts.
 
 Prepare the parent server or client kit first:
 

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -204,6 +204,15 @@ Prepare the parent server or client kit first:
 
    nvflare deploy prepare ./site-1 --config k8s.yaml --output ./site-1-k8s
 
+After ``deploy prepare`` and before staging or starting the parent pod, deployment
+owners may edit ``local/resources.json.default`` in the prepared kit to adjust
+study-specific launcher inputs. The generated K8s launcher config sets
+``study_data_pvc_file_path`` to ``<workspace_mount_path>/local/study_data.yaml``
+by default. You can change that path, remove it when no study-data PVC mounts
+should be added, and/or add ``study_job_spec_file_path`` to point to a study to
+Pod-template mapping file. Stage or copy any referenced files under
+``local/`` so the parent process can read them at the in-pod paths.
+
 Then choose one of the following two staging methods before starting the parent
 pod with Helm.
 

--- a/examples/devops/openshift/index.md
+++ b/examples/devops/openshift/index.md
@@ -530,6 +530,15 @@ nvflare deploy prepare workspace/<project>/prod_00/site-1 \
 
 After preparation, verify that `local/resources.json.default` contains `k8s_launcher`. Server kits should use `nvflare.app_opt.job_launcher.k8s_launcher.ServerK8sJobLauncher` and client kits should use `nvflare.app_opt.job_launcher.k8s_launcher.ClientK8sJobLauncher`. For in-cluster deployments, `config_file_path` should be `null` or empty so the launcher uses the parent pod's ServiceAccount token. NVFlare handles Kubernetes Python client 36.x token values that already include the `bearer` scheme prefix.
 
+Before staging or starting the parent pods, you may edit the prepared
+`local/resources.json.default` launcher args for study-specific job pod behavior.
+`nvflare deploy prepare` sets `study_data_pvc_file_path` to
+`<workspace_mount_path>/local/study_data.yaml` by default. You can change that
+path, remove it when no study-data PVC mounts should be added, and/or add
+`study_job_spec_file_path` to point to a study-to-Pod-template mapping file.
+Stage any referenced mapping and pod template files with `local/`, or make sure
+they exist at the configured in-pod paths.
+
 ### Create PVCs and Stage Kits
 
 Create the namespace and workspace PVCs:

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -391,8 +391,9 @@ def _merge_named_items(template_items, job_items, label: str) -> list:
 
 
 def _select_job_container(containers: list[dict], container_name: str) -> dict:
+    target_names = {name for name in (container_name, "nvflare_job") if isinstance(name, str) and name}
     for container in containers:
-        if container.get("name") in (container_name, "nvflare_job"):
+        if container.get("name") in target_names:
             return container
     return containers[0]
 

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -24,6 +24,8 @@ from abc import abstractmethod
 from datetime import datetime
 from enum import Enum
 
+import yaml
+
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey, JobConstants
 from nvflare.apis.fl_context import FLContext
@@ -251,6 +253,150 @@ def study_dataset_volume_name(study: str, dataset: str) -> str:
     return site_name_to_rfc1123(f"data-{study}-{dataset}", max_length=63)
 
 
+def _load_yaml_file(file_path: str, label: str):
+    try:
+        with open(file_path, "rt") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise ValueError(f"{label} file '{file_path}' was not found") from e
+    except OSError as e:
+        raise ValueError(f"Could not read {label} file '{file_path}': {e}") from e
+    except yaml.YAMLError as e:
+        raise ValueError(f"Could not parse {label} file '{file_path}': {e}") from e
+
+
+def load_study_job_spec_file(file_path: str, logger: logging.Logger = None) -> dict:
+    study_job_spec = _load_yaml_file(file_path, "study job spec")
+    if study_job_spec is None:
+        study_job_spec = {}
+    if not isinstance(study_job_spec, dict):
+        raise ValueError(f"file at study_job_spec_file_path '{file_path}' does not contain a dictionary.")
+    if not study_job_spec and logger:
+        logger.warning("study job spec file '%s' has no study entries; built-in pod manifests will be used", file_path)
+    for study, pod_spec_file in study_job_spec.items():
+        if not isinstance(study, str) or not study:
+            raise ValueError(f"study name {study!r} in '{file_path}' must be a non-empty string.")
+        if not isinstance(pod_spec_file, str) or not pod_spec_file:
+            raise ValueError(
+                f"study job spec entry for study '{study}' in '{file_path}' must be a non-empty pod YAML file path."
+            )
+    return study_job_spec
+
+
+def resolve_study_job_spec_path(
+    study_job_spec: dict, study: str, file_path: str, logger: logging.Logger = None
+) -> str | None:
+    if not study or not study_job_spec:
+        return None
+    pod_spec_file = study_job_spec.get(study)
+    if pod_spec_file is None:
+        if logger:
+            logger.warning(
+                "study job spec file '%s' has no entry for study '%s'; built-in pod manifest will be used",
+                file_path,
+                study,
+            )
+        return None
+    if os.path.isabs(pod_spec_file):
+        return pod_spec_file
+    return os.path.join(os.path.dirname(file_path), pod_spec_file)
+
+
+def load_pod_spec_file(file_path: str) -> dict:
+    pod_spec = _load_yaml_file(file_path, "pod spec")
+    if not isinstance(pod_spec, dict):
+        raise ValueError(f"pod spec file '{file_path}' must contain a Kubernetes Pod dictionary.")
+    kind = pod_spec.get("kind")
+    if kind and kind != "Pod":
+        raise ValueError(f"pod spec file '{file_path}' must define kind: Pod.")
+    return pod_spec
+
+
+def _ensure_manifest_mapping(parent: dict, key: str, label: str) -> dict:
+    value = parent.get(key)
+    if value is None:
+        value = {}
+        parent[key] = value
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a dictionary.")
+    return value
+
+
+def _ensure_manifest_containers(spec: dict) -> list[dict]:
+    containers = spec.get("containers")
+    if containers is None:
+        containers = [{}]
+        spec["containers"] = containers
+    if not isinstance(containers, list):
+        raise ValueError("pod spec containers must be a list.")
+    if not containers:
+        containers.append({})
+    for container in containers:
+        if not isinstance(container, dict):
+            raise ValueError("pod spec containers entries must be dictionaries.")
+    return containers
+
+
+def _prepare_pod_manifest_template(pod_manifest_template: dict) -> dict:
+    if not isinstance(pod_manifest_template, dict):
+        raise ValueError("pod manifest template must be a dictionary.")
+    kind = pod_manifest_template.get("kind")
+    if kind and kind != "Pod":
+        raise ValueError("pod manifest template must define kind: Pod.")
+    pod_manifest = copy.deepcopy(pod_manifest_template)
+    pod_manifest.setdefault("apiVersion", "v1")
+    pod_manifest["kind"] = "Pod"
+    _ensure_manifest_mapping(pod_manifest, "metadata", "pod manifest metadata")
+    spec = _ensure_manifest_mapping(pod_manifest, "spec", "pod manifest spec")
+    _ensure_manifest_containers(spec)
+    return pod_manifest
+
+
+def _merge_named_items(template_items, job_items, label: str) -> list:
+    if template_items is None:
+        template_items = []
+    if job_items is None:
+        job_items = []
+    if not isinstance(template_items, list) or not isinstance(job_items, list):
+        raise ValueError(f"{label} must be a list.")
+
+    job_items_by_name = {}
+    unnamed_job_items = []
+    for item in job_items:
+        if not isinstance(item, dict):
+            raise ValueError(f"{label} entries must be dictionaries.")
+        name = item.get("name")
+        if isinstance(name, str) and name:
+            job_items_by_name[name] = item
+        else:
+            unnamed_job_items.append(item)
+
+    result = []
+    used_job_item_names = set()
+    for item in template_items:
+        if not isinstance(item, dict):
+            raise ValueError(f"{label} entries must be dictionaries.")
+        name = item.get("name")
+        if name in job_items_by_name:
+            result.append(copy.deepcopy(job_items_by_name[name]))
+            used_job_item_names.add(name)
+        else:
+            result.append(copy.deepcopy(item))
+
+    for name, item in job_items_by_name.items():
+        if name not in used_job_item_names:
+            result.append(copy.deepcopy(item))
+    result.extend(copy.deepcopy(unnamed_job_items))
+    return result
+
+
+def _select_job_container(containers: list[dict], container_name: str) -> dict:
+    for container in containers:
+        if container.get("name") in (container_name, "nvflare_job"):
+            return container
+    return containers[0]
+
+
 class K8sJobHandle(JobHandleSpec):
     def __init__(
         self,
@@ -264,6 +410,7 @@ class K8sJobHandle(JobHandleSpec):
         workspace_transfer: WorkspaceTransferManager = None,
         workspace_job_id: str = "",
         pod_name: str = None,
+        pod_manifest_template: dict = None,
     ):
         super().__init__()
         self.job_id = job_id
@@ -276,28 +423,39 @@ class K8sJobHandle(JobHandleSpec):
         self.api_instance = api_instance
         self.namespace = namespace
         self.pending_timeout = _normalize_pending_timeout(pending_timeout)
-        self.pod_manifest = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": None},  # set by job_config['name']
-            "spec": {
-                "containers": None,  # link to container_list
-                "volumes": None,  # link to volume_list
-                "restartPolicy": "Never",
-            },
-        }
+        self.python_path = python_path
+        self.uses_pod_manifest_template = pod_manifest_template is not None
+        if self.uses_pod_manifest_template:
+            self.pod_manifest = _prepare_pod_manifest_template(pod_manifest_template)
+        else:
+            self.pod_manifest = {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": None},  # set by job_config['name']
+                "spec": {
+                    "containers": None,  # link to container_list
+                    "volumes": None,  # link to volume_list
+                    "restartPolicy": "Never",
+                },
+            }
         self.volume_list = []
 
-        self.container_list = [
-            {
-                "image": None,
-                "name": None,
-                "command": [python_path],
-                "args": None,  # args_list + args_dict + args_sets
-                "volumeMounts": None,  # volume_mount_list
-                "imagePullPolicy": "Always",
-            }
-        ]
+        if self.uses_pod_manifest_template:
+            spec = self.pod_manifest["spec"]
+            self.container_list = spec["containers"]
+            self.job_container = _select_job_container(self.container_list, job_config.get("container_name"))
+        else:
+            self.container_list = [
+                {
+                    "image": None,
+                    "name": None,
+                    "command": [python_path],
+                    "args": None,  # args_list + args_dict + args_sets
+                    "volumeMounts": None,  # volume_mount_list
+                    "imagePullPolicy": "Always",
+                }
+            ]
+            self.job_container = self.container_list[0]
         command = job_config.get("command")
         if not command:
             raise ValueError("job_config must contain a non-empty 'command' key")
@@ -329,35 +487,60 @@ class K8sJobHandle(JobHandleSpec):
                 continue
             self.container_args_module_args_dict_as_list.append(k)
             self.container_args_module_args_dict_as_list.append(str(v))
-        self.volume_list.extend(job_config.get("volume_list", []))
-        self.pod_manifest["metadata"]["name"] = job_config.get("name")
-        self.pod_manifest["spec"]["containers"] = self.container_list
-        self.pod_manifest["spec"]["volumes"] = self.volume_list
+        job_volume_list = job_config.get("volume_list", [])
+        metadata = _ensure_manifest_mapping(self.pod_manifest, "metadata", "pod manifest metadata")
+        spec = _ensure_manifest_mapping(self.pod_manifest, "spec", "pod manifest spec")
+        metadata["name"] = job_config.get("name")
+        spec["restartPolicy"] = "Never"
+        if self.uses_pod_manifest_template:
+            spec["volumes"] = _merge_named_items(spec.get("volumes"), job_volume_list, "pod spec volumes")
+        else:
+            self.volume_list.extend(job_volume_list)
+            spec["containers"] = self.container_list
+            spec["volumes"] = self.volume_list
         image_pull_secrets = _normalize_image_pull_secrets(job_config.get("image_pull_secrets"))
         if image_pull_secrets:
-            self.pod_manifest["spec"]["imagePullSecrets"] = [{"name": name} for name in image_pull_secrets]
+            image_pull_secret_refs = [{"name": name} for name in image_pull_secrets]
+            if self.uses_pod_manifest_template:
+                spec["imagePullSecrets"] = _merge_named_items(
+                    spec.get("imagePullSecrets"), image_pull_secret_refs, "pod spec imagePullSecrets"
+                )
+            else:
+                spec["imagePullSecrets"] = image_pull_secret_refs
         security_context = job_config.get("security_context")
         if security_context:
-            self.pod_manifest["spec"]["securityContext"] = security_context
+            spec["securityContext"] = security_context
 
         image = job_config.get("image")
         if not image:
             raise ValueError("job_config must contain a non-empty 'image' key")
-        self.container_list[0]["image"] = image
-        self.container_list[0]["name"] = job_config.get("container_name", "nvflare_job")
-        self.container_list[0]["args"] = (
+        container = self.job_container
+        container["image"] = image
+        container["name"] = job_config.get("container_name", "nvflare_job")
+        container["command"] = [self.python_path]
+        container["args"] = (
             self.container_args_python_args_list
             + self.container_args_module_args_dict_as_list
             + self.container_args_module_args_sets
         )
-        self.container_list[0]["volumeMounts"] = self.container_volume_mount_list
+        if self.uses_pod_manifest_template:
+            container.setdefault("imagePullPolicy", "Always")
+            container["volumeMounts"] = _merge_named_items(
+                container.get("volumeMounts"), self.container_volume_mount_list, "container volumeMounts"
+            )
+        else:
+            container["volumeMounts"] = self.container_volume_mount_list
         # resources now always includes ephemeral-storage; GPU limits are merged
         # into the same dict only when requested for the job.
         if job_config.get("resources"):
-            self.container_list[0]["resources"] = job_config["resources"]
+            container["resources"] = job_config["resources"]
         env_vars = {k: v for k, v in job_config.get("env", {}).items() if str(v)}
         if env_vars:
-            self.container_list[0]["env"] = [{"name": k, "value": str(v)} for k, v in env_vars.items()]
+            env_items = [{"name": k, "value": str(v)} for k, v in env_vars.items()]
+            if self.uses_pod_manifest_template:
+                container["env"] = _merge_named_items(container.get("env"), env_items, "container env")
+            else:
+                container["env"] = env_items
 
     def get_manifest(self):
         return copy.deepcopy(self.pod_manifest)
@@ -696,7 +879,7 @@ class K8sJobLauncher(JobLauncherSpec):
     def __init__(
         self,
         config_file_path: str,
-        study_data_pvc_file_path: str,
+        study_data_pvc_file_path: str = None,
         timeout=None,
         namespace=DEFAULT_NAMESPACE,
         pending_timeout=DEFAULT_PENDING_TIMEOUT,
@@ -706,11 +889,17 @@ class K8sJobLauncher(JobLauncherSpec):
         default_python_path: str = None,
         workspace_mount_path: str = WORKSPACE_MOUNT_PATH,
         image_pull_secrets: list[str] = None,
+        study_job_spec_file_path: str = None,
     ):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.config_file_path = config_file_path
         self.study_data_pvc_file_path = study_data_pvc_file_path
+        if study_job_spec_file_path is not None and (
+            not isinstance(study_job_spec_file_path, str) or not study_job_spec_file_path
+        ):
+            raise ValueError("study_job_spec_file_path must be a non-empty string or None")
+        self.study_job_spec_file_path = study_job_spec_file_path
         self.timeout = timeout
         self.namespace = namespace
         self.pending_timeout = _normalize_pending_timeout(pending_timeout)
@@ -728,7 +917,20 @@ class K8sJobLauncher(JobLauncherSpec):
         self.workspace_mount_path = workspace_mount_path
         self.image_pull_secrets = _normalize_image_pull_secrets(image_pull_secrets)
         self.study_data_pvc_dict = None
+        self.study_job_spec_dict = None
         self.core_v1 = None
+
+    def _get_pod_manifest_template(self, study: str):
+        if not self.study_job_spec_file_path or not study:
+            return None
+        if self.study_job_spec_dict is None:
+            self.study_job_spec_dict = load_study_job_spec_file(self.study_job_spec_file_path, logger=self.logger)
+        pod_spec_file_path = resolve_study_job_spec_path(
+            self.study_job_spec_dict, study, self.study_job_spec_file_path, logger=self.logger
+        )
+        if not pod_spec_file_path:
+            return None
+        return load_pod_spec_file(pod_spec_file_path)
 
     def _ensure_startup_secret(self, site_name: str, startup_dir: str) -> str:
         """Create or update a k8s Secret containing the site startup kit.
@@ -819,13 +1021,22 @@ class K8sJobLauncher(JobLauncherSpec):
                 f"or resource_spec['{site_name}']['k8s']['image'] (legacy)."
             )
         study = job_meta.get(JobMetaKey.STUDY.value)
+        pod_manifest_template = self._get_pod_manifest_template(study)
         data_mounts = []
-        if should_mount_study_data(study):
+        if should_mount_study_data(study) and self.study_data_pvc_file_path:
             if self.study_data_pvc_dict is None:
                 self.study_data_pvc_dict = load_study_data_file(self.study_data_pvc_file_path, logger=self.logger)
             data_mounts = resolve_study_dataset_mounts(
                 self.study_data_pvc_dict, study, self.study_data_pvc_file_path, logger=self.logger
             )
+            if pod_manifest_template is not None and data_mounts:
+                self.logger.warning(
+                    "study_job_spec_file_path '%s' is used for study '%s'; matching entries from "
+                    "study_data_pvc_file_path '%s' will be added as extra volume mounts",
+                    self.study_job_spec_file_path,
+                    study,
+                    self.study_data_pvc_file_path,
+                )
         site_resources = (job_meta.get(JobMetaKey.RESOURCE_SPEC.value) or {}).get(site_name) or {}
         flat_gpu_count = (
             0
@@ -938,6 +1149,7 @@ class K8sJobLauncher(JobLauncherSpec):
                 workspace_transfer=workspace_transfer,
                 workspace_job_id=raw_job_id,
                 pod_name=pod_name,
+                pod_manifest_template=pod_manifest_template,
             )
             pod_manifest = job_handle.get_manifest()
             self.logger.debug(

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -894,6 +894,10 @@ class K8sJobLauncher(JobLauncherSpec):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.config_file_path = config_file_path
+        if study_data_pvc_file_path is not None and (
+            not isinstance(study_data_pvc_file_path, str) or not study_data_pvc_file_path
+        ):
+            raise ValueError("study_data_pvc_file_path must be a non-empty string or None")
         self.study_data_pvc_file_path = study_data_pvc_file_path
         if study_job_spec_file_path is not None and (
             not isinstance(study_job_spec_file_path, str) or not study_job_spec_file_path
@@ -918,6 +922,7 @@ class K8sJobLauncher(JobLauncherSpec):
         self.image_pull_secrets = _normalize_image_pull_secrets(image_pull_secrets)
         self.study_data_pvc_dict = None
         self.study_job_spec_dict = None
+        self.pod_manifest_template_dict = {}
         self.core_v1 = None
 
     def _get_pod_manifest_template(self, study: str):
@@ -930,7 +935,9 @@ class K8sJobLauncher(JobLauncherSpec):
         )
         if not pod_spec_file_path:
             return None
-        return load_pod_spec_file(pod_spec_file_path)
+        if pod_spec_file_path not in self.pod_manifest_template_dict:
+            self.pod_manifest_template_dict[pod_spec_file_path] = load_pod_spec_file(pod_spec_file_path)
+        return self.pod_manifest_template_dict[pod_spec_file_path]
 
     def _ensure_startup_secret(self, site_name: str, startup_dir: str) -> str:
         """Create or update a k8s Secret containing the site startup kit.

--- a/nvflare/app_opt/job_launcher/k8s_launcher.py
+++ b/nvflare/app_opt/job_launcher/k8s_launcher.py
@@ -975,6 +975,22 @@ class K8sJobLauncher(JobLauncherSpec):
                 raise
         return secret_name
 
+    def _replace_pod_manifest_template_namespace(self, pod_manifest: dict) -> None:
+        metadata = _ensure_manifest_mapping(pod_manifest, "metadata", "pod manifest metadata")
+        if "namespace" not in metadata:
+            return
+
+        template_namespace = metadata["namespace"]
+        if template_namespace == self.namespace:
+            return
+
+        metadata["namespace"] = self.namespace
+        self.logger.warning(
+            "job pod is launched in namespace '%s' instead of metadata.namespace '%s'",
+            self.namespace,
+            template_namespace,
+        )
+
     def launch_job(self, job_meta: dict, fl_ctx: FLContext) -> JobHandleSpec:
         if self.core_v1 is None:
             from kubernetes import config
@@ -1159,6 +1175,8 @@ class K8sJobLauncher(JobLauncherSpec):
                 pod_manifest_template=pod_manifest_template,
             )
             pod_manifest = job_handle.get_manifest()
+            if pod_manifest_template is not None:
+                self._replace_pod_manifest_template_namespace(pod_manifest)
             self.logger.debug(
                 "launch job with k8s_launcher: pod_name=%s namespace=%s image=%s",
                 pod_manifest["metadata"]["name"],

--- a/nvflare/app_opt/job_launcher/workspace_cell_transfer.py
+++ b/nvflare/app_opt/job_launcher/workspace_cell_transfer.py
@@ -26,8 +26,10 @@ so large bundles move in chunks instead of being buffered into a single message.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
+import posixpath
 import secrets
 import shutil
 import stat
@@ -37,6 +39,8 @@ import time
 import zipfile
 from dataclasses import dataclass
 from pathlib import PurePosixPath
+
+import yaml
 
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
@@ -67,7 +71,9 @@ BOOTSTRAP_CONNECT_TIMEOUT = 30.0
 BOOTSTRAP_CONNECT_POLL_INTERVAL = 0.1
 
 _BOOTSTRAP_CELL_PREFIX = "ws_transfer_"
-_WORKSPACE_DOWNLOAD_EXCLUDES = frozenset({"local/study_data.yaml", "local/study_job_spec.yaml"})
+_DEFAULT_WORKSPACE_DOWNLOAD_EXCLUDES = frozenset({"local/study_data.yaml", "local/study_job_spec.yaml"})
+_RESOURCE_CONFIG_NAMES = ("resources.json", "resources.json.default")
+_K8S_LAUNCHER_COMPONENT_ID = "k8s_launcher"
 
 
 @dataclass
@@ -77,6 +83,120 @@ class _JobTransferRecord:
     transfer_token: str
     download_tx_id: str = ""
     download_bundle_path: str = ""
+
+
+def _safe_rel_path(path: str) -> str | None:
+    if not isinstance(path, str) or not path:
+        return None
+    normalized = posixpath.normpath(path.replace("\\", "/").replace(os.sep, "/"))
+    if normalized in ("", "."):
+        return None
+    rel_path = PurePosixPath(normalized)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        return None
+    return normalized
+
+
+def _config_path_to_workspace_rel(
+    path: str, workspace_root: str, workspace_mount_path: str | None = None
+) -> str | None:
+    if not isinstance(path, str) or not path:
+        return None
+    normalized = path.replace("\\", "/").replace(os.sep, "/")
+    if not posixpath.isabs(normalized):
+        return _safe_rel_path(normalized)
+
+    prefixes = []
+    if isinstance(workspace_mount_path, str) and workspace_mount_path:
+        prefixes.append(workspace_mount_path.replace("\\", "/").replace(os.sep, "/").rstrip("/"))
+    prefixes.append(os.path.abspath(workspace_root).replace(os.sep, "/").rstrip("/"))
+
+    for prefix in prefixes:
+        if normalized.startswith(f"{prefix}/"):
+            return _safe_rel_path(normalized[len(prefix) + 1 :])
+    return None
+
+
+def _load_resource_config(path: str) -> dict | None:
+    try:
+        with open(path, "rt") as f:
+            resource_config = json.load(f)
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        logger.debug("could not inspect resource config '%s' for workspace download excludes: %s", path, e)
+        return None
+    return resource_config if isinstance(resource_config, dict) else None
+
+
+def _iter_k8s_launcher_args(workspace_root: str):
+    local_dir = os.path.join(workspace_root, "local")
+    for resource_config_name in _RESOURCE_CONFIG_NAMES:
+        resource_config = _load_resource_config(os.path.join(local_dir, resource_config_name))
+        if not resource_config:
+            continue
+        components = resource_config.get("components")
+        if not isinstance(components, list):
+            continue
+        for component in components:
+            if not isinstance(component, dict) or component.get("id") != _K8S_LAUNCHER_COMPONENT_ID:
+                continue
+            args = component.get("args")
+            if isinstance(args, dict):
+                yield args
+
+
+def _resolve_study_job_spec_entry_rel(
+    pod_spec_file: str, mapping_rel_path: str, workspace_root: str, workspace_mount_path: str | None
+) -> str | None:
+    if not isinstance(pod_spec_file, str) or not pod_spec_file:
+        return None
+    if posixpath.isabs(pod_spec_file):
+        return _config_path_to_workspace_rel(pod_spec_file, workspace_root, workspace_mount_path)
+    mapping_dir = str(PurePosixPath(mapping_rel_path).parent)
+    if mapping_dir == ".":
+        mapping_dir = ""
+    return _safe_rel_path(posixpath.join(mapping_dir, pod_spec_file.replace("\\", "/").replace(os.sep, "/")))
+
+
+def _add_study_job_spec_excludes(
+    excluded_paths: set[str], workspace_root: str, mapping_rel_path: str, workspace_mount_path: str | None
+) -> None:
+    mapping_abs_path = os.path.join(workspace_root, *PurePosixPath(mapping_rel_path).parts)
+    try:
+        with open(mapping_abs_path, "rt") as f:
+            study_job_spec = yaml.safe_load(f)
+    except FileNotFoundError:
+        return
+    except Exception as e:
+        logger.debug("could not inspect study job spec '%s' for workspace download excludes: %s", mapping_abs_path, e)
+        return
+    if not isinstance(study_job_spec, dict):
+        return
+    for pod_spec_file in study_job_spec.values():
+        pod_spec_rel_path = _resolve_study_job_spec_entry_rel(
+            pod_spec_file, mapping_rel_path, workspace_root, workspace_mount_path
+        )
+        if pod_spec_rel_path:
+            excluded_paths.add(pod_spec_rel_path)
+
+
+def _workspace_download_excludes(workspace_root: str) -> frozenset[str]:
+    excluded_paths = set(_DEFAULT_WORKSPACE_DOWNLOAD_EXCLUDES)
+    for args in _iter_k8s_launcher_args(workspace_root):
+        workspace_mount_path = args.get("workspace_mount_path")
+        study_data_rel_path = _config_path_to_workspace_rel(
+            args.get("study_data_pvc_file_path"), workspace_root, workspace_mount_path
+        )
+        if study_data_rel_path:
+            excluded_paths.add(study_data_rel_path)
+        study_job_spec_rel_path = _config_path_to_workspace_rel(
+            args.get("study_job_spec_file_path"), workspace_root, workspace_mount_path
+        )
+        if study_job_spec_rel_path:
+            excluded_paths.add(study_job_spec_rel_path)
+            _add_study_job_spec_excludes(excluded_paths, workspace_root, study_job_spec_rel_path, workspace_mount_path)
+    return frozenset(excluded_paths)
 
 
 def _write_dir_to_zip(zf: zipfile.ZipFile, src: str, root: str, excluded_paths: frozenset[str] = frozenset()) -> None:
@@ -92,8 +212,9 @@ def _write_dir_to_zip(zf: zipfile.ZipFile, src: str, root: str, excluded_paths: 
 
 
 def _zip_workspace_to_file(workspace_root: str, job_id: str, file_path: str) -> None:
+    excluded_paths = _workspace_download_excludes(workspace_root)
     with zipfile.ZipFile(file_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        _write_dir_to_zip(zf, os.path.join(workspace_root, "local"), workspace_root, _WORKSPACE_DOWNLOAD_EXCLUDES)
+        _write_dir_to_zip(zf, os.path.join(workspace_root, "local"), workspace_root, excluded_paths)
         _write_dir_to_zip(zf, os.path.join(workspace_root, job_id), workspace_root)
 
 

--- a/nvflare/app_opt/job_launcher/workspace_cell_transfer.py
+++ b/nvflare/app_opt/job_launcher/workspace_cell_transfer.py
@@ -67,7 +67,7 @@ BOOTSTRAP_CONNECT_TIMEOUT = 30.0
 BOOTSTRAP_CONNECT_POLL_INTERVAL = 0.1
 
 _BOOTSTRAP_CELL_PREFIX = "ws_transfer_"
-_WORKSPACE_DOWNLOAD_EXCLUDES = frozenset({"local/study_data.yaml"})
+_WORKSPACE_DOWNLOAD_EXCLUDES = frozenset({"local/study_data.yaml", "local/study_job_spec.yaml"})
 
 
 @dataclass

--- a/nvflare/tool/deploy/deploy_commands.py
+++ b/nvflare/tool/deploy/deploy_commands.py
@@ -483,6 +483,8 @@ def _prepare_k8s(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) 
         launcher_args["security_context"] = job_launcher["job_pod_security_context"]
     if job_launcher.get("image_pull_secrets") is not None:
         launcher_args["image_pull_secrets"] = job_launcher["image_pull_secrets"]
+    if "study_job_spec_file_path" in job_launcher:
+        launcher_args["study_job_spec_file_path"] = job_launcher["study_job_spec_file_path"]
 
     _patch_resources(kit_info.kit_dir, "k8s_launcher", launcher_path, launcher_args)
     _patch_comm_config_for_k8s(kit_info.kit_dir, kit_info.role, kit_info.name, parent_port, server_service_name)
@@ -577,6 +579,7 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
                 "default_python_path",
                 "job_pod_security_context",
                 "image_pull_secrets",
+                "study_job_spec_file_path",
             },
             "job_launcher",
         )
@@ -597,6 +600,7 @@ def _validate_runtime_config(runtime: str, config: dict[str, Any]) -> None:
         _optional_non_negative_int(job_launcher, "pending_timeout", "job_launcher")
         _optional_mapping(job_launcher, "job_pod_security_context", "job_launcher")
         _optional_k8s_secret_name_list(job_launcher, "image_pull_secrets", "job launcher image pull references")
+        _optional_str(job_launcher, "study_job_spec_file_path", "job_launcher")
 
 
 def _validate_kit(kit_dir: Path) -> KitInfo:

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -1452,6 +1452,7 @@ class TestK8sJobLauncherInit:
         # study_data.yaml is populated lazily
         assert launcher.study_data_pvc_dict is None
         assert launcher.study_job_spec_dict is None
+        assert launcher.pod_manifest_template_dict == {}
 
     def test_init_stores_custom_workspace_mount_path(self):
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
@@ -1493,6 +1494,16 @@ class TestK8sJobLauncherInit:
                 config_file_path="/fake/kube/config",
                 study_data_pvc_file_path="/fake/study_data.yaml",
                 study_job_spec_file_path=study_job_spec_file_path,
+            )
+
+    @pytest.mark.parametrize("study_data_pvc_file_path", ["", 1, False])
+    def test_init_rejects_invalid_study_data_pvc_file_path(self, study_data_pvc_file_path):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        with pytest.raises(ValueError, match="study_data_pvc_file_path"):
+            ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path=study_data_pvc_file_path,
             )
 
     def test_init_rejects_empty_ephemeral_storage(self):
@@ -2139,6 +2150,68 @@ spec:
             assert volume_names == {"workspace-job", "startup-kit"}
             assert mount_names == {"workspace-job", "startup-kit"}
             _mock_study_data_yaml.safe_load.assert_not_called()
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_template_is_cached_per_launcher(self, tmp_path):
+        from nvflare.app_opt.job_launcher import k8s_launcher as k8s_launcher_module
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        pod_file = tmp_path / "study-a-pod.yaml"
+        pod_file.write_text(
+            """
+apiVersion: v1
+kind: Pod
+spec:
+  serviceAccountName: first-sa
+  containers:
+    - name: nvflare_job
+      image: template-image
+""",
+            encoding="utf-8",
+        )
+        study_job_spec_file = tmp_path / "study_job_spec.yaml"
+        study_job_spec_file.write_text(f"study-a: {pod_file}\n", encoding="utf-8")
+
+        patches = _make_k8s_launcher_patches(patch_open=False)
+        _mock_study_data_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
+        try:
+            mock_api = MagicMock()
+            mock_core_cls.return_value = mock_api
+            mock_transfer = MagicMock()
+            mock_transfer_cls.get_or_create.return_value = mock_transfer
+            mock_transfer.owner_fqcn = "site-1.parent"
+            mock_transfer.add_job.return_value = "transfer-token"
+            self._prime_running(mock_api)
+
+            launcher = ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path=None,
+                namespace="test-ns",
+                study_job_spec_file_path=str(study_job_spec_file),
+            )
+
+            with patch.object(
+                k8s_launcher_module, "load_pod_spec_file", wraps=k8s_launcher_module.load_pod_spec_file
+            ) as mock_load_pod_spec:
+                launcher.launch_job(_make_launch_job_meta(study="study-a"), _make_launch_fl_ctx())
+                pod_file.write_text(
+                    """
+apiVersion: v1
+kind: Pod
+spec:
+  serviceAccountName: second-sa
+  containers:
+    - name: nvflare_job
+      image: template-image
+""",
+                    encoding="utf-8",
+                )
+                launcher.launch_job(_make_launch_job_meta(study="study-a"), _make_launch_fl_ctx())
+
+            assert mock_load_pod_spec.call_count == 1
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            assert manifest["spec"]["serviceAccountName"] == "first-sa"
         finally:
             _exit_patches(patches)
 

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -358,6 +358,29 @@ class TestK8sJobHandle:
         container = handle.get_manifest()["spec"]["containers"][0]
         assert container["name"] == "nvflare_job"
 
+    def test_manifest_template_prefers_nvflare_job_over_unnamed_first_container(self):
+        cfg = _make_job_config()
+        del cfg["container_name"]
+        pod_manifest_template = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "spec": {
+                "containers": [
+                    {"image": "sidecar:v1"},
+                    {"name": "nvflare_job", "image": "template-image"},
+                ]
+            },
+        }
+
+        handle = K8sJobHandle("job-1", _make_api_instance(), cfg, pod_manifest_template=pod_manifest_template)
+
+        containers = handle.get_manifest()["spec"]["containers"]
+        assert containers[0] == {"image": "sidecar:v1"}
+        assert containers[1]["name"] == "nvflare_job"
+        assert containers[1]["image"] == "nvflare/nvflare:test"
+        assert containers[1]["command"] == ["/usr/local/bin/python"]
+        assert "nvflare.private.fed.app.client.worker_process" in containers[1]["args"]
+
     def test_manifest_restart_policy(self):
         cfg = _make_job_config()
         handle = K8sJobHandle("job-1", _make_api_instance(), cfg)

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -1344,7 +1344,7 @@ class TestJobArgsDict:
 # ---------------------------------------------------------------------------
 # K8sJobLauncher handle_event
 # ---------------------------------------------------------------------------
-def _make_k8s_launcher_patches():
+def _make_k8s_launcher_patches(patch_open=True):
     # kubernetes is imported inside launch_job (not at module level), so we rely
     # on the sys.modules stubs injected at the top of this file.  The only
     # YAML dependency we need to intercept is in the shared study_data helper,
@@ -1352,12 +1352,14 @@ def _make_k8s_launcher_patches():
     # already-stubbed _k8s_core module is patched with patch.object so each
     # test gets a fresh, controllable mock and the original stub is restored.
     # WorkspaceTransferManager is patched so tests don't register real CellNet handlers.
-    return [
-        patch("builtins.open", create=True),
+    patches = [
         patch("nvflare.app_opt.job_launcher.study_data.yaml"),
         patch.object(_k8s_core, "CoreV1Api"),
         patch("nvflare.app_opt.job_launcher.k8s_launcher.WorkspaceTransferManager"),
     ]
+    if patch_open:
+        patches.insert(0, patch("builtins.open", create=True))
+    return patches
 
 
 def _enter_patches(patches):
@@ -1438,15 +1440,18 @@ class TestK8sJobLauncherInit:
             timeout=60,
             namespace="test-ns",
             image_pull_secrets=["job-regcred"],
+            study_job_spec_file_path="/fake/study_job_spec.yaml",
         )
 
         assert launcher.study_data_pvc_file_path == "/fake/study_data.yaml"
+        assert launcher.study_job_spec_file_path == "/fake/study_job_spec.yaml"
         assert launcher.timeout == 60
         assert launcher.namespace == "test-ns"
         assert launcher.workspace_mount_path == WORKSPACE_MOUNT_PATH
         assert launcher.image_pull_secrets == ["job-regcred"]
         # study_data.yaml is populated lazily
         assert launcher.study_data_pvc_dict is None
+        assert launcher.study_job_spec_dict is None
 
     def test_init_stores_custom_workspace_mount_path(self):
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
@@ -1477,6 +1482,17 @@ class TestK8sJobLauncherInit:
                 config_file_path="/fake/kube/config",
                 study_data_pvc_file_path="/fake/study_data.yaml",
                 workspace_mount_path=1,
+            )
+
+    @pytest.mark.parametrize("study_job_spec_file_path", ["", 1, False])
+    def test_init_rejects_invalid_study_job_spec_file_path(self, study_job_spec_file_path):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        with pytest.raises(ValueError, match="study_job_spec_file_path"):
+            ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path="/fake/study_data.yaml",
+                study_job_spec_file_path=study_job_spec_file_path,
             )
 
     def test_init_rejects_empty_ephemeral_storage(self):
@@ -1936,6 +1952,274 @@ class TestK8sJobLauncherLaunchJob:
                 {"name": "job-regcred"},
                 {"name": "mirror-regcred"},
             ]
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_uses_study_specific_pod_template(self, tmp_path, caplog):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        pod_dir = tmp_path / "pod_specs"
+        pod_dir.mkdir()
+        pod_file = pod_dir / "study-a-pod.yaml"
+        pod_file.write_text(
+            """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: template-name
+  labels:
+    from-template: "true"
+spec:
+  serviceAccountName: custom-sa
+  restartPolicy: Always
+  nodeSelector:
+    accelerator: gpu
+  imagePullSecrets:
+    - name: template-regcred
+  volumes:
+    - name: template-volume
+      emptyDir: {}
+    - name: workspace-job
+      emptyDir:
+        sizeLimit: old
+    - name: startup-kit
+      secret:
+        secretName: old-startup-secret
+  containers:
+    - name: trainer
+      image: template-image
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: KEEP_ME
+          value: "yes"
+        - name: NVFL_WORKSPACE_TRANSFER_TOKEN
+          value: old-token
+      volumeMounts:
+        - name: template-volume
+          mountPath: /template
+        - name: workspace-job
+          mountPath: /old-workspace
+        - name: startup-kit
+          mountPath: /old-startup
+          readOnly: false
+      resources:
+        limits:
+          cpu: "999"
+    - name: sidecar
+      image: sidecar:v1
+""",
+            encoding="utf-8",
+        )
+        study_job_spec_file = tmp_path / "study_job_spec.yaml"
+        study_job_spec_file.write_text("study-a: pod_specs/study-a-pod.yaml\n", encoding="utf-8")
+        study_data_file = tmp_path / "study_data.yaml"
+        study_data_file.write_text("study-a: {}\n", encoding="utf-8")
+
+        patches = _make_k8s_launcher_patches(patch_open=False)
+        _mock_study_data_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
+        try:
+            _mock_study_data_yaml.safe_load.return_value = {
+                "study-a": {"training": {"source": "study-train-pvc", "mode": "ro"}}
+            }
+            mock_api = MagicMock()
+            mock_core_cls.return_value = mock_api
+            mock_transfer = MagicMock()
+            mock_transfer_cls.get_or_create.return_value = mock_transfer
+            mock_transfer.owner_fqcn = "site-1.parent"
+            mock_transfer.add_job.return_value = "transfer-token"
+            self._prime_running(mock_api)
+
+            launcher = ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path=str(study_data_file),
+                namespace="test-ns",
+                default_python_path="/usr/bin/python3",
+                image_pull_secrets=["job-regcred"],
+                study_job_spec_file_path=str(study_job_spec_file),
+            )
+            meta = _make_launch_job_meta(image="repo/nvflare-job:v2", study="study-a", ephemeral_storage="8Gi")
+            meta[JobMetaKey.JOB_LAUNCHER_SPEC.value]["site-1"]["k8s"].update({"cpu": "2", "memory": "8Gi"})
+
+            with caplog.at_level(logging.WARNING):
+                launcher.launch_job(meta, _make_launch_fl_ctx())
+
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            assert manifest["metadata"]["name"] == _EXPECTED_POD_NAME
+            assert manifest["metadata"]["labels"] == {"from-template": "true"}
+            assert manifest["spec"]["serviceAccountName"] == "custom-sa"
+            assert manifest["spec"]["nodeSelector"] == {"accelerator": "gpu"}
+            assert manifest["spec"]["restartPolicy"] == "Never"
+            assert manifest["spec"]["imagePullSecrets"] == [
+                {"name": "template-regcred"},
+                {"name": "job-regcred"},
+            ]
+
+            volume_map = {v["name"]: v for v in manifest["spec"]["volumes"]}
+            training_volume = study_dataset_volume_name("study-a", "training")
+            assert "template-volume" in volume_map
+            assert volume_map["workspace-job"]["emptyDir"]["sizeLimit"] == "8Gi"
+            assert volume_map["startup-kit"]["secret"]["secretName"] == "nvflare-startup-site-1-f505dccd"
+            assert volume_map[training_volume]["persistentVolumeClaim"]["claimName"] == "study-train-pvc"
+
+            job_container = manifest["spec"]["containers"][0]
+            assert job_container["name"] == f"container-{_EXPECTED_JOB_ID}"
+            assert job_container["image"] == "repo/nvflare-job:v2"
+            assert job_container["command"] == ["/usr/bin/python3"]
+            assert job_container["imagePullPolicy"] == "IfNotPresent"
+            assert _WORKER_MODULE in job_container["args"]
+            assert manifest["spec"]["containers"][1] == {"name": "sidecar", "image": "sidecar:v1"}
+
+            mount_map = {m["name"]: m for m in job_container["volumeMounts"]}
+            assert mount_map["template-volume"] == {"name": "template-volume", "mountPath": "/template"}
+            assert mount_map["workspace-job"]["mountPath"] == WORKSPACE_MOUNT_PATH
+            assert mount_map["startup-kit"]["mountPath"] == f"{WORKSPACE_MOUNT_PATH}/startup"
+            assert mount_map["startup-kit"]["readOnly"] is True
+            assert mount_map[training_volume] == {
+                "name": training_volume,
+                "mountPath": "/data/study-a/training",
+                "readOnly": True,
+            }
+
+            env_map = {e["name"]: e["value"] for e in job_container["env"]}
+            assert env_map["KEEP_ME"] == "yes"
+            assert env_map[ENV_WORKSPACE_TRANSFER_TOKEN] == "transfer-token"
+            assert env_map[ENV_WORKSPACE_OWNER_FQCN] == "site-1.parent"
+
+            resources = job_container["resources"]
+            assert resources["limits"]["cpu"] == "2"
+            assert resources["limits"]["memory"] == "8Gi"
+            assert resources["requests"]["ephemeral-storage"] == "8Gi"
+            assert "study_job_spec_file_path" in caplog.text
+            assert "study_data_pvc_file_path" in caplog.text
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_uses_study_template_without_study_data_path(self, tmp_path):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        pod_file = tmp_path / "study-a-pod.yaml"
+        pod_file.write_text(
+            """
+apiVersion: v1
+kind: Pod
+spec:
+  serviceAccountName: custom-sa
+  containers:
+    - name: nvflare_job
+      image: template-image
+""",
+            encoding="utf-8",
+        )
+        study_job_spec_file = tmp_path / "study_job_spec.yaml"
+        study_job_spec_file.write_text(f"study-a: {pod_file}\n", encoding="utf-8")
+
+        patches = _make_k8s_launcher_patches(patch_open=False)
+        _mock_study_data_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
+        try:
+            mock_api = MagicMock()
+            mock_core_cls.return_value = mock_api
+            mock_transfer = MagicMock()
+            mock_transfer_cls.get_or_create.return_value = mock_transfer
+            mock_transfer.owner_fqcn = "site-1.parent"
+            mock_transfer.add_job.return_value = "transfer-token"
+            self._prime_running(mock_api)
+
+            launcher = ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path=None,
+                namespace="test-ns",
+                study_job_spec_file_path=str(study_job_spec_file),
+            )
+
+            launcher.launch_job(_make_launch_job_meta(study="study-a"), _make_launch_fl_ctx())
+
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            volume_names = {v["name"] for v in manifest["spec"]["volumes"]}
+            mount_names = {m["name"] for m in manifest["spec"]["containers"][0]["volumeMounts"]}
+            assert volume_names == {"workspace-job", "startup-kit"}
+            assert mount_names == {"workspace-job", "startup-kit"}
+            _mock_study_data_yaml.safe_load.assert_not_called()
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_uses_builtin_template_when_study_job_spec_missing_study(self, tmp_path, caplog):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        pod_file = tmp_path / "other-pod.yaml"
+        pod_file.write_text(
+            """
+apiVersion: v1
+kind: Pod
+spec:
+  serviceAccountName: custom-sa
+  containers:
+    - name: trainer
+      image: template-image
+""",
+            encoding="utf-8",
+        )
+        study_job_spec_file = tmp_path / "study_job_spec.yaml"
+        study_job_spec_file.write_text(f"other-study: {pod_file}\n", encoding="utf-8")
+
+        patches = _make_k8s_launcher_patches(patch_open=False)
+        _mock_study_data_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
+        try:
+            mock_api = MagicMock()
+            mock_core_cls.return_value = mock_api
+            mock_transfer = MagicMock()
+            mock_transfer_cls.get_or_create.return_value = mock_transfer
+            mock_transfer.owner_fqcn = "site-1.parent"
+            mock_transfer.add_job.return_value = "transfer-token"
+            self._prime_running(mock_api)
+
+            launcher = ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path="/fake/study_data.yaml",
+                namespace="test-ns",
+                study_job_spec_file_path=str(study_job_spec_file),
+            )
+            with caplog.at_level(logging.WARNING):
+                launcher.launch_job(_make_launch_job_meta(study="study-a"), _make_launch_fl_ctx())
+
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            assert "serviceAccountName" not in manifest["spec"]
+            assert manifest["spec"]["containers"][0]["image"] == "nvflare/nvflare:latest"
+            assert "has no entry for study 'study-a'" in caplog.text
+        finally:
+            _exit_patches(patches)
+
+    def test_pod_manifest_rejects_non_pod_study_job_spec(self, tmp_path):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        pod_file = tmp_path / "job.yaml"
+        pod_file.write_text(
+            """
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: not-a-pod
+""",
+            encoding="utf-8",
+        )
+        study_job_spec_file = tmp_path / "study_job_spec.yaml"
+        study_job_spec_file.write_text(f"study-a: {pod_file}\n", encoding="utf-8")
+
+        patches = _make_k8s_launcher_patches(patch_open=False)
+        _mock_study_data_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
+        try:
+            mock_api = MagicMock()
+            mock_core_cls.return_value = mock_api
+            launcher = ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path="/fake/study_data.yaml",
+                namespace="test-ns",
+                study_job_spec_file_path=str(study_job_spec_file),
+            )
+
+            with pytest.raises(ValueError, match="kind: Pod"):
+                launcher.launch_job(_make_launch_job_meta(study="study-a"), _make_launch_fl_ctx())
+            mock_api.create_namespaced_pod.assert_not_called()
+            mock_transfer_cls.get_or_create.assert_not_called()
         finally:
             _exit_patches(patches)
 

--- a/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py
@@ -2153,6 +2153,57 @@ spec:
         finally:
             _exit_patches(patches)
 
+    def test_pod_manifest_template_namespace_mismatch_uses_launcher_namespace(self, tmp_path, caplog):
+        from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher
+
+        pod_file = tmp_path / "study-a-pod.yaml"
+        pod_file.write_text(
+            """
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: template-ns
+spec:
+  containers:
+    - name: nvflare_job
+      image: template-image
+""",
+            encoding="utf-8",
+        )
+        study_job_spec_file = tmp_path / "study_job_spec.yaml"
+        study_job_spec_file.write_text(f"study-a: {pod_file}\n", encoding="utf-8")
+
+        patches = _make_k8s_launcher_patches(patch_open=False)
+        _mock_study_data_yaml, mock_core_cls, mock_transfer_cls, *_ = _enter_patches(patches)
+        try:
+            mock_api = MagicMock()
+            mock_core_cls.return_value = mock_api
+            mock_transfer = MagicMock()
+            mock_transfer_cls.get_or_create.return_value = mock_transfer
+            mock_transfer.owner_fqcn = "site-1.parent"
+            mock_transfer.add_job.return_value = "transfer-token"
+            self._prime_running(mock_api)
+
+            launcher = ClientK8sJobLauncher(
+                config_file_path="/fake/kube/config",
+                study_data_pvc_file_path=None,
+                namespace="test-ns",
+                study_job_spec_file_path=str(study_job_spec_file),
+            )
+
+            with caplog.at_level(logging.WARNING):
+                launcher.launch_job(_make_launch_job_meta(study="study-a"), _make_launch_fl_ctx())
+
+            manifest = mock_api.create_namespaced_pod.call_args.kwargs["body"]
+            assert manifest["metadata"]["namespace"] == "test-ns"
+            assert mock_api.create_namespaced_pod.call_args.kwargs["namespace"] == "test-ns"
+            assert (
+                "job pod is launched in namespace 'test-ns' instead of metadata.namespace 'template-ns'" in caplog.text
+            )
+            _mock_study_data_yaml.safe_load.assert_not_called()
+        finally:
+            _exit_patches(patches)
+
     def test_pod_manifest_template_is_cached_per_launcher(self, tmp_path):
         from nvflare.app_opt.job_launcher import k8s_launcher as k8s_launcher_module
         from nvflare.app_opt.job_launcher.k8s_launcher import ClientK8sJobLauncher

--- a/tests/unit_test/app_opt/job_launcher/workspace_cell_transfer_test.py
+++ b/tests/unit_test/app_opt/job_launcher/workspace_cell_transfer_test.py
@@ -121,6 +121,7 @@ class TestWorkspaceTransferManager:
                 os.path.join(ws_root, "local", "study_data.yaml"),
                 b"study-a:\n  training:\n    source: nvfldata\n    mode: ro\n",
             )
+            _write_file(os.path.join(ws_root, "local", "study_job_spec.yaml"), b"study-a: study-a-pod.yaml\n")
             _write_file(os.path.join(ws_root, "local", "custom", "helper.py"), b"VALUE = 1\n")
             zip_path = os.path.join(tmp, "workspace.zip")
 
@@ -132,6 +133,7 @@ class TestWorkspaceTransferManager:
             assert "local/custom/helper.py" in names
             assert f"{JOB_ID}/app/config/config_train.json" in names
             assert "local/study_data.yaml" not in names
+            assert "local/study_job_spec.yaml" not in names
 
     def test_prepare_download_returns_ref_for_valid_token(self, monkeypatch):
         with tempfile.TemporaryDirectory() as ws_root:

--- a/tests/unit_test/app_opt/job_launcher/workspace_cell_transfer_test.py
+++ b/tests/unit_test/app_opt/job_launcher/workspace_cell_transfer_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import stat
 import tempfile
@@ -134,6 +135,45 @@ class TestWorkspaceTransferManager:
             assert f"{JOB_ID}/app/config/config_train.json" in names
             assert "local/study_data.yaml" not in names
             assert "local/study_job_spec.yaml" not in names
+
+    def test_workspace_bundle_excludes_configured_study_job_spec_and_templates(self):
+        with tempfile.TemporaryDirectory() as ws_root, tempfile.TemporaryDirectory() as tmp:
+            _make_workspace(ws_root, JOB_ID)
+            resource_config = {
+                "components": [
+                    {
+                        "id": "k8s_launcher",
+                        "path": "nvflare.app_opt.job_launcher.k8s_launcher.ClientK8sJobLauncher",
+                        "args": {
+                            "workspace_mount_path": "/workspace",
+                            "study_data_pvc_file_path": "/workspace/local/custom_data.yaml",
+                            "study_job_spec_file_path": "/workspace/local/configs/custom_study_jobs.yaml",
+                        },
+                    }
+                ]
+            }
+            _write_file(os.path.join(ws_root, "local", "resources.json"), json.dumps(resource_config).encode())
+            _write_file(os.path.join(ws_root, "local", "custom_data.yaml"), b"study-a: {}\n")
+            _write_file(
+                os.path.join(ws_root, "local", "configs", "custom_study_jobs.yaml"),
+                b"study-a: ../pod_specs/h100-pod.yaml\nstudy-b: /workspace/local/pod_specs/abs-pod.yaml\n",
+            )
+            _write_file(os.path.join(ws_root, "local", "pod_specs", "h100-pod.yaml"), b"kind: Pod\n")
+            _write_file(os.path.join(ws_root, "local", "pod_specs", "abs-pod.yaml"), b"kind: Pod\n")
+            _write_file(os.path.join(ws_root, "local", "custom", "helper.py"), b"VALUE = 1\n")
+            zip_path = os.path.join(tmp, "workspace.zip")
+
+            _zip_workspace_to_file(ws_root, JOB_ID, zip_path)
+
+            with zipfile.ZipFile(zip_path) as zf:
+                names = set(zf.namelist())
+            assert "local/resources.json" in names
+            assert "local/custom/helper.py" in names
+            assert f"{JOB_ID}/app/config/config_train.json" in names
+            assert "local/custom_data.yaml" not in names
+            assert "local/configs/custom_study_jobs.yaml" not in names
+            assert "local/pod_specs/h100-pod.yaml" not in names
+            assert "local/pod_specs/abs-pod.yaml" not in names
 
     def test_prepare_download_returns_ref_for_valid_token(self, monkeypatch):
         with tempfile.TemporaryDirectory() as ws_root:

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -646,6 +646,7 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
                 "default_python_path": "/usr/bin/python3",
                 "job_pod_security_context": {"runAsNonRoot": True},
                 "image_pull_secrets": ["job-regcred", "site.registry.example.com"],
+                "study_job_spec_file_path": "/workspace/local/study_job_spec.yaml",
             },
         },
     )
@@ -663,6 +664,7 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
     assert launcher["args"]["pending_timeout"] == 7
     assert launcher["args"]["security_context"] == {"runAsNonRoot": True}
     assert launcher["args"]["image_pull_secrets"] == ["job-regcred", "site.registry.example.com"]
+    assert launcher["args"]["study_job_spec_file_path"] == "/workspace/local/study_job_spec.yaml"
 
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["internal"]["resources"] == {
@@ -1357,6 +1359,14 @@ def test_prepare_rejects_admin_kit_without_writing_output(tmp_path, capsys):
                 "job_launcher": {"default_python_path": False},
             },
             "job_launcher.default_python_path",
+        ),
+        (
+            {
+                "runtime": "k8s",
+                "parent": {"docker_image": "repo/nvflare:dev"},
+                "job_launcher": {"study_job_spec_file_path": 7},
+            },
+            "job_launcher.study_job_spec_file_path",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

This PR adds study-specific Kubernetes job pod template support to the K8s job launcher. The current `main` branch behavior remains the default behavior: when users do not configure a study job pod spec file, NVFlare launches job pods the same way it does today.

The new `study_job_spec_file_path` launcher argument enables an additional and more complete control point for job pod construction. It lets deployment owners define per-study Pod templates while keeping the generated NVFlare job command, workspace mounts, startup kit mounts, and existing study-data PVC behavior under launcher control.

## Three Supported Cases

1. `study_data_pvc_file_path` only: this is the current default behavior from `nvflare deploy prepare` for K8s. Study-data PVC mappings from `study_data.yaml` are applied, and job pods otherwise use the launcher-generated pod spec.
2. `study_job_spec_file_path` only: the launcher reads a study-to-Pod-template mapping file and applies the matching Pod template for the job study. No study-data PVC mounts are added unless configured elsewhere.
3. Both `study_data_pvc_file_path` and `study_job_spec_file_path`: the launcher applies both controls, using the study-data PVC mapping and the study-specific Pod template together.

## H100 GPU Node Selection Use Case

A primary use case is GPU scheduling. Users can place node selection, tolerations, affinity, runtime class, image pull secrets, or other Kubernetes Pod-level settings in a study-specific template, then map only the relevant study to that template. This is useful when an H100 study must run on H100 GPU nodes while other studies continue using ordinary CPU scheduling or different GPU pools.

The exact H100 node label must match the target cluster. For example, if H100 nodes are labeled with `nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3`, users can target those nodes with a study-specific Pod template like this.

Example `local/study_job_spec.yaml`:

```yaml
h100_study: pod_specs/h100-job-pod.yaml
```

Example `local/pod_specs/h100-job-pod.yaml`:

```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    nvflare-study: h100-study
spec:
  nodeSelector:
    nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
  tolerations:
    - key: nvidia.com/gpu
      operator: Exists
      effect: NoSchedule
  containers:
    - name: nvflare_job
      resources:
        limits:
          nvidia.com/gpu: "1"
```

After `nvflare deploy prepare`, users can edit `local/resources.json.default` to add:

```json
"study_job_spec_file_path": "/var/tmp/nvflare/workspace/local/study_job_spec.yaml"
```

They can also change or remove the generated `study_data_pvc_file_path` depending on whether study-data PVC mounts are needed.

## GPU Labeling References and Reviewer Pointers

This PR also updates the K8s deployment guide so users have enough information to build a useful job pod template:

- [`Cloud GPU Setup References`](https://github.com/IsaacYangSLA/NVFlare/blob/job_pod_spec/docs/user_guide/admin_guide/deployment/helm_chart.rst#cloud-gpu-setup-references) points users to provider-specific GPU setup docs and the NVIDIA GPU Operator docs.
- [`Minimal Study Job Pod Template`](https://github.com/IsaacYangSLA/NVFlare/blob/job_pod_spec/docs/user_guide/admin_guide/deployment/helm_chart.rst#minimal-study-job-pod-template) shows the H100 `nodeSelector`, `kubectl get nodes -L nvidia.com/gpu.product,nvidia.com/gpu.count,nvidia.com/gpu.present`, an `affinity.nodeAffinity` alternative, and the distinction between scheduler placement fields in the template and launcher-owned GPU resource requests.

Reference docs for the GPU node-labeling behavior:

- NVIDIA k8s-device-plugin / GPU Feature Discovery label catalog: https://github.com/NVIDIA/k8s-device-plugin#catalog-of-labels
- NVIDIA GPU Operator docs: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/
- Kubernetes `nodeSelector` and node affinity docs: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/

## Validation

- Verified the three cases in OpenShift CRC: `study_data_pvc_file_path` only, `study_job_spec_file_path` only, and both together.
- Verified job pods completed successfully for server, `site-1`, and `site-2` in each case.
- Ran `./runtest.sh -s` successfully.
