### PR TITLE
[Main] ccwf swarm: fix SwarmServerConfig.min_clients default + start_task_timeout

### DIFF
--- a/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
+++ b/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
@@ -34,14 +34,24 @@ if __name__ == "__main__":
 
     aggregator = InTimeAccumulateWeightedAggregator(expected_data_kind=DataKind.WEIGHTS)
     job.add_swarm(
-        server_config=SwarmServerConfig(num_rounds=num_rounds),
+        server_config=SwarmServerConfig(
+            num_rounds=num_rounds,
+            # Default 10s is too short for clients that initialize CIFAR-10 dataset
+            # and the PyTorch model after responding to swarm_config.
+            start_task_timeout=300,
+        ),
         client_config=SwarmClientConfig(
             executor=ScriptRunner(script=train_script),
             aggregator=aggregator,
             persistor=PTFileModelPersistor(model=Net()),
             shareable_generator=SimpleModelShareableGenerator(),
         ),
-        cse_config=CrossSiteEvalConfig(eval_task_timeout=300),
+        cse_config=CrossSiteEvalConfig(
+            # Default 10s is too short for clients that need to (re)load CIFAR-10
+            # before responding to cse_start, same race as swarm_start above.
+            start_task_timeout=300,
+            eval_task_timeout=300,
+        ),
     )
 
     # job.export_job("/tmp/nvflare/jobs/job_config")

--- a/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
+++ b/examples/advanced/job_api/pt/swarm_script_runner_cifar10.py
@@ -46,12 +46,7 @@ if __name__ == "__main__":
             persistor=PTFileModelPersistor(model=Net()),
             shareable_generator=SimpleModelShareableGenerator(),
         ),
-        cse_config=CrossSiteEvalConfig(
-            # Default 10s is too short for clients that need to (re)load CIFAR-10
-            # before responding to cse_start, same race as swarm_start above.
-            start_task_timeout=300,
-            eval_task_timeout=300,
-        ),
+        cse_config=CrossSiteEvalConfig(eval_task_timeout=300),
     )
 
     # job.export_job("/tmp/nvflare/jobs/job_config")

--- a/nvflare/app_common/ccwf/ccwf_job.py
+++ b/nvflare/app_common/ccwf/ccwf_job.py
@@ -48,7 +48,7 @@ class SwarmServerConfig:
         private_p2p: bool = True,
         aggr_clients=None,
         train_clients=None,
-        min_clients=None,
+        min_clients: int = 0,
     ):
         self.num_rounds = num_rounds
         self.start_round = start_round

--- a/tests/unit_test/app_common/ccwf/test_ccwf_job_config.py
+++ b/tests/unit_test/app_common/ccwf/test_ccwf_job_config.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for ccwf_job config dataclass defaults.
+
+SwarmServerConfig.min_clients was previously defaulted to None, which the
+add_swarm() wiring forwarded to SwarmServerController.__init__ (typed
+min_clients: int = 0). The value then reached BaseServerCtl.__init__ where
+`if min_clients < 0:` raised TypeError ("'<' not supported between instances
+of 'NoneType' and 'int'") at construction time, making the swarm CIFAR10
+example fail before any simulator was even started.
+
+The fix sets SwarmServerConfig.min_clients default to 0 so that the type
+contract (int) is honored end-to-end and the documented "0 means all
+participating clients are required" semantics from BaseServerCtl applies.
+"""
+
+from nvflare.app_common.ccwf.ccwf_job import SwarmServerConfig
+
+
+def test_swarm_server_config_default_min_clients_is_zero():
+    """Default SwarmServerConfig must use min_clients=0, not None.
+
+    None as a default would propagate through add_swarm() into
+    BaseServerCtl.__init__ where `if min_clients < 0:` raises TypeError.
+    """
+    config = SwarmServerConfig(num_rounds=1)
+    assert config.min_clients == 0
+    assert config.min_clients is not None
+
+
+def test_swarm_server_config_explicit_min_clients_preserved():
+    """Explicit min_clients value passes through unchanged."""
+    config = SwarmServerConfig(num_rounds=1, min_clients=2)
+    assert config.min_clients == 2


### PR DESCRIPTION
## Summary

- Forward-port the CCWF swarm fixes from #4568 to `main` for [NVBug 6433799](https://nvbugspro.nvidia.com/bug/6433799).
- Change `SwarmServerConfig.min_clients` from `None` to the controller-compatible default `int = 0`.
- Give the swarm and cross-site-evaluation startup tasks 300 seconds in the CIFAR-10 example.
- Add regression coverage for the default and explicitly configured `min_clients` values.

## Root cause and impact

`CCWFJob.add_swarm()` forwards `SwarmServerConfig.min_clients` to `SwarmServerController`. The configuration default was `None`, which overrides the controller's safe integer default and reaches `if min_clients < 0`, raising `TypeError` while the job is being constructed. As a result, swarm jobs that do not explicitly specify `min_clients` cannot start on `main`.

The example's 10-second default startup timeout can also expire while a client initializes CIFAR-10 and PyTorch, causing a `FATAL_SYSTEM_ERROR` despite continued client progress.

## Validation

- `python -m pytest -q tests/unit_test/app_common/ccwf` — 118 passed
- Python compilation check for all three changed files
- `git diff --check`

Forward-port of #4568 from the 2.8 branch.
