### PR TITLE
Harden stream teardown notifications and peer retry windows

### DIFF
--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import math
 import threading
 from collections import deque
 from typing import Callable, Deque, Dict, Optional, Tuple
@@ -52,6 +53,14 @@ COUNTER_NAME_RECEIVED = "received"
 RESULT_DATA = 0
 RESULT_NO_DATA = 1
 RESULT_EOS = 2
+
+
+def _abbrev(value, limit: int = 64) -> str:
+    # for logging peer-controlled header values, which can be arbitrarily large
+    text = repr(value)
+    if len(text) > limit:
+        text = f"{text[:limit]}...({len(text)} chars)"
+    return text
 
 
 class RxTask:
@@ -217,19 +226,27 @@ class RxTask:
             # completed tasks in memory indefinitely.
             try:
                 # int headers beyond the float range raise OverflowError;
-                # equivalent strings round-trip to inf and hit the clamp below
+                # equivalent strings round-trip to inf and are non-finite
                 requested_ttl = float(retry_timeout) + float(retry_wait)
             except (TypeError, ValueError, OverflowError):
+                requested_ttl = None
+            if requested_ttl is None or not math.isfinite(requested_ttl):
+                # NaN must not reach the max() below: max(a, nan) is
+                # order-dependent, so non-finite values are rejected outright
                 log.warning(
                     f"{self} ignoring invalid retry window headers from {self.origin}: "
-                    f"{retry_timeout!r}/{retry_wait!r}"
+                    f"{_abbrev(retry_timeout)}/{_abbrev(retry_wait)}"
                 )
             else:
                 if requested_ttl > MAX_COMPLETED_TASK_TTL:
-                    log.warning(
-                        f"{self} clamping retry window requested by {self.origin} "
-                        f"from {requested_ttl}s to {MAX_COMPLETED_TASK_TTL}s"
-                    )
+                    if requested_ttl > self.completed_task_ttl:
+                        # warn only when the cap actually lowers the effective
+                        # window; otherwise the local config already governs
+                        log.warning(
+                            f"{self} retry window requested by {self.origin} ({requested_ttl}s) "
+                            f"exceeds the {MAX_COMPLETED_TASK_TTL}s cap; raise streaming_retry_timeout "
+                            f"on this site if a longer window is needed"
+                        )
                     requested_ttl = MAX_COMPLETED_TASK_TTL
                 self.completed_task_ttl = max(self.completed_task_ttl, requested_ttl)
 

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -42,6 +42,10 @@ ACK_INTERVAL = 1024 * 1024 * 4
 READ_TIMEOUT = 300
 COMPLETED_TASK_TTL = 60.0
 RETRY_WAIT = 5.0
+# Hard cap on the peer-requested retry window: the sender's RETRY_TIMEOUT and
+# RETRY_WAIT headers are hints, and an unbounded value would let a peer pin
+# completed tasks in memory indefinitely.
+MAX_COMPLETED_TASK_TTL = 3600.0
 COUNTER_NAME_RECEIVED = "received"
 
 # Read result status
@@ -88,6 +92,7 @@ class RxTask:
         self.failed = False
         self.error = None
         self.error_msg = None
+        self.error_notified = False  # protected by ack_lock, like the ack state
         self.stop_lock = threading.RLock()
         self.cleanup_timer = None
 
@@ -207,7 +212,24 @@ class RxTask:
         retry_timeout = message.get_header(StreamHeaderKey.RETRY_TIMEOUT, None)
         retry_wait = message.get_header(StreamHeaderKey.RETRY_WAIT, None)
         if retry_timeout is not None and retry_wait is not None:
-            self.completed_task_ttl = max(self.completed_task_ttl, float(retry_timeout) + float(retry_wait))
+            # The sender's retry window is a peer-supplied hint: validate and
+            # clamp it so a bad value cannot crash the chunk handler or pin
+            # completed tasks in memory indefinitely.
+            try:
+                requested_ttl = float(retry_timeout) + float(retry_wait)
+            except (TypeError, ValueError):
+                log.warning(
+                    f"{self} ignoring invalid retry window headers from {self.origin}: "
+                    f"{retry_timeout!r}/{retry_wait!r}"
+                )
+            else:
+                if requested_ttl > MAX_COMPLETED_TASK_TTL:
+                    log.warning(
+                        f"{self} clamping retry window requested by {self.origin} "
+                        f"from {requested_ttl}s to {MAX_COMPLETED_TASK_TTL}s"
+                    )
+                    requested_ttl = MAX_COMPLETED_TASK_TTL
+                self.completed_task_ttl = max(self.completed_task_ttl, requested_ttl)
 
         self.stream_future = StreamFuture(self.sid, self.headers)
         self.stream_future.set_size(self.size)
