### PR TITLE
Redact client auth token from log messages

### DIFF
--- a/docs/design/job_process_credential_transport_design.md
+++ b/docs/design/job_process_credential_transport_design.md
@@ -56,7 +56,9 @@ design doc's step tables document the new step.
 
 ## Threat notes
 
-Protects against command-line inspection and log/telemetry capture. Does not protect against:
+Protects against command-line inspection and log/telemetry capture. As a ride-along, the
+token value is also redacted from server/client/relay log messages (registration,
+re-activation, heartbeat, removal, relay auth) — issue #4858 item 2. Does not protect against:
 root/admins, code inside the job process, same-UID readers of `/proc/<pid>/environ` (the
 exec-time snapshot persists for the process lifetime regardless of `os.environ.pop`), or
 credential reuse after theft (the per-job-credentials PR's job).

--- a/nvflare/private/fed/app/relay/relay.py
+++ b/nvflare/private/fed/app/relay/relay.py
@@ -224,7 +224,7 @@ def main(args):
             local_cell_fqcn=my_fqcn,
         )
 
-    logger.info(f"Successfully authenticated to {server_identity}: {token=} {ssid=}")
+    logger.info(f"Successfully authenticated to {server_identity}: {ssid=}")
 
     # wait until stopped
     logger.info(f"Started relay {my_identity=} {my_fqcn=} {root_url=} {parent_url=} {parent_fqcn=}")

--- a/nvflare/private/fed/client/communicator.py
+++ b/nvflare/private/fed/client/communicator.py
@@ -569,7 +569,7 @@ class Communicator:
             )
             return_code = result.get_header(MessageHeaderKey.RETURN_CODE)
             if return_code == ReturnCode.UNAUTHENTICATED:
-                self.logger.info(f"Client token: {token} has been removed from the server.")
+                self.logger.info("Client token has been removed from the server.")
 
             server_message = result.get_header(CellMessageHeaderKeys.MESSAGE)
 

--- a/nvflare/private/fed/server/client_manager.py
+++ b/nvflare/private/fed/server/client_manager.py
@@ -136,7 +136,7 @@ class ClientManager:
                 self.logger.error(f"failed to persist disabled-client state for {client_name}: {ex}")
                 raise
         removed_tokens = [token for token, _client in removed_clients]
-        self.logger.info(f"Client {client_name} disabled. Removed active tokens: {removed_tokens}")
+        self.logger.info(f"Client {client_name} disabled. Removed {len(removed_tokens)} active token(s).")
         return removed_tokens
 
     def enable_client(self, client_name: str) -> bool:
@@ -182,9 +182,10 @@ class ClientManager:
                 # do not update self.clients for non-regular clients
                 client_kind = client_type
 
+            # Never log the token value: it is a bearer credential (see #4858).
             self.logger.info(
-                "Client: New {} {} joined. Sent token: {}.  Total clients: {}".format(
-                    client_kind, client.name + "@" + client_ip, client.token, len(self.clients)
+                "Client: New {} {} joined. Sent token.  Total clients: {}".format(
+                    client_kind, client.name + "@" + client_ip, len(self.clients)
                 )
             )
         return client
@@ -206,7 +207,7 @@ class ClientManager:
                     "Client Name:{} \tToken: {} left.  Total clients: {}".format(client.name, token, len(self.clients))
                 )
             else:
-                self.logger.warning("remove_client: unknown token %s", token)
+                self.logger.warning("remove_client: unknown token")
             return client
 
     def login_client(self, client_login, fl_ctx: FLContext, client_type):
@@ -395,7 +396,7 @@ class ClientManager:
             client = self.clients.get(token)
             if client:
                 client.last_connect_time = time.time()
-                self.logger.debug(f"Receive heartbeat from Client:{token}")
+                self.logger.debug(f"Receive heartbeat from Client:{client_name}")
                 return False
             else:
                 for _token, _client in self.clients.items():
@@ -406,8 +407,7 @@ class ClientManager:
                             sticky=False,
                         )
                         self.logger.info(
-                            f"Failed to re-activate the client:{client_name} with token: {token}. "
-                            f"Client already exist with token: {_token}."
+                            f"Failed to re-activate the client:{client_name}: already registered with another token."
                         )
                         return False
 
@@ -415,7 +415,7 @@ class ClientManager:
                 self._set_client_props(client, client_fqcn, fl_ctx)
                 self.clients.update({token: client})
                 self.name_to_clients[client.name] = client
-                self.logger.info(f"Re-activate the client: {client_name} at {client_fqcn} with token: {token}")
+                self.logger.info(f"Re-activate the client: {client_name} at {client_fqcn}")
                 return True
 
     @staticmethod

--- a/nvflare/private/fed/utils/identity_utils.py
+++ b/nvflare/private/fed/utils/identity_utils.py
@@ -194,5 +194,5 @@ class TokenVerifier:
             verify_content(content=client_name + token, signature=signature, public_key=self.public_key)
             return True
         except Exception as ex:
-            self.logger.error(f"exception verifying token: {client_name=} {token=}: {secure_format_exception(ex)}")
+            self.logger.error(f"exception verifying token: {client_name=}: {secure_format_exception(ex)}")
             return False


### PR DESCRIPTION
## Summary

- Remove the client auth token value from all log messages. The `(client_name, token, signature)` triple is a replayable bearer credential (#4858); logging it hands a working credential to anyone with log access (aggregators, support bundles).
- Redacted sites: registration (`client_manager.py` "Sent token"), disable-client token list (now a count), unknown-token warning, heartbeat debug (logs client name instead), client re-activation, relay auth success, unauthenticated-quit (`communicator.py`), and token-verification failure (`identity_utils.py`).
- Design-doc threat notes updated to record the redaction.

Addresses item 2 of #4858 (item 1 landed in #4929).