### PR TITLE
Document shared-file restriction for container deploys

### DIFF
--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -51,6 +51,15 @@ not run parent server or client processes.
 The input kit is treated as read-only. Runtime-specific files are written to
 the prepared output directory.
 
+.. note::
+
+   Docker and Kubernetes preparation support only the TCP internal transport.
+   If the input kit's ``local/comm_config.json`` explicitly sets
+   ``internal.scheme`` to ``shared-file``, ``deploy prepare`` stops with an
+   ``INVALID_KIT`` error instead of rewriting the scheme to TCP. Run the
+   original kit in process mode or use the Slurm runtime for shared-file
+   transport (see :ref:`slurm_shared_file_channel`).
+
 *************
 Docker Config
 *************


### PR DESCRIPTION
## Summary

- document that Docker and Kubernetes deployment preparation supports only the TCP internal transport
- explain that an explicit `internal.scheme: shared-file` now fails with `INVALID_KIT` instead of being silently rewritten
- direct shared-file users to the original process-mode kit or the Slurm shared-file channel

## Why

PR #4972 made container deployment preparation fail fast for the unsupported shared-file transport. The deploy command reference should state that runtime boundary and the supported alternatives before users encounter the error.

## Validation

- `SKIP_API_DOCS=1 sphinx-build -q -b html docs <output>` (completed with existing repository documentation warnings)
- `git diff --check`
