### PR TITLE
[Auto-FL] Improve skill quality guidance

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: nvflare-autofl
-description: "Improve or optimize an existing NVFLARE job or project through an agent-assisted Auto-FL campaign: fix low accuracy or an underperforming metric, or try a bounded number of approaches (for example 'try two approaches') while keeping the data and evaluation setup unchanged; preserves FLARE execution, policy, artifacts, and reproducibility and produces a results report."
+description: "Use for agent-assisted Auto-FL optimization of an existing NVFLARE job in simulation, POC, or production. Do not use for code conversion, diagnosis-only work, or deployment setup."
 license: Apache-2.0
 version: "0.1.0"
 compatibility: "Requires NVFLARE 2.8.0+, Python, and permission to run NVFLARE jobs in the selected environment."
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
+  tags: [nvflare, federated-learning, optimization]
   min_flare_version: "2.8.0"
   blast_radius: submits_production
   category: Optimization
@@ -15,13 +16,19 @@ metadata:
 
 **All optimization must go through the official campaign runner (`run_job_campaign.py`): never optimize or edit the user's project directly outside a prepared candidate.**
 
-## Use When
-Use this skill when the user asks to optimize an existing NVFLARE `job.py` for accuracy, AUC, loss, runtime,
-robustness, or another metric in simulation, POC, or production.
+## Purpose
+Use this skill when the user asks to optimize an existing NVFLARE `job.py` for accuracy, AUC, loss, runtime, robustness, or another metric in simulation, POC, or production.
 
-## Do Not Use When
-Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs without an optimization goal,
-production deployment setup, evaluation/statistics-only recipes, or generic tuning outside an NVFLARE job.
+## Limitations
+Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs without an optimization goal, production deployment setup, evaluation/statistics-only recipes, or generic tuning outside an NVFLARE job.
+
+## Available Scripts
+| Script | Purpose | Arguments |
+| --- | --- | --- |
+| `scripts/run_job_campaign.py` | Authoritative campaign lifecycle runner | `ACTION JOB` plus action-specific flags |
+| `scripts/campaign_guard.py` | Read-only ledger diagnostics | `[RESULTS]` and diagnostic thresholds |
+| `scripts/plot_progress.py` | Render campaign progress | `[RESULTS]`, `--output`, `--mode`, `--metric` |
+| `scripts/job_importer.py` | Import library used by the campaign runner | Not a standalone CLI |
 
 ## Workflow
 Use this skill to optimize an existing NVFLARE `job.py` without asking the user to learn a new Auto-FL command tree.
@@ -181,6 +188,9 @@ argument-only linked candidates are rejected at evaluate time. After the first r
 workload-appropriate ideas — client optimizer, loss, schedule, and architecture qualify; avoid Byzantine-robust
 aggregation for benign campaigns. If no source-backed exploration is compatible, record why in the event. Flags, env
 vars, and full semantics: [continuous-campaigns.md](references/continuous-campaigns.md).
+
+## Troubleshooting
+On import or validation failure, fix the reported contract issue without bypassing the runner. On exit 75, reuse the exact approved prefix or wait for the human. For noisy scores, follow [experiment comparability](references/experiment-comparability.md).
 
 ## Stop Handling
 

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -16,10 +16,10 @@ metadata:
 
 **All optimization must go through the official campaign runner (`run_job_campaign.py`): never optimize or edit the user's project directly outside a prepared candidate.**
 
-## Purpose
+## Use When
 Use this skill when the user asks to optimize an existing NVFLARE `job.py` for accuracy, AUC, loss, runtime, robustness, or another metric in simulation, POC, or production.
 
-## Limitations
+## Do Not Use When
 Do not use for converting non-FL training code into NVFLARE, diagnosing failed jobs without an optimization goal, production deployment setup, evaluation/statistics-only recipes, or generic tuning outside an NVFLARE job.
 
 ## Available Scripts

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-autofl
 description: "Use for agent-assisted Auto-FL optimization of an existing NVFLARE job in simulation, POC, or production. Do not use for code conversion, diagnosis-only work, or deployment setup."
 license: Apache-2.0
-version: "0.1.1"
+version: "0.1.0"
 compatibility: "Requires NVFLARE 2.8.0+, Python, and permission to run NVFLARE jobs in the selected environment."
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -2,7 +2,7 @@
 name: nvflare-autofl
 description: "Use for agent-assisted Auto-FL optimization of an existing NVFLARE job in simulation, POC, or production. Do not use for code conversion, diagnosis-only work, or deployment setup."
 license: Apache-2.0
-version: "0.1.0"
+version: "0.1.1"
 compatibility: "Requires NVFLARE 2.8.0+, Python, and permission to run NVFLARE jobs in the selected environment."
 metadata:
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"

--- a/skills/nvflare-autofl/references/experiment-comparability.md
+++ b/skills/nvflare-autofl/references/experiment-comparability.md
@@ -54,10 +54,9 @@ observed run-to-run spread, and treat candidate score differences within that
 spread as noise rather than real improvement when reporting results.
 
 Host environment drift is not a variance source: simulator child processes
-receive a sanitized environment built from a fixed runtime allowlist plus the
-variable names declared in `environment.simulator_env_passthrough` (see the
-[job import contract](job-import-contract.md)). Jobs that need variables such
-as `DATASET_DIR` must declare them there explicitly.
+receive a sanitized environment built from a fixed runtime allowlist plus only
+the variable names declared in `environment.simulator_env_passthrough`. Jobs
+that need variables such as `DATASET_DIR` must declare them there explicitly.
 
 ## Data Distribution Experiments
 


### PR DESCRIPTION
## Summary

- tighten the Auto-FL trigger description and add metadata tags
- preserve the repository-standard `Use When` and `Do Not Use When` sections while adding script and troubleshooting guidance
- remove a reference-to-reference dependency from the experiment comparability guide
- keep the change documentation-only with no Auto-FL runtime behavior changes

## SkillEvaluator result

- `nvflare-autofl`: **83.5/B → 94.0/A**
- seven-skill catalog average: **91.5/A → 93.0/A**
- targeted deterministic Tier 1: all 10 checks pass for `nvflare-autofl`

The remaining Auto-FL quality advisories are heuristic convention nudges. In particular, the skill intentionally retains this repository's `Use When` and `Do Not Use When` headings instead of renaming them solely to satisfy literal `Purpose` and `Limitations` checks. The evaluator also asks for a `run_script()` example, but Auto-FL has no such API; the skill continues to document its real Python runner interface.

## Validation

- `skillevaluator quality-check ./skills/nvflare-autofl -r cli` — 94.0/A
- `skillevaluator quality-check ./skills -r cli` — 93.0/A catalog average
- `skillevaluator validate ./skills/nvflare-autofl --no-dedup -r cli` — all 10 Tier 1 checks pass
- `python -m dev_tools.agent.skills.checks.cli --skills-root skills` — 0 findings
- `pytest tests/unit_test/tool/autofl_skill_campaign_guard_test.py -q` (20 passed)
- `git diff --check`
- `./runtest.sh -s` could not start in the current shell because its dependency bootstrap attempted a system Python install blocked by PEP 668
