### PR TITLE
[Auto-FL] Restrict campaigns to score maximization

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -40,11 +40,12 @@ Resolve [run_job_campaign.py](scripts/run_job_campaign.py) relative to this `SKI
 `RUNNER`, and initialize the campaign:
 
 ```bash
-python "$RUNNER" initialize ./job.py [--metric <metric>] --mode <max|min> --env <sim|poc|prod> [--max-candidates <n>]
+python "$RUNNER" initialize ./job.py [--metric <metric>] --env <sim|poc|prod> [--max-candidates <n>]
 ```
 
-For conditional recipes, safe refusals, and unnamed simulator roots, read the [job import
-contract](references/job-import-contract.md).
+Campaigns always maximize the optimization metric — matching NVFLARE best-model selection — so loss-like objectives
+must be reported by the job as negated metrics (for example `neg_val_loss`) where higher is better. For conditional
+recipes, safe refusals, and unnamed simulator roots, read the [job import contract](references/job-import-contract.md).
 
 Read `autofl.yaml` and the JSON response, then prepare an agent-authored candidate with a short hypothesis and
 optional candidate-only arguments:
@@ -178,8 +179,7 @@ Treat plateau as a decision checkpoint, not an automatic stop: summarize it in t
 `progress.png`, run the runner's `status` action to refresh `.nvflare/autofl/campaign_state.json`, choose the returned
 next mode, and continue unless the state reports `final_response_allowed=true`. Use `campaign_guard.py` only for
 read-only ledger diagnostics; it never updates authoritative campaign state. After a source-backed review, record it
-with `record --literature
---hypothesis "<sources and decision>"`. Each review gets a persistent
+with `record --literature --hypothesis "<sources and decision>"`. Each review gets a persistent
 `literature_event_id` and requires an exploration batch before normal flow resumes: `exploration_batch_size` (default
 3) scored source-backed candidates linked via `prepare --literature-event <id>` — a faithful implementation, a tuned
 variant, and an ablation. The plateau clock resets when that batch completes, not when the review is recorded;

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -27,7 +27,7 @@ Do not use for converting non-FL training code into NVFLARE, diagnosing failed j
 | --- | --- | --- |
 | `scripts/run_job_campaign.py` | Authoritative campaign lifecycle runner | `ACTION JOB` plus action-specific flags |
 | `scripts/campaign_guard.py` | Read-only ledger diagnostics | `[RESULTS]` and diagnostic thresholds |
-| `scripts/plot_progress.py` | Render campaign progress | `[RESULTS]`, `--output`, `--mode`, `--metric` |
+| `scripts/plot_progress.py` | Render campaign progress | `[RESULTS]`, `--output`, `--metric` |
 | `scripts/job_importer.py` | Import library used by the campaign runner | Not a standalone CLI |
 
 ## Workflow

--- a/skills/nvflare-autofl/references/bounded-campaign-example.md
+++ b/skills/nvflare-autofl/references/bounded-campaign-example.md
@@ -4,7 +4,7 @@ When the user asks for a bounded number of approaches, for example "try two appr
 `--max-candidates 2`; the baseline run does not count toward the cap:
 
 ```bash
-python "$RUNNER" initialize ./job.py --metric accuracy --mode max --env sim --max-candidates 2
+python "$RUNNER" initialize ./job.py --metric accuracy --env sim --max-candidates 2
 python "$RUNNER" prepare ./job.py --name <candidate-1> --hypothesis "<expected improvement>"
 python "$RUNNER" evaluate ./job.py --manifest <candidate_manifest.json>
 python "$RUNNER" prepare ./job.py --name <candidate-2> --hypothesis "<expected improvement>"

--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -16,9 +16,9 @@ tunable sweep is a checkpoint only. Execute `next_action` while
 Budget and baseline accounting is explicit in the state payload:
 `remaining_candidates` is `candidate_cap - candidate_attempts` (null when
 uncapped), `baseline_status` stays `pending` until a scored baseline ledger row
-exists, `baseline_score` and `improvement` (sign-adjusted so a positive value
-always means better for the campaign `--mode`) report baseline-versus-best
-progress, and `abandoned_candidates` counts abandoned candidate manifests,
+exists, `baseline_score` and `improvement` (best minus baseline; campaigns
+always maximize the metric, so positive always means better) report
+baseline-versus-best progress, and `abandoned_candidates` counts abandoned candidate manifests,
 which never count as candidate attempts. Changing the effective candidate cap
 between invocations appends `{changed_at, old, new, source}` to `cap_changes`
 in `.nvflare/autofl/campaign.json` so budget changes stay auditable. External

--- a/skills/nvflare-autofl/scripts/campaign_guard.py
+++ b/skills/nvflare-autofl/scripts/campaign_guard.py
@@ -51,13 +51,6 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def parse_mode_arg(value: str) -> str:
-    """Argparse type for legacy ``--mode`` flags: only score maximization is supported."""
-    if value != "max":
-        raise argparse.ArgumentTypeError(MODE_MAX_ONLY_MESSAGE)
-    return value
-
-
 def parse_score(value: Any) -> Optional[float]:
     if isinstance(value, bool):
         return None
@@ -504,12 +497,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--hard-crash-threshold", type=int, default=DEFAULT_HARD_CRASH_THRESHOLD)
     parser.add_argument("--exploration-batch-size", type=int, default=DEFAULT_EXPLORATION_BATCH_SIZE)
     parser.add_argument("--family-repeat-limit", type=int, default=DEFAULT_FAMILY_REPEAT_LIMIT)
-    parser.add_argument(
-        "--mode",
-        type=parse_mode_arg,
-        default="max",
-        help="objective direction; only 'max' is supported (report negated metrics to minimize a loss)",
-    )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
 

--- a/skills/nvflare-autofl/scripts/campaign_guard.py
+++ b/skills/nvflare-autofl/scripts/campaign_guard.py
@@ -36,6 +36,12 @@ DEFAULT_PLATEAU_THRESHOLD = 8
 DEFAULT_EXPLORATION_BATCH_SIZE = 3
 DEFAULT_FAMILY_REPEAT_LIMIT = 6
 DEFAULT_STOP_FILES = ("STOP_AUTOFL", ".nvflare/autofl/STOP")
+MODE_MAX_ONLY_MESSAGE = (
+    "Auto-FL campaigns only support mode 'max'; minimization is not supported because NVFLARE "
+    "best-model selection treats higher key_metric values as better. Report a negated metric "
+    "from the job (for example neg_val_loss) so that higher is better, matching the "
+    "IntimeModelSelector negate_key_metric guidance."
+)
 ATTEMPT_STATUSES = {"candidate", "keep", "discard", "crash"}
 SCORED_ATTEMPT_STATUSES = {"keep", "discard"}
 LITERATURE_EVENT_STATUSES = {"event", "literature", "checkpoint"}
@@ -43,6 +49,13 @@ LITERATURE_EVENT_STATUSES = {"event", "literature", "checkpoint"}
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_mode_arg(value: str) -> str:
+    """Argparse type for legacy ``--mode`` flags: only score maximization is supported."""
+    if value != "max":
+        raise argparse.ArgumentTypeError(MODE_MAX_ONLY_MESSAGE)
+    return value
 
 
 def parse_score(value: Any) -> Optional[float]:
@@ -178,22 +191,20 @@ def family_repeat_stalled(rows: List[Dict[str, str]], limit: int) -> bool:
     return all(candidate_kind(row) == "argument_only" for row in recent)
 
 
-def better(new_score: Optional[float], old_score: Optional[float], mode: str, min_delta: float = 0.0) -> bool:
+def better(new_score: Optional[float], old_score: Optional[float], min_delta: float = 0.0) -> bool:
     new_score = parse_score(new_score)
     old_score = parse_score(old_score)
     if new_score is None:
         return False
     if old_score is None:
         return True
-    if mode == "min":
-        return new_score < old_score - min_delta
     return new_score > old_score + min_delta
 
 
-def best_score(rows: List[Dict[str, str]], mode: str) -> Optional[float]:
+def best_score(rows: List[Dict[str, str]]) -> Optional[float]:
     best = None
     for _, _, score in scored_rows_with_index(rows, is_retained):
-        if better(score, best, mode):
+        if better(score, best):
             best = score
     return best
 
@@ -208,18 +219,17 @@ def scored_baseline_score(rows: List[Dict[str, str]]) -> Optional[float]:
     return None
 
 
-def improvement_over_baseline(baseline: Optional[float], best: Optional[float], mode: str) -> Optional[float]:
-    """Best-vs-baseline delta, sign-adjusted so a positive value always means better for the campaign mode."""
+def improvement_over_baseline(baseline: Optional[float], best: Optional[float]) -> Optional[float]:
+    """Best-minus-baseline delta; campaigns always maximize, so a positive value always means better."""
     if baseline is None or best is None:
         return None
-    return baseline - best if mode == "min" else best - baseline
+    return best - baseline
 
 
 def plateau_status(
     rows: List[Dict[str, str]],
     threshold: int,
     min_delta: float,
-    mode: str,
     exploration_batch_size: int = DEFAULT_EXPLORATION_BATCH_SIZE,
 ) -> Dict[str, Any]:
     retained = scored_rows_with_index(rows, is_retained)
