### PR TITLE
Touch skills for NVSkills CI validation

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-autofl
 description: "Optimize an existing NVFLARE job.py through an agent-assisted Auto-FL campaign that preserves FLARE execution, policy, artifacts, and reproducibility."
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0" # NVSkills CI validation touch: no behavior change.
 compatibility: "Requires NVFLARE 2.8.0+, Python, and permission to run NVFLARE jobs in the selected environment."
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-convert-lightning
 description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; do not use for plain PyTorch, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
-version: "0.2.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.2.0" # NVSkills CI validation touch: no behavior change.
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-convert-pytorch
 description: "Convert existing PyTorch training code into an NVFLARE federated job using Client API model exchange, local validation, and job export; do not use for other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
-version: "0.2.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.2.0" # NVSkills CI validation touch: no behavior change.
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-diagnose-job/SKILL.md
+++ b/skills/nvflare-diagnose-job/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-diagnose-job
 description: "Diagnose failed, stalled, or suspicious NVFLARE jobs in simulation, POC, or production by collecting bounded evidence and mapping failure patterns to recovery actions."
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0" # NVSkills CI validation touch: no behavior change.
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-fed-stats/SKILL.md
+++ b/skills/nvflare-fed-stats/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-fed-stats
 description: "Compute federated statistics over tabular data (count, sum, mean, stddev, var, histogram, quantile, noise-protected min/max) and image data (count, failure_count, pixel-intensity histogram) across NVFLARE sites via FedStatsRecipe — automatic and non-interactive from the dataset, feature names (header or supplied), and optionally a README or notes declaring which statistics to compute; do not use for model training conversion, hierarchical statistics, deployment, POC/production lifecycle, or failed-job diagnosis."
 license: Apache-2.0
-version: "0.2.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.2.0" # NVSkills CI validation touch: no behavior change.
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-orient/SKILL.md
+++ b/skills/nvflare-orient/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-orient
 description: "Route open-ended or ambiguous NVFLARE requests by inspecting the local project and recommending one specific workflow skill without editing files; do not use for an explicit conversion request, even when its framework still needs detection."
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0" # NVSkills CI validation touch: no behavior change.
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-shared/SKILL.md
+++ b/skills/nvflare-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-shared
 description: Shared NVFLARE conversion references and templates used by the other NVFLARE agent skills (conversion workflow, validation ladder, dependency install, model exchange, metrics/artifact reporting, and the custom aggregator template). Not a user-triggered skill; loaded via references from the conversion skills.
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0" # NVSkills CI validation touch: no behavior change.
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"


### PR DESCRIPTION
## Summary
- make a no-op inline YAML comment refresh across all NVFLARE SKILL.md entrypoints
- use this PR to exercise the NVSkills CI workflow after the license checker fix landed

## Validation
- python3 ci/check_license_header.py
- python3 -m pytest tests/unit_test/tool/agent_skill_checks/lints_test.py
- ./runtest.sh -s
- pre-push agent skill lint

The parsed skill metadata is unchanged; only YAML comments on the version lines changed.