### PR TITLE
Add recipe-k8s example: submit a Recipe job to clients in two k8s clusters

### DIFF
--- a/docker/Dockerfile.job
+++ b/docker/Dockerfile.job
@@ -21,7 +21,7 @@ RUN mkdir -p /usr/local/bin \
     && ln -sf /usr/bin/python /usr/local/bin/python3 \
     && python -m pip install --ignore-installed "PyYAML>=6.0" \
     && NVFL_RELEASE=1 python -m pip install "." \
-    && python -c "import nvflare; import torch"
+    && python -c "import nvflare; import torch; import torchvision"
 
 WORKDIR /app
 

--- a/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
@@ -145,6 +145,33 @@ prepared chart's workspace PVC name, creates the namespace and PVCs, stages
 at ``workspace_mount_path``, installs the Helm chart, and prints recent pod
 logs.
 
+Submit a Recipe Job
+===================
+
+After all three participants are running, submit the NumPy Recipe example from
+the same local NVFlare checkout used to prepare the startup kits. Find the
+latest admin startup directory, then pass the image that all three Brev
+clusters can pull:
+
+.. code-block:: shell
+
+   ADMIN_KIT="$(find /tmp/nvflare/brev-provision/brev_nvflare_project \
+     -path '*/admin@nvidia.com/startup' -type d | sort | tail -n 1)"
+
+   cd examples/advanced/recipe-k8s
+   python3 job.py \
+     --startup-kit "$ADMIN_KIT" \
+     --site-1-image "$IMAGE" \
+     --site-2-image "$IMAGE" \
+     --server-image "$IMAGE"
+
+The ``--server-image`` argument is needed here because this quickstart prepares
+the server with ``ServerK8sJobLauncher`` as well as preparing both clients with
+``ClientK8sJobLauncher``. The example targets the two clients explicitly and
+uses ``set_recipe_meta`` to add their scheduler-facing ``resource_spec`` and
+Kubernetes ``launcher_spec`` entries. See the
+:github_nvflare_link:`complete example and metadata explanation <examples/advanced/recipe-k8s>`.
+
 Useful Overrides
 ================
 

--- a/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst
@@ -70,21 +70,34 @@ Before running the scripts, have:
 * three running Brev Kubernetes environments for ``server``, ``site-1``, and
   ``site-2``;
 * a DNS name or IP for the server that both sites can reach;
-* an NVFlare container image that all three environments can pull;
+* an NVFlare parent container image that all three environments can pull;
+* a PyTorch NVFlare job image that all three environments can pull;
 * the Brev CLI installed and logged in on your local workstation.
 
 Prepare and Copy Kits
 =====================
 
-From your local NVFlare checkout, set the server host and image, then run the
-prepare script:
+From your local NVFlare checkout, set the server host, parent image, and
+PyTorch workload image. The maintained Dockerfiles can build the two images;
+push them to a registry that all three environments can pull from:
 
 .. code-block:: shell
 
    export SERVER_HOST=server1.example.com
-   export IMAGE=registry.example.com/nvflare:dev
+   export IMAGE=registry.example.com/nvflare-parent:dev
+   export JOB_IMAGE=registry.example.com/nvflare-job:dev
+
+   docker build -t "$IMAGE" -f docker/Dockerfile.parent .
+   docker build -t "$JOB_IMAGE" -f docker/Dockerfile.job .
+   docker push "$IMAGE"
+   docker push "$JOB_IMAGE"
 
    bash docs/user_guide/admin_guide/deployment/brev_scripts/prepare_brev_startup_kits.sh
+
+``IMAGE`` runs the long-lived parent processes and includes the Kubernetes
+launcher dependencies. ``JOB_IMAGE`` runs the submitted CIFAR-10 workloads and
+includes PyTorch and torchvision. They may be the same custom image only when
+that image satisfies both sets of requirements.
 
 By default, the script copies kits to Brev environments named ``server``,
 ``site-1``, and ``site-2``.
@@ -148,10 +161,10 @@ logs.
 Submit a Recipe Job
 ===================
 
-After all three participants are running, submit the NumPy Recipe example from
-the same local NVFlare checkout used to prepare the startup kits. Find the
-latest admin startup directory, then pass the image that all three Brev
-clusters can pull:
+After all three participants are running, submit the PyTorch CIFAR-10 Recipe
+example from the same local NVFlare checkout used to prepare the startup kits.
+Find the latest admin startup directory, then pass the workload image that all
+three Brev clusters can pull:
 
 .. code-block:: shell
 
@@ -161,9 +174,8 @@ clusters can pull:
    cd examples/advanced/recipe-k8s
    python3 job.py \
      --startup-kit "$ADMIN_KIT" \
-     --site-1-image "$IMAGE" \
-     --site-2-image "$IMAGE" \
-     --server-image "$IMAGE"
+     --image "$JOB_IMAGE" \
+     --server-image "$JOB_IMAGE"
 
 The ``--server-image`` argument is needed here because this quickstart prepares
 the server with ``ServerK8sJobLauncher`` as well as preparing both clients with

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -307,6 +307,12 @@ The helper does not validate runtime resource availability, production
 enrollment, or whether sites named in metadata are present for a run. The
 execution environment and deployment still determine which sites are present.
 
+For a complete production example, see the
+:github_nvflare_link:`Recipe job on Kubernetes clients <examples/advanced/recipe-k8s>`.
+It uses ``ProdEnv`` to submit to ``site-1`` and ``site-2`` in separate
+Kubernetes clusters, keeps GPU requirements in ``resource_spec``, and places
+the per-cluster job images and container settings in ``launcher_spec``.
+
 Execution Environments
 ----------------------
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -309,9 +309,10 @@ execution environment and deployment still determine which sites are present.
 
 For a complete production example, see the
 :github_nvflare_link:`Recipe job on Kubernetes clients <examples/advanced/recipe-k8s>`.
-It uses ``ProdEnv`` to submit to ``site-1`` and ``site-2`` in separate
-Kubernetes clusters, keeps GPU requirements in ``resource_spec``, and places
-the per-cluster job images and container settings in ``launcher_spec``.
+It uses ``ProdEnv`` to submit a PyTorch CIFAR-10 job to ``site-1`` and
+``site-2`` in separate Kubernetes clusters, keeps GPU requirements in
+``resource_spec``, and places the per-cluster job images and container
+settings in ``launcher_spec``.
 
 Execution Environments
 ----------------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -185,6 +185,7 @@ When you open a notebook, select the kernel `nvflare_example` using the dropdown
 | Example                                                     | Framework | Summary                                                                                                                  |
 |-------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
 | [Docker Job Launcher](./docker/README.md)                   | NA        | End-to-end Docker runtime example using `nvflare deploy prepare` and per-job Docker containers. |
+| [Recipe Job on Kubernetes Clients](./advanced/recipe-k8s/README.md) | NumPy | Submit a Recipe API job to two NVFlare clients running in separate Kubernetes clusters with per-site resource and launcher metadata. |
 | [OpenShift Deployment](./devops/openshift/README.md)        | NA        | OpenShift-specific deployment guide and helper scripts using the Kubernetes runtime support. |
 | [DevOps Deployment Examples](./devops/README.md)            | NA        | Test-only helper scripts for trying NVFlare deployment flows on Kubernetes and managed cloud clusters; not production deployment guidance. |
 | [Monitoring](./advanced/monitoring/README.md)               | NA        | FLARE Monitoring provides an initial solution for tracking system metrics of your federated learning jobs. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -185,7 +185,7 @@ When you open a notebook, select the kernel `nvflare_example` using the dropdown
 | Example                                                     | Framework | Summary                                                                                                                  |
 |-------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
 | [Docker Job Launcher](./docker/README.md)                   | NA        | End-to-end Docker runtime example using `nvflare deploy prepare` and per-job Docker containers. |
