### PR TITLE
Make recipe --export/--export-dir import safe

### DIFF
--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -83,8 +83,8 @@ def _consume_recipe_args() -> tuple:
 _RECIPE_EXPORT, _RECIPE_EXPORT_DIR = _consume_recipe_args()
 
 
-def _peek_recipe_args(argv: Optional[List[str]] = None) -> tuple:
-    """Return the export flags consumed at import time (argv argument is ignored)."""
+def _peek_recipe_args() -> tuple:
+    """Return the export flags consumed at import time."""
     return _RECIPE_EXPORT, _RECIPE_EXPORT_DIR
 
 

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -17,6 +17,15 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Union
 
+# Single source of truth for the default export dir. Kept in the current working
+# directory on purpose: an export is a user-requested artifact, so it lands next to
+# where the script ran (discoverable and predictable), and a relative path stays
+# portable across OSes -- unlike a fixed /tmp path, which is non-portable on Windows
+# and collision-prone on shared hosts.
+DEFAULT_EXPORT_DIR = "./fl_job"
+
+_CONSUMED = False
+
 
 def _consume_recipe_args() -> tuple:
     """Strip --export / --export-dir from sys.argv and return (export, export_dir).
@@ -24,10 +33,20 @@ def _consume_recipe_args() -> tuple:
     Called once at module import time so that the caller's argparse never sees
     these flags regardless of the order in which parse_args() and execute() appear
     in job.py.
+
+    Transactional: sys.argv is only mutated if the parse is clean. A malformed
+    (dangling) --export-dir aborts the pass without mutating sys.argv and without
+    enabling export, so a malformed import can neither raise nor silently export.
+    The decision is frozen after the first call so repeated direct calls return the
+    recorded import-time result rather than re-scanning a since-mutated sys.argv.
     """
+    global _CONSUMED
+    if _CONSUMED:
+        return _RECIPE_EXPORT, _RECIPE_EXPORT_DIR
+
     argv = sys.argv[1:]
     export = False
-    export_dir = "./fl_job"
+    export_dir = DEFAULT_EXPORT_DIR
     remaining = []
     i = 0
     while i < len(argv):
@@ -36,7 +55,14 @@ def _consume_recipe_args() -> tuple:
             i += 1
         elif argv[i] == "--export-dir":
             if i + 1 >= len(argv):
-                raise ValueError("--export-dir requires an argument")
+                # Dangling --export-dir with no value: abort the entire pass. Do not
+                # mutate sys.argv and do not enable export. Leaving argv intact lets the
+                # caller's own parser surface the leftover flags; enabling export here
+                # could export to the default dir against the user's intent (e.g. under
+                # parse_known_args()). Freeze the decision so a later direct call returns
+                # it instead of re-scanning a since-mutated sys.argv.
+                _CONSUMED = True
+                return False, DEFAULT_EXPORT_DIR
             export_dir = argv[i + 1]
             i += 2
         elif argv[i].startswith("--export-dir="):
@@ -46,6 +72,7 @@ def _consume_recipe_args() -> tuple:
             remaining.append(argv[i])
             i += 1
     sys.argv[1:] = remaining
+    _CONSUMED = True
     return export, export_dir
 
 

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import ast
-import importlib
 import inspect
 import pkgutil
 import sys
 from enum import Enum
+from importlib import import_module
 from pathlib import Path
 
 from nvflare.tool.cli_output import output_usage_error
@@ -377,7 +377,7 @@ def _static_recipe_parameters(module_name: str, class_name: str) -> list:
 
 def _try_import_recipe_class(module_name: str, class_name: str):
     try:
-        module = importlib.import_module(module_name)
+        module = import_module(module_name)
     except (ImportError, SyntaxError):
         return None
     return getattr(module, class_name, None)
@@ -807,7 +807,7 @@ def _load_catalog(framework: str = None, include_recipe_class: bool = False) -> 
         if framework and root["framework"] != framework:
             continue
         try:
-            package = importlib.import_module(root["package"])
+            package = import_module(root["package"])
         except (ImportError, SyntaxError):
             pass
 
@@ -816,7 +816,7 @@ def _load_catalog(framework: str = None, include_recipe_class: bool = False) -> 
                 if module_name.endswith(".__init__"):
                     continue
                 try:
