### PR TITLE
Fix obsolete POC setup command in tutorial setup_poc.ipynb

### DIFF
--- a/examples/tutorials/setup_poc.ipynb
+++ b/examples/tutorials/setup_poc.ipynb
@@ -422,25 +422,9 @@
    "source": [
     "## Prepare job example directories\n",
     "\n",
-    "By default, the `nvflare poc prepare` command will setup a symbolic link to the NVFlare/examples directory, assuming that you have used `git clone` to download  NVFlare from github and have defined the NVFLARE_HOME env. variable.\n",
-    "    \n",
-    "Rather than setting the NVFLARE_HOME env. variables, instead link to your desired jobs with the following command to setup to the job directory:\n",
-    "    \n",
-    "```\n",
-    "nvflare poc prepare-jobs-dir -j [JOBS_DIR]\n",
-    "```\n",
+    "When `NVFLARE_HOME` points to a cloned NVFlare repository, `nvflare poc prepare` automatically links `$NVFLARE_HOME/examples` to the project admin's transfer directory. No separate command is needed.\n",
     "\n",
-    "For example we can set the jobs directory to NVFlare/examples: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41053a0c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! nvflare poc prepare-jobs-dir -j .."
+    "For jobs stored elsewhere, copy them into the project admin's transfer directory before submitting them."
    ]
   },
   {


### PR DESCRIPTION
### Description

The setup_poc.ipynb tutorial referenced the removed nvflare poc prepare-jobs-dir command, causing the notebook to fail
when followed or executed.

This PR removes the obsolete command and documents the current behavior: nvflare poc prepare automatically links
$NVFLARE_HOME/examples when NVFLARE_HOME points to an NVFlare repository. Jobs stored elsewhere can be copied into the project admin’s transfer directory.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
