### PR TITLE
Add configurable root CA validity

### DIFF
--- a/docs/user_guide/nvflare_cli/provision_command.rst
+++ b/docs/user_guide/nvflare_cli/provision_command.rst
@@ -40,6 +40,29 @@ section includes structured guidance such as:
 This keeps JSON output machine-readable while still carrying follow-up
 instructions.
 
+Root CA validity
+================
+
+Centralized provisioning creates a self-signed project root CA that is valid
+for 360 days by default. To select a different initial validity, set the
+positive integer ``root_valid_days`` for ``CertBuilder`` in ``project.yml``:
+
+.. code-block:: yaml
+
+   builders:
+     - path: nvflare.lighter.impl.cert.CertBuilder
+       args:
+         root_valid_days: 3650
+
+This setting only applies when a workspace creates its root. Later runs reuse
+the root in the workspace's ``state`` directory and report its actual
+``NotBefore`` and ``NotAfter`` values. A configured validity that does not
+match the existing root fails clearly. Participant certificates keep their
+normal 360-day validity unless the root expires sooner.
+
+Changing an established root requires a separate multi-root rollover;
+``root_valid_days`` never extends or replaces it.
+
 Certificate Identity Overrides
 ==============================
 

--- a/nvflare/lighter/dummy_project.yml
+++ b/nvflare/lighter/dummy_project.yml
@@ -58,4 +58,8 @@ builders:
       # to different url.
       # download_job_url: http://download.server.com/
   - path: nvflare.lighter.impl.cert.CertBuilder
+    # root_valid_days applies only when this workspace creates its root CA for the first time.
+    # The default is 360 days. For example, use the following to create a 10-year root:
+    # args:
+    #   root_valid_days: 3650
   - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/nvflare/lighter/impl/cert.py
+++ b/nvflare/lighter/impl/cert.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import json
 import os
 
@@ -27,6 +28,7 @@ from nvflare.lighter.spec import Builder
 from nvflare.lighter.utils import Identity, generate_cert, generate_keys, serialize_cert, serialize_pri_key
 
 MAX_CN_LENGTH = 64
+DEFAULT_CERT_VALID_DAYS = 360
 
 
 class _CertState:
@@ -95,13 +97,24 @@ class _CertState:
 
 
 class CertBuilder(Builder):
-    def __init__(self):
+    def __init__(self, root_valid_days=DEFAULT_CERT_VALID_DAYS):
         """Build certificate chain for every participant.
 
         Handles building (creating and self-signing) the root CA certificates, creating server, client and
         admin certificates, and having them signed by the root CA for secure communication. If the state folder has
         information about previously generated certs, it loads them back and reuses them.
+
+        Args:
+            root_valid_days: validity period in days for a newly generated root CA certificate. This value does not
+                renew or replace a root CA already stored in the provisioning state.
         """
+        if isinstance(root_valid_days, bool) or not isinstance(root_valid_days, int) or root_valid_days <= 0:
+            raise ValueError(
+                f"root_valid_days must be a positive integer, got {root_valid_days!r} "
+                f"({type(root_valid_days).__name__})"
+            )
+
+        self.root_valid_days = root_valid_days
         self.root_cert = None
         self.persistent_state = None
         self.serialized_cert = None
@@ -178,13 +191,34 @@ class CertBuilder(Builder):
             self.pub_key = self.pri_key.public_key()
             self.subject = self.root_cert.subject
             self.issuer = self.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+            self._validate_existing_root_validity()
+
+    def _validate_existing_root_validity(self):
+        actual_validity = self.root_cert.not_valid_after_utc - self.root_cert.not_valid_before_utc
+        requested_validity = datetime.timedelta(days=self.root_valid_days)
+        if actual_validity != requested_validity:
+            actual_days = actual_validity.total_seconds() / datetime.timedelta(days=1).total_seconds()
+            raise ValueError(
+                f"root_valid_days={self.root_valid_days} does not match the existing root CA certificate's actual "
+                f"validity of {actual_days:g} days (NotBefore {self.root_cert.not_valid_before_utc.isoformat()}, "
+                f"NotAfter {self.root_cert.not_valid_after_utc.isoformat()}). root_valid_days only controls a newly "
+                "generated root; use a new provisioning workspace or a root CA rollover procedure to change it."
+            )
 
     def _build_root(self, subject, subject_org):
         assert isinstance(self.persistent_state, _CertState)
         if not self.persistent_state.is_available:
             pri_key, pub_key = generate_keys()
             self.issuer = subject