@@ -276,8 +298,12 @@ class RxTask:
                         needs_ack = ack_seq != self.seq_ack or ack_offset > self.offset_ack
                 if needs_ack:
                     ack_to_send = (ack_offset, ack_seq)
+                # completed also marks the trailing and post-completion
+                # flow-control ACKs of a non-reliable stream as advisory: the
+                # non-reliable sender finishes at send-completion and never
+                # waits for them (see _send_ack).
+                self.completed = True
                 if self.reliable:
-                    self.completed = True
                     schedule_remove = True
                 else:
                     remove_now = True
@@ -332,6 +358,14 @@ class RxTask:
             self._remove_task()
 
     def _send_error(self, error_msg: str):
+        # Only a re-notification of an error that was already delivered is optional: the
+        # first error notification is required, and a failed first attempt keeps retries
+        # at ERROR (mirrors _send_ack). A retained failed task re-notifies on every
+        # retried chunk, and at job teardown those re-notifications race the sender's
+        # cells going away. As with ACKs, "delivered" means accepted by the first hop.
+        with self.ack_lock:
+            already_notified = self.error_notified
+        log_func = log.debug if already_notified else log.error
         message = Message()
 
         message.add_headers(
@@ -342,14 +376,21 @@ class RxTask:
             }
         )
         try:
-            errors = self.cell.fire_and_forget(STREAM_CHANNEL, STREAM_ACK_TOPIC, self.origin, message)
+            errors = self.cell.fire_and_forget(
+                STREAM_CHANNEL, STREAM_ACK_TOPIC, self.origin, message, optional=already_notified
+            )
         except Exception as ex:
-            log.error(f"{self} failed to send error to {self.origin}: {ex}")
+            log_func(f"{self} failed to send error to {self.origin}: {ex}")
+            return
         else:
             errors = errors or {}
             error = errors.get(self.origin)
             if error:
-                log.error(f"{self} failed to send error to {self.origin}: {error}")
+                log_func(f"{self} failed to send error to {self.origin}: {error}")
+                return
+
+        with self.ack_lock:
+            self.error_notified = True
 
     def _remove_task(self):
         with self.stop_lock:
@@ -452,11 +493,16 @@ class RxTask:
         return self.received_offset if self.completed else self.offset
 
     def _send_ack(self, offset, seq):
-        # Only a re-ACK at or behind state that was sent successfully is optional. The first final
-        # ACK is still required even though stop() has already marked the receive task completed.
+        # For a reliable stream, only a re-ACK at or behind state that was sent successfully
+        # is optional: the first final ACK is still required even though stop() has already
+        # marked the receive task completed, and a failed first attempt keeps retries at
+        # ERROR. For a non-reliable stream every ACK after completion is advisory - the
+        # sender finishes at send-completion and never waits for them. Note "already acked"
+        # means accepted by the first hop, not delivered end-to-end; a mid-route drop is
+        # still surfaced by the sender's own retry timeout.
         with self.ack_lock:
             already_acked = seq <= self.seq_ack and offset <= self.offset_ack
