### PR TITLE
Add Auto-FL paper reference

### DIFF
--- a/research/auto-fl-research/README.md
+++ b/research/auto-fl-research/README.md
@@ -307,3 +307,16 @@ See `ACKNOWLEDGEMENTS.md` for provenance. In short:
 - the **control-plane idea** and `program.md` workflow are adapted from [karpathy/autoresearch](https://github.com/karpathy/autoresearch);
 - the **literature-loop / QWBE-style proposal workflow** is inspired by the public [Camyla project](https://yifangao112.github.io/camyla-page) and adapted only at the instruction/artifact level;
 - the **FL execution substrate** is adapted from existing NVFlare examples and utilities, mainly [CIFAR-10 in PyTorch](../../examples/advanced/cifar10/pt/cifar10-sim).
+
+## Citation
+
+If you use this example, please cite the Auto-FL-Research paper:
+
+```bibtex
+@article{roth2026auto,
+  title={Auto-FL-Research: Agentic Search for Federated Learning Algorithms},
+  author={Roth, Holger R and Xu, Ziyue and Chen, Chester and Xu, Daguang and Cnudde, Peter and Feng, Andrew},
+  journal={arXiv preprint arXiv:2607.01366},
+  year={2026}
+}
+```

--- a/research/auto-fl-research/README.md
+++ b/research/auto-fl-research/README.md
@@ -2,6 +2,8 @@
 
 This bundle is a practical starting point for an **autoresearch-style** Auto-FL loop on top of NVFlare using agents.
 
+It accompanies the paper [**Auto-FL-Research: Agentic Search for Federated Learning Algorithms**](https://arxiv.org/abs/2607.01366).
+
 ## Example progress
 
 The plot below is an example result from using this harness with Claude Code, model: Opus 4.7 (1M context),


### PR DESCRIPTION
## Summary

- Link the Auto-FL-Research arXiv paper from the example README.
- Place the reference near the top so readers can discover the methodology and evaluation behind the example.
- Add a copy-ready BibTeX entry in a dedicated citation section.

## Why

The upstream Auto-FL research example did not reference its accompanying paper.

## Impact

Documentation only. This does not change example behavior or dependencies.

## Validation

- `./runtest.sh -s`
- `git diff --check`
