### PR TITLE
Reduce external metric logging latency

### DIFF
--- a/nvflare/client/flare_agent.py
+++ b/nvflare/client/flare_agent.py
@@ -49,7 +49,7 @@ from nvflare.fuel.utils.fobs.decomposers.via_downloader import (
 )
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.fuel.utils.pipe.cell_pipe import CellPipe
-from nvflare.fuel.utils.pipe.pipe import Message, Mode, Pipe
+from nvflare.fuel.utils.pipe.pipe import Message, Mode, Pipe, Topic
 from nvflare.fuel.utils.pipe.pipe_handler import PipeHandler
 from nvflare.private.fed.utils.fed_utils import register_ext_decomposers
 
@@ -1145,7 +1145,7 @@ class FlareAgent:
         if not self.metric_pipe_handler:
             raise RuntimeError("metric pipe is not available")
 
-        msg = Message.new_request(topic="metric", data=record)
+        msg = Message.new_request(topic=Topic.METRIC, data=record)
         return self.metric_pipe_handler.send_to_peer(msg, self.submit_result_timeout)
 
 

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -17,7 +17,7 @@ import copy
 import os
 import threading
 import uuid
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from nvflare.apis.fl_constant import ServerCommandNames
 from nvflare.apis.signal import Signal
@@ -126,6 +126,7 @@ class Adapter:
         req_id = request.get_header(MessageHeaderKey.REQ_ID, "")
         secure = request.get_header(MessageHeaderKey.SECURE, False)
         optional = request.get_header(MessageHeaderKey.OPTIONAL, False)
+        reliable = request.get_header(StreamHeaderKey.RELIABLE, None)
         self.logger.debug(f"{stream_req_id=}: on {channel=}, {topic=}")
         response = self.cb(request, *args, **kwargs)
         self.logger.debug(f"response available: {stream_req_id=}: on {channel=}, {topic=}")
@@ -146,7 +147,13 @@ class Adapter:
         encode_payload(response, StreamHeaderKey.PAYLOAD_ENCODING, fobs_ctx=self.cell.get_fobs_context())
         self.logger.debug(f"sending: {stream_req_id=}: {response.headers=}, target={origin}")
         reply_future = self.cell.send_blob(
-            CellChannel.RETURN_ONLY, f"{channel}:{topic}", origin, response, secure, optional
+            channel=CellChannel.RETURN_ONLY,
+            topic=f"{channel}:{topic}",
+            target=origin,
+            message=response,
+            secure=secure,
+            optional=optional,
+            reliable=reliable,
         )
         self.logger.debug(f"Done sending: {stream_req_id=}: {reply_future=}")
 
@@ -363,6 +370,7 @@ class Cell(StreamCell):
         progress_wait_cb=None,
         num_receivers=1,
         receiver_ids=None,
+        reliable: Optional[bool] = None,
     ):
         """Stream one request to the target
 
@@ -375,13 +383,24 @@ class Cell(StreamCell):
             secure: is P2P security to be applied
             optional: is the message optional
             abort_signal: signal to abort the message
+            reliable: whether failed or unacknowledged stream chunks should be retried.
+                If not specified, this is read from comm_config.json.
 
         Returns: reply data
 
         """
         self._encode_message(request, abort_signal, num_receivers=num_receivers, receiver_ids=receiver_ids)
         return self._send_one_request(
-            channel, target, topic, request, timeout, secure, optional, abort_signal, progress_wait_cb
+            channel=channel,
+            target=target,
+            topic=topic,
+            request=request,
+            timeout=timeout,
+            secure=secure,
+            optional=optional,
+            abort_signal=abort_signal,
+            progress_wait_cb=progress_wait_cb,
+            reliable=reliable,
         )
 
     def _send_one_request(
@@ -395,6 +414,7 @@ class Cell(StreamCell):
         optional=False,
         abort_signal=None,
         progress_wait_cb=None,
+        reliable: Optional[bool] = None,
     ):
         req_id = str(uuid.uuid4())
         request.add_headers({StreamHeaderKey.STREAM_REQ_ID: req_id})
