### PR TITLE
Fix global model discovery for job downloads

### DIFF
--- a/docs/design/job_download_artifact_contract_test_plan.md
+++ b/docs/design/job_download_artifact_contract_test_plan.md
@@ -35,19 +35,26 @@ transfer layer. That path may differ if collision handling adds a suffix.
    current directory parent, preventing a nested `./<job_id>/<job_id>` result
    while preserving the final `./<job_id>` default behavior.
 4. Explicit `--output-dir` is passed through as an absolute destination.
-5. Artifact discovery reports a global model when a common model file is present,
-   for example `FL_global_model.pt`, `global_model.pt`, or `global_model.pth`.
-6. Artifact discovery reports `metrics_summary` when `metrics_summary.json` is
+5. Artifact discovery reports a global model when a common model file is present
+   in a canonical server-owned location, for example `FL_global_model.pt`,
+   `global_model.pt`, or `global_model.pth` under `workspace`, `server`, or
+   `app_server`.
+6. Client-side checkpoints are never reported as the global model, including when
+   they use a common global-model filename or sort before the server directory.
+7. A canonical `artifact_manifest.json` resolves custom global-model filenames.
+   Manifest paths are relative to the manifest and must remain inside the download
+   tree without traversing symlinks.
+8. Artifact discovery reports `metrics_summary` when `metrics_summary.json` is
    present.
-7. Artifact discovery reports `client_logs` as a mapping from site name to local
+9. Artifact discovery reports `client_logs` as a mapping from site name to local
    `log.txt` path, excluding server logs when identifiable.
-8. Missing expected artifact categories are listed in `missing_artifacts` without
+10. Missing expected artifact categories are listed in `missing_artifacts` without
    failing the command.
-9. Empty or nonexistent download paths produce a successful response with an
+11. Empty or nonexistent download paths produce a successful response with an
    empty `artifacts` object and relevant `missing_artifacts`.
-10. Artifact discovery skips symlinked files or directories that could resolve
+12. Artifact discovery skips symlinked files or directories that could resolve
     outside `download_path`.
-11. Existing error behavior remains unchanged for `JobNotFound`,
+13. Existing error behavior remains unchanged for `JobNotFound`,
     `AuthenticationError`, and `NoConnection`.
 
 ## Documentation Checks
@@ -61,5 +68,6 @@ transfer layer. That path may differ if collision handling adds a suffix.
 
 - No server-side path disclosure.
 - No server protocol changes.
-- No attempt to guarantee every framework-specific model naming convention.
+- Custom model names require an authoritative artifact manifest; the CLI does not
+  infer their meaning from an extension or directory-walk order.
 - No command failure solely because model, metrics, or logs are absent.

--- a/docs/design/nvflare_cli.md
+++ b/docs/design/nvflare_cli.md
@@ -1775,6 +1775,15 @@ files instead of inferring paths from server locations or assuming a fixed layou
 `download_path`. Agents must treat `artifact_discovery: "skipped"` as "not inspected",
 not as proof that expected artifacts are absent.
 
+Global-model discovery is provenance-aware. Common model filenames are considered
+only at the downloaded result root or in canonical server-owned `workspace`,
+`server`, and `app_server` locations; files in client subtrees are not candidates.
+An `artifact_manifest.json` in a canonical server-owned location can identify a
+custom filename. Its schema-version-`1` `artifacts.global_model` value is relative
+to the manifest and must resolve inside the download tree without symlinks. A
+present manifest is authoritative, so invalid or absent targets do not fall back to
+filename matching.
+
 ### Add `nvflare study`
 
 All `nvflare study` commands connect to the server and require a startup kit to be

--- a/docs/user_guide/nvflare_cli/job_cli.rst
+++ b/docs/user_guide/nvflare_cli/job_cli.rst
@@ -400,6 +400,28 @@ such as model, metrics, or client logs, that were not found locally. Missing
 artifacts do not make the command fail when the download itself succeeds.
 ``round_metrics`` is reported when the per-round JSONL artifact exists; it is
 optional because older jobs and jobs without aggregation metrics do not create it.
