### PR TITLE
Fix Scaffold tensor controls for BF16/CUDA

### DIFF
--- a/nvflare/app_common/workflows/scaffold.py
+++ b/nvflare/app_common/workflows/scaffold.py
@@ -31,6 +31,26 @@ from .base_fedavg import (
 )
 
 
+def _zero_control_value(value):
+    """Zero an array or tensor in place without changing its type, dtype, or device."""
+    try:
+        value[...] = 0
+    except (IndexError, TypeError):
+        value = np.zeros_like(value)
+    return value
+
+
+def _add_control_delta(control, delta):
+    """Add a control delta while preserving a tensor control's dtype and device."""
+    new_tensor = getattr(control, "new_tensor", None)
+    add = getattr(control, "add_", None)
+    if callable(new_tensor) and callable(add) and not callable(getattr(delta, "new_tensor", None)):
+        add(new_tensor(delta))
+        return control
+    control += delta
+    return control
+
+
 class Scaffold(BaseFedAvg):
     """Controller for Scaffold Workflow. *Note*: This class is based on `ModelController`.
     Implements [SCAFFOLD](https://proceedings.mlr.press/v119/karimireddy20a.html).
@@ -71,7 +91,7 @@ class Scaffold(BaseFedAvg):
         self._global_ctrl_weights = copy.deepcopy(self.model.params)
         # Initialize correction term with zeros
         for k in self._global_ctrl_weights.keys():
-            self._global_ctrl_weights[k] = np.zeros_like(self._global_ctrl_weights[k])
+            self._global_ctrl_weights[k] = _zero_control_value(self._global_ctrl_weights[k])
 
     def run(self) -> None:
         disk_offload_context = None
@@ -112,7 +132,7 @@ class Scaffold(BaseFedAvg):
             # update SCAFFOLD global controls
             ctr_diff = aggregate_results.meta[AlgorithmConstants.SCAFFOLD_CTRL_DIFF]
             for v_name, v_value in ctr_diff.items():
-                self._global_ctrl_weights[v_name] += v_value
+                self._global_ctrl_weights[v_name] = _add_control_delta(self._global_ctrl_weights[v_name], v_value)
 
             self.save_model(self.model)
 

--- a/nvflare/app_opt/pt/scaffold.py
+++ b/nvflare/app_opt/pt/scaffold.py
@@ -114,7 +114,10 @@ class PTScaffoldHelper(object):
             c_new_para[key] = (
                 c_new_para[key] - c_global_para[key] + (global_model_para[key] - net_para[key]) / (self.cnt * curr_lr)
             )
-            self.c_delta_para[key] = (c_new_para[key] - c_local_para[key]).cpu().numpy()
+            c_delta = (c_new_para[key] - c_local_para[key]).cpu()
+            if c_delta.dtype == torch.bfloat16:
+                c_delta = c_delta.to(torch.float32)
+            self.c_delta_para[key] = c_delta.numpy()
         self.c_local.load_state_dict(c_new_para)
 
     def load_global_controls(self, weights):

--- a/tests/unit_test/app_common/workflow/fedavg_test.py
+++ b/tests/unit_test/app_common/workflow/fedavg_test.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 import nvflare.app_common.utils.tensor_disk_offload_context as tensor_disk_offload_context_module
 from nvflare.apis.client import Client
 from nvflare.apis.controller_spec import ClientTask, Task
-from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.fl_constant import FLMetaKey, ReservedKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
@@ -1054,6 +1056,138 @@ class TestScaffoldDownloadToDiskContext:
         assert cell.ctx["enable_tensor_disk_offload"] is False
         assert cell.ctx[_TENSOR_DISK_OFFLOAD_ROOT_DIR] is None
         assert not root_dir.exists()
+
+
+class TestScaffoldControlValues:
+    @staticmethod
+    def _initialize_scaffold(params):
+        from nvflare.app_common.workflows.scaffold import Scaffold
+
+        controller = Scaffold(num_clients=1, num_rounds=1)
+        controller.load_model = lambda: FLModel(params=params)
+        controller.warning = lambda _: None
+        engine = MagicMock()
+        engine.get_component.return_value = None
+        fl_ctx = FLContext()
+        fl_ctx.put(ReservedKey.ENGINE, engine, private=True, sticky=False)
+        controller.initialize(fl_ctx)
+        return controller
+
+    @staticmethod
+    def _run_control_round(control, client_delta):
+        from nvflare.app_common.app_constant import AlgorithmConstants
+        from nvflare.app_common.workflows.scaffold import Scaffold
+
+        controller = Scaffold(num_clients=1, num_rounds=1)
+        controller.fl_ctx = FLContext()
+        controller.model = FLModel(params={"w": copy.deepcopy(control)})
+        controller._global_ctrl_weights = {"w": control}
+        controller.sample_clients = lambda _: ["site-1"]
+        sent = {}
+
+        def send_model_and_wait(targets, data):
+            sent["control"] = data.meta[AlgorithmConstants.SCAFFOLD_CTRL_GLOBAL]["w"]
+            return []
+
+        controller.send_model_and_wait = send_model_and_wait
+        controller.aggregate = lambda results, aggregate_fn=None: FLModel(
+            params={"w": copy.deepcopy(control)},
+            meta={AlgorithmConstants.SCAFFOLD_CTRL_DIFF: {"w": client_delta}},
+        )
+        controller.update_model = lambda model, aggr_result: model
+        controller.save_model = lambda model: None
+        controller.run()
+        return controller, sent
+
+    def test_initialize_keeps_numpy_control_values_as_arrays(self):
+        params = {"w": np.array([1.0, np.nan], dtype=np.float32)}
+
+        controller = self._initialize_scaffold(params)
+
+        control = controller._global_ctrl_weights["w"]
+        assert isinstance(control, np.ndarray)
+        assert control.dtype == np.float32
+        np.testing.assert_array_equal(control, np.zeros_like(params["w"]))
+        assert np.isnan(params["w"][1])
+
+    def test_initialize_keeps_cpu_float32_control_values_as_tensors(self):
+        torch = pytest.importorskip("torch")
+        params = {"w": torch.tensor([1.0, float("nan")], dtype=torch.float32)}
+
+        controller = self._initialize_scaffold(params)
+
+        control = controller._global_ctrl_weights["w"]
+        assert isinstance(control, torch.Tensor)
+        assert control.dtype == torch.float32
+        assert control.device.type == "cpu"
+        assert torch.equal(control, torch.zeros_like(params["w"]))
+        assert torch.isnan(params["w"][1])
+
+    def test_initialize_keeps_cpu_bfloat16_control_values_as_tensors(self):
+        torch = pytest.importorskip("torch")
+        params = {"w": torch.tensor([1.0, float("nan")], dtype=torch.bfloat16)}
+
+        controller = self._initialize_scaffold(params)
+
+        control = controller._global_ctrl_weights["w"]
+        assert isinstance(control, torch.Tensor)
+        assert control.dtype == torch.bfloat16
+        assert control.device.type == "cpu"
+        assert torch.equal(control, torch.zeros_like(params["w"]))
+        assert torch.isnan(params["w"][1])
+
+    def test_initialize_keeps_cuda_control_values_as_tensors(self):
+        torch = pytest.importorskip("torch")
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA is not available")
+        params = {"w": torch.tensor([1.0, float("nan")], dtype=torch.float32, device="cuda")}
+
+        controller = self._initialize_scaffold(params)
+
+        control = controller._global_ctrl_weights["w"]
+        assert isinstance(control, torch.Tensor)
+        assert control.dtype == torch.float32
+        assert control.device == params["w"].device
+        assert torch.equal(control, torch.zeros_like(params["w"]))
+        assert torch.isnan(params["w"][1])
+
+    @pytest.mark.parametrize("dtype_name", ["float32", "bfloat16"])
+    def test_round_keeps_cpu_tensor_controls_when_client_delta_is_numpy(self, dtype_name):
+        torch = pytest.importorskip("torch")
+        dtype = getattr(torch, dtype_name)
+        control = torch.zeros(2, dtype=dtype)
+
+        controller, sent = self._run_control_round(control, np.ones(2, dtype=np.float32))
+
+        assert sent["control"] is control
+        assert sent["control"].dtype == dtype
+        assert sent["control"].device.type == "cpu"
+        assert controller._global_ctrl_weights["w"] is control
+        assert torch.equal(control, torch.ones_like(control))
+
+    def test_round_keeps_numpy_float32_controls_when_client_delta_is_numpy(self):
+        control = np.zeros(2, dtype=np.float32)
+
+        controller, sent = self._run_control_round(control, np.ones(2, dtype=np.float32))
+
+        assert sent["control"] is control
+        assert sent["control"].dtype == np.float32
+        assert controller._global_ctrl_weights["w"] is control
+        np.testing.assert_array_equal(control, np.ones_like(control))
+
+    def test_round_keeps_cuda_tensor_controls_when_client_delta_is_numpy(self):
+        torch = pytest.importorskip("torch")
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA is not available")
+        control = torch.zeros(2, dtype=torch.float32, device="cuda")
+
+        controller, sent = self._run_control_round(control, np.ones(2, dtype=np.float32))
+
+        assert sent["control"] is control
+        assert sent["control"].dtype == torch.float32
+        assert sent["control"].device == control.device
+        assert controller._global_ctrl_weights["w"] is control
+        assert torch.equal(control, torch.ones_like(control))
 
 
 class TestFedAvgWorkflowEvents:

--- a/tests/unit_test/app_opt/pt/scaffold_test.py
+++ b/tests/unit_test/app_opt/pt/scaffold_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PyTorch SCAFFOLD helper."""
+
+import copy
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from nvflare.app_opt.pt.scaffold import PTScaffoldHelper
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_terms_update_returns_float32_numpy_control_delta(dtype):
+    model = torch.nn.Linear(2, 1, bias=False).to(dtype=dtype)
+    with torch.no_grad():
+        model.weight.fill_(1)
+    model_global = copy.deepcopy(model)
+
+    helper = PTScaffoldHelper()
+    helper.init(model)
+    c_global_para, c_local_para = helper.get_params()
+    with torch.no_grad():
+        model.weight.add_(1)
+    helper.model_update(model, curr_lr=1.0, c_global_para=c_global_para, c_local_para=c_local_para)
+    helper.terms_update(
+        model=model,
+        curr_lr=1.0,
+        c_global_para=c_global_para,
+        c_local_para=c_local_para,
+        model_global=model_global,
+    )
+
+    actual = helper.get_delta_controls()["weight"]
+    expected = (model_global.state_dict()["weight"] - model.state_dict()["weight"]).cpu().to(torch.float32).numpy()
+
+    assert isinstance(actual, np.ndarray)
+    assert actual.dtype == np.float32
+    np.testing.assert_allclose(actual, expected)
+    assert helper.c_local.state_dict()["weight"].dtype == dtype


