### PR TITLE
Propagate oversized streaming failures and abort runs

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -337,6 +337,16 @@ class Cell(StreamCell):
         else:
             return True
 
+    def _make_stream_error_reply(self, future, phase: str, target: str, channel: str, topic: str):
+        error = getattr(future, "error", None)
+        if not error:
+            return None
+
+        detail = secure_format_exception(error)
+        msg = f"{phase} stream failed for {channel}/{topic} with {target}: {detail}"
+        self.logger.error(msg)
+        return make_reply(ReturnCode.PROCESS_EXCEPTION, error=msg)
+
     def _encode_message(self, msg: Message, abort_signal, num_receivers=1, receiver_ids=None) -> int:
         try:
             props = {
@@ -417,6 +427,10 @@ class Cell(StreamCell):
             self.logger.debug(f"{req_id=}: entering sending wait {timeout=}")
             sending_complete = self._future_wait(future, timeout, abort_signal)
             if not sending_complete:
+                error_reply = self._make_stream_error_reply(future, "request", target, channel, topic)
+                if error_reply:
+                    waiter.result = error_reply
+                    return self._get_result(req_id)
                 self.logger.debug(f"{req_id=}: sending timeout {timeout=}")
                 return self._get_result(req_id)
 
@@ -458,7 +472,7 @@ class Cell(StreamCell):
                     self.logger.info(f"{req_id=}: receiving aborted {timeout=}")
                     return self._get_result(req_id)
                 if getattr(r_future, "error", None):
-                    self.logger.info(f"{req_id=}: receiving failed with stream error")
+                    waiter.result = self._make_stream_error_reply(r_future, "reply", target, channel, topic)
                     return self._get_result(req_id)
                 if progress_wait_cb:
                     # The same bounded progress policy applies after the first byte: a streamed reply body can still
@@ -479,13 +493,19 @@ class Cell(StreamCell):
             pt = bool(waiter.result.get_header(MessageHeaderKey.PASS_THROUGH, False))
             if channel in self.decode_pass_through_channels:
                 pt = True
-            decode_payload(
-                waiter.result,
-                encoding_key=StreamHeaderKey.PAYLOAD_ENCODING,
-                fobs_ctx=self.get_fobs_context(
-                    props={FOBSContextKey.ABORT_SIGNAL: abort_signal, FOBSContextKey.PASS_THROUGH: pt}
-                ),
-            )
+            try:
+                decode_payload(
+                    waiter.result,
+                    encoding_key=StreamHeaderKey.PAYLOAD_ENCODING,
+                    fobs_ctx=self.get_fobs_context(
+                        props={FOBSContextKey.ABORT_SIGNAL: abort_signal, FOBSContextKey.PASS_THROUGH: pt}
+                    ),
+                )
+            except Exception as ex:
+                detail = secure_format_exception(ex)
+                msg = f"failed to decode reply payload for {channel}/{topic} from {target}: {detail}"
+                self.logger.error(msg)
+                waiter.result = make_reply(ReturnCode.PROCESS_EXCEPTION, error=msg)
             self.logger.debug(f"{req_id=}: return result {waiter.result=}")
             return self._get_result(req_id)
         except Exception as ex:

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -345,7 +345,9 @@ class Cell(StreamCell):
         detail = secure_format_exception(error)
         msg = f"{phase} stream failed for {channel}/{topic} with {target}: {detail}"
         self.logger.error(msg)
-        return make_reply(ReturnCode.PROCESS_EXCEPTION, error=msg)
+        reply = make_reply(ReturnCode.PROCESS_EXCEPTION, error=msg)
+        reply.set_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR, True)
+        return reply
 
     def _encode_message(self, msg: Message, abort_signal, num_receivers=1, receiver_ids=None) -> int:
         try:
@@ -506,6 +508,7 @@ class Cell(StreamCell):
                 msg = f"failed to decode reply payload for {channel}/{topic} from {target}: {detail}"
                 self.logger.error(msg)
                 waiter.result = make_reply(ReturnCode.PROCESS_EXCEPTION, error=msg)
