### PR TITLE
Preserve abort requests during client job launch

### DIFF
--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -77,6 +77,8 @@ class _PendingJobHandle(JobHandleSpec):
     def wait(self):
         with self._lock:
             job_handle = self._job_handle
+        if job_handle is None:
+            raise RuntimeError("cannot wait for a pending job handle before it is attached")
         return job_handle.wait()
 
 
@@ -295,6 +297,8 @@ class JobExecutor(ClientExecutor):
             }
         try:
             job_handle = job_launcher.launch_job(job_meta, fl_ctx)
+            if job_handle is None:
+                raise RuntimeError(f"job launcher returned no job handle for job '{job_id}'")
         except BaseException:
             with self.lock:
                 if self.run_processes.get(job_id, {}).get(RunProcessKey.JOB_HANDLE) is pending_handle:

--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -23,7 +23,7 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import AdminCommandNames, ConnPropKey, FLContextKey, RunProcessKey, SystemConfigs
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
-from nvflare.apis.job_launcher_spec import JobLauncherSpec, JobProcessArgs, JobReturnCode
+from nvflare.apis.job_launcher_spec import JobHandleSpec, JobLauncherSpec, JobProcessArgs, JobReturnCode
 from nvflare.apis.resource_manager_spec import ResourceManagerSpec
 from nvflare.apis.workspace import Workspace
 from nvflare.fuel.common.exit_codes import PROCESS_EXIT_REASON, ProcessExitCode
@@ -44,6 +44,40 @@ REPORTABLE_JOB_FAILURES = {
     ProcessExitCode.CONFIG_ERROR: PROCESS_EXIT_REASON[ProcessExitCode.CONFIG_ERROR],
     JobReturnCode.ABORTED: "aborted",
 }