@@ -407,7 +427,13 @@ class Cell(StreamCell):
 
         try:
             future = self.send_blob(
-                channel=channel, topic=topic, target=target, message=request, secure=secure, optional=optional
+                channel=channel,
+                topic=topic,
+                target=target,
+                message=request,
+                secure=secure,
+                optional=optional,
+                reliable=reliable,
             )
 
             self.logger.debug(f"{req_id=}: Waiting starts")

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -315,12 +315,11 @@ class RxTask:
                     ack_seq = self.seq
                     with self.ack_lock:
                         needs_ack = ack_seq != self.seq_ack or ack_offset > self.offset_ack
-                if needs_ack:
+                # A reliable sender needs the terminal ACK to retire its retry
+                # state. A non-reliable sender completes after its final send,
+                # so a trailing ACK only adds an unnecessary round trip.
+                if self.reliable and needs_ack:
                     ack_to_send = (ack_offset, ack_seq)
-                # completed also marks the trailing and post-completion
-                # flow-control ACKs of a non-reliable stream as advisory: the
-                # non-reliable sender finishes at send-completion and never
-                # waits for them (see _send_ack).
                 self.completed = True
                 if self.reliable:
                     schedule_remove = True
@@ -479,8 +478,13 @@ class RxTask:
 
             with self.ack_lock:
                 ack_lag = self.offset - self.offset_ack
-                final_ack_needed = final_chunk_consumed and (self.offset > self.offset_ack or self.seq > self.seq_ack)
-            if ack_lag >= self.ack_interval or final_ack_needed:
+                flow_control_ack_needed = not self.completed and ack_lag >= self.ack_interval
+                final_ack_needed = (
+                    self.reliable
+                    and final_chunk_consumed
+                    and (self.offset > self.offset_ack or self.seq > self.seq_ack)
+                )
+            if flow_control_ack_needed or final_ack_needed:
                 ack_to_send = (self.offset, self.seq)
 
             if self.stream_future:
@@ -515,10 +519,10 @@ class RxTask:
         # For a reliable stream, only a re-ACK at or behind state that was sent successfully
         # is optional: the first final ACK is still required even though stop() has already
         # marked the receive task completed, and a failed first attempt keeps retries at
-        # ERROR. For a non-reliable stream every ACK after completion is advisory - the
-        # sender finishes at send-completion and never waits for them. Note "already acked"
-        # means accepted by the first hop, not delivered end-to-end; a mid-route drop is
-        # still surfaced by the sender's own retry timeout.
+        # ERROR. Non-reliable streams can still send required mid-stream flow-control ACKs,
+        # but do not automatically send a terminal ACK. Note "already acked" means accepted
+        # by the first hop, not delivered end-to-end; a mid-route drop is still surfaced by
+        # the sender's own retry timeout.
         with self.ack_lock:
             already_acked = seq <= self.seq_ack and offset <= self.offset_ack
         optional = self.completed and (already_acked or not self.reliable)

--- a/nvflare/fuel/utils/pipe/cell_pipe.py
+++ b/nvflare/fuel/utils/pipe/cell_pipe.py
@@ -30,7 +30,7 @@ from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.sec.authn import set_add_auth_headers_filters
 from nvflare.fuel.utils.attributes_exportable import ExportMode
 from nvflare.fuel.utils.config_service import search_file
-from nvflare.fuel.utils.constants import Mode
+from nvflare.fuel.utils.constants import Mode, PipeChannelName
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.fuel.utils.validation_utils import check_object_type, check_str
 
@@ -44,6 +44,8 @@ _HEADER_MSG_ID = _PREFIX + "msg_id"
 _HEADER_REQ_ID = _PREFIX + "req_id"
 _HEADER_START_TIME = _PREFIX + "start"
 _HEADER_HB_SEQ = _PREFIX + "hb_seq"
+
+_METRIC_CHANNEL = _PREFIX + PipeChannelName.METRIC
 
 _logger = logging.getLogger(__name__)
 
@@ -499,10 +501,16 @@ class CellPipe(Pipe):
             progress_wait_cb=getattr(msg, "_progress_wait_cb", None),
             num_receivers=num_receivers,
             receiver_ids=receiver_ids,
