### PR TITLE
[Auto-FL] Diagnose outdated nvflare when trial result root is unresolved

### DIFF
--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -127,6 +127,8 @@ DEFAULT_SIMULATOR_NO_PROGRESS_TIMEOUT = 240
 DEFAULT_JOB_HELP_TIMEOUT = 30
 MAX_CAPTURED_PROCESS_OUTPUT = 1024 * 1024
 SIMULATOR_WORKSPACE_ROOT_ENV_VAR = "NVFLARE_SIMULATOR_WORKSPACE_ROOT"
+SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION = "2.9.0"
+DEFAULT_WORKSPACE_OVERRIDE_PROBE_TIMEOUT = 30
 CAMPAIGN_LOCK_PATH = ".nvflare/autofl/campaign.lock"
 
 FIXED_BUDGET_TO_CLI = {
@@ -2030,6 +2032,76 @@ def changed_simulator_roots(simulator_base: Path, before: Dict[Path, int]) -> Li
     return sorted(path for path, modified in after.items() if before.get(path) != modified)
 
 
+def probe_simulator_workspace_override_support(
+    python: str, cwd: Path, timeout: int = DEFAULT_WORKSPACE_OVERRIDE_PROBE_TIMEOUT
+) -> Dict[str, Any]:
+    """Ask the campaign interpreter whether its nvflare honors the simulator workspace override.
+
+    Returns ``supported`` as True/False when ``nvflare.recipe.sim_env`` is importable, and None when the
+    probe is inconclusive (nvflare missing, import error, timeout); ``version`` is "" when unknown.
+    """
+
+    script = (
+        "import json\n"
+        "try:\n"
+        "    from importlib import metadata\n"
+        "    version = metadata.version('nvflare')\n"
+        "except Exception:\n"
+        "    version = ''\n"
+        "try:\n"
+        "    from nvflare.recipe import sim_env\n"
+        f"    supported = getattr(sim_env, 'SIMULATOR_WORKSPACE_ROOT_ENV_VAR', '') == {SIMULATOR_WORKSPACE_ROOT_ENV_VAR!r}\n"
+        "except Exception:\n"
+        "    supported = None\n"
+        "print(json.dumps({'version': version, 'supported': supported}))\n"
+    )
+    try:
+        completed = subprocess.run(
+            [python, "-c", script],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True,
+        )
+        payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    except (OSError, subprocess.SubprocessError, ValueError, IndexError):
+        return {"version": "", "supported": None}
+    if not isinstance(payload, dict):
+        return {"version": "", "supported": None}
+    version = payload.get("version")
+    supported = payload.get("supported")
+    return {
+        "version": version.strip() if isinstance(version, str) else "",
+        "supported": supported if isinstance(supported, bool) else None,
+    }
+
+
+def nvflare_version_predates_workspace_override(version: str) -> bool:
+    match = re.match(r"(\d+)\.(\d+)", version or "")
+    if not match:
+        return False
+    minimum = tuple(int(part) for part in SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION.split(".")[:2])
+    return (int(match.group(1)), int(match.group(2))) < minimum
+
+
+def unresolved_result_dir_failure_reason(python: str, cwd: Path) -> str:
+    probe = probe_simulator_workspace_override_support(python, cwd)
+    supported = probe["supported"]
+    version = probe["version"]
+    outdated = supported is False or (supported is None and nvflare_version_predates_workspace_override(version))
+    if outdated:
+        return (
+            f"job exited successfully but the installed nvflare ({version or 'unknown version'}) does not honor "
+            f"{SIMULATOR_WORKSPACE_ROOT_ENV_VAR}, so simulator results were written outside the isolated trial "
+            f"workspace; upgrade to nvflare>={SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION}"
+        )
+    return (
+        "job exited successfully but no deterministic NVFlare result directory was resolved; "
+        "expose a literal job name, support --name, or print the direct simulator result directory"
+    )
+
+
 def run_job(
     run_def: JobRun,
     *,
@@ -2107,10 +2179,7 @@ def run_job(
             run_def.failure_reason = f"exit_code={rc}"
     elif result_dir is None:
         run_def.status = "crash"
-        run_def.failure_reason = (
-            "job exited successfully but no deterministic NVFlare result directory was resolved; "
-            "expose a literal job name, support --name, or print the direct simulator result directory"
-        )
+        run_def.failure_reason = unresolved_result_dir_failure_reason(python, cwd)
     else:
         artifact_root = artifact_dir.parent
         evidence = extract_metric_evidence(artifact_root, metrics)

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2039,7 +2039,7 @@ def probe_simulator_workspace_override_support(
 
     Returns ``supported`` as True/False when ``nvflare.recipe.sim_env`` is importable, and None when the
     probe is inconclusive (package missing, import error, timeout); ``version`` is "" when unknown.
-    ``version`` is read from the imported package's ``__version__`` so it describes the same nvflare the
+    ``version`` is read from the imported package's ``__version__`` so it describes the same package the
     capability check (and the job) resolves; distribution metadata is only a fallback when the import fails.
     """
 

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2039,15 +2039,23 @@ def probe_simulator_workspace_override_support(
 
     Returns ``supported`` as True/False when ``nvflare.recipe.sim_env`` is importable, and None when the
     probe is inconclusive (package missing, import error, timeout); ``version`` is "" when unknown.
+    ``version`` is read from the imported package's ``__version__`` so it describes the same nvflare the
+    capability check (and the job) resolves; distribution metadata is only a fallback when the import fails.
     """
 
     script = (
         "import json\n"
         "try:\n"
-        "    from importlib import metadata\n"
-        "    version = metadata.version('nvflare')\n"
+        "    import nvflare\n"
+        "    version = str(getattr(nvflare, '__version__', '') or '')\n"
         "except Exception:\n"
         "    version = ''\n"
+        "if not version:\n"
+        "    try:\n"
+        "        from importlib import metadata\n"
+        "        version = metadata.version('nvflare')\n"
+        "    except Exception:\n"
+        "        version = ''\n"
         "try:\n"
         "    from nvflare.recipe import sim_env\n"
         f"    supported = getattr(sim_env, 'SIMULATOR_WORKSPACE_ROOT_ENV_VAR', '') == {SIMULATOR_WORKSPACE_ROOT_ENV_VAR!r}\n"

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2093,7 +2093,22 @@ def nvflare_version_predates_workspace_override(version: str) -> bool:
     return (int(match.group(1)), int(match.group(2))) < minimum
 
 
-def unresolved_result_dir_failure_reason(python: str, cwd: Path) -> str:
+def discovered_environment_name(config: Dict[str, Any]) -> str:
+    environment = config.get("environment", {})
+    discovered = environment.get("discovered", {}) if isinstance(environment, dict) else {}
+    name = discovered.get("name") if isinstance(discovered, dict) else None
+    return name if isinstance(name, str) else ""
+
+
+def unresolved_result_dir_failure_reason(python: str, cwd: Path, config: Dict[str, Any]) -> str:
+    generic_reason = (
+        "job exited successfully but no deterministic NVFlare result directory was resolved; "
+        "expose a literal job name, support --name, or print the direct simulator result directory"
+    )
+    # Only the recipe SimEnv honors the workspace override; FedJob.simulator_run and other job
+    # surfaces ignore it on every release, so the upgrade advice below would misdirect them.
+    if discovered_environment_name(config) != "SimEnv":
+        return generic_reason
     probe = probe_simulator_workspace_override_support(python, cwd)
     supported = probe["supported"]
     version = probe["version"]
@@ -2104,10 +2119,7 @@ def unresolved_result_dir_failure_reason(python: str, cwd: Path) -> str:
             f"{SIMULATOR_WORKSPACE_ROOT_ENV_VAR}, so simulator results were written outside the isolated trial "
             f"workspace; upgrade to nvflare>={SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION}"
         )
-    return (
-        "job exited successfully but no deterministic NVFlare result directory was resolved; "
-        "expose a literal job name, support --name, or print the direct simulator result directory"
-    )
+    return generic_reason
 
 
 def run_job(
@@ -2187,7 +2199,7 @@ def run_job(
             run_def.failure_reason = f"exit_code={rc}"
     elif result_dir is None:
         run_def.status = "crash"
-        run_def.failure_reason = unresolved_result_dir_failure_reason(python, cwd)
+        run_def.failure_reason = unresolved_result_dir_failure_reason(python, cwd, config)
     else:
         artifact_root = artifact_dir.parent
         evidence = extract_metric_evidence(artifact_root, metrics)

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2035,10 +2035,10 @@ def changed_simulator_roots(simulator_base: Path, before: Dict[Path, int]) -> Li
 def probe_simulator_workspace_override_support(
     python: str, cwd: Path, timeout: int = DEFAULT_WORKSPACE_OVERRIDE_PROBE_TIMEOUT
 ) -> Dict[str, Any]:
-    """Ask the campaign interpreter whether its nvflare honors the simulator workspace override.
+    """Ask the campaign interpreter whether the installed package supports the simulator workspace override.
 
     Returns ``supported`` as True/False when ``nvflare.recipe.sim_env`` is importable, and None when the
-    probe is inconclusive (nvflare missing, import error, timeout); ``version`` is "" when unknown.
+    probe is inconclusive (package missing, import error, timeout); ``version`` is "" when unknown.
     """
 
     script = (

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -748,11 +748,11 @@ def test_run_without_deterministic_result_root_records_actionable_failure(tmp_pa
     job = tmp_path / "job.py"
     job.write_text("print('done')\n", encoding="utf-8")
     monkeypatch.setattr(runner, "run", lambda *args, **kwargs: (0, "done\n", 0.1))
-    monkeypatch.setattr(
-        runner,
-        "probe_simulator_workspace_override_support",
-        lambda *args, **kwargs: {"version": "2.9.0", "supported": True},
-    )
+
+    def probe_must_not_run(*args, **kwargs):
+        raise AssertionError("probe must not run when no SimEnv environment was discovered")
+
+    monkeypatch.setattr(runner, "probe_simulator_workspace_override_support", probe_must_not_run)
 
     record = runner.run_job(
         runner.JobRun("candidate", [], "candidate"),
@@ -796,7 +796,7 @@ def test_run_without_result_root_blames_nvflare_without_workspace_override(tmp_p
         timeout=10,
         simulator_no_progress_timeout=0,
         metrics=["accuracy"],
-        config={"job": {}},
+        config={"job": {}, "environment": {"discovered": {"name": "SimEnv", "args": {}}}},
     )
 
     assert record.status == "crash"
@@ -805,9 +805,41 @@ def test_run_without_result_root_blames_nvflare_without_workspace_override(tmp_p
     assert "print the direct simulator result directory" not in record.failure_reason
 
 
+def test_run_without_result_root_keeps_generic_diagnosis_for_fed_job(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('done')\n", encoding="utf-8")
+    monkeypatch.setattr(runner, "run", lambda *args, **kwargs: (0, "done\n", 0.1))
+
+    def probe_must_not_run(*args, **kwargs):
+        raise AssertionError("probe must not run when the job does not use SimEnv")
+
+    monkeypatch.setattr(runner, "probe_simulator_workspace_override_support", probe_must_not_run)
+
+    record = runner.run_job(
+        runner.JobRun("candidate", [], "candidate"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config={"job": {"fed_job_args": {"name": {"value": "candidate_job", "confidence": "high"}}}},
+    )
+
+    assert record.status == "crash"
+    assert "no deterministic NVFlare result directory" in record.failure_reason
+    assert "upgrade to nvflare" not in record.failure_reason
+
+
 def test_unresolved_result_dir_failure_reason_uses_version_when_probe_is_inconclusive(tmp_path, monkeypatch):
     runner = _load_runner()
     probes = {}
+    sim_env_config = {"environment": {"discovered": {"name": "SimEnv", "args": {}}}}
 
     def fake_probe(*args, **kwargs):
         return probes["result"]
@@ -815,19 +847,39 @@ def test_unresolved_result_dir_failure_reason_uses_version_when_probe_is_inconcl
     monkeypatch.setattr(runner, "probe_simulator_workspace_override_support", fake_probe)
 
     probes["result"] = {"version": "2.6.2", "supported": None}
-    reason = runner.unresolved_result_dir_failure_reason(sys.executable, tmp_path)
+    reason = runner.unresolved_result_dir_failure_reason(sys.executable, tmp_path, sim_env_config)
     assert "installed nvflare (2.6.2) does not honor" in reason
     assert f"nvflare>={runner.SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION}" in reason
 
     probes["result"] = {"version": "", "supported": None}
     assert "print the direct simulator result directory" in runner.unresolved_result_dir_failure_reason(
-        sys.executable, tmp_path
+        sys.executable, tmp_path, sim_env_config
     )
 
     probes["result"] = {"version": "2.8.0", "supported": True}
     assert "print the direct simulator result directory" in runner.unresolved_result_dir_failure_reason(
-        sys.executable, tmp_path
+        sys.executable, tmp_path, sim_env_config
     )
+
+
+def test_unresolved_result_dir_failure_reason_stays_generic_without_sim_env(tmp_path, monkeypatch):
+    runner = _load_runner()
+
+    def probe_must_not_run(*args, **kwargs):
+        raise AssertionError("probe must not run when the discovered environment is not SimEnv")
+
+    monkeypatch.setattr(runner, "probe_simulator_workspace_override_support", probe_must_not_run)
+
+    for config in (
+        {"job": {}},
+        {"job": {"fed_job_args": {"name": {"value": "fraud_job", "confidence": "high"}}}},
+        {"environment": {"discovered": {"name": "PocEnv", "args": {}}}},
+        {"environment": {}},
+        {"environment": None},
+    ):
+        reason = runner.unresolved_result_dir_failure_reason(sys.executable, tmp_path, config)
+        assert "print the direct simulator result directory" in reason
+        assert "upgrade to nvflare" not in reason
 
 
 def test_probe_simulator_workspace_override_support_inspects_installed_sim_env(tmp_path):

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -748,6 +748,11 @@ def test_run_without_deterministic_result_root_records_actionable_failure(tmp_pa
     job = tmp_path / "job.py"
     job.write_text("print('done')\n", encoding="utf-8")
     monkeypatch.setattr(runner, "run", lambda *args, **kwargs: (0, "done\n", 0.1))
+    monkeypatch.setattr(
+        runner,
+        "probe_simulator_workspace_override_support",
+        lambda *args, **kwargs: {"version": "2.9.0", "supported": True},
+    )
 
     record = runner.run_job(
         runner.JobRun("candidate", [], "candidate"),
@@ -766,6 +771,97 @@ def test_run_without_deterministic_result_root_records_actionable_failure(tmp_pa
 
     assert record.status == "crash"
     assert "print the direct simulator result directory" in record.failure_reason
+
+
+def test_run_without_result_root_blames_nvflare_without_workspace_override(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('done')\n", encoding="utf-8")
+    monkeypatch.setattr(runner, "run", lambda *args, **kwargs: (0, "done\n", 0.1))
+    monkeypatch.setattr(
+        runner,
+        "probe_simulator_workspace_override_support",
+        lambda *args, **kwargs: {"version": "2.8.0", "supported": False},
+    )
+
+    record = runner.run_job(
+        runner.JobRun("candidate", [], "candidate"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text="",
+        fixed_args=[],
+        base_args=[],
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config={"job": {}},
+    )
+
+    assert record.status == "crash"
+    assert "installed nvflare (2.8.0) does not honor NVFLARE_SIMULATOR_WORKSPACE_ROOT" in record.failure_reason
+    assert f"nvflare>={runner.SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION}" in record.failure_reason
+    assert "print the direct simulator result directory" not in record.failure_reason
+
+
+def test_unresolved_result_dir_failure_reason_uses_version_when_probe_is_inconclusive(tmp_path, monkeypatch):
+    runner = _load_runner()
+    probes = {}
+
+    def fake_probe(*args, **kwargs):
+        return probes["result"]
+
+    monkeypatch.setattr(runner, "probe_simulator_workspace_override_support", fake_probe)
+
+    probes["result"] = {"version": "2.6.2", "supported": None}
+    reason = runner.unresolved_result_dir_failure_reason(sys.executable, tmp_path)
+    assert "installed nvflare (2.6.2) does not honor" in reason
+    assert f"nvflare>={runner.SIMULATOR_WORKSPACE_OVERRIDE_MIN_NVFLARE_VERSION}" in reason
+
+    probes["result"] = {"version": "", "supported": None}
+    assert "print the direct simulator result directory" in runner.unresolved_result_dir_failure_reason(
+        sys.executable, tmp_path
+    )
+
+    probes["result"] = {"version": "2.8.0", "supported": True}
+    assert "print the direct simulator result directory" in runner.unresolved_result_dir_failure_reason(
+        sys.executable, tmp_path
+    )
+
+
+def test_probe_simulator_workspace_override_support_inspects_installed_sim_env(tmp_path):
+    runner = _load_runner()
+    sim_env = tmp_path / "nvflare" / "recipe" / "sim_env.py"
+    sim_env.parent.mkdir(parents=True)
+    tmp_path.joinpath("nvflare", "__init__.py").write_text("", encoding="utf-8")
+    sim_env.parent.joinpath("__init__.py").write_text("", encoding="utf-8")
+
+    sim_env.write_text("WORKSPACE_ROOT = '/tmp/nvflare/simulation'\n", encoding="utf-8")
+    probe = runner.probe_simulator_workspace_override_support(sys.executable, tmp_path)
+    assert probe["supported"] is False
+
+    sim_env.write_text(
+        "SIMULATOR_WORKSPACE_ROOT_ENV_VAR = 'NVFLARE_SIMULATOR_WORKSPACE_ROOT'\n",
+        encoding="utf-8",
+    )
+    probe = runner.probe_simulator_workspace_override_support(sys.executable, tmp_path)
+    assert probe["supported"] is True
+
+    probe = runner.probe_simulator_workspace_override_support(str(tmp_path / "missing-python"), tmp_path)
+    assert probe == {"version": "", "supported": None}
+
+
+def test_nvflare_version_predates_workspace_override():
+    runner = _load_runner()
+
+    assert runner.nvflare_version_predates_workspace_override("2.8.0")
+    assert runner.nvflare_version_predates_workspace_override("2.7.1+160.g67022752b")
+    assert not runner.nvflare_version_predates_workspace_override("2.9.0")
+    assert not runner.nvflare_version_predates_workspace_override("2.10.0rc1")
+    assert not runner.nvflare_version_predates_workspace_override("3.0.0")
+    assert not runner.nvflare_version_predates_workspace_override("")
+    assert not runner.nvflare_version_predates_workspace_override("unknown")
 
 
 def test_run_discovers_and_persists_printed_unnamed_simulator_root(tmp_path, monkeypatch):

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -834,12 +834,14 @@ def test_probe_simulator_workspace_override_support_inspects_installed_sim_env(t
     runner = _load_runner()
     sim_env = tmp_path / "nvflare" / "recipe" / "sim_env.py"
     sim_env.parent.mkdir(parents=True)
-    tmp_path.joinpath("nvflare", "__init__.py").write_text("", encoding="utf-8")
+    tmp_path.joinpath("nvflare", "__init__.py").write_text("__version__ = '2.7.0'\n", encoding="utf-8")
     sim_env.parent.joinpath("__init__.py").write_text("", encoding="utf-8")
 
     sim_env.write_text("WORKSPACE_ROOT = '/tmp/nvflare/simulation'\n", encoding="utf-8")
     probe = runner.probe_simulator_workspace_override_support(sys.executable, tmp_path)
     assert probe["supported"] is False
+    # version must describe the imported (shadowing) package, not any installed distribution's metadata
+    assert probe["version"] == "2.7.0"
 
     sim_env.write_text(
         "SIMULATOR_WORKSPACE_ROOT_ENV_VAR = 'NVFLARE_SIMULATOR_WORKSPACE_ROOT'\n",


### PR DESCRIPTION
### Description

Follow-up to #4780. The Auto-FL skill isolates each simulator trial via the `NVFLARE_SIMULATOR_WORKSPACE_ROOT` override that `SimEnv` honors since that PR. When the skill runs against an older installed nvflare (any release <= 2.8.0), `SimEnv` ignores the variable, results land outside the watched temp workspace, and every baseline fails with the generic message:

> job exited successfully but no deterministic NVFlare result directory was resolved; expose a literal job name, support --name, or print the direct simulator result directory

which is misleading for the real cause (skill from `main` paired with a pre-override nvflare release).

This PR improves that failure path in `run_job`: when no result root resolves after a clean exit, the runner probes the campaign interpreter's nvflare — checking whether `nvflare.recipe.sim_env` defines `SIMULATOR_WORKSPACE_ROOT_ENV_VAR` (capability check, so dev installs with versioneer strings are not misclassified), falling back to `importlib.metadata.version("nvflare")` when the module is unimportable. If the installed nvflare predates the override, `failure_reason` now names the installed version and the minimum required one, e.g.:

> job exited successfully but the installed nvflare (2.8.0) does not honor NVFLARE_SIMULATOR_WORKSPACE_ROOT, so simulator results were written outside the isolated trial workspace; upgrade to nvflare>=2.9.0

The probe only runs on the already-failing path; matched skill/nvflare versions see no behavior change.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.