-        optional = self.completed and already_acked
+        optional = self.completed and (already_acked or not self.reliable)
         log_func = log.debug if optional else log.error
         message = Message()
         message.add_headers(

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -216,8 +216,10 @@ class RxTask:
             # clamp it so a bad value cannot crash the chunk handler or pin
             # completed tasks in memory indefinitely.
             try:
+                # int headers beyond the float range raise OverflowError;
+                # equivalent strings round-trip to inf and hit the clamp below
                 requested_ttl = float(retry_timeout) + float(retry_wait)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 log.warning(
                     f"{self} ignoring invalid retry window headers from {self.origin}: "
                     f"{retry_timeout!r}/{retry_wait!r}"

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -573,6 +573,9 @@ def test_non_reliable_trailing_ack_is_optional_and_debug_only(caplog):
 
     assert task.completed is True
     assert cell.fire_and_forget.call_args.kwargs == {"optional": True}
+    trailing_ack = cell.fire_and_forget.call_args.args[3]
+    assert trailing_ack.get_header(StreamHeaderKey.SEQUENCE) == 0
+    assert trailing_ack.get_header(StreamHeaderKey.OFFSET) == 3
     assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
     assert "failed to ack seq 0" in caplog.text
 
@@ -691,7 +694,10 @@ def test_overflowing_sender_retry_window_is_ignored(monkeypatch):
     assert task.completed_task_ttl == 2.0
 
 
-def test_infinite_sender_retry_window_is_clamped(monkeypatch):
+@pytest.mark.parametrize("bad_value", ["1e400", "nan"])  # inf and NaN are both non-finite
+def test_non_finite_sender_retry_window_is_ignored(monkeypatch, bad_value):
+    # NaN would bypass a plain ">" clamp check and its safety under max() is
+    # order-dependent, so non-finite windows are rejected as invalid outright
     monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 1.0)
     monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 1.0)
     cell = SimpleNamespace()
@@ -702,11 +708,110 @@ def test_infinite_sender_retry_window_is_clamped(monkeypatch):
         data_type=StreamDataType.CHUNK,
         payload=b"x",
         reliable=True,
-        retry_wait="1e400",  # string beyond float range: rounds to inf
-        retry_timeout="1e400",
+        retry_wait=bad_value,
+        retry_timeout=bad_value,
     )
     task = RxTask.find_or_create_task(message, cell)
 
     task.process_chunk(message)
 
+    assert task.completed_task_ttl == 2.0
+
+
+def test_clamp_warning_only_when_effective_window_is_lowered(monkeypatch, caplog):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 1.0)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 1.0)
+    cell = SimpleNamespace()
+    message = _make_chunk(
+        "site-1",
+        sid=538,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        payload=b"x",
+        reliable=True,
+        retry_wait=1.0,
+        retry_timeout=1e9,
+    )
+    task = RxTask.find_or_create_task(message, cell)
+
+    with caplog.at_level(logging.WARNING, logger="nvflare.fuel.f3.streaming.byte_receiver"):
+        task.process_chunk(message)
+
     assert task.completed_task_ttl == MAX_COMPLETED_TASK_TTL
+    assert "exceeds" in caplog.text and "streaming_retry_timeout" in caplog.text
+
+
+def test_clamp_is_silent_when_local_window_already_governs(monkeypatch, caplog):
+    # receiver-local config larger than both the cap and the request: the cap
+    # changes nothing, so no warning should be emitted
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 7000.0)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 5.0)
+    cell = SimpleNamespace()
+    message = _make_chunk(
+        "site-1",
+        sid=539,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        payload=b"x",
+        reliable=True,
+        retry_wait=5.0,
+        retry_timeout=5000.0,
+    )
+    task = RxTask.find_or_create_task(message, cell)
+
+    with caplog.at_level(logging.WARNING, logger="nvflare.fuel.f3.streaming.byte_receiver"):
+        task.process_chunk(message)
+
+    assert task.completed_task_ttl == 7005.0
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+
+
+def test_error_notified_transitions_after_late_successful_notification():
+    # first notification fails (stays required); a later re-notification that
+    # succeeds flips error_notified, and only then do further ones go optional
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={"site-1": "target_unreachable"}))
+    message = _make_chunk("site-1", sid=540, seq=0, data_type=StreamDataType.CHUNK, payload=b"x", reliable=True)
+    task = RxTask.find_or_create_task(message, cell)
+
+    task.stop(StreamError("stream failed"), notify=True)
+    assert task.error_notified is False
+
+    cell.fire_and_forget.return_value = {}
+    assert task.process_chunk(message) is False
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": False}
+    assert task.error_notified is True
+
+    assert task.process_chunk(message) is False
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": True}
+
+
+def test_error_renotification_exception_is_debug_only(caplog):
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
+    message = _make_chunk("site-1", sid=541, seq=0, data_type=StreamDataType.CHUNK, payload=b"x", reliable=True)
+    task = RxTask.find_or_create_task(message, cell)
+    task.stop(StreamError("stream failed"), notify=True)
+    assert task.error_notified is True
+
+    cell.fire_and_forget.side_effect = RuntimeError("connection closed")
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="nvflare.fuel.f3.streaming.byte_receiver"):
+        assert task.process_chunk(message) is False
+
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": True}
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert "connection closed" in caplog.text
+
+
+def test_stop_error_after_completion_is_noop_for_non_reliable():
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
+    message = _make_chunk("site-1", sid=542, seq=0, data_type=StreamDataType.FINAL, payload=b"abc", reliable=False)
+    task = RxTask.find_or_create_task(message, cell)
+
+    assert task.process_chunk(message) is True
+    assert task.completed is True
+    calls = cell.fire_and_forget.call_count
+
+    task.stop(StreamError("late failure"), notify=True)
+
+    assert task.failed is False
+    assert cell.fire_and_forget.call_count == calls

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -22,7 +22,7 @@ import pytest
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.message import Message
-from nvflare.fuel.f3.streaming.byte_receiver import RxStream, RxTask
+from nvflare.fuel.f3.streaming.byte_receiver import MAX_COMPLETED_TASK_TTL, RxStream, RxTask
 from nvflare.fuel.f3.streaming.stream_const import STREAM_ACK_TOPIC, STREAM_CHANNEL, StreamDataType, StreamHeaderKey
 from nvflare.fuel.f3.streaming.stream_types import StreamError
 