+                waiter.result.set_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR, True)
             self.logger.debug(f"{req_id=}: return result {waiter.result=}")
             return self._get_result(req_id)
         except Exception as ex:

--- a/nvflare/fuel/f3/cellnet/defs.py
+++ b/nvflare/fuel/f3/cellnet/defs.py
@@ -35,6 +35,8 @@ class MessageHeaderKey:
     CHANNEL = CELLNET_PREFIX + "channel"
     RETURN_CODE = CELLNET_PREFIX + "return_code"
     ERROR = CELLNET_PREFIX + "error"
+    # Marks a locally generated stream/decode failure, distinct from a remote callback exception.
+    PAYLOAD_PROCESSING_ERROR = CELLNET_PREFIX + "payload_processing_error"
     PAYLOAD_ENCODING = CELLNET_PREFIX + "payload_encoding"
     ROUTE = CELLNET_PREFIX + "route"
     ORIGINAL_HEADERS = CELLNET_PREFIX + "original_headers"

--- a/nvflare/fuel/f3/streaming/blob_streamer.py
+++ b/nvflare/fuel/f3/streaming/blob_streamer.py
@@ -105,6 +105,20 @@ class BlobHandler:
         else:
             future.set_exception(error)
 
+    def _fail_and_notify(
+        self,
+        stream: Stream,
+        future: StreamFuture,
+        error: StreamError,
+        args: tuple,
+        kwargs: dict,
+    ):
+        self._fail(stream, future, error)
+        # A declared-size rejection happens before the normal callback is scheduled. Notify the
+        # registered callback with the failed future so request/reply users can stop waiting and
+        # surface the exact stream error to their caller.
+        callback_thread_pool.submit(self._run_blob_cb, future, stream, args, kwargs)
+
     def _store_chunk(self, blob_task: BlobTask, buf: BytesAlike, buf_size: int, thread_id: int) -> bool:
         length = len(buf)
         if blob_task.pre_allocated:
@@ -153,12 +167,12 @@ class BlobHandler:
         try:
             blob_task = BlobTask(future, stream, self.max_blob_size)
         except StreamError as ex:
-            self._fail(stream, future, ex)
+            self._fail_and_notify(stream, future, ex, args, kwargs)
             return 0
         except MemoryError as ex:
             error = StreamError(f"Unable to allocate buffer for declared blob size {stream.get_size()}")
             error.__cause__ = ex
-            self._fail(stream, future, error)
+            self._fail_and_notify(stream, future, error, args, kwargs)
             return 0
 
         stream_thread_pool.submit(self._read_stream, blob_task)

--- a/nvflare/fuel/f3/streaming/download_service.py
+++ b/nvflare/fuel/f3/streaming/download_service.py
@@ -1137,7 +1137,11 @@ def download_object(
                         f"[DOWNLOAD_FAILED] Max retries ({max_retries}) exhausted for {from_fqcn}, "
                         f"ref={ref_id}. Giving up."
                     )
-            consumer.download_failed(ref_id, f"error requesting data from {from_fqcn} after {duration} secs: {rc}")
+            reason = f"error requesting data from {from_fqcn} after {duration} secs: {rc}"
+            remote_error = reply.get_header(MessageHeaderKey.ERROR)
+            if remote_error:
+                reason = f"{reason}: {remote_error}"
+            consumer.download_failed(ref_id, reason)
             _emit_progress("failed", force=True)
             return
 

--- a/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
+++ b/nvflare/fuel/utils/fobs/decomposers/via_downloader.py
@@ -804,7 +804,7 @@ class ViaDownloaderDecomposer(fobs.Decomposer, ABC):
         )
         if err:
             self.logger.error(f"failed to download from {fqcn} for source {ref}: {err}")