-| [Recipe Job on Kubernetes Clients](./advanced/recipe-k8s/README.md) | NumPy | Submit a Recipe API job to two NVFlare clients running in separate Kubernetes clusters with per-site resource and launcher metadata. |
+| [Recipe Job on Kubernetes Clients](./advanced/recipe-k8s/README.md) | PyTorch | Train CIFAR-10 through the Recipe API on two NVFlare clients in separate Kubernetes clusters with per-site resource and launcher metadata. |
 | [OpenShift Deployment](./devops/openshift/README.md)        | NA        | OpenShift-specific deployment guide and helper scripts using the Kubernetes runtime support. |
 | [DevOps Deployment Examples](./devops/README.md)            | NA        | Test-only helper scripts for trying NVFlare deployment flows on Kubernetes and managed cloud clusters; not production deployment guidance. |
 | [Monitoring](./advanced/monitoring/README.md)               | NA        | FLARE Monitoring provides an initial solution for tracking system metrics of your federated learning jobs. |

--- a/examples/advanced/recipe-k8s/README.md
+++ b/examples/advanced/recipe-k8s/README.md
@@ -129,10 +129,13 @@ python3 job.py \
 ```
 
 If the server is also prepared with `ServerK8sJobLauncher`, add an image that
-its cluster can pull:
+its cluster can pull. The server pod defaults to one CPU and `2Gi` of memory;
+override those values with `--server-cpu` and `--server-memory`:
 
 ```bash
-  --server-image registry-server.example.com/nvflare-job:2.9
+  --server-image registry-server.example.com/nvflare-job:2.9 \
+  --server-cpu 4 \
+  --server-memory 8Gi
 ```
 
 ## Inspect Without Submitting
@@ -140,6 +143,12 @@ its cluster can pull:
 Recipe export uses the same metadata-building path without connecting to the
 NVFlare server. The startup-kit argument must still name an existing directory
 because `ProdEnv` validates it during construction:
+
+`--export` and `--export-dir` are standard Recipe API flags. The
+`nvflare.recipe` package consumes them before `job.py` parses its
+example-specific arguments, and `recipe.execute()` exports instead of calling
+`ProdEnv.deploy()`. They therefore do not appear as arguments in
+`define_parser()`.
 
 ```bash
 python3 job.py \

--- a/examples/advanced/recipe-k8s/README.md
+++ b/examples/advanced/recipe-k8s/README.md
@@ -1,0 +1,156 @@
+# Submit a Recipe Job to Two Kubernetes Clients
+
+> **Development Branch Notice**
+> This example uses `set_recipe_meta`, part of the NVFlare 2.9 Recipe API. The
+> `requirements.txt` file pins the first upcoming NVFlare release that supports
+> it. Until that package is published on PyPI, install NVFlare from this
+> repository instead of changing the pin to an older release.
+
+This example submits one NumPy FedAvg job to an existing production NVFlare
+system with one server and two clients. The clients, `site-1` and `site-2`, run
+in separate Kubernetes clusters and use `ClientK8sJobLauncher` to create a job
+pod in their respective cluster.
+
+```text
+workstation (job.py + ProdEnv)
+             |
+        NVFlare server
+          /       \
+ site-1 parent   site-2 parent
+ K8s cluster A  K8s cluster B
+      |               |
+ site-1 job pod  site-2 job pod
+```
+
+The client-only metadata assumes that the server site uses a process job
+launcher. If the server instead uses `ServerK8sJobLauncher`, pass
+`--server-image` so its job pod has an image specification too. Launcher
+selection itself remains a site runtime policy.
+
+## What the Example Demonstrates
+
+[`job.py`](job.py) uses `set_recipe_meta` twice:
+
+- `JobMetaKey.RESOURCE_SPEC` supplies scheduler-facing resource requirements
+  for each client. The CPU demo requests zero GPUs by default; use
+  `--site-1-gpus` and `--site-2-gpus` for GPU jobs.
+- `JobMetaKey.JOB_LAUNCHER_SPEC` supplies each client's Kubernetes job image,
+  Python path, CPU, memory, and ephemeral storage. This enum value is written
+  to generated `meta.json` as `launcher_spec`, not `job_launcher_spec`.
+
+The client site names are provisioned NVFlare participant identities, not
+Kubernetes cluster names. No kubeconfig, namespace, or cluster endpoint belongs
+in the job metadata. Each long-running client parent already has the launcher
+configuration and credentials for its own cluster. The participant name
+`default` cannot be used here because it is reserved for shared launcher
+settings.
+
+The recipe also passes
+`per_site_config={"site-1": {}, "site-2": {}}`. Those entries target the two
+client apps explicitly. Resource and launcher metadata alone do not change a
+recipe's deployment map.
+
+## Prerequisites
+
+- A running production NVFlare system with one server and two provisioned
+  clients whose names match `--site-1-name` and `--site-2-name`.
+- Each client configured with `ClientK8sJobLauncher`, including namespace,
+  workspace storage, ServiceAccount, and RBAC for creating job pods and startup
+  Secrets. NVFlare allows exactly one job launcher per site, so the Kubernetes
+  launcher must replace the default process launcher rather than be added
+  alongside it; `nvflare deploy prepare` handles this. See the
+  [Kubernetes Helm deployment guide](../../../docs/user_guide/admin_guide/deployment/helm_chart.rst).
+- An admin startup kit on the workstation running `job.py`.
+- Site authorization policies that permit submitted custom code (BYOC), since
+  the recipe bundles `client.py` with the job.
+- A job image for each cluster. Each image must contain a compatible NVFlare
+  installation and NumPy, and must be pullable from that cluster. The two image
+  arguments may point to different registries. The recipe bundles `client.py`
+  into the submitted job, so the training script need not be baked into the
+  images.
+
+The [Brev scripted deployment quickstart](../../../docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst)
+creates this exact `server`, `site-1`, and `site-2` topology across three
+independent Kubernetes environments.
+
+## Install
+
+From the repository root, install the current source while NVFlare 2.9 is not
+yet published:
+
+```bash
+python3 -m pip install -e .
+```
+
+After the pinned release is available, the example dependencies can instead be
+installed normally:
+
+```bash
+python3 -m pip install -r examples/advanced/recipe-k8s/requirements.txt
+```
+
+The same compatible NVFlare version must be present in the server and client
+job images.
+
+## Submit and Monitor the Job
+
+Run from the example directory so the recipe can bundle the relative
+`client.py` training script with a path that is also portable inside the job
+pods:
+
+```bash
+cd examples/advanced/recipe-k8s
+
+python3 job.py \
+  --startup-kit /path/to/admin/startup \
+  --site-1-image registry-a.example.com/nvflare-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-job:2.9
+```
+
+`ProdEnv` submits the generated job through the admin startup kit. The script
+prints the job ID, monitors the job until completion, downloads the result, and
+prints the final status and result path.
+
+For clients with different participant names or resource needs:
+
+```bash
+python3 job.py \
+  --startup-kit /path/to/admin/startup \
+  --site-1-name hospital-a \
+  --site-2-name hospital-b \
+  --site-1-image registry-a.example.com/nvflare-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-job:2.9 \
+  --site-1-gpus 1 \
+  --site-2-gpus 2 \
+  --site-1-cpu 4 \
+  --site-2-cpu 8 \
+  --site-1-memory 16Gi \
+  --site-2-memory 32Gi
+```
+
+If the server is also prepared with `ServerK8sJobLauncher`, add an image that
+its cluster can pull:
+
+```bash
+  --server-image registry-server.example.com/nvflare-job:2.9
+```
+
+## Inspect Without Submitting
+
+Recipe export uses the same metadata-building path without connecting to the
+NVFlare server. The startup-kit argument must still name an existing directory
+because `ProdEnv` validates it during construction:
+
+```bash
+python3 job.py \
+  --startup-kit /path/to/admin/startup \
+  --site-1-image registry-a.example.com/nvflare-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-job:2.9 \
+  --export --export-dir /tmp/nvflare-recipe-job
+
+python3 -m json.tool /tmp/nvflare-recipe-job/hello-numpy-k8s/meta.json
+```
+
+The exported metadata contains flat per-site GPU requests under
+`resource_spec` and per-site Kubernetes container settings under
+`launcher_spec`.

