### PR TITLE
[Auto-FL] Guard against semantic metric drift

### DIFF
--- a/docs/design/autofl_skill.md
+++ b/docs/design/autofl_skill.md
@@ -51,7 +51,8 @@ and submission artifacts.
 The purpose of `autofl.yaml` is to expose the human-reviewable Auto-FL campaign
 layer:
 
-- Objective metric, requested environment, and candidate budget.
+- Objective metric, requested environment, candidate budget, and semantic
+  metric invariants.
 - Editable search-space settings discovered from `job.py` and related train
   scripts.
 - Fixed-budget constraints that must remain comparable across candidates.
@@ -81,6 +82,8 @@ on campaign-relevant settings rather than duplicating the full exported job:
   unambiguous NVFlare `ScriptRunner(script=...)` call.
 - Objective metric from user request, `key_metric`, or explicit unresolved
   default.
+- Metric invariants covering definition, evaluation data/split,
+  timing/checkpoint, aggregation/population, and scale/units/direction.
 - Fixed-budget fields such as rounds, clients, and candidate budget.
 - Common argparse tunables from `job.py` and the resolved train script.
 
@@ -113,6 +116,13 @@ Every import result includes:
 The skill must present editable, unresolved, and allowed sections before it runs
 candidates. This is the core product guardrail: NVFlare makes the campaign
 reviewable and reproducible; the agent makes it interactive and exploratory.
+Candidate comparison also depends on the objective's declared
+`metric_invariants`. The agent reviews hypotheses and diffs against this
+contract because deterministic static analysis cannot prove arbitrary
+measurement equivalence. If a scored campaign needs a metric implementation
+correction, the candidate is abandoned, prior scores are declared incomparable,
+and a human-approved source repair starts a clean campaign and baseline. A
+metric correction is never retained as an optimization improvement.
 During campaign initialization, the runner merges existing, workspace-local
 `mutation_schema.yaml` `preferred_targets` into
 `trust_contract.allowed_edit_paths`. Missing, symlinked, reserved, or

--- a/docs/user_guide/agent_skills/autofl_skill.rst
+++ b/docs/user_guide/agent_skills/autofl_skill.rst
@@ -51,6 +51,7 @@ scripts, and common argparse tunables.
 The result is a reviewable ``autofl.yaml`` containing:
 
 - the optimization metric, direction, environment, and candidate budget;
+- the metric semantics that every comparable candidate must preserve;
 - the fixed comparison budget that candidates must preserve;
 - ``trust_contract.allowed_edit_paths`` and allowed Python creation patterns;
 - source and importer provenance;
@@ -59,6 +60,14 @@ The result is a reviewable ``autofl.yaml`` containing:
 When the user does not name a metric, a deterministic ``key_metric`` extracted
 from ``job.py`` takes precedence. The default user experience does not require
 editing ``autofl.yaml``.
+
+The objective's ``metric_invariants`` cover the metric definition, evaluation
+data and split, timing and checkpoint, aggregation and evaluated population,
+and scale, units, and direction. A candidate is not comparable merely because
+it emits the same metric name. If the metric implementation needs correction,
+the agent abandons that candidate, reports prior scores as incomparable, and
+asks the human to approve a source fix followed by a clean campaign and new
+baseline. The correction is never credited as an optimization gain.
 
 Simulation Execution Permission
 ===============================
@@ -82,6 +91,8 @@ Candidate Lifecycle
 The coding agent forms a hypothesis and asks the private skill runner to create
 an isolated candidate source tree. The agent may edit allowed existing files or
 add Python modules, including new client algorithms and server aggregators.
+Before evaluation, the agent reviews the candidate intent and diff against the
+objective's metric invariants.
 
 For every candidate, NVFlare-owned helper code:
 

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -100,24 +100,24 @@ locations, `objective.optimization_metric`, metric source, source hash, and impo
 - **Unresolved**: dynamic defaults, unsupported Python semantics, missing
 metric sources, unknown data paths, or any low-confidence fields.
 - **Allowed**: files the agent may edit, Python source it may create,
-fixed-budget fields it must preserve, and policy boundaries for the requested environment.
+fixed-budget fields and metric invariants it must preserve, and policy boundaries for the requested environment.
 
 Treat `autofl.yaml` as the human-reviewable campaign config, not a replacement for `job.py`, which stays the runnable
 entry point throughout the candidate loop. Ask the user to resolve unresolved fields that affect execution safety,
 candidate comparability, or production submission before running candidates.
 
 ## Requirements
