### PR TITLE
Include site names in Slurm job names

### DIFF
--- a/docs/design/slurm_job_launcher_design.md
+++ b/docs/design/slurm_job_launcher_design.md
@@ -96,7 +96,7 @@ Each launched job uses one transient directory:
 The job key is the SHA-256 digest of the NVFlare job ID. Runtime identity is deterministic:
 
 ```text
-job name = nvfl-<first-8-job-key>
+job name = nvfl-<first-32-site-name-characters>-<first-8-job-key>
 comment  = nvfl:<job-id>
 ```
 
@@ -125,8 +125,9 @@ infrastructure launch failure.
 ## Monitoring and results
 
 Live lookup uses `squeue --name=<job-name>` for the submitting user and selects the row with the handle's job ID.
-The job name contains only an eight-character hash prefix, so rows with other IDs can share the same name and are
-ignored. The selected row must match the numeric UID, full name, and derived comment.
+The site-qualified name avoids collisions when several NVFlare sites share a Slurm user and run the same federated
+job. Rows with other IDs are still ignored, and the selected row must match the numeric UID, full name, and derived
+comment.
 
 When a job is absent from `squeue`, `sacct --jobs=<job-id>` is authoritative. The returned allocation must match the
 exact ID, deterministic job name, and submitting user.

--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -297,9 +297,11 @@ completion. User abort and pending timeout verify ownership before ``scancel``;
 normal framework shutdown terminates running handles through the same path
 before the Slurm launcher closes launch admission.
 
-Job output is ``<run-dir>/slurm-<slurm-job-id>.out``. Use ``squeue`` for live
-state and ``sacct`` for completed jobs. Preserve the complete workspace and
-relevant scheduler records for investigation.
+Slurm job names include the first 32 characters of the NVFlare site name and a
+short job hash, so operators can distinguish sites sharing one Slurm user. Job output is
+``<run-dir>/slurm-<slurm-job-id>.out``. Use ``squeue`` for live state and
+``sacct`` for completed jobs. Preserve the complete workspace and relevant
+scheduler records for investigation.
 
 After a parent crash, the launcher does not cancel surviving allocations or
 remove their job artifacts; this matches the Docker and Kubernetes launchers.

