### PR TITLE
Add FedCE and FedSM recipe support

### DIFF
--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -234,6 +234,8 @@ is given an optimizer.
 
 FedSM currently requires every configured site to participate in every round. FedSM and FedCE are
 separate recipes and cannot be enabled together as independent features.
+FedSM checkpoints use PyTorch's restricted weights-only loader by default. Set ``load_weights_only=False``
+only when resuming a trusted checkpoint whose metadata contains types that the restricted loader does not support.
 
 
 FedProx

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -220,7 +220,7 @@ a global model, one personalized model per client, and a selector model.
         name="fedsm-pt",
         model=MyModel(),
         selector_model=MySelector(num_classes=3),
-        client_ids=["site-1", "site-2", "site-3"],
+        sites=["site-1", "site-2", "site-3"],
         min_clients=3,
         num_rounds=10,
         train_script="client.py",
@@ -232,7 +232,7 @@ The client script uses ``PTFedSMHelper.load_bundle()`` before its task-specific 
 differences; the personalized entry is a full model. Selector optimizer state is synchronized when the helper
 is given an optimizer.
 
-FedSM currently requires every configured ``client_id`` to participate in every round. FedSM and FedCE are
+FedSM currently requires every configured site to participate in every round. FedSM and FedCE are
 separate recipes and cannot be enabled together as independent features.
 
 

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -179,6 +179,62 @@ FedAvg with secure aggregation using homomorphic encryption.
 
 - `examples/advanced/cifar10/pt/cifar10-real-world#secure-aggregation-using-homomorphic-encryption <https://github.com/NVIDIA/NVFlare/tree/main/examples/advanced/cifar10/pt/cifar10-real-world#42-secure-aggregation-using-homomorphic-encryption>`_
 
+FedCE
+=====
+
+``FedCERecipe`` implements contribution-aware aggregation for PyTorch. It estimates each client's
+contribution from gradient-direction novelty and a client-computed leave-one-out (minus-model) score,
+then uses those estimates as aggregation weights.
+
+.. code-block:: python
+
+    from nvflare.app_opt.pt.recipes import FedCERecipe
+
+    recipe = FedCERecipe(
+        name="fedce-pt",
+        model=MyModel(),
+        min_clients=3,
+        num_rounds=10,
+        train_script="client.py",
+        fedce_mode="plus",
+    )
+
+FedCE requires a compatible client training script. The script must return model differences and set
+``FLModel.meta["fedce_minus_val"]``. The ``PTFedCEHelper`` utility constructs the minus model,
+reads the prior contribution weight from the received model metadata, and attaches the score to the result.
+The score should increase with estimated contribution, matching the research implementation's
+``1 - minus-model validation metric`` convention.
+FedCE is therefore a dedicated algorithm recipe, not a passive option on ``FedAvgRecipe``.
+
+FedSM
+=====
+
+``FedSMRecipe`` implements personalized federated learning with SoftPull for PyTorch. It jointly manages
+a global model, one personalized model per client, and a selector model.
+
+.. code-block:: python
+
+    from nvflare.app_opt.pt.recipes import FedSMRecipe
+
+    recipe = FedSMRecipe(
+        name="fedsm-pt",
+        model=MyModel(),
+        selector_model=MySelector(num_classes=3),
+        client_ids=["site-1", "site-2", "site-3"],
+        min_clients=3,
+        num_rounds=10,
+        train_script="client.py",
+        soft_pull_lambda=0.7,
+    )
+
+The client script uses ``PTFedSMHelper.load_bundle()`` before its task-specific training loops and
+``PTFedSMHelper.build_result()`` afterward. Global and selector entries in the returned bundle are model
+differences; the personalized entry is a full model. Selector optimizer state is synchronized when the helper
+is given an optimizer.
+
+FedSM currently requires every configured ``client_id`` to participate in every round. FedSM and FedCE are
+separate recipes and cannot be enabled together as independent features.
+
 
 FedProx
 =======

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -204,6 +204,8 @@ FedCE requires a compatible client training script. The script must return model
 reads the prior contribution weight from the received model metadata, and attaches the score to the result.
 The score should increase with estimated contribution, matching the research implementation's
 ``1 - minus-model validation metric`` convention.
+When ``model`` is supplied as a dict config, pass ``trainable_param_names`` explicitly so contribution
+estimation excludes non-trainable state such as BatchNorm running statistics and counters.
 FedCE is therefore a dedicated algorithm recipe, not a passive option on ``FedAvgRecipe``.
 
 FedSM

--- a/nvflare/app_opt/pt/__init__.py
+++ b/nvflare/app_opt/pt/__init__.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from nvflare.app_opt.pt.ditto import PTDittoHelper
+from nvflare.app_opt.pt.fedce import FedCEConstants, FedCEModelAggregator, PTFedCEHelper
 from nvflare.app_opt.pt.fedopt import PTFedOptModelShareableGenerator
 from nvflare.app_opt.pt.fedproxloss import PTFedProxLoss
+from nvflare.app_opt.pt.fedsm import FedSMConstants, FedSMModelAggregator, PTFedSMHelper, PTFedSMModelPersistor
 from nvflare.app_opt.pt.file_model_locator import PTFileModelLocator
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.app_opt.pt.he_model_reader_writer import HEPTModelReaderWriter

