### PR TITLE
[2.8] Fix recipe catalog import mocking

### DIFF
--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -299,6 +299,10 @@ def _module_source_path(module_name: str):
     return _NVFLARE_PACKAGE_ROOT.joinpath(*parts[1:]).with_suffix(".py")
 
 
+def _import_module(module_name: str):
+    return importlib.import_module(module_name)
+
+
 def _ast_default_value(node):
     if node is None:
         return None
@@ -377,7 +381,7 @@ def _static_recipe_parameters(module_name: str, class_name: str) -> list:
 
 def _try_import_recipe_class(module_name: str, class_name: str):
     try:
-        module = importlib.import_module(module_name)
+        module = _import_module(module_name)
     except (ImportError, SyntaxError):
         return None
     return getattr(module, class_name, None)
@@ -806,7 +810,7 @@ def _load_catalog(framework: str = None, include_recipe_class: bool = False) -> 
         if framework and root["framework"] != framework:
             continue
         try:
-            package = importlib.import_module(root["package"])
+            package = _import_module(root["package"])
         except (ImportError, SyntaxError):
             pass
 
@@ -815,7 +819,7 @@ def _load_catalog(framework: str = None, include_recipe_class: bool = False) -> 
                 if module_name.endswith(".__init__"):
                     continue
                 try:
-                    mod = importlib.import_module(module_name)
+                    mod = _import_module(module_name)
                 except (ImportError, SyntaxError):
                     continue
 

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -566,11 +566,11 @@ def test_recipe_catalog_is_discovered_from_package_modules(monkeypatch):
             return fake_module
         raise ImportError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.fedavg", False)],
     )
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
 
     catalog = _load_catalog(framework="pytorch")
 
@@ -619,11 +619,11 @@ def test_recipe_catalog_prefers_specific_algorithm_marker_over_fedavg_class_name
             return fake_module
         raise ImportError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.kmeans", False)],
     )
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
 
     catalog = _load_catalog(framework="sklearn")
 
@@ -665,11 +665,11 @@ def test_recipe_catalog_core_framework_is_not_special_catch_all(monkeypatch):
             return core_module
         raise ModuleNotFoundError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.core.fedavg", False)],
     )
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
 
     assert _load_catalog(framework="pytorch") == []
     assert _load_catalog(framework="core") == [
@@ -706,11 +706,11 @@ def test_recipe_catalog_skips_plain_import_errors_from_optional_recipes(monkeypa
             raise ImportError("broken recipe import")
         raise ModuleNotFoundError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.broken", False)],
     )
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
 
     assert _load_catalog(framework="pytorch") == []
 
@@ -734,11 +734,11 @@ def test_recipe_catalog_skips_syntax_errors_from_optional_recipes(monkeypatch):
             raise SyntaxError("invalid syntax")
         raise ModuleNotFoundError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.broken", False)],
     )
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
 
     assert _load_catalog(framework="pytorch") == []
 
@@ -781,11 +781,11 @@ def test_recipe_catalog_prefers_leaf_recipe_class_when_module_has_base_and_subcl
             return fake_module
         raise ImportError(name)
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli.importlib.import_module", fake_import_module)
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
         lambda path, prefix="": [(None, "fake.recipes.swarm", False)],
     )
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
 
     catalog = _load_catalog(framework="pytorch")
 


### PR DESCRIPTION
## Summary
- Add a local `_import_module()` wrapper in `recipe_cli.py` for recipe catalog imports.
- Update recipe catalog tests to patch that wrapper instead of patching `importlib.import_module` on the shared stdlib module.

## Root Cause
The 2.8 tests replaced `nvflare.tool.recipe.recipe_cli.importlib.import_module`, which mutates the shared `importlib` module object. Newer pytest monkeypatch target resolution can call `importlib.import_module()` internally after that patch is installed, so resolving later string targets can hit the fake importer and fail with `ImportError: nvflare`.

Main already avoids this pattern by patching a local import wrapper; this PR backports the minimal same-shape fix to 2.8.
