### PR TITLE
Add shared-file transport driver for cell communication

### DIFF
--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -54,8 +54,9 @@ Before starting a parent, verify:
 - The runtime workspace, images, datasets, and secret-mount sources are visible
   at the same absolute paths on all participating nodes. The shared filesystem
   supports ``O_EXCL`` and atomic rename.
-- Compute nodes can reach ``parent_host:internal_port``. Multi-node jobs also
-  require connectivity among their allocated nodes.
+- Compute nodes can reach ``parent_host:internal_port``, or the site uses the
+  shared-file worker channel instead (see :ref:`slurm_shared_file_channel`).
+  Multi-node jobs also require connectivity among their allocated nodes.
 - Slurm partition, association, QOS, reservation, cgroup, and device policies
   enforce the site's resource limits.
 
@@ -201,6 +202,53 @@ cannot launch jobs. NVFlare does not guess or resolve a host name.
 Server kits reject ``parent``. Run the server parent on a stable host with a
 stable external NVFlare federation endpoint.
 
+.. _slurm_shared_file_channel:
+
+Shared-File Worker Channel
+==========================
+
+When compute nodes cannot open a TCP connection to the parent host but share a
+POSIX-coherent filesystem such as Lustre with it, the worker-to-parent channel
+can run over shared files instead of TCP. Configure the client kit's
+``local/comm_config.json`` before running prepare:
+
+.. code-block:: json
+
+   {
+     "backbone": {"connect_generation": 1},
+     "internal": {
+       "scheme": "file",
+       "resources": {
+         "root_dir": "/lustre/proj123/nvflare/site-1-cellnet",
+         "connection_security": "clear"
+       }
+     }
+   }
+
+``root_dir`` must be an absolute path visible at the same path on the parent
+host and all compute nodes. ``connect_generation: 1`` routes all job traffic
+through the parent, so workers need no network connectivity at all.
+``nvflare deploy prepare`` preserves a file-based comm config as-is and does
+not apply the TCP host and port patch; ``internal_port`` and ``parent_host``
+are then not used for the worker channel.
+
+At runtime the parent creates a listener directory under ``root_dir`` and
+passes its ``file://0/...`` URL to each worker unchanged. Apptainer and Pyxis
+jobs bind-mount the listener directory read-write at the same path inside the
+container automatically; bare jobs use it directly. Directories are created
+with mode ``0o770`` and log files with ``0o660`` regardless of umask.
+Directory permissions are the only access control on this channel, so keep
+``root_dir`` owned by the dedicated site account with no wider group access
+than required.
+
+Polling intervals, lease timing, and fsync behavior are tunable through the
+``internal.resources`` map; see the ``FileDriver`` documentation in
+``nvflare.fuel.f3.drivers.file_driver`` for the parameters and their
+filesystem metadata cost. At the defaults an idle connection issues roughly
+1.4 client-side metadata syscalls per second; raising ``max_poll_interval``
+reduces idle load proportionally at the cost of first-message latency, and
+data transfers are unaffected by the poll settings.
+
 Study Settings
 ==============
 
@@ -283,8 +331,10 @@ Security and Operations
 =======================
 
 The worker-to-parent internal channel is clear TCP, matching the Kubernetes
-launcher. Use it only on a trusted or isolated site network. This does not
-change the configured security of the external NVFlare federation channel.
+launcher, or clear shared-file I/O when the file transport is configured (see
+:ref:`slurm_shared_file_channel`). Use it only on a trusted or isolated site
+network or filesystem. This does not change the configured security of the
+external NVFlare federation channel.
 
 Working accounting is mandatory. The parent refuses to start if ``sacct`` is
 unavailable. A later scheduler or accounting outage leaves affected jobs

