### PR TITLE
Constrain broken kagglesdk versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -102,6 +102,8 @@ test_support =
     nbformat
     nbmake
     kagglehub!=1.0.1
+    # kagglesdk 0.1.31 and 0.1.32 import a missing competitions.legacy package.
+    kagglesdk<0.1.31; python_version >= "3.11"
 
 test =
     %(all)s


### PR DESCRIPTION
## Summary

- constrain `kagglesdk` to versions before 0.1.31 for Python 3.11 and newer
- keep the existing `kagglehub` constraint and Python 3.10 dependency resolution unchanged
- limit the workaround to NVFlare's test and development extras

## Root cause

`kagglesdk` 0.1.31 and 0.1.32 import `kagglesdk.competitions.legacy`, but that package is absent from the published wheels and upstream source. Fresh CI environments therefore fail while importing `kagglehub`, before unit tests are collected.

The Python 3.11-3.14 pre-merge jobs began resolving `kagglesdk` 0.1.32 immediately after its June 30 publication. This is independent of the pull request code under test and affects any fresh NVFlare test environment.

## Impact

This changes only test/development dependency resolution. Normal NVFlare runtime dependencies are unchanged. The upper bound can be removed after Kaggle publishes a corrected SDK release.

## Validation

- built the NVFlare wheel and verified its metadata contains `kagglesdk<0.1.31; python_version >= "3.11"`
- verified `kagglehub==1.0.2` resolves with `kagglesdk==0.1.30`
- `python -m pytest tests/unit_test/app_opt/kaggle/download_data_test.py -q` (8 passed)
- `./runtest.sh -s --skip-install`

Failing run: https://github.com/NVIDIA/NVFlare/actions/runs/28473335329
