### PR TITLE
[Auto-FL] Declare canonical selection metric and fix cross-site fallback extraction

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -14,20 +14,17 @@ metadata:
 # NVFLARE Auto-FL
 
 ## Use When
-Use this skill when the user asks to optimize an existing NVFLARE `job.py` for accuracy,
-AUC, loss, runtime, robustness, or another metric in simulation, POC, or production.
+Use this skill when the user asks to optimize an existing NVFLARE `job.py` for accuracy, AUC, loss, runtime, robustness, or another metric in simulation, POC, or production.
 
 ## Do Not Use When
-Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs without an optimization goal,
-production deployment setup, evaluation/statistics-only recipes, or generic tuning outside an NVFLARE job.
+Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs without an optimization goal, production deployment setup, evaluation/statistics-only recipes, or generic tuning outside an NVFLARE job.
 
 ## Workflow
 Use this skill to optimize an existing NVFLARE `job.py` without asking the user to learn
 a new Auto-FL command tree. The user selects this skill, points to a job, and states the
 objective, environment, and optional budget. NVFLARE provides the deterministic campaign
 import, execution substrate, policy boundaries, artifacts, and machine-readable
-contracts. The coding agent owns hypotheses, source edits, new algorithm
-implementations, and candidate choice.
+contracts. The coding agent owns hypotheses, source edits, new algorithm implementations, and candidate choice.
 
 Resolve [run_job_campaign.py](scripts/run_job_campaign.py) relative to this `SKILL.md`, store its absolute path as `RUNNER`, and initialize the campaign:
 
@@ -43,11 +40,9 @@ Read `autofl.yaml` and the JSON response, then prepare an agent-authored candida
 python "$RUNNER" prepare ./job.py --name <candidate> --hypothesis "<expected improvement>" [--run-args "<args>"] [--family <slug>] [--literature-event <id>]
 ```
 
-Pass `--family <slug>` and `--literature-event <id>` when the candidate develops a
-recorded literature review; both persist in the manifest and as ledger columns.
+Pass `--family <slug>` and `--literature-event <id>` when the candidate develops a recorded literature review; both persist in the manifest and as ledger columns.
 
-Edit only the returned candidate source directory. Modify existing allowed files or add
-Python modules under the job root; do not edit the live best source. Then evaluate:
+Edit only the returned candidate source directory. Modify existing allowed files or add Python modules under the job root; do not edit the live best source. Then evaluate:
 
 ```bash
 python "$RUNNER" evaluate ./job.py --manifest <candidate_manifest.json>
@@ -81,6 +76,10 @@ state, artifacts, and reports. After each action, read `.nvflare/autofl/campaign
 and finalize only when `final_response_allowed=true`. For long-running behavior read
 [continuous campaigns](references/continuous-campaigns.md); for budgets and rerun
 evidence read [experiment comparability](references/experiment-comparability.md).
+
+The ledger score extracted per the objective `metric_extraction_order` is the canonical selection surface
+for keep/discard and best-candidate decisions. Cross-site server-final scores are diagnostic unless the
+user explicitly requests selection on them.
 
 Read `autofl.yaml` and show the user a concise campaign summary:
 

--- a/skills/nvflare-autofl/references/experiment-comparability.md
+++ b/skills/nvflare-autofl/references/experiment-comparability.md
@@ -3,6 +3,14 @@
 Use this reference for Auto-FL reruns, recipe comparisons, data replacement,
 data distribution, synthetic data, and site heterogeneity requests.
 
+## Canonical Selection Metric
+
+The per-run ledger score, extracted with the objective's
+`metric_extraction_order`, is the canonical selection surface for baseline,
+keep/discard, and best-candidate comparisons. Cross-site server-final
+global-model scores from `cross_val_results.json` are diagnostic unless the
+user explicitly requests selection on them.
+
 ## Iterative Reruns
 
 When the user asks to change batch size, train args, number of rounds,

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -80,6 +80,11 @@ RESULT_FIELDS = [
     "literature_event_id",
 ]
 
+# Marker shared by every server-side global-model entry in cross_val_results.json: the legacy
+# CrossSiteModelEval workflow prefixes SRV_ (SRV_FL_global_model, SRV_best_FL_global_model.pt)
+# while the ModelController CrossSiteEval records the raw checkpoint name (FL_global_model.pt).
+SERVER_GLOBAL_MODEL_KEY_MARKER = "FL_global_model"
+
 CANDIDATE_MANIFEST_SCHEMA_VERSION = "nvflare.autofl.candidate.v1"
 CANDIDATE_MANIFEST_STATUSES = {"prepared", "ready_for_external_execution", "keep", "discard", "crash", "abandoned"}
 CAMPAIGN_METADATA_SCHEMA_VERSION = "nvflare.autofl.campaign.v1"
@@ -1348,6 +1353,27 @@ def metric_from_list(items: Any, metric: str) -> Optional[float]:
     return None
 
 
+def server_final_metric_values(payload: Any, metric: str) -> List[float]:
+    """Collect the metric values recorded for server-side global-model entries in a cross-site payload."""
+    values: List[float] = []
+    if isinstance(payload, dict):
+        for key, entry in payload.items():
+            if isinstance(key, str) and SERVER_GLOBAL_MODEL_KEY_MARKER in key:
+                value = find_metric_value(entry, [metric])
+                if value is not None:
+                    values.append(value)
+            else:
+                values.extend(server_final_metric_values(entry, metric))
+    elif isinstance(payload, list):
+        for item in payload:
+            values.extend(server_final_metric_values(item, metric))
+    return values
+
+
+def best_metric_value(values: Sequence[float], mode: str) -> float:
+    return min(values) if mode == "min" else max(values)
+
+
 def text_metric_matches(text: str, metric: str) -> List[Tuple[int, float]]:
     number = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
     context = r"(?:(?:final|test|validation|cross[-_ ]site)\s+)*"
@@ -1399,7 +1425,9 @@ def text_metric_matches(text: str, metric: str) -> List[Tuple[int, float]]:
     return evaluation_matches or direct_matches or mapping_matches or framework_matches
 
 
-def extract_metric_evidence(artifact_root: Path, metrics: Sequence[str] | str) -> Optional[MetricEvidence]:
+def extract_metric_evidence(
+    artifact_root: Path, metrics: Sequence[str] | str, mode: str = "max"
+) -> Optional[MetricEvidence]:
     metric_order = normalize_metric_order(metrics)
     metric_files = sorted(artifact_root.glob("**/metrics_summary.json")) + sorted(
         artifact_root.glob("**/cross_val_results.json")
@@ -1413,6 +1441,17 @@ def extract_metric_evidence(artifact_root: Path, metrics: Sequence[str] | str) -
         payloads.append((path, payload))
     for metric in metric_order:
         for path, payload in payloads:
+            if path.name == "cross_val_results.json":
+                # Cross-site payloads score every site/model pair; prefer the server-final
+                # global model over whichever entry happens to appear first.
+                server_final = server_final_metric_values(payload, metric)
+                if server_final:
+                    return MetricEvidence(
+                        score=best_metric_value(server_final, mode),
+                        metric_name=metric,
+                        source=f"structured:{path.name}#server_final",
+                        artifact=str(path.resolve()),
+                    )
             score = find_metric_value(payload, [metric])
             if score is not None:
                 return MetricEvidence(
@@ -1443,8 +1482,8 @@ def extract_metric_evidence(artifact_root: Path, metrics: Sequence[str] | str) -
     return None
 
 
-def extract_score(artifact_root: Path, metrics: Sequence[str] | str) -> Optional[float]:
-    evidence = extract_metric_evidence(artifact_root, metrics)
+def extract_score(artifact_root: Path, metrics: Sequence[str] | str, mode: str = "max") -> Optional[float]:
+    evidence = extract_metric_evidence(artifact_root, metrics, mode)
     return evidence.score if evidence else None
 
 
@@ -2136,6 +2175,7 @@ def run_job(
     simulator_no_progress_timeout: int,
     metrics: Sequence[str],
     config: Dict[str, Any],
+    mode: str = "max",
 ) -> RunRecord:
     baseline_run = run_def.status == "baseline"
     log_path = output_root / run_def.name / "run.log"
@@ -2202,7 +2242,7 @@ def run_job(
         run_def.failure_reason = unresolved_result_dir_failure_reason(python, cwd, config)
     else:
         artifact_root = artifact_dir.parent
-        evidence = extract_metric_evidence(artifact_root, metrics)
+        evidence = extract_metric_evidence(artifact_root, metrics, mode)
         if evidence is None:
             run_def.status = "crash"
             run_def.failure_reason = f"matching metric not found; {metric_search_description(artifact_root, metrics)}"
@@ -2807,6 +2847,7 @@ def execute_sim_baseline(
         simulator_no_progress_timeout=no_progress_timeout,
         metrics=metric_extraction_order(config, args.metric),
         config=config,
+        mode=args.mode,
     )
 
 
@@ -3287,6 +3328,7 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
             simulator_no_progress_timeout=no_progress_timeout,
             metrics=metric_extraction_order(config, args.metric),
             config=config,
+            mode=args.mode,
         )
     except BaseException as error:
         try:
@@ -3437,7 +3479,7 @@ def record_external_result(args: argparse.Namespace, job: Path) -> int:
         raise ValueError("--score must be a finite number")
     evidence = None
     if score is None and artifact_path:
-        evidence = extract_metric_evidence(artifact_path, metric_extraction_order(config, args.metric))
+        evidence = extract_metric_evidence(artifact_path, metric_extraction_order(config, args.metric), args.mode)
         score = evidence.score if evidence else None
     elif score is not None:
         evidence = MetricEvidence(

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -2731,3 +2731,120 @@ if __name__ == "__main__":
     )
     assert manifest["status"] == "keep"
     assert manifest["changed_files"] == ["job.py"]
+
+
+def test_cross_val_extraction_prefers_best_server_final_global_model_entry(tmp_path):
+    runner = _load_runner()
+    result_path = tmp_path / "cross_val_results.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "site-1": {
+                    "site-1": {"accuracy": 0.99},
+                    "SRV_FL_global_model.pt": {"accuracy": 0.71},
+                },
+                "site-2": {
+                    "site-2": {"accuracy": 0.95},
+                    "SRV_FL_global_model.pt": {"accuracy": 0.74},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+
+    assert evidence.score == pytest.approx(0.74)
+    assert evidence.metric_name == "accuracy"
+    assert evidence.source == "structured:cross_val_results.json#server_final"
+    assert evidence.artifact == str(result_path.resolve())
+
+
+def test_cross_val_extraction_resolves_modern_unprefixed_global_model_entries(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {
+                    "site-1": {"accuracy": 0.99},
+                    "FL_global_model.pt": {"accuracy": 0.71},
+                },
+                "site-2": {
+                    "site-2": {"accuracy": 0.95},
+                    "FL_global_model.pt": {"accuracy": 0.74},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+
+    assert evidence.score == pytest.approx(0.74)
+    assert evidence.source == "structured:cross_val_results.json#server_final"
+
+
+def test_cross_val_extraction_resolves_srv_best_only_global_model_entries(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {
+                    "site-1": {"accuracy": 0.99},
+                    "SRV_best_FL_global_model.pt": {"accuracy": 0.66},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+
+    assert evidence.score == pytest.approx(0.66)
+    assert evidence.source == "structured:cross_val_results.json#server_final"
+
+
+def test_cross_val_extraction_uses_min_over_server_final_entries_in_min_mode(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {
+                    "site-1": {"loss": 0.10},
+                    "SRV_FL_global_model.pt": {"loss": 0.42},
+                },
+                "site-2": {"SRV_FL_global_model.pt": {"loss": 0.37}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert runner.extract_score(tmp_path, ["loss"], mode="min") == pytest.approx(0.37)
+
+
+def test_cross_val_extraction_falls_back_to_first_match_without_server_final_entries(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("cross_val_results.json").write_text(
+        json.dumps({"site-1": {"site-1": {"accuracy": 0.9}, "site-2": {"accuracy": 0.6}}}),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+    assert evidence.score == pytest.approx(0.9)
+    assert evidence.source == "structured:cross_val_results.json"
+
+    tmp_path.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {
+                    "site-1": {"accuracy": 0.9},
+                    "SRV_FL_global_model.pt": {"loss": 0.4},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+    assert evidence.score == pytest.approx(0.9)
+    assert evidence.source == "structured:cross_val_results.json"


### PR DESCRIPTION
# Fix cross-site fallback extraction and declare the canonical Auto-FL selection metric

## Description
When an Auto-FL run's score falls back to `cross_val_results.json` (a normal path for imported jobs whose only structured metric artifact is the cross-site evaluation output), the extraction returned the **first recursive key match in dict insertion order**. Cross-site payloads score every site/model pair, so this could silently record a site-local model's self-evaluation (e.g. 0.99) instead of the global model's score (e.g. 0.74) — corrupting keep/discard decisions and best-candidate selection.

## What changed
- **Extraction fix** in `skills/nvflare-autofl/scripts/run_job_campaign.py`: when a `cross_val_results.json` payload contains server-side global-model entries (any key containing `FL_global_model` — covers legacy `SRV_FL_global_model` from `CrossSiteModelEval`, modern unprefixed `FL_global_model.pt` from `CrossSiteEval`, and `SRV_best_` variants), the extracted value is the mode-aware best over those entries; plain first-match remains only as the fallback when no server-final entries exist. The campaign `--mode` is plumbed through extraction so min-mode campaigns take the minimum.
- **Provenance**: server-final extractions record `metric_source` as `structured:cross_val_results.json#server_final`, so pre/post-fix ledger rows are distinguishable.
- **Docs**: `SKILL.md` and `references/experiment-comparability.md` now state that the ledger score extracted per `metric_extraction_order` is the canonical selection surface, and cross-site server-final scores are diagnostic.
- **Tests**: five new tests — modern unprefixed payload shape, `SRV_best`-only payload, legacy shape, min-mode, and provenance suffix present/absent. Four of the five fail on the pre-fix code (verified).

## Scope note
An earlier draft of this PR also added `selection_metric` to campaign state and a per-run `server_final_best` ledger column. Both were deliberately dropped to keep the incubating skill's schema surface minimal — external consumers can read the existing `best_candidate`/`best_score` fields, and the `selection_metric` plumbing had made `status` depend on `autofl.yaml` (now restored to main's behavior). The reviewed implementations remain in this PR's history (`7cfd27841`, `f633e94bb`) if demand materializes.

## Testing
`python3.12 -m pytest tests/unit_test/tool/autofl_skill_runner_test.py tests/unit_test/tool/autofl_skill_campaign_guard_test.py tests/unit_test/tool/autofl_skill_plot_progress_test.py tests/unit_test/tool/autofl_skill_job_importer_test.py tests/unit_test/tool/agent_skill_checks -q` — 330 passed. black/isort/flake8 clean on changed files. Rebased onto current `main`.
