### PR TITLE
Enforce BYOC for job-selected launcher content

### DIFF
--- a/nvflare/private/fed/utils/app_authz.py
+++ b/nvflare/private/fed/utils/app_authz.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 from nvflare.apis.app_validation import AppValidationKey, AppValidator
 from nvflare.app_opt.flower.defs import Constant as FlowerConstant
 from nvflare.fuel.sec.authz import AuthorizationService, AuthzContext, Person
+from nvflare.utils.job_launcher_utils import get_job_launcher_spec
 
 _RIGHT_BYOC = "byoc"
 _RIGHT_FLOWER_PREDEPLOYED = "server-predeployed-flwr"
@@ -40,6 +43,16 @@ class AppAuthzService(object):
             return err, {}
 
         return "", app_info
+
+    @staticmethod
+    def derive_local_app_info(app_info: dict, job_meta: dict, site_name: str) -> dict:
+        for mode in ("docker", "k8s"):
+            spec = get_job_launcher_spec(job_meta, site_name, mode)
+            if "image" in spec or "python_path" in spec:
+                app_info = copy.deepcopy(app_info)
+                app_info[AppValidationKey.BYOC] = True
+                break
+        return app_info
 
     @staticmethod
     def authorize_app_info(

--- a/nvflare/private/fed/utils/app_deployer.py
+++ b/nvflare/private/fed/utils/app_deployer.py
@@ -88,6 +88,8 @@ class AppDeployer(AppDeployerSpec):
                     shutil.rmtree(run_dir, ignore_errors=True)
                 return err
 
+            app_info = AppAuthzService.derive_local_app_info(app_info, job_meta, workspace.site_name)
+
             job_meta = copy.deepcopy(job_meta)
             if app_info.get(AppValidationKey.BYOC, False):
                 job_meta[AppValidationKey.BYOC] = True

--- a/tests/unit_test/private/fed/utils/app_deployer_test.py
+++ b/tests/unit_test/private/fed/utils/app_deployer_test.py
@@ -32,7 +32,7 @@ from nvflare.private.fed.utils.app_authz import AppAuthzService
 from nvflare.private.fed.utils.app_deployer import AppDeployer
 from nvflare.private.fed.utils.fed_utils import authorize_build_component
 from nvflare.private.json_configer import ConfigContext
-from nvflare.security.security import EmptyAuthorizer
+from nvflare.security.security import EmptyAuthorizer, FLAuthorizer
 
 
 def _make_workspace(root_dir: str) -> Workspace:
@@ -56,6 +56,31 @@ def _job_meta(submitter_role: str):
         JobMetaKey.SUBMITTER_ORG: "nvidia",
         JobMetaKey.SUBMITTER_ROLE: submitter_role,
     }
+
+
+def _launcher_meta(mode: str, source: str, values: dict) -> dict:
+    if source == "default":
+        return {JobMetaKey.JOB_LAUNCHER_SPEC.value: {"default": {mode: values}}}
+    if source == "site":
+        return {JobMetaKey.JOB_LAUNCHER_SPEC.value: {"site-1": {mode: values}}}
+    if source == "legacy":
+        return {JobMetaKey.RESOURCE_SPEC.value: {"site-1": {mode: values}}}
+    raise ValueError(f"unsupported launcher metadata source: {source}")
+
+
+def _byoc_none_authorizer():
+    return FLAuthorizer(
+        "site-org",
+        {
+            "format_version": "1.0",
+            "permissions": {
+                "lead": {
+                    "submit_job": "any",
+                    "byoc": "none",
+                }
+            },
+        },
+    )
 
 
 def test_deploy_rejects_traversing_job_id_before_touching_outside_path(tmp_path):
@@ -160,6 +185,24 @@ def test_deploy_detects_custom_dir_as_local_byoc_for_allow_list(tmp_path):
         )
         == ""
     )
+
+
+@pytest.mark.parametrize("mode", ["docker", "k8s"])
+@pytest.mark.parametrize("source", ["default", "site", "legacy"])
+@pytest.mark.parametrize("field", ["image", "python_path"])
+def test_deploy_requires_byoc_for_job_selected_launcher_content(tmp_path, monkeypatch, mode, source, field):
+    workspace = _make_workspace(str(tmp_path / "workspace"))
+    monkeypatch.setattr(AppAuthzService, "app_validator", DefaultAppValidator(site_type=SiteType.CLIENT))
+    monkeypatch.setattr(AuthorizationService, "the_authorizer", _byoc_none_authorizer())
+    job_meta = _job_meta("lead")
+    job_meta[AppValidationKey.BYOC] = False
+    job_meta.update(_launcher_meta(mode, source, {field: "attacker.example/value"}))
+
+    with patch("nvflare.private.fed.utils.app_deployer.PrivacyService.is_scope_allowed", return_value=True):
+        err = AppDeployer().deploy(workspace, "job-1", job_meta, "app", _make_app_zip(), None)
+
+    assert err == "BYOC not permitted"
+    assert not os.path.exists(workspace.get_run_dir("job-1"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Treat any job-specified Docker or Kubernetes `image` or `python_path` as BYOC.
- Derive that classification before local app deployment authorization, so a submitter with `byoc: none` is rejected before launch.
- Cover `launcher_spec.default`, per-site `launcher_spec`, and legacy nested `resource_spec` forms.

## Root cause
A job without `custom/` was treated as non-BYOC even when its launcher metadata selected executable container content.
