### PR TITLE
Tighten resource spec validation

### DIFF
--- a/nvflare/private/fed/server/job_meta_validator.py
+++ b/nvflare/private/fed/server/job_meta_validator.py
@@ -260,15 +260,15 @@ class JobMetaValidator(JobMetaValidatorSpec):
         logger.debug(f"validate resource for job {job_name}")
 
         resource_spec = meta.get(JobMetaKey.RESOURCE_SPEC.value)
-        if resource_spec and not isinstance(resource_spec, dict):
+        if resource_spec is not None and not isinstance(resource_spec, dict):
             raise ValueError(f"Invalid resource_spec for job {job_name}")
 
         if not resource_spec:
             logger.debug("empty resource spec provided")
 
-        if resource_spec:
+        if isinstance(resource_spec, dict):
             for k in resource_spec:
-                if resource_spec[k] and not isinstance(resource_spec[k], dict):
+                if not isinstance(resource_spec[k], dict):
                     raise ValueError(f"value for key {k} in resource spec is expecting a dictionary")
 
     _VALID_LAUNCHER_MODES = {"process", "docker", "k8s"}

--- a/tests/unit_test/private/fed/server/job_meta_validator_test.py
+++ b/tests/unit_test/private/fed/server/job_meta_validator_test.py
@@ -23,6 +23,7 @@ import pytest
 
 from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.fl_constant import JobConstants
+from nvflare.apis.job_def import JobMetaKey
 from nvflare.app_opt.flower.defs import Constant as FlowerConstant
 from nvflare.fuel.utils.zip_utils import get_all_file_paths, normpath_for_zip, split_path
 from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
@@ -139,6 +140,20 @@ class TestJobMetaValidator:
     def test_validate_invalid_deploy_map(self, meta):
         with pytest.raises(ValueError):
             JobMetaValidator._validate_deploy_map("unit_test", meta)
+
+    @pytest.mark.parametrize("resource_spec", [None, {}])
+    def test_validate_resource_accepts_empty_spec(self, resource_spec):
+        JobMetaValidator._validate_resource("unit_test", {JobMetaKey.RESOURCE_SPEC.value: resource_spec})
+
+    @pytest.mark.parametrize("resource_spec", [[], "", 0, False])
+    def test_validate_resource_rejects_non_mapping_spec(self, resource_spec):
+        with pytest.raises(ValueError, match="Invalid resource_spec"):
+            JobMetaValidator._validate_resource("unit_test", {JobMetaKey.RESOURCE_SPEC.value: resource_spec})
+
+    @pytest.mark.parametrize("site_spec", [None, [], "", 0, False])
+    def test_validate_resource_rejects_non_mapping_site_spec(self, site_spec):
+        with pytest.raises(ValueError, match="expecting a dictionary"):
+            JobMetaValidator._validate_resource("unit_test", {JobMetaKey.RESOURCE_SPEC.value: {"site-1": site_spec}})
 
     @pytest.mark.parametrize("job_name", VALID_JOBS)
     def test_validate_valid_jobs(self, job_name):


### PR DESCRIPTION
## What changed

- require `resource_spec` to be a mapping when non-null and require every per-site value to be a mapping

## Why

The validator used truthiness checks, so falsey non-mapping values such as `[]`, `""`, `0`, `false`, and null per-site values bypassed validation. These malformed values could then be silently treated as empty resource requirements or fail later during scheduling.

## Impact

Job metadata validation continues to accept a null or empty top-level `resource_spec`, but rejects every other non-mapping top-level or per-site value at submission time.

## Verification

- `.venv/bin/python -m pytest tests/unit_test/private/fed/server/job_meta_validator_test.py -q` — 54 passed
- `./runtest.sh -s` — passed (black, isort, flake8, agent-skill lint)
- `git diff --check` — passed

No Slurm files, constants, or dependencies are included.
