### PR TITLE
Redact headers from unknown Cell reply warnings

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -561,7 +561,7 @@ class Cell(StreamCell):
         try:
             waiter = self.requests_dict[req_id]
         except KeyError as e:
-            self.logger.warning(f"Receiving unknown {req_id=}, discarded: {e} headers: {headers}")
+            self.logger.warning(f"Receiving unknown {req_id=}, discarded: {e}")
             return
         waiter.receiving_future = future
         waiter.in_receiving.set()

--- a/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from unittest.mock import MagicMock
 
 import nvflare.fuel.f3.cellnet.cell as cell_module
@@ -42,6 +43,26 @@ def _make_cell():
     cell.decode_pass_through_topics = set()
     cell.get_fobs_context = MagicMock(return_value={})
     return cell
+
+
+def test_unknown_reply_warning_does_not_log_headers(caplog):
+    cell = _make_cell()
+    cell.logger = logging.getLogger("test_unknown_reply_warning")
+    future = MagicMock()
+    future.headers = {
+        cell_module.StreamHeaderKey.STREAM_REQ_ID: "late-request",
+        "__token__": "secret-token-sentinel",
+        "__token_signature__": "secret-signature-sentinel",
+        "other": "other-secret-sentinel",
+    }
+
+    with caplog.at_level(logging.WARNING, logger=cell.logger.name):
+        cell._process_reply(future)
+
+    assert "Receiving unknown req_id='late-request'" in caplog.text
+    assert "secret-token-sentinel" not in caplog.text
+    assert "secret-signature-sentinel" not in caplog.text
+    assert "other-secret-sentinel" not in caplog.text
 
 
 def test_encode_message_can_stamp_receiver_ids_for_multi_receiver_download_refs(monkeypatch):


### PR DESCRIPTION
## What

- Stop including the complete reply-header dictionary in the warning for an unknown Cell request ID.
- Add a regression test with sentinel header values to verify the warning remains useful without exposing header contents.

## Why

A late reply can arrive after its request waiter has already been removed. The unknown-reply warning serialized every header in that reply, including values that may be sensitive.

## Impact

The warning still identifies the unknown request ID and records that the reply was discarded. Only the raw header dump is removed.

This is a pre-existing CellNet logging issue discovered while validating PR #4962; that PR does not modify the affected CellNet path.

## Checks

- `python -m pytest tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py -q` — 10 passed
- `python -m pytest tests/unit_test/fuel/f3/cellnet -q` — 210 passed
- `./runtest.sh -s` — passed
