### PR TITLE
Stop warning on the negated key metric the warning itself recommends

### DIFF
--- a/nvflare/app_common/widgets/intime_model_selector.py
+++ b/nvflare/app_common/widgets/intime_model_selector.py
@@ -31,13 +31,22 @@ from nvflare.widgets.widget import Widget
 # catch short names such as "mse" that are unsafe to match as substrings ("dice" contains "ce").
 _LOWER_IS_BETTER_SUBSTRING_HINTS = ("loss", "err")
 _LOWER_IS_BETTER_TOKEN_HINTS = {"bce", "ce", "cer", "mae", "mse", "nll", "perplexity", "ppl", "rmse", "wer"}
+# A "neg" token marks a metric the client already negated, which is the remedy this
+# module's own warning recommends ("neg_<key_metric>"). Such a name is higher-is-better
+# even though it still carries the original lower-is-better hint, so exempt it before
+# applying the hints. Matched as a token, not a substring, so "negative_class_loss" and
+# similar genuinely lower-is-better names are still caught.
+_ALREADY_NEGATED_TOKEN = "neg"
 
 
 def _looks_lower_is_better(metric_name: str) -> bool:
     name = metric_name.lower()
+    tokens = re.split(r"[^a-z0-9]+", name)
+    if _ALREADY_NEGATED_TOKEN in tokens:
+        return False
     if any(hint in name for hint in _LOWER_IS_BETTER_SUBSTRING_HINTS):
         return True
-    return any(token in _LOWER_IS_BETTER_TOKEN_HINTS for token in re.split(r"[^a-z0-9]+", name))
+    return any(token in _LOWER_IS_BETTER_TOKEN_HINTS for token in tokens)
 
 
 class IntimeModelSelector(Widget):
@@ -76,8 +85,10 @@ class IntimeModelSelector(Widget):
             self.logger.warning(
                 f"key_metric '{self.key_metric}' looks like a lower-is-better metric, but model selection "
                 f"treats higher values as better. If lower values indicate a better model, set "
-                f"negate_key_metric=True or report a negated metric from the client (e.g., "
-                f"'neg_{self.key_metric}'); otherwise the worst global model will be selected as the best."
+                f"key_metric_mode='min' when using the Recipe API, or set negate_key_metric=True when "
+                f"configuring IntimeModelSelector directly. Alternatively, report a negated metric from "
+                f"the client (e.g., 'neg_{self.key_metric}'); otherwise the worst global model will be "
+                f"selected as the best."
             )
 
         self.logger.info(f"model selection weights control: {aggregation_weights}")

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -205,12 +205,3 @@ After export, inspect the server configuration. The disabled state must contain
 no active model-selector component. The metric and recipe-default states must
 contain a selector with the resolved key. Treat a mismatch, or missing-metric
 warnings from a supposedly disabled job, as validation failure.
-
-A correctly negated key can also draw a startup warning that it "looks like a
-lower-is-better metric". The model selector applies a name heuristic that
-matches substrings such as `loss` and `err`, and a `neg_` prefix does not clear
-it, so `neg_loss`, `neg_val_loss`, and `eval_neg_loss` all trip it even though
-they are the recommended configuration. Treat that one-time warning as a known
-false positive on a negated key. Do not "fix" it by selecting the un-negated
-metric — that selects the worst global model — or by renaming the companion to
-hide the substring.

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -103,6 +103,17 @@ class TestInTimeModelSelector:
             ("val_loss", True, False),
             ("val_accuracy", False, False),
             ("dice", False, False),
+            # A client-negated metric is higher-is-better. "neg_<key_metric>" is the exact
+            # remedy this warning recommends, so following the advice must silence it
+            # rather than repeat it and suggest "neg_neg_val_loss".
+            ("neg_loss", False, False),
+            ("neg_val_loss", False, False),
+            ("eval_neg_loss", False, False),
+            ("neg_wer", False, False),
+            ("neg_error_rate", False, False),
+            # "negative" is not a "neg" token, so genuinely lower-is-better names that
+            # merely begin with those letters are still caught.
+            ("negative_class_loss", False, True),
         ],
     )
     def test_loss_like_key_metric_warning(self, caplog, key_metric, negate_key_metric, expect_warning):
