### PR TITLE
Fix flaky job_runner completion-loop tests by scoping the time.sleep patch

### DIFF
--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -27,6 +27,17 @@ from nvflare.private.fed.server.job_runner import JobRunner
 from nvflare.private.fed.server.message_send import ClientReply
 
 
+def _patch_job_runner_sleep(side_effect):
+    """Patch the ``time`` name bound inside the job_runner module only.
+
+    Patching ``job_runner.time.sleep`` would mutate the process-global ``time``
+    module, so a leftover daemon thread from another test in the same worker
+    calling ``time.sleep`` would run the side effect and trip the loop's stop
+    condition early (FLARE-3034).
+    """
+    return patch("nvflare.private.fed.server.job_runner.time", **{"sleep.side_effect": side_effect})
+
+
 def _make_runner_inputs(num_clients=1):
     runner = JobRunner(workspace_root="/tmp")
     runner.log_info = MagicMock()
@@ -254,7 +265,7 @@ def test_job_complete_process_saves_workspace_before_publishing_aborted_status()
     def _stop_after_first_pass(_):
         runner.ask_to_stop = True
 
-    with patch("nvflare.private.fed.server.job_runner.time.sleep", side_effect=_stop_after_first_pass):
+    with _patch_job_runner_sleep(_stop_after_first_pass):
         runner._job_complete_process(engine)
 
     completion_ctx.set_prop.assert_called_once_with(FLContextKey.CURRENT_JOB_ID, "job-1")
@@ -467,7 +478,7 @@ def test_job_complete_process_fires_job_aborted_for_aborted_launcher_return_code
     def _stop_after_first_pass(_):
         runner.ask_to_stop = True
 
-    with patch("nvflare.private.fed.server.job_runner.time.sleep", side_effect=_stop_after_first_pass):
+    with _patch_job_runner_sleep(_stop_after_first_pass):
         runner._job_complete_process(engine)
 
     runner._save_workspace.assert_called_once_with(completion_ctx)
@@ -510,7 +521,7 @@ def test_job_complete_process_keeps_processing_jobs_when_save_workspace_fails():
     def _stop_after_first_pass(_):
         runner.ask_to_stop = True
 
-    with patch("nvflare.private.fed.server.job_runner.time.sleep", side_effect=_stop_after_first_pass):
+    with _patch_job_runner_sleep(_stop_after_first_pass):
         runner._job_complete_process(engine)
 
     assert runner._save_workspace.call_args_list == [call(first_ctx), call(second_ctx)]
@@ -565,7 +576,7 @@ def test_job_complete_process_retries_save_without_recomputing_finished_status()
         if sleep_count == 2:
             runner.ask_to_stop = True
 
-    with patch("nvflare.private.fed.server.job_runner.time.sleep", side_effect=_stop_after_second_pass):
+    with _patch_job_runner_sleep(_stop_after_second_pass):
         runner._job_complete_process(engine)
 
     assert runner._save_workspace.call_args_list == [call(first_ctx), call(second_ctx)]
@@ -614,7 +625,7 @@ def test_job_complete_process_retries_status_publish_without_resaving_workspace(
         if sleep_count == 2:
             runner.ask_to_stop = True
 
-    with patch("nvflare.private.fed.server.job_runner.time.sleep", side_effect=_stop_after_second_pass):
+    with _patch_job_runner_sleep(_stop_after_second_pass):
         runner._job_complete_process(engine)
 
     runner._save_workspace.assert_called_once_with(first_ctx)


### PR DESCRIPTION
## Summary
- Fixes the flaky test `test_job_complete_process_retries_save_without_recomputing_finished_status` (FLARE-3034), which failed once on PR #4872 CI (unit-tests ubuntu-22.04/3.10) with `_save_workspace` recording only `call(first_ctx)` instead of `[call(first_ctx), call(second_ctx)]`, then passed on rerun.
- Root cause: `patch("nvflare.private.fed.server.job_runner.time.sleep")` patches `sleep` on the process-global `time` module, since `job_runner.time` is the shared module singleton. Some unit tests leave daemon threads behind that loop on `time.sleep` (e.g. `SessionManager.monitor_sessions` in `nvflare/fuel/hci/server/sess.py`, the download-service monitor loop). When such a thread wakes inside the microseconds-wide patch window on the same pytest-xdist worker, it executes the test's side_effect, increments the sleep counter early, and sets `ask_to_stop` after only one pass of `_job_complete_process`.
- Reproduced deterministically by running the test file with a stray daemon thread looping on `time.sleep`: all five tests that patch `job_runner.time.sleep` fail this way (196/200 runs).
- Fix: patch the `time` name bound inside the job_runner module (`patch("nvflare.private.fed.server.job_runner.time")`) via a shared `_patch_job_runner_sleep` helper, so the mock is invisible to other threads and modules. All five call sites converted; 1040/1040 runs pass under the same contention after the fix.