### PR TITLE
Filter analysis files from released agent skills

### DIFF
--- a/nvflare/tool/agent/skill_manager.py
+++ b/nvflare/tool/agent/skill_manager.py
@@ -30,7 +30,9 @@ from typing import Optional
 import nvflare
 from nvflare.tool.agent.skill_manifest import (
     IGNORED_SKILL_FILE_NAMES,
+    MANIFEST_CONTENT_MODE_RELEASE,
     MANIFEST_FILE_NAME,
+    RELEASE_SKILL_FILE_EXCLUDE_NAMES,
     SHARED_SKILL_REFERENCE_DIR,
     build_skill_manifest,
     load_manifest,
@@ -241,7 +243,11 @@ def _install_plan(
             "source_hash": skill["source_hash"],
             "relative_path": skill["relative_path"],
             "target_path": str(target_skill_dir),
-            "files": [] if source_symlink else _files_to_copy(source_skill_dir, target_skill_dir),
+            "files": (
+                []
+                if source_symlink
+                else _files_to_copy(source_skill_dir, target_skill_dir, exclude_names=_copy_exclude_names(source))
+            ),
             "version_delta": "new",
         }
         if source_symlink:
@@ -358,7 +364,8 @@ def _sync_shared_references(source: SkillSource, target: Path) -> None:
     source_shared = source.root / SHARED_SKILL_REFERENCE_DIR
     if not source_shared.is_dir():
         return
-    source_hash = skill_tree_hash(source_shared)
+    exclude_names = _copy_exclude_names(source)
+    source_hash = skill_tree_hash(source_shared, exclude_names=exclude_names)
     target_shared = target / SHARED_SKILL_REFERENCE_DIR
     plan_entry = {"name": SHARED_SKILL_REFERENCE_DIR, "source_hash": source_hash}
     if not target_shared.exists():
@@ -369,7 +376,7 @@ def _sync_shared_references(source: SkillSource, target: Path) -> None:
     install_manifest = _read_install_manifest(target_shared)
     if not install_manifest or install_manifest.get("managed_by") != "nvflare":
         raise FileExistsError(f"shared reference target is not managed by nvflare: {target_shared}")
-    installed_source_hash = skill_tree_hash(target_shared, exclude_names={INSTALL_MANIFEST_FILE_NAME})
+    installed_source_hash = skill_tree_hash(target_shared, exclude_names={INSTALL_MANIFEST_FILE_NAME, *exclude_names})
     managed_source_hash = install_manifest.get("source_hash")
     if installed_source_hash != managed_source_hash:
         raise FileExistsError(f"shared reference target has local modifications: {target_shared}")
@@ -498,7 +505,7 @@ def _stage_skill(
     symlink = _first_symlink_in_tree(source_dir)
     if symlink:
         raise ValueError(f"skill source must not contain symlinks: {symlink.relative_to(source_dir).as_posix()}")
-    shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES))
+    shutil.copytree(source_dir, staged_dir, ignore=shutil.ignore_patterns(*_copy_exclude_names(source)))
     manifest = {
         "schema_version": "1",
         "managed_by": "nvflare",
@@ -601,14 +608,22 @@ def _first_symlink_in_tree(root_dir: Path) -> Optional[Path]:
     return None
 
 
-def _files_to_copy(source_dir: Path, target_dir: Path) -> list[dict]:
+def _copy_exclude_names(source: SkillSource) -> set[str]:
+    if source.manifest.get("content_mode") == MANIFEST_CONTENT_MODE_RELEASE:
+        return set(RELEASE_SKILL_FILE_EXCLUDE_NAMES)
+    return set(IGNORED_SKILL_FILE_NAMES)
+
+
+def _files_to_copy(source_dir: Path, target_dir: Path, *, exclude_names: set[str]) -> list[dict]:
     files = []
     for root, dir_names, file_names in os.walk(source_dir, topdown=True, followlinks=False):
         root_path = Path(root)
         dir_names.sort()
         file_names.sort()
-        dir_names[:] = [name for name in dir_names if name != "__pycache__" and not (root_path / name).is_symlink()]
+        dir_names[:] = [name for name in dir_names if name not in exclude_names and not (root_path / name).is_symlink()]
         for file_name in file_names:
+            if file_name in exclude_names:
+                continue
             file_path = root_path / file_name
             if file_path.is_symlink():
                 continue

--- a/nvflare/tool/agent/skill_manifest.py
+++ b/nvflare/tool/agent/skill_manifest.py
@@ -27,6 +27,10 @@ from typing import Iterable, Optional
 MANIFEST_FILE_NAME = "manifest.json"
 MANIFEST_SCHEMA_VERSION = "1"
 IGNORED_SKILL_FILE_NAMES = {"__pycache__", "*.pyc", "*.pyo"}
+ANALYSIS_ONLY_SKILL_FILE_NAMES = {"BENCHMARK.md", "evals"}
+RELEASE_SKILL_FILE_EXCLUDE_NAMES = IGNORED_SKILL_FILE_NAMES | ANALYSIS_ONLY_SKILL_FILE_NAMES
+MANIFEST_CONTENT_MODE_DEV = "dev"
+MANIFEST_CONTENT_MODE_RELEASE = "release"
 SHARED_SKILL_REFERENCE_DIR = "_shared"
 HASH_READ_CHUNK_BYTES = 1024 * 1024
 
@@ -59,11 +63,18 @@ def skill_tree_hash(skill_dir: Path, *, exclude_names: Optional[set[str]] = None
     return digest.hexdigest()
 
 
-def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_version: str = "") -> dict:
+def build_skill_manifest(
+    skills_root: Path | str,
+    *,
+    source_type: str,
+    nvflare_version: str = "",
+    include_analysis_files: bool = True,
+) -> dict:
     """Build the released-skill manifest for a skills source root."""
     root = Path(skills_root)
     skills = []
     findings = []
+    source_hash_exclude_names = _source_hash_exclude_names(include_analysis_files)
     if root.is_dir():
         for child in sorted(root.iterdir(), key=lambda p: p.name):
             if _should_skip_skill_dir(child):
@@ -82,7 +93,7 @@ def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_v
                 continue
             metadata = dict(result.metadata)
             try:
-                source_hash = skill_tree_hash(child)
+                source_hash = skill_tree_hash(child, exclude_names=source_hash_exclude_names)
             except (OSError, ValueError) as exc:
                 raise SkillManifestError(
                     "AGENT_SKILL_MANIFEST_BUILD_FAILED",
@@ -105,6 +116,7 @@ def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_v
     return {
         "schema_version": MANIFEST_SCHEMA_VERSION,
         "source_type": source_type,
+        "content_mode": MANIFEST_CONTENT_MODE_DEV if include_analysis_files else MANIFEST_CONTENT_MODE_RELEASE,
         "nvflare_version": nvflare_version,
         "skills": skills,
         "findings": findings,
@@ -113,6 +125,12 @@ def build_skill_manifest(skills_root: Path | str, *, source_type: str, nvflare_v
 
 def _should_skip_skill_dir(path: Path) -> bool:
     return path.name.startswith(".") or path.name.startswith("_") or not path.is_dir()
+
+
+def _source_hash_exclude_names(include_analysis_files: bool) -> set[str]:
+    if not include_analysis_files:
+        return set(RELEASE_SKILL_FILE_EXCLUDE_NAMES)
+    return set(IGNORED_SKILL_FILE_NAMES)
 
 
 def write_manifest(manifest: dict, manifest_path: Path | str) -> None:
@@ -151,36 +169,46 @@ def load_manifest(manifest_path: Path | str) -> dict:
 
 
 def copy_released_skills_to_bundle(
-    skills_root: Path | str, bundle_root: Path | str, *, nvflare_version: str = ""
+    skills_root: Path | str,
+    bundle_root: Path | str,
+    *,
+    nvflare_version: str = "",
+    include_analysis_files: bool = True,
 ) -> dict:
     """Copy valid released skills and write their manifest into a package bundle directory."""
     source_root = Path(skills_root)
     target_root = Path(bundle_root)
     _clean_bundle_root(target_root)
 
-    manifest = build_skill_manifest(source_root, source_type="wheel", nvflare_version=nvflare_version)
-    _copy_shared_references_to_bundle(source_root, target_root)
+    manifest = build_skill_manifest(
+        source_root,
+        source_type="wheel",
+        nvflare_version=nvflare_version,
+        include_analysis_files=include_analysis_files,
+    )
+    ignore_names = IGNORED_SKILL_FILE_NAMES if include_analysis_files else RELEASE_SKILL_FILE_EXCLUDE_NAMES
+    _copy_shared_references_to_bundle(source_root, target_root, ignore_names=ignore_names)
     for skill in manifest["skills"]:
         shutil.copytree(
             source_root / skill["relative_path"],
             target_root / skill["relative_path"],
-            ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES),
+            ignore=shutil.ignore_patterns(*ignore_names),
         )
     write_manifest(manifest, target_root / MANIFEST_FILE_NAME)
     return manifest
 
 
-def _copy_shared_references_to_bundle(source_root: Path, target_root: Path) -> None:
+def _copy_shared_references_to_bundle(source_root: Path, target_root: Path, *, ignore_names: set[str]) -> None:
     shared_root = source_root / SHARED_SKILL_REFERENCE_DIR
     if not shared_root.is_dir():
         return
     # Validate that shared references contain no symlinks. The hash value is
     # not needed here; skill_tree_hash raises before copying unsafe content.
-    skill_tree_hash(shared_root)
+    skill_tree_hash(shared_root, exclude_names=ignore_names)
     shutil.copytree(
         shared_root,
         target_root / SHARED_SKILL_REFERENCE_DIR,
-        ignore=shutil.ignore_patterns(*IGNORED_SKILL_FILE_NAMES),
+        ignore=shutil.ignore_patterns(*ignore_names),
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,10 @@ def _package_agent_skills_enabled():
     return value not in {"0", "false", "no", "off"}
 
 
+def _package_agent_skills_analysis_files():
+    return release != "1"
+
+
 def _no_skills_wheel_build_tag():
     return os.environ.get("NVFLARE_NO_SKILLS_WHEEL_BUILD_TAG", "1no_skills").strip()
 
@@ -125,6 +129,7 @@ class AgentSkillsBuildPy(_base_build_py):
                 os.path.join(ROOT_DIR, "skills"),
                 bundle_root,
                 nvflare_version=version,
+                include_analysis_files=_package_agent_skills_analysis_files(),
             )
         else:
             agent_skill_manifest.write_empty_skill_bundle(

--- a/tests/unit_test/tool/agent/seed_skill_packaging_test.py
+++ b/tests/unit_test/tool/agent/seed_skill_packaging_test.py
@@ -15,6 +15,7 @@
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 import zipfile
@@ -59,7 +60,7 @@ def test_convert_pytorch_eval_requires_declared_primary_metric_alignment():
     assert "reports that scalar as validation evidence" in description
 
 
-def test_seed_bundle_copy_includes_references_evals_and_log_fixtures(tmp_path):
+def test_seed_bundle_copy_includes_analysis_fixtures_by_default(tmp_path):
     skills_root = _repo_root() / "skills"
     bundle_root = tmp_path / "bundle"
 
@@ -69,7 +70,10 @@ def test_seed_bundle_copy_includes_references_evals_and_log_fixtures(tmp_path):
     assert SEED_SKILLS.issubset(names)
     assert (bundle_root / "_shared" / "nvflare-job-lifecycle.md").is_file()
     _assert_convert_pytorch_payload(bundle_root / "nvflare-convert-pytorch")
-    _assert_diagnose_payload(bundle_root / "nvflare-diagnose-job")
+    _assert_diagnose_runtime_payload(bundle_root / "nvflare-diagnose-job")
+    _assert_analysis_payload_present(bundle_root / "nvflare-diagnose-job")
+    assert bundle_root.joinpath("nvflare-convert-pytorch", "BENCHMARK.md").is_file()
+    assert bundle_root.joinpath("nvflare-convert-pytorch", "evals", "evals.json").is_file()
 
 
 def test_seed_skills_install_into_codex_and_claude_temp_targets(tmp_path):
@@ -88,13 +92,40 @@ def test_seed_skills_install_into_codex_and_claude_temp_targets(tmp_path):
     assert claude_target.joinpath("_shared", "nvflare-job-lifecycle.md").is_file()
     _assert_convert_pytorch_payload(codex_target / "nvflare-convert-pytorch")
     _assert_convert_pytorch_payload(claude_target / "nvflare-convert-pytorch")
-    _assert_diagnose_payload(codex_target / "nvflare-diagnose-job")
-    _assert_diagnose_payload(claude_target / "nvflare-diagnose-job")
+    _assert_diagnose_runtime_payload(codex_target / "nvflare-diagnose-job")
+    _assert_diagnose_runtime_payload(claude_target / "nvflare-diagnose-job")
+    _assert_analysis_payload_present(codex_target / "nvflare-diagnose-job")
+    _assert_analysis_payload_present(claude_target / "nvflare-diagnose-job")
 
     codex_list = list_skills(agent="codex", target_dir=codex_target, source=source)
     claude_list = list_skills(agent="claude", target_dir=claude_target, source=source)
     assert SEED_SKILLS.issubset({skill["name"] for skill in codex_list["installed"]})
     assert SEED_SKILLS.issubset({skill["name"] for skill in claude_list["installed"]})
+
+
+def test_released_seed_skills_install_without_analysis_fixtures(tmp_path):
+    skills_root = _repo_root() / "skills"
+    bundle_root = tmp_path / "bundle"
+    manifest = copy_released_skills_to_bundle(
+        skills_root, bundle_root, nvflare_version="2.8.0", include_analysis_files=False
+    )
+    source = SkillSource(source_type="wheel", root=bundle_root, manifest=manifest)
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+    repeat_plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    assert plan["applied"] is True
+    assert repeat_plan["applied"] is True
+    assert all(
+        entry["action"] == "skip" and entry.get("reason") == "already_installed" for entry in repeat_plan["skills"]
+    )
+    listed = list_skills(agent="codex", target_dir=target, source=source)
+    assert SEED_SKILLS.issubset({skill["name"] for skill in listed["installed"]})
+    _assert_diagnose_runtime_payload(target / "nvflare-diagnose-job")
+    _assert_analysis_payload_filtered(target / "nvflare-diagnose-job")
+    _assert_analysis_payload_filtered(target / "nvflare-convert-pytorch")
+    _assert_runtime_markdown_references_resolve(target)
 
 
 def test_seed_skills_dry_run_selects_all_seed_skills_without_copying(tmp_path):
@@ -140,6 +171,43 @@ def test_setup_build_py_can_disable_packaged_agent_skills(tmp_path):
     assert manifest["findings"] == []
     for skill_name in SEED_SKILLS:
         assert not bundle_root.joinpath(skill_name).exists()
+
+
+@pytest.mark.xdist_group(name="setup_py_packaging")
+def test_setup_build_py_release_filters_analysis_fixtures(tmp_path):
+    repo_root = _repo_root()
+    build_lib = tmp_path / "build_lib"
+    env = os.environ.copy()
+    env["NVFL_RELEASE"] = "1"
+
+    result = subprocess.run(
+        [sys.executable, "setup.py", "build_py", "--build-lib", str(build_lib)],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    bundle_root = build_lib / "nvflare" / "tool" / "agent" / "bundled_skills"
+    manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert manifest["source_type"] == "wheel"
+    assert manifest["content_mode"] == "release"
+    assert SEED_SKILLS.issubset({skill["name"] for skill in manifest["skills"]})
+    _assert_diagnose_runtime_payload(bundle_root / "nvflare-diagnose-job")
+    _assert_analysis_payload_filtered(bundle_root / "nvflare-diagnose-job")
+    _assert_analysis_payload_filtered(bundle_root / "nvflare-convert-pytorch")
+    _assert_runtime_markdown_references_resolve(bundle_root)
+
+    target = tmp_path / "target"
+    source = SkillSource(source_type="wheel", root=bundle_root, manifest=manifest)
+    install_plan = install_skills(agent="codex", target_dir=target, source=source)
+    listed = list_skills(agent="codex", target_dir=target, source=source)
+    assert install_plan["applied"] is True
+    assert SEED_SKILLS.issubset({skill["name"] for skill in listed["installed"]})
+    _assert_runtime_markdown_references_resolve(target)
 
 
 @pytest.mark.xdist_group(name="setup_py_packaging")
@@ -213,14 +281,38 @@ def _assert_convert_pytorch_payload(skill_dir: Path) -> None:
     assert "Must not require `rg` to be installed" in packaged_text
 
 
-def _assert_diagnose_payload(skill_dir: Path) -> None:
+def _assert_diagnose_runtime_payload(skill_dir: Path) -> None:
     assert skill_dir.joinpath("SKILL.md").is_file()
     assert skill_dir.joinpath("references", "evidence-collection.md").is_file()
     assert skill_dir.joinpath("references", "failure-patterns.md").is_file()
+
+
+def _assert_analysis_payload_present(skill_dir: Path) -> None:
     assert skill_dir.joinpath("evals", "evals.json").is_file()
     assert skill_dir.joinpath("evals", "files", "poc_component_not_authorized.log").is_file()
     assert skill_dir.joinpath("evals", "files", "simulation_import_error.log").is_file()
     assert skill_dir.joinpath("evals", "files", "transfer_progress_timeout.log").is_file()
+
+
+def _assert_analysis_payload_filtered(skill_dir: Path) -> None:
+    assert not skill_dir.joinpath("BENCHMARK.md").exists()
+    assert not skill_dir.joinpath("evals").exists()
+
+
+def _assert_runtime_markdown_references_resolve(root: Path) -> None:
+    missing = []
+    for markdown_path in sorted(root.rglob("*.md")):
+        rel_parts = markdown_path.relative_to(root).parts
+        if "evals" in rel_parts or markdown_path.name == "BENCHMARK.md":
+            continue
+        text = markdown_path.read_text(encoding="utf-8")
+        for ref in sorted(set(re.findall(r"`([^`]+\.md)`", text))):
+            ref_path = Path(ref)
+            if ref_path.is_absolute():
+                continue
+            if not (markdown_path.parent / ref_path).resolve(strict=False).is_file():
+                missing.append(f"{markdown_path.relative_to(root).as_posix()} -> {ref}")
+    assert missing == []
 
 
 def _repo_root() -> Path:

--- a/tests/unit_test/tool/agent/skill_manager_test.py
+++ b/tests/unit_test/tool/agent/skill_manager_test.py
@@ -30,7 +30,7 @@ from nvflare.tool.agent.skill_manager import (
     list_skills,
     resolve_agent_target_dir,
 )
-from nvflare.tool.agent.skill_manifest import build_skill_manifest, write_manifest
+from nvflare.tool.agent.skill_manifest import build_skill_manifest, skill_tree_hash, write_manifest
 
 
 def test_resolve_codex_target_uses_codex_home(tmp_path):
@@ -228,6 +228,58 @@ def test_install_skills_installs_all_by_default(tmp_path):
     install_manifest = json.loads(skill_dir.joinpath(INSTALL_MANIFEST_FILE_NAME).read_text(encoding="utf-8"))
     assert install_manifest["managed_by"] == "nvflare"
     assert install_manifest["name"] == "nvflare-test-skill"
+
+
+def test_install_skills_keeps_analysis_files_for_dev_wheel_source(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    skill_dir.joinpath("BENCHMARK.md").write_text("# Benchmark-only notes\n", encoding="utf-8")
+    skill_dir.joinpath("evals").mkdir()
+    skill_dir.joinpath("evals", "evals.json").write_text("{}\n", encoding="utf-8")
+    source = SkillSource(
+        source_type="wheel",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="wheel", nvflare_version="2.8.0"),
+    )
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    installed = target / "nvflare-test-skill"
+    assert plan["applied"] is True
+    assert installed.joinpath("SKILL.md").is_file()
+    assert installed.joinpath("BENCHMARK.md").is_file()
+    assert installed.joinpath("evals", "evals.json").is_file()
+    assert (
+        skill_tree_hash(installed, exclude_names={INSTALL_MANIFEST_FILE_NAME})
+        == source.manifest["skills"][0]["source_hash"]
+    )
+
+
+def test_install_skills_filters_analysis_files_for_release_source(tmp_path):
+    root = tmp_path / "skills"
+    skill_dir = _write_skill(root, "nvflare-test-skill")
+    skill_dir.joinpath("BENCHMARK.md").write_text("# Benchmark-only notes\n", encoding="utf-8")
+    skill_dir.joinpath("evals").mkdir()
+    skill_dir.joinpath("evals", "evals.json").write_text("{}\n", encoding="utf-8")
+    source = SkillSource(
+        source_type="wheel",
+        root=root,
+        manifest=build_skill_manifest(root, source_type="wheel", nvflare_version="2.8.0", include_analysis_files=False),
+    )
+    target = tmp_path / "target"
+
+    plan = install_skills(agent="codex", target_dir=target, source=source)
+
+    installed = target / "nvflare-test-skill"
+    assert plan["applied"] is True
+    assert installed.joinpath("SKILL.md").is_file()
+    assert not installed.joinpath("BENCHMARK.md").exists()
+    assert not installed.joinpath("evals").exists()
+    assert (
+        skill_tree_hash(installed, exclude_names={INSTALL_MANIFEST_FILE_NAME})
+        == source.manifest["skills"][0]["source_hash"]
+    )
 
 
 def test_install_skills_reports_missing_named_skill(tmp_path):

--- a/tests/unit_test/tool/agent/skill_manifest_test.py
+++ b/tests/unit_test/tool/agent/skill_manifest_test.py
@@ -23,6 +23,9 @@ import pytest
 
 from nvflare.tool.agent import bundled_skills, skill_manifest
 from nvflare.tool.agent.skill_manifest import (
+    MANIFEST_CONTENT_MODE_DEV,
+    MANIFEST_CONTENT_MODE_RELEASE,
+    RELEASE_SKILL_FILE_EXCLUDE_NAMES,
     SkillManifestError,
     build_skill_manifest,
     copy_released_skills_to_bundle,
@@ -52,6 +55,26 @@ def test_build_skill_manifest_includes_valid_skill(tmp_path):
             "relative_path": "nvflare-test-skill",
         }
     ]
+
+
+def test_build_skill_manifest_hashes_release_runtime_payload_only_when_requested(tmp_path):
+    skill_dir = _write_skill(tmp_path, "nvflare-test-skill")
+    skill_dir.joinpath("BENCHMARK.md").write_text("# Benchmark notes\n", encoding="utf-8")
+    skill_dir.joinpath("evals").mkdir()
+    skill_dir.joinpath("evals", "evals.json").write_text("{}\n", encoding="utf-8")
+
+    editable = build_skill_manifest(tmp_path, source_type="editable", nvflare_version="2.8.0")
+    wheel = build_skill_manifest(tmp_path, source_type="wheel", nvflare_version="2.8.0")
+    release = build_skill_manifest(tmp_path, source_type="wheel", nvflare_version="2.8.0", include_analysis_files=False)
+
+    assert editable["skills"][0]["source_hash"] == skill_tree_hash(skill_dir)
+    assert wheel["content_mode"] == MANIFEST_CONTENT_MODE_DEV
+    assert wheel["skills"][0]["source_hash"] == skill_tree_hash(skill_dir)
+    assert release["content_mode"] == MANIFEST_CONTENT_MODE_RELEASE
+    assert release["skills"][0]["source_hash"] == skill_tree_hash(
+        skill_dir, exclude_names=RELEASE_SKILL_FILE_EXCLUDE_NAMES
+    )
+    assert editable["skills"][0]["source_hash"] != release["skills"][0]["source_hash"]
 
 
 def test_skill_tree_hash_changes_when_skill_content_changes(tmp_path):
@@ -228,18 +251,50 @@ def test_load_frontmatter_module_does_not_cache_failed_fallback_module(monkeypat
     assert module_name not in sys.modules
 
 
-def test_copy_released_skills_to_bundle_writes_manifest_and_files(tmp_path):
+def test_copy_released_skills_to_bundle_keeps_analysis_files_by_default(tmp_path):
     source_root = tmp_path / "skills"
     bundle_root = tmp_path / "bundle"
-    _write_skill(source_root, "nvflare-test-skill")
+    skill_dir = _write_skill(source_root, "nvflare-test-skill")
+    skill_dir.joinpath("BENCHMARK.md").write_text("# Analysis-only benchmark notes\n", encoding="utf-8")
+    skill_dir.joinpath("evals").mkdir()
+    skill_dir.joinpath("evals", "evals.json").write_text("{}\n", encoding="utf-8")
 
     manifest = copy_released_skills_to_bundle(source_root, bundle_root, nvflare_version="2.8.0")
 
     assert bundle_root.joinpath("manifest.json").is_file()
     assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+    assert bundle_root.joinpath("nvflare-test-skill", "BENCHMARK.md").is_file()
+    assert bundle_root.joinpath("nvflare-test-skill", "evals", "evals.json").is_file()
     saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
     assert saved_manifest == manifest
+    assert saved_manifest["content_mode"] == MANIFEST_CONTENT_MODE_DEV
     assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+    assert saved_manifest["skills"][0]["source_hash"] == skill_tree_hash(bundle_root / "nvflare-test-skill")
+
+
+def test_copy_released_skills_to_bundle_filters_analysis_files_for_release_mode(tmp_path):
+    source_root = tmp_path / "skills"
+    bundle_root = tmp_path / "bundle"
+    skill_dir = _write_skill(source_root, "nvflare-test-skill")
+    skill_dir.joinpath("BENCHMARK.md").write_text("# Analysis-only benchmark notes\n", encoding="utf-8")
+    skill_dir.joinpath("evals").mkdir()
+    skill_dir.joinpath("evals", "evals.json").write_text("{}\n", encoding="utf-8")
+
+    manifest = copy_released_skills_to_bundle(
+        source_root, bundle_root, nvflare_version="2.8.0", include_analysis_files=False
+    )
+
+    assert bundle_root.joinpath("manifest.json").is_file()
+    assert bundle_root.joinpath("nvflare-test-skill", "SKILL.md").is_file()
+    assert not bundle_root.joinpath("nvflare-test-skill", "BENCHMARK.md").exists()
+    assert not bundle_root.joinpath("nvflare-test-skill", "evals").exists()
+    saved_manifest = json.loads(bundle_root.joinpath("manifest.json").read_text(encoding="utf-8"))
+    assert saved_manifest == manifest
+    assert saved_manifest["content_mode"] == MANIFEST_CONTENT_MODE_RELEASE
+    assert saved_manifest["skills"][0]["name"] == "nvflare-test-skill"
+    assert saved_manifest["skills"][0]["source_hash"] == skill_tree_hash(
+        bundle_root / "nvflare-test-skill", exclude_names=RELEASE_SKILL_FILE_EXCLUDE_NAMES
+    )
 
 
 def test_copy_released_skills_to_bundle_cleans_existing_bundle_content(tmp_path):


### PR DESCRIPTION
## Summary
- keep BENCHMARK.md and eval fixtures in editable installs and normal dev/test wheel bundles
- filter BENCHMARK.md and evals/ only for release packaging mode (NVFL_RELEASE=1)
- record bundle content_mode in the skill manifest and use it for install filtering/drift hashes instead of treating every wheel as release
- verify release-filtered bundles can still be installed, listed, and loaded without broken runtime markdown references

## Tests
- python3 -m pytest tests/unit_test/tool/agent/skill_manifest_test.py tests/unit_test/tool/agent/skill_manager_test.py tests/unit_test/tool/agent/seed_skill_packaging_test.py -q
- ./runtest.sh -s