### PR TITLE
[Auto-FL] Refresh campaign state when mutable settings change before action gating

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -162,6 +162,8 @@ infer a cap from an inherited environment variable. Do not count import, validat
 baseline, or infrastructure-only retries; count a real candidate crash after execution starts. Runner state must
 report `candidate_cap_source=explicit` or `uncapped`, plus `remaining_candidates`, `baseline_status`,
 `baseline_score`, `improvement`, and `abandoned_candidates`; cap changes append to `cap_changes` in campaign metadata.
+A persisted cap change refreshes `campaign_state.json` before action gating, so raising `--max-candidates` reopens a
+cap-exhausted campaign.
 
 Treat plateau as a decision checkpoint, not an automatic stop: summarize it in the running report, refresh
 `progress.png`, run the runner's `status` action to refresh `.nvflare/autofl/campaign_state.json`, choose the returned

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2728,7 +2728,13 @@ def campaign_settings(args: argparse.Namespace) -> Dict[str, Any]:
     return {name: getattr(args, name) for name in CAMPAIGN_SETTING_NAMES}
 
 
-def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]) -> None:
+def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]) -> bool:
+    """Restore persisted settings onto args; persist explicit mutable changes.
+
+    Returns True when a mutable-settings change was persisted to campaign.json, so
+    callers can refresh the authoritative campaign state under the new settings
+    before any preflight gate reads it.
+    """
     settings = metadata.get("settings")
     if not isinstance(settings, dict):
         raise ValueError("campaign metadata is missing settings")
@@ -2767,6 +2773,7 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
             raise ValueError("campaign metadata is missing workspace_root")
         workspace = Path(workspace_value)
         write_json(campaign_metadata_path(workspace), metadata)
+    return changed
 
 
 def campaign_timeout(args: argparse.Namespace, schema: Dict[str, Any]) -> Tuple[int, int]:
@@ -2969,8 +2976,10 @@ def initialize_campaign(args: argparse.Namespace, job: Path) -> int:
     metadata_path = campaign_metadata_path(workspace)
     if metadata_path.exists():
         metadata = load_campaign_metadata(workspace, job)
-        restore_campaign_settings(args, metadata)
+        settings_changed = restore_campaign_settings(args, metadata)
         paths = campaign_paths(args, job)