--- a/examples/advanced/recipe-k8s/README.md
+++ b/examples/advanced/recipe-k8s/README.md
@@ -1,4 +1,4 @@
-# Submit a Recipe Job to Two Kubernetes Clients
+# Submit a CIFAR-10 Recipe Job to Two Kubernetes Clients
 
 > **Development Branch Notice**
 > This example uses `set_recipe_meta`, part of the NVFlare 2.9 Recipe API. The
@@ -6,10 +6,12 @@
 > it. Until that package is published on PyPI, install NVFlare from this
 > repository instead of changing the pin to an older release.
 
-This example submits one NumPy FedAvg job to an existing production NVFlare
-system with one server and two clients. The clients, `site-1` and `site-2`, run
-in separate Kubernetes clusters and use `ClientK8sJobLauncher` to create a job
-pod in their respective cluster.
+This example submits a PyTorch FedAvg job that trains a small CIFAR-10 image
+classifier to an existing production NVFlare system with one server and two
+clients. The clients, `site-1` and `site-2`, run in separate Kubernetes
+clusters and use `ClientK8sJobLauncher` to create a job pod in their respective
+cluster. Each client is assigned a disjoint strided partition of the CIFAR-10
+training set; the bounded default sample counts are described below.
 
 ```text
 workstation (job.py + ProdEnv)
@@ -38,6 +40,10 @@ selection itself remains a site runtime policy.
   Python path, CPU, memory, and ephemeral storage. This enum value is written
   to generated `meta.json` as `launcher_spec`, not `job_launcher_spec`.
 
+The Recipe uses the PyTorch `FedAvgRecipe`, bundles [`client.py`](client.py)
+and [`model.py`](model.py), and gives the two clients different data-partition
+indices through `per_site_config`.
+
 The client site names are provisioned NVFlare participant identities, not
 Kubernetes cluster names. No kubeconfig, namespace, or cluster endpoint belongs
 in the job metadata. Each long-running client parent already has the launcher
@@ -45,10 +51,14 @@ configuration and credentials for its own cluster. The participant name
 `default` cannot be used here because it is reserved for shared launcher
 settings.
 
-The recipe also passes
-`per_site_config={"site-1": {}, "site-2": {}}`. Those entries target the two
-client apps explicitly. Resource and launcher metadata alone do not change a
-recipe's deployment map.
+In a production team, the platform team typically supplies approved image
+URLs, Python paths, and resource defaults, often through an organization-owned
+wrapper around this script. The data scientist then supplies the training code
+and job-specific choices.
+
+The recipe also uses `per_site_config` to target the two client apps explicitly
+and pass partition index `0` to `site-1` and index `1` to `site-2`. Resource
+and launcher metadata alone do not change a recipe's deployment map.
 
 ## Prerequisites
 
@@ -62,12 +72,18 @@ recipe's deployment map.
   [Kubernetes Helm deployment guide](../../../docs/user_guide/admin_guide/deployment/helm_chart.rst).
 - An admin startup kit on the workstation running `job.py`.
 - Site authorization policies that permit submitted custom code (BYOC), since
-  the recipe bundles `client.py` with the job.
+  the recipe bundles `client.py` and `model.py` with the job.
 - A job image for each cluster. Each image must contain a compatible NVFlare
-  installation and NumPy, and must be pullable from that cluster. The two image
-  arguments may point to different registries. The recipe bundles `client.py`
-  into the submitted job, so the training script need not be baked into the
-  images.
+  installation with the `PT` extra (PyTorch and torchvision), and must be
+  pullable from that cluster. Use `--image` when both clusters pull the same
+  image, or the two site-specific arguments for different registries.
+- Outbound access from each client job pod to download CIFAR-10, or the dataset
+  already available at the path passed with `--data-dir` and selected with
+  `--no-download-data`.
+
+The server runtime also needs the NVFlare `PT` dependencies for model
+persistence. If the server uses `ServerK8sJobLauncher`, its `--server-image`
+must contain them.
 
 The [Brev scripted deployment quickstart](../../../docs/user_guide/admin_guide/deployment/brev_scripted_deployment.rst)
 creates this exact `server`, `site-1`, and `site-2` topology across three
@@ -79,7 +95,7 @@ From the repository root, install the current source while NVFlare 2.9 is not
 yet published:
 
 ```bash
-python3 -m pip install -e .
+python3 -m pip install -e ".[PT]"
 ```
 
 After the pinned release is available, the example dependencies can instead be
@@ -94,22 +110,33 @@ job images.
 
 ## Submit and Monitor the Job
 
-Run from the example directory so the recipe can bundle the relative
-`client.py` training script with a path that is also portable inside the job
-pods:
+Run from the example directory so the recipe can bundle the relative training
+code with paths that are also portable inside the job pods:
 
 ```bash
 cd examples/advanced/recipe-k8s
 
 python3 job.py \
   --startup-kit /path/to/admin/startup \
-  --site-1-image registry-a.example.com/nvflare-job:2.9 \
-  --site-2-image registry-b.example.com/nvflare-job:2.9
+  --image registry.example.com/nvflare-pt-job:2.9
 ```
 
 `ProdEnv` submits the generated job through the admin startup kit. The script
 prints the job ID, monitors the job until completion, downloads the result, and
-prints the final status and result path.
+prints the final status and result path. A site-specific image takes precedence
+over `--image`; the shared option applies only to clients and never implies a
+server image.
+
+By default, each ephemeral client pod downloads CIFAR-10 under `/tmp`, uses a
+disjoint strided partition, and caps its partition at 5,000 training and 1,000
+test samples for a bounded demo runtime. Set both sample limits to `0` to use
+the complete partitions. For a platform-managed dataset volume, use
+`--no-download-data --data-dir <mounted-path>`; dataset mounting remains site
+runtime policy rather than Recipe metadata.
+
+This example uses at most one device per client, so each `--site-*-gpus` value
+must be `0` or `1`. When set to `1`, the client requires CUDA and fails clearly
+instead of silently falling back to CPU in a GPU-requesting pod.
 
 For clients with different participant names or resource needs:
 
@@ -118,14 +145,16 @@ python3 job.py \
   --startup-kit /path/to/admin/startup \
   --site-1-name hospital-a \
   --site-2-name hospital-b \
-  --site-1-image registry-a.example.com/nvflare-job:2.9 \
-  --site-2-image registry-b.example.com/nvflare-job:2.9 \
+  --site-1-image registry-a.example.com/nvflare-pt-job:2.9 \
+  --site-2-image registry-b.example.com/nvflare-pt-job:2.9 \
   --site-1-gpus 1 \
-  --site-2-gpus 2 \
+  --site-2-gpus 1 \
   --site-1-cpu 4 \
   --site-2-cpu 8 \
   --site-1-memory 16Gi \
-  --site-2-memory 32Gi
+  --site-2-memory 32Gi \
+  --local-epochs 2 \
+  --batch-size 128
 ```
 
 If the server is also prepared with `ServerK8sJobLauncher`, add an image that
