### PR TITLE
Remove stale Torch dependencies from framework-neutral examples

### DIFF
--- a/examples/hello-world/hello-log-streaming/requirements.txt
+++ b/examples/hello-world/hello-log-streaming/requirements.txt
@@ -1,3 +1,2 @@
 nvflare~=2.7.2rc
 tensorboard
-torch

--- a/examples/hello-world/hello-numpy/requirements.txt
+++ b/examples/hello-world/hello-numpy/requirements.txt
@@ -1,3 +1,2 @@
 nvflare~=2.7.2rc
 tensorboard
-torch

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-10_federated_XGBoost/10.1_fed_xgboost/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-10_federated_XGBoost/10.1_fed_xgboost/requirements.txt
@@ -2,7 +2,6 @@ nvflare~=2.7.2rc
 kagglehub
 openmined-psi>=2.0.5
 pandas~=2.3
-torch
 scikit-learn
 shap
 matplotlib

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-10_federated_XGBoost/10.2_secure_fed_xgboost/requirements.txt
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-10_federated_XGBoost/10.2_secure_fed_xgboost/requirements.txt
@@ -2,7 +2,6 @@ nvflare~=2.7.2rc
 kagglehub
 openmined-psi>=2.0.5
 pandas~=2.3
-torch
 scikit-learn
 shap
 matplotlib


### PR DESCRIPTION
## What changed

- remove the stale `torch` dependency from `hello-numpy`
- apply the same cleanup to the NumPy-based `hello-log-streaming` example
- remove the same obsolete dependency from the regular and secure federated XGBoost tutorial requirements

## Why

These examples use NVFlare's framework-neutral `TensorBoardEventWriter`, which depends on the standalone `tensorboard` package rather than `torch.utils.tensorboard.SummaryWriter`. The Torch requirements remained after the TensorBoard receiver stopped importing PyTorch in #4382. `hello-log-streaming` later inherited the stale requirement from `hello-numpy`.

## Impact

Installing these framework-neutral examples no longer downloads the large PyTorch package unnecessarily. Examples that contain actual or indirect PyTorch code retain their Torch requirements.

## Validation

- one-round `hello-numpy` simulation with two clients in an isolated environment where Torch is not installed
- `15 passed`: `tb_event_writer_test.py` and `tb_receiver_test.py`
- `./runtest.sh -s`
- `git diff --check`