+        if settings_changed:
+            refresh_campaign_state(args, job, metadata, paths)
         records = load_results(paths["results"])
         if args.target_env == "sim" and not any(
             record.status == "baseline" and record.score is not None for record in records
@@ -3092,12 +3101,47 @@ def count_abandoned_candidates(workspace: Path) -> int:
     return count
 
 
+def refresh_campaign_state(
+    args: argparse.Namespace, job: Path, metadata: Dict[str, Any], paths: Dict[str, Path]
+) -> Tuple[List[RunRecord], Dict[str, Any]]:
+    """Recompute and persist campaign_state.json under the current effective settings without running a job."""
+    records = load_results(paths["results"])
+    pending = pending_candidate_manifests(job.parent)
+    state = write_state(
+        paths["state"],
+        paths["results"],
+        records,
+        args.max_candidates,
+        mode=args.mode,
+        stop_files=resolve_stop_files(job.parent, args.stop_file),
+        plateau_threshold=args.plateau_threshold,
+        plateau_min_delta=args.plateau_min_delta,
+        hard_crash_threshold=args.hard_crash_threshold,
+        exploration_batch_size=args.exploration_batch_size,
+        family_repeat_limit=args.family_repeat_limit,
+        pending_manifest_count=len(pending),
+        abandoned_candidate_count=count_abandoned_candidates(job.parent),
+        persist=False,
+    )
+    state.update(
+        {
+            "best_candidate": metadata.get("best_candidate"),
+            "best_source_sha256": metadata.get("best_source_sha256"),
+            "pending_candidate_manifest": str(pending[0].resolve()) if pending else None,
+        }
+    )
+    write_state_if_changed(paths["state"], state)
+    return records, state
+
+
 def prepare_candidate(args: argparse.Namespace, job: Path) -> int:
     workspace = job.parent
     metadata = load_campaign_metadata(workspace, job)
-    restore_campaign_settings(args, metadata)
-    ensure_campaign_not_stopped(workspace, args, action="prepare a candidate")
+    settings_changed = restore_campaign_settings(args, metadata)
     paths = campaign_paths(args, job)
+    if settings_changed:
+        refresh_campaign_state(args, job, metadata, paths)
+    ensure_campaign_not_stopped(workspace, args, action="prepare a candidate")
     records = load_results(paths["results"])
     if not any(record.status == "baseline" and record.score is not None for record in records):
         raise ValueError("a scored baseline is required before preparing candidates")
@@ -3359,9 +3403,11 @@ def finalize_candidate_result(
 def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
     workspace = job.parent
     metadata = load_campaign_metadata(workspace, job)
-    restore_campaign_settings(args, metadata)
-    ensure_campaign_not_stopped(workspace, args, action="evaluate a candidate")
+    settings_changed = restore_campaign_settings(args, metadata)
     paths = campaign_paths(args, job)
+    if settings_changed:
+        refresh_campaign_state(args, job, metadata, paths)
+    ensure_campaign_not_stopped(workspace, args, action="evaluate a candidate")
     manifest_path = Path(args.manifest).resolve() if args.manifest else None
     if manifest_path is None:
         pending = pending_candidate_manifests(workspace)
@@ -3526,8 +3572,10 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
 def abandon_candidate(args: argparse.Namespace, job: Path) -> int:
     workspace = job.parent
     metadata = load_campaign_metadata(workspace, job)
-    restore_campaign_settings(args, metadata)
+    settings_changed = restore_campaign_settings(args, metadata)
     paths = campaign_paths(args, job)
+    if settings_changed:
+        refresh_campaign_state(args, job, metadata, paths)
     manifest_path = Path(args.manifest).resolve() if args.manifest else None
     if manifest_path is None:
         pending = pending_candidate_manifests(workspace)
@@ -3575,10 +3623,13 @@ def abandon_candidate(args: argparse.Namespace, job: Path) -> int:
 
 def suggest_candidates(args: argparse.Namespace, job: Path) -> int:
     metadata = load_campaign_metadata(job.parent, job)
-    restore_campaign_settings(args, metadata)
+    settings_changed = restore_campaign_settings(args, metadata)
+    paths = campaign_paths(args, job)
+    if settings_changed:
+        refresh_campaign_state(args, job, metadata, paths)
     if args.limit < 1:
         raise ValueError("--limit must be positive")
-    config = read_yaml(campaign_paths(args, job)["autofl_yaml"])
+    config = read_yaml(paths["autofl_yaml"])
     help_text = job_help(args.python, job, job.parent)
     suggestions = [
         {"name": candidate.name, "run_args": candidate.args, "hypothesis": candidate.description}
@@ -3596,8 +3647,10 @@ def suggest_candidates(args: argparse.Namespace, job: Path) -> int:
 def record_external_result(args: argparse.Namespace, job: Path) -> int:
     workspace = job.parent
     metadata = load_campaign_metadata(workspace, job)
-    restore_campaign_settings(args, metadata)
+    settings_changed = restore_campaign_settings(args, metadata)
     paths = campaign_paths(args, job)
+    if settings_changed:
+        refresh_campaign_state(args, job, metadata, paths)
     config = read_yaml(paths["autofl_yaml"])
     artifact_path = Path(args.external_artifacts).resolve() if args.external_artifacts else None
     score = parse_finite_metric_value(args.score) if args.score is not None else None
@@ -3753,32 +3806,7 @@ def show_campaign_status(args: argparse.Namespace, job: Path) -> int:
     metadata = load_campaign_metadata(job.parent, job)
     restore_campaign_settings(args, metadata)
     paths = campaign_paths(args, job)
-    records = load_results(paths["results"])
-    pending = pending_candidate_manifests(job.parent)
-    state = write_state(
-        paths["state"],
-        paths["results"],
-        records,
-        args.max_candidates,
-        mode=args.mode,
-        stop_files=resolve_stop_files(job.parent, args.stop_file),
-        plateau_threshold=args.plateau_threshold,
-        plateau_min_delta=args.plateau_min_delta,
-        hard_crash_threshold=args.hard_crash_threshold,
-        exploration_batch_size=args.exploration_batch_size,
-        family_repeat_limit=args.family_repeat_limit,
-        pending_manifest_count=len(pending),
-        abandoned_candidate_count=count_abandoned_candidates(job.parent),
-        persist=False,
-    )
-    state.update(
-        {
-            "best_candidate": metadata.get("best_candidate"),
-            "best_source_sha256": metadata.get("best_source_sha256"),
-            "pending_candidate_manifest": str(pending[0].resolve()) if pending else None,
-        }
-    )
-    write_state_if_changed(paths["state"], state)
+    records, state = refresh_campaign_state(args, job, metadata, paths)
     print_campaign_result(paths, records, state, campaign=metadata)
     return 0
 

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -2641,6 +2641,103 @@ def test_effective_cap_changes_append_audit_records_to_campaign_metadata(tmp_pat
     assert all(entry["changed_at"] for entry in cap_changes)
 
 
+def test_raising_cap_reopens_exhausted_campaign_with_consistent_state(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    results_path = tmp_path / "results.tsv"
+    records = runner.load_results(results_path)
+    records.append(runner.RunRecord("discard", "candidate_1", 0.4, 1.0, "none", "candidate", "python job.py", ""))
+    runner.write_results(results_path, records)
+    assert runner.main(["status", str(job), "--max-candidates", "1"]) == 0
+
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["candidate_cap"] == 1
+    assert state["final_response_allowed"] is True
+    assert state["reason"] == "candidate_cap_exhausted"
+
+    assert (
+        runner.main(
+            ["prepare", str(job), "--name", "reopened", "--hypothesis", "resume search", "--max-candidates", "2"]
+        )
+        == 0
+    )
+
+    metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
+    assert metadata["settings"]["max_candidates"] == 2
+    assert [(entry["old"], entry["new"]) for entry in metadata["cap_changes"]] == [(None, 1), (1, 2)]
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["candidate_cap"] == 2
+    assert state["final_response_allowed"] is False
+    assert state["remaining_candidates"] == 1
+    assert tmp_path.joinpath(".nvflare/autofl/candidates/reopened/candidate_manifest.json").exists()
+
+
+def test_cap_change_with_unrelated_preflight_rejection_keeps_files_consistent(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    assert runner.main(["prepare", str(job), "--name", "draft", "--hypothesis", "draft candidate"]) == 0
+
+    rc = runner.main(
+        ["prepare", str(job), "--name", "second", "--hypothesis", "second candidate", "--max-candidates", "5"]
+    )
+
+    assert rc == 2
+    assert "pending candidate" in capsys.readouterr().err
+    metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
+    state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
+    assert metadata["settings"]["max_candidates"] == 5
+    assert [(entry["old"], entry["new"]) for entry in metadata["cap_changes"]] == [(None, 5)]
+    assert state["candidate_cap"] == 5
+    assert state["final_response_allowed"] is False
+    assert not tmp_path.joinpath(".nvflare/autofl/candidates/second").exists()
+
+
+def test_preflight_rejection_without_settings_change_is_write_free(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    assert runner.main(["prepare", str(job), "--name", "draft", "--hypothesis", "draft candidate"]) == 0
+    watched = [
+        tmp_path / ".nvflare/autofl/campaign.json",
+        tmp_path / ".nvflare/autofl/campaign_state.json",
+        tmp_path / "results.tsv",
+    ]
+    before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in watched}
+
+    rc = runner.main(["prepare", str(job), "--name", "second", "--hypothesis", "second candidate"])
+
+    assert rc == 2
+    assert "pending candidate" in capsys.readouterr().err
+    for path in watched:
+        assert (path.read_bytes(), path.stat().st_mtime_ns) == before[path]
+
+
+def test_lowering_cap_below_attempts_clamps_remaining_and_keeps_state_consistent(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    results_path = tmp_path / "results.tsv"
+    records = runner.load_results(results_path)
+    records.append(runner.RunRecord("discard", "candidate_1", 0.4, 1.0, "none", "candidate", "python job.py", ""))
+    records.append(runner.RunRecord("discard", "candidate_2", 0.3, 1.0, "none", "candidate", "python job.py", ""))
+    runner.write_results(results_path, records)
+    assert runner.main(["status", str(job), "--max-candidates", "3"]) == 0
+
+    rc = runner.main(["prepare", str(job), "--name", "late", "--hypothesis", "late candidate", "--max-candidates", "1"])
+
+    assert rc == 2
+    assert "campaign is already final: candidate_cap_exhausted" in capsys.readouterr().err
+    metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
+    state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
+    assert metadata["settings"]["max_candidates"] == 1
+    assert [(entry["old"], entry["new"]) for entry in metadata["cap_changes"]] == [(None, 3), (3, 1)]
+    assert state["candidate_cap"] == 1
+    assert state["candidate_attempts"] == 2
+    assert state["remaining_candidates"] == 0
+    assert state["final_response_allowed"] is True
+    assert state["reason"] == "candidate_cap_exhausted"
+    assert not tmp_path.joinpath(".nvflare/autofl/candidates/late").exists()
+
+
 def test_runner_state_reports_budget_and_baseline_accounting(tmp_path, monkeypatch):
     runner = _load_runner()
     job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=1.0, mode="min")


### PR DESCRIPTION
## Description

Mid-campaign changes to mutable Auto-FL campaign settings (e.g. `--max-candidates`) were persisted into `campaign.json` by `restore_campaign_settings`, but action preflight gates then read the stale persisted `campaign_state.json` computed under the old settings. Two defects resulted: raising the deliberately mutable cap could never reopen a cap-exhausted campaign (`prepare ... --max-candidates 2` on a cap-1-exhausted campaign was rejected with "campaign is already final"), and the rejected action mutated campaign metadata (new cap + `cap_changes` audit entry) while leaving the authoritative state stale and contradictory.

## What changed

- `restore_campaign_settings` now returns `True` when it persisted a mutable-settings change to `campaign.json`.
- New `refresh_campaign_state` helper (extracted from the `status` action's existing state-write path: `write_state(persist=False)` + metadata fields + `write_state_if_changed`) recomputes and persists `campaign_state.json` under the current effective settings without running a job; `show_campaign_status` now reuses it.
- All campaign actions that restore settings (`initialize` on an existing campaign, `prepare`, `evaluate`, `abandon`, `suggest`, `record`) refresh the persisted state immediately after a persisted settings change, before any preflight gate (final-response gate, stop-file gate, pending-candidate gate) reads it.
- SKILL.md documents that a persisted cap change refreshes state before action gating, so raising `--max-candidates` reopens a cap-exhausted campaign (file stays at 200 lines).

## Why

`max_candidates` is deliberately mutable and `cap_changes` exists precisely to audit mid-campaign budget changes; gating on state computed under the superseded cap made that workflow impossible and broke the invariant that `campaign_state.json` is authoritative and consistent with `campaign.json`. No new flags or schema changes; `cap_changes` and the state schema stay as merged in #4926.

## Testing

- New: raising the cap on an exhausted campaign succeeds end-to-end (state: `candidate_cap=2`, `final_response_allowed=false`, `remaining_candidates=1`; metadata: cap 2 + audit entries).
- New: cap change followed by an unrelated preflight rejection (pending candidate) keeps both files in agreement while still failing with the unrelated error.
- New: preflight rejection without a settings change is completely write-free (bytes and mtime_ns unchanged).
- New: lowering the cap below recorded attempts keeps `remaining_candidates` clamped at 0 and finalizes consistently.
- Full battery: 352 passed (`autofl_skill_runner_test.py`, `autofl_skill_campaign_guard_test.py`, `autofl_skill_plot_progress_test.py`, `autofl_skill_job_importer_test.py`, `agent_skill_checks`). black/isort/flake8 clean.

Verification note: the base code additionally allowed a cap **overrun** (lowering the cap below recorded attempts still let `prepare` proceed); the state refresh fixes that path too, covered by the clamped-lowering test. Known pre-existing behavior unchanged by this PR: `.nvflare/autofl/campaign.lock` is rewritten per invocation even on rejected actions.