### PR TITLE
Restore TaskScriptRunner globals after abandoned trainer

### DIFF
--- a/nvflare/app_common/executors/client_api/in_process_backend.py
+++ b/nvflare/app_common/executors/client_api/in_process_backend.py
@@ -92,6 +92,7 @@ class InProcessBackend(ClientAPIBackendSpec):
         self._data_bus: Optional[DataBus] = None
         self._event_manager: Optional[EventManager] = None
         self._client_api: Optional[InProcessClientAPI] = None
+        self._task_fn_wrapper: Optional[TaskScriptRunner] = None
         self._task_fn_thread: Optional[threading.Thread] = None
         self._local_result = _NO_RESULT
         self._abort = False
@@ -119,7 +120,7 @@ class InProcessBackend(ClientAPIBackendSpec):
             workspace: Workspace = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
             job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
             custom_dir = workspace.get_app_custom_dir(job_id)
-            task_fn_wrapper = TaskScriptRunner(
+            self._task_fn_wrapper = TaskScriptRunner(
                 custom_dir=custom_dir, script_path=task_script_path, script_args=context.task_script_args
             )
 
@@ -139,7 +140,7 @@ class InProcessBackend(ClientAPIBackendSpec):
             # thread would then block process exit even after finalize() gives up its
             # bounded join. finalize() still joins cooperatively first.
             self._task_fn_thread = threading.Thread(
-                target=task_fn_wrapper.run, name="client_api_in_process_trainer", daemon=True
+                target=self._task_fn_wrapper.run, name="client_api_in_process_trainer", daemon=True
             )
             self._task_fn_thread.start()
         except Exception:
@@ -274,6 +275,8 @@ class InProcessBackend(ClientAPIBackendSpec):
                         f"after TOPIC_STOP; abandoning it (daemon thread, will not block process exit; "
                         f"its API is closed, so any later send/log from it is dropped)"
                     )
+                    if self._task_fn_wrapper is not None:
+                        self._task_fn_wrapper.release_runtime()
         except Exception:
             self.logger.error(secure_format_traceback())
         finally:

--- a/nvflare/app_common/executors/task_script_runner.py
+++ b/nvflare/app_common/executors/task_script_runner.py
@@ -15,6 +15,7 @@ import builtins
 import os
 import runpy
 import sys
+import threading
 import traceback
 
 from nvflare.client.in_process.api import TOPIC_ABORT
@@ -22,8 +23,6 @@ from nvflare.fuel.data_event.data_bus import DataBus
 from nvflare.fuel.data_event.event_manager import EventManager
 from nvflare.fuel.utils.log_utils import get_module_logger
 from nvflare.fuel.utils.secret_utils import resolve_secret_refs, split_command_preserving_secret_refs
-
-print_fn = builtins.print
 
 
 class TaskScriptRunner:
@@ -44,14 +43,18 @@ class TaskScriptRunner:
         self.custom_dir = custom_dir
         self.script_path = script_path
         self.script_full_path = self.get_script_full_path(self.custom_dir, self.script_path)
+        self._runtime_lock = threading.Lock()
+        self._runtime_released = False
+        self._original_print = None
+        self._original_argv = None
+        self._original_argv_values = None
+        self._task_argv = None
 
     def run(self):
         """Call the task_fn with any required arguments."""
         self.logger.info(f"start task run() with full path: {self.script_full_path}")
-        curr_argv = sys.argv
         try:
-            builtins.print = log_print if self.redirect_print_to_log else print_fn
-            sys.argv = self.get_sys_argv()
+            self._activate_runtime(self.get_sys_argv())
             runpy.run_path(self.script_full_path, run_name="__main__")
         except ImportError as ie:
             msg = "attempted relative import with no known parent package"
@@ -70,8 +73,32 @@ class TaskScriptRunner:
             self.event_manager.fire_event(TOPIC_ABORT, f"'{self.script_full_path}' is aborted, {msg}")
             raise e
         finally:
-            sys.argv = curr_argv
-            builtins.print = print_fn
+            self.release_runtime()
+
+    def _activate_runtime(self, task_argv):
+        with self._runtime_lock:
+            # finalize() can release a trainer before its thread reaches this point.
+            if self._runtime_released:
+                return
+            self._original_argv = sys.argv
+            self._original_argv_values = list(sys.argv)
+            self._task_argv = task_argv
+            sys.argv = self._task_argv
+            if self.redirect_print_to_log:
+                self._original_print = builtins.print
+                builtins.print = log_print
+
+    def release_runtime(self):
+        """Restore globals owned by this runner, even when its thread must be abandoned."""
+        with self._runtime_lock:
+            first_release = not self._runtime_released
+            self._runtime_released = True
+            if first_release and self._original_print is not None:
+                builtins.print = self._original_print
+            if self._original_argv is not None:
+                self._original_argv[:] = self._original_argv_values
+                if first_release and sys.argv is self._task_argv:
+                    sys.argv = self._original_argv
 
     def get_sys_argv(self):
         # Preserve the runner's legacy whitespace splitting for existing arguments. Only quoted

