### PR TITLE
Remove NVSkills CI bootstrap comments from skill frontmatter

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-autofl
 description: "Optimize an existing NVFLARE job.py through an agent-assisted Auto-FL campaign that preserves FLARE execution, policy, artifacts, and reproducibility."
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0"
 compatibility: "Requires NVFLARE 2.8.0+, Python, and permission to run NVFLARE jobs in the selected environment."
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-convert-lightning
 description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; do not use for plain PyTorch, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
-version: "0.2.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.2.0"
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-convert-pytorch
 description: "Convert existing PyTorch training code into an NVFLARE federated job using Client API model exchange, local validation, and job export; do not use for other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
-version: "0.2.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.2.0"
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-diagnose-job/SKILL.md
+++ b/skills/nvflare-diagnose-job/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-diagnose-job
 description: "Diagnose failed, stalled, or suspicious NVFLARE jobs in simulation, POC, or production by collecting bounded evidence and mapping failure patterns to recovery actions."
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0"
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-fed-stats/SKILL.md
+++ b/skills/nvflare-fed-stats/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-fed-stats
 description: "Compute federated statistics over tabular data (count, sum, mean, stddev, var, histogram, quantile, noise-protected min/max) and image data (count, failure_count, pixel-intensity histogram) across NVFLARE sites via FedStatsRecipe — automatic and non-interactive from the dataset, feature names (header or supplied), and optionally a README or notes declaring which statistics to compute; do not use for model training conversion, hierarchical statistics, deployment, POC/production lifecycle, or failed-job diagnosis."
 license: Apache-2.0
-version: "0.2.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.2.0"
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-orient/SKILL.md
+++ b/skills/nvflare-orient/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-orient
 description: "Route open-ended or ambiguous NVFLARE requests by inspecting the local project and recommending one specific workflow skill without editing files; do not use for an explicit conversion request, even when its framework still needs detection."
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0"
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"

--- a/skills/nvflare-shared/SKILL.md
+++ b/skills/nvflare-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-shared
 description: Shared NVFLARE conversion references and templates used by the other NVFLARE agent skills (conversion workflow, validation ladder, dependency install, model exchange, metrics/artifact reporting, and the custom aggregator template). Not a user-triggered skill; loaded via references from the conversion skills.
 license: Apache-2.0
-version: "0.1.0" # NVSkills CI bootstrap: no behavior change.
+version: "0.1.0"
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min_flare_version: "2.8.0"


### PR DESCRIPTION
## Summary

- Remove the one-time `# NVSkills CI bootstrap: no behavior change.` inline comments that #4931 added to the `version:` line of every skill's SKILL.md frontmatter.
- YAML parsers ignore inline comments, so the parsed frontmatter is byte-identical before and after; versions are intentionally unchanged.

## Why

The comments existed only to give every skill a diff so the PR would route the full catalog through the newly configured NVSkills CI. On #4931 the `/nvskills-ci` dispatch never reported back (no commit status, no signature commit), so the comments merged as permanent cruft without serving their purpose.

Because this PR again touches all seven SKILL.md files, it satisfies the NVSkills CI watched-path gate — once the dispatch issue from #4931 is resolved, a `/nvskills-ci` comment here can perform the intended full-catalog validation against clean frontmatter. This PR therefore both removes the bootstrap hack and replaces #4931 as the bootstrap/test vehicle.

## Proposed upstream fix: `/nvskills-ci --all`

Catalog-wide validation should not require no-op file touches. A diff-independent scope flag would fix this permanently, and needs no changes in team repos — the trigger in `request-nvskills-ci.yml` uses `startsWith(comment.body, '/nvskills-ci')`, which already matches `/nvskills-ci --all`. Concretely:

1. **`NVIDIA/skills` `team-request.yml`** (reusable workflow): in the "Resolve request context" step, parse `--all` from the comment body into a `request_scope` value (`all` vs default `changed`); skip the `has_watched_change` paths gate when scope is `all`; add `request_scope` to the `workflow_dispatch` payload sent to `nvskills-ci`.
2. **`NVIDIA/nvskills-ci` `nvskills-ci.yml`**: accept a `request_scope` input, allowlist-validate it (`changed`/`all`) in `scripts/validate_request.py`, and — when scope is `all` — also skip that script's own server-side watched-files gate (it independently re-fetches the PR file list and raises `SkippedRequest` when no changes fall under watched paths), then expose the scope to the trigger step.
3. **`scripts/trigger_downstream.py`**: forward it as a GitLab pipeline variable in `build_variables()`, e.g. `NVSKILLS_VALIDATE_SCOPE` (default `changed`).
4. **Downstream GitLab pipeline**: when `NVSKILLS_VALIDATE_SCOPE=all`, enumerate every skill under the watched roots (`skills/`, `team-skills/`, `plugins/`, `rules/team-rules/`) at `SOURCE_HEAD_SHA` instead of deriving the skill set from the base..head diff, then attach signatures for the full catalog.

No new privilege surface: the existing maintain/admin requester check in `team-request.yml` already gates the command, and `--all` only widens validation coverage, not permissions.

## Validation

- `python3 -m pytest tests/unit_test/tool/agent_skill_checks/` — 134 passed
- `python3 ci/check_license_header.py` — all folders pass
