### PR TITLE
Clarify unreleased example version guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,4 +12,4 @@
 - Treat `main` as the development branch for the next NVFlare release.
 - On `main`, example `requirements.txt` files may intentionally pin the first upcoming NVFlare version that supports a new feature, even if that package is not published on PyPI yet.
 - Do not change those pins back to the latest stable release just to make `pip install -r requirements.txt` succeed.
-- When a requirement points to an unreleased NVFlare version, add a prominent note in the example docs telling users to install NVFlare from this repo until that package is published.
+- The requirements pin is sufficient. Do not add temporary main-branch or install-from-source caveats solely because the pinned version is not published yet.


### PR DESCRIPTION
### Summary

- clarify that an upcoming NVFlare version pin in an example requirement is sufficient on the development branch
- avoid adding temporary main-branch or install-from-source caveats solely because that pinned package is not published yet

### Why

`main` targets the next NVFlare release, so these caveats become short-lived cleanup work while the requirement
already records the first compatible version. This repository-wide agent guidance is split from #4895 to keep the
FedProx feature PR focused.

### Validation

- `git diff --check`
- Not run (agent-guidance-only change)
