### PR TITLE
Restore Auto-FL natural-trigger phrases in the skill description

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-autofl
-description: "Use for agent-assisted Auto-FL optimization of an existing NVFLARE job in simulation, POC, or production. Do not use for code conversion, diagnosis-only work, or deployment setup."
+description: "Use to improve or optimize an existing NVFLARE job with low accuracy or an underperforming metric ('try two approaches') via an Auto-FL campaign. Do not use for conversion, diagnosis, or deployment."
 license: Apache-2.0
 version: "0.1.0"
 compatibility: "Requires NVFLARE 2.8.0+, Python, and permission to run NVFLARE jobs in the selected environment."


### PR DESCRIPTION
# Restore Auto-FL natural-trigger phrases in the skill description

## Description
#4946 tightened the `nvflare-autofl` frontmatter description for SkillEvaluator quality (83.5/B → 94.0/A) but dropped the natural user phrasings that #4925 introduced after the Auto-FL benchmark showed weak natural-trigger activation on smaller models (1/5 and 0/5 without them). This restores the trigger phrases inside the evaluator's discoverability limit, keeping both the score and the routing content.

## What changed
One line — the frontmatter description (198 chars, evaluator limit is 200):

> Use to improve or optimize an existing NVFLARE job with low accuracy or an underperforming metric ('try two approaches') via an Auto-FL campaign. Do not use for conversion, diagnosis, or deployment.

It keeps #4946's evaluator-rewarded shape ("Use to… / Do not use for…" with negative triggers) and restores #4925's benchmark-driven phrases: *improve/optimize an existing NVFLARE job*, *low accuracy*, *underperforming metric*, *'try two approaches'*.

## Local NVSkills CI reproduction (SkillEvaluator 0.1.0)
Per the nvidia-skill-evaluations workflow, baseline recorded on pristine `main` (`12043d005`) before editing; deterministic checks only (no AI-reviewed scoring implied):

| Check | Baseline (main) | This PR |
|---|---|---|
| `quality-check ./skills/nvflare-autofl` | 94.0/A (Discoverability 95) | **94.0/A** (Discoverability 95) |
| `quality-check ./skills` (catalog) | 93.0/A | **93.0/A** |
| `validate ./skills/nvflare-autofl --no-dedup` (Tier 1) | — | **10/10 pass** (incl. Secrets Detection with Gitleaks 8.30.1) |
| `python -m dev_tools.agent.skills.checks.cli --skills-root skills` | 0 findings | 0 findings |
| `pytest tests/unit_test/tool/agent_skill_checks -q` (incl. natural-phrasing trigger evals) | 139 passed | 139 passed |

The prior 392-char draft of this description cost 5 Discoverability points (`Description very long (…), recommend 50-150`, deduction fires above 200 chars) — this version stays under the threshold, so no score trade-off remains. Remaining advisories are the same heuristic convention nudges #4946 documented (`run_script()` example, literal `Purpose`/`Limitations` headings).

Note for a remote run: `/nvskills-ci` requires the branch on NVIDIA/NVFlare directly — fork PRs are rejected by policy.
