### PR TITLE
[Auto-FL] Clarify key_metric direction and warn on loss-like metrics

### DIFF
--- a/nvflare/app_common/np/recipes/fedavg.py
+++ b/nvflare/app_common/np/recipes/fedavg.py
@@ -69,7 +69,9 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction.
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
-        key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".
+        key_metric: Metric used to determine if the model is globally best. Higher values must indicate
+            a better model; for lower-is-better metrics such as a loss, report a negated value from the
+            client (e.g., "neg_loss"). Defaults to "accuracy".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.

--- a/nvflare/app_common/widgets/intime_model_selector.py
+++ b/nvflare/app_common/widgets/intime_model_selector.py
@@ -42,8 +42,10 @@ class IntimeModelSelector(Widget):
             validation_metric_name (str, optional): key used to save initial validation metric in the
                 DXO meta properties (defaults to MetaKey.INITIAL_METRICS).
             key_metric: if metrics are a `dict`, `key_metric` can select the metric used for global model selection.
-                Defaults to "val_accuracy".
-            negate_key_metric: Whether to invert the key metric. Should be used if key metric is a loss. Defaults to `False`.
+                Defaults to "val_accuracy". Higher values are treated as better unless `negate_key_metric` is set.
+            negate_key_metric: Whether to invert the key metric. Must be `True` if the key metric is
+                lower-is-better (e.g., a loss); otherwise the model with the worst metric would be selected
+                as the global best. Defaults to `False`.
         """
         super().__init__()
 
@@ -54,6 +56,14 @@ class IntimeModelSelector(Widget):
         self.aggregation_weights = aggregation_weights or {}
         self.key_metric = key_metric
         self.negate_key_metric = negate_key_metric
+
+        if not self.negate_key_metric and any(hint in self.key_metric.lower() for hint in ("loss", "err")):
+            self.logger.warning(
+                f"key_metric '{self.key_metric}' looks like a lower-is-better metric, but model selection "
+                f"treats higher values as better. If lower values indicate a better model, set "
+                f"negate_key_metric=True or report a negated metric from the client (e.g., "
+                f"'neg_{self.key_metric}'); otherwise the worst global model will be selected as the best."
+            )
 
         self.logger.info(f"model selection weights control: {aggregation_weights}")
         self._reset_stats()

--- a/nvflare/app_common/widgets/intime_model_selector.py
+++ b/nvflare/app_common/widgets/intime_model_selector.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import numpy as np
 
 from nvflare.apis.dxo import DataKind, MetaKey, from_shareable
@@ -23,6 +25,19 @@ from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.widget import Widget
+
+# Best-effort heuristic for lower-is-better metric names; not exhaustive.
+# Substring hints catch compound names like "val_loss" or "error_rate"; token hints
+# catch short names such as "mse" that are unsafe to match as substrings ("dice" contains "ce").
+_LOWER_IS_BETTER_SUBSTRING_HINTS = ("loss", "err")
+_LOWER_IS_BETTER_TOKEN_HINTS = {"bce", "ce", "cer", "mae", "mse", "nll", "perplexity", "ppl", "rmse", "wer"}
+
+
+def _looks_lower_is_better(metric_name: str) -> bool:
+    name = metric_name.lower()
+    if any(hint in name for hint in _LOWER_IS_BETTER_SUBSTRING_HINTS):
+        return True
+    return any(token in _LOWER_IS_BETTER_TOKEN_HINTS for token in re.split(r"[^a-z0-9]+", name))
 
 
 class IntimeModelSelector(Widget):
@@ -57,7 +72,7 @@ class IntimeModelSelector(Widget):
         self.key_metric = key_metric
         self.negate_key_metric = negate_key_metric
 
-        if not self.negate_key_metric and any(hint in self.key_metric.lower() for hint in ("loss", "err")):
+        if not self.negate_key_metric and _looks_lower_is_better(self.key_metric):
             self.logger.warning(
                 f"key_metric '{self.key_metric}' looks like a lower-is-better metric, but model selection "
                 f"treats higher values as better. If lower values indicate a better model, set "

--- a/nvflare/app_opt/pt/job_config/base_fed_job.py
+++ b/nvflare/app_opt/pt/job_config/base_fed_job.py
@@ -42,7 +42,8 @@ class BaseFedJob(UnifiedBaseFedJob):
         mandatory_clients (list[str] | None, optional): mandatory clients to run the job. Default None.
         key_metric (str, optional): Metric used to determine if the model is globally best.
             if metrics are a `dict`, `key_metric` can select the metric used for global model selection.
-            Defaults to "accuracy".
+            Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
         validation_json_generator (ValidationJsonGenerator | None, optional): A component for generating validation results.
             if not provided, a ValidationJsonGenerator will be configured.
         model_selector: (FLComponent | None, optional): A component for selecting the best model during training.

--- a/nvflare/app_opt/pt/job_config/fed_avg.py
+++ b/nvflare/app_opt/pt/job_config/fed_avg.py
@@ -45,7 +45,8 @@ class FedAvgJob(BaseFedJob):
             mandatory_clients (List[str], optional): mandatory clients to run the job. Default None.
             key_metric (str, optional): Metric used to determine if the model is globally best.
                 if metrics are a `dict`, `key_metric` can select the metric used for global model selection.
-                Defaults to "accuracy".
+                Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+                report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
         """
         if not isinstance(initial_model, nn.Module):
             raise ValueError(f"Expected initial model to be nn.Module, but got type {type(initial_model)}.")

