### PR TITLE
Add recipe-k8s example: submit a Recipe job to clients in two Kubernetes clusters

### DIFF
--- a/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
@@ -145,6 +145,33 @@ prepared chart's workspace PVC name, creates the namespace and PVCs, stages
 at ``workspace_mount_path``, installs the Helm chart, and prints recent pod
 logs.
 
+Submit a Recipe Job
+===================
+
+After all three participants are running, submit the NumPy Recipe example from
+the same local NVFlare checkout used to prepare the startup kits. Find the
+latest admin startup directory, then pass the image that all three Brev
+clusters can pull:
+
+.. code-block:: shell
+
+   ADMIN_KIT="$(find /tmp/nvflare/brev-provision/brev_nvflare_project \
+     -path '*/admin@nvidia.com/startup' -type d | sort | tail -n 1)"
+
+   cd examples/advanced/recipe-k8s
+   python3 job.py \
+     --startup-kit "$ADMIN_KIT" \
+     --site-1-image "$IMAGE" \
+     --site-2-image "$IMAGE" \
+     --server-image "$IMAGE"
+
+The ``--server-image`` argument is needed here because this quickstart prepares
+the server with ``ServerK8sJobLauncher`` as well as preparing both clients with
+``ClientK8sJobLauncher``. The example targets the two clients explicitly and
+uses ``set_recipe_meta`` to add their scheduler-facing ``resource_spec`` and
+Kubernetes ``launcher_spec`` entries. See the
+:github_nvflare_link:`complete example and metadata explanation <examples/advanced/recipe-k8s>`.
+
 Useful Overrides
 ================
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -307,6 +307,12 @@ The helper does not validate runtime resource availability, production
 enrollment, or whether sites named in metadata are present for a run. The
 execution environment and deployment still determine which sites are present.
 
+For a complete production example, see the
+:github_nvflare_link:`Recipe job on Kubernetes clients <examples/advanced/recipe-k8s>`.
+It uses ``ProdEnv`` to submit to ``site-1`` and ``site-2`` in separate
+Kubernetes clusters, keeps GPU requirements in ``resource_spec``, and places
+the per-cluster job images and container settings in ``launcher_spec``.
+
 Execution Environments
 ----------------------
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -185,6 +185,7 @@ When you open a notebook, select the kernel `nvflare_example` using the dropdown
 | Example                                                     | Framework | Summary                                                                                                                  |
 |-------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
 | [Docker Job Launcher](./docker/README.md)                   | NA        | End-to-end Docker runtime example using `nvflare deploy prepare` and per-job Docker containers. |
+| [Recipe Job on Kubernetes Clients](./advanced/recipe-k8s/README.md) | NumPy | Submit a Recipe API job to two NVFlare clients running in separate Kubernetes clusters with per-site resource and launcher metadata. |
 | [OpenShift Deployment](./devops/openshift/README.md)        | NA        | OpenShift-specific deployment guide and helper scripts using the Kubernetes runtime support. |
 | [DevOps Deployment Examples](./devops/README.md)            | NA        | Test-only helper scripts for trying NVFlare deployment flows on Kubernetes and managed cloud clusters; not production deployment guidance. |
 | [Monitoring](./advanced/monitoring/README.md)               | NA        | FLARE Monitoring provides an initial solution for tracking system metrics of your federated learning jobs. |

