### PR TITLE
Compute BYOC locally before allow-list bypass

### DIFF
--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -179,15 +179,15 @@ class JobExecutor(ClientExecutor):
         meta_file = workspace.get_job_meta_path(job_id)
         try:
             local_job_meta = get_job_meta_from_workspace(workspace, job_id)
-            local_app_info = {AppValidationKey.BYOC: True} if local_job_meta.get(AppValidationKey.BYOC, False) else {}
+            local_byoc = local_job_meta.get(AppValidationKey.BYOC, False)
         except Exception as e:
             self.logger.warning(
                 f"could not read local app validation info for job '{job_id}'; treating as non-BYOC: "
                 f"{secure_format_exception(e)}"
             )
-            local_app_info = {}
+            local_byoc = False
         job_meta = copy.deepcopy(job_meta)
-        if local_app_info.get(AppValidationKey.BYOC, False):
+        if local_byoc:
             job_meta[AppValidationKey.BYOC] = True
         else:
             job_meta.pop(AppValidationKey.BYOC, None)

--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -17,6 +17,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, ConnPropKey, FLContextKey, RunProcessKey, SystemConfigs
 from nvflare.apis.fl_context import FLContext
@@ -30,7 +31,7 @@ from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.private.defs import CellChannel, CellChannelTopic, JobFailureMsgKey, new_cell_message
-from nvflare.private.fed.utils.fed_utils import get_job_launcher, get_return_code
+from nvflare.private.fed.utils.fed_utils import get_job_launcher, get_job_meta_from_workspace, get_return_code
 from nvflare.security.logging import secure_format_exception, secure_log_traceback
 
 from .client_status import ClientStatus, get_status_message
@@ -176,8 +177,22 @@ class JobExecutor(ClientExecutor):
         # update the job meta
         workspace = Workspace(args.workspace, site_name=client.client_name)
         meta_file = workspace.get_job_meta_path(job_id)
+        try:
+            local_job_meta = get_job_meta_from_workspace(workspace, job_id)
+            local_app_info = {AppValidationKey.BYOC: True} if local_job_meta.get(AppValidationKey.BYOC, False) else {}
+        except Exception as e:
+            self.logger.warning(
+                f"could not read local app validation info for job '{job_id}'; treating as non-BYOC: "
+                f"{secure_format_exception(e)}"
+            )
+            local_app_info = {}
+        job_meta = copy.deepcopy(job_meta)
+        if local_app_info.get(AppValidationKey.BYOC, False):
+            job_meta[AppValidationKey.BYOC] = True
+        else:
+            job_meta.pop(AppValidationKey.BYOC, None)
 
-        # rewrite the meta file with the received meta
+        # Preserve the locally detected BYOC value when refreshing server-supplied job meta.
         with open(meta_file, "w") as f:
             json.dump(job_meta, f, indent=4)
 

--- a/nvflare/private/fed/utils/app_authz.py
+++ b/nvflare/private/fed/utils/app_authz.py
@@ -31,20 +31,26 @@ class AppAuthzService(object):
         AppAuthzService.app_validator = app_validator
 
     @staticmethod
