### PR TITLE
FLARE-2986 Use signer identity for client app authz

### DIFF
--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -198,6 +198,18 @@ def cert_to_dict(cert):
     }
 
 
+def _cert_to_submitter(cert):
+    def _get_subject_attr(oid):
+        attrs = cert.subject.get_attributes_for_oid(oid)
+        return attrs[0].value if attrs else ""
+
+    return (
+        _get_subject_attr(NameOID.COMMON_NAME),
+        _get_subject_attr(NameOID.ORGANIZATION_NAME),
+        _get_subject_attr(NameOID.UNSTRUCTURED_NAME),
+    )
+
+
 def generate_password(passlen=16):
     s = string.ascii_letters + string.digits
     p = "".join(secrets.choice(s) for _ in range(passlen))
@@ -286,7 +298,9 @@ def sign_folders(folder, signing_pri_key, crt_path=None, max_depth=9999, signatu
             break
 
 
-def verify_folder_signature(src_folder, root_ca_path, single_signer=False, signature_file=NVFLARE_SIG_FILE):
+def verify_folder_signature_and_get_signers(
+    src_folder, root_ca_path, single_signer=False, signature_file=NVFLARE_SIG_FILE
+):
     """Verify the signature of each file in one folder recursively.
 
     This function iterates over all files in one folder verifying its signature stored in the signature_file
@@ -304,26 +318,33 @@ def verify_folder_signature(src_folder, root_ca_path, single_signer=False, signa
         signature_file (str): The file name to store signature.  Defaults to NVFLARE_SIG_FILE.
 
     Returns:
-        True if all files have valid signatures.
-        False if any file fails signature check.
+        A tuple of (verified, signers).
+        verified is True if all files have valid signatures.
+        verified is False if any file fails signature check.
+        signers contains unique (name, org, role) tuples from verified certificates.
 
     """
 
     try:
         root_ca_cert = load_crt(root_ca_path)
         root_ca_public_key = root_ca_cert.public_key()
+        root_submitter = _cert_to_submitter(root_ca_cert)
+        signers = {}
         for root, folders, files in os.walk(src_folder):
             try:
                 with open(os.path.join(root, signature_file), "rt") as f:
                     signatures = json.load(f)
                 if single_signer:
                     public_key = root_ca_public_key
+                    signer = root_submitter
                 else:
                     cert = load_crt(os.path.join(root, NVFLARE_SUBMITTER_CRT_FILE))
                     public_key = cert.public_key()
                     verify_cert(cert_to_be_verified=cert, root_ca_public_key=root_ca_public_key)
+                    signer = _cert_to_submitter(cert)
+                signers[signer] = signer
             except Exception:
-                return False
+                return False, []
 
             for file in files:
                 if file == signature_file or file == NVFLARE_SUBMITTER_CRT_FILE:
@@ -337,7 +358,7 @@ def verify_folder_signature(src_folder, root_ca_path, single_signer=False, signa
                             public_key=public_key,
                         )
                 else:
-                    return False
+                    return False, []
             for folder in folders:
                 signature = signatures.get(folder)
                 if signature:
@@ -347,10 +368,18 @@ def verify_folder_signature(src_folder, root_ca_path, single_signer=False, signa
                         public_key=public_key,
                     )
                 else:
-                    return False
-        return True
+                    return False, []
+        return True, list(signers.values())
     except Exception:
-        return False
+        return False, []
+
+
+def verify_folder_signature(src_folder, root_ca_path, single_signer=False, signature_file=NVFLARE_SIG_FILE):
+    """Verify folder signatures and preserve the legacy boolean return contract."""
+    verified, _signers = verify_folder_signature_and_get_signers(
+        src_folder, root_ca_path, single_signer, signature_file
+    )
+    return verified
 
 
 def sign_all(content_folder, signing_pri_key):

--- a/nvflare/private/fed/utils/app_deployer.py
+++ b/nvflare/private/fed/utils/app_deployer.py
@@ -21,6 +21,8 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.utils.zip_utils import unzip_all_from_bytes
+from nvflare.lighter.tool_consts import NVFLARE_SIG_FILE
+from nvflare.lighter.utils import verify_folder_signature_and_get_signers
 from nvflare.private.privacy_manager import PrivacyService
 from nvflare.security.logging import secure_format_exception
 
@@ -65,18 +67,34 @@ class AppDeployer(AppDeployerSpec):
             submitter_name = job_meta.get(JobMetaKey.SUBMITTER_NAME, "")
             submitter_org = job_meta.get(JobMetaKey.SUBMITTER_ORG, "")
             submitter_role = job_meta.get(JobMetaKey.SUBMITTER_ROLE, "")
+            authz_submitters = [(submitter_name, submitter_org, submitter_role)]
 
-            authorized, err = AppAuthzService.authorize(
-                app_path=app_path,
-                submitter_name=submitter_name,
-                submitter_org=submitter_org,
-                submitter_role=submitter_role,
-                job_meta=job_meta,
-            )
-            if err or not authorized:
-                if os.path.exists(run_dir):
-                    shutil.rmtree(run_dir, ignore_errors=True)
-                return err if err else "not authorized"
+            sig_file = os.path.join(app_path, NVFLARE_SIG_FILE)
+            if os.path.exists(sig_file):
+                root_ca_path = workspace.get_file_path_in_startup("rootCA.pem")
+                verified, signers = verify_folder_signature_and_get_signers(app_path, root_ca_path)
+                if not verified:
+                    if os.path.exists(run_dir):
+                        shutil.rmtree(run_dir, ignore_errors=True)
+                    return f"app {app_name} does not pass signature verification"
+                if not signers:
+                    if os.path.exists(run_dir):
+                        shutil.rmtree(run_dir, ignore_errors=True)
+                    return f"app {app_name}: signature verified but no signer identity could be extracted"
+                authz_submitters = signers
+
+            for authz_name, authz_org, authz_role in authz_submitters:
+                authorized, err = AppAuthzService.authorize(
+                    app_path=app_path,
+                    submitter_name=authz_name,
+                    submitter_org=authz_org,
+                    submitter_role=authz_role,
+                    job_meta=job_meta,
+                )
+                if err or not authorized:
+                    if os.path.exists(run_dir):
+                        shutil.rmtree(run_dir, ignore_errors=True)
+                    return err if err else "not authorized"
 
         except Exception as e:
             raise Exception(f"exception {secure_format_exception(e)} when deploying app {app_name}")

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -33,7 +33,13 @@ from nvflare.lighter.impl.cert import serialize_cert
 from nvflare.lighter.tool_consts import NVFLARE_SIG_FILE
 from nvflare.lighter.utils import Identity, cert_to_dict
 from nvflare.lighter.utils import generate_cert as lighter_generate_cert
-from nvflare.lighter.utils import load_private_key_file, load_yaml, sign_folders, verify_folder_signature
+from nvflare.lighter.utils import (
+    load_private_key_file,
+    load_yaml,
+    sign_folders,
+    verify_folder_signature,
+    verify_folder_signature_and_get_signers,
+)
 
 folders = ["folder1", "folder2"]
 files = ["file1", "file2"]
@@ -260,6 +266,43 @@ class TestVerifyFolderSignature:
         folder, root_ca_path, client_crt_path, client_pri_key, _ = self._setup_certs_and_folder(tmp_path)
         sign_folders(folder, client_pri_key, crt_path=client_crt_path)
         assert verify_folder_signature(folder, root_ca_path, single_signer=False) is True
+
+    def test_verify_folder_signature_returns_signer_identity(self, tmp_path):
+        """Verifier exposes the trusted submitter identity from the signing cert."""
+        root_pri_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+        root_pub_key = root_pri_key.public_key()
+        root_cert = lighter_generate_cert(
+            subject=Identity("root", "nvidia"),
+            issuer=Identity("root", "nvidia"),
+            signing_pri_key=root_pri_key,
+            subject_pub_key=root_pub_key,
+            ca=True,
+        )
+
+        signer_pri_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+        signer_pub_key = signer_pri_key.public_key()
+        signer_cert = lighter_generate_cert(
+            subject=Identity("alice@nvidia.com", "nvidia", "lead"),
+            issuer=Identity("root", "nvidia"),
+            signing_pri_key=root_pri_key,
+            subject_pub_key=signer_pub_key,
+        )
+
+        root_ca_path = tmp_path / "root.crt"
+        signer_crt_path = tmp_path / "alice.crt"
+        root_ca_path.write_bytes(serialize_cert(root_cert))
+        signer_crt_path.write_bytes(serialize_cert(signer_cert))
+
+        folder = tmp_path / "signed_folder"
+        folder.mkdir()
+        (folder / "config.json").write_bytes(b"{}")
+        sign_folders(str(folder), signer_pri_key, crt_path=str(signer_crt_path))
+
+        verified, signers = verify_folder_signature_and_get_signers(str(folder), str(root_ca_path))
+
+        assert verified is True
+        assert len(signers) == 1
+        assert signers[0] == ("alice@nvidia.com", "nvidia", "lead")
 
     def test_verify_folder_signature_success_single_signer(self, tmp_path):
         """Verify returns True when folder is signed by root key only (single_signer=True)."""

--- a/tests/unit_test/private/fed/utils/app_deployer_test.py
+++ b/tests/unit_test/private/fed/utils/app_deployer_test.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import os
+from unittest.mock import patch
 
 import pytest
 
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.workspace import Workspace
+from nvflare.lighter.tool_consts import NVFLARE_SIG_FILE
 from nvflare.private.fed.utils.app_deployer import AppDeployer
 
 
@@ -24,6 +27,14 @@ def _make_workspace(root_dir: str) -> Workspace:
     os.makedirs(os.path.join(root_dir, "startup"), exist_ok=True)
     os.makedirs(os.path.join(root_dir, "local"), exist_ok=True)
     return Workspace(root_dir, site_name="site-1")
+
+
+def _job_meta(submitter_role: str):
+    return {
+        JobMetaKey.SUBMITTER_NAME: "server-claimed@nvidia.com",
+        JobMetaKey.SUBMITTER_ORG: "nvidia",
+        JobMetaKey.SUBMITTER_ROLE: submitter_role,
+    }
 
 
 def test_deploy_rejects_traversing_job_id_before_touching_outside_path(tmp_path):
@@ -44,3 +55,102 @@ def test_deploy_rejects_traversing_job_id_before_touching_outside_path(tmp_path)
         )
 
     assert marker.read_text() == "keep"