--- a/examples/advanced/recipe-k8s/README.md
+++ b/examples/advanced/recipe-k8s/README.md
@@ -1,0 +1,156 @@
+# Submit a Recipe Job to Two Kubernetes Clients
+
+> **Development Branch Notice**
+> This example uses `set_recipe_meta`, part of the NVFlare 2.9 Recipe API. The
+> `requirements.txt` file pins the first upcoming NVFlare release that supports
+> it. Until that package is published on PyPI, install NVFlare from this
+> repository instead of changing the pin to an older release.
+
+This example submits one NumPy FedAvg job to an existing production NVFlare
+system with one server and two clients. The clients, `site-1` and `site-2`, run
+in separate Kubernetes clusters and use `ClientK8sJobLauncher` to create a job
+pod in their respective cluster.
+
+```text
+workstation (job.py + ProdEnv)
+             |
+        NVFlare server
+          /       \
+ site-1 parent   site-2 parent
+ K8s cluster A  K8s cluster B
+      |               |
+ site-1 job pod  site-2 job pod
+```
+
+The client-only metadata assumes that the server site uses a process job
+launcher. If the server instead uses `ServerK8sJobLauncher`, pass
+`--server-image` so its job pod has an image specification too. Launcher
+selection itself remains a site runtime policy.
+
+## What the Example Demonstrates
+
+[`job.py`](job.py) uses `set_recipe_meta` twice:
+
+- `JobMetaKey.RESOURCE_SPEC` supplies scheduler-facing resource requirements
+  for each client. The CPU demo requests zero GPUs by default; use
+  `--site-1-gpus` and `--site-2-gpus` for GPU jobs.
+- `JobMetaKey.JOB_LAUNCHER_SPEC` supplies each client's Kubernetes job image,
+  Python path, CPU, memory, and ephemeral storage. This enum value is written
+  to generated `meta.json` as `launcher_spec`, not `job_launcher_spec`.
+
+The client site names are provisioned NVFlare participant identities, not
+Kubernetes cluster names. No kubeconfig, namespace, or cluster endpoint belongs
+in the job metadata. Each long-running client parent already has the launcher
+configuration and credentials for its own cluster. The participant name
+`default` cannot be used here because it is reserved for shared launcher
+settings.
+
+The recipe also passes
+`per_site_config={"site-1": {}, "site-2": {}}`. Those entries target the two
+client apps explicitly. Resource and launcher metadata alone do not change a
+recipe's deployment map.
+
+## Prerequisites
+
+- A running production NVFlare system with one server and two provisioned
+  clients whose names match `--site-1-name` and `--site-2-name`.
+- Each client configured with `ClientK8sJobLauncher`, including namespace,
+  workspace storage, ServiceAccount, and RBAC for creating job pods and startup
+  Secrets. NVFlare allows exactly one job launcher per site, so the Kubernetes
+  launcher must replace the default process launcher rather than be added
+  alongside it; `nvflare deploy prepare` handles this. See the
+  [Kubernetes Helm deployment guide](../../../docs/user_guide/admin_guide/deployment/helm_chart.rst).
+- An admin startup kit on the workstation running `job.py`.
+- Site authorization policies that permit submitted custom code (BYOC), since
+  the recipe bundles `client.py` with the job.
+- A job image for each cluster. Each image must contain a compatible NVFlare
+  installation and NumPy, and must be pullable from that cluster. The two image
+  arguments may point to different registries. The recipe bundles `client.py`
+  into the submitted job, so the training script need not be baked into the
+  images.
+
+The [Brev scripted deployment quickstart](../../../docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst)
+creates this exact `server`, `site-1`, and `site-2` topology across three
+independent Kubernetes environments.
+
+## Install
+
+From the repository root, install the current source while NVFlare 2.9 is not
+yet published:
+
+```bash
+python3 -m pip install -e .
+```
+
+After the pinned release is available, the example dependencies can instead be
+installed normally:
+
+```bash
+python3 -m pip install -r examples/advanced/recipe-k8s/requirements.txt
+```
+
+The same compatible NVFlare version must be present in the server and client
+job images.
+
+## Submit and Monitor the Job
+
+Run from the example directory so the recipe can bundle the relative
+`client.py` training script with a path that is also portable inside the job
+pods:
+
+```bash
+cd examples/advanced/recipe-k8s
+
+python3 job.py \
+  --startup-kit /path/to/admin/startup \
+  --site-1-image registry-a.example.com/nvflare-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-job:2.9
+```
+
+`ProdEnv` submits the generated job through the admin startup kit. The script
+prints the job ID, monitors the job until completion, downloads the result, and
+prints the final status and result path.
+
+For clients with different participant names or resource needs:
+
+```bash
+python3 job.py \
+  --startup-kit /path/to/admin/startup \
+  --site-1-name hospital-a \
+  --site-2-name hospital-b \
+  --site-1-image registry-a.example.com/nvflare-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-job:2.9 \
+  --site-1-gpus 1 \
+  --site-2-gpus 2 \
+  --site-1-cpu 4 \
+  --site-2-cpu 8 \
+  --site-1-memory 16Gi \
+  --site-2-memory 32Gi
+```
+
+If the server is also prepared with `ServerK8sJobLauncher`, add an image that
+its cluster can pull:
+
+```bash
+  --server-image registry-server.example.com/nvflare-job:2.9
+```
+
+## Inspect Without Submitting
+
+Recipe export uses the same metadata-building path without connecting to the
+NVFlare server. The startup-kit argument must still name an existing directory
+because `ProdEnv` validates it during construction:
+
+```bash
+python3 job.py \
+  --startup-kit /path/to/admin/startup \
+  --site-1-image registry-a.example.com/nvflare-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-job:2.9 \
+  --export --export-dir /tmp/nvflare-recipe-job
+
+python3 -m json.tool /tmp/nvflare-recipe-job/hello-numpy-k8s/meta.json
+```
+
+The exported metadata contains flat per-site GPU requests under
+`resource_spec` and per-site Kubernetes container settings under
+`launcher_spec`.

