### PR TITLE
Redact remaining client auth token log sites

### DIFF
--- a/nvflare/private/fed/client/fed_client_base.py
+++ b/nvflare/private/fed/client/fed_client_base.py
@@ -272,9 +272,7 @@ class FederatedClientBase:
                 if self.token is not None:
                     self.fl_ctx.set_prop(FLContextKey.CLIENT_NAME, self.client_name, private=False)
                     self.logger.info(
-                        "Successfully registered client:{} for project {}. Token:{} SSID:{}".format(
-                            self.client_name, project_name, self.token, self.ssid
-                        )
+                        "Successfully registered client:{} for project {}.".format(self.client_name, project_name)
                     )
 
             except FLCommunicationError:

--- a/nvflare/private/fed/server/client_manager.py
+++ b/nvflare/private/fed/server/client_manager.py
@@ -203,9 +203,7 @@ class ClientManager:
             client = self.clients.pop(token, None)
             if client:
                 self.name_to_clients.pop(client.name, None)
-                self.logger.info(
-                    "Client Name:{} \tToken: {} left.  Total clients: {}".format(client.name, token, len(self.clients))
-                )
+                self.logger.info("Client Name:{} left.  Total clients: {}".format(client.name, len(self.clients)))
             else:
                 self.logger.warning("remove_client: unknown token")
             return client

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -233,8 +233,8 @@ class BaseServer(ABC):
         for token in delete:
             client = self.logout_client(token)
             self.logger.info(
-                "Remove the dead Client. Name: {}\t Token: {}.  Total clients: {}".format(
-                    client.name, token, len(self.client_manager.get_clients())
+                "Remove the dead Client. Name: {}.  Total clients: {}".format(
+                    client.name, len(self.client_manager.get_clients())
                 )
             )
 


### PR DESCRIPTION
## Summary

- Completes the token log redaction from #4932, which missed three sites (one flagged by review on #4932, two more found by a multiline-aware sweep — the earlier grep missed log calls whose format string sits on a separate line from `logger.info(`):
  - `client_manager.py` `remove_client` success branch: "Token: {} left" fired on every clean client disconnect
  - `fed_server.py` dead-client sweep: "Remove the dead Client ... Token: {}"
  - `fed_client_base.py` registration success: client logged its own "Token:{} SSID:{}" at INFO
- Non-credential tokens (HCI session parts, CellPipe naming tokens, resource-reservation tokens) were checked and left as is.

Addresses item 2 of #4858, together with #4932.