### PR TITLE
[Auto-FL] Remove synthetic data injection

### DIFF
--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -347,9 +347,6 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--python", default=os.environ.get("PYTHON") or sys.executable)
-    parser.add_argument("--prefer-synthetic", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--synthetic-train-size", type=int, default=2048)
-    parser.add_argument("--synthetic-test-size", type=int, default=256)
     parser.add_argument("--name", help="candidate name for prepare")
     parser.add_argument("--hypothesis", help="candidate hypothesis for prepare")
     parser.add_argument("--family", help="algorithm family slug for prepare or record --literature")
@@ -1804,13 +1801,6 @@ def build_base_args(args: argparse.Namespace, help_text: str, schema: Dict[str, 
     budget_args = build_comparison_budget_args(schema, help_text)
     if budget_args:
         base.extend(budget_args)
-    if args.prefer_synthetic and supports_flag(help_text, "--synthetic_data"):
-        if "--synthetic_data" not in base:
-            base.append("--synthetic_data")
-        if supports_flag(help_text, "--train_size") and "--train_size" not in base:
-            base.extend(["--train_size", str(args.synthetic_train_size)])
-        if supports_flag(help_text, "--test_size") and "--test_size" not in base:
-            base.extend(["--test_size", str(args.synthetic_test_size)])
     return base
 
 
@@ -2717,9 +2707,6 @@ CAMPAIGN_SETTING_NAMES = (
     "timeout",
     "simulator_no_progress_timeout",
     "python",
-    "prefer_synthetic",
-    "synthetic_train_size",
-    "synthetic_test_size",
 )
 
 MUTABLE_CAMPAIGN_SETTING_NAMES = {

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2736,6 +2736,15 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
     settings = metadata.get("settings")
     if not isinstance(settings, dict):
         raise ValueError("campaign metadata is missing settings")
+    if settings.get("prefer_synthetic"):
+        # Pre-removal campaigns scored their baseline and prior candidates on injected
+        # synthetic data; new runs use real data, so ledger comparisons cross a data regime.
+        print(
+            "Warning: prior scores in this campaign were computed on synthetic data "
+            "(legacy prefer_synthetic setting); new runs use the job's real data, so ledger "
+            "comparisons mix data regimes. Consider re-initializing the campaign.",
+            file=sys.stderr,
+        )
     explicit = getattr(args, "_explicit_settings", set())
     changed = False
     for name in CAMPAIGN_SETTING_NAMES:

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -80,7 +80,7 @@ def _initialize_fake_campaign(runner, tmp_path, monkeypatch, *, target_env="sim"
         )
 
     monkeypatch.setattr(runner, "run_job", fake_run)
-    argv = ["initialize", str(job), "--env", target_env, "--no-prefer-synthetic"]
+    argv = ["initialize", str(job), "--env", target_env]
     if mode is not None:
         argv.extend(["--mode", mode])
     assert runner.main(argv) == 0
@@ -195,7 +195,7 @@ def test_initialize_merges_existing_mutation_schema_preferred_targets_into_autof
         ),
     )
 
-    assert runner.main(["initialize", str(job), "--no-prefer-synthetic"]) == 0
+    assert runner.main(["initialize", str(job)]) == 0
 
     config = runner.read_yaml(tmp_path / "autofl.yaml")
     assert "custom_aggregators.py" in config["trust_contract"]["allowed_edit_paths"]
@@ -412,8 +412,44 @@ def test_comparison_budget_suppresses_duplicate_imported_fixed_budget_args():
 
     assert runner.build_fixed_args(config, help_text, schema) == []
 
-    args = SimpleNamespace(base_args="", prefer_synthetic=False, synthetic_train_size=1, synthetic_test_size=1)
+    args = SimpleNamespace(base_args="")
     assert runner.build_base_args(args, help_text, schema) == ["--n_clients", "8", "--num_rounds", "20"]
+
+
+def test_build_base_args_never_injects_dataset_flags_for_synthetic_capable_jobs():
+    runner = _load_runner()
+    help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
+
+    assert runner.build_base_args(SimpleNamespace(base_args=""), help_text, {}) == []
+
+    schema = {"comparison_budget_args": {"default_candidate_budget": {"num_rounds": 5}}}
+    help_text_with_budget = f"{help_text} [--num_rounds NUM_ROUNDS]"
+    assert runner.build_base_args(SimpleNamespace(base_args=""), help_text_with_budget, schema) == [
+        "--num_rounds",
+        "5",
+    ]
+
+
+def test_explicit_base_args_pass_through_verbatim():
+    runner = _load_runner()
+    help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
+
+    args = SimpleNamespace(base_args="--synthetic_data --train_size 64")
+    assert runner.build_base_args(args, help_text, {}) == ["--synthetic_data", "--train_size", "64"]
+
+
+def test_restore_campaign_settings_ignores_legacy_synthetic_settings(tmp_path):
+    runner = _load_runner()
+    args = runner.parse_args(["status", "job.py"])
+    settings = runner.campaign_settings(args)
+    settings.update({"prefer_synthetic": True, "synthetic_train_size": 2048, "synthetic_test_size": 256})
+    metadata = {"settings": settings, "workspace_root": str(tmp_path)}
+
+    assert runner.restore_campaign_settings(args, metadata) is False
+
+    assert not hasattr(args, "prefer_synthetic")
+    help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
+    assert runner.build_base_args(args, help_text, {}) == []
 
 
 @pytest.mark.parametrize(
@@ -1668,7 +1704,7 @@ def test_initialize_socket_failure_returns_75_without_counting_candidate(tmp_pat
         ),
     )
 
-    assert runner.main(["initialize", str(job), "--env", "sim", "--no-prefer-synthetic"]) == 75
+    assert runner.main(["initialize", str(job), "--env", "sim"]) == 75
 
     records = runner.load_results(tmp_path / "results.tsv")
     state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
@@ -2421,7 +2457,7 @@ def test_initialize_retries_an_unscored_baseline(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(runner, "run_job", fake_run)
-    command = ["initialize", str(job), "--no-prefer-synthetic"]
+    command = ["initialize", str(job)]
     assert runner.main(command) == 1
     assert runner.main(command) == 0
     records = runner.load_results(tmp_path / "results.tsv")
@@ -2601,7 +2637,7 @@ def test_omitted_metric_uses_imported_job_metric(tmp_path, monkeypatch):
 
     monkeypatch.setattr(runner, "run_job", fake_run)
 
-    assert runner.main(["initialize", str(job), "--no-prefer-synthetic"]) == 0
+    assert runner.main(["initialize", str(job)]) == 0
     metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
     assert metadata["settings"]["metric"] == "auc"
 
@@ -3019,7 +3055,6 @@ if __name__ == "__main__":
             str(job),
             "--metric",
             "accuracy",
-            "--no-prefer-synthetic",
         ],
         cwd=tmp_path,
         env=env,

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -438,7 +438,7 @@ def test_explicit_base_args_pass_through_verbatim():
     assert runner.build_base_args(args, help_text, {}) == ["--synthetic_data", "--train_size", "64"]
 
 
-def test_restore_campaign_settings_ignores_legacy_synthetic_settings(tmp_path):
+def test_restore_campaign_settings_ignores_legacy_synthetic_settings(tmp_path, capsys):
     runner = _load_runner()
     args = runner.parse_args(["status", "job.py"])
     settings = runner.campaign_settings(args)
@@ -450,6 +450,20 @@ def test_restore_campaign_settings_ignores_legacy_synthetic_settings(tmp_path):
     assert not hasattr(args, "prefer_synthetic")
     help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
     assert runner.build_base_args(args, help_text, {}) == []
+    # The prior baseline/candidates were scored on injected synthetic data; new runs use
+    # real data, so the ledger crosses a data regime — warn instead of staying silent.
+    stderr = capsys.readouterr().err
+    assert "computed on synthetic data" in stderr
+    assert "re-initializing" in stderr
+
+
+def test_restore_campaign_settings_does_not_warn_without_legacy_synthetic_setting(tmp_path, capsys):
+    runner = _load_runner()
+    args = runner.parse_args(["status", "job.py"])
+    metadata = {"settings": runner.campaign_settings(args), "workspace_root": str(tmp_path)}
+
+    assert runner.restore_campaign_settings(args, metadata) is False
+    assert "synthetic" not in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Remove Auto-FL synthetic data injection

## Problem (QA finding)

A QA evaluation of the Auto-FL campaign runner found that it **silently replaced real data with synthetic data in 10/10 trials**. The failure was deterministic, not flaky:

- `run_job_campaign.py` defined `--prefer-synthetic` (`BooleanOptionalAction`) with **default `True`**, plus `--synthetic-train-size` (2048) and `--synthetic-test-size` (256).
- `build_base_args` then injected `--synthetic_data --train_size N --test_size N` into the baseline and **every candidate run** whenever the imported job's `--help` output advertised those flags.

Any job that supports a synthetic smoke mode was therefore optimized against fabricated data unless the operator knew to pass `--no-prefer-synthetic`. Campaign scores and keep/discard decisions could be entirely disconnected from the user's real dataset, with no error and no visible warning.

## Why removal instead of flipping the default

Flipping the default to `False` would keep the injection code path alive: one flag (or one persisted legacy setting) away from silently rewriting dataset arguments again. Removing the option makes this failure class **structurally impossible** — the runner no longer contains any code that touches dataset flags. `build_base_args` is now exactly: shlex-split `--base-args` + comparison-budget args from the job's mutation schema.

## Explicit path for synthetic smoke runs

Users who genuinely want a synthetic run still have a first-class, *explicit* mechanism — the existing generic `--base-args` flag (\"extra job args applied to baseline and all candidates\"):

```
python run_job_campaign.py initialize ./job.py --base-args \"--synthetic_data --train_size 64\"
```

A new test verifies these args pass through verbatim.

## Legacy-campaign compatibility

Existing campaigns whose `campaign.json` settings still contain `prefer_synthetic` / `synthetic_train_size` / `synthetic_test_size` keep working: `restore_campaign_settings` iterates only the current `CAMPAIGN_SETTING_NAMES`, so unknown persisted keys are ignored silently. A dedicated test proves a legacy metadata dict with `prefer_synthetic: true` restores without error and injects nothing.

## Changes

- `skills/nvflare-autofl/scripts/run_job_campaign.py`
  - Delete `--prefer-synthetic`, `--synthetic-train-size`, `--synthetic-test-size` parser args.
  - Delete the synthetic injection block in `build_base_args`.
  - Drop the three synthetic keys from `CAMPAIGN_SETTING_NAMES`.
- `tests/unit_test/tool/autofl_skill_runner_test.py`
  - Remove the 7 stale `--no-prefer-synthetic` / `SimpleNamespace(prefer_synthetic=...)` references.
  - Add: no-injection-by-default test for synthetic-capable jobs, verbatim `--base-args` pass-through test, legacy-settings compatibility test.
- Docs: no changes needed — `SKILL.md` (still 200 lines) never mentioned the flag, and `references/experiment-comparability.md`'s synthetic section covers user-specified data generation, not the runner option. The runner diff is pure deletion.

## Testing

```
python3.12 -m pytest tests/unit_test/tool/autofl_skill_runner_test.py \
  tests/unit_test/tool/autofl_skill_campaign_guard_test.py \
  tests/unit_test/tool/autofl_skill_plot_progress_test.py \
  tests/unit_test/tool/autofl_skill_job_importer_test.py \
  tests/unit_test/tool/agent_skill_checks -q
# 360 passed
```

black (-l 120), isort (black profile), and flake8 clean on changed files.