### PR TITLE
Add NVSkills CI request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,22 @@
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## What

Adds the standard NVSkills CI request workflow at `.github/workflows/request-nvskills-ci.yml`, copied verbatim from the NVIDIA/skills template (source of truth).

## Why

Enables NVSkills CI for this repository. The workflow is a thin trigger that delegates to the central reusable workflow `NVIDIA/skills/.github/workflows/team-request.yml@main`, so all validation logic stays maintained in one place.

Triggers:
- `/nvskills-ci` comments on pull requests
- signature-attach pushes from the NVSkills bot (`nv-skills-ci[bot]`, overridable via repo vars)

Requires the `NVSKILLS_CI_DISPATCH_TOKEN` secret to be configured on the repository.