@@ -133,16 +162,37 @@ its cluster can pull. The server pod defaults to one CPU and `2Gi` of memory;
 override those values with `--server-cpu` and `--server-memory`:
 
 ```bash
-  --server-image registry-server.example.com/nvflare-job:2.9 \
+  --server-image registry-server.example.com/nvflare-pt-job:2.9 \
   --server-cpu 4 \
   --server-memory 8Gi
 ```
 
-## Inspect Without Submitting
+### Expected Output and Troubleshooting
 
-Recipe export uses the same metadata-building path without connecting to the
-NVFlare server. The startup-kit argument must still name an existing directory
-because `ProdEnv` validates it during construction:
+The submission process may print monitoring details between these lines:
+
+```text
+Job ID: <job-id>
+Waiting for job to complete...
+Job status: FINISHED:COMPLETED
+Result: <downloaded-result-path>
+```
+
+While the job is running, run (or ask the platform team to run) `kubectl get
+pods` against each client cluster and launcher namespace to see the job pods.
+For common failures:
+
+- `ErrImagePull` or `ImagePullBackOff`: verify the registry URL and pull
+  Secret, then inspect the pod with `kubectl --context <cluster> -n <namespace>
+  describe pod <pod>`.
+- No job pod, or a `Forbidden` event: verify the launcher's namespace,
+  ServiceAccount, and RBAC, then inspect the long-running client parent logs.
+- Submission or scheduling does not progress: verify the admin startup kit and
+  username, exact provisioned client names, connected clients, and requested
+  GPU availability. A CIFAR-10 download error instead indicates that the job
+  pod needs outbound access or a pre-populated `--data-dir`.
+
+## Inspect Without Submitting
 
 `--export` and `--export-dir` are standard Recipe API flags. The
 `nvflare.recipe` package consumes them before `job.py` parses its
@@ -150,14 +200,17 @@ example-specific arguments, and `recipe.execute()` exports instead of calling
 `ProdEnv.deploy()`. They therefore do not appear as arguments in
 `define_parser()`.
 
+Recipe export uses the same metadata-building path without connecting to the
+NVFlare server. The startup-kit argument must still name an existing directory
+because `ProdEnv` validates it during construction:
+
 ```bash
 python3 job.py \
   --startup-kit /path/to/admin/startup \
-  --site-1-image registry-a.example.com/nvflare-job:2.9 \
-  --site-2-image registry-b.example.com/nvflare-job:2.9 \
+  --image registry.example.com/nvflare-pt-job:2.9 \
   --export --export-dir /tmp/nvflare-recipe-job
 
-python3 -m json.tool /tmp/nvflare-recipe-job/hello-numpy-k8s/meta.json
+python3 -m json.tool /tmp/nvflare-recipe-job/cifar10-k8s/meta.json
 ```
 
 The exported metadata contains flat per-site GPU requests under

