### PR TITLE
Fix: Handle missing resource module on Windows

### DIFF
--- a/nvflare/fuel/f3/cellnet/net_agent.py
+++ b/nvflare/fuel/f3/cellnet/net_agent.py
@@ -16,11 +16,15 @@ import copy
 import hashlib
 import os
 import random
-import resource
 import threading
 import time
 from abc import ABC
 from typing import List, Union
+
+try:
+    import resource
+except ImportError:
+    resource = None
 
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.connector_manager import ConnectorData
@@ -914,7 +918,10 @@ class NetAgent:
 
     def _do_process_info(self, request: Message) -> Union[None, Message]:
 
-        usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if resource is not None:
+            usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        else:
+            usage = "N/A (not supported on this platform)"
         rows = [
             ["Process ID", str(os.getpid())],
             ["Memory Usage", str(usage)],


### PR DESCRIPTION
## Problem
`nvflare.fuel.f3.cellnet.net_agent` imports the `resource` module at the top level.
This module is Unix-only and raises `ModuleNotFoundError` on Windows, making it
impossible to `import nvflare` at all.

## Root Cause
`resource` is used only in `_do_process_info()` to report memory usage via
`resource.getrusage()`. The import is unconditional despite only one method needing it.

## Fix
- Wrap `import resource` in `try/except ImportError`, setting `resource = None` when unavailable
- Guard the single usage in `_do_process_info()` to return `"N/A"` when `resource` is `None`

## Testing
- Windows 11: `from nvflare.fuel.f3.cellnet.net_agent import NetAgent` — passes after fix
- Linux (WSL2 Ubuntu): no behavior change, `resource` imports normally