-            raise RuntimeError(f"failed to download from {fqcn}")
+            raise RuntimeError(f"failed to download from {fqcn}: {err}")
         else:
             self.logger.debug(f"downloaded {len(items)} items successfully")
         return items

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -459,7 +459,10 @@ class Communicator:
         elif return_code == ReturnCode.AUTHENTICATION_ERROR:
             self.logger.warning("get_task request authentication failed.")
             task = None
-        elif return_code == ReturnCode.PROCESS_EXCEPTION:
+        # Remote callback process exceptions remain retryable; only local stream/decode failures are fatal.
+        elif return_code == ReturnCode.PROCESS_EXCEPTION and task.get_header(
+            MessageHeaderKey.PAYLOAD_PROCESSING_ERROR, False
+        ):
             error = task.get_header(MessageHeaderKey.ERROR, "unknown task payload processing error")
             reason = f"Failed to receive task from {parent_fqcn}: {error}"
             self.logger.error(reason)

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -459,6 +459,17 @@ class Communicator:
         elif return_code == ReturnCode.AUTHENTICATION_ERROR:
             self.logger.warning("get_task request authentication failed.")
             task = None
+        elif return_code == ReturnCode.PROCESS_EXCEPTION:
+            error = task.get_header(MessageHeaderKey.ERROR, "unknown task payload processing error")
+            reason = f"Failed to receive task from {parent_fqcn}: {error}"
+            self.logger.error(reason)
+            fl_ctx.set_prop(FLContextKey.EVENT_DATA, reason, private=True, sticky=False)
+            run_abort_signal = fl_ctx.get_run_abort_signal()
+            if run_abort_signal:
+                run_abort_signal.trigger(True)
+            if self.engine:
+                self.engine.fire_event(EventType.FATAL_SYSTEM_ERROR, fl_ctx)
+            task = None
         else:
             self.logger.warning(f"Failed to get_task from {parent_fqcn}. Will try it again.")
             task = None

--- a/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
@@ -180,7 +180,8 @@ def test_receiving_wait_does_not_extend_stream_future_error(monkeypatch):
         progress_wait_cb=progress_wait_cb,
     )
 
-    assert result.get_header(cell_module.MessageHeaderKey.RETURN_CODE) == ReturnCode.TIMEOUT
+    assert result.get_header(cell_module.MessageHeaderKey.RETURN_CODE) == ReturnCode.PROCESS_EXCEPTION
+    assert "stream failed" in result.get_header(cell_module.MessageHeaderKey.ERROR)
     progress_wait_cb.assert_not_called()
 
 

--- a/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 import nvflare.fuel.f3.cellnet.cell as cell_module
 from nvflare.apis.signal import Signal
 from nvflare.fuel.f3.cellnet.cell import Cell
-from nvflare.fuel.f3.cellnet.defs import ReturnCode
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.utils.fobs import FOBSContextKey
 from nvflare.fuel.utils.waiter_utils import WaiterRC
@@ -182,7 +182,74 @@ def test_receiving_wait_does_not_extend_stream_future_error(monkeypatch):
 
     assert result.get_header(cell_module.MessageHeaderKey.RETURN_CODE) == ReturnCode.PROCESS_EXCEPTION
     assert "stream failed" in result.get_header(cell_module.MessageHeaderKey.ERROR)
+    assert result.get_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR)
     progress_wait_cb.assert_not_called()