--- a/nvflare/app_opt/pt/fedce.py
+++ b/nvflare/app_opt/pt/fedce.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch components for FedCE contribution-aware aggregation."""
+
+import copy
+import math
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+import torch
+
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+from nvflare.app_common.aggregators.model_aggregator import ModelAggregator
+from nvflare.app_common.aggregators.weighted_aggregation_helper import (
+    WeightedAggregationHelper,
+    filter_aggregatable_metrics,
+)
+
+
+class FedCEConstants:
+    """Metadata keys shared by the FedCE server and client training script."""
+
+    MINUS_MODEL_SCORE = "fedce_minus_val"
+    CONTRIBUTION_WEIGHTS = "fedce_coef"
+
+
+class PTFedCEHelper:
+    """Client-side utilities for the FedCE-specific training contract."""
+
+    @staticmethod
+    def get_contribution_weight(global_model: FLModel, client_name: str, default: float = 0.0) -> float:
+        weights = (global_model.meta or {}).get(FedCEConstants.CONTRIBUTION_WEIGHTS, {})
+        return float(weights.get(client_name, default))
+
+    @staticmethod
+    def make_minus_model(global_model, previous_local_state: Dict, contribution_weight: float):
+        """Construct the FedCE leave-one-out model for local validation.
+
+        ``previous_local_state`` is the client's trained model state from the
+        preceding round. Non-floating buffers are copied from the global model.
+        """
+        if not 0.0 <= contribution_weight < 1.0:
+            raise ValueError(f"contribution_weight must be in [0, 1), got {contribution_weight}")
+        minus_model = copy.deepcopy(global_model)
+        denominator = 1.0 - contribution_weight
+        global_state = global_model.state_dict()
+        minus_state = minus_model.state_dict()
+        for name, global_value in global_state.items():
+            if name not in previous_local_state:
+                continue
+            if not (global_value.is_floating_point() or global_value.is_complex()):
+                minus_state[name].copy_(global_value)
+                continue
+            previous_value = torch.as_tensor(
+                previous_local_state[name],
+                device=global_value.device,
+                dtype=global_value.dtype,
+            )
+            minus_state[name].copy_((global_value - contribution_weight * previous_value) / denominator)
+        return minus_model
+
+    @staticmethod
+    def set_minus_model_score(result: FLModel, score: float) -> FLModel:
+        """Attach a contribution score, where larger values mean greater contribution."""
+        result.meta[FedCEConstants.MINUS_MODEL_SCORE] = float(score)
+        return result
+
+
+def _normalize(values: List[float], epsilon: float) -> List[float]:
+    if not values:
+        raise ValueError("cannot normalize an empty value list")
+    if any(not math.isfinite(float(value)) for value in values):
+        raise ValueError(f"FedCE contribution values must be finite, got {values}")
+    clipped = [max(float(value), epsilon) for value in values]
+    total = sum(clipped)
+    if total <= 0.0:
+        return [1.0 / len(values)] * len(values)
+    return [value / total for value in clipped]
+
+
+class FedCEModelAggregator(ModelAggregator):
+    """Aggregate client weight differences using FedCE contribution estimates.
+
+    FedCE combines two signals: gradient-direction novelty and a client-provided
+    score obtained by validating a leave-one-out ("minus") model. The resulting
+    contribution weights are returned in the global model metadata so clients can
+    construct the next round's minus model.
+
+    Client results must use ``ParamsType.DIFF`` and include
+    ``FLModel.meta[FedCEConstants.MINUS_MODEL_SCORE]``.
+    """
+
+    MODES = ("plus", "times")
+
+    def __init__(
+        self,
+        mode: str = "plus",
+        trainable_param_names: Optional[List[str]] = None,
+        epsilon: float = 1e-6,
+    ):
+        super().__init__()
+        if mode not in self.MODES:
+            raise ValueError(f"mode must be one of {self.MODES}, got {mode!r}")
+        if epsilon <= 0.0:
+            raise ValueError(f"epsilon must be greater than 0, got {epsilon}")
+
+        self.mode = mode
+        self.trainable_param_names = list(trainable_param_names or [])
+        self.epsilon = epsilon
+        self._results: Dict[str, FLModel] = {}
+        self._contribution_weights: Dict[str, float] = {}
+        self._cosine_history: Dict[str, List[float]] = defaultdict(list)
+
+    def reset_stats(self):
+        self._results = {}
+
+    def accept_model(self, model: FLModel):
+        client_name = (model.meta or {}).get("client_name")
+        if not client_name:
+            raise ValueError("FedCE client result is missing FLModel.meta['client_name']")
+        if model.params_type != ParamsType.DIFF:
+            raise ValueError(
+                f"FedCE requires ParamsType.DIFF results, got {model.params_type} from client {client_name!r}"
+            )
+        if not model.params:
+            raise ValueError(f"FedCE received empty parameters from client {client_name!r}")
+        if FedCEConstants.MINUS_MODEL_SCORE not in model.meta:
+            raise ValueError(
+                f"FedCE client {client_name!r} did not return required metadata "
+                f"{FedCEConstants.MINUS_MODEL_SCORE!r}"
+            )
+        if client_name in self._results:
+            raise ValueError(f"FedCE received more than one result from client {client_name!r} in the same round")
+        task_meta = model.meta.get("props", {})
+        prior_weights = task_meta.get(FedCEConstants.CONTRIBUTION_WEIGHTS) if isinstance(task_meta, dict) else None
+        if not self._contribution_weights and isinstance(prior_weights, dict):
+            self._contribution_weights = {name: float(weight) for name, weight in prior_weights.items()}
+        self._results[client_name] = model
+
+    def aggregate_model(self) -> FLModel:
+        if not self._results:
+            raise ValueError("FedCE cannot aggregate an empty result set")
+
+        clients = sorted(self._results)
+        param_names = self._get_cosine_param_names(clients)
+        prior_weights = self._get_prior_weights(clients)
+        consensus = self._weighted_vector(clients, prior_weights, param_names)
+
+        cosine_scores = []
+        minus_scores = []
+        for client in clients:
+            client_vector = self._flatten_params(self._results[client].params, param_names)
+            without_client = consensus - prior_weights[client] * client_vector
+            if torch.linalg.vector_norm(client_vector) == 0 or torch.linalg.vector_norm(without_client) == 0:
+                similarity = 0.0
+            else:
+                similarity = float(torch.cosine_similarity(client_vector, without_client, dim=0).item())
+            self._cosine_history[client].append(similarity)
+            mean_similarity = sum(self._cosine_history[client]) / len(self._cosine_history[client])
+            cosine_scores.append(max(0.0, 1.0 - mean_similarity))
+            minus_scores.append(float(self._results[client].meta[FedCEConstants.MINUS_MODEL_SCORE]))
+
+        cosine_weights = _normalize(cosine_scores, self.epsilon)
+        minus_weights = _normalize(minus_scores, self.epsilon)
+        if self.mode == "plus":
+            combined = [cosine + minus for cosine, minus in zip(cosine_weights, minus_weights)]
+        else:
+            combined = [cosine * minus for cosine, minus in zip(cosine_weights, minus_weights)]
+        normalized = _normalize(combined, self.epsilon)
+        self._contribution_weights = dict(zip(clients, normalized))
+
+        params_helper = WeightedAggregationHelper()
+        metrics_helper = WeightedAggregationHelper()
+        all_metrics = True
+        current_round = None
+        for client in clients:
+            result = self._results[client]
+            current_round = result.current_round
+            weight = self._contribution_weights[client]
+            params_helper.add(
+                data=result.params,
+                weight=weight,
+                contributor_name=client,
+                contribution_round=current_round,
+            )
+            if result.metrics is None:
+                all_metrics = False
+            elif all_metrics:
+                aggregatable_metrics = filter_aggregatable_metrics(result.metrics)
+                if aggregatable_metrics:
+                    metrics_helper.add(
+                        data=aggregatable_metrics,
+                        weight=weight,
+                        contributor_name=client,
+                        contribution_round=current_round,
+                    )
+
+        metrics = metrics_helper.get_result() if all_metrics and metrics_helper.total else None
+        return FLModel(
+            params=params_helper.get_result(),
+            params_type=ParamsType.DIFF,
+            metrics=metrics or None,
+            current_round=current_round,
+            meta={
+                FedCEConstants.CONTRIBUTION_WEIGHTS: dict(self._contribution_weights),
+                "nr_aggregated": len(clients),
+            },
+        )
+
+    def _get_cosine_param_names(self, clients: List[str]) -> List[str]:
+        common = set(self._results[clients[0]].params)
+        for client in clients[1:]:
+            common.intersection_update(self._results[client].params)
+        if self.trainable_param_names:
+            common.intersection_update(self.trainable_param_names)
+        if not common:
+            raise ValueError("FedCE client updates have no common trainable parameters")
+        return sorted(common)
+
+    def _get_prior_weights(self, clients: List[str]) -> Dict[str, float]:
+        values = [self._contribution_weights.get(client, 1.0) for client in clients]
+        return dict(zip(clients, _normalize(values, self.epsilon)))
+
+    def _weighted_vector(self, clients: List[str], weights: Dict[str, float], param_names: List[str]):
+        result = None
+        for client in clients:
+            vector = self._flatten_params(self._results[client].params, param_names)
+            weighted = weights[client] * vector
+            result = weighted if result is None else result + weighted
+        return result
+
+    @staticmethod
+    def _flatten_params(params: Dict, param_names: List[str]) -> torch.Tensor:
+        tensors = []
+        for name in param_names:
+            value = params[name]
+            materialize = getattr(value, "materialize", None)
+            if callable(materialize):
+                value = materialize()
+            tensors.append(torch.as_tensor(value).detach().reshape(-1).to(device="cpu", dtype=torch.float32))
+        return torch.cat(tensors)

--- a/nvflare/app_opt/pt/fedce.py
+++ b/nvflare/app_opt/pt/fedce.py
@@ -16,7 +16,6 @@
 
 import copy
 import math
-from collections import defaultdict
 from typing import Dict, List, Optional
 
 import torch
@@ -121,7 +120,8 @@ class FedCEModelAggregator(ModelAggregator):
         self.epsilon = epsilon
         self._results: Dict[str, FLModel] = {}
         self._contribution_weights: Dict[str, float] = {}
-        self._cosine_history: Dict[str, List[float]] = defaultdict(list)
+        self._cosine_means: Dict[str, float] = {}
+        self._cosine_counts: Dict[str, int] = {}
 
     def reset_stats(self):
         self._results = {}
@@ -143,6 +143,8 @@ class FedCEModelAggregator(ModelAggregator):
             )
         if client_name in self._results:
             raise ValueError(f"FedCE received more than one result from client {client_name!r} in the same round")
+        # BaseModelController copies the outgoing model metadata into the
+        # returned model's ``props`` entry before invoking this aggregator.
         task_meta = model.meta.get("props", {})
         prior_weights = task_meta.get(FedCEConstants.CONTRIBUTION_WEIGHTS) if isinstance(task_meta, dict) else None
         if not self._contribution_weights and isinstance(prior_weights, dict):
@@ -167,8 +169,11 @@ class FedCEModelAggregator(ModelAggregator):
                 similarity = 0.0
             else:
                 similarity = float(torch.cosine_similarity(client_vector, without_client, dim=0).item())
-            self._cosine_history[client].append(similarity)
-            mean_similarity = sum(self._cosine_history[client]) / len(self._cosine_history[client])
+            count = self._cosine_counts.get(client, 0) + 1
+            previous_mean = self._cosine_means.get(client, 0.0)
+            mean_similarity = previous_mean + (similarity - previous_mean) / count
+            self._cosine_counts[client] = count
+            self._cosine_means[client] = mean_similarity
             cosine_scores.append(max(0.0, 1.0 - mean_similarity))
             minus_scores.append(float(self._results[client].meta[FedCEConstants.MINUS_MODEL_SCORE]))
 

--- a/nvflare/app_opt/pt/fedsm.py
+++ b/nvflare/app_opt/pt/fedsm.py
@@ -70,8 +70,26 @@ class PTFedSMHelper:
         self._selector_before = None
 
     def load_bundle(self, incoming: FLModel, client_name: Optional[str] = None):
+        if incoming.params_type != ParamsType.FULL:
+            raise ValueError(f"FedSM incoming bundle must use ParamsType.FULL, got {incoming.params_type}")
+
         params = incoming.params or {}
-        target = incoming.meta.get(FedSMConstants.TARGET_ID)
+        required_params = {
+            FedSMConstants.GLOBAL_MODEL,
+            FedSMConstants.PERSONAL_MODEL,
+            FedSMConstants.SELECTOR_MODEL,
+        }
+        missing_params = required_params.difference(params)
+        if missing_params:
+            raise ValueError(f"FedSM incoming bundle is missing parameter entries: {sorted(missing_params)}")
+
+        meta = incoming.meta or {}
+        required_meta = {FedSMConstants.TARGET_ID, FedSMConstants.SELECTOR_LABEL}
+        missing_meta = required_meta.difference(meta)
+        if missing_meta:
+            raise ValueError(f"FedSM incoming bundle is missing metadata entries: {sorted(missing_meta)}")
+
+        target = meta[FedSMConstants.TARGET_ID]
         if client_name is not None and target != client_name:
             raise ValueError(f"FedSM bundle targets {target!r}, but this client is {client_name!r}")
         self.global_model.load_state_dict(params[FedSMConstants.GLOBAL_MODEL])
@@ -85,7 +103,7 @@ class PTFedSMHelper:
             current_state = self.selector_optimizer.state_dict()
             current_state["state"] = optimizer_state
             self.selector_optimizer.load_state_dict(current_state)
-        return incoming.meta[FedSMConstants.SELECTOR_LABEL]
+        return meta[FedSMConstants.SELECTOR_LABEL]
 
     def build_result(self, num_steps: int, metrics: Optional[Dict] = None) -> FLModel:
         if self._global_before is None or self._selector_before is None:
@@ -251,6 +269,7 @@ class PTFedSMModelPersistor(ModelPersistor):
         client_ids: List[str],
         source_ckpt_file_full_name: Optional[str] = None,
         global_model_file_name: str = "FL_fedsm_model.pt",
+        load_weights_only: bool = True,
     ):
         super().__init__()
         self.model = model
@@ -258,6 +277,7 @@ class PTFedSMModelPersistor(ModelPersistor):
         self.client_ids = list(client_ids)
         self.source_ckpt_file_full_name = source_ckpt_file_full_name
         self.global_model_file_name = global_model_file_name
+        self.load_weights_only = load_weights_only
         self._ckpt_save_path = None
 
     def handle_event(self, event: str, fl_ctx: FLContext):
@@ -316,7 +336,7 @@ class PTFedSMModelPersistor(ModelPersistor):
             path = os.path.join(app_root, WorkspaceConstants.CUSTOM_FOLDER_NAME, path)
         if not os.path.exists(path):
             raise ValueError(f"FedSM source checkpoint not found: {path}")
-        return torch.load(path, map_location="cpu", weights_only=True)
+        return torch.load(path, map_location="cpu", weights_only=self.load_weights_only)
 
     def save_model(self, model: ModelLearnable, fl_ctx: FLContext):
         if self._ckpt_save_path is None:
@@ -346,6 +366,12 @@ class FedSM(BaseFedAvg):
         self.aggregator = aggregator or FedSMModelAggregator()
         self.task_name = task_name
 
+        if self.num_clients != len(self.client_id_label_mapping):
+            raise ValueError(
+                "FedSM num_clients must equal the number of entries in client_id_label_mapping "
+                "so every personalized model participates in each round"
+            )
+
     def run(self):
         model = self.load_model()
         model.start_round = self.start_round
@@ -358,9 +384,7 @@ class FedSM(BaseFedAvg):
             self.fl_ctx.set_prop(AppConstants.NUM_ROUNDS, self.num_rounds, private=True, sticky=False)
             self.event(AppEventType.ROUND_STARTED)
             clients = self.sample_clients(self.num_clients)
-            missing = [client for client in clients if client not in self.client_id_label_mapping]
-            if missing:
-                raise ValueError(f"FedSM has no selector labels for clients: {missing}")
+            self._validate_sampled_clients(clients)
 
             results = []
             for client in clients:
@@ -395,6 +419,17 @@ class FedSM(BaseFedAvg):
             self.event(AppEventType.ROUND_DONE)
             self.info(f"FedSM round {self.current_round} finished")
             self._maybe_cleanup_memory()
+
+    def _validate_sampled_clients(self, clients: List[str]):
+        expected = set(self.client_id_label_mapping)
+        sampled = set(clients)
+        missing = sorted(expected.difference(sampled))
+        unexpected = sorted(sampled.difference(expected))
+        if missing or unexpected:
+            raise RuntimeError(
+                "FedSM requires every configured client in every round; "
+                f"missing clients: {missing}; unexpected clients: {unexpected}"
+            )
 
     def _make_client_model(self, model: FLModel, client: str) -> FLModel:
         bundle = model.params

--- a/nvflare/app_opt/pt/fedsm.py
+++ b/nvflare/app_opt/pt/fedsm.py
@@ -15,6 +15,7 @@
 """PyTorch components and client helpers for personalized learning with FedSM."""
 
 import copy
+import math
 import os
 import time
 from numbers import Number
@@ -32,7 +33,7 @@ from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.aggregators.model_aggregator import ModelAggregator
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
-from nvflare.app_common.workflows.base_fedavg import BaseFedAvg
+from nvflare.app_common.workflows.base_fedavg import BaseFedAvg, _aggregate_fl_model_metrics
 
 
 class FedSMConstants:
@@ -140,11 +141,17 @@ def _to_cpu_copy(value):
 def _weighted_average(values: List, weights: List[float]):
     first = values[0]
     if isinstance(first, dict):
-        common_keys = set(first)
-        for value in values[1:]:
-            common_keys.intersection_update(value)
+        expected_keys = set(first)
+        for index, value in enumerate(values[1:], start=1):
+            if not isinstance(value, dict) or set(value) != expected_keys:
+                actual_keys = set(value) if isinstance(value, dict) else set()
+                raise ValueError(
+                    "FedSM cannot average model states with different keys: "
+                    f"expected {sorted(expected_keys, key=str)}, got {sorted(actual_keys, key=str)} "
+                    f"at value index {index}"
+                )
         return {
-            key: _weighted_average([value[key] for value in values], weights) for key in sorted(common_keys, key=str)
+            key: _weighted_average([value[key] for value in values], weights) for key in sorted(expected_keys, key=str)
         }
     if isinstance(first, torch.Tensor):
         if not (first.is_floating_point() or first.is_complex()):
@@ -210,11 +217,18 @@ class FedSMModelAggregator(ModelAggregator):
             raise ValueError("FedSM cannot aggregate an empty result set")
 
         clients = sorted(self._results)
-        raw_weights = [
-            float((self._results[client].meta or {}).get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0)) for client in clients
-        ]
+        raw_weights = []
+        for client in clients:
+            raw_weight = (self._results[client].meta or {}).get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0)
+            try:
+                weight = float(raw_weight)
+            except (TypeError, ValueError, OverflowError) as e:
+                raise ValueError(f"FedSM client {client!r} returned invalid step weight {raw_weight!r}") from e
+            if not math.isfinite(weight) or weight <= 0.0:
+                raise ValueError(f"FedSM client {client!r} step weight must be finite and positive, got {raw_weight!r}")
+            raw_weights.append(weight)
         total = sum(raw_weights)
-        weights = [weight / total for weight in raw_weights] if total > 0 else [1.0 / len(clients)] * len(clients)
+        weights = [weight / total for weight in raw_weights]
 
         global_update = _weighted_average(
             [self._results[client].params[FedSMConstants.GLOBAL_MODEL] for client in clients],
@@ -251,9 +265,12 @@ class FedSMModelAggregator(ModelAggregator):
         if all(state is not None for state in optimizer_states):
             bundle[FedSMConstants.SELECTOR_OPTIMIZER] = _weighted_average(optimizer_states, weights)
 
+        metrics = _aggregate_fl_model_metrics([self._results[client] for client in clients])
+
         return FLModel(
             params=bundle,
             params_type=ParamsType.FULL,
+            metrics=metrics,
             current_round=self._results[clients[0]].current_round,
             meta={"nr_aggregated": len(clients)},
         )

--- a/nvflare/app_opt/pt/fedsm.py
+++ b/nvflare/app_opt/pt/fedsm.py
@@ -1,0 +1,437 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch components and client helpers for personalized learning with FedSM."""
+
+import copy
+import os
+import time
+from numbers import Number
+from typing import Dict, List, Optional
+
+import numpy as np
+import torch
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey, FLMetaKey, WorkspaceConstants
+from nvflare.apis.fl_context import FLContext
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+from nvflare.app_common.abstract.model import ModelLearnable, ModelLearnableKey, make_model_learnable
+from nvflare.app_common.abstract.model_persistor import ModelPersistor
+from nvflare.app_common.aggregators.model_aggregator import ModelAggregator
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.workflows.base_fedavg import BaseFedAvg
+
+
+class FedSMConstants:
+    """Names used in the FedSM model bundle and client contract."""
+
+    GLOBAL_MODEL = "global_model"
+    PERSONAL_MODEL = "personal_model"
+    PERSONAL_MODELS = "personal_models"
+    SELECTOR_MODEL = "selector_model"
+    SELECTOR_OPTIMIZER = "selector_optimizer"
+    TARGET_ID = "fedsm_target_id"
+    SELECTOR_LABEL = "fedsm_selector_label"
+
+
+class PTFedSMHelper:
+    """Load and return the multi-model bundle expected by ``FedSMRecipe``.
+
+    The user remains responsible for the task-specific training loops. Call
+    :meth:`load_bundle` before training, then :meth:`build_result` after training.
+    """
+
+    def __init__(self, global_model, personal_model, selector_model, selector_optimizer=None):
+        for name, model in (
+            ("global_model", global_model),
+            ("personal_model", personal_model),
+            ("selector_model", selector_model),
+        ):
+            if not isinstance(model, torch.nn.Module):
+                raise TypeError(f"{name} must be torch.nn.Module, got {type(model).__name__}")
+        self.global_model = global_model
+        self.personal_model = personal_model
+        self.selector_model = selector_model
+        self.selector_optimizer = selector_optimizer
+        self._global_before = None
+        self._selector_before = None
+
+    def load_bundle(self, incoming: FLModel, client_name: Optional[str] = None):
+        params = incoming.params or {}
+        target = incoming.meta.get(FedSMConstants.TARGET_ID)
+        if client_name is not None and target != client_name:
+            raise ValueError(f"FedSM bundle targets {target!r}, but this client is {client_name!r}")
+        self.global_model.load_state_dict(params[FedSMConstants.GLOBAL_MODEL])
+        self.personal_model.load_state_dict(params[FedSMConstants.PERSONAL_MODEL])
+        self.selector_model.load_state_dict(params[FedSMConstants.SELECTOR_MODEL])
+        self._global_before = _to_cpu_copy(self.global_model.state_dict())
+        self._selector_before = _to_cpu_copy(self.selector_model.state_dict())
+
+        optimizer_state = params.get(FedSMConstants.SELECTOR_OPTIMIZER)
+        if self.selector_optimizer is not None and optimizer_state:
+            current_state = self.selector_optimizer.state_dict()
+            current_state["state"] = optimizer_state
+            self.selector_optimizer.load_state_dict(current_state)
+        return incoming.meta[FedSMConstants.SELECTOR_LABEL]
+
+    def build_result(self, num_steps: int, metrics: Optional[Dict] = None) -> FLModel:
+        if self._global_before is None or self._selector_before is None:
+            raise RuntimeError("load_bundle() must be called before build_result()")
+        params = {
+            FedSMConstants.GLOBAL_MODEL: self._state_diff(self._global_before, self.global_model.state_dict()),
+            FedSMConstants.PERSONAL_MODEL: _to_cpu_copy(self.personal_model.state_dict()),
+            FedSMConstants.SELECTOR_MODEL: self._state_diff(self._selector_before, self.selector_model.state_dict()),
+        }
+        if self.selector_optimizer is not None:
+            params[FedSMConstants.SELECTOR_OPTIMIZER] = _to_cpu_copy(
+                self.selector_optimizer.state_dict().get("state", {})
+            )
+        return FLModel(
+            params=params,
+            params_type=ParamsType.FULL,
+            metrics=metrics,
+            meta={FLMetaKey.NUM_STEPS_CURRENT_ROUND: num_steps},
+        )
+
+    @staticmethod
+    def _state_diff(before: Dict, after: Dict) -> Dict:
+        return {name: _to_cpu_copy(after[name]) - before[name] for name in before if name in after}
+
+
+def _to_cpu_copy(value):
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().clone()
+    if isinstance(value, dict):
+        return {key: _to_cpu_copy(item) for key, item in value.items()}
+    return copy.deepcopy(value)
+
+
+def _weighted_average(values: List, weights: List[float]):
+    first = values[0]
+    if isinstance(first, dict):
+        common_keys = set(first)
+        for value in values[1:]:
+            common_keys.intersection_update(value)
+        return {
+            key: _weighted_average([value[key] for value in values], weights) for key in sorted(common_keys, key=str)
+        }
+    if isinstance(first, torch.Tensor):
+        if not (first.is_floating_point() or first.is_complex()):
+            averaged = torch.zeros_like(first, device="cpu", dtype=torch.float64)
+            for value, weight in zip(values, weights):
+                averaged.add_(torch.as_tensor(value, device="cpu", dtype=torch.float64), alpha=weight)
+            return averaged.round().to(dtype=first.dtype)
+        result = torch.zeros_like(first, device="cpu")
+        for value, weight in zip(values, weights):
+            result.add_(torch.as_tensor(value, device="cpu", dtype=result.dtype), alpha=weight)
+        return result
+    if isinstance(first, np.ndarray):
+        return sum(weight * np.asarray(value) for value, weight in zip(values, weights))
+    if isinstance(first, Number):
+        return sum(weight * value for value, weight in zip(values, weights))
+    raise TypeError(f"FedSM cannot average values of type {type(first).__name__}")
+
+
+def _add_state_diff(state: Dict, state_diff: Dict) -> Dict:
+    updated = _to_cpu_copy(state)
+    for name, value in state_diff.items():
+        if name not in updated:
+            continue
+        updated[name] = updated[name] + value
+    return updated
+
+
+class FedSMModelAggregator(ModelAggregator):
+    """Aggregate global, personalized, and selector model updates for FedSM."""
+
+    def __init__(self, soft_pull_lambda: float = 0.7):
+        super().__init__()
+        if not 0.0 <= soft_pull_lambda <= 1.0:
+            raise ValueError(f"soft_pull_lambda must be in [0, 1], got {soft_pull_lambda}")
+        self.soft_pull_lambda = soft_pull_lambda
+        self._results: Dict[str, FLModel] = {}
+
+    def reset_stats(self):
+        self._results = {}
+
+    def accept_model(self, model: FLModel):
+        client_name = (model.meta or {}).get("client_name")
+        if not client_name:
+            raise ValueError("FedSM client result is missing FLModel.meta['client_name']")
+        if model.params_type != ParamsType.FULL:
+            raise ValueError(
+                f"FedSM requires ParamsType.FULL bundle results, got {model.params_type} from {client_name!r}"
+            )
+        required = {
+            FedSMConstants.GLOBAL_MODEL,
+            FedSMConstants.PERSONAL_MODEL,
+            FedSMConstants.SELECTOR_MODEL,
+        }
+        missing = required.difference(model.params or {})
+        if missing:
+            raise ValueError(f"FedSM client {client_name!r} result is missing bundle entries: {sorted(missing)}")
+        if client_name in self._results:
+            raise ValueError(f"FedSM received more than one result from client {client_name!r} in the same round")
+        self._results[client_name] = model
+
+    def aggregate_model(self) -> FLModel:
+        if not self._results:
+            raise ValueError("FedSM cannot aggregate an empty result set")
+
+        clients = sorted(self._results)
+        raw_weights = [
+            float((self._results[client].meta or {}).get(FLMetaKey.NUM_STEPS_CURRENT_ROUND, 1.0)) for client in clients
+        ]
+        total = sum(raw_weights)
+        weights = [weight / total for weight in raw_weights] if total > 0 else [1.0 / len(clients)] * len(clients)
+
+        global_update = _weighted_average(
+            [self._results[client].params[FedSMConstants.GLOBAL_MODEL] for client in clients],
+            weights,
+        )
+        selector_update = _weighted_average(
+            [self._results[client].params[FedSMConstants.SELECTOR_MODEL] for client in clients],
+            weights,
+        )
+
+        personal_updates = {}
+        if len(clients) == 1:
+            only_client = clients[0]
+            personal_updates[only_client] = _to_cpu_copy(
+                self._results[only_client].params[FedSMConstants.PERSONAL_MODEL]
+            )
+        else:
+            for target in clients:
+                target_weights = [
+                    self.soft_pull_lambda if source == target else (1.0 - self.soft_pull_lambda) / (len(clients) - 1)
+                    for source in clients
+                ]
+                personal_updates[target] = _weighted_average(
+                    [self._results[source].params[FedSMConstants.PERSONAL_MODEL] for source in clients],
+                    target_weights,
+                )
+
+        bundle = {
+            FedSMConstants.GLOBAL_MODEL: global_update,
+            FedSMConstants.PERSONAL_MODELS: personal_updates,
+            FedSMConstants.SELECTOR_MODEL: selector_update,
+        }
+        optimizer_states = [self._results[client].params.get(FedSMConstants.SELECTOR_OPTIMIZER) for client in clients]
+        if all(state is not None for state in optimizer_states):
+            bundle[FedSMConstants.SELECTOR_OPTIMIZER] = _weighted_average(optimizer_states, weights)
+
+        return FLModel(
+            params=bundle,
+            params_type=ParamsType.FULL,
+            current_round=self._results[clients[0]].current_round,
+            meta={"nr_aggregated": len(clients)},
+        )
+
+
+class PTFedSMModelPersistor(ModelPersistor):
+    """Persist the complete FedSM model bundle in a PyTorch checkpoint."""
+
+    def __init__(
+        self,
+        model,
+        selector_model,
+        client_ids: List[str],
+        source_ckpt_file_full_name: Optional[str] = None,
+        global_model_file_name: str = "FL_fedsm_model.pt",
+    ):
+        super().__init__()
+        self.model = model
+        self.selector_model = selector_model
+        self.client_ids = list(client_ids)
+        self.source_ckpt_file_full_name = source_ckpt_file_full_name
+        self.global_model_file_name = global_model_file_name
+        self._ckpt_save_path = None
+
+    def handle_event(self, event: str, fl_ctx: FLContext):
+        if event == EventType.START_RUN:
+            self._initialize(fl_ctx)
+
+    def _initialize(self, fl_ctx: FLContext):
+        app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+        log_dir = fl_ctx.get_prop(AppConstants.LOG_DIR)
+        output_dir = os.path.join(app_root, log_dir) if log_dir else app_root
+        os.makedirs(output_dir, exist_ok=True)
+        self._ckpt_save_path = os.path.join(output_dir, self.global_model_file_name)
+        self.model = self._resolve_model(self.model, "model", fl_ctx)
+        self.selector_model = self._resolve_model(self.selector_model, "selector_model", fl_ctx)
+        from nvflare.app_opt.pt.decomposers import TensorDecomposer
+        from nvflare.fuel.utils import fobs
+
+        fobs.register(TensorDecomposer)
+
+    def _resolve_model(self, value, name: str, fl_ctx: FLContext):
+        if isinstance(value, dict):
+            from nvflare.fuel.utils.class_utils import instantiate_class
+
+            value = instantiate_class(value.get("path"), value.get("args", {}))
+        elif isinstance(value, str):
+            value = fl_ctx.get_engine().get_component(value)
+        if not isinstance(value, torch.nn.Module):
+            raise TypeError(f"{name} must resolve to torch.nn.Module, got {type(value).__name__}")
+        return value
+
+    def load_model(self, fl_ctx: FLContext) -> ModelLearnable:
+        checkpoint = self._load_checkpoint(fl_ctx)
+        if checkpoint and "model_bundle" in checkpoint:
+            return make_model_learnable(_to_cpu_copy(checkpoint["model_bundle"]), checkpoint.get("meta", {}))
+
+        if checkpoint:
+            global_state = checkpoint.get("model", checkpoint)
+        else:
+            global_state = self.model.state_dict()
+        global_state = _to_cpu_copy(global_state)
+        selector_state = _to_cpu_copy(self.selector_model.state_dict())
+        bundle = {
+            FedSMConstants.GLOBAL_MODEL: global_state,
+            FedSMConstants.PERSONAL_MODELS: {client_id: _to_cpu_copy(global_state) for client_id in self.client_ids},
+            FedSMConstants.SELECTOR_MODEL: selector_state,
+            FedSMConstants.SELECTOR_OPTIMIZER: {},
+        }
+        return make_model_learnable(bundle, {})
+
+    def _load_checkpoint(self, fl_ctx: FLContext):
+        if not self.source_ckpt_file_full_name:
+            return None
+        path = self.source_ckpt_file_full_name
+        if not os.path.isabs(path):
+            app_root = fl_ctx.get_prop(FLContextKey.APP_ROOT)
+            path = os.path.join(app_root, WorkspaceConstants.CUSTOM_FOLDER_NAME, path)
+        if not os.path.exists(path):
+            raise ValueError(f"FedSM source checkpoint not found: {path}")
+        return torch.load(path, map_location="cpu", weights_only=True)
+
+    def save_model(self, model: ModelLearnable, fl_ctx: FLContext):
+        if self._ckpt_save_path is None:
+            self._initialize(fl_ctx)
+        torch.save(
+            {
+                "model_bundle": _to_cpu_copy(model[ModelLearnableKey.WEIGHTS]),
+                "meta": copy.deepcopy(model[ModelLearnableKey.META]),
+            },
+            self._ckpt_save_path,
+        )
+
+
+class FedSM(BaseFedAvg):
+    """Controller for the multi-model FedSM training lifecycle."""
+
+    def __init__(
+        self,
+        *args,
+        client_id_label_mapping: Dict[str, int],
+        aggregator: Optional[FedSMModelAggregator] = None,
+        task_name: str = AppConstants.TASK_TRAIN,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.client_id_label_mapping = dict(client_id_label_mapping)
+        self.aggregator = aggregator or FedSMModelAggregator()
+        self.task_name = task_name
+
+    def run(self):
+        model = self.load_model()
+        model.start_round = self.start_round
+        model.total_rounds = self.num_rounds
+
+        for self.current_round in range(self.start_round, self.start_round + self.num_rounds):
+            self.info(f"FedSM round {self.current_round} started")
+            model.current_round = self.current_round
+            self.fl_ctx.set_prop(AppConstants.CURRENT_ROUND, self.current_round, private=True, sticky=False)
+            self.fl_ctx.set_prop(AppConstants.NUM_ROUNDS, self.num_rounds, private=True, sticky=False)
+            self.event(AppEventType.ROUND_STARTED)
+            clients = self.sample_clients(self.num_clients)
+            missing = [client for client in clients if client not in self.client_id_label_mapping]
+            if missing:
+                raise ValueError(f"FedSM has no selector labels for clients: {missing}")
+
+            results = []
+            for client in clients:
+                request = self._make_client_model(model, client)
+                self.send_model(
+                    task_name=self.task_name,
+                    targets=[client],
+                    data=request,
+                    callback=results.append,
+                )
+
+            while self.get_num_standing_tasks():
+                if self.abort_signal.triggered:
+                    return
+                time.sleep(self._task_check_period)
+            if len(results) != len(clients):
+                raise RuntimeError(f"FedSM received {len(results)} of {len(clients)} expected client results")
+
+            aggregated = self.aggregate(results, aggregate_fn=self._aggregate_results)
+            self.event(AppEventType.BEFORE_SHAREABLE_TO_LEARNABLE)
+            model.params = self._update_bundle(model.params, aggregated.params)
+            model.meta = aggregated.meta
+            model.metrics = aggregated.metrics
+            self.fl_ctx.set_prop(
+                AppConstants.GLOBAL_MODEL,
+                make_model_learnable(model.params, model.meta),
+                private=True,
+                sticky=True,
+            )
+            self.event(AppEventType.AFTER_SHAREABLE_TO_LEARNABLE)
+            self.save_model(model)
+            self.event(AppEventType.ROUND_DONE)
+            self.info(f"FedSM round {self.current_round} finished")
+            self._maybe_cleanup_memory()
+
+    def _make_client_model(self, model: FLModel, client: str) -> FLModel:
+        bundle = model.params
+        params = {
+            FedSMConstants.GLOBAL_MODEL: _to_cpu_copy(bundle[FedSMConstants.GLOBAL_MODEL]),
+            FedSMConstants.PERSONAL_MODEL: _to_cpu_copy(bundle[FedSMConstants.PERSONAL_MODELS][client]),
+            FedSMConstants.SELECTOR_MODEL: _to_cpu_copy(bundle[FedSMConstants.SELECTOR_MODEL]),
+            FedSMConstants.SELECTOR_OPTIMIZER: _to_cpu_copy(bundle.get(FedSMConstants.SELECTOR_OPTIMIZER, {})),
+        }
+        return FLModel(
+            params=params,
+            params_type=ParamsType.FULL,
+            current_round=self.current_round,
+            total_rounds=self.num_rounds,
+            meta={
+                FedSMConstants.TARGET_ID: client,
+                FedSMConstants.SELECTOR_LABEL: self.client_id_label_mapping[client],
+            },
+        )
+
+    def _aggregate_results(self, results: List[FLModel]) -> FLModel:
+        self.aggregator.reset_stats()
+        for result in results:
+            self.aggregator.accept_model(result)
+        return self.aggregator.aggregate_model()
+
+    @staticmethod
+    def _update_bundle(bundle: Dict, update: Dict) -> Dict:
+        updated = _to_cpu_copy(bundle)
+        updated[FedSMConstants.GLOBAL_MODEL] = _add_state_diff(
+            updated[FedSMConstants.GLOBAL_MODEL], update[FedSMConstants.GLOBAL_MODEL]
+        )
+        updated[FedSMConstants.SELECTOR_MODEL] = _add_state_diff(
+            updated[FedSMConstants.SELECTOR_MODEL], update[FedSMConstants.SELECTOR_MODEL]
+        )
+        for client, personal_model in update[FedSMConstants.PERSONAL_MODELS].items():
+            updated[FedSMConstants.PERSONAL_MODELS][client] = _to_cpu_copy(personal_model)
+        if FedSMConstants.SELECTOR_OPTIMIZER in update:
+            updated[FedSMConstants.SELECTOR_OPTIMIZER] = _to_cpu_copy(update[FedSMConstants.SELECTOR_OPTIMIZER])
+        return updated

--- a/nvflare/app_opt/pt/recipes/__init__.py
+++ b/nvflare/app_opt/pt/recipes/__init__.py
@@ -21,6 +21,14 @@ from .scaffold import ScaffoldRecipe
 
 # Lazy imports for recipes with optional dependencies or to avoid circular imports
 def __getattr__(name):
+    if name == "FedCERecipe":
+        from .fedce import FedCERecipe
+
+        return FedCERecipe
+    if name == "FedSMRecipe":
+        from .fedsm import FedSMRecipe
+
+        return FedSMRecipe
     if name == "FedAvgRecipeWithHE":
         from .fedavg_he import FedAvgRecipeWithHE
 
@@ -34,6 +42,8 @@ def __getattr__(name):
 
 __all__ = [
     "FedAvgRecipe",
+    "FedCERecipe",
+    "FedSMRecipe",
     "CyclicRecipe",
     "FedOptRecipe",
     "ScaffoldRecipe",

--- a/nvflare/app_opt/pt/recipes/fedce.py
+++ b/nvflare/app_opt/pt/recipes/fedce.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from nvflare.app_opt.pt.fedce import FedCEModelAggregator
 from nvflare.client.config import ExchangeFormat, TransferType
@@ -45,6 +45,7 @@ class FedCERecipe(FedAvgRecipe):
         train_script: str,
         train_args: str = "",
         fedce_mode: str = "plus",
+        trainable_param_names: Optional[List[str]] = None,
         launch_external_process: bool = False,
         command: str = "python3 -u",
         server_expected_format: ExchangeFormat = ExchangeFormat.PYTORCH,
@@ -63,15 +64,29 @@ class FedCERecipe(FedAvgRecipe):
         if server_expected_format != ExchangeFormat.PYTORCH:
             raise ValueError("FedCERecipe requires server_expected_format=ExchangeFormat.PYTORCH")
 
-        trainable_param_names = None
-        named_parameters = getattr(model, "named_parameters", None)
-        if callable(named_parameters):
+        if trainable_param_names is None:
+            named_parameters = getattr(model, "named_parameters", None)
+            if not callable(named_parameters):
+                raise ValueError(
+                    "trainable_param_names is required when model does not expose named_parameters(), "
+                    "including dict-config models"
+                )
             trainable_param_names = [name for name, parameter in named_parameters() if parameter.requires_grad]
+        elif (
+            not isinstance(trainable_param_names, list)
+            or not trainable_param_names
+            or any(not isinstance(name, str) or not name for name in trainable_param_names)
+            or len(trainable_param_names) != len(set(trainable_param_names))
+        ):
+            raise ValueError("trainable_param_names must be a non-empty list of unique parameter names")
+        if not trainable_param_names:
+            raise ValueError("FedCE requires at least one trainable parameter")
 
         self.fedce_mode = fedce_mode
+        self.trainable_param_names = list(trainable_param_names)
         self.fedce_aggregator = FedCEModelAggregator(
             mode=fedce_mode,
-            trainable_param_names=trainable_param_names,
+            trainable_param_names=self.trainable_param_names,
         )
         super().__init__(
             name=name,

--- a/nvflare/app_opt/pt/recipes/fedce.py
+++ b/nvflare/app_opt/pt/recipes/fedce.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Optional, Union
+
+from nvflare.app_opt.pt.fedce import FedCEModelAggregator
+from nvflare.client.config import ExchangeFormat, TransferType
+
+from .fedavg import FedAvgRecipe
+
+
+class FedCERecipe(FedAvgRecipe):
+    """PyTorch recipe for federated training via contribution estimation (FedCE).
+
+    FedCE uses FedAvg's single-global-model lifecycle, but replaces ordinary
+    sample-count aggregation with contribution-aware aggregation. Client scripts
+    must return weight differences and set ``fedce_minus_val`` in the
+    outgoing ``FLModel.meta``. Starting in round 1, the received global model
+    metadata contains ``fedce_coef`` for constructing the local
+    leave-one-out model.
+
+    This recipe intentionally requires PyTorch exchange format and DIFF transfer.
+    It is not composable with FedSM.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "fedce",
+        model: Union[Any, Dict[str, Any], None] = None,
+        initial_ckpt: Optional[str] = None,
+        min_clients: int,
+        num_rounds: int = 2,
+        train_script: str,
+        train_args: str = "",
+        fedce_mode: str = "plus",
+        launch_external_process: bool = False,
+        command: str = "python3 -u",
+        server_expected_format: ExchangeFormat = ExchangeFormat.PYTORCH,
+        per_site_config: Optional[Dict[str, Dict]] = None,
+        launch_once: bool = True,
+        shutdown_timeout: float = 0.0,
+        key_metric: str = "accuracy",
+        stop_cond: Optional[str] = None,
+        patience: Optional[int] = None,
+        best_model_filename: Optional[str] = None,
+        server_memory_gc_rounds: int = 0,
+        enable_tensor_disk_offload: bool = False,
+        client_memory_gc_rounds: int = 0,
+        cuda_empty_cache: bool = False,
+    ):
+        if server_expected_format != ExchangeFormat.PYTORCH:
+            raise ValueError("FedCERecipe requires server_expected_format=ExchangeFormat.PYTORCH")
+
+        trainable_param_names = None
+        named_parameters = getattr(model, "named_parameters", None)
+        if callable(named_parameters):
+            trainable_param_names = [name for name, parameter in named_parameters() if parameter.requires_grad]
+
+        self.fedce_mode = fedce_mode
+        self.fedce_aggregator = FedCEModelAggregator(
+            mode=fedce_mode,
+            trainable_param_names=trainable_param_names,
+        )
+        super().__init__(
+            name=name,
+            model=model,
+            initial_ckpt=initial_ckpt,
+            min_clients=min_clients,
+            num_rounds=num_rounds,
+            train_script=train_script,
+            train_args=train_args,
+            aggregator=self.fedce_aggregator,
+            launch_external_process=launch_external_process,
+            command=command,
+            server_expected_format=server_expected_format,
+            params_transfer_type=TransferType.DIFF,
+            per_site_config=per_site_config,
+            launch_once=launch_once,
+            shutdown_timeout=shutdown_timeout,
+            key_metric=key_metric,
+            stop_cond=stop_cond,
+            patience=patience,
+            best_model_filename=best_model_filename,
+            server_memory_gc_rounds=server_memory_gc_rounds,
+            enable_tensor_disk_offload=enable_tensor_disk_offload,
+            client_memory_gc_rounds=client_memory_gc_rounds,
+            cuda_empty_cache=cuda_empty_cache,
+        )

--- a/nvflare/app_opt/pt/recipes/fedsm.py
+++ b/nvflare/app_opt/pt/recipes/fedsm.py
@@ -49,6 +49,7 @@ class FedSMRecipe(Recipe):
         site_label_mapping: Optional[Dict[str, int]] = None,
         soft_pull_lambda: float = 0.7,
         initial_ckpt: Optional[str] = None,
+        load_weights_only: bool = True,
         launch_external_process: bool = False,
         command: str = "python3 -u",
         server_expected_format: ExchangeFormat = ExchangeFormat.PYTORCH,
@@ -101,15 +102,17 @@ class FedSMRecipe(Recipe):
         self.site_label_mapping = dict(mapping)
         self.soft_pull_lambda = soft_pull_lambda
         self.initial_ckpt = initial_ckpt
+        self.load_weights_only = load_weights_only
         self.server_expected_format = server_expected_format
 
-        job = BaseFedJob(name=name, min_clients=min_clients)
+        job = BaseFedJob(name=name, min_clients=min_clients, mandatory_clients=sites)
         ckpt_path = prepare_initial_ckpt(initial_ckpt, job)
         persistor = PTFedSMModelPersistor(
             model=model,
             selector_model=selector_model,
             client_ids=sites,
             source_ckpt_file_full_name=ckpt_path,
+            load_weights_only=load_weights_only,
         )
         persistor_id = job.to_server(persistor, id="persistor")
 

--- a/nvflare/app_opt/pt/recipes/fedsm.py
+++ b/nvflare/app_opt/pt/recipes/fedsm.py
@@ -30,8 +30,9 @@ class FedSMRecipe(Recipe):
     FULL bundle containing global and selector weight differences plus the full
     personalized model. They may also return selector optimizer state.
 
-    Unlike FedAvg, FedSM requires the complete client identity set before job
-    construction. For now every configured client participates in every round.
+    Unlike FedAvg, FedSM requires the complete site set before job construction.
+    The recipe creates one client app per site, and every configured site
+    participates in every round.
     """
 
     def __init__(
@@ -40,12 +41,12 @@ class FedSMRecipe(Recipe):
         name: str = "fedsm",
         model: Union[Any, Dict[str, Any]],
         selector_model: Union[Any, Dict[str, Any]],
-        client_ids: List[str],
+        sites: List[str],
         min_clients: int,
         num_rounds: int = 2,
         train_script: str,
         train_args: str = "",
-        client_id_label_mapping: Optional[Dict[str, int]] = None,
+        site_label_mapping: Optional[Dict[str, int]] = None,
         soft_pull_lambda: float = 0.7,
         initial_ckpt: Optional[str] = None,
         launch_external_process: bool = False,
@@ -61,25 +62,25 @@ class FedSMRecipe(Recipe):
             raise ValueError("FedSMRecipe requires model")
         if selector_model is None:
             raise ValueError("FedSMRecipe requires selector_model")
-        if not isinstance(client_ids, list) or not client_ids:
-            raise ValueError("client_ids must be a non-empty list of unique client names")
-        if any(not isinstance(client_id, str) or not client_id for client_id in client_ids):
-            raise ValueError("client_ids must contain non-empty strings")
-        if len(client_ids) != len(set(client_ids)):
-            raise ValueError("client_ids must be a non-empty list of unique client names")
-        if min_clients != len(client_ids):
+        if not isinstance(sites, list) or not sites:
+            raise ValueError("sites must be a non-empty list of unique site names")
+        if any(not isinstance(site, str) or not site for site in sites):
+            raise ValueError("sites must contain non-empty strings")
+        if len(sites) != len(set(sites)):
+            raise ValueError("sites must be a non-empty list of unique site names")
+        if min_clients != len(sites):
             raise ValueError(
-                "FedSMRecipe currently requires min_clients to equal len(client_ids) "
+                "FedSMRecipe currently requires min_clients to equal len(sites) "
                 "so every personalized model participates in each SoftPull update"
             )
         if server_expected_format != ExchangeFormat.PYTORCH:
             raise ValueError("FedSMRecipe requires server_expected_format=ExchangeFormat.PYTORCH")
 
-        mapping = client_id_label_mapping or {client_id: index for index, client_id in enumerate(client_ids)}
-        if set(mapping) != set(client_ids):
-            raise ValueError("client_id_label_mapping keys must exactly match client_ids")
-        if set(mapping.values()) != set(range(len(client_ids))):
-            raise ValueError("client_id_label_mapping values must be contiguous selector labels starting at 0")
+        mapping = site_label_mapping or {site: index for index, site in enumerate(sites)}
+        if set(mapping) != set(sites):
+            raise ValueError("site_label_mapping keys must exactly match sites")
+        if set(mapping.values()) != set(range(len(sites))):
+            raise ValueError("site_label_mapping values must be contiguous selector labels starting at 0")
 
         from nvflare.recipe.utils import prepare_initial_ckpt, recipe_model_to_job_model, validate_ckpt
 
@@ -92,12 +93,12 @@ class FedSMRecipe(Recipe):
         self.name = name
         self.model = model
         self.selector_model = selector_model
-        self.client_ids = list(client_ids)
+        self.sites = list(sites)
         self.min_clients = min_clients
         self.num_rounds = num_rounds
         self.train_script = train_script
         self.train_args = train_args
-        self.client_id_label_mapping = dict(mapping)
+        self.site_label_mapping = dict(mapping)
         self.soft_pull_lambda = soft_pull_lambda
         self.initial_ckpt = initial_ckpt
         self.server_expected_format = server_expected_format
@@ -107,7 +108,7 @@ class FedSMRecipe(Recipe):
         persistor = PTFedSMModelPersistor(
             model=model,
             selector_model=selector_model,
-            client_ids=client_ids,
+            client_ids=sites,
             source_ckpt_file_full_name=ckpt_path,
         )
         persistor_id = job.to_server(persistor, id="persistor")
@@ -123,19 +124,25 @@ class FedSMRecipe(Recipe):
         )
         job.to_server(controller)
 
-        executor = ScriptRunner(
-            script=train_script,
-            script_args=train_args,
-            launch_external_process=launch_external_process,
-            command=command,
-            framework=FrameworkType.PYTORCH,
-            server_expected_format=server_expected_format,
-            params_transfer_type=TransferType.FULL,
-            launch_once=launch_once,
-            shutdown_timeout=shutdown_timeout,
-            memory_gc_rounds=client_memory_gc_rounds,
-            cuda_empty_cache=cuda_empty_cache,
-        )
-        job.to_clients(executor)
+        for site in sites:
+            executor = ScriptRunner(
+                script=train_script,
+                script_args=train_args,
+                launch_external_process=launch_external_process,
+                command=command,
+                framework=FrameworkType.PYTORCH,
+                server_expected_format=server_expected_format,
+                params_transfer_type=TransferType.FULL,
+                launch_once=launch_once,
+                shutdown_timeout=shutdown_timeout,
+                memory_gc_rounds=client_memory_gc_rounds,
+                cuda_empty_cache=cuda_empty_cache,
+            )
+            job.to(executor, site)
 
         super().__init__(job)
+
+    def configured_sites(self) -> List[str]:
+        if self._helper_per_site_config is not None:
+            return super().configured_sites()
+        return list(self.sites)

--- a/nvflare/app_opt/pt/recipes/fedsm.py
+++ b/nvflare/app_opt/pt/recipes/fedsm.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Optional, Union
+
+from nvflare.app_opt.pt.fedsm import FedSM, FedSMModelAggregator, PTFedSMModelPersistor
+from nvflare.client.config import ExchangeFormat, TransferType
+from nvflare.fuel.utils.constants import FrameworkType
+from nvflare.job_config.base_fed_job import BaseFedJob
+from nvflare.job_config.script_runner import ScriptRunner
+from nvflare.recipe.spec import Recipe
+
+
+class FedSMRecipe(Recipe):
+    """PyTorch recipe for personalized federated learning with FedSM.
+
+    FedSM jointly trains a global model, one personalized model per client, and
+    a selector model. Client scripts receive a model bundle and must return a
+    FULL bundle containing global and selector weight differences plus the full
+    personalized model. They may also return selector optimizer state.
+
+    Unlike FedAvg, FedSM requires the complete client identity set before job
+    construction. For now every configured client participates in every round.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "fedsm",
+        model: Union[Any, Dict[str, Any]],
+        selector_model: Union[Any, Dict[str, Any]],
+        client_ids: List[str],
+        min_clients: int,
+        num_rounds: int = 2,
+        train_script: str,
+        train_args: str = "",
+        client_id_label_mapping: Optional[Dict[str, int]] = None,
+        soft_pull_lambda: float = 0.7,
+        initial_ckpt: Optional[str] = None,
+        launch_external_process: bool = False,
+        command: str = "python3 -u",
+        server_expected_format: ExchangeFormat = ExchangeFormat.PYTORCH,
+        launch_once: bool = True,
+        shutdown_timeout: float = 0.0,
+        server_memory_gc_rounds: int = 0,
+        client_memory_gc_rounds: int = 0,
+        cuda_empty_cache: bool = False,
+    ):
+        if model is None:
+            raise ValueError("FedSMRecipe requires model")
+        if selector_model is None:
+            raise ValueError("FedSMRecipe requires selector_model")
+        if not isinstance(client_ids, list) or not client_ids:
+            raise ValueError("client_ids must be a non-empty list of unique client names")
+        if any(not isinstance(client_id, str) or not client_id for client_id in client_ids):
+            raise ValueError("client_ids must contain non-empty strings")
+        if len(client_ids) != len(set(client_ids)):
+            raise ValueError("client_ids must be a non-empty list of unique client names")
+        if min_clients != len(client_ids):
+            raise ValueError(
+                "FedSMRecipe currently requires min_clients to equal len(client_ids) "
+                "so every personalized model participates in each SoftPull update"
+            )
+        if server_expected_format != ExchangeFormat.PYTORCH:
+            raise ValueError("FedSMRecipe requires server_expected_format=ExchangeFormat.PYTORCH")
+
+        mapping = client_id_label_mapping or {client_id: index for index, client_id in enumerate(client_ids)}
+        if set(mapping) != set(client_ids):
+            raise ValueError("client_id_label_mapping keys must exactly match client_ids")
+        if set(mapping.values()) != set(range(len(client_ids))):
+            raise ValueError("client_id_label_mapping values must be contiguous selector labels starting at 0")
+
+        from nvflare.recipe.utils import prepare_initial_ckpt, recipe_model_to_job_model, validate_ckpt
+
+        validate_ckpt(initial_ckpt)
+        if isinstance(model, dict):
+            model = recipe_model_to_job_model(model)
+        if isinstance(selector_model, dict):
+            selector_model = recipe_model_to_job_model(selector_model)
+
+        self.name = name
+        self.model = model
+        self.selector_model = selector_model
+        self.client_ids = list(client_ids)
+        self.min_clients = min_clients
+        self.num_rounds = num_rounds
+        self.train_script = train_script
+        self.train_args = train_args
+        self.client_id_label_mapping = dict(mapping)
+        self.soft_pull_lambda = soft_pull_lambda
+        self.initial_ckpt = initial_ckpt
+        self.server_expected_format = server_expected_format
+
+        job = BaseFedJob(name=name, min_clients=min_clients)
+        ckpt_path = prepare_initial_ckpt(initial_ckpt, job)
+        persistor = PTFedSMModelPersistor(
+            model=model,
+            selector_model=selector_model,
+            client_ids=client_ids,
+            source_ckpt_file_full_name=ckpt_path,
+        )
+        persistor_id = job.to_server(persistor, id="persistor")
+
+        aggregator = FedSMModelAggregator(soft_pull_lambda=soft_pull_lambda)
+        controller = FedSM(
+            num_clients=min_clients,
+            num_rounds=num_rounds,
+            persistor_id=persistor_id,
+            client_id_label_mapping=mapping,
+            aggregator=aggregator,
+            memory_gc_rounds=server_memory_gc_rounds,
+        )
+        job.to_server(controller)
+
+        executor = ScriptRunner(
+            script=train_script,
+            script_args=train_args,
+            launch_external_process=launch_external_process,
+            command=command,
+            framework=FrameworkType.PYTORCH,
+            server_expected_format=server_expected_format,
+            params_transfer_type=TransferType.FULL,
+            launch_once=launch_once,
+            shutdown_timeout=shutdown_timeout,
+            memory_gc_rounds=client_memory_gc_rounds,
+            cuda_empty_cache=cuda_empty_cache,
+        )
+        job.to_clients(executor)
+
+        super().__init__(job)

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -51,6 +51,28 @@ _DOCUMENTED_RECIPE_SPECS = {
         "aggregation": "weighted_average",
         "state_exchange": "full_model",
     },
+    "fedce-pt": {
+        "module": "nvflare.app_opt.pt.recipes.fedce",
+        "class": "FedCERecipe",
+        "description": "PyTorch federated training via client contribution estimation (FedCE).",
+        "framework": "pytorch",
+        "algorithm": "fedce",
+        "aggregation": "contribution_weighted_average",
+        "state_exchange": "weight_diff",
+        "heterogeneity_support": ["non_iid", "contribution_fairness"],
+        "notes": ["Client scripts must return fedce_minus_val metadata; FedCE is not a passive FedAvg flag."],
+    },
+    "fedsm-pt": {
+        "module": "nvflare.app_opt.pt.recipes.fedsm",
+        "class": "FedSMRecipe",
+        "description": "PyTorch personalized federated learning with FedSM and SoftPull.",
+        "framework": "pytorch",
+        "algorithm": "fedsm",
+        "aggregation": "softpull",
+        "state_exchange": "model_bundle",
+        "heterogeneity_support": ["non_iid", "personalization"],
+        "notes": ["FedSM exchanges global, per-client personalized, selector, and optional selector optimizer state."],
+    },
     "fedavg-tf": {
         "module": "nvflare.app_opt.tf.recipes.fedavg",
         "class": "FedAvgRecipe",
@@ -582,13 +604,14 @@ def _privacy_compatible(entry: dict, parameters: list, recipe_cls) -> list:
 def _client_requirements(entry: dict, parameters: list) -> dict:
     by_name = {p["name"]: p for p in parameters}
     per_site_config = by_name.get("per_site_config")
+    site_list = by_name.get("sites") or by_name.get("client_ids")
     requirements = {
         "state_exchange": entry.get("state_exchange"),
         "requires_training_script": "train_script" in by_name,
         "requires_per_site_config": bool(per_site_config and per_site_config["required"]),
-        "requires_site_list": "sites" in by_name,
+        "requires_site_list": site_list is not None,
     }
-    for name in ("min_clients", "sites", "label_owner", "client_ranks"):
+    for name in ("min_clients", "sites", "client_ids", "label_owner", "client_ranks"):
         parameter = by_name.get(name)
         if parameter:
             requirements[name] = {

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -604,14 +604,13 @@ def _privacy_compatible(entry: dict, parameters: list, recipe_cls) -> list:
 def _client_requirements(entry: dict, parameters: list) -> dict:
     by_name = {p["name"]: p for p in parameters}
     per_site_config = by_name.get("per_site_config")
-    site_list = by_name.get("sites") or by_name.get("client_ids")
     requirements = {
         "state_exchange": entry.get("state_exchange"),
         "requires_training_script": "train_script" in by_name,
         "requires_per_site_config": bool(per_site_config and per_site_config["required"]),
-        "requires_site_list": site_list is not None,
+        "requires_site_list": "sites" in by_name,
     }
-    for name in ("min_clients", "sites", "client_ids", "label_owner", "client_ranks"):
+    for name in ("min_clients", "sites", "label_owner", "client_ranks"):
         parameter = by_name.get(name)
         if parameter:
             requirements[name] = {

--- a/tests/unit_test/app_opt/pt/fedce_test.py
+++ b/tests/unit_test/app_opt/pt/fedce_test.py
@@ -46,7 +46,7 @@ def test_fedce_weights_favor_higher_minus_model_score():
     assert result.params["weight"].tolist() == pytest.approx([weights["site-1"], weights["site-2"]])
 
 
-def test_fedce_reset_keeps_contribution_history_for_next_round():
+def test_fedce_reset_keeps_constant_space_cosine_mean_for_next_round():
     aggregator = FedCEModelAggregator()
     aggregator.accept_model(_result("site-1", [1.0], 0.7))
     aggregator.accept_model(_result("site-2", [2.0], 0.3))
@@ -59,7 +59,20 @@ def test_fedce_reset_keeps_contribution_history_for_next_round():
 
     assert aggregator._contribution_weights
     assert first.keys() == aggregator._contribution_weights.keys()
-    assert len(aggregator._cosine_history["site-1"]) == 2
+    assert aggregator._cosine_counts["site-1"] == 2
+    assert set(aggregator._cosine_means) == {"site-1", "site-2"}
+
+
+def test_fedce_recovers_prior_weights_from_dispatched_model_metadata():
+    aggregator = FedCEModelAggregator()
+    prior_weights = {"site-1": 0.8, "site-2": 0.2}
+    site_1 = _result("site-1", [1.0], 0.7)
+    site_1.meta["props"] = {FedCEConstants.CONTRIBUTION_WEIGHTS: prior_weights}
+
+    aggregator.accept_model(site_1)
+    aggregator.accept_model(_result("site-2", [2.0], 0.3))
+
+    assert aggregator._get_prior_weights(["site-1", "site-2"]) == prior_weights
 
 
 def test_fedce_requires_minus_model_score():

--- a/tests/unit_test/app_opt/pt/fedce_test.py
+++ b/tests/unit_test/app_opt/pt/fedce_test.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+from nvflare.app_opt.pt.fedce import FedCEConstants, FedCEModelAggregator, PTFedCEHelper
+
+
+def _result(client, update, minus_score, round_number=0):
+    return FLModel(
+        params={"weight": torch.tensor(update, dtype=torch.float32)},
+        params_type=ParamsType.DIFF,
+        current_round=round_number,
+        meta={
+            "client_name": client,
+            FedCEConstants.MINUS_MODEL_SCORE: minus_score,
+        },
+    )
+
+
+def test_fedce_weights_favor_higher_minus_model_score():
+    aggregator = FedCEModelAggregator(mode="plus")
+    aggregator.accept_model(_result("site-1", [1.0, 0.0], 0.9))
+    aggregator.accept_model(_result("site-2", [0.0, 1.0], 0.1))
+
+    result = aggregator.aggregate_model()
+    weights = result.meta[FedCEConstants.CONTRIBUTION_WEIGHTS]
+
+    assert result.params_type == ParamsType.DIFF
+    assert sum(weights.values()) == pytest.approx(1.0)
+    assert weights["site-1"] > weights["site-2"]
+    assert result.params["weight"].tolist() == pytest.approx([weights["site-1"], weights["site-2"]])
+
+
+def test_fedce_reset_keeps_contribution_history_for_next_round():
+    aggregator = FedCEModelAggregator()
+    aggregator.accept_model(_result("site-1", [1.0], 0.7))
+    aggregator.accept_model(_result("site-2", [2.0], 0.3))
+    first = aggregator.aggregate_model().meta[FedCEConstants.CONTRIBUTION_WEIGHTS]
+
+    aggregator.reset_stats()
+    aggregator.accept_model(_result("site-1", [2.0], 0.7, round_number=1))
+    aggregator.accept_model(_result("site-2", [1.0], 0.3, round_number=1))
+    aggregator.aggregate_model()
+
+    assert aggregator._contribution_weights
+    assert first.keys() == aggregator._contribution_weights.keys()
+    assert len(aggregator._cosine_history["site-1"]) == 2
+
+
+def test_fedce_requires_minus_model_score():
+    aggregator = FedCEModelAggregator()
+    result = FLModel(
+        params={"weight": torch.tensor([1.0])},
+        params_type=ParamsType.DIFF,
+        meta={"client_name": "site-1"},
+    )
+
+    with pytest.raises(ValueError, match=FedCEConstants.MINUS_MODEL_SCORE):
+        aggregator.accept_model(result)
+
+
+def test_fedce_requires_diff_results():
+    aggregator = FedCEModelAggregator()
+    result = FLModel(
+        params={"weight": torch.tensor([1.0])},
+        params_type=ParamsType.FULL,
+        meta={"client_name": "site-1", FedCEConstants.MINUS_MODEL_SCORE: 1.0},
+    )
+
+    with pytest.raises(ValueError, match="ParamsType.DIFF"):
+        aggregator.accept_model(result)
+
+
+def test_fedce_helper_builds_minus_model_and_attaches_score():
+    model = torch.nn.Linear(1, 1, bias=False)
+    model.weight.data.fill_(10.0)
+    previous = {"weight": torch.tensor([[4.0]])}
+
+    minus_model = PTFedCEHelper.make_minus_model(model, previous, contribution_weight=0.25)
+    result = FLModel(params={"weight": torch.tensor([[1.0]])}, params_type=ParamsType.DIFF)
+    PTFedCEHelper.set_minus_model_score(result, 0.8)
+
+    assert minus_model.weight.item() == pytest.approx(12.0)
+    assert result.meta[FedCEConstants.MINUS_MODEL_SCORE] == pytest.approx(0.8)

--- a/tests/unit_test/app_opt/pt/fedce_test.py
+++ b/tests/unit_test/app_opt/pt/fedce_test.py
@@ -17,7 +17,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
-from nvflare.app_opt.pt.fedce import FedCEConstants, FedCEModelAggregator, PTFedCEHelper
+from nvflare.app_opt.pt.fedce import FedCEConstants, FedCEModelAggregator, PTFedCEHelper, _normalize
 
 
 def _result(client, update, minus_score, round_number=0):
@@ -110,3 +110,109 @@ def test_fedce_helper_builds_minus_model_and_attaches_score():
 
     assert minus_model.weight.item() == pytest.approx(12.0)
     assert result.meta[FedCEConstants.MINUS_MODEL_SCORE] == pytest.approx(0.8)
+
+
+def test_fedce_helper_reads_weight_and_handles_non_trainable_buffers():
+    class BufferedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor([10.0]))
+            self.register_buffer("counter", torch.tensor([3], dtype=torch.int64))
+            self.register_buffer("untouched", torch.tensor([4], dtype=torch.int64))
+
+    global_model = FLModel(meta={FedCEConstants.CONTRIBUTION_WEIGHTS: {"site-1": 0.4}})
+    assert PTFedCEHelper.get_contribution_weight(global_model, "site-1") == pytest.approx(0.4)
+    assert PTFedCEHelper.get_contribution_weight(global_model, "site-2", default=0.2) == pytest.approx(0.2)
+
+    model = BufferedModel()
+    minus_model = PTFedCEHelper.make_minus_model(
+        model,
+        {"weight": torch.tensor([4.0]), "counter": torch.tensor([99], dtype=torch.int64)},
+        contribution_weight=0.25,
+    )
+
+    assert minus_model.counter.item() == 3
+    assert minus_model.untouched.item() == 4
+    assert minus_model.weight.item() == pytest.approx(12.0)
+
+
+@pytest.mark.parametrize("weight", [-0.1, 1.0])
+def test_fedce_helper_rejects_invalid_contribution_weight(weight):
+    with pytest.raises(ValueError, match="contribution_weight must be"):
+        PTFedCEHelper.make_minus_model(torch.nn.Linear(1, 1), {}, weight)
+
+
+@pytest.mark.parametrize("values", [[], [float("nan")], [float("inf")]])
+def test_fedce_normalize_rejects_invalid_values(values):
+    with pytest.raises(ValueError):
+        _normalize(values, epsilon=1e-6)
+
+
+def test_fedce_aggregator_validates_configuration_and_results():
+    with pytest.raises(ValueError, match="mode must be"):
+        FedCEModelAggregator(mode="invalid")
+    with pytest.raises(ValueError, match="epsilon must be"):
+        FedCEModelAggregator(epsilon=0.0)
+
+    aggregator = FedCEModelAggregator()
+    with pytest.raises(ValueError, match="missing FLModel.meta"):
+        aggregator.accept_model(
+            FLModel(
+                params={"weight": torch.tensor([1.0])},
+                params_type=ParamsType.DIFF,
+                meta={FedCEConstants.MINUS_MODEL_SCORE: 1.0},
+            )
+        )
+    with pytest.raises(ValueError, match="empty parameters"):
+        aggregator.accept_model(
+            FLModel(
+                params={},
+                params_type=ParamsType.DIFF,
+                meta={"client_name": "site-1", FedCEConstants.MINUS_MODEL_SCORE: 1.0},
+            )
+        )
+    with pytest.raises(ValueError, match="empty result set"):
+        aggregator.aggregate_model()
+
+    result = _result("site-1", [1.0], 1.0)
+    aggregator.accept_model(result)
+    with pytest.raises(ValueError, match="more than one result"):
+        aggregator.accept_model(result)
+
+
+def test_fedce_times_mode_handles_zero_updates_and_aggregates_metrics():
+    aggregator = FedCEModelAggregator(mode="times")
+    site_1 = _result("site-1", [0.0, 0.0], 0.8)
+    site_1.metrics = {"accuracy": 0.5, "label": "ignored"}
+    site_2 = _result("site-2", [1.0, 0.0], 0.2)
+    site_2.metrics = {"accuracy": 1.0, "label": "ignored"}
+    aggregator.accept_model(site_1)
+    aggregator.accept_model(site_2)
+
+    result = aggregator.aggregate_model()
+
+    weights = result.meta[FedCEConstants.CONTRIBUTION_WEIGHTS]
+    expected_accuracy = 0.5 * weights["site-1"] + weights["site-2"]
+    assert result.metrics["accuracy"] == pytest.approx(expected_accuracy)
+    assert "label" not in result.metrics
+    assert result.meta["nr_aggregated"] == 2
+
+
+def test_fedce_rejects_updates_without_common_trainable_parameters():
+    aggregator = FedCEModelAggregator(trainable_param_names=["missing"])
+    aggregator.accept_model(_result("site-1", [1.0], 0.5))
+    aggregator.accept_model(_result("site-2", [2.0], 0.5))
+
+    with pytest.raises(ValueError, match="no common trainable parameters"):
+        aggregator.aggregate_model()
+
+
+def test_fedce_materializes_lazy_parameters():
+    class LazyValue:
+        @staticmethod
+        def materialize():
+            return torch.tensor([1.0, 2.0])
+
+    flattened = FedCEModelAggregator._flatten_params({"weight": LazyValue()}, ["weight"])
+
+    assert flattened.tolist() == [1.0, 2.0]

--- a/tests/unit_test/app_opt/pt/fedsm_test.py
+++ b/tests/unit_test/app_opt/pt/fedsm_test.py
@@ -99,13 +99,18 @@ def test_fedsm_aggregates_fedavg_and_softpull_models():
 
 def test_fedsm_uses_num_steps_for_global_and_selector_updates():
     aggregator = FedSMModelAggregator()
-    aggregator.accept_model(_result("site-1", 0.0, 0.0, 0.0, steps=1))
-    aggregator.accept_model(_result("site-2", 8.0, 10.0, 4.0, steps=3))
+    site_1 = _result("site-1", 0.0, 0.0, 0.0, steps=1)
+    site_1.metrics = {"accuracy": 0.0, "label": "ignored"}
+    site_2 = _result("site-2", 8.0, 10.0, 4.0, steps=3)
+    site_2.metrics = {"accuracy": 1.0, "label": "ignored"}
+    aggregator.accept_model(site_1)
+    aggregator.accept_model(site_2)
 
     result = aggregator.aggregate_model()
 
     assert result.params[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(6.0)
     assert result.params[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(3.0)
+    assert result.metrics == {"accuracy": pytest.approx(0.75)}
 
 
 def test_fedsm_updates_mixed_semantics_bundle():
@@ -293,6 +298,8 @@ def test_fedsm_weighted_average_supports_buffers_numpy_and_scalars():
     assert integer.item() == 2
     assert array.tolist() == pytest.approx([2.5])
     assert scalar == pytest.approx(4.0)
+    with pytest.raises(ValueError, match="different keys"):
+        _weighted_average([{"weight": torch.tensor(1.0)}, {"bias": torch.tensor(1.0)}], [0.5, 0.5])
     with pytest.raises(TypeError, match="cannot average"):
         _weighted_average([object(), object()], [0.5, 0.5])
 
@@ -305,7 +312,7 @@ def test_fedsm_add_state_diff_ignores_unknown_parameters():
     assert copied_meta.value == 3
 
 
-def test_fedsm_aggregator_validates_results_and_single_client_fallback():
+def test_fedsm_aggregator_validates_results_and_single_client_updates():
     with pytest.raises(ValueError, match="soft_pull_lambda"):
         FedSMModelAggregator(soft_pull_lambda=1.1)
 
@@ -333,13 +340,36 @@ def test_fedsm_aggregator_validates_results_and_single_client_fallback():
     aggregator.accept_model(result)
     with pytest.raises(ValueError, match="more than one result"):
         aggregator.accept_model(result)
+    with pytest.raises(ValueError, match="finite and positive"):
+        aggregator.aggregate_model()
 
+    aggregator.reset_stats()
+    aggregator.accept_model(_result("site-1", 2.0, 4.0, 6.0, steps="invalid"))
+    with pytest.raises(ValueError, match="invalid step weight"):
+        aggregator.aggregate_model()
+
+    aggregator.reset_stats()
+    valid_result = _result("site-1", 2.0, 4.0, 6.0, steps=1)
+    valid_result.params[FedSMConstants.SELECTOR_OPTIMIZER] = {"step": torch.tensor(1.0)}
+    aggregator.accept_model(valid_result)
     aggregated = aggregator.aggregate_model()
 
     assert aggregated.params[FedSMConstants.PERSONAL_MODELS]["site-1"]["weight"].item() == pytest.approx(4.0)
     assert aggregated.params[FedSMConstants.SELECTOR_OPTIMIZER]["step"].item() == pytest.approx(1.0)
     aggregator.reset_stats()
     assert aggregator._results == {}
+
+
+def test_fedsm_rejects_partial_personal_model_states():
+    aggregator = FedSMModelAggregator()
+    site_1 = _result("site-1", 1.0, 2.0, 3.0)
+    site_2 = _result("site-2", 1.0, 2.0, 3.0)
+    site_2.params[FedSMConstants.PERSONAL_MODEL] = {}
+    aggregator.accept_model(site_1)
+    aggregator.accept_model(site_2)
+
+    with pytest.raises(ValueError, match="different keys"):
+        aggregator.aggregate_model()
 
 
 def test_fedsm_persistor_round_trips_complete_bundle(tmp_path):

--- a/tests/unit_test/app_opt/pt/fedsm_test.py
+++ b/tests/unit_test/app_opt/pt/fedsm_test.py
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import Mock
+
+import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
 
-from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey, FLMetaKey
 from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
 from nvflare.app_common.abstract.model import ModelLearnableKey
-from nvflare.app_opt.pt.fedsm import FedSM, FedSMConstants, FedSMModelAggregator, PTFedSMHelper, PTFedSMModelPersistor
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_opt.pt.fedsm import (
+    FedSM,
+    FedSMConstants,
+    FedSMModelAggregator,
+    PTFedSMHelper,
+    PTFedSMModelPersistor,
+    _add_state_diff,
+    _to_cpu_copy,
+    _weighted_average,
+)
 
 
 class _CheckpointMeta:
@@ -41,6 +55,32 @@ def _result(client, global_diff, personal, selector_diff, steps=1):
         params_type=ParamsType.FULL,
         meta={"client_name": client, FLMetaKey.NUM_STEPS_CURRENT_ROUND: steps},
     )
+
+
+def _initial_bundle():
+    return FLModel(
+        params={
+            FedSMConstants.GLOBAL_MODEL: _state(10.0),
+            FedSMConstants.PERSONAL_MODELS: {"site-1": _state(1.0), "site-2": _state(2.0)},
+            FedSMConstants.SELECTOR_MODEL: _state(20.0),
+            FedSMConstants.SELECTOR_OPTIMIZER: {},
+        },
+        params_type=ParamsType.FULL,
+    )
+
+
+def _persistor_fl_ctx(tmp_path, log_dir=None):
+    fl_ctx = Mock()
+
+    def get_prop(key):
+        if key == FLContextKey.APP_ROOT:
+            return str(tmp_path)
+        if key == AppConstants.LOG_DIR:
+            return log_dir
+        return None
+
+    fl_ctx.get_prop.side_effect = get_prop
+    return fl_ctx
 
 
 def test_fedsm_aggregates_fedavg_and_softpull_models():
@@ -79,6 +119,7 @@ def test_fedsm_updates_mixed_semantics_bundle():
         FedSMConstants.GLOBAL_MODEL: _state(2.0),
         FedSMConstants.PERSONAL_MODELS: {"site-1": _state(3.0), "site-2": _state(4.0)},
         FedSMConstants.SELECTOR_MODEL: _state(-5.0),
+        FedSMConstants.SELECTOR_OPTIMIZER: {"step": 1},
     }
 
     updated = FedSM._update_bundle(bundle, update)
@@ -86,6 +127,7 @@ def test_fedsm_updates_mixed_semantics_bundle():
     assert updated[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(12.0)
     assert updated[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(15.0)
     assert updated[FedSMConstants.PERSONAL_MODELS]["site-1"]["weight"].item() == pytest.approx(3.0)
+    assert updated[FedSMConstants.SELECTOR_OPTIMIZER] == {"step": 1}
 
 
 def test_fedsm_requires_complete_result_bundle():
@@ -126,6 +168,54 @@ def test_fedsm_helper_loads_bundle_and_returns_mixed_update_types():
     assert result.params[FedSMConstants.PERSONAL_MODEL]["weight"].item() == pytest.approx(7.0)
     assert result.params[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(6.0)
     assert result.meta[FLMetaKey.NUM_STEPS_CURRENT_ROUND] == 7
+
+
+def test_fedsm_helper_synchronizes_selector_optimizer_state():
+    global_model = torch.nn.Linear(1, 1, bias=False)
+    personal_model = torch.nn.Linear(1, 1, bias=False)
+    selector_model = torch.nn.Linear(1, 1, bias=False)
+    optimizer = torch.optim.Adam(selector_model.parameters(), lr=0.1)
+    selector_model(torch.tensor([[1.0]])).sum().backward()
+    optimizer.step()
+    optimizer_state = optimizer.state_dict()["state"]
+    helper = PTFedSMHelper(global_model, personal_model, selector_model, optimizer)
+    incoming = FLModel(
+        params={
+            FedSMConstants.GLOBAL_MODEL: global_model.state_dict(),
+            FedSMConstants.PERSONAL_MODEL: personal_model.state_dict(),
+            FedSMConstants.SELECTOR_MODEL: selector_model.state_dict(),
+            FedSMConstants.SELECTOR_OPTIMIZER: optimizer_state,
+        },
+        params_type=ParamsType.FULL,
+        meta={FedSMConstants.TARGET_ID: "site-1", FedSMConstants.SELECTOR_LABEL: 0},
+    )
+
+    helper.load_bundle(incoming, client_name="site-1")
+    result = helper.build_result(num_steps=1)
+
+    assert result.params[FedSMConstants.SELECTOR_OPTIMIZER]
+
+
+def test_fedsm_helper_validates_models_target_and_call_order():
+    model = torch.nn.Linear(1, 1, bias=False)
+    with pytest.raises(TypeError, match="personal_model must be"):
+        PTFedSMHelper(model, object(), model)
+
+    helper = PTFedSMHelper(model, torch.nn.Linear(1, 1, bias=False), torch.nn.Linear(1, 1, bias=False))
+    with pytest.raises(RuntimeError, match=r"load_bundle\(\) must be called"):
+        helper.build_result(num_steps=1)
+
+    incoming = FLModel(
+        params={
+            FedSMConstants.GLOBAL_MODEL: model.state_dict(),
+            FedSMConstants.PERSONAL_MODEL: model.state_dict(),
+            FedSMConstants.SELECTOR_MODEL: model.state_dict(),
+        },
+        params_type=ParamsType.FULL,
+        meta={FedSMConstants.TARGET_ID: "site-2", FedSMConstants.SELECTOR_LABEL: 1},
+    )
+    with pytest.raises(ValueError, match="targets 'site-2'"):
+        helper.load_bundle(incoming, client_name="site-1")
 
 
 def test_fedsm_helper_rejects_non_full_bundle():
@@ -192,6 +282,66 @@ def test_fedsm_requires_num_clients_to_match_label_mapping():
         )
 
 
+def test_fedsm_weighted_average_supports_buffers_numpy_and_scalars():
+    integer = _weighted_average(
+        [torch.tensor([1], dtype=torch.int64), torch.tensor([4], dtype=torch.int64)],
+        [0.5, 0.5],
+    )
+    array = _weighted_average([np.array([1.0]), np.array([3.0])], [0.25, 0.75])
+    scalar = _weighted_average([2.0, 6.0], [0.5, 0.5])
+
+    assert integer.item() == 2
+    assert array.tolist() == pytest.approx([2.5])
+    assert scalar == pytest.approx(4.0)
+    with pytest.raises(TypeError, match="cannot average"):
+        _weighted_average([object(), object()], [0.5, 0.5])
+
+
+def test_fedsm_add_state_diff_ignores_unknown_parameters():
+    updated = _add_state_diff(_state(2.0), {"missing": torch.tensor([10.0])})
+    copied_meta = _to_cpu_copy(_CheckpointMeta(3))
+
+    assert updated["weight"].item() == pytest.approx(2.0)
+    assert copied_meta.value == 3
+
+
+def test_fedsm_aggregator_validates_results_and_single_client_fallback():
+    with pytest.raises(ValueError, match="soft_pull_lambda"):
+        FedSMModelAggregator(soft_pull_lambda=1.1)
+
+    aggregator = FedSMModelAggregator()
+    with pytest.raises(ValueError, match="missing FLModel.meta"):
+        aggregator.accept_model(
+            FLModel(
+                params={FedSMConstants.GLOBAL_MODEL: _state(1.0)},
+                params_type=ParamsType.FULL,
+            )
+        )
+    with pytest.raises(ValueError, match="ParamsType.FULL"):
+        aggregator.accept_model(
+            FLModel(
+                params={"weight": torch.tensor([1.0])},
+                params_type=ParamsType.DIFF,
+                meta={"client_name": "site-1"},
+            )
+        )
+    with pytest.raises(ValueError, match="empty result set"):
+        aggregator.aggregate_model()
+
+    result = _result("site-1", 2.0, 4.0, 6.0, steps=0)
+    result.params[FedSMConstants.SELECTOR_OPTIMIZER] = {"step": torch.tensor(1.0)}
+    aggregator.accept_model(result)
+    with pytest.raises(ValueError, match="more than one result"):
+        aggregator.accept_model(result)
+
+    aggregated = aggregator.aggregate_model()
+
+    assert aggregated.params[FedSMConstants.PERSONAL_MODELS]["site-1"]["weight"].item() == pytest.approx(4.0)
+    assert aggregated.params[FedSMConstants.SELECTOR_OPTIMIZER]["step"].item() == pytest.approx(1.0)
+    aggregator.reset_stats()
+    assert aggregator._results == {}
+
+
 def test_fedsm_persistor_round_trips_complete_bundle(tmp_path):
     model = torch.nn.Linear(1, 1, bias=False)
     selector = torch.nn.Linear(1, 2, bias=False)
@@ -216,6 +366,69 @@ def test_fedsm_persistor_round_trips_complete_bundle(tmp_path):
     )
 
 
+def test_fedsm_persistor_initializes_from_event_and_resolves_model_configs(tmp_path):
+    model = torch.nn.Linear(1, 1, bias=False)
+    selector = torch.nn.Linear(1, 2, bias=False)
+    fl_ctx = _persistor_fl_ctx(tmp_path, log_dir="models")
+    persistor = PTFedSMModelPersistor(model, selector, ["site-1"])
+
+    persistor.handle_event(EventType.START_RUN, fl_ctx)
+
+    assert persistor._ckpt_save_path == str(tmp_path / "models" / "FL_fedsm_model.pt")
+    configured = persistor._resolve_model(
+        {"path": "torch.nn.Linear", "args": {"in_features": 1, "out_features": 1}},
+        "model",
+        fl_ctx,
+    )
+    assert isinstance(configured, torch.nn.Linear)
+
+    fl_ctx.get_engine.return_value.get_component.return_value = model
+    assert persistor._resolve_model("model_component", "model", fl_ctx) is model
+    with pytest.raises(TypeError, match="must resolve to torch.nn.Module"):
+        persistor._resolve_model(object(), "model", fl_ctx)
+
+
+def test_fedsm_persistor_resolves_relative_paths_and_legacy_checkpoints(tmp_path):
+    model = torch.nn.Linear(1, 1, bias=False)
+    selector = torch.nn.Linear(1, 2, bias=False)
+    fl_ctx = _persistor_fl_ctx(tmp_path)
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    checkpoint = custom_dir / "legacy.pt"
+    torch.save({"model": _state(9.0)}, checkpoint)
+    persistor = PTFedSMModelPersistor(
+        model,
+        selector,
+        ["site-1"],
+        source_ckpt_file_full_name="legacy.pt",
+    )
+
+    learnable = persistor.load_model(fl_ctx)
+
+    assert learnable[ModelLearnableKey.WEIGHTS][FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(9.0)
+
+    missing = PTFedSMModelPersistor(
+        model,
+        selector,
+        ["site-1"],
+        source_ckpt_file_full_name="missing.pt",
+    )
+    with pytest.raises(ValueError, match="source checkpoint not found"):
+        missing.load_model(fl_ctx)
+
+
+def test_fedsm_persistor_save_initializes_output_path(tmp_path):
+    model = torch.nn.Linear(1, 1, bias=False)
+    selector = torch.nn.Linear(1, 2, bias=False)
+    persistor = PTFedSMModelPersistor(model, selector, ["site-1"])
+    fl_ctx = _persistor_fl_ctx(tmp_path)
+    learnable = persistor.load_model(fl_ctx)
+
+    persistor.save_model(learnable, fl_ctx)
+
+    assert (tmp_path / "FL_fedsm_model.pt").exists()
+
+
 def test_fedsm_persistor_can_load_trusted_checkpoint_with_custom_metadata(tmp_path):
     model = torch.nn.Linear(1, 1, bias=False)
     selector = torch.nn.Linear(1, 2, bias=False)
@@ -235,3 +448,105 @@ def test_fedsm_persistor_can_load_trusted_checkpoint_with_custom_metadata(tmp_pa
     ).load_model(fl_ctx=None)
 
     assert resumed[ModelLearnableKey.META]["custom"].value == 7
+
+
+def test_fedsm_controller_runs_complete_round():
+    controller = FedSM(
+        num_clients=2,
+        num_rounds=1,
+        client_id_label_mapping={"site-1": 0, "site-2": 1},
+    )
+    controller.fl_ctx = Mock()
+    controller.abort_signal = Mock(triggered=False)
+    controller.load_model = Mock(return_value=_initial_bundle())
+    controller.sample_clients = Mock(return_value=["site-1", "site-2"])
+    controller.get_num_standing_tasks = Mock(return_value=0)
+    controller.event = Mock()
+    controller.info = Mock()
+    controller.save_model = Mock()
+    controller._maybe_cleanup_memory = Mock()
+    controller.aggregate = lambda results, aggregate_fn: aggregate_fn(results)
+
+    def send_model(*, targets, callback, **kwargs):
+        client = targets[0]
+        callback(
+            _result(
+                client,
+                global_diff=2.0 if client == "site-1" else 4.0,
+                personal=3.0 if client == "site-1" else 5.0,
+                selector_diff=1.0 if client == "site-1" else 3.0,
+            )
+        )
+
+    controller.send_model = send_model
+
+    controller.run()
+
+    saved = controller.save_model.call_args.args[0]
+    assert saved.params[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(13.0)
+    assert saved.params[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(22.0)
+    assert controller.save_model.call_count == 1
+    assert controller.fl_ctx.set_prop.call_count == 3
+
+
+def test_fedsm_controller_rejects_incomplete_results():
+    controller = FedSM(
+        num_clients=2,
+        num_rounds=1,
+        client_id_label_mapping={"site-1": 0, "site-2": 1},
+    )
+    controller.fl_ctx = Mock()
+    controller.abort_signal = Mock(triggered=False)
+    controller.load_model = Mock(return_value=_initial_bundle())
+    controller.sample_clients = Mock(return_value=["site-1", "site-2"])
+    controller.send_model = Mock()
+    controller.get_num_standing_tasks = Mock(return_value=0)
+    controller.event = Mock()
+    controller.info = Mock()
+
+    with pytest.raises(RuntimeError, match="received 0 of 2 expected"):
+        controller.run()
+
+
+def test_fedsm_controller_returns_when_aborted_with_standing_tasks():
+    controller = FedSM(
+        num_clients=2,
+        num_rounds=1,
+        client_id_label_mapping={"site-1": 0, "site-2": 1},
+    )
+    controller.fl_ctx = Mock()
+    controller.abort_signal = Mock(triggered=True)
+    controller.load_model = Mock(return_value=_initial_bundle())
+    controller.sample_clients = Mock(return_value=["site-1", "site-2"])
+    controller.send_model = Mock()
+    controller.get_num_standing_tasks = Mock(return_value=1)
+    controller.event = Mock()
+    controller.info = Mock()
+    controller.save_model = Mock()
+
+    controller.run()
+
+    controller.save_model.assert_not_called()
+
+
+def test_fedsm_controller_waits_for_standing_tasks(monkeypatch):
+    controller = FedSM(
+        num_clients=2,
+        num_rounds=1,
+        client_id_label_mapping={"site-1": 0, "site-2": 1},
+    )
+    controller.fl_ctx = Mock()
+    controller.abort_signal = Mock(triggered=False)
+    controller.load_model = Mock(return_value=_initial_bundle())
+    controller.sample_clients = Mock(return_value=["site-1", "site-2"])
+    controller.send_model = Mock()
+    controller.get_num_standing_tasks = Mock(side_effect=[1, 0])
+    controller.event = Mock()
+    controller.info = Mock()
+    sleep = Mock()
+    monkeypatch.setattr("nvflare.app_opt.pt.fedsm.time.sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="received 0 of 2 expected"):
+        controller.run()
+
+    sleep.assert_called_once_with(controller._task_check_period)

--- a/tests/unit_test/app_opt/pt/fedsm_test.py
+++ b/tests/unit_test/app_opt/pt/fedsm_test.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+from nvflare.app_common.abstract.model import ModelLearnableKey
+from nvflare.app_opt.pt.fedsm import FedSM, FedSMConstants, FedSMModelAggregator, PTFedSMHelper, PTFedSMModelPersistor
+
+
+def _state(value):
+    return {"weight": torch.tensor([value], dtype=torch.float32)}
+
+
+def _result(client, global_diff, personal, selector_diff, steps=1):
+    return FLModel(
+        params={
+            FedSMConstants.GLOBAL_MODEL: _state(global_diff),
+            FedSMConstants.PERSONAL_MODEL: _state(personal),
+            FedSMConstants.SELECTOR_MODEL: _state(selector_diff),
+        },
+        params_type=ParamsType.FULL,
+        meta={"client_name": client, FLMetaKey.NUM_STEPS_CURRENT_ROUND: steps},
+    )
+
+
+def test_fedsm_aggregates_fedavg_and_softpull_models():
+    aggregator = FedSMModelAggregator(soft_pull_lambda=0.75)
+    aggregator.accept_model(_result("site-1", global_diff=2.0, personal=0.0, selector_diff=4.0))
+    aggregator.accept_model(_result("site-2", global_diff=4.0, personal=10.0, selector_diff=8.0))
+
+    result = aggregator.aggregate_model()
+
+    assert result.params[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(3.0)
+    assert result.params[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(6.0)
+    personal = result.params[FedSMConstants.PERSONAL_MODELS]
+    assert personal["site-1"]["weight"].item() == pytest.approx(2.5)
+    assert personal["site-2"]["weight"].item() == pytest.approx(7.5)
+
+
+def test_fedsm_uses_num_steps_for_global_and_selector_updates():
+    aggregator = FedSMModelAggregator()
+    aggregator.accept_model(_result("site-1", 0.0, 0.0, 0.0, steps=1))
+    aggregator.accept_model(_result("site-2", 8.0, 10.0, 4.0, steps=3))
+
+    result = aggregator.aggregate_model()
+
+    assert result.params[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(6.0)
+    assert result.params[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(3.0)
+
+
+def test_fedsm_updates_mixed_semantics_bundle():
+    bundle = {
+        FedSMConstants.GLOBAL_MODEL: _state(10.0),
+        FedSMConstants.PERSONAL_MODELS: {"site-1": _state(1.0), "site-2": _state(2.0)},
+        FedSMConstants.SELECTOR_MODEL: _state(20.0),
+        FedSMConstants.SELECTOR_OPTIMIZER: {},
+    }
+    update = {
+        FedSMConstants.GLOBAL_MODEL: _state(2.0),
+        FedSMConstants.PERSONAL_MODELS: {"site-1": _state(3.0), "site-2": _state(4.0)},
+        FedSMConstants.SELECTOR_MODEL: _state(-5.0),
+    }
+
+    updated = FedSM._update_bundle(bundle, update)
+
+    assert updated[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(12.0)
+    assert updated[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(15.0)
+    assert updated[FedSMConstants.PERSONAL_MODELS]["site-1"]["weight"].item() == pytest.approx(3.0)
+
+
+def test_fedsm_requires_complete_result_bundle():
+    aggregator = FedSMModelAggregator()
+    result = FLModel(
+        params={FedSMConstants.GLOBAL_MODEL: _state(1.0)},
+        params_type=ParamsType.FULL,
+        meta={"client_name": "site-1"},
+    )
+
+    with pytest.raises(ValueError, match="missing bundle entries"):
+        aggregator.accept_model(result)
+
+
+def test_fedsm_helper_loads_bundle_and_returns_mixed_update_types():
+    global_model = torch.nn.Linear(1, 1, bias=False)
+    personal_model = torch.nn.Linear(1, 1, bias=False)
+    selector_model = torch.nn.Linear(1, 1, bias=False)
+    helper = PTFedSMHelper(global_model, personal_model, selector_model)
+    incoming = FLModel(
+        params={
+            FedSMConstants.GLOBAL_MODEL: {"weight": torch.tensor([[1.0]])},
+            FedSMConstants.PERSONAL_MODEL: {"weight": torch.tensor([[2.0]])},
+            FedSMConstants.SELECTOR_MODEL: {"weight": torch.tensor([[3.0]])},
+            FedSMConstants.SELECTOR_OPTIMIZER: {},
+        },
+        params_type=ParamsType.FULL,
+        meta={FedSMConstants.TARGET_ID: "site-1", FedSMConstants.SELECTOR_LABEL: 0},
+    )
+
+    assert helper.load_bundle(incoming, client_name="site-1") == 0
+    global_model.weight.data.add_(4.0)
+    personal_model.weight.data.add_(5.0)
+    selector_model.weight.data.add_(6.0)
+    result = helper.build_result(num_steps=7)
+
+    assert result.params[FedSMConstants.GLOBAL_MODEL]["weight"].item() == pytest.approx(4.0)
+    assert result.params[FedSMConstants.PERSONAL_MODEL]["weight"].item() == pytest.approx(7.0)
+    assert result.params[FedSMConstants.SELECTOR_MODEL]["weight"].item() == pytest.approx(6.0)
+    assert result.meta[FLMetaKey.NUM_STEPS_CURRENT_ROUND] == 7
+
+
+def test_fedsm_persistor_round_trips_complete_bundle(tmp_path):
+    model = torch.nn.Linear(1, 1, bias=False)
+    selector = torch.nn.Linear(1, 2, bias=False)
+    persistor = PTFedSMModelPersistor(model, selector, ["site-1", "site-2"])
+    learnable = persistor.load_model(fl_ctx=None)
+    checkpoint = tmp_path / "fedsm.pt"
+    persistor._ckpt_save_path = str(checkpoint)
+    persistor.save_model(learnable, fl_ctx=None)
+
+    resumed = PTFedSMModelPersistor(
+        model,
+        selector,
+        ["site-1", "site-2"],
+        source_ckpt_file_full_name=str(checkpoint),
+    ).load_model(fl_ctx=None)
+    bundle = resumed[ModelLearnableKey.WEIGHTS]
+
+    assert set(bundle[FedSMConstants.PERSONAL_MODELS]) == {"site-1", "site-2"}
+    assert torch.equal(
+        bundle[FedSMConstants.GLOBAL_MODEL]["weight"],
+        learnable[ModelLearnableKey.WEIGHTS][FedSMConstants.GLOBAL_MODEL]["weight"],
+    )

--- a/tests/unit_test/app_opt/pt/fedsm_test.py
+++ b/tests/unit_test/app_opt/pt/fedsm_test.py
@@ -22,6 +22,11 @@ from nvflare.app_common.abstract.model import ModelLearnableKey
 from nvflare.app_opt.pt.fedsm import FedSM, FedSMConstants, FedSMModelAggregator, PTFedSMHelper, PTFedSMModelPersistor
 
 
+class _CheckpointMeta:
+    def __init__(self, value):
+        self.value = value
+
+
 def _state(value):
     return {"weight": torch.tensor([value], dtype=torch.float32)}
 
@@ -123,6 +128,70 @@ def test_fedsm_helper_loads_bundle_and_returns_mixed_update_types():
     assert result.meta[FLMetaKey.NUM_STEPS_CURRENT_ROUND] == 7
 
 
+def test_fedsm_helper_rejects_non_full_bundle():
+    model = torch.nn.Linear(1, 1, bias=False)
+    helper = PTFedSMHelper(model, torch.nn.Linear(1, 1, bias=False), torch.nn.Linear(1, 1, bias=False))
+    incoming = FLModel(
+        params={"weight": torch.tensor([[1.0]])},
+        params_type=ParamsType.DIFF,
+        meta={FedSMConstants.TARGET_ID: "site-1", FedSMConstants.SELECTOR_LABEL: 0},
+    )
+
+    with pytest.raises(ValueError, match="ParamsType.FULL"):
+        helper.load_bundle(incoming, client_name="site-1")
+
+
+def test_fedsm_helper_reports_missing_bundle_entries():
+    model = torch.nn.Linear(1, 1, bias=False)
+    helper = PTFedSMHelper(model, torch.nn.Linear(1, 1, bias=False), torch.nn.Linear(1, 1, bias=False))
+    incoming = FLModel(
+        params={FedSMConstants.GLOBAL_MODEL: {"weight": torch.tensor([[1.0]])}},
+        params_type=ParamsType.FULL,
+        meta={},
+    )
+
+    with pytest.raises(ValueError, match="missing parameter entries"):
+        helper.load_bundle(incoming, client_name="site-1")
+
+
+def test_fedsm_helper_reports_missing_bundle_metadata():
+    model = torch.nn.Linear(1, 1, bias=False)
+    helper = PTFedSMHelper(model, torch.nn.Linear(1, 1, bias=False), torch.nn.Linear(1, 1, bias=False))
+    incoming = FLModel(
+        params={
+            FedSMConstants.GLOBAL_MODEL: {"weight": torch.tensor([[1.0]])},
+            FedSMConstants.PERSONAL_MODEL: {"weight": torch.tensor([[2.0]])},
+            FedSMConstants.SELECTOR_MODEL: {"weight": torch.tensor([[3.0]])},
+        },
+        params_type=ParamsType.FULL,
+        meta={},
+    )
+
+    with pytest.raises(ValueError, match="missing metadata entries"):
+        helper.load_bundle(incoming, client_name="site-1")
+
+
+def test_fedsm_requires_exact_configured_client_set_each_round():
+    controller = FedSM(
+        num_clients=2,
+        client_id_label_mapping={"site-1": 0, "site-2": 1},
+    )
+
+    controller._validate_sampled_clients(["site-1", "site-2"])
+    with pytest.raises(RuntimeError, match=r"missing clients: \['site-2'\]"):
+        controller._validate_sampled_clients(["site-1"])
+    with pytest.raises(RuntimeError, match=r"unexpected clients: \['site-3'\]"):
+        controller._validate_sampled_clients(["site-1", "site-3"])
+
+
+def test_fedsm_requires_num_clients_to_match_label_mapping():
+    with pytest.raises(ValueError, match="num_clients must equal"):
+        FedSM(
+            num_clients=1,
+            client_id_label_mapping={"site-1": 0, "site-2": 1},
+        )
+
+
 def test_fedsm_persistor_round_trips_complete_bundle(tmp_path):
     model = torch.nn.Linear(1, 1, bias=False)
     selector = torch.nn.Linear(1, 2, bias=False)
@@ -145,3 +214,24 @@ def test_fedsm_persistor_round_trips_complete_bundle(tmp_path):
         bundle[FedSMConstants.GLOBAL_MODEL]["weight"],
         learnable[ModelLearnableKey.WEIGHTS][FedSMConstants.GLOBAL_MODEL]["weight"],
     )
+
+
+def test_fedsm_persistor_can_load_trusted_checkpoint_with_custom_metadata(tmp_path):
+    model = torch.nn.Linear(1, 1, bias=False)
+    selector = torch.nn.Linear(1, 2, bias=False)
+    persistor = PTFedSMModelPersistor(model, selector, ["site-1"])
+    learnable = persistor.load_model(fl_ctx=None)
+    learnable[ModelLearnableKey.META]["custom"] = _CheckpointMeta(7)
+    checkpoint = tmp_path / "fedsm-custom-meta.pt"
+    persistor._ckpt_save_path = str(checkpoint)
+    persistor.save_model(learnable, fl_ctx=None)
+
+    resumed = PTFedSMModelPersistor(
+        model,
+        selector,
+        ["site-1"],
+        source_ckpt_file_full_name=str(checkpoint),
+        load_weights_only=False,
+    ).load_model(fl_ctx=None)
+
+    assert resumed[ModelLearnableKey.META]["custom"].value == 7

--- a/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn
+
+from nvflare.apis.job_def import SERVER_SITE_NAME
+from nvflare.app_common.abstract.fl_model import ParamsType
+from nvflare.app_common.workflows.fedavg import FedAvg
+from nvflare.app_opt.pt.fedce import FedCEModelAggregator
+from nvflare.app_opt.pt.fedsm import FedSM, FedSMModelAggregator, PTFedSMModelPersistor
+from nvflare.app_opt.pt.recipes.fedce import FedCERecipe
+from nvflare.app_opt.pt.recipes.fedsm import FedSMRecipe
+from nvflare.client.config import ExchangeFormat
+
+
+def _models():
+    return nn.Linear(2, 1), nn.Linear(2, 2)
+
+
+def test_fedce_recipe_uses_fedavg_with_contribution_aggregator():
+    model, _ = _models()
+    recipe = FedCERecipe(model=model, min_clients=2, train_script=__file__)
+    server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
+    controller = server_app.app_config.workflows[0].controller
+
+    assert isinstance(controller, FedAvg)
+    assert isinstance(controller.aggregator, FedCEModelAggregator)
+    assert recipe.params_transfer_type.value == ParamsType.DIFF.value
+    assert recipe.server_expected_format == ExchangeFormat.PYTORCH
+
+
+def test_fedce_recipe_rejects_non_pytorch_exchange():
+    model, _ = _models()
+    with pytest.raises(ValueError, match="requires server_expected_format"):
+        FedCERecipe(
+            model=model,
+            min_clients=2,
+            train_script=__file__,
+            server_expected_format=ExchangeFormat.NUMPY,
+        )
+
+
+def test_fedsm_recipe_builds_dedicated_components():
+    model, selector = _models()
+    recipe = FedSMRecipe(
+        model=model,
+        selector_model=selector,
+        client_ids=["site-1", "site-2"],
+        min_clients=2,
+        train_script=__file__,
+    )
+    server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
+    controller = server_app.app_config.workflows[0].controller
+
+    assert isinstance(controller, FedSM)
+    assert isinstance(controller.aggregator, FedSMModelAggregator)
+    assert isinstance(server_app.app_config.components["persistor"], PTFedSMModelPersistor)
+    assert recipe.client_id_label_mapping == {"site-1": 0, "site-2": 1}
+
+
+def test_fedsm_recipe_requires_every_configured_client_each_round():
+    model, selector = _models()
+    with pytest.raises(ValueError, match=r"min_clients to equal len\(client_ids\)"):
+        FedSMRecipe(
+            model=model,
+            selector_model=selector,
+            client_ids=["site-1", "site-2"],
+            min_clients=1,
+            train_script=__file__,
+        )
+
+
+def test_fedsm_recipe_requires_exact_label_mapping():
+    model, selector = _models()
+    with pytest.raises(ValueError, match="keys must exactly match"):
+        FedSMRecipe(
+            model=model,
+            selector_model=selector,
+            client_ids=["site-1", "site-2"],
+            client_id_label_mapping={"site-1": 0},
+            min_clients=2,
+            train_script=__file__,
+        )
+
+
+def test_fedce_and_fedsm_recipes_export_server_components(tmp_path):
+    model, selector = _models()
+    FedCERecipe(
+        name="test-fedce-export",
+        model=model,
+        min_clients=2,
+        train_script=__file__,
+    ).export(str(tmp_path / "fedce"))
+    FedSMRecipe(
+        name="test-fedsm-export",
+        model=model,
+        selector_model=selector,
+        client_ids=["site-1", "site-2"],
+        min_clients=2,
+        train_script=__file__,
+    ).export(str(tmp_path / "fedsm"))
+
+    fedce_config = json.loads((tmp_path / "fedce/test-fedce-export/app/config/config_fed_server.json").read_text())
+    fedsm_config = json.loads((tmp_path / "fedsm/test-fedsm-export/app/config/config_fed_server.json").read_text())
+
+    assert fedce_config["workflows"][0]["path"].endswith("workflows.fedavg.FedAvg")
+    assert fedce_config["workflows"][0]["args"]["aggregator"]["path"].endswith("FedCEModelAggregator")
+    assert fedsm_config["workflows"][0]["path"].endswith("pt.fedsm.FedSM")
+    persistor = next(component for component in fedsm_config["components"] if component["id"] == "persistor")
+    assert persistor["path"].endswith("PTFedSMModelPersistor")

--- a/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
@@ -117,6 +117,7 @@ def test_fedce_and_fedsm_recipes_export_server_components(tmp_path):
         sites=["site-1", "site-2"],
         min_clients=2,
         train_script=__file__,
+        load_weights_only=False,
     )
     fedsm_recipe.add_client_config({"site_setting": 1}, clients=["site-1"])
     fedsm_recipe.export(str(tmp_path / "fedsm"))
@@ -131,8 +132,10 @@ def test_fedce_and_fedsm_recipes_export_server_components(tmp_path):
     assert fedsm_config["workflows"][0]["path"].endswith("pt.fedsm.FedSM")
     persistor = next(component for component in fedsm_config["components"] if component["id"] == "persistor")
     assert persistor["path"].endswith("PTFedSMModelPersistor")
+    assert persistor["args"]["load_weights_only"] is False
 
     fedsm_meta = json.loads((tmp_path / "fedsm/test-fedsm-export/meta.json").read_text())
+    assert fedsm_meta["mandatory_clients"] == ["site-1", "site-2"]
     assert fedsm_meta["deploy_map"] == {
         "app_server": ["server"],
         "app_site-1": ["site-1"],

--- a/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
@@ -19,11 +19,7 @@ import pytest
 torch = pytest.importorskip("torch")
 from torch import nn
 
-from nvflare.apis.job_def import SERVER_SITE_NAME
 from nvflare.app_common.abstract.fl_model import ParamsType
-from nvflare.app_common.workflows.fedavg import FedAvg
-from nvflare.app_opt.pt.fedce import FedCEModelAggregator
-from nvflare.app_opt.pt.fedsm import FedSM, FedSMModelAggregator, PTFedSMModelPersistor
 from nvflare.app_opt.pt.recipes.fedce import FedCERecipe
 from nvflare.app_opt.pt.recipes.fedsm import FedSMRecipe
 from nvflare.client.config import ExchangeFormat
@@ -36,11 +32,7 @@ def _models():
 def test_fedce_recipe_uses_fedavg_with_contribution_aggregator():
     model, _ = _models()
     recipe = FedCERecipe(model=model, min_clients=2, train_script=__file__)
-    server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
-    controller = server_app.app_config.workflows[0].controller
 
-    assert isinstance(controller, FedAvg)
-    assert isinstance(controller.aggregator, FedCEModelAggregator)
     assert recipe.params_transfer_type.value == ParamsType.DIFF.value
     assert recipe.server_expected_format == ExchangeFormat.PYTORCH
 
@@ -61,26 +53,22 @@ def test_fedsm_recipe_builds_dedicated_components():
     recipe = FedSMRecipe(
         model=model,
         selector_model=selector,
-        client_ids=["site-1", "site-2"],
+        sites=["site-1", "site-2"],
         min_clients=2,
         train_script=__file__,
     )
-    server_app = recipe.job._deploy_map[SERVER_SITE_NAME]
-    controller = server_app.app_config.workflows[0].controller
 
-    assert isinstance(controller, FedSM)
-    assert isinstance(controller.aggregator, FedSMModelAggregator)
-    assert isinstance(server_app.app_config.components["persistor"], PTFedSMModelPersistor)
-    assert recipe.client_id_label_mapping == {"site-1": 0, "site-2": 1}
+    assert recipe.site_label_mapping == {"site-1": 0, "site-2": 1}
+    assert recipe.configured_sites() == ["site-1", "site-2"]
 
 
 def test_fedsm_recipe_requires_every_configured_client_each_round():
     model, selector = _models()
-    with pytest.raises(ValueError, match=r"min_clients to equal len\(client_ids\)"):
+    with pytest.raises(ValueError, match=r"min_clients to equal len\(sites\)"):
         FedSMRecipe(
             model=model,
             selector_model=selector,
-            client_ids=["site-1", "site-2"],
+            sites=["site-1", "site-2"],
             min_clients=1,
             train_script=__file__,
         )
@@ -92,11 +80,26 @@ def test_fedsm_recipe_requires_exact_label_mapping():
         FedSMRecipe(
             model=model,
             selector_model=selector,
-            client_ids=["site-1", "site-2"],
-            client_id_label_mapping={"site-1": 0},
+            sites=["site-1", "site-2"],
+            site_label_mapping={"site-1": 0},
             min_clients=2,
             train_script=__file__,
         )
+
+
+def test_fedsm_recipe_supports_pr_4862_targeted_client_helpers():
+    model, selector = _models()
+    recipe = FedSMRecipe(
+        model=model,
+        selector_model=selector,
+        sites=["site-1", "site-2"],
+        min_clients=2,
+        train_script=__file__,
+    )
+
+    recipe.add_client_config({"site_setting": 1}, clients=["site-1"])
+    with pytest.raises(ValueError, match="unknown client site"):
+        recipe.add_client_config({"site_setting": 3}, clients=["site-3"])
 
 
 def test_fedce_and_fedsm_recipes_export_server_components(tmp_path):
@@ -107,20 +110,39 @@ def test_fedce_and_fedsm_recipes_export_server_components(tmp_path):
         min_clients=2,
         train_script=__file__,
     ).export(str(tmp_path / "fedce"))
-    FedSMRecipe(
+    fedsm_recipe = FedSMRecipe(
         name="test-fedsm-export",
         model=model,
         selector_model=selector,
-        client_ids=["site-1", "site-2"],
+        sites=["site-1", "site-2"],
         min_clients=2,
         train_script=__file__,
-    ).export(str(tmp_path / "fedsm"))
+    )
+    fedsm_recipe.add_client_config({"site_setting": 1}, clients=["site-1"])
+    fedsm_recipe.export(str(tmp_path / "fedsm"))
 
     fedce_config = json.loads((tmp_path / "fedce/test-fedce-export/app/config/config_fed_server.json").read_text())
-    fedsm_config = json.loads((tmp_path / "fedsm/test-fedsm-export/app/config/config_fed_server.json").read_text())
+    fedsm_config = json.loads(
+        (tmp_path / "fedsm/test-fedsm-export/app_server/config/config_fed_server.json").read_text()
+    )
 
     assert fedce_config["workflows"][0]["path"].endswith("workflows.fedavg.FedAvg")
     assert fedce_config["workflows"][0]["args"]["aggregator"]["path"].endswith("FedCEModelAggregator")
     assert fedsm_config["workflows"][0]["path"].endswith("pt.fedsm.FedSM")
     persistor = next(component for component in fedsm_config["components"] if component["id"] == "persistor")
     assert persistor["path"].endswith("PTFedSMModelPersistor")
+
+    fedsm_meta = json.loads((tmp_path / "fedsm/test-fedsm-export/meta.json").read_text())
+    assert fedsm_meta["deploy_map"] == {
+        "app_server": ["server"],
+        "app_site-1": ["site-1"],
+        "app_site-2": ["site-2"],
+    }
+    site_1_config = json.loads(
+        (tmp_path / "fedsm/test-fedsm-export/app_site-1/config/config_fed_client.json").read_text()
+    )
+    site_2_config = json.loads(
+        (tmp_path / "fedsm/test-fedsm-export/app_site-2/config/config_fed_client.json").read_text()
+    )
+    assert site_1_config["site_setting"] == 1
+    assert "site_setting" not in site_2_config

--- a/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
@@ -19,7 +19,8 @@ import pytest
 torch = pytest.importorskip("torch")
 from torch import nn
 
-from nvflare.app_common.abstract.fl_model import ParamsType
+from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
+from nvflare.app_opt.pt.fedce import FedCEConstants
 from nvflare.app_opt.pt.recipes.fedce import FedCERecipe
 from nvflare.app_opt.pt.recipes.fedsm import FedSMRecipe
 from nvflare.client.config import ExchangeFormat
@@ -46,6 +47,51 @@ def test_fedce_recipe_rejects_non_pytorch_exchange():
             train_script=__file__,
             server_expected_format=ExchangeFormat.NUMPY,
         )
+
+
+def test_fedce_dict_model_requires_explicit_trainable_names_and_filters_buffers():
+    model = {"path": "torch.nn.BatchNorm1d", "args": {"num_features": 1}}
+    with pytest.raises(ValueError, match="trainable_param_names is required"):
+        FedCERecipe(model=model, min_clients=2, train_script=__file__)
+
+    recipe = FedCERecipe(
+        model=model,
+        min_clients=2,
+        train_script=__file__,
+        trainable_param_names=["weight", "bias"],
+    )
+    for client in ("site-1", "site-2"):
+        recipe.fedce_aggregator.accept_model(
+            FLModel(
+                params={
+                    "weight": torch.tensor([1.0]),
+                    "bias": torch.tensor([0.0]),
+                    "running_mean": torch.tensor([10.0]),
+                    "running_var": torch.tensor([2.0]),
+                    "num_batches_tracked": torch.tensor(3),
+                },
+                params_type=ParamsType.DIFF,
+                meta={"client_name": client, FedCEConstants.MINUS_MODEL_SCORE: 0.5},
+            )
+        )
+
+    assert recipe.fedce_aggregator._get_cosine_param_names(["site-1", "site-2"]) == ["bias", "weight"]
+
+
+@pytest.mark.parametrize("names", [[], [""], ["weight", "weight"], "weight"])
+def test_fedce_recipe_rejects_invalid_explicit_trainable_names(names):
+    with pytest.raises(ValueError, match="non-empty list of unique"):
+        FedCERecipe(
+            model={"path": "torch.nn.Linear", "args": {"in_features": 1, "out_features": 1}},
+            min_clients=2,
+            train_script=__file__,
+            trainable_param_names=names,
+        )
+
+
+def test_fedce_recipe_requires_at_least_one_trainable_parameter():
+    with pytest.raises(ValueError, match="at least one trainable parameter"):
+        FedCERecipe(model=nn.Identity(), min_clients=2, train_script=__file__)
 
 
 def test_fedsm_recipe_builds_dedicated_components():

--- a/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_fedsm_recipe_test.py
@@ -87,6 +87,46 @@ def test_fedsm_recipe_requires_exact_label_mapping():
         )
 
 
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"model": None}, "requires model"),
+        ({"selector_model": None}, "requires selector_model"),
+        ({"sites": []}, "non-empty list"),
+        ({"sites": [""], "min_clients": 1}, "non-empty strings"),
+        ({"sites": ["site-1", "site-1"]}, "unique site names"),
+        ({"server_expected_format": ExchangeFormat.NUMPY}, "requires server_expected_format"),
+        ({"site_label_mapping": {"site-1": 1, "site-2": 2}}, "contiguous selector labels"),
+    ],
+)
+def test_fedsm_recipe_validates_contract(overrides, match):
+    model, selector = _models()
+    kwargs = {
+        "model": model,
+        "selector_model": selector,
+        "sites": ["site-1", "site-2"],
+        "min_clients": 2,
+        "train_script": __file__,
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=match):
+        FedSMRecipe(**kwargs)
+
+
+def test_fedsm_recipe_accepts_dict_model_configs():
+    recipe = FedSMRecipe(
+        model={"class_path": "torch.nn.Linear", "args": {"in_features": 2, "out_features": 1}},
+        selector_model={"path": "torch.nn.Linear", "args": {"in_features": 2, "out_features": 2}},
+        sites=["site-1"],
+        min_clients=1,
+        train_script=__file__,
+    )
+
+    assert recipe.model["path"] == "torch.nn.Linear"
+    assert recipe.selector_model["path"] == "torch.nn.Linear"
+
+
 def test_fedsm_recipe_supports_pr_4862_targeted_client_helpers():
     model, selector = _models()
     recipe = FedSMRecipe(
@@ -98,8 +138,18 @@ def test_fedsm_recipe_supports_pr_4862_targeted_client_helpers():
     )
 
     recipe.add_client_config({"site_setting": 1}, clients=["site-1"])
+    assert recipe.configured_sites() == ["site-1", "site-2"]
+    recipe.set_per_site_config({"site-1": {}, "site-2": {}})
+    assert recipe.configured_sites() == ["site-1", "site-2"]
     with pytest.raises(ValueError, match="unknown client site"):
         recipe.add_client_config({"site_setting": 3}, clients=["site-3"])
+
+
+def test_pt_recipe_package_lazy_loads_fedce_and_fedsm():
+    import nvflare.app_opt.pt.recipes as recipes
+
+    assert recipes.__getattr__("FedCERecipe") is FedCERecipe
+    assert recipes.__getattr__("FedSMRecipe") is FedSMRecipe
 
 
 def test_fedce_and_fedsm_recipes_export_server_components(tmp_path):

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -480,8 +480,9 @@ def test_recipe_catalog_includes_all_documented_recipe_variants():
     catalog = _load_catalog()
     names = {entry["name"] for entry in catalog}
 
-    assert len(_DOCUMENTED_RECIPE_SPECS) == 21
+    assert len(_DOCUMENTED_RECIPE_SPECS) == 23
     assert set(_DOCUMENTED_RECIPE_SPECS).issubset(names)
+    assert {"fedce-pt", "fedsm-pt"}.issubset(names)
 
 
 def test_recipe_list_filters_documented_recipe_variants_without_optional_dependencies(monkeypatch, capsys):
@@ -516,6 +517,22 @@ def test_recipe_show_fedprox_documents_fedavg_constructor(monkeypatch, capsys):
     assert data["class"] == "FedAvgRecipe"
     assert data["notes"]
     assert "same recipe constructor as fedavg-pt" in data["notes"][0]
+
+
+def test_recipe_show_fedsm_reports_required_client_ids(monkeypatch, capsys):
+    import json
+
+    from nvflare.tool import cli_output
+    from nvflare.tool.recipe.recipe_cli import cmd_recipe_show
+
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+
+    cmd_recipe_show(Namespace(name="fedsm-pt"))
+
+    payload = json.loads(capsys.readouterr().out)
+    requirements = payload["data"]["client_requirements"]
+    assert requirements["requires_site_list"] is True
+    assert requirements["client_ids"] == {"required": True, "default": None}
 
 
 def test_recipe_show_uses_static_metadata_when_optional_dependency_is_missing(monkeypatch, capsys):

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -519,7 +519,7 @@ def test_recipe_show_fedprox_documents_fedavg_constructor(monkeypatch, capsys):
     assert "same recipe constructor as fedavg-pt" in data["notes"][0]
 
 
-def test_recipe_show_fedsm_reports_required_client_ids(monkeypatch, capsys):
+def test_recipe_show_fedsm_reports_required_sites(monkeypatch, capsys):
     import json
 
     from nvflare.tool import cli_output
@@ -532,7 +532,7 @@ def test_recipe_show_fedsm_reports_required_client_ids(monkeypatch, capsys):
     payload = json.loads(capsys.readouterr().out)
     requirements = payload["data"]["client_requirements"]
     assert requirements["requires_site_list"] is True
-    assert requirements["client_ids"] == {"required": True, "default": None}
+    assert requirements["sites"] == {"required": True, "default": None}
 
 
 def test_recipe_show_uses_static_metadata_when_optional_dependency_is_missing(monkeypatch, capsys):


### PR DESCRIPTION
Adds dedicated PyTorch recipes and reusable components for FedCE contribution estimation and FedSM personalized federated learning.

### Description

Add FedCERecipe with:

- Contribution-aware model aggregation.
- Gradient-direction and minus-model contribution signals.
- PTFedCEHelper utilities for client integration.
- FedCE coefficient propagation between rounds.

Add FedSMRecipe with:

- Global, personalized, and selector model management.
- SoftPull aggregation for personalized models.
- Optional selector optimizer-state synchronization.
- PTFedSMHelper utilities for loading and returning model bundles.
- Complete model-bundle persistence and checkpoint resume support.

Restrict both recipes to PyTorch and document their client-script contracts.

Keep FedCE and FedSM as separate, non-composable algorithms.

Add both recipes to the public exports and recipe CLI catalog.

Add user documentation and recipe examples.

Add aggregation, helper, persistence, validation, export, and catalog tests.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
