### PR TITLE
Bind START_JOB metadata to deployed metadata

### DIFF
--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import copy
 import json
+import os
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -20,6 +21,7 @@ from abc import ABC, abstractmethod
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, ConnPropKey, FLContextKey, RunProcessKey, SystemConfigs
 from nvflare.apis.fl_context import FLContext
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_launcher_spec import JobLauncherSpec, JobProcessArgs, JobReturnCode
 from nvflare.apis.resource_manager_spec import ResourceManagerSpec
 from nvflare.apis.workspace import Workspace
@@ -176,8 +178,24 @@ class JobExecutor(ClientExecutor):
         # update the job meta
         workspace = Workspace(args.workspace, site_name=client.client_name)
         meta_file = workspace.get_job_meta_path(job_id)
+        if not os.path.exists(meta_file):
+            raise RuntimeError(f"missing deployed job metadata file for job '{job_id}': {meta_file}")
+        with open(meta_file) as f:
+            deployed_job_meta = json.load(f)
+        for meta_key in (
+            JobMetaKey.JOB_ID.value,
+            JobMetaKey.RESOURCE_SPEC.value,
+            JobMetaKey.JOB_LAUNCHER_SPEC.value,
+            JobMetaKey.SCOPE.value,
+            JobMetaKey.STUDY.value,
+        ):
+            deployed_value = deployed_job_meta.get(meta_key)
+            if deployed_value != job_meta.get(meta_key):
+                raise RuntimeError(f"START_JOB metadata differs from deployed job metadata for '{meta_key}'")
+            if meta_key in deployed_job_meta:
+                job_meta[meta_key] = copy.deepcopy(deployed_value)
 
-        # rewrite the meta file with the received meta
+        # Preserve deploy-time launch metadata while recording scheduler-maintained start metadata.
         with open(meta_file, "w") as f:
             json.dump(job_meta, f, indent=4)
 

--- a/tests/unit_test/private/fed/client/client_executor_test.py
+++ b/tests/unit_test/private/fed/client/client_executor_test.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_constant import FLContextKey, RunProcessKey
+from nvflare.apis.fl_constant import FLContextKey, JobConstants, RunProcessKey
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_launcher_spec import JobReturnCode
+from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.core_cell import FQCN
 from nvflare.private.defs import CellChannel, CellChannelTopic, JobFailureMsgKey