@@ -559,3 +559,112 @@ def test_completed_task_ttl_keeps_longer_local_retry_window(monkeypatch):
     task.process_chunk(message)
 
     assert task.completed_task_ttl == 35.0
+
+
+def test_non_reliable_trailing_ack_is_optional_and_debug_only(caplog):
+    # the non-reliable sender finishes at send-completion and never waits for
+    # the trailing ACK, so its delivery failure at teardown must not ERROR
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={"site-1": "target_unreachable"}))
+    message = _make_chunk("site-1", sid=530, seq=0, data_type=StreamDataType.FINAL, payload=b"abc", reliable=False)
+    task = RxTask.find_or_create_task(message, cell)
+
+    with caplog.at_level(logging.DEBUG, logger="nvflare.fuel.f3.streaming.byte_receiver"):
+        assert task.process_chunk(message) is True
+
+    assert task.completed is True
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": True}
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert "failed to ack seq 0" in caplog.text
+
+
+def test_non_reliable_midstream_flow_control_ack_remains_required():
+    # before completion the sender may be blocked on the flow-control window,
+    # so mid-stream ACKs stay required
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
+    task = RxTask(sid=531, origin="site-1", cell=cell, reliable=False)
+
+    assert task._send_ack(offset=10, seq=2) is True
+
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": False}
+
+
+def test_failed_task_error_renotification_is_optional_and_debug_only(caplog):
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
+    message = _make_chunk("site-1", sid=532, seq=0, data_type=StreamDataType.CHUNK, payload=b"abc", reliable=True)
+    task = RxTask.find_or_create_task(message, cell)
+
+    task.stop(StreamError("stream failed"), notify=True)
+
+    assert task.error_notified is True
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": False}
+
+    # teardown race: the sender's cells are gone when the retried chunk re-notifies
+    cell.fire_and_forget.return_value = {"site-1": "target_unreachable"}
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="nvflare.fuel.f3.streaming.byte_receiver"):
+        assert task.process_chunk(message) is False
+
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": True}
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert "failed to send error" in caplog.text
+
+
+def test_failed_first_error_notification_keeps_renotifications_required(caplog):
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={"site-1": "target_unreachable"}))
+    message = _make_chunk("site-1", sid=533, seq=0, data_type=StreamDataType.CHUNK, payload=b"abc", reliable=True)
+    task = RxTask.find_or_create_task(message, cell)
+
+    task.stop(StreamError("stream failed"), notify=True)
+
+    assert task.error_notified is False
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="nvflare.fuel.f3.streaming.byte_receiver"):
+        assert task.process_chunk(message) is False
+
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": False}
+    assert [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert "failed to send error" in caplog.text
+
+
+def test_completed_task_ttl_clamps_excessive_sender_retry_window(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 1.0)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 1.0)
+    cell = SimpleNamespace()
+    message = _make_chunk(
+        "site-1",
+        sid=534,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        payload=b"x",
+        reliable=True,
+        retry_wait=1e6,
+        retry_timeout=1e9,
+    )
+    task = RxTask.find_or_create_task(message, cell)
+
+    task.process_chunk(message)
+
+    assert task.completed_task_ttl == MAX_COMPLETED_TASK_TTL
+
+
+def test_invalid_sender_retry_window_is_ignored(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 1.0)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 1.0)
+    cell = SimpleNamespace()
+    message = _make_chunk(
+        "site-1",
+        sid=535,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        payload=b"x",
+        reliable=True,
+        retry_wait="bogus",
+        retry_timeout=20.0,
+    )
+    task = RxTask.find_or_create_task(message, cell)
+
+    # a non-numeric peer header must not crash the chunk handler
+    task.process_chunk(message)
+
+    assert task.completed_task_ttl == 2.0

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -668,3 +668,45 @@ def test_invalid_sender_retry_window_is_ignored(monkeypatch):
     task.process_chunk(message)
 
     assert task.completed_task_ttl == 2.0
