### PR TITLE
Fix Collab call identity contracts

### DIFF
--- a/nvflare/collab/api/exceptions.py
+++ b/nvflare/collab/api/exceptions.py
@@ -30,9 +30,11 @@ class CollabCallError(Exception):
         cause_type: str = None,
         remote_traceback: str = None,
     ):
+        self.target = site
+        self.target_name = site
         self.site = site.split(".", 1)[0]
         self.func_name = func_name
         self.cause = cause
         self.cause_type = cause_type or type(cause).__name__
         self.remote_traceback = remote_traceback
-        super().__init__(f"call to {self.site}.{func_name} failed: {cause}")
+        super().__init__(f"call to {self.target_name}.{func_name} failed: {cause}")

--- a/nvflare/collab/api/exceptions.py
+++ b/nvflare/collab/api/exceptions.py
@@ -30,7 +30,12 @@ class CollabCallError(Exception):
         cause_type: str = None,
         remote_traceback: str = None,
     ):
-        self.target = site
+        """Create an error for a failed Collab call.
+
+        Args:
+            site: The logical site name or fully qualified ``<site>.<object>`` target.
+                The legacy ``site`` attribute always contains only the site prefix.
+        """
         self.target_name = site
         self.site = site.split(".", 1)[0]
         self.func_name = func_name

--- a/nvflare/collab/api/group_call_context.py
+++ b/nvflare/collab/api/group_call_context.py
@@ -285,7 +285,10 @@ class GroupCallContext:
 
             # swap caller/callee
             original_caller = ctx.caller
-            ctx.caller = ctx.callee
+            # The callback observes the remote logical site as its caller.
+            # Keep self.target_name fully qualified for routing and diagnostics,
+            # but do not expose the target object suffix as caller identity.
+            ctx.caller = ResultWaiter._get_site_name(self.target_name)
             ctx.callee = original_caller
 
             if not isinstance(result, Exception):

--- a/nvflare/collab/api/group_call_context.py
+++ b/nvflare/collab/api/group_call_context.py
@@ -28,6 +28,11 @@ _SHORT_WAIT = 1.0
 _FAILURE_MARKER = object()
 
 
+def _get_site_name(target_name: str):
+    # target_name is either <site_name> or <site_name>.<obj_name>
+    return target_name.split(".", 1)[0]
+
+
 class ResultQueue:
     def __init__(self, limit: int):
         if limit <= 0:
@@ -119,7 +124,7 @@ class ResultWaiter(threading.Event):
     def __init__(self, sites: list[str]):
         super().__init__()
         self.sites = sites
-        self._expected_sites = {self._get_site_name(site) for site in sites}
+        self._expected_sites = {_get_site_name(site) for site in sites}
         if len(self._expected_sites) != len(sites):
             raise ValueError(f"sites must be unique but got {sites}")
         self._received_sites = set()
@@ -178,12 +183,6 @@ class ResultWaiter(threading.Event):
             if done:
                 break
 
-    @staticmethod
-    def _get_site_name(target_name: str):
-        # target_name is either <site_name> or <site_name>.<obj_name>
-        parts = target_name.split(".")
-        return parts[0]
-
     def set_result(self, target_name: str, result):
         return self._set_outcome(target_name, result=result)
 
@@ -191,7 +190,7 @@ class ResultWaiter(threading.Event):
         return self._set_outcome(target_name, error=error)
 
     def _set_outcome(self, target_name: str, result=None, error: CollabCallError = None):
-        site_name = self._get_site_name(target_name)
+        site_name = _get_site_name(target_name)
         with self._result_lock:
             if site_name not in self._expected_sites:
                 self.logger.warning(f"ignored result from unexpected site '{site_name}'")
@@ -210,7 +209,7 @@ class ResultWaiter(threading.Event):
             return True
 
     def add_partial_result(self, target_name: str, partial_result):
-        site_name = self._get_site_name(target_name)
+        site_name = _get_site_name(target_name)
         self.results.append((site_name, partial_result), is_whole=False)
 
 