@@ -34,6 +39,154 @@ EXPECTED_REPORTABLE_JOB_FAILURES = {
 
 def test_reportable_job_failures_has_expected_codes():
     assert REPORTABLE_JOB_FAILURES == EXPECTED_REPORTABLE_JOB_FAILURES
+
+
+def _write_deployed_meta(tmp_path, job_id, deployed_meta):
+    (tmp_path / "startup").mkdir()
+    (tmp_path / "local").mkdir()
+    workspace = Workspace(str(tmp_path), site_name="site-1")
+    (tmp_path / job_id).mkdir()
+    with open(workspace.get_job_meta_path(job_id), "w") as f:
+        json.dump(deployed_meta, f)
+    return workspace
+
+
+def test_start_app_allows_scheduler_metadata(tmp_path):
+    job_id = "job-1"
+    deployed_meta = {
+        JobConstants.JOB_ID: job_id,
+        JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"docker": {"image": "trusted/image:1"}}},
+    }
+    workspace = _write_deployed_meta(tmp_path, job_id, deployed_meta)
+    start_meta = {
+        **deployed_meta,
+        JobMetaKey.STATUS.value: "RUNNING",
+        JobMetaKey.JOB_CLIENTS.value: [{"name": "site-1", "token": "token-1"}],
+    }
+
+    client = MagicMock()
+    client.client_name = "site-1"
+    client.cell.get_internal_listener_url.return_value = "tcp://parent:8002"
+    client.cell.get_internal_listener_params.return_value = {}
+    fl_ctx = MagicMock()
+    fl_ctx.get_prop.side_effect = lambda key, *args, **kwargs: {
+        FLContextKey.WORKSPACE_OBJECT: workspace,
+        FLContextKey.SERVER_CONFIG: [{"service": {"scheme": "grpc", "target": "parent:8002"}}],
+    }.get(key)
+    launcher = MagicMock()
+    launcher.launch_job.return_value = MagicMock()
+
+    with (
+        patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
+        patch.object(threading.Thread, "start", lambda self: None),
+    ):
+        JobExecutor(client=client, startup=workspace.get_startup_kit_dir()).start_app(
+            client,
+            job_id,
+            start_meta,
+            SimpleNamespace(workspace=str(tmp_path), set=[]),
+            None,
+            None,
+            None,
+            fl_ctx,
+        )
+
+    launch_meta = launcher.launch_job.call_args.args[0]
+    assert launch_meta[JobMetaKey.JOB_CLIENTS.value] == [{"name": "site-1", "token": "token-1"}]
+    assert launch_meta[JobMetaKey.JOB_LAUNCHER_SPEC.value]["default"]["docker"]["image"] == "trusted/image:1"
+
+
+@pytest.mark.parametrize(
+    "deployed_meta, start_meta, expected_key",
+    [
+        (
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"docker": {"image": "trusted/image:1"}}},
+            },
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"docker": {"image": "attacker/image:latest"}}},
+            },
+            JobMetaKey.JOB_LAUNCHER_SPEC.value,
+        ),
+        (
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"k8s": {"image": "trusted/image:1"}}},
+            },
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"k8s": {"image": "attacker/image:latest"}}},
+            },
+            JobMetaKey.JOB_LAUNCHER_SPEC.value,
+        ),
+        (
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.RESOURCE_SPEC.value: {"site-1": {"docker": {"image": "trusted/image:1"}}},
+            },
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.RESOURCE_SPEC.value: {"site-1": {"docker": {"image": "attacker/image:latest"}}},
+            },
+            JobMetaKey.RESOURCE_SPEC.value,
+        ),
+        (
+            {JobConstants.JOB_ID: "job-1", JobMetaKey.STUDY.value: "study-a"},
+            {JobConstants.JOB_ID: "job-1", JobMetaKey.STUDY.value: "study-b"},
+            JobMetaKey.STUDY.value,
+        ),
+        (
+            {JobConstants.JOB_ID: "job-1", JobMetaKey.SCOPE.value: "scope-a"},
+            {JobConstants.JOB_ID: "job-1", JobMetaKey.SCOPE.value: "scope-b"},
+            JobMetaKey.SCOPE.value,
+        ),
+        (
+            {JobConstants.JOB_ID: "job-1"},
+            {JobConstants.JOB_ID: "job-2"},
+            JobMetaKey.JOB_ID.value,
+        ),
+        (
+            {JobConstants.JOB_ID: "job-1"},
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"docker": {"image": "attacker/image:latest"}}},
+            },
+            JobMetaKey.JOB_LAUNCHER_SPEC.value,
+        ),
+        (
+            {
+                JobConstants.JOB_ID: "job-1",
+                JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {"docker": {"image": "trusted/image:1"}}},
+            },
+            {JobConstants.JOB_ID: "job-1"},
+            JobMetaKey.JOB_LAUNCHER_SPEC.value,
+        ),
+    ],
+)
+def test_start_app_rejects_launch_metadata_drift(tmp_path, deployed_meta, start_meta, expected_key):
+    job_id = "job-1"
+    workspace = _write_deployed_meta(tmp_path, job_id, deployed_meta)
+    client = MagicMock()
+    client.client_name = "site-1"
+
+    with patch("nvflare.private.fed.client.client_executor.get_job_launcher") as get_job_launcher:
+        with pytest.raises(RuntimeError, match=expected_key):
+            JobExecutor(client=client, startup=workspace.get_startup_kit_dir()).start_app(
+                client=client,
+                job_id=job_id,
+                job_meta=start_meta,
+                args=SimpleNamespace(workspace=str(tmp_path), set=[]),
+                allocated_resource=None,
+                token=None,
+                resource_manager=None,
+                fl_ctx=MagicMock(),
+            )
+
+    get_job_launcher.assert_not_called()
+    with open(workspace.get_job_meta_path(job_id)) as f:
+        assert json.load(f) == deployed_meta
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Bind client START_JOB launch metadata to the deployed job metadata before selecting a job launcher.

The client now reads the deployed `meta.json` and rejects START_JOB metadata drift for launch/runtime-sensitive fields:

- `job_id`
- `resource_spec`
- `launcher_spec`
- `scope`
- `study`

Scheduler-maintained start metadata such as status and participating clients can still be recorded.

## Why

Deploy-time app authorization and metadata verification happen before the client writes the deployed `meta.json`. START_JOB previously accepted fresh `job_meta` from the server, rewrote local metadata with it, and selected Docker/K8s launch settings from that start-time metadata. A tampered START_JOB could therefore replace image/resource/study/scope metadata after deploy.