+
+
+class _PendingJobHandle(JobHandleSpec):
+    """Hold an abort request until a launcher returns the real job handle."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._job_handle = None
+        self._terminate_requested = False
+
+    def attach(self, job_handle: JobHandleSpec) -> bool:
+        with self._lock:
+            self._job_handle = job_handle
+            return self._terminate_requested
+
+    def terminate(self):
+        with self._lock:
+            job_handle = self._job_handle
+            if job_handle is None:
+                self._terminate_requested = True
+                return
+        return job_handle.terminate()
+
+    def poll(self):
+        with self._lock:
+            job_handle = self._job_handle
+        if job_handle is None:
+            return None
+        return job_handle.poll()
+
+    def wait(self):
+        with self._lock:
+            job_handle = self._job_handle
+        return job_handle.wait()
 
 
 class ClientExecutor(ABC):
@@ -251,7 +285,26 @@ class JobExecutor(ClientExecutor):
                 job_args[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", parent_conn_sec)
 
         fl_ctx.set_prop(key=FLContextKey.JOB_PROCESS_ARGS, value=job_args, private=True, sticky=False)
-        job_handle = job_launcher.launch_job(job_meta, fl_ctx)
+        pending_handle = _PendingJobHandle()
+        with self.lock:
+            if job_id in self.run_processes:
+                raise RuntimeError(f"client app for job '{job_id}' is still registered")
+            self.run_processes[job_id] = {
+                RunProcessKey.JOB_HANDLE: pending_handle,
+                RunProcessKey.STATUS: ClientStatus.STARTING,
+            }
+        try:
+            job_handle = job_launcher.launch_job(job_meta, fl_ctx)
+        except BaseException:
+            with self.lock:
+                if self.run_processes.get(job_id, {}).get(RunProcessKey.JOB_HANDLE) is pending_handle:
+                    self.run_processes.pop(job_id, None)
+            raise
+
+        abort_requested = pending_handle.attach(job_handle)
+        if abort_requested:
+            self.abort_app(job_id)
+
         self.logger.info(f"Launched job {job_id} with job launcher: {type(job_launcher)} ")
 
         fl_ctx.set_prop(FLContextKey.JOB_META, job_meta, private=True, sticky=False)
@@ -259,12 +312,6 @@ class JobExecutor(ClientExecutor):
         engine.fire_event(EventType.AFTER_JOB_LAUNCH, fl_ctx)
 
         client.multi_gpu = False
-
-        with self.lock:
-            self.run_processes[job_id] = {
-                RunProcessKey.JOB_HANDLE: job_handle,
-                RunProcessKey.STATUS: ClientStatus.STARTING,
-            }
 
         thread = threading.Thread(
             target=self._wait_child_process_finish,

--- a/tests/unit_test/private/fed/client/client_executor_test.py
+++ b/tests/unit_test/private/fed/client/client_executor_test.py
@@ -84,7 +84,7 @@ def _make_start_app_inputs(tmp_path, job_id="job-1"):
     return job_meta, workspace, client, fl_ctx
 
 
-def test_start_app_pending_handle_poll_before_launcher_returns(tmp_path):
+def test_start_app_pending_handle_operations_before_launcher_returns(tmp_path):
     job_id = "job-1"
     job_meta, workspace, client, fl_ctx = _make_start_app_inputs(tmp_path, job_id)
     executor = JobExecutor(client=client, startup=workspace.get_startup_kit_dir())
@@ -93,6 +93,8 @@ def test_start_app_pending_handle_poll_before_launcher_returns(tmp_path):
     def launch_job(*_args):
         pending_handle = executor.run_processes[job_id][RunProcessKey.JOB_HANDLE]
         assert pending_handle.poll() is None
+        with pytest.raises(RuntimeError, match="before it is attached"):
+            pending_handle.wait()
         return MagicMock()
 
     launcher.launch_job.side_effect = launch_job
@@ -166,6 +168,31 @@ def test_start_app_removes_pending_handle_when_launch_fails(tmp_path):
     with (
         patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
         pytest.raises(RuntimeError, match="launch failed"),
+    ):
+        executor.start_app(
+            client,
+            job_id,
+            job_meta,
+            SimpleNamespace(workspace=str(tmp_path), set=[]),
+            None,
+            None,
+            None,
+            fl_ctx,
+        )
+
+    assert job_id not in executor.run_processes
+
+
+def test_start_app_removes_pending_handle_when_launcher_returns_no_handle(tmp_path):
+    job_id = "job-1"
+    job_meta, workspace, client, fl_ctx = _make_start_app_inputs(tmp_path, job_id)
+    executor = JobExecutor(client=client, startup=workspace.get_startup_kit_dir())
+    launcher = MagicMock()
+    launcher.launch_job.return_value = None
+
+    with (
+        patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
+        pytest.raises(RuntimeError, match="returned no job handle"),
     ):
         executor.start_app(
             client,

--- a/tests/unit_test/private/fed/client/client_executor_test.py
+++ b/tests/unit_test/private/fed/client/client_executor_test.py
@@ -69,6 +69,148 @@ def _write_deployed_meta(tmp_path, job_id, deployed_meta):
     return workspace
 
 
+def _make_start_app_inputs(tmp_path, job_id="job-1"):
+    job_meta = {JobConstants.JOB_ID: job_id}
+    workspace = _write_deployed_meta(tmp_path, job_id, job_meta)
+    client = MagicMock()
+    client.client_name = "site-1"
+    client.cell.get_internal_listener_url.return_value = "tcp://parent:8002"
+    client.cell.get_internal_listener_params.return_value = {}
+    fl_ctx = MagicMock()
+    fl_ctx.get_prop.side_effect = lambda key, *args, **kwargs: {
+        FLContextKey.WORKSPACE_OBJECT: workspace,
+        FLContextKey.SERVER_CONFIG: [{"service": {"scheme": "grpc", "target": "parent:8002"}}],
+    }.get(key)
+    return job_meta, workspace, client, fl_ctx
+
+
+def test_start_app_pending_handle_poll_before_launcher_returns(tmp_path):
+    job_id = "job-1"
+    job_meta, workspace, client, fl_ctx = _make_start_app_inputs(tmp_path, job_id)
+    executor = JobExecutor(client=client, startup=workspace.get_startup_kit_dir())
+    launcher = MagicMock()
+
+    def launch_job(*_args):
+        pending_handle = executor.run_processes[job_id][RunProcessKey.JOB_HANDLE]
+        assert pending_handle.poll() is None
+        return MagicMock()
+
+    launcher.launch_job.side_effect = launch_job
+
+    with (
+        patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
+        patch.object(threading.Thread, "start", lambda self: None),
+    ):
+        executor.start_app(
+            client,
+            job_id,
+            job_meta,
+            SimpleNamespace(workspace=str(tmp_path), set=[]),
+            None,
+            None,
+            None,
+            fl_ctx,
+        )
+
+
+def test_start_app_applies_abort_while_launcher_is_running(tmp_path):
+    job_id = "job-1"
+    job_meta, workspace, client, fl_ctx = _make_start_app_inputs(tmp_path, job_id)
+    executor = JobExecutor(client=client, startup=workspace.get_startup_kit_dir())
+    job_handle = MagicMock()
+    job_handle.poll.return_value = JobReturnCode.ABORTED
+    launcher = MagicMock()
+
+    def launch_job(*_args):
+        assert executor.get_status(job_id) == ClientStatus.STARTING
+        ClientEngine.abort_app(SimpleNamespace(client_executor=executor), job_id)
+        return job_handle
+
+    launcher.launch_job.side_effect = launch_job
+
+    with (
+        patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
+        patch.object(threading.Thread, "start", lambda self: None),
+    ):
+        executor.start_app(
+            client,
+            job_id,
+            job_meta,
+            SimpleNamespace(workspace=str(tmp_path), set=[]),
+            None,
+            None,
+            None,
+            fl_ctx,
+        )
+
+    pending_handle = executor.run_processes[job_id][RunProcessKey.JOB_HANDLE]
+    job_handle.terminate.assert_called_once_with()
+    client.cell.fire_and_forget.assert_not_called()
+    assert pending_handle.poll() == JobReturnCode.ABORTED
+    pending_handle.wait()
+    job_handle.wait.assert_called_once_with()
+
+
+def test_start_app_removes_pending_handle_when_launch_fails(tmp_path):
+    job_id = "job-1"
+    job_meta, workspace, client, fl_ctx = _make_start_app_inputs(tmp_path, job_id)
+    executor = JobExecutor(client=client, startup=workspace.get_startup_kit_dir())
+    launcher = MagicMock()
+
+    def launch_job(*_args):
+        executor.abort_app(job_id)
+        raise RuntimeError("launch failed")
+
+    launcher.launch_job.side_effect = launch_job
+
+    with (
+        patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
+        pytest.raises(RuntimeError, match="launch failed"),
+    ):
+        executor.start_app(
+            client,
+            job_id,
+            job_meta,
+            SimpleNamespace(workspace=str(tmp_path), set=[]),
+            None,
+            None,
+            None,
+            fl_ctx,
+        )
+
+    assert job_id not in executor.run_processes
+
+
+def test_start_app_does_not_replace_existing_launch_registration(tmp_path):
+    job_id = "job-1"
+    job_meta, workspace, client, fl_ctx = _make_start_app_inputs(tmp_path, job_id)
+    executor = JobExecutor(client=client, startup=workspace.get_startup_kit_dir())
+    existing_handle = MagicMock()
+    executor.run_processes[job_id] = {
+        RunProcessKey.JOB_HANDLE: existing_handle,
+        RunProcessKey.STATUS: ClientStatus.STARTING,
+    }
+    launcher = MagicMock()
+
+    with (
+        patch("nvflare.private.fed.client.client_executor.get_job_launcher", return_value=launcher),
+        pytest.raises(RuntimeError, match="still registered"),
+    ):
+        executor.start_app(
+            client,
+            job_id,
+            job_meta,
+            SimpleNamespace(workspace=str(tmp_path), set=[]),
+            None,
+            None,
+            None,
+            fl_ctx,
+        )
+
+    assert executor.run_processes[job_id][RunProcessKey.JOB_HANDLE] is existing_handle
+    launcher.launch_job.assert_not_called()
+
+
 def test_start_app_allows_scheduler_metadata(tmp_path):
     job_id = "job-1"
     deployed_meta = {


### PR DESCRIPTION
## Summary

- register a pending job handle before invoking the client job launcher
- preserve early terminate requests and forward them after the real handle is attached
- make pre-attach polling report the job as still running and protect launch registration ownership

## Why

Client job launchers can block before returning a usable job handle. Previously, the job was not added to `run_processes` until after `launch_job()` returned, so an abort received during that window saw the app as stopped and was discarded. The job could then finish launching and continue despite the abort request.

The pending handle makes the launch visible as `STARTING`, remembers an early terminate request, and forwards it as soon as the launcher returns its real handle. It also removes its registration if launch fails without disturbing another owner.

This preserves abort intent; it does not interrupt the launcher's synchronous submission call, so cancellation remains bounded by launch latency.

## Validation

- `.venv/bin/python -m pytest tests/unit_test/private/fed/client/client_executor_test.py -v` (25 passed)
- `./runtest.sh -s`