--- a/nvflare/app_opt/pt/job_config/fed_sag_mlflow.py
+++ b/nvflare/app_opt/pt/job_config/fed_sag_mlflow.py
@@ -53,7 +53,8 @@ class SAGMLFlowJob(BaseFedJob):
             mandatory_clients (List[str], optional): mandatory clients to run the job. Default None.
             key_metric (str, optional): Metric used to determine if the model is globally best.
                 if metrics are a `dict`, `key_metric` can select the metric used for global model selection.
-                Defaults to "accuracy".
+                Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+                report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
             kwargs: kwargs dict
         """
         super().__init__(initial_model, name, min_clients, mandatory_clients, key_metric)

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -71,7 +71,9 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction.
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
-        key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".
+        key_metric: Metric used to determine if the model is globally best. Higher values must indicate
+            a better model; for lower-is-better metrics such as a loss, report a negated value from the
+            client (e.g., "neg_loss"). Defaults to "accuracy".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.

--- a/nvflare/app_opt/sklearn/recipes/fedavg.py
+++ b/nvflare/app_opt/sklearn/recipes/fedavg.py
@@ -60,7 +60,9 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction. Nested values become
             part of the generated job definition and must not contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
-            a dict, key_metric selects the metric used for global model selection. Defaults to "accuracy".
+            a dict, key_metric selects the metric used for global model selection. Higher values must
+            indicate a better model; for lower-is-better metrics such as a loss, report a negated value
+            from the client (e.g., "neg_loss"). Defaults to "accuracy".
         launch_once: Whether the external process will be launched only once at the beginning
             or on each task. Only used if `launch_external_process` is True. Defaults to True.
         shutdown_timeout: If provided, will wait for this number of seconds before shutdown.

--- a/nvflare/app_opt/sklearn/recipes/kmeans.py
+++ b/nvflare/app_opt/sklearn/recipes/kmeans.py
@@ -83,7 +83,8 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction. Nested values become
             part of the generated job definition and must not contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
-            a dict, key_metric selects the metric used for global model selection. Defaults to "metrics"
+            a dict, key_metric selects the metric used for global model selection. Higher values must
+            indicate a better model. Defaults to "metrics"
             (which corresponds to the homogeneity score sent by the K-Means client).
 
     Example:

--- a/nvflare/app_opt/sklearn/recipes/svm.py
+++ b/nvflare/app_opt/sklearn/recipes/svm.py
@@ -82,7 +82,8 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction. Nested values become
             part of the generated job definition and must not contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
-            a dict, key_metric selects the metric used for global model selection. Defaults to "AUC"
+            a dict, key_metric selects the metric used for global model selection. Higher values must
+            indicate a better model. Defaults to "AUC"
             (which corresponds to the ROC AUC score sent by the SVM client in round 1).
 
     Example:

--- a/nvflare/app_opt/tf/job_config/base_fed_job.py
+++ b/nvflare/app_opt/tf/job_config/base_fed_job.py
@@ -46,7 +46,8 @@ class BaseFedJob(UnifiedBaseFedJob):
         mandatory_clients (List[str], optional): mandatory clients to run the job. Default None.
         key_metric (str, optional): Metric used to determine if the model is globally best.
             if metrics are a `dict`, `key_metric` can select the metric used for global model selection.
-            Defaults to "accuracy".
+            Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
         validation_json_generator (ValidationJsonGenerator, optional): A component for generating validation results.
             if not provided, a ValidationJsonGenerator will be configured.
         model_selector: (FLComponent, optional): A component for selecting the best model during training.

--- a/nvflare/app_opt/tf/job_config/fed_avg.py
+++ b/nvflare/app_opt/tf/job_config/fed_avg.py
@@ -45,7 +45,8 @@ class FedAvgJob(BaseFedJob):
             mandatory_clients (List[str], optional): mandatory clients to run the job. Default None.
             key_metric (str, optional): Metric used to determine if the model is globally best.
                 if metrics are a `dict`, `key_metric` can select the metric used for global model selection.
-                Defaults to "accuracy".
+                Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+                report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
         """
         if not isinstance(initial_model, tf.keras.Model):
             raise ValueError(f"Expected initial model to be tf.keras.Model, but got type {type(initial_model)}.")

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -78,7 +78,8 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             Only used if `launch_external_process` is True. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
-            Defaults to "accuracy".
+            Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
         best_model_filename: Filename for saving the best model. Accepted for API compatibility.
             The default TensorFlow persistor does not currently create a separate best-model artifact.
         save_filename: Deprecated alias for best_model_filename. If both are specified, they must match.