-                    mod = importlib.import_module(module_name)
+                    mod = import_module(module_name)
                 except (ImportError, SyntaxError):
                     continue
 

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -529,16 +529,50 @@ def test_recipe_spec_import_strips_export_flags_from_sys_argv(monkeypatch):
     importlib.reload(spec_module)
 
     assert sys.argv == ["python", "job.py", "--other", "value"]
+    assert spec_module._peek_recipe_args() == (True, "/tmp/out")
 
 
-def test_consume_recipe_args_requires_export_dir_argument(monkeypatch):
+def test_recipe_spec_import_strips_export_dir_equals_form(monkeypatch):
     import sys
+
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--export-dir=out", "--other"])
 
     import nvflare.recipe.spec as spec_module
 
+    importlib.reload(spec_module)
+
+    assert sys.argv == ["python", "job.py", "--other"]
+    assert spec_module._peek_recipe_args() == (True, "out")
+
+
+def test_consume_recipe_args_dangling_export_dir_does_not_raise(monkeypatch):
+    import sys
+
     monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--export-dir"])
-    with pytest.raises(ValueError, match="--export-dir requires an argument"):
-        spec_module._consume_recipe_args()
+
+    import nvflare.recipe.spec as spec_module
+
+    importlib.reload(spec_module)  # malformed input must not raise on import
+
+    # Transactional: the whole pass is abandoned -- export stays disabled and sys.argv
+    # is left untouched so the caller's own parser can surface the leftover flags.
+    assert spec_module._peek_recipe_args() == (False, spec_module.DEFAULT_EXPORT_DIR)
+    assert sys.argv == ["python", "job.py", "--export", "--export-dir"]
+
+
+def test_consume_recipe_args_freezes_import_time_decision(monkeypatch):
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--export-dir"])
+
+    import nvflare.recipe.spec as spec_module
+
+    importlib.reload(spec_module)
+
+    # A later direct call returns the recorded import-time decision even if sys.argv
+    # has since changed -- it must not re-scan and flip to a different answer.
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--export-dir", "out"])
+    assert spec_module._consume_recipe_args() == (False, spec_module.DEFAULT_EXPORT_DIR)
 
 
 def test_export_processes_falsy_env(tmp_path):

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -532,6 +532,20 @@ def test_recipe_spec_import_strips_export_flags_from_sys_argv(monkeypatch):
     assert spec_module._peek_recipe_args() == (True, "/tmp/out")
 
 
+def test_recipe_spec_import_bare_export_uses_default_dir(monkeypatch):
+    import sys
+
+    # The canonical invocation: `python job.py --export` with no --export-dir.
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--other"])
+
+    import nvflare.recipe.spec as spec_module
+
+    importlib.reload(spec_module)
+
+    assert sys.argv == ["python", "job.py", "--other"]
+    assert spec_module._peek_recipe_args() == (True, spec_module.DEFAULT_EXPORT_DIR)
+
+
 def test_recipe_spec_import_strips_export_dir_equals_form(monkeypatch):
     import sys
 

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -18,6 +18,8 @@ from types import ModuleType
 
 import pytest
 
+import nvflare.tool.recipe.recipe_cli as recipe_cli
+
 
 def test_recipe_missing_subcommand_prints_help_then_error(capsys):
     from nvflare.tool import cli_output
@@ -568,7 +570,7 @@ def test_recipe_catalog_is_discovered_from_package_modules(monkeypatch):
             return fake_module
         raise ImportError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.fedavg", False)],
@@ -621,7 +623,7 @@ def test_recipe_catalog_prefers_specific_algorithm_marker_over_fedavg_class_name
             return fake_module
         raise ImportError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.kmeans", False)],
@@ -667,7 +669,7 @@ def test_recipe_catalog_core_framework_is_not_special_catch_all(monkeypatch):
             return core_module
         raise ModuleNotFoundError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.core.fedavg", False)],
