### PR TITLE
Expose key_metric_mode in FedAvg recipes

### DIFF
--- a/nvflare/app_common/np/recipes/fedavg.py
+++ b/nvflare/app_common/np/recipes/fedavg.py
@@ -70,8 +70,10 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. Higher values must indicate
-            a better model; for lower-is-better metrics such as a loss, report a negated value from the
-            client (e.g., "neg_loss"). Defaults to "accuracy".
+            a better model; for lower-is-better metrics such as a loss, set negate_key_metric=True or
+            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -129,6 +131,7 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        negate_key_metric: bool = False,
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
@@ -164,6 +167,7 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,

--- a/nvflare/app_common/np/recipes/fedavg.py
+++ b/nvflare/app_common/np/recipes/fedavg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from nvflare.apis.dxo import DataKind
 from nvflare.app_common.abstract.aggregator import Aggregator
@@ -69,11 +69,9 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction.
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
-        key_metric: Metric used to determine if the model is globally best. Higher values must indicate
-            a better model; for lower-is-better metrics such as a loss, set negate_key_metric=True or
-            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+        key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
+            such as for loss, and "max" when higher values are better. Defaults to "max".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -131,7 +129,7 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
@@ -167,7 +165,7 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,

--- a/nvflare/app_common/np/recipes/fedavg.py
+++ b/nvflare/app_common/np/recipes/fedavg.py
@@ -70,8 +70,9 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".
-        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
-            such as for loss, and "max" when higher values are better. Defaults to "max".
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better
+            and "max" when higher values are better. If omitted and stop_cond uses the same metric,
+            the mode is inferred from its comparison operator; otherwise it defaults to "max".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -129,7 +130,7 @@ class NumpyFedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        key_metric_mode: Literal["min", "max"] = "max",
+        key_metric_mode: Optional[Literal["min", "max"]] = None,
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from nvflare.apis.dxo import DataKind
 from nvflare.app_common.abstract.aggregator import Aggregator
@@ -71,11 +71,9 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction.
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
-        key_metric: Metric used to determine if the model is globally best. Higher values must indicate
-            a better model; for lower-is-better metrics such as a loss, set negate_key_metric=True or
-            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+        key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
+            such as for loss, and "max" when higher values are better. Defaults to "max".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -129,7 +127,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
@@ -166,7 +164,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -72,8 +72,10 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. Higher values must indicate
-            a better model; for lower-is-better metrics such as a loss, report a negated value from the
-            client (e.g., "neg_loss"). Defaults to "accuracy".
+            a better model; for lower-is-better metrics such as a loss, set negate_key_metric=True or
+            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -127,6 +129,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        negate_key_metric: bool = False,
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
@@ -163,6 +166,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,

--- a/nvflare/app_opt/pt/recipes/fedavg.py
+++ b/nvflare/app_opt/pt/recipes/fedavg.py
@@ -72,8 +72,9 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: Whether external process is launched once or per task. Defaults to True.
         shutdown_timeout: Seconds to wait before shutdown. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. Defaults to "accuracy".
-        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
-            such as for loss, and "max" when higher values are better. Defaults to "max".
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better
+            and "max" when higher values are better. If omitted and stop_cond uses the same metric,
+            the mode is inferred from its comparison operator; otherwise it defaults to "max".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -127,7 +128,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        key_metric_mode: Literal["min", "max"] = "max",
+        key_metric_mode: Optional[Literal["min", "max"]] = None,
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,

