### PR TITLE
Remove hard-coded simulator IPC password

### DIFF
--- a/nvflare/fuel/common/multi_process_executor_constants.py
+++ b/nvflare/fuel/common/multi_process_executor_constants.py
@@ -27,8 +27,6 @@ class CommunicationMetaData(object):
     SHAREABLE = "shareable"
     RELAYER = "relayer"
     RANK_PROCESS_STARTED = "rank_process_started"
-    PARENT_PASSWORD = "parent process secret password"
-    CHILD_PASSWORD = "client process secret password"
 
 
 class CommunicateData(object):

--- a/nvflare/private/fed/app/simulator/simulator_runner.py
+++ b/nvflare/private/fed/app/simulator/simulator_runner.py
@@ -45,7 +45,6 @@ from nvflare.apis.job_def import ALL_SITES, JobMetaKey
 from nvflare.apis.utils.job_utils import convert_legacy_zipped_app_to_job
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.exit_codes import ProcessExitCode
-from nvflare.fuel.common.multi_process_executor_constants import CommunicationMetaData
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.f3.stats_pool import StatsPoolManager
 from nvflare.fuel.hci.server.authz import AuthorizationService
@@ -851,7 +850,7 @@ class SimulatorClientRunner(FLComponent):
         while not conn:
             try:
                 address = ("localhost", open_port)
-                conn = Client(address, authkey=CommunicationMetaData.CHILD_PASSWORD.encode())
+                conn = Client(address)
             except Exception:
                 if time.time() - start > timeout:
                     raise RuntimeError(

--- a/nvflare/private/fed/app/simulator/simulator_worker.py
+++ b/nvflare/private/fed/app/simulator/simulator_worker.py
@@ -23,7 +23,6 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_constant import FLContextKey, RunnerTask, WorkspaceConstants
 from nvflare.apis.workspace import Workspace
-from nvflare.fuel.common.multi_process_executor_constants import CommunicationMetaData
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
@@ -226,7 +225,7 @@ class ClientTaskWorker(FLComponent):
 
 def _create_connection(listen_port):
     address = ("localhost", int(listen_port))
-    listener = Listener(address, authkey=CommunicationMetaData.CHILD_PASSWORD.encode())
+    listener = Listener(address)
     conn = listener.accept()
     return conn
 

--- a/tests/unit_test/private/fed/app/simulator/simulator_runner_test.py
+++ b/tests/unit_test/private/fed/app/simulator/simulator_runner_test.py
@@ -27,6 +27,7 @@ import pytest
 
 from nvflare.apis.fl_constant import FLContextKey, MachineStatus, WorkspaceConstants
 from nvflare.apis.job_def import JobMetaKey
+from nvflare.private.fed.app.simulator import simulator_worker
 from nvflare.private.fed.app.simulator.simulator_runner import SimulatorClientRunner, SimulatorRunner
 from nvflare.private.fed.utils.fed_utils import split_gpus
 
@@ -204,3 +205,28 @@ class TestSimulatorRunner:
         new_sys_path = runner._get_new_sys_path()
         assert old_sys_path == new_sys_path
         sys.path = old_sys_path
+
+    def test_create_connection_does_not_require_authkey(self):
+        args = Namespace(workspace="/tmp")
+        args.set = []
+        runner = SimulatorClientRunner(None, args, [], None, None, None)
+        conn = Mock()
+
+        with patch("nvflare.private.fed.app.simulator.simulator_runner.Client", return_value=conn) as client:
+            result = runner._create_connection(1234)
+
+        assert result is conn
+        client.assert_called_once_with(("localhost", 1234))
+
+    def test_worker_create_connection_does_not_require_authkey(self):
+        conn = Mock()
+        listener = Mock()
+        listener.accept.return_value = conn
+
+        with patch(
+            "nvflare.private.fed.app.simulator.simulator_worker.Listener", return_value=listener
+        ) as listener_cls:
+            result = simulator_worker._create_connection(1234)
+
+        assert result is conn
+        listener_cls.assert_called_once_with(("localhost", 1234))


### PR DESCRIPTION
## Summary
- remove static simulator IPC password constants reported in NVBug 6118682
- stop passing a hard-coded multiprocessing authkey between simulator runner and worker
- add regression coverage confirming simulator IPC connections do not require an authkey

## Validation
- `~/nvflare-env/3.12/bin/python -m pytest tests/unit_test/private/fed/app/simulator/simulator_runner_test.py -q`
- `~/nvflare-env/3.12/bin/python -m black --check nvflare/fuel/common/multi_process_executor_constants.py nvflare/private/fed/app/simulator/simulator_runner.py nvflare/private/fed/app/simulator/simulator_worker.py tests/unit_test/private/fed/app/simulator/simulator_runner_test.py`
- `~/nvflare-env/3.12/bin/python -m isort --check nvflare/fuel/common/multi_process_executor_constants.py nvflare/private/fed/app/simulator/simulator_runner.py nvflare/private/fed/app/simulator/simulator_worker.py tests/unit_test/private/fed/app/simulator/simulator_runner_test.py`
- `~/nvflare-env/3.12/bin/python -m flake8 nvflare/fuel/common/multi_process_executor_constants.py nvflare/private/fed/app/simulator/simulator_runner.py nvflare/private/fed/app/simulator/simulator_worker.py tests/unit_test/private/fed/app/simulator/simulator_runner_test.py`
- `git diff --check`

## Notes
- Full `./runtest.sh -s` was attempted from `~/nvflare-env/3.12`; it failed on unrelated vendor files under `examples/.../node_modules/.../flatted.py`, so scoped style checks were used for the touched files.