@@ -111,6 +122,19 @@ class TestInTimeModelSelector:
             IntimeModelSelector(key_metric=key_metric, negate_key_metric=negate_key_metric)
         warned = any("looks like a lower-is-better metric" in record.getMessage() for record in caplog.records)
         assert warned == expect_warning
+
+    def test_loss_like_key_metric_warning_recommends_configuration_api(self, caplog):
+        logger_name = f"{IntimeModelSelector.__module__}.{IntimeModelSelector.__qualname__}"
+        with caplog.at_level(logging.WARNING, logger=logger_name):
+            IntimeModelSelector(key_metric="val_loss")
+
+        message = next(
+            record.getMessage()
+            for record in caplog.records
+            if "looks like a lower-is-better metric" in record.getMessage()
+        )
+        assert "key_metric_mode='min' when using the Recipe API" in message
+        assert "negate_key_metric=True when configuring IntimeModelSelector directly" in message
 
     def test_model_selection_publishes_metrics_selection_info(self):
         handler = IntimeModelSelector(key_metric="loss", negate_key_metric=True)

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -213,18 +213,6 @@ def test_pytorch_family_construction_owns_best_model_metric_policy():
     assert "disabled state must contain no active model-selector component" in normalized_construction
     assert "missing-metric warnings from a supposedly disabled job" in normalized_construction
 
-    # The selector's lower-is-better name heuristic matches the "loss" substring and a
-    # neg_ prefix does not clear it, so the recommended negated key trips a false
-    # positive.  The guidance must say so, or an agent "fixes" it by selecting the
-    # un-negated metric and silently picks the worst global model.
-    from nvflare.app_common.widgets.intime_model_selector import _looks_lower_is_better
-
-    assert _looks_lower_is_better("neg_val_loss") is True
-    assert _looks_lower_is_better("eval_neg_loss") is True
-    assert "known\nfalse positive on a negated key" in construction_text
-    assert "a `neg_` prefix does not clear" in normalized_construction
-    assert "that selects the worst global model" in normalized_construction
-
     hf_root = repo_root / "skills" / "nvflare-convert-huggingface"
     hf_skill_text = hf_root.joinpath("SKILL.md").read_text(encoding="utf-8")
     hf_conversion_text = hf_root.joinpath("references/huggingface-conversion.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Description

`IntimeModelSelector` uses a best-effort name heuristic to warn when a
lower-is-better metric is configured with higher-is-better model selection.

For Recipe API users, #4953 now exposes the preferred configuration directly:

```python
key_metric="val_loss"
key_metric_mode="min"
```

For users who configure `IntimeModelSelector` directly, the corresponding
component option is `negate_key_metric=True`. Reporting an already-negated
client metric such as `neg_val_loss` remains a valid compatibility path.

The heuristic matched `loss` and `err` as substrings, but did not recognize that
a `neg` token already made the metric higher-is-better. Consequently names such
as `neg_val_loss`, `eval_neg_loss`, and `neg_wer` emitted a warning that was
incorrect for the configured values and suggested negating the metric again.

## Change

- Exempt a standalone `neg` token before applying lower-is-better name hints.
- Keep token matching narrow so names such as `negative_class_loss` still warn.
- Update the warning with configuration-layer-specific guidance:
  - Recipe API: `key_metric_mode="min"`
  - Direct `IntimeModelSelector` configuration: `negate_key_metric=True`
  - Already-negated client metrics remain an alternative.
- Remove only the obsolete conversion-skill note and test assertions that
  documented the false positive as expected behavior. No skill workflow,
  generated asset, or metric-selection recommendation changes.

## Behavior

| Metric name | Warns after this change |
|---|---|
| `val_loss`, `eval_loss`, `val_mse`, `rmse`, `perplexity` | yes |
| `negative_class_loss` | yes |
| `neg_loss`, `neg_val_loss`, `eval_neg_loss`, `neg_wer`, `neg_error_rate` | no |
| `val_accuracy`, `dice`, `f1` | no |

This changes warning behavior only. Model-selection calculations and public APIs
are unchanged.

## Validation

- `python -m pytest -q tests/unit_test/app_common/widgets/in_time_model_selector_test.py tests/unit_test/tool/agent_skill_checks/seed_skills_test.py`: `39 passed`
- `./runtest.sh -s`: black, isort, flake8, and agent-skill lint passed
- Pre-push agent-skill lint: `0 error(s), 0 warning(s), 0 info finding(s)`
- `git diff --check`: passed