@@ -238,7 +248,7 @@ def plateau_status(
     best_scored_idx = -1
     best_name = ""
     for scored_idx, (row_idx, row, score) in enumerate(retained):
-        if better(score, best, mode, min_delta):
+        if better(score, best, min_delta):
             best = score
             best_row_idx = row_idx
             best_scored_idx = scored_idx
@@ -308,7 +318,6 @@ def guard_state_for_rows(
     plateau_threshold: int = DEFAULT_PLATEAU_THRESHOLD,
     min_delta: float = DEFAULT_MIN_DELTA,
     hard_crash_threshold: int = DEFAULT_HARD_CRASH_THRESHOLD,
-    mode: str = "max",
     pending_manifest_count: int = 0,
     exploration_batch_size: int = DEFAULT_EXPLORATION_BATCH_SIZE,
     family_repeat_limit: int = DEFAULT_FAMILY_REPEAT_LIMIT,
@@ -326,7 +335,7 @@ def guard_state_for_rows(
     stop_file_hits = existing_stop_files(stop_files or list(DEFAULT_STOP_FILES))
     batches = exploration_batches(rows, exploration_batch_size)
     active_batch = next((batch for batch in batches if batch["completion_index"] is None), None)
-    plateau = plateau_status(rows, plateau_threshold, min_delta, mode, exploration_batch_size)
+    plateau = plateau_status(rows, plateau_threshold, min_delta, exploration_batch_size)
 
     decision = "continue"
     reason = "continue"
@@ -403,7 +412,7 @@ def guard_state_for_rows(
     else:
         instruction = "Do not produce a final answer. Propose and prepare the next same-budget candidate now."
 
-    retained_best = best_score(rows, mode)
+    retained_best = best_score(rows)
     baseline = scored_baseline_score(rows)
     return {
         "schema_version": "nvflare.autofl.campaign_state.v1",
@@ -422,7 +431,7 @@ def guard_state_for_rows(
         "best_score": retained_best,
         "baseline_status": "complete" if baseline is not None else "pending",
         "baseline_score": baseline,
-        "improvement": improvement_over_baseline(baseline, retained_best, mode),
+        "improvement": improvement_over_baseline(baseline, retained_best),
         "stop_files": stop_file_hits,
         "plateau": plateau,
         "exploration_batch": active_batch or (batches[-1] if batches else None),
@@ -441,7 +450,6 @@ def guard_state(
     plateau_threshold: int = DEFAULT_PLATEAU_THRESHOLD,
     min_delta: float = DEFAULT_MIN_DELTA,
     hard_crash_threshold: int = DEFAULT_HARD_CRASH_THRESHOLD,
-    mode: str = "max",
     pending_manifest_count: int = 0,
     exploration_batch_size: int = DEFAULT_EXPLORATION_BATCH_SIZE,
     family_repeat_limit: int = DEFAULT_FAMILY_REPEAT_LIMIT,
@@ -454,7 +462,6 @@ def guard_state(
         plateau_threshold=plateau_threshold,
         min_delta=min_delta,
         hard_crash_threshold=hard_crash_threshold,
-        mode=mode,
         pending_manifest_count=pending_manifest_count,
         exploration_batch_size=exploration_batch_size,
         family_repeat_limit=family_repeat_limit,
@@ -497,7 +504,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--hard-crash-threshold", type=int, default=DEFAULT_HARD_CRASH_THRESHOLD)
     parser.add_argument("--exploration-batch-size", type=int, default=DEFAULT_EXPLORATION_BATCH_SIZE)
     parser.add_argument("--family-repeat-limit", type=int, default=DEFAULT_FAMILY_REPEAT_LIMIT)
-    parser.add_argument("--mode", choices=["max", "min"], default="max")
+    parser.add_argument(
+        "--mode",
+        type=parse_mode_arg,
+        default="max",
+        help="objective direction; only 'max' is supported (report negated metrics to minimize a loss)",
+    )
     parser.add_argument("--format", choices=["text", "json"], default="text")
     args = parser.parse_args(argv)
 
@@ -524,7 +536,6 @@ def main(argv: Optional[List[str]] = None) -> int:
         plateau_threshold=args.plateau_threshold,
         min_delta=args.min_delta,
         hard_crash_threshold=args.hard_crash_threshold,
-        mode=args.mode,
         exploration_batch_size=args.exploration_batch_size,
         family_repeat_limit=args.family_repeat_limit,
     )

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -34,6 +34,13 @@ import yaml
 AUTOFL_CONFIG_SCHEMA_VERSION = "nvflare.autofl.config.v1"
 IMPORTER_VERSION = "nvflare-autofl-job-importer/v1"
 ALLOWED_CREATE_PATTERNS = ["**/*.py"]
+# Keep this text aligned with campaign_guard.MODE_MAX_ONLY_MESSAGE; the importer stays standalone.
+MODE_MAX_ONLY_MESSAGE = (
+    "Auto-FL campaigns only support mode 'max'; minimization is not supported because NVFLARE "
+    "best-model selection treats higher key_metric values as better. Report a negated metric "
+    "from the job (for example neg_val_loss) so that higher is better, matching the "
+    "IntimeModelSelector negate_key_metric guidance."
+)
 
 SUPPORTED_ENV_NAMES = {"PocEnv", "ProdEnv", "SimEnv"}
 NON_OPTIMIZATION_RECIPE_NAMES = {"FedEvalRecipe", "FedStatsRecipe", "NumpyCrossSiteEvalRecipe"}
@@ -151,7 +158,8 @@ class DeterministicJobImporter:
         Args:
             job_path: Path to ``job.py`` or a directory containing ``job.py``.
             metric: Optional optimization metric requested by the user.
-            mode: ``max`` or ``min`` objective direction.
+            mode: Objective direction; only ``max`` is supported. Kept for command-shape
+                compatibility so callers report negated metrics instead of minimizing.
             target_env: Optional target environment, such as ``sim`` or ``prod``.
             max_candidates: Optional fixed candidate budget.
             job_args: Optional job CLI arguments used to resolve argparse defaults
@@ -161,8 +169,8 @@ class DeterministicJobImporter:
             A deterministic, YAML-serializable mapping.
         """
 
-        if mode not in {"max", "min"}:
-            raise JobImportError("mode must be 'max' or 'min'")
+        if mode != "max":
+            raise JobImportError(MODE_MAX_ONLY_MESSAGE)
 
         source_path = self._resolve_job_path(job_path)
         try:
@@ -197,7 +205,7 @@ class DeterministicJobImporter:
             unresolved.append(_unresolved("job.train_script", "no train_script was found or resolved"))
 
         metric_name, metric_source, metric_issue = self._resolve_metric(metric, job_call, parser_args)
-        objective = _objective_contract(metric_name, mode, metric_source)
+        objective = _objective_contract(metric_name, metric_source)
         if metric_issue:
             unresolved.append(metric_issue)
 
@@ -1232,13 +1240,14 @@ def _trust_extracted(
     return extracted
 
 
-def _objective_contract(metric_name: str, mode: str, source: str) -> Dict[str, Any]:
+def _objective_contract(metric_name: str, source: str) -> Dict[str, Any]:
     return {
         "metric": metric_name,
         "requested_metric": metric_name,
         "optimization_metric": metric_name,
         "metric_extraction_order": [metric_name],
-        "mode": mode,
+        # Constant for schema stability: campaigns always maximize the optimization metric.
+        "mode": "max",
         "metric_contract_source": source,
     }
 

--- a/skills/nvflare-autofl/scripts/plot_progress.py
+++ b/skills/nvflare-autofl/scripts/plot_progress.py
@@ -171,10 +171,6 @@ def better(value: float, incumbent: Optional[float]) -> bool:
     return load_campaign_guard().better(value, incumbent)
 
 
-def parse_mode_arg(value: str) -> str:
-    return load_campaign_guard().parse_mode_arg(value)
-
-
 def cumulative_best(values: Sequence[float]) -> List[float]:
     incumbent = None
     result = []
@@ -545,12 +541,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("path", nargs="?", default="results.tsv", help="path to the Auto-FL TSV ledger")
     parser.add_argument("--output", default="progress.png", help="output PNG path")
-    parser.add_argument(
-        "--mode",
-        type=parse_mode_arg,
-        default="max",
-        help="objective direction; only 'max' is supported (report negated metrics to minimize a loss)",
-    )
     parser.add_argument("--metric", default="score", help="metric label shown in the plot")
     parser.add_argument("--max-labels", type=int, default=6)
     parser.add_argument("--max-literature-labels", type=int, default=4)

--- a/skills/nvflare-autofl/scripts/plot_progress.py
+++ b/skills/nvflare-autofl/scripts/plot_progress.py
@@ -167,15 +167,19 @@ def normalize_records(records: Iterable[Any]) -> List[ProgressRecord]:
     return normalized
 
 
-def better(value: float, incumbent: Optional[float], mode: str) -> bool:
-    return load_campaign_guard().better(value, incumbent, mode)
+def better(value: float, incumbent: Optional[float]) -> bool:
+    return load_campaign_guard().better(value, incumbent)
 
 
-def cumulative_best(values: Sequence[float], mode: str) -> List[float]:
+def parse_mode_arg(value: str) -> str:
+    return load_campaign_guard().parse_mode_arg(value)
+
+
+def cumulative_best(values: Sequence[float]) -> List[float]:
     incumbent = None
     result = []
     for value in values:
-        if better(value, incumbent, mode):
+        if better(value, incumbent):
             incumbent = value
         result.append(incumbent)
     return result
@@ -196,45 +200,31 @@ def percentile(values: Sequence[float], fraction: float) -> float:
     return ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * weight
 
 
-def default_y_limits(
-    scores: Sequence[float], baseline: float, mode: str, full_y_range: bool = False
-) -> Tuple[float, float]:
+def default_y_limits(scores: Sequence[float], baseline: float, full_y_range: bool = False) -> Tuple[float, float]:
     score_min = min(scores)
     score_max = max(scores)
     if full_y_range:
         span = max(score_max - score_min, 0.01)
         return score_min - max(0.01, span * 0.08), score_max + max(0.01, span * 0.16)
 
-    if mode == "max":
-        useful_min = min(baseline, percentile(scores, 0.20))
-        useful_span = max(score_max - useful_min, 0.01)
-        lower = useful_min - max(0.01, useful_span * 0.20)
-        upper = score_max + max(0.015, useful_span * 0.35)
-        if score_min >= lower:
-            full_span = max(score_max - score_min, 0.01)
-            lower = score_min - max(0.01, full_span * 0.08)
-        return lower, upper
-
-    useful_max = max(baseline, percentile(scores, 0.80))
-    useful_span = max(useful_max - score_min, 0.01)
-    lower = score_min - max(0.015, useful_span * 0.35)
-    upper = useful_max + max(0.01, useful_span * 0.20)
-    if score_max <= upper:
+    useful_min = min(baseline, percentile(scores, 0.20))
+    useful_span = max(score_max - useful_min, 0.01)
+    lower = useful_min - max(0.01, useful_span * 0.20)
+    upper = score_max + max(0.015, useful_span * 0.35)
+    if score_min >= lower:
         full_span = max(score_max - score_min, 0.01)
-        upper = score_max + max(0.01, full_span * 0.08)
+        lower = score_min - max(0.01, full_span * 0.08)
     return lower, upper
 
 
-def select_observed_milestones(
-    valid: Sequence[ProgressRecord], mode: str, max_labels: int
-) -> List[Tuple[float, ProgressRecord]]:
+def select_observed_milestones(valid: Sequence[ProgressRecord], max_labels: int) -> List[Tuple[float, ProgressRecord]]:
     if max_labels <= 0:
         return []
     incumbent = None
     milestones = []
     final_running_best = None
     for record in valid:
-        if record.score is None or not better(record.score, incumbent, mode):
+        if record.score is None or not better(record.score, incumbent):
             continue
         delta = 0.0 if incumbent is None else abs(record.score - incumbent)
         final_running_best = (delta, record)
@@ -295,7 +285,6 @@ def label_placement(
 def plot_progress(
     records: Iterable[Any],
     output: Path,
-    mode: str,
     metric_label: str,
     max_labels: int = 6,
     max_literature_labels: int = 4,
@@ -319,7 +308,7 @@ def plot_progress(
     baseline = baseline_row.score
     best_row = valid[0]
     for record in valid[1:]:
-        if better(record.score, best_row.score, mode):
+        if better(record.score, best_row.score):
             best_row = record
     best_score = best_row.score
 
@@ -381,7 +370,7 @@ def plot_progress(
     observed_scores = [record.score for record in valid]
     ax.step(
         [record.index for record in valid],
-        cumulative_best(observed_scores, mode),
+        cumulative_best(observed_scores),
         where="post",
         color="#27ae60",
         linewidth=2.2,
@@ -402,9 +391,8 @@ def plot_progress(
         if literature_runtime:
             runtime_title += f" ({format_runtime(literature_runtime)})"
 
-    direction = "higher" if mode == "max" else "lower"
     ax.set_xlabel("Experiment #", fontsize=12)
-    ax.set_ylabel(f"{metric_label} ({direction} is better)", fontsize=12)
+    ax.set_ylabel(f"{metric_label} (higher is better)", fontsize=12)
     ax.set_title(
         f"Auto-FL Progress ({metric_label}): {len(rows)} rows, {len(valid)} scored, "
         f"{sum(record.status == 'keep' for record in rows)} kept, "
@@ -423,7 +411,7 @@ def plot_progress(
     )
     ax.grid(True, alpha=0.2)
 
-    y_limits = default_y_limits(observed_scores, baseline, mode, full_y_range=full_y_range)
+    y_limits = default_y_limits(observed_scores, baseline, full_y_range=full_y_range)
     ax.set_ylim(*y_limits)
     ax.set_xlim(-0.5, max(len(rows) - 0.5, max(record.index for record in valid) + 0.5))
 
@@ -464,7 +452,7 @@ def plot_progress(
             )
             annotation.set_clip_on(True)
 
-    for label_number, (_, record) in enumerate(select_observed_milestones(valid, mode, max_labels)):
+    for label_number, (_, record) in enumerate(select_observed_milestones(valid, max_labels)):
         offset, horizontal_align, vertical_align = label_placement(label_number, record, ax.get_xlim(), ax.get_ylim())
         milestone_text = f"#{record.index} {record.score:.4f}: {record_label(record, 28)}"
         if record.literature_event_id:
@@ -557,7 +545,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("path", nargs="?", default="results.tsv", help="path to the Auto-FL TSV ledger")
     parser.add_argument("--output", default="progress.png", help="output PNG path")
-    parser.add_argument("--mode", choices=["max", "min"], default="max")
+    parser.add_argument(
+        "--mode",
+        type=parse_mode_arg,
+        default="max",
+        help="objective direction; only 'max' is supported (report negated metrics to minimize a loss)",
+    )
     parser.add_argument("--metric", default="score", help="metric label shown in the plot")
     parser.add_argument("--max-labels", type=int, default=6)
     parser.add_argument("--max-literature-labels", type=int, default=4)
@@ -568,7 +561,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     baseline, best = plot_progress(
         records,
         Path(args.output),
-        args.mode,
         args.metric,
         max_labels=args.max_labels,
         max_literature_labels=args.max_literature_labels,

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -1331,6 +1331,7 @@ def apply_metric_contract(
     schema_objective = (schema or {}).get("objective", {})
     if isinstance(schema_objective, dict):
         schema_mode = schema_objective.get("mode")
+        # Deliberate leniency: an explicit `mode: null` is tolerated and treated as max.
         if schema_mode is not None and schema_mode != "max":
             raise ValueError(
                 f"mutation_schema.yaml declares objective.mode={schema_mode!r}, which is not supported. "

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -272,7 +272,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     )
     parser.add_argument("job", help="NVFlare job.py to optimize")
     parser.add_argument("--metric", help="optimization metric; omit to use job.py key_metric")
-    parser.add_argument("--mode", choices=["max", "min"], default="max")
+    parser.add_argument(
+        "--mode",
+        type=guard.parse_mode_arg,
+        default="max",
+        help="objective direction; only 'max' is supported (report negated metrics to minimize a loss)",
+    )
     parser.add_argument("--env", dest="target_env", choices=["sim", "poc", "prod"], default="sim")
     cap_group = parser.add_mutually_exclusive_group()
     cap_group.add_argument(
@@ -1325,6 +1330,12 @@ def apply_metric_contract(
     objective = objective_contract(config, requested_metric)
     schema_objective = (schema or {}).get("objective", {})
     if isinstance(schema_objective, dict):
+        schema_mode = schema_objective.get("mode")
+        if schema_mode is not None and schema_mode != "max":
+            raise ValueError(
+                f"mutation_schema.yaml declares objective.mode={schema_mode!r}, which is not supported. "
+                f"{load_campaign_guard().MODE_MAX_ONLY_MESSAGE}"
+            )
         schema_requested = schema_objective.get("requested_metric") or schema_objective.get("metric")
         if not schema_requested or schema_requested == objective["requested_metric"]:
             for key in ("optimization_metric", "metric_extraction_order", "metric_source"):
@@ -2426,8 +2437,8 @@ def load_results(path: Path) -> List[RunRecord]:
     return records
 
 
-def better(new_score: Optional[float], old_score: Optional[float], mode: str) -> bool:
-    return load_campaign_guard().better(new_score, old_score, mode)
+def better(new_score: Optional[float], old_score: Optional[float]) -> bool:
+    return load_campaign_guard().better(new_score, old_score)
 
 
 def write_state(
@@ -2436,7 +2447,6 @@ def write_state(
     records: List[RunRecord],
     max_candidates: Optional[int],
     *,
-    mode: str = "max",
     stop_files: Optional[List[str]] = None,
     plateau_threshold: Optional[int] = None,
     plateau_min_delta: Optional[float] = None,
@@ -2462,7 +2472,6 @@ def write_state(
         plateau_threshold=plateau_threshold,
         min_delta=plateau_min_delta,
         hard_crash_threshold=hard_crash_threshold,
-        mode=mode,
         pending_manifest_count=pending_manifest_count,
         exploration_batch_size=exploration_batch_size,
         family_repeat_limit=family_repeat_limit,
@@ -2511,7 +2520,7 @@ def load_progress_plotter():
     return load_sibling_module("plot_progress.py", "nvflare_autofl_plot_progress")
 
 
-def write_progress_fallback(path: Path, records: List[RunRecord], mode: str, metric_label: str) -> None:
+def write_progress_fallback(path: Path, records: List[RunRecord], metric_label: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         from PIL import Image, ImageDraw, ImageFont
@@ -2551,7 +2560,7 @@ def write_progress_fallback(path: Path, records: List[RunRecord], mode: str, met
             color = (40, 160, 90) if record.status in {"baseline", "keep"} else (150, 150, 150)
             draw.ellipse((x - 5, y - 5, x + 5, y + 5), fill=color, outline="black")
             draw.text((x + 6, y - 14), f"{record.name}: {record.score:.3f}", fill=color, font=font)
-            if better(record.score, running_best, mode):
+            if better(record.score, running_best):
                 running_best = record.score
             if running_best == record.score:
                 if last_point:
@@ -2560,19 +2569,19 @@ def write_progress_fallback(path: Path, records: List[RunRecord], mode: str, met
     image.save(path)
 
 
-def write_progress(path: Path, records: List[RunRecord], mode: str, metric_label: str) -> None:
+def write_progress(path: Path, records: List[RunRecord], metric_label: str) -> None:
     plotter = load_progress_plotter()
     try:
-        plotter.plot_progress(records, path, mode, metric_label)
+        plotter.plot_progress(records, path, metric_label)
     except (plotter.NoScoredResultsError, plotter.PlotDependencyError):
-        write_progress_fallback(path, records, mode, metric_label)
+        write_progress_fallback(path, records, metric_label)
 
 
 def write_report(path: Path, config: Dict[str, Any], records: List[RunRecord], args: argparse.Namespace) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     best = None
     for record in records:
-        if record.status in {"baseline", "keep"} and better(record.score, best.score if best else None, args.mode):
+        if record.status in {"baseline", "keep"} and better(record.score, best.score if best else None):
             best = record
     candidate_budget = (
         str(args.max_candidates) if args.max_candidates is not None else "uncapped; runs until manual interruption"
@@ -2745,6 +2754,13 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
             "comparisons mix data regimes. Consider re-initializing the campaign.",
             file=sys.stderr,
         )
+    persisted_mode = settings.get("mode", "max")
+    if persisted_mode != "max":
+        raise ValueError(
+            f"campaign was initialized with mode={persisted_mode!r}, which is no longer supported. "
+            f"{load_campaign_guard().MODE_MAX_ONLY_MESSAGE} Re-initialize the campaign with a metric "
+            "whose higher values are better."
+        )
     explicit = getattr(args, "_explicit_settings", set())
     changed = False
     for name in CAMPAIGN_SETTING_NAMES:
@@ -2823,7 +2839,6 @@ def import_job_config(
         str(job),
         workspace_root=str(job.parent),
         metric=args.metric,
-        mode=args.mode,
         target_env=args.target_env,
         max_candidates=args.max_candidates,
         job_args=shlex.split(args.base_args),
@@ -2869,10 +2884,10 @@ def campaign_admission_errors(config: Dict[str, Any]) -> List[str]:
     return errors
 
 
-def best_retained_record(records: Sequence[RunRecord], mode: str) -> Optional[RunRecord]:
+def best_retained_record(records: Sequence[RunRecord]) -> Optional[RunRecord]:
     best = None
     for record in records:
-        if record.status in {"baseline", "keep"} and better(record.score, best.score if best else None, mode):
+        if record.status in {"baseline", "keep"} and better(record.score, best.score if best else None):
             best = record
     return best
 
@@ -2897,7 +2912,6 @@ def refresh_campaign_artifacts(
         paths["results"],
         records,
         args.max_candidates,
-        mode=args.mode,
         stop_files=resolve_stop_files(paths["workspace"], args.stop_file),
         plateau_threshold=args.plateau_threshold,
         plateau_min_delta=args.plateau_min_delta,
@@ -2930,7 +2944,7 @@ def refresh_campaign_artifacts(
         }
     )
     write_json(paths["state"], state)
-    write_progress(paths["progress"], records, args.mode, optimization_metric(config, args.metric))
+    write_progress(paths["progress"], records, optimization_metric(config, args.metric))
     write_report(paths["report"], config, records, args)
     return state
 
@@ -3118,7 +3132,6 @@ def refresh_campaign_state(
         paths["results"],
         records,
         args.max_candidates,
-        mode=args.mode,
         stop_files=resolve_stop_files(job.parent, args.stop_file),
         plateau_threshold=args.plateau_threshold,
         plateau_min_delta=args.plateau_min_delta,
@@ -3193,7 +3206,8 @@ def prepare_candidate(args: argparse.Namespace, job: Path) -> int:
         "base_candidate": metadata.get("best_candidate"),
         "base_source_sha256": source_hash(best_files),
         "fixed_budget_sha256": metadata.get("fixed_budget_sha256"),
-        "objective": {"metric": args.metric, "mode": args.mode},
+        # mode is a constant for schema stability: campaigns always maximize the metric.
+        "objective": {"metric": args.metric, "mode": "max"},
         "environment": args.target_env,
         "run_args": shlex.split(args.run_args),
         "changed_files": [],
@@ -3314,10 +3328,10 @@ def finalize_candidate_result(
     previous_snapshot = None
     try:
         records = load_results(paths["results"])
-        previous_best = best_retained_record(records, args.mode)
+        previous_best = best_retained_record(records)
         if record.status == "candidate":
             record.status = (
-                "keep" if better(record.score, previous_best.score if previous_best else None, args.mode) else "discard"
+                "keep" if better(record.score, previous_best.score if previous_best else None) else "discard"
             )
         patch_path = manifest_path.parent / "candidate.patch"
         rollback_files = capture_file_versions(

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2759,8 +2759,9 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
     if persisted_mode != "max":
         raise ValueError(
             f"campaign was initialized with mode={persisted_mode!r}, which is no longer supported. "
-            f"{load_campaign_guard().MODE_MAX_ONLY_MESSAGE} Re-initialize the campaign with a metric "
-            "whose higher values are better."
+            f"{load_campaign_guard().MODE_MAX_ONLY_MESSAGE} Delete the campaign's .nvflare/autofl "
+            "directory (or start in a fresh workspace) and initialize again with a metric whose "
+            "higher values are better."
         )
     explicit = getattr(args, "_explicit_settings", set())
     changed = False

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -272,12 +272,6 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     )
     parser.add_argument("job", help="NVFlare job.py to optimize")
     parser.add_argument("--metric", help="optimization metric; omit to use job.py key_metric")
-    parser.add_argument(
-        "--mode",
-        type=guard.parse_mode_arg,
-        default="max",
-        help="objective direction; only 'max' is supported (report negated metrics to minimize a loss)",
-    )
     parser.add_argument("--env", dest="target_env", choices=["sim", "poc", "prod"], default="sim")
     cap_group = parser.add_mutually_exclusive_group()
     cap_group.add_argument(
@@ -377,6 +371,9 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     if args.uncapped:
         args.max_candidates = None
         args._explicit_settings.add("max_candidates")
+    # No CLI surface: campaigns always maximize. The constant keeps the persisted
+    # settings/state schema stable and lets the legacy-campaign gate compare against it.
+    args.mode = "max"
     return args
 
 

--- a/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
+++ b/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
@@ -165,7 +165,7 @@ def test_guard_improvement_is_best_minus_baseline():
     assert guard.guard_state_for_rows(regressed)["improvement"] == pytest.approx(0.0)
 
 
-def test_guard_cli_rejects_minimization_mode(tmp_path, capsys):
+def test_guard_cli_has_no_mode_flag(tmp_path, capsys):
     guard = _load_guard()
     results = tmp_path / "results.tsv"
     _write_results(results, [_row("baseline", "baseline", "0.85")])
@@ -174,11 +174,9 @@ def test_guard_cli_rejects_minimization_mode(tmp_path, capsys):
         guard.main([str(results), "--mode", "min"])
 
     assert excinfo.value.code == 2
-    stderr = capsys.readouterr().err
-    assert "minimization is not supported" in stderr
-    assert "neg_val_loss" in stderr
+    assert "unrecognized arguments: --mode" in capsys.readouterr().err
 
-    assert guard.main([str(results), "--mode", "max"]) == 0
+    assert guard.main([str(results)]) == 0
 
 
 def test_guard_finalization_instruction_enumerates_report_artifacts():

--- a/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
+++ b/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
@@ -161,6 +161,7 @@ def test_guard_improvement_is_best_minus_baseline():
     regressed = [_row("baseline", "baseline", "0.9"), _row("discard", "lower_accuracy", "0.8")]
 
     assert guard.guard_state_for_rows(improved)["improvement"] == pytest.approx(0.05)
+    # Discarded candidates never lower the retained best, so improvement floors at 0 rather than going negative.
     assert guard.guard_state_for_rows(regressed)["improvement"] == pytest.approx(0.0)
 
 

--- a/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
+++ b/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
@@ -155,13 +155,29 @@ def test_guard_reports_baseline_status_transition_and_baseline_score():
     assert complete["improvement"] == pytest.approx(0.0)
 
 
-def test_guard_improvement_is_sign_adjusted_for_each_mode():
+def test_guard_improvement_is_best_minus_baseline():
     guard = _load_guard()
-    max_rows = [_row("baseline", "baseline", "0.85"), _row("keep", "higher_accuracy", "0.9")]
-    min_rows = [_row("baseline", "baseline", "1.0"), _row("keep", "lower_loss", "0.8")]
+    improved = [_row("baseline", "baseline", "0.85"), _row("keep", "higher_accuracy", "0.9")]
+    regressed = [_row("baseline", "baseline", "0.9"), _row("discard", "lower_accuracy", "0.8")]
 
-    assert guard.guard_state_for_rows(max_rows, mode="max")["improvement"] == pytest.approx(0.05)
-    assert guard.guard_state_for_rows(min_rows, mode="min")["improvement"] == pytest.approx(0.2)
+    assert guard.guard_state_for_rows(improved)["improvement"] == pytest.approx(0.05)
+    assert guard.guard_state_for_rows(regressed)["improvement"] == pytest.approx(0.0)
+
+
+def test_guard_cli_rejects_minimization_mode(tmp_path, capsys):
+    guard = _load_guard()
+    results = tmp_path / "results.tsv"
+    _write_results(results, [_row("baseline", "baseline", "0.85")])
+
+    with pytest.raises(SystemExit) as excinfo:
+        guard.main([str(results), "--mode", "min"])
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "minimization is not supported" in stderr
+    assert "neg_val_loss" in stderr
+
+    assert guard.main([str(results), "--mode", "max"]) == 0
 
 
 def test_guard_finalization_instruction_enumerates_report_artifacts():

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -147,6 +147,26 @@ def test_import_recipe_job_extracts_trust_contract_without_executing_code(tmp_pa
     assert config["unresolved"] == []
 
 
+def test_import_rejects_minimization_mode(tmp_path):
+    job_path = _write_recipe_job(tmp_path)
+
+    with pytest.raises(job_importer.JobImportError, match="minimization is not supported") as excinfo:
+        import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path), mode="min")
+
+    assert "neg_val_loss" in str(excinfo.value)
+
+
+def test_importer_mode_guidance_matches_campaign_guard():
+    repo_root = Path(__file__).parents[3]
+    guard_path = repo_root / "skills" / "nvflare-autofl" / "scripts" / "campaign_guard.py"
+    spec = importlib.util.spec_from_file_location("nvflare_autofl_skill_campaign_guard_for_importer", guard_path)
+    guard = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = guard
+    spec.loader.exec_module(guard)
+
+    assert job_importer.MODE_MAX_ONLY_MESSAGE == guard.MODE_MAX_ONLY_MESSAGE
+
+
 def test_import_is_repeatable_and_yaml_round_trips(tmp_path):
     job_path = _write_recipe_job(tmp_path)
     importer = DeterministicJobImporter(workspace_root=str(tmp_path))

--- a/tests/unit_test/tool/autofl_skill_plot_progress_test.py
+++ b/tests/unit_test/tool/autofl_skill_plot_progress_test.py
@@ -235,7 +235,7 @@ def test_progress_plot_distinguishes_candidate_kinds(tmp_path):
     assert output.stat().st_size > 20_000
 
 
-def test_plot_cli_rejects_minimization_mode(tmp_path, capsys):
+def test_plot_cli_has_no_mode_flag(tmp_path, capsys):
     plotter = _load_plotter()
     ledger = tmp_path / "results.tsv"
     ledger.write_text("status\tname\tscore\nbaseline\tbaseline\t0.5\n", encoding="utf-8")
@@ -244,6 +244,4 @@ def test_plot_cli_rejects_minimization_mode(tmp_path, capsys):
         plotter.main([str(ledger), "--output", str(tmp_path / "progress.png"), "--mode", "min"])
 
     assert excinfo.value.code == 2
-    stderr = capsys.readouterr().err
-    assert "minimization is not supported" in stderr
-    assert "neg_val_loss" in stderr
+    assert "unrecognized arguments: --mode" in capsys.readouterr().err

--- a/tests/unit_test/tool/autofl_skill_plot_progress_test.py
+++ b/tests/unit_test/tool/autofl_skill_plot_progress_test.py
@@ -45,46 +45,29 @@ def _record(plotter, index, score, status="discard", name=None, runtime=300.0, k
     )
 
 
-def test_robust_y_limits_focus_on_improvement_region_for_maximize():
+def test_robust_y_limits_focus_on_improvement_region():
     plotter = _load_plotter()
     scores = [0.50, 0.55, 0.687] + [0.70 + index * 0.002 for index in range(20)]
 
-    lower, upper = plotter.default_y_limits(scores, baseline=0.687, mode="max")
+    lower, upper = plotter.default_y_limits(scores, baseline=0.687)
 
     assert lower > 0.60
     assert lower < 0.687
     assert upper > max(scores)
 
 
-def test_robust_y_limits_focus_on_improvement_region_for_minimize():
+def test_milestone_selection_tracks_the_running_maximum():
     plotter = _load_plotter()
-    scores = [2.0, 1.8, 0.90] + [0.80 - index * 0.01 for index in range(20)]
-
-    lower, upper = plotter.default_y_limits(scores, baseline=0.90, mode="min")
-
-    assert lower < min(scores)
-    assert upper > 0.90
-    assert upper < 1.5
-
-
-@pytest.mark.parametrize(
-    "mode,scores,expected_best",
-    [
-        ("max", [0.5, 0.6, 0.55, 0.7, 0.69, 0.8], 0.8),
-        ("min", [0.8, 0.7, 0.75, 0.6, 0.62, 0.5], 0.5),
-    ],
-)
-def test_milestone_selection_supports_both_objective_directions(mode, scores, expected_best):
-    plotter = _load_plotter()
+    scores = [0.5, 0.6, 0.55, 0.7, 0.69, 0.8]
     records = [
         _record(plotter, index, score, status="baseline" if index == 0 else "keep")
         for index, score in enumerate(scores)
     ]
 
-    milestones = plotter.select_observed_milestones(records, mode=mode, max_labels=3)
+    milestones = plotter.select_observed_milestones(records, max_labels=3)
 
     assert len(milestones) <= 3
-    assert milestones[-1][1].score == expected_best
+    assert milestones[-1][1].score == 0.8
 
 
 def test_load_results_uses_productized_ledger_fields(tmp_path):
@@ -223,7 +206,7 @@ def test_rich_progress_plot_renders_png(tmp_path):
     records.insert(10, _record(plotter, 10, None, status="literature", name="literature_review_1", runtime=45.0))
     output = tmp_path / "progress.png"
 
-    baseline, best = plotter.plot_progress(records, output, mode="max", metric_label="test_accuracy")
+    baseline, best = plotter.plot_progress(records, output, metric_label="test_accuracy")
 
     assert baseline == pytest.approx(0.687)
     assert best == pytest.approx(0.73)
@@ -244,9 +227,23 @@ def test_progress_plot_distinguishes_candidate_kinds(tmp_path):
     ]
     output = tmp_path / "progress.png"
 
-    baseline, best = plotter.plot_progress(records, output, mode="max", metric_label="test_accuracy")
+    baseline, best = plotter.plot_progress(records, output, metric_label="test_accuracy")
 
     assert baseline == pytest.approx(0.687)
     assert best == pytest.approx(0.75)
     assert output.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
     assert output.stat().st_size > 20_000
+
+
+def test_plot_cli_rejects_minimization_mode(tmp_path, capsys):
+    plotter = _load_plotter()
+    ledger = tmp_path / "results.tsv"
+    ledger.write_text("status\tname\tscore\nbaseline\tbaseline\t0.5\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        plotter.main([str(ledger), "--output", str(tmp_path / "progress.png"), "--mode", "min"])
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "minimization is not supported" in stderr
+    assert "neg_val_loss" in stderr

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -2854,18 +2854,17 @@ def test_status_reuses_persisted_guard_settings(tmp_path, monkeypatch):
     assert observed["family_repeat_limit"] == 9
 
 
-def test_initialize_rejects_minimization_mode_with_negated_metric_guidance(tmp_path, capsys):
+def test_initialize_has_no_mode_flag(tmp_path, capsys):
     runner = _load_runner()
     job = tmp_path / "job.py"
     job.write_text("print('job')\n", encoding="utf-8")
 
+    # Campaigns always maximize; the direction flag is gone rather than vestigial.
     with pytest.raises(SystemExit) as excinfo:
         runner.main(["initialize", str(job), "--mode", "min"])
 
     assert excinfo.value.code == 2
-    stderr = capsys.readouterr().err
-    assert "minimization is not supported" in stderr
-    assert "neg_val_loss" in stderr
+    assert "unrecognized arguments: --mode" in capsys.readouterr().err
     assert not tmp_path.joinpath(".nvflare").exists()
 
 

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -2880,12 +2880,21 @@ def test_resuming_legacy_minimization_campaign_is_rejected_with_guidance(tmp_pat
     state_before = tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_bytes()
     capsys.readouterr()
 
-    for action in ("status", "prepare", "evaluate"):
+    # Every lifecycle action routes through the same restore_campaign_settings gate.
+    for action in ("status", "prepare", "evaluate", "abandon", "record", "suggest"):
         assert runner.main([action, str(job)]) == 2
         stderr = capsys.readouterr().err
         assert "mode='min'" in stderr
         assert "minimization is not supported" in stderr
         assert "neg_val_loss" in stderr
+
+    # The recommended recovery must not be circular: initialize on the legacy campaign
+    # is rejected too, but its message names the concrete escape hatch.
+    assert runner.main(["initialize", str(job)]) == 2
+    stderr = capsys.readouterr().err
+    assert "minimization is not supported" in stderr
+    assert ".nvflare/autofl" in stderr
+    assert "fresh workspace" in stderr
 
     # The campaign never silently flips to maximization: no state was rewritten.
     assert tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_bytes() == state_before

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -56,7 +56,7 @@ def _campaign_config():
     }
 
 
-def _initialize_fake_campaign(runner, tmp_path, monkeypatch, *, target_env="sim", baseline_score=0.5, mode=None):
+def _initialize_fake_campaign(runner, tmp_path, monkeypatch, *, target_env="sim", baseline_score=0.5):
     job = tmp_path / "job.py"
     client = tmp_path / "client.py"
     job.write_text("print('job')\n", encoding="utf-8")
@@ -81,8 +81,6 @@ def _initialize_fake_campaign(runner, tmp_path, monkeypatch, *, target_env="sim"
 
     monkeypatch.setattr(runner, "run_job", fake_run)
     argv = ["initialize", str(job), "--env", target_env]
-    if mode is not None:
-        argv.extend(["--mode", mode])
     assert runner.main(argv) == 0
     return job, client, config
 
@@ -292,8 +290,8 @@ def test_metric_paths_reject_non_finite_values(tmp_path, value):
 
     assert runner.find_metric_value({"accuracy": value}, ["accuracy"]) is None
     assert runner.find_metric_value({"metrics": [{"name": "accuracy", "value": value}]}, ["accuracy"]) is None
-    assert runner.better(value, 0.5, "max") is False
-    assert runner.better(0.6, value, "max") is True
+    assert runner.better(value, 0.5) is False
+    assert runner.better(0.6, value) is True
     with pytest.raises(ValueError, match="non-finite score"):
         runner.write_results(
             tmp_path / "results.tsv",
@@ -395,6 +393,17 @@ def test_runner_applies_schema_metric_contract():
     assert updated["objective"]["optimization_metric"] == "test_accuracy"
     assert updated["objective"]["metric_extraction_order"] == ["test_accuracy", "accuracy"]
     assert updated["objective"]["metric_source"] == "held-out CIFAR-10 test set"
+
+
+def test_schema_metric_contract_rejects_minimization_objective():
+    runner = _load_runner()
+    config = {"objective": {"metric": "val_loss"}}
+    schema = {"objective": {"metric": "val_loss", "mode": "min"}}
+
+    with pytest.raises(ValueError, match="minimization is not supported") as excinfo:
+        runner.apply_metric_contract(config, "val_loss", schema)
+
+    assert "neg_val_loss" in str(excinfo.value)
 
 
 def test_comparison_budget_suppresses_duplicate_imported_fixed_budget_args():
@@ -1542,7 +1551,7 @@ def test_small_retained_improvement_does_not_reset_plateau_clock(tmp_path):
         plateau_min_delta=0.0005,
     )
 
-    assert runner.best_retained_record(records, "max").name == "candidate_1"
+    assert runner.best_retained_record(records).name == "candidate_1"
     assert state["best_score"] == pytest.approx(0.8503)
     assert state["plateau"]["best_score"] == pytest.approx(0.85)
     assert state["reason"] == "plateau_literature"
@@ -2790,26 +2799,28 @@ def test_lowering_cap_below_attempts_clamps_remaining_and_keeps_state_consistent
 
 def test_runner_state_reports_budget_and_baseline_accounting(tmp_path, monkeypatch):
     runner = _load_runner()
-    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=1.0, mode="min")
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.5)
     state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
 
     state = json.loads(state_path.read_text(encoding="utf-8"))
     assert state["remaining_candidates"] is None
     assert state["baseline_status"] == "complete"
-    assert state["baseline_score"] == pytest.approx(1.0)
+    assert state["baseline_score"] == pytest.approx(0.5)
     assert state["improvement"] == pytest.approx(0.0)
     assert state["abandoned_candidates"] == 0
 
     results_path = tmp_path / "results.tsv"
     records = runner.load_results(results_path)
-    records.append(runner.RunRecord("keep", "lower_loss", 0.8, 1.0, "none", "lower loss", "python job.py", ""))
+    records.append(
+        runner.RunRecord("keep", "higher_accuracy", 0.8, 1.0, "none", "higher accuracy", "python job.py", "")
+    )
     runner.write_results(results_path, records)
 
     assert runner.main(["status", str(job), "--max-candidates", "3"]) == 0
     state = json.loads(state_path.read_text(encoding="utf-8"))
     assert state["remaining_candidates"] == 2
-    # mode=min: positive improvement means the loss went down against the baseline.
-    assert state["improvement"] == pytest.approx(0.2)
+    # improvement is best minus baseline; campaigns always maximize the metric.
+    assert state["improvement"] == pytest.approx(0.3)
 
 
 def test_status_reuses_persisted_guard_settings(tmp_path, monkeypatch):
@@ -2843,21 +2854,41 @@ def test_status_reuses_persisted_guard_settings(tmp_path, monkeypatch):
     assert observed["family_repeat_limit"] == 9
 
 
-def test_status_restores_persisted_minimization_mode(tmp_path, monkeypatch):
+def test_initialize_rejects_minimization_mode_with_negated_metric_guidance(tmp_path, capsys):
     runner = _load_runner()
-    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=1.0, mode="min")
-    results_path = tmp_path / "results.tsv"
-    records = runner.load_results(results_path)
-    records.append(runner.RunRecord("keep", "lower_loss", 0.8, 1.0, "none", "lower loss", "python job.py", ""))
-    runner.write_results(results_path, records)
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
 
-    assert runner.main(["status", str(job)]) == 0
+    with pytest.raises(SystemExit) as excinfo:
+        runner.main(["initialize", str(job), "--mode", "min"])
 
-    metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
-    state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
-    assert metadata["settings"]["mode"] == "min"
-    assert state["best_score"] == pytest.approx(0.8)
-    assert runner.main(["status", str(job), "--mode", "max"]) == 2
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "minimization is not supported" in stderr
+    assert "neg_val_loss" in stderr
+    assert not tmp_path.joinpath(".nvflare").exists()
+
+
+def test_resuming_legacy_minimization_campaign_is_rejected_with_guidance(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    metadata_path = tmp_path / ".nvflare/autofl/campaign.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["settings"]["mode"] == "max"
+    metadata["settings"]["mode"] = "min"
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    state_before = tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_bytes()
+    capsys.readouterr()
+
+    for action in ("status", "prepare", "evaluate"):
+        assert runner.main([action, str(job)]) == 2
+        stderr = capsys.readouterr().err
+        assert "mode='min'" in stderr
+        assert "minimization is not supported" in stderr
+        assert "neg_val_loss" in stderr
+
+    # The campaign never silently flips to maximization: no state was rewritten.
+    assert tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_bytes() == state_before
 
 
 def test_explicit_immutable_campaign_setting_change_is_rejected(tmp_path, monkeypatch):
@@ -2948,7 +2979,7 @@ def test_suggest_returns_fallbacks_without_executing_them(tmp_path, monkeypatch,
     assert all(item["run_args"] for item in payload["suggestions"])
 
 
-def test_import_job_config_forwards_minimization_mode(tmp_path, monkeypatch):
+def test_import_job_config_forwards_job_args_without_direction_plumbing(tmp_path, monkeypatch):
     runner = _load_runner()
     job = tmp_path / "job.py"
     job.write_text("print('job')\n", encoding="utf-8")
@@ -2968,10 +2999,11 @@ def test_import_job_config_forwards_minimization_mode(tmp_path, monkeypatch):
             return runner.yaml.safe_dump(config)
 
     monkeypatch.setattr(runner, "load_job_importer", lambda: FakeImporter)
-    args = runner.parse_args(["initialize", str(job), "--mode", "min", "--base-args", "--mode training"])
+    # A job-owned "--mode" flag in --base-args is unrelated to the removed objective direction.
+    args = runner.parse_args(["initialize", str(job), "--base-args", "--mode training"])
     runner.import_job_config(args, job, output, tmp_path / "import.log", 10)
 
-    assert captured["mode"] == "min"
+    assert "mode" not in captured
     assert captured["job_args"] == ["--mode", "training"]
 
 
@@ -3201,7 +3233,7 @@ def test_cross_val_extraction_mean_penalizes_easiest_site_bias(tmp_path):
 
     assert skewed_score == pytest.approx(0.70)
     assert uniform_score == pytest.approx(0.80)
-    assert runner.better(uniform_score, skewed_score, "max")
+    assert runner.better(uniform_score, skewed_score)
 
 
 def test_cross_val_extraction_prefers_final_checkpoint_entries_over_best(tmp_path):


### PR DESCRIPTION
# Restrict Auto-FL campaigns to score maximization

## Problem

A QA evaluation of the Auto-FL skill showed that `--mode min` campaigns correctly rank candidates by lower loss, but NVFlare's core best-model selection was higher-is-better. PR #4939 added docstrings plus a runtime warning in `IntimeModelSelector` when a loss-like `key_metric` is used without `negate_key_metric`. As a result, a min-mode campaign silently coexists with a max-direction saved "best" checkpoint — the campaign's "best" candidate and the persisted `best_FL_global_model` checkpoint disagree, with measured loss gaps of +0.0014 to +0.72 in the evaluation.

## Fix: make the mismatch structurally impossible

Rather than trying to thread a direction flag through model selection, this PR removes minimization support from the skill entirely. Max-only campaigns cannot diverge from core best-model selection, aligning the skill with core best-model selection. Users who want to minimize a loss follow the same guidance #4939 gives for `IntimeModelSelector`: report a negated metric from the job (e.g. `neg_val_loss`) so that higher is better.

## Changes

- **CLI compatibility with actionable rejection**: `run_job_campaign.py`, `campaign_guard.py`, and `plot_progress.py` keep their `--mode` flags for command-shape compatibility, but a shared `parse_mode_arg` type accepts only `max`. `--mode min` fails with: minimization is not supported; report a negated metric (e.g. `neg_val_loss`) so higher is better, matching NVFLARE best-model selection (`IntimeModelSelector` `negate_key_metric`).
- **Legacy campaigns are rejected, never silently flipped**: resuming any lifecycle action on a campaign whose persisted `campaign.json` settings say `mode: "min"` fails with the same guidance (plus a re-initialize hint) before any state is rewritten, instead of silently re-ranking the ledger in the opposite direction.
- **Mutation-schema and importer objectives**: a `mutation_schema.yaml` `objective.mode` other than `max` is rejected at metric-contract time, and `job_importer` raises `JobImportError` with the same guidance for `mode != "max"`.
- **Direction plumbing deleted**: `mode` parameters and `min` branches removed from `campaign_guard` (`better`, `best_score`, `improvement_over_baseline` → always `best - baseline`, `plateau_status`, `guard_state`), `run_job_campaign` (write_state/refresh/report/progress threading), and `plot_progress` (y-limits, milestones, cumulative best, axis label).
- **Schema stability**: persisted fields named `mode` keep emitting the constant `"max"` — `campaign.json` `settings.mode`, the candidate manifest `objective.mode`, and the importer-generated `autofl.yaml` `objective.mode` — so external judges reading these files see an unchanged schema.
- **Docs**: `SKILL.md` (still exactly 200 lines) drops `--mode <max|min>` from the initialize synopsis and states that campaigns always maximize the optimization metric and loss-like objectives must be reported negated; references updated accordingly.

## Tests

- Converted min-mode tests (including the mode=min improvement-sign guard test from #4926) to max-only equivalents.
- New rejection tests: (a) `initialize --mode min`, (b) resuming a legacy persisted-min campaign across `status`/`prepare`/`evaluate` with no state rewrite, (c) mutation-schema objective `mode: min`, (d) `campaign_guard.py --mode min` and `plot_progress.py --mode min` CLIs, plus an importer/guard guidance-message parity test.
- Full battery green: `pytest tests/unit_test/tool/autofl_skill_*_test.py tests/unit_test/tool/agent_skill_checks -q` → 361 passed. black/isort/flake8 clean on changed files.