### PR TITLE
[FLARE-3068] Allow Slurm studies to override Python path

### DIFF
--- a/docs/design/study_runtime_config.md
+++ b/docs/design/study_runtime_config.md
@@ -81,6 +81,7 @@ studies:
 
     slurm:                              # Slurm only; site-owned study override
       sandbox: apptainer                # apptainer | pyxis | none
+      python_path: /opt/nvflare/bin/python3
       setup: "source /opt/studies/lung-cancer.sh"
       partition: fl-gpu
       account: lung-cancer-project

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -320,7 +320,7 @@ class SlurmJobLauncher(JobLauncherSpec):
 
     def _effective_study_values(
         self, runtime: StudyRuntime, job_image: Optional[str] = None
-    ) -> tuple[str, Optional[str], str, dict]:
+    ) -> tuple[str, Optional[str], str, str, dict]:
         slurm = runtime.slurm
         sandbox = slurm.get("sandbox", self.config.sandbox)
         if job_image is not None:
@@ -339,10 +339,11 @@ class SlurmJobLauncher(JobLauncherSpec):
                 label="effective image",
             )
         )
+        python_path = slurm.get("python_path", self.config.python_path)
         setup = slurm.get("setup", self.config.setup)
         directives = dict(self.config.sbatch_directives)
         directives.update({key: slurm[key] for key in ("partition", "account", "qos") if key in slurm})
-        return sandbox, image, setup, directives
+        return sandbox, image, python_path, setup, directives
 
     def _study_environment(self, runtime: StudyRuntime) -> tuple[dict, dict]:
         environment = dict(runtime.env)
@@ -435,7 +436,7 @@ class SlurmJobLauncher(JobLauncherSpec):
         # AppDeployer classifies a selected Slurm image as BYOC and authorizes it
         # before the locally deployed job reaches this launcher.
         job_image = job_spec.get("image")
-        sandbox, image, setup, directives = self._effective_study_values(runtime, job_image)
+        sandbox, image, python_path, setup, directives = self._effective_study_values(runtime, job_image)
         resources = _resolve_resources(
             job_meta,
             site_name,
@@ -474,7 +475,7 @@ class SlurmJobLauncher(JobLauncherSpec):
             study_env=study_env,
             study_secret_env=secret_env,
             mounts=tuple(mounts),
-            python_path=self.config.python_path,
+            python_path=python_path,
             python_env=self._python_environment(workspace, job_id),
             forward_env=self.config.forward_env,
             additional_node_command=additional_node_command,

--- a/nvflare/app_opt/job_launcher/study_runtime.py
+++ b/nvflare/app_opt/job_launcher/study_runtime.py
@@ -52,7 +52,7 @@ _STUDY_KEYS = {
 _MOUNT_DATASET_KEYS = {"type", "source", "mode"}
 _SECRET_ENV_KEYS = {"source", "key"}
 _SECRET_MOUNT_KEYS = {"source", "mount_path", "mode", "items"}
-_SLURM_KEYS = {"sandbox", "setup", "partition", "account", "qos"}
+_SLURM_KEYS = {"sandbox", "python_path", "setup", "partition", "account", "qos"}
 SLURM_SANDBOXES = frozenset({"apptainer", "pyxis", "none"})
 _VALID_LAUNCHER_MODES = {"process", "docker", "k8s", "slurm"}
 
@@ -401,6 +401,8 @@ def _parse_slurm(study: str, entry, file_path: str) -> dict:
         if key == "sandbox":
             if not isinstance(value, str) or value not in SLURM_SANDBOXES:
                 raise _error(file_path, f"{key_label} must be one of {sorted(SLURM_SANDBOXES)}.")
+        elif key == "python_path":
+            value = _require_slurm_absolute_path(value, key_label, file_path)
         elif key == "setup":
             value = _require_utf8_text(value, key_label, file_path, allow_empty=True)
         else:

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -465,6 +465,7 @@ studies:
       image: %s
     slurm:
       sandbox: apptainer
+      python_path: /opt/nvflare/bin/python3
 """
         % (tmp_path / "study.sif"),
         encoding="utf-8",
@@ -480,6 +481,7 @@ studies:
     plan = launcher._build_launch_plan(meta, _fl_ctx(workspace))
 
     assert plan.image == str(tmp_path / "job.sif")
+    assert plan.python_path == "/opt/nvflare/bin/python3"
 
 
 def test_sandbox_none_rejects_byoc_authorized_job_image(tmp_path):

--- a/tests/unit_test/app_opt/job_launcher/study_runtime_test.py
+++ b/tests/unit_test/app_opt/job_launcher/study_runtime_test.py
@@ -88,6 +88,7 @@ studies:
         mount_path: /run/secrets/pathology
     slurm:
       sandbox: apptainer
+      python_path: /opt/nvflare/bin/python3
       setup: |
         module load cuda
       partition: gpu
@@ -132,6 +133,7 @@ class TestLoadStudyRuntimeFile:
         assert runtime.secret_mounts[0].source == "/lustre/secrets/pathology"
         assert runtime.slurm == {
             "sandbox": "apptainer",
+            "python_path": "/opt/nvflare/bin/python3",
             "setup": "module load cuda\n",
             "partition": "gpu",
             "account": 1234,
@@ -405,6 +407,7 @@ class TestLoadStudyRuntimeFile:
             ("backend: apptainer", "unknown key"),
             ("sandbox: docker", "must be one of"),
             ("sandbox: {name: none}", "must be one of"),
+            ("python_path: relative/python3", "absolute path"),
             ("partition: true", "non-empty string or integer"),
             ('partition: "gpu debug"', "must not contain whitespace"),
             ("partition: |\n        gpu\n        debug", "must not contain whitespace"),


### PR DESCRIPTION
## Summary

- allow `studies.<study>.slurm.python_path` in `local/study_runtime.yaml`
- validate the study override as an absolute path
- resolve the study path into the Slurm launch plan, falling back to the site path
- document the field in the study runtime schema

## Root cause

A study could override the effective Slurm sandbox, but the launch plan always used the site-level `python_path`.
The strict study-runtime parser also rejected `python_path`, so a container study could not replace a host-only
interpreter path. The resulting worker command failed to execute and exited with RC 1.