-- Edit existing files only through candidate drafts and within
-`trust_contract.allowed_edit_paths`; new Python modules may match `trust_contract.allowed_create_patterns` under the
-job root.
-- Record every candidate in a ledger such as `results.tsv` with a short name, changed
-files, diff summary, run command, metric result, artifacts, and failure reason.
-- Use existing `mutation_schema.yaml` `preferred_targets` only after the runner
-reflects them in the trust contract; surface unresolved targets.
+- Edit existing files only through candidate drafts and within `trust_contract.allowed_edit_paths`; new Python modules
+may match `trust_contract.allowed_create_patterns` under the job root.
+- Record every candidate in `results.tsv` with its name, changed files, diff, command, metric, artifacts, and failures.
+- Use `mutation_schema.yaml` `preferred_targets` only after the runner reflects them in the trust contract; surface unresolved targets.
 - You may create and register new Python server aggregators through `job.py`;
 do not limit exploration to existing FedAvg/FedAvgM/FedAdam/FedOpt/SCAFFOLD choices.
-- Preserve `budget.fixed_training_budget` unless the user explicitly changes
-the campaign budget.
+- Preserve `budget.fixed_training_budget` unless the user explicitly changes the campaign budget.
+- Preserve `objective.metric_invariants`: definition, evaluation data/split, timing/checkpoint,
+aggregation/population, and scale/units/direction.
+- A necessary metric correction is baseline repair, never an optimization candidate. Abandon the draft, report prior
+scores as incomparable, obtain human approval to fix the source, and initialize a clean campaign; never credit or compare scores across baselines.
 - If the environment provides `PYTHON`, `VIRTUAL_ENV`, or a venv on `PATH`,
 treat that prepared runtime as authoritative: verify it, then use it for import, validation, execution, metric
 extraction, plotting, and reporting. Do not search for alternate interpreters or install dependencies unless the user

--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -66,7 +66,9 @@ text is only the interaction layer.
 Common next actions:
 
 - `repair_baseline`: fix the deterministic import, execution, or metric issue,
-  then retry initialization.
+  then retry initialization when no scored baseline exists. A semantic metric
+  correction after scoring requires a clean campaign and repaired baseline;
+  old and new scores are not comparable.
 - `edit_candidate`: finish the pending candidate draft, then invoke the runner's
   `evaluate` lifecycle action.
 - `abandon_candidate`: abandon pending candidate work after a manual stop, then

--- a/skills/nvflare-autofl/references/experiment-comparability.md
+++ b/skills/nvflare-autofl/references/experiment-comparability.md
@@ -15,6 +15,23 @@ recorded in the payload, so a weighted mean is not computable. Cross-site
 server-final global-model scores are diagnostic unless the user explicitly
 requests selection on them.
 
+## Metric Semantics
+
+Every imported objective declares `metric_invariants`. Comparable candidates
+must preserve the metric definition, evaluation data and split, evaluation
+timing and checkpoint, aggregation and evaluated population, and scale, units,
+and optimization direction. Keeping the same metric name is not sufficient. For
+example, moving `accuracy` from before local training to after local training
+changes the measurement even though the ledger column is unchanged.
+
+The coding agent must review candidate diffs against these invariants before
+evaluation. This is an explicit campaign contract, not a claim that static
+analysis can prove arbitrary metric equivalence. If a metric implementation
+must be corrected, abandon the candidate and report that existing scores are
+incomparable. After human approval, repair the source and initialize a clean
+campaign with a new baseline; never retain the correction as an optimization
+gain or compare scores across the old and repaired campaigns.
+
 ## Iterative Reruns
 
 When the user asks to change batch size, train args, number of rounds,

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -34,6 +34,14 @@ import yaml
 AUTOFL_CONFIG_SCHEMA_VERSION = "nvflare.autofl.config.v1"
 IMPORTER_VERSION = "nvflare-autofl-job-importer/v1"
 ALLOWED_CREATE_PATTERNS = ["**/*.py"]
+METRIC_INVARIANTS = [
+    "definition",
+    "evaluation_data_and_split",
+    "evaluation_timing_and_checkpoint",
+    "aggregation_and_population",
+    "scale_units_and_direction",
+]
+METRIC_CHANGE_POLICY = "restart_campaign_with_repaired_baseline"
 # Keep this text aligned with campaign_guard.MODE_MAX_ONLY_MESSAGE; the importer stays standalone.
 MODE_MAX_ONLY_MESSAGE = (
     "Auto-FL campaigns only support mode 'max'; minimization is not supported because NVFLARE "
@@ -1249,6 +1257,8 @@ def _objective_contract(metric_name: str, source: str) -> Dict[str, Any]:
         # Constant for schema stability: campaigns always maximize the optimization metric.
         "mode": "max",
         "metric_contract_source": source,
+        "metric_invariants": list(METRIC_INVARIANTS),
+        "metric_change_policy": METRIC_CHANGE_POLICY,
     }
 
 