-            self.root_cert = self._generate_cert(subject, subject_org, self.issuer, pri_key, pub_key, ca=True)
+            self.root_cert = self._generate_cert(
+                subject,
+                subject_org,
+                self.issuer,
+                pri_key,
+                pub_key,
+                valid_days=self.root_valid_days,
+                ca=True,
+            )
             self.pri_key = pri_key
             self.pub_key = pub_key
             self.serialized_cert = serialize_cert(self.root_cert)
@@ -283,6 +317,10 @@ class CertBuilder(Builder):
         self._build_root(project.name, subject_org=None)
         ctx[CtxKey.ROOT_CERT] = self.root_cert
         ctx[CtxKey.ROOT_PRI_KEY] = self.pri_key
+        ctx.info(
+            f"Root CA validity: NotBefore={self.root_cert.not_valid_before_utc.isoformat()}, "
+            f"NotAfter={self.root_cert.not_valid_after_utc.isoformat()}"
+        )
 
         server = project.get_server()
         if server:
@@ -306,6 +344,16 @@ class CertBuilder(Builder):
         else:
             role = None
 
+        now = datetime.datetime.now(datetime.timezone.utc)
+        root_not_after = self.root_cert.not_valid_after_utc
+        if root_not_after <= now:
+            raise RuntimeError(
+                f"cannot generate certificate for '{participant.name}': root CA expired at {root_not_after.isoformat()}"
+            )
+        not_valid_after = (
+            root_not_after if root_not_after < now + datetime.timedelta(days=DEFAULT_CERT_VALID_DAYS) else None
+        )
+
         server = participant if participant.type == ParticipantType.SERVER else None
         cert = self._generate_cert(
             subject,
@@ -315,6 +363,8 @@ class CertBuilder(Builder):
             pub_key,
             role=role,
             server=server,
+            not_valid_before=now,
+            not_valid_after=not_valid_after,
         )
         return pri_key, cert
 
@@ -325,13 +375,15 @@ class CertBuilder(Builder):
         issuer,
         signing_pri_key,
         subject_pub_key,
-        valid_days=360,
+        valid_days=DEFAULT_CERT_VALID_DAYS,
         ca=False,
         role=None,
         server: Participant = None,
         server_default_host=None,
         server_additional_hosts=None,
         extra_extensions=None,
+        not_valid_before=None,
+        not_valid_after=None,
     ):
         if server:
             # This is to generate a server cert.
@@ -349,6 +401,8 @@ class CertBuilder(Builder):
             server_default_host=server_default_host,
             server_additional_hosts=server_additional_hosts,
             extra_extensions=extra_extensions,
+            not_valid_before=not_valid_before,
+            not_valid_after=not_valid_after,
         )
 
     def finalize(self, project: Project, ctx: ProvisionContext):

