### PR TITLE
Add recipe secret parameter safeguards

### DIFF
--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -19,6 +19,16 @@ For model input formats, checkpoint behavior, and execution environments, see
 :ref:`job_recipe`. For common Recipe methods, helpers, and stable API behavior,
 see :ref:`recipe_api`.
 
+.. important::
+
+   Recipe arguments and helper configuration become part of the generated job
+   definition. Never put an actual password, token, API key, private key, or
+   other credential in any recipe parameter, including nested dictionaries.
+   Keep secrets in site environment variables or mounted secret files. Use
+   ``secret_ref`` or ``secret_file_ref`` only at supported runtime boundaries;
+   otherwise read the secret directly inside your training code. See
+   :ref:`recipe_secrets` for the supported locations.
+
 Fed Task
 ==============
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -223,6 +223,23 @@ data loaders, validators, or other recipe behavior.
    ``data_path`` or ``batch_size``. For FedAvg, pass those values through
    ``train_args`` unless your recipe explicitly documents another shape.
 
+No Secrets In Recipe Parameters
+-------------------------------
+
+Recipe parameters are job definition, not secret storage. Values such as
+``train_args``, ``task_args``, ``eval_args``, ``per_site_config``, config
+override dictionaries, execution parameters, and dictionaries passed to
+``add_client_config`` or ``add_server_config`` can be serialized in clear text
+into the generated job. They must never contain actual passwords, API keys,
+tokens, private keys, or other credentials.
+
+Recipes emit ``PotentialSecretWarning`` when a supplied value looks like an
+actual secret, but this heuristic check cannot prove that a value is safe.
+Keep the value at the executing site. Use ``secret_ref`` for a site environment
+variable or ``secret_file_ref`` for a mounted secret file only at a supported
+runtime boundary. See :ref:`recipe_secrets` for the supported locations,
+examples, and deployment guidance.
+
 Recipe Metadata
 ---------------
 

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -208,11 +208,12 @@ values. A secret's environment-variable name, a reference placeholder, or the
 path to a mounted secret file is configuration and can be supplied. The secret
 value itself must remain at the executing site.
 
-To catch mistakes, recipes scan their parameters with heuristics (well-known
-token formats, password-like flag and key names, high-entropy strings) and
-emit a ``nvflare.recipe.secrets.PotentialSecretWarning`` when a value looks
-like an actual secret. ``recipe.export()`` additionally scans the generated
-config files of the exported job. The scan is best-effort: it neither finds
+To catch mistakes, recipes scan their current parameters before export or run
+with heuristics (well-known token formats, password-like flag and key names,
+high-entropy strings) and emit a
+``nvflare.recipe.secrets.PotentialSecretWarning`` when a value looks like an
+actual secret. ``recipe.export()`` additionally scans the generated config
+files of the exported job. The scan is best-effort: it neither finds
 every possible credential nor makes a supplied value safe. Absence of a
 warning does not prove that a parameter is safe. Investigate each warning and
 keep any actual secret at the site, using a reference only at a supported
@@ -264,7 +265,13 @@ There are two supported ways to make a secret available at runtime:
     ordinary configuration variables first, tokenizes the command, and then
     resolves each reference immediately before the script or process starts.
     Resolving after tokenization keeps a secret containing spaces in one
-    argument.
+    argument. The subprocess launcher rejects references in command strings for
+    directly invoked or leading-``env``-wrapped ``sh``/``bash`` and PowerShell.
+    This is a targeted safeguard, not a general code-interpreter detector. Never
+    put a reference in any argument another program will parse as code, including
+    another shell, a shell hidden behind a different wrapper, or ``python -c``.
+    Pass the secret through the child environment or read it from a mounted file
+    inside the invoked command instead.
 
   * Values explicitly read from a runtime job JSON file with
     ``get_job_config_value``, ``get_client_config_value``, or
@@ -274,7 +281,10 @@ There are two supported ways to make a secret available at runtime:
     resolve recursively when the value is read; dictionary keys are not resolved.
     These raw-file helpers do not expand ordinary placeholders such as
     ``{SITE_NAME}``, so do not combine those placeholders in a value consumed
-    this way.
+    this way. Internal client-launcher timeout/count overrides are copied into a
+    subprocess runtime config and therefore reject secret references instead of
+    resolving them. Use references for values that site component code reads
+    directly through these getters.
 
   Arbitrary component constructor arguments, job metadata, packaged custom
   files, and other job artifacts keep references as placeholders and are not

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -50,12 +50,14 @@ All concrete recipes support the common execution surface:
 ``recipe.export(job_dir, server_exec_params=None, client_exec_params=None, env=None)``
    Export the current recipe definition as a deployable NVFlare job directory.
    If ``env`` is supplied, the recipe can apply environment-specific processing
-   before export.
+   before export. Execution parameter dictionaries become part of the job
+   definition and must not contain secret values; see :ref:`recipe_secrets`.
 
 ``recipe.execute(env, server_exec_params=None, client_exec_params=None)``
    Execute the current recipe definition through an execution environment and
-   return a ``Run`` handle. When the Python process receives the Recipe export
-   flags, ``execute`` exports instead of submitting:
+   return a ``Run`` handle. Execution parameter dictionaries must not contain
+   secret values. When the Python process receives the Recipe export flags,
+   ``execute`` exports instead of submitting:
 
    .. code-block:: shell
 
@@ -64,6 +66,7 @@ All concrete recipes support the common execution surface:
 ``recipe.run(env, server_exec_params=None, client_exec_params=None)``
    Submit directly through the environment and return a ``Run`` handle. Most
    user examples should use ``execute`` so export flags continue to work.
+   Execution parameter dictionaries must not contain secret values.
 
 Recipe helpers mutate the recipe object. Call helpers before ``export()`` or
 ``execute()`` for the job you are about to create. After a job has been
@@ -80,10 +83,12 @@ Config helpers:
 
 ``recipe.add_client_config(config, clients=None)``
    Add top-level generated client app configuration parameters. If ``clients``
-   is omitted, the config applies to all generated client apps.
+   is omitted, the config applies to all generated client apps. The dictionary
+   is stored in clear text and must not contain secret values.
 
 ``recipe.add_server_config(config)``
-   Add top-level generated server app configuration parameters.
+   Add top-level generated server app configuration parameters. The dictionary
+   is stored in clear text and must not contain secret values.
 
 These config helpers are for documented top-level configuration knobs such as
 timeouts and streaming chunk sizes. They are not a component-placement API; do
@@ -139,7 +144,9 @@ Utility helpers:
    Add supported experiment tracking receivers such as TensorBoard, MLflow, or
    Weights & Biases. With ``client_side=True``, ``clients`` limits which sites
    receive the client-side receiver; call once per site with different
-   ``tracking_config`` values for per-site tracking destinations.
+   ``tracking_config`` values for per-site tracking destinations. Keep tracking
+   credentials in the executing site's environment or mounted secret files;
+   never put them in ``tracking_config``.
 
 ``add_cross_site_evaluation(recipe, submit_model_timeout=600, validation_timeout=6000, participating_clients=None)``
    Add cross-site evaluation to a training recipe when the recipe/framework
@@ -152,7 +159,8 @@ For NVFlare 2.9, the public Recipe configuration surface also includes:
 
 ``set_per_site_config(recipe, config)``
    Provide site-keyed, recipe-specific configuration. Each concrete recipe
-   interprets the site dictionaries for its own workflow.
+   interprets the site dictionaries for its own workflow. Nested values become
+   part of the job definition and must not contain secret values.
 
 ``recipe.configured_sites()``
    Return top-level site names from helper-provided per-site config when
@@ -168,7 +176,8 @@ For NVFlare 2.9, the public Recipe configuration surface also includes:
    internals, keys with dedicated constructor fields (``min_clients``,
    ``mandatory_clients``), and ``study``, which the server assigns from the
    admin session at submission. See the Recipe Metadata section of the Recipe
-   guide for per-key value shapes and examples.
+   guide for per-key value shapes and examples. Metadata is stored in clear
+   text and must not contain secret values.
 
 Repeated metadata calls for the same key replace that key's previous helper
 value. Different metadata keys accumulate. Keys that overlap a dedicated
@@ -178,6 +187,132 @@ keys, the helper value is what appears in the generated ``meta.json``
 specs on the generated job, a warning is emitted for specs already registered
 when the helper is called, but specs added afterwards are overridden without
 one.
+
+.. _recipe_secrets:
+
+Keeping Secrets Out Of Recipe Parameters
+----------------------------------------
+
+Recipe parameters are part of the job definition, not a secret transport.
+Values supplied through recipe constructors and mutating helpers can be
+serialized in clear text into generated configuration files. This includes
+``train_args``, ``task_args``, ``eval_args``, ``per_site_config``, task data and
+metadata, server/client config override dictionaries, execution parameters,
+recipe metadata, tracking configuration, and dictionaries passed to
+``add_client_config`` / ``add_server_config``. These values must **never**
+contain actual passwords, API keys, access tokens, private keys, or other
+credentials.
+
+This contract applies to nested strings too, not just top-level parameter
+values. A secret's environment-variable name, a reference placeholder, or the
+path to a mounted secret file is configuration and can be supplied. The secret
+value itself must remain at the executing site.
+
+To catch mistakes, recipes scan their parameters with heuristics (well-known
+token formats, password-like flag and key names, high-entropy strings) and
+emit a ``nvflare.recipe.secrets.PotentialSecretWarning`` when a value looks
+like an actual secret. ``recipe.export()`` additionally scans the generated
+config files of the exported job. The scan is best-effort: it neither finds
+every possible credential nor makes a supplied value safe. Absence of a
+warning does not prove that a parameter is safe. Investigate each warning and
+keep any actual secret at the site, using a reference only at a supported
+runtime boundary; use the standard
+``warnings.filterwarnings`` machinery only after establishing that a finding
+is a false positive. NVFlare emits detector warnings from a synthetic source
+location so Python's warning formatter cannot echo a user source line that
+contains the flagged value. A valid reference in a known unsupported parameter
+emits ``UnsupportedSecretRefWarning`` instead of being silently accepted.
+
+There are two supported ways to make a secret available at runtime:
+
+* **Read it from the site environment (preferred).** Set an environment
+  variable or mount a secret file (for example, a Kubernetes Secret volume) on each site,
+  and read it inside your training script with ``os.environ`` or by opening
+  the mounted file. Nothing secret ever enters the job definition. Passing a
+  *path* to a mounted secret file in a recipe parameter is fine -- the path
+  is not the secret.
+
+* **Use a secret reference at a supported runtime boundary.** Put a placeholder
+  in a supported recipe value instead of the actual secret. Use ``secret_ref``
+  for an environment variable and ``secret_file_ref`` for a file containing
+  the secret:
+
+  .. code-block:: python
+
+     from nvflare.recipe.secrets import secret_file_ref, secret_ref
+
+     recipe = FedAvgRecipe(
+         ...,
+         train_args=f"--epochs 5 --api-key {secret_ref('MY_API_KEY')}",
+     )
+     recipe.add_client_config(
+         {"service_password": secret_file_ref("/var/run/secrets/service/password")}
+     )
+
+     # In site-side component code:
+     from nvflare.utils.configs import get_client_config_value
+
+     service_password = get_client_config_value(fl_ctx, "service_password")
+
+  The exported job contains only ``${secret:MY_API_KEY}`` and
+  ``${secret:file:/var/run/secrets/service/password}``. References resolve only
+  at these explicit runtime boundaries:
+
+  * Command arguments consumed by NVFlare's task script runner or subprocess
+    launcher. This includes recipe ``train_args``, ``task_args``, ``eval_args``,
+    and ``script_args`` when those arguments use these runners. NVFlare expands
+    ordinary configuration variables first, tokenizes the command, and then
+    resolves each reference immediately before the script or process starts.
+    Resolving after tokenization keeps a secret containing spaces in one
+    argument.
+
+  * Values explicitly read from a runtime job JSON file with
+    ``get_job_config_value``, ``get_client_config_value``, or
+    ``get_server_config_value``. Typically, a recipe adds a top-level value with
+    ``add_client_config`` or ``add_server_config`` and site-side code reads it
+    through the matching specialized getter. References in nested string values
+    resolve recursively when the value is read; dictionary keys are not resolved.
+    These raw-file helpers do not expand ordinary placeholders such as
+    ``{SITE_NAME}``, so do not combine those placeholders in a value consumed
+    this way.
+
+  Arbitrary component constructor arguments, job metadata, packaged custom
+  files, and other job artifacts keep references as placeholders and are not
+  secret delivery mechanisms. Read the site environment or mounted file inside
+  user code for those cases. In particular, Flower ``extra_env`` and
+  ``run_config`` values do not support secret references.
+
+  If an environment variable or file is unavailable, the config getter or
+  script/process launch fails with an error that identifies the missing
+  reference but never includes a secret value. Resolved values exist only in
+  runtime memory and are not written back to generated job configuration.
+
+Environment variables must be set in the environment of the server or client
+job process that uses the reference. For native-process POC and production
+deployments, this can be the environment inherited by that process. Docker and
+Kubernetes job containers do not automatically inherit arbitrary host shell
+variables or host mounts: configure the launcher/container spec to inject the
+variable or mount the file into the actual job container. A referenced file
+must exist at the same whitespace- and brace-free path inside the consuming process or
+container and should be readable only by that identity.
+
+For Kubernetes, project a Secret key into the job container as an environment
+variable or mounted file, then use the corresponding reference helper. The
+Recipe API does not query a Kubernetes Secret directly by Secret name and key.
+
+Note that with external-process execution, command-line arguments (including
+resolved secret references) are visible to local process listings on the
+executing site, as with any command-line tool. Reading the secret from the
+environment or mounted file inside the training script avoids this too. Code
+and configured components must also avoid printing resolved values: reference
+resolution keeps values out of the exported job but cannot sanitize output
+produced by user code.
+
+Threaded simulation runs in-process client scripts concurrently and shares the
+process-global ``sys.argv`` and environment. Use external-process execution for
+secret-bearing command arguments in the simulator, or preferably read a
+site-local secret directly inside code, rather than relying on in-process
+per-client argument isolation.
 
 Execution Environments
 ----------------------

--- a/nvflare/app_common/executors/client_api_launcher_executor.py
+++ b/nvflare/app_common/executors/client_api_launcher_executor.py
@@ -31,6 +31,7 @@ from nvflare.fuel.f3.streaming.transfer_progress import (
     resolve_streaming_progress_config,
 )
 from nvflare.fuel.utils.attributes_exportable import ExportMode
+from nvflare.fuel.utils.secret_utils import has_secret_refs
 from nvflare.fuel.utils.validation_utils import check_non_negative_int
 from nvflare.utils.configs import get_client_config_value
 
@@ -227,7 +228,23 @@ class ClientAPILauncherExecutor(LauncherExecutor):
                     )
 
     def _get_client_config_override(self, fl_ctx: FLContext, key: str):
-        return get_client_config_value(fl_ctx, key, _CONFIG_VALUE_MISSING)
+        try:
+            value = get_client_config_value(fl_ctx, key, _CONFIG_VALUE_MISSING, resolve_refs=False)
+        except ValueError:
+            msg = f"Cannot read client config override {key!r}"
+            self.log_error(fl_ctx, msg)
+            raise ValueError(msg) from None
+        if value is not _CONFIG_VALUE_MISSING and has_secret_refs(value):
+            # These overrides are serialized into the subprocess Client API config. Resolving
+            # a reference here would write its secret value to disk, violating the memory-only
+            # contract for resolved secrets.
+            msg = (
+                f"Secret references are not supported for client config override {key!r} "
+                "because this value is written to runtime configuration"
+            )
+            self.log_error(fl_ctx, msg)
+            raise ValueError(msg)
+        return value
 
     def _apply_positive_float_client_config_override(self, fl_ctx: FLContext, key: str, attr_name: str):
         value = self._get_client_config_override(fl_ctx, key)

--- a/nvflare/app_common/executors/task_script_runner.py
+++ b/nvflare/app_common/executors/task_script_runner.py
@@ -21,6 +21,7 @@ from nvflare.client.in_process.api import TOPIC_ABORT
 from nvflare.fuel.data_event.data_bus import DataBus
 from nvflare.fuel.data_event.event_manager import EventManager
 from nvflare.fuel.utils.log_utils import get_module_logger
+from nvflare.fuel.utils.secret_utils import resolve_secret_refs, split_command_preserving_secret_refs
 
 print_fn = builtins.print
 
@@ -47,12 +48,11 @@ class TaskScriptRunner:
     def run(self):
         """Call the task_fn with any required arguments."""
         self.logger.info(f"start task run() with full path: {self.script_full_path}")
+        curr_argv = sys.argv
         try:
-            curr_argv = sys.argv
             builtins.print = log_print if self.redirect_print_to_log else print_fn
             sys.argv = self.get_sys_argv()
             runpy.run_path(self.script_full_path, run_name="__main__")
-            sys.argv = curr_argv
         except ImportError as ie:
             msg = "attempted relative import with no known parent package"
             if ie.msg == msg:
@@ -70,10 +70,26 @@ class TaskScriptRunner:
             self.event_manager.fire_event(TOPIC_ABORT, f"'{self.script_full_path}' is aborted, {msg}")
             raise e
         finally:
+            sys.argv = curr_argv
             builtins.print = print_fn
 
     def get_sys_argv(self):
-        args_list = [] if not self.script_args else self.script_args.split()
+        # Preserve the runner's legacy whitespace splitting for existing arguments. Only quoted
+        # spans containing a secret ref are grouped, so a composite such as
+        # "Bearer ${secret:TOKEN}" remains one argument without changing unrelated backslashes.
+        args_list = (
+            []
+            if not self.script_args
+            else split_command_preserving_secret_refs(
+                self.script_args,
+                posix=False,
+                group_secret_ref_quotes="${secret:" in self.script_args,
+            )
+        )
+        # Resolve ${secret:ENV_VAR} references from this site's environment after splitting,
+        # so injected values containing whitespace stay single arguments. The resolved values
+        # exist only in the argv handed to the script and must never be logged.
+        args_list = [resolve_secret_refs(arg) for arg in args_list]
         return [self.script_full_path] + args_list
 
     def get_script_full_path(self, custom_dir, script_path) -> str:

--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -25,7 +25,7 @@ from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.launcher import Launcher, LauncherRunStatus
 from nvflare.fuel.utils.log_utils import get_obj_logger
-from nvflare.fuel.utils.secret_utils import resolve_secret_refs, split_command_preserving_secret_refs
+from nvflare.fuel.utils.secret_utils import has_secret_refs, resolve_secret_refs, split_command_preserving_secret_refs
 from nvflare.utils.job_launcher_utils import add_custom_dir_to_path
 
 
@@ -69,6 +69,103 @@ def get_line(buffer: bytearray):
 # Lines from the subprocess consoleHandler match this; raw print() lines do not.
 _ANSI_ESC_RE = re.compile(r"\x1b\[[0-9;]*m")
 _LOG_LINE_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
+_SHELL_COMMAND_INTERPRETERS = frozenset({"sh", "bash"})
+_POWERSHELL_COMMAND_INTERPRETERS = frozenset({"powershell", "pwsh"})
+_ENV_COMMAND_WRAPPERS = frozenset({"env"})
+_SHELL_OPTIONS_WITH_VALUE = frozenset({"-o", "-O", "--init-file", "--rcfile"})
+
+
+def _command_basename(command: str) -> str:
+    """Return a command basename for either POSIX or Windows-style paths."""
+    return command.replace("\\", "/").rsplit("/", maxsplit=1)[-1]
+
+
+def _raise_nested_command_secret_ref(interpreter: str, option: str) -> None:
+    detail = f"{interpreter} {option}"
+    raise ValueError(f"secret references are not supported in nested interpreter command strings ({detail})")
+
+
+def _unwrap_env_commands(command_seq: list[str]) -> list[str]:
+    """Unwrap simple leading env commands without guessing option operands."""
+    while command_seq and _command_basename(command_seq[0]).casefold().removesuffix(".exe") in _ENV_COMMAND_WRAPPERS:
+        interpreter = _command_basename(command_seq[0])
+        command_seq = command_seq[1:]
+        parse_options = True
+        while command_seq:
+            option = command_seq[0]
+            if parse_options and option == "--":
+                command_seq = command_seq[1:]
+                parse_options = False
+                continue
+            if "=" in option and not option.startswith(("-", "=")):
+                command_seq = command_seq[1:]
+                continue
+            if not parse_options:
+                break
+            if option in {"-i", "--ignore-environment"}:
+                command_seq = command_seq[1:]
+                continue
+            if option.startswith("-"):
+                if any(has_secret_refs(arg) for arg in command_seq):
+                    _raise_nested_command_secret_ref(interpreter, option)
+                return []
+            break
+    return command_seq
+
+
+def _reject_shell_command_refs(command_seq: list[str], interpreter: str) -> None:
+    index = 1
+    while index < len(command_seq):
+        option = command_seq[index]
+        if option == "--" or not option.startswith("-"):
+            return
+        # POSIX shells allow short options to be combined, for example ``bash -lc``.
+        if not option.startswith("--") and "c" in option[1:]:
+            command_index = index + 1
+            if has_secret_refs(option) or (
+                command_index < len(command_seq) and has_secret_refs(command_seq[command_index])
+            ):
+                _raise_nested_command_secret_ref(interpreter, option)
+            return
+        index += 2 if option in _SHELL_OPTIONS_WITH_VALUE else 1
+
+
+def _reject_powershell_code_refs(command_seq: list[str], interpreter: str) -> None:
+    for index, option in enumerate(command_seq[1:], start=1):
+        normalized_option = option.casefold()
+        if option == "--" or not option.startswith("-") or normalized_option in {"-file", "-f"}:
+            return
+        if normalized_option in {"-command", "-c"}:
+            if any(has_secret_refs(arg) for arg in command_seq[index + 1 :]):
+                _raise_nested_command_secret_ref(interpreter, option)
+            return
+        if normalized_option in {"-encodedcommand", "-e", "-ec", "-enc"}:
+            if index + 1 < len(command_seq) and has_secret_refs(command_seq[index + 1]):
+                _raise_nested_command_secret_ref(interpreter, option)
+            return
+        if any(has_secret_refs(arg) for arg in command_seq[index:]):
+            _raise_nested_command_secret_ref(interpreter, option)
+        return
+
+
+def _reject_secret_refs_in_nested_command(command_seq: list[str]) -> None:
+    """Reject refs in code strings for direct or explicitly env-wrapped shell interpreters."""
+    command_seq = _unwrap_env_commands(command_seq)
+    if not command_seq:
+        return
+
+    interpreter = _command_basename(command_seq[0])
+    normalized_interpreter = interpreter.casefold().removesuffix(".exe")
+    if normalized_interpreter in _SHELL_COMMAND_INTERPRETERS:
+        _reject_shell_command_refs(command_seq, interpreter)
+    elif normalized_interpreter in _POWERSHELL_COMMAND_INTERPRETERS:
+        _reject_powershell_code_refs(command_seq, interpreter)
+
+
+def _prepare_command(command: str) -> list[str]:
+    command_seq = split_command_preserving_secret_refs(command, posix=True)
+    _reject_secret_refs_in_nested_command(command_seq)
+    return [resolve_secret_refs(token) for token in command_seq]
 
 
 def _route_subprocess_line(line: str, logger) -> None:
@@ -170,11 +267,10 @@ class SubprocessLauncher(Launcher):
                 add_custom_dir_to_path(app_custom_folder, env)
 
                 # Resolve ${secret:ENV_VAR} references from this site's environment after shlex
