### PR TITLE
Use public PyPI for integration dependencies

### DIFF
--- a/ci/run_integration.sh
+++ b/ci/run_integration.sh
@@ -28,6 +28,13 @@ PYTEST_ARGS=(-v --log-cli-level=INFO --capture=no)
 XGBOOST_REQUIREMENTS_FILE="${REPO_ROOT}/examples/advanced/xgboost/requirements.txt"
 XGBOOST_FEDERATED_WHEEL_URL="${XGBOOST_FEDERATED_WHEEL_URL:-}"
 
+# All dependencies installed by this script are public. Do not inherit an extra
+# package index whose stale candidates can shadow packages from public PyPI.
+unset PIP_EXTRA_INDEX_URL
+export PIP_CONFIG_FILE="/dev/null"
+export PIP_INDEX_URL="https://pypi.org/simple"
+export PIPENV_PYPI_MIRROR="${PIP_INDEX_URL}"
+
 # CRITICAL: Set gRPC environment variables before ANY imports that might use gRPC.
 # See: https://github.com/grpc/grpc/issues/28557
 export GRPC_POLL_STRATEGY="poll"


### PR DESCRIPTION
## Summary

- configure NVFlare integration jobs to use public PyPI for public dependencies
- ignore inherited pip configuration and remove the extra package index
- apply the same source configuration to both pip and Pipenv install paths

## Root cause

Pip combines candidates from `index-url` and `extra-index-url` without giving the primary index priority. The inherited `sw-spark-pypi` index advertised newly released public distributions such as `cryptography==50.0.0` and `ipython==9.16.0`, but their Artifactory wheel URLs returned HTTP 404. This caused nightly integration jobs to fail during dependency installation before tests ran, even though the same distributions were available from public PyPI.

NVFlare's runtime, development, and integration dependencies do not require private packages. Explicit package sources, such as the PyTorch wheel index and federated XGBoost wheel URL, remain command-specific.

## Validation

- `bash -n ci/run_integration.sh`
- `git diff --check`
- `./runtest.sh -s`
