### PR TITLE
Create output directory for NeMo SFT predictions

### DIFF
--- a/integration/nemo/examples/supervised_fine_tuning/predict.py
+++ b/integration/nemo/examples/supervised_fine_tuning/predict.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from collections import OrderedDict
 
 import model_checkpoint
@@ -62,6 +63,12 @@ def _greedy_generate_no_cache(model, input_ids, max_new_tokens: int, eos_token_i
     return generated
 
 
+def _write_predictions(output_json: str, checkpoint: str, results: list[dict[str, str]]) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(output_json)), exist_ok=True)
+    with open(output_json, "w") as f:
+        json.dump({"checkpoint": checkpoint, "predictions": results}, f, indent=2)
+
+
 def main():
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -97,8 +104,7 @@ def main():
         generated = tokenizer.decode(output_ids[0][inputs["input_ids"].shape[-1] :], skip_special_tokens=True).strip()
         results.append({"prompt": prompt, "generated": generated})
 
-    with open(args.output_json, "w") as f:
-        json.dump({"checkpoint": args.checkpoint, "predictions": results}, f, indent=2)
+    _write_predictions(args.output_json, args.checkpoint, results)
     for item in results:
         print(f"PROMPT: {item['prompt']}")
         print(f"GENERATED: {item['generated']}")

--- a/tests/unit_test/examples/nemo_sft_job_test.py
+++ b/tests/unit_test/examples/nemo_sft_job_test.py
@@ -443,6 +443,22 @@ def test_sft_predict_uses_no_cache_greedy_loop():
     assert [call["use_cache"] for call in model.calls] == [False, False]
 
 
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch is required to import prediction helpers")
+def test_sft_predict_creates_output_parent_dir(tmp_path):
+    predict_module = _load_example_module("predict")
+    output_json = tmp_path / "missing" / "nested" / "predictions.json"
+
+    predict_module._write_predictions(str(output_json), "checkpoint.pt", [{"prompt": "p", "generated": "g"}])
+
+    with open(output_json) as f:
+        data = json.load(f)
+
+    assert data == {
+        "checkpoint": "checkpoint.pt",
+        "predictions": [{"prompt": "p", "generated": "g"}],
+    }
+
+
 def test_sft_synthetic_data_generator_writes_site_and_validation_files(tmp_path):
     data_module = _load_example_module("data/create_synthetic_sft_data")
     out_dir = tmp_path / "synthetic"


### PR DESCRIPTION
## Summary

- Creates the parent directory before `predict.py` writes `--output_json` for the NeMo SFT example.
- Moves the prediction JSON write into a small helper so the behavior is covered directly.
- Adds a regression test for writing predictions to a missing nested output directory.

Fixes the merged PR #4779 Greptile comment: https://github.com/NVIDIA/NVFlare/pull/4779#discussion_r3469121156

## Validation

- `pytest tests/unit_test/examples/nemo_sft_job_test.py -q` -> 17 passed
- `black --check integration/nemo/examples/supervised_fine_tuning/predict.py tests/unit_test/examples/nemo_sft_job_test.py`
- `isort --check-only integration/nemo/examples/supervised_fine_tuning/predict.py tests/unit_test/examples/nemo_sft_job_test.py`
- `git diff --check`

Used scoped style checks for the two changed files as the closest relevant equivalent to the full project style gate for this narrow follow-up.