+
+Global-model discovery uses server provenance rather than the order of files in
+the download tree. Common model filenames are considered only in canonical
+server-owned locations such as ``workspace``, ``server``, and ``app_server``;
+client checkpoints are not labeled as the global model. Jobs that save the global
+model under a custom filename can place ``artifact_manifest.json`` in a canonical
+server-owned location. The manifest requires schema version ``1`` and a path
+relative to the manifest:
+
+.. code-block:: json
+
+   {
+     "schema_version": "1",
+     "artifacts": {
+       "global_model": "app_server/production-checkpoint.bin"
+     }
+   }
+
+Manifest paths must stay inside the downloaded job tree and cannot traverse
+symlinks. When a manifest is present, it is authoritative; the CLI does not fall
+back to filename guessing if the manifest is invalid or its target is absent.
+
 When ``artifact_discovery`` is ``skipped``, the CLI did not have a local
 directory to inspect, so ``artifacts`` and ``missing_artifacts`` are ``null``
 instead of claiming that expected artifacts were verified absent.

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -1223,11 +1223,12 @@ def _manifest_global_model(download_path: str, manifest_paths: List[Tuple[int, s
 
     candidate_path = os.path.normpath(os.path.join(os.path.dirname(manifest_path), model_path))
     root_real_path = os.path.realpath(download_path)
-    if (
-        os.path.normcase(candidate_path) == os.path.normcase(manifest_path)
-        or not _is_path_within(root_real_path, candidate_path)
-        or not os.path.isfile(candidate_path)
-    ):
+    if not _is_path_within(root_real_path, candidate_path) or not os.path.isfile(candidate_path):
+        return True, None
+    try:
+        if os.path.samefile(candidate_path, manifest_path):
+            return True, None
+    except OSError:
         return True, None
 
     # Reject a symlink at any level, matching the normal artifact traversal's

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -23,6 +23,7 @@ import time
 import traceback
 from contextlib import contextmanager
 from functools import partial
+from pathlib import PurePath
 from tempfile import mkdtemp
 from typing import List, Optional, Tuple
 
@@ -1217,7 +1218,7 @@ def _manifest_global_model(download_path: str, manifest_paths: List[Tuple[int, s
     model_path = manifest_artifacts.get("global_model") if isinstance(manifest_artifacts, dict) else None
     if manifest_version != "1" or not isinstance(model_path, str) or not model_path:
         return True, None
-    if os.path.isabs(model_path) or ".." in model_path.split(os.sep):
+    if os.path.isabs(model_path) or ".." in PurePath(model_path).parts:
         return True, None
 
     candidate_path = os.path.normpath(os.path.join(os.path.dirname(manifest_path), model_path))
@@ -1225,7 +1226,7 @@ def _manifest_global_model(download_path: str, manifest_paths: List[Tuple[int, s
     if (
         os.path.normcase(candidate_path) == os.path.normcase(manifest_path)
         or not _is_path_within(root_real_path, candidate_path)
-        or not os.path.exists(candidate_path)
+        or not os.path.isfile(candidate_path)
     ):
         return True, None
 

--- a/nvflare/tool/job/job_cli.py
+++ b/nvflare/tool/job/job_cli.py
@@ -129,6 +129,7 @@ _JOB_DOWNLOAD_GLOBAL_MODEL_NAMES = (
     "model_global.json",
     "model_global.joblib",
 )
+_JOB_DOWNLOAD_ARTIFACT_MANIFEST = "artifact_manifest.json"
 _JOB_DOWNLOAD_EXPECTED_ARTIFACTS = ("global_model", "metrics_summary", "client_logs")
 
 
@@ -1173,16 +1174,90 @@ def _site_name_from_log_path(download_path: str, log_path: str) -> Optional[str]
     return parent
 
 
+def _canonical_server_artifact_rank(download_path: str, artifact_path: str) -> Optional[int]:
+    """Rank known server-owned locations without treating client subtrees as authoritative."""
+    try:
+        rel_path = os.path.relpath(artifact_path, download_path)
+    except ValueError:
+        return None
+
+    rel_parts = rel_path.split(os.sep)
+    parent_parts = rel_parts[:-1]
+    if not parent_parts:
+        # Retain compatibility with callers that pass a server result directory
+        # directly instead of the outer job download directory.
+        return 1
+
+    if parent_parts[0].lower() == "workspace":
+        parent_parts = parent_parts[1:]
+        if not parent_parts:
+            return 0
+
+    first_parent = parent_parts[0].lower()
+    if first_parent == "app_server":
+        return 2
+    if first_parent == "server":
+        return 3
+    return None
+
+
+def _manifest_global_model(download_path: str, manifest_paths: List[Tuple[int, str]]) -> Tuple[bool, Optional[str]]:
+    if not manifest_paths:
+        return False, None
+
+    _, manifest_path = min(manifest_paths, key=lambda item: (item[0], os.path.relpath(item[1], download_path)))
+    try:
+        with open(manifest_path, encoding="utf-8") as file:
+            manifest = json.load(file)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return True, None
+
+    manifest_version = manifest.get("schema_version") if isinstance(manifest, dict) else None
+    manifest_artifacts = manifest.get("artifacts") if isinstance(manifest, dict) else None
+    model_path = manifest_artifacts.get("global_model") if isinstance(manifest_artifacts, dict) else None
+    if manifest_version != "1" or not isinstance(model_path, str) or not model_path:
+        return True, None
+    if os.path.isabs(model_path) or ".." in model_path.split(os.sep):
+        return True, None
+
+    candidate_path = os.path.normpath(os.path.join(os.path.dirname(manifest_path), model_path))
+    root_real_path = os.path.realpath(download_path)
+    if (
+        os.path.normcase(candidate_path) == os.path.normcase(manifest_path)
+        or not _is_path_within(root_real_path, candidate_path)
+        or not os.path.exists(candidate_path)
+    ):
+        return True, None
+
+    # Reject a symlink at any level, matching the normal artifact traversal's
+    # containment guarantees.
+    rel_candidate = os.path.relpath(candidate_path, download_path)
+    current_path = download_path
+    for part in rel_candidate.split(os.sep):
+        current_path = os.path.join(current_path, part)
+        if os.path.islink(current_path):
+            return True, None
+    return True, candidate_path
+
+
 def _discover_job_download_artifacts(download_path: str) -> Tuple[dict, List[str]]:
     artifacts = {}
     client_logs = {}
+    global_model_candidates = []
+    manifest_paths = []
 
     for file_path in _iter_files_under(download_path):
         file_name = os.path.basename(file_path)
-        if file_name in _JOB_DOWNLOAD_GLOBAL_MODEL_NAMES and "global_model" not in artifacts:
-            artifacts["global_model"] = file_path
+        server_rank = _canonical_server_artifact_rank(download_path, file_path)
+        if file_name == _JOB_DOWNLOAD_ARTIFACT_MANIFEST and server_rank is not None:
+            manifest_paths.append((server_rank, file_path))
             continue
-        elif file_name == "metrics_summary.json" and "metrics_summary" not in artifacts:
+        if file_name in _JOB_DOWNLOAD_GLOBAL_MODEL_NAMES and server_rank is not None:
+            name_rank = _JOB_DOWNLOAD_GLOBAL_MODEL_NAMES.index(file_name)
+            rel_path = os.path.relpath(file_path, download_path)
+            global_model_candidates.append(((server_rank, name_rank, rel_path), file_path))
+            continue
+        if file_name == "metrics_summary.json" and "metrics_summary" not in artifacts:
             artifacts["metrics_summary"] = file_path
             continue
         elif file_name == "round_metrics.jsonl" and "round_metrics" not in artifacts:
@@ -1194,6 +1269,13 @@ def _discover_job_download_artifacts(download_path: str) -> Tuple[dict, List[str
         site_name = _site_name_from_log_path(download_path, file_path)
         if site_name and site_name not in client_logs:
             client_logs[site_name] = file_path
+
+    manifest_present, manifest_model = _manifest_global_model(download_path, manifest_paths)
+    if manifest_model:
+        artifacts["global_model"] = manifest_model
+    elif not manifest_present and global_model_candidates:
+        _, model_path = min(global_model_candidates, key=lambda item: item[0])
+        artifacts["global_model"] = model_path
     if client_logs:
         artifacts["client_logs"] = client_logs
 

--- a/tests/unit_test/tool/job/job_download_test.py
+++ b/tests/unit_test/tool/job/job_download_test.py
@@ -142,6 +142,99 @@ class TestJobDownload:
         assert envelope["data"]["artifacts"]["global_model"] == str(model_path)
         assert "global_model" not in envelope["data"]["missing_artifacts"]
 
+    def test_download_does_not_treat_client_checkpoint_as_global_model(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        client_dir = download_path / "site-1"
+        client_dir.mkdir(parents=True)
+        (client_dir / "FL_global_model.pt").write_text("client model")
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_download_discovers_global_model_from_workspace_root(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        model_path = workspace_dir / "FL_global_model.pt"
+        model_path.write_text("server model")
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert envelope["data"]["artifacts"]["global_model"] == str(model_path)
+
+    def test_download_prefers_canonical_root_model_over_client_checkpoint(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        client_dir = download_path / "site-1"
+        client_dir.mkdir(parents=True)
+        root_model = download_path / "global_model.pt"
+        root_model.write_text("server model")
+        (client_dir / "FL_global_model.pt").write_text("client model")
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert envelope["data"]["artifacts"]["global_model"] == str(root_model)
+
+    def test_download_prefers_server_model_over_alphabetically_earlier_client_dir(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        client_dir = download_path / "app_client-1"
+        server_dir = download_path / "server"
+        client_dir.mkdir(parents=True)
+        server_dir.mkdir()
+        (client_dir / "FL_global_model.pt").write_text("client model")
+        server_model = server_dir / "global_model.pt"
+        server_model.write_text("server model")
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert envelope["data"]["artifacts"]["global_model"] == str(server_model)
+
+    def test_download_manifest_resolves_custom_global_model_name(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        server_dir = workspace_dir / "app_server"
+        server_dir.mkdir(parents=True)
+        custom_model = server_dir / "production-checkpoint.bin"
+        custom_model.write_text("server model")
+        (workspace_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": "app_server/production-checkpoint.bin"}})
+        )
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert envelope["data"]["artifacts"]["global_model"] == str(custom_model)
+        assert "global_model" not in envelope["data"]["missing_artifacts"]
+
+    def test_download_does_not_fall_back_when_manifest_target_is_missing(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "FL_global_model.pt").write_text("server model")
+        (workspace_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": "missing-model.pt"}})
+        )
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_download_ignores_client_artifact_manifest(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        client_dir = download_path / "site-1"
+        client_dir.mkdir(parents=True)
+        client_model = client_dir / "client-checkpoint.bin"
+        client_model.write_text("client model")
+        (client_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": client_model.name}})
+        )
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
     def test_download_discovers_metrics_artifacts_and_client_logs(self, tmp_path, capsys):
         """metrics artifacts and client log.txt files are reported from the local download path."""
         download_path = tmp_path / "results"
@@ -184,8 +277,9 @@ class TestJobDownload:
         _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
 
         artifacts = envelope["data"]["artifacts"]
-        assert artifacts["global_model"] == str(model_path)
+        assert "global_model" not in artifacts
         assert artifacts["metrics_summary"] == str(metrics_path)
+        assert "global_model" in envelope["data"]["missing_artifacts"]
         assert "client_logs" not in artifacts
         assert "client_logs" in envelope["data"]["missing_artifacts"]
 

--- a/tests/unit_test/tool/job/job_download_test.py
+++ b/tests/unit_test/tool/job/job_download_test.py
@@ -261,6 +261,40 @@ class TestJobDownload:
         assert "global_model" not in envelope["data"]["artifacts"]
         assert "global_model" in envelope["data"]["missing_artifacts"]
 
+    def test_manifest_global_model_rejects_alternate_case_self_target(self, tmp_path):
+        from nvflare.tool.job.job_cli import _manifest_global_model
+
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        manifest_path = workspace_dir / "artifact_manifest.json"
+        alternate_case_path = workspace_dir / "ARTIFACT_MANIFEST.JSON"
+        manifest_path.write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": alternate_case_path.name}})
+        )
+        if not alternate_case_path.exists():
+            try:
+                os.link(manifest_path, alternate_case_path)
+            except OSError:
+                pytest.skip("filesystem does not support hard links")
+
+        assert os.path.samefile(manifest_path, alternate_case_path)
+        assert _manifest_global_model(str(download_path), [(0, str(manifest_path))]) == (True, None)
+
+    def test_manifest_global_model_rejects_samefile_error(self, tmp_path):
+        from nvflare.tool.job.job_cli import _manifest_global_model
+
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        model_path = workspace_dir / "custom-model.pt"
+        model_path.write_text("server model")
+        manifest_path = workspace_dir / "artifact_manifest.json"
+        manifest_path.write_text(json.dumps({"schema_version": "1", "artifacts": {"global_model": model_path.name}}))
+
+        with patch("nvflare.tool.job.job_cli.os.path.samefile", side_effect=OSError):
+            assert _manifest_global_model(str(download_path), [(0, str(manifest_path))]) == (True, None)
+
     def test_download_manifest_rejects_parent_path(self, tmp_path, capsys):
         download_path = tmp_path / "results"
         workspace_dir = download_path / "workspace"

--- a/tests/unit_test/tool/job/job_download_test.py
+++ b/tests/unit_test/tool/job/job_download_test.py
@@ -220,6 +220,84 @@ class TestJobDownload:
         assert "global_model" not in envelope["data"]["artifacts"]
         assert "global_model" in envelope["data"]["missing_artifacts"]
 
+    def test_download_does_not_fall_back_when_manifest_is_invalid_json(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "FL_global_model.pt").write_text("server model")
+        (workspace_dir / "artifact_manifest.json").write_text("{invalid json")
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_download_does_not_fall_back_when_manifest_schema_is_invalid(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        model_path = workspace_dir / "FL_global_model.pt"
+        model_path.write_text("server model")
+        (workspace_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "2", "artifacts": {"global_model": model_path.name}})
+        )
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_download_manifest_rejects_directory_target(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        model_dir = workspace_dir / "app_server"
+        model_dir.mkdir(parents=True)
+        (workspace_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": model_dir.name}})
+        )
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_download_manifest_rejects_parent_path(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        root_model = download_path / "custom-model.pt"
+        root_model.write_text("server model")
+        (workspace_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": f"../{root_model.name}"}})
+        )
+
+        # Simulate Windows accepting a forward-slash manifest path while os.sep is a backslash.
+        with patch("nvflare.tool.job.job_cli.os.sep", "\\"):
+            _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_download_manifest_rejects_symlink_target(self, tmp_path, capsys):
+        download_path = tmp_path / "results"
+        workspace_dir = download_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        model_path = workspace_dir / "custom-model.pt"
+        model_path.write_text("server model")
+        symlink_path = workspace_dir / "model-link.pt"
+        try:
+            symlink_path.symlink_to(model_path)
+        except OSError:
+            pytest.skip("filesystem does not support symlinks")
+        (workspace_dir / "artifact_manifest.json").write_text(
+            json.dumps({"schema_version": "1", "artifacts": {"global_model": symlink_path.name}})
+        )
+
+        _, envelope = self._download_json(self._make_args(output_dir=tmp_path / "dest"), download_path, capsys)
+
+        assert "global_model" not in envelope["data"]["artifacts"]
+        assert "global_model" in envelope["data"]["missing_artifacts"]
+
     def test_download_ignores_client_artifact_manifest(self, tmp_path, capsys):
         download_path = tmp_path / "results"
         client_dir = download_path / "site-1"
@@ -234,6 +312,12 @@ class TestJobDownload:
 
         assert "global_model" not in envelope["data"]["artifacts"]
         assert "global_model" in envelope["data"]["missing_artifacts"]
+
+    def test_canonical_server_artifact_rank_handles_relpath_error(self):
+        from nvflare.tool.job.job_cli import _canonical_server_artifact_rank
+
+        with patch("nvflare.tool.job.job_cli.os.path.relpath", side_effect=ValueError):
+            assert _canonical_server_artifact_rank("download", "artifact") is None
 
     def test_download_discovers_metrics_artifacts_and_client_logs(self, tmp_path, capsys):
         """metrics artifacts and client log.txt files are reported from the local download path."""


### PR DESCRIPTION
### Description

`nvflare job download --format json` previously selected the first recognized global-model filename found anywhere under the downloaded result. That made directory-walk order authoritative and allowed client checkpoints to be mislabeled as the job's global model.

This change:

- limits legacy known-filename matching to canonical server-owned result locations (`workspace`, `server`, and `app_server`, plus a directly supplied server result root);
- ranks candidates explicitly instead of relying on `os.walk` order;
- supports an authoritative schema-version-1 `artifact_manifest.json` for custom global-model filenames;
- validates manifest targets remain regular files inside the download tree and do not traverse parent components or symlinks;
- treats a present server manifest as authoritative instead of silently falling back when it is invalid or its target is absent;
- updates the CLI contract documentation.

### Review follow-up

- Reject directory targets with `os.path.isfile`.
- Use `PurePath.parts` for separator-independent parent traversal checks.
- Cover malformed JSON, invalid schemas, missing targets, directory targets, parent traversal, symlink targets, and defensive cross-drive path handling.

### Types of changes

- [x] Non-breaking bug fix
- [x] New tests added to cover the changes
- [x] Documentation updated

### Validation

- `pytest tests/unit_test/tool/job -q` — 313 passed
- Focused coverage run — every line in the added discovery/manifest block is covered
- `./runtest.sh -s --skip-install` — Black, isort, flake8, and agent-skill lint passed
- `git diff --check`
