### PR TITLE
[Main] Fix admin leaf validation for custom roles and legacy certificates

### DIFF
--- a/nvflare/fuel/sec/admin_cert.py
+++ b/nvflare/fuel/sec/admin_cert.py
@@ -16,7 +16,6 @@ from cryptography import x509
 from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 ADMIN_CERT_PLACEHOLDER_CN = "nvflare-admin"
-ALLOWED_FLARE_ADMIN_ROLES = {"project_admin", "org_admin", "lead", "member"}
 
 
 class AdminCertValidationError(ValueError):
@@ -24,22 +23,18 @@ class AdminCertValidationError(ValueError):
 
 
 def validate_admin_leaf_cert(cert: x509.Certificate, reject_placeholder_cn: bool = True):
-    """Validate the FLARE admin certificate fields that relying parties consume.
+    """Validate the security-sensitive properties of a FLARE admin leaf certificate.
 
     Legacy FLARE leaf certs may omit KeyUsage and EKU. Treat absent extensions
     as unrestricted for compatibility, but enforce admin-client usage
-    constraints when the issuer includes them.
+    constraints when the issuer includes them. Organization and role are
+    optional authorization attributes: authentication must not require them or
+    constrain roles to a built-in list because authorization policy supports
+    custom roles.
     """
     common_name = _require_subject_attr(cert, NameOID.COMMON_NAME, "commonName")
     if reject_placeholder_cn and common_name == ADMIN_CERT_PLACEHOLDER_CN:
         raise AdminCertValidationError("admin certificate commonName must be a real admin identity")
-
-    _require_subject_attr(cert, NameOID.ORGANIZATION_NAME, "organizationName")
-    role = _require_subject_attr(cert, NameOID.UNSTRUCTURED_NAME, "unstructuredName")
-    if role not in ALLOWED_FLARE_ADMIN_ROLES:
-        raise AdminCertValidationError(
-            f"admin certificate subject unstructuredName must be one of {sorted(ALLOWED_FLARE_ADMIN_ROLES)}"
-        )
 
     _reject_ca_leaf(cert)
     _validate_key_usage(cert)

--- a/tests/unit_test/fuel/sec/admin_cert_test.py
+++ b/tests/unit_test/fuel/sec/admin_cert_test.py
@@ -20,9 +20,7 @@ from nvflare.fuel.sec.admin_cert import AdminCertValidationError, validate_admin
 from nvflare.lighter.utils import Identity, generate_cert, generate_keys
 
 
-def _make_admin_cert(
-    role="lead", common_name="alice@nvidia.com", org="nvidia", ca=False, extra_extensions=None
-):
+def _make_admin_cert(role="lead", common_name="alice@nvidia.com", org="nvidia", ca=False, extra_extensions=None):
     root_key, root_pub_key = generate_keys()
     root_cert = generate_cert(
         subject=Identity("root", "nvidia"),

--- a/tests/unit_test/fuel/sec/admin_cert_test.py
+++ b/tests/unit_test/fuel/sec/admin_cert_test.py
@@ -20,7 +20,9 @@ from nvflare.fuel.sec.admin_cert import AdminCertValidationError, validate_admin
 from nvflare.lighter.utils import Identity, generate_cert, generate_keys
 
 
-def _make_admin_cert(role="lead", common_name="alice@nvidia.com", ca=False, extra_extensions=None):
+def _make_admin_cert(
+    role="lead", common_name="alice@nvidia.com", org="nvidia", ca=False, extra_extensions=None
+):
     root_key, root_pub_key = generate_keys()
     root_cert = generate_cert(
         subject=Identity("root", "nvidia"),
@@ -31,7 +33,7 @@ def _make_admin_cert(role="lead", common_name="alice@nvidia.com", ca=False, extr
     )
     admin_key, admin_pub_key = generate_keys()
     admin_cert = generate_cert(
-        subject=Identity(common_name, "nvidia", role),
+        subject=Identity(common_name, org, role),
         issuer=Identity("root", "nvidia"),
         signing_pri_key=root_key,
         subject_pub_key=admin_pub_key,
@@ -48,11 +50,22 @@ def test_validate_admin_leaf_cert_accepts_flare_roles(role):
     validate_admin_leaf_cert(admin_cert)
 
 
-def test_validate_admin_leaf_cert_rejects_unknown_role():
-    _root_cert, admin_cert = _make_admin_cert(role="admin")
+def test_validate_admin_leaf_cert_accepts_custom_role():
+    _root_cert, admin_cert = _make_admin_cert(role="self_defined")
 
-    with pytest.raises(AdminCertValidationError, match="unstructuredName"):
-        validate_admin_leaf_cert(admin_cert)
+    validate_admin_leaf_cert(admin_cert)
+
+
+def test_validate_admin_leaf_cert_accepts_missing_organization():
+    _root_cert, admin_cert = _make_admin_cert(org=None)
+
+    validate_admin_leaf_cert(admin_cert)
+
+
+def test_validate_admin_leaf_cert_accepts_missing_role():
+    _root_cert, admin_cert = _make_admin_cert(role=None)
+
+    validate_admin_leaf_cert(admin_cert)
 
 
 def test_validate_admin_leaf_cert_rejects_ca_cert():

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -535,9 +535,7 @@ class TestVerifyFolderSignature:
 
         sign_folders(str(folder), client_pri_key, crt_path=str(client_crt_path))
 
-        verified, signers = verify_folder_signature_and_get_signers(
-            str(folder), str(root_ca_path), single_signer=False
-        )
+        verified, signers = verify_folder_signature_and_get_signers(str(folder), str(root_ca_path), single_signer=False)
 
         assert verified is True
         assert signers == [("client", "nvidia", "self_defined")]

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -509,7 +509,7 @@ class TestVerifyFolderSignature:
 
         assert verify_folder_signature(str(folder), str(root_ca_path), single_signer=False) is False
 
-    def test_verify_folder_signature_rejects_submitter_cert_with_unknown_role(self, tmp_path):
+    def test_verify_folder_signature_accepts_submitter_cert_with_custom_role(self, tmp_path):
         root_pri_key, root_pub_key = lighter_utils.generate_keys()
         client_pri_key, client_pub_key = lighter_utils.generate_keys()
         root_cert = lighter_generate_cert(
@@ -520,7 +520,7 @@ class TestVerifyFolderSignature:
             ca=True,
         )
         client_cert = lighter_generate_cert(
-            subject=Identity("client", "nvidia", "admin"),
+            subject=Identity("client", "nvidia", "self_defined"),
             issuer=Identity("root", "nvidia"),
             signing_pri_key=root_pri_key,
             subject_pub_key=client_pub_key,
@@ -535,7 +535,12 @@ class TestVerifyFolderSignature:
 
         sign_folders(str(folder), client_pri_key, crt_path=str(client_crt_path))
 
-        assert verify_folder_signature(str(folder), str(root_ca_path), single_signer=False) is False
+        verified, signers = verify_folder_signature_and_get_signers(
+            str(folder), str(root_ca_path), single_signer=False
+        )
+
+        assert verified is True
+        assert signers == [("client", "nvidia", "self_defined")]
 
 
 @pytest.mark.xdist_group(name="lighter_utils_group")


### PR DESCRIPTION
## Summary

- Fix the admin-login regression introduced by #4827 for [NVBug 6423411](https://nvbugspro.nvidia.com/bug/6423411).
- Allow custom admin roles supported by authorization policy.
- Accept legacy and distributed-provisioning admin certificates that omit optional organization or role subject attributes.
- Add regression coverage for login certificate validation and signed-folder verification with custom roles.

## Root cause

`validate_admin_leaf_cert()` mixed authentication checks with authorization policy. It required `organizationName` and `unstructuredName` on every admin certificate and restricted roles to four built-in values. That rejected previously valid custom roles and legacy/provisioned certificates before authorization policy could evaluate them, preventing admin sessions from being created.

## Fix and security boundary

The validator now treats organization and role as optional authorization metadata. Authentication still requires a real common-name identity and retains the non-CA leaf, digital-signature key usage, and client-auth EKU checks. Existing login and signature flows continue to verify certificate chains and identity binding before using the leaf certificate.

## Validation

- 131 affected security, login, certificate-chain, signature, and identity tests passed.
- Ruff checks passed for all changed files.
- Python compilation and `git diff --check` passed.