+
+
+def test_sending_stream_future_error_returns_payload_processing_error():
+    cell = _make_cell()
+    future = MagicMock(error=RuntimeError("request stream failed"))
+    cell.send_blob.return_value = future
+    cell._future_wait.return_value = False
+
+    result = cell._send_one_request(
+        channel="task",
+        target="site-1",
+        topic="train",
+        request=Message(headers={}, payload=None),
+        timeout=1.0,
+        abort_signal=Signal(),
+    )
+
+    assert result.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.PROCESS_EXCEPTION
+    assert "request stream failed" in result.get_header(MessageHeaderKey.ERROR)
+    assert result.get_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR)
+    assert cell.requests_dict == {}
+
+
+def test_sending_timeout_without_stream_error_remains_timeout():
+    cell = _make_cell()
+    cell.send_blob.return_value = MagicMock(error=None)
+    cell._future_wait.return_value = False
+
+    result = cell._send_one_request(
+        channel="task",
+        target="site-1",
+        topic="train",
+        request=Message(headers={}, payload=None),
+        timeout=1.0,
+        abort_signal=Signal(),
+    )
+
+    assert result.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.TIMEOUT
+    assert result.get_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR) is None
+    assert cell.requests_dict == {}
+
+
+def test_reply_decode_error_returns_payload_processing_error(monkeypatch):
+    cell = _make_cell()
+
+    def _conditional_wait(_event, _timeout, _abort_signal):
+        waiter = next(iter(cell.requests_dict.values()))
+        waiter.receiving_future = _ReplyFuture()
+        return WaiterRC.IS_SET
+
+    monkeypatch.setattr(cell_module, "conditional_wait", _conditional_wait)
+    monkeypatch.setattr(cell_module, "decode_payload", MagicMock(side_effect=RuntimeError("decode failed")))
+
+    result = cell._send_one_request(
+        channel="task",
+        target="site-1",
+        topic="train",
+        request=Message(headers={}, payload=None),
+        timeout=1.0,
+        abort_signal=Signal(),
+    )
+
+    assert result.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.PROCESS_EXCEPTION
+    assert "decode failed" in result.get_header(MessageHeaderKey.ERROR)
+    assert result.get_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR)
+    assert cell.requests_dict == {}
 
 
 def test_remote_processing_wait_returns_timeout_when_progress_callback_is_false(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/blob_streamer_test.py
+++ b/tests/unit_test/fuel/f3/streaming/blob_streamer_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -96,7 +97,13 @@ def test_blob_handler_uses_dedicated_streaming_blob_limit(monkeypatch):
 
 def test_handle_blob_cb_stops_task_on_declared_size_above_limit(monkeypatch):
     monkeypatch.setattr(CommConfigurator, "get_streaming_max_blob_size", lambda self: 4)
-    handler = BlobHandler(lambda future: None)
+    callback_called = threading.Event()
+
+    def blob_cb(callback_future):
+        assert isinstance(callback_future.exception(timeout=0.1), StreamError)
+        callback_called.set()
+
+    handler = BlobHandler(blob_cb)
     future = StreamFuture(stream_id=7)
     stopped = {}
 
@@ -113,6 +120,7 @@ def test_handle_blob_cb_stops_task_on_declared_size_above_limit(monkeypatch):
     assert isinstance(error, StreamError)
     assert "exceeds configured limit" in str(error)
     assert stopped["error"] is error
+    assert callback_called.wait(1.0)
 
 
 def test_handle_blob_cb_stops_task_on_memory_error(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/download_object_test.py
+++ b/tests/unit_test/fuel/f3/streaming/download_object_test.py
@@ -53,7 +53,7 @@ class MockConsumer(Consumer):
         self.failure_reason = reason
 
 
-def _make_reply(rc: str, status=None, data=None, state=None) -> Message:
+def _make_reply(rc: str, status=None, data=None, state=None, error=None) -> Message:
     """Build a Message that mimics what cell.send_request returns."""
     payload = {}
     if status is not None:
@@ -65,6 +65,8 @@ def _make_reply(rc: str, status=None, data=None, state=None) -> Message:
 
     msg = Message()
     msg.set_header(MessageHeaderKey.RETURN_CODE, rc)
+    if error:
+        msg.set_header(MessageHeaderKey.ERROR, error)
     msg.payload = payload
     return msg
 
@@ -302,6 +304,19 @@ class TestDownloadObject:
 
         assert consumer.failed
         assert not consumer.completed
+        assert cell.send_request.call_count == 1
+
+    def test_non_timeout_error_preserves_remote_error(self, cell, consumer):
+        """The caller needs the stream rejection reason to report an actionable task failure."""
+        cell.send_request.return_value = _make_reply(
+            ReturnCode.PROCESS_EXCEPTION,
+            error="Declared blob size 2097152 exceeds configured limit 1048576",
+        )
+
+        download_object("server.site-1", "ref-001", 10.0, cell, consumer)
+
+        assert consumer.failed
+        assert "Declared blob size 2097152 exceeds configured limit 1048576" in consumer.failure_reason
         assert cell.send_request.call_count == 1
 
     def test_producer_error(self, cell, consumer):

--- a/tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py
+++ b/tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py
@@ -155,6 +155,18 @@ class TestViaDownloaderRecomposeLazyRefGuard:
             decomposer.recompose({EncKey.TYPE: EncType.REF, EncKey.DATA: "T0"}, manager)
 
 
+def test_download_from_remote_cell_preserves_download_error(monkeypatch):
+    decomposer = _DummyViaDownloader()
+    error = "Declared blob size 2097152 exceeds configured limit 1048576"
+    monkeypatch.setattr(decomposer, "download", lambda **_kwargs: (error, None))
+
+    with pytest.raises(RuntimeError, match=error):
+        decomposer._download_from_remote_cell(
+            {fobs.FOBSContextKey.CELL: object()},
+            {"fqcn": "server.job", "ref_id": "ref-1"},
+        )
+
+
 class TestViaDownloaderTimeoutPolicy:
     def test_create_downloader_uses_generic_default_when_no_timeouts_are_configured(self, monkeypatch):
         observed = {}

--- a/tests/unit_test/private/fed/client/communicator_test.py
+++ b/tests/unit_test/private/fed/client/communicator_test.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvflare.apis.fl_context import FLContext
+from unittest.mock import MagicMock
+
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
+from nvflare.apis.fl_context import FLContext, FLContextManager
+from nvflare.apis.signal import Signal
+from nvflare.fuel.f3.cellnet.defs import ReturnCode
+from nvflare.fuel.f3.cellnet.utils import make_reply
 from nvflare.private.defs import ClientRegMsgKey
 from nvflare.private.fed.client.communicator import Communicator
 
@@ -28,3 +35,25 @@ def test_get_site_config_for_registration_ignores_non_dict_config():
     communicator = Communicator(client_config={"client_name": "site-1", ClientRegMsgKey.SITE_CONFIG: ["bad"]})
 
     assert communicator._get_site_config_for_registration(FLContext()) is None
+
+
+def test_pull_task_process_exception_aborts_run(monkeypatch):
+    engine = MagicMock()
+    abort_signal = Signal()
+    fl_ctx = FLContextManager(engine=engine, identity_name="site-1", job_id="job-1").new_context()
+    fl_ctx.set_prop(FLContextKey.RUN_ABORT_SIGNAL, abort_signal, private=True, sticky=False)
+
+    error = "Declared blob size 2097152 exceeds configured limit 1048576"
+    cell = MagicMock()
+    cell.send_request.return_value = make_reply(ReturnCode.PROCESS_EXCEPTION, error=error)
+    communicator = Communicator(client_config={"client_name": "site-1"}, cell=cell)
+    communicator.engine = engine
+    monkeypatch.setattr("nvflare.private.fed.client.communicator.determine_parent_fqcn", lambda *_args: "server")
+
+    task = communicator.pull_task("project", "token", "ssid", fl_ctx)
+
+    assert task is None
+    assert abort_signal.triggered
+    assert error in fl_ctx.get_prop(FLContextKey.EVENT_DATA)
+    engine.fire_event.assert_called_once_with(EventType.FATAL_SYSTEM_ERROR, fl_ctx)
+    assert cell.send_request.call_args.kwargs["target"] == "server.job-1"

--- a/tests/unit_test/private/fed/client/communicator_test.py
+++ b/tests/unit_test/private/fed/client/communicator_test.py
@@ -18,7 +18,7 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext, FLContextManager
 from nvflare.apis.signal import Signal
-from nvflare.fuel.f3.cellnet.defs import ReturnCode
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.utils import make_reply
 from nvflare.private.defs import ClientRegMsgKey
 from nvflare.private.fed.client.communicator import Communicator
@@ -45,7 +45,9 @@ def test_pull_task_process_exception_aborts_run(monkeypatch):
 
     error = "Declared blob size 2097152 exceeds configured limit 1048576"
     cell = MagicMock()
-    cell.send_request.return_value = make_reply(ReturnCode.PROCESS_EXCEPTION, error=error)
+    reply = make_reply(ReturnCode.PROCESS_EXCEPTION, error=error)
+    reply.set_header(MessageHeaderKey.PAYLOAD_PROCESSING_ERROR, True)
+    cell.send_request.return_value = reply
     communicator = Communicator(client_config={"client_name": "site-1"}, cell=cell)
     communicator.engine = engine
     monkeypatch.setattr("nvflare.private.fed.client.communicator.determine_parent_fqcn", lambda *_args: "server")
@@ -57,3 +59,23 @@ def test_pull_task_process_exception_aborts_run(monkeypatch):
     assert error in fl_ctx.get_prop(FLContextKey.EVENT_DATA)
     engine.fire_event.assert_called_once_with(EventType.FATAL_SYSTEM_ERROR, fl_ctx)
     assert cell.send_request.call_args.kwargs["target"] == "server.job-1"
+
+
+def test_pull_task_generic_process_exception_retries(monkeypatch):
+    engine = MagicMock()
+    abort_signal = Signal()
+    fl_ctx = FLContextManager(engine=engine, identity_name="site-1", job_id="job-1").new_context()
+    fl_ctx.set_prop(FLContextKey.RUN_ABORT_SIGNAL, abort_signal, private=True, sticky=False)
+
+    cell = MagicMock()
+    cell.send_request.return_value = make_reply(ReturnCode.PROCESS_EXCEPTION, error="task callback failed")
+    communicator = Communicator(client_config={"client_name": "site-1"}, cell=cell)
+    communicator.engine = engine
+    monkeypatch.setattr("nvflare.private.fed.client.communicator.determine_parent_fqcn", lambda *_args: "server")
+
+    task = communicator.pull_task("project", "token", "ssid", fl_ctx)
+
+    assert task is None
+    assert not abort_signal.triggered
+    assert fl_ctx.get_prop(FLContextKey.EVENT_DATA) is None
+    engine.fire_event.assert_not_called()


### PR DESCRIPTION
## Summary

Fix NVBugs 6446102 so an oversized streamed task fails with its original error and stops the run instead of hanging silently.

- notify the registered blob callback when a declared-size or allocation check rejects a stream before normal dispatch
- turn request, reply, and payload decode stream failures into `PROCESS_EXCEPTION` replies with actionable error details
- preserve the remote failure through the download/decomposition path
- trigger the client run abort signal and `FATAL_SYSTEM_ERROR` when task retrieval fails during payload processing

## Root cause

The receiver rejected a blob larger than `streaming_max_blob_size`, but that early rejection never scheduled the registered blob callback. The cell request waiter therefore did not receive the failed future, downstream layers discarded error details, and task polling continued instead of aborting the run.

## Validation

- `~/nvflare-env/3.12/bin/python -m pytest -q tests/unit_test/fuel/f3 tests/unit_test/fuel/utils/fobs/decomposers/via_downloader_test.py tests/unit_test/private/fed/client/communicator_test.py` — 549 passed
- scoped Black, isort, and flake8 checks for all 10 changed files — passed
- `git diff --check` — passed
- simulator with a 1 MiB stream limit and a 3 MB NumPy model — exact size-limit error reached the client, `FATAL_SYSTEM_ERROR` stopped the client runner, and the server workflow observed the abort signal instead of hanging
- simulator control with a 4 MiB limit and the same model — completed successfully

## Style-check note

`./runtest.sh -s` was run with Python 3.12. Its repository-wide Black check stops on three unchanged vendored `flatted.py` copies under the healthcare tutorial `node_modules/.pnpm` tree. Black reports 2479 other files unchanged. The scoped Black, isort, and flake8 checks for every file in this PR pass.