@@ -288,7 +287,7 @@ class GroupCallContext:
             # The callback observes the remote logical site as its caller.
             # Keep self.target_name fully qualified for routing and diagnostics,
             # but do not expose the target object suffix as caller identity.
-            ctx.caller = ResultWaiter._get_site_name(self.target_name)
+            ctx.caller = _get_site_name(self.target_name)
             ctx.callee = original_caller
 
             if not isinstance(result, Exception):

--- a/nvflare/collab/api/proxy.py
+++ b/nvflare/collab/api/proxy.py
@@ -206,16 +206,16 @@ class Proxy:
         Returns: result of the function, or None when an optional call fails.
 
         """
+        p = self
         try:
             if call_opt.target:
-                p = self.get_child(call_opt.target)
-                if not p:
+                child = self.get_child(call_opt.target)
+                if not child:
                     raise RuntimeError(
                         f"site {self.name} does not have collab target named '{call_opt.target}': "
                         f"make sure to use correct target when calling '{func_name}'."
                     )
-            else:
-                p = self
+                p = child
 
             p, func_itf, call_args, call_kwargs = p.adjust_func_args(func_name, args, kwargs)
             with p.app.new_context(self.caller_name, self.name) as ctx:
@@ -234,7 +234,7 @@ class Proxy:
             if isinstance(ex, CollabCallError):
                 call_error = ex
             else:
-                call_error = CollabCallError(self.name, func_name, ex)
+                call_error = CollabCallError(p.target_name, func_name, ex)
             if call_opt.optional:
                 self.logger.warning(f"optional {call_error}")
                 return None

--- a/nvflare/collab/runtime/cell_dispatcher.py
+++ b/nvflare/collab/runtime/cell_dispatcher.py
@@ -47,6 +47,9 @@ class CellDispatcher(_InvocationDispatcher):
     ):
         set_call_context(context)
 
+        if call_opt.secure and not self.cell.core_cell.supports_secure_messages():
+            raise RuntimeError("secure Collab call requires a Cell configured with certificates")
+
         payload = {
             ObjectCallKey.CALLER: self.caller,
             ObjectCallKey.TARGET_NAME: target_name,

--- a/nvflare/collab/runtime/cell_dispatcher.py
+++ b/nvflare/collab/runtime/cell_dispatcher.py
@@ -36,6 +36,10 @@ class CellDispatcher(_InvocationDispatcher):
         self.target_fqcn = target_fqcn
         self.thread_executor = thread_executor
 
+    def _check_secure_call_supported(self, call_opt: CallOption):
+        if call_opt.secure and not self.cell.core_cell.supports_secure_messages():
+            raise RuntimeError("secure Collab call requires a Cell configured with certificates")
+
     def _call_target(
         self,
         context,
@@ -47,8 +51,7 @@ class CellDispatcher(_InvocationDispatcher):
     ):
         set_call_context(context)
 
-        if call_opt.secure and not self.cell.core_cell.supports_secure_messages():
-            raise RuntimeError("secure Collab call requires a Cell configured with certificates")
+        self._check_secure_call_supported(call_opt)
 
         payload = {
             ObjectCallKey.CALLER: self.caller,
@@ -128,6 +131,10 @@ class CellDispatcher(_InvocationDispatcher):
             return None
 
     def call_target_in_group(self, gcc: GroupCallContext, func_name: str, *args, **kwargs):
+        # Validate local preconditions before handing work to the executor. In
+        # particular, fire-and-forget calls return before worker failures can
+        # be observed, so an invalid secure configuration must fail here.
+        self._check_secure_call_supported(gcc.call_opt)
         future = self.thread_executor.submit(self._run_func, gcc, func_name, args, kwargs)
         future.add_done_callback(lambda done: self._group_call_done(done, gcc, func_name))
 

--- a/nvflare/collab/runtime/dispatch.py
+++ b/nvflare/collab/runtime/dispatch.py
@@ -65,7 +65,7 @@ def _error_reply(error: str, logger, error_type: str = None, traceback_text: str
 
 
 def _preprocess(app: App, caller, target_obj_name, target_name, func_name, func, args, kwargs):
-    ctx = app.new_context(caller=caller, callee=app.name)
+    ctx = app.new_context(caller=caller, callee=target_name)
 
     # make sure the final kwargs conforms to func interface
     obj_itf = app.get_target_object_publish_interface(target_obj_name)

--- a/nvflare/collab/runtime/dispatch.py
+++ b/nvflare/collab/runtime/dispatch.py
@@ -64,8 +64,9 @@ def _error_reply(error: str, logger, error_type: str = None, traceback_text: str
     )
 
 
-def _preprocess(app: App, caller, target_obj_name, target_name, func_name, func, args, kwargs):
-    ctx = app.new_context(caller=caller, callee=target_name)
+def _preprocess(app: App, caller, target_obj_name, func_name, func, args, kwargs):
+    callee = f"{app.name}.{target_obj_name}" if target_obj_name else app.name
+    ctx = app.new_context(caller=caller, callee=callee)
 
     # make sure the final kwargs conforms to func interface
     obj_itf = app.get_target_object_publish_interface(target_obj_name)
@@ -146,9 +147,7 @@ def _call_app_method(request: Message, app: App, logger) -> Message:
     # invoke this method
     previous_ctx = get_call_context()
     try:
-        _, method_args, method_kwargs = _preprocess(
-            app, caller, obj_name, target_name, method_name, m, method_args, method_kwargs
-        )
+        _, method_args, method_kwargs = _preprocess(app, caller, obj_name, method_name, m, method_args, method_kwargs)
         result = m(*method_args, **method_kwargs)
 
         return new_cell_message(

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -2248,3 +2248,6 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
     def is_secure(self):
         return self.secure
+
+    def supports_secure_messages(self):
+        return self.credential_manager.cell_cipher is not None

--- a/tests/unit_test/collab/invocation_test.py
+++ b/tests/unit_test/collab/invocation_test.py
@@ -91,20 +91,22 @@ def test_group_send_completion_is_idempotent():
 def test_group_result_callback_has_isolated_kwargs_and_restores_thread_context():
     app = MagicMock()
     previous_ctx = Context(app=app, caller="previous", callee="previous", abort_signal=Signal())
-    call_ctx = Context(app=app, caller="server", callee="site-1", abort_signal=Signal())
+    call_ctx = Context(app=app, caller="server", callee="site-1.client", abort_signal=Signal())
     callback_contexts = []
     shared_kwargs = {"marker": "value"}
 
     def process_result(_gcc, result, marker, context=None):
         assert marker == "value"
         assert get_call_context() is context
+        assert context.caller == "site-1"
+        assert context.callee == "server"
         callback_contexts.append(context)
         return f"processed {result}"
 
     waiter = ResultWaiter(["site-1"])
     gcc = GroupCallContext(
         app=app,
-        target_name="site-1",
+        target_name="site-1.client",
         call_opt=CallOption(),
         func_name="train",
         process_cb=process_result,
@@ -123,6 +125,7 @@ def test_group_result_callback_has_isolated_kwargs_and_restores_thread_context()
     assert gcc.cb_kwargs is not shared_kwargs
     assert CollabMethodArgName.CONTEXT not in shared_kwargs
     assert len(callback_contexts) == 1
+    assert gcc.target_name == "site-1.client"
     assert next(iter(waiter.results)) == ("site-1", "processed raw")
 
 

--- a/tests/unit_test/collab/proxy_test.py
+++ b/tests/unit_test/collab/proxy_test.py
@@ -93,6 +93,25 @@ def test_proxy_rejects_duplicate_positional_and_keyword_argument():
     backend.call_target.assert_not_called()
 
 
+def test_child_proxy_local_failure_preserves_fully_qualified_target():
+    proxy, backend = _make_binding_proxy()
+    child = Proxy(
+        app=proxy.app,
+        target_name="site-1.trainer",
+        target_fqn="",
+        backend=backend,
+        target_interface=get_object_publish_interface(_BindingTarget()).to_dict(),
+    )
+    proxy.add_child("trainer", child)
+
+    with pytest.raises(CollabCallError, match="multiple values for argument 'value'") as exc_info:
+        proxy(target="trainer").update(1, value=2, rounds=3)
+
+    assert exc_info.value.site == "site-1"
+    assert exc_info.value.target_name == "site-1.trainer"
+    backend.call_target.assert_not_called()
+
+
 def test_proxy_enforces_keyword_only_and_positional_only_arguments():
     proxy, backend = _make_binding_proxy()
 

--- a/tests/unit_test/collab/runtime/cell_dispatcher_test.py
+++ b/tests/unit_test/collab/runtime/cell_dispatcher_test.py
@@ -163,7 +163,6 @@ def test_remote_error_preserves_type_and_traceback():
 
     error = exc_info.value
     assert error.site == "site-1"
-    assert error.target == "site-1.trainer"
     assert error.target_name == "site-1.trainer"
     assert error.func_name == "train"
     assert error.cause_type == "ValueError"
@@ -171,9 +170,10 @@ def test_remote_error_preserves_type_and_traceback():
     assert str(error) == "call to site-1.trainer.train failed: ValueError: invalid input"
 
 
-def test_secure_call_fails_immediately_when_cell_does_not_support_secure_messages():
+def test_fire_and_forget_secure_call_fails_before_executor_submission_when_cell_is_not_secure():
     cell = MagicMock()
     cell.core_cell.supports_secure_messages.return_value = False
+    thread_executor = MagicMock()
     dispatcher = CellDispatcher(
         manager=MagicMock(),
         engine=MagicMock(),
@@ -181,21 +181,20 @@ def test_secure_call_fails_immediately_when_cell_does_not_support_secure_message
         cell=cell,
         target_fqcn="site-1/job",
         abort_signal=MagicMock(),
-        thread_executor=MagicMock(),
+        thread_executor=thread_executor,
     )
 
-    try:
-        with pytest.raises(RuntimeError, match="requires a Cell configured with certificates"):
-            dispatcher._call_target(
-                context=MagicMock(),
-                target_name="site-1.trainer",
-                call_opt=CallOption(secure=True),
-                func_name="train",
-            )
-    finally:
-        set_call_context(None)
+    with pytest.raises(RuntimeError, match="requires a Cell configured with certificates"):
+        dispatcher.call_target(
+            context=MagicMock(),
+            target_name="site-1.trainer",
+            call_opt=CallOption(secure=True, expect_result=False),
+            func_name="train",
+        )
 
+    thread_executor.submit.assert_not_called()
     cell.send_request.assert_not_called()
+    cell.fire_and_forget.assert_not_called()
 
 
 def test_group_worker_restores_previous_context():

--- a/tests/unit_test/collab/runtime/cell_dispatcher_test.py
+++ b/tests/unit_test/collab/runtime/cell_dispatcher_test.py
@@ -163,9 +163,39 @@ def test_remote_error_preserves_type_and_traceback():
 
     error = exc_info.value
     assert error.site == "site-1"
+    assert error.target == "site-1.trainer"
+    assert error.target_name == "site-1.trainer"
     assert error.func_name == "train"
     assert error.cause_type == "ValueError"
     assert error.remote_traceback == "remote traceback"
+    assert str(error) == "call to site-1.trainer.train failed: ValueError: invalid input"
+
+
+def test_secure_call_fails_immediately_when_cell_does_not_support_secure_messages():
+    cell = MagicMock()
+    cell.core_cell.supports_secure_messages.return_value = False
+    dispatcher = CellDispatcher(
+        manager=MagicMock(),
+        engine=MagicMock(),
+        caller="server",
+        cell=cell,
+        target_fqcn="site-1/job",
+        abort_signal=MagicMock(),
+        thread_executor=MagicMock(),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="requires a Cell configured with certificates"):
+            dispatcher._call_target(
+                context=MagicMock(),
+                target_name="site-1.trainer",
+                call_opt=CallOption(secure=True),
+                func_name="train",
+            )
+    finally:
+        set_call_context(None)
+
+    cell.send_request.assert_not_called()
 
 
 def test_group_worker_restores_previous_context():

--- a/tests/unit_test/collab/runtime/dispatch_test.py
+++ b/tests/unit_test/collab/runtime/dispatch_test.py
@@ -152,7 +152,7 @@ def test_named_object_call_context_uses_fully_qualified_callee():
         {},
         {
             ObjectCallKey.CALLER: "server",
-            ObjectCallKey.TARGET_NAME: "site-1.trainer",
+            ObjectCallKey.TARGET_NAME: "other-site.trainer",
             ObjectCallKey.METHOD_NAME: "identify",
         },
     )

--- a/tests/unit_test/collab/runtime/dispatch_test.py
+++ b/tests/unit_test/collab/runtime/dispatch_test.py
@@ -55,6 +55,12 @@ class _ThreadCapturingClient:
         return "result"
 
 
+class _ContextCapturingClient:
+    @publish
+    def identify(self, context=None):
+        return context.caller, context.callee
+
+
 def test_prepare_for_remote_call_registers_blob_callback():
     cell = MagicMock()
     app = MagicMock()
@@ -136,6 +142,25 @@ def test_remote_call_restores_previous_context_after_success():
 
     assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
     assert reply.payload[CallReplyKey.RESULT] == "result"
+
+
+def test_named_object_call_context_uses_fully_qualified_callee():
+    app = ClientApp(_SuccessfulClient())
+    app.name = "site-1"
+    app.add_collab_object("trainer", _ContextCapturingClient())
+    request = new_cell_message(
+        {},
+        {
+            ObjectCallKey.CALLER: "server",
+            ObjectCallKey.TARGET_NAME: "site-1.trainer",
+            ObjectCallKey.METHOD_NAME: "identify",
+        },
+    )
+
+    reply = _call_app_method(request, app, MagicMock())
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
+    assert reply.payload[CallReplyKey.RESULT] == ("server", "site-1.trainer")
 
 
 def test_remote_call_restores_positional_only_arguments_for_invocation():

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_test.py
@@ -223,6 +223,14 @@ def test_encrypt_and_decrypt_secure_payload():
     assert not message.get_header(MessageHeaderKey.ENCRYPTED, False)
 
 
+@pytest.mark.parametrize("cell_cipher, expected", [(None, False), (MagicMock(), True)])
+def test_supports_secure_messages_requires_cell_cipher(cell_cipher, expected):
+    cell = _cell()
+    cell.credential_manager = SimpleNamespace(cell_cipher=cell_cipher)
+
+    assert cell.supports_secure_messages() is expected
+
+
 @pytest.mark.parametrize("payload", ["text", 1, {}])
 def test_encrypt_rejects_unsupported_payload(payload):
     cell = _cell()


### PR DESCRIPTION
## What changed

- Normalize async callback caller identity to the logical remote site while retaining the fully qualified target for routing.
- Use the fully qualified target name as the callee for named-object dispatch.
- Preserve the fully qualified target on `CollabCallError` and in its diagnostic message while keeping the site-only compatibility field.
- Fail secure Collab calls immediately when the local Cell lacks certificate-backed secure-message support.
- Add regression coverage for all four behaviors.

## Why

Collab call contexts and errors were inconsistently collapsing or expanding target identities. In addition, secure calls from a non-secure simulation environment attempted certificate exchange and surfaced as a timeout instead of reporting the invalid precondition immediately.

## Impact

Callbacks, named-object handlers, and errors now expose consistent caller/callee/target identities. Invalid secure-call configurations fail locally with an actionable error rather than waiting for the remote-call timeout.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ~/venv/3.12/bin/python -m pytest -q tests/unit_test/collab tests/unit_test/fuel/f3/cellnet/core_cell_test.py` — 118 passed
- Black, isort, and flake8 checks on all changed files
- License-header validation for `nvflare` and `tests`
- `git diff --check`