--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -217,7 +217,7 @@ can run over shared files instead of TCP. Configure the client kit's
    {
      "backbone": {"connect_generation": 1},
      "internal": {
-       "scheme": "file",
+       "scheme": "shared-file",
        "resources": {
          "root_dir": "/lustre/proj123/nvflare/site-1-cellnet",
          "connection_security": "clear"
@@ -233,7 +233,7 @@ not apply the TCP host and port patch; ``internal_port`` and ``parent_host``
 are then not used for the worker channel.
 
 At runtime the parent creates a listener directory under ``root_dir`` and
-passes its ``file://0/...`` URL to each worker unchanged. Apptainer and Pyxis
+passes its ``shared-file://0/...`` URL to each worker unchanged. Apptainer and Pyxis
 jobs bind-mount the listener directory read-write at the same path inside the
 container automatically; bare jobs use it directly. Directories are created
 with mode ``0o770`` and log files with ``0o660`` regardless of umask.

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -45,6 +45,8 @@ from nvflare.app_opt.job_launcher.study_runtime import (
     load_study_runtime_file,
     resolve_study_runtime,
 )
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.drivers.file_driver import parse_file_url
 from nvflare.utils.job_launcher_utils import (
     get_client_job_args,
     get_credential_env,
@@ -549,12 +551,20 @@ class DockerJobLauncher(JobLauncherSpec):
         # Derive parent_url at runtime: site name (= container name on Docker DNS) + port
         # from the original PARENT_URL in job_args. This avoids baking parent_url into
         # resources.json at provision time.
+        file_parent_dir = None
         if JobProcessArgs.PARENT_URL in job_args:
             flag, original_url = job_args[JobProcessArgs.PARENT_URL]
             if str(original_url).startswith("file:"):
-                # Shared-file transport URLs are location-independent; pass through unchanged
-                # (the listener directory must be volume-mounted into the container)
-                pass
+                # Shared-file transport URLs are location-independent; pass through unchanged and
+                # bind-mount the listener directory at the same path inside the container
+                try:
+                    file_parent_dir = parse_file_url(str(original_url))
+                except CommError as e:
+                    raise ValueError(f"invalid shared-file parent URL {original_url!r}: {e}")
+                if file_parent_dir.startswith(self.WORKSPACE_MOUNT):
+                    raise ValueError(
+                        f"shared-file parent directory {file_parent_dir} overlaps the container workspace mount"
+                    )
             else:
                 port = original_url.rsplit(":", 1)[-1]
                 parent_url = f"tcp://{site_name}:{port}"
@@ -716,6 +726,11 @@ class DockerJobLauncher(JobLauncherSpec):
                         type="bind",
                         read_only=dataset_mount.read_only,
                     )
+                )
+            if file_parent_dir:
+                # The job cell must update leases and append its log, so read-write
+                mounts.append(
+                    docker.types.Mount(target=file_parent_dir, source=file_parent_dir, type="bind", read_only=False)
                 )
             if study_runtime is not None:
                 for secret_mount in study_runtime.secret_mounts:

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -18,6 +18,7 @@ import re
 import threading
 import time
 from abc import abstractmethod
+from urllib.parse import urlsplit
 
 try:
     import docker.errors
@@ -46,6 +47,7 @@ from nvflare.app_opt.job_launcher.study_runtime import (
     resolve_study_runtime,
 )
 from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.drivers.file_driver import SCHEME as SHARED_FILE_SCHEME
 from nvflare.fuel.f3.drivers.file_driver import parse_file_url
 from nvflare.utils.job_launcher_utils import (
     get_client_job_args,
@@ -554,7 +556,7 @@ class DockerJobLauncher(JobLauncherSpec):
         file_parent_dir = None
         if JobProcessArgs.PARENT_URL in job_args:
             flag, original_url = job_args[JobProcessArgs.PARENT_URL]
-            if str(original_url).startswith("file:"):
+            if urlsplit(str(original_url)).scheme == SHARED_FILE_SCHEME:
                 # Shared-file transport URLs are location-independent; pass through unchanged and
                 # bind-mount the listener directory at the same path inside the container
                 try:

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -551,10 +551,15 @@ class DockerJobLauncher(JobLauncherSpec):
         # resources.json at provision time.
         if JobProcessArgs.PARENT_URL in job_args:
             flag, original_url = job_args[JobProcessArgs.PARENT_URL]
-            port = original_url.rsplit(":", 1)[-1]
-            parent_url = f"tcp://{site_name}:{port}"
-            job_args = dict(job_args)
-            job_args[JobProcessArgs.PARENT_URL] = (flag, parent_url)
+            if str(original_url).startswith("file:"):
+                # Shared-file transport URLs are location-independent; pass through unchanged
+                # (the listener directory must be volume-mounted into the container)
+                pass
+            else:
+                port = original_url.rsplit(":", 1)[-1]
+                parent_url = f"tcp://{site_name}:{port}"
+                job_args = dict(job_args)
+                job_args[JobProcessArgs.PARENT_URL] = (flag, parent_url)
 
         module_args = self.get_module_args(job_args)
         module_args_list = []

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -55,6 +55,8 @@ from nvflare.app_opt.job_launcher.study_runtime import (
     resolve_study_runtime,
     study_runtime_file_path,
 )
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.drivers.file_driver import parse_file_url
 from nvflare.utils.job_launcher_utils import (
     get_client_job_args,
     get_credential_env,
@@ -160,13 +162,26 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
     flag, raw_url = entry
     try:
         parsed = urlsplit(str(raw_url))
+    except ValueError as e:
+        raise SlurmLauncherError("malformed parent URL in JOB_PROCESS_ARGS") from e
+
+    if parsed.scheme == "file":
+        # Shared-file transport: the directory path is location-independent, so the URL
+        # (including its tuning query parameters) is preserved without any host/port rewrite
+        try:
+            parse_file_url(str(raw_url))
+        except CommError as e:
+            raise SlurmLauncherError(f"malformed shared-file parent URL in JOB_PROCESS_ARGS: {raw_url!r}") from e
+        return copied
+
+    try:
         port = parsed.port
         host = parsed.hostname
     except ValueError as e:
         raise SlurmLauncherError("malformed parent URL in JOB_PROCESS_ARGS") from e
     if parsed.scheme != "tcp" or port != internal_port or not host:
         raise SlurmLauncherError(
-            f"parent URL must use tcp and configured internal_port {internal_port}, got {raw_url!r}"
+            f"parent URL must use file or tcp with configured internal_port {internal_port}, got {raw_url!r}"
         )
     host = _resolve_parent_host(parent_host)
     rendered_host = host if host.startswith("[") and host.endswith("]") else f"[{host}]" if ":" in host else host
@@ -174,6 +189,17 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
     rewritten = urlunsplit(("tcp", netloc, parsed.path, parsed.query, parsed.fragment))
     copied[JobProcessArgs.PARENT_URL] = (flag, rewritten)
     return copied
+
+
+def _file_parent_mount(parent_url: str, workspace_path: str) -> Optional[BindMount]:
+    """Bind mount for a shared-file transport parent URL so the CJ container can reach the
+    listener directory at the same absolute path as the CP."""
+    if urlsplit(str(parent_url)).scheme != "file":
+        return None
+    listen_dir = parse_file_url(str(parent_url))
+    destination = _validate_mount_destination(listen_dir, "shared-file parent directory")
+    source = _validate_mount_source(listen_dir, workspace_path, "shared-file parent directory")
+    return BindMount(source, destination, "rw")
 
 
 class SlurmJobLauncher(JobLauncherSpec):
@@ -374,7 +400,13 @@ class SlurmJobLauncher(JobLauncherSpec):
         )
         study_env, secret_env = self._study_environment(runtime)
         secret_env.update(get_credential_env(job_args))
-        mounts = self._study_mounts(runtime) if sandbox != "none" else ()
+        mounts = list(self._study_mounts(runtime)) if sandbox != "none" else []
+        if sandbox != "none":
+            parent_mount = _file_parent_mount(str(job_args[JobProcessArgs.PARENT_URL][1]), self.config.workspace_path)
+            if parent_mount:
+                if any(_paths_overlap(parent_mount.destination, mount.destination) for mount in mounts):
+                    raise SlurmLauncherError("shared-file parent directory overlaps a study mount destination")
+                mounts.append(parent_mount)
         return LaunchPlan(
             job_id=job_id,
             run_dir=run_dir,
@@ -387,7 +419,7 @@ class SlurmJobLauncher(JobLauncherSpec):
             setup=setup,
             study_env=study_env,
             study_secret_env=secret_env,
-            mounts=mounts,
+            mounts=tuple(mounts),
             python_path=self.config.python_path,
             python_env=self._python_environment(workspace, job_id),
             forward_env=self.config.forward_env,

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -56,6 +56,7 @@ from nvflare.app_opt.job_launcher.study_runtime import (
     study_runtime_file_path,
 )
 from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.drivers.file_driver import SCHEME as SHARED_FILE_SCHEME
 from nvflare.fuel.f3.drivers.file_driver import parse_file_url
 from nvflare.utils.job_launcher_utils import (
     get_client_job_args,
@@ -165,7 +166,7 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
     except ValueError as e:
         raise SlurmLauncherError("malformed parent URL in JOB_PROCESS_ARGS") from e
 
-    if parsed.scheme == "file":
+    if parsed.scheme == SHARED_FILE_SCHEME:
         # Shared-file transport: the directory path is location-independent, so the URL
         # (including its tuning query parameters) is preserved without any host/port rewrite
         try:
@@ -181,7 +182,8 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
         raise SlurmLauncherError("malformed parent URL in JOB_PROCESS_ARGS") from e
     if parsed.scheme != "tcp" or port != internal_port or not host:
         raise SlurmLauncherError(
-            f"parent URL must use file or tcp with configured internal_port {internal_port}, got {raw_url!r}"
+            f"parent URL must use {SHARED_FILE_SCHEME} or tcp with configured internal_port "
+            f"{internal_port}, got {raw_url!r}"
         )
     host = _resolve_parent_host(parent_host)
     rendered_host = host if host.startswith("[") and host.endswith("]") else f"[{host}]" if ":" in host else host
@@ -194,7 +196,7 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
 def _file_parent_mount(parent_url: str, workspace_path: str) -> Optional[BindMount]:
     """Bind mount for a shared-file transport parent URL so the CJ container can reach the
     listener directory at the same absolute path as the CP."""
-    if urlsplit(str(parent_url)).scheme != "file":
+    if urlsplit(str(parent_url)).scheme != SHARED_FILE_SCHEME:
         return None
     listen_dir = parse_file_url(str(parent_url))
     destination = _validate_mount_destination(listen_dir, "shared-file parent directory")

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -74,6 +74,10 @@ LISTENER_STALE_TIME = 3600.0
 TMP_DIR_STALE_TIME = 3600.0
 MIN_POLL_INTERVAL = 0.001
 READ_CHUNK = 8 * 1024 * 1024
+# After the peer's closed marker, keep draining until this many consecutive quiet polls; covers
+# chunked reads of a large final frame and short cross-file visibility lag on networked FS
+DRAIN_GRACE_POLLS = 20
+DRAIN_POLL_INTERVAL = 0.05
 
 
 def parse_file_url(url: str) -> str:
@@ -177,10 +181,10 @@ class _ConnConfig:
                     merged[key] = value
 
         self.poll_interval = max(float(merged.get(POLL_INTERVAL, 0.01)), MIN_POLL_INTERVAL)
-        self.max_poll_interval = max(float(merged.get(MAX_POLL_INTERVAL, 0.5)), self.poll_interval)
+        self.max_poll_interval = max(float(merged.get(MAX_POLL_INTERVAL, 2.0)), self.poll_interval)
         self.max_log_size = int(float(params.get(MAX_LOG_SIZE, 1024 * 1024 * 1024)))
-        self.lease_interval = float(merged.get(LEASE_INTERVAL, 5.0))
-        self.lease_timeout = float(merged.get(LEASE_TIMEOUT, 30.0))
+        self.lease_interval = float(merged.get(LEASE_INTERVAL, 15.0))
+        self.lease_timeout = float(merged.get(LEASE_TIMEOUT, 60.0))
         self.fsync = bool(str2bool(merged.get(FSYNC, False)))
         self.dir_mode = _parse_mode(merged.get(DIR_MODE), 0o770)
         self.file_mode = _parse_mode(merged.get(FILE_MODE), 0o660)
@@ -413,6 +417,7 @@ class FileConnection(Connection):
         last_housekeeping = now
         peer_seen = now
         peer_mtime = None
+        peer_active = False
 
         try:
             while not self.closing and not stopped.is_set():
@@ -420,22 +425,31 @@ class FileConnection(Connection):
                 if now - last_housekeeping >= self.cfg.lease_interval:
                     last_housekeeping = now
                     _touch(self.my_lease, self.cfg.file_mode)
-                    if os.path.exists(self.closed_file):
-                        self.logger.debug(f"{self}: closed by peer")
-                        self._drain()
-                        break
-                    mtime = _mtime(self.peer_lease)
-                    if mtime is not None and mtime != peer_mtime:
-                        peer_mtime = mtime
+                    if peer_active:
+                        # Frames arrived since the last housekeeping, so the peer is alive; skip
+                        # the peer-lease and closed-marker stats. A close mid-traffic is caught
+                        # once the stream goes quiet (the marker follows all data anyway).
+                        peer_active = False
                         peer_seen = now
-                    elif now - peer_seen > self.cfg.lease_timeout:
-                        self.logger.info(f"{self}: peer lease is stale, closing")
+                        peer_mtime = None
+                    elif os.path.exists(self.closed_file):
+                        self.logger.debug(f"{self}: closed by peer")
+                        self._drain(stopped)
                         break
+                    else:
+                        mtime = _mtime(self.peer_lease)
+                        if mtime is not None and mtime != peer_mtime:
+                            peer_mtime = mtime
+                            peer_seen = now
+                        elif now - peer_seen > self.cfg.lease_timeout:
+                            self.logger.info(f"{self}: peer lease is stale, closing")
+                            break
 
                 frames = self.reader.read_frames()
                 if frames:
                     self.received_anything = True
                     peer_seen = now
+                    peer_active = True
                     for frame in frames:
                         self.process_frame(frame)
                 if frames or self.reader.progressed:
@@ -447,15 +461,24 @@ class FileConnection(Connection):
         finally:
             self.reader.close()
 
-    def _drain(self):
-        """Deliver frames still in the log after the peer's closed marker (which follows all data)"""
-        while True:
+    def _drain(self, stopped: threading.Event):
+        """Deliver frames still in the log after the peer's closed marker (which follows all
+        data). Reads are chunked, so a large final frame spans several read calls that return no
+        complete frame yet — keep going while bytes are being consumed, and only give up after
+        DRAIN_GRACE_POLLS consecutive quiet polls (grace for delayed visibility on networked FS).
+        """
+        quiet_polls = 0
+        while quiet_polls < DRAIN_GRACE_POLLS:
             frames = self.reader.read_frames()
-            if not frames:
-                return
-            self.received_anything = True
-            for frame in frames:
-                self.process_frame(frame)
+            if frames:
+                self.received_anything = True
+                for frame in frames:
+                    self.process_frame(frame)
+            if frames or self.reader.progressed:
+                quiet_polls = 0
+            else:
+                quiet_polls += 1
+                stopped.wait(min(self.cfg.poll_interval, DRAIN_POLL_INTERVAL))
 
 
 class FileDriver(BaseDriver):
@@ -492,14 +515,19 @@ class FileDriver(BaseDriver):
     The tuning resources are optional (defaults in _ConnConfig) and are propagated to the child
     cell through the query string of the generated connect URL; a cell can locally override them
     (except max_log_size, which must match on both sides) via a "file" section in its own
-    comm_config.json. Filesystem metadata load: an idle connection costs one stat per poll tick
-    per direction plus one lease utime per lease_interval per side, so defaults cost roughly 4-5
-    metadata ops/sec per idle connection; raise max_poll_interval (e.g. to 1-2s) to shrink it
-    proportionally at the cost of first-message latency. Data bursts are read without sleeping,
-    so throughput is unaffected by the poll settings. Note for NFS: attribute caching (actimeo)
-    can delay lease-change and size visibility; mount with a low actimeo or raise lease_timeout
-    well above the attribute-cache window. fsync=true is recommended on filesystems without
-    close-to-open or POSIX coherence.
+    comm_config.json. The example above pins lower-latency polling than the defaults.
+
+    Filesystem metadata load: an idle connection costs one log stat per poll tick per direction
+    (2/max_poll_interval per second) plus roughly 3 lease/marker ops per lease_interval per side,
+    about 1.4 client-side metadata syscalls/sec per idle connection at the defaults
+    (max_poll_interval=2, lease_interval=15) — these are client syscall counts; caching may or
+    may not absorb them server-side. A listener adds ~0.5 listdir/sec. Costs shrink
+    proportionally as max_poll_interval grows, at the price of first-message-after-idle latency.
+    During traffic the peer-lease and closed-marker checks are skipped, data is read in 8MB
+    chunks without sleeping, and stat frequency tracks frame arrival, so throughput is unaffected
+    by poll settings. Note for NFS: attribute caching (actimeo) can delay lease-change and size
+    visibility; mount with a low actimeo or raise lease_timeout well above the attribute-cache
+    window. fsync=true is recommended on filesystems without close-to-open or POSIX coherence.
     """
 
     def __init__(self):

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -18,7 +18,7 @@ import threading
 import time
 import uuid
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.connection import BytesAlike, Connection
@@ -54,6 +54,33 @@ A2P = "a2p"  # active-to-passive log prefix
 P2A = "p2a"  # passive-to-active log prefix
 
 LISTENER_STALE_TIME = 600.0
+
+
+def parse_file_url(url: str) -> str:
+    """Parse and validate a file transport URL of the form file://0/absolute/dir.
+
+    The authority must be the empty-host placeholder "0" and the path must be an absolute
+    directory. This is the single source of truth for file URL semantics; launchers and deploy
+    tools that need the directory (e.g. to bind-mount it into a container) should use this
+    instead of parsing the URL themselves.
+
+    Returns:
+        The absolute directory path (query parameters excluded).
+
+    Raises:
+        CommError: If the URL is not a valid file transport URL.
+    """
+    parsed = urlsplit(url)
+    if parsed.scheme != "file":
+        raise CommError(CommError.BAD_CONFIG, f"Not a file transport URL: {url}")
+    if parsed.netloc != "0":
+        raise CommError(
+            CommError.BAD_CONFIG, f"Invalid file URL {url}: authority must be the placeholder '0' (file://0/abs/dir)"
+        )
+    path = parsed.path.rstrip("/")
+    if not path or not os.path.isabs(path):
+        raise CommError(CommError.BAD_CONFIG, f"Invalid file URL {url}: an absolute directory path is required")
+    return path
 
 
 def _touch(path: str):
@@ -344,6 +371,29 @@ class FileDriver(BaseDriver):
     ("0" is the empty-host placeholder). The passive side owns the directory; each active peer
     creates a connection subdirectory with one append log per direction. There is no transport
     security: directory permissions are the trust boundary.
+
+    Typical use is job-cell to client-parent communication, configured in the client's
+    comm_config.json. connect_generation 1 routes job-cell traffic through the client parent
+    instead of dialing the server directly:
+
+        {
+            "backbone": {"connect_generation": 1},
+            "internal": {
+                "scheme": "file",
+                "resources": {
+                    "root_dir": "/absolute/shared/path/cellnet",
+                    "connection_security": "clear",
+                    "poll_interval": 0.05,
+                    "max_poll_interval": 0.5,
+                    "lease_interval": 5,
+                    "lease_timeout": 30,
+                    "fsync": false
+                }
+            }
+        }
+
+    The tuning resources are optional (defaults shown in _ConnConfig) and are propagated to the
+    child cell through the query string of the generated connect URL.
     """
 
     def __init__(self):
@@ -440,10 +490,12 @@ class FileDriver(BaseDriver):
 
     @staticmethod
     def _get_dir_from_params(params: dict) -> str:
+        url = params.get(DriverParams.URL.value)
+        if url:
+            return parse_file_url(url)
         path = params.get(DriverParams.PATH.value)
         if not path or path == "/":
-            url = params.get(DriverParams.URL.value)
-            raise CommError(CommError.BAD_CONFIG, f"Missing directory path in URL {url}, expected file://0/abs/dir")
+            raise CommError(CommError.BAD_CONFIG, "Missing directory path, expected URL of form file://0/abs/dir")
         return path
 
     def _scan_for_connections(self, conns_dir: str, connector: ConnectorInfo, cfg: _ConnConfig) -> int:

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -316,7 +316,9 @@ class _LogReader:
             data = self.file.read(min(size - self.offset, READ_CHUNK))
         except OSError:
             # Not created yet (writer still opening the next log after rotation), or transient
-            # FS error; either way retry on the next poll and rely on lease timeout for liveness
+            # FS error. Drop any open handle so a stale descriptor (e.g. ESTALE after NFS server
+            # recovery) is replaced by a fresh open on the next poll instead of wedging forever.
+            self.close()
             return None
         if data:
             self.offset += len(data)

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import os
 import shutil
 import struct
@@ -20,6 +21,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode, urlsplit
 
+from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.connection import BytesAlike, Connection
 from nvflare.fuel.f3.drivers.base_driver import BaseDriver
@@ -27,8 +29,11 @@ from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
 from nvflare.fuel.f3.drivers.driver_params import DriverCap, DriverParams
 from nvflare.fuel.f3.drivers.net_utils import MAX_FRAME_SIZE
 from nvflare.fuel.f3.sfm.prefix import PREFIX_LEN
+from nvflare.fuel.utils.argument_utils import str2bool
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.security.logging import secure_format_exception
+
+log = logging.getLogger(__name__)
 
 FRAME_LEN_STRUCT = struct.Struct(">I")
 
@@ -40,20 +45,35 @@ MAX_LOG_SIZE = "max_log_size"
 LEASE_INTERVAL = "lease_interval"
 LEASE_TIMEOUT = "lease_timeout"
 FSYNC = "fsync"
+DIR_MODE = "dir_mode"
+FILE_MODE = "file_mode"
 
 # Tuning params propagated from listener resources to the connect URL so the active side uses the same values
-_TUNING_PARAMS = [POLL_INTERVAL, MAX_POLL_INTERVAL, MAX_LOG_SIZE, LEASE_INTERVAL, LEASE_TIMEOUT, FSYNC]
+_TUNING_PARAMS = [
+    POLL_INTERVAL,
+    MAX_POLL_INTERVAL,
+    MAX_LOG_SIZE,
+    LEASE_INTERVAL,
+    LEASE_TIMEOUT,
+    FSYNC,
+    FILE_MODE,
+    DIR_MODE,
+]
 
 # Directory layout
 CONNS_DIR = "conns"
 LISTENER_PREFIX = "lst_"
 LISTENER_LEASE_FILE = "lease"
+OWNER_MARKER = ".nvf_file_transport"
 CLOSED_FILE = "closed"
 TMP_PREFIX = "."
 A2P = "a2p"  # active-to-passive log prefix
 P2A = "p2a"  # passive-to-active log prefix
 
-LISTENER_STALE_TIME = 600.0
+LISTENER_STALE_TIME = 3600.0
+TMP_DIR_STALE_TIME = 3600.0
+MIN_POLL_INTERVAL = 0.001
+READ_CHUNK = 8 * 1024 * 1024
 
 
 def parse_file_url(url: str) -> str:
@@ -83,16 +103,26 @@ def parse_file_url(url: str) -> str:
     return path
 
 
-def _touch(path: str):
+def _validate_dir_path(path: str):
+    for ch in ("?", "#", "\n", "\r"):
+        if ch in path:
+            raise CommError(
+                CommError.BAD_CONFIG, f"Unsupported character {ch!r} in file transport directory path: {path}"
+            )
+
+
+def _touch(path: str, mode: Optional[int] = None):
     try:
         os.utime(path, None)
     except FileNotFoundError:
         try:
             open(path, "ab").close()
-        except OSError:
-            pass
-    except OSError:
-        pass
+            if mode is not None:
+                os.chmod(path, mode)
+        except OSError as ex:
+            log.debug(f"Cannot create {path}: {secure_format_exception(ex)}")
+    except OSError as ex:
+        log.debug(f"Cannot touch {path}: {secure_format_exception(ex)}")
 
 
 def _mtime(path: str) -> Optional[float]:
@@ -102,22 +132,58 @@ def _mtime(path: str) -> Optional[float]:
         return None
 
 
-def _to_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
+def _make_new_dir(path: str, mode: int):
+    os.makedirs(path)
+    os.chmod(path, mode)
+
+
+def _create_file(path: str, mode: int):
+    open(path, "ab").close()
+    os.chmod(path, mode)
+
+
+def _log_path(conn_dir: str, prefix: str, index: int) -> str:
+    return os.path.join(conn_dir, f"{prefix}.{index}.log")
+
+
+def _sealed_path(conn_dir: str, prefix: str, index: int) -> str:
+    return os.path.join(conn_dir, f"{prefix}.{index}.sealed")
+
+
+def _parse_mode(value: Any, default: int) -> int:
     if value is None:
-        return False
-    return str(value).strip().lower() in ("true", "1", "yes", "y", "t")
+        return default
+    if isinstance(value, int):
+        return value
+    return int(str(value), 8)
 
 
 class _ConnConfig:
+    """Effective tuning values for one connection.
+
+    Precedence: hardcoded defaults < connector params (listener resources / URL query) < the
+    local comm_config "file" section, so a cell can locally override polling/lease/fsync for its
+    own mount. max_log_size is exempt from local override because reader-side rotation detection
+    requires the same value on both sides of a connection.
+    """
+
     def __init__(self, params: dict):
-        self.poll_interval = float(params.get(POLL_INTERVAL, 0.01))
-        self.max_poll_interval = float(params.get(MAX_POLL_INTERVAL, 0.5))
-        self.max_log_size = int(params.get(MAX_LOG_SIZE, 1024 * 1024 * 1024))
-        self.lease_interval = float(params.get(LEASE_INTERVAL, 5.0))
-        self.lease_timeout = float(params.get(LEASE_TIMEOUT, 30.0))
-        self.fsync = _to_bool(params.get(FSYNC, False))
+        merged = dict(params)
+        config = CommConfigurator().get_config()
+        local_overrides = config.get("file") if config else None
+        if local_overrides:
+            for key, value in local_overrides.items():
+                if key != MAX_LOG_SIZE:
+                    merged[key] = value
+
+        self.poll_interval = max(float(merged.get(POLL_INTERVAL, 0.01)), MIN_POLL_INTERVAL)
+        self.max_poll_interval = max(float(merged.get(MAX_POLL_INTERVAL, 0.5)), self.poll_interval)
+        self.max_log_size = int(float(params.get(MAX_LOG_SIZE, 1024 * 1024 * 1024)))
+        self.lease_interval = float(merged.get(LEASE_INTERVAL, 5.0))
+        self.lease_timeout = float(merged.get(LEASE_TIMEOUT, 30.0))
+        self.fsync = bool(str2bool(merged.get(FSYNC, False)))
+        self.dir_mode = _parse_mode(merged.get(DIR_MODE), 0o770)
+        self.file_mode = _parse_mode(merged.get(FILE_MODE), 0o660)
 
 
 class _LogWriter:
@@ -138,19 +204,16 @@ class _LogWriter:
         self.closed = False
         self.lock = threading.Lock()
 
-    def log_path(self, index: int) -> str:
-        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.log")
-
-    def sealed_path(self, index: int) -> str:
-        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.sealed")
-
     def append(self, frame: BytesAlike):
         with self.lock:
             if self.closed:
                 raise CommError(CommError.CLOSED, "Log writer is closed")
             if self.file is None:
-                path = self.log_path(self.index)
+                path = _log_path(self.conn_dir, self.prefix, self.index)
+                existed = os.path.exists(path)
                 self.file = open(path, "ab")
+                if not existed:
+                    os.chmod(path, self.cfg.file_mode)
                 self.size = os.path.getsize(path)
             self.file.write(frame)
             self.file.flush()
@@ -161,16 +224,22 @@ class _LogWriter:
                 self._rotate()
 
     def _rotate(self):
-        # fsync before sealing so the recorded size is never ahead of visible data
+        # fsync before sealing so the recorded size is never ahead of visible data. self.file is
+        # cleared before any fallible step so a failed rotation never wedges the writer on a
+        # closed handle; the caller closes the connection on error and a reconnect starts clean.
         os.fsync(self.file.fileno())
         self.file.close()
-        sealed = self.sealed_path(self.index)
+        self.file = None
+        sealed = _sealed_path(self.conn_dir, self.prefix, self.index)
         tmp = sealed + ".tmp"
         with open(tmp, "w") as f:
             f.write(str(self.size))
+        os.chmod(tmp, self.cfg.file_mode)
         os.replace(tmp, sealed)
+        next_path = _log_path(self.conn_dir, self.prefix, self.index + 1)
         self.index += 1
-        self.file = open(self.log_path(self.index), "ab")
+        self.file = open(next_path, "ab")
+        os.chmod(next_path, self.cfg.file_mode)
         self.size = 0
 
     def close(self):
@@ -196,58 +265,59 @@ class _LogReader:
         self.offset = 0
         self.file = None
         self.buffer = bytearray()
-
-    def log_path(self, index: int) -> str:
-        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.log")
-
-    def sealed_path(self, index: int) -> str:
-        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.sealed")
+        self.progressed = False
 
     def read_frames(self) -> list:
+        self.progressed = False
         data = self._read_new_data()
         if data:
             self.buffer.extend(data)
+            self.progressed = True
 
         frames = []
-        while True:
-            frame = self._extract_frame()
-            if frame is None:
+        pos = 0
+        buf = self.buffer
+        total = len(buf)
+        while total - pos >= FRAME_LEN_STRUCT.size:
+            length = FRAME_LEN_STRUCT.unpack_from(buf, pos)[0]
+            if length < PREFIX_LEN or length > MAX_FRAME_SIZE:
+                raise CommError(
+                    CommError.BAD_DATA,
+                    f"Corrupt frame length {length} in {_log_path(self.conn_dir, self.prefix, self.index)}",
+                )
+            if total - pos < length:
                 break
-            frames.append(frame)
+            frames.append(bytes(memoryview(buf)[pos : pos + length]))
+            pos += length
+        if pos:
+            del buf[:pos]
 
-        self._advance_if_sealed()
+        # A seal is only ever written at or past max_log_size, so skip the probe until then.
+        # This requires max_log_size to be identical on both sides of a connection.
+        if self.offset >= self.cfg.max_log_size:
+            self._advance_if_sealed()
         return frames
 
     def _read_new_data(self) -> Optional[bytes]:
-        path = self.log_path(self.index)
+        path = _log_path(self.conn_dir, self.prefix, self.index)
         try:
             size = os.stat(path).st_size
+            if size <= self.offset:
+                return None
+            if self.file is None:
+                self.file = open(path, "rb")
+            self.file.seek(self.offset)
+            data = self.file.read(min(size - self.offset, READ_CHUNK))
         except OSError:
-            # Not created yet (writer still opening the next log after rotation)
+            # Not created yet (writer still opening the next log after rotation), or transient
+            # FS error; either way retry on the next poll and rely on lease timeout for liveness
             return None
-        if size <= self.offset:
-            return None
-        if self.file is None:
-            self.file = open(path, "rb")
-        self.file.seek(self.offset)
-        data = self.file.read(size - self.offset)
-        self.offset += len(data)
+        if data:
+            self.offset += len(data)
         return data
 
-    def _extract_frame(self) -> Optional[bytes]:
-        if len(self.buffer) < FRAME_LEN_STRUCT.size:
-            return None
-        length = FRAME_LEN_STRUCT.unpack_from(self.buffer, 0)[0]
-        if length < PREFIX_LEN or length > MAX_FRAME_SIZE:
-            raise CommError(CommError.BAD_DATA, f"Corrupt frame length {length} in {self.log_path(self.index)}")
-        if len(self.buffer) < length:
-            return None
-        frame = bytes(self.buffer[:length])
-        del self.buffer[:length]
-        return frame
-
     def _advance_if_sealed(self):
-        sealed = self.sealed_path(self.index)
+        sealed = _sealed_path(self.conn_dir, self.prefix, self.index)
         try:
             with open(sealed) as f:
                 final_size = int(f.read())
@@ -256,11 +326,14 @@ class _LogReader:
         if self.offset < final_size:
             return
         if self.buffer:
-            raise CommError(CommError.BAD_DATA, f"Partial frame at end of sealed log {self.log_path(self.index)}")
+            raise CommError(
+                CommError.BAD_DATA,
+                f"Partial frame at end of sealed log {_log_path(self.conn_dir, self.prefix, self.index)}",
+            )
         if self.file:
             self.file.close()
             self.file = None
-        for path in (self.log_path(self.index), sealed):
+        for path in (_log_path(self.conn_dir, self.prefix, self.index), sealed):
             try:
                 os.unlink(path)
             except OSError:
@@ -285,20 +358,21 @@ class FileConnection(Connection):
         self.conn_dir = conn_dir
         self.cfg = cfg
         self.closing = False
+        self.received_anything = False
         self.logger = get_obj_logger(self)
 
         active = connector.mode == Mode.ACTIVE
-        self.side = "a" if active else "p"
+        side = "a" if active else "p"
         peer_side = "p" if active else "a"
-        self.my_lease = os.path.join(conn_dir, f"{self.side}.lease")
+        self.my_lease = os.path.join(conn_dir, f"{side}.lease")
         self.peer_lease = os.path.join(conn_dir, f"{peer_side}.lease")
         self.closed_file = os.path.join(conn_dir, CLOSED_FILE)
         self.writer = _LogWriter(conn_dir, A2P if active else P2A, cfg)
         self.reader = _LogReader(conn_dir, P2A if active else A2P, cfg)
 
-        _touch(self.my_lease)
+        _touch(self.my_lease, cfg.file_mode)
         self.conn_props = {
-            DriverParams.LOCAL_ADDR.value: f"{conn_dir}#{self.side}",
+            DriverParams.LOCAL_ADDR.value: f"{conn_dir}#{side}",
             DriverParams.PEER_ADDR.value: f"{conn_dir}#{peer_side}",
         }
 
@@ -309,17 +383,23 @@ class FileConnection(Connection):
         if self.closing:
             return
         self.closing = True
-        _touch(self.closed_file)
+        # Close the writer before creating the closed marker so the marker always follows all
+        # data: any in-flight append completes under the writer lock, later appends are rejected,
+        # and a peer that sees the marker can trust a final drain to observe every frame.
         self.writer.close()
+        _touch(self.closed_file, self.cfg.file_mode)
 
     def send_frame(self, frame: BytesAlike):
         if self.closing:
             raise CommError(CommError.CLOSED, f"Connection {self.name} is closed")
         try:
             self.writer.append(frame)
-        except CommError:
-            raise
         except Exception as ex:
+            # A failed append may have left a torn frame in the log; the framing can never
+            # recover, so close the connection to force a clean reconnect.
+            self.close()
+            if isinstance(ex, CommError):
+                raise
             raise CommError(CommError.ERROR, f"Error sending frame: {secure_format_exception(ex)}")
 
     def read_loop(self, stopped: threading.Event):
@@ -334,33 +414,48 @@ class FileConnection(Connection):
         peer_seen = now
         peer_mtime = None
 
-        while not self.closing and not stopped.is_set():
-            now = time.monotonic()
-            if now - last_housekeeping >= self.cfg.lease_interval:
-                last_housekeeping = now
-                _touch(self.my_lease)
-                if os.path.exists(self.closed_file):
-                    self.logger.debug(f"{self}: closed by peer")
-                    break
-                mtime = _mtime(self.peer_lease)
-                if mtime is not None and mtime != peer_mtime:
-                    peer_mtime = mtime
+        try:
+            while not self.closing and not stopped.is_set():
+                now = time.monotonic()
+                if now - last_housekeeping >= self.cfg.lease_interval:
+                    last_housekeeping = now
+                    _touch(self.my_lease, self.cfg.file_mode)
+                    if os.path.exists(self.closed_file):
+                        self.logger.debug(f"{self}: closed by peer")
+                        self._drain()
+                        break
+                    mtime = _mtime(self.peer_lease)
+                    if mtime is not None and mtime != peer_mtime:
+                        peer_mtime = mtime
+                        peer_seen = now
+                    elif now - peer_seen > self.cfg.lease_timeout:
+                        self.logger.info(f"{self}: peer lease is stale, closing")
+                        break
+
+                frames = self.reader.read_frames()
+                if frames:
+                    self.received_anything = True
                     peer_seen = now
-                elif now - peer_seen > self.cfg.lease_timeout:
-                    self.logger.info(f"{self}: peer lease is stale, closing")
-                    break
+                    for frame in frames:
+                        self.process_frame(frame)
+                if frames or self.reader.progressed:
+                    interval = self.cfg.poll_interval
+                else:
+                    interval = min(interval * 1.5, self.cfg.max_poll_interval)
+                if not frames:
+                    stopped.wait(interval)
+        finally:
+            self.reader.close()
 
+    def _drain(self):
+        """Deliver frames still in the log after the peer's closed marker (which follows all data)"""
+        while True:
             frames = self.reader.read_frames()
-            if frames:
-                peer_seen = now
-                interval = self.cfg.poll_interval
-                for frame in frames:
-                    self.process_frame(frame)
-            else:
-                interval = min(interval * 1.5, self.cfg.max_poll_interval)
-                stopped.wait(interval)
-
-        self.reader.close()
+            if not frames:
+                return
+            self.received_anything = True
+            for frame in frames:
+                self.process_frame(frame)
 
 
 class FileDriver(BaseDriver):
@@ -370,7 +465,9 @@ class FileDriver(BaseDriver):
     them (e.g. an HPC compute node and a gateway node). The URL form is file://0/absolute/dir
     ("0" is the empty-host placeholder). The passive side owns the directory; each active peer
     creates a connection subdirectory with one append log per direction. There is no transport
-    security: directory permissions are the trust boundary.
+    security: directory permissions are the trust boundary. Directories are created 0o770 and
+    files 0o660 regardless of umask; override with the dir_mode/file_mode resources (octal
+    strings) if the two sides run as different users needing other group semantics.
 
     Typical use is job-cell to client-parent communication, configured in the client's
     comm_config.json. connect_generation 1 routes job-cell traffic through the client parent
@@ -392,8 +489,17 @@ class FileDriver(BaseDriver):
             }
         }
 
-    The tuning resources are optional (defaults shown in _ConnConfig) and are propagated to the
-    child cell through the query string of the generated connect URL.
+    The tuning resources are optional (defaults in _ConnConfig) and are propagated to the child
+    cell through the query string of the generated connect URL; a cell can locally override them
+    (except max_log_size, which must match on both sides) via a "file" section in its own
+    comm_config.json. Filesystem metadata load: an idle connection costs one stat per poll tick
+    per direction plus one lease utime per lease_interval per side, so defaults cost roughly 4-5
+    metadata ops/sec per idle connection; raise max_poll_interval (e.g. to 1-2s) to shrink it
+    proportionally at the cost of first-message latency. Data bursts are read without sleeping,
+    so throughput is unaffected by the poll settings. Note for NFS: attribute caching (actimeo)
+    can delay lease-change and size visibility; mount with a low actimeo or raise lease_timeout
+    well above the attribute-cache window. fsync=true is recommended on filesystems without
+    close-to-open or POSIX coherence.
     """
 
     def __init__(self):
@@ -401,7 +507,7 @@ class FileDriver(BaseDriver):
         self.stop_event = threading.Event()
         self.dir_lock = threading.Lock()
         self.handled_dirs = set()
-        self.done_dirs = set()
+        self.done_dirs: Dict[str, float] = {}
         self.logger = get_obj_logger(self)
 
     @staticmethod
@@ -418,11 +524,16 @@ class FileDriver(BaseDriver):
         if not root_dir:
             raise CommError(CommError.BAD_CONFIG, f"'{ROOT_DIR}' resource is required for scheme {scheme}")
         root_dir = os.path.abspath(root_dir)
-        os.makedirs(root_dir, exist_ok=True)
+        _validate_dir_path(root_dir)
+        cfg = _ConnConfig(resources)
+        if not os.path.isdir(root_dir):
+            _make_new_dir(root_dir, cfg.dir_mode)
         _remove_stale_listener_dirs(root_dir)
 
         listen_dir = os.path.join(root_dir, LISTENER_PREFIX + uuid.uuid4().hex[:8])
-        os.makedirs(os.path.join(listen_dir, CONNS_DIR))
+        _make_new_dir(listen_dir, cfg.dir_mode)
+        _make_new_dir(os.path.join(listen_dir, CONNS_DIR), cfg.dir_mode)
+        _create_file(os.path.join(listen_dir, OWNER_MARKER), cfg.file_mode)
 
         url = f"{scheme}://0{listen_dir}"
         tuning = {k: str(resources[k]) for k in _TUNING_PARAMS if k in resources}
@@ -435,25 +546,34 @@ class FileDriver(BaseDriver):
         cfg = _ConnConfig(connector.params)
         listen_dir = self._get_dir_from_params(connector.params)
         conns_dir = os.path.join(listen_dir, CONNS_DIR)
-        os.makedirs(conns_dir, exist_ok=True)
+        if not os.path.isdir(conns_dir):
+            os.makedirs(conns_dir, exist_ok=True)
+            os.chmod(conns_dir, cfg.dir_mode)
         lease = os.path.join(listen_dir, LISTENER_LEASE_FILE)
 
         interval = cfg.poll_interval
         last_housekeeping = 0.0
 
         while not self._stopping(connector):
+            try:
+                entries = sorted(os.listdir(conns_dir))
+            except OSError as ex:
+                raise CommError(CommError.ERROR, f"Cannot list {conns_dir}: {secure_format_exception(ex)}")
+
             now = time.monotonic()
             if now - last_housekeeping >= cfg.lease_interval:
                 last_housekeeping = now
-                _touch(lease)
-                self._gc_conn_dirs(conns_dir, cfg)
+                _touch(lease, cfg.file_mode)
+                self._gc_conn_dirs(conns_dir, cfg, entries)
 
-            new_conns = self._scan_for_connections(conns_dir, connector, cfg)
+            new_conns = self._adopt_new_dirs(conns_dir, entries, connector, cfg)
             if new_conns:
                 interval = cfg.poll_interval
             else:
                 interval = min(interval * 1.5, cfg.max_poll_interval)
                 connector.stopped.wait(interval)
+
+        self._cleanup_listen_dir(listen_dir)
 
     def connect(self, connector: ConnectorInfo):
         self.connector = connector
@@ -465,9 +585,9 @@ class FileDriver(BaseDriver):
 
         name = uuid.uuid4().hex[:12]
         tmp_dir = os.path.join(conns_dir, TMP_PREFIX + name)
-        os.makedirs(tmp_dir)
+        _make_new_dir(tmp_dir, cfg.dir_mode)
         for log_name in (f"{A2P}.0.log", f"{P2A}.0.log"):
-            open(os.path.join(tmp_dir, log_name), "ab").close()
+            _create_file(os.path.join(tmp_dir, log_name), cfg.file_mode)
         conn_dir = os.path.join(conns_dir, name)
         os.rename(tmp_dir, conn_dir)
 
@@ -478,6 +598,10 @@ class FileDriver(BaseDriver):
         finally:
             conn.close()
             self.close_connection(conn)
+            if not conn.received_anything:
+                # Nothing ever arrived (e.g. the listener is dead); remove our own dir so
+                # reconnect attempts don't accumulate directories on the shared filesystem
+                shutil.rmtree(conn_dir, ignore_errors=True)
 
     def shutdown(self):
         self.stop_event.set()
@@ -494,16 +618,13 @@ class FileDriver(BaseDriver):
         if url:
             return parse_file_url(url)
         path = params.get(DriverParams.PATH.value)
-        if not path or path == "/":
+        if path:
+            path = path.rstrip("/")
+        if not path or not os.path.isabs(path):
             raise CommError(CommError.BAD_CONFIG, "Missing directory path, expected URL of form file://0/abs/dir")
         return path
 
-    def _scan_for_connections(self, conns_dir: str, connector: ConnectorInfo, cfg: _ConnConfig) -> int:
-        try:
-            entries = sorted(os.listdir(conns_dir))
-        except OSError as ex:
-            raise CommError(CommError.ERROR, f"Cannot list {conns_dir}: {secure_format_exception(ex)}")
-
+    def _adopt_new_dirs(self, conns_dir: str, entries: list, connector: ConnectorInfo, cfg: _ConnConfig) -> int:
         new_conns = 0
         for entry in entries:
             if entry.startswith(TMP_PREFIX):
@@ -511,10 +632,21 @@ class FileDriver(BaseDriver):
             with self.dir_lock:
                 if entry in self.handled_dirs:
                     continue
-                self.handled_dirs.add(entry)
             conn_dir = os.path.join(conns_dir, entry)
             if not os.path.isdir(conn_dir):
                 continue
+            if os.path.exists(os.path.join(conn_dir, CLOSED_FILE)) or not os.path.isfile(
+                os.path.join(conn_dir, f"{A2P}.0.log")
+            ):
+                # Leftover from a previous listener incarnation: already closed, or its logs were
+                # partially consumed. Adopting it would replay or wedge; mark for GC instead.
+                _touch(os.path.join(conn_dir, CLOSED_FILE), cfg.file_mode)
+                with self.dir_lock:
+                    self.handled_dirs.add(entry)
+                    self.done_dirs[entry] = time.monotonic()
+                continue
+            with self.dir_lock:
+                self.handled_dirs.add(entry)
             conn = FileConnection(conn_dir, connector, cfg)
             self.add_connection(conn)
             t = threading.Thread(target=self._conn_loop, args=(conn, entry), name=f"file_conn_{entry}", daemon=True)
@@ -531,31 +663,51 @@ class FileDriver(BaseDriver):
             conn.close()
             self.close_connection(conn)
             with self.dir_lock:
-                self.done_dirs.add(entry)
+                self.done_dirs[entry] = time.monotonic()
 
-    def _gc_conn_dirs(self, conns_dir: str, cfg: _ConnConfig):
-        """Remove connection dirs whose connection has ended, once the closed marker is old
-        enough for the peer to have noticed it."""
+    def _gc_conn_dirs(self, conns_dir: str, cfg: _ConnConfig, entries: list):
+        """Remove ended connection dirs after a locally-timed grace period (no cross-node clock
+        comparison), plus orphaned tmp dirs from crashed dialers."""
         with self.dir_lock:
-            done = list(self.done_dirs)
+            done = list(self.done_dirs.items())
 
-        for entry in done:
+        now = time.monotonic()
+        for entry, done_time in done:
+            if now - done_time <= 2 * cfg.lease_timeout:
+                continue
             conn_dir = os.path.join(conns_dir, entry)
+            shutil.rmtree(conn_dir, ignore_errors=True)
             if os.path.isdir(conn_dir):
-                closed_mtime = _mtime(os.path.join(conn_dir, CLOSED_FILE))
-                if closed_mtime is None:
-                    _touch(os.path.join(conn_dir, CLOSED_FILE))
-                    continue
-                if time.time() - closed_mtime <= 2 * cfg.lease_timeout:
-                    continue
-                shutil.rmtree(conn_dir, ignore_errors=True)
+                # Removal failed (e.g. peer still holds files open on NFS); keep the entry so the
+                # dir is retried later and never re-adopted as a new connection
+                continue
             with self.dir_lock:
-                self.done_dirs.discard(entry)
+                self.done_dirs.pop(entry, None)
                 self.handled_dirs.discard(entry)
+
+        for entry in entries:
+            if not entry.startswith(TMP_PREFIX):
+                continue
+            tmp_dir = os.path.join(conns_dir, entry)
+            mtime = _mtime(tmp_dir)
+            if mtime is not None and time.time() - mtime > TMP_DIR_STALE_TIME:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def _cleanup_listen_dir(self, listen_dir: str):
+        """On clean shutdown, remove the listener dir if this driver's get_urls() minted it"""
+        if os.path.basename(listen_dir).startswith(LISTENER_PREFIX) and os.path.isfile(
+            os.path.join(listen_dir, OWNER_MARKER)
+        ):
+            shutil.rmtree(listen_dir, ignore_errors=True)
 
 
 def _remove_stale_listener_dirs(root_dir: str):
-    """GC listener dirs from previous runs whose lease has not been touched for a long time"""
+    """GC listener dirs from previous runs whose lease has not been touched for a long time.
+
+    Only directories carrying the driver's ownership marker are ever removed, so a mistakenly
+    broad root_dir cannot cause loss of unrelated data. Removal runs in a background thread to
+    keep cell startup off the critical path of large tree deletions.
+    """
     try:
         entries = os.listdir(root_dir)
     except OSError:
@@ -565,8 +717,12 @@ def _remove_stale_listener_dirs(root_dir: str):
         if not entry.startswith(LISTENER_PREFIX):
             continue
         listen_dir = os.path.join(root_dir, entry)
+        if not os.path.isfile(os.path.join(listen_dir, OWNER_MARKER)):
+            continue
         mtime = _mtime(os.path.join(listen_dir, LISTENER_LEASE_FILE))
         if mtime is None:
             mtime = _mtime(listen_dir)
         if mtime is None or time.time() - mtime > LISTENER_STALE_TIME:
-            shutil.rmtree(listen_dir, ignore_errors=True)
+            threading.Thread(
+                target=shutil.rmtree, args=(listen_dir,), kwargs={"ignore_errors": True}, daemon=True
+            ).start()

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -120,7 +120,8 @@ def _touch(path: str, mode: Optional[int] = None):
         os.utime(path, None)
     except FileNotFoundError:
         try:
-            open(path, "ab").close()
+            with open(path, "ab"):
+                pass
             if mode is not None:
                 os.chmod(path, mode)
         except OSError as ex:
@@ -142,7 +143,8 @@ def _make_new_dir(path: str, mode: int):
 
 
 def _create_file(path: str, mode: int):
-    open(path, "ab").close()
+    with open(path, "ab"):
+        pass
     os.chmod(path, mode)
 
 
@@ -420,7 +422,7 @@ class FileConnection(Connection):
         peer_active = False
 
         try:
-            while not self.closing and not stopped.is_set():
+            while not self.closing and not stopped.is_set() and not self.connector.stopped.is_set():
                 now = time.monotonic()
                 if now - last_housekeeping >= self.cfg.lease_interval:
                     last_housekeeping = now
@@ -586,7 +588,13 @@ class FileDriver(BaseDriver):
             try:
                 entries = sorted(os.listdir(conns_dir))
             except OSError as ex:
-                raise CommError(CommError.ERROR, f"Cannot list {conns_dir}: {secure_format_exception(ex)}")
+                if not os.path.isdir(conns_dir):
+                    raise CommError(CommError.ERROR, f"Listener dir is gone: {conns_dir}")
+                # Transient shared-FS error (e.g. ESTALE, brief server blip): keep the accept
+                # loop alive and retry after a poll interval
+                self.logger.debug(f"Cannot list {conns_dir}: {secure_format_exception(ex)}")
+                connector.stopped.wait(cfg.max_poll_interval)
+                continue
 
             now = time.monotonic()
             if now - last_housekeeping >= cfg.lease_interval:

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -14,7 +14,6 @@
 import logging
 import os
 import shutil
-import struct
 import threading
 import time
 import uuid
@@ -28,14 +27,14 @@ from nvflare.fuel.f3.drivers.base_driver import BaseDriver
 from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
 from nvflare.fuel.f3.drivers.driver_params import DriverCap, DriverParams
 from nvflare.fuel.f3.drivers.net_utils import MAX_FRAME_SIZE
-from nvflare.fuel.f3.sfm.prefix import PREFIX_LEN
+from nvflare.fuel.f3.sfm.prefix import PREFIX_LEN, Prefix
 from nvflare.fuel.utils.argument_utils import str2bool
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.security.logging import secure_format_exception
 
 log = logging.getLogger(__name__)
 
-FRAME_LEN_STRUCT = struct.Struct(">I")
+SCHEME = "shared-file"
 
 # Resource/query parameter names
 ROOT_DIR = "root_dir"
@@ -67,8 +66,9 @@ LISTENER_LEASE_FILE = "lease"
 OWNER_MARKER = ".nvf_file_transport"
 CLOSED_FILE = "closed"
 TMP_PREFIX = "."
-A2P = "a2p"  # active-to-passive log prefix
-P2A = "p2a"  # passive-to-active log prefix
+# Log files are named after the side that writes them, following the CellPipe convention
+ACTIVE_LOG = "active"  # written by the active (dialing) side
+PASSIVE_LOG = "passive"  # written by the passive (listener) side
 
 LISTENER_STALE_TIME = 3600.0
 TMP_DIR_STALE_TIME = 3600.0
@@ -81,29 +81,30 @@ DRAIN_POLL_INTERVAL = 0.05
 
 
 def parse_file_url(url: str) -> str:
-    """Parse and validate a file transport URL of the form file://0/absolute/dir.
+    """Parse and validate a shared-file transport URL of the form shared-file://0/absolute/dir.
 
     The authority must be the empty-host placeholder "0" and the path must be an absolute
-    directory. This is the single source of truth for file URL semantics; launchers and deploy
-    tools that need the directory (e.g. to bind-mount it into a container) should use this
-    instead of parsing the URL themselves.
+    directory. This is the single source of truth for shared-file URL semantics; launchers and
+    deploy tools that need the directory (e.g. to bind-mount it into a container) should use
+    this instead of parsing the URL themselves.
 
     Returns:
         The absolute directory path (query parameters excluded).
 
     Raises:
-        CommError: If the URL is not a valid file transport URL.
+        CommError: If the URL is not a valid shared-file transport URL.
     """
     parsed = urlsplit(url)
-    if parsed.scheme != "file":
-        raise CommError(CommError.BAD_CONFIG, f"Not a file transport URL: {url}")
+    if parsed.scheme != SCHEME:
+        raise CommError(CommError.BAD_CONFIG, f"Not a {SCHEME} transport URL: {url}")
     if parsed.netloc != "0":
         raise CommError(
-            CommError.BAD_CONFIG, f"Invalid file URL {url}: authority must be the placeholder '0' (file://0/abs/dir)"
+            CommError.BAD_CONFIG,
+            f"Invalid {SCHEME} URL {url}: authority must be the placeholder '0' ({SCHEME}://0/abs/dir)",
         )
     path = parsed.path.rstrip("/")
     if not path or not os.path.isabs(path):
-        raise CommError(CommError.BAD_CONFIG, f"Invalid file URL {url}: an absolute directory path is required")
+        raise CommError(CommError.BAD_CONFIG, f"Invalid {SCHEME} URL {url}: an absolute directory path is required")
     return path
 
 
@@ -168,15 +169,16 @@ class _ConnConfig:
     """Effective tuning values for one connection.
 
     Precedence: hardcoded defaults < connector params (listener resources / URL query) < the
-    local comm_config "file" section, so a cell can locally override polling/lease/fsync for its
-    own mount. max_log_size is exempt from local override because reader-side rotation detection
+    local comm_config "shared-file" section, so a cell can locally override polling/lease/fsync
+    for its own mount. max_log_size is exempt from local override because reader-side rotation
+    detection
     requires the same value on both sides of a connection.
     """
 
     def __init__(self, params: dict):
         merged = dict(params)
         config = CommConfigurator().get_config()
-        local_overrides = config.get("file") if config else None
+        local_overrides = config.get(SCHEME) if config else None
         if local_overrides:
             for key, value in local_overrides.items():
                 if key != MAX_LOG_SIZE:
@@ -284,8 +286,8 @@ class _LogReader:
         pos = 0
         buf = self.buffer
         total = len(buf)
-        while total - pos >= FRAME_LEN_STRUCT.size:
-            length = FRAME_LEN_STRUCT.unpack_from(buf, pos)[0]
+        while total - pos >= PREFIX_LEN:
+            length = Prefix.from_bytes(memoryview(buf)[pos:]).length
             if length < PREFIX_LEN or length > MAX_FRAME_SIZE:
                 raise CommError(
                     CommError.BAD_DATA,
@@ -370,13 +372,13 @@ class FileConnection(Connection):
         self.logger = get_obj_logger(self)
 
         active = connector.mode == Mode.ACTIVE
-        side = "a" if active else "p"
-        peer_side = "p" if active else "a"
+        side = ACTIVE_LOG if active else PASSIVE_LOG
+        peer_side = PASSIVE_LOG if active else ACTIVE_LOG
         self.my_lease = os.path.join(conn_dir, f"{side}.lease")
         self.peer_lease = os.path.join(conn_dir, f"{peer_side}.lease")
         self.closed_file = os.path.join(conn_dir, CLOSED_FILE)
-        self.writer = _LogWriter(conn_dir, A2P if active else P2A, cfg)
-        self.reader = _LogReader(conn_dir, P2A if active else A2P, cfg)
+        self.writer = _LogWriter(conn_dir, side, cfg)
+        self.reader = _LogReader(conn_dir, peer_side, cfg)
 
         _touch(self.my_lease, cfg.file_mode)
         self.conn_props = {
@@ -489,7 +491,7 @@ class FileDriver(BaseDriver):
     """Transport driver that exchanges SFM frames through a shared filesystem (e.g. Lustre).
 
     Intended for deployments where two cells share a filesystem but have no network path between
-    them (e.g. an HPC compute node and a gateway node). The URL form is file://0/absolute/dir
+    them (e.g. an HPC compute node and a gateway node). The URL form is shared-file://0/absolute/dir
     ("0" is the empty-host placeholder). The passive side owns the directory; each active peer
     creates a connection subdirectory with one append log per direction. There is no transport
     security: directory permissions are the trust boundary. Directories are created 0o770 and
@@ -503,7 +505,7 @@ class FileDriver(BaseDriver):
         {
             "backbone": {"connect_generation": 1},
             "internal": {
-                "scheme": "file",
+                "scheme": "shared-file",
                 "resources": {
                     "root_dir": "/absolute/shared/path/cellnet",
                     "connection_security": "clear",
@@ -518,7 +520,7 @@ class FileDriver(BaseDriver):
 
     The tuning resources are optional (defaults in _ConnConfig) and are propagated to the child
     cell through the query string of the generated connect URL; a cell can locally override them
-    (except max_log_size, which must match on both sides) via a "file" section in its own
+    (except max_log_size, which must match on both sides) via a "shared-file" section in its own
     comm_config.json. The example above pins lower-latency polling than the defaults.
 
     Filesystem metadata load: an idle connection costs one log stat per poll tick per direction
@@ -544,7 +546,7 @@ class FileDriver(BaseDriver):
 
     @staticmethod
     def supported_transports() -> List[str]:
-        return ["file"]
+        return [SCHEME]
 
     @staticmethod
     def capabilities() -> Dict[str, Any]:
@@ -624,7 +626,7 @@ class FileDriver(BaseDriver):
         name = uuid.uuid4().hex[:12]
         tmp_dir = os.path.join(conns_dir, TMP_PREFIX + name)
         _make_new_dir(tmp_dir, cfg.dir_mode)
-        for log_name in (f"{A2P}.0.log", f"{P2A}.0.log"):
+        for log_name in (f"{ACTIVE_LOG}.0.log", f"{PASSIVE_LOG}.0.log"):
             _create_file(os.path.join(tmp_dir, log_name), cfg.file_mode)
         conn_dir = os.path.join(conns_dir, name)
         os.rename(tmp_dir, conn_dir)
@@ -659,7 +661,7 @@ class FileDriver(BaseDriver):
         if path:
             path = path.rstrip("/")
         if not path or not os.path.isabs(path):
-            raise CommError(CommError.BAD_CONFIG, "Missing directory path, expected URL of form file://0/abs/dir")
+            raise CommError(CommError.BAD_CONFIG, f"Missing directory path, expected URL of form {SCHEME}://0/abs/dir")
         return path
 
     def _adopt_new_dirs(self, conns_dir: str, entries: list, connector: ConnectorInfo, cfg: _ConnConfig) -> int:
@@ -674,7 +676,7 @@ class FileDriver(BaseDriver):
             if not os.path.isdir(conn_dir):
                 continue
             if os.path.exists(os.path.join(conn_dir, CLOSED_FILE)) or not os.path.isfile(
-                os.path.join(conn_dir, f"{A2P}.0.log")
+                os.path.join(conn_dir, f"{ACTIVE_LOG}.0.log")
             ):
                 # Leftover from a previous listener incarnation: already closed, or its logs were
                 # partially consumed. Adopting it would replay or wedge; mark for GC instead.

--- a/nvflare/fuel/f3/drivers/file_driver.py
+++ b/nvflare/fuel/f3/drivers/file_driver.py
@@ -1,0 +1,520 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shutil
+import struct
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
+
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.connection import BytesAlike, Connection
+from nvflare.fuel.f3.drivers.base_driver import BaseDriver
+from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
+from nvflare.fuel.f3.drivers.driver_params import DriverCap, DriverParams
+from nvflare.fuel.f3.drivers.net_utils import MAX_FRAME_SIZE
+from nvflare.fuel.f3.sfm.prefix import PREFIX_LEN
+from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.security.logging import secure_format_exception
+
+FRAME_LEN_STRUCT = struct.Struct(">I")
+
+# Resource/query parameter names
+ROOT_DIR = "root_dir"
+POLL_INTERVAL = "poll_interval"
+MAX_POLL_INTERVAL = "max_poll_interval"
+MAX_LOG_SIZE = "max_log_size"
+LEASE_INTERVAL = "lease_interval"
+LEASE_TIMEOUT = "lease_timeout"
+FSYNC = "fsync"
+
+# Tuning params propagated from listener resources to the connect URL so the active side uses the same values
+_TUNING_PARAMS = [POLL_INTERVAL, MAX_POLL_INTERVAL, MAX_LOG_SIZE, LEASE_INTERVAL, LEASE_TIMEOUT, FSYNC]
+
+# Directory layout
+CONNS_DIR = "conns"
+LISTENER_PREFIX = "lst_"
+LISTENER_LEASE_FILE = "lease"
+CLOSED_FILE = "closed"
+TMP_PREFIX = "."
+A2P = "a2p"  # active-to-passive log prefix
+P2A = "p2a"  # passive-to-active log prefix
+
+LISTENER_STALE_TIME = 600.0
+
+
+def _touch(path: str):
+    try:
+        os.utime(path, None)
+    except FileNotFoundError:
+        try:
+            open(path, "ab").close()
+        except OSError:
+            pass
+    except OSError:
+        pass
+
+
+def _mtime(path: str) -> Optional[float]:
+    try:
+        return os.stat(path).st_mtime
+    except OSError:
+        return None
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in ("true", "1", "yes", "y", "t")
+
+
+class _ConnConfig:
+    def __init__(self, params: dict):
+        self.poll_interval = float(params.get(POLL_INTERVAL, 0.01))
+        self.max_poll_interval = float(params.get(MAX_POLL_INTERVAL, 0.5))
+        self.max_log_size = int(params.get(MAX_LOG_SIZE, 1024 * 1024 * 1024))
+        self.lease_interval = float(params.get(LEASE_INTERVAL, 5.0))
+        self.lease_timeout = float(params.get(LEASE_TIMEOUT, 30.0))
+        self.fsync = _to_bool(params.get(FSYNC, False))
+
+
+class _LogWriter:
+    """Single-writer append log. Frames are appended verbatim; the SFM prefix provides framing.
+
+    A frame never spans two log files: rotation only happens between appends. The final size of a
+    rotated log is recorded in a ".sealed" file so the reader can tell "log complete" from
+    "appends not yet visible" on a networked filesystem.
+    """
+
+    def __init__(self, conn_dir: str, prefix: str, cfg: _ConnConfig):
+        self.conn_dir = conn_dir
+        self.prefix = prefix
+        self.cfg = cfg
+        self.index = 0
+        self.size = 0
+        self.file = None
+        self.closed = False
+        self.lock = threading.Lock()
+
+    def log_path(self, index: int) -> str:
+        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.log")
+
+    def sealed_path(self, index: int) -> str:
+        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.sealed")
+
+    def append(self, frame: BytesAlike):
+        with self.lock:
+            if self.closed:
+                raise CommError(CommError.CLOSED, "Log writer is closed")
+            if self.file is None:
+                path = self.log_path(self.index)
+                self.file = open(path, "ab")
+                self.size = os.path.getsize(path)
+            self.file.write(frame)
+            self.file.flush()
+            if self.cfg.fsync:
+                os.fsync(self.file.fileno())
+            self.size += len(frame)
+            if self.size >= self.cfg.max_log_size:
+                self._rotate()
+
+    def _rotate(self):
+        # fsync before sealing so the recorded size is never ahead of visible data
+        os.fsync(self.file.fileno())
+        self.file.close()
+        sealed = self.sealed_path(self.index)
+        tmp = sealed + ".tmp"
+        with open(tmp, "w") as f:
+            f.write(str(self.size))
+        os.replace(tmp, sealed)
+        self.index += 1
+        self.file = open(self.log_path(self.index), "ab")
+        self.size = 0
+
+    def close(self):
+        with self.lock:
+            self.closed = True
+            if self.file:
+                try:
+                    self.file.flush()
+                    self.file.close()
+                except OSError:
+                    pass
+                self.file = None
+
+
+class _LogReader:
+    """Tails the peer's append log, extracting whole frames and advancing across sealed logs."""
+
+    def __init__(self, conn_dir: str, prefix: str, cfg: _ConnConfig):
+        self.conn_dir = conn_dir
+        self.prefix = prefix
+        self.cfg = cfg
+        self.index = 0
+        self.offset = 0
+        self.file = None
+        self.buffer = bytearray()
+
+    def log_path(self, index: int) -> str:
+        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.log")
+
+    def sealed_path(self, index: int) -> str:
+        return os.path.join(self.conn_dir, f"{self.prefix}.{index}.sealed")
+
+    def read_frames(self) -> list:
+        data = self._read_new_data()
+        if data:
+            self.buffer.extend(data)
+
+        frames = []
+        while True:
+            frame = self._extract_frame()
+            if frame is None:
+                break
+            frames.append(frame)
+
+        self._advance_if_sealed()
+        return frames
+
+    def _read_new_data(self) -> Optional[bytes]:
+        path = self.log_path(self.index)
+        try:
+            size = os.stat(path).st_size
+        except OSError:
+            # Not created yet (writer still opening the next log after rotation)
+            return None
+        if size <= self.offset:
+            return None
+        if self.file is None:
+            self.file = open(path, "rb")
+        self.file.seek(self.offset)
+        data = self.file.read(size - self.offset)
+        self.offset += len(data)
+        return data
+
+    def _extract_frame(self) -> Optional[bytes]:
+        if len(self.buffer) < FRAME_LEN_STRUCT.size:
+            return None
+        length = FRAME_LEN_STRUCT.unpack_from(self.buffer, 0)[0]
+        if length < PREFIX_LEN or length > MAX_FRAME_SIZE:
+            raise CommError(CommError.BAD_DATA, f"Corrupt frame length {length} in {self.log_path(self.index)}")
+        if len(self.buffer) < length:
+            return None
+        frame = bytes(self.buffer[:length])
+        del self.buffer[:length]
+        return frame
+
+    def _advance_if_sealed(self):
+        sealed = self.sealed_path(self.index)
+        try:
+            with open(sealed) as f:
+                final_size = int(f.read())
+        except (OSError, ValueError):
+            return
+        if self.offset < final_size:
+            return
+        if self.buffer:
+            raise CommError(CommError.BAD_DATA, f"Partial frame at end of sealed log {self.log_path(self.index)}")
+        if self.file:
+            self.file.close()
+            self.file = None
+        for path in (self.log_path(self.index), sealed):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self.index += 1
+        self.offset = 0
+
+    def close(self):
+        if self.file:
+            try:
+                self.file.close()
+            except OSError:
+                pass
+            self.file = None
+
+
+class FileConnection(Connection):
+    """A connection emulated over a shared directory with one append log per direction."""
+
+    def __init__(self, conn_dir: str, connector: ConnectorInfo, cfg: _ConnConfig):
+        super().__init__(connector)
+        self.conn_dir = conn_dir
+        self.cfg = cfg
+        self.closing = False
+        self.logger = get_obj_logger(self)
+
+        active = connector.mode == Mode.ACTIVE
+        self.side = "a" if active else "p"
+        peer_side = "p" if active else "a"
+        self.my_lease = os.path.join(conn_dir, f"{self.side}.lease")
+        self.peer_lease = os.path.join(conn_dir, f"{peer_side}.lease")
+        self.closed_file = os.path.join(conn_dir, CLOSED_FILE)
+        self.writer = _LogWriter(conn_dir, A2P if active else P2A, cfg)
+        self.reader = _LogReader(conn_dir, P2A if active else A2P, cfg)
+
+        _touch(self.my_lease)
+        self.conn_props = {
+            DriverParams.LOCAL_ADDR.value: f"{conn_dir}#{self.side}",
+            DriverParams.PEER_ADDR.value: f"{conn_dir}#{peer_side}",
+        }
+
+    def get_conn_properties(self) -> dict:
+        return self.conn_props
+
+    def close(self):
+        if self.closing:
+            return
+        self.closing = True
+        _touch(self.closed_file)
+        self.writer.close()
+
+    def send_frame(self, frame: BytesAlike):
+        if self.closing:
+            raise CommError(CommError.CLOSED, f"Connection {self.name} is closed")
+        try:
+            self.writer.append(frame)
+        except CommError:
+            raise
+        except Exception as ex:
+            raise CommError(CommError.ERROR, f"Error sending frame: {secure_format_exception(ex)}")
+
+    def read_loop(self, stopped: threading.Event):
+        """Poll the incoming log and deliver frames until the connection ends.
+
+        Liveness is tracked by observed changes of the peer's lease mtime (not absolute file
+        times), so it is immune to clock skew between nodes.
+        """
+        interval = self.cfg.poll_interval
+        now = time.monotonic()
+        last_housekeeping = now
+        peer_seen = now
+        peer_mtime = None
+
+        while not self.closing and not stopped.is_set():
+            now = time.monotonic()
+            if now - last_housekeeping >= self.cfg.lease_interval:
+                last_housekeeping = now
+                _touch(self.my_lease)
+                if os.path.exists(self.closed_file):
+                    self.logger.debug(f"{self}: closed by peer")
+                    break
+                mtime = _mtime(self.peer_lease)
+                if mtime is not None and mtime != peer_mtime:
+                    peer_mtime = mtime
+                    peer_seen = now
+                elif now - peer_seen > self.cfg.lease_timeout:
+                    self.logger.info(f"{self}: peer lease is stale, closing")
+                    break
+
+            frames = self.reader.read_frames()
+            if frames:
+                peer_seen = now
+                interval = self.cfg.poll_interval
+                for frame in frames:
+                    self.process_frame(frame)
+            else:
+                interval = min(interval * 1.5, self.cfg.max_poll_interval)
+                stopped.wait(interval)
+
+        self.reader.close()
+
+
+class FileDriver(BaseDriver):
+    """Transport driver that exchanges SFM frames through a shared filesystem (e.g. Lustre).
+
+    Intended for deployments where two cells share a filesystem but have no network path between
+    them (e.g. an HPC compute node and a gateway node). The URL form is file://0/absolute/dir
+    ("0" is the empty-host placeholder). The passive side owns the directory; each active peer
+    creates a connection subdirectory with one append log per direction. There is no transport
+    security: directory permissions are the trust boundary.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.stop_event = threading.Event()
+        self.dir_lock = threading.Lock()
+        self.handled_dirs = set()
+        self.done_dirs = set()
+        self.logger = get_obj_logger(self)
+
+    @staticmethod
+    def supported_transports() -> List[str]:
+        return ["file"]
+
+    @staticmethod
+    def capabilities() -> Dict[str, Any]:
+        return {DriverCap.SEND_HEARTBEAT.value: True, DriverCap.SUPPORT_SSL.value: False}
+
+    @staticmethod
+    def get_urls(scheme: str, resources: dict) -> (str, str):
+        root_dir = resources.get(ROOT_DIR)
+        if not root_dir:
+            raise CommError(CommError.BAD_CONFIG, f"'{ROOT_DIR}' resource is required for scheme {scheme}")
+        root_dir = os.path.abspath(root_dir)
+        os.makedirs(root_dir, exist_ok=True)
+        _remove_stale_listener_dirs(root_dir)
+
+        listen_dir = os.path.join(root_dir, LISTENER_PREFIX + uuid.uuid4().hex[:8])
+        os.makedirs(os.path.join(listen_dir, CONNS_DIR))
+
+        url = f"{scheme}://0{listen_dir}"
+        tuning = {k: str(resources[k]) for k in _TUNING_PARAMS if k in resources}
+        if tuning:
+            url += "?" + urlencode(tuning)
+        return url, url
+
+    def listen(self, connector: ConnectorInfo):
+        self.connector = connector
+        cfg = _ConnConfig(connector.params)
+        listen_dir = self._get_dir_from_params(connector.params)
+        conns_dir = os.path.join(listen_dir, CONNS_DIR)
+        os.makedirs(conns_dir, exist_ok=True)
+        lease = os.path.join(listen_dir, LISTENER_LEASE_FILE)
+
+        interval = cfg.poll_interval
+        last_housekeeping = 0.0
+
+        while not self._stopping(connector):
+            now = time.monotonic()
+            if now - last_housekeeping >= cfg.lease_interval:
+                last_housekeeping = now
+                _touch(lease)
+                self._gc_conn_dirs(conns_dir, cfg)
+
+            new_conns = self._scan_for_connections(conns_dir, connector, cfg)
+            if new_conns:
+                interval = cfg.poll_interval
+            else:
+                interval = min(interval * 1.5, cfg.max_poll_interval)
+                connector.stopped.wait(interval)
+
+    def connect(self, connector: ConnectorInfo):
+        self.connector = connector
+        cfg = _ConnConfig(connector.params)
+        listen_dir = self._get_dir_from_params(connector.params)
+        conns_dir = os.path.join(listen_dir, CONNS_DIR)
+        if not os.path.isdir(conns_dir):
+            raise CommError(CommError.NOT_READY, f"Listener dir is not ready: {conns_dir}")
+
+        name = uuid.uuid4().hex[:12]
+        tmp_dir = os.path.join(conns_dir, TMP_PREFIX + name)
+        os.makedirs(tmp_dir)
+        for log_name in (f"{A2P}.0.log", f"{P2A}.0.log"):
+            open(os.path.join(tmp_dir, log_name), "ab").close()
+        conn_dir = os.path.join(conns_dir, name)
+        os.rename(tmp_dir, conn_dir)
+
+        conn = FileConnection(conn_dir, connector, cfg)
+        self.add_connection(conn)
+        try:
+            conn.read_loop(self.stop_event)
+        finally:
+            conn.close()
+            self.close_connection(conn)
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.close_all()
+
+    # Internal methods
+
+    def _stopping(self, connector: ConnectorInfo) -> bool:
+        return self.stop_event.is_set() or connector.stopped.is_set()
+
+    @staticmethod
+    def _get_dir_from_params(params: dict) -> str:
+        path = params.get(DriverParams.PATH.value)
+        if not path or path == "/":
+            url = params.get(DriverParams.URL.value)
+            raise CommError(CommError.BAD_CONFIG, f"Missing directory path in URL {url}, expected file://0/abs/dir")
+        return path
+
+    def _scan_for_connections(self, conns_dir: str, connector: ConnectorInfo, cfg: _ConnConfig) -> int:
+        try:
+            entries = sorted(os.listdir(conns_dir))
+        except OSError as ex:
+            raise CommError(CommError.ERROR, f"Cannot list {conns_dir}: {secure_format_exception(ex)}")
+
+        new_conns = 0
+        for entry in entries:
+            if entry.startswith(TMP_PREFIX):
+                continue
+            with self.dir_lock:
+                if entry in self.handled_dirs:
+                    continue
+                self.handled_dirs.add(entry)
+            conn_dir = os.path.join(conns_dir, entry)
+            if not os.path.isdir(conn_dir):
+                continue
+            conn = FileConnection(conn_dir, connector, cfg)
+            self.add_connection(conn)
+            t = threading.Thread(target=self._conn_loop, args=(conn, entry), name=f"file_conn_{entry}", daemon=True)
+            t.start()
+            new_conns += 1
+        return new_conns
+
+    def _conn_loop(self, conn: FileConnection, entry: str):
+        try:
+            conn.read_loop(self.stop_event)
+        except Exception as ex:
+            self.logger.error(f"Connection {conn} closed due to error: {secure_format_exception(ex)}")
+        finally:
+            conn.close()
+            self.close_connection(conn)
+            with self.dir_lock:
+                self.done_dirs.add(entry)
+
+    def _gc_conn_dirs(self, conns_dir: str, cfg: _ConnConfig):
+        """Remove connection dirs whose connection has ended, once the closed marker is old
+        enough for the peer to have noticed it."""
+        with self.dir_lock:
+            done = list(self.done_dirs)
+
+        for entry in done:
+            conn_dir = os.path.join(conns_dir, entry)
+            if os.path.isdir(conn_dir):
+                closed_mtime = _mtime(os.path.join(conn_dir, CLOSED_FILE))
+                if closed_mtime is None:
+                    _touch(os.path.join(conn_dir, CLOSED_FILE))
+                    continue
+                if time.time() - closed_mtime <= 2 * cfg.lease_timeout:
+                    continue
+                shutil.rmtree(conn_dir, ignore_errors=True)
+            with self.dir_lock:
+                self.done_dirs.discard(entry)
+                self.handled_dirs.discard(entry)
+
+
+def _remove_stale_listener_dirs(root_dir: str):
+    """GC listener dirs from previous runs whose lease has not been touched for a long time"""
+    try:
+        entries = os.listdir(root_dir)
+    except OSError:
+        return
+
+    for entry in entries:
+        if not entry.startswith(LISTENER_PREFIX):
+            continue
+        listen_dir = os.path.join(root_dir, entry)
+        mtime = _mtime(os.path.join(listen_dir, LISTENER_LEASE_FILE))
+        if mtime is None:
+            mtime = _mtime(listen_dir)
+        if mtime is None or time.time() - mtime > LISTENER_STALE_TIME:
+            shutil.rmtree(listen_dir, ignore_errors=True)

--- a/nvflare/tool/deploy/slurm_deploy.py
+++ b/nvflare/tool/deploy/slurm_deploy.py
@@ -27,6 +27,7 @@ from nvflare.app_opt.job_launcher.slurm.config import (
     normalize_slurm_launcher_settings,
     normalize_slurm_workspace_path,
 )
+from nvflare.fuel.f3.drivers.file_driver import SCHEME as SHARED_FILE_SCHEME
 from nvflare.tool.deploy.deploy_common import (
     COMM_CONFIG_JSON,
     RESOURCES_JSON_DEFAULT,
@@ -189,7 +190,7 @@ def _patch_comm_config(kit_dir: Path, port: int) -> None:
     internal = comm_config.setdefault("internal", {})
     if not isinstance(internal, dict):
         _fail("INVALID_KIT", "comm_config.json internal must be a mapping.", "Fix the startup kit comm config.")
-    if internal.get("scheme") == "file":
+    if internal.get("scheme") == SHARED_FILE_SCHEME:
         _validate_file_comm_config(comm_config)
         _write_json(comm_config_path, comm_config)
         return

--- a/nvflare/tool/deploy/slurm_deploy.py
+++ b/nvflare/tool/deploy/slurm_deploy.py
@@ -189,6 +189,10 @@ def _patch_comm_config(kit_dir: Path, port: int) -> None:
     internal = comm_config.setdefault("internal", {})
     if not isinstance(internal, dict):
         _fail("INVALID_KIT", "comm_config.json internal must be a mapping.", "Fix the startup kit comm config.")
+    if internal.get("scheme") == "file":
+        _validate_file_comm_config(comm_config)
+        _write_json(comm_config_path, comm_config)
+        return
     internal["scheme"] = "tcp"
     resources = _internal_resources(comm_config)
     resources.update(
@@ -199,6 +203,25 @@ def _patch_comm_config(kit_dir: Path, port: int) -> None:
         }
     )
     _write_json(comm_config_path, comm_config)
+
+
+def _validate_file_comm_config(comm_config: dict) -> None:
+    """A kit configured for the shared-file transport is preserved as-is; only validate it.
+    TCP host/port fields are deliberately not added to file resources."""
+    resources = _internal_resources(comm_config)
+    root_dir = resources.get("root_dir")
+    if not isinstance(root_dir, str) or not Path(root_dir).is_absolute():
+        _fail(
+            "INVALID_KIT",
+            "file transport requires an absolute internal.resources.root_dir.",
+            "Fix the startup kit comm config.",
+        )
+    if resources.setdefault("connection_security", "clear") != "clear":
+        _fail(
+            "INVALID_KIT",
+            "file transport supports only clear connection security.",
+            "Fix the startup kit comm config.",
+        )
 
 
 def _render_template(

--- a/nvflare/tool/deploy/slurm_deploy.py
+++ b/nvflare/tool/deploy/slurm_deploy.py
@@ -206,8 +206,8 @@ def _patch_comm_config(kit_dir: Path, port: int) -> None:
 
 
 def _validate_file_comm_config(comm_config: dict) -> None:
-    """A kit configured for the shared-file transport is preserved as-is; only validate it.
-    TCP host/port fields are deliberately not added to file resources."""
+    """Validate a kit configured for the shared-file transport, defaulting connection_security
+    to "clear" when absent. TCP host/port fields are deliberately not added to file resources."""
     resources = _internal_resources(comm_config)
     root_dir = resources.get("root_dir")
     if not isinstance(root_dir, str) or not Path(root_dir).is_absolute():

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -645,7 +645,7 @@ class TestDockerJobLauncherLaunchJob:
         dc.containers.run.return_value = container
         dc.containers.get.return_value = _make_container("running")
 
-        parent_url = "file://0/lustre/nvflare/cellnet/lst_12345678?poll_interval=0.05"
+        parent_url = "shared-file://0/lustre/nvflare/cellnet/lst_12345678?poll_interval=0.05"
         fl_ctx, _ = _make_fl_ctx(parent_url=parent_url)
         launcher.launch_job(_make_job_meta(), fl_ctx)
 
@@ -659,7 +659,7 @@ class TestDockerJobLauncherLaunchJob:
 
     def test_launch_rejects_malformed_shared_file_parent_url(self):
         launcher = _make_launcher(workspace="/host/workspace")
-        fl_ctx, _ = _make_fl_ctx(parent_url="file://lustre/not-placeholder")
+        fl_ctx, _ = _make_fl_ctx(parent_url="shared-file://lustre/not-placeholder")
 
         with pytest.raises(ValueError, match="invalid shared-file parent URL"):
             launcher.launch_job(_make_job_meta(), fl_ctx)

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -637,6 +637,33 @@ class TestDockerJobLauncherLaunchJob:
         with pytest.raises(RuntimeError):
             launcher.launch_job(_make_job_meta(), fl_ctx)
 
+    def test_launch_preserves_and_mounts_shared_file_parent_url(self):
+        launcher = _make_launcher(workspace="/host/workspace")
+        dc = launcher._docker_client
+        container = MagicMock()
+        container.id = "abc123"
+        dc.containers.run.return_value = container
+        dc.containers.get.return_value = _make_container("running")
+
+        parent_url = "file://0/lustre/nvflare/cellnet/lst_12345678?poll_interval=0.05"
+        fl_ctx, _ = _make_fl_ctx(parent_url=parent_url)
+        launcher.launch_job(_make_job_meta(), fl_ctx)
+
+        call_kwargs = dc.containers.run.call_args[1]
+        command_str = " ".join(str(a) for a in call_kwargs["command"])
+        assert parent_url in command_str
+        mounts_by_target = _mounts_by_target(call_kwargs["mounts"])
+        listener_mount = mounts_by_target["/lustre/nvflare/cellnet/lst_12345678"]
+        assert listener_mount["Source"] == "/lustre/nvflare/cellnet/lst_12345678"
+        assert listener_mount["ReadOnly"] is False
+
+    def test_launch_rejects_malformed_shared_file_parent_url(self):
+        launcher = _make_launcher(workspace="/host/workspace")
+        fl_ctx, _ = _make_fl_ctx(parent_url="file://lustre/not-placeholder")
+
+        with pytest.raises(ValueError, match="invalid shared-file parent URL"):
+            launcher.launch_job(_make_job_meta(), fl_ctx)
+
     def test_launch_workspace_bind_mounted(self):
         launcher = _make_launcher(workspace="/host/workspace")
         dc = launcher._docker_client

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -25,6 +25,7 @@ from nvflare.apis.job_launcher_spec import JobProcessArgs, JobProcessEnv
 from nvflare.apis.workspace import Workspace
 from nvflare.app_opt.job_launcher.slurm.config import (
     SLURM_CHILD_PROCESS_ENV,
+    BindMount,
     SlurmLauncherError,
     _validate_mount_destination,
 )
@@ -152,13 +153,25 @@ def test_parent_url_rewrite_formats_ipv6_host():
     assert rewritten[JobProcessArgs.PARENT_URL][1] == "tcp://[2001:db8::2]:8102"
 
 
+def test_shared_file_parent_url_is_preserved_without_parent_host():
+    parent_url = "file://0/lustre/nvflare/cellnet/lst_12345678?poll_interval=0.05&lease_timeout=30"
+    args = {JobProcessArgs.PARENT_URL: ("-p", parent_url)}
+
+    rewritten = _rewrite_parent_url(args, None, 8102)
+
+    assert rewritten[JobProcessArgs.PARENT_URL][1] == parent_url
+    assert args[JobProcessArgs.PARENT_URL][1] == parent_url
+
+
 @pytest.mark.parametrize(
     "entry, message",
     [
         (None, "missing or malformed"),
         (("-p", "tcp://old:not-a-port"), "malformed parent URL"),
-        (("-p", "http://old:8102"), "must use tcp"),
+        (("-p", "http://old:8102"), "must use file or tcp"),
         (("-p", "tcp://old:9000"), "configured internal_port"),
+        (("-p", "file://host/not-placeholder"), "malformed shared-file"),
+        (("-p", "file://0"), "malformed shared-file"),
     ],
 )
 def test_parent_url_rewrite_rejects_malformed_or_incompatible_value(entry, message):
@@ -166,6 +179,56 @@ def test_parent_url_rewrite_rejects_malformed_or_incompatible_value(entry, messa
 
     with pytest.raises(SlurmLauncherError, match=message):
         _rewrite_parent_url(args, "new-host", 8102)
+
+
+def _file_parent_context(workspace, listener):
+    context = _fl_ctx(workspace)
+    context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_URL] = (
+        "-p",
+        f"file://0{listener}?poll_interval=0.05",
+    )
+    return context
+
+
+@pytest.mark.parametrize("sandbox", ["pyxis", "apptainer"])
+def test_containerized_slurm_mounts_shared_file_parent_directory_read_write(tmp_path, sandbox):
+    workspace = _workspace(tmp_path)
+    image = tmp_path / ("image.sqsh" if sandbox == "pyxis" else "image.sif")
+    image.write_text("image", encoding="utf-8")
+    listener = tmp_path / "cellnet" / "lst_12345678"
+    listener.mkdir(parents=True)
+    launcher = _launcher(tmp_path, workspace, sandbox=sandbox, image=str(image))
+
+    plan = launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _file_parent_context(workspace, listener))
+
+    assert len(plan.mounts) == 1
+    assert plan.mounts[0].source == str(listener)
+    assert plan.mounts[0].destination == str(listener)
+    assert plan.mounts[0].mode == "rw"
+
+
+def test_bare_slurm_does_not_mount_shared_file_parent_directory(tmp_path):
+    workspace = _workspace(tmp_path)
+    listener = tmp_path / "cellnet" / "lst_12345678"
+    listener.mkdir(parents=True)
+    launcher = _launcher(tmp_path, workspace, sandbox="none")
+
+    plan = launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _file_parent_context(workspace, listener))
+
+    assert plan.mounts == ()
+
+
+def test_shared_file_parent_overlapping_study_mount_is_rejected(tmp_path, monkeypatch):
+    workspace = _workspace(tmp_path)
+    image = tmp_path / "image.sqsh"
+    image.write_text("image", encoding="utf-8")
+    listener = tmp_path / "cellnet" / "lst_12345678"
+    listener.mkdir(parents=True)
+    launcher = _launcher(tmp_path, workspace, sandbox="pyxis", image=str(image))
+    monkeypatch.setattr(launcher, "_study_mounts", lambda runtime: (BindMount(str(listener), str(listener), "ro"),))
+
+    with pytest.raises(SlurmLauncherError, match="overlaps a study mount"):
+        launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _file_parent_context(workspace, listener))
 
 
 @pytest.mark.parametrize("path", ["relative", "//double", "/tmp/../bad", "/proc/value", "/sys"])
@@ -270,8 +333,7 @@ studies:
       image: %s
     slurm:
       sandbox: apptainer
-"""
-        % (tmp_path / "study.sif"),
+""" % (tmp_path / "study.sif"),
         encoding="utf-8",
     )
     launcher = _launcher(tmp_path, workspace, sandbox="apptainer", image=str(tmp_path / "site.sif"))

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -154,7 +154,7 @@ def test_parent_url_rewrite_formats_ipv6_host():
 
 
 def test_shared_file_parent_url_is_preserved_without_parent_host():
-    parent_url = "file://0/lustre/nvflare/cellnet/lst_12345678?poll_interval=0.05&lease_timeout=30"
+    parent_url = "shared-file://0/lustre/nvflare/cellnet/lst_12345678?poll_interval=0.05&lease_timeout=30"
     args = {JobProcessArgs.PARENT_URL: ("-p", parent_url)}
 
     rewritten = _rewrite_parent_url(args, None, 8102)
@@ -168,10 +168,10 @@ def test_shared_file_parent_url_is_preserved_without_parent_host():
     [
         (None, "missing or malformed"),
         (("-p", "tcp://old:not-a-port"), "malformed parent URL"),
-        (("-p", "http://old:8102"), "must use file or tcp"),
+        (("-p", "http://old:8102"), "must use shared-file or tcp"),
         (("-p", "tcp://old:9000"), "configured internal_port"),
-        (("-p", "file://host/not-placeholder"), "malformed shared-file"),
-        (("-p", "file://0"), "malformed shared-file"),
+        (("-p", "shared-file://host/not-placeholder"), "malformed shared-file"),
+        (("-p", "shared-file://0"), "malformed shared-file"),
     ],
 )
 def test_parent_url_rewrite_rejects_malformed_or_incompatible_value(entry, message):
@@ -185,7 +185,7 @@ def _file_parent_context(workspace, listener):
     context = _fl_ctx(workspace)
     context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_URL] = (
         "-p",
-        f"file://0{listener}?poll_interval=0.05",
+        f"shared-file://0{listener}?poll_interval=0.05",
     )
     return context
 

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -333,7 +333,8 @@ studies:
       image: %s
     slurm:
       sandbox: apptainer
-""" % (tmp_path / "study.sif"),
+"""
+        % (tmp_path / "study.sif"),
         encoding="utf-8",
     )
     launcher = _launcher(tmp_path, workspace, sandbox="apptainer", image=str(tmp_path / "site.sif"))

--- a/tests/unit_test/fuel/f3/drivers/file_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/file_driver_test.py
@@ -155,6 +155,19 @@ class TestLogRoundtrip:
 
         assert received == frames
 
+    def test_reader_recovers_from_stale_file_handle(self, tmp_path):
+        cfg = _ConnConfig({})
+        writer = _LogWriter(str(tmp_path), "a2p", cfg)
+        reader = _LogReader(str(tmp_path), "a2p", cfg)
+
+        writer.append(_frame(b"first"))
+        assert reader.read_frames() == [_frame(b"first")]
+
+        os.close(reader.file.fileno())
+        writer.append(_frame(b"second"))
+        assert reader.read_frames() == []
+        assert reader.read_frames() == [_frame(b"second")]
+
     def test_partial_frame_visibility(self, tmp_path):
         cfg = _ConnConfig({})
         reader = _LogReader(str(tmp_path), "a2p", cfg)

--- a/tests/unit_test/fuel/f3/drivers/file_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/file_driver_test.py
@@ -16,15 +16,18 @@ import stat
 import struct
 import time
 from threading import Event
+from types import SimpleNamespace
 
 import pytest
 
 from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.communicator import Communicator
 from nvflare.fuel.f3.connection import Connection
-from nvflare.fuel.f3.drivers.connector_info import Mode
+from nvflare.fuel.f3.drivers.connector_info import ConnectorInfo, Mode
 from nvflare.fuel.f3.drivers.file_driver import (
     OWNER_MARKER,
+    READ_CHUNK,
+    FileConnection,
     FileDriver,
     _ConnConfig,
     _LogReader,
@@ -286,6 +289,22 @@ class TestFileDriver:
         finally:
             comm_b.stop()
             comm_a.stop()
+
+    def test_drain_delivers_final_frame_larger_than_read_chunk(self, tmp_path):
+        conn_dir = tmp_path / "conn"
+        conn_dir.mkdir()
+        frame = _frame(bytes(READ_CHUNK + 1040))
+        (conn_dir / "a2p.0.log").write_bytes(frame)
+        (conn_dir / "closed").touch()
+
+        connector = ConnectorInfo("test", None, {}, Mode.PASSIVE, 0, 0, False, Event())
+        conn = FileConnection(str(conn_dir), connector, _ConnConfig({"poll_interval": "0.005"}))
+        received = []
+        conn.register_frame_receiver(SimpleNamespace(process_frame=received.append))
+
+        conn._drain(Event())
+
+        assert received == [frame]
 
     def test_permissions_ignore_umask(self, tmp_path):
         old_umask = os.umask(0o022)

--- a/tests/unit_test/fuel/f3/drivers/file_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/file_driver_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import stat
 import struct
 import time
 from threading import Event
@@ -22,15 +23,23 @@ from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.communicator import Communicator
 from nvflare.fuel.f3.connection import Connection
 from nvflare.fuel.f3.drivers.connector_info import Mode
-from nvflare.fuel.f3.drivers.file_driver import _ConnConfig, _LogReader, _LogWriter, parse_file_url
+from nvflare.fuel.f3.drivers.file_driver import (
+    OWNER_MARKER,
+    FileDriver,
+    _ConnConfig,
+    _LogReader,
+    _LogWriter,
+    parse_file_url,
+)
 from nvflare.fuel.f3.endpoint import Endpoint, EndpointMonitor, EndpointState
 from nvflare.fuel.f3.message import Message, MessageReceiver
+from nvflare.fuel.f3.sfm.prefix import PREFIX_LEN
 
 APP_ID = 321
 NODE_A = "file-comm-a"
 NODE_B = "file-comm-b"
 
-FAST_PARAMS = {"poll_interval": "0.005", "lease_interval": "0.2", "lease_timeout": "2"}
+FAST_PARAMS = {"poll_interval": "0.005", "lease_interval": "0.2", "lease_timeout": "5"}
 
 
 class _State:
@@ -76,8 +85,8 @@ def _wait_until(condition, timeout=15.0) -> bool:
 
 
 def _frame(payload: bytes) -> bytes:
-    length = 16 + len(payload)
-    return struct.pack(">I", length) + bytes(12) + payload
+    length = PREFIX_LEN + len(payload)
+    return struct.pack(">I", length) + bytes(PREFIX_LEN - 4) + payload
 
 
 class TestParseFileUrl:
@@ -254,3 +263,103 @@ class TestFileDriver:
         comm = _make_comm(NODE_A, _State())
         with pytest.raises(CommError):
             comm.start_listener("file", {})
+
+    def test_close_drains_pending_frames(self, tmp_path):
+        state = _State()
+        comm_a = _make_comm(NODE_A, state)
+        comm_b = _make_comm(NODE_B, state)
+
+        try:
+            _, url, _ = comm_a.start_listener("file", {"root_dir": str(tmp_path), **FAST_PARAMS})
+            comm_a.start()
+            comm_b.add_connector(url, Mode.ACTIVE)
+            comm_b.start()
+            assert state.ready[NODE_A].wait(15) and state.ready[NODE_B].wait(15)
+
+            expected = [f"tail-{i}".encode() for i in range(30)]
+            for payload in expected:
+                comm_b.send(Endpoint(NODE_A), APP_ID, Message({}, payload))
+            comm_b.stop()
+
+            assert _wait_until(lambda: len(state.received_from[NODE_B]) == len(expected))
+            assert sorted(state.received_from[NODE_B]) == sorted(expected)
+        finally:
+            comm_b.stop()
+            comm_a.stop()
+
+    def test_permissions_ignore_umask(self, tmp_path):
+        old_umask = os.umask(0o022)
+        state = _State()
+        comm_a = _make_comm(NODE_A, state)
+        comm_b = _make_comm(NODE_B, state)
+
+        def _mode(path):
+            return stat.S_IMODE(os.stat(path).st_mode)
+
+        try:
+            _, url, _ = comm_a.start_listener("file", {"root_dir": str(tmp_path), **FAST_PARAMS})
+            comm_a.start()
+            comm_b.add_connector(url, Mode.ACTIVE)
+            comm_b.start()
+            assert state.ready[NODE_A].wait(15) and state.ready[NODE_B].wait(15)
+
+            listen_dir = tmp_path / next(p for p in os.listdir(tmp_path))
+            assert _mode(listen_dir) == 0o770
+            conn_dir = next((listen_dir / "conns").iterdir())
+            assert _mode(conn_dir) == 0o770
+            assert _mode(conn_dir / "a2p.0.log") == 0o660
+        finally:
+            os.umask(old_umask)
+            comm_b.stop()
+            comm_a.stop()
+
+    def test_active_cleans_up_when_listener_dead(self, tmp_path):
+        listen_dir = tmp_path / "cell"
+        (listen_dir / "conns").mkdir(parents=True)
+        state = _State()
+        comm_b = _make_comm(NODE_B, state)
+        url = f"file://0{listen_dir}?poll_interval=0.005&lease_interval=0.2&lease_timeout=1"
+
+        try:
+            comm_b.add_connector(url, Mode.ACTIVE)
+            comm_b.start()
+            assert _wait_until(lambda: len(os.listdir(listen_dir / "conns")) > 0, 5)
+            assert _wait_until(lambda: len(os.listdir(listen_dir / "conns")) == 0, 15)
+        finally:
+            comm_b.stop()
+
+
+class TestGetUrls:
+    def test_gc_requires_ownership_marker(self, tmp_path):
+        old = time.time() - 7200
+        foreign = tmp_path / "lst_foreign"
+        foreign.mkdir()
+        (foreign / "data.txt").write_text("keep me")
+        os.utime(foreign, (old, old))
+
+        dead = tmp_path / "lst_dead"
+        (dead / "conns").mkdir(parents=True)
+        (dead / OWNER_MARKER).touch()
+        (dead / "lease").touch()
+        os.utime(dead / "lease", (old, old))
+
+        FileDriver.get_urls("file", {"root_dir": str(tmp_path)})
+
+        assert foreign.exists() and (foreign / "data.txt").exists()
+        assert _wait_until(lambda: not dead.exists(), 5)
+
+    def test_reserved_chars_rejected(self, tmp_path):
+        for ch in ("?", "#"):
+            with pytest.raises(CommError):
+                FileDriver.get_urls("file", {"root_dir": str(tmp_path) + f"/bad{ch}dir"})
+
+
+class TestConnConfig:
+    def test_robust_param_parsing(self):
+        cfg = _ConnConfig({"max_log_size": "1000000000.0", "poll_interval": "0", "fsync": "False"})
+        assert cfg.max_log_size == 1_000_000_000
+        assert cfg.poll_interval >= 0.001
+        assert cfg.max_poll_interval >= cfg.poll_interval
+        assert cfg.fsync is False
+        assert _ConnConfig({"fsync": "true"}).fsync is True
+        assert _ConnConfig({"dir_mode": "700", "file_mode": "600"}).dir_mode == 0o700

--- a/tests/unit_test/fuel/f3/drivers/file_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/file_driver_test.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import struct
+import time
+from threading import Event
+
+import pytest
+
+from nvflare.fuel.f3.comm_error import CommError
+from nvflare.fuel.f3.communicator import Communicator
+from nvflare.fuel.f3.connection import Connection
+from nvflare.fuel.f3.drivers.connector_info import Mode
+from nvflare.fuel.f3.drivers.file_driver import _ConnConfig, _LogReader, _LogWriter
+from nvflare.fuel.f3.endpoint import Endpoint, EndpointMonitor, EndpointState
+from nvflare.fuel.f3.message import Message, MessageReceiver
+
+APP_ID = 321
+NODE_A = "file-comm-a"
+NODE_B = "file-comm-b"
+
+FAST_PARAMS = {"poll_interval": "0.005", "lease_interval": "0.2", "lease_timeout": "2"}
+
+
+class _State:
+    def __init__(self):
+        self.ready = {NODE_A: Event(), NODE_B: Event()}
+        self.disconnected = {NODE_A: Event(), NODE_B: Event()}
+        self.received_from = {NODE_A: [], NODE_B: []}
+
+
+class _Monitor(EndpointMonitor):
+    def __init__(self, state: _State):
+        self.state = state
+
+    def state_change(self, endpoint: Endpoint):
+        if endpoint.state == EndpointState.READY:
+            self.state.ready[endpoint.name].set()
+        elif endpoint.state == EndpointState.DISCONNECTED:
+            self.state.disconnected[endpoint.name].set()
+
+
+class _Receiver(MessageReceiver):
+    def __init__(self, state: _State):
+        self.state = state
+
+    def process_message(self, endpoint: Endpoint, connection: Connection, app_id: int, message: Message):
+        self.state.received_from[endpoint.name].append(message.payload)
+
+
+def _make_comm(name: str, state: _State) -> Communicator:
+    comm = Communicator(Endpoint(name, {}))
+    comm.register_monitor(_Monitor(state))
+    comm.register_message_receiver(APP_ID, _Receiver(state))
+    return comm
+
+
+def _wait_until(condition, timeout=15.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if condition():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _frame(payload: bytes) -> bytes:
+    length = 16 + len(payload)
+    return struct.pack(">I", length) + bytes(12) + payload
+
+
+class TestLogRoundtrip:
+    def test_rotation_and_cleanup(self, tmp_path):
+        cfg = _ConnConfig({"max_log_size": 100})
+        writer = _LogWriter(str(tmp_path), "a2p", cfg)
+        reader = _LogReader(str(tmp_path), "a2p", cfg)
+
+        frames = [_frame(f"payload-{i}".encode()) for i in range(20)]
+        received = []
+        for frame in frames:
+            writer.append(frame)
+            received.extend(reader.read_frames())
+        received.extend(reader.read_frames())
+        writer.close()
+        reader.close()
+
+        assert received == frames
+        logs = [f for f in os.listdir(tmp_path) if f.endswith(".log")]
+        assert len(logs) <= 2
+
+    def test_frame_larger_than_log_cap(self, tmp_path):
+        cfg = _ConnConfig({"max_log_size": 64})
+        writer = _LogWriter(str(tmp_path), "a2p", cfg)
+        reader = _LogReader(str(tmp_path), "a2p", cfg)
+
+        frames = [_frame(bytes(1000)), _frame(b"small"), _frame(bytes(2000))]
+        received = []
+        for frame in frames:
+            writer.append(frame)
+            received.extend(reader.read_frames())
+        received.extend(reader.read_frames())
+
+        assert received == frames
+
+    def test_partial_frame_visibility(self, tmp_path):
+        cfg = _ConnConfig({})
+        reader = _LogReader(str(tmp_path), "a2p", cfg)
+        frame = _frame(b"split-delivery")
+
+        with open(os.path.join(tmp_path, "a2p.0.log"), "ab") as f:
+            f.write(frame[:10])
+            f.flush()
+            assert reader.read_frames() == []
+            f.write(frame[10:])
+            f.flush()
+        assert reader.read_frames() == [frame]
+
+
+class TestFileDriver:
+    def test_message_exchange_and_close(self, tmp_path):
+        state = _State()
+        comm_a = _make_comm(NODE_A, state)
+        comm_b = _make_comm(NODE_B, state)
+
+        try:
+            resources = {"root_dir": str(tmp_path), **FAST_PARAMS}
+            _, url, _ = comm_a.start_listener("file", resources)
+            assert url.startswith("file://0/")
+            comm_a.start()
+
+            comm_b.add_connector(url, Mode.ACTIVE)
+            comm_b.start()
+
+            assert state.ready[NODE_A].wait(15)
+            assert state.ready[NODE_B].wait(15)
+
+            comm_a.send(Endpoint(NODE_B), APP_ID, Message({}, b"hello-from-a"))
+            comm_b.send(Endpoint(NODE_A), APP_ID, Message({}, b"hello-from-b"))
+
+            assert _wait_until(lambda: state.received_from[NODE_A] and state.received_from[NODE_B])
+            assert state.received_from[NODE_A] == [b"hello-from-a"]
+            assert state.received_from[NODE_B] == [b"hello-from-b"]
+
+            comm_b.stop()
+            assert state.disconnected[NODE_B].wait(15)
+        finally:
+            comm_b.stop()
+            comm_a.stop()
+
+    def test_many_messages_with_rotation(self, tmp_path):
+        state = _State()
+        comm_a = _make_comm(NODE_A, state)
+        comm_b = _make_comm(NODE_B, state)
+
+        try:
+            resources = {"root_dir": str(tmp_path), "max_log_size": "300", **FAST_PARAMS}
+            _, url, _ = comm_a.start_listener("file", resources)
+            comm_a.start()
+            comm_b.add_connector(url, Mode.ACTIVE)
+            comm_b.start()
+
+            assert state.ready[NODE_A].wait(15) and state.ready[NODE_B].wait(15)
+
+            expected = [f"msg-{i}".encode() for i in range(40)] + [bytes(100 * 1024)]
+            for payload in expected:
+                comm_b.send(Endpoint(NODE_A), APP_ID, Message({}, payload))
+
+            assert _wait_until(lambda: len(state.received_from[NODE_B]) == len(expected))
+            assert sorted(state.received_from[NODE_B]) == sorted(expected)
+
+            conn_dirs = list((tmp_path / next(p for p in os.listdir(tmp_path)) / "conns").iterdir())
+            assert len(conn_dirs) == 1
+            logs = [f for f in os.listdir(conn_dirs[0]) if f.startswith("a2p") and f.endswith(".log")]
+            assert len(logs) <= 2
+        finally:
+            comm_b.stop()
+            comm_a.stop()
+
+    def test_reconnect(self, tmp_path):
+        state = _State()
+        comm_a = _make_comm(NODE_A, state)
+        comm_b = _make_comm(NODE_B, state)
+
+        comm_b2 = None
+        try:
+            resources = {"root_dir": str(tmp_path), **FAST_PARAMS}
+            _, url, _ = comm_a.start_listener("file", resources)
+            comm_a.start()
+            comm_b.add_connector(url, Mode.ACTIVE)
+            comm_b.start()
+
+            assert state.ready[NODE_B].wait(15)
+            comm_b.stop()
+            assert state.disconnected[NODE_B].wait(15)
+
+            state.ready[NODE_A].clear()
+            state.ready[NODE_B].clear()
+            comm_b2 = _make_comm(NODE_B, state)
+            comm_b2.add_connector(url, Mode.ACTIVE)
+            comm_b2.start()
+
+            assert state.ready[NODE_B].wait(15)
+            assert state.ready[NODE_A].wait(15)
+            comm_b2.send(Endpoint(NODE_A), APP_ID, Message({}, b"after-reconnect"))
+            assert _wait_until(lambda: b"after-reconnect" in state.received_from[NODE_B])
+        finally:
+            comm_b.stop()
+            if comm_b2:
+                comm_b2.stop()
+            comm_a.stop()
+
+    def test_missing_root_dir(self):
+        comm = _make_comm(NODE_A, _State())
+        with pytest.raises(CommError):
+            comm.start_listener("file", {})

--- a/tests/unit_test/fuel/f3/drivers/file_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/file_driver_test.py
@@ -96,10 +96,10 @@ class TestParseFileUrl:
     @pytest.mark.parametrize(
         "url, expected",
         [
-            ("file://0/lustre/proj/cellnet", "/lustre/proj/cellnet"),
-            ("file://0/lustre/proj/cellnet/", "/lustre/proj/cellnet"),
-            ("file://0/a/b?poll_interval=0.05&fsync=False", "/a/b"),
-            ("file://0/a#frag", "/a"),
+            ("shared-file://0/lustre/proj/cellnet", "/lustre/proj/cellnet"),
+            ("shared-file://0/lustre/proj/cellnet/", "/lustre/proj/cellnet"),
+            ("shared-file://0/a/b?poll_interval=0.05&fsync=False", "/a/b"),
+            ("shared-file://0/a#frag", "/a"),
         ],
     )
     def test_valid_urls(self, url, expected):
@@ -108,13 +108,13 @@ class TestParseFileUrl:
     @pytest.mark.parametrize(
         "url",
         [
-            "file://lustre/proj/cellnet",  # non-0 authority, path would be silently wrong
-            "file:///lustre/proj/cellnet",  # empty authority
-            "file://0",  # no path
-            "file://0/",  # root path
-            "file://localhost/a/b",
+            "shared-file://lustre/proj/cellnet",  # non-0 authority, path would be silently wrong
+            "shared-file:///lustre/proj/cellnet",  # empty authority
+            "shared-file://0",  # no path
+            "shared-file://0/",  # root path
+            "shared-file://localhost/a/b",
             "tcp://host:1234",
-            "file:relative/path",
+            "shared-file:relative/path",
         ],
     )
     def test_invalid_urls(self, url):
@@ -125,8 +125,8 @@ class TestParseFileUrl:
 class TestLogRoundtrip:
     def test_rotation_and_cleanup(self, tmp_path):
         cfg = _ConnConfig({"max_log_size": 100})
-        writer = _LogWriter(str(tmp_path), "a2p", cfg)
-        reader = _LogReader(str(tmp_path), "a2p", cfg)
+        writer = _LogWriter(str(tmp_path), "active", cfg)
+        reader = _LogReader(str(tmp_path), "active", cfg)
 
         frames = [_frame(f"payload-{i}".encode()) for i in range(20)]
         received = []
@@ -143,8 +143,8 @@ class TestLogRoundtrip:
 
     def test_frame_larger_than_log_cap(self, tmp_path):
         cfg = _ConnConfig({"max_log_size": 64})
-        writer = _LogWriter(str(tmp_path), "a2p", cfg)
-        reader = _LogReader(str(tmp_path), "a2p", cfg)
+        writer = _LogWriter(str(tmp_path), "active", cfg)
+        reader = _LogReader(str(tmp_path), "active", cfg)
 
         frames = [_frame(bytes(1000)), _frame(b"small"), _frame(bytes(2000))]
         received = []
@@ -157,8 +157,8 @@ class TestLogRoundtrip:
 
     def test_reader_recovers_from_stale_file_handle(self, tmp_path):
         cfg = _ConnConfig({})
-        writer = _LogWriter(str(tmp_path), "a2p", cfg)
-        reader = _LogReader(str(tmp_path), "a2p", cfg)
+        writer = _LogWriter(str(tmp_path), "active", cfg)
+        reader = _LogReader(str(tmp_path), "active", cfg)
 
         writer.append(_frame(b"first"))
         assert reader.read_frames() == [_frame(b"first")]
@@ -170,10 +170,10 @@ class TestLogRoundtrip:
 
     def test_partial_frame_visibility(self, tmp_path):
         cfg = _ConnConfig({})
-        reader = _LogReader(str(tmp_path), "a2p", cfg)
+        reader = _LogReader(str(tmp_path), "active", cfg)
         frame = _frame(b"split-delivery")
 
-        with open(os.path.join(tmp_path, "a2p.0.log"), "ab") as f:
+        with open(os.path.join(tmp_path, "active.0.log"), "ab") as f:
             f.write(frame[:10])
             f.flush()
             assert reader.read_frames() == []
@@ -190,8 +190,8 @@ class TestFileDriver:
 
         try:
             resources = {"root_dir": str(tmp_path), **FAST_PARAMS}
-            _, url, _ = comm_a.start_listener("file", resources)
-            assert url.startswith("file://0/")
+            _, url, _ = comm_a.start_listener("shared-file", resources)
+            assert url.startswith("shared-file://0/")
             comm_a.start()
 
             comm_b.add_connector(url, Mode.ACTIVE)
@@ -220,7 +220,7 @@ class TestFileDriver:
 
         try:
             resources = {"root_dir": str(tmp_path), "max_log_size": "300", **FAST_PARAMS}
-            _, url, _ = comm_a.start_listener("file", resources)
+            _, url, _ = comm_a.start_listener("shared-file", resources)
             comm_a.start()
             comm_b.add_connector(url, Mode.ACTIVE)
             comm_b.start()
@@ -236,7 +236,7 @@ class TestFileDriver:
 
             conn_dirs = list((tmp_path / next(p for p in os.listdir(tmp_path)) / "conns").iterdir())
             assert len(conn_dirs) == 1
-            logs = [f for f in os.listdir(conn_dirs[0]) if f.startswith("a2p") and f.endswith(".log")]
+            logs = [f for f in os.listdir(conn_dirs[0]) if f.startswith("active") and f.endswith(".log")]
             assert len(logs) <= 2
         finally:
             comm_b.stop()
@@ -250,7 +250,7 @@ class TestFileDriver:
         comm_b2 = None
         try:
             resources = {"root_dir": str(tmp_path), **FAST_PARAMS}
-            _, url, _ = comm_a.start_listener("file", resources)
+            _, url, _ = comm_a.start_listener("shared-file", resources)
             comm_a.start()
             comm_b.add_connector(url, Mode.ACTIVE)
             comm_b.start()
@@ -278,7 +278,7 @@ class TestFileDriver:
     def test_missing_root_dir(self):
         comm = _make_comm(NODE_A, _State())
         with pytest.raises(CommError):
-            comm.start_listener("file", {})
+            comm.start_listener("shared-file", {})
 
     def test_close_drains_pending_frames(self, tmp_path):
         state = _State()
@@ -286,7 +286,7 @@ class TestFileDriver:
         comm_b = _make_comm(NODE_B, state)
 
         try:
-            _, url, _ = comm_a.start_listener("file", {"root_dir": str(tmp_path), **FAST_PARAMS})
+            _, url, _ = comm_a.start_listener("shared-file", {"root_dir": str(tmp_path), **FAST_PARAMS})
             comm_a.start()
             comm_b.add_connector(url, Mode.ACTIVE)
             comm_b.start()
@@ -307,7 +307,7 @@ class TestFileDriver:
         conn_dir = tmp_path / "conn"
         conn_dir.mkdir()
         frame = _frame(bytes(READ_CHUNK + 1040))
-        (conn_dir / "a2p.0.log").write_bytes(frame)
+        (conn_dir / "active.0.log").write_bytes(frame)
         (conn_dir / "closed").touch()
 
         connector = ConnectorInfo("test", None, {}, Mode.PASSIVE, 0, 0, False, Event())
@@ -329,7 +329,7 @@ class TestFileDriver:
             return stat.S_IMODE(os.stat(path).st_mode)
 
         try:
-            _, url, _ = comm_a.start_listener("file", {"root_dir": str(tmp_path), **FAST_PARAMS})
+            _, url, _ = comm_a.start_listener("shared-file", {"root_dir": str(tmp_path), **FAST_PARAMS})
             comm_a.start()
             comm_b.add_connector(url, Mode.ACTIVE)
             comm_b.start()
@@ -339,7 +339,7 @@ class TestFileDriver:
             assert _mode(listen_dir) == 0o770
             conn_dir = next((listen_dir / "conns").iterdir())
             assert _mode(conn_dir) == 0o770
-            assert _mode(conn_dir / "a2p.0.log") == 0o660
+            assert _mode(conn_dir / "active.0.log") == 0o660
         finally:
             os.umask(old_umask)
             comm_b.stop()
@@ -350,7 +350,7 @@ class TestFileDriver:
         (listen_dir / "conns").mkdir(parents=True)
         state = _State()
         comm_b = _make_comm(NODE_B, state)
-        url = f"file://0{listen_dir}?poll_interval=0.005&lease_interval=0.2&lease_timeout=1"
+        url = f"shared-file://0{listen_dir}?poll_interval=0.005&lease_interval=0.2&lease_timeout=1"
 
         try:
             comm_b.add_connector(url, Mode.ACTIVE)
@@ -375,7 +375,7 @@ class TestGetUrls:
         (dead / "lease").touch()
         os.utime(dead / "lease", (old, old))
 
-        FileDriver.get_urls("file", {"root_dir": str(tmp_path)})
+        FileDriver.get_urls("shared-file", {"root_dir": str(tmp_path)})
 
         assert foreign.exists() and (foreign / "data.txt").exists()
         assert _wait_until(lambda: not dead.exists(), 5)
@@ -383,7 +383,7 @@ class TestGetUrls:
     def test_reserved_chars_rejected(self, tmp_path):
         for ch in ("?", "#"):
             with pytest.raises(CommError):
-                FileDriver.get_urls("file", {"root_dir": str(tmp_path) + f"/bad{ch}dir"})
+                FileDriver.get_urls("shared-file", {"root_dir": str(tmp_path) + f"/bad{ch}dir"})
 
 
 class TestConnConfig:

--- a/tests/unit_test/fuel/f3/drivers/file_driver_test.py
+++ b/tests/unit_test/fuel/f3/drivers/file_driver_test.py
@@ -22,7 +22,7 @@ from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.communicator import Communicator
 from nvflare.fuel.f3.connection import Connection
 from nvflare.fuel.f3.drivers.connector_info import Mode
-from nvflare.fuel.f3.drivers.file_driver import _ConnConfig, _LogReader, _LogWriter
+from nvflare.fuel.f3.drivers.file_driver import _ConnConfig, _LogReader, _LogWriter, parse_file_url
 from nvflare.fuel.f3.endpoint import Endpoint, EndpointMonitor, EndpointState
 from nvflare.fuel.f3.message import Message, MessageReceiver
 
@@ -78,6 +78,36 @@ def _wait_until(condition, timeout=15.0) -> bool:
 def _frame(payload: bytes) -> bytes:
     length = 16 + len(payload)
     return struct.pack(">I", length) + bytes(12) + payload
+
+
+class TestParseFileUrl:
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("file://0/lustre/proj/cellnet", "/lustre/proj/cellnet"),
+            ("file://0/lustre/proj/cellnet/", "/lustre/proj/cellnet"),
+            ("file://0/a/b?poll_interval=0.05&fsync=False", "/a/b"),
+            ("file://0/a#frag", "/a"),
+        ],
+    )
+    def test_valid_urls(self, url, expected):
+        assert parse_file_url(url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file://lustre/proj/cellnet",  # non-0 authority, path would be silently wrong
+            "file:///lustre/proj/cellnet",  # empty authority
+            "file://0",  # no path
+            "file://0/",  # root path
+            "file://localhost/a/b",
+            "tcp://host:1234",
+            "file:relative/path",
+        ],
+    )
+    def test_invalid_urls(self, url):
+        with pytest.raises(CommError):
+            parse_file_url(url)
 
 
 class TestLogRoundtrip:

--- a/tests/unit_test/tool/deploy/slurm_deploy_test.py
+++ b/tests/unit_test/tool/deploy/slurm_deploy_test.py
@@ -55,6 +55,46 @@ def _slurm_config(tmp_path, **launcher_overrides):
     }
 
 
+def test_prepare_slurm_preserves_file_transport_comm_config(tmp_path, capsys):
+    kit = _make_client_kit(tmp_path)
+    file_internal = {
+        "scheme": "file",
+        "resources": {
+            "root_dir": "/lustre/proj/cellnet",
+            "poll_interval": 0.05,
+            "lease_timeout": 30,
+        },
+    }
+    (kit / "local" / "comm_config.json").write_text(
+        json.dumps({"backbone": {"connect_generation": 1}, "internal": file_internal}), encoding="utf-8"
+    )
+    output = tmp_path / "site-1-slurm"
+
+    _run_prepare(kit, output, _slurm_config(tmp_path, internal_port=9210))
+    capsys.readouterr()
+
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    assert comm_config["backbone"] == {"connect_generation": 1}
+    resources = comm_config["internal"]["resources"]
+    assert comm_config["internal"]["scheme"] == "file"
+    assert resources["root_dir"] == "/lustre/proj/cellnet"
+    assert resources["connection_security"] == "clear"
+    assert "host" not in resources and "port" not in resources
+
+
+def test_prepare_slurm_rejects_relative_file_transport_root_dir(tmp_path, capsys):
+    kit = _make_client_kit(tmp_path)
+    (kit / "local" / "comm_config.json").write_text(
+        json.dumps({"internal": {"scheme": "file", "resources": {"root_dir": "relative/cellnet"}}}),
+        encoding="utf-8",
+    )
+    output = tmp_path / "site-1-slurm"
+
+    with pytest.raises(SystemExit):
+        _run_prepare(kit, output, _slurm_config(tmp_path))
+    assert "absolute internal.resources.root_dir" in capsys.readouterr().err
+
+
 def test_render_template_is_one_pass(tmp_path, monkeypatch):
     template = tmp_path / "test.sh"
     template.write_text("@@NVFLARE_FIRST@@\n@@NVFLARE_SECOND@@\n", encoding="utf-8")

--- a/tests/unit_test/tool/deploy/slurm_deploy_test.py
+++ b/tests/unit_test/tool/deploy/slurm_deploy_test.py
@@ -58,7 +58,7 @@ def _slurm_config(tmp_path, **launcher_overrides):
 def test_prepare_slurm_preserves_file_transport_comm_config(tmp_path, capsys):
     kit = _make_client_kit(tmp_path)
     file_internal = {
-        "scheme": "file",
+        "scheme": "shared-file",
         "resources": {
             "root_dir": "/lustre/proj/cellnet",
             "poll_interval": 0.05,
@@ -76,7 +76,7 @@ def test_prepare_slurm_preserves_file_transport_comm_config(tmp_path, capsys):
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["backbone"] == {"connect_generation": 1}
     resources = comm_config["internal"]["resources"]
-    assert comm_config["internal"]["scheme"] == "file"
+    assert comm_config["internal"]["scheme"] == "shared-file"
     assert resources["root_dir"] == "/lustre/proj/cellnet"
     assert resources["connection_security"] == "clear"
     assert "host" not in resources and "port" not in resources
@@ -85,7 +85,7 @@ def test_prepare_slurm_preserves_file_transport_comm_config(tmp_path, capsys):
 def test_prepare_slurm_rejects_relative_file_transport_root_dir(tmp_path, capsys):
     kit = _make_client_kit(tmp_path)
     (kit / "local" / "comm_config.json").write_text(
-        json.dumps({"internal": {"scheme": "file", "resources": {"root_dir": "relative/cellnet"}}}),
+        json.dumps({"internal": {"scheme": "shared-file", "resources": {"root_dir": "relative/cellnet"}}}),
         encoding="utf-8",
     )
     output = tmp_path / "site-1-slurm"


### PR DESCRIPTION
## Summary

- Adds a new `file` scheme transport driver (`nvflare/fuel/f3/drivers/file_driver.py`) that exchanges SFM frames through a shared filesystem such as Lustre, for deployments where two cells share storage but have no network path between them (e.g. an HPC compute node running the client job cell and a gateway node running the client parent).
- Each connection is a directory with one append-only log per direction. The 16-byte SFM prefix provides framing; logs rotate at a size cap and are sealed with their final size so readers can distinguish a complete log from appends that are not yet visible. Consumed logs are deleted to bound disk usage.
- Liveness uses lease files judged by observed mtime changes (immune to cross-node clock skew) plus adaptive polling with backoff. SFM heartbeats ride the log, so existing PING/PONG and stall detection work unchanged. The closed marker is written only after all data, and readers drain pending frames on orderly close.
- Robustness: torn appends and rotation failures close the connection for a clean reconnect; garbage collection is gated on a driver ownership marker (never touches unrelated directories) and timed with local monotonic clocks; the active side removes its own connection dir when a listener is dead; reads are chunked with single-copy frame extraction.
- Security: no transport encryption; directory permissions are the trust boundary. Directories are created 0o770 and files 0o660 regardless of umask, overridable via `dir_mode`/`file_mode` resources. The driver reports `SUPPORT_SSL: False` so secure-required connectors are rejected.
- `parse_file_url` is exported as the single source of truth for the `file://0/<absolute-dir>` URL form; malformed URLs (non-'0' authority, relative paths, reserved characters in paths) are rejected.
- Slurm integration: the Slurm launcher preserves valid file parent URLs (query parameters intact) and keeps tcp rewriting unchanged; pyxis and apptainer launch plans bind-mount the listener directory read-write at the same absolute path, rejecting overlap with study mounts; `deploy prepare` preserves an existing `internal.scheme: file` comm config (validating absolute `root_dir` and clear connection security) instead of overwriting it with tcp; the Docker launcher passes file URLs through unchanged.
- Configuration: `internal: {scheme: "file", resources: {root_dir: ...}}` plus `backbone: {connect_generation: 1}` in the client comm_config routes job-cell traffic through the client parent. Tuning resources propagate to the child cell via the connect URL query; a cell can override them locally (except `max_log_size`) through a `file` section in its own comm_config.

Validated end-to-end on real Lustre with Slurm (bare and Pyxis) workers communicating with their client parent, aggregating with a cloud server. Local cross-process benchmark: large-payload throughput on par with tcp/grpc (~1.7 GB/s at 100MB payloads); small-message round-trip is poll-bound (~2 poll intervals). An idle connection costs roughly 1.4 client-side metadata syscalls/sec at defaults (max_poll_interval=2s), shrinking proportionally as max_poll_interval grows; the Docker launcher bind-mounts the listener directory into job containers.