--- a/tests/unit_test/app_common/executors/in_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/in_process_backend_test.py
@@ -22,6 +22,8 @@ process singleton, so leaks would cross into later jobs in the same process), bo
 wait, and LOG routing through the executor-owned fire_log_analytics().
 """
 
+import builtins
+import sys
 import time
 from unittest.mock import MagicMock, Mock, patch
 
@@ -200,11 +202,15 @@ class TestInitializeAndFinalize:
         assert not _backend_callbacks_subscribed(clean_databus, backend)
         assert not backend._task_fn_thread.is_alive()
 
-    def test_finalize_bounded_when_trainer_stuck_in_user_code(self, tmp_path, caplog):
+    def test_finalize_bounded_when_trainer_stuck_in_user_code(self, tmp_path, caplog, capsys):
         """A trainer wedged in user code never observes TOPIC_STOP: with result_wait_timeout,
         execute() returns while the thread still runs, so finalize() must join with a bound
-        and abandon (daemon thread) instead of hanging CJ/simulator teardown forever."""
+        and abandon (daemon thread) instead of hanging CJ/simulator teardown forever. Abandoning
+        the runner must restore the process globals that TaskScriptRunner owns."""
         (tmp_path / "train.py").write_text("import time\nwhile True: time.sleep(0.5)\n")
+        original_print = builtins.print
+        original_argv = sys.argv
+        original_argv_values = list(sys.argv)
         backend, fl_ctx = _initialized_backend(str(tmp_path), result_wait_timeout=0.05)
         try:
             result = backend.execute("train", Shareable(), fl_ctx, Signal())
@@ -217,6 +223,13 @@ class TestInitializeAndFinalize:
                 backend.finalize(FLContext())
                 elapsed = time.monotonic() - start
         assert elapsed < 5.0, "finalize must not hang on a stuck trainer"
+        assert backend._task_fn_thread.is_alive()
+        assert builtins.print is original_print
+        assert sys.argv is original_argv
+        assert list(sys.argv) == original_argv_values
+        capsys.readouterr()
+        print("unrelated output")
+        assert capsys.readouterr().out == "unrelated output\n"
         assert "did not stop within" in caplog.text
 
     def test_initialize_configures_memory_management(self, custom_dir):

--- a/tests/unit_test/app_common/executors/task_script_runner_test.py
+++ b/tests/unit_test/app_common/executors/task_script_runner_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
 import os
 import shutil
 import sys
@@ -227,6 +228,32 @@ class TestTaskScriptRunner(unittest.TestCase):
             wrapper.run()
         finally:
             sys.path = old_sys_path
+
+    def test_run_redirects_print_from_imported_module(self):
+        old_sys_path = sys.path.copy()
+        original_print = builtins.print
+        helper_module = "task_script_runner_print_helper"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            helper_path = os.path.join(temp_dir, f"{helper_module}.py")
+            script_path = os.path.join(temp_dir, "train.py")
+            with open(helper_path, "w", encoding="utf-8") as helper_file:
+                helper_file.write('print("helper output")\n')
+            with open(script_path, "w", encoding="utf-8") as script_file:
+                script_file.write(f'import {helper_module}\nprint("script output")\n')
+
+            sys.path.insert(0, temp_dir)
+            try:
+                wrapper = TaskScriptRunner(custom_dir=temp_dir, script_path="train.py")
+                with patch.object(wrapper.logger, "info") as mock_log:
+                    wrapper.run()
+
+                mock_log.assert_any_call("helper output")
+                mock_log.assert_any_call("script output")
+                assert builtins.print is original_print
+            finally:
+                sys.modules.pop(helper_module, None)
+                sys.path[:] = old_sys_path
 
     def test_run_scripts_with_sub_dirs2(self):
         old_sys_path = sys.path


### PR DESCRIPTION
### Description

Fixes process-global `print` and `sys.argv` leaks from `TaskScriptRunner` when an in-process trainer is abandoned.

`TaskScriptRunner.run()` temporarily replaces `builtins.print` and `sys.argv` so the task script and its imported helper modules log consistently and receive task-specific arguments. Normally its `finally` block restores both globals. With bounded shutdown, however, a trainer stuck indefinitely in user code remains alive as a daemon thread, so that `finally` block is never reached. Later work in the same process then inherits the task logger and task argv; under pytest this made `capsys` empty and caused unrelated CLI failures.

This change keeps the existing script logging behavior and adds an idempotent runtime-release hook. `InProcessBackend.finalize()` retains the runner and calls that hook after its bounded join gives up, restoring the original `builtins.print` and the original `sys.argv` object and contents even though the trainer thread is still alive.

Regression coverage verifies:

- prints from both the task script and an imported helper module still reach the runner logger;
- abandoning a live trainer restores the exact original `print` and `sys.argv`;
- normal stdout capture continues working afterward;
- test cleanup restores `sys.path` in place.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [ ] Documentation updated.

### Validation

- Focused runner, backend, secret-reference, and capture regression set: 61 passed.
- Affected CLI, certificate, deploy, package, job, POC, schema, and system-output tests: 913 passed.
- `./runtest.sh -s` passed: Black (2,414 files), isort, flake8, and agent-skill lint.
- `git diff --check` passed.
