### PR TITLE
Download CIFAR-10 from a mirror first in integration test prep

### DIFF
--- a/tests/integration_test/tools/prepare_cifar10.py
+++ b/tests/integration_test/tools/prepare_cifar10.py
@@ -29,6 +29,9 @@ except ImportError:  # pragma: no cover - fcntl is available on CI Linux/macOS.
 DEFAULT_CACHE_ROOT = "/tmp/nvf-test-data"
 CIFAR10_DIR_NAME = "cifar-10-batches-py"
 
+# This archive matches torchvision's CIFAR10 MD5; torchvision's default host is unreliable in CI.
+DEFAULT_DOWNLOAD_URL = "https://zenodo.org/records/15602362/files/cifar-10-python.tar.gz?download=1"
+
 
 def _normalize_path(path: str) -> str:
     return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
@@ -65,9 +68,20 @@ def _is_valid_cifar10_root(root: str) -> bool:
 def _download_cifar10(root: str):
     from torchvision.datasets import CIFAR10
 
+    urls = [os.environ.get("NVFLARE_CIFAR10_URL", DEFAULT_DOWNLOAD_URL), CIFAR10.url]
     print(f"Preparing CIFAR-10 cache at {root}")
-    CIFAR10(root=root, train=True, download=True)
-    CIFAR10(root=root, train=False, download=True)
+    last_error = None
+    for url in dict.fromkeys(urls):
+        CIFAR10.url = url
+        try:
+            CIFAR10(root=root, train=True, download=True)
+            CIFAR10(root=root, train=False, download=True)
+            break
+        except Exception as download_error:
+            print(f"CIFAR-10 download from {url} failed: {download_error}")
+            last_error = download_error
+    else:
+        raise RuntimeError("CIFAR-10 download failed from all sources") from last_error
 
     if not _is_valid_cifar10_root(root):
         raise RuntimeError(f"CIFAR-10 cache at {root} failed integrity validation")

--- a/tests/integration_test/tools/prepare_cifar10.py
+++ b/tests/integration_test/tools/prepare_cifar10.py
@@ -68,20 +68,24 @@ def _is_valid_cifar10_root(root: str) -> bool:
 def _download_cifar10(root: str):
     from torchvision.datasets import CIFAR10
 
-    urls = [os.environ.get("NVFLARE_CIFAR10_URL", DEFAULT_DOWNLOAD_URL), CIFAR10.url]
+    original_url = CIFAR10.url
+    urls = [os.environ.get("NVFLARE_CIFAR10_URL") or DEFAULT_DOWNLOAD_URL, original_url]
     print(f"Preparing CIFAR-10 cache at {root}")
     last_error = None
-    for url in dict.fromkeys(urls):
-        CIFAR10.url = url
-        try:
-            CIFAR10(root=root, train=True, download=True)
-            CIFAR10(root=root, train=False, download=True)
-            break
-        except Exception as download_error:
-            print(f"CIFAR-10 download from {url} failed: {download_error}")
-            last_error = download_error
-    else:
-        raise RuntimeError("CIFAR-10 download failed from all sources") from last_error
+    try:
+        for url in dict.fromkeys(urls):
+            CIFAR10.url = url
+            try:
+                CIFAR10(root=root, train=True, download=True)
+                CIFAR10(root=root, train=False, download=True)
+                break
+            except Exception as download_error:
+                print(f"CIFAR-10 download from {url} failed: {download_error}")
+                last_error = download_error
+        else:
+            raise RuntimeError("CIFAR-10 download failed from all sources") from last_error
+    finally:
+        CIFAR10.url = original_url
 
     if not _is_valid_cifar10_root(root):
         raise RuntimeError(f"CIFAR-10 cache at {root} failed integrity validation")


### PR DESCRIPTION
### Description

The torchvision default CIFAR-10 host (`www.cs.toronto.edu`) has been degrading since 2026-06-23 and currently times out entirely — it now 301-redirects to `cave.cs.toronto.edu`, which does not accept connections (see pytorch/vision#9536). This fails every CIFAR-dependent nightly integration stage (`client_api`, `client_api_qa`, `model_controller_api`, `pytorch`, `cifar`) in `prepare_cifar10.py`, before any test runs.

This PR makes the CIFAR-10 prep mirror-aware:

- Try a Zenodo mirror of the byte-identical archive first (Zenodo records are immutable and DOI-backed).
- Fall back to the torchvision default URL if the mirror fails.
- Allow overriding the primary source via `NVFLARE_CIFAR10_URL` (e.g., for an internal mirror) — config-only, no code change needed later.

torchvision's built-in MD5 validation applies to every source, so integrity is unchanged.

### Verification

- Downloaded the full archive from the Zenodo URL: MD5 is `c58f30108f718f92721af3b95e74349a`, an exact match for torchvision's expected `tgz_md5` (size also matches: 170,498,071 bytes).
- Hermetic test of the retry logic (fake torchvision module): mirror-first with upstream never contacted, fallback on mirror failure, chained error when all sources fail, env-override priority, and URL dedup all pass.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