-    def authorize(
-        app_path: str,
+    def validate_app(app_path: str) -> (str, dict):
+        if not AppAuthzService.app_validator:
+            return "", {}
+
+        err, app_info = AppAuthzService.app_validator.validate(app_path)
+        if err:
+            return err, {}
+        if not isinstance(app_info, dict):
+            return f"app validator must return app info as dict but got {type(app_info)}", {}
+
+        return "", app_info
+
+    @staticmethod
+    def authorize_app_info(
+        app_info: dict,
         submitter_name: str,
         submitter_org: str,
         submitter_role: str,
         job_meta: dict = None,
     ) -> (bool, str):
-        if not AppAuthzService.app_validator:
-            return True, ""
-
-        err, app_info = AppAuthzService.app_validator.validate(app_path)
-        if err:
-            return False, err
-
         app_has_custom_code = app_info.get(AppValidationKey.BYOC, False)
         if app_has_custom_code:
             ctx = AuthzContext(
@@ -75,3 +81,23 @@ class AppAuthzService(object):
                 )
 
         return True, ""
+
+    @staticmethod
+    def authorize(
+        app_path: str,
+        submitter_name: str,
+        submitter_org: str,
+        submitter_role: str,
+        job_meta: dict = None,
+    ) -> (bool, str):
+        err, app_info = AppAuthzService.validate_app(app_path)
+        if err:
+            return False, err
+
+        return AppAuthzService.authorize_app_info(
+            app_info=app_info,
+            submitter_name=submitter_name,
+            submitter_org=submitter_org,
+            submitter_role=submitter_role,
+            job_meta=job_meta,
+        )

--- a/nvflare/private/fed/utils/app_authz.py
+++ b/nvflare/private/fed/utils/app_authz.py
@@ -38,8 +38,6 @@ class AppAuthzService(object):
         err, app_info = AppAuthzService.app_validator.validate(app_path)
         if err:
             return err, {}
-        if not isinstance(app_info, dict):
-            return f"app validator must return app info as dict but got {type(app_info)}", {}
 
         return "", app_info
 

--- a/nvflare/private/fed/utils/app_deployer.py
+++ b/nvflare/private/fed/utils/app_deployer.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import os
 import shutil
 
 from nvflare.apis.app_deployer_spec import AppDeployerSpec
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.workspace import Workspace
@@ -59,15 +61,26 @@ class AppDeployer(AppDeployerSpec):
             with open(app_file, "wt") as f:
                 f.write(f"{app_name}")
 
-            with open(job_meta_file, "w") as f:
-                json.dump(job_meta, f, indent=4)
-
             submitter_name = job_meta.get(JobMetaKey.SUBMITTER_NAME, "")
             submitter_org = job_meta.get(JobMetaKey.SUBMITTER_ORG, "")
             submitter_role = job_meta.get(JobMetaKey.SUBMITTER_ROLE, "")
 
-            authorized, err = AppAuthzService.authorize(
-                app_path=app_path,
+            err, app_info = AppAuthzService.validate_app(app_path)
+            if err:
+                if os.path.exists(run_dir):
+                    shutil.rmtree(run_dir, ignore_errors=True)
+                return err
+
+            job_meta = copy.deepcopy(job_meta)
+            if app_info.get(AppValidationKey.BYOC, False):
+                job_meta[AppValidationKey.BYOC] = True
+            else:
+                job_meta.pop(AppValidationKey.BYOC, None)
+            with open(job_meta_file, "w") as f:
+                json.dump(job_meta, f, indent=4)
+
+            authorized, err = AppAuthzService.authorize_app_info(
+                app_info=app_info,
                 submitter_name=submitter_name,
                 submitter_org=submitter_org,
                 submitter_role=submitter_role,

--- a/tests/unit_test/private/fed/client/client_executor_test.py
+++ b/tests/unit_test/private/fed/client/client_executor_test.py
@@ -138,6 +138,7 @@ def test_wait_child_process_does_not_report_non_failure_return_code(return_code)
     [
         ({AppValidationKey.BYOC: True}, {}, False),
         ({}, {AppValidationKey.BYOC: True}, True),
+        ({AppValidationKey.BYOC: True}, None, False),
     ],
 )
 def test_start_app_preserves_locally_detected_byoc_when_rewriting_job_meta(
@@ -145,8 +146,9 @@ def test_start_app_preserves_locally_detected_byoc_when_rewriting_job_meta(
 ):
     workspace = _make_workspace(str(tmp_path / "workspace"))
     os.makedirs(workspace.get_run_dir("job-1"), exist_ok=True)
-    with open(workspace.get_job_meta_path("job-1"), "w") as f:
-        json.dump(local_meta, f)
+    if local_meta is not None:
+        with open(workspace.get_job_meta_path("job-1"), "w") as f:
+            json.dump(local_meta, f)
 
     client = MagicMock()
     client.client_name = "site-1"

--- a/tests/unit_test/private/fed/client/client_executor_test.py
+++ b/tests/unit_test/private/fed/client/client_executor_test.py
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_constant import FLContextKey, RunProcessKey
+from nvflare.apis.fl_constant import FLContextKey, ReservedKey, RunProcessKey
+from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_launcher_spec import JobReturnCode
+from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.core_cell import FQCN
 from nvflare.private.defs import CellChannel, CellChannelTopic, JobFailureMsgKey
@@ -30,6 +36,21 @@ EXPECTED_REPORTABLE_JOB_FAILURES = {
     ProcessExitCode.CONFIG_ERROR: "config error",
     JobReturnCode.ABORTED: "aborted",
 }
+
+
+class _FakeLauncher:
+    def __init__(self):
+        self.launched_meta = None
+
+    def launch_job(self, job_meta, fl_ctx):
+        self.launched_meta = job_meta
+        return MagicMock()
+
+
+def _make_workspace(root_dir: str) -> Workspace:
+    os.makedirs(os.path.join(root_dir, "startup"), exist_ok=True)
+    os.makedirs(os.path.join(root_dir, "local"), exist_ok=True)
+    return Workspace(root_dir, site_name="site-1")
 
 
 def test_reportable_job_failures_has_expected_codes():
@@ -110,3 +131,57 @@ def test_wait_child_process_does_not_report_non_failure_return_code(return_code)
     client.cell.fire_and_forget.assert_not_called()
     assert "job-1" not in job_executor.run_processes
     engine.fire_event.assert_called_once_with(EventType.JOB_COMPLETED, fl_ctx)
+
+
+@pytest.mark.parametrize(
+    "server_meta, local_meta, expected_byoc",
+    [
+        ({AppValidationKey.BYOC: True}, {}, False),
+        ({}, {AppValidationKey.BYOC: True}, True),
+    ],
+)
+def test_start_app_preserves_locally_detected_byoc_when_rewriting_job_meta(
+    tmp_path, server_meta, local_meta, expected_byoc
+):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+    os.makedirs(workspace.get_run_dir("job-1"), exist_ok=True)
+    with open(workspace.get_job_meta_path("job-1"), "w") as f:
+        json.dump(local_meta, f)
+
+    client = MagicMock()
+    client.client_name = "site-1"
+    client.token = "token"
+    client.token_signature = "signature"
+    client.ssid = "ssid"
+    client.cell.get_internal_listener_url.return_value = "localhost:8002"
+    client.cell.get_internal_listener_params.return_value = {}
+
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, private=True, sticky=False)
+    fl_ctx.set_prop(FLContextKey.SERVER_CONFIG, [{"service": {"scheme": "grpc", "target": "server"}}])
+    engine = MagicMock()
+    fl_ctx.set_prop(ReservedKey.ENGINE, engine, private=True, sticky=False)
+
+    launcher = _FakeLauncher()
+    executor = JobExecutor(client=client, startup="startup")
+    args = types.SimpleNamespace(workspace=workspace.get_root_dir(), set=[])
+
+    with patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher):
+        with patch("nvflare.private.fed.client.client_executor.threading.Thread") as mock_thread:
+            mock_thread.return_value.start.return_value = None
+            executor.start_app(
+                client=client,
+                job_id="job-1",
+                job_meta=server_meta,
+                args=args,
+                allocated_resource=None,
+                token=None,
+                resource_manager=None,
+                fl_ctx=fl_ctx,
+            )
+
+    with open(workspace.get_job_meta_path("job-1")) as f:
+        refreshed_meta = json.load(f)
+
+    assert refreshed_meta.get(AppValidationKey.BYOC, False) is expected_byoc
+    assert launcher.launched_meta.get(AppValidationKey.BYOC, False) is expected_byoc

--- a/tests/unit_test/private/fed/utils/app_authz_test.py
+++ b/tests/unit_test/private/fed/utils/app_authz_test.py
@@ -43,6 +43,42 @@ def setup_authz():
 class TestAppAuthzService:
     """Test AppAuthzService authorization logic for Flower predeployed mode."""
 
+    def test_validate_app_without_validator_returns_empty_info(self, tmp_path):
+        AppAuthzService.initialize(None)
+
+        error, app_info = AppAuthzService.validate_app(str(tmp_path / "app"))
+
+        assert error == ""
+        assert app_info == {}
+
+    def test_validate_app_rejects_non_dict_app_info(self, tmp_path):
+        app_path = str(tmp_path / "app")
+        (tmp_path / "app").mkdir()
+
+        AppAuthzService.initialize(_MockAppValidator(validate_return=("", [])))
+
+        error, app_info = AppAuthzService.validate_app(app_path)
+
+        assert "app validator must return app info as dict" in error
+        assert app_info == {}
+
+    def test_authorize_returns_validation_error(self, tmp_path):
+        app_path = str(tmp_path / "app")
+        (tmp_path / "app").mkdir()
+
+        AppAuthzService.initialize(_MockAppValidator(validate_return=("invalid app", {})))
+
+        authorized, error = AppAuthzService.authorize(
+            app_path=app_path,
+            submitter_name="test_user",
+            submitter_org="test_org",
+            submitter_role="org_admin",
+            job_meta={},
+        )
+
+        assert not authorized
+        assert error == "invalid app"
+
     def test_authorize_flower_predeployed_granted(self, tmp_path):
         """Predeployed mode with granted right -> succeeds."""
         app_path = str(tmp_path / "app")
@@ -126,6 +162,24 @@ class TestAppAuthzService:
 
         assert authorized
         assert error == ""
+
+    def test_authorize_byoc_denied(self, tmp_path):
+        app_path = str(tmp_path / "app")
+        (tmp_path / "app").mkdir()
+
+        AppAuthzService.initialize(_MockAppValidator(validate_return=("", {AppValidationKey.BYOC: True})))
+
+        with patch.object(AuthorizationService, "authorize", return_value=(False, "not permitted")):
+            authorized, error = AppAuthzService.authorize(
+                app_path=app_path,
+                submitter_name="test_user",
+                submitter_org="test_org",
+                submitter_role="org_admin",
+                job_meta={},
+            )
+
+        assert not authorized
+        assert error == "BYOC not permitted"
 
     def test_authorize_both_flags(self, tmp_path):
         """Both BYOC and predeployed flags -> both checks run."""

--- a/tests/unit_test/private/fed/utils/app_authz_test.py
+++ b/tests/unit_test/private/fed/utils/app_authz_test.py
@@ -43,42 +43,6 @@ def setup_authz():
 class TestAppAuthzService:
     """Test AppAuthzService authorization logic for Flower predeployed mode."""
 
-    def test_validate_app_without_validator_returns_empty_info(self, tmp_path):
-        AppAuthzService.initialize(None)
-
-        error, app_info = AppAuthzService.validate_app(str(tmp_path / "app"))
-
-        assert error == ""
-        assert app_info == {}
-
-    def test_validate_app_rejects_non_dict_app_info(self, tmp_path):
-        app_path = str(tmp_path / "app")
-        (tmp_path / "app").mkdir()
-
-        AppAuthzService.initialize(_MockAppValidator(validate_return=("", [])))
-
-        error, app_info = AppAuthzService.validate_app(app_path)
-
-        assert "app validator must return app info as dict" in error
-        assert app_info == {}
-
-    def test_authorize_returns_validation_error(self, tmp_path):
-        app_path = str(tmp_path / "app")
-        (tmp_path / "app").mkdir()
-
-        AppAuthzService.initialize(_MockAppValidator(validate_return=("invalid app", {})))
-
-        authorized, error = AppAuthzService.authorize(
-            app_path=app_path,
-            submitter_name="test_user",
-            submitter_org="test_org",
-            submitter_role="org_admin",
-            job_meta={},
-        )
-
-        assert not authorized
-        assert error == "invalid app"
-
     def test_authorize_flower_predeployed_granted(self, tmp_path):
         """Predeployed mode with granted right -> succeeds."""
         app_path = str(tmp_path / "app")
@@ -162,24 +126,6 @@ class TestAppAuthzService:
 
         assert authorized
         assert error == ""
-
-    def test_authorize_byoc_denied(self, tmp_path):
-        app_path = str(tmp_path / "app")
-        (tmp_path / "app").mkdir()
-
-        AppAuthzService.initialize(_MockAppValidator(validate_return=("", {AppValidationKey.BYOC: True})))
-
-        with patch.object(AuthorizationService, "authorize", return_value=(False, "not permitted")):
-            authorized, error = AppAuthzService.authorize(
-                app_path=app_path,
-                submitter_name="test_user",
-                submitter_org="test_org",
-                submitter_role="org_admin",
-                job_meta={},
-            )
-
-        assert not authorized
-        assert error == "BYOC not permitted"
 
     def test_authorize_both_flags(self, tmp_path):
         """Both BYOC and predeployed flags -> both checks run."""

--- a/tests/unit_test/private/fed/utils/app_deployer_test.py
+++ b/tests/unit_test/private/fed/utils/app_deployer_test.py
@@ -120,50 +120,6 @@ def test_deploy_strips_server_supplied_byoc_without_local_byoc_app(tmp_path):
     assert "allow_list" in build_err
 
 
-def test_deploy_validation_error_cleans_run_dir_without_writing_meta(tmp_path):
-    workspace = _make_workspace(str(tmp_path / "workspace"))
-
-    with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
-        with patch(
-            "nvflare.private.fed.utils.app_deployer.AppAuthzService.validate_app",
-            return_value=("invalid app", {}),
-        ):
-            err = AppDeployer().deploy(
-                workspace=workspace,
-                job_id="job-1",
-                job_meta={AppValidationKey.BYOC: True},
-                app_name="app",
-                app_data=_make_app_zip(),
-                fl_ctx=None,
-            )
-
-    assert err == "invalid app"
-    assert not os.path.exists(workspace.get_run_dir("job-1"))
-    assert not os.path.exists(workspace.get_job_meta_path("job-1"))
-
-
-def test_deploy_authorization_failure_cleans_run_dir(tmp_path):
-    workspace = _make_workspace(str(tmp_path / "workspace"))
-
-    with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
-        with patch("nvflare.private.fed.utils.app_deployer.AppAuthzService.validate_app", return_value=("", {})):
-            with patch(
-                "nvflare.private.fed.utils.app_deployer.AppAuthzService.authorize_app_info",
-                return_value=(False, ""),
-            ):
-                err = AppDeployer().deploy(
-                    workspace=workspace,
-                    job_id="job-1",
-                    job_meta={},
-                    app_name="app",
-                    app_data=_make_app_zip(),
-                    fl_ctx=None,
-                )
-
-    assert err == "not authorized"
-    assert not os.path.exists(workspace.get_run_dir("job-1"))
-
-
 def test_deploy_detects_custom_dir_as_local_byoc_for_allow_list(tmp_path):
     workspace = _make_workspace(str(tmp_path / "workspace"))
     AuthorizationService.initialize(EmptyAuthorizer())

--- a/tests/unit_test/private/fed/utils/app_deployer_test.py
+++ b/tests/unit_test/private/fed/utils/app_deployer_test.py
@@ -12,18 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+import json
 import os
+from unittest.mock import patch
+from zipfile import ZipFile
 
 import pytest
 
+from nvflare.apis.app_validation import AppValidationKey
+from nvflare.apis.fl_constant import FLContextKey, SiteType
+from nvflare.apis.fl_context import FLContext
 from nvflare.apis.workspace import Workspace
+from nvflare.fuel.sec.authz import AuthorizationService
+from nvflare.private.fed.app.default_app_validator import DefaultAppValidator
+from nvflare.private.fed.utils.app_authz import AppAuthzService
 from nvflare.private.fed.utils.app_deployer import AppDeployer
+from nvflare.private.fed.utils.fed_utils import authorize_build_component
+from nvflare.private.json_configer import ConfigContext
+from nvflare.security.security import EmptyAuthorizer
 
 
 def _make_workspace(root_dir: str) -> Workspace:
     os.makedirs(os.path.join(root_dir, "startup"), exist_ok=True)
     os.makedirs(os.path.join(root_dir, "local"), exist_ok=True)
     return Workspace(root_dir, site_name="site-1")
+
+
+def _make_app_zip(include_custom=False) -> bytes:
+    output = io.BytesIO()
+    with ZipFile(output, "w") as zip_file:
+        zip_file.writestr("config/config_fed_client.json", "{}")
+        if include_custom:
+            zip_file.writestr("custom/local_code.py", "VALUE = 1\n")
+    return output.getvalue()
 
 
 def test_deploy_rejects_traversing_job_id_before_touching_outside_path(tmp_path):
@@ -44,3 +66,87 @@ def test_deploy_rejects_traversing_job_id_before_touching_outside_path(tmp_path)
         )
 
     assert marker.read_text() == "keep"