-            # Metrics are already protected by the pipe request/reply and retry
-            # path. Avoid the additional per-stream retry/terminal-ACK round trip
-            # that serializes high-frequency metric logging.
-            reliable=False if msg.topic == Topic.METRIC else None,
+            # Everything requested over the metric pipe channel is small
+            # telemetry (metric records of either the Client API "metric" topic
+            # or the legacy MetricsSender topic) or a tiny optional control
+            # message, all already confirmed by this request/reply exchange and
+            # retried by the PipeHandler. Disable per-stream retry/terminal-ACK
+            # reliability there: it only adds a round trip that serializes
+            # high-frequency metric logging. Scoping by channel (not topic)
+            # keeps transport reliability for a task that happens to be named
+            # "metric" on the task pipe.
+            reliable=False if self.channel == _METRIC_CHANNEL else None,
         )
         if reply:
             rc = reply.get_header(MessageHeaderKey.RETURN_CODE)

--- a/nvflare/fuel/utils/pipe/cell_pipe.py
+++ b/nvflare/fuel/utils/pipe/cell_pipe.py
@@ -499,6 +499,10 @@ class CellPipe(Pipe):
             progress_wait_cb=getattr(msg, "_progress_wait_cb", None),
             num_receivers=num_receivers,
             receiver_ids=receiver_ids,
+            # Metrics are already protected by the pipe request/reply and retry
+            # path. Avoid the additional per-stream retry/terminal-ACK round trip
+            # that serializes high-frequency metric logging.
+            reliable=False if msg.topic == Topic.METRIC else None,
         )
         if reply:
             rc = reply.get_header(MessageHeaderKey.RETURN_CODE)

--- a/nvflare/fuel/utils/pipe/pipe.py
+++ b/nvflare/fuel/utils/pipe/pipe.py
@@ -30,6 +30,7 @@ class Topic(object):
     ABORT = "_ABORT_"
     END = "_END_"
     HEARTBEAT = "_HEARTBEAT_"
+    METRIC = "metric"
     PEER_GONE = "_PEER_GONE_"
     STREAM_PROGRESS = STREAM_PROGRESS_TOPIC
 

--- a/tests/unit_test/app_common/ccwf/test_swarm_progress_e2e.py
+++ b/tests/unit_test/app_common/ccwf/test_swarm_progress_e2e.py
@@ -83,7 +83,7 @@ class _CellStackFake:
             ctx.update(props)
         return ctx
 
-    def send_blob(self, channel, topic, target, message, secure=False, optional=False):
+    def send_blob(self, channel, topic, target, message, secure=False, optional=False, reliable=None):
         self.sent_blobs.append((channel, topic, target, message))
         return _ReadyStreamFuture()
 

--- a/tests/unit_test/app_common/executors/task_exchanger_stream_progress_test.py
+++ b/tests/unit_test/app_common/executors/task_exchanger_stream_progress_test.py
@@ -123,7 +123,7 @@ class _CellStackFake:
             ctx.update(props)
         return ctx
 
-    def send_blob(self, channel, topic, target, message, secure=False, optional=False):
+    def send_blob(self, channel, topic, target, message, secure=False, optional=False, reliable=None):
         self.sent_blobs.append((channel, topic, target, message))
         return _ReadyStreamFuture()
 

--- a/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
@@ -64,6 +64,38 @@ def test_encode_message_can_stamp_receiver_ids_for_multi_receiver_download_refs(
     assert captured[FOBSContextKey.RECEIVER_IDS] == ["receiver-a", "receiver-b"]
 
 
+def test_send_request_forwards_stream_reliability_override():
+    cell = _make_cell()
+    cell._encode_message = MagicMock()
+    cell._send_one_request = MagicMock(return_value=Message(headers={}, payload=None))
+    request = Message(headers={}, payload=None)
+
+    cell._send_request(channel="metric", target="site-1", topic="metric", request=request, reliable=False)
+
+    assert cell._send_one_request.call_args.kwargs["reliable"] is False
+
+
+def test_send_one_request_forwards_stream_reliability_override(monkeypatch):
+    cell = _make_cell()
+
+    def _conditional_wait(_event, _timeout, _abort_signal):
+        waiter = next(iter(cell.requests_dict.values()))
+        waiter.receiving_future = _ReplyFuture()
+        return WaiterRC.IS_SET
+
+    monkeypatch.setattr(cell_module, "conditional_wait", _conditional_wait)
+
+    cell._send_one_request(
+        channel="metric",
+        target="site-1",
+        topic="metric",
+        request=Message(headers={}, payload=None),
+        reliable=False,
+    )
+
+    assert cell.send_blob.call_args.kwargs["reliable"] is False
+
+
 def test_remote_processing_wait_continues_without_resend_while_progress_callback_is_true(monkeypatch):
     cell = _make_cell()
     waits = []

--- a/tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py
+++ b/tests/unit_test/fuel/f3/cellnet/test_pass_through_header.py
@@ -166,6 +166,21 @@ class TestAdapterPassThroughHeader:
             captured.get(FOBSContextKey.PASS_THROUGH) is True
         ), "decode_ctx must contain PASS_THROUGH=True when the message header carries it"
 