### PR DESCRIPTION
## Summary

Fix SCAFFOLD control variates when the PyTorch recipe preserves tensors with
`server_expected_format=ExchangeFormat.PYTORCH`.

## Why this change is needed

Tensor disk offload requires the server model to remain backed by PyTorch tensors instead of being converted to NumPy. SCAFFOLD creates a second set of values—the global control variates—with the same representation as the model parameters. The existing controller still assumed that those controls were NumPy arrays:

1. It initialized them with `np.zeros_like`, which tries to convert preserved PyTorch tensors to NumPy. That fails for CUDA tensors and for `torch.bfloat16`.
2. Client SCAFFOLD control deltas are intentionally serialized as NumPy arrays. NumPy cannot represent BF16, so `.cpu().numpy()` fails for BF16 deltas.
3. Once the server controls remain tensors, adding the aggregated NumPy delta directly to a BF16 or CUDA tensor also fails.

As a result, the advertised PyTorch/tensor-offload SCAFFOLD path could fail before training or at the end of its first round for BF16/CUDA models.

## What changed

- Initialize global control values without changing their representation: PyTorch tensors stay tensors on their original device/dtype, and NumPy arrays stay arrays. This uses duck typing so `app_common` does not gain a PyTorch dependency.
- Convert only BF16 client control deltas to float32 immediately before NumPy serialization; float32 behavior is unchanged.
- Convert NumPy control deltas back to the existing tensor control's dtype/device before the server adds them, while retaining the prior in-place NumPy path.

The SCAFFOLD formula, aggregation weighting, checkpoint persistence behavior, and tensor disk-offload mechanism are unchanged; this fixes representation handling at their boundaries.