### PR TITLE
[Auto-FL] Harden final report outcomes

### DIFF
--- a/docs/design/autofl_skill.md
+++ b/docs/design/autofl_skill.md
@@ -284,6 +284,11 @@ writes:
 - `autofl_report_summary.json`, a machine-readable
   `nvflare.autofl.report.v1` summary for tools and future automation.
 
+When campaign state records an unfinished literature exploration batch, the
+report marks that checkpoint as incomplete instead of treating the partial
+evidence as a confirmed negative result. The Markdown report uses a relative
+reference for `progress.png` so the report and plot remain portable together.
+
 The helper does not edit source, ledger, manifests, or campaign state and does
 not require Git. If an abrupt interruption leaves state active, the human must
 confirm interruption after execution is independently checked; the report

--- a/docs/user_guide/agent_skills/autofl_skill.rst
+++ b/docs/user_guide/agent_skills/autofl_skill.rst
@@ -183,6 +183,9 @@ identified strictly by ``status=baseline``; ``best`` includes only a scored
 baseline or ``keep`` row, while a better unretained ``discard`` is reported as
 ``best_observed``. If a valid plot cannot be produced, the Markdown and JSON
 reports are still generated with an explicit plot-availability warning.
+An exploration batch stopped before its required candidate count is reported
+as incomplete, and the Markdown report references ``progress.png`` relatively
+so the two artifacts can be moved together.
 
 The concise synthesis follows the same evidence rules. "What helped" contains
 only strict improvements that were retained. "What did not help" presents

--- a/skills/nvflare-autofl-report/references/report-contract.md
+++ b/skills/nvflare-autofl-report/references/report-contract.md
@@ -72,6 +72,10 @@ even if a malformed crash row contains a numeric score:
 - `not_confirmed`: candidates ran but none matched or improved the incumbent;
 - `failed`: attempts produced no score;
 - `not_evaluated`: no candidate attempt followed the checkpoint.
+- `incomplete`: authoritative campaign state shows that fewer than the required
+  exploration candidates completed before the campaign stopped. The report
+  preserves measured evidence but does not present the partial batch as a
+  confirmed negative result.
 
 Preserve `[src: ...]` markers from the checkpoint. These are campaign-recorded
 source identifiers, not independently verified citations.
@@ -152,6 +156,10 @@ silently present repeated test-set selection as an unbiased final estimate.
   `nvflare.autofl.report.v1`;
 - `progress.png`: refreshed using the `nvflare-autofl` product plotter when
   plotting is available.
+
+The Markdown report embeds an available progress plot using a path relative to
+the report file. JSON and the report artifact appendix retain absolute paths
+for provenance.
 
 The JSON summary remains `nvflare.autofl.report.v1` and includes
 `artifacts.progress_plot_available` and `objective.metric_contract_source`,

--- a/skills/nvflare-autofl-report/references/report-contract.md
+++ b/skills/nvflare-autofl-report/references/report-contract.md
@@ -71,7 +71,7 @@ even if a malformed crash row contains a numeric score:
 - `matched`: the best following candidate tied the incumbent;
 - `not_confirmed`: candidates ran but none matched or improved the incumbent;
 - `failed`: attempts produced no score;
-- `not_evaluated`: no candidate attempt followed the checkpoint.
+- `not_evaluated`: no candidate attempt followed the checkpoint;
 - `incomplete`: authoritative campaign state shows that fewer than the required
   exploration candidates completed before the campaign stopped. The report
   preserves measured evidence but does not present the partial batch as a
@@ -165,6 +165,9 @@ The JSON summary remains `nvflare.autofl.report.v1` and includes
 `artifacts.progress_plot_available` and `objective.metric_contract_source`,
 plus `selection`, `outcome_summary`, `abandoned_candidates`, and
 `state_accounting` for the concise evidence synthesis and consistency check.
+Each `literature_reviews` entry carries `completion`, either an object with
+`completed`, `required`, `complete`, and `reason`, or `null` when campaign state
+does not record a matching exploration batch.
 Missing plotting dependencies or an invalid existing PNG produce warnings and
 `progress_plot_available=false`, but do not suppress the Markdown or JSON
 report. The invalid or failed plot artifact is preserved and is not embedded