+
+
+def test_overflowing_sender_retry_window_is_ignored(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 1.0)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 1.0)
+    cell = SimpleNamespace()
+    message = _make_chunk(
+        "site-1",
+        sid=536,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        payload=b"x",
+        reliable=True,
+        retry_wait=10**400,  # int beyond float range: float() raises OverflowError
+        retry_timeout=10**400,
+    )
+    task = RxTask.find_or_create_task(message, cell)
+
+    task.process_chunk(message)
+
+    assert task.completed_task_ttl == 2.0
+
+
+def test_infinite_sender_retry_window_is_clamped(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_timeout", lambda self, default: 1.0)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_wait", lambda self, default: 1.0)
+    cell = SimpleNamespace()
+    message = _make_chunk(
+        "site-1",
+        sid=537,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        payload=b"x",
+        reliable=True,
+        retry_wait="1e400",  # string beyond float range: rounds to inf
+        retry_timeout="1e400",
+    )
+    task = RxTask.find_or_create_task(message, cell)
+
+    task.process_chunk(message)
+
+    assert task.completed_task_ttl == MAX_COMPLETED_TASK_TTL


### PR DESCRIPTION
### Description

Follow-ups from the [post-merge three-perspective review of #4844](https://github.com/NVIDIA/NVFlare/pull/4844#issuecomment-4877282265), addressing the three actionable findings plus the suggested doc comment:

1. **`_send_error` teardown race** — retained failed reliable tasks re-notify the sender on every retried chunk; when those re-notifications race job teardown they produced the same spurious `cannot forward req: no path` ERRORs that #4844 fixed for re-ACKs. `_send_error` now mirrors `_send_ack`: a re-notification of an error already accepted by the first hop is sent with `optional=True` and its delivery failure logged at DEBUG. The first notification stays required at ERROR, and a failed first attempt keeps retries at ERROR.
2. **Non-reliable streams covered** — `stop()` now marks non-reliable tasks completed, and every post-completion ACK of a non-reliable stream is advisory: the non-reliable sender finishes at send-completion and never waits for the trailing/flow-control ACKs (verified in `byte_streamer.py` — the window wait only gates mid-stream sends). Mid-stream flow-control ACKs remain required, since the sender may be blocked on the window.
3. **Peer-controlled task TTL clamped and validated** — `_handle_new_stream` no longer trusts the sender's `RETRY_TIMEOUT`/`RETRY_WAIT` headers blindly: non-numeric values are ignored with a warning instead of raising `float()` errors inside the chunk handler, and the requested retry window is clamped to `MAX_COMPLETED_TASK_TTL` (1h) so a malicious peer cannot pin completed `RxTask`s in memory indefinitely across arbitrary SIDs.
4. **Doc comment** — `_send_ack`/`_send_error` now document that "already acked/notified" means accepted by the first hop, not delivered end-to-end, and that a mid-route drop is still surfaced by the sender's own retry timeout.

### Tests

The new unit tests in `byte_receiver_test.py` (bringing the file to 39, all passing, plus black/isort/flake8) pin: non-reliable trailing ACK optional + DEBUG-only failure with its OFFSET/SEQUENCE headers, non-reliable mid-stream ACK still required, error re-notification optional + DEBUG-only after a delivered first notification (including the exception path), retries still required after a failed first notification, the `error_notified` success-after-failure transition, `stop(error)`-after-completion as a no-op, TTL clamping and its warning conditions, and non-numeric / overflowing / non-finite retry headers neither crashing the handler nor bypassing the clamp.

NVBug: 6389772 (follow-up; original fix merged in #4844)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