--- a/nvflare/app_opt/job_launcher/slurm/config.py
+++ b/nvflare/app_opt/job_launcher/slurm/config.py
@@ -360,6 +360,7 @@ def normalize_slurm_launcher_settings(
 @dataclass(frozen=True)
 class LaunchPlan:
     job_id: str
+    site_name: str
     run_dir: str
     exe_module: str
     module_args: tuple

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -377,6 +377,7 @@ class SlurmJobLauncher(JobLauncherSpec):
         mounts = self._study_mounts(runtime) if sandbox != "none" else ()
         return LaunchPlan(
             job_id=job_id,
+            site_name=site_name,
             run_dir=run_dir,
             exe_module=self.EXE_MODULE,
             module_args=self.get_module_args(job_args),

--- a/nvflare/app_opt/job_launcher/slurm/manager.py
+++ b/nvflare/app_opt/job_launcher/slurm/manager.py
@@ -55,6 +55,7 @@ _ACCOUNTING_RETRY_INTERVAL = 6.0
 _COMMAND_TIMEOUT = 10.0
 _MIN_SLURM_VERSION = (23, 2)
 _SLURM_VERSION_RE = re.compile(r"^slurm\s+(\d+)\.(\d+)", re.IGNORECASE)
+_JOB_NAME_SITE_LENGTH = 32
 
 
 def _job_key(job_id: str) -> str:
@@ -98,8 +99,8 @@ def _cleanup_job_dir(job_dir: str) -> None:
         pass
 
 
-def _job_name(job_key: str) -> str:
-    return f"nvfl-{job_key[:8]}"
+def _job_name(site_name: str, job_key: str) -> str:
+    return f"nvfl-{site_name[:_JOB_NAME_SITE_LENGTH]}-{job_key[:8]}"
 
 
 def _is_terminal(state: str) -> bool:
@@ -261,6 +262,7 @@ class SlurmJobManager:
                 if plan.job_id in self._handles:
                     raise SlurmLauncherError(f"job '{plan.job_id}' already has a live Slurm handle")
             job_key, job_dir = self._prepare_job_dir(plan.job_id, plan.sandbox != "none")
+            job_name = _job_name(plan.site_name, job_key)
             try:
                 self._write_job_files(plan, job_dir)
                 try:
@@ -268,7 +270,7 @@ class SlurmJobManager:
                         _submission_argv(
                             plan,
                             job_dir,
-                            _job_name(job_key),
+                            job_name,
                             self._marker(plan.job_id),
                             self.config,
                         ),
@@ -299,7 +301,7 @@ class SlurmJobManager:
                 handle = SlurmJobHandle(
                     self,
                     plan.job_id,
-                    job_key,
+                    job_name,
                     job_dir,
                     submission.job_id,
                     plan.resources.pending_timeout,
@@ -348,7 +350,7 @@ class SlurmJobManager:
         handle.accounting_last_query = now
         result = self.adapter.accounting_by_id(
             handle.job_id,
-            _job_name(handle.job_key),
+            handle.job_name,
             timeout=_COMMAND_TIMEOUT,
         )
         if result.status == LookupStatus.UNAVAILABLE:
@@ -375,7 +377,7 @@ class SlurmJobManager:
                 return handle.terminal_result
             active = self.adapter.active_by_id(
                 handle.job_id,
-                _job_name(handle.job_key),
+                handle.job_name,
                 self._marker(handle.nvflare_job_id),
                 timeout=_COMMAND_TIMEOUT,
             )
@@ -424,7 +426,7 @@ class SlurmJobHandle(JobHandleSpec):
         self,
         manager: SlurmJobManager,
         nvflare_job_id: str,
-        job_key: str,
+        job_name: str,
         job_dir: str,
         job_id: str,
         pending_timeout: float,
@@ -432,7 +434,7 @@ class SlurmJobHandle(JobHandleSpec):
     ):
         self.manager = manager
         self.nvflare_job_id = nvflare_job_id
-        self.job_key = job_key
+        self.job_name = job_name
         self.job_dir = job_dir
         self.pending_timeout = pending_timeout
         self.poll_interval = poll_interval

--- a/tests/unit_test/app_opt/job_launcher/slurm_batch_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_batch_test.py
@@ -50,6 +50,7 @@ def _plan(tmp_path, sandbox="none", resources=None, mounts=(), forward_env=()):
     run_dir.mkdir(parents=True, exist_ok=True)
     return LaunchPlan(
         job_id="job-1",
+        site_name="site-1",
         run_dir=str(run_dir),
         exe_module="worker.module",
         module_args=("-n", "job-1"),

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -185,6 +185,7 @@ def test_launch_plan_uses_fixed_worker_and_one_resolved_job_spec(tmp_path):
     plan = launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _fl_ctx(workspace))
 
     assert plan.exe_module == ClientSlurmJobLauncher.EXE_MODULE
+    assert plan.site_name == "site-1"
     parent_url_index = plan.module_args.index("-p") + 1
     assert plan.module_args[parent_url_index] == "tcp://compute.example:8102"
     assert "secret-token" not in plan.module_args

--- a/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
@@ -39,7 +39,7 @@ from nvflare.app_opt.job_launcher.slurm.config import (
     SlurmRecord,
     SubmissionResult,
 )
-from nvflare.app_opt.job_launcher.slurm.manager import SlurmJobManager, _ensure_dir, _job_key
+from nvflare.app_opt.job_launcher.slurm.manager import SlurmJobManager, _ensure_dir, _job_key, _job_name
 from nvflare.app_opt.job_launcher.slurm.scheduler_client import _SlurmCliAdapter
 from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.private.fed.server.fed_server import FederatedServer
@@ -141,6 +141,7 @@ def _plan(tmp_path, pending_timeout=5, setup="", sandbox="none", image=None):
     run_dir.mkdir(exist_ok=True)
     return LaunchPlan(
         job_id="job-1",
+        site_name="site-1",
         run_dir=str(run_dir),
         exe_module="worker.module",
         module_args=("-n", "job-1"),
@@ -315,9 +316,25 @@ def test_launch_returns_handle_with_deterministic_identity(tmp_path):
     assert Path(handle.job_dir, "batch.sh").is_file()
     assert not Path(handle.job_dir, SANDBOX_ROOT).exists()
     submit_argv = adapter.calls[0][1]
-    assert f"--job-name=nvfl-{handle.job_key[:8]}" in submit_argv
+    assert f"--job-name={handle.job_name}" in submit_argv
+    assert handle.job_name == _job_name("site-1", _job_key("job-1"))
     assert f"--output={_plan(tmp_path).run_dir}/slurm-%j.out" in submit_argv
     assert adapter.calls[0][0] == "submit"
+
+
+def test_job_name_distinguishes_sites_running_the_same_job():
+    job_key = _job_key("job-1")
+    first = _job_name("site-1", job_key)
+    second = _job_name("site-2", job_key)
+
+    assert first == f"nvfl-site-1-{job_key[:8]}"
+    assert first != second
+
+
+def test_job_name_limits_site_name_length():
+    job_name = _job_name("s" * 100, _job_key("job-1"))
+
+    assert job_name == f"nvfl-{'s' * 32}-{_job_key('job-1')[:8]}"
 
 
 def test_stale_job_artifacts_block_relaunch(tmp_path):
@@ -422,7 +439,7 @@ def test_handle_monitors_only_its_returned_id_when_job_name_is_shared(tmp_path):
         runner=run_command,
     )
     manager = _manager(tmp_path, scheduler)
-    job_name = f"nvfl-{_job_key('job-1')[:8]}"
+    job_name = _job_name("site-1", _job_key("job-1"))
     marker = "nvfl:job-1"
     results.extend(
         [


### PR DESCRIPTION
## What changed

- include the NVFlare site name in deterministic Slurm job names
- retain the exact submitted job name on the live handle for `squeue` and `sacct` lookups
- document the new operator-visible name and cover site separation and length limits

## Why

Two NVFlare clients sharing one Slurm Unix user receive the same federated job ID. The previous name used only the
job-ID hash, so both allocations had the same Slurm job name and produced misleading `sharing name` warnings even
though monitoring correctly selected the exact Slurm ID.

The new format is:

```text
nvfl-<first-32-site-name-characters>-<first-8-job-hash>
```
