### PR TITLE
Persist study registry to workspace root for read-only staged local dirs

### DIFF
--- a/docs/design/multistudy_cli.md
+++ b/docs/design/multistudy_cli.md
@@ -55,6 +55,8 @@ The shipped multi-study design stores named-study state in `study_registry.json`
 
 The backend for all mutations is the same `study_registry.json` file the server loads at startup. The server applies mutations through a serialized validate-write-publish flow so the runtime registry and the persisted file remain aligned under normal operation and fail closed on validation/write errors.
 
+The persisted registry lives at the server workspace root (`<workspace>/study_registry.json`). A provisioned copy under `local/` acts as a first-start seed only: once a runtime mutation is persisted, the root copy is authoritative and shadows the seed. Writes never target `local/`, which may be a read-only mount (e.g. Kubernetes deployments that stage `local/` as a ConfigMap).
+
 ---
 
 ## Core Principles

--- a/docs/user_guide/admin_guide/multi_study_guide.rst
+++ b/docs/user_guide/admin_guide/multi_study_guide.rst
@@ -158,11 +158,19 @@ radius — use separate NVFlare deployments.
 Updating Studies
 ================
 
-Studies can be created, updated, and removed at runtime using the ``nvflare study`` command family
-without reprovisioning or restarting the server: ``register`` creates or merges a study,
-``add-site`` / ``remove-site`` change site enrollment, ``add-user`` / ``remove-user`` manage
-study-user membership, and ``remove`` deletes a study. See :ref:`study_command` for the full
-command reference.
+The ``nvflare study`` command family manages the server-side study registry at runtime, without
+reprovisioning or restarting the server: ``register`` creates or merges a study, ``add-site`` /
+``remove-site`` change site enrollment, ``add-user`` / ``remove-user`` manage study-user
+membership, and ``remove`` deletes a study. See :ref:`study_command` for the full command
+reference.
+
+These commands change only the server's view of a study — enrollment, login membership, and job
+scoping. They do not configure the participating sites: sites must already be provisioned and
+connected to be enrolled (adding a new site or admin identity to the deployment still requires
+provisioning, since certificates must be issued), and per-site runtime resources for a study —
+data mounts, job images, and related settings in each site's ``local/study_runtime.yaml`` — are
+managed by each site's operator, not by these commands. Until a site defines runtime resources for
+a study, jobs for that study run at that site without any study-specific data mounts or settings.
 
 Runtime study mutations are persisted to ``study_registry.json`` in the server workspace root, not
 in the ``local/`` folder. The provisioned copy under ``local/`` is only a first-start seed: once a
@@ -170,7 +178,3 @@ runtime mutation has been persisted, the workspace-root copy is authoritative, s
 and survives server restarts. Because writes never target ``local/``, runtime study management also
 works in deployments where ``local/`` is mounted read-only, such as Kubernetes deployments that
 stage ``local/`` as a ConfigMap.
-
-Runtime study management operates on already-provisioned participants: adding new client sites or
-admin identities to the deployment still requires provisioning, since those need certificates
-issued for them. Studies can only enroll sites and users that exist in the deployment.

--- a/docs/user_guide/admin_guide/multi_study_guide.rst
+++ b/docs/user_guide/admin_guide/multi_study_guide.rst
@@ -66,7 +66,8 @@ Validation rules:
 - Admins listed in a study must reference existing admin participants.
 - Study names use lowercase alphanumeric characters plus hyphens or underscores, 1-63 characters, and must start and end with an alphanumeric character.
 - ``"default"`` is reserved and cannot be used as a study name.
-- Provisioning generates ``study_registry.json`` in the server's ``local/`` folder.
+- Provisioning generates ``study_registry.json`` in the server's ``local/`` folder, which seeds the
+  runtime registry on first server start (see :ref:`updating_studies`).
 
 Per-Study Role Resolution
 =========================