+    @pytest.mark.parametrize("reliable", [False, True])
+    def test_reply_uses_request_stream_reliability(self, reliable):
+        captured = {}
+        adapter = _make_adapter(captured)
+        headers = _headers_without_pass_through(stream_req_id="stream-1")
+        headers[StreamHeaderKey.RELIABLE] = reliable
+
+        with (
+            patch("nvflare.fuel.f3.cellnet.cell.decode_payload"),
+            patch("nvflare.fuel.f3.cellnet.cell.encode_payload"),
+        ):
+            adapter.call(_make_future(headers))
+
+        assert adapter.cell.send_blob.call_args.kwargs["reliable"] is reliable
+
     def test_no_header_sets_pass_through_false_in_decode_ctx(self):
         """No PASS_THROUGH header (Swarm P2P messages) → decode_ctx[PASS_THROUGH] = False.
 

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -561,30 +561,40 @@ def test_completed_task_ttl_keeps_longer_local_retry_window(monkeypatch):
     assert task.completed_task_ttl == 35.0
 
 
-def test_non_reliable_trailing_ack_is_optional_and_debug_only(caplog):
-    # the non-reliable sender finishes at send-completion and never waits for
-    # the trailing ACK, so its delivery failure at teardown must not ERROR
-    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={"site-1": "target_unreachable"}))
+def test_non_reliable_final_chunk_does_not_send_trailing_ack():
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
     message = _make_chunk("site-1", sid=530, seq=0, data_type=StreamDataType.FINAL, payload=b"abc", reliable=False)
     task = RxTask.find_or_create_task(message, cell)
 
-    with caplog.at_level(logging.DEBUG, logger="nvflare.fuel.f3.streaming.byte_receiver"):
-        assert task.process_chunk(message) is True
+    assert task.process_chunk(message) is True
+    task.ack_interval = 1
+    assert task.read(1) == b"a"
+    assert task.read(2) == b"bc"
 
     assert task.completed is True
-    assert cell.fire_and_forget.call_args.kwargs == {"optional": True}
-    trailing_ack = cell.fire_and_forget.call_args.args[3]
-    assert trailing_ack.get_header(StreamHeaderKey.SEQUENCE) == 0
-    assert trailing_ack.get_header(StreamHeaderKey.OFFSET) == 3
-    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
-    assert "failed to ack seq 0" in caplog.text
+    cell.fire_and_forget.assert_not_called()
+
+
+def test_non_reliable_midstream_read_sends_flow_control_ack():
+    cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
+    message = _make_chunk("site-1", sid=531, seq=0, data_type=StreamDataType.CHUNK, payload=b"abc", reliable=False)
+    task = RxTask.find_or_create_task(message, cell)
+    task.ack_interval = 1
+
+    assert task.process_chunk(message) is True
+    assert task.read(3) == b"abc"
+
+    assert cell.fire_and_forget.call_args.kwargs == {"optional": False}
+    flow_control_ack = cell.fire_and_forget.call_args.args[3]
+    assert flow_control_ack.get_header(StreamHeaderKey.SEQUENCE) == 0
+    assert flow_control_ack.get_header(StreamHeaderKey.OFFSET) == 3
 
 
 def test_non_reliable_midstream_flow_control_ack_remains_required():
     # before completion the sender may be blocked on the flow-control window,
     # so mid-stream ACKs stay required
     cell = SimpleNamespace(fire_and_forget=MagicMock(return_value={}))
-    task = RxTask(sid=531, origin="site-1", cell=cell, reliable=False)
+    task = RxTask(sid=543, origin="site-1", cell=cell, reliable=False)
 
     assert task._send_ack(offset=10, seq=2) is True
 

--- a/tests/unit_test/fuel/utils/pipe/cell_pipe_test.py
+++ b/tests/unit_test/fuel/utils/pipe/cell_pipe_test.py
@@ -319,6 +319,24 @@ def test_stream_progress_is_fire_and_forget():
     pipe.cell.send_request.assert_not_called()
 
 
+def test_metric_disables_stream_reliability_but_keeps_request_reply():
+    pipe = _make_pipe()
+    msg = _make_msg(topic=Topic.METRIC)
+
+    assert pipe.send(msg, timeout=1.0) is True
+
+    pipe.cell.fire_and_forget.assert_not_called()
+    assert pipe.cell.send_request.call_args.kwargs["reliable"] is False
+
+
+def test_non_metric_uses_configured_stream_reliability():
+    pipe = _make_pipe()
+
+    assert pipe.send(_make_msg(), timeout=1.0) is True
+
+    assert pipe.cell.send_request.call_args.kwargs["reliable"] is None
+
+
 def test_stream_progress_does_not_update_peer_active_time():
     pipe = _make_pipe()
     pipe.last_peer_active_time = 123.0

--- a/tests/unit_test/fuel/utils/pipe/cell_pipe_test.py
+++ b/tests/unit_test/fuel/utils/pipe/cell_pipe_test.py
@@ -54,6 +54,7 @@ from nvflare.fuel.utils.pipe.cell_pipe import (
     _HEADER_MSG_ID,
     _HEADER_MSG_TYPE,
     _HEADER_REQ_ID,
+    _METRIC_CHANNEL,
     CellPipe,
     _cell_fqcn,
     _from_cell_message,
@@ -319,9 +320,12 @@ def test_stream_progress_is_fire_and_forget():
     pipe.cell.send_request.assert_not_called()
 
 
-def test_metric_disables_stream_reliability_but_keeps_request_reply():
+@pytest.mark.parametrize("topic", [Topic.METRIC, "_metrics_sender"])
+def test_metric_channel_disables_stream_reliability_but_keeps_request_reply(topic):
+    # covers both the Client API metric topic and the legacy MetricsSender topic
     pipe = _make_pipe()
-    msg = _make_msg(topic=Topic.METRIC)
+    pipe.channel = _METRIC_CHANNEL
+    msg = _make_msg(topic=topic)
 
     assert pipe.send(msg, timeout=1.0) is True
 
@@ -329,10 +333,12 @@ def test_metric_disables_stream_reliability_but_keeps_request_reply():
     assert pipe.cell.send_request.call_args.kwargs["reliable"] is False
 
 
-def test_non_metric_uses_configured_stream_reliability():
+def test_non_metric_channel_uses_configured_stream_reliability():
+    # a task that happens to be named "metric" on another pipe channel keeps
+    # the configured transport reliability
     pipe = _make_pipe()
 
-    assert pipe.send(_make_msg(), timeout=1.0) is True
+    assert pipe.send(_make_msg(topic=Topic.METRIC), timeout=1.0) is True
 
     assert pipe.cell.send_request.call_args.kwargs["reliable"] is None
 


### PR DESCRIPTION
## Summary

- send external-process metric messages with stream reliability disabled while retaining the existing CellPipe request/reply confirmation and PipeHandler retry behavior; the override is scoped to the metric pipe channel, so it covers both the Client API `metric` topic and the legacy MetricsSender `_metrics_sender` topic, while a task that happens to be named "metric" on the task pipe keeps configured transport reliability
- propagate the request stream's reliability choice to its reply, avoiding a second reliable-stream terminal ACK for metric responses
- send terminal stream ACKs only for reliable streams while preserving required mid-stream flow-control ACKs for large non-reliable transfers

## Root cause

PR #4785 added a terminal ACK for every completed stream. For high-frequency external-process metrics, each small synchronous request and reply then incurred stream reliability/ACK work in addition to the existing application-level request/reply confirmation. This serialized per-step metric logging and caused the slowdown reported in NVBugs 6435631.

## Validation

- expanded targeted Cell, CellPipe, ByteReceiver, swarm-progress, and task-exchanger suite plus real Cell download request/reply test: `195 passed`
- isolated Cell routing suite: `9 passed`
- full project style gate with Python 3.12: `./runtest.sh -s --skip-install`
- alternating real Cell request/reply benchmark (2 x 500 messages per mode): non-reliable mean `0.421 ms`, reliable mean `1.363 ms` (`3.24x` ratio)

NVBugs: 6435631