--- a/tests/unit_test/lighter/cert_builder_test.py
+++ b/tests/unit_test/lighter/cert_builder_test.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.lighter.constants import CtxKey, ParticipantType
+from nvflare.lighter.entity import Participant, Project
+from nvflare.lighter.impl.cert import CertBuilder
+from nvflare.lighter.impl.workspace import WorkspaceBuilder
+from nvflare.lighter.prov_utils import prepare_builders
+from nvflare.lighter.provisioner import Provisioner
+from nvflare.lighter.utils import load_crt
+
+
+def _make_project():
+    return Project(
+        name="test-project",
+        description="certificate validity test",
+        participants=[
+            Participant(type=ParticipantType.SERVER, name="server1", org="test_org"),
+            Participant(type=ParticipantType.CLIENT, name="site-1", org="test_org"),
+        ],
+    )
+
+
+def _cert_builder_from_project_config(root_valid_days):
+    config = {
+        "builders": [
+            {
+                "path": "nvflare.lighter.impl.cert.CertBuilder",
+                "args": {"root_valid_days": root_valid_days},
+            }
+        ]
+    }
+    return prepare_builders(config)[0]
+
+
+def _provision(workspace, cert_builder):
+    provisioner = Provisioner(str(workspace), [WorkspaceBuilder(), cert_builder])
+    return provisioner.provision(_make_project())
+
+
+def _server_cert(workspace):
+    return load_crt(str(workspace / "test-project" / "prod_00" / "server1" / "startup" / "server.crt"))
+
+
+def test_default_root_validity_is_reported(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+
+    ctx = _provision(workspace, CertBuilder())
+
+    assert not ctx.get(CtxKey.BUILD_ERROR)
+    root_cert = ctx[CtxKey.ROOT_CERT]
+    assert root_cert.not_valid_after_utc - root_cert.not_valid_before_utc == datetime.timedelta(days=360)
+    assert (
+        f"Root CA validity: NotBefore={root_cert.not_valid_before_utc.isoformat()}, "
+        f"NotAfter={root_cert.not_valid_after_utc.isoformat()}" in capsys.readouterr().out
+    )
+
+
+def test_project_config_custom_root_validity_preserves_leaf_default(tmp_path):
+    workspace = tmp_path / "workspace"
+
+    ctx = _provision(workspace, _cert_builder_from_project_config(3650))
+
+    assert not ctx.get(CtxKey.BUILD_ERROR)
+    root_cert = ctx[CtxKey.ROOT_CERT]
+    leaf_cert = _server_cert(workspace)
+    assert root_cert.not_valid_after_utc - root_cert.not_valid_before_utc == datetime.timedelta(days=3650)
+    assert leaf_cert.not_valid_after_utc - leaf_cert.not_valid_before_utc == datetime.timedelta(days=360)
+    assert leaf_cert.not_valid_after_utc <= root_cert.not_valid_after_utc
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.0, "3650", "ten years", None, [], {}])
+def test_project_config_rejects_invalid_root_valid_days(value):
+    with pytest.raises(ValueError, match="root_valid_days must be a positive integer"):
+        _cert_builder_from_project_config(value)
+
+
+def test_existing_root_validity_mismatch_fails_clearly(tmp_path):
+    workspace = tmp_path / "workspace"
+    first_ctx = _provision(workspace, CertBuilder())
+    assert not first_ctx.get(CtxKey.BUILD_ERROR)
+
+    second_ctx = _provision(workspace, CertBuilder(root_valid_days=3650))
+
+    assert second_ctx.get(CtxKey.BUILD_ERROR)
+    error = "\n".join(second_ctx.get_errors())
+    assert "root_valid_days=3650 does not match the existing root CA certificate's actual validity of 360 days" in error
+    assert "root_valid_days only controls a newly generated root" in error
+
+
+def test_existing_root_with_matching_validity_is_reused(tmp_path):
+    workspace = tmp_path / "workspace"
+    first_ctx = _provision(workspace, _cert_builder_from_project_config(3650))
+
+    second_ctx = _provision(workspace, _cert_builder_from_project_config(3650))
+
+    assert not second_ctx.get(CtxKey.BUILD_ERROR)
+    assert second_ctx[CtxKey.ROOT_CERT].serial_number == first_ctx[CtxKey.ROOT_CERT].serial_number
+
+
+def test_leaf_validity_is_bounded_by_shorter_root(tmp_path):
+    workspace = tmp_path / "workspace"
+    builder = CertBuilder(root_valid_days=1)
+
+    with patch.object(builder, "_generate_cert", wraps=builder._generate_cert) as generate_cert:
+        ctx = _provision(workspace, builder)
+
+    assert not ctx.get(CtxKey.BUILD_ERROR)
+    root_cert = ctx[CtxKey.ROOT_CERT]
+    leaf_cert = _server_cert(workspace)
+    bounded_calls = [call for call in generate_cert.call_args_list if call.kwargs.get("not_valid_after")]
+    assert bounded_calls
+    assert all(call.kwargs["not_valid_before"] is not None for call in bounded_calls)
+    assert leaf_cert.not_valid_before_utc == bounded_calls[0].kwargs["not_valid_before"].replace(microsecond=0)
+    assert leaf_cert.not_valid_before_utc >= root_cert.not_valid_before_utc
+    assert leaf_cert.not_valid_after_utc == root_cert.not_valid_after_utc
+    assert leaf_cert.not_valid_after_utc - leaf_cert.not_valid_before_utc <= datetime.timedelta(days=1)


### PR DESCRIPTION
## Summary

- add a strictly validated `root_valid_days` option to centralized `CertBuilder` provisioning
- preserve the 360-day default, reject persisted-root mismatches, and bound new participant certificates by the root expiry
- report the root certificate validity and document initial validity versus root rollover
