### PR TITLE
Validate CC verifier namespace coverage

### DIFF
--- a/nvflare/app_opt/confidential_computing/cc_manager.py
+++ b/nvflare/app_opt/confidential_computing/cc_manager.py
@@ -291,6 +291,23 @@ class CCManager(FLComponent):
             if not cc_info:  # a cc-enabled site does not have any cc_info
                 invalid_participant_list.append(k + " namespace: {None} ")
                 continue
+            required_namespaces = set(self.cc_verifiers)
+            present_namespaces = set()
+            duplicate_namespaces = set()
+            for v in cc_info:
+                namespace = v.get(CC_NAMESPACE, "")
+                if namespace in present_namespaces:
+                    duplicate_namespaces.add(namespace)
+                present_namespaces.add(namespace)
+
+            missing_namespaces = required_namespaces - present_namespaces
+            unknown_namespaces = present_namespaces - required_namespaces
+            invalid_namespaces = missing_namespaces | unknown_namespaces | duplicate_namespaces
+            if invalid_namespaces:
+                for namespace in sorted(invalid_namespaces):
+                    invalid_participant_list.append(k + " namespace: {" + namespace + "}")
+                continue
+
             for v in cc_info:
                 token = v.get(CC_TOKEN, "")
                 namespace = v.get(CC_NAMESPACE, "")

--- a/tests/unit_test/app_opt/confidential_computing/cc_manager_test.py
+++ b/tests/unit_test/app_opt/confidential_computing/cc_manager_test.py
@@ -34,6 +34,7 @@ from nvflare.app_opt.confidential_computing.tdx_authorizer import TDX_NAMESPACE,
 
 VALID_TOKEN = "valid_token"
 INVALID_TOKEN = "invalid_token"
+GPU_NAMESPACE = "gpu"
 
 
 def _verify_token(token: str) -> bool:
@@ -279,6 +280,59 @@ class TestCCManager:
         assert result["client1." + TDX_NAMESPACE] is True
         assert len(invalid_list) == 1
         assert "client2" in invalid_list[0]
+
+    def test_verify_participants_tokens_fails_with_missing_required_namespace(self, logger, cc_test_env, monkeypatch):
+        """Test verification fails if a CC-enabled site omits a required verifier namespace."""
+        logger.info("Testing _verify_participants_tokens with missing namespace")
+        cc_manager, fl_ctx, tdx_authorizer = cc_test_env
+
+        gpu_authorizer = Mock()
+        gpu_authorizer.verify = _verify_token
+        monkeypatch.setitem(cc_manager.cc_verifiers, GPU_NAMESPACE, gpu_authorizer)
+
+        participants_tokens = {
+            "client1": [{CC_TOKEN: VALID_TOKEN, CC_NAMESPACE: TDX_NAMESPACE}],
+        }
+
+        result, invalid_list = cc_manager._verify_participants_tokens(participants_tokens)
+
+        assert result == {}
+        assert len(invalid_list) == 1
+        assert f"client1 namespace: {{{GPU_NAMESPACE}}}" in invalid_list
+
+    def test_verify_participants_tokens_fails_with_duplicate_namespace(self, logger, cc_test_env):
+        """Test verification fails if a CC-enabled site submits duplicate verifier namespaces."""
+        logger.info("Testing _verify_participants_tokens with duplicate namespace")
+        cc_manager, fl_ctx, tdx_authorizer = cc_test_env
+
+        participants_tokens = {
+            "client1": [
+                {CC_TOKEN: VALID_TOKEN, CC_NAMESPACE: TDX_NAMESPACE},
+                {CC_TOKEN: VALID_TOKEN, CC_NAMESPACE: TDX_NAMESPACE},
+            ],
+        }
+
+        result, invalid_list = cc_manager._verify_participants_tokens(participants_tokens)
+
+        assert result == {}
+        assert len(invalid_list) == 1
+        assert f"client1 namespace: {{{TDX_NAMESPACE}}}" in invalid_list
+
+    def test_verify_participants_tokens_fails_with_unknown_namespace(self, logger, cc_test_env):
+        """Test verification fails if a CC-enabled site submits an unknown verifier namespace."""
+        logger.info("Testing _verify_participants_tokens with unknown namespace")
+        cc_manager, fl_ctx, tdx_authorizer = cc_test_env
+
+        participants_tokens = {
+            "client1": [{CC_TOKEN: VALID_TOKEN, CC_NAMESPACE: GPU_NAMESPACE}],
+        }
+
+        result, invalid_list = cc_manager._verify_participants_tokens(participants_tokens)
+
+        assert result == {}
+        assert len(invalid_list) == 2
+        assert f"client1 namespace: {{{GPU_NAMESPACE}}}" in invalid_list
+        assert f"client1 namespace: {{{TDX_NAMESPACE}}}" in invalid_list
 
     def test_verify_participants_tokens_not_in_enabled_sites(self, logger, cc_test_env):
         """Test that sites not in enabled_sites are automatically validated."""


### PR DESCRIPTION
## Summary

- Require each CC-enabled participant to submit exactly one token for each configured verifier namespace before token verification.
- Reject missing, duplicate, and unknown verifier namespaces during CC token validation.
- Add unit coverage for missing, duplicate, and unknown namespace submissions.

## Why

`CCManager` builds a namespace-to-verifier map from configured `cc_verifier_ids`, but token validation only walked the namespaces submitted by each participant. A participant with incomplete namespace coverage could pass validation if the submitted token was valid. This makes the check fail closed before individual tokens are verified.

## Testing

- `.venv/bin/python -m pytest tests/unit_test/app_opt/confidential_computing/cc_manager_test.py -q`
- `.venv/bin/python -m black --check nvflare/app_opt/confidential_computing/cc_manager.py tests/unit_test/app_opt/confidential_computing/cc_manager_test.py`
- `.venv/bin/python -m isort --check-only nvflare/app_opt/confidential_computing/cc_manager.py tests/unit_test/app_opt/confidential_computing/cc_manager_test.py`
- `.venv/bin/python -m flake8 nvflare/app_opt/confidential_computing/cc_manager.py tests/unit_test/app_opt/confidential_computing/cc_manager_test.py`
- `source .venv/bin/activate && ./runtest.sh -s`