+
+
+def test_deploy_strips_server_supplied_byoc_without_local_byoc_app(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+    job_meta = {AppValidationKey.BYOC: True}
+
+    with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
+        with patch("nvflare.private.fed.utils.app_deployer.AppAuthzService.validate_app", return_value=("", {})):
+            with patch(
+                "nvflare.private.fed.utils.app_deployer.AppAuthzService.authorize_app_info",
+                return_value=(True, ""),
+            ):
+                err = AppDeployer().deploy(
+                    workspace=workspace,
+                    job_id="job-1",
+                    job_meta=job_meta,
+                    app_name="app",
+                    app_data=_make_app_zip(),
+                    fl_ctx=None,
+                )
+
+    assert err is None
+    with open(workspace.get_job_meta_path("job-1")) as f:
+        local_meta = json.load(f)
+    assert local_meta.get(AppValidationKey.BYOC, False) is False
+
+    resources_file = os.path.join(workspace.get_site_config_dir(), "resources.json")
+    with open(resources_file, "w") as f:
+        json.dump({"class_allow_list": []}, f)
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, sticky=False, private=True)
+    fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "job-1", sticky=False, private=False)
+
+    build_err = authorize_build_component(
+        {"path": "subprocess.Popen", "args": {}},
+        ConfigContext(),
+        None,
+        fl_ctx=fl_ctx,
+        event_handlers=[],
+    )
+    assert "subprocess.Popen" in build_err
+    assert "allow_list" in build_err
+
+
+def test_deploy_detects_custom_dir_as_local_byoc_for_allow_list(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+    AuthorizationService.initialize(EmptyAuthorizer())
+    AppAuthzService.initialize(DefaultAppValidator(site_type=SiteType.CLIENT))
+
+    try:
+        with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
+            err = AppDeployer().deploy(
+                workspace=workspace,
+                job_id="job-1",
+                job_meta={AppValidationKey.BYOC: False},
+                app_name="app",
+                app_data=_make_app_zip(include_custom=True),
+                fl_ctx=None,
+            )
+    finally:
+        AppAuthzService.initialize(None)
+
+    assert err is None
+    with open(workspace.get_job_meta_path("job-1")) as f:
+        local_meta = json.load(f)
+    assert local_meta[AppValidationKey.BYOC] is True
+
+    resources_file = os.path.join(workspace.get_site_config_dir(), "resources.json")
+    with open(resources_file, "w") as f:
+        json.dump({"class_allow_list": []}, f)
+    fl_ctx = FLContext()
+    fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, sticky=False, private=True)
+    fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "job-1", sticky=False, private=False)
+
+    assert (
+        authorize_build_component(
+            {"path": "subprocess.Popen", "args": {}},
+            ConfigContext(),
+            None,
+            fl_ctx=fl_ctx,
+            event_handlers=[],
+        )
+        == ""
+    )