-                # splitting, so injected values never re-tokenize. The resolved values exist only
-                # in the argument vector of the subprocess and must never be logged.
-                command_seq = [
-                    resolve_secret_refs(token) for token in split_command_preserving_secret_refs(command, posix=True)
-                ]
+                # splitting, so injected values never re-tokenize. References in supported nested
+                # shell command strings are rejected because those strings are parsed again.
+                # Resolved values exist only in the subprocess argv and must never be logged.
+                command_seq = _prepare_command(command)
                 self._process = subprocess.Popen(
                     command_seq,
                     shell=False,
@@ -209,10 +305,7 @@ class SubprocessLauncher(Launcher):
                 self._terminate_process()
                 self._log_thread.join()
                 if self._clean_up_script:
-                    command_seq = [
-                        resolve_secret_refs(token)
-                        for token in split_command_preserving_secret_refs(self._clean_up_script, posix=True)
-                    ]
+                    command_seq = _prepare_command(self._clean_up_script)
                     process = subprocess.Popen(command_seq, cwd=self._app_dir, shell=False)
                     process.wait()
                 self._process = None

--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -14,7 +14,6 @@
 
 import os
 import re
-import shlex
 import signal
 import subprocess
 from threading import Lock, Thread
@@ -26,6 +25,7 @@ from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
 from nvflare.app_common.abstract.launcher import Launcher, LauncherRunStatus
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.fuel.utils.secret_utils import resolve_secret_refs, split_command_preserving_secret_refs
 from nvflare.utils.job_launcher_utils import add_custom_dir_to_path
 
 
@@ -169,7 +169,12 @@ class SubprocessLauncher(Launcher):
                 app_custom_folder = workspace.get_app_custom_dir(job_id)
                 add_custom_dir_to_path(app_custom_folder, env)
 
-                command_seq = shlex.split(command)
+                # Resolve ${secret:ENV_VAR} references from this site's environment after shlex
+                # splitting, so injected values never re-tokenize. The resolved values exist only
+                # in the argument vector of the subprocess and must never be logged.
+                command_seq = [
+                    resolve_secret_refs(token) for token in split_command_preserving_secret_refs(command, posix=True)
+                ]
                 self._process = subprocess.Popen(
                     command_seq,
                     shell=False,
@@ -204,7 +209,10 @@ class SubprocessLauncher(Launcher):
                 self._terminate_process()
                 self._log_thread.join()
                 if self._clean_up_script:
-                    command_seq = shlex.split(self._clean_up_script)
+                    command_seq = [
+                        resolve_secret_refs(token)
+                        for token in split_command_preserving_secret_refs(self._clean_up_script, posix=True)
+                    ]
                     process = subprocess.Popen(command_seq, cwd=self._app_dir, shell=False)
                     process.wait()
                 self._process = None

--- a/nvflare/app_common/np/recipes/cross_site_eval.py
+++ b/nvflare/app_common/np/recipes/cross_site_eval.py
@@ -21,6 +21,7 @@ from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.np.np_model_locator import NPModelLocator
 from nvflare.app_common.np.np_validator import NPValidator
 from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
+from nvflare.fuel.utils.secret_utils import warn_on_potential_secrets
 from nvflare.job_config.api import FedJob
 from nvflare.job_config.script_runner import FrameworkType, ScriptRunner
 from nvflare.recipe.spec import Recipe
@@ -58,6 +59,10 @@ class _CrossSiteEvalValidator(BaseModel):
 
 class NumpyCrossSiteEvalRecipe(Recipe):
     """Recipe for standalone cross-site evaluation with pre-trained NumPy models.
+
+    Recipe parameters become part of the generated job definition and must never
+    contain actual secret values. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
 
     Creates a cross-site evaluation workflow that loads pre-trained models and evaluates
     them across all client sites without performing any training.
@@ -139,6 +144,9 @@ class NumpyCrossSiteEvalRecipe(Recipe):
             client_memory_gc_rounds=client_memory_gc_rounds,
             cuda_empty_cache=cuda_empty_cache,
         )
+        if eval_args:
+            warn_on_potential_secrets(eval_args, context="recipe parameter 'eval_args'")
+        warn_on_potential_secrets(command, context="recipe parameter 'command'")
 
         job = FedJob(name=name, min_clients=min_clients)
 

--- a/nvflare/app_common/np/recipes/fedavg.py
+++ b/nvflare/app_common/np/recipes/fedavg.py
@@ -24,6 +24,10 @@ from nvflare.recipe.fedavg import FedAvgRecipe as UnifiedFedAvgRecipe
 class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
     """A recipe for implementing Federated Averaging (FedAvg) with NumPy in NVFlare.
 
+    Recipe parameters, including ``train_args`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
     from multiple clients by computing a weighted average based on the amount of local
     training data. This recipe sets up a complete federated learning workflow with
@@ -61,7 +65,8 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
         params_transfer_type (str): How to transfer the parameters. DIFF enables automatic difference
             calculation for full-model client results. A client's FLModel.params_type remains authoritative.
             Defaults to TransferType.FULL.
-        per_site_config: Per-site configuration for the federated learning job.
+        per_site_config: Per-site configuration for the federated learning job. Nested
+            values become part of the generated job definition and must not contain secrets.
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".

--- a/nvflare/app_common/np/recipes/lr/fedavg.py
+++ b/nvflare/app_common/np/recipes/lr/fedavg.py
@@ -52,6 +52,10 @@ class _FedAvgValidator(BaseModel):
 class FedAvgLrRecipe(Recipe):
     """A recipe for implementing Federated Averaging (FedAvg) for Logistic Regression with Newton Raphson.
 
+    Recipe parameters become part of the generated job definition and must never
+    contain actual secret values. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
     from multiple clients by computing a weighted average based on the amount of local
     training data. This recipe sets up a complete federated learning workflow using

--- a/nvflare/app_common/psi/recipes/dh_psi.py
+++ b/nvflare/app_common/psi/recipes/dh_psi.py
@@ -27,6 +27,9 @@ class DhPSIRecipe(Recipe):
     """Job recipe for running DH-PSI.
 
     This is a job composition helper (server workflow + client executors/components).
+    Recipe parameters become part of the generated job definition and must never
+    contain actual secret values. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
     """
 
     def __init__(

--- a/nvflare/app_opt/flower/recipe.py
+++ b/nvflare/app_opt/flower/recipe.py
@@ -21,6 +21,7 @@ from packaging.version import InvalidVersion, Version
 from nvflare.app_common.tie.defs import Constant
 from nvflare.client.api import ClientAPIType
 from nvflare.client.api_spec import CLIENT_API_TYPE_KEY
+from nvflare.fuel.utils.secret_utils import warn_on_potential_secrets, warn_on_unsupported_secret_refs
 from nvflare.fuel.utils.validation_utils import check_object_type
 from nvflare.recipe.spec import Recipe
 
@@ -59,6 +60,10 @@ def _create_flower_job(**kwargs):
 
 class FlowerRecipe(Recipe):
     """Recipe class for Flower federated learning using NVFlare.
+
+    Recipe parameters become part of the generated job definition and must never
+    contain actual secret values. Read secrets from the site environment or mounted files in
+    Flower code; ``extra_env`` and ``run_config`` do not resolve secret references.
 
     This class provides a high-level interface for configuring Flower
     federated learning jobs. It wraps the FlowerJob and provides
@@ -137,6 +142,13 @@ class FlowerRecipe(Recipe):
             check_object_type("run_config", run_config, dict)
         if extra_env is not None:
             check_object_type("extra_env", extra_env, dict)
+
+        if extra_env:
+            warn_on_potential_secrets(extra_env, context="recipe parameter 'extra_env'")
+            warn_on_unsupported_secret_refs(extra_env, context="recipe parameter 'extra_env'")
+        if run_config:
+            warn_on_potential_secrets(run_config, context="recipe parameter 'run_config'")
+            warn_on_unsupported_secret_refs(run_config, context="recipe parameter 'run_config'")
 
         # needs to init client api to stream metrics
         # only external client api works with the current flower integration

--- a/nvflare/app_opt/pt/recipes/cyclic.py
+++ b/nvflare/app_opt/pt/recipes/cyclic.py
@@ -24,6 +24,10 @@ from nvflare.recipe.utils import extract_persistor_id
 class CyclicRecipe(BaseCyclicRecipe):
     """PyTorch-specific Cyclic federated learning recipe.
 
+    Recipe parameters, including ``train_args`` and config override dictionaries,
+    must never contain actual secret values. Read secrets from site environment variables or
+    mounted files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     Args:
         name: Name identifier for the federated learning job. Defaults to "cyclic".
         model: Starting model object to begin training. Can be:

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -26,6 +26,10 @@ from nvflare.recipe.fedavg import FedAvgRecipe as UnifiedFedAvgRecipe
 class FedAvgRecipe(UnifiedFedAvgRecipe):
     """A recipe for implementing Federated Averaging (FedAvg) for PyTorch.
 
+    Recipe parameters, including ``train_args`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
     from multiple clients by computing a weighted average based on the amount of local
     training data. This recipe sets up a complete federated learning workflow with
@@ -63,7 +67,8 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             Defaults to TransferType.FULL.
         model_persistor: Custom model persistor. If None, PTFileModelPersistor will be used.
         model_locator: Custom model locator. If None, PTFileModelLocator will be used.
-        per_site_config: Per-site configuration for the federated learning job.
+        per_site_config: Per-site configuration for the federated learning job. Nested
+            values become part of the generated job definition and must not contain secrets.
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".

--- a/nvflare/app_opt/pt/recipes/fedavg_he.py
+++ b/nvflare/app_opt/pt/recipes/fedavg_he.py
@@ -66,6 +66,11 @@ class _FedAvgRecipeWithHEValidator(BaseModel):
 class FedAvgRecipeWithHE(Recipe):
     """A recipe for implementing Federated Averaging (FedAvg) with Homomorphic Encryption (HE) in NVFlare.
 
+    Recipe parameters, including ``train_args``, become part of the generated job
+    definition and must never contain actual secret values. Read secrets from site environment
+    variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
     from multiple clients by computing a weighted average based on the amount of local
     training data. This recipe adds homomorphic encryption to preserve privacy during

--- a/nvflare/app_opt/pt/recipes/fedeval.py
+++ b/nvflare/app_opt/pt/recipes/fedeval.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel, field_validator
 
 from nvflare.app_common.workflows.model_controller import ModelController
 from nvflare.client.config import ExchangeFormat
-from nvflare.fuel.utils.secret_utils import warn_on_unsupported_secret_refs_outside_keys
 from nvflare.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import FrameworkType, ScriptRunner
 from nvflare.recipe.spec import Recipe
@@ -54,6 +53,7 @@ class EvalController(ModelController):
 
 
 class FedEvalRecipe(Recipe):
+    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = frozenset({"command", "eval_args"})
     """A recipe for federated evaluation of a PyTorch model across multiple sites.
 
     This recipe sets up a federated evaluation workflow where a global model
@@ -151,11 +151,6 @@ class FedEvalRecipe(Recipe):
         self.server_expected_format = server_expected_format
         self.validation_timeout = validation_timeout
         self.per_site_config = per_site_config
-        warn_on_unsupported_secret_refs_outside_keys(
-            self.per_site_config,
-            supported_value_keys={"command", "eval_args"},
-            context="recipe parameter 'per_site_config'",
-        )
         self.client_memory_gc_rounds = client_memory_gc_rounds
         self.cuda_empty_cache = cuda_empty_cache
 

--- a/nvflare/app_opt/pt/recipes/fedeval.py
+++ b/nvflare/app_opt/pt/recipes/fedeval.py
@@ -53,7 +53,6 @@ class EvalController(ModelController):
 
 
 class FedEvalRecipe(Recipe):
-    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = frozenset({"command", "eval_args"})
     """A recipe for federated evaluation of a PyTorch model across multiple sites.
 
     This recipe sets up a federated evaluation workflow where a global model
@@ -119,6 +118,8 @@ class FedEvalRecipe(Recipe):
         )
         ```
     """
+
+    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = frozenset({"command", "eval_args"})
 
     def __init__(
         self,

--- a/nvflare/app_opt/pt/recipes/fedeval.py
+++ b/nvflare/app_opt/pt/recipes/fedeval.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, field_validator
 
 from nvflare.app_common.workflows.model_controller import ModelController
 from nvflare.client.config import ExchangeFormat
+from nvflare.fuel.utils.secret_utils import warn_on_unsupported_secret_refs_outside_keys
 from nvflare.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import FrameworkType, ScriptRunner
 from nvflare.recipe.spec import Recipe
@@ -74,7 +75,9 @@ class FedEvalRecipe(Recipe):
             The file may not exist locally (server-side path).
         min_clients: Minimum number of clients required to start evaluation.
         eval_script: Path to the evaluation script that will be executed on each client.
-        eval_args: Command line arguments to pass to the evaluation script. Defaults to "".
+        eval_args: Command line arguments to pass to the evaluation script. The string is
+            stored in the job definition and must not contain actual secret values; see
+            :mod:`nvflare.recipe.secrets` for safe runtime references. Defaults to "".
         launch_external_process: Whether to launch the script in external process. Defaults to False.
         command: If launch_external_process=True, command to run script (prepended to script).
             Defaults to "python3 -u".
@@ -84,6 +87,7 @@ class FedEvalRecipe(Recipe):
         per_site_config: Per-site configuration for the evaluation job. Dictionary mapping
             site names to configuration dicts. Each config dict can contain optional overrides:
             eval_script, eval_args, launch_external_process, command, server_expected_format.
+            Values are stored in the job definition and must not contain actual secret values.
             If not provided, the same configuration will be used for all clients. Defaults to None.
 
     Example:
@@ -147,6 +151,11 @@ class FedEvalRecipe(Recipe):
         self.server_expected_format = server_expected_format
         self.validation_timeout = validation_timeout
         self.per_site_config = per_site_config
+        warn_on_unsupported_secret_refs_outside_keys(
+            self.per_site_config,
+            supported_value_keys={"command", "eval_args"},
+            context="recipe parameter 'per_site_config'",
+        )
         self.client_memory_gc_rounds = client_memory_gc_rounds
         self.cuda_empty_cache = cuda_empty_cache
 

--- a/nvflare/app_opt/pt/recipes/fedopt.py
+++ b/nvflare/app_opt/pt/recipes/fedopt.py
@@ -56,6 +56,11 @@ class _FedOptValidator(BaseModel):
 class FedOptRecipe(Recipe):
     """A recipe for implementing Federated Optimization (FedOpt) in NVFlare.
 
+    Recipe parameters, including ``train_args``, ``optimizer_args``, and
+    ``lr_scheduler_args``, must never contain actual secret values. Read secrets from site
+    environment variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     FedOpt is a federated learning algorithm that optimizes the global model using a server-side optimizer and learning rate scheduler.
     After each round, the global model is updated using the specified optimizer and learning rate scheduler.
     The algorithm is proposed in Reddi et al. "Adaptive Federated Optimization." arXiv preprint arXiv:2003.00295 (2020).

--- a/nvflare/app_opt/pt/recipes/scaffold.py
+++ b/nvflare/app_opt/pt/recipes/scaffold.py
@@ -50,6 +50,11 @@ class _ScaffoldValidator(BaseModel):
 class ScaffoldRecipe(Recipe):
     """A recipe for implementing Scaffold in NVFlare.
 
+    Recipe parameters, including ``train_args``, become part of the generated job
+    definition and must never contain actual secret values. Read secrets from site environment
+    variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     Implements the training algorithm proposed in
     Karimireddy et al. "SCAFFOLD: Stochastic Controlled Averaging for Federated Learning"
     (https://arxiv.org/abs/1910.06378).

--- a/nvflare/app_opt/pt/recipes/swarm.py
+++ b/nvflare/app_opt/pt/recipes/swarm.py
@@ -26,6 +26,11 @@ from nvflare.app_common.ccwf.comps.simple_model_shareable_generator import Simpl
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.fuel.utils.constants import Mode
 from nvflare.fuel.utils.pipe.file_pipe import FilePipe
+from nvflare.fuel.utils.secret_utils import (
+    warn_on_potential_secrets,
+    warn_on_unsupported_secret_refs,
+    warn_on_unsupported_secret_refs_outside_keys,
+)
 from nvflare.fuel.utils.validation_utils import check_positive_int, check_positive_number
 from nvflare.job_config.script_runner import ScriptRunner
 from nvflare.recipe.spec import Recipe
@@ -55,6 +60,11 @@ class _SwarmValidator(BaseModel):
 
 class BaseSwarmLearningRecipe(Recipe):
     """Base recipe for Swarm Learning (framework-agnostic).
+
+    Server, client, and cross-site-evaluation config values become part of the generated
+    job definition and must never contain actual secrets. Read secrets from site environment
+    variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
 
     Args:
         name: Name of the federated learning job.
@@ -97,7 +107,9 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
         initial_ckpt: Path to a pre-trained checkpoint file (.pt, .pth). Can be:
             - Relative path: file will be bundled into the job's custom/ directory.
             - Absolute path: treated as a server-side path, used as-is at runtime.
-        train_args: Additional arguments for the training script.
+        train_args: Additional arguments for the training script. The dictionary is stored
+            in the job definition and must not contain actual secret values; see
+            :mod:`nvflare.recipe.secrets` for safe runtime references.
         do_cross_site_eval: Whether to perform cross-site evaluation. When combined with
             ``launch_external_process=True``, the trained model is loaded from the
             persistor on disk (saved by PTFileModelPersistor after each round).  Two
@@ -154,11 +166,13 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             Values here take precedence over named constructor parameters, except
             ``min_clients``, which must be set through the named parameter to keep
             scheduler, server-controller, and client aggregation quorums aligned.
+            This dictionary is stored in the job definition and must not contain secrets.
         client_config_overrides: Advanced shallow overrides for ``SwarmClientConfig``.
             Values here take precedence over named constructor parameters. Recipe-managed
             fields (executor, aggregator, persistor, shareable generator, and
             ``min_responses_required``) cannot be replaced through this dictionary; use
             ``BaseSwarmLearningRecipe`` for custom components or quorum settings.
+            This dictionary is stored in the job definition and must not contain secrets.
         pipe_type: Pipe used for communication between the NVFlare client process
             and the external training process when ``launch_external_process=True``.
             Accepted values:
@@ -238,6 +252,33 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
         pipe_root_path: Optional[str] = None,
     ):
         _SwarmValidator(initial_ckpt=initial_ckpt)
+        warn_on_potential_secrets(command, context="recipe parameter 'command'")
+
+        if train_args:
+            warn_on_potential_secrets(train_args, context="recipe parameter 'train_args'")
+            warn_on_unsupported_secret_refs_outside_keys(
+                train_args,
+                supported_value_keys={"script_args"},
+                context="recipe parameter 'train_args'",
+            )
+        if server_config_overrides:
+            warn_on_potential_secrets(
+                server_config_overrides,
+                context="recipe parameter 'server_config_overrides'",
+            )
+            warn_on_unsupported_secret_refs(
+                server_config_overrides,
+                context="recipe parameter 'server_config_overrides'",
+            )
+        if client_config_overrides:
+            warn_on_potential_secrets(
+                client_config_overrides,
+                context="recipe parameter 'client_config_overrides'",
+            )
+            warn_on_unsupported_secret_refs(
+                client_config_overrides,
+                context="recipe parameter 'client_config_overrides'",
+            )
 
         validated_server_config_overrides = merge_config_overrides(
             {}, server_config_overrides, "server_config_overrides"

--- a/nvflare/app_opt/sklearn/recipes/fedavg.py
+++ b/nvflare/app_opt/sklearn/recipes/fedavg.py
@@ -25,6 +25,10 @@ from nvflare.recipe.fedavg import FedAvgRecipe as UnifiedFedAvgRecipe
 class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
     """A recipe for implementing Federated Averaging (FedAvg) with Scikit-learn.
 
+    Recipe parameters, including ``train_args`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     This recipe sets up a complete federated learning workflow with memory-efficient
     InTime aggregation, specifically designed for scikit-learn models.
 
@@ -54,7 +58,8 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
             Defaults to "python3 -u".
         per_site_config: Per-site configuration for the federated learning job. Dictionary mapping
             site names to configuration dicts. If not provided, the same configuration will be used
-            for all clients.
+            for all clients. Nested values become part of the generated job definition and must not
+            contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
             a dict, key_metric selects the metric used for global model selection. Defaults to "accuracy".
         launch_once: Whether the external process will be launched only once at the beginning

--- a/nvflare/app_opt/sklearn/recipes/kmeans.py
+++ b/nvflare/app_opt/sklearn/recipes/kmeans.py
@@ -43,6 +43,10 @@ class _KMeansValidator(BaseModel):
 class KMeansFedAvgRecipe(FedAvgRecipe):
     """A recipe for Federated K-Means Clustering with Scikit-learn.
 
+    Recipe parameters, including ``train_args`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     This recipe implements federated K-Means clustering using a mini-batch aggregation
     strategy. The aggregation follows the scheme defined in MiniBatchKMeans where each
     client's results are treated as a mini-batch for updating global centers.
@@ -77,7 +81,8 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             Defaults to "python3 -u".
         per_site_config: Per-site configuration for the federated learning job. Dictionary mapping
             site names to configuration dicts. If not provided, the same configuration will be used
-            for all clients.
+            for all clients. Nested values become part of the generated job definition and must not
+            contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
             a dict, key_metric selects the metric used for global model selection. Defaults to "metrics"
             (which corresponds to the homogeneity score sent by the K-Means client).

--- a/nvflare/app_opt/sklearn/recipes/svm.py
+++ b/nvflare/app_opt/sklearn/recipes/svm.py
@@ -43,6 +43,10 @@ class _SVMValidator(BaseModel):
 class SVMFedAvgRecipe(FedAvgRecipe):
     """A recipe for Federated SVM with Scikit-learn.
 
+    Recipe parameters, including ``train_args`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     This recipe implements federated SVM training using support vector aggregation.
     Unlike iterative algorithms, SVM training only requires one round:
     - Round 0: Each client trains a local SVM and sends their support vectors
@@ -76,7 +80,8 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             Defaults to "python3 -u".
         per_site_config: Per-site configuration for the federated learning job. Dictionary mapping
             site names to configuration dicts. If not provided, the same configuration will be used
-            for all clients.
+            for all clients. Nested values become part of the generated job definition and must not
+            contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
             a dict, key_metric selects the metric used for global model selection. Defaults to "AUC"
             (which corresponds to the ROC AUC score sent by the SVM client in round 1).

--- a/nvflare/app_opt/tf/recipes/cyclic.py
+++ b/nvflare/app_opt/tf/recipes/cyclic.py
@@ -24,6 +24,10 @@ from nvflare.recipe.utils import extract_persistor_id
 class CyclicRecipe(BaseCyclicRecipe):
     """TensorFlow-specific Cyclic federated learning recipe.
 
+    Recipe parameters, including ``train_args`` and config override dictionaries,
+    must never contain actual secret values. Read secrets from site environment variables or
+    mounted files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     Args:
         name: Name identifier for the federated learning job. Defaults to "cyclic".
         model: Starting model object to begin training. Can be:

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -25,6 +25,10 @@ from nvflare.recipe.fedavg import FedAvgRecipe as UnifiedFedAvgRecipe
 class FedAvgRecipe(UnifiedFedAvgRecipe):
     """A recipe for implementing Federated Averaging (FedAvg) for TensorFlow.
 
+    Recipe parameters, including ``train_args`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
     from multiple clients by computing a weighted average based on the amount of local
     training data. This recipe sets up a complete federated learning workflow with
@@ -65,6 +69,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             site names to configuration dicts. Each config dict can contain optional overrides:
             train_script, train_args, launch_external_process, command, framework,
             server_expected_format, params_transfer_type, launch_once, shutdown_timeout.
+            Nested values become part of the generated job definition and must not contain secrets.
             If not provided, the same configuration will be used for all clients.
         launch_once: Whether the external process will be launched only once at the beginning
             or on each task. Only used if `launch_external_process` is True. Defaults to True.

--- a/nvflare/app_opt/tf/recipes/fedopt.py
+++ b/nvflare/app_opt/tf/recipes/fedopt.py
@@ -48,6 +48,11 @@ class _FedOptValidator(BaseModel):
 class FedOptRecipe(Recipe):
     """A recipe for implementing Federated Optimization (FedOpt) in NVFlare with TensorFlow.
 
+    Recipe parameters, including ``train_args``, ``optimizer_args``, and
+    ``lr_scheduler_args``, must never contain actual secret values. Read secrets from site
+    environment variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     FedOpt is a federated learning algorithm that uses server-side optimization with momentum
     to improve convergence. The algorithm is proposed in Reddi et al. "Adaptive Federated
     Optimization." arXiv preprint arXiv:2003.00295 (2020).

--- a/nvflare/app_opt/tf/recipes/scaffold.py
+++ b/nvflare/app_opt/tf/recipes/scaffold.py
@@ -46,6 +46,11 @@ class _ScaffoldValidator(BaseModel):
 class ScaffoldRecipe(Recipe):
     """A recipe for implementing SCAFFOLD in NVFlare with TensorFlow.
 
+    Recipe parameters, including ``train_args``, become part of the generated job
+    definition and must never contain actual secret values. Read secrets from site environment
+    variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     Implements the training algorithm proposed in
     Karimireddy et al. "SCAFFOLD: Stochastic Controlled Averaging for Federated Learning"
     (https://arxiv.org/abs/1910.06378).

--- a/nvflare/app_opt/xgboost/recipes/bagging.py
+++ b/nvflare/app_opt/xgboost/recipes/bagging.py
@@ -74,6 +74,10 @@ class _XGBBaggingValidator(BaseModel):
 class XGBBaggingRecipe(Recipe):
     """XGBoost Tree-Based Recipe for federated learning (supports Bagging and Cyclic modes).
 
+    Recipe parameters, including ``xgb_params`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     This recipe implements tree-based federated XGBoost with two training modes:
     - **Bagging**: Each client trains a local sub-forest, aggregated on server (federated Random Forest)
     - **Cyclic**: Clients train sequentially in rounds, each contributing to the global model
@@ -99,6 +103,7 @@ class XGBBaggingRecipe(Recipe):
         per_site_config (dict, optional): Per-site configuration mapping site names to config dicts.
             Each config dict must contain 'data_loader' key with XGBDataLoader instance.
             Can optionally include 'lr_scale' for scaled learning rate mode.
+            Nested values become part of the generated job definition and must not contain secrets.
             Example: {"site-1": {"data_loader": CSVDataLoader(...), "lr_scale": 0.5}, "site-2": {...}}
 
     Example:
@@ -139,6 +144,8 @@ class XGBBaggingRecipe(Recipe):
             env = SimEnv(num_clients=3)
             run = recipe.execute(env)
     """
+
+    _UNSUPPORTED_SECRET_REF_ATTRS = Recipe._UNSUPPORTED_SECRET_REF_ATTRS | {"per_site_config"}
 
     def __init__(
         self,

--- a/nvflare/app_opt/xgboost/recipes/histogram.py
+++ b/nvflare/app_opt/xgboost/recipes/histogram.py
@@ -54,6 +54,10 @@ class _XGBHistogramValidator(BaseModel):
 class XGBHorizontalRecipe(Recipe):
     """XGBoost Horizontal Federated Learning Recipe.
 
+    Recipe parameters, including ``xgb_params`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     This recipe implements horizontal federated XGBoost using histogram-based algorithms.
     In horizontal federated learning, each client has different samples with the same features.
     The histogram-based approach enables efficient gradient boosting by computing histograms
@@ -78,6 +82,7 @@ class XGBHorizontalRecipe(Recipe):
         metrics_writer_id (str, optional): ID of the metrics writer component. Default is 'metrics_writer'.
         per_site_config (dict): Per-site configuration mapping site names to config dicts.
             Each config dict must contain 'data_loader' key with XGBDataLoader instance.
+            Nested values become part of the generated job definition and must not contain secrets.
             Example: {"site-1": {"data_loader": CSVDataLoader(...)}, "site-2": {...}}
 
     Example:
@@ -117,6 +122,8 @@ class XGBHorizontalRecipe(Recipe):
         - TensorBoard tracking is automatically configured for both server and clients.
         - Executor and metrics components are automatically added to all clients.
     """
+
+    _UNSUPPORTED_SECRET_REF_ATTRS = Recipe._UNSUPPORTED_SECRET_REF_ATTRS | {"per_site_config"}
 
     def __init__(
         self,

--- a/nvflare/app_opt/xgboost/recipes/vertical.py
+++ b/nvflare/app_opt/xgboost/recipes/vertical.py
@@ -63,6 +63,10 @@ class _XGBVerticalValidator(BaseModel):
 class XGBVerticalRecipe(Recipe):
     """XGBoost Vertical Federated Learning Recipe.
 
+    Recipe parameters, including ``xgb_params`` and nested ``per_site_config`` values,
+    must never contain actual secrets. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
+
     This recipe implements vertical federated XGBoost where different clients have different features
     for the same samples. In vertical FL, data is split by columns (features) rather than rows (samples).
 
@@ -95,6 +99,7 @@ class XGBVerticalRecipe(Recipe):
         model_file_name (str, optional): Model file name. Default is 'test.model.json'.
         per_site_config (dict, optional): Per-site configuration mapping site names to config dicts.
             Each config dict must contain 'data_loader' key with XGBDataLoader instance.
+            Nested values become part of the generated job definition and must not contain secrets.
             Example: {"site-1": {"data_loader": VerticalDataLoader(...)}, "site-2": {...}}
 
     Example:
@@ -148,6 +153,8 @@ class XGBVerticalRecipe(Recipe):
         - Executor and metrics components are automatically added to all clients
         - TensorBoard tracking is automatically configured
     """
+
+    _UNSUPPORTED_SECRET_REF_ATTRS = Recipe._UNSUPPORTED_SECRET_REF_ATTRS | {"per_site_config"}
 
     def __init__(
         self,

--- a/nvflare/edge/tools/edge_fed_buff_recipe.py
+++ b/nvflare/edge/tools/edge_fed_buff_recipe.py
@@ -181,6 +181,11 @@ class EvaluatorConfig:
 class EdgeFedBuffRecipe(Recipe):
     """Recipe class for cross-edge federated learning using NVFlare's hierarchical edge system.
 
+    Recipe parameters and nested manager configuration values become part of the generated
+    job definition and must never contain actual secrets. Read secrets from site environment
+    variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     This class provides a high-level interface for configuring cross-edge
     federated learning jobs. It configures the necessary components
     including model managers, device managers, evaluators, and device simulation settings.

--- a/nvflare/edge/tools/et_fed_buff_recipe.py
+++ b/nvflare/edge/tools/et_fed_buff_recipe.py
@@ -34,6 +34,11 @@ _DEVICE_CONFIG_FILE_NAME = "device_config.json"
 class ETFedBuffRecipe(EdgeFedBuffRecipe):
     """Edge Training FedBuff Recipe for embedded/edge device training.
 
+    Recipe parameters and nested manager configuration values become part of the generated
+    job definition and must never contain actual secrets. Read secrets from site environment
+    variables or mounted files; references are supported only where documented in
+    :mod:`nvflare.recipe.secrets`.
+
     This recipe extends EdgeFedBuffRecipe for edge devices with DeviceModel wrapper.
 
     Args:

--- a/nvflare/fuel/utils/job_secret_scanner.py
+++ b/nvflare/fuel/utils/job_secret_scanner.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Secret validation for generated NVFlare job configuration files."""
+
+import json
+import os
+from typing import List, Optional
+
+from nvflare.fuel.utils.secret_utils import SecretFinding, warn_on_potential_secrets
+
+_GENERATED_JOB_CONFIG_FILES = frozenset(
+    {
+        "config_fed_client.json",
+        "config_fed_server.json",
+        "meta.json",
+    }
+)
+
+
+def warn_on_potential_secrets_in_job_dir(
+    job_dir: str,
+    job_name: Optional[str] = None,
+    context: str = "generated job file",
+) -> List[SecretFinding]:
+    """Warn about potential secrets in generated job JSON files.
+
+    This is a last-line, best-effort scan of the artifact that will be exported,
+    simulated, or submitted. User code under ``custom/`` is intentionally excluded.
+
+    Args:
+        job_dir: Export root or the generated job directory itself.
+        job_name: Optional job name when ``job_dir`` is an export root.
+        context: Description used to identify a scanned file in warning messages.
+    Returns:
+        All potential-secret findings emitted while scanning the job.
+    """
+    job_root = os.path.join(job_dir, job_name) if job_name else job_dir
+    if not os.path.isdir(job_root):
+        job_root = job_dir
+
+    findings = []
+    for root, dirs, files in os.walk(job_root):
+        dirs[:] = [directory for directory in dirs if directory != "custom"]
+        for file_name in files:
+            if file_name not in _GENERATED_JOB_CONFIG_FILES:
+                continue
+
+            path = os.path.join(root, file_name)
+            try:
+                with open(path, encoding="utf-8") as file:
+                    data = json.load(file)
+            except (OSError, UnicodeError, ValueError):
+                # Job generation owns the validity of these files. Secret scanning is
+                # best-effort and must not mask a more useful error from that layer.
+                continue
+
+            # Only use the allow-listed basename in warning context. Job and app directory names
+            # are user-controlled and could themselves contain credential material.
+            findings.extend(warn_on_potential_secrets(data, context=f"{context} '{file_name}'"))
+
+    return findings

--- a/nvflare/fuel/utils/secret_utils.py
+++ b/nvflare/fuel/utils/secret_utils.py
@@ -123,8 +123,8 @@ def secret_file_ref(path: str) -> str:
 
     This is intended for secrets projected as files, including Kubernetes Secret volume keys.
     The path itself is stored in the generated job config; the file content is read only on the
-    executing site at runtime. The file content is injected exactly as stored, including any
-    trailing newline.
+    executing site at runtime. One trailing newline commonly added by secret-file tooling is
+    removed before injection.
 
     Args:
         path: runtime path of the mounted secret file. Absolute paths are strongly recommended;
@@ -186,7 +186,7 @@ def resolve_secret_refs(value: Any, env: Optional[Mapping[str, str]] = None) -> 
             raise ValueError("cannot resolve secret reference: invalid secret reference syntax")
         try:
             with open(path, encoding="utf-8") as f:
-                return f.read()
+                return f.read().removesuffix("\n")
         except (OSError, UnicodeError, ValueError):
             raise ValueError(
                 f"cannot resolve secret file reference for path {path!r}: "
@@ -620,20 +620,24 @@ def warn_on_unsupported_secret_ref_keys(value: Any, context: str) -> bool:
     return True
 
 
-def _contains_secret_ref_outside_keys(value: Any, supported_value_keys: frozenset[str]) -> bool:
+def _contains_secret_ref_outside_keys(
+    value: Any, supported_value_keys: frozenset[str], supported_value_depth: int
+) -> bool:
     if isinstance(value, str):
         return has_secret_refs(value)
     if isinstance(value, Mapping):
         for key, item in value.items():
             if _contains_secret_ref(key):
                 return True
-            if isinstance(key, str) and key in supported_value_keys:
+            if supported_value_depth == 1 and isinstance(key, str) and key in supported_value_keys:
                 continue
-            if _contains_secret_ref_outside_keys(item, supported_value_keys):
+            if _contains_secret_ref_outside_keys(item, supported_value_keys, max(supported_value_depth - 1, 0)):
                 return True
         return False
     if isinstance(value, (list, tuple)):
-        return any(_contains_secret_ref_outside_keys(item, supported_value_keys) for item in value)
+        return any(
+            _contains_secret_ref_outside_keys(item, supported_value_keys, supported_value_depth) for item in value
+        )
     return False
 
 
@@ -641,9 +645,14 @@ def warn_on_unsupported_secret_refs_outside_keys(
     value: Any,
     supported_value_keys: set[str],
     context: str,
+    supported_value_depth: int = 1,
 ) -> bool:
-    """Warn when references occur outside explicitly supported mapping values."""
-    if not _contains_secret_ref_outside_keys(value, frozenset(supported_value_keys)):
+    """Warn when references occur outside explicitly supported mapping values.
+
+    ``supported_value_depth`` controls the mapping depth at which supported keys are exempted.
+    Per-site configuration uses depth 2 for its site key and immediate field values.
+    """
+    if not _contains_secret_ref_outside_keys(value, frozenset(supported_value_keys), supported_value_depth):
         return False
     supported = ", ".join(sorted(supported_value_keys))
     _emit_safe_warning(

--- a/nvflare/fuel/utils/secret_utils.py
+++ b/nvflare/fuel/utils/secret_utils.py
@@ -371,11 +371,55 @@ def _is_exempt_value(value: str) -> bool:
     return _looks_like_path(v)
 
 
-def _split_tokens(text: str) -> List[str]:
+def _split_token_variants(text: str) -> List[List[str]]:
+    """Return tokenizations needed to conservatively scan command-like text."""
     try:
-        return shlex.split(text, posix=True)
+        return [shlex.split(text, posix=True)]
     except ValueError:
-        return text.split()
+        # Recipe parameters can contain incomplete shell quoting while they are being composed.
+        # A plain whitespace split can separate the value of a secret-named flag from the rest of
+        # its unterminated quoted span and make the detector miss it. Conversely, an unmatched
+        # quote before a flag can make a lenient tokenizer absorb the flag into one token. Scan
+        # both interpretations; findings are deduplicated before they are returned.
+        lenient_tokens = _split_tokens_leniently(text)
+        whitespace_tokens = text.split()
+        if lenient_tokens == whitespace_tokens:
+            return [lenient_tokens]
+        return [lenient_tokens, whitespace_tokens]
+
+
+def _split_tokens_leniently(text: str) -> List[str]:
+    """Best-effort shell tokenization that keeps unterminated quoted spans together."""
+    tokens: List[str] = []
+    token: List[str] = []
+    quote = None
+    escaped = False
+
+    for char in text:
+        if escaped:
+            token.append(char)
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif quote:
+            if char == quote:
+                quote = None
+            else:
+                token.append(char)
+        elif char in {"'", '"'}:
+            quote = char
+        elif char.isspace():
+            if token:
+                tokens.append("".join(token))
+                token = []
+        else:
+            token.append(char)
+
+    if escaped:
+        token.append("\\")
+    if token:
+        tokens.append("".join(token))
+    return tokens
 
 
 def _iter_flag_findings(tokens: List[str], location: str):
@@ -468,13 +512,13 @@ def _scan_string(text: str, location: str, findings: List[SecretFinding]) -> Non
     for reason, pattern in _KNOWN_TOKEN_PATTERNS:
         for match in pattern.finditer(text):
             findings.append(SecretFinding(location, reason, _mask(match.group(0))))
-    tokens = _split_tokens(text)
-    findings.extend(_iter_flag_findings(tokens, location))
     findings.extend(_iter_assignment_findings(text, location))
-    for token in tokens:
-        finding = _entropy_finding(token, location)
-        if finding:
-            findings.append(finding)
+    for tokens in _split_token_variants(text):
+        findings.extend(_iter_flag_findings(tokens, location))
+        for token in tokens:
+            finding = _entropy_finding(token, location)
+            if finding:
+                findings.append(finding)
 
 
 def _scan_value(value: Any, location: str, findings: List[SecretFinding]) -> None:
@@ -538,13 +582,15 @@ def find_potential_secrets(value: Any, location: str = "value") -> List[SecretFi
 
 
 def _emit_safe_warning(message: str, category: type[Warning]) -> None:
-    """Emit a warning without attributing it to a user source line that might contain a secret."""
+    """Emit a warning without exposing a caller source line that may contain a secret.
+
+    Warning-as-error policies are deliberately neutralized for these diagnostics. Letting the
+    warning exception escape would render caller frames in a traceback, including an inline recipe
+    parameter containing the very secret this scanner is trying to keep out of logs.
+    """
     try:
         warnings.warn_explicit(message, category, filename="<nvflare-secret-scan>", lineno=1)
     except category:
-        # A global ``-W error`` policy would otherwise turn the warning into a traceback that can
-        # render the caller's inline recipe source. Re-emit this security diagnostic as a warning
-        # from the synthetic location instead of allowing that source-bearing exception to escape.
         with warnings.catch_warnings():
             warnings.simplefilter("always", category)
             warnings.warn_explicit(message, category, filename="<nvflare-secret-scan>", lineno=1)
@@ -629,7 +675,14 @@ def _contains_secret_ref_outside_keys(
         for key, item in value.items():
             if _contains_secret_ref(key):
                 return True
-            if supported_value_depth == 1 and isinstance(key, str) and key in supported_value_keys:
+            if (
+                supported_value_depth == 1
+                and isinstance(key, str)
+                and key in supported_value_keys
+                and isinstance(item, str)
+            ):
+                # These runtime boundaries consume direct string fields. Do not exempt a nested
+                # mapping/list merely because its parent happens to use a supported field name.
                 continue
             if _contains_secret_ref_outside_keys(item, supported_value_keys, max(supported_value_depth - 1, 0)):
                 return True

--- a/nvflare/fuel/utils/secret_utils.py
+++ b/nvflare/fuel/utils/secret_utils.py
@@ -1,0 +1,654 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for keeping secret values out of job definitions.
+
+Job parameters (training script args, per-site config, extra config dicts) are written in clear
+text into the generated job configuration files, which are exported, logged, and shared. They
+must therefore never contain actual secret values. This module provides two complementary tools
+to support that contract:
+
+* Secret references: :func:`secret_ref` and :func:`secret_file_ref` build placeholders that can be
+  used at supported runtime boundaries instead of actual secret values. Only placeholders are
+  stored in generated job configuration; supported consumers call :func:`resolve_secret_refs`
+  with values from the executing site's environment or mounted secret files at runtime.
+
+* Secret detection: :func:`find_potential_secrets` and :func:`warn_on_potential_secrets` scan
+  user-supplied parameter values for things that look like actual secrets (well-known token
+  formats, password-like flags or keys, high-entropy strings) so mistakes can be flagged before
+  the values end up in exported job configs and logs.
+
+Messages produced by this module report only the flagged value's length, never any of its
+characters, so warning text is safe to log and share.
+"""
+
+import math
+import os
+import re
+import shlex
+import warnings
+from typing import Any, List, Mapping, NamedTuple, Optional
+
+__all__ = [
+    "PotentialSecretWarning",
+    "UnsupportedSecretRefWarning",
+    "SecretFinding",
+    "SECRET_REF_PATTERN",
+    "secret_ref",
+    "secret_file_ref",
+    "has_secret_refs",
+    "resolve_secret_refs",
+    "split_command_preserving_secret_refs",
+    "find_potential_secrets",
+    "warn_on_potential_secrets",
+    "warn_on_unsupported_secret_refs",
+    "warn_on_unsupported_secret_ref_keys",
+    "warn_on_unsupported_secret_refs_outside_keys",
+]
+
+# Secret references are resolved on the *executing site* by supported runtime consumers.
+# Environment references retain the concise ${secret:NAME} spelling; mounted-file references
+# use ${secret:file:/path/to/key}. Whitespace and braces in file paths are intentionally
+# unsupported so references remain portable across command and configuration encodings.
+SECRET_REF_PATTERN = re.compile(r"\$\{secret:(?:file:(?P<file>[^{}\s\x00]+)|(?P<env>[A-Za-z_][A-Za-z0-9_]*))\}")
+
+# Match both valid and malformed markers so tokenization cannot consume quotes or backslashes
+# inside them before the resolver validates their syntax.
+_SECRET_MARKER_PATTERN = re.compile(r"\$\{secret:[^}\r\n]*(?:\}|$)")
+
+_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+_ASSIGNMENT_START_PATTERN = re.compile(
+    r"""(?ix)(?=(?P<assignment>(?:^|[\s;=,("'`?&])(?:export\s+)?(?:\$env:)?"""
+    r"""(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*))"""
+)
+
+
+class PotentialSecretWarning(UserWarning):
+    """Warning category emitted when a job parameter looks like it contains an actual secret value."""
+
+
+class UnsupportedSecretRefWarning(UserWarning):
+    """Warning emitted when a secret reference appears outside a supported runtime boundary."""
+
+
+class SecretFinding(NamedTuple):
+    """One potential secret found by :func:`find_potential_secrets`.
+
+    Attributes:
+        location: where the value was found, e.g. ``"train_args (secret-named flag)"``.
+        reason: why it was flagged, e.g. ``"GitHub token"``.
+        preview: masked preview of the value, safe to log and share.
+    """
+
+    location: str
+    reason: str
+    preview: str
+
+
+def secret_ref(env_var: str) -> str:
+    """Build a secret reference placeholder for use in job parameters.
+
+    The returned string carries no secret value and is safe to store in job configs. A supported
+    runtime consumer on the executing site replaces it with the value of the named environment
+    variable. See :mod:`nvflare.recipe.secrets` for supported parameter locations.
+
+    Args:
+        env_var: name of the environment variable that holds the secret on the executing site.
+
+    Returns:
+        The placeholder string ``${secret:<env_var>}``.
+
+    Example:
+        train_args=f"--api-key {secret_ref('MY_API_KEY')}"
+    """
+    if not isinstance(env_var, str) or not _ENV_VAR_NAME_PATTERN.match(env_var):
+        raise ValueError("env_var must be a valid environment variable name ([A-Za-z_][A-Za-z0-9_]*)")
+    return "${secret:" + env_var + "}"
+
+
+def secret_file_ref(path: str) -> str:
+    """Build a reference to a secret stored in a mounted text file on the executing site.
+
+    This is intended for secrets projected as files, including Kubernetes Secret volume keys.
+    The path itself is stored in the generated job config; the file content is read only on the
+    executing site at runtime. The file content is injected exactly as stored, including any
+    trailing newline.
+
+    Args:
+        path: runtime path of the mounted secret file. Absolute paths are strongly recommended;
+            whitespace and brace characters are not supported.
+
+    Returns:
+        The placeholder string ``${secret:file:<path>}``.
+    """
+    if (
+        not isinstance(path, str)
+        or not path
+        or not path.isprintable()
+        or any(c in path for c in ("{", "}", "\0"))
+        or any(c.isspace() for c in path)
+    ):
+        raise ValueError("path must be a non-empty printable secret file path without braces or whitespace")
+    return "${secret:file:" + path + "}"
+
+
+def has_secret_refs(value: Any) -> bool:
+    """Return whether a string contains an environment or mounted-file secret reference."""
+    return isinstance(value, str) and SECRET_REF_PATTERN.search(value) is not None
+
+
+def resolve_secret_refs(value: Any, env: Optional[Mapping[str, str]] = None) -> Any:
+    """Resolve secret references recursively without changing mapping keys.
+
+    Intended to be called at runtime on the executing site, as late as possible and only on the
+    in-memory value handed to user code. Environment references use ``${secret:NAME}``;
+    mounted-file references use ``${secret:file:/path/to/key}``. Resolved values must never be
+    logged or written back into config files.
+
+    Args:
+        value: string or nested mapping/list/tuple whose string values should be resolved.
+        env: source of secret values; defaults to ``os.environ``.
+
+    Returns:
+        A resolved value. Containers are copied; mapping keys are preserved unchanged.
+
+    Raises:
+        ValueError: if reference syntax is invalid, a referenced environment variable is not set,
+            or a referenced file cannot be read. Errors never include a resolved value, so they
+            are safe to log.
+    """
+    source = os.environ if env is None else env
+
+    def _sub(match: re.Match) -> str:
+        env_name = match.group("env")
+        if env_name is not None:
+            if env_name not in source:
+                raise ValueError(
+                    f"cannot resolve secret reference '${{secret:{env_name}}}': "
+                    f"environment variable '{env_name}' is not set on this site"
+                )
+            return source[env_name]
+
+        path = match.group("file")
+        if not path.isprintable():
+            raise ValueError("cannot resolve secret reference: invalid secret reference syntax")
+        try:
+            with open(path, encoding="utf-8") as f:
+                return f.read()
+        except (OSError, UnicodeError, ValueError):
+            raise ValueError(
+                f"cannot resolve secret file reference for path {path!r}: "
+                f"secret file {path!r} cannot be read on this site"
+            ) from None
+
+    if isinstance(value, str):
+        # Validate all markers before resolving any of them. This prevents malformed or manually
+        # composed references from silently surviving as literals and avoids partial resolution
+        # if another reference in the same value is invalid.
+        if "${secret:" in SECRET_REF_PATTERN.sub("", value):
+            raise ValueError("cannot resolve secret reference: invalid secret reference syntax")
+        return SECRET_REF_PATTERN.sub(_sub, value)
+    if isinstance(value, Mapping):
+        return {key: resolve_secret_refs(item, env=source) for key, item in value.items()}
+    if isinstance(value, list):
+        return [resolve_secret_refs(item, env=source) for item in value]
+    if isinstance(value, tuple):
+        return tuple(resolve_secret_refs(item, env=source) for item in value)
+    return value
+
+
+def _shield_quoted_secret_ref_composites(command: str, marker_prefix: str):
+    """Shield only quoted spans that contain a secret-ref marker.
+
+    TaskScriptRunner historically uses whitespace-only splitting. Shielding these spans lets it
+    support ``"Bearer ${secret:TOKEN}"`` without changing the treatment of unrelated quotes or
+    backslashes elsewhere in the command.
+    """
+    quoted_prefix = f"{marker_prefix}QUOTED_"
+    quoted_values = []
+    parts = []
+    index = 0
+
+    while index < len(command):
+        quote = command[index]
+        if quote not in {"'", '"'}:
+            parts.append(quote)
+            index += 1
+            continue
+
+        end = index + 1
+        while end < len(command):
+            if command[end] == "\\" and end + 1 < len(command):
+                end += 2
+            elif command[end] == quote:
+                break
+            else:
+                end += 1
+
+        if end < len(command) and marker_prefix in command[index + 1 : end]:
+            marker = f"{quoted_prefix}{len(quoted_values)}__"
+            quoted_values.append((marker, command[index + 1 : end]))
+            parts.append(marker)
+            index = end + 1
+        else:
+            # Keep non-secret-ref quoting byte-for-byte compatible with legacy splitting.
+            span_end = end + 1 if end < len(command) else len(command)
+            parts.append(command[index:span_end])
+            index = span_end
+
+    return "".join(parts), quoted_values
+
+
+def split_command_preserving_secret_refs(command: str, posix: bool, group_secret_ref_quotes: bool = False) -> List[str]:
+    """Tokenize a command without interpreting characters inside secret reference markers.
+
+    Valid and malformed markers are temporarily replaced with inert tokens. Restoring them after
+    tokenization ensures the runtime resolver sees exactly what the recipe supplied, including
+    quote and backslash characters in mounted-file paths. ``posix=False`` retains the task script
+    runner's legacy whitespace-only splitting; ``posix=True`` uses :func:`shlex.split`. With
+    ``group_secret_ref_quotes=True``, only quoted spans containing references are grouped and
+    unquoted; unrelated arguments retain the legacy behavior.
+    """
+    marker_prefix = "__NVFLARE_SECRET_MARKER_"
+    while marker_prefix in command:
+        marker_prefix = "_" + marker_prefix
+
+    references = []
+
+    def _shield(match: re.Match) -> str:
+        marker = f"{marker_prefix}{len(references)}__"
+        references.append((marker, match.group(0)))
+        return marker
+
+    shielded = _SECRET_MARKER_PATTERN.sub(_shield, command)
+    quoted_values = []
+    if group_secret_ref_quotes:
+        shielded, quoted_values = _shield_quoted_secret_ref_composites(shielded, marker_prefix)
+    tokens = shlex.split(shielded) if posix else shielded.split()
+    for index, token in enumerate(tokens):
+        for marker, quoted_value in quoted_values:
+            token = token.replace(marker, quoted_value)
+        for marker, reference in references:
+            token = token.replace(marker, reference)
+        tokens[index] = token
+    return tokens
+
+
+# Well-known credential formats. These are high-confidence: matching strings are almost
+# certainly actual secrets, not identifiers or hyperparameters.
+_KNOWN_TOKEN_PATTERNS = [
+    ("GitHub token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")),
+    ("GitLab token", re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}")),
+    ("API key (sk- format)", re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}")),
+    ("AWS access key ID", re.compile(r"\b(?:AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}\b")),
+    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_\-]{35}")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{10,}")),
+    ("Hugging Face token", re.compile(r"\bhf_[A-Za-z0-9]{28,}")),
+    ("JSON web token", re.compile(r"\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}")),
+    ("private key block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY(?: BLOCK)?-----")),
+    ("credential embedded in URL", re.compile(r"\b[a-zA-Z][a-zA-Z0-9+.\-]*://[^/\s:@]+:[^/\s@]+@")),
+]
+
+# Flag/key names that suggest their value is a credential. Matches whole name segments
+# ("api_key", "--auth-token") but not substrings inside larger words ("tokenizer", "max_tokens").
+# A bare "key" segment is only matched as the final segment ("wandb_key" yes, "key_metric" no).
+_SECRET_KEY_NAME_PATTERN = re.compile(
+    r"(?i)(?:(?:^|[_\-.])(?:password|passwd|pwd|passphrase|secret|token|apikey|api[_\-]key|"
+    r"accesskey|access[_\-]key|authtoken|auth[_\-]token|authorization|credentials?|privatekey|"
+    r"private[_\-]key|clientsecret|client[_\-]secret|auth)(?=$|[_\-.])|[_\-.]key$)"
+)
+
+_BASE64_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=_-")
+_HEX_CHARS = frozenset("0123456789abcdefABCDEF")
+
+# Values that commonly appear after secret-named flags but are clearly not secrets.
+_NON_SECRET_WORDS = frozenset({"true", "false", "none", "null", "yes", "no", "auto", "default", "disabled", "enabled"})
+
+_LEGACY_REFERENCE_PATTERNS = (
+    re.compile(r"^\$(?:[A-Z_][A-Z0-9_]*|\{[A-Z_][A-Z0-9_]*\})$"),
+    re.compile(r"^%[A-Z_][A-Z0-9_]*%$"),
+    re.compile(r"^\{[A-Z_][A-Z0-9_]*\}$"),
+)
+
+
+def _shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    counts: dict = {}
+    for ch in value:
+        counts[ch] = counts.get(ch, 0) + 1
+    total = len(value)
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def _mask(value: str) -> str:
+    """Return a masked value description containing no secret characters."""
+    return f"'***' ({len(value)} chars)"
+
+
+def _looks_like_path(value: str) -> bool:
+    if value.startswith(("/", "./", "../", "~", "\\", "file:")):
+        return True
+    # Windows drive path, e.g. C:\... or C:/...
+    return len(value) > 2 and value[1] == ":" and value[2] in ("/", "\\")
+
+
+def _is_exempt_value(value: str) -> bool:
+    """Values that are references or locations rather than secret material itself."""
+    v = value.strip().strip("'\"")
+    if len(v) < 6:
+        return True
+    if v.lower() in _NON_SECRET_WORDS:
+        return True
+    if "${secret:" in v:
+        remainder = SECRET_REF_PATTERN.sub("", v)
+        if "${secret:" in remainder:
+            return False
+        # A valid reference alone, or with a conventional authorization-scheme prefix, carries
+        # no secret material. Other adjacent text is still scanned so a valid reference cannot
+        # be used to hide a literal value in a secret-named field.
+        remainder = remainder.strip(" \t\r\n'\"=:,;/-")
+        if not remainder or remainder.lower() in {"bearer", "basic"}:
+            return True
+        return False
+    # Require a complete, conventional placeholder. This prevents a literal such as
+    # "$uperSecret123" from bypassing checks merely because it starts with '$'.
+    if any(pattern.fullmatch(v) for pattern in _LEGACY_REFERENCE_PATTERNS):
+        return True
+    # Paths point at mounted secret files -- the recommended practice, not a leak.
+    return _looks_like_path(v)
+
+
+def _split_tokens(text: str) -> List[str]:
+    try:
+        return shlex.split(text, posix=True)
+    except ValueError:
+        return text.split()
+
+
+def _iter_flag_findings(tokens: List[str], location: str):
+    """Yield findings for command-line style '--secret-named-flag value' pairs."""
+    for i, token in enumerate(tokens):
+        if not token.startswith("-"):
+            continue
+        name = token.lstrip("-")
+        value = None
+        if "=" in name:
+            name, value = name.split("=", 1)
+        elif i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+            value = tokens[i + 1]
+        if not name or value is None:
+            continue
+        if _SECRET_KEY_NAME_PATTERN.search(name) and not _is_exempt_value(value):
+            yield SecretFinding(
+                location=f"{location} (secret-named flag)",
+                reason="value of a secret-named flag",
+                preview=_mask(value.strip().strip("'\"")),
+            )
+
+
+def _extract_assignment_value(text: str, start: int, unquoted_limit: int) -> tuple[str, int]:
+    if start >= len(text):
+        return "", start
+
+    quote = text[start]
+    if quote in {"'", '"'}:
+        end = start + 1
+        while end < len(text):
+            if text[end] == "\\" and end + 1 < len(text):
+                end += 2
+            elif text[end] == quote:
+                return text[start : end + 1], end
+            else:
+                end += 1
+        return text[start:], len(text)
+
+    limit = min(unquoted_limit, len(text))
+    end = start
+    while end < limit and not text[end].isspace() and text[end] != ";":
+        end += 1
+    return text[start:end], start
+
+
+def _iter_assignment_findings(text: str, location: str):
+    """Yield findings for shell, option-wrapped, and PowerShell secret assignments."""
+    matches = list(_ASSIGNMENT_START_PATTERN.finditer(text))
+    index = 0
+    while index < len(matches):
+        match = matches[index]
+        name = match.group("name")
+        value_start = match.end("assignment")
+        unquoted_limit = len(text)
+        if index + 1 < len(matches):
+            next_start = matches[index + 1].start("assignment")
+            # Optional prefixes (for example an opening quote plus ``export``) can produce
+            # duplicate candidates whose start precedes this same assignment's value.
+            if next_start > value_start:
+                unquoted_limit = next_start
+        value, skip_nested_before = _extract_assignment_value(text, value_start, unquoted_limit)
+        if _SECRET_KEY_NAME_PATTERN.search(name) and not _is_exempt_value(value):
+            yield SecretFinding(
+                location=f"{location} (secret-named assignment)",
+                reason="value of a secret-named assignment",
+                preview=_mask(value.strip().strip("'\"")),
+            )
+        index += 1
+        while index < len(matches) and matches[index].start("assignment") < skip_nested_before:
+            index += 1
+
+
+def _entropy_finding(token: str, location: str) -> Optional[SecretFinding]:
+    value = token.strip().strip("'\",;")
+    if len(value) < 20 or _is_exempt_value(value):
+        return None
+    if all(c in _HEX_CHARS for c in value):
+        if len(value) >= 32 and _shannon_entropy(value) > 3.0:
+            return SecretFinding(location, "high-entropy hex string", _mask(value))
+        return None
+    if all(c in _BASE64_CHARS for c in value) and _shannon_entropy(value) > 4.5:
+        return SecretFinding(location, "high-entropy string", _mask(value))
+    return None
+
+
+def _scan_string(text: str, location: str, findings: List[SecretFinding]) -> None:
+    if "${secret:" in SECRET_REF_PATTERN.sub("", text):
+        findings.append(SecretFinding(location, "malformed secret reference", _mask(text)))
+    for reason, pattern in _KNOWN_TOKEN_PATTERNS:
+        for match in pattern.finditer(text):
+            findings.append(SecretFinding(location, reason, _mask(match.group(0))))
+    tokens = _split_tokens(text)
+    findings.extend(_iter_flag_findings(tokens, location))
+    findings.extend(_iter_assignment_findings(text, location))
+    for token in tokens:
+        finding = _entropy_finding(token, location)
+        if finding:
+            findings.append(finding)
+
+
+def _scan_value(value: Any, location: str, findings: List[SecretFinding]) -> None:
+    if isinstance(value, str):
+        _scan_string(value, location, findings)
+    elif isinstance(value, Mapping):
+        for index, (key, item) in enumerate(value.items()):
+            key_findings: List[SecretFinding] = []
+            if isinstance(key, str):
+                _scan_string(key, f"{location} (mapping key #{index})", key_findings)
+            findings.extend(key_findings)
+            # Never copy mapping keys into warning locations: a heuristic miss in a key must not
+            # leak that key when a descendant value produces a finding.
+            child_location = f"{location} (mapping value #{index})"
+            if isinstance(key, str) and isinstance(item, str):
+                if _SECRET_KEY_NAME_PATTERN.search(key) and not _is_exempt_value(item):
+                    findings.append(
+                        SecretFinding(
+                            location=child_location,
+                            reason="value of a secret-named key",
+                            preview=_mask(item.strip().strip("'\"")),
+                        )
+                    )
+            _scan_value(item, child_location, findings)
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _scan_value(item, f"{location}[{index}]", findings)
+
+
+def find_potential_secrets(value: Any, location: str = "value") -> List[SecretFinding]:
+    """Scan a parameter value for anything that looks like an actual secret.
+
+    Strings are checked for well-known credential formats, secret-named command-line flags with
+    inline values, credentials embedded in URLs, and high-entropy tokens. Dicts and lists are
+    scanned recursively; dict entries whose key names suggest a credential (password, token,
+    api_key, ...) are flagged when their value looks like actual secret material. Stand-alone,
+    valid secret references (``${secret:NAME}``), env-var/config placeholders, and
+    file paths are not flagged -- those are the recommended ways to hand secrets to a job.
+
+    This is a heuristic intended to catch mistakes, not a guarantee: absence of findings does not
+    prove a value is safe.
+
+    Args:
+        value: the parameter value to scan (str, dict, list, or any nesting of them).
+        location: human-readable description of where the value came from; used in findings.
+
+    Returns:
+        List of :class:`SecretFinding`, deduplicated by location and preview. Findings contain
+        only masked previews and are safe to log.
+    """
+    findings: List[SecretFinding] = []
+    _scan_value(value, location, findings)
+    deduped: List[SecretFinding] = []
+    seen = set()
+    for finding in findings:
+        key = (finding.location, finding.preview)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(finding)
+    return deduped
+
+
+def _emit_safe_warning(message: str, category: type[Warning]) -> None:
+    """Emit a warning without attributing it to a user source line that might contain a secret."""
+    try:
+        warnings.warn_explicit(message, category, filename="<nvflare-secret-scan>", lineno=1)
+    except category:
+        # A global ``-W error`` policy would otherwise turn the warning into a traceback that can
+        # render the caller's inline recipe source. Re-emit this security diagnostic as a warning
+        # from the synthetic location instead of allowing that source-bearing exception to escape.
+        with warnings.catch_warnings():
+            warnings.simplefilter("always", category)
+            warnings.warn_explicit(message, category, filename="<nvflare-secret-scan>", lineno=1)
+
+
+def warn_on_potential_secrets(value: Any, context: str) -> List[SecretFinding]:
+    """Scan a parameter value and emit a :class:`PotentialSecretWarning` for each finding.
+
+    Warning messages contain only masked previews, never the flagged values, so they are safe to
+    appear in logs that get shared.
+
+    Args:
+        value: the parameter value to scan.
+        context: where the value came from, e.g. ``"recipe parameter 'train_args'"``.
+
+    Returns:
+        The list of findings (empty if nothing was flagged).
+    """
+    findings = find_potential_secrets(value, location=context)
+    for finding in findings:
+        _emit_safe_warning(
+            f"Potential secret value in {finding.location}: {finding.reason} {finding.preview}. "
+            "Job parameters are written in clear text into the generated job configuration and may "
+            "appear in logs and exported job folders - never put actual secret values in them. "
+            "Read secrets from site environment variables or mounted secret files inside your "
+            "training code, or pass a placeholder created with nvflare.recipe.secrets.secret_ref() "
+            "or secret_file_ref() in a supported runtime parameter; see nvflare.recipe.secrets.",
+            PotentialSecretWarning,
+        )
+    return findings
+
+
+def _contains_secret_ref(value: Any) -> bool:
+    if isinstance(value, str):
+        return has_secret_refs(value)
+    if isinstance(value, Mapping):
+        return any(_contains_secret_ref(key) or _contains_secret_ref(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret_ref(item) for item in value)
+    return False
+
+
+def warn_on_unsupported_secret_refs(value: Any, context: str) -> bool:
+    """Warn when a value contains references that its runtime consumer will not resolve."""
+    if not _contains_secret_ref(value):
+        return False
+    _emit_safe_warning(
+        f"Secret reference in {context} is outside a supported runtime boundary and will remain "
+        "a literal placeholder. Read the secret from the site environment or mounted file inside "
+        "user code; see nvflare.recipe.secrets for supported reference locations.",
+        UnsupportedSecretRefWarning,
+    )
+    return True
+
+
+def _contains_secret_ref_in_keys(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(_contains_secret_ref(key) or _contains_secret_ref_in_keys(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret_ref_in_keys(item) for item in value)
+    return False
+
+
+def warn_on_unsupported_secret_ref_keys(value: Any, context: str) -> bool:
+    """Warn when nested mapping keys contain references, since keys are never resolved."""
+    if not _contains_secret_ref_in_keys(value):
+        return False
+    _emit_safe_warning(
+        f"Secret reference in a mapping key under {context} will remain a literal placeholder. "
+        "Dictionary keys are never resolved; use a fixed key and put the reference in its value.",
+        UnsupportedSecretRefWarning,
+    )
+    return True
+
+
+def _contains_secret_ref_outside_keys(value: Any, supported_value_keys: frozenset[str]) -> bool:
+    if isinstance(value, str):
+        return has_secret_refs(value)
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if _contains_secret_ref(key):
+                return True
+            if isinstance(key, str) and key in supported_value_keys:
+                continue
+            if _contains_secret_ref_outside_keys(item, supported_value_keys):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret_ref_outside_keys(item, supported_value_keys) for item in value)
+    return False
+
+
+def warn_on_unsupported_secret_refs_outside_keys(
+    value: Any,
+    supported_value_keys: set[str],
+    context: str,
+) -> bool:
+    """Warn when references occur outside explicitly supported mapping values."""
+    if not _contains_secret_ref_outside_keys(value, frozenset(supported_value_keys)):
+        return False
+    supported = ", ".join(sorted(supported_value_keys))
+    _emit_safe_warning(
+        f"Secret reference in {context} is outside a supported field and will remain a literal "
+        f"placeholder. Only these fields resolve references: {supported}.",
+        UnsupportedSecretRefWarning,
+    )
+    return True

--- a/nvflare/fuel/utils/secret_utils.py
+++ b/nvflare/fuel/utils/secret_utils.py
@@ -221,14 +221,13 @@ def _shield_quoted_secret_ref_composites(command: str, marker_prefix: str):
     parts = []
     index = 0
 
-    while index < len(command):
-        quote = command[index]
-        if quote not in {"'", '"'}:
-            parts.append(quote)
-            index += 1
-            continue
+    def _is_quote_opener(position: int) -> bool:
+        if position == 0:
+            return True
+        return command[position - 1].isspace() or command[position - 1] in "=([{,:"
 
-        end = index + 1
+    def _find_quote(start: int, quote: str) -> int:
+        end = start
         while end < len(command):
             if command[end] == "\\" and end + 1 < len(command):
                 end += 2
@@ -236,17 +235,39 @@ def _shield_quoted_secret_ref_composites(command: str, marker_prefix: str):
                 break
             else:
                 end += 1
+        return end
+
+    while index < len(command):
+        quote = command[index]
+        if quote not in {"'", '"'}:
+            parts.append(quote)
+            index += 1
+            continue
+
+        end = _find_quote(index + 1, quote)
 
         if end < len(command) and marker_prefix in command[index + 1 : end]:
             marker = f"{quoted_prefix}{len(quoted_values)}__"
             quoted_values.append((marker, command[index + 1 : end]))
             parts.append(marker)
             index = end + 1
+        elif not _is_quote_opener(index):
+            # Apostrophes and stray quotes embedded in an unquoted token are literal under the
+            # runner's legacy whitespace split. Advancing one character lets a later real opener
+            # use the same delimiter. The secret-bearing-span case above deliberately comes first
+            # to retain support for shell-style concatenation such as ``prefix"Bearer ${secret:X}"``.
+            parts.append(quote)
+            index += 1
+        elif end < len(command):
+            # Keep matched non-secret-ref quoting byte-for-byte compatible with legacy splitting.
+            # Skipping the entire pair also prevents its closing delimiter from being mistaken for
+            # the opener of a later span.
+            parts.append(command[index : end + 1])
+            index = end + 1
         else:
-            # Keep non-secret-ref quoting byte-for-byte compatible with legacy splitting.
-            span_end = end + 1 if end < len(command) else len(command)
-            parts.append(command[index:span_end])
-            index = span_end
+            # Preserve an unmatched quote byte-for-byte, but continue from the next character.
+            parts.append(quote)
+            index += 1
 
     return "".join(parts), quoted_values
 

--- a/nvflare/fuel/utils/wfconf.py
+++ b/nvflare/fuel/utils/wfconf.py
@@ -26,6 +26,7 @@ from .class_loader import load_class
 from .class_utils import ModuleScanner, get_class_path_from_config, instantiate_class
 from .dict_utils import extract_first_level_primitive, merge_dict
 from .json_scanner import JsonObjectProcessor, JsonScanner, Node
+from .secret_utils import SECRET_REF_PATTERN
 
 
 class ConfigContext(object):
@@ -130,7 +131,11 @@ class _EnvUpdater(JsonObjectProcessor):
             # For example: "{ROOT_DIR}"
             # Such vars will be replaced with values defined in self.vars.
             try:
-                element = element.format(**self.vars)
+                # Shield runtime secret references from str.format while expanding ordinary
+                # NVFlare variables in the same string. Doubling the reference braces makes
+                # str.format preserve them literally for the site-local secret resolver.
+                format_value = SECRET_REF_PATTERN.sub(lambda match: "${{" + match.group(0)[2:-1] + "}}", element)
+                element = format_value.format(**self.vars)
             except:
                 # If the substitution fails, return the original value
                 element = original_value

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -24,6 +24,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict, List
 
 from nvflare.fuel.utils.class_utils import get_component_init_parameters
+from nvflare.fuel.utils.job_secret_scanner import warn_on_potential_secrets_in_job_dir
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.fuel.utils.validation_utils import check_object_type
 from nvflare.job_config.base_app_config import BaseAppConfig
@@ -170,6 +171,7 @@ class FedJobConfig:
     def simulator_run(self, workspace, clients=None, n_clients=None, threads=None, gpu=None, log_config=None):
         with TemporaryDirectory() as job_root:
             self.generate_job_config(job_root)
+            warn_on_potential_secrets_in_job_dir(job_root, job_name=self.job_name)
 
             try:
                 command = (

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -80,7 +80,11 @@ class BaseScriptRunner:
 
         Args:
             script (str): Script to run. For in-process must be a python script path. For ex-process can be any script support by `command`.
-            script_args (str): Optional arguments for script (appended to script).
+            script_args (str): Optional arguments for script (appended to script). The string is written in
+                clear text into the generated job config, so it must never contain actual secret values;
+                use :func:`nvflare.recipe.secrets.secret_ref` for a site environment variable or
+                :func:`nvflare.recipe.secrets.secret_file_ref` for a mounted secret file. The
+                executing site resolves the placeholder at runtime.
             launch_external_process (bool): Whether to launch the script in external process. Defaults to False.
             command (str): If launch_external_process=True, command to run script (prepended to script). Defaults to "python3".
             framework (str): Framework is used to determine the `params_exchange_format`. Defaults to FrameworkType.PYTORCH.
@@ -381,7 +385,11 @@ class ScriptRunner(BaseScriptRunner):
 
         Args:
             script (str): Script to run. For in-process must be a python script path. For ex-process can be any script support by `command`.
-            script_args (str): Optional arguments for script (appended to script).
+            script_args (str): Optional arguments for script (appended to script). The string is written in
+                clear text into the generated job config, so it must never contain actual secret values;
+                use :func:`nvflare.recipe.secrets.secret_ref` for a site environment variable or
+                :func:`nvflare.recipe.secrets.secret_file_ref` for a mounted secret file. The
+                executing site resolves the placeholder at runtime.
             launch_external_process (bool): Whether to launch the script in external process. Defaults to False.
             command (str): If launch_external_process=True, command to run script (prepended to script). Defaults to "python3".
             framework (str): Framework is used to determine the `params_exchange_format`. Defaults to FrameworkType.PYTORCH.

--- a/nvflare/recipe/__init__.py
+++ b/nvflare/recipe/__init__.py
@@ -17,6 +17,7 @@ from .fedavg import FedAvgRecipe
 from .poc_env import PocEnv
 from .prod_env import ProdEnv
 from .run import Run
+from .secrets import PotentialSecretWarning, UnsupportedSecretRefWarning, secret_file_ref, secret_ref
 from .sim_env import SimEnv
 from .utils import add_cross_site_evaluation, add_experiment_tracking, set_per_site_config, set_recipe_meta
 
@@ -31,4 +32,8 @@ __all__ = [
     "set_recipe_meta",
     "FedAvgRecipe",
     "FedTaskRecipe",
+    "PotentialSecretWarning",
+    "UnsupportedSecretRefWarning",
+    "secret_ref",
+    "secret_file_ref",
 ]

--- a/nvflare/recipe/cyclic.py
+++ b/nvflare/recipe/cyclic.py
@@ -21,6 +21,7 @@ from nvflare.app_common.shareablegenerators import FullModelShareableGenerator
 from nvflare.app_common.workflows.cyclic_ctl import CyclicController
 from nvflare.client.config import ExchangeFormat, TransferType
 from nvflare.fuel.utils.constants import FrameworkType
+from nvflare.fuel.utils.secret_utils import warn_on_unsupported_secret_refs_outside_keys
 from nvflare.job_config.script_runner import ScriptRunner
 from nvflare.recipe.spec import Recipe
 
@@ -75,6 +76,8 @@ class CyclicRecipe(Recipe):
         min_clients: Minimum number of clients required to participate. Must be >= 2.
         train_script: Path to the client training script to execute.
         train_args: Additional command-line arguments to pass to the training script.
+            Written in clear text into the generated job config, so it must never contain
+            actual secret values; see :mod:`nvflare.recipe.secrets` for how to pass secrets.
         launch_external_process: Whether to run training in a separate process. Defaults to False.
         command: Shell command to execute the training script. Defaults to "python3 -u".
         framework: ML framework type for compatibility. Defaults to FrameworkType.NUMPY.
@@ -91,8 +94,10 @@ class CyclicRecipe(Recipe):
         server_config_overrides: Advanced shallow overrides for ``CyclicController``.
             Values here take precedence over named constructor parameters.
             ``task_check_period`` must be positive when supplied.
+            This dictionary is stored in the job definition and must not contain secrets.
         client_config_overrides: Advanced shallow overrides for ``ScriptRunner``.
             Values here take precedence over named constructor parameters.
+            This dictionary is stored in the job definition and must not contain secrets.
 
     Raises:
         ValidationError: If min_clients < 2 or other parameter validation fails.
@@ -180,6 +185,11 @@ class CyclicRecipe(Recipe):
         self.shutdown_timeout = v.shutdown_timeout
         self.server_config_overrides = server_config_overrides
         self.client_config_overrides = client_config_overrides
+        warn_on_unsupported_secret_refs_outside_keys(
+            self.client_config_overrides,
+            supported_value_keys={"command", "script_args"},
+            context="recipe parameter 'client_config_overrides'",
+        )
 
         # Validate that we have at least one model source
         if self.model is None and self.initial_ckpt is None:

--- a/nvflare/recipe/fed_task.py
+++ b/nvflare/recipe/fed_task.py
@@ -67,6 +67,10 @@ class FedTaskRecipe(Recipe):
 
     Users are responsible for ensuring that ``task_script`` accepts the supplied
     ``task_args`` and any ``task_data`` or ``task_meta`` payloads it consumes.
+    These values become part of the generated job definition and must never
+    contain actual secret values. Secret references are supported in ``task_args``;
+    ``task_data`` and ``task_meta`` keep references literal, so read secrets from
+    the site environment or mounted files inside the task script instead.
 
     Args:
         name: Name of the federated job. Defaults to "fed_task".
@@ -76,9 +80,14 @@ class FedTaskRecipe(Recipe):
         min_responses: Minimum number of task results to wait for. If None, waits for all selected clients.
         timeout: Task timeout in seconds. Defaults to 0, meaning no timeout.
         task_data: Optional params dict sent to each client as ``FLModel.params``.
+            The dict is stored in the job definition and must not contain secret values or
+            secret references.
         task_meta: Optional metadata dict sent to each client as ``FLModel.meta``.
+            The dict is stored in the job definition and must not contain secret values or
+            secret references.
         task_script: Path to the client script.
-        task_args: Command line arguments passed to the client script.
+        task_args: Command line arguments passed to the client script. The string is
+            stored in the job definition and must not contain actual secret values.
         launch_external_process: Whether to launch the script in an external process.
         command: Command used when ``launch_external_process`` is True.
         framework: Framework used by ``ScriptRunner`` for parameter exchange. Defaults to RAW.

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -25,6 +25,7 @@ from nvflare.app_common.app_constant import DefaultCheckpointFileName
 from nvflare.app_common.workflows.fedavg import FedAvg
 from nvflare.client.config import ExchangeFormat, TransferType
 from nvflare.fuel.utils.constants import FrameworkType
+from nvflare.fuel.utils.secret_utils import warn_on_unsupported_secret_refs_outside_keys
 from nvflare.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import ScriptRunner
 from nvflare.recipe.spec import Recipe
@@ -96,7 +97,12 @@ class FedAvgRecipe(Recipe):
         min_clients: Minimum number of clients required to start a training round.
         num_rounds: Number of federated training rounds to execute. Defaults to 2.
         train_script: Path to the training script that will be executed on each client.
-        train_args: Command line arguments to pass to the training script.
+        train_args: Command line arguments to pass to the training script. Written in clear
+            text into the generated job config, so it must never contain actual secret values
+            (a PotentialSecretWarning is emitted if it looks like it does). To pass a secret,
+            use :func:`nvflare.recipe.secrets.secret_ref` for a site environment variable or
+            :func:`nvflare.recipe.secrets.secret_file_ref` for a mounted secret file. The
+            executing site resolves the placeholder at runtime.
         aggregator: Custom aggregator (ModelAggregator) for combining client model updates.
             Must implement accept_model(), aggregate_model(), reset_stats() methods.
             If None, uses built-in memory-efficient weighted averaging. Defaults to None.
@@ -130,6 +136,9 @@ class FedAvgRecipe(Recipe):
             - launch_once (bool): Whether to launch external process once or per task
             - shutdown_timeout (float): Shutdown timeout in seconds
             If not provided, the same configuration will be used for all clients.
+            Like train_args, per-site values are written in clear text into the generated job
+            config and must never contain actual secret values; see
+            :mod:`nvflare.recipe.secrets` for how to pass secrets safely.
         launch_once: Whether the external process will be launched only once at the beginning
             or on each task. Only used if `launch_external_process` is True. Defaults to True.
         shutdown_timeout: If provided, will wait for this number of seconds before shutdown.
@@ -272,6 +281,11 @@ class FedAvgRecipe(Recipe):
         self.per_site_config = v.per_site_config
         self._validate_per_site_config(self.per_site_config)
         self._validate_aggregator_data_kind()
+        warn_on_unsupported_secret_refs_outside_keys(
+            self.per_site_config,
+            supported_value_keys={"command", "train_args"},
+            context="recipe parameter 'per_site_config'",
+        )
         self.launch_once = v.launch_once
         self.shutdown_timeout = v.shutdown_timeout
         self.key_metric = v.key_metric

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -70,7 +70,6 @@ class _FedAvgValidator(BaseModel):
 
 
 class FedAvgRecipe(Recipe):
-    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = frozenset({"command", "train_args"})
     """Unified FedAvg recipe for PyTorch, TensorFlow, and Scikit-learn.
 
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
@@ -169,6 +168,8 @@ class FedAvgRecipe(Recipe):
         If you want to use a custom aggregator, you can pass it in the aggregator parameter.
         The custom aggregator must be a subclass of the Aggregator class.
     """
+
+    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = frozenset({"command", "train_args"})
 
     def __init__(
         self,

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -25,7 +25,6 @@ from nvflare.app_common.app_constant import DefaultCheckpointFileName
 from nvflare.app_common.workflows.fedavg import FedAvg
 from nvflare.client.config import ExchangeFormat, TransferType
 from nvflare.fuel.utils.constants import FrameworkType
-from nvflare.fuel.utils.secret_utils import warn_on_unsupported_secret_refs_outside_keys
 from nvflare.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import ScriptRunner
 from nvflare.recipe.spec import Recipe
@@ -71,6 +70,7 @@ class _FedAvgValidator(BaseModel):
 
 
 class FedAvgRecipe(Recipe):
+    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = frozenset({"command", "train_args"})
     """Unified FedAvg recipe for PyTorch, TensorFlow, and Scikit-learn.
 
     FedAvg is a fundamental federated learning algorithm that aggregates model updates
@@ -281,11 +281,6 @@ class FedAvgRecipe(Recipe):
         self.per_site_config = v.per_site_config
         self._validate_per_site_config(self.per_site_config)
         self._validate_aggregator_data_kind()
-        warn_on_unsupported_secret_refs_outside_keys(
-            self.per_site_config,
-            supported_value_keys={"command", "train_args"},
-            context="recipe parameter 'per_site_config'",
-        )
         self.launch_once = v.launch_once
         self.shutdown_timeout = v.shutdown_timeout
         self.key_metric = v.key_metric

--- a/nvflare/recipe/fedstats.py
+++ b/nvflare/recipe/fedstats.py
@@ -15,12 +15,17 @@
 from typing import Any, Dict, List
 
 from nvflare.app_common.abstract.statistics_spec import Statistics
+from nvflare.fuel.utils.secret_utils import warn_on_potential_secrets, warn_on_unsupported_secret_refs
 from nvflare.job_config.stats_job import StatsJob
 from nvflare.recipe.spec import Recipe
 
 
 class FedStatsRecipe(Recipe):
     """A recipe for federated statistics computation.
+
+    Recipe parameters become part of the generated job definition and must never
+    contain actual secret values. Read secrets from site environment variables or mounted
+    files; references are supported only where documented in :mod:`nvflare.recipe.secrets`.
 
     FedStatsRecipe is a specialized recipe that facilitates the computation of
     statistics across multiple federated sites. It creates and configures a
@@ -80,6 +85,14 @@ class FedStatsRecipe(Recipe):
         max_noise_level: float = 0.3,
         max_bins_percent: float = 10,
     ):
+        warn_on_potential_secrets(
+            statistic_configs,
+            context="recipe parameter 'statistic_configs'",
+        )
+        warn_on_unsupported_secret_refs(
+            statistic_configs,
+            context="recipe parameter 'statistic_configs'",
+        )
         job = StatsJob(
             name=name,
             statistic_configs=statistic_configs,

--- a/nvflare/recipe/secrets.py
+++ b/nvflare/recipe/secrets.py
@@ -70,7 +70,9 @@ from nvflare.fuel.utils.secret_utils import (
     secret_file_ref,
     secret_ref,
     warn_on_potential_secrets,
+    warn_on_unsupported_secret_ref_keys,
     warn_on_unsupported_secret_refs,
+    warn_on_unsupported_secret_refs_outside_keys,
 )
 
 __all__ = [
@@ -85,4 +87,6 @@ __all__ = [
     "find_potential_secrets",
     "warn_on_potential_secrets",
     "warn_on_unsupported_secret_refs",
+    "warn_on_unsupported_secret_ref_keys",
+    "warn_on_unsupported_secret_refs_outside_keys",
 ]

--- a/nvflare/recipe/secrets.py
+++ b/nvflare/recipe/secrets.py
@@ -38,13 +38,19 @@ runtime boundaries:
 
 * command arguments consumed by NVFlare's task script runner or subprocess launcher (including
   recipe ``train_args``, ``task_args``, and ``eval_args`` that use those runners); these resolve
-  after argument tokenization, immediately before the script or process starts;
+  after argument tokenization, immediately before the script or process starts. The subprocess
+  launcher rejects references in command strings for directly invoked or leading-``env``-wrapped
+  ``sh``/``bash`` and PowerShell. This is a targeted safeguard, not a general code-interpreter
+  detector: never put a reference in any argument another program will parse as code, including
+  another shell, a shell hidden behind a different wrapper, or ``python -c``. Read those secrets
+  from the child environment or a mounted file instead;
 * values explicitly read from a runtime job JSON file with
   :func:`nvflare.utils.configs.get_job_config_value` or its
   :func:`nvflare.utils.configs.get_client_config_value` and
   :func:`nvflare.utils.configs.get_server_config_value` wrappers. A typical recipe adds a
   top-level value with ``add_client_config`` or ``add_server_config``; nested strings resolve
-  when that value is read.
+  when that value is read. Internal client-launcher timeout/count overrides are written into a
+  subprocess runtime config and therefore reject references instead of resolving them.
 
 Environment references are read from the executing process's environment; file references are
 read from that site's filesystem. Resolved values stay in runtime memory and are not written back
@@ -52,9 +58,10 @@ to generated configuration. Dictionary keys are not resolved. Arbitrary componen
 arguments, metadata, custom files, and other job artifacts do not resolve references. Read secrets
 inside user code for those cases. Mounted-file reference paths cannot contain whitespace or braces.
 
-Recipes automatically scan their parameters and emit :class:`PotentialSecretWarning` when a
-value looks like an actual secret. Detection is best-effort and does not make a supplied value
-safe. A valid reference in an explicitly unsupported parameter emits
+Recipes automatically scan their parameters before export or run and emit
+:class:`PotentialSecretWarning` when a value looks like an actual secret. Detection is
+best-effort and does not make a supplied value safe. A valid reference in an explicitly
+unsupported parameter emits
 :class:`UnsupportedSecretRefWarning`. See
 :func:`nvflare.fuel.utils.secret_utils.find_potential_secrets` for the heuristics.
 """

--- a/nvflare/recipe/secrets.py
+++ b/nvflare/recipe/secrets.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public helpers for keeping secrets out of recipe parameters.
+
+Recipe parameters (``train_args``, ``task_args``, ``eval_args``, ``per_site_config``,
+``add_client_config`` / ``add_server_config`` dicts, exec params, and other nested recipe
+values) can be written in clear text into generated job configuration. They must never
+contain actual secret values.
+
+Instead, either read secrets from environment variables or mounted secret files inside your
+training code, or put a :func:`secret_ref` or :func:`secret_file_ref` placeholder in a supported
+runtime parameter::
+
+    from nvflare.recipe.secrets import secret_file_ref, secret_ref
+
+    recipe = FedAvgRecipe(
+        ...,
+        train_args=f"--epochs 5 --api-key {secret_ref('MY_API_KEY')}",
+    )
+    recipe.add_client_config(
+        {"service_password": secret_file_ref("/var/run/secrets/service/password")}
+    )
+
+Only the placeholders appear in the exported job. Secret references are supported at two explicit
+runtime boundaries:
+
+* command arguments consumed by NVFlare's task script runner or subprocess launcher (including
+  recipe ``train_args``, ``task_args``, and ``eval_args`` that use those runners); these resolve
+  after argument tokenization, immediately before the script or process starts;
+* values explicitly read from a runtime job JSON file with
+  :func:`nvflare.utils.configs.get_job_config_value` or its
+  :func:`nvflare.utils.configs.get_client_config_value` and
+  :func:`nvflare.utils.configs.get_server_config_value` wrappers. A typical recipe adds a
+  top-level value with ``add_client_config`` or ``add_server_config``; nested strings resolve
+  when that value is read.
+
+Environment references are read from the executing process's environment; file references are
+read from that site's filesystem. Resolved values stay in runtime memory and are not written back
+to generated configuration. Dictionary keys are not resolved. Arbitrary component constructor
+arguments, metadata, custom files, and other job artifacts do not resolve references. Read secrets
+inside user code for those cases. Mounted-file reference paths cannot contain whitespace or braces.
+
+Recipes automatically scan their parameters and emit :class:`PotentialSecretWarning` when a
+value looks like an actual secret. Detection is best-effort and does not make a supplied value
+safe. A valid reference in an explicitly unsupported parameter emits
+:class:`UnsupportedSecretRefWarning`. See
+:func:`nvflare.fuel.utils.secret_utils.find_potential_secrets` for the heuristics.
+"""
+
+from nvflare.fuel.utils.secret_utils import (
+    SECRET_REF_PATTERN,
+    PotentialSecretWarning,
+    SecretFinding,
+    UnsupportedSecretRefWarning,
+    find_potential_secrets,
+    has_secret_refs,
+    resolve_secret_refs,
+    secret_file_ref,
+    secret_ref,
+    warn_on_potential_secrets,
+    warn_on_unsupported_secret_refs,
+)
+
+__all__ = [
+    "PotentialSecretWarning",
+    "UnsupportedSecretRefWarning",
+    "SecretFinding",
+    "SECRET_REF_PATTERN",
+    "secret_ref",
+    "secret_file_ref",
+    "has_secret_refs",
+    "resolve_secret_refs",
+    "find_potential_secrets",
+    "warn_on_potential_secrets",
+    "warn_on_unsupported_secret_refs",
+]

--- a/nvflare/recipe/session_mgr.py
+++ b/nvflare/recipe/session_mgr.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional
 
 from nvflare.fuel.flare_api.api_spec import MonitorReturnCode
 from nvflare.fuel.flare_api.flare_api import Session, new_secure_session
+from nvflare.fuel.utils.job_secret_scanner import warn_on_potential_secrets_in_job_dir
 from nvflare.job_config.api import FedJob
 
 
@@ -54,12 +55,15 @@ class SessionManager:
 
     def submit_job(self, job: FedJob) -> str:
         """Submit a job and return job ID."""
-        sess = self._get_session()
         with tempfile.TemporaryDirectory() as temp_dir:
             job.export_job(temp_dir)
+            warn_on_potential_secrets_in_job_dir(temp_dir, job_name=job.name)
             job_path = os.path.join(temp_dir, job.name)
-            job_id = sess.submit_job(job_path)
-            sess.close()
+            sess = self._get_session()
+            try:
+                job_id = sess.submit_job(job_path)
+            finally:
+                sess.close()
             print(f"Submitted job '{job.name}' with ID: {job_id}")
             return job_id
 

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -364,8 +364,10 @@ class Recipe(ABC):
         """
         if server_exec_params:
             warn_on_potential_secrets(server_exec_params, context="server_exec_params")
+            warn_on_unsupported_secret_ref_keys(server_exec_params, context="server_exec_params")
         if client_exec_params:
             warn_on_potential_secrets(client_exec_params, context="client_exec_params")
+            warn_on_unsupported_secret_ref_keys(client_exec_params, context="client_exec_params")
 
         params_snapshot = None
         if server_exec_params is not None or client_exec_params is not None:

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -91,6 +91,12 @@ def _peek_recipe_args() -> tuple:
 from nvflare.apis.filter import Filter
 from nvflare.app_common.widgets.decomposer_reg import DecomposerRegister
 from nvflare.fuel.utils.fobs import Decomposer
+from nvflare.fuel.utils.job_secret_scanner import warn_on_potential_secrets_in_job_dir
+from nvflare.fuel.utils.secret_utils import (
+    warn_on_potential_secrets,
+    warn_on_unsupported_secret_ref_keys,
+    warn_on_unsupported_secret_refs,
+)
 from nvflare.job_config.api import FedJob
 from nvflare.job_config.defs import FilterType
 
@@ -183,15 +189,83 @@ class ExecEnv(ABC):
 
 class Recipe(ABC):
 
+    _SECRET_PARAMETER_ATTRS = (
+        "train_args",
+        "eval_args",
+        "task_args",
+        "command",
+        "task_data",
+        "task_meta",
+        "per_site_config",
+        "server_config_overrides",
+        "client_config_overrides",
+        "optimizer_args",
+        "lr_scheduler_args",
+        "xgb_params",
+        "statistic_configs",
+        "extra_env",
+        "run_config",
+        "device_training_params",
+    )
+
+    _UNSUPPORTED_SECRET_REF_ATTRS = frozenset(
+        {
+            "task_data",
+            "task_meta",
+            "server_config_overrides",
+            "optimizer_args",
+            "lr_scheduler_args",
+            "xgb_params",
+            "statistic_configs",
+            "extra_env",
+            "run_config",
+            "device_training_params",
+        }
+    )
+
     def __init__(self, job: FedJob):
         """This is base class of a recipe. Recipes are implemented by jobs.
         A concrete recipe must provide the job for recipe implementation.
+
+        Security contract -- no secrets in recipe parameters:
+            Recipe parameters (``train_args``, ``task_args``, ``eval_args``,
+            ``per_site_config``, config overrides, dicts passed to
+            ``add_client_config``/``add_server_config``, exec params, etc.) can be written in
+            clear text into generated job configuration. These parameters and their nested
+            values must never contain actual passwords, API keys, tokens, private keys, or
+            other credentials. Instead, read secrets from site environment variables or
+            mounted secret files inside your code, or pass a placeholder created with
+            :func:`nvflare.recipe.secrets.secret_ref` or
+            :func:`nvflare.recipe.secrets.secret_file_ref` at a supported runtime boundary.
+            See :mod:`nvflare.recipe.secrets` for the supported parameter locations.
+
+            Recipes scan their parameters with heuristics and emit
+            :class:`nvflare.recipe.secrets.PotentialSecretWarning` when a value looks like an
+            actual secret. The scan is best-effort: absence of a warning does not prove a
+            parameter is safe to share.
 
         Args:
             job: the job that implements the recipe.
         """
         self.job = job
         self._helper_per_site_config = None
+        warn_on_potential_secrets(getattr(job, "name", None), context="recipe parameter 'name'")
+        self._warn_potential_secrets_in_params()
+
+    def _warn_potential_secrets_in_params(self):
+        """Warn if common recipe parameters look like they contain actual secret values.
+
+        Runs on conventional parameter attributes that concrete recipes retain before
+        calling ``Recipe.__init__``. Recipes that transform a parameter before calling
+        this constructor validate that original value explicitly.
+        """
+        for attr in self._SECRET_PARAMETER_ATTRS:
+            value = getattr(self, attr, None)
+            if value is not None:
+                context = f"recipe parameter '{attr}'"
+                warn_on_potential_secrets(value, context=context)
+                if attr in self._UNSUPPORTED_SECRET_REF_ATTRS:
+                    warn_on_unsupported_secret_refs(value, context=context)
 
     def process_env(self, env: ExecEnv):
         """Process environment-specific configuration.
@@ -207,7 +281,12 @@ class Recipe(ABC):
         The generic helper validates only the site-keyed shape. Recipes that
         need to map fields into generated app config, command arguments, data
         loaders, or validators should override ``_apply_per_site_config``.
+
+        Per-site config values end up in the generated job configuration in clear
+        text and must never contain actual secret values; see the Recipe class
+        docstring for the recommended alternatives.
         """
+        warn_on_potential_secrets(config, context="per_site_config")
         self._helper_per_site_config = dict(config)
         self._apply_per_site_config(dict(self._helper_per_site_config))
 
@@ -283,6 +362,11 @@ class Recipe(ABC):
 
         Any original additional_params are restored when the context exits.
         """
+        if server_exec_params:
+            warn_on_potential_secrets(server_exec_params, context="server_exec_params")
+        if client_exec_params:
+            warn_on_potential_secrets(client_exec_params, context="client_exec_params")
+
         params_snapshot = None
         if server_exec_params is not None or client_exec_params is not None:
             params_snapshot = self._snapshot_additional_params()
@@ -407,6 +491,11 @@ class Recipe(ABC):
     def add_client_config(self, config: Dict, clients: Optional[List[str]] = None):
         """Add top-level configuration parameters to config_fed_client.json.
 
+        The config values are written in clear text into the generated
+        ``config_fed_client.json`` and must never contain actual secret values;
+        a ``PotentialSecretWarning`` is emitted for values that look like secrets.
+        See the Recipe class docstring for the recommended alternatives.
+
         Args:
             config: Dictionary of configuration parameters to add.
             clients: Optional list of specific client names. If None, applies to all clients.
@@ -417,6 +506,8 @@ class Recipe(ABC):
         if not isinstance(config, dict):
             raise TypeError(f"config must be a dict, got {type(config).__name__}")
 
+        warn_on_potential_secrets(config, context="add_client_config config")
+        warn_on_unsupported_secret_ref_keys(config, context="add_client_config config")
         self._add_to_client_apps(config, clients=clients)
 
     def add_client_file(self, file_path: str, clients: Optional[List[str]] = None):
@@ -471,6 +562,11 @@ class Recipe(ABC):
     def add_server_config(self, config: Dict):
         """Add top-level configuration parameters to config_fed_server.json.
 
+        The config values are written in clear text into the generated
+        ``config_fed_server.json`` and must never contain actual secret values;
+        a ``PotentialSecretWarning`` is emitted for values that look like secrets.
+        See the Recipe class docstring for the recommended alternatives.
+
         Args:
             config: Dictionary of configuration parameters to add.
 
@@ -480,6 +576,8 @@ class Recipe(ABC):
         if not isinstance(config, dict):
             raise TypeError(f"config must be a dict, got {type(config).__name__}")
 
+        warn_on_potential_secrets(config, context="add_server_config config")
+        warn_on_unsupported_secret_ref_keys(config, context="add_server_config config")
         self.job.to_server(config)
 
     def add_server_file(self, file_path: str):
@@ -567,6 +665,19 @@ class Recipe(ABC):
         self.job.to_server(DecomposerRegister(class_names), id="decomposer_reg")
         self._add_to_client_apps(DecomposerRegister(class_names), id="decomposer_reg")
 
+    def _warn_potential_secrets_in_exported_job(self, job_dir: str) -> None:
+        """Scan the exported job's generated config files for secret-looking values.
+
+        This is a last-line best-effort check on the artifacts actually produced;
+        it does not redact values or make a job folder safe. Only generated JSON
+        config files are scanned -- user code bundled under ``custom/`` is not.
+        """
+        warn_on_potential_secrets_in_job_dir(
+            job_dir=job_dir,
+            job_name=getattr(self.job, "name", None),
+            context="exported job file",
+        )
+
     def export(
         self,
         job_dir: str,
@@ -575,6 +686,12 @@ class Recipe(ABC):
         env: Optional[ExecEnv] = None,
     ):
         """Export the recipe to a job definition.
+
+        Recipe parameters can appear in the exported job folder in clear text. Generated
+        config files are scanned and a ``PotentialSecretWarning`` is emitted for values that
+        look like actual secrets. This best-effort scan does not redact values or prove that
+        an export is safe; callers must follow the Recipe no-secret contract. See the Recipe
+        class docstring for how to pass references instead.
 
         Args:
             job_dir: directory where the job will be exported to.
@@ -585,10 +702,12 @@ class Recipe(ABC):
         Returns: None
 
         """
+        self._warn_potential_secrets_in_params()
         with self._temporary_exec_params(server_exec_params=server_exec_params, client_exec_params=client_exec_params):
             if env is not None:
                 self.process_env(env)
             self.job.export_job(job_dir)
+        self._warn_potential_secrets_in_exported_job(job_dir)
 
     def run(
         self, env: ExecEnv, server_exec_params: Optional[dict] = None, client_exec_params: Optional[dict] = None
@@ -603,6 +722,7 @@ class Recipe(ABC):
         Returns: Run to get job ID and execution results
 
         """
+        self._warn_potential_secrets_in_params()
         with self._temporary_exec_params(server_exec_params=server_exec_params, client_exec_params=client_exec_params):
             self.process_env(env)
             job_id = env.deploy(self.job)

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -96,6 +96,7 @@ from nvflare.fuel.utils.secret_utils import (
     warn_on_potential_secrets,
     warn_on_unsupported_secret_ref_keys,
     warn_on_unsupported_secret_refs,
+    warn_on_unsupported_secret_refs_outside_keys,
 )
 from nvflare.job_config.api import FedJob
 from nvflare.job_config.defs import FilterType
@@ -220,8 +221,11 @@ class Recipe(ABC):
             "extra_env",
             "run_config",
             "device_training_params",
+            "per_site_config",
         }
     )
+
+    _SUPPORTED_PER_SITE_SECRET_REF_KEYS = None
 
     def __init__(self, job: FedJob):
         """This is base class of a recipe. Recipes are implemented by jobs.
@@ -265,7 +269,15 @@ class Recipe(ABC):
                 context = f"recipe parameter '{attr}'"
                 warn_on_potential_secrets(value, context=context)
                 if attr in self._UNSUPPORTED_SECRET_REF_ATTRS:
-                    warn_on_unsupported_secret_refs(value, context=context)
+                    if attr == "per_site_config" and self._SUPPORTED_PER_SITE_SECRET_REF_KEYS is not None:
+                        warn_on_unsupported_secret_refs_outside_keys(
+                            value,
+                            supported_value_keys=self._SUPPORTED_PER_SITE_SECRET_REF_KEYS,
+                            supported_value_depth=2,
+                            context=context,
+                        )
+                    else:
+                        warn_on_unsupported_secret_refs(value, context=context)
 
     def process_env(self, env: ExecEnv):
         """Process environment-specific configuration.
@@ -287,6 +299,15 @@ class Recipe(ABC):
         docstring for the recommended alternatives.
         """
         warn_on_potential_secrets(config, context="per_site_config")
+        if self._SUPPORTED_PER_SITE_SECRET_REF_KEYS is not None:
+            warn_on_unsupported_secret_refs_outside_keys(
+                config,
+                supported_value_keys=self._SUPPORTED_PER_SITE_SECRET_REF_KEYS,
+                supported_value_depth=2,
+                context="per_site_config",
+            )
+        else:
+            warn_on_unsupported_secret_refs(config, context="per_site_config")
         self._helper_per_site_config = dict(config)
         self._apply_per_site_config(dict(self._helper_per_site_config))
 

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -243,7 +243,7 @@ class Recipe(ABC):
             :func:`nvflare.recipe.secrets.secret_file_ref` at a supported runtime boundary.
             See :mod:`nvflare.recipe.secrets` for the supported parameter locations.
 
-            Recipes scan their parameters with heuristics and emit
+            Before export or run, recipes scan their parameters with heuristics and emit
             :class:`nvflare.recipe.secrets.PotentialSecretWarning` when a value looks like an
             actual secret. The scan is best-effort: absence of a warning does not prove a
             parameter is safe to share.
@@ -254,14 +254,13 @@ class Recipe(ABC):
         self.job = job
         self._helper_per_site_config = None
         warn_on_potential_secrets(getattr(job, "name", None), context="recipe parameter 'name'")
-        self._warn_potential_secrets_in_params()
 
     def _warn_potential_secrets_in_params(self):
         """Warn if common recipe parameters look like they contain actual secret values.
 
-        Runs on conventional parameter attributes that concrete recipes retain before
-        calling ``Recipe.__init__``. Recipes that transform a parameter before calling
-        this constructor validate that original value explicitly.
+        Runs immediately before export or run on conventional parameter attributes that
+        concrete recipes retain. Recipes that transform a parameter before calling this
+        constructor validate that original value explicitly.
         """
         for attr in self._SECRET_PARAMETER_ATTRS:
             value = getattr(self, attr, None)

--- a/nvflare/recipe/utils.py
+++ b/nvflare/recipe/utils.py
@@ -23,6 +23,7 @@ from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE
 from nvflare.apis.dxo import DataKind
 from nvflare.apis.job_def import USER_SETTABLE_JOB_META_KEYS, JobMetaKey
 from nvflare.fuel.utils.import_utils import optional_import
+from nvflare.fuel.utils.secret_utils import warn_on_potential_secrets, warn_on_unsupported_secret_refs
 from nvflare.job_config.api import FedJob
 from nvflare.job_config.fed_job_config import FedJobConfig
 from nvflare.recipe.spec import Recipe
@@ -234,10 +235,13 @@ def set_recipe_meta(recipe: Recipe, key: JobMetaKey, value: Any) -> None:
     completely JSON-serializable, cannot contain non-finite floats, and have
     their keys coerced to strings as they will appear in ``meta.json``. The
     value is stored in ``meta_props`` and replaces any existing ``meta_props``
-    value for that key.
+    value for that key. Metadata is emitted in clear text in ``meta.json`` and
+    must never contain actual secret values; see :mod:`nvflare.recipe.secrets`.
     """
     key_str = _normalize_recipe_meta_key(key)
     normalized_value = _normalize_recipe_meta_value(key, key_str, value)
+    warn_on_potential_secrets(normalized_value, context=f"recipe metadata '{key_str}'")
+    warn_on_unsupported_secret_refs(normalized_value, context=f"recipe metadata '{key_str}'")
     job_config = _get_recipe_job_config(recipe)
 
     # RESOURCE_SPEC also has a dedicated FedJobConfig field (populated via
@@ -280,7 +284,9 @@ def set_per_site_config(recipe: Recipe, config: Dict[str, Dict]) -> None:
 
     Each recipe is responsible for validating and interpreting the fields inside
     each site's dictionary. The execution environment still controls which
-    clients are present for a run.
+    clients are present for a run. Per-site values become part of the generated
+    job definition and must never contain actual secret values; see
+    :mod:`nvflare.recipe.secrets`.
     """
     recipe.set_per_site_config(_validate_per_site_config_shape(config))
 
@@ -321,7 +327,10 @@ def add_experiment_tracking(
     Args:
         recipe: Recipe instance to augment with experiment tracking.
         tracking_type: Type of tracking to enable ("mlflow", "tensorboard", or "wandb").
-        tracking_config: Optional configuration dict for the tracking receiver.
+        tracking_config: Optional configuration dict for the tracking receiver. It becomes
+            part of the generated job definition and must never contain actual credentials;
+            configure authentication through the executing site's environment or a mounted
+            secret instead.
         client_side: If True, add tracking to clients (each client tracks locally).
         server_side: If True, add tracking to server (aggregates metrics from all clients). Default: True.
         clients: Optional list of client names for client-side tracking. If None, the
@@ -354,6 +363,8 @@ def add_experiment_tracking(
         )
     """
     tracking_config = tracking_config or {}
+    warn_on_potential_secrets(tracking_config, context="tracking_config")
+    warn_on_unsupported_secret_refs(tracking_config, context="tracking_config")
     if tracking_type not in TRACKING_REGISTRY:
         raise ValueError(f"Invalid tracking type: {tracking_type}")
 

--- a/nvflare/utils/configs.py
+++ b/nvflare/utils/configs.py
@@ -23,26 +23,37 @@ from nvflare.apis.fl_context import FLContext
 from nvflare.fuel.utils.secret_utils import resolve_secret_refs
 
 
-def get_job_config_value(fl_ctx: FLContext, config_file: str, key: str, default: Any = None) -> Any:
+def get_job_config_value(
+    fl_ctx: FLContext,
+    config_file: str,
+    key: str,
+    default: Any = None,
+    *,
+    resolve_refs: bool = True,
+) -> Any:
     """Generic function to read from any job config file.
 
-    Secret references in the selected value are resolved recursively at this runtime boundary.
-    This helper reads the exported JSON directly, so ordinary NVFlare placeholders such as
-    ``{SITE_NAME}`` are not expanded here and remain literal in the returned value, even when
-    they appear alongside secret references.
+    By default, secret references in the selected value are resolved recursively at this runtime
+    boundary. This helper reads the exported JSON directly, so ordinary NVFlare placeholders
+    such as ``{SITE_NAME}`` are not expanded here and remain literal in the returned value, even
+    when they appear alongside secret references.
 
     Args:
         fl_ctx: FLContext
         config_file: Name of the config file (e.g., JobConstants.CLIENT_JOB_CONFIG)
         key: The configuration key to read
         default: Default value if key is not found or reading fails. Defaults to None.
+        resolve_refs: Whether to resolve secret references in the selected value. Defaults to
+            True. Internal consumers that may serialize the value again must set this to False
+            and reject references rather than persisting resolved secret material.
 
     Returns:
         The configuration value if found, otherwise the default value.
 
     Raises:
-        ValueError: If the selected value contains a malformed reference, a referenced
-            environment variable is unset, or a referenced file cannot be read.
+        ValueError: If ``resolve_refs`` is True and the selected value contains a malformed
+            reference, a referenced environment variable is unset, or a referenced file cannot
+            be read.
     """
     value_found = False
     value = default
@@ -61,29 +72,36 @@ def get_job_config_value(fl_ctx: FLContext, config_file: str, key: str, default:
         # Silently return default on any error
         return default
 
-    # Resolve outside the broad file-reading exception handler so an unavailable secret
-    # reference fails explicitly instead of silently becoming the caller's default.
-    return resolve_secret_refs(value) if value_found else default
+    # When requested, resolve outside the broad file-reading exception handler so an unavailable
+    # secret reference fails explicitly instead of silently becoming the caller's default.
+    if not value_found:
+        return default
+    return resolve_secret_refs(value) if resolve_refs else value
 
 
-def get_client_config_value(fl_ctx: FLContext, key: str, default: Any = None) -> Any:
+def get_client_config_value(fl_ctx: FLContext, key: str, default: Any = None, *, resolve_refs: bool = True) -> Any:
     """Read a value from config_fed_client.json.
 
     This utility function reads top-level configuration values from the client config JSON file.
-    Jobs can set these values using recipe.add_client_config({"key": value}). Secret references
-    in the selected value are resolved recursively when it is read; dictionary keys are unchanged.
+    Jobs can set these values using recipe.add_client_config({"key": value}). By default, secret
+    references in the selected value are resolved recursively when it is read; dictionary keys
+    are unchanged.
 
     Args:
         fl_ctx: FLContext
         key: The configuration key to read
         default: Default value if key is not found or reading fails. Defaults to None.
+        resolve_refs: Whether to resolve secret references in the selected value. Defaults to
+            True. Consumers that may serialize the returned value must disable resolution and
+            reject references.
 
     Returns:
         The configuration value if found, otherwise the default value.
 
     Raises:
-        ValueError: If the selected value contains a malformed reference, a referenced
-            environment variable is unset, or a referenced file cannot be read.
+        ValueError: If ``resolve_refs`` is True and the selected value contains a malformed
+            reference, a referenced environment variable is unset, or a referenced file cannot
+            be read.
 
     Example:
         ```python
@@ -94,27 +112,38 @@ def get_client_config_value(fl_ctx: FLContext, key: str, default: Any = None) ->
         timeout = get_client_config_value(fl_ctx, EXTERNAL_PRE_INIT_TIMEOUT, default=300.0)
         ```
     """
-    return get_job_config_value(fl_ctx, JobConstants.CLIENT_JOB_CONFIG, key, default)
+    return get_job_config_value(
+        fl_ctx,
+        JobConstants.CLIENT_JOB_CONFIG,
+        key,
+        default,
+        resolve_refs=resolve_refs,
+    )
 
 
-def get_server_config_value(fl_ctx: FLContext, key: str, default: Any = None) -> Any:
+def get_server_config_value(fl_ctx: FLContext, key: str, default: Any = None, *, resolve_refs: bool = True) -> Any:
     """Read a value from config_fed_server.json.
 
     This utility function reads top-level configuration values from the server config JSON file.
-    Jobs can set these values using recipe.add_server_config({"key": value}). Secret references
-    in the selected value are resolved recursively when it is read; dictionary keys are unchanged.
+    Jobs can set these values using recipe.add_server_config({"key": value}). By default, secret
+    references in the selected value are resolved recursively when it is read; dictionary keys
+    are unchanged.
 
     Args:
         fl_ctx: FLContext
         key: The configuration key to read
         default: Default value if key is not found or reading fails. Defaults to None.
+        resolve_refs: Whether to resolve secret references in the selected value. Defaults to
+            True. Consumers that may serialize the returned value must disable resolution and
+            reject references.
 
     Returns:
         The configuration value if found, otherwise the default value.
 
     Raises:
-        ValueError: If the selected value contains a malformed reference, a referenced
-            environment variable is unset, or a referenced file cannot be read.
+        ValueError: If ``resolve_refs`` is True and the selected value contains a malformed
+            reference, a referenced environment variable is unset, or a referenced file cannot
+            be read.
 
     Example:
         ```python
@@ -124,4 +153,10 @@ def get_server_config_value(fl_ctx: FLContext, key: str, default: Any = None) ->
         custom_param = get_server_config_value(fl_ctx, "custom_param", default="default_value")
         ```
     """
-    return get_job_config_value(fl_ctx, JobConstants.SERVER_JOB_CONFIG, key, default)
+    return get_job_config_value(
+        fl_ctx,
+        JobConstants.SERVER_JOB_CONFIG,
+        key,
+        default,
+        resolve_refs=resolve_refs,
+    )

--- a/nvflare/utils/configs.py
+++ b/nvflare/utils/configs.py
@@ -27,9 +27,9 @@ def get_job_config_value(fl_ctx: FLContext, config_file: str, key: str, default:
     """Generic function to read from any job config file.
 
     Secret references in the selected value are resolved recursively at this runtime boundary.
-    This helper reads the exported JSON directly, so it does not expand ordinary NVFlare
-    placeholders such as ``{SITE_NAME}``. Do not combine those placeholders with secret
-    references in values consumed through this helper.
+    This helper reads the exported JSON directly, so ordinary NVFlare placeholders such as
+    ``{SITE_NAME}`` are not expanded here and remain literal in the returned value, even when
+    they appear alongside secret references.
 
     Args:
         fl_ctx: FLContext

--- a/nvflare/utils/configs.py
+++ b/nvflare/utils/configs.py
@@ -20,10 +20,16 @@ from typing import Any
 
 from nvflare.apis.fl_constant import JobConstants
 from nvflare.apis.fl_context import FLContext
+from nvflare.fuel.utils.secret_utils import resolve_secret_refs
 
 
 def get_job_config_value(fl_ctx: FLContext, config_file: str, key: str, default: Any = None) -> Any:
     """Generic function to read from any job config file.
+
+    Secret references in the selected value are resolved recursively at this runtime boundary.
+    This helper reads the exported JSON directly, so it does not expand ordinary NVFlare
+    placeholders such as ``{SITE_NAME}``. Do not combine those placeholders with secret
+    references in values consumed through this helper.
 
     Args:
         fl_ctx: FLContext
@@ -33,7 +39,13 @@ def get_job_config_value(fl_ctx: FLContext, config_file: str, key: str, default:
 
     Returns:
         The configuration value if found, otherwise the default value.
+
+    Raises:
+        ValueError: If the selected value contains a malformed reference, a referenced
+            environment variable is unset, or a referenced file cannot be read.
     """
+    value_found = False
+    value = default
     try:
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
@@ -43,19 +55,23 @@ def get_job_config_value(fl_ctx: FLContext, config_file: str, key: str, default:
         if os.path.exists(config_file_path):
             with open(config_file_path, "r") as f:
                 config_data = json.load(f)
-                return config_data.get(key, default)
+                value = config_data.get(key, default)
+                value_found = key in config_data
     except Exception:
         # Silently return default on any error
-        pass
+        return default
 
-    return default
+    # Resolve outside the broad file-reading exception handler so an unavailable secret
+    # reference fails explicitly instead of silently becoming the caller's default.
+    return resolve_secret_refs(value) if value_found else default
 
 
 def get_client_config_value(fl_ctx: FLContext, key: str, default: Any = None) -> Any:
     """Read a value from config_fed_client.json.
 
     This utility function reads top-level configuration values from the client config JSON file.
-    Jobs can set these values using recipe.add_client_config({"key": value}).
+    Jobs can set these values using recipe.add_client_config({"key": value}). Secret references
+    in the selected value are resolved recursively when it is read; dictionary keys are unchanged.
 
     Args:
         fl_ctx: FLContext
@@ -64,6 +80,10 @@ def get_client_config_value(fl_ctx: FLContext, key: str, default: Any = None) ->
 
     Returns:
         The configuration value if found, otherwise the default value.
+
+    Raises:
+        ValueError: If the selected value contains a malformed reference, a referenced
+            environment variable is unset, or a referenced file cannot be read.
 
     Example:
         ```python
@@ -81,7 +101,8 @@ def get_server_config_value(fl_ctx: FLContext, key: str, default: Any = None) ->
     """Read a value from config_fed_server.json.
 
     This utility function reads top-level configuration values from the server config JSON file.
-    Jobs can set these values using recipe.add_server_config({"key": value}).
+    Jobs can set these values using recipe.add_server_config({"key": value}). Secret references
+    in the selected value are resolved recursively when it is read; dictionary keys are unchanged.
 
     Args:
         fl_ctx: FLContext
@@ -90,6 +111,10 @@ def get_server_config_value(fl_ctx: FLContext, key: str, default: Any = None) ->
 
     Returns:
         The configuration value if found, otherwise the default value.
+
+    Raises:
+        ValueError: If the selected value contains a malformed reference, a referenced
+            environment variable is unset, or a referenced file cannot be read.
 
     Example:
         ```python

--- a/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
+++ b/tests/unit_test/app_common/executors/client_api_launcher_executor_test.py
@@ -259,10 +259,58 @@ _GCV_MODULE = "nvflare.app_common.executors.client_api_launcher_executor.get_cli
 def _make_gcv_stub(overrides: dict):
     """Return a get_client_config_value replacement that answers from *overrides*."""
 
-    def _gcv(fl_ctx, key, default=None):
+    def _gcv(fl_ctx, key, default=None, *, resolve_refs=True):
         return overrides.get(key, default)
 
     return _gcv
+
+
+def test_client_config_secret_ref_is_rejected_with_key_context(monkeypatch):
+    from nvflare.client.config import ConfigKey
+
+    errors = []
+    calls = []
+
+    def _return_raw_ref(fl_ctx, key, default=None, *, resolve_refs=True):
+        calls.append((key, resolve_refs))
+        return "${secret:SITE_API_KEY}"
+
+    monkeypatch.setattr(_GCV_MODULE, _return_raw_ref)
+    monkeypatch.setattr(ClientAPILauncherExecutor, "log_error", lambda self, fl_ctx, msg: errors.append(msg))
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
+
+    with pytest.raises(ValueError, match="Secret references are not supported.*'submit_result_timeout'"):
+        executor._get_client_config_override(MagicMock(), ConfigKey.SUBMIT_RESULT_TIMEOUT)
+
+    assert calls == [(ConfigKey.SUBMIT_RESULT_TIMEOUT, False)]
+    assert errors == [
+        "Secret references are not supported for client config override 'submit_result_timeout' "
+        "because this value is written to runtime configuration"
+    ]
+
+
+def test_client_config_secret_ref_is_never_resolved_or_written(monkeypatch):
+    from nvflare.client.config import ConfigKey
+
+    resolved_secret = "synthetic-resolved-secret-value"
+    writes = []
+    monkeypatch.setenv("SITE_API_KEY", resolved_secret)
+    monkeypatch.setattr(
+        _GCV_MODULE,
+        _make_gcv_stub({ConfigKey.SUBMIT_RESULT_TIMEOUT: "${secret:SITE_API_KEY}"}),
+    )
+    monkeypatch.setattr(
+        "nvflare.app_common.executors.client_api_launcher_executor.write_config_to_file",
+        lambda config_data, config_file_path: writes.append(config_data),
+    )
+    monkeypatch.setattr(ClientAPILauncherExecutor, "log_error", lambda self, fl_ctx, msg: None)
+    executor = ClientAPILauncherExecutor(pipe_id="test_pipe")
+
+    with pytest.raises(ValueError, match="Secret references are not supported.*'submit_result_timeout'"):
+        executor.initialize(_FakeFLContext(_FakeCell()))
+
+    assert writes == []
+    assert resolved_secret not in repr(writes)
 
 
 class _RecordingLock:

--- a/tests/unit_test/app_common/executors/task_script_runner_test.py
+++ b/tests/unit_test/app_common/executors/task_script_runner_test.py
@@ -15,12 +15,15 @@
 import os
 import shutil
 import sys
+import tempfile
 import unittest
+from unittest.mock import patch
 
 import pytest
 
 from nvflare.app_common.executors.task_script_runner import TaskScriptRunner
 from nvflare.client.in_process.api import TOPIC_ABORT, TOPIC_STOP
+from nvflare.fuel.utils.secret_utils import secret_file_ref
 
 
 class TestTaskScriptRunner(unittest.TestCase):
@@ -56,6 +59,103 @@ class TestTaskScriptRunner(unittest.TestCase):
 
         self.assertTrue(wrapper.script_full_path.endswith(script_path))
         self._assert_argv_path(wrapper, os.path.join(self.nvflare_root, "nvflare", "cli.py"), ["--batch_size", "4"])
+
+    def test_secret_ref_args_resolved_from_env(self):
+        script_path = "nvflare/cli.py"
+        script_args = "--api_key ${secret:TEST_SECRET_REF_VAR}"
+        wrapper = TaskScriptRunner(custom_dir=self.nvflare_root, script_path=script_path, script_args=script_args)
+
+        with patch.dict(os.environ, {"TEST_SECRET_REF_VAR": "resolved secret"}):
+            argv = wrapper.get_sys_argv()
+
+        # the value from the site env is injected as a single argument, even with whitespace
+        assert argv[1:] == ["--api_key", "resolved secret"]
+        # the configured args (what job configs carry) still hold only the placeholder
+        assert "${secret:TEST_SECRET_REF_VAR}" in wrapper.script_args
+        assert "resolved secret" not in wrapper.script_args
+
+    def test_secret_ref_in_quoted_composite_argument(self):
+        wrapper = TaskScriptRunner(
+            custom_dir=self.nvflare_root,
+            script_path="nvflare/cli.py",
+            script_args='--authorization "Bearer ${secret:TEST_SECRET_REF_VAR}"',
+        )
+
+        with patch.dict(os.environ, {"TEST_SECRET_REF_VAR": "resolved secret"}):
+            argv = wrapper.get_sys_argv()
+
+        assert argv[1:] == ["--authorization", "Bearer resolved secret"]
+
+    def test_secret_ref_does_not_change_unrelated_backslashes_or_quotes(self):
+        wrapper = TaskScriptRunner(
+            custom_dir=self.nvflare_root,
+            script_path="nvflare/cli.py",
+            script_args=(
+                r'--regex \d+ --path C:\data\x --legacy "two words" '
+                r'--authorization "Bearer ${secret:TEST_SECRET_REF_VAR}"'
+            ),
+        )
+
+        with patch.dict(os.environ, {"TEST_SECRET_REF_VAR": "resolved"}):
+            argv = wrapper.get_sys_argv()
+
+        assert argv[1:] == [
+            "--regex",
+            r"\d+",
+            "--path",
+            r"C:\data\x",
+            "--legacy",
+            '"two',
+            'words"',
+            "--authorization",
+            "Bearer resolved",
+        ]
+
+    def test_secret_file_ref_content_is_one_argument(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_path = os.path.join(temp_dir, "api-key")
+            with open(secret_path, "w", encoding="utf-8") as secret_file:
+                secret_file.write("resolved secret --not-option")
+
+            placeholder = secret_file_ref(secret_path)
+            wrapper = TaskScriptRunner(
+                custom_dir=self.nvflare_root,
+                script_path="nvflare/cli.py",
+                script_args=f"--api_key {placeholder}",
+            )
+
+            argv = wrapper.get_sys_argv()
+
+        assert argv[1:] == ["--api_key", "resolved secret --not-option"]
+        assert placeholder in wrapper.script_args
+        assert "resolved secret" not in wrapper.script_args
+
+    def test_secret_ref_args_missing_env_var_raises(self):
+        script_path = "nvflare/cli.py"
+        script_args = "--api_key ${secret:TEST_UNSET_SECRET_VAR}"
+        wrapper = TaskScriptRunner(custom_dir=self.nvflare_root, script_path=script_path, script_args=script_args)
+
+        os.environ.pop("TEST_UNSET_SECRET_VAR", None)
+        with pytest.raises(ValueError, match="TEST_UNSET_SECRET_VAR"):
+            wrapper.get_sys_argv()
+
+    def test_run_restores_sys_argv_when_script_fails(self):
+        wrapper = TaskScriptRunner(
+            custom_dir=self.nvflare_root,
+            script_path="nvflare/cli.py",
+            script_args="--api_key ${secret:TEST_SECRET_REF_VAR}",
+            redirect_print_to_log=False,
+        )
+        original_argv = sys.argv
+
+        with patch.dict(os.environ, {"TEST_SECRET_REF_VAR": "resolved secret"}):
+            with patch(
+                "nvflare.app_common.executors.task_script_runner.runpy.run_path", side_effect=RuntimeError("boom")
+            ):
+                with pytest.raises(RuntimeError, match="boom"):
+                    wrapper.run()
+
+        assert sys.argv is original_argv
 
     def test_app_scripts_with_sub_dirs1(self):
         # curr_dir = os.getcwd()

--- a/tests/unit_test/app_common/launchers/subprocess_launcher_test.py
+++ b/tests/unit_test/app_common/launchers/subprocess_launcher_test.py
@@ -225,6 +225,110 @@ class TestSubprocessLauncher:
                 "__test_task", DXO(DataKind.WEIGHTS, {}).to_shareable(), self._make_fl_ctx(str(tmp_path)), Signal()
             )
 
+    @pytest.mark.parametrize(
+        "script",
+        [
+            "sh -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "/bin/bash -lc 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "bash --rcfile /tmp/bashrc -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            r'"C:\Program Files\Git\bin\BASH.EXE" -c "echo ${secret:TEST_SECRET_REF_VAR}"',
+            "env FOO=bar sh -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "env -- FOO=bar sh -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "env -- OUTER=1 env -- INNER=2 sh -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "/usr/bin/env -i FOO=bar /bin/bash -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "env --unknown-option value sh -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+            "env -S \"bash -c 'echo ${secret:TEST_SECRET_REF_VAR}'\"",
+            r'"C:\Program Files\PowerShell\7\PwSh.ExE" -CoMmAnD "Write-Output ${secret:TEST_SECRET_REF_VAR}"',
+            "pwsh -Command 'Invoke-Expression ${secret:TEST_SECRET_REF_VAR}'",
+            "pwsh -Bogus value -Command 'Invoke-Expression ${secret:TEST_SECRET_REF_VAR}'",
+            "pwsh -EncodedCommand ${secret:TEST_SECRET_REF_VAR}",
+            "pwsh -enc ${secret:TEST_SECRET_REF_VAR}",
+        ],
+    )
+    def test_start_external_process_rejects_secret_ref_in_nested_command(self, monkeypatch, tmp_path, script):
+        popen = Mock()
+        monkeypatch.setattr("nvflare.app_common.launchers.subprocess_launcher.subprocess.Popen", popen)
+        monkeypatch.setenv("TEST_SECRET_REF_VAR", "'; injected-command #")
+        launcher = SubprocessLauncher(script, launch_once=False)
+        launcher._app_dir = str(tmp_path)
+
+        with pytest.raises(ValueError, match="nested interpreter command strings"):
+            launcher.launch_task(
+                "__test_task", DXO(DataKind.WEIGHTS, {}).to_shareable(), self._make_fl_ctx(str(tmp_path)), Signal()
+            )
+
+        popen.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "script,expected_command",
+        [
+            (
+                "bash train.sh ${secret:TEST_SECRET_REF_VAR}",
+                ["bash", "train.sh", "resolved secret"],
+            ),
+            (
+                "pwsh -File train.ps1 ${secret:TEST_SECRET_REF_VAR}",
+                ["pwsh", "-File", "train.ps1", "resolved secret"],
+            ),
+            (
+                "env -- API_TOKEN=${secret:TEST_SECRET_REF_VAR} sh -c 'echo \"$API_TOKEN\"'",
+                ["env", "--", "API_TOKEN=resolved secret", "sh", "-c", 'echo "$API_TOKEN"'],
+            ),
+            (
+                "echo python -c ${secret:TEST_SECRET_REF_VAR}",
+                ["echo", "python", "-c", "resolved secret"],
+            ),
+            (
+                "python train.py --label node -e ${secret:TEST_SECRET_REF_VAR}",
+                ["python", "train.py", "--label", "node", "-e", "resolved secret"],
+            ),
+            (
+                "pwsh train.ps1 -Command ${secret:TEST_SECRET_REF_VAR}",
+                ["pwsh", "train.ps1", "-Command", "resolved secret"],
+            ),
+        ],
+    )
+    def test_start_external_process_allows_secret_ref_in_interpreter_argv(
+        self, monkeypatch, tmp_path, script, expected_command
+    ):
+        popen_calls = []
+
+        class _Proc:
+            pid = 1234
+            stdout = BufferedReader(BytesIO(b""))
+
+            def __init__(self, *args, **kwargs):
+                popen_calls.append({"args": args, "kwargs": kwargs})
+
+        monkeypatch.setattr("nvflare.app_common.launchers.subprocess_launcher.subprocess.Popen", _Proc)
+        monkeypatch.setenv("TEST_SECRET_REF_VAR", "resolved secret")
+        launcher = SubprocessLauncher(script, launch_once=False)
+        launcher._app_dir = str(tmp_path)
+
+        launcher.launch_task(
+            "__test_task", DXO(DataKind.WEIGHTS, {}).to_shareable(), self._make_fl_ctx(str(tmp_path)), Signal()
+        )
+        launcher._log_thread.join()
+
+        assert popen_calls[0]["args"][0] == expected_command
+
+    def test_clean_up_rejects_secret_ref_in_nested_command(self, monkeypatch):
+        popen = Mock()
+        launcher = SubprocessLauncher(
+            "python train.py",
+            launch_once=False,
+            clean_up_script="env FOO=bar bash -c 'echo ${secret:TEST_SECRET_REF_VAR}'",
+        )
+        launcher._process = Mock()
+        launcher._log_thread = Mock()
+        launcher._terminate_process = Mock()
+        monkeypatch.setattr("nvflare.app_common.launchers.subprocess_launcher.subprocess.Popen", popen)
+
+        with pytest.raises(ValueError, match="nested interpreter command strings"):
+            launcher._stop_external_process()
+
+        popen.assert_not_called()
+
     def test_stop_external_process_terminates_posix_process_group(self, monkeypatch):
         killpg_calls = []
 

--- a/tests/unit_test/app_common/launchers/subprocess_launcher_test.py
+++ b/tests/unit_test/app_common/launchers/subprocess_launcher_test.py
@@ -30,6 +30,7 @@ from nvflare.app_common.launchers.subprocess_launcher import (
     _route_subprocess_line,
     log_subprocess_output,
 )
+from nvflare.fuel.utils.secret_utils import secret_file_ref
 
 
 class TestSubprocessLauncher:
@@ -160,6 +161,69 @@ class TestSubprocessLauncher:
 
         assert popen_calls[0]["kwargs"]["start_new_session"] is True
         assert launcher._process is not None
+
+    def test_start_external_process_resolves_secret_refs(self, monkeypatch, tmp_path):
+        popen_calls = []
+
+        class _Proc:
+            pid = 1234
+            stdout = BufferedReader(BytesIO(b""))
+
+            def __init__(self, *args, **kwargs):
+                popen_calls.append({"args": args, "kwargs": kwargs})
+
+        monkeypatch.setattr("nvflare.app_common.launchers.subprocess_launcher.subprocess.Popen", _Proc)
+        monkeypatch.setenv("TEST_SECRET_REF_VAR", "resolved secret")
+        launcher = SubprocessLauncher("python train.py --api-key ${secret:TEST_SECRET_REF_VAR}", launch_once=False)
+        launcher._app_dir = str(tmp_path)
+
+        launcher.launch_task(
+            "__test_task", DXO(DataKind.WEIGHTS, {}).to_shareable(), self._make_fl_ctx(str(tmp_path)), Signal()
+        )
+        launcher._log_thread.join()
+
+        # the value from the site env is injected as a single argument, even with whitespace
+        assert popen_calls[0]["args"][0] == ["python", "train.py", "--api-key", "resolved secret"]
+        # the launcher's configured script (what job configs carry) still holds only the placeholder
+        assert "${secret:TEST_SECRET_REF_VAR}" in launcher._script
+        assert "resolved secret" not in launcher._script
+
+    def test_start_external_process_resolves_file_ref_as_one_argument(self, monkeypatch, tmp_path):
+        popen_calls = []
+
+        class _Proc:
+            pid = 1234
+            stdout = BufferedReader(BytesIO(b""))
+
+            def __init__(self, *args, **kwargs):
+                popen_calls.append({"args": args, "kwargs": kwargs})
+
+        secret_path = tmp_path / "api'key\\value"
+        secret_path.write_text("resolved secret --not-option")
+        placeholder = secret_file_ref(str(secret_path))
+        monkeypatch.setattr("nvflare.app_common.launchers.subprocess_launcher.subprocess.Popen", _Proc)
+        launcher = SubprocessLauncher(f"python train.py --api-key {placeholder}", launch_once=False)
+        launcher._app_dir = str(tmp_path)
+
+        launcher.launch_task(
+            "__test_task", DXO(DataKind.WEIGHTS, {}).to_shareable(), self._make_fl_ctx(str(tmp_path)), Signal()
+        )
+        launcher._log_thread.join()
+
+        assert popen_calls[0]["args"][0] == ["python", "train.py", "--api-key", "resolved secret --not-option"]
+        assert placeholder in launcher._script
+        assert "resolved secret" not in launcher._script
+
+    def test_start_external_process_missing_secret_ref_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("nvflare.app_common.launchers.subprocess_launcher.subprocess.Popen", Mock())
+        monkeypatch.delenv("TEST_UNSET_SECRET_VAR", raising=False)
+        launcher = SubprocessLauncher("python train.py --api-key ${secret:TEST_UNSET_SECRET_VAR}", launch_once=False)
+        launcher._app_dir = str(tmp_path)
+
+        with pytest.raises(ValueError, match="TEST_UNSET_SECRET_VAR"):
+            launcher.launch_task(
+                "__test_task", DXO(DataKind.WEIGHTS, {}).to_shareable(), self._make_fl_ctx(str(tmp_path)), Signal()
+            )
 
     def test_stop_external_process_terminates_posix_process_group(self, monkeypatch):
         killpg_calls = []

--- a/tests/unit_test/app_opt/pt/recipes/fed_eval_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fed_eval_recipe_test.py
@@ -82,8 +82,10 @@ class TestFedEvalRecipe:
         params = dict(base_recipe_params)
         params["eval_args"] = "--password hunter22x"
 
+        recipe = FedEvalRecipe(name="secret_eval", model=model, **params)
+
         with pytest.warns(PotentialSecretWarning, match="eval_args"):
-            FedEvalRecipe(name="secret_eval", model=model, **params)
+            recipe._warn_potential_secrets_in_params()
 
     def test_external_command_secret_ref_is_supported(self, mock_file_system, base_recipe_params, simple_model):
         model, _ = simple_model

--- a/tests/unit_test/app_opt/pt/recipes/fed_eval_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fed_eval_recipe_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -20,6 +21,7 @@ from pydantic import ValidationError
 
 from nvflare.app_opt.pt.recipes.fedeval import FedEvalRecipe
 from nvflare.client.config import ExchangeFormat
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning, UnsupportedSecretRefWarning
 
 
 class SimpleTestModel(nn.Module):
@@ -74,6 +76,30 @@ def assert_recipe_basics(recipe, expected_name, expected_params):
 
 class TestFedEvalRecipe:
     """Test cases for FedEvalRecipe class."""
+
+    def test_warns_on_secret_in_eval_args(self, mock_file_system, base_recipe_params, simple_model):
+        model, _ = simple_model
+        params = dict(base_recipe_params)
+        params["eval_args"] = "--password hunter22x"
+
+        with pytest.warns(PotentialSecretWarning, match="eval_args"):
+            FedEvalRecipe(name="secret_eval", model=model, **params)
+
+    def test_external_command_secret_ref_is_supported(self, mock_file_system, base_recipe_params, simple_model):
+        model, _ = simple_model
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnsupportedSecretRefWarning)
+            FedEvalRecipe(
+                name="command_secret_ref",
+                model=model,
+                per_site_config={
+                    "site-1": {
+                        "launch_external_process": True,
+                        "command": "env API_TOKEN=${secret:API_TOKEN} python3 -u",
+                    }
+                },
+                **base_recipe_params,
+            )
 
     def test_basic_initialization(self, mock_file_system, base_recipe_params, simple_model):
         """Test FedEvalRecipe initialization with default parameters."""

--- a/tests/unit_test/fuel/utils/job_secret_scanner_test.py
+++ b/tests/unit_test/fuel/utils/job_secret_scanner_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import warnings
+
+import pytest
+
+from nvflare.fuel.utils.job_secret_scanner import warn_on_potential_secrets_in_job_dir
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning
+
+
+def test_warns_on_generated_config_without_exposing_value(tmp_path):
+    config_dir = tmp_path / "job" / "app" / "config"
+    config_dir.mkdir(parents=True)
+    secret = "ghp_" + "Ab1" * 12
+    (config_dir / "config_fed_client.json").write_text(json.dumps({"token": secret}))
+
+    with pytest.warns(PotentialSecretWarning) as record:
+        findings = warn_on_potential_secrets_in_job_dir(str(tmp_path), job_name="job")
+
+    assert findings
+    assert all(secret not in str(warning.message) for warning in record)
+
+
+def test_ignores_custom_source_files(tmp_path):
+    custom_dir = tmp_path / "job" / "app" / "custom"
+    custom_dir.mkdir(parents=True)
+    (custom_dir / "config_fed_client.json").write_text(json.dumps({"password": "hunter22x"}))
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        findings = warn_on_potential_secrets_in_job_dir(str(tmp_path), job_name="job")
+
+    assert findings == []
+    assert not [warning for warning in record if issubclass(warning.category, PotentialSecretWarning)]

--- a/tests/unit_test/fuel/utils/secret_utils_test.py
+++ b/tests/unit_test/fuel/utils/secret_utils_test.py
@@ -128,6 +128,47 @@ class TestSecretRef:
         with pytest.raises(ValueError, match="invalid secret reference syntax"):
             resolve_secret_refs(tokens[1], env={"BADNAME": "must-not-resolve"})
 
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            (
+                '--publisher O\'Reilly --authorization "Bearer ${secret:TOKEN}"',
+                ["--publisher", "O'Reilly", "--authorization", "Bearer ${secret:TOKEN}"],
+            ),
+            (
+                "--note unmatched\"quote --authorization 'Bearer ${secret:TOKEN}'",
+                ["--note", 'unmatched"quote', "--authorization", "Bearer ${secret:TOKEN}"],
+            ),
+            (
+                '--note unmatched"quote --authorization "Bearer ${secret:TOKEN}"',
+                ["--note", 'unmatched"quote', "--authorization", "Bearer ${secret:TOKEN}"],
+            ),
+            (
+                '--authorization="Bearer ${secret:TOKEN}"',
+                ["--authorization=Bearer ${secret:TOKEN}"],
+            ),
+            (
+                '--authorization=prefix"Bearer ${secret:TOKEN}"',
+                ["--authorization=prefixBearer ${secret:TOKEN}"],
+            ),
+        ],
+    )
+    def test_command_tokenization_finds_quoted_secret_ref_after_unmatched_quote(self, command, expected):
+        tokens = split_command_preserving_secret_refs(command, posix=False, group_secret_ref_quotes=True)
+
+        assert tokens == expected
+
+    def test_command_tokenization_preserves_balanced_non_secret_quotes_around_unquoted_ref(self):
+        for quoted in ('"one"', '"one "', '"one:"'):
+            command = f'--a {quoted} --b ${{secret:TOKEN}} --c "two"'
+            tokens = split_command_preserving_secret_refs(
+                command,
+                posix=False,
+                group_secret_ref_quotes=True,
+            )
+
+            assert tokens == command.split()
+
     def test_resolve_missing_env_var_raises_without_leaking(self):
         with pytest.raises(ValueError) as exc_info:
             resolve_secret_refs("--key ${secret:MISSING_VAR}", env={"OTHER": "other-value"})

--- a/tests/unit_test/fuel/utils/secret_utils_test.py
+++ b/tests/unit_test/fuel/utils/secret_utils_test.py
@@ -1,0 +1,371 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import warnings
+
+import pytest
+
+from nvflare.fuel.utils.secret_utils import (
+    PotentialSecretWarning,
+    UnsupportedSecretRefWarning,
+    find_potential_secrets,
+    has_secret_refs,
+    resolve_secret_refs,
+    secret_file_ref,
+    secret_ref,
+    split_command_preserving_secret_refs,
+    warn_on_potential_secrets,
+    warn_on_unsupported_secret_ref_keys,
+    warn_on_unsupported_secret_refs,
+    warn_on_unsupported_secret_refs_outside_keys,
+)
+
+# Fake credentials for testing the detector -- none of these are real.
+FAKE_GITHUB_TOKEN = "ghp_" + "Ab1" * 12
+FAKE_AWS_KEY_ID = "AKIA" + "ABCDEFGHIJKLMNOP"
+FAKE_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N3XgL0n3I9P"
+FAKE_HEX_KEY = "0123456789abcdef0123456789abcdef01234567"
+FAKE_HIGH_ENTROPY = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789+/=-_"
+
+
+class TestSecretRef:
+    def test_secret_ref_format(self):
+        assert secret_ref("MY_API_KEY") == "${secret:MY_API_KEY}"
+
+    @pytest.mark.parametrize("bad_name", ["", "1BAD", "MY-KEY", "MY KEY", None, 123])
+    def test_secret_ref_invalid_name_raises(self, bad_name):
+        with pytest.raises(ValueError):
+            secret_ref(bad_name)
+
+    def test_secret_file_ref_format(self):
+        assert secret_file_ref("/var/run/secrets/my-app/api-key") == "${secret:file:/var/run/secrets/my-app/api-key}"
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "",
+            "/bad{path",
+            "/bad}path",
+            "/secret path/key",
+            "/bad\npath",
+            "/bad\0path",
+            "/bad\x1bpath",
+            None,
+            123,
+        ],
+    )
+    def test_secret_file_ref_invalid_path_raises(self, bad_path):
+        with pytest.raises(ValueError):
+            secret_file_ref(bad_path)
+
+    def test_has_secret_refs(self):
+        assert has_secret_refs("--key ${secret:MY_KEY}")
+        assert has_secret_refs("--key-file ${secret:file:/var/run/secrets/my-app/api-key}")
+        assert not has_secret_refs("--key plainvalue")
+        assert not has_secret_refs(123)
+
+    def test_resolve_single_ref(self):
+        assert resolve_secret_refs("--key ${secret:A}", env={"A": "value-a"}) == "--key value-a"
+
+    def test_resolve_multiple_refs(self):
+        result = resolve_secret_refs("${secret:A}:${secret:B}", env={"A": "x", "B": "y z"})
+        assert result == "x:y z"
+
+    def test_resolve_file_ref(self, tmp_path):
+        secret_file = tmp_path / "api-key"
+        secret_file.write_text("file-secret-value")
+
+        assert resolve_secret_refs(secret_file_ref(str(secret_file)), env={}) == "file-secret-value"
+
+    def test_resolve_env_and_file_refs_recursively_without_resolving_keys(self, tmp_path):
+        secret_file = tmp_path / "api-key"
+        secret_file.write_text("file-secret-value")
+        unresolved_key = "${secret:KEY_MUST_NOT_BE_RESOLVED}"
+        value = {
+            "env": "prefix-${secret:API_KEY}",
+            "nested": [secret_file_ref(str(secret_file)), {"pair": ("${secret:A}", "plain")}],
+            unresolved_key: "${secret:B}",
+        }
+
+        result = resolve_secret_refs(
+            value,
+            env={"API_KEY": "env-secret-value", "A": "a-secret-value", "B": "b-secret-value"},
+        )
+
+        assert result == {
+            "env": "prefix-env-secret-value",
+            "nested": ["file-secret-value", {"pair": ("a-secret-value", "plain")}],
+            unresolved_key: "b-secret-value",
+        }
+
+    def test_resolve_no_refs_passthrough(self):
+        assert resolve_secret_refs("--epochs 5", env={}) == "--epochs 5"
+
+    @pytest.mark.parametrize("posix", [False, True])
+    def test_command_tokenization_preserves_reference_characters(self, posix):
+        reference = "${secret:file:/tmp/api'key\\value}"
+        tokens = split_command_preserving_secret_refs(f"python train.py --api-key {reference}", posix=posix)
+
+        assert tokens == ["python", "train.py", "--api-key", reference]
+
+    def test_command_tokenization_preserves_malformed_reference_for_validation(self):
+        malformed = "${secret:BAD\\NAME}"
+        tokens = split_command_preserving_secret_refs(f"--api-key {malformed}", posix=True)
+
+        assert tokens == ["--api-key", malformed]
+        with pytest.raises(ValueError, match="invalid secret reference syntax"):
+            resolve_secret_refs(tokens[1], env={"BADNAME": "must-not-resolve"})
+
+    def test_resolve_missing_env_var_raises_without_leaking(self):
+        with pytest.raises(ValueError) as exc_info:
+            resolve_secret_refs("--key ${secret:MISSING_VAR}", env={"OTHER": "other-value"})
+        assert "MISSING_VAR" in str(exc_info.value)
+        assert "other-value" not in str(exc_info.value)
+
+    def test_resolve_missing_file_raises_without_leaking_other_values(self, tmp_path):
+        missing_file = tmp_path / "missing-api-key"
+        with pytest.raises(ValueError) as exc_info:
+            resolve_secret_refs(secret_file_ref(str(missing_file)), env={"OTHER": "other-secret-value"})
+        assert str(missing_file) in str(exc_info.value)
+        assert "other-secret-value" not in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "malformed_ref",
+        ["${secret:BAD-NAME}", "${secret:UNFINISHED", "${secret:file:/secret path/key}"],
+    )
+    def test_resolve_malformed_ref_raises_without_echoing_value(self, malformed_ref):
+        with pytest.raises(ValueError) as exc_info:
+            resolve_secret_refs(malformed_ref, env={})
+
+        assert "invalid secret reference syntax" in str(exc_info.value)
+        assert malformed_ref not in str(exc_info.value)
+
+
+class TestFindPotentialSecrets:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            f"--api_key {FAKE_GITHUB_TOKEN}",
+            f"--aws-key {FAKE_AWS_KEY_ID}",
+            FAKE_JWT,
+            "-----BEGIN PRIVATE KEY-----\nMIIabcdef\n-----END PRIVATE KEY-----",
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "--tracking_uri https://alice:p4ssw0rd123@tracking.example.com",
+            "--password hunter22x",
+            "--auth-token=abcd1234efgh",
+            "env API_PASSWORD=hunter22x python3 -u",
+            "API_TOKEN=actualSecret123",
+            "docker run --env=API_PASSWORD=hunter22x image",
+            "kubectl run app --env=API_TOKEN=actualSecret123",
+            'powershell -Command "$env:API_PASSWORD=hunter22x"',
+            "sh -c 'export API_PASSWORD=hunter22x; python3 train.py'",
+            "sh -c 'MODE=prod API_PASSWORD=hunter22x python3 train.py'",
+            'powershell -Command "$env:MODE=prod; $env:API_PASSWORD=hunter22x; python train.py"',
+            "curl 'https://example.test?mode=prod&API_TOKEN=hunter22x'",
+            "MODE=prod,API_PASSWORD=hunter22x",
+            "MODE=prod&API_PASSWORD=hunter22x",
+            "env API_PASSWORD=?hunter22x python3",
+            "env API_PASSWORD=&hunter22x python3",
+            "env API_PASSWORD=,hunter22x python3",
+            "env API_PASSWORD=abc?hunter22x python3",
+            'API_TOKEN="sv=2024-01-01&sig=abcdefgh123456"',
+            'API_PASSWORD="abc MODE=hunter22x"',
+            f"--wandb_key {FAKE_HEX_KEY}",
+            FAKE_HIGH_ENTROPY,
+            {"api_key": "abcd1234efgh"},
+            {"outer": {"client_secret": "abcd1234efgh"}},
+            {"receivers": [{"password": "abcd1234efgh"}]},
+            {"password": "$uperSecret123"},
+            {"Authorization": "Bearer abcdefgh123456"},
+        ],
+    )
+    def test_positives(self, value):
+        assert find_potential_secrets(value, location="test")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "--epochs 10 --lr 0.001 --batch_size 32",
+            "--tokenizer_path /models/tok --max_tokens 512",
+            "--data_path /data/site-1/train.csv",
+            "--key_metric accuracy",
+            "--use_auth true",
+            "https://mlflow.example.com/api/2.0/experiments",
+            "/opt/very/long/path/to/experiment/data_v2/train",
+            f"--api-key {secret_ref('MY_KEY')}",
+            "env API_TOKEN=${secret:API_TOKEN} python3 -u",
+            "API_TOKEN=${secret:API_TOKEN}&MODE=prod",
+            "API_PASSWORD=$API_PASSWORD python3 -u",
+            "docker run --env=API_TOKEN=${secret:API_TOKEN} image",
+            'powershell -Command "$env:API_PASSWORD=${secret:API_PASSWORD}"',
+            "sh -c 'export API_PASSWORD=${secret:API_PASSWORD}; python3 train.py'",
+            'powershell -Command "$env:MODE=prod; $env:API_PASSWORD=${secret:API_PASSWORD}; python train.py"',
+            'AUTHORIZATION="Bearer ${secret:AUTH_TOKEN}" python3 -u',
+            "env DATA_PATH=/data/site-1/train.csv python3 -u",
+            {"token": "${secret:MY_TOKEN}"},
+            {"token": "${secret:file:/var/run/secrets/my-app/api-key}"},
+            {"private_key": "/etc/secrets/key.pem"},
+            {"password": "$PASSWORD_VAR"},
+            {"password": "${PASSWORD_VAR}"},
+            {"password": "%PASSWORD_VAR%"},
+            {"token": "{JOB_ID}"},
+            {"epochs": 10, "lr": 0.001},
+            ["--epochs", "10"],
+            42,
+            None,
+        ],
+    )
+    def test_negatives(self, value):
+        assert find_potential_secrets(value, location="test") == []
+
+    def test_finding_reports_location(self):
+        findings = find_potential_secrets({"site-1": {"api_key": "abcd1234efgh"}}, location="per_site_config")
+        assert len(findings) == 1
+        assert "per_site_config" in findings[0].location
+        assert findings[0].reason == "value of a secret-named key"
+
+    def test_findings_never_contain_the_secret(self):
+        secret_value = "abcdefgh1234567890secret"
+        findings = find_potential_secrets({"password": secret_value}, location="test")
+        assert findings
+        for finding in findings:
+            assert secret_value not in finding.preview
+            assert secret_value not in finding.location
+            assert secret_value not in finding.reason
+
+    def test_secret_like_mapping_key_is_masked_in_all_findings(self):
+        findings = find_potential_secrets(
+            {FAKE_GITHUB_TOKEN: {"password": "abcdefgh1234"}},
+            location="test",
+        )
+        assert findings
+        for finding in findings:
+            assert FAKE_GITHUB_TOKEN not in finding.preview
+            assert FAKE_GITHUB_TOKEN not in finding.location
+            assert FAKE_GITHUB_TOKEN not in finding.reason
+
+    def test_low_entropy_mapping_key_is_not_copied_into_descendant_finding(self):
+        key_secret = "hunter22x"
+        findings = find_potential_secrets({key_secret: {"password": "abcdefgh1234"}}, location="test")
+        assert findings
+        assert all(key_secret not in finding.location for finding in findings)
+
+    def test_secret_like_flag_name_is_masked_in_all_findings(self):
+        secret_flag = f"--api-key-{FAKE_GITHUB_TOKEN}"
+        findings = find_potential_secrets(f"{secret_flag} dummyvalue", location="test")
+        assert findings
+        for finding in findings:
+            assert FAKE_GITHUB_TOKEN not in finding.preview
+            assert FAKE_GITHUB_TOKEN not in finding.location
+            assert FAKE_GITHUB_TOKEN not in finding.reason
+
+    def test_findings_deduplicated(self):
+        # the same token as both flag value and known format must yield one finding per location
+        findings = find_potential_secrets(f"--github_token {FAKE_GITHUB_TOKEN}", location="test")
+        previews = [f.preview for f in findings]
+        assert len(previews) == len(set((f.location, f.preview) for f in findings))
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            {"password": "${secret:BAD-NAME}"},
+            {"password": "${secret:KEY}hunter22x"},
+        ],
+    )
+    def test_malformed_or_composite_refs_do_not_bypass_detection(self, value):
+        assert find_potential_secrets(value, location="test")
+
+    def test_authorization_scheme_with_valid_ref_is_safe(self):
+        assert find_potential_secrets({"auth_token": "Bearer ${secret:AUTH_TOKEN}"}, location="test") == []
+
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_unterminated_quoted_assignment_with_backslashes_scans_safely(self, quote):
+        value = f"API_PASSWORD={quote}" + "\\" * 256
+
+        start = time.monotonic()
+        find_potential_secrets(value, location="test")
+        assert time.monotonic() - start < 1.0
+
+
+class TestWarnOnPotentialSecrets:
+    def test_warns_with_context_and_no_leak(self):
+        with pytest.warns(PotentialSecretWarning) as record:
+            findings = warn_on_potential_secrets(f"--api_key {FAKE_GITHUB_TOKEN}", context="train_args")
+        assert findings
+        messages = [str(w.message) for w in record]
+        assert any("train_args" in m for m in messages)
+        assert all(FAKE_GITHUB_TOKEN not in m for m in messages)
+        assert all(w.filename == "<nvflare-secret-scan>" for w in record)
+
+    def test_no_warning_for_clean_value(self):
+        import warnings as warnings_module
+
+        with warnings_module.catch_warnings(record=True) as record:
+            warnings_module.simplefilter("always")
+            findings = warn_on_potential_secrets("--epochs 5 --lr 0.1", context="train_args")
+        assert findings == []
+        assert not [w for w in record if issubclass(w.category, PotentialSecretWarning)]
+
+    def test_warning_as_error_is_safely_reemitted_without_raising(self):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("error", PotentialSecretWarning)
+            findings = warn_on_potential_secrets(
+                {"password": "actualSecret123"},
+                context="add_client_config config",
+            )
+
+        assert findings
+        assert len(record) == 1
+        assert record[0].filename == "<nvflare-secret-scan>"
+
+
+class TestUnsupportedSecretRefs:
+    def test_warns_without_including_reference(self):
+        reference = secret_ref("MY_API_KEY")
+        with pytest.warns(UnsupportedSecretRefWarning) as record:
+            assert warn_on_unsupported_secret_refs(
+                {"nested": [reference]},
+                context="recipe parameter 'task_data'",
+            )
+
+        assert all(reference not in str(w.message) for w in record)
+        assert all(w.filename == "<nvflare-secret-scan>" for w in record)
+
+    def test_no_warning_without_reference(self):
+        assert not warn_on_unsupported_secret_refs({"nested": ["plain"]}, context="test")
+
+    def test_warns_for_nested_mapping_key_but_not_value(self):
+        reference = secret_ref("MY_API_KEY")
+        with pytest.warns(UnsupportedSecretRefWarning):
+            assert warn_on_unsupported_secret_ref_keys(
+                {"outer": [{reference: "value"}]},
+                context="add_client_config config",
+            )
+        assert not warn_on_unsupported_secret_ref_keys({"outer": [{"token": reference}]}, context="test")
+
+    def test_warns_only_outside_supported_mapping_values(self):
+        reference = secret_ref("MY_API_KEY")
+        assert not warn_on_unsupported_secret_refs_outside_keys(
+            {"site-1": {"train_args": f"--api-key {reference}"}},
+            supported_value_keys={"train_args"},
+            context="per_site_config",
+        )
+        with pytest.warns(UnsupportedSecretRefWarning, match="train_args"):
+            assert warn_on_unsupported_secret_refs_outside_keys(
+                {"site-1": {"train_script": reference}},
+                supported_value_keys={"train_args"},
+                context="per_site_config",
+            )

--- a/tests/unit_test/fuel/utils/secret_utils_test.py
+++ b/tests/unit_test/fuel/utils/secret_utils_test.py
@@ -85,7 +85,7 @@ class TestSecretRef:
 
     def test_resolve_file_ref(self, tmp_path):
         secret_file = tmp_path / "api-key"
-        secret_file.write_text("file-secret-value")
+        secret_file.write_text("file-secret-value\n")
 
         assert resolve_secret_refs(secret_file_ref(str(secret_file)), env={}) == "file-secret-value"
 
@@ -361,11 +361,20 @@ class TestUnsupportedSecretRefs:
         assert not warn_on_unsupported_secret_refs_outside_keys(
             {"site-1": {"train_args": f"--api-key {reference}"}},
             supported_value_keys={"train_args"},
+            supported_value_depth=2,
             context="per_site_config",
         )
+        with pytest.warns(UnsupportedSecretRefWarning):
+            assert warn_on_unsupported_secret_refs_outside_keys(
+                {"site-1": {"subsection": {"train_args": reference}}},
+                supported_value_keys={"train_args"},
+                supported_value_depth=2,
+                context="per_site_config",
+            )
         with pytest.warns(UnsupportedSecretRefWarning, match="train_args"):
             assert warn_on_unsupported_secret_refs_outside_keys(
                 {"site-1": {"train_script": reference}},
                 supported_value_keys={"train_args"},
+                supported_value_depth=2,
                 context="per_site_config",
             )

--- a/tests/unit_test/fuel/utils/secret_utils_test.py
+++ b/tests/unit_test/fuel/utils/secret_utils_test.py
@@ -299,6 +299,16 @@ class TestFindPotentialSecrets:
         find_potential_secrets(value, location="test")
         assert time.monotonic() - start < 1.0
 
+    def test_unterminated_quoted_flag_value_is_scanned_as_one_value(self):
+        findings = find_potential_secrets('--password "short secret value', location="test")
+
+        assert any(finding.reason == "value of a secret-named flag" for finding in findings)
+
+    def test_unterminated_quote_before_flag_does_not_hide_flag(self):
+        findings = find_potential_secrets('"legacy --password hunter22x', location="test")
+
+        assert any(finding.reason == "value of a secret-named flag" for finding in findings)
+
 
 class TestWarnOnPotentialSecrets:
     def test_warns_with_context_and_no_leak(self):
@@ -320,16 +330,18 @@ class TestWarnOnPotentialSecrets:
         assert not [w for w in record if issubclass(w.category, PotentialSecretWarning)]
 
     def test_warning_as_error_is_safely_reemitted_without_raising(self):
+        secret_value = "actualSecret123"
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("error", PotentialSecretWarning)
             findings = warn_on_potential_secrets(
-                {"password": "actualSecret123"},
+                {"password": secret_value},
                 context="add_client_config config",
             )
 
         assert findings
         assert len(record) == 1
         assert record[0].filename == "<nvflare-secret-scan>"
+        assert secret_value not in str(record[0].message)
 
 
 class TestUnsupportedSecretRefs:
@@ -367,6 +379,13 @@ class TestUnsupportedSecretRefs:
         with pytest.warns(UnsupportedSecretRefWarning):
             assert warn_on_unsupported_secret_refs_outside_keys(
                 {"site-1": {"subsection": {"train_args": reference}}},
+                supported_value_keys={"train_args"},
+                supported_value_depth=2,
+                context="per_site_config",
+            )
+        with pytest.warns(UnsupportedSecretRefWarning):
+            assert warn_on_unsupported_secret_refs_outside_keys(
+                {"site-1": {"train_args": {"nested": reference}}},
                 supported_value_keys={"train_args"},
                 supported_value_depth=2,
                 context="per_site_config",

--- a/tests/unit_test/fuel/utils/wfconf_test.py
+++ b/tests/unit_test/fuel/utils/wfconf_test.py
@@ -21,7 +21,8 @@ import pytest
 
 from nvflare.app_common.np.np_model_locator import NPModelLocator
 from nvflare.fuel.common.excepts import ConfigError
-from nvflare.fuel.utils.wfconf import Configurator, get_component_refs
+from nvflare.fuel.utils.json_scanner import JsonScanner
+from nvflare.fuel.utils.wfconf import Configurator, get_component_refs, resolve_var_refs
 
 
 @pytest.fixture
@@ -166,3 +167,11 @@ class TestGetComponentRefs:
             component = {key: ""}
             with pytest.raises(ConfigError, match="must not be empty"):
                 get_component_refs(component)
+
+
+def test_resolve_var_refs_preserves_secret_ref_while_expanding_system_var():
+    config = {"script_args": "--site {SITE_NAME} --api-key ${secret:API_KEY}"}
+
+    resolve_var_refs(JsonScanner(config), {"SITE_NAME": "site-1"})
+
+    assert config["script_args"] == "--site site-1 --api-key ${secret:API_KEY}"

--- a/tests/unit_test/private/json_configer_test.py
+++ b/tests/unit_test/private/json_configer_test.py
@@ -23,12 +23,14 @@ from nvflare.apis.fl_constant import FLContextKey, SystemConfigs
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import UnsafeComponentError
 from nvflare.app_common.executors.multi_process_executor import MultiProcessExecutor, WorkerComponentBuilder
+from nvflare.app_common.executors.task_script_runner import TaskScriptRunner
 from nvflare.app_common.widgets.component_path_authorizer import CLASS_ALLOW_LIST, ComponentPathAuthorizer
 from nvflare.fuel.common.excepts import ComponentNotAuthorized
 from nvflare.fuel.common.multi_process_executor_constants import CommunicationMetaData
 from nvflare.fuel.utils import class_utils
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.json_scanner import Node
+from nvflare.fuel.utils.secret_utils import secret_file_ref
 from nvflare.private.fed.app.client.sub_worker_process import SubWorkerExecutor
 from nvflare.private.fed.client.client_run_manager import ClientRunManager
 from nvflare.private.fed.server.server_engine import ServerEngine
@@ -108,12 +110,13 @@ class FakeWorkspace:
 
 
 class _NestedComponentConfigurator(JsonConfigurator):
-    def __init__(self, config_file_name):
+    def __init__(self, config_file_name, sys_vars=None):
         super().__init__(
             config_file_name=config_file_name,
             base_pkgs=["nvflare"],
             module_names=["apis"],
             exclude_libs=True,
+            sys_vars=sys_vars,
         )
         self.component = None
 
@@ -183,6 +186,71 @@ def _make_authorized_configurator(config_file):
         authorizer=ComponentPathAuthorizer(),
     )
     return configurator
+
+
+def test_configure_expands_system_vars_but_preserves_secret_refs_for_runtime_consumers(tmp_path):
+    secret_file = tmp_path / "mounted-api-key"
+    secret_file.write_text("file-secret-value")
+    unresolved_key = "${secret:KEY_MUST_NOT_BE_RESOLVED}"
+    config_file = tmp_path / "config.json"
+    _write_component_config(
+        config_file,
+        {
+            "path": _component_path(ContainerComponent),
+            "args": {
+                "settings": {
+                    "mixed": "--site {SITE_NAME} --api-key ${secret:TEST_CONFIG_API_KEY}",
+                    "nested": [secret_file_ref(str(secret_file)), {"token": "${secret:TEST_CONFIG_SECOND_KEY}"}],
+                    unresolved_key: "plain-value",
+                }
+            },
+        },
+    )
+    config_data = json.loads(config_file.read_text())
+    config_data["custom_config"] = {"token": "${secret:TEST_CONFIG_API_KEY}"}
+    config_file.write_text(json.dumps(config_data))
+
+    configurator = _NestedComponentConfigurator(str(config_file), sys_vars={"SITE_NAME": "site-1"})
+    configurator.configure()
+
+    assert configurator.component.settings == {
+        "mixed": "--site site-1 --api-key ${secret:TEST_CONFIG_API_KEY}",
+        "nested": [secret_file_ref(str(secret_file)), {"token": "${secret:TEST_CONFIG_SECOND_KEY}"}],
+        unresolved_key: "plain-value",
+    }
+    assert configurator.config_data["custom_config"] == {"token": "${secret:TEST_CONFIG_API_KEY}"}
+
+
+def test_configured_in_process_executor_resolves_file_ref_only_at_script_start(tmp_path):
+    script_file = tmp_path / "train.py"
+    script_file.write_text("pass\n")
+    secret_file = tmp_path / "api-key"
+    secret_file.write_text("resolved secret --not-option")
+    placeholder = secret_file_ref(str(secret_file))
+    config_file = tmp_path / "config.json"
+    _write_component_config(
+        config_file,
+        {
+            "path": "nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor",
+            "args": {
+                "task_script_path": "train.py",
+                "task_script_args": f"--site {{SITE_NAME}} --api-key {placeholder}",
+            },
+        },
+    )
+
+    configurator = _NestedComponentConfigurator(str(config_file), sys_vars={"SITE_NAME": "site-1"})
+    configurator.configure()
+
+    assert configurator.component._task_script_args == f"--site site-1 --api-key {placeholder}"
+    runner = TaskScriptRunner(
+        custom_dir=str(tmp_path),
+        script_path=configurator.component._task_script_path,
+        script_args=configurator.component._task_script_args,
+    )
+    assert runner.get_sys_argv()[1:] == ["--site", "site-1", "--api-key", "resolved secret --not-option"]
+    assert placeholder in configurator.component._task_script_args
+    assert "resolved secret" not in configurator.component._task_script_args
 
 
 def _record_load_class_calls(monkeypatch):

--- a/tests/unit_test/recipe/cyclic_recipe_test.py
+++ b/tests/unit_test/recipe/cyclic_recipe_test.py
@@ -14,6 +14,7 @@
 
 """Tests for CyclicRecipe and framework-specific variants with initial_ckpt support."""
 
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -22,6 +23,7 @@ import torch.nn as nn
 from nvflare.apis.job_def import ALL_SITES
 from nvflare.app_opt.pt.job_config.model import PTModel
 from nvflare.fuel.utils.constants import FrameworkType
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning, UnsupportedSecretRefWarning
 from nvflare.recipe.cyclic import CyclicRecipe as BaseCyclicRecipe
 
 
@@ -62,6 +64,34 @@ def base_recipe_params():
 
 class TestBaseCyclicRecipe:
     """Test cases for base CyclicRecipe class."""
+
+    def test_warns_on_secret_in_client_config_overrides(self, mock_file_system, base_recipe_params, simple_model):
+        secret = "ghp_" + "Ab1" * 12
+
+        with pytest.warns(PotentialSecretWarning) as record:
+            BaseCyclicRecipe(
+                name="secret_override",
+                model=PTModel(model=simple_model),
+                client_config_overrides={"command": secret},
+                framework=FrameworkType.PYTORCH,
+                **base_recipe_params,
+            )
+
+        messages = [str(warning.message) for warning in record]
+        assert any("client_config_overrides" in message for message in messages)
+        assert all(secret not in message for message in messages)
+
+    def test_external_command_secret_ref_is_supported(self, mock_file_system, base_recipe_params, simple_model):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnsupportedSecretRefWarning)
+            BaseCyclicRecipe(
+                name="command_secret_ref",
+                model=PTModel(model=simple_model),
+                launch_external_process=True,
+                client_config_overrides={"command": "env API_TOKEN=${secret:API_TOKEN} python3 -u"},
+                framework=FrameworkType.PYTORCH,
+                **base_recipe_params,
+            )
 
     def test_initial_ckpt_must_exist_for_relative_path(self):
         """Test that non-existent relative paths are rejected (no mock - validation must run)."""

--- a/tests/unit_test/recipe/cyclic_recipe_test.py
+++ b/tests/unit_test/recipe/cyclic_recipe_test.py
@@ -68,14 +68,16 @@ class TestBaseCyclicRecipe:
     def test_warns_on_secret_in_client_config_overrides(self, mock_file_system, base_recipe_params, simple_model):
         secret = "ghp_" + "Ab1" * 12
 
+        recipe = BaseCyclicRecipe(
+            name="secret_override",
+            model=PTModel(model=simple_model),
+            client_config_overrides={"command": secret},
+            framework=FrameworkType.PYTORCH,
+            **base_recipe_params,
+        )
+
         with pytest.warns(PotentialSecretWarning) as record:
-            BaseCyclicRecipe(
-                name="secret_override",
-                model=PTModel(model=simple_model),
-                client_config_overrides={"command": secret},
-                framework=FrameworkType.PYTORCH,
-                **base_recipe_params,
-            )
+            recipe._warn_potential_secrets_in_params()
 
         messages = [str(warning.message) for warning in record]
         assert any("client_config_overrides" in message for message in messages)

--- a/tests/unit_test/recipe/eval_recipe_test.py
+++ b/tests/unit_test/recipe/eval_recipe_test.py
@@ -21,6 +21,8 @@ from unittest.mock import patch
 
 import pytest
 
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning
+
 
 @pytest.fixture
 def mock_file_system():
@@ -35,6 +37,31 @@ def mock_file_system():
 
 class TestNumpyCrossSiteEvalRecipe:
     """Test cases for NumpyCrossSiteEvalRecipe."""
+
+    def test_warns_on_secret_in_eval_args(self, mock_file_system):
+        from nvflare.app_common.np.recipes.cross_site_eval import NumpyCrossSiteEvalRecipe
+
+        with pytest.warns(PotentialSecretWarning, match="eval_args"):
+            NumpyCrossSiteEvalRecipe(
+                name="secret_cse",
+                min_clients=2,
+                eval_script="evaluate.py",
+                eval_args="--password hunter22x",
+            )
+
+    def test_warns_on_secret_assignment_in_external_command(self, mock_file_system):
+        from nvflare.app_common.np.recipes.cross_site_eval import NumpyCrossSiteEvalRecipe
+
+        with pytest.warns(PotentialSecretWarning, match="command") as record:
+            NumpyCrossSiteEvalRecipe(
+                name="secret_command_cse",
+                min_clients=2,
+                eval_script="evaluate.py",
+                launch_external_process=True,
+                command="env API_PASSWORD=hunter22x python3 -u",
+            )
+
+        assert all("hunter22x" not in str(warning.message) for warning in record)
 
     def test_basic_initialization(self, mock_file_system):
         """Test NumpyCrossSiteEvalRecipe basic initialization."""

--- a/tests/unit_test/recipe/fed_task_recipe_test.py
+++ b/tests/unit_test/recipe/fed_task_recipe_test.py
@@ -22,7 +22,8 @@ from nvflare.apis.job_def import ALL_SITES
 from nvflare.app_common.workflows.cmd_task_controller import CmdTaskController
 from nvflare.client.config import ExchangeFormat
 from nvflare.fuel.utils.constants import FrameworkType
-from nvflare.recipe import FedTaskRecipe
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning, UnsupportedSecretRefWarning
+from nvflare.recipe import FedTaskRecipe, secret_ref
 
 
 @pytest.fixture
@@ -35,6 +36,42 @@ def temp_task_script():
 
 
 class TestFedTaskRecipe:
+    def test_warns_on_secret_in_task_args(self, temp_task_script):
+        secret = "ghp_" + "Ab1" * 12
+
+        with pytest.warns(PotentialSecretWarning) as record:
+            FedTaskRecipe(
+                name="secret_task",
+                task_name="embed",
+                min_clients=1,
+                task_script=temp_task_script,
+                task_args=f"--api-key {secret}",
+            )
+
+        messages = [str(warning.message) for warning in record]
+        assert any("task_args" in message for message in messages)
+        assert all(secret not in message for message in messages)
+
+    def test_warns_on_secret_in_task_payload(self, temp_task_script):
+        with pytest.warns(PotentialSecretWarning, match="task_data"):
+            FedTaskRecipe(
+                name="secret_payload",
+                task_name="embed",
+                min_clients=1,
+                task_script=temp_task_script,
+                task_data={"auth_token": "abcd1234efgh"},
+            )
+
+    def test_warns_when_task_payload_uses_unsupported_secret_ref(self, temp_task_script):
+        with pytest.warns(UnsupportedSecretRefWarning, match="task_data"):
+            FedTaskRecipe(
+                name="secret_ref_payload",
+                task_name="embed",
+                min_clients=1,
+                task_script=temp_task_script,
+                task_data={"auth_token": secret_ref("API_TOKEN")},
+            )
+
     def test_initializes_model_free_one_round_task(self, temp_task_script):
         recipe = FedTaskRecipe(
             name="embedding_job",

--- a/tests/unit_test/recipe/fed_task_recipe_test.py
+++ b/tests/unit_test/recipe/fed_task_recipe_test.py
@@ -39,38 +39,44 @@ class TestFedTaskRecipe:
     def test_warns_on_secret_in_task_args(self, temp_task_script):
         secret = "ghp_" + "Ab1" * 12
 
+        recipe = FedTaskRecipe(
+            name="secret_task",
+            task_name="embed",
+            min_clients=1,
+            task_script=temp_task_script,
+            task_args=f"--api-key {secret}",
+        )
+
         with pytest.warns(PotentialSecretWarning) as record:
-            FedTaskRecipe(
-                name="secret_task",
-                task_name="embed",
-                min_clients=1,
-                task_script=temp_task_script,
-                task_args=f"--api-key {secret}",
-            )
+            recipe._warn_potential_secrets_in_params()
 
         messages = [str(warning.message) for warning in record]
         assert any("task_args" in message for message in messages)
         assert all(secret not in message for message in messages)
 
     def test_warns_on_secret_in_task_payload(self, temp_task_script):
+        recipe = FedTaskRecipe(
+            name="secret_payload",
+            task_name="embed",
+            min_clients=1,
+            task_script=temp_task_script,
+            task_data={"auth_token": "abcd1234efgh"},
+        )
+
         with pytest.warns(PotentialSecretWarning, match="task_data"):
-            FedTaskRecipe(
-                name="secret_payload",
-                task_name="embed",
-                min_clients=1,
-                task_script=temp_task_script,
-                task_data={"auth_token": "abcd1234efgh"},
-            )
+            recipe._warn_potential_secrets_in_params()
 
     def test_warns_when_task_payload_uses_unsupported_secret_ref(self, temp_task_script):
+        recipe = FedTaskRecipe(
+            name="secret_ref_payload",
+            task_name="embed",
+            min_clients=1,
+            task_script=temp_task_script,
+            task_data={"auth_token": secret_ref("API_TOKEN")},
+        )
+
         with pytest.warns(UnsupportedSecretRefWarning, match="task_data"):
-            FedTaskRecipe(
-                name="secret_ref_payload",
-                task_name="embed",
-                min_clients=1,
-                task_script=temp_task_script,
-                task_data={"auth_token": secret_ref("API_TOKEN")},
-            )
+            recipe._warn_potential_secrets_in_params()
 
     def test_initializes_model_free_one_round_task(self, temp_task_script):
         recipe = FedTaskRecipe(

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -39,6 +39,7 @@ from nvflare.client.constants import CLIENT_API_CONFIG
 from nvflare.fuel.utils.class_utils import instantiate_class
 from nvflare.fuel.utils.secret_utils import UnsupportedSecretRefWarning
 from nvflare.job_config.base_fed_job import BaseFedJob
+from nvflare.recipe.fedavg import FedAvgRecipe as BaseFedAvgRecipe
 
 
 class SimpleTestModel(nn.Module):
@@ -226,6 +227,10 @@ def _run_exported_external_process_executor_startup(executor_config, config_dir,
 
 
 class TestFedAvgRecipe:
+    def test_class_docstrings_are_preserved(self):
+        assert BaseFedAvgRecipe.__doc__
+        assert FedAvgRecipe.__doc__
+
     def test_external_command_secret_ref_is_supported(self, mock_file_system, base_recipe_params, simple_model):
         with warnings.catch_warnings():
             warnings.simplefilter("error", UnsupportedSecretRefWarning)

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,6 +37,7 @@ from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
 from nvflare.client.config import ConfigKey, TransferType
 from nvflare.client.constants import CLIENT_API_CONFIG
 from nvflare.fuel.utils.class_utils import instantiate_class
+from nvflare.fuel.utils.secret_utils import UnsupportedSecretRefWarning
 from nvflare.job_config.base_fed_job import BaseFedJob
 
 
@@ -224,6 +226,21 @@ def _run_exported_external_process_executor_startup(executor_config, config_dir,
 
 
 class TestFedAvgRecipe:
+    def test_external_command_secret_ref_is_supported(self, mock_file_system, base_recipe_params, simple_model):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnsupportedSecretRefWarning)
+            FedAvgRecipe(
+                name="command_secret_ref",
+                model=simple_model,
+                per_site_config={
+                    "site-1": {
+                        "launch_external_process": True,
+                        "command": "env API_TOKEN=${secret:API_TOKEN} python3 -u",
+                    }
+                },
+                **base_recipe_params,
+            )
+
     """Test cases for FedAvgRecipe class."""
 
     def test_default_aggregator_initialization(self, mock_file_system, base_recipe_params, simple_model):

--- a/tests/unit_test/recipe/fedstats_recipe_test.py
+++ b/tests/unit_test/recipe/fedstats_recipe_test.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning, UnsupportedSecretRefWarning
+from nvflare.recipe import secret_ref
+from nvflare.recipe.fedstats import FedStatsRecipe
+
+
+def test_fedstats_warns_for_secret_like_statistic_config():
+    with patch("nvflare.recipe.fedstats.StatsJob") as stats_job_cls:
+        with pytest.warns(PotentialSecretWarning, match="statistic_configs"):
+            recipe = FedStatsRecipe(
+                name="stats",
+                stats_output_path="stats.json",
+                sites=["site-1"],
+                statistic_configs={"password": "hunter22x"},
+                stats_generator=Mock(),
+            )
+
+    stats_job_cls.return_value.setup_clients.assert_called_once_with(["site-1"])
+    assert recipe.job is stats_job_cls.return_value
+
+
+def test_fedstats_warns_for_unsupported_secret_ref():
+    with patch("nvflare.recipe.fedstats.StatsJob"):
+        with pytest.warns(UnsupportedSecretRefWarning, match="statistic_configs"):
+            FedStatsRecipe(
+                name="stats",
+                stats_output_path="stats.json",
+                sites=["site-1"],
+                statistic_configs={"api_token": secret_ref("API_TOKEN")},
+                stats_generator=Mock(),
+            )

--- a/tests/unit_test/recipe/flower_recipe_test.py
+++ b/tests/unit_test/recipe/flower_recipe_test.py
@@ -22,6 +22,8 @@ import pytest
 from nvflare.app_opt.flower.recipe import FlowerRecipe
 from nvflare.client.api import ClientAPIType
 from nvflare.client.api_spec import CLIENT_API_TYPE_KEY
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning, UnsupportedSecretRefWarning
+from nvflare.recipe import secret_ref
 
 
 @pytest.mark.parametrize("flwr_version", ["1.15.9", "1.16rc0", "1.25.9", "1.26.0rc0"])
@@ -66,6 +68,33 @@ def test_flower_recipe_forwards_run_config():
     assert recipe.job is fake_job
     kwargs = mock_flower_job.call_args.kwargs
     assert kwargs["run_config"] == run_config
+
+
+@pytest.mark.parametrize(
+    "parameter, value",
+    [
+        ("extra_env", {"API_TOKEN": "abcd1234efgh"}),
+        ("run_config", {"password": "hunter22x"}),
+    ],
+)
+def test_flower_recipe_warns_on_secret_parameters(parameter, value):
+    fake_job = object()
+
+    with patch("nvflare.app_opt.flower.recipe.get_package_version", return_value="1.26.0"):
+        with patch("nvflare.app_opt.flower.recipe._create_flower_job", return_value=fake_job):
+            with pytest.warns(PotentialSecretWarning, match=parameter):
+                FlowerRecipe(flower_content="mock_flower_content", **{parameter: value})
+
+
+@pytest.mark.parametrize("parameter", ["extra_env", "run_config"])
+def test_flower_recipe_warns_on_unsupported_secret_refs(parameter):
+    fake_job = object()
+    value = {"api_token": secret_ref("API_TOKEN")}
+
+    with patch("nvflare.app_opt.flower.recipe.get_package_version", return_value="1.26.0"):
+        with patch("nvflare.app_opt.flower.recipe._create_flower_job", return_value=fake_job):
+            with pytest.warns(UnsupportedSecretRefWarning, match=parameter):
+                FlowerRecipe(flower_content="mock_flower_content", **{parameter: value})
 
 
 @pytest.mark.parametrize("flwr_version", ["1.26.0", "1.26.1", "1.27.5"])

--- a/tests/unit_test/recipe/recipe_secrets_test.py
+++ b/tests/unit_test/recipe/recipe_secrets_test.py
@@ -52,19 +52,21 @@ def _no_secret_warnings(record):
 
 class TestRecipeSecretScanning:
     def test_train_args_with_token_warns_without_leaking(self, make_recipe):
+        recipe = make_recipe(train_args=f"--api_key {FAKE_GITHUB_TOKEN}")
         with pytest.warns(PotentialSecretWarning) as record:
-            make_recipe(train_args=f"--api_key {FAKE_GITHUB_TOKEN}")
+            recipe._warn_potential_secrets_in_params()
         messages = [str(w.message) for w in record]
         assert any("train_args" in m for m in messages)
         assert all(FAKE_GITHUB_TOKEN not in m for m in messages)
 
     def test_external_command_with_token_warns_without_leaking(self, make_recipe):
         password = "hunter22x"
+        recipe = make_recipe(
+            launch_external_process=True,
+            command=f"env API_PASSWORD={password} python3 -u",
+        )
         with pytest.warns(PotentialSecretWarning) as record:
-            make_recipe(
-                launch_external_process=True,
-                command=f"env API_PASSWORD={password} python3 -u",
-            )
+            recipe._warn_potential_secrets_in_params()
         messages = [str(w.message) for w in record]
         assert any("command" in message for message in messages)
         assert all(password not in message for message in messages)
@@ -72,26 +74,29 @@ class TestRecipeSecretScanning:
     def test_external_command_secret_ref_assignment_is_safe(self, make_recipe):
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("always")
-            make_recipe(
+            recipe = make_recipe(
                 launch_external_process=True,
                 command="env API_PASSWORD=${secret:API_PASSWORD} python3 -u",
             )
+            recipe._warn_potential_secrets_in_params()
         assert _no_secret_warnings(record)
 
     def test_clean_train_args_no_warning(self, make_recipe):
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("always")
-            make_recipe(train_args="--epochs 5 --lr 0.1 --data_path /data/site-1")
+            recipe = make_recipe(train_args="--epochs 5 --lr 0.1 --data_path /data/site-1")
+            recipe._warn_potential_secrets_in_params()
         assert _no_secret_warnings(record)
 
     def test_per_site_config_with_password_warns(self, make_recipe):
+        recipe = make_recipe(
+            per_site_config={
+                "site-1": {"train_args": "--password hunter22x"},
+                "site-2": {"train_args": "--epochs 5"},
+            }
+        )
         with pytest.warns(PotentialSecretWarning) as record:
-            make_recipe(
-                per_site_config={
-                    "site-1": {"train_args": "--password hunter22x"},
-                    "site-2": {"train_args": "--epochs 5"},
-                }
-            )
+            recipe._warn_potential_secrets_in_params()
         messages = [str(w.message) for w in record]
         assert any("per_site_config" in m for m in messages)
         assert all("hunter22x" not in m for m in messages)
@@ -134,9 +139,7 @@ class TestRecipeSecretScanning:
             recipe.export(str(tmp_path), **{params_name: params})
 
     def test_export_scans_generated_config_files(self, make_recipe, tmp_path):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", PotentialSecretWarning)  # constructor warning is tested elsewhere
-            recipe = make_recipe(train_args=f"--api_key {FAKE_GITHUB_TOKEN}")
+        recipe = make_recipe(train_args=f"--api_key {FAKE_GITHUB_TOKEN}")
         with pytest.warns(PotentialSecretWarning) as record:
             recipe.export(str(tmp_path))
         messages = [str(w.message) for w in record]
@@ -153,6 +156,17 @@ class TestRecipeSecretScanning:
             run = recipe.run(env)
 
         assert run.get_job_id() == "job-id"
+
+    def test_warning_ignored_during_construction_is_emitted_on_run(self, make_recipe):
+        env = MagicMock()
+        env.deploy.return_value = "job-id"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PotentialSecretWarning)
+            recipe = make_recipe(train_args=f"--api-key {FAKE_GITHUB_TOKEN}")
+
+        with pytest.warns(PotentialSecretWarning, match="train_args"):
+            recipe.run(env)
 
 
 class TestSecretRefEndToEnd:

--- a/tests/unit_test/recipe/recipe_secrets_test.py
+++ b/tests/unit_test/recipe/recipe_secrets_test.py
@@ -125,6 +125,14 @@ class TestRecipeSecretScanning:
             recipe.export(str(tmp_path), client_exec_params={"api_key": "abcd1234efgh"})
         assert any("client_exec_params" in str(w.message) for w in record)
 
+    @pytest.mark.parametrize("params_name", ["server_exec_params", "client_exec_params"])
+    def test_exec_params_warn_for_nested_secret_ref_key(self, make_recipe, tmp_path, params_name):
+        recipe = make_recipe()
+        params = {"service": {secret_ref("DYNAMIC_KEY"): "value"}}
+
+        with pytest.warns(UnsupportedSecretRefWarning, match=params_name):
+            recipe.export(str(tmp_path), **{params_name: params})
+
     def test_export_scans_generated_config_files(self, make_recipe, tmp_path):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PotentialSecretWarning)  # constructor warning is tested elsewhere

--- a/tests/unit_test/recipe/recipe_secrets_test.py
+++ b/tests/unit_test/recipe/recipe_secrets_test.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import warnings
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvflare.fuel.utils.constants import FrameworkType
+from nvflare.recipe import PotentialSecretWarning, UnsupportedSecretRefWarning, secret_file_ref, secret_ref
+from nvflare.recipe.fedavg import FedAvgRecipe
+
+# Fake credential for testing the detector -- not a real token.
+FAKE_GITHUB_TOKEN = "ghp_" + "Ab1" * 12
+
+
+@pytest.fixture()
+def make_recipe(tmp_path):
+    script = tmp_path / "train.py"
+    script.write_text("print('training')\n")
+
+    def _make_recipe(train_args="", **kwargs):
+        return FedAvgRecipe(
+            name="secrets-test-job",
+            model=[1.0, 2.0],
+            min_clients=2,
+            num_rounds=1,
+            train_script=str(script),
+            train_args=train_args,
+            framework=FrameworkType.NUMPY,
+            **kwargs,
+        )
+
+    return _make_recipe
+
+
+def _no_secret_warnings(record):
+    return [w for w in record if issubclass(w.category, PotentialSecretWarning)] == []
+
+
+class TestRecipeSecretScanning:
+    def test_train_args_with_token_warns_without_leaking(self, make_recipe):
+        with pytest.warns(PotentialSecretWarning) as record:
+            make_recipe(train_args=f"--api_key {FAKE_GITHUB_TOKEN}")
+        messages = [str(w.message) for w in record]
+        assert any("train_args" in m for m in messages)
+        assert all(FAKE_GITHUB_TOKEN not in m for m in messages)
+
+    def test_external_command_with_token_warns_without_leaking(self, make_recipe):
+        password = "hunter22x"
+        with pytest.warns(PotentialSecretWarning) as record:
+            make_recipe(
+                launch_external_process=True,
+                command=f"env API_PASSWORD={password} python3 -u",
+            )
+        messages = [str(w.message) for w in record]
+        assert any("command" in message for message in messages)
+        assert all(password not in message for message in messages)
+
+    def test_external_command_secret_ref_assignment_is_safe(self, make_recipe):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            make_recipe(
+                launch_external_process=True,
+                command="env API_PASSWORD=${secret:API_PASSWORD} python3 -u",
+            )
+        assert _no_secret_warnings(record)
+
+    def test_clean_train_args_no_warning(self, make_recipe):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            make_recipe(train_args="--epochs 5 --lr 0.1 --data_path /data/site-1")
+        assert _no_secret_warnings(record)
+
+    def test_per_site_config_with_password_warns(self, make_recipe):
+        with pytest.warns(PotentialSecretWarning) as record:
+            make_recipe(
+                per_site_config={
+                    "site-1": {"train_args": "--password hunter22x"},
+                    "site-2": {"train_args": "--epochs 5"},
+                }
+            )
+        messages = [str(w.message) for w in record]
+        assert any("per_site_config" in m for m in messages)
+        assert all("hunter22x" not in m for m in messages)
+
+    def test_set_per_site_config_warns(self, make_recipe):
+        recipe = make_recipe()
+        with pytest.warns(PotentialSecretWarning):
+            recipe.set_per_site_config({"site-1": {"api_key": "abcd1234efgh"}})
+
+    def test_add_client_config_warns(self, make_recipe):
+        recipe = make_recipe()
+        with pytest.warns(PotentialSecretWarning):
+            recipe.add_client_config({"auth_token": "abcd1234efgh"})
+
+    def test_add_server_config_warns(self, make_recipe):
+        recipe = make_recipe()
+        with pytest.warns(PotentialSecretWarning):
+            recipe.add_server_config({"password": "abcd1234efgh"})
+
+    @pytest.mark.parametrize("method_name", ["add_client_config", "add_server_config"])
+    def test_add_config_warns_for_nested_secret_ref_key(self, make_recipe, method_name):
+        recipe = make_recipe()
+        config = {"service": {secret_ref("DYNAMIC_KEY"): "value"}}
+
+        with pytest.warns(UnsupportedSecretRefWarning, match=method_name):
+            getattr(recipe, method_name)(config)
+
+    def test_exec_params_warn_on_export(self, make_recipe, tmp_path):
+        recipe = make_recipe()
+        with pytest.warns(PotentialSecretWarning) as record:
+            recipe.export(str(tmp_path), client_exec_params={"api_key": "abcd1234efgh"})
+        assert any("client_exec_params" in str(w.message) for w in record)
+
+    def test_export_scans_generated_config_files(self, make_recipe, tmp_path):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PotentialSecretWarning)  # constructor warning is tested elsewhere
+            recipe = make_recipe(train_args=f"--api_key {FAKE_GITHUB_TOKEN}")
+        with pytest.warns(PotentialSecretWarning) as record:
+            recipe.export(str(tmp_path))
+        messages = [str(w.message) for w in record]
+        assert any("exported job file" in m for m in messages)
+        assert all(FAKE_GITHUB_TOKEN not in m for m in messages)
+
+    def test_run_rescans_recipe_parameters(self, make_recipe):
+        recipe = make_recipe()
+        recipe.train_args = f"--api-key {FAKE_GITHUB_TOKEN}"
+        env = MagicMock()
+        env.deploy.return_value = "job-id"
+
+        with pytest.warns(PotentialSecretWarning, match="train_args"):
+            run = recipe.run(env)
+
+        assert run.get_job_id() == "job-id"
+
+
+class TestSecretRefEndToEnd:
+    def test_secret_ref_in_train_args_no_warning_and_placeholder_in_export(self, make_recipe, tmp_path):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            recipe = make_recipe(train_args=f"--epochs 5 --api-key {secret_ref('MY_API_KEY')}")
+            recipe.export(str(tmp_path))
+        assert _no_secret_warnings(record)
+
+        client_configs = []
+        for root, _dirs, files in os.walk(tmp_path):
+            for file_name in files:
+                if file_name == "config_fed_client.json":
+                    with open(os.path.join(root, file_name)) as f:
+                        client_configs.append(f.read())
+        assert client_configs
+        assert any("${secret:MY_API_KEY}" in config for config in client_configs)
+
+    def test_secret_file_ref_is_public_and_placeholder_is_exported(self, make_recipe, tmp_path):
+        placeholder = secret_file_ref("/var/run/secrets/my-app/api-key")
+        recipe = make_recipe(train_args=f"--api-key {placeholder}")
+
+        recipe.export(str(tmp_path))
+
+        client_configs = []
+        for root, _dirs, files in os.walk(tmp_path):
+            for file_name in files:
+                if file_name == "config_fed_client.json":
+                    with open(os.path.join(root, file_name)) as f:
+                        client_configs.append(f.read())
+        assert client_configs
+        assert any(placeholder in config for config in client_configs)

--- a/tests/unit_test/recipe/session_mgr_test.py
+++ b/tests/unit_test/recipe/session_mgr_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning
+from nvflare.job_config.api import FedJob
+from nvflare.recipe.session_mgr import SessionManager
+
+
+def test_submit_job_scans_generated_config_before_submission():
+    job = FedJob(name="secret-submit-job", min_clients=1)
+    job.to_server({"auth_token": "abcd1234efgh"})
+
+    session = MagicMock()
+    session.submit_job.return_value = "job-id"
+    manager = SessionManager({})
+    manager._get_session = MagicMock(return_value=session)
+
+    with pytest.warns(PotentialSecretWarning, match="generated job file"):
+        assert manager.submit_job(job) == "job-id"
+
+    session.submit_job.assert_called_once()
+    session.close.assert_called_once()

--- a/tests/unit_test/recipe/swarm_recipe_test.py
+++ b/tests/unit_test/recipe/swarm_recipe_test.py
@@ -22,6 +22,7 @@ import pytest
 
 from nvflare.apis.dxo import DataKind
 from nvflare.apis.job_def import ALL_SITES
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning
 
 torch = pytest.importorskip("torch")
 
@@ -47,6 +48,35 @@ def simple_pt_model():
 
 class TestSwarmLearningRecipe:
     """Test cases for SwarmLearningRecipe."""
+
+    def test_warns_on_secret_in_train_args(self, mock_file_system, simple_pt_model):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        with pytest.warns(PotentialSecretWarning, match="train_args"):
+            SwarmLearningRecipe(
+                name="secret_swarm",
+                model=simple_pt_model,
+                num_rounds=1,
+                train_script="train.py",
+                min_clients=2,
+                train_args={"script_args": "--password hunter22x"},
+            )
+
+    def test_warns_on_secret_assignment_in_external_command(self, mock_file_system, simple_pt_model):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        with pytest.warns(PotentialSecretWarning, match="command") as record:
+            SwarmLearningRecipe(
+                name="secret_command_swarm",
+                model=simple_pt_model,
+                num_rounds=1,
+                train_script="train.py",
+                min_clients=2,
+                launch_external_process=True,
+                command="env API_PASSWORD=hunter22x python3 -u",
+            )
+
+        assert all("hunter22x" not in str(warning.message) for warning in record)
 
     def test_import_from_new_location(self, mock_file_system, simple_pt_model):
         """Test importing from new location (app_opt/pt/recipes)."""

--- a/tests/unit_test/recipe/utils_test.py
+++ b/tests/unit_test/recipe/utils_test.py
@@ -23,7 +23,9 @@ import pytest
 
 from nvflare.apis.dxo import DataKind
 from nvflare.apis.job_def import JobMetaKey
+from nvflare.fuel.utils.secret_utils import PotentialSecretWarning, UnsupportedSecretRefWarning
 from nvflare.job_config.api import FedJob
+from nvflare.recipe import secret_ref
 from nvflare.recipe.spec import Recipe
 from nvflare.recipe.utils import (
     extract_persistor_id,
@@ -367,6 +369,13 @@ class TestRecipeMetaHelper:
         assert exported_meta["custom_props"] == {"team": "research"}
         assert exported_meta["owner"] == "alice"
 
+    def test_set_recipe_meta_warns_for_secret_and_unsupported_ref(self):
+        recipe = self._make_recipe("test_recipe_meta_secret", min_clients=1)
+        with pytest.warns(PotentialSecretWarning, match="custom_props"):
+            set_recipe_meta(recipe, JobMetaKey.CUSTOM_PROPS, {"password": "hunter22x"})
+        with pytest.warns(UnsupportedSecretRefWarning, match="custom_props"):
+            set_recipe_meta(recipe, JobMetaKey.CUSTOM_PROPS, {"token": secret_ref("API_TOKEN")})
+
     def test_set_recipe_meta_warns_and_overrides_registered_resource_specs(self, tmp_path):
         recipe = self._make_recipe("test_recipe_meta_resource_conflict", min_clients=2)
         recipe.job.job.add_resource_spec("base-site", {"num_of_gpus": 0})
@@ -605,6 +614,17 @@ class TestAddExperimentTrackingClients:
 
     def _make_recipe(self, name="test_tracking_clients"):
         return Recipe(FedJob(name=name, min_clients=1))
+
+    def test_tracking_config_warns_for_secret_and_unsupported_ref(self, dummy_tracking):
+        from nvflare.recipe.utils import add_experiment_tracking
+
+        recipe = self._make_recipe()
+        with pytest.warns(PotentialSecretWarning, match="tracking_config"):
+            add_experiment_tracking(recipe, dummy_tracking, {"password": "hunter22x"})
+
+        recipe = self._make_recipe()
+        with pytest.warns(UnsupportedSecretRefWarning, match="tracking_config"):
+            add_experiment_tracking(recipe, dummy_tracking, {"token": secret_ref("API_TOKEN")})
 
     def test_client_side_tracking_specific_clients(self, dummy_tracking):
         from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE

--- a/tests/unit_test/utils/configs_test.py
+++ b/tests/unit_test/utils/configs_test.py
@@ -71,6 +71,7 @@ class TestConfigUtils:
             with open(config_file, "w") as f:
                 json.dump({"service": {"token": placeholder}}, f)
 
+            assert get_client_config_value(fl_ctx, "service", resolve_refs=False) == {"token": placeholder}
             assert get_client_config_value(fl_ctx, "service") == {"token": "client-secret-value"}
             with open(config_file) as f:
                 assert json.load(f)["service"]["token"] == placeholder

--- a/tests/unit_test/utils/configs_test.py
+++ b/tests/unit_test/utils/configs_test.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock
 import pytest
 
 from nvflare.apis.fl_constant import JobConstants
+from nvflare.recipe import secret_file_ref, secret_ref
 from nvflare.utils.configs import get_client_config_value, get_server_config_value
 
 
@@ -56,6 +57,54 @@ class TestConfigUtils:
 
             # Test reading existing key
             assert get_client_config_value(fl_ctx, "EXTERNAL_PRE_INIT_TIMEOUT") == 900.0
+
+    def test_get_client_config_value_resolves_nested_env_secret_refs(self, mock_fl_ctx, monkeypatch):
+        fl_ctx, workspace = mock_fl_ctx
+        monkeypatch.setenv("TEST_CLIENT_CONFIG_SECRET", "client-secret-value")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, "config")
+            os.makedirs(config_dir)
+            workspace.get_app_config_dir.return_value = config_dir
+            config_file = os.path.join(config_dir, JobConstants.CLIENT_JOB_CONFIG)
+            placeholder = secret_ref("TEST_CLIENT_CONFIG_SECRET")
+            with open(config_file, "w") as f:
+                json.dump({"service": {"token": placeholder}}, f)
+
+            assert get_client_config_value(fl_ctx, "service") == {"token": "client-secret-value"}
+            with open(config_file) as f:
+                assert json.load(f)["service"]["token"] == placeholder
+
+    def test_get_client_config_value_preserves_ordinary_placeholders(self, mock_fl_ctx, monkeypatch):
+        fl_ctx, workspace = mock_fl_ctx
+        monkeypatch.setenv("TEST_CLIENT_CONFIG_SECRET", "client-secret-value")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, "config")
+            os.makedirs(config_dir)
+            workspace.get_app_config_dir.return_value = config_dir
+            config_file = os.path.join(config_dir, JobConstants.CLIENT_JOB_CONFIG)
+            with open(config_file, "w") as f:
+                json.dump({"service": "{SITE_NAME}:${secret:TEST_CLIENT_CONFIG_SECRET}"}, f)
+
+            assert get_client_config_value(fl_ctx, "service") == "{SITE_NAME}:client-secret-value"
+
+    def test_get_client_config_value_missing_secret_ref_raises_instead_of_returning_default(
+        self, mock_fl_ctx, monkeypatch
+    ):
+        fl_ctx, workspace = mock_fl_ctx
+        monkeypatch.delenv("TEST_MISSING_CONFIG_SECRET", raising=False)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, "config")
+            os.makedirs(config_dir)
+            workspace.get_app_config_dir.return_value = config_dir
+            config_file = os.path.join(config_dir, JobConstants.CLIENT_JOB_CONFIG)
+            with open(config_file, "w") as f:
+                json.dump({"service": "${secret:TEST_MISSING_CONFIG_SECRET}"}, f)
+
+            with pytest.raises(ValueError, match="TEST_MISSING_CONFIG_SECRET"):
+                get_client_config_value(fl_ctx, "service", default="must-not-be-returned")
 
     def test_get_client_config_value_missing_key(self, mock_fl_ctx):
         """Test reading a non-existent key returns default value."""
@@ -106,6 +155,25 @@ class TestConfigUtils:
             # Test reading existing keys
             assert get_server_config_value(fl_ctx, "custom_param") == "custom_value"
             assert get_server_config_value(fl_ctx, "timeout") == 600
+
+    def test_get_server_config_value_resolves_file_secret_ref(self, mock_fl_ctx):
+        fl_ctx, workspace = mock_fl_ctx
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, "config")
+            os.makedirs(config_dir)
+            workspace.get_app_config_dir.return_value = config_dir
+            secret_file = os.path.join(tmpdir, "mounted-secret")
+            with open(secret_file, "w") as f:
+                f.write("server-secret-value")
+            config_file = os.path.join(config_dir, JobConstants.SERVER_JOB_CONFIG)
+            placeholder = secret_file_ref(secret_file)
+            with open(config_file, "w") as f:
+                json.dump({"service_password": placeholder}, f)
+
+            assert get_server_config_value(fl_ctx, "service_password") == "server-secret-value"
+            with open(config_file) as f:
+                assert json.load(f)["service_password"] == placeholder
 
     def test_get_server_config_value_missing_key(self, mock_fl_ctx):
         """Test reading a non-existent key returns default value."""


### PR DESCRIPTION
## Summary

- Establishes and documents the contract that recipe parameters must never contain actual secret values.
- Adds masked potential-secret detection for recipe parameters and generated job artifacts.
- Adds environment-variable and mounted-file secret references with late runtime resolution at supported boundaries.
- Warns when references are used outside supported runtime consumers.

## User impact

Recipe authors can keep credentials in site environment variables or mounted secret files while exporting shareable job definitions containing only placeholders. Warnings never echo detected values, and runtime resolution is limited to explicit script/subprocess argument and configuration-reader boundaries.

## Validation

- Feature suite: 712 passed, 18 skipped
- `./runtest.sh -s`: Black, isort, flake8, and agent-skill lint passed
- `git diff --check` passed