@@ -151,12 +152,21 @@ Multi-study is suited for scenarios where organizations share trust (same PKI, s
 want logical isolation of experiments. For stronger isolation — separate PKI, separate blast
 radius — use separate NVFlare deployments.
 
+.. _updating_studies:
+
 Updating Studies
 ================
 
 Study site enrollment and user membership can be updated at runtime using the ``nvflare study``
 command family without reprovisioning or restarting the server. See :ref:`study_command` for the
 full command reference.
+
+Runtime study mutations are persisted to ``study_registry.json`` in the server workspace root, not
+in the ``local/`` folder. The provisioned copy under ``local/`` is only a first-start seed: once a
+runtime mutation has been persisted, the workspace-root copy is authoritative, shadows the seed,
+and survives server restarts. Because writes never target ``local/``, runtime study management also
+works in deployments where ``local/`` is mounted read-only, such as Kubernetes deployments that
+stage ``local/`` as a ConfigMap.
 
 Changing the core study definition (adding new studies or altering the base provisioned
 configuration) requires reprovisioning and a server restart.

--- a/docs/user_guide/admin_guide/multi_study_guide.rst
+++ b/docs/user_guide/admin_guide/multi_study_guide.rst
@@ -11,8 +11,9 @@ sites participate and what role each admin user has. Study-aware job and client-
 are scoped to the active study. The default study (``"default"``) is the fallback session context:
 it uses the certificate-based role and scopes visibility to jobs in the default study.
 
-If ``studies:`` is absent from ``project.yml``, the deployment is single-tenant and only the
-``default`` study can be used at login.
+If ``studies:`` is absent from ``project.yml``, the deployment starts single-tenant: only the
+``default`` study can be used at login until studies are registered at runtime (see
+:ref:`updating_studies`).
 
 Configuring Studies in project.yml
 ==================================
@@ -157,9 +158,11 @@ radius — use separate NVFlare deployments.
 Updating Studies
 ================
 
-Study site enrollment and user membership can be updated at runtime using the ``nvflare study``
-command family without reprovisioning or restarting the server. See :ref:`study_command` for the
-full command reference.
+Studies can be created, updated, and removed at runtime using the ``nvflare study`` command family
+without reprovisioning or restarting the server: ``register`` creates or merges a study,
+``add-site`` / ``remove-site`` change site enrollment, ``add-user`` / ``remove-user`` manage
+study-user membership, and ``remove`` deletes a study. See :ref:`study_command` for the full
+command reference.
 
 Runtime study mutations are persisted to ``study_registry.json`` in the server workspace root, not
 in the ``local/`` folder. The provisioned copy under ``local/`` is only a first-start seed: once a
@@ -168,5 +171,6 @@ and survives server restarts. Because writes never target ``local/``, runtime st
 works in deployments where ``local/`` is mounted read-only, such as Kubernetes deployments that
 stage ``local/`` as a ConfigMap.
 
-Changing the core study definition (adding new studies or altering the base provisioned
-configuration) requires reprovisioning and a server restart.
+Runtime study management operates on already-provisioned participants: adding new client sites or
+admin identities to the deployment still requires provisioning, since those need certificates
+issued for them. Studies can only enroll sites and users that exist in the deployment.

--- a/nvflare/apis/fl_constant.py
+++ b/nvflare/apis/fl_constant.py
@@ -453,6 +453,7 @@ class WorkspaceConstants:
     PRIVACY_CONFIG = "privacy.json"
     SAMPLE_PRIVACY_CONFIG = PRIVACY_CONFIG + ".sample"
     JOB_RESOURCES_CONFIG = "job_resources.json"
+    STUDY_REGISTRY_CONFIG = "study_registry.json"
 
     ADMIN_STARTUP_CONFIG = "fed_admin.json"
 

--- a/nvflare/apis/workspace.py
+++ b/nvflare/apis/workspace.py
@@ -157,18 +157,18 @@ class Workspace:
     def get_file_path_in_root(self, file_basename: str):
         return os.path.join(self.root_dir, file_basename)
 
-    def get_study_registry_file_path(self) -> str:
+    def get_study_registry_write_path(self) -> str:
         # The registry is runtime-mutable state kept in the workspace root, which stays writable
         # in deployments that mount the site config dir read-only (e.g. K8s ConfigMap staging).
+        return self.get_file_path_in_root(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+
+    def get_study_registry_file_path(self) -> str:
         # A provisioned copy in the site config dir only seeds the registry until the first
-        # runtime mutation is persisted to the root.
-        root_path = self.get_file_path_in_root(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
-        if os.path.exists(root_path):
-            return root_path
-        seed_path = self.get_file_path_in_site_config(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
-        if os.path.exists(seed_path):
-            return seed_path
-        return root_path
+        # runtime mutation is persisted to the workspace root; the root copy then shadows it.
+        write_path = self.get_study_registry_write_path()
+        if os.path.exists(write_path):
+            return write_path
+        return self._fallback_path([WorkspaceConstants.STUDY_REGISTRY_CONFIG]) or write_path
 
     def get_server_startup_file_path(self):
         # this is to get the full path to "fed_server.json"

--- a/nvflare/apis/workspace.py
+++ b/nvflare/apis/workspace.py
@@ -157,6 +157,19 @@ class Workspace:
     def get_file_path_in_root(self, file_basename: str):
         return os.path.join(self.root_dir, file_basename)
 
+    def get_study_registry_file_path(self) -> str:
+        # The registry is runtime-mutable state kept in the workspace root, which stays writable
+        # in deployments that mount the site config dir read-only (e.g. K8s ConfigMap staging).
+        # A provisioned copy in the site config dir only seeds the registry until the first
+        # runtime mutation is persisted to the root.
+        root_path = self.get_file_path_in_root(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+        if os.path.exists(root_path):
+            return root_path
+        seed_path = self.get_file_path_in_site_config(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+        if os.path.exists(seed_path):
+            return seed_path
+        return root_path
+
     def get_server_startup_file_path(self):
         # this is to get the full path to "fed_server.json"
         return self.get_file_path_in_startup(WorkspaceConstants.SERVER_STARTUP_CONFIG)

--- a/nvflare/private/fed/server/study_cmds.py
+++ b/nvflare/private/fed/server/study_cmds.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 from typing import Dict, List, Tuple
 
 from nvflare.apis.client import ClientPropKey
-from nvflare.apis.fl_constant import AdminCommandNames, WorkspaceConstants
+from nvflare.apis.fl_constant import AdminCommandNames
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec
 from nvflare.apis.utils.format_check import name_check
@@ -247,15 +247,6 @@ class StudyCommandModule(CommandModule, CommandUtil):
         }
 
     @staticmethod
-    def _registry_read_path(engine: ServerEngine) -> str:
-        return engine.get_workspace().get_study_registry_file_path()
-
-    @staticmethod
-    def _registry_write_path(engine: ServerEngine) -> str:
-        # always write to the workspace root: the site config dir may be a read-only mount
-        return engine.get_workspace().get_file_path_in_root(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
-
-    @staticmethod
     def _load_registry_config(path: str) -> dict:
         if not os.path.exists(path):
             return {"format_version": StudyRegistry.FORMAT_VERSION, "studies": {}}
@@ -424,7 +415,8 @@ class StudyCommandModule(CommandModule, CommandUtil):
             if not isinstance(engine, ServerEngine):
                 raise TypeError(f"engine must be ServerEngine but got {type(engine)}")
 
-            config = self._load_registry_config(self._registry_read_path(engine))
+            workspace = engine.get_workspace()
+            config = self._load_registry_config(workspace.get_study_registry_file_path())
             working = deepcopy(config)
             payload = mutation_cb(engine, working)
             if payload is None:
@@ -434,7 +426,7 @@ class StudyCommandModule(CommandModule, CommandUtil):
                 self._reply(conn, payload)
                 return
             new_registry = StudyRegistry(working)
-            self._write_registry_config(self._registry_write_path(engine), working)
+            self._write_registry_config(workspace.get_study_registry_write_path(), working)
             StudyRegistryService.initialize(new_registry)
             self._reply(conn, payload)
         except Exception as e:

--- a/nvflare/private/fed/server/study_cmds.py
+++ b/nvflare/private/fed/server/study_cmds.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 from typing import Dict, List, Tuple
 
 from nvflare.apis.client import ClientPropKey
-from nvflare.apis.fl_constant import AdminCommandNames
+from nvflare.apis.fl_constant import AdminCommandNames, WorkspaceConstants
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec
 from nvflare.apis.utils.format_check import name_check
@@ -247,8 +247,13 @@ class StudyCommandModule(CommandModule, CommandUtil):
         }
 
     @staticmethod
-    def _registry_path(engine: ServerEngine) -> str:
-        return engine.get_workspace().get_file_path_in_site_config("study_registry.json")
+    def _registry_read_path(engine: ServerEngine) -> str:
+        return engine.get_workspace().get_study_registry_file_path()
+
+    @staticmethod
+    def _registry_write_path(engine: ServerEngine) -> str:
+        # always write to the workspace root: the site config dir may be a read-only mount
+        return engine.get_workspace().get_file_path_in_root(WorkspaceConstants.STUDY_REGISTRY_CONFIG)
 
     @staticmethod
     def _load_registry_config(path: str) -> dict:
@@ -419,8 +424,7 @@ class StudyCommandModule(CommandModule, CommandUtil):
             if not isinstance(engine, ServerEngine):
                 raise TypeError(f"engine must be ServerEngine but got {type(engine)}")
 
-            path = self._registry_path(engine)
-            config = self._load_registry_config(path)
+            config = self._load_registry_config(self._registry_read_path(engine))
             working = deepcopy(config)
             payload = mutation_cb(engine, working)
             if payload is None:
@@ -430,7 +434,7 @@ class StudyCommandModule(CommandModule, CommandUtil):
                 self._reply(conn, payload)
                 return
             new_registry = StudyRegistry(working)
-            self._write_registry_config(path, working)
+            self._write_registry_config(self._registry_write_path(engine), working)
             StudyRegistryService.initialize(new_registry)
             self._reply(conn, payload)
         except Exception as e:

--- a/nvflare/private/fed/utils/fed_utils.py
+++ b/nvflare/private/fed/utils/fed_utils.py
@@ -230,7 +230,7 @@ def security_init(secure_train: bool, site_org: str, workspace: Workspace, app_v
         print("AuthorizationService error: {}".format(err))
         sys.exit(1)
 
-    studies_file = workspace.get_file_path_in_site_config("study_registry.json")
+    studies_file = workspace.get_study_registry_file_path()
     registry = None
     if os.path.exists(studies_file):
         with open(studies_file, "rt") as f:

--- a/tests/unit_test/apis/workspace_test.py
+++ b/tests/unit_test/apis/workspace_test.py
@@ -72,6 +72,30 @@ class TestWorkspace:
 
             assert result == expected
 
+    def test_study_registry_path_defaults_to_root_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ws = self._make_workspace(tmp_dir)
+            expected = os.path.join(tmp_dir, WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+            assert ws.get_study_registry_file_path() == expected
+
+    def test_study_registry_path_falls_back_to_site_config_seed(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ws = self._make_workspace(tmp_dir)
+            seed = os.path.join(tmp_dir, "local", WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+            with open(seed, "wt") as f:
+                f.write("{}")
+            assert ws.get_study_registry_file_path() == seed
+
+    def test_study_registry_path_prefers_root_copy_over_seed(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            ws = self._make_workspace(tmp_dir)
+            seed = os.path.join(tmp_dir, "local", WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+            root_copy = os.path.join(tmp_dir, WorkspaceConstants.STUDY_REGISTRY_CONFIG)
+            for path in (seed, root_copy):
+                with open(path, "wt") as f:
+                    f.write("{}")
+            assert ws.get_study_registry_file_path() == root_copy
+
     @pytest.mark.parametrize(
         "job_id",
         [

--- a/tests/unit_test/private/fed/server/study_cmds_test.py
+++ b/tests/unit_test/private/fed/server/study_cmds_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 from contextlib import contextmanager
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
@@ -19,6 +21,7 @@ from unittest.mock import MagicMock, patch
 from nvflare.apis.client import Client, ClientPropKey
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec
+from nvflare.apis.workspace import Workspace
 from nvflare.fuel.hci.server.authz import PreAuthzReturnCode
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.private.fed.server.study_cmds import StudyCommandModule
@@ -99,7 +102,8 @@ def _mutation_ctx(initial_config=None):
         patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.initialize"),
         # Make isinstance(engine, ServerEngine) pass for MagicMock engines
         patch("nvflare.private.fed.server.study_cmds.ServerEngine", MagicMock),
-        patch.object(StudyCommandModule, "_registry_path", return_value="/fake/path"),
+        patch.object(StudyCommandModule, "_registry_read_path", return_value="/fake/path"),
+        patch.object(StudyCommandModule, "_registry_write_path", return_value="/fake/path"),
         patch.object(StudyCommandModule, "_load_registry_config", side_effect=lambda _: deepcopy(initial_config)),
         patch.object(StudyCommandModule, "_write_registry_config"),
     ):
@@ -872,7 +876,8 @@ def _mutation_ctx_with_write_tracker(initial_config=None):
         patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.release_lock"),
         patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.initialize"),
         patch("nvflare.private.fed.server.study_cmds.ServerEngine", MagicMock),
-        patch.object(StudyCommandModule, "_registry_path", return_value="/fake/path"),
+        patch.object(StudyCommandModule, "_registry_read_path", return_value="/fake/path"),
+        patch.object(StudyCommandModule, "_registry_write_path", return_value="/fake/path"),
         patch.object(StudyCommandModule, "_load_registry_config", side_effect=lambda _: deepcopy(initial_config)),
         patch.object(StudyCommandModule, "_write_registry_config") as mock_write,
     ):
@@ -909,3 +914,70 @@ class TestAtomicityGuarantee:
             self._module().cmd_add_study_site(conn, ["add_study_site", "ghost", "--sites", "site-new"])
         assert conn.last_reply["error_code"] == "STUDY_NOT_FOUND"
         mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Section 13: persistence path — read-only local/ dir (K8s staged ConfigMap)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _service_ctx():
+    """Patches locking and publish, but leaves path resolution and disk I/O real."""
+    with (
+        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.acquire_lock", return_value=True),
+        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.release_lock"),
+        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.initialize"),
+        patch("nvflare.private.fed.server.study_cmds.ServerEngine", MagicMock),
+    ):
+        yield
+
+
+class TestRegistryPersistencePath:
+    @staticmethod
+    def _make_engine_with_workspace(tmp_path, site_map):
+        (tmp_path / "startup").mkdir()
+        (tmp_path / "local").mkdir()
+        engine = _make_engine(site_map)
+        engine.get_workspace.return_value = Workspace(str(tmp_path))
+        return engine
+
+    def test_mutation_with_read_only_local_seeds_from_local_and_persists_to_root(self, tmp_path):
+        engine = self._make_engine_with_workspace(tmp_path, {"site-a": "org_a"})
+        seed = {
+            "format_version": "1.0",
+            "studies": {"seed-study": {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]}},
+        }
+        (tmp_path / "local" / "study_registry.json").write_text(json.dumps(seed))
+        os.chmod(tmp_path / "local", 0o555)
+        try:
+            conn = _FakeConnection(role="project_admin", org="project", engine=engine)
+            with _service_ctx():
+                StudyCommandModule().cmd_register_study(
+                    conn, ["register_study", "study1", "--site-org", "org_a:site-a"]
+                )
+            assert not (conn.last_reply or {}).get("error_code"), conn.last_reply
+            persisted = json.loads((tmp_path / "study_registry.json").read_text())
+            assert set(persisted["studies"]) == {"seed-study", "study1"}
+            assert json.loads((tmp_path / "local" / "study_registry.json").read_text()) == seed
+        finally:
+            os.chmod(tmp_path / "local", 0o755)
+
+    def test_root_copy_shadows_local_seed(self, tmp_path):
+        engine = self._make_engine_with_workspace(tmp_path, {"site-a": "org_a"})
+        seed = {
+            "format_version": "1.0",
+            "studies": {"seed-study": {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]}},
+        }
+        root_state = {
+            "format_version": "1.0",
+            "studies": {"root-study": {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]}},
+        }
+        (tmp_path / "local" / "study_registry.json").write_text(json.dumps(seed))
+        (tmp_path / "study_registry.json").write_text(json.dumps(root_state))
+        conn = _FakeConnection(role="project_admin", org="project", engine=engine)
+        with _service_ctx():
+            StudyCommandModule().cmd_register_study(conn, ["register_study", "study1", "--site-org", "org_a:site-a"])
+        assert not (conn.last_reply or {}).get("error_code"), conn.last_reply
+        persisted = json.loads((tmp_path / "study_registry.json").read_text())
+        assert set(persisted["studies"]) == {"root-study", "study1"}

--- a/tests/unit_test/private/fed/server/study_cmds_test.py
+++ b/tests/unit_test/private/fed/server/study_cmds_test.py
@@ -92,18 +92,25 @@ def _make_engine(site_map: dict):
 
 
 @contextmanager
-def _mutation_ctx(initial_config=None):
-    """Patches all I/O and locking so _with_mutation runs without disk access."""
-    if initial_config is None:
-        initial_config = _EMPTY_REGISTRY
+def _service_ctx():
+    """Patches StudyRegistryService locking/publish; leaves path resolution and disk I/O real."""
     with (
         patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.acquire_lock", return_value=True),
         patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.release_lock"),
         patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.initialize"),
         # Make isinstance(engine, ServerEngine) pass for MagicMock engines
         patch("nvflare.private.fed.server.study_cmds.ServerEngine", MagicMock),
-        patch.object(StudyCommandModule, "_registry_read_path", return_value="/fake/path"),
-        patch.object(StudyCommandModule, "_registry_write_path", return_value="/fake/path"),
+    ):
+        yield
+
+
+@contextmanager
+def _mutation_ctx(initial_config=None):
+    """Patches all I/O and locking so _with_mutation runs without disk access."""
+    if initial_config is None:
+        initial_config = _EMPTY_REGISTRY
+    with (
+        _service_ctx(),
         patch.object(StudyCommandModule, "_load_registry_config", side_effect=lambda _: deepcopy(initial_config)),
         patch.object(StudyCommandModule, "_write_registry_config"),
     ):
@@ -872,12 +879,7 @@ def _mutation_ctx_with_write_tracker(initial_config=None):
     if initial_config is None:
         initial_config = _EMPTY_REGISTRY
     with (
-        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.acquire_lock", return_value=True),
-        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.release_lock"),
-        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.initialize"),
-        patch("nvflare.private.fed.server.study_cmds.ServerEngine", MagicMock),
-        patch.object(StudyCommandModule, "_registry_read_path", return_value="/fake/path"),
-        patch.object(StudyCommandModule, "_registry_write_path", return_value="/fake/path"),
+        _service_ctx(),
         patch.object(StudyCommandModule, "_load_registry_config", side_effect=lambda _: deepcopy(initial_config)),
         patch.object(StudyCommandModule, "_write_registry_config") as mock_write,
     ):
@@ -921,18 +923,6 @@ class TestAtomicityGuarantee:
 # ---------------------------------------------------------------------------
 
 
-@contextmanager
-def _service_ctx():
-    """Patches locking and publish, but leaves path resolution and disk I/O real."""
-    with (
-        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.acquire_lock", return_value=True),
-        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.release_lock"),
-        patch("nvflare.private.fed.server.study_cmds.StudyRegistryService.initialize"),
-        patch("nvflare.private.fed.server.study_cmds.ServerEngine", MagicMock),
-    ):
-        yield
-
-
 class TestRegistryPersistencePath:
     @staticmethod
     def _make_engine_with_workspace(tmp_path, site_map):
@@ -942,22 +932,29 @@ class TestRegistryPersistencePath:
         engine.get_workspace.return_value = Workspace(str(tmp_path))
         return engine
 
+    @staticmethod
+    def _registry_config(*studies):
+        return {
+            "format_version": "1.0",
+            "studies": {s: {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]} for s in studies},
+        }
+
+    @staticmethod
+    def _register_study1(tmp_path, engine):
+        """Registers study1 with real path resolution and disk I/O; returns the persisted root registry."""
+        conn = _FakeConnection(role="project_admin", org="project", engine=engine)
+        with _service_ctx():
+            StudyCommandModule().cmd_register_study(conn, ["register_study", "study1", "--site-org", "org_a:site-a"])
+        assert not (conn.last_reply or {}).get("error_code"), conn.last_reply
+        return json.loads((tmp_path / "study_registry.json").read_text())
+
     def test_mutation_with_read_only_local_seeds_from_local_and_persists_to_root(self, tmp_path):
         engine = self._make_engine_with_workspace(tmp_path, {"site-a": "org_a"})
-        seed = {
-            "format_version": "1.0",
-            "studies": {"seed-study": {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]}},
-        }
+        seed = self._registry_config("seed-study")
         (tmp_path / "local" / "study_registry.json").write_text(json.dumps(seed))
         os.chmod(tmp_path / "local", 0o555)
         try:
-            conn = _FakeConnection(role="project_admin", org="project", engine=engine)
-            with _service_ctx():
-                StudyCommandModule().cmd_register_study(
-                    conn, ["register_study", "study1", "--site-org", "org_a:site-a"]
-                )
-            assert not (conn.last_reply or {}).get("error_code"), conn.last_reply
-            persisted = json.loads((tmp_path / "study_registry.json").read_text())
+            persisted = self._register_study1(tmp_path, engine)
             assert set(persisted["studies"]) == {"seed-study", "study1"}
             assert json.loads((tmp_path / "local" / "study_registry.json").read_text()) == seed
         finally:
@@ -965,19 +962,7 @@ class TestRegistryPersistencePath:
 
     def test_root_copy_shadows_local_seed(self, tmp_path):
         engine = self._make_engine_with_workspace(tmp_path, {"site-a": "org_a"})
-        seed = {
-            "format_version": "1.0",
-            "studies": {"seed-study": {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]}},
-        }
-        root_state = {
-            "format_version": "1.0",
-            "studies": {"root-study": {"site_orgs": {"org_a": ["site-a"]}, "admins": ["admin@example.com"]}},
-        }
-        (tmp_path / "local" / "study_registry.json").write_text(json.dumps(seed))
-        (tmp_path / "study_registry.json").write_text(json.dumps(root_state))
-        conn = _FakeConnection(role="project_admin", org="project", engine=engine)
-        with _service_ctx():
-            StudyCommandModule().cmd_register_study(conn, ["register_study", "study1", "--site-org", "org_a:site-a"])
-        assert not (conn.last_reply or {}).get("error_code"), conn.last_reply
-        persisted = json.loads((tmp_path / "study_registry.json").read_text())
+        (tmp_path / "local" / "study_registry.json").write_text(json.dumps(self._registry_config("seed-study")))
+        (tmp_path / "study_registry.json").write_text(json.dumps(self._registry_config("root-study")))
+        persisted = self._register_study1(tmp_path, engine)
         assert set(persisted["studies"]) == {"root-study", "study1"}

--- a/tests/unit_test/private/fed/test_fed_utils.py
+++ b/tests/unit_test/private/fed/test_fed_utils.py
@@ -36,7 +36,7 @@ def _make_workspace(startup_dir):
     ws.get_startup_kit_dir.return_value = startup_dir
     ws.get_audit_file_path.return_value = startup_dir + "/audit.log"
     ws.get_authorization_file_path.return_value = None
-    ws.get_file_path_in_site_config.return_value = startup_dir + "/study_registry.json"
+    ws.get_study_registry_file_path.return_value = startup_dir + "/study_registry.json"
     return ws
 
 


### PR DESCRIPTION
Fixes FLARE-3036.

### Description

Runtime study mutations (`register_study`, `add_study_site`, `remove_study`, ...) persisted `study_registry.json` under `workspace/local`. In Kubernetes deployments the staged `local/` ConfigMap is mounted read-only, so every mutation failed with `Read-only file system` after successful authentication and authorization.

Mutations now persist the registry to the workspace root, which stays writable (the PVC mount in K8s). The provisioned copy under `local/` acts as a first-start seed only: reads prefer the workspace-root copy and fall back to the seed, so the first mutation starts from the provisioned studies and the root copy is authoritative from then on, surviving server restarts. This follows the existing convention of keeping runtime-mutable server state (snapshot storage, job storage, audit log) out of `local/`.

- Added `WorkspaceConstants.STUDY_REGISTRY_CONFIG` and `Workspace.get_study_registry_file_path()` (root copy if present, else `local/` seed).
- `StudyCommandModule._with_mutation` loads via the resolver and always writes to the workspace root; the atomic temp-file replace is unchanged.
- Server startup load (`security_init`) uses the same resolver.
- New tests cover resolver precedence and a mutation against a read-only `local/` dir that seeds from `local/` and persists to the root — the previously untested combination of a staged read-only site config dir with a runtime study mutation.
- Docs: multi-study guide and multistudy CLI design doc now state where the registry persists.

No deploy/Helm changes are needed; `deploy k8 stage` continues to bundle the provisioned registry into the ConfigMap, where it serves as the first-start seed. `study_runtime.yaml` (#4872) is unaffected: it is static site-owned config that is never written at runtime and intentionally stays in `local/`.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Documentation updated.