--- a/tests/unit_test/private/fed/utils/app_deployer_test.py
+++ b/tests/unit_test/private/fed/utils/app_deployer_test.py
@@ -110,6 +110,50 @@ def test_deploy_strips_server_supplied_byoc_without_local_byoc_app(tmp_path):
     assert "allow_list" in build_err
 
 
+def test_deploy_validation_error_cleans_run_dir_without_writing_meta(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+
+    with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
+        with patch(
+            "nvflare.private.fed.utils.app_deployer.AppAuthzService.validate_app",
+            return_value=("invalid app", {}),
+        ):
+            err = AppDeployer().deploy(
+                workspace=workspace,
+                job_id="job-1",
+                job_meta={AppValidationKey.BYOC: True},
+                app_name="app",
+                app_data=_make_app_zip(),
+                fl_ctx=None,
+            )
+
+    assert err == "invalid app"
+    assert not os.path.exists(workspace.get_run_dir("job-1"))
+    assert not os.path.exists(workspace.get_job_meta_path("job-1"))
+
+
+def test_deploy_authorization_failure_cleans_run_dir(tmp_path):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+
+    with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
+        with patch("nvflare.private.fed.utils.app_deployer.AppAuthzService.validate_app", return_value=("", {})):
+            with patch(
+                "nvflare.private.fed.utils.app_deployer.AppAuthzService.authorize_app_info",
+                return_value=(False, ""),
+            ):
+                err = AppDeployer().deploy(
+                    workspace=workspace,
+                    job_id="job-1",
+                    job_meta={},
+                    app_name="app",
+                    app_data=_make_app_zip(),
+                    fl_ctx=None,
+                )
+
+    assert err == "not authorized"
+    assert not os.path.exists(workspace.get_run_dir("job-1"))
+
+
 def test_deploy_detects_custom_dir_as_local_byoc_for_allow_list(tmp_path):
     workspace = _make_workspace(str(tmp_path / "workspace"))
     AuthorizationService.initialize(EmptyAuthorizer())


### PR DESCRIPTION
## Summary

Fix the client-side BYOC trust boundary so server-provided job metadata cannot independently disable the non-BYOC component class allow-list.

The client already validates extracted app contents for BYOC authorization. This change makes the client persist and preserve `job_meta["byoc"]` from that local validation result instead of trusting the server-provided value.

## Why

`ComponentPathAuthorizer` skips the non-BYOC class allow-list when `job_meta["byoc"]` is true. Before this change, that metadata could be supplied by the server even when the extracted app did not contain local BYOC content. That made BYOC authorization and allow-list behavior depend on different sources.

## What Changed

- Split app validation from app authorization so deploy can reuse the same local `app_info` for both authorization and metadata.
- In `AppDeployer`, validate extracted app contents before writing final job metadata, then derive `byoc` from local validation.
- In `JobExecutor.start_app`, preserve the locally detected BYOC value when refreshing server-supplied metadata before launch.
- Added regression coverage for forged server BYOC metadata, local `custom/` BYOC detection, and launch-time metadata refresh.