--- a/nvflare/job_config/base_fed_job.py
+++ b/nvflare/job_config/base_fed_job.py
@@ -59,6 +59,8 @@ class BaseFedJob(FedJob):
             mandatory_clients: Mandatory clients to run the job. Default None.
             key_metric: Metric used to determine if the model is globally best.
                 If metrics are a dict, key_metric can select the metric used for global model selection.
+                Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+                report a negated value from the client (e.g., "neg_loss").
                 Defaults to "accuracy". Only used if model_selector is not provided.
             validation_json_generator: A component for generating validation results.
                 If not provided, a ValidationJsonGenerator will be configured.

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -145,7 +145,8 @@ class FedAvgRecipe(Recipe):
             Only used if `launch_external_process` is True. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
-            Defaults to "accuracy".
+            Higher values must indicate a better model; for lower-is-better metrics such as a loss,
+            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -96,8 +96,13 @@ class TestInTimeModelSelector:
         [
             ("val_loss", False, True),
             ("error_rate", False, True),
+            ("val_mse", False, True),
+            ("rmse", False, True),
+            ("val_ce", False, True),
+            ("perplexity", False, True),
             ("val_loss", True, False),
             ("val_accuracy", False, False),
+            ("dice", False, False),
         ],
     )
     def test_loss_like_key_metric_warning(self, caplog, key_metric, negate_key_metric, expect_warning):

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -106,7 +106,8 @@ class TestInTimeModelSelector:
         ],
     )
     def test_loss_like_key_metric_warning(self, caplog, key_metric, negate_key_metric, expect_warning):
-        with caplog.at_level(logging.WARNING):
+        logger_name = f"{IntimeModelSelector.__module__}.{IntimeModelSelector.__qualname__}"
+        with caplog.at_level(logging.WARNING, logger=logger_name):
             IntimeModelSelector(key_metric=key_metric, negate_key_metric=negate_key_metric)
         warned = any("looks like a lower-is-better metric" in record.getMessage() for record in caplog.records)
         assert warned == expect_warning

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import pytest
 
 from nvflare.apis.dxo import DXO, DataKind, MetaKey
@@ -88,6 +90,21 @@ class TestInTimeModelSelector:
             handler.handle_event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT, fl_ctx)
         handler.handle_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
         assert (engine.last_event == AppEventType.GLOBAL_BEST_MODEL_AVAILABLE) == expected
+
+    @pytest.mark.parametrize(
+        "key_metric,negate_key_metric,expect_warning",
+        [
+            ("val_loss", False, True),
+            ("error_rate", False, True),
+            ("val_loss", True, False),
+            ("val_accuracy", False, False),
+        ],
+    )
+    def test_loss_like_key_metric_warning(self, caplog, key_metric, negate_key_metric, expect_warning):
+        with caplog.at_level(logging.WARNING):
+            IntimeModelSelector(key_metric=key_metric, negate_key_metric=negate_key_metric)
+        warned = any("looks like a lower-is-better metric" in record.getMessage() for record in caplog.records)
+        assert warned == expect_warning
 
     def test_model_selection_publishes_metrics_selection_info(self):
         handler = IntimeModelSelector(key_metric="loss", negate_key_metric=True)


### PR DESCRIPTION
Clarifies the higher-is-better metric convention and warns when a loss-like metric would otherwise select the worst checkpoint.

### Description

`IntimeModelSelector` always treats higher `key_metric` values as better, but none of the docstrings at the recipe/job layer said so. A FedAvg job whose `key_metric` is a loss (lower = better) silently selects the round with the highest loss as `best_FL_global_model.pt`, and the job still completes successfully.

Per the design decision in #3962, the recipe layer intentionally exposes only `key_metric` (no `negate_key_metric`); the agreed convention is that higher values indicate a better model and clients report a negated value for lower-is-better metrics. The documentation half of that decision was never implemented — this PR adds it, plus a guardrail:

- Document the higher-is-better convention everywhere `key_metric` is exposed: `FedAvgRecipe` (unified/PT/TF/NumPy/sklearn), `KMeansRecipe`, `SVMRecipe`, `BaseFedJob` (common/PT/TF), legacy `FedAvgJob`/`SAGMLFlowJob` job configs, and `IntimeModelSelector` itself, with the recommended client-side negation workaround (e.g., report `neg_loss`).
- `IntimeModelSelector` now logs a warning when `key_metric` looks lower-is-better (name contains "loss"/"err") and `negate_key_metric` is not set, so the silent worst-model selection becomes visible in the logs.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally (black/isort/flake8 on changed files; pytest `tests/unit_test/{recipe,job_config,app_common/widgets}`: 587 passed).
- [x] In-line docstrings updated.