--- a/examples/advanced/recipe-k8s/client.py
+++ b/examples/advanced/recipe-k8s/client.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nvflare.client as flare
+from nvflare.app_common.np.constants import NPConstants
+
+
+def main() -> None:
+    flare.init()
+    site_name = flare.system_info()["site_name"]
+
+    while flare.is_running():
+        input_model = flare.receive()
+        input_weights = input_model.params[NPConstants.NUMPY_KEY]
+
+        # Stand in for local training with a deterministic update.
+        output_weights = input_weights + 1
+        weight_mean = float(np.mean(output_weights))
+        print(
+            f"site={site_name} round={input_model.current_round} weight_mean={weight_mean:.4f}",
+            flush=True,
+        )
+
+        flare.send(
+            flare.FLModel(
+                params={NPConstants.NUMPY_KEY: output_weights},
+                params_type=flare.ParamsType.FULL,
+                metrics={"weight_mean": weight_mean},
+                current_round=input_model.current_round,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/recipe-k8s/job.py
+++ b/examples/advanced/recipe-k8s/job.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+from nvflare.apis.job_def import JobMetaKey
+from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+from nvflare.recipe import ProdEnv, set_recipe_meta
+
+
+def non_negative_int(value: str) -> int:
+    value = int(value)
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return value
+
+
+def define_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Submit a NumPy FedAvg recipe to two NVFlare clients that use Kubernetes job launchers."
+    )
+    parser.add_argument("--startup-kit", required=True, help="Path to the production admin startup directory.")
+    parser.add_argument("--username", default="admin@nvidia.com", help="Provisioned admin participant name.")
+    parser.add_argument("--study", default="default", help="Study in which to submit the job.")
+    parser.add_argument("--job-name", default="hello-numpy-k8s")
+    parser.add_argument("--num-rounds", type=int, default=3)
+
+    parser.add_argument("--site-1-name", default="site-1", help="First provisioned NVFlare client name.")
+    parser.add_argument("--site-2-name", default="site-2", help="Second provisioned NVFlare client name.")
+    parser.add_argument("--site-1-image", required=True, help="Job image pullable by the first client's cluster.")
+    parser.add_argument("--site-2-image", required=True, help="Job image pullable by the second client's cluster.")
+    parser.add_argument("--site-1-gpus", type=non_negative_int, default=0)
+    parser.add_argument("--site-2-gpus", type=non_negative_int, default=0)
+    parser.add_argument("--site-1-cpu", default="1", help="Kubernetes CPU limit for the first client job pod.")
+    parser.add_argument("--site-2-cpu", default="1", help="Kubernetes CPU limit for the second client job pod.")
+    parser.add_argument("--site-1-memory", default="2Gi", help="Memory limit for the first client job pod.")
+    parser.add_argument("--site-2-memory", default="2Gi", help="Memory limit for the second client job pod.")
+
+    parser.add_argument("--python-path", default="/usr/local/bin/python3", help="Python executable in the job images.")
+    parser.add_argument("--ephemeral-storage", default="2Gi", help="Workspace storage for each Kubernetes job pod.")
+    parser.add_argument(
+        "--server-image",
+        help=(
+            "Job image for a server that also uses a Kubernetes job launcher. "
+            "Omit this when the server uses the process launcher."
+        ),
+    )
+    return parser
+
+
+def k8s_launcher_spec(image: str, cpu: str, memory: str, python_path: str, ephemeral_storage: str) -> dict:
+    return {
+        "image": image,
+        "python_path": python_path,
+        "cpu": cpu,
+        "memory": memory,
+        "ephemeral_storage": ephemeral_storage,
+    }
+
+
+def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
+    if args.site_1_name == args.site_2_name:
+        raise ValueError("--site-1-name and --site-2-name must identify different clients")
+    if "default" in (args.site_1_name, args.site_2_name):
+        raise ValueError("client name 'default' is reserved for shared launcher settings")
+    if args.num_rounds < 1:
+        raise ValueError("--num-rounds must be greater than 0")
+
+    client_sites = (args.site_1_name, args.site_2_name)
+    recipe = NumpyFedAvgRecipe(
+        name=args.job_name,
+        model=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        min_clients=len(client_sites),
+        num_rounds=args.num_rounds,
+        train_script="client.py",
+        # Explicit per-site entries target these two clients. Recipe metadata
+        # describes resources and launchers; it does not select deploy targets.
+        per_site_config={site_name: {} for site_name in client_sites},
+        key_metric="weight_mean",
+    )
+
+    # Scheduler-facing resource requirements stay separate from Kubernetes
+    # container settings. K8sJobLauncher maps num_of_gpus to nvidia.com/gpu.
+    set_recipe_meta(
+        recipe,
+        JobMetaKey.RESOURCE_SPEC,
+        {
+            args.site_1_name: {"num_of_gpus": args.site_1_gpus},
+            args.site_2_name: {"num_of_gpus": args.site_2_gpus},
+        },
+    )
+
+    launcher_spec = {
+        args.site_1_name: {
+            "k8s": k8s_launcher_spec(
+                args.site_1_image,
+                args.site_1_cpu,
+                args.site_1_memory,
+                args.python_path,
+                args.ephemeral_storage,
+            )
+        },
+        args.site_2_name: {
+            "k8s": k8s_launcher_spec(
+                args.site_2_image,
+                args.site_2_cpu,
+                args.site_2_memory,
+                args.python_path,
+                args.ephemeral_storage,
+            )
+        },
+    }
+    if args.server_image:
+        # The server's provisioned identity may not literally be "server".
+        # A default supplies its K8s image while the client blocks above keep
+        # their cluster-specific images and settings.
+        launcher_spec["default"] = {
+            "k8s": k8s_launcher_spec(
+                args.server_image,
+                "1",
+                "2Gi",
+                args.python_path,
+                args.ephemeral_storage,
+            )
+        }
+
+    set_recipe_meta(recipe, JobMetaKey.JOB_LAUNCHER_SPEC, launcher_spec)
+    return recipe
+
+
+def main() -> None:
+    args = define_parser().parse_args()
+    recipe = create_recipe(args)
+    env = ProdEnv(
+        startup_kit_location=args.startup_kit,
+        username=args.username,
+        study=args.study,
+    )
+
+    run = recipe.execute(env)
+    print(f"Job ID: {run.get_job_id()}")
+    result = run.get_result()
+    print(f"Job status: {run.get_status()}")
+    print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/recipe-k8s/requirements.txt
+++ b/examples/advanced/recipe-k8s/requirements.txt
@@ -1,0 +1,2 @@
+nvflare~=2.9.0rc
+numpy


### PR DESCRIPTION
## Summary

- Add a self-contained NumPy FedAvg Recipe example for one NVFlare server and two clients running in separate Kubernetes clusters.
- Target the exact client identities through `per_site_config`.
- Use `set_recipe_meta` for flat, scheduler-facing `resource_spec` GPU requirements and per-site `launcher_spec.k8s` pod settings.
- Support different client registries and an optional shared server image for `ServerK8sJobLauncher`.
- Document prerequisites, BYOC authorization, export/submission commands, and the existing Brev three-cluster topology.
- Link the example from the Recipe guide and examples index.

## Why

Recipe users need a complete production submission example that keeps resource scheduling metadata separate from Kubernetes launcher configuration. The example also makes clear that cluster credentials and endpoints belong to each site's prepared runtime, while job metadata is keyed by NVFlare participant identity.

## User impact

Users can adapt one runnable `ProdEnv` script to submit a job to two Kubernetes-backed clients, including clients that pull images from different registries or request different CPU, memory, storage, and GPU resources.

## Validation

- Exported the recipe with client-only and Kubernetes-server configurations.
- Verified `meta.json` resource, launcher, and deploy-map entries.
- Verified both client apps bundle `client.py` and use the portable `task_script_path: "client.py"`.
- `python3 -m pytest -q tests/unit_test/recipe/utils_test.py` — 56 passed.
- Scoped Black, isort, flake8, Python compilation, and license checks passed.
- Sphinx dummy documentation build completed with existing repository warnings.
- A live Kubernetes submission was not run because no active NVFlare Kubernetes system was available.