@@ -708,7 +710,7 @@ def test_recipe_catalog_skips_plain_import_errors_from_optional_recipes(monkeypa
             raise ImportError("broken recipe import")
         raise ModuleNotFoundError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.broken", False)],
@@ -736,7 +738,7 @@ def test_recipe_catalog_skips_syntax_errors_from_optional_recipes(monkeypatch):
             raise SyntaxError("invalid syntax")
         raise ModuleNotFoundError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.broken", False)],
@@ -783,7 +785,7 @@ def test_recipe_catalog_prefers_leaf_recipe_class_when_module_has_base_and_subcl
             return fake_module
         raise ImportError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.swarm", False)],


### PR DESCRIPTION
## Description

Importing `nvflare.recipe.spec` consumes `--export` / `--export-dir` from `sys.argv` at **module import time**, so a recipe job script's own `argparse.parse_args()` never sees them (the strip has to happen at import because job scripts typically call their own `parse_args()` before `recipe.execute()`).

The problem: the consumer **raised `ValueError`** on a dangling `--export-dir`. Import should not blow up because of unrelated command-line tokens it does not own. Today any benign import that happens to have a bare `--export-dir` in `sys.argv` — a unit test introspecting recipe classes, a notebook, the recipe catalog loader, a third-party tool — crashes on import:

```python
sys.argv = ["mytool", "--export-dir"]
import nvflare.recipe.spec     # ValueError: --export-dir requires an argument
```

## Changes

- Make `_consume_recipe_args()` **transactional**: parse into a scratch list and only mutate `sys.argv` when the parse is clean. A dangling `--export-dir` now **abandons the whole pass** — `sys.argv` is left untouched and export stays disabled — instead of raising.
  - This also avoids the subtler failure where a half-consumed `--export --export-dir` would record `export=True` and silently export to the default dir against the user's intent (e.g. under `parse_known_args()`).
- **Freeze the decision** after the first call (`_CONSUMED`) so repeated direct calls return the recorded import-time result rather than re-scanning a since-mutated `sys.argv`.
- Promote the default export dir to a single `DEFAULT_EXPORT_DIR = "./fl_job"` constant (kept relative/CWD: an export is a user-requested, discoverable artifact, and a relative path stays portable across OSes — unlike a fixed `/tmp` path).

Well-formed `--export` / `--export-dir VALUE` / `--export-dir=VALUE` behavior is **unchanged**, with **zero per-recipe argparse wiring**.

## Why not an `argv[0]`-based guard

A "only consume when the process isn't the `nvflare` CLI" heuristic was considered and rejected: it's fragile (breaks under `python -m nvflare.cli`, pytest, subprocess, where `argv[0]` isn't `nvflare`) and unnecessary — the `nvflare` CLI is already safe because its own `parse_args()` runs before `recipe.spec` is ever imported (the CLI imports recipe modules lazily, after parsing).

## Tests

`tests/unit_test/recipe/spec_test.py`:
- replaced the `ValueError`-expecting test with: dangling `--export-dir` does **not** raise on import, leaves `sys.argv` untouched, and does not enable export
- decision is frozen across a later direct call even if `sys.argv` changes
- added `--export-dir=VALUE` equals-form coverage and `_peek_recipe_args()` assertions on the existing strip test

All recipe unit tests pass (`327 passed, 18 skipped`); black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Follow-up commit: harden `recipe_cli` import faking (test-isolation fix)

The first version of this PR turned the `unit-tests` matrix red with 6 failures in
`tests/unit_test/tool/recipe_cli_test.py` (`ImportError: nvflare`). Root cause: those tests
faked module loading via `monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", ...)`.
Since `recipe_cli.importlib` is the **global** `importlib` module, that replaced
`importlib.import_module` process-wide — including the copy pytest's own `monkeypatch.resolve`
uses to walk dotted string targets. Under certain xdist worker orderings (which this PR's
changed test count reshuffles into) a later test's `monkeypatch.setattr` then failed while
resolving its target. The defect is pre-existing test-isolation fragility; this PR only
surfaced it via scheduling.

Fix: bind `import_module` locally in `recipe_cli.py` (`from importlib import import_module`) and
patch that local name with the object form of `monkeypatch.setattr`. The tests no longer mutate
the global `importlib` and no longer resolve through it, so the catalog tests are hermetic under
any scheduling. `import_module` is the same function — **no production behavior change**.