--- a/examples/advanced/recipe-k8s/client.py
+++ b/examples/advanced/recipe-k8s/client.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nvflare.client as flare
+from nvflare.app_common.np.constants import NPConstants
+
+
+def main() -> None:
+    flare.init()
+    site_name = flare.system_info()["site_name"]
+
+    while flare.is_running():
+        input_model = flare.receive()
+        input_weights = input_model.params[NPConstants.NUMPY_KEY]
+
+        # Stand in for local training with a deterministic update.
+        output_weights = input_weights + 1
+        weight_mean = float(np.mean(output_weights))
+        print(
+            f"site={site_name} round={input_model.current_round} weight_mean={weight_mean:.4f}",
+            flush=True,
+        )
+
+        flare.send(
+            flare.FLModel(
+                params={NPConstants.NUMPY_KEY: output_weights},
+                params_type=flare.ParamsType.FULL,
+                metrics={"weight_mean": weight_mean},
+                current_round=input_model.current_round,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/recipe-k8s/client.py
+++ b/examples/advanced/recipe-k8s/client.py
@@ -12,33 +12,130 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+import argparse
+
+import torch
+from model import Cifar10Net
+from torch import nn
+from torch.optim import SGD
+from torch.utils.data import DataLoader, Subset
+from torchvision.datasets import CIFAR10
+from torchvision.transforms import Compose, Normalize, ToTensor
 
 import nvflare.client as flare
-from nvflare.app_common.np.constants import NPConstants
+
+
+def define_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--site-index", type=int, required=True)
+    parser.add_argument("--num-sites", type=int, required=True)
+    parser.add_argument("--local-epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--data-dir", default="/tmp/nvflare/cifar10")
+    parser.add_argument("--download", action="store_true")
+    parser.add_argument("--max-train-samples", type=int, default=5000)
+    parser.add_argument("--max-test-samples", type=int, default=1000)
+    parser.add_argument("--require-gpu", action="store_true")
+    return parser
+
+
+def partition_dataset(dataset, site_index: int, num_sites: int, max_samples: int) -> Subset:
+    indices = list(range(site_index, len(dataset), num_sites))
+    if max_samples:
+        indices = indices[:max_samples]
+    return Subset(dataset, indices)
+
+
+def select_device(require_gpu: bool) -> torch.device:
+    if not require_gpu:
+        return torch.device("cpu")
+    if not torch.cuda.is_available():
+        raise RuntimeError("A GPU was requested for this client, but CUDA is not available")
+    return torch.device("cuda:0")
+
+
+def evaluate(model: nn.Module, data_loader: DataLoader, device: torch.device) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for images, labels in data_loader:
+            predictions = model(images.to(device)).argmax(dim=1)
+            labels = labels.to(device)
+            correct += (predictions == labels).sum().item()
+            total += labels.size(0)
+    return correct / total
+
+
+def train(
+    model: nn.Module,
+    data_loader: DataLoader,
+    device: torch.device,
+    local_epochs: int,
+) -> float:
+    model.train()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = SGD(model.parameters(), lr=0.01, momentum=0.9)
+    total_loss = 0.0
+    total_batches = 0
+
+    for _ in range(local_epochs):
+        for images, labels in data_loader:
+            images, labels = images.to(device), labels.to(device)
+            optimizer.zero_grad()
+            loss = criterion(model(images), labels)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item()
+            total_batches += 1
+
+    return total_loss / total_batches
 
 
 def main() -> None:
+    args = define_parser().parse_args()
+    device = select_device(args.require_gpu)
+    transform = Compose([ToTensor(), Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+    train_dataset = CIFAR10(root=args.data_dir, train=True, download=args.download, transform=transform)
+    test_dataset = CIFAR10(root=args.data_dir, train=False, download=args.download, transform=transform)
+    site_train_dataset = partition_dataset(train_dataset, args.site_index, args.num_sites, args.max_train_samples)
+    site_test_dataset = partition_dataset(test_dataset, args.site_index, args.num_sites, args.max_test_samples)
+    train_loader = DataLoader(
+        site_train_dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+    )
+    test_loader = DataLoader(site_test_dataset, batch_size=args.batch_size, num_workers=args.num_workers)
+
     flare.init()
     site_name = flare.system_info()["site_name"]
+    print(f"site={site_name} device={device}", flush=True)
+    model = Cifar10Net()
 
     while flare.is_running():
         input_model = flare.receive()
-        input_weights = input_model.params[NPConstants.NUMPY_KEY]
+        model.load_state_dict(input_model.params)
+        model.to(device)
 
-        # Stand in for local training with a deterministic update.
-        output_weights = input_weights + 1
-        weight_mean = float(np.mean(output_weights))
+        global_accuracy = evaluate(model, test_loader, device)
+        loss = train(model, train_loader, device, args.local_epochs)
+        local_accuracy = evaluate(model, test_loader, device)
         print(
-            f"site={site_name} round={input_model.current_round} weight_mean={weight_mean:.4f}",
+            f"site={site_name} round={input_model.current_round} loss={loss:.4f} "
+            f"global_accuracy={global_accuracy:.4f} local_accuracy={local_accuracy:.4f}",
             flush=True,
         )
 
         flare.send(
             flare.FLModel(
-                params={NPConstants.NUMPY_KEY: output_weights},
+                params=model.cpu().state_dict(),
                 params_type=flare.ParamsType.FULL,
-                metrics={"weight_mean": weight_mean},
+                # Model selection evaluates the received global model, not the
+                # local weights that will be aggregated after this round.
+                metrics={"accuracy": global_accuracy},
+                meta={"NUM_STEPS_CURRENT_ROUND": args.local_epochs * len(train_loader)},
                 current_round=input_model.current_round,
             )
         )

--- a/examples/advanced/recipe-k8s/job.py
+++ b/examples/advanced/recipe-k8s/job.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import argparse
+from pathlib import Path
+
+from model import Cifar10Net
 
 from nvflare.apis.job_def import JobMetaKey
-from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
 from nvflare.recipe import ProdEnv, set_recipe_meta
 
 
@@ -29,9 +32,26 @@ def non_negative_int(value: str) -> int:
     return parsed_value
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed_value = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer") from None
+    if parsed_value < 1:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed_value
+
+
+def gpu_count(value: str) -> int:
+    parsed_value = non_negative_int(value)
+    if parsed_value > 1:
+        raise argparse.ArgumentTypeError("must be 0 or 1 because this example uses one device per client")
+    return parsed_value
+
+
 def define_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Submit a NumPy FedAvg recipe to two NVFlare clients that use Kubernetes job launchers.",
+        description="Submit a CIFAR-10 FedAvg recipe to two NVFlare clients that use Kubernetes job launchers.",
         epilog=(
             "Standard Recipe flags --export and --export-dir DIR are consumed by nvflare.recipe "
             "before this parser processes the example-specific options."
@@ -40,19 +60,45 @@ def define_parser() -> argparse.ArgumentParser:
     parser.add_argument("--startup-kit", required=True, help="Path to the production admin startup directory.")
     parser.add_argument("--username", default="admin@nvidia.com", help="Provisioned admin participant name.")
     parser.add_argument("--study", default="default", help="Study in which to submit the job.")
-    parser.add_argument("--job-name", default="hello-numpy-k8s")
-    parser.add_argument("--num-rounds", type=int, default=3)
+    parser.add_argument("--job-name", default="cifar10-k8s")
+    parser.add_argument("--num-rounds", type=positive_int, default=3)
 
     parser.add_argument("--site-1-name", default="site-1", help="First provisioned NVFlare client name.")
     parser.add_argument("--site-2-name", default="site-2", help="Second provisioned NVFlare client name.")
-    parser.add_argument("--site-1-image", required=True, help="Job image pullable by the first client's cluster.")
-    parser.add_argument("--site-2-image", required=True, help="Job image pullable by the second client's cluster.")
-    parser.add_argument("--site-1-gpus", type=non_negative_int, default=0)
-    parser.add_argument("--site-2-gpus", type=non_negative_int, default=0)
+    parser.add_argument(
+        "--image",
+        help="Shared client job image. A site-specific image overrides this value for that client.",
+    )
+    parser.add_argument("--site-1-image", help="Job image pullable by the first client's cluster.")
+    parser.add_argument("--site-2-image", help="Job image pullable by the second client's cluster.")
+    parser.add_argument("--site-1-gpus", type=gpu_count, default=0)
+    parser.add_argument("--site-2-gpus", type=gpu_count, default=0)
     parser.add_argument("--site-1-cpu", default="1", help="Kubernetes CPU limit for the first client job pod.")
     parser.add_argument("--site-2-cpu", default="1", help="Kubernetes CPU limit for the second client job pod.")
     parser.add_argument("--site-1-memory", default="2Gi", help="Memory limit for the first client job pod.")
     parser.add_argument("--site-2-memory", default="2Gi", help="Memory limit for the second client job pod.")
+    parser.add_argument("--local-epochs", type=positive_int, default=1, help="Local CIFAR-10 epochs per FL round.")
+    parser.add_argument("--batch-size", type=positive_int, default=64, help="Client training batch size.")
+    parser.add_argument("--num-workers", type=non_negative_int, default=0, help="Client data-loader workers.")
+    parser.add_argument("--data-dir", default="/tmp/nvflare/cifar10", help="CIFAR-10 directory in client job pods.")
+    parser.add_argument(
+        "--download-data",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Download CIFAR-10 in each client pod; use --no-download-data for a pre-populated data directory.",
+    )
+    parser.add_argument(
+        "--max-train-samples",
+        type=non_negative_int,
+        default=5000,
+        help="Maximum training samples per client; 0 uses the full partition.",
+    )
+    parser.add_argument(
+        "--max-test-samples",
+        type=non_negative_int,
+        default=1000,
+        help="Maximum test samples per client; 0 uses the full partition.",
+    )
 
     parser.add_argument("--python-path", default="/usr/local/bin/python3", help="Python executable in the job images.")
     parser.add_argument("--ephemeral-storage", default="2Gi", help="Workspace storage for each Kubernetes job pod.")
@@ -68,6 +114,23 @@ def define_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.site_1_name == args.site_2_name:
+        parser.error("--site-1-name and --site-2-name must identify different clients")
+    if "default" in (args.site_1_name, args.site_2_name):
+        parser.error("client name 'default' is reserved for shared launcher settings")
+    if any(character.isspace() for character in args.data_dir):
+        parser.error("--data-dir must not contain whitespace")
+
+    missing_image_args = []
+    if not (args.site_1_image or args.image):
+        missing_image_args.append("--site-1-image")
+    if not (args.site_2_image or args.image):
+        missing_image_args.append("--site-2-image")
+    if missing_image_args:
+        parser.error(f"provide --image or specify {', '.join(missing_image_args)}")
+
+
 def k8s_launcher_spec(image: str, cpu: str, memory: str, python_path: str, ephemeral_storage: str) -> dict:
     return {
         "image": image,
@@ -78,26 +141,55 @@ def k8s_launcher_spec(image: str, cpu: str, memory: str, python_path: str, ephem
     }
 
 
-def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
-    if args.site_1_name == args.site_2_name:
-        raise ValueError("--site-1-name and --site-2-name must identify different clients")
-    if "default" in (args.site_1_name, args.site_2_name):
-        raise ValueError("client name 'default' is reserved for shared launcher settings")
-    if args.num_rounds < 1:
-        raise ValueError("--num-rounds must be greater than 0")
+def client_train_args(args: argparse.Namespace, site_index: int, gpus: int) -> str:
+    train_args = [
+        "--site-index",
+        str(site_index),
+        "--num-sites",
+        "2",
+        "--local-epochs",
+        str(args.local_epochs),
+        "--batch-size",
+        str(args.batch_size),
+        "--num-workers",
+        str(args.num_workers),
+        "--data-dir",
+        args.data_dir,
+        "--max-train-samples",
+        str(args.max_train_samples),
+        "--max-test-samples",
+        str(args.max_test_samples),
+    ]
+    if args.download_data:
+        train_args.append("--download")
+    if gpus:
+        train_args.append("--require-gpu")
+    return " ".join(train_args)
 
+
+def create_recipe(args: argparse.Namespace) -> FedAvgRecipe:
     client_sites = (args.site_1_name, args.site_2_name)
-    recipe = NumpyFedAvgRecipe(
+    recipe = FedAvgRecipe(
         name=args.job_name,
-        model=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        model=Cifar10Net(),
         min_clients=len(client_sites),
         num_rounds=args.num_rounds,
         train_script="client.py",
         # Explicit per-site entries target these two clients. Recipe metadata
         # describes resources and launchers; it does not select deploy targets.
-        per_site_config={site_name: {} for site_name in client_sites},
-        key_metric="weight_mean",
+        per_site_config={
+            args.site_1_name: {"train_args": client_train_args(args, site_index=0, gpus=args.site_1_gpus)},
+            args.site_2_name: {"train_args": client_train_args(args, site_index=1, gpus=args.site_2_gpus)},
+        },
+        key_metric="accuracy",
     )
+
+    # The client training script and the server-side PyTorch persistor both
+    # import the model definition, so bundle it into every generated app.
+    model_path = str(Path(__file__).with_name("model.py"))
+    recipe.job.add_file_to_server(model_path)
+    for site_name in client_sites:
+        recipe.job.add_file_to(model_path, site_name)
 
     # Scheduler-facing resource requirements stay separate from Kubernetes
     # container settings. K8sJobLauncher maps num_of_gpus to nvidia.com/gpu.
@@ -113,7 +205,7 @@ def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
     launcher_spec = {
         args.site_1_name: {
             "k8s": k8s_launcher_spec(
-                args.site_1_image,
+                args.site_1_image or args.image,
                 args.site_1_cpu,
                 args.site_1_memory,
                 args.python_path,
@@ -122,7 +214,7 @@ def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
         },
         args.site_2_name: {
             "k8s": k8s_launcher_spec(
-                args.site_2_image,
+                args.site_2_image or args.image,
                 args.site_2_cpu,
                 args.site_2_memory,
                 args.python_path,
@@ -149,7 +241,9 @@ def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
 
 
 def main() -> None:
-    args = define_parser().parse_args()
+    parser = define_parser()
+    args = parser.parse_args()
+    validate_args(parser, args)
     recipe = create_recipe(args)
     env = ProdEnv(
         startup_kit_location=args.startup_kit,
@@ -158,7 +252,8 @@ def main() -> None:
     )
 
     run = recipe.execute(env)
-    print(f"Job ID: {run.get_job_id()}")
+    print(f"Job ID: {run.get_job_id()}", flush=True)
+    print("Waiting for job to complete...", flush=True)
     result = run.get_result()
     print(f"Job status: {run.get_status()}")
     print(f"Result: {result}")

--- a/examples/advanced/recipe-k8s/job.py
+++ b/examples/advanced/recipe-k8s/job.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+from nvflare.apis.job_def import JobMetaKey
+from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+from nvflare.recipe import ProdEnv, set_recipe_meta
+
+
+def non_negative_int(value: str) -> int:
+    value = int(value)
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return value
+
+
+def define_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Submit a NumPy FedAvg recipe to two NVFlare clients that use Kubernetes job launchers."
+    )
+    parser.add_argument("--startup-kit", required=True, help="Path to the production admin startup directory.")
+    parser.add_argument("--username", default="admin@nvidia.com", help="Provisioned admin participant name.")
+    parser.add_argument("--study", default="default", help="Study in which to submit the job.")
+    parser.add_argument("--job-name", default="hello-numpy-k8s")
+    parser.add_argument("--num-rounds", type=int, default=3)
+
+    parser.add_argument("--site-1-name", default="site-1", help="First provisioned NVFlare client name.")
+    parser.add_argument("--site-2-name", default="site-2", help="Second provisioned NVFlare client name.")
+    parser.add_argument("--site-1-image", required=True, help="Job image pullable by the first client's cluster.")
+    parser.add_argument("--site-2-image", required=True, help="Job image pullable by the second client's cluster.")
+    parser.add_argument("--site-1-gpus", type=non_negative_int, default=0)
+    parser.add_argument("--site-2-gpus", type=non_negative_int, default=0)
+    parser.add_argument("--site-1-cpu", default="1", help="Kubernetes CPU limit for the first client job pod.")
+    parser.add_argument("--site-2-cpu", default="1", help="Kubernetes CPU limit for the second client job pod.")
+    parser.add_argument("--site-1-memory", default="2Gi", help="Memory limit for the first client job pod.")
+    parser.add_argument("--site-2-memory", default="2Gi", help="Memory limit for the second client job pod.")
+
+    parser.add_argument("--python-path", default="/usr/local/bin/python3", help="Python executable in the job images.")
+    parser.add_argument("--ephemeral-storage", default="2Gi", help="Workspace storage for each Kubernetes job pod.")
+    parser.add_argument(
+        "--server-image",
+        help=(
+            "Job image for a server that also uses a Kubernetes job launcher. "
+            "Omit this when the server uses the process launcher."
+        ),
+    )
+    return parser
+
+
+def k8s_launcher_spec(image: str, cpu: str, memory: str, python_path: str, ephemeral_storage: str) -> dict:
+    return {
+        "image": image,
+        "python_path": python_path,
+        "cpu": cpu,
+        "memory": memory,
+        "ephemeral_storage": ephemeral_storage,
+    }
+
+
+def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
+    if args.site_1_name == args.site_2_name:
+        raise ValueError("--site-1-name and --site-2-name must identify different clients")
+    if "default" in (args.site_1_name, args.site_2_name):
+        raise ValueError("client name 'default' is reserved for shared launcher settings")
+    if args.num_rounds < 1:
+        raise ValueError("--num-rounds must be greater than 0")
+
+    client_sites = (args.site_1_name, args.site_2_name)
+    recipe = NumpyFedAvgRecipe(
+        name=args.job_name,
+        model=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        min_clients=len(client_sites),
+        num_rounds=args.num_rounds,
+        train_script="client.py",
+        # Explicit per-site entries target these two clients. Recipe metadata
+        # describes resources and launchers; it does not select deploy targets.
+        per_site_config={site_name: {} for site_name in client_sites},
+        key_metric="weight_mean",
+    )
+
+    # Scheduler-facing resource requirements stay separate from Kubernetes
+    # container settings. K8sJobLauncher maps num_of_gpus to nvidia.com/gpu.
+    set_recipe_meta(
+        recipe,
+        JobMetaKey.RESOURCE_SPEC,
+        {
+            args.site_1_name: {"num_of_gpus": args.site_1_gpus},
+            args.site_2_name: {"num_of_gpus": args.site_2_gpus},
+        },
+    )
+
+    launcher_spec = {
+        args.site_1_name: {
+            "k8s": k8s_launcher_spec(
+                args.site_1_image,
+                args.site_1_cpu,
+                args.site_1_memory,
+                args.python_path,
+                args.ephemeral_storage,
+            )
+        },
+        args.site_2_name: {
+            "k8s": k8s_launcher_spec(
+                args.site_2_image,
+                args.site_2_cpu,
+                args.site_2_memory,
+                args.python_path,
+                args.ephemeral_storage,
+            )
+        },
+    }
+    if args.server_image:
+        # The server's provisioned identity may not literally be "server".
+        # A default supplies its K8s image while the client blocks above keep
+        # their cluster-specific images and settings.
+        launcher_spec["default"] = {
+            "k8s": k8s_launcher_spec(
+                args.server_image,
+                "1",
+                "2Gi",
+                args.python_path,
+                args.ephemeral_storage,
+            )
+        }
+
+    set_recipe_meta(recipe, JobMetaKey.JOB_LAUNCHER_SPEC, launcher_spec)
+    return recipe
+
+
+def main() -> None:
+    args = define_parser().parse_args()
+    recipe = create_recipe(args)
+    env = ProdEnv(
+        startup_kit_location=args.startup_kit,
+        username=args.username,
+        study=args.study,
+    )
+
+    run = recipe.execute(env)
+    print(f"Job ID: {run.get_job_id()}")
+    result = run.get_result()
+    print(f"Job status: {run.get_status()}")
+    print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/recipe-k8s/job.py
+++ b/examples/advanced/recipe-k8s/job.py
@@ -20,15 +20,22 @@ from nvflare.recipe import ProdEnv, set_recipe_meta
 
 
 def non_negative_int(value: str) -> int:
-    value = int(value)
-    if value < 0:
+    try:
+        parsed_value = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer") from None
+    if parsed_value < 0:
         raise argparse.ArgumentTypeError("must be greater than or equal to 0")
-    return value
+    return parsed_value
 
 
 def define_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Submit a NumPy FedAvg recipe to two NVFlare clients that use Kubernetes job launchers."
+        description="Submit a NumPy FedAvg recipe to two NVFlare clients that use Kubernetes job launchers.",
+        epilog=(
+            "Standard Recipe flags --export and --export-dir DIR are consumed by nvflare.recipe "
+            "before this parser processes the example-specific options."
+        ),
     )
     parser.add_argument("--startup-kit", required=True, help="Path to the production admin startup directory.")
     parser.add_argument("--username", default="admin@nvidia.com", help="Provisioned admin participant name.")
@@ -56,6 +63,8 @@ def define_parser() -> argparse.ArgumentParser:
             "Omit this when the server uses the process launcher."
         ),
     )
+    parser.add_argument("--server-cpu", default="1", help="Kubernetes CPU limit for the server job pod.")
+    parser.add_argument("--server-memory", default="2Gi", help="Memory limit for the server job pod.")
     return parser
 
 
@@ -128,8 +137,8 @@ def create_recipe(args: argparse.Namespace) -> NumpyFedAvgRecipe:
         launcher_spec["default"] = {
             "k8s": k8s_launcher_spec(
                 args.server_image,
-                "1",
-                "2Gi",
+                args.server_cpu,
+                args.server_memory,
                 args.python_path,
                 args.ephemeral_storage,
             )

--- a/examples/advanced/recipe-k8s/job.py
+++ b/examples/advanced/recipe-k8s/job.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from model import Cifar10Net
 
 from nvflare.apis.job_def import JobMetaKey
+from nvflare.apis.utils.format_check import name_check
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
 from nvflare.recipe import ProdEnv, set_recipe_meta
 
@@ -60,7 +61,11 @@ def define_parser() -> argparse.ArgumentParser:
     parser.add_argument("--startup-kit", required=True, help="Path to the production admin startup directory.")
     parser.add_argument("--username", default="admin@nvidia.com", help="Provisioned admin participant name.")
     parser.add_argument("--study", default="default", help="Study in which to submit the job.")
-    parser.add_argument("--job-name", default="cifar10-k8s")
+    parser.add_argument(
+        "--job-name",
+        default="cifar10-k8s",
+        help="Job and export-directory name; use letters, numbers, dots, underscores, and hyphens.",
+    )
     parser.add_argument("--num-rounds", type=positive_int, default=3)
 
     parser.add_argument("--site-1-name", default="site-1", help="First provisioned NVFlare client name.")
@@ -115,6 +120,11 @@ def define_parser() -> argparse.ArgumentParser:
 
 
 def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if name_check(args.job_name, "job_name")[0]:
+        parser.error(
+            "--job-name must start with a letter or number and contain only letters, numbers, dots, underscores, "
+            "and hyphens"
+        )
     if args.site_1_name == args.site_2_name:
         parser.error("--site-1-name and --site-2-name must identify different clients")
     if "default" in (args.site_1_name, args.site_2_name):

--- a/examples/advanced/recipe-k8s/model.py
+++ b/examples/advanced/recipe-k8s/model.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import nn
+
+
+class Cifar10Net(nn.Module):
+    """Small convolutional network for the CIFAR-10 example."""
+
+    def __init__(self):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(3, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(64 * 8 * 8, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.classifier(self.features(inputs))

--- a/examples/advanced/recipe-k8s/requirements.txt
+++ b/examples/advanced/recipe-k8s/requirements.txt
@@ -1,2 +1,1 @@
-nvflare~=2.9.0rc
-numpy
+nvflare[PT]~=2.9.0rc

--- a/examples/advanced/recipe-k8s/requirements.txt
+++ b/examples/advanced/recipe-k8s/requirements.txt
@@ -1,0 +1,2 @@
+nvflare~=2.9.0rc
+numpy

--- a/tests/unit_test/examples/recipe_k8s_test.py
+++ b/tests/unit_test/examples/recipe_k8s_test.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import json
+import os
+import sys
+
+import pytest
+
+HAS_PT_DEPS = all(importlib.util.find_spec(dep) is not None for dep in ("torch", "torchvision"))
+pytestmark = pytest.mark.skipif(not HAS_PT_DEPS, reason="PyTorch example dependencies are not installed")
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+EXAMPLE_DIR = os.path.join(REPO_ROOT, "examples", "advanced", "recipe-k8s")
+
+
+@pytest.fixture
+def load_example_module():
+    loaded_modules = []
+    original_model_module = sys.modules.pop("model", None)
+    sys.path.insert(0, EXAMPLE_DIR)
+
+    def _load(file_name: str, module_name: str):
+        spec = importlib.util.spec_from_file_location(module_name, os.path.join(EXAMPLE_DIR, file_name))
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        loaded_modules.append(module_name)
+        return module
+
+    yield _load
+
+    sys.path.pop(0)
+    for module_name in loaded_modules:
+        sys.modules.pop(module_name, None)
+    if original_model_module is not None:
+        sys.modules["model"] = original_model_module
+    else:
+        sys.modules.pop("model", None)
+
+
+def _parse_validated(job_module, *extra_args):
+    parser = job_module.define_parser()
+    args = parser.parse_args(["--startup-kit", "/tmp/admin", *extra_args])
+    job_module.validate_args(parser, args)
+    return args
+
+
+@pytest.mark.parametrize(
+    "extra_args, expected_error",
+    [
+        (["--image", "shared", "--num-rounds", "0"], "must be greater than 0"),
+        (["--image", "shared", "--site-2-name", "site-1"], "must identify different clients"),
+        (["--image", "shared", "--site-1-name", "default"], "is reserved"),
+        ([], "provide --image"),
+        (["--image", "shared", "--site-1-gpus", "2"], "must be 0 or 1"),
+        (["--image", "shared", "--data-dir", "/data/cifar ten"], "must not contain whitespace"),
+    ],
+)
+def test_invalid_cli_values_use_argparse_errors(load_example_module, capsys, extra_args, expected_error):
+    job_module = load_example_module("job.py", "recipe_k8s_job_invalid")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_validated(job_module, *extra_args)
+
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert expected_error in stderr
+    assert "Traceback" not in stderr
+
+
+def test_recipe_export_contains_cifar_code_and_k8s_metadata(load_example_module, monkeypatch, tmp_path):
+    job_module = load_example_module("job.py", "recipe_k8s_job_export")
+    monkeypatch.chdir(EXAMPLE_DIR)
+    args = _parse_validated(
+        job_module,
+        "--image",
+        "registry.example/shared:dev",
+        "--site-2-image",
+        "registry.example/site-2:dev",
+        "--site-1-gpus",
+        "1",
+        "--server-image",
+        "registry.example/server:dev",
+        "--server-cpu",
+        "4",
+        "--server-memory",
+        "8Gi",
+    )
+
+    recipe = job_module.create_recipe(args)
+    recipe.export(str(tmp_path))
+    job_root = tmp_path / "cifar10-k8s"
+
+    with open(job_root / "meta.json") as meta_file:
+        meta = json.load(meta_file)
+    assert meta["deploy_map"] == {
+        "app_server": ["server"],
+        "app_site-1": ["site-1"],
+        "app_site-2": ["site-2"],
+    }
+    assert meta["resource_spec"] == {
+        "site-1": {"num_of_gpus": 1},
+        "site-2": {"num_of_gpus": 0},
+    }
+    assert meta["launcher_spec"]["site-1"]["k8s"]["image"] == "registry.example/shared:dev"
+    assert meta["launcher_spec"]["site-2"]["k8s"]["image"] == "registry.example/site-2:dev"
+    assert meta["launcher_spec"]["default"]["k8s"]["image"] == "registry.example/server:dev"
+    assert meta["launcher_spec"]["default"]["k8s"]["cpu"] == "4"
+    assert meta["launcher_spec"]["default"]["k8s"]["memory"] == "8Gi"
+
+    for app_name in ("app_server", "app_site-1", "app_site-2"):
+        assert (job_root / app_name / "custom" / "model.py").is_file()
+    for app_name in ("app_site-1", "app_site-2"):
+        assert (job_root / app_name / "custom" / "client.py").is_file()
+
+    with open(job_root / "app_site-1" / "config" / "config_fed_client.json") as config_file:
+        site_1_config = json.load(config_file)
+    executor_args = site_1_config["executors"][0]["executor"]["args"]
+    assert executor_args["task_script_path"] == "client.py"
+    assert "--site-index 0" in executor_args["task_script_args"]
+    assert "--num-sites 2" in executor_args["task_script_args"]
+    assert "--download" in executor_args["task_script_args"]
+    assert "--require-gpu" in executor_args["task_script_args"]
+
+    with open(job_root / "app_site-2" / "config" / "config_fed_client.json") as config_file:
+        site_2_config = json.load(config_file)
+    site_2_args = site_2_config["executors"][0]["executor"]["args"]["task_script_args"]
+    assert "--site-index 1" in site_2_args
+    assert "--num-sites 2" in site_2_args
+    assert "--require-gpu" not in site_2_args
+
+
+def test_cifar_model_and_partitions(load_example_module, monkeypatch):
+    import torch
+    from torch.utils.data import DataLoader, TensorDataset
+
+    client_module = load_example_module("client.py", "recipe_k8s_client")
+    model_module = sys.modules["model"]
+    model = model_module.Cifar10Net()
+
+    assert model(torch.zeros(2, 3, 32, 32)).shape == (2, 10)
+
+    site_0 = client_module.partition_dataset(list(range(12)), site_index=0, num_sites=2, max_samples=3)
+    site_1 = client_module.partition_dataset(list(range(12)), site_index=1, num_sites=2, max_samples=0)
+    assert site_0.indices == [0, 2, 4]
+    assert site_1.indices == [1, 3, 5, 7, 9, 11]
+    assert set(site_0.indices).isdisjoint(site_1.indices)
+
+    data_loader = DataLoader(
+        TensorDataset(torch.rand(4, 3, 32, 32), torch.tensor([0, 1, 2, 3])),
+        batch_size=2,
+    )
+    loss = client_module.train(model, data_loader, torch.device("cpu"), local_epochs=1)
+    accuracy = client_module.evaluate(model, data_loader, torch.device("cpu"))
+    assert loss > 0
+    assert 0 <= accuracy <= 1
+
+    monkeypatch.setattr(client_module.torch.cuda, "is_available", lambda: False)
+    assert client_module.select_device(require_gpu=False).type == "cpu"
+    with pytest.raises(RuntimeError, match="CUDA is not available"):
+        client_module.select_device(require_gpu=True)
+
+    monkeypatch.setattr(client_module.torch.cuda, "is_available", lambda: True)
+    assert client_module.select_device(require_gpu=False).type == "cpu"
+    assert client_module.select_device(require_gpu=True).type == "cuda"

--- a/tests/unit_test/examples/recipe_k8s_test.py
+++ b/tests/unit_test/examples/recipe_k8s_test.py
@@ -67,6 +67,8 @@ def _parse_validated(job_module, *extra_args):
         ([], "provide --image"),
         (["--image", "shared", "--site-1-gpus", "2"], "must be 0 or 1"),
         (["--image", "shared", "--data-dir", "/data/cifar ten"], "must not contain whitespace"),
+        (["--image", "shared", "--job-name", "bad name"], "--job-name must start"),
+        (["--image", "shared", "--job-name", "bad/name"], "--job-name must start"),
     ],
 )
 def test_invalid_cli_values_use_argparse_errors(load_example_module, capsys, extra_args, expected_error):


### PR DESCRIPTION
### Description

Add `examples/advanced/recipe-k8s`, a production Recipe API example that submits one PyTorch CIFAR-10 FedAvg job through `ProdEnv` to an NVFlare system with one server and two clients running in separate Kubernetes clusters.

The example uses `set_recipe_meta` to supply:

- `JobMetaKey.RESOURCE_SPEC`: flat per-site scheduler-facing GPU requirements, which `K8sJobLauncher` also translates into `nvidia.com/gpu` requests and limits.
- `JobMetaKey.JOB_LAUNCHER_SPEC`: per-site Kubernetes job images, Python paths, CPU, memory, and ephemeral storage, plus an optional `default` block for a server prepared with `ServerK8sJobLauncher`.

The two clients train a bundled PyTorch model on disjoint CIFAR-10 partitions. The example also documents shared and per-site workload images, CPU/GPU behavior, expected output, troubleshooting, and the division of responsibilities between data scientists and platform teams.

Also add the example to the examples index, link it from the Recipe Metadata guide, document submitting it from the Brev scripted three-cluster quickstart, and verify torchvision in the maintained workload image.

Verified by exporting the job and inspecting the generated `meta.json` and app packages, and by running 119 targeted tests plus scoped Black, isort, and flake8 checks.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.