--- a/nvflare/app_opt/pt/recipes/fedce.py
+++ b/nvflare/app_opt/pt/recipes/fedce.py
@@ -56,7 +56,7 @@ class FedCERecipe(FedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        key_metric_mode: Literal["min", "max"] = "max",
+        key_metric_mode: Optional[Literal["min", "max"]] = None,
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
         best_model_filename: Optional[str] = None,

--- a/nvflare/app_opt/pt/recipes/fedce.py
+++ b/nvflare/app_opt/pt/recipes/fedce.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from nvflare.app_opt.pt.fedce import FedCEModelAggregator
 from nvflare.client.config import ExchangeFormat, TransferType
@@ -56,6 +56,7 @@ class FedCERecipe(FedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        key_metric_mode: Literal["min", "max"] = "max",
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
         best_model_filename: Optional[str] = None,
@@ -112,6 +113,7 @@ class FedCERecipe(FedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            key_metric_mode=key_metric_mode,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,

--- a/nvflare/app_opt/pt/recipes/fedprox.py
+++ b/nvflare/app_opt/pt/recipes/fedprox.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from nvflare.apis.dxo import DataKind
 from nvflare.app_common.abstract.aggregator import Aggregator
@@ -55,6 +55,7 @@ class FedProxRecipe(FedAvgRecipe):
         launch_once: Whether an external client process is launched once.
         shutdown_timeout: Seconds to wait for client shutdown.
         key_metric: Metric used for best-model selection.
+        key_metric_mode: Whether the key metric should be minimized ("min") or maximized ("max").
         stop_cond: Optional early-stopping condition.
         patience: Optional early-stopping patience.
         best_model_filename: Optional best-model filename.
@@ -90,6 +91,7 @@ class FedProxRecipe(FedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        key_metric_mode: Literal["min", "max"] = "max",
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
         best_model_filename: Optional[str] = None,
@@ -124,6 +126,7 @@ class FedProxRecipe(FedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            key_metric_mode=key_metric_mode,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,

--- a/nvflare/app_opt/pt/recipes/fedprox.py
+++ b/nvflare/app_opt/pt/recipes/fedprox.py
@@ -56,6 +56,8 @@ class FedProxRecipe(FedAvgRecipe):
         shutdown_timeout: Seconds to wait for client shutdown.
         key_metric: Metric used for best-model selection.
         key_metric_mode: Whether the key metric should be minimized ("min") or maximized ("max").
+            If omitted and stop_cond uses the same metric, the mode is inferred from its comparison operator;
+            otherwise it defaults to "max".
         stop_cond: Optional early-stopping condition.
         patience: Optional early-stopping patience.
         best_model_filename: Optional best-model filename.
@@ -91,7 +93,7 @@ class FedProxRecipe(FedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        key_metric_mode: Literal["min", "max"] = "max",
+        key_metric_mode: Optional[Literal["min", "max"]] = None,
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
         best_model_filename: Optional[str] = None,

--- a/nvflare/app_opt/sklearn/recipes/fedavg.py
+++ b/nvflare/app_opt/sklearn/recipes/fedavg.py
@@ -61,8 +61,10 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
             part of the generated job definition and must not contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
             a dict, key_metric selects the metric used for global model selection. Higher values must
-            indicate a better model; for lower-is-better metrics such as a loss, report a negated value
-            from the client (e.g., "neg_loss"). Defaults to "accuracy".
+            indicate a better model; for lower-is-better metrics such as a loss, set negate_key_metric=True
+            or report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
         launch_once: Whether the external process will be launched only once at the beginning
             or on each task. Only used if `launch_external_process` is True. Defaults to True.
         shutdown_timeout: If provided, will wait for this number of seconds before shutdown.
@@ -142,6 +144,7 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
         command: str = "python3 -u",
         per_site_config: Optional[dict[str, dict]] = None,
         key_metric: str = "accuracy",
+        negate_key_metric: bool = False,
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
     ):
@@ -170,6 +173,7 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
             model_persistor=persistor,  # Pass sklearn-specific persistor
             per_site_config=per_site_config,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
         )

--- a/nvflare/app_opt/sklearn/recipes/fedavg.py
+++ b/nvflare/app_opt/sklearn/recipes/fedavg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Literal, Optional
 
 from nvflare.apis.dxo import DataKind
 from nvflare.app_common.abstract.aggregator import Aggregator
@@ -60,11 +60,9 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
             ``set_per_site_config(recipe, config)`` immediately after construction. Nested values become
             part of the generated job definition and must not contain secrets.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are
-            a dict, key_metric selects the metric used for global model selection. Higher values must
-            indicate a better model; for lower-is-better metrics such as a loss, set negate_key_metric=True
-            or report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+            a dict, key_metric selects the metric used for global model selection. Defaults to "accuracy".
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
+            such as for loss, and "max" when higher values are better. Defaults to "max".
         launch_once: Whether the external process will be launched only once at the beginning
             or on each task. Only used if `launch_external_process` is True. Defaults to True.
         shutdown_timeout: If provided, will wait for this number of seconds before shutdown.
@@ -144,7 +142,7 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
         command: str = "python3 -u",
         per_site_config: Optional[dict[str, dict]] = None,
         key_metric: str = "accuracy",
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
     ):
@@ -173,7 +171,7 @@ class SklearnFedAvgRecipe(UnifiedFedAvgRecipe):
             model_persistor=persistor,  # Pass sklearn-specific persistor
             per_site_config=per_site_config,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
         )

--- a/nvflare/app_opt/sklearn/recipes/kmeans.py
+++ b/nvflare/app_opt/sklearn/recipes/kmeans.py
@@ -86,6 +86,8 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             a dict, key_metric selects the metric used for global model selection. Higher values must
             indicate a better model. Defaults to "metrics"
             (which corresponds to the homogeneity score sent by the K-Means client).
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
 
     Example:
         Basic usage with same config for all clients:
@@ -149,6 +151,7 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
         command: str = "python3 -u",
         per_site_config: Optional[dict[str, dict]] = None,
         key_metric: str = "metrics",  # Matches client's metric key
+        negate_key_metric: bool = False,
     ):
         v = _KMeansValidator(n_clusters=n_clusters, model_path=model_path)
         self.n_clusters = v.n_clusters
@@ -183,5 +186,6 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             model_persistor=persistor,
             per_site_config=per_site_config,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
         )
         self._job.to_server(assembler, id=assembler_id)

--- a/nvflare/app_opt/sklearn/recipes/kmeans.py
+++ b/nvflare/app_opt/sklearn/recipes/kmeans.py
@@ -87,7 +87,7 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             indicate a better model. Defaults to "metrics"
             (which corresponds to the homogeneity score sent by the K-Means client).
         negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+            Use this if key_metric is a lower-is-better metric. Defaults to False.
 
     Example:
         Basic usage with same config for all clients:

--- a/nvflare/app_opt/sklearn/recipes/kmeans.py
+++ b/nvflare/app_opt/sklearn/recipes/kmeans.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, conint, field_validator
 
@@ -86,8 +86,8 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             a dict, key_metric selects the metric used for global model selection. Higher values must
             indicate a better model. Defaults to "metrics"
             (which corresponds to the homogeneity score sent by the K-Means client).
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this if key_metric is a lower-is-better metric. Defaults to False.
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better
+            and "max" when higher values are better. Defaults to "max".
 
     Example:
         Basic usage with same config for all clients:
@@ -151,7 +151,7 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
         command: str = "python3 -u",
         per_site_config: Optional[dict[str, dict]] = None,
         key_metric: str = "metrics",  # Matches client's metric key
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
     ):
         v = _KMeansValidator(n_clusters=n_clusters, model_path=model_path)
         self.n_clusters = v.n_clusters
@@ -186,6 +186,6 @@ class KMeansFedAvgRecipe(FedAvgRecipe):
             model_persistor=persistor,
             per_site_config=per_site_config,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
         )
         self._job.to_server(assembler, id=assembler_id)

--- a/nvflare/app_opt/sklearn/recipes/svm.py
+++ b/nvflare/app_opt/sklearn/recipes/svm.py
@@ -86,7 +86,7 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             indicate a better model. Defaults to "AUC"
             (which corresponds to the ROC AUC score sent by the SVM client in round 1).
         negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+            Use this if key_metric is a lower-is-better metric. Defaults to False.
 
     Example:
         Basic usage with same config for all clients:

--- a/nvflare/app_opt/sklearn/recipes/svm.py
+++ b/nvflare/app_opt/sklearn/recipes/svm.py
@@ -85,6 +85,8 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             a dict, key_metric selects the metric used for global model selection. Higher values must
             indicate a better model. Defaults to "AUC"
             (which corresponds to the ROC AUC score sent by the SVM client in round 1).
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
 
     Example:
         Basic usage with same config for all clients:
@@ -146,6 +148,7 @@ class SVMFedAvgRecipe(FedAvgRecipe):
         command: str = "python3 -u",
         per_site_config: Optional[dict[str, dict]] = None,
         key_metric: str = "AUC",  # Matches client's metric key
+        negate_key_metric: bool = False,
     ):
         v = _SVMValidator(kernel=kernel, model_path=model_path)
         self.kernel = v.kernel
@@ -181,6 +184,7 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             model_persistor=persistor,
             per_site_config=per_site_config,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
         )
 
         # Add the SVMAssembler as a component to the job

--- a/nvflare/app_opt/sklearn/recipes/svm.py
+++ b/nvflare/app_opt/sklearn/recipes/svm.py
@@ -85,8 +85,8 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             a dict, key_metric selects the metric used for global model selection. Higher values must
             indicate a better model. Defaults to "AUC"
             (which corresponds to the ROC AUC score sent by the SVM client in round 1).
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this if key_metric is a lower-is-better metric. Defaults to False.
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better
+            and "max" when higher values are better. Defaults to "max".
 
     Example:
         Basic usage with same config for all clients:
@@ -148,7 +148,7 @@ class SVMFedAvgRecipe(FedAvgRecipe):
         command: str = "python3 -u",
         per_site_config: Optional[dict[str, dict]] = None,
         key_metric: str = "AUC",  # Matches client's metric key
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
     ):
         v = _SVMValidator(kernel=kernel, model_path=model_path)
         self.kernel = v.kernel
@@ -184,7 +184,7 @@ class SVMFedAvgRecipe(FedAvgRecipe):
             model_persistor=persistor,
             per_site_config=per_site_config,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
         )
 
         # Add the SVMAssembler as a component to the job

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -79,7 +79,10 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
             Higher values must indicate a better model; for lower-is-better metrics such as a loss,
-            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
+            set negate_key_metric=True or report a negated value from the client (e.g., "neg_loss").
+            Defaults to "accuracy".
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
         best_model_filename: Filename for saving the best model. Accepted for API compatibility.
             The default TensorFlow persistor does not currently create a separate best-model artifact.
         save_filename: Deprecated alias for best_model_filename. If both are specified, they must match.
@@ -129,6 +132,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        negate_key_metric: bool = False,
         best_model_filename: Optional[str] = None,
         save_filename: Optional[str] = None,
         server_memory_gc_rounds: int = 0,
@@ -155,6 +159,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
             best_model_filename=best_model_filename,
             save_filename=save_filename,
             server_memory_gc_rounds=server_memory_gc_rounds,

--- a/nvflare/app_opt/tf/recipes/fedavg.py
+++ b/nvflare/app_opt/tf/recipes/fedavg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from nvflare.apis.dxo import DataKind
 from nvflare.app_common.abstract.aggregator import Aggregator
@@ -78,11 +78,9 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             Only used if `launch_external_process` is True. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
-            Higher values must indicate a better model; for lower-is-better metrics such as a loss,
-            set negate_key_metric=True or report a negated value from the client (e.g., "neg_loss").
             Defaults to "accuracy".
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
+            such as for loss, and "max" when higher values are better. Defaults to "max".
         best_model_filename: Filename for saving the best model. Accepted for API compatibility.
             The default TensorFlow persistor does not currently create a separate best-model artifact.
         save_filename: Deprecated alias for best_model_filename. If both are specified, they must match.
@@ -132,7 +130,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
         best_model_filename: Optional[str] = None,
         save_filename: Optional[str] = None,
         server_memory_gc_rounds: int = 0,
