### PR TITLE
Allow custom admin roles in admin certificate validation

### DIFF
--- a/nvflare/fuel/sec/admin_cert.py
+++ b/nvflare/fuel/sec/admin_cert.py
@@ -16,7 +16,6 @@ from cryptography import x509
 from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 ADMIN_CERT_PLACEHOLDER_CN = "nvflare-admin"
-ALLOWED_FLARE_ADMIN_ROLES = {"project_admin", "org_admin", "lead", "member"}
 
 
 class AdminCertValidationError(ValueError):
@@ -35,11 +34,9 @@ def validate_admin_leaf_cert(cert: x509.Certificate, reject_placeholder_cn: bool
         raise AdminCertValidationError("admin certificate commonName must be a real admin identity")
 
     _require_subject_attr(cert, NameOID.ORGANIZATION_NAME, "organizationName")
-    role = _require_subject_attr(cert, NameOID.UNSTRUCTURED_NAME, "unstructuredName")
-    if role not in ALLOWED_FLARE_ADMIN_ROLES:
-        raise AdminCertValidationError(
-            f"admin certificate subject unstructuredName must be one of {sorted(ALLOWED_FLARE_ADMIN_ROLES)}"
-        )
+    # Role must be present but is not restricted to built-in roles: provisioning
+    # supports custom roles, and unknown roles fail closed in authorization.
+    _require_subject_attr(cert, NameOID.UNSTRUCTURED_NAME, "unstructuredName")
 
     _reject_ca_leaf(cert)
     _validate_key_usage(cert)

--- a/tests/unit_test/fuel/sec/admin_cert_test.py
+++ b/tests/unit_test/fuel/sec/admin_cert_test.py
@@ -41,15 +41,15 @@ def _make_admin_cert(role="lead", common_name="alice@nvidia.com", ca=False, extr
     return root_cert, admin_cert
 
 
-@pytest.mark.parametrize("role", ["project_admin", "org_admin", "lead", "member"])
-def test_validate_admin_leaf_cert_accepts_flare_roles(role):
+@pytest.mark.parametrize("role", ["project_admin", "org_admin", "lead", "member", "self_defined"])
+def test_validate_admin_leaf_cert_accepts_builtin_and_custom_roles(role):
     _root_cert, admin_cert = _make_admin_cert(role=role)
 
     validate_admin_leaf_cert(admin_cert)
 
 
-def test_validate_admin_leaf_cert_rejects_unknown_role():
-    _root_cert, admin_cert = _make_admin_cert(role="admin")
+def test_validate_admin_leaf_cert_rejects_missing_role():
+    _root_cert, admin_cert = _make_admin_cert(role=None)
 
     with pytest.raises(AdminCertValidationError, match="unstructuredName"):
         validate_admin_leaf_cert(admin_cert)

--- a/tests/unit_test/lighter/utils_test.py
+++ b/tests/unit_test/lighter/utils_test.py
@@ -509,7 +509,7 @@ class TestVerifyFolderSignature:
 
         assert verify_folder_signature(str(folder), str(root_ca_path), single_signer=False) is False
 
-    def test_verify_folder_signature_rejects_submitter_cert_with_unknown_role(self, tmp_path):
+    def test_verify_folder_signature_accepts_submitter_cert_with_custom_role(self, tmp_path):
         root_pri_key, root_pub_key = lighter_utils.generate_keys()
         client_pri_key, client_pub_key = lighter_utils.generate_keys()
         root_cert = lighter_generate_cert(
@@ -535,7 +535,7 @@ class TestVerifyFolderSignature:
 
         sign_folders(str(folder), client_pri_key, crt_path=str(client_crt_path))
 
-        assert verify_folder_signature(str(folder), str(root_ca_path), single_signer=False) is False
+        assert verify_folder_signature(str(folder), str(root_ca_path), single_signer=False) is True
 
 
 @pytest.mark.xdist_group(name="lighter_utils_group")


### PR DESCRIPTION
## Summary

- Provisioning intentionally supports custom admin roles (restored in #3280, unknown roles produce a warning only), but the admin leaf certificate validation added in #4827 hard-rejects any role outside the four built-in roles (`project_admin`, `org_admin`, `lead`, `member`). As a result, a provisioned custom-role admin kit fails admin login (`nvflare/fuel/hci/server/login.py`) and job-submitter signature verification (`nvflare/lighter/utils.py`) with an opaque certificate validation error.
- Remove the built-in-role allowlist from `validate_admin_leaf_cert`, restoring pre-#4827 behavior for custom roles. The role (subject `unstructuredName`) must still be present, and all other #4827 hardening is retained: placeholder-CN rejection, organization presence, CA-leaf rejection, keyUsage/extendedKeyUsage checks.
- Unknown roles remain safe: authorization fails closed, so a custom role has no rights unless the site's `authorization.json` explicitly grants them.
- Update tests: accept custom roles in cert validation and folder-signature verification; add a rejects-missing-role test.

Related: #3280, #4827