### PR TITLE
Reject symlinks in signed folders

### DIFF
--- a/nvflare/lighter/utils.py
+++ b/nvflare/lighter/utils.py
@@ -331,9 +331,20 @@ def load_private_key_file(file_path):
         return serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
 
 
+def _check_for_symlinks(root, folders, files):
+    for name in folders + files:
+        path = os.path.join(root, name)
+        if os.path.islink(path):
+            raise ValueError(f"symbolic links are not allowed in signed folders: {path}")
+
+
 def sign_folders(folder, signing_pri_key, crt_path=None, max_depth=9999, signature_file=NVFLARE_SIG_FILE):
+    if os.path.islink(folder):
+        raise ValueError(f"signed folder must not be a symbolic link: {folder}")
+
     depth = 0
     for root, folders, files in os.walk(folder):
+        _check_for_symlinks(root, folders, files)
         depth = depth + 1
         signatures = dict()
         for file in files:
@@ -386,11 +397,15 @@ def verify_folder_signature_and_get_signers(
     """
 
     try:
+        if os.path.islink(src_folder):
+            return False, []
+
         root_ca_cert = load_crt(root_ca_path)
         root_ca_public_key = root_ca_cert.public_key()
         root_submitter = _cert_to_submitter(root_ca_cert)
         signers = {}
         for root, folders, files in os.walk(src_folder):
+            _check_for_symlinks(root, folders, files)
             try:
                 with open(os.path.join(root, signature_file), "rt") as f:
                     signatures = json.load(f)

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -387,6 +387,28 @@ class TestVerifyFolderSignature:
             f.write(b"tampered content")
         assert verify_folder_signature(folder, root_ca_path, single_signer=False) is False
 
+    def test_verify_folder_signature_fails_when_subdirectory_replaced_by_symlink(self, tmp_path):
+        folder, root_ca_path, client_crt_path, client_pri_key, _ = self._setup_certs_and_folder(tmp_path)
+        sign_folders(folder, client_pri_key, crt_path=client_crt_path)
+
+        replacement = tmp_path / "replacement"
+        replacement.mkdir()
+        (replacement / "nested.txt").write_bytes(b"tampered content")
+        subdir = os.path.join(folder, "subdir")
+        shutil.rmtree(subdir)
+        os.symlink(replacement, subdir, target_is_directory=True)
+
+        assert verify_folder_signature(folder, root_ca_path, single_signer=False) is False
+
+    def test_sign_folders_rejects_symlinks(self, tmp_path):
+        folder, _root_ca_path, _client_crt_path, client_pri_key, _ = self._setup_certs_and_folder(tmp_path)
+        target = tmp_path / "target.txt"
+        target.write_bytes(b"content")
+        os.symlink(target, os.path.join(folder, "link.txt"))
+
+        with pytest.raises(ValueError, match="symbolic links are not allowed"):
+            sign_folders(folder, client_pri_key)
+
     def test_verify_folder_signature_fails_when_signature_file_missing(self, tmp_path):
         """Verify returns False when a directory has no signature file."""
         folder, root_ca_path, client_crt_path, client_pri_key, _ = self._setup_certs_and_folder(tmp_path)

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -409,6 +409,17 @@ class TestVerifyFolderSignature:
         with pytest.raises(ValueError, match="symbolic links are not allowed"):
             sign_folders(folder, client_pri_key)
 
+    def test_sign_and_verify_reject_symlinked_root(self, tmp_path):
+        folder, root_ca_path, client_crt_path, client_pri_key, _ = self._setup_certs_and_folder(tmp_path)
+        sign_folders(folder, client_pri_key, crt_path=client_crt_path)
+        real_folder = tmp_path / "real_folder"
+        os.rename(folder, real_folder)
+        os.symlink(real_folder, folder, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="signed folder must not be a symbolic link"):
+            sign_folders(folder, client_pri_key)
+        assert verify_folder_signature(folder, root_ca_path, single_signer=False) is False
+
     def test_verify_folder_signature_fails_when_signature_file_missing(self, tmp_path):
         """Verify returns False when a directory has no signature file."""
         folder, root_ca_path, client_crt_path, client_pri_key, _ = self._setup_certs_and_folder(tmp_path)


### PR DESCRIPTION
## Summary

- reject symbolic links when signing folder trees
- fail folder signature verification when the root or any entry is a symbolic link
- add regression coverage for signed-directory-to-symlink substitution

## Root cause

Folder signatures cover directory names, while `os.walk()` does not recurse into substituted directory symlinks by default. A signed directory could therefore be replaced by a same-named symlink and still pass verification.

This change rejects symlinks without changing the signature manifest format. Existing manifests containing regular files and directories remain compatible.