@@ -159,7 +157,7 @@ class FedAvgRecipe(UnifiedFedAvgRecipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
             best_model_filename=best_model_filename,
             save_filename=save_filename,
             server_memory_gc_rounds=server_memory_gc_rounds,

--- a/nvflare/job_config/base_fed_job.py
+++ b/nvflare/job_config/base_fed_job.py
@@ -65,6 +65,7 @@ class BaseFedJob(FedJob):
                 Defaults to "accuracy". Only used if model_selector is not provided.
             negate_key_metric: Whether the model selector should invert key_metric before comparing models.
                 Use this for lower-is-better metrics such as losses. Defaults to False.
+                Only used if model_selector is not provided.
             validation_json_generator: A component for generating validation results.
                 If not provided, a ValidationJsonGenerator will be configured.
             model_selector: A component for selecting the best model during training.

--- a/nvflare/job_config/base_fed_job.py
+++ b/nvflare/job_config/base_fed_job.py
@@ -40,6 +40,7 @@ class BaseFedJob(FedJob):
         min_clients: int = 1,
         mandatory_clients: Optional[List[str]] = None,
         key_metric: str = "accuracy",
+        negate_key_metric: bool = False,
         validation_json_generator: Optional[ValidationJsonGenerator] = None,
         model_selector: Optional[FLComponent] = None,
         convert_to_fed_event: Optional[ConvertToFedEvent] = None,
@@ -60,8 +61,10 @@ class BaseFedJob(FedJob):
             key_metric: Metric used to determine if the model is globally best.
                 If metrics are a dict, key_metric can select the metric used for global model selection.
                 Higher values must indicate a better model; for lower-is-better metrics such as a loss,
-                report a negated value from the client (e.g., "neg_loss").
+                set negate_key_metric=True or report a negated value from the client (e.g., "neg_loss").
                 Defaults to "accuracy". Only used if model_selector is not provided.
+            negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+                Use this for lower-is-better metrics such as losses. Defaults to False.
             validation_json_generator: A component for generating validation results.
                 If not provided, a ValidationJsonGenerator will be configured.
             model_selector: A component for selecting the best model during training.
@@ -103,7 +106,10 @@ class BaseFedJob(FedJob):
             # Default to IntimeModelSelector if key_metric is provided
             from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 
-            self.to_server(id="model_selector", obj=IntimeModelSelector(key_metric=key_metric))
+            self.to_server(
+                id="model_selector",
+                obj=IntimeModelSelector(key_metric=key_metric, negate_key_metric=negate_key_metric),
+            )
 
         # Metrics artifact writer
         if metrics_artifact_writer is not None:

--- a/nvflare/job_config/base_fed_job.py
+++ b/nvflare/job_config/base_fed_job.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from nvflare.apis.analytix import ANALYTIC_EVENT_TYPE
 from nvflare.apis.fl_component import FLComponent
@@ -40,7 +40,7 @@ class BaseFedJob(FedJob):
         min_clients: int = 1,
         mandatory_clients: Optional[List[str]] = None,
         key_metric: str = "accuracy",
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
         validation_json_generator: Optional[ValidationJsonGenerator] = None,
         model_selector: Optional[FLComponent] = None,
         convert_to_fed_event: Optional[ConvertToFedEvent] = None,
@@ -60,11 +60,9 @@ class BaseFedJob(FedJob):
             mandatory_clients: Mandatory clients to run the job. Default None.
             key_metric: Metric used to determine if the model is globally best.
                 If metrics are a dict, key_metric can select the metric used for global model selection.
-                Higher values must indicate a better model; for lower-is-better metrics such as a loss,
-                set negate_key_metric=True or report a negated value from the client (e.g., "neg_loss").
                 Defaults to "accuracy". Only used if model_selector is not provided.
-            negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-                Use this for lower-is-better metrics such as losses. Defaults to False.
+            key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
+                such as for loss, and "max" when higher values are better. Defaults to "max".
                 Only used if model_selector is not provided.
             validation_json_generator: A component for generating validation results.
                 If not provided, a ValidationJsonGenerator will be configured.
@@ -84,6 +82,9 @@ class BaseFedJob(FedJob):
             metrics_artifact_writer: Component for writing server-side metrics artifacts.
                 If not provided, a MetricsArtifactWriter will be configured.
         """
+        if key_metric_mode not in ("min", "max"):
+            raise ValueError(f"key_metric_mode must be 'min' or 'max', but got {key_metric_mode!r}")
+
         super().__init__(
             name=name,
             min_clients=min_clients,
@@ -109,7 +110,7 @@ class BaseFedJob(FedJob):
 
             self.to_server(
                 id="model_selector",
-                obj=IntimeModelSelector(key_metric=key_metric, negate_key_metric=negate_key_metric),
+                obj=IntimeModelSelector(key_metric=key_metric, negate_key_metric=key_metric_mode == "min"),
             )
 
         # Metrics artifact writer

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -55,6 +55,7 @@ class _FedAvgValidator(BaseModel):
     launch_once: bool = True
     shutdown_timeout: float = 0.0
     key_metric: str = "accuracy"
+    negate_key_metric: bool = False
     # New FedAvg features
     stop_cond: Optional[str] = None
     patience: Optional[int] = None
@@ -146,7 +147,10 @@ class FedAvgRecipe(Recipe):
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
             Higher values must indicate a better model; for lower-is-better metrics such as a loss,
-            report a negated value from the client (e.g., "neg_loss"). Defaults to "accuracy".
+            set negate_key_metric=True or report a negated value from the client (e.g., "neg_loss").
+            Defaults to "accuracy".
+        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
+            Use this for lower-is-better metrics such as losses. Defaults to False.
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -197,6 +201,7 @@ class FedAvgRecipe(Recipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
+        negate_key_metric: bool = False,
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
@@ -246,6 +251,7 @@ class FedAvgRecipe(Recipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
+            negate_key_metric=negate_key_metric,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,
@@ -291,6 +297,7 @@ class FedAvgRecipe(Recipe):
         self.launch_once = v.launch_once
         self.shutdown_timeout = v.shutdown_timeout
         self.key_metric = v.key_metric
+        self.negate_key_metric = v.negate_key_metric
         self.stop_cond = v.stop_cond
         self.patience = v.patience
         self.best_model_filename = v.best_model_filename
@@ -324,6 +331,7 @@ class FedAvgRecipe(Recipe):
             name=self.name,
             min_clients=self.min_clients,
             key_metric=self.key_metric,
+            negate_key_metric=self.negate_key_metric,
         )
 
         # Setup framework-specific model components and persistor

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
 import warnings
 from typing import Any, Dict, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from nvflare.apis.dxo import DataKind
 from nvflare.app_common.abstract.aggregator import Aggregator
 from nvflare.app_common.abstract.model_persistor import ModelPersistor
 from nvflare.app_common.app_constant import DefaultCheckpointFileName
+from nvflare.app_common.utils.math_utils import parse_compare_criteria
 from nvflare.app_common.workflows.fedavg import FedAvg
 from nvflare.client.config import ExchangeFormat, TransferType
 from nvflare.fuel.utils.constants import FrameworkType
@@ -28,6 +30,13 @@ from nvflare.job_config.base_fed_job import BaseFedJob
 from nvflare.job_config.script_runner import ScriptRunner
 from nvflare.recipe.spec import Recipe
 from nvflare.recipe.utils import _apply_legacy_constructor_config, _validate_per_site_targets
+
+_KEY_METRIC_MODE_BY_STOP_OPERATOR = {
+    operator.gt: "max",
+    operator.ge: "max",
+    operator.lt: "min",
+    operator.le: "min",
+}
 
 
 # Internal — not part of the public API
@@ -55,7 +64,7 @@ class _FedAvgValidator(BaseModel):
     launch_once: bool = True
     shutdown_timeout: float = 0.0
     key_metric: str = "accuracy"
-    key_metric_mode: Literal["min", "max"] = "max"
+    key_metric_mode: Optional[Literal["min", "max"]] = None
     # New FedAvg features
     stop_cond: Optional[str] = None
     patience: Optional[int] = None
@@ -68,6 +77,23 @@ class _FedAvgValidator(BaseModel):
     enable_tensor_disk_offload: bool = False
     client_memory_gc_rounds: int = 0
     cuda_empty_cache: bool = False
+
+    @model_validator(mode="after")
+    def resolve_key_metric_mode(self):
+        stop_metric = None
+        stop_mode = None
+        if self.stop_cond:
+            stop_metric, _, op_fn = parse_compare_criteria(self.stop_cond)
+            stop_mode = _KEY_METRIC_MODE_BY_STOP_OPERATOR.get(op_fn)
+
+        if self.key_metric_mode is None:
+            self.key_metric_mode = stop_mode if stop_metric == self.key_metric and stop_mode else "max"
+        elif stop_metric == self.key_metric and stop_mode and self.key_metric_mode != stop_mode:
+            raise ValueError(
+                f"key_metric_mode={self.key_metric_mode!r} conflicts with stop_cond={self.stop_cond!r}: "
+                f"both use metric {self.key_metric!r}, but stop_cond implies mode {stop_mode!r}"
+            )
+        return self
 
 
 class FedAvgRecipe(Recipe):
@@ -147,8 +173,9 @@ class FedAvgRecipe(Recipe):
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
             Defaults to "accuracy".
-        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
-            such as for loss, and "max" when higher values are better. Defaults to "max".
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better
+            and "max" when higher values are better. If omitted and stop_cond uses the same metric,
+            the mode is inferred from its comparison operator; otherwise it defaults to "max".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -199,7 +226,7 @@ class FedAvgRecipe(Recipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        key_metric_mode: Literal["min", "max"] = "max",
+        key_metric_mode: Optional[Literal["min", "max"]] = None,
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,

--- a/nvflare/recipe/fedavg.py
+++ b/nvflare/recipe/fedavg.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from pydantic import BaseModel
 
@@ -55,7 +55,7 @@ class _FedAvgValidator(BaseModel):
     launch_once: bool = True
     shutdown_timeout: float = 0.0
     key_metric: str = "accuracy"
-    negate_key_metric: bool = False
+    key_metric_mode: Literal["min", "max"] = "max"
     # New FedAvg features
     stop_cond: Optional[str] = None
     patience: Optional[int] = None
@@ -146,11 +146,9 @@ class FedAvgRecipe(Recipe):
             Only used if `launch_external_process` is True. Defaults to 0.0.
         key_metric: Metric used to determine if the model is globally best. If validation metrics are a dict,
             key_metric selects the metric used for global model selection by the IntimeModelSelector.
-            Higher values must indicate a better model; for lower-is-better metrics such as a loss,
-            set negate_key_metric=True or report a negated value from the client (e.g., "neg_loss").
             Defaults to "accuracy".
-        negate_key_metric: Whether the model selector should invert key_metric before comparing models.
-            Use this for lower-is-better metrics such as losses. Defaults to False.
+        key_metric_mode: One of "min" or "max". Use "min" when lower key_metric values are better,
+            such as for loss, and "max" when higher values are better. Defaults to "max".
         stop_cond: Early stopping condition based on metric. String literal in the format of
             '<key> <op> <value>' (e.g. "accuracy >= 80"). If None, early stopping is disabled.
         patience: Number of rounds with no improvement after which FL will be stopped.
@@ -201,7 +199,7 @@ class FedAvgRecipe(Recipe):
         launch_once: bool = True,
         shutdown_timeout: float = 0.0,
         key_metric: str = "accuracy",
-        negate_key_metric: bool = False,
+        key_metric_mode: Literal["min", "max"] = "max",
         # New FedAvg features
         stop_cond: Optional[str] = None,
         patience: Optional[int] = None,
@@ -251,7 +249,7 @@ class FedAvgRecipe(Recipe):
             launch_once=launch_once,
             shutdown_timeout=shutdown_timeout,
             key_metric=key_metric,
-            negate_key_metric=negate_key_metric,
+            key_metric_mode=key_metric_mode,
             stop_cond=stop_cond,
             patience=patience,
             best_model_filename=best_model_filename,
@@ -297,7 +295,7 @@ class FedAvgRecipe(Recipe):
         self.launch_once = v.launch_once
         self.shutdown_timeout = v.shutdown_timeout
         self.key_metric = v.key_metric
-        self.negate_key_metric = v.negate_key_metric
+        self.key_metric_mode = v.key_metric_mode
         self.stop_cond = v.stop_cond
         self.patience = v.patience
         self.best_model_filename = v.best_model_filename
@@ -331,7 +329,7 @@ class FedAvgRecipe(Recipe):
             name=self.name,
             min_clients=self.min_clients,
             key_metric=self.key_metric,
-            negate_key_metric=self.negate_key_metric,
+            key_metric_mode=self.key_metric_mode,
         )
 
         # Setup framework-specific model components and persistor

--- a/tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py
@@ -19,6 +19,7 @@ import pytest
 torch = pytest.importorskip("torch")
 from torch import nn
 
+from nvflare.apis.job_def import SERVER_SITE_NAME
 from nvflare.app_common.abstract.fl_model import FLModel, ParamsType
 from nvflare.app_opt.pt.fedce import FedCEConstants
 from nvflare.app_opt.pt.recipes.fedce import FedCERecipe
@@ -30,6 +31,22 @@ def test_fedce_recipe_uses_fedavg_with_contribution_aggregator():
 
     assert recipe.params_transfer_type.value == ParamsType.DIFF.value
     assert recipe.server_expected_format == ExchangeFormat.PYTORCH
+
+
+def test_fedce_recipe_forwards_key_metric_mode():
+    recipe = FedCERecipe(
+        model=nn.Linear(2, 1),
+        min_clients=2,
+        train_script=__file__,
+        key_metric="loss",
+        key_metric_mode="min",
+    )
+
+    server_app = recipe._job._deploy_map[SERVER_SITE_NAME]
+    selector = server_app.app_config.components.get("model_selector")
+    assert recipe.key_metric_mode == "min"
+    assert selector.key_metric == "loss"
+    assert selector.negate_key_metric is True
 
 
 @pytest.mark.parametrize("min_clients", [0, 1])

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -353,6 +353,21 @@ class TestFedAvgRecipe:
         assert isinstance(metrics_writer, MetricsArtifactWriter)
         assert not hasattr(metrics_writer, "key_metric")
 
+    def test_negate_key_metric_passthrough_pt(self, mock_file_system, base_recipe_params, simple_model):
+        recipe = FedAvgRecipe(
+            name="test_fedavg_negate_key_metric",
+            model=simple_model,
+            key_metric="eval_loss",
+            negate_key_metric=True,
+            **base_recipe_params,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert isinstance(model_selector, IntimeModelSelector)
+        assert model_selector.key_metric == "eval_loss"
+        assert model_selector.negate_key_metric is True
+        assert recipe.negate_key_metric is True
+
     def test_metrics_writer_does_not_copy_policy_from_custom_selector(self):
         key_metric = "custom_score"
         job = BaseFedJob(
@@ -493,6 +508,22 @@ class TestFedAvgRecipeKeyMetricVariants:
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == key_metric
+
+    def test_negate_key_metric_passthrough_numpy(self, mock_file_system):
+        recipe = NumpyFedAvgRecipe(
+            name="test_numpy_negate_key_metric",
+            model=[1.0, 2.0, 3.0],
+            min_clients=2,
+            train_script="mock_train_script.py",
+            key_metric="val_loss",
+            negate_key_metric=True,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert isinstance(model_selector, IntimeModelSelector)
+        assert model_selector.key_metric == "val_loss"
+        assert model_selector.negate_key_metric is True
+        assert recipe.negate_key_metric is True
 
 
 class TestNumpyFedAvgRecipe:

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -370,16 +370,18 @@ class TestFedAvgRecipe:
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == key_metric
+        assert model_selector.negate_key_metric is False
+        assert recipe.key_metric_mode == "max"
         metrics_writer = get_server_component(recipe, "metrics_artifact_writer")
         assert isinstance(metrics_writer, MetricsArtifactWriter)
         assert not hasattr(metrics_writer, "key_metric")
 
-    def test_negate_key_metric_passthrough_pt(self, mock_file_system, base_recipe_params, simple_model):
+    def test_key_metric_mode_min_pt(self, mock_file_system, base_recipe_params, simple_model):
         recipe = FedAvgRecipe(
-            name="test_fedavg_negate_key_metric",
+            name="test_fedavg_key_metric_mode_min",
             model=simple_model,
             key_metric="eval_loss",
-            negate_key_metric=True,
+            key_metric_mode="min",
             **base_recipe_params,
         )
 
@@ -387,7 +389,20 @@ class TestFedAvgRecipe:
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == "eval_loss"
         assert model_selector.negate_key_metric is True
-        assert recipe.negate_key_metric is True
+        assert recipe.key_metric_mode == "min"
+
+    def test_key_metric_mode_rejects_invalid_value(self, mock_file_system, base_recipe_params, simple_model):
+        with pytest.raises(ValueError, match="key_metric_mode"):
+            FedAvgRecipe(
+                name="test_fedavg_invalid_key_metric_mode",
+                model=simple_model,
+                key_metric_mode="median",
+                **base_recipe_params,
+            )
+
+    def test_base_fed_job_rejects_invalid_key_metric_mode(self):
+        with pytest.raises(ValueError, match="key_metric_mode must be 'min' or 'max'"):
+            BaseFedJob(key_metric_mode="median")
 
     def test_metrics_writer_does_not_copy_policy_from_custom_selector(self):
         key_metric = "custom_score"
@@ -529,86 +544,88 @@ class TestFedAvgRecipeKeyMetricVariants:
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == key_metric
+        assert model_selector.negate_key_metric is False
+        assert recipe.key_metric_mode == "max"
 
-    def test_negate_key_metric_passthrough_numpy(self, mock_file_system):
+    def test_key_metric_mode_min_numpy(self, mock_file_system):
         recipe = NumpyFedAvgRecipe(
-            name="test_numpy_negate_key_metric",
+            name="test_numpy_key_metric_mode_min",
             model=[1.0, 2.0, 3.0],
             min_clients=2,
             train_script="mock_train_script.py",
             key_metric="val_loss",
-            negate_key_metric=True,
+            key_metric_mode="min",
         )
 
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == "val_loss"
         assert model_selector.negate_key_metric is True
-        assert recipe.negate_key_metric is True
+        assert recipe.key_metric_mode == "min"
 
-    def test_negate_key_metric_passthrough_sklearn(self, mock_file_system):
+    def test_key_metric_mode_min_sklearn(self, mock_file_system):
         recipe = SklearnFedAvgRecipe(
-            name="test_sklearn_negate_key_metric",
+            name="test_sklearn_key_metric_mode_min",
             min_clients=2,
             model_params={"n_classes": 2},
             train_script="mock_train_script.py",
             key_metric="val_loss",
-            negate_key_metric=True,
+            key_metric_mode="min",
         )
 
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == "val_loss"
         assert model_selector.negate_key_metric is True
-        assert recipe.negate_key_metric is True
+        assert recipe.key_metric_mode == "min"
 
-    def test_negate_key_metric_passthrough_kmeans(self, mock_file_system):
+    def test_key_metric_mode_min_kmeans(self, mock_file_system):
         recipe = KMeansFedAvgRecipe(
-            name="test_kmeans_negate_key_metric",
+            name="test_kmeans_key_metric_mode_min",
             min_clients=2,
             n_clusters=3,
             train_script="mock_train_script.py",
             key_metric="inertia",
-            negate_key_metric=True,
+            key_metric_mode="min",
         )
 
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == "inertia"
         assert model_selector.negate_key_metric is True
-        assert recipe.negate_key_metric is True
+        assert recipe.key_metric_mode == "min"
 
-    def test_negate_key_metric_passthrough_svm(self, mock_file_system):
+    def test_key_metric_mode_min_svm(self, mock_file_system):
         recipe = SVMFedAvgRecipe(
-            name="test_svm_negate_key_metric",
+            name="test_svm_key_metric_mode_min",
             min_clients=2,
             train_script="mock_train_script.py",
             key_metric="hinge_loss",
-            negate_key_metric=True,
+            key_metric_mode="min",
         )
 
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == "hinge_loss"
         assert model_selector.negate_key_metric is True
-        assert recipe.negate_key_metric is True
+        assert recipe.key_metric_mode == "min"
 
-    def test_negate_key_metric_passthrough_tf(self, mock_file_system, monkeypatch):
+    def test_key_metric_mode_min_tf(self, mock_file_system, monkeypatch):
         TFFedAvgRecipe = load_tf_fedavg_recipe(monkeypatch)
         recipe = TFFedAvgRecipe(
-            name="test_tf_negate_key_metric",
+            name="test_tf_key_metric_mode_min",
             min_clients=2,
             train_script="mock_train_script.py",
             model_persistor=DummyPersistor(),
             key_metric="val_loss",
-            negate_key_metric=True,
+            key_metric_mode="min",
         )
 
         model_selector = get_model_selector(recipe)
         assert isinstance(model_selector, IntimeModelSelector)
         assert model_selector.key_metric == "val_loss"
         assert model_selector.negate_key_metric is True
-        assert recipe.negate_key_metric is True
+        assert recipe.key_metric_mode == "min"
 
 
 class TestNumpyFedAvgRecipe:

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import inspect
 import json
+import sys
 import warnings
+from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -33,11 +37,14 @@ from nvflare.app_common.np.recipes import NumpyFedAvgRecipe
 from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 from nvflare.app_common.widgets.metrics_artifact_writer import MetricsArtifactWriter
 from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.app_opt.sklearn.recipes import KMeansFedAvgRecipe, SklearnFedAvgRecipe, SVMFedAvgRecipe
 from nvflare.client.config import TransferType
 from nvflare.fuel.utils.secret_utils import UnsupportedSecretRefWarning
 from nvflare.job_config.base_fed_job import BaseFedJob
 from nvflare.recipe import set_per_site_config, set_recipe_meta
 from nvflare.recipe.fedavg import FedAvgRecipe as BaseFedAvgRecipe
+
+_TF_FEDAVG_RECIPE_MODULE = "_nvflare_tf_fedavg_recipe_for_test"
 
 
 class SimpleTestModel(nn.Module):
@@ -184,6 +191,20 @@ def get_server_controller(recipe):
 def get_client_executor(recipe, site_name):
     client_app = recipe._job._deploy_map[site_name]
     return client_app.app_config.executors[0].executor
+
+
+def load_tf_fedavg_recipe(monkeypatch):
+    """Load only tf/recipes/fedavg.py so this unit test does not require TensorFlow."""
+    fake_tf_model_module = ModuleType("nvflare.app_opt.tf.job_config.model")
+    fake_tf_model_module.TFModel = object
+    monkeypatch.setitem(sys.modules, "nvflare.app_opt.tf.job_config.model", fake_tf_model_module)
+
+    module_path = Path(__file__).parents[3] / "nvflare" / "app_opt" / "tf" / "recipes" / "fedavg.py"
+    spec = importlib.util.spec_from_file_location(_TF_FEDAVG_RECIPE_MODULE, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, _TF_FEDAVG_RECIPE_MODULE, module)
+    spec.loader.exec_module(module)
+    return module.FedAvgRecipe
 
 
 def _get_train_executor_config(client_config):
@@ -493,7 +514,7 @@ class TestFedAvgRecipe:
 
 
 class TestFedAvgRecipeKeyMetricVariants:
-    """Test key_metric passthrough for NumPy FedAvg recipes."""
+    """Test key_metric passthrough for framework recipe variants."""
 
     def test_key_metric_passthrough_numpy(self, mock_file_system):
         key_metric = "val_loss"
@@ -515,6 +536,70 @@ class TestFedAvgRecipeKeyMetricVariants:
             model=[1.0, 2.0, 3.0],
             min_clients=2,
             train_script="mock_train_script.py",
+            key_metric="val_loss",
+            negate_key_metric=True,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert isinstance(model_selector, IntimeModelSelector)
+        assert model_selector.key_metric == "val_loss"
+        assert model_selector.negate_key_metric is True
+        assert recipe.negate_key_metric is True
+
+    def test_negate_key_metric_passthrough_sklearn(self, mock_file_system):
+        recipe = SklearnFedAvgRecipe(
+            name="test_sklearn_negate_key_metric",
+            min_clients=2,
+            model_params={"n_classes": 2},
+            train_script="mock_train_script.py",
+            key_metric="val_loss",
+            negate_key_metric=True,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert isinstance(model_selector, IntimeModelSelector)
+        assert model_selector.key_metric == "val_loss"
+        assert model_selector.negate_key_metric is True
+        assert recipe.negate_key_metric is True
+
+    def test_negate_key_metric_passthrough_kmeans(self, mock_file_system):
+        recipe = KMeansFedAvgRecipe(
+            name="test_kmeans_negate_key_metric",
+            min_clients=2,
+            n_clusters=3,
+            train_script="mock_train_script.py",
+            key_metric="inertia",
+            negate_key_metric=True,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert isinstance(model_selector, IntimeModelSelector)
+        assert model_selector.key_metric == "inertia"
+        assert model_selector.negate_key_metric is True
+        assert recipe.negate_key_metric is True
+
+    def test_negate_key_metric_passthrough_svm(self, mock_file_system):
+        recipe = SVMFedAvgRecipe(
+            name="test_svm_negate_key_metric",
+            min_clients=2,
+            train_script="mock_train_script.py",
+            key_metric="hinge_loss",
+            negate_key_metric=True,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert isinstance(model_selector, IntimeModelSelector)
+        assert model_selector.key_metric == "hinge_loss"
+        assert model_selector.negate_key_metric is True
+        assert recipe.negate_key_metric is True
+
+    def test_negate_key_metric_passthrough_tf(self, mock_file_system, monkeypatch):
+        TFFedAvgRecipe = load_tf_fedavg_recipe(monkeypatch)
+        recipe = TFFedAvgRecipe(
+            name="test_tf_negate_key_metric",
+            min_clients=2,
+            train_script="mock_train_script.py",
+            model_persistor=DummyPersistor(),
             key_metric="val_loss",
             negate_key_metric=True,
         )

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -400,6 +400,53 @@ class TestFedAvgRecipe:
                 **base_recipe_params,
             )
 
+    def test_key_metric_mode_is_inferred_from_matching_stop_condition(
+        self, mock_file_system, base_recipe_params, simple_model
+    ):
+        recipe = FedAvgRecipe(
+            name="test_fedavg_inferred_key_metric_mode",
+            model=simple_model,
+            key_metric="loss",
+            stop_cond="loss <= 0.2",
+            **base_recipe_params,
+        )
+
+        model_selector = get_model_selector(recipe)
+        assert recipe.key_metric_mode == "min"
+        assert model_selector.negate_key_metric is True
+
+    def test_matching_stop_condition_rejects_conflicting_key_metric_mode(
+        self, mock_file_system, base_recipe_params, simple_model
+    ):
+        with pytest.raises(ValueError, match="both use metric 'loss'.*implies mode 'min'"):
+            FedAvgRecipe(
+                name="test_fedavg_conflicting_key_metric_mode",
+                model=simple_model,
+                key_metric="loss",
+                key_metric_mode="max",
+                stop_cond="loss <= 0.2",
+                **base_recipe_params,
+            )
+
+    def test_different_selection_and_stop_metrics_are_supported(
+        self, mock_file_system, base_recipe_params, simple_model
+    ):
+        recipe = FedAvgRecipe(
+            name="test_fedavg_different_selection_and_stop_metrics",
+            model=simple_model,
+            key_metric="accuracy",
+            key_metric_mode="max",
+            stop_cond="loss <= 0.2",
+            **base_recipe_params,
+        )
+
+        model_selector = get_model_selector(recipe)
+        controller = get_server_controller(recipe)
+        assert recipe.key_metric_mode == "max"
+        assert model_selector.key_metric == "accuracy"
+        assert model_selector.negate_key_metric is False
+        assert controller.stop_condition[0] == "loss"
+
     def test_base_fed_job_rejects_invalid_key_metric_mode(self):
         with pytest.raises(ValueError, match="key_metric_mode must be 'min' or 'max'"):
             BaseFedJob(key_metric_mode="median")

--- a/tests/unit_test/recipe/fedprox_recipe_test.py
+++ b/tests/unit_test/recipe/fedprox_recipe_test.py
@@ -81,6 +81,14 @@ class TestFedProxRecipe:
         assert recipe.fedprox_mu == 0.2
         assert _get_controller(recipe).fedprox_mu == 0.2
 
+    def test_key_metric_mode_is_forwarded(self, mock_file_system):
+        recipe = _make_recipe(key_metric="loss", key_metric_mode="min")
+
+        assert recipe.key_metric_mode == "min"
+        selector = recipe._job._deploy_map[SERVER_SITE_NAME].app_config.components.get("model_selector")
+        assert selector.key_metric == "loss"
+        assert selector.negate_key_metric is True
+
     @pytest.mark.parametrize("fedprox_mu", [None, 0.0, -0.1, float("inf"), float("nan"), True, "0.1"])
     def test_invalid_mu_is_rejected(self, mock_file_system, fedprox_mu):
         with pytest.raises((TypeError, ValueError), match="finite positive number"):


### PR DESCRIPTION
## Summary

- Expose `key_metric_mode` across the unified FedAvg recipe and the PyTorch, FedProx, FedCE, NumPy, sklearn, KMeans, SVM, and TensorFlow recipe wrappers.
- Map `"min"` internally to the existing `IntimeModelSelector.negate_key_metric` implementation while preserving the default higher-is-better behavior with `"max"`.
- Reject invalid mode values instead of accepting an ambiguous comparison policy.
- Infer an omitted mode from `stop_cond` when it monitors the same metric, reject conflicting same-metric directions, and allow model selection and early stopping to monitor different metrics.

The public name follows the `mode="min"|"max"` convention used by PyTorch scheduler APIs and Lightning checkpoint and early-stopping APIs. The existing selector-level `negate_key_metric` API is unchanged.

## Testing

- `python -m pytest tests/unit_test/recipe tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py -q` - 551 passed, 22 skipped
- `./runtest.sh -s`
- `./runtest.sh -l`
- `git diff --check`
