### PR TITLE
Fix Docker job image build: remove stale skill_manifest.py COPY

### DIFF
--- a/examples/docker/Dockerfile.nvflare-job
+++ b/examples/docker/Dockerfile.nvflare-job
@@ -7,8 +7,7 @@ WORKDIR /opt/NVFlare
 # This layer is cached until packaging metadata or setup helpers change — PyTorch
 # won't re-download on every source edit.
 COPY pyproject.toml setup.py setup.cfg versioneer.py README.md ./
-RUN mkdir -p nvflare/tool/agent && touch nvflare/__init__.py nvflare/tool/__init__.py nvflare/tool/agent/__init__.py
-COPY nvflare/tool/agent/skill_manifest.py ./nvflare/tool/agent/skill_manifest.py
+RUN mkdir -p nvflare && touch nvflare/__init__.py
 RUN pip install -U pip && pip install -e ".[dev,MONITORING,PT]"
 
 # Copy real source — only this layer reruns on source changes.


### PR DESCRIPTION
Fixes # N/A — found by the nightly regression (all `docker_launcher` example tests); tracked internally.

### Description

`examples/docker/build_docker.sh` fails on current `main`, so the `nvflare-job` image cannot be built. `Dockerfile.nvflare-job` has a `COPY nvflare/tool/agent/skill_manifest.py ...` in its early dependency-install layer, but that file no longer exists, so the build fails with `"nvflare/tool/agent/skill_manifest.py": not found` (exit 1).

Root cause (cross-PR): #4830 added that COPY because `setup.py` imported `skill_manifest.py` during editable-install metadata generation; #4837 later removed `skill_manifest.py` and its `setup.py` reference but left the Dockerfile COPY line stale.

This PR drops the stale COPY and simplifies the package-stub creation back to `mkdir -p nvflare && touch nvflare/__init__.py` (`setup.py` no longer references `skill_manifest.py` or `nvflare/tool/agent`, so the sparse layer only needs the top-level `nvflare` package stub).

Verified: `bash examples/docker/build_docker.sh` now exits 0 and builds both `nvflare-site:latest` and `nvflare-job:latest`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.