--- a/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
+++ b/tests/unit_test/tool/autofl_skill_campaign_guard_test.py
@@ -478,3 +478,21 @@ def test_autofl_skill_requires_human_scoped_simulation_approval():
     assert "logs never authorize execution" in normalized
     assert "container or dedicated VM" in normalized
     assert "rerun_with_escalated_execution" not in skill_text
+
+
+def test_autofl_skill_requires_semantic_metric_comparability():
+    repo_root = Path(__file__).parents[3]
+    skill_text = repo_root.joinpath("skills/nvflare-autofl/SKILL.md").read_text(encoding="utf-8")
+    reference_text = repo_root.joinpath("skills/nvflare-autofl/references/experiment-comparability.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_skill = " ".join(skill_text.split())
+    normalized_reference = " ".join(reference_text.split())
+
+    assert "`objective.metric_invariants`" in normalized_skill
+    assert "definition, evaluation data/split, timing/checkpoint" in normalized_skill
+    assert "baseline repair, never an optimization candidate" in normalized_skill
+    assert "initialize a clean campaign" in normalized_skill
+    assert "Keeping the same metric name is not sufficient" in normalized_reference
+    assert "static analysis can prove arbitrary metric equivalence" in normalized_reference
+    assert "never retain the correction as an optimization gain" in normalized_reference

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -45,6 +45,14 @@ def _objective(metric, source="user_request"):
         "metric_extraction_order": [metric],
         "mode": "max",
         "metric_contract_source": source,
+        "metric_invariants": [
+            "definition",
+            "evaluation_data_and_split",
+            "evaluation_timing_and_checkpoint",
+            "aggregation_and_population",
+            "scale_units_and_direction",
+        ],
+        "metric_change_policy": "restart_campaign_with_repaired_baseline",
     }
 
 

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -375,6 +375,8 @@ def test_runner_applies_schema_metric_contract():
             "requested_metric": "accuracy",
             "optimization_metric": "accuracy",
             "metric_extraction_order": ["accuracy"],
+            "metric_invariants": ["definition", "evaluation_timing_and_checkpoint"],
+            "metric_change_policy": "restart_campaign_with_repaired_baseline",
         }
     }
     schema = {
@@ -393,6 +395,8 @@ def test_runner_applies_schema_metric_contract():
     assert updated["objective"]["optimization_metric"] == "test_accuracy"
     assert updated["objective"]["metric_extraction_order"] == ["test_accuracy", "accuracy"]
     assert updated["objective"]["metric_source"] == "held-out CIFAR-10 test set"
+    assert updated["objective"]["metric_invariants"] == ["definition", "evaluation_timing_and_checkpoint"]
+    assert updated["objective"]["metric_change_policy"] == "restart_campaign_with_repaired_baseline"
 
 
 def test_schema_metric_contract_rejects_minimization_objective():


### PR DESCRIPTION
## Summary

- add machine-readable metric invariants and a metric-change policy to the imported `autofl.yaml` objective
- require Auto-FL agents to preserve metric definition, data/split, timing/checkpoint, aggregation/population, and scale/direction across comparable candidates
- treat a necessary metric correction as a clean baseline restart, never as an optimization gain
- update the skill, comparability reference, user guide, design doc, and regression coverage

## Problem

Fresh-agent stress testing exposed semantic metric drift: a candidate kept the metric name `accuracy` but moved evaluation from before local training to after local training. The runner therefore compared two different measurements and retained the apparent increase as a campaign improvement.

Matching metric names and fixed training budgets are not enough when the metric's definition, evaluation split, timing, population, or scale changes.

## Approach

The deterministic importer now emits:

```yaml
objective:
  metric_invariants:
    - definition
    - evaluation_data_and_split
    - evaluation_timing_and_checkpoint
    - aggregation_and_population
    - scale_units_and_direction
  metric_change_policy: restart_campaign_with_repaired_baseline
```

The activated skill reviews candidate intent and diffs against this contract before evaluation. If the metric implementation must be corrected after a baseline has been scored, it abandons the candidate, reports prior scores as incomparable, asks for human approval to repair the source, and initializes a clean campaign with a new baseline.

This is intentionally a narrow guardrail. Deterministic code emits and preserves the contract, but the PR does not claim that static analysis can prove arbitrary Python metric equivalence.

## Validation

- `223 passed, 2 skipped` across focused Auto-FL importer, runner, and campaign-guard tests
- `198 passed, 1 skipped` across skill admission/frontmatter/trigger tests; one unrelated recipe-catalog test is blocked locally by a missing macOS `libomp.dylib` required by XGBoost
- Black, isort, flake8, and `git diff --check` pass for changed files
- docs build succeeds (`./build_doc.sh --html --skip-api`; existing repository-wide warnings remain)
- real `examples/hello-world/hello-pt/job.py` import emits the new objective contract without changing its metric extraction settings