+
+
+@pytest.mark.parametrize(
+    "metadata_role,signer_role,expected_err",
+    [
+        ("lead", "member", "BYOC not permitted"),
+        ("member", "lead", None),
+    ],
+)
+def test_deploy_signed_app_authorizes_with_signer_role(tmp_path, metadata_role, signer_role, expected_err):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+    signer = ("signer@nvidia.com", "nvidia", signer_role)
+
+    def fake_unzip(_app_data, app_path):
+        os.makedirs(app_path, exist_ok=True)
+        with open(os.path.join(app_path, NVFLARE_SIG_FILE), "wt") as f:
+            f.write("{}")
+
+    def authorize_only_lead(**kwargs):
+        authorized = kwargs["submitter_role"] == "lead"
+        return authorized, "" if authorized else "BYOC not permitted"
+
+    with (
+        patch("nvflare.private.fed.utils.app_deployer.unzip_all_from_bytes", side_effect=fake_unzip),
+        patch(
+            "nvflare.private.fed.utils.app_deployer.verify_folder_signature_and_get_signers",
+            return_value=(True, [signer]),
+        ) as mock_verify,
+        patch(
+            "nvflare.private.fed.utils.app_deployer.AppAuthzService.authorize", side_effect=authorize_only_lead
+        ) as mock_authz,
+    ):
+        err = AppDeployer().deploy(
+            workspace=workspace,
+            job_id="job-1",
+            job_meta=_job_meta(submitter_role=metadata_role),
+            app_name="app",
+            app_data=b"not-needed",
+            fl_ctx=None,
+        )
+
+    mock_verify.assert_called_once_with(
+        workspace.get_app_dir("job-1"), workspace.get_file_path_in_startup("rootCA.pem")
+    )
+    assert err == expected_err
+    assert mock_authz.call_args.kwargs["submitter_role"] == signer_role
+
+
+def test_deploy_signed_app_reports_missing_signer_identity(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+
+    def fake_unzip(_app_data, app_path):
+        os.makedirs(app_path, exist_ok=True)
+        with open(os.path.join(app_path, NVFLARE_SIG_FILE), "wt") as f:
+            f.write("{}")
+
+    with (
+        patch("nvflare.private.fed.utils.app_deployer.unzip_all_from_bytes", side_effect=fake_unzip),
+        patch(
+            "nvflare.private.fed.utils.app_deployer.verify_folder_signature_and_get_signers",
+            return_value=(True, []),
+        ),
+        patch("nvflare.private.fed.utils.app_deployer.AppAuthzService.authorize") as mock_authz,
+    ):
+        err = AppDeployer().deploy(
+            workspace=workspace,
+            job_id="job-1",
+            job_meta=_job_meta(submitter_role="lead"),
+            app_name="app",
+            app_data=b"not-needed",
+            fl_ctx=None,
+        )
+
+    assert err == "app app: signature verified but no signer identity could be extracted"
+    mock_authz.assert_not_called()
+
+
+def test_deploy_unsigned_app_uses_metadata_submitter(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+
+    with (
+        patch("nvflare.private.fed.utils.app_deployer.unzip_all_from_bytes"),
+        patch("nvflare.private.fed.utils.app_deployer.verify_folder_signature_and_get_signers") as mock_verify,
+        patch(
+            "nvflare.private.fed.utils.app_deployer.AppAuthzService.authorize", return_value=(True, "")
+        ) as mock_authz,
+    ):
+        err = AppDeployer().deploy(
+            workspace=workspace,
+            job_id="job-1",
+            job_meta=_job_meta(submitter_role="member"),
+            app_name="app",
+            app_data=b"not-needed",
+            fl_ctx=None,
+        )
+
+    assert err is None
+    mock_verify.assert_not_called()
+    assert mock_authz.call_args.kwargs["submitter_role"] == "member"


### PR DESCRIPTION
## What
- Return verified signer identity attributes from folder signature verification while preserving the existing boolean verifier API.
- For signed app content, authorize client app deployment using the verified signer name/org/role instead of server-supplied submitter metadata.
- Add focused tests for signer-derived authorization, metadata fallback for unsigned apps, and signer extraction from verified certificates.

## Why
Client BYOC authorization was using submitter role metadata supplied through the job package. A server-provided privileged role could therefore drive client-side code authorization even when the signed app certificate belonged to a non-privileged signer. Signed app authorization now uses the role bound to the verified signing certificate.
