### PR TITLE
Scan bundled NVFlare skills with public SkillSpector

### DIFF
--- a/3rdParty/SkillSpector.LICENSE.txt
+++ b/3rdParty/SkillSpector.LICENSE.txt
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,8 @@ test_support =
     isort==5.13.2
     flake8==7.1.1
     black==25.9.0
-    click==8.1.7
+    click==8.1.7; python_version < "3.14"
+    click==8.2.1; python_version >= "3.14"
     pytest-xdist==3.6.1
     pytest-cov==5.0.0
     pandas>=1.5.1
@@ -119,9 +120,13 @@ test_mac =
 dev =
     %(doc)s
     %(test)s
+    # Python 3.12 and 3.13 are excluded because openmined.psi pins protobuf==6.30.2,
+    # while SkillSpector requires protobuf>=6.32.1.
+    skillspector @ git+https://github.com/NVIDIA/SkillSpector.git@fd25398d7aa99353d86237b9c260759351f0e644 ; python_version == "3.14"
 dev_mac =
     %(doc)s
     %(test_mac)s
+    skillspector @ git+https://github.com/NVIDIA/SkillSpector.git@fd25398d7aa99353d86237b9c260759351f0e644 ; python_version == "3.14"
 # CPU-only variant of `app_opt`: omits torch (install separately from
 # https://download.pytorch.org/whl/cpu first) and bitsandbytes (GPU-only).
 # torchvision is included so the extra is self-sufficient for tests; install
@@ -148,6 +153,7 @@ test_cpu =
 dev_cpu =
     %(doc)s
     %(test_cpu)s
+    skillspector @ git+https://github.com/NVIDIA/SkillSpector.git@fd25398d7aa99353d86237b9c260759351f0e644 ; python_version == "3.14"
 
 [options.entry_points]
 console_scripts =

--- a/tests/unit_test/tool/agent_skill_checks/skillspector_static_scan_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/skillspector_static_scan_test.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+COMMAND_TIMEOUT = 30
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SKILL_DIRS = tuple(sorted(path.parent for path in (REPO_ROOT / "skills").glob("*/SKILL.md")))
+BLOCKING_SEVERITIES = {"HIGH", "CRITICAL"}
+KEY_ENV_NAMES = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_PROXY_API_KEY",
+    "ANTHROPIC_PROXY_ENDPOINT_URL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_PROFILE",
+    "AWS_SECRET_ACCESS_KEY",
+    "GOOGLE_API_KEY",
+    "LANGSMITH_API_KEY",
+    "NVIDIA_INFERENCE_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "SKILLSPECTOR_MODEL",
+    "SKILLSPECTOR_PROVIDER",
+)
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=lambda path: path.name)
+def test_skillspector_keyless_static_scan_of_bundled_skill(skill_dir, tmp_path):
+    if sys.version_info[:2] != (3, 14):
+        pytest.skip("skillspector is included in NVFlare development dependencies on Python 3.14")
+
+    skillspector = shutil.which("skillspector")
+    assert skillspector, "skillspector must be installed by NVFlare's Python 3.14 development dependencies"
+
+    report_path = tmp_path / f"{skill_dir.name}-skillspector-report.json"
+    command = [
+        skillspector,
+        "scan",
+        str(skill_dir),
+        "--format",
+        "json",
+        "--no-llm",
+        "--output",
+        str(report_path),
+    ]
+
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=COMMAND_TIMEOUT,
+        env=_keyless_env(),
+        check=False,
+    )
+
+    assert completed.returncode == 0, (
+        f"{' '.join(command)} failed with exit code {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+    assert report_path.is_file(), f"skillspector did not create the JSON report\nstdout:\n{completed.stdout}"
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    risk_assessment = report["risk_assessment"]
+    risk_score = risk_assessment["score"]
+    issues = report["issues"]
+
+    assert report["skill"]["name"] == skill_dir.name
+    assert isinstance(risk_score, (int, float)) and not isinstance(risk_score, bool)
+    assert 0 <= risk_score <= 100
+    assert isinstance(issues, list)
+    assert risk_assessment["recommendation"] != "DO_NOT_INSTALL"
+    assert risk_assessment["severity"] not in BLOCKING_SEVERITIES
+    assert not [issue for issue in issues if issue["severity"] in BLOCKING_SEVERITIES]
+
+
+def _keyless_env():
+    env = os.environ.copy()
+    env["LANGCHAIN_TRACING_V2"] = "false"
+    env["LANGSMITH_TRACING"] = "false"
+    for name in KEY_ENV_NAMES:
+        env.pop(name, None)
+    return env


### PR DESCRIPTION
## What this PR does

- Replaces the private `NVIDIA/SkillEvaluator` dependency and test path with the public [NVIDIA/SkillSpector](https://github.com/NVIDIA/SkillSpector), pinned to commit `fd25398d7aa99353d86237b9c260759351f0e644`.
- Runs a deterministic, keyless `skillspector scan --no-llm` against every bundled `skills/*/SKILL.md`; each bundled skill is a separate pytest case, and newly added top-level skills are discovered automatically.
- Makes the Python 3.14 test lane fail if the declared SkillSpector executable is missing, the scan fails, the JSON report is malformed, or a skill receives a `HIGH`/`CRITICAL` or `DO_NOT_INSTALL` result.
- Adds SkillSpector to the existing `dev`, `dev_mac`, and `dev_cpu` extras. There is no dedicated SkillSpector extra.
- Adds the upstream Apache-2.0 license at `3rdParty/SkillSpector.LICENSE.txt`.

## Dependency compatibility

SkillSpector is enabled on Python 3.14. Python 3.12 and 3.13 are excluded because NVFlare dev dependencies include `openmined.psi`, which pins `protobuf==6.30.2`, while SkillSpector requires `protobuf>=6.32.1`. The Python 3.14 Click pin is also raised to 8.2.1 to satisfy SkillSpector/Typer while retaining Click 8.1.7 on older interpreters.

The normal Python 3.14 `dev_cpu` premerge installation supplies SkillSpector, so no private-repository token or custom install step is required.

## Testing

- Python 3.14.6, CI-style parallel run: `8 passed in 21.02s`
- `./runtest.sh -s`
- Python 3.14 Linux target resolution: `uv pip install --python-version 3.14 --python-platform x86_64-manylinux_2_28 --dry-run -e ".[dev_cpu]"`