### PR TITLE
[Auto-FL] Reduce cross-site fallback scores with a defined per-site mean

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -80,8 +80,10 @@ long-running behavior read [continuous campaigns](references/continuous-campaign
 read [experiment comparability](references/experiment-comparability.md).
 
 The ledger score extracted per the objective `metric_extraction_order` is the canonical selection surface for
-keep/discard and best-candidate decisions. Cross-site server-final scores are diagnostic unless the user explicitly
-requests selection on them.
+keep/discard and best-candidate decisions. The `cross_val_results.json` fallback score is the unweighted mean of the
+server global model's metric across evaluating sites (final checkpoint preferred over `best_`; per-site weights are
+not recorded in the payload). Cross-site server-final scores are diagnostic unless the user explicitly requests
+selection on them.
 
 Read `autofl.yaml` and show the user a concise campaign summary:
 

--- a/skills/nvflare-autofl/references/experiment-comparability.md
+++ b/skills/nvflare-autofl/references/experiment-comparability.md
@@ -7,9 +7,13 @@ data distribution, synthetic data, and site heterogeneity requests.
 
 The per-run ledger score, extracted with the objective's
 `metric_extraction_order`, is the canonical selection surface for baseline,
-keep/discard, and best-candidate comparisons. Cross-site server-final
-global-model scores from `cross_val_results.json` are diagnostic unless the
-user explicitly requests selection on them.
+keep/discard, and best-candidate comparisons. When extraction falls back to
+`cross_val_results.json`, the score is the unweighted mean of the server
+global model's metric across the evaluating sites, preferring final-checkpoint
+entries over `best_`-checkpoint entries; per-site sample counts are not
+recorded in the payload, so a weighted mean is not computable. Cross-site
+server-final global-model scores are diagnostic unless the user explicitly
+requests selection on them.
 
 ## Iterative Reruns
 

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -84,6 +84,9 @@ RESULT_FIELDS = [
 # CrossSiteModelEval workflow prefixes SRV_ (SRV_FL_global_model, SRV_best_FL_global_model.pt)
 # while the ModelController CrossSiteEval records the raw checkpoint name (FL_global_model.pt).
 SERVER_GLOBAL_MODEL_KEY_MARKER = "FL_global_model"
+# Sub-marker for best-checkpoint global-model entries (SRV_best_FL_global_model.pt,
+# best_FL_global_model.pt) as opposed to final-checkpoint entries.
+SERVER_BEST_GLOBAL_MODEL_KEY_MARKER = "best_FL_global_model"
 
 CANDIDATE_MANIFEST_SCHEMA_VERSION = "nvflare.autofl.candidate.v1"
 CANDIDATE_MANIFEST_STATUSES = {"prepared", "ready_for_external_execution", "keep", "discard", "crash", "abandoned"}
@@ -1399,25 +1402,32 @@ def metric_from_list(items: Any, metric: str) -> Optional[float]:
     return None
 
 
-def server_final_metric_values(payload: Any, metric: str) -> List[float]:
-    """Collect the metric values recorded for server-side global-model entries in a cross-site payload."""
-    values: List[float] = []
+def server_global_model_metric_values(payload: Any, metric: str) -> Tuple[List[float], List[float]]:
+    """Collect per-site metric values for server-side global-model entries in a cross-site payload.
+
+    Returns (final_values, best_values): entries whose key contains the best-checkpoint marker
+    (SRV_best_FL_global_model.pt, best_FL_global_model.pt) land in best_values; the remaining
+    global-model entries are final-checkpoint values.
+    """
+    final_values: List[float] = []
+    best_values: List[float] = []
     if isinstance(payload, dict):
         for key, entry in payload.items():
             if isinstance(key, str) and SERVER_GLOBAL_MODEL_KEY_MARKER in key:
                 value = find_metric_value(entry, [metric])
                 if value is not None:
-                    values.append(value)
+                    target = best_values if SERVER_BEST_GLOBAL_MODEL_KEY_MARKER in key else final_values
+                    target.append(value)
             else:
-                values.extend(server_final_metric_values(entry, metric))
+                nested_final, nested_best = server_global_model_metric_values(entry, metric)
+                final_values.extend(nested_final)
+                best_values.extend(nested_best)
     elif isinstance(payload, list):
         for item in payload:
-            values.extend(server_final_metric_values(item, metric))
-    return values
-
-
-def best_metric_value(values: Sequence[float], mode: str) -> float:
-    return min(values) if mode == "min" else max(values)
+            nested_final, nested_best = server_global_model_metric_values(item, metric)
+            final_values.extend(nested_final)
+            best_values.extend(nested_best)
+    return final_values, best_values
 
 
 def text_metric_matches(text: str, metric: str) -> List[Tuple[int, float]]:
@@ -1471,9 +1481,7 @@ def text_metric_matches(text: str, metric: str) -> List[Tuple[int, float]]:
     return evaluation_matches or direct_matches or mapping_matches or framework_matches
 
 
-def extract_metric_evidence(
-    artifact_root: Path, metrics: Sequence[str] | str, mode: str = "max"
-) -> Optional[MetricEvidence]:
+def extract_metric_evidence(artifact_root: Path, metrics: Sequence[str] | str) -> Optional[MetricEvidence]:
     metric_order = normalize_metric_order(metrics)
     metric_files = sorted(artifact_root.glob("**/metrics_summary.json")) + sorted(
         artifact_root.glob("**/cross_val_results.json")
@@ -1488,12 +1496,16 @@ def extract_metric_evidence(
     for metric in metric_order:
         for path, payload in payloads:
             if path.name == "cross_val_results.json":
-                # Cross-site payloads score every site/model pair; prefer the server-final
-                # global model over whichever entry happens to appear first.
-                server_final = server_final_metric_values(payload, metric)
-                if server_final:
+                # Cross-site payloads score every site/model pair; prefer the server global
+                # model over whichever entry happens to appear first, and final-checkpoint
+                # entries over best_-checkpoint entries. Per-site sample counts are not
+                # recorded in the payload, so the defined reducer is the unweighted mean
+                # across evaluating sites (a max/min would just pick the easiest site).
+                final_values, best_values = server_global_model_metric_values(payload, metric)
+                server_values = final_values or best_values
+                if server_values:
                     return MetricEvidence(
-                        score=best_metric_value(server_final, mode),
+                        score=sum(server_values) / len(server_values),
                         metric_name=metric,
                         source=f"structured:{path.name}#server_final",
                         artifact=str(path.resolve()),
@@ -1528,8 +1540,8 @@ def extract_metric_evidence(
     return None
 
 
-def extract_score(artifact_root: Path, metrics: Sequence[str] | str, mode: str = "max") -> Optional[float]:
-    evidence = extract_metric_evidence(artifact_root, metrics, mode)
+def extract_score(artifact_root: Path, metrics: Sequence[str] | str) -> Optional[float]:
+    evidence = extract_metric_evidence(artifact_root, metrics)
     return evidence.score if evidence else None
 
 
@@ -2269,7 +2281,6 @@ def run_job(
     simulator_no_progress_timeout: int,
     metrics: Sequence[str],
     config: Dict[str, Any],
-    mode: str = "max",
 ) -> RunRecord:
     baseline_run = run_def.status == "baseline"
     log_path = output_root / run_def.name / "run.log"
@@ -2335,7 +2346,7 @@ def run_job(
         run_def.failure_reason = unresolved_result_dir_failure_reason(python, cwd, config)
     else:
         artifact_root = artifact_dir.parent
-        evidence = extract_metric_evidence(artifact_root, metrics, mode)
+        evidence = extract_metric_evidence(artifact_root, metrics)
         if evidence is None:
             run_def.status = "crash"
             run_def.failure_reason = f"matching metric not found; {metric_search_description(artifact_root, metrics)}"
@@ -2960,7 +2971,6 @@ def execute_sim_baseline(
         simulator_no_progress_timeout=no_progress_timeout,
         metrics=metric_extraction_order(config, args.metric),
         config=config,
-        mode=args.mode,
     )
 
 
@@ -3454,7 +3464,6 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
             simulator_no_progress_timeout=no_progress_timeout,
             metrics=metric_extraction_order(config, args.metric),
             config=config,
-            mode=args.mode,
         )
     except BaseException as error:
         try:
@@ -3605,7 +3614,7 @@ def record_external_result(args: argparse.Namespace, job: Path) -> int:
         raise ValueError("--score must be a finite number")
     evidence = None
     if score is None and artifact_path:
-        evidence = extract_metric_evidence(artifact_path, metric_extraction_order(config, args.metric), args.mode)
+        evidence = extract_metric_evidence(artifact_path, metric_extraction_order(config, args.metric))
         score = evidence.score if evidence else None
     elif score is not None:
         evidence = MetricEvidence(

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -2971,7 +2971,7 @@ if __name__ == "__main__":
     assert manifest["changed_files"] == ["job.py"]
 
 
-def test_cross_val_extraction_prefers_best_server_final_global_model_entry(tmp_path):
+def test_cross_val_extraction_averages_server_final_global_model_entries(tmp_path):
     runner = _load_runner()
     result_path = tmp_path / "cross_val_results.json"
     result_path.write_text(
@@ -2992,7 +2992,8 @@ def test_cross_val_extraction_prefers_best_server_final_global_model_entry(tmp_p
 
     evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
 
-    assert evidence.score == pytest.approx(0.74)
+    # Unweighted mean over the global model's per-site scores; site-local entries never count.
+    assert evidence.score == pytest.approx((0.71 + 0.74) / 2)
     assert evidence.metric_name == "accuracy"
     assert evidence.source == "structured:cross_val_results.json#server_final"
     assert evidence.artifact == str(result_path.resolve())
@@ -3018,7 +3019,67 @@ def test_cross_val_extraction_resolves_modern_unprefixed_global_model_entries(tm
 
     evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
 
-    assert evidence.score == pytest.approx(0.74)
+    assert evidence.score == pytest.approx((0.71 + 0.74) / 2)
+    assert evidence.source == "structured:cross_val_results.json#server_final"
+
+
+def test_cross_val_extraction_mean_penalizes_easiest_site_bias(tmp_path):
+    # Reviewer counterexample: a max reduction would score [0.90, 0.50] as 0.90 and rank it above
+    # a uniformly better [0.80, 0.80]; the unweighted mean ranks the uniform candidate higher.
+    runner = _load_runner()
+    skewed = tmp_path / "skewed"
+    uniform = tmp_path / "uniform"
+    skewed.mkdir()
+    uniform.mkdir()
+    skewed.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {"SRV_FL_global_model.pt": {"accuracy": 0.90}},
+                "site-2": {"SRV_FL_global_model.pt": {"accuracy": 0.50}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    uniform.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {"SRV_FL_global_model.pt": {"accuracy": 0.80}},
+                "site-2": {"SRV_FL_global_model.pt": {"accuracy": 0.80}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    skewed_score = runner.extract_score(skewed, ["accuracy"])
+    uniform_score = runner.extract_score(uniform, ["accuracy"])
+
+    assert skewed_score == pytest.approx(0.70)
+    assert uniform_score == pytest.approx(0.80)
+    assert runner.better(uniform_score, skewed_score, "max")
+
+
+def test_cross_val_extraction_prefers_final_checkpoint_entries_over_best(tmp_path):
+    runner = _load_runner()
+    tmp_path.joinpath("cross_val_results.json").write_text(
+        json.dumps(
+            {
+                "site-1": {
+                    "SRV_FL_global_model.pt": {"accuracy": 0.60},
+                    "SRV_best_FL_global_model.pt": {"accuracy": 0.90},
+                },
+                "site-2": {
+                    "SRV_FL_global_model.pt": {"accuracy": 0.80},
+                    "SRV_best_FL_global_model.pt": {"accuracy": 0.95},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
+
+    # Only the final-checkpoint class is averaged; best_-checkpoint entries are excluded.
+    assert evidence.score == pytest.approx((0.60 + 0.80) / 2)
     assert evidence.source == "structured:cross_val_results.json#server_final"
 
 
@@ -3030,7 +3091,8 @@ def test_cross_val_extraction_resolves_srv_best_only_global_model_entries(tmp_pa
                 "site-1": {
                     "site-1": {"accuracy": 0.99},
                     "SRV_best_FL_global_model.pt": {"accuracy": 0.66},
-                }
+                },
+                "site-2": {"SRV_best_FL_global_model.pt": {"accuracy": 0.70}},
             }
         ),
         encoding="utf-8",
@@ -3038,11 +3100,12 @@ def test_cross_val_extraction_resolves_srv_best_only_global_model_entries(tmp_pa
 
     evidence = runner.extract_metric_evidence(tmp_path, ["accuracy"])
 
-    assert evidence.score == pytest.approx(0.66)
+    # Without any final-checkpoint entries the best_-checkpoint class is averaged instead.
+    assert evidence.score == pytest.approx((0.66 + 0.70) / 2)
     assert evidence.source == "structured:cross_val_results.json#server_final"
 
 
-def test_cross_val_extraction_uses_min_over_server_final_entries_in_min_mode(tmp_path):
+def test_cross_val_extraction_single_site_mean_is_the_value_itself(tmp_path):
     runner = _load_runner()
     tmp_path.joinpath("cross_val_results.json").write_text(
         json.dumps(
@@ -3050,14 +3113,13 @@ def test_cross_val_extraction_uses_min_over_server_final_entries_in_min_mode(tmp
                 "site-1": {
                     "site-1": {"loss": 0.10},
                     "SRV_FL_global_model.pt": {"loss": 0.42},
-                },
-                "site-2": {"SRV_FL_global_model.pt": {"loss": 0.37}},
+                }
             }
         ),
         encoding="utf-8",
     )
 
-    assert runner.extract_score(tmp_path, ["loss"], mode="min") == pytest.approx(0.37)
+    assert runner.extract_score(tmp_path, ["loss"]) == pytest.approx(0.42)
 
 
 def test_cross_val_extraction_falls_back_to_first_match_without_server_final_entries(tmp_path):


### PR DESCRIPTION
# Description

Follow-up to #4927 (cross-site fallback extraction). A reviewer correctly flagged that the fallback reducer was wrong: `server_final_metric_values()` flattened the server global model's scores across ALL evaluating sites (cross_val payloads are `results[data_client][model_owner]` matrices) AND across final/best checkpoints (both `SRV_FL_global_model` and `SRV_best_FL_global_model` match the `FL_global_model` marker), then `best_metric_value()` took max in mode `max` — selecting the easiest site, not an aggregate. A skewed candidate scoring `[0.90, 0.50]` extracted `0.90` and beat a uniformly better `[0.80, 0.80]`.

## What changed

- **Checkpoint preference**: the collector (`server_global_model_metric_values`) now returns two classes — final-checkpoint global-model entries and `best_`-checkpoint entries (keys containing `best_FL_global_model`). Final-class values are used when any exist; otherwise the best-checkpoint class is the fallback.
- **Reducer**: the selected class is reduced with the unweighted arithmetic mean across evaluating sites (per-site sample counts are not recorded in `cross_val_results.json`, so a weighted mean is not computable). The `#server_final` provenance suffix and the gating to `cross_val_results.json` payloads (plain first-match when no global-model entries exist) are unchanged.
- **Dead plumbing removal**: the mean is direction-independent, so the `mode` parameter #4927 threaded through `extract_metric_evidence` / `extract_score` / `run_job` solely for `best_metric_value` is removed along with `best_metric_value` itself. `--mode` remains a campaign argument for keep/discard comparisons, guard state, and the job importer.
- **Docs**: SKILL.md and `references/experiment-comparability.md` now document the mean-based fallback, the final-over-`best_` checkpoint preference, and the missing per-site weights.

## Why

Max/min over per-site cross-site scores rewards candidates that overfit the easiest site and penalizes uniform improvement, biasing keep/discard and best-candidate selection whenever the ledger score falls back to `cross_val_results.json`. The unweighted mean is the only defined aggregate given that the payload records no per-site sample counts.

## Testing

`python3.12 -m pytest tests/unit_test/tool/autofl_skill_runner_test.py tests/unit_test/tool/autofl_skill_campaign_guard_test.py tests/unit_test/tool/autofl_skill_plot_progress_test.py tests/unit_test/tool/autofl_skill_job_importer_test.py tests/unit_test/tool/agent_skill_checks -q` — 350 passed.

New regression tests:
- Reviewer counterexample verbatim: `[0.90, 0.50]` -> 0.70 vs `[0.80, 0.80]` -> 0.80; the uniform candidate ranks higher.
- Payload with both `SRV_FL_global_model` and `SRV_best_FL_global_model` entries averages only the final class; a `best_`-only payload falls back to the best class.
- Single-site payload: mean of one value is the value itself.
- Existing #4927 tests updated to mean expectations (e.g. 0.74 -> 0.725) while keeping their guards: site-local entries are never selected, `#server_final` provenance asserted, plain first-match fallback unchanged; no test passes `mode` into the extraction functions anymore.

black/isort/flake8 clean on changed files; SKILL.md within the 200-line lint limit.