### PR TITLE
[Auto-FL] Document run-to-run variance and aggregation-order nondeterminism

### DIFF
--- a/nvflare/app_common/aggregators/weighted_aggregation_helper.py
+++ b/nvflare/app_common/aggregators/weighted_aggregation_helper.py
@@ -151,7 +151,14 @@ class WeightedAggregationHelper(object):
         return hasattr(tensor, "add_") and hasattr(tensor, "mul_") and hasattr(tensor, "clone")
 
     def add(self, data, weight, contributor_name, contribution_round):
-        """Compute weighted sum and sum of weights."""
+        """Compute weighted sum and sum of weights.
+
+        Note:
+            Contributions accumulate in call (result-arrival) order: each weighted contribution is
+            added into a running per-key total (in place on backends that support it). Floating-point
+            rounding is therefore order dependent (non-associative), so identical inputs can yield
+            ulp-level differences between runs; bitwise reproducibility is not guaranteed for >=2 clients.
+        """
         with self.lock:
             for k, v in data.items():
                 if self.exclude_vars is not None and self.exclude_vars.search(k):

--- a/nvflare/app_common/workflows/fedavg.py
+++ b/nvflare/app_common/workflows/fedavg.py
@@ -48,6 +48,9 @@ class FedAvg(BaseFedAvg):
 
     Uses InTime (streaming) aggregation for memory efficiency - each client result is
     aggregated immediately upon receipt rather than collecting all results first.
+    Streaming accumulation applies contributions in result-arrival order; floating-point
+    addition is non-associative, so identical inputs can produce ulp-level differences
+    between runs and bitwise reproducibility is not guaranteed for >=2 clients.
 
     Supports custom aggregators via the ModelAggregator interface.
 

--- a/skills/nvflare-autofl/references/experiment-comparability.md
+++ b/skills/nvflare-autofl/references/experiment-comparability.md
@@ -26,6 +26,21 @@ comparable unless the user asks to tune them. Report a small results table with
 recipe, settings, metric value, command, status, and result path. If a candidate
 cannot run, report the blocker instead of silently dropping it.
 
+## Run-To-Run Variance
+
+A pinned `--seed` argument only makes runs comparable when the job itself seeds
+every process: the `job.py` process and each per-client simulator subprocess
+must seed Python's `random`, NumPy, and the ML framework (for PyTorch also
+`torch.manual_seed` plus DataLoader worker seeding). Unseeded fixtures can show
+a large baseline spread even under identical settings, and streaming (in-time)
+server aggregation applies results in arrival order, so bitwise reproducibility
+is not guaranteed for two or more clients.
+
+Seed in job code rather than relying on the campaign `--seed` argument alone.
+When a job is noisy, re-run the unmodified baseline a few times to measure the
+observed run-to-run spread, and treat candidate score differences within that
+spread as noise rather than real improvement when reporting results.
+
 ## Data Distribution Experiments
 
 When the user asks to compare IID and heterogeneous data splits, define the split

--- a/skills/nvflare-autofl/references/experiment-comparability.md
+++ b/skills/nvflare-autofl/references/experiment-comparability.md
@@ -41,6 +41,12 @@ When a job is noisy, re-run the unmodified baseline a few times to measure the
 observed run-to-run spread, and treat candidate score differences within that
 spread as noise rather than real improvement when reporting results.
 
+Host environment drift is not a variance source: simulator child processes
+receive a sanitized environment built from a fixed runtime allowlist plus the
+variable names declared in `environment.simulator_env_passthrough` (see the
+[job import contract](job-import-contract.md)). Jobs that need variables such
+as `DATASET_DIR` must declare them there explicitly.
+
 ## Data Distribution Experiments
 
 When the user asks to compare IID and heterogeneous data splits, define the split

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -20,3 +20,16 @@ the sole changed direct child of that trial workspace, validates that the root
 cannot escape the workspace, and persists the discovered name for cleanup,
 stall monitoring, and subsequent candidates. Ambiguous or out-of-workspace
 results fail closed.
+
+Simulator child processes — baseline and candidate runs and the runner's
+capability probe — do not inherit the full host environment. The runner
+forwards a fixed runtime allowlist (interpreter and virtualenv/conda paths,
+`HOME` and temp directories, locale, proxy and CA-bundle settings, threading
+limits, CUDA/NVIDIA device visibility, and dynamic-library paths), so host
+secrets never reach campaign-executed code and host-environment drift cannot
+silently change candidate behavior. Declare job-specific variables such as
+`DATASET_DIR` by name in `environment.simulator_env_passthrough` in
+`autofl.yaml`; values are read from the host at run time and never stored.
+Generated configs include `simulator_env_passthrough: []`, a missing field
+means no extra variables, and entries that are not valid environment-variable
+names fail closed.


### PR DESCRIPTION
# Document Auto-FL run-to-run variance and aggregation-order nondeterminism

## Description
Doc-only follow-up from an external agent-benchmark evaluation of the `nvflare-autofl` skill, where the fixture baseline `val_accuracy` spread ~2x across trials despite a pinned seed. The root cause is fixture-side (per-process seeding), but two pieces of verified, non-obvious knowledge are worth capturing in NVFlare:

## What changed
- **`skills/nvflare-autofl/references/experiment-comparability.md`**: new "Run-To-Run Variance" section — a pinned `--seed` argument only makes runs comparable when the job itself seeds every process (the `job.py` process *and* each per-client simulator subprocess: `random`, NumPy, framework RNGs, DataLoader workers); guidance to measure baseline noise by re-running the unmodified baseline and to treat sub-noise candidate deltas as noise.
- **`skills/nvflare-autofl/references/job-import-contract.md`** and **`experiment-comparability.md`**: document the sanitized simulator child environment introduced in #4940 — the fixed runtime allowlist and the `environment.simulator_env_passthrough` config field (declare job-specific variable *names* such as `DATASET_DIR`; values are read at run time, never stored) — and note in the variance section that host environment drift is excluded as a variance source. Lives in `references/` because the SKILL.md 200-line cap left the field otherwise undocumented outside generated `autofl.yaml` and error messages. **Merge-order note:** this documents behavior added by #4940 (approved), so this PR should land after it.
- **`nvflare/app_common/aggregators/weighted_aggregation_helper.py`** and **`nvflare/app_common/workflows/fedavg.py`**: docstring notes that streaming (InTime) aggregation accumulates contributions in result-arrival order, which is floating-point order dependent (non-associative rounding), so identical inputs can yield ulp-level differences between runs and bitwise reproducibility is not guaranteed for >=2 clients. No behavior change.

## Scope note
An earlier draft of this PR also added a per-run `seed` ledger column, a `--keep-min-delta` keep/discard noise margin, and an `initialize --baseline-repeats` noise probe. Those were deliberately dropped to keep the incubating Auto-FL skill surface minimal — the benchmark's variance is fixable in the fixture, and none of these features had user demand. The reviewed implementations remain in this PR's history (`0c13bc072`, `8873cf058`) should demand materialize.

## Testing
- `python3.12 -m pytest tests/unit_test/app_common/aggregators tests/unit_test/app_common/workflow/fedavg_test.py tests/unit_test/tool/agent_skill_checks -q` — 330 passed, 2 skipped (includes the skill content lints over the edited reference doc).
- flake8/black/isort clean on the two touched Python files (docstring-only edits).