--- a/skills/nvflare-autofl-report/scripts/generate_report.py
+++ b/skills/nvflare-autofl-report/scripts/generate_report.py
@@ -34,6 +34,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+from urllib.parse import quote
 
 try:
     import fcntl
@@ -746,6 +747,26 @@ def manifest_summary(record: Optional[RunRecord], campaign_root: Path) -> Dict[s
     }
 
 
+def validated_exploration_batch(exploration_batch: Any) -> Optional[Tuple[str, int, int]]:
+    if not isinstance(exploration_batch, dict):
+        return None
+    event_id = exploration_batch.get("literature_event_id")
+    completed = exploration_batch.get("completed")
+    required = exploration_batch.get("required")
+    if (
+        not isinstance(event_id, str)
+        or not event_id
+        or not isinstance(completed, int)
+        or isinstance(completed, bool)
+        or not isinstance(required, int)
+        or isinstance(required, bool)
+        or completed < 0
+        or required <= 0
+    ):
+        return None
+    return event_id, completed, required
+
+
 def literature_outcomes(
     records: Sequence[RunRecord],
     exploration_batch: Optional[Dict[str, Any]] = None,
@@ -756,6 +777,7 @@ def literature_outcomes(
         if is_literature_event(record):
             events.append((index, record, record.literature_event_id))
     outcomes = []
+    validated_batch = validated_exploration_batch(exploration_batch)
     for start, event, event_id in events:
         before = select_best(records[:start], retained_only=True)
         attempts = [
@@ -770,23 +792,14 @@ def literature_outcomes(
         scored = [record for record in attempts if is_finalized_scored_record(record)]
         segment_best = select_best(scored)
         completion = None
-        if isinstance(exploration_batch, dict) and exploration_batch.get("literature_event_id") == event_id:
-            completed = exploration_batch.get("completed")
-            required = exploration_batch.get("required")
-            if (
-                isinstance(completed, int)
-                and not isinstance(completed, bool)
-                and isinstance(required, int)
-                and not isinstance(required, bool)
-                and completed >= 0
-                and required > 0
-            ):
-                completion = {
-                    "completed": completed,
-                    "required": required,
-                    "complete": completed >= required,
-                    "reason": None if completed >= required else termination_reason,
-                }
+        if validated_batch and bool(event_id) and validated_batch[0] == event_id:
+            _, completed, required = validated_batch
+            completion = {
+                "completed": completed,
+                "required": required,
+                "complete": completed >= required,
+                "reason": None if completed >= required else termination_reason,
+            }
         if completion and not completion["complete"]:
             outcome = "incomplete"
             delta = None if segment_best is None or before is None else segment_best.score - before.score
@@ -835,7 +848,11 @@ def literature_outcomes(
     return outcomes
 
 
-def literature_completion_warnings(reviews: Sequence[Dict[str, Any]]) -> List[str]:
+def literature_completion_warnings(
+    reviews: Sequence[Dict[str, Any]],
+    exploration_batch: Optional[Dict[str, Any]] = None,
+    termination_reason: Optional[str] = None,
+) -> List[str]:
     warnings = []
     for review in reviews:
         completion = review.get("completion")
@@ -845,6 +862,15 @@ def literature_completion_warnings(reviews: Sequence[Dict[str, Any]]) -> List[st
         warnings.append(
             f"Literature exploration batch {review['literature_event_id'] or review['event']} was incomplete at "
             f"{reason}: {completion['completed']} of {completion['required']} required candidates completed."
+        )
+    validated_batch = validated_exploration_batch(exploration_batch)
+    review_event_ids = {review.get("literature_event_id") for review in reviews}
+    if validated_batch and validated_batch[1] < validated_batch[2] and validated_batch[0] not in review_event_ids:
+        event_id, completed, required = validated_batch
+        reason = termination_reason or "campaign termination"
+        warnings.append(
+            f"Literature exploration batch {event_id} was incomplete at {reason}: {completed} of {required} required "
+            "candidates completed, but no matching literature checkpoint was found in the results ledger."
         )
     return warnings
 
@@ -1342,9 +1368,10 @@ def md_cell(value: Any, limit: int = 180) -> str:
 
 def markdown_artifact_path(artifact: str, report: str) -> str:
     try:
-        return Path(os.path.relpath(artifact, start=Path(report).parent)).as_posix()
+        path = Path(os.path.relpath(artifact, start=Path(report).parent)).as_posix()
     except ValueError:
-        return Path(artifact).as_posix()
+        path = Path(artifact).as_posix()
+    return quote(path, safe="/:")
 
 
 def literature_outcome_label(review: Dict[str, Any]) -> str:
@@ -1352,7 +1379,7 @@ def literature_outcome_label(review: Dict[str, Any]) -> str:
     if isinstance(completion, dict) and completion.get("complete") is False:
         label = f"incomplete ({completion['completed']}/{completion['required']}"
         if completion.get("reason"):
-            label += f"; {completion['reason']}"
+            label += f"; {md_cell(completion['reason'], 60)}"
         return label + ")"
     return str(review["outcome"])
 
@@ -1836,7 +1863,13 @@ def generate_locked(args: argparse.Namespace, root: Path) -> Dict[str, Any]:
         exploration_batch=state.get("exploration_batch"),
         termination_reason=termination_reason,
     )
-    warnings.extend(literature_completion_warnings(reviews))
+    warnings.extend(
+        literature_completion_warnings(
+            reviews,
+            exploration_batch=state.get("exploration_batch"),
+            termination_reason=termination_reason,
+        )
+    )
     summary = {
         "schema_version": SUMMARY_SCHEMA_VERSION,
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/skills/nvflare-autofl-report/scripts/generate_report.py
+++ b/skills/nvflare-autofl-report/scripts/generate_report.py
@@ -746,7 +746,11 @@ def manifest_summary(record: Optional[RunRecord], campaign_root: Path) -> Dict[s
     }
 
 
-def literature_outcomes(records: Sequence[RunRecord]) -> List[Dict[str, Any]]:
+def literature_outcomes(
+    records: Sequence[RunRecord],
+    exploration_batch: Optional[Dict[str, Any]] = None,
+    termination_reason: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     events = []
     for index, record in enumerate(records):
         if is_literature_event(record):
@@ -765,7 +769,28 @@ def literature_outcomes(records: Sequence[RunRecord]) -> List[Dict[str, Any]]:
         ]
         scored = [record for record in attempts if is_finalized_scored_record(record)]
         segment_best = select_best(scored)
-        if segment_best is None:
+        completion = None
+        if isinstance(exploration_batch, dict) and exploration_batch.get("literature_event_id") == event_id:
+            completed = exploration_batch.get("completed")
+            required = exploration_batch.get("required")
+            if (
+                isinstance(completed, int)
+                and not isinstance(completed, bool)
+                and isinstance(required, int)
+                and not isinstance(required, bool)
+                and completed >= 0
+                and required > 0
+            ):
+                completion = {
+                    "completed": completed,
+                    "required": required,
+                    "complete": completed >= required,
+                    "reason": None if completed >= required else termination_reason,
+                }
+        if completion and not completion["complete"]:
+            outcome = "incomplete"
+            delta = None if segment_best is None or before is None else segment_best.score - before.score
+        elif segment_best is None:
             outcome = "failed" if attempts else "not_evaluated"
             delta = None
         elif before is None or better(segment_best.score, before.score):
@@ -790,6 +815,7 @@ def literature_outcomes(records: Sequence[RunRecord]) -> List[Dict[str, Any]]:
                 "best_score": None if segment_best is None else segment_best.score,
                 "delta_from_incumbent": delta,
                 "candidate_attempts": [record.name for record in attempts],
+                "completion": completion,
                 "candidate_results": [
                     {
                         "name": record.name,
@@ -807,6 +833,20 @@ def literature_outcomes(records: Sequence[RunRecord]) -> List[Dict[str, Any]]:
             }
         )
     return outcomes
+
+
+def literature_completion_warnings(reviews: Sequence[Dict[str, Any]]) -> List[str]:
+    warnings = []
+    for review in reviews:
+        completion = review.get("completion")
+        if not isinstance(completion, dict) or completion.get("complete") is not False:
+            continue
+        reason = completion.get("reason") or "campaign termination"
+        warnings.append(
+            f"Literature exploration batch {review['literature_event_id'] or review['event']} was incomplete at "
+            f"{reason}: {completion['completed']} of {completion['required']} required candidates completed."
+        )
+    return warnings
 
 
 def candidate_outcome_payload(record: RunRecord, incumbent: Optional[RunRecord]) -> Dict[str, Any]:
@@ -1300,6 +1340,23 @@ def md_cell(value: Any, limit: int = 180) -> str:
     return text if len(text) <= limit else text[: limit - 3] + "..."
 
 
+def markdown_artifact_path(artifact: str, report: str) -> str:
+    try:
+        return Path(os.path.relpath(artifact, start=Path(report).parent)).as_posix()
+    except ValueError:
+        return Path(artifact).as_posix()
+
+
+def literature_outcome_label(review: Dict[str, Any]) -> str:
+    completion = review.get("completion")
+    if isinstance(completion, dict) and completion.get("complete") is False:
+        label = f"incomplete ({completion['completed']}/{completion['required']}"
+        if completion.get("reason"):
+            label += f"; {completion['reason']}"
+        return label + ")"
+    return str(review["outcome"])
+
+
 def format_score(value: Optional[float]) -> str:
     return "n/a" if value is None else f"{value:.6f}"
 
@@ -1386,7 +1443,10 @@ def report_markdown(summary: Dict[str, Any], records: Sequence[RunRecord]) -> st
         else:
             lines.append("No finalized scored result was available.")
     progress_lines = (
-        [f"![Auto-FL progress]({summary['artifacts']['progress_plot']})"]
+        [
+            "![Auto-FL progress]("
+            f"{markdown_artifact_path(summary['artifacts']['progress_plot'], summary['artifacts']['report'])})"
+        ]
         if summary["artifacts"]["progress_plot_available"]
         else ["Progress plot unavailable; see the validation and comparability warnings below."]
     )
@@ -1592,17 +1652,19 @@ def report_markdown(summary: Dict[str, Any], records: Sequence[RunRecord]) -> st
                     result = format_score(candidate["score"])
                 evidence_items.append(f"{candidate['name']}={result}")
             evidence = "; ".join(evidence_items) or "no candidate recorded"
+            outcome_label = literature_outcome_label(item)
             lines.append(
                 f"| `{md_cell(item['event'], 45)}` (`{item['literature_event_id'] or 'not recorded'}`) | "
                 f"{md_cell('; '.join(item['sources']) or 'not recorded', 100)} | "
-                f"{item['outcome']} | `{md_cell(evidence, 130)}` | {format_delta(item['delta_from_incumbent'])} |"
+                f"{outcome_label} | `{md_cell(evidence, 130)}` | {format_delta(item['delta_from_incumbent'])} |"
             )
         lines.extend(["", "Checkpoint hypotheses and decisions:", ""])
         for item in summary["literature_reviews"]:
             candidates = ", ".join(item["candidate_attempts"]) or "none recorded"
+            outcome_label = literature_outcome_label(item)
             lines.extend(
                 wrap_markdown_bullet(
-                    f"- **{item['event']} ({item['outcome']}):** ",
+                    f"- **{item['event']} ({outcome_label}):** ",
                     f"{item['hypothesis']} Measured candidates: `{md_cell(candidates, 300)}`.",
                 )
             )
@@ -1769,7 +1831,12 @@ def generate_locked(args: argparse.Namespace, root: Path) -> Dict[str, Any]:
     cap = state.get("candidate_cap")
     cap_label = "uncapped" if cap in {None, "", 0} else cap
     lineage = candidate_lineage(best, records)
-    reviews = literature_outcomes(records)
+    reviews = literature_outcomes(
+        records,
+        exploration_batch=state.get("exploration_batch"),
+        termination_reason=termination_reason,
+    )
+    warnings.extend(literature_completion_warnings(reviews))
     summary = {
         "schema_version": SUMMARY_SCHEMA_VERSION,
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/tests/unit_test/tool/autofl_skill_report_test.py
+++ b/tests/unit_test/tool/autofl_skill_report_test.py
@@ -750,6 +750,16 @@ def test_report_generates_product_artifacts_and_candidate_lineage(tmp_path, monk
     assert "Metric artifact: `runs/inherited_tuning/cross_val_results.json`" in report
 
 
+def test_markdown_artifact_path_escapes_image_destination(tmp_path):
+    reporter = _load_reporter()
+    report_path = tmp_path / "reports" / "final report (1)#.md"
+    progress_path = tmp_path / "artifacts" / "progress plot (1)#.png"
+
+    assert reporter.markdown_artifact_path(str(progress_path), str(report_path)) == (
+        "../artifacts/progress%20plot%20%281%29%23.png"
+    )
+
+
 def test_report_synthesizes_literature_against_checkpoint_incumbent(tmp_path, monkeypatch):
     reporter = _load_reporter()
     _write_campaign(tmp_path)
@@ -819,6 +829,129 @@ def test_report_marks_cap_truncated_literature_batch_incomplete(tmp_path, monkey
     assert summary["outcome_summary"]["literature"]["counts"] == {"incomplete": 1}
     assert any("2 of 3 required candidates completed" in warning for warning in summary["warnings"])
     assert "incomplete (2/3; candidate_cap_exhausted)" in report
+
+
+def test_report_keeps_completed_literature_batch_outcome(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    _write_rows(
+        tmp_path,
+        [
+            _row("baseline", "baseline", "0.500000"),
+            _row("literature", "literature_review_1", literature_event_id="lit-0001"),
+            _row("discard", "literature_candidate_1", "0.490000", literature_event_id="lit-0001"),
+        ],
+    )
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["exploration_batch"] = {
+        "literature_event_id": "lit-0001",
+        "completed": 1,
+        "required": 1,
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+    review = summary["literature_reviews"][0]
+
+    assert review["outcome"] == "not_confirmed"
+    assert review["completion"] == {
+        "completed": 1,
+        "required": 1,
+        "complete": True,
+        "reason": None,
+    }
+    assert not any("exploration batch" in warning for warning in summary["warnings"])
+
+
+@pytest.mark.parametrize(
+    "exploration_batch",
+    [
+        {"literature_event_id": "lit-0001", "completed": "2", "required": 3},
+        {"literature_event_id": "lit-0001", "completed": 0, "required": 0},
+        {"literature_event_id": "lit-0001", "completed": True, "required": 3},
+    ],
+)
+def test_report_ignores_malformed_exploration_batch(tmp_path, monkeypatch, exploration_batch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["exploration_batch"] = exploration_batch
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+
+    assert summary["literature_reviews"][0]["outcome"] == "helped"
+    assert summary["literature_reviews"][0]["completion"] is None
+    assert not any("exploration batch" in warning for warning in summary["warnings"])
+
+
+def test_report_does_not_match_empty_exploration_batch_id(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    _write_rows(
+        tmp_path,
+        [
+            _row("baseline", "baseline", "0.500000"),
+            _row("literature", "literature_review_without_id"),
+            _row("discard", "unattributed_candidate", "0.490000"),
+        ],
+    )
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["exploration_batch"] = {"literature_event_id": "", "completed": 1, "required": 2}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+
+    assert summary["literature_reviews"][0]["outcome"] == "not_evaluated"
+    assert summary["literature_reviews"][0]["completion"] is None
+    assert not any("exploration batch" in warning for warning in summary["warnings"])
+
+
+def test_report_escapes_literature_completion_reason_in_markdown_table(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update(
+        {
+            "reason": "candidate_cap|exhausted",
+            "exploration_batch": {"literature_event_id": "lit-0001", "completed": 2, "required": 3},
+        }
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    _generate(reporter, tmp_path, monkeypatch)
+    report = tmp_path.joinpath("autofl_final_report.md").read_text(encoding="utf-8")
+    outcome_row = next(line for line in report.splitlines() if "literature_review_1" in line and line.startswith("|"))
+
+    assert "incomplete (2/3; candidate_cap\\|exhausted)" in outcome_row
+    assert outcome_row.replace("\\|", "").count("|") == 6
+
+
+def test_report_warns_about_unmatched_incomplete_exploration_batch(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update(
+        {
+            "reason": "candidate_cap_exhausted",
+            "exploration_batch": {"literature_event_id": "lit-missing", "completed": 2, "required": 3},
+        }
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+
+    assert summary["literature_reviews"][0]["completion"] is None
+    assert any(
+        "batch lit-missing was incomplete at candidate_cap_exhausted: 2 of 3 required candidates completed" in warning
+        and "no matching literature checkpoint" in warning
+        for warning in summary["warnings"]
+    )
 
 
 def test_report_selects_first_final_and_largest_milestone_jumps(tmp_path, monkeypatch):

--- a/tests/unit_test/tool/autofl_skill_report_test.py
+++ b/tests/unit_test/tool/autofl_skill_report_test.py
@@ -743,6 +743,8 @@ def test_report_generates_product_artifacts_and_candidate_lineage(tmp_path, monk
     assert "## Literature Review Outcomes" in report
     assert "## Validation And Comparability Notes" in report
     assert "Product Findings" not in report
+    assert "![Auto-FL progress](progress.png)" in report
+    assert f"![Auto-FL progress]({tmp_path.joinpath('progress.png').resolve()})" not in report
     assert str(tmp_path.joinpath("progress.png").resolve()) in report
     assert "Metric extraction source: `json:cross_val_results.json`" in report
     assert "Metric artifact: `runs/inherited_tuning/cross_val_results.json`" in report
@@ -772,6 +774,51 @@ def test_report_synthesizes_literature_against_checkpoint_incumbent(tmp_path, mo
             "sources": ["Li18 arXiv:1812.06127", "Karimireddy19"],
         },
     }
+
+
+def test_report_marks_cap_truncated_literature_batch_incomplete(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    _write_rows(
+        tmp_path,
+        [
+            _row("baseline", "baseline", "0.500000"),
+            _row("literature", "literature_review_1", literature_event_id="lit-0001"),
+            _row("discard", "literature_candidate_1", "0.490000", literature_event_id="lit-0001"),
+            _row("discard", "literature_candidate_2", "0.495000", literature_event_id="lit-0001"),
+        ],
+    )
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update(
+        {
+            "reason": "candidate_cap_exhausted",
+            "candidate_cap": 2,
+            "candidate_cap_source": "explicit",
+            "exploration_batch": {
+                "literature_event_id": "lit-0001",
+                "completed": 2,
+                "required": 3,
+                "completion_index": None,
+            },
+        }
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+    report = tmp_path.joinpath("autofl_final_report.md").read_text(encoding="utf-8")
+    review = summary["literature_reviews"][0]
+
+    assert review["outcome"] == "incomplete"
+    assert review["completion"] == {
+        "completed": 2,
+        "required": 3,
+        "complete": False,
+        "reason": "candidate_cap_exhausted",
+    }
+    assert summary["outcome_summary"]["literature"]["counts"] == {"incomplete": 1}
+    assert any("2 of 3 required candidates completed" in warning for warning in summary["warnings"])
+    assert "incomplete (2/3; candidate_cap_exhausted)" in report
 
 
 def test_report_selects_first_final_and_largest_milestone_jumps(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- classify a cap-truncated literature exploration batch as `incomplete` using authoritative campaign state
- preserve partial measured evidence and warn when an incomplete state batch has no matching ledger checkpoint
- validate exploration-batch IDs and counters, and safely render free-text termination reasons
- embed `progress.png` with a report-relative, URL-encoded Markdown path while retaining absolute provenance paths
- update the report contract, design doc, user guide, and regression coverage

## Motivation

The canonical 100-candidate CIFAR-10 H100 campaign stopped at its explicit cap with the final literature batch at 2 of 3 required candidates. The final report labeled that checkpoint `not_confirmed`, even though the planned evidence collection was incomplete. Its absolute Markdown image path also broke when the report and plot were downloaded together.

This patch makes those final artifacts honest and portable without changing campaign execution or the report schema.

## Validation

- `pytest -q tests/unit_test/tool/autofl_skill_report_test.py` (`107 passed`)
- `pytest -q tests/unit_test/tool/agent_skill_checks` (`192 passed, 1 skipped`)
- Black and isort checks
- flake8 on changed Python files
- `git diff --check`
- `./build_doc.sh --html --skip-api` (passed with pre-existing documentation warnings)
