### PR TITLE
Fail jobs when result publication fails

### DIFF
--- a/docs/design/no_shared_pvc_k8s_workspace_design.md
+++ b/docs/design/no_shared_pvc_k8s_workspace_design.md
@@ -159,8 +159,11 @@ The upload sequence is:
 7. The parent extracts the uploaded results back into the parent workspace and
    removes the per-job transfer state.
 
-Upload is performed from the process shutdown path. If upload fails, the worker
-or runner logs a warning with the failure details.
+Upload is performed from the process shutdown path. When a workspace owner is
+configured, successful upload is required for successful child completion. An
+upload failure makes an otherwise successful child fail; if another error is
+already being handled, that primary error is preserved and the upload failure
+is logged as a secondary error.
 
 ## Security Model
 

--- a/nvflare/app_opt/job_launcher/workspace_cell_transfer.py
+++ b/nvflare/app_opt/job_launcher/workspace_cell_transfer.py
@@ -33,6 +33,7 @@ import posixpath
 import secrets
 import shutil
 import stat
+import sys
 import tempfile
 import threading
 import time
@@ -637,7 +638,7 @@ def upload_results(args, secure_mode: bool) -> None:
 
     run_dir = os.path.join(args.workspace, args.job_id)
     if not os.path.isdir(run_dir):
-        return
+        raise RuntimeError(f"results workspace does not exist for {args.job_id}: {run_dir}")
 
     temp_bundle = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
     temp_bundle.close()
@@ -707,8 +708,14 @@ def upload_results(args, secure_mode: bool) -> None:
         _close_bootstrap_cell()
 
 
-def upload_results_safely(args, secure_mode: bool, log=None) -> None:
+def upload_results_on_shutdown(args, secure_mode: bool, log=None) -> None:
+    has_primary_error = sys.exc_info()[0] is not None
     try:
         upload_results(args, secure_mode)
     except Exception as e:
-        (log or logger).warning(f"failed to upload job results for {args.job_id}: {secure_format_exception(e)}")
+        if not has_primary_error:
+            raise
+        (log or logger).error(
+            f"failed to upload job results for {args.job_id} while handling another error: "
+            f"{secure_format_exception(e)}"
+        )

--- a/nvflare/private/fed/app/client/worker_process.py
+++ b/nvflare/private/fed/app/client/worker_process.py
@@ -22,7 +22,7 @@ import threading
 from nvflare.apis.fl_constant import ConfigVarName, FLContextKey, JobConstants, SiteType, SystemConfigs
 from nvflare.apis.job_launcher_spec import JobProcessEnv, pop_credential_env
 from nvflare.apis.workspace import Workspace
-from nvflare.app_opt.job_launcher.workspace_cell_transfer import download_workspace, upload_results_safely
+from nvflare.app_opt.job_launcher.workspace_cell_transfer import download_workspace, upload_results_on_shutdown
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.utils.argument_utils import parse_vars
 from nvflare.fuel.utils.config_service import ConfigService
@@ -142,7 +142,7 @@ def main(args):
         if err:
             if logger:
                 logger.warning(err)
-        upload_results_safely(args, secure_train, log=logger)
+        upload_results_on_shutdown(args, secure_train, log=logger)
 
 
 def parse_arguments():

--- a/nvflare/private/fed/app/server/runner_process.py
+++ b/nvflare/private/fed/app/server/runner_process.py
@@ -22,7 +22,7 @@ import threading
 from nvflare.apis.fl_constant import ConfigVarName, JobConstants, SiteType, SystemConfigs
 from nvflare.apis.job_launcher_spec import JobProcessEnv, pop_credential_env
 from nvflare.apis.workspace import Workspace
-from nvflare.app_opt.job_launcher.workspace_cell_transfer import download_workspace, upload_results_safely
+from nvflare.app_opt.job_launcher.workspace_cell_transfer import download_workspace, upload_results_on_shutdown
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.sec.authn import set_add_auth_headers_filters
@@ -136,7 +136,7 @@ def main(args):
             if err:
                 if logger:
                     logger.warning(err)
-            upload_results_safely(args, secure_train, log=logger)
+            upload_results_on_shutdown(args, secure_train, log=logger)
 
     except ConfigError as e:
         logger = get_script_logger()

--- a/tests/unit_test/app_opt/job_launcher/workspace_cell_transfer_test.py
+++ b/tests/unit_test/app_opt/job_launcher/workspace_cell_transfer_test.py
@@ -33,6 +33,7 @@ from nvflare.app_opt.job_launcher.workspace_cell_transfer import (
     download_workspace,
     make_workspace_transfer_fqcn,
     upload_results,
+    upload_results_on_shutdown,
 )
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.utils import make_reply, new_cell_message
@@ -560,6 +561,14 @@ class TestWorkspaceBootstrapHelpers:
         with pytest.raises(RuntimeError, match=ENV_WORKSPACE_TRANSFER_TOKEN):
             upload_results(args, secure_mode=False)
 
+    def test_upload_results_raises_when_run_dir_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(ENV_WORKSPACE_OWNER_FQCN, "site-1.parent")
+        monkeypatch.setenv(ENV_WORKSPACE_TRANSFER_TOKEN, "token-1")
+        args = SimpleNamespace(workspace=str(tmp_path), job_id=JOB_ID, parent_url="tcp://parent")
+
+        with pytest.raises(RuntimeError, match="results workspace does not exist"):
+            upload_results(args, secure_mode=False)
+
     def test_upload_results_publishes_ref_to_parent(self, monkeypatch):
         with tempfile.TemporaryDirectory() as ws_root:
             _write_file(os.path.join(ws_root, JOB_ID, "result.txt"), b"done")
@@ -599,6 +608,47 @@ class TestWorkspaceBootstrapHelpers:
             assert request.payload["job_id"] == JOB_ID
             assert request.payload["ref_id"] == "ref-upload"
             assert request.payload["transfer_token"] == "token-1"
+            fake_downloader.delete_transaction.assert_called_once_with()
+
+    def test_upload_results_raises_on_negative_reply(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as ws_root:
+            _write_file(os.path.join(ws_root, JOB_ID, "result.txt"), b"done")
+            fake_cell = _FakeCell(
+                fqcn="site-1.parent",
+                reply=make_reply(ReturnCode.COMM_ERROR, error="receiver failed"),
+            )
+            fake_downloader = MagicMock()
+            fake_downloader.tx_id = "tx-upload"
+
+            monkeypatch.setenv(ENV_WORKSPACE_OWNER_FQCN, "site-1.parent")
+            monkeypatch.setenv(ENV_WORKSPACE_TRANSFER_TOKEN, "token-1")
+            monkeypatch.setattr(
+                "nvflare.app_opt.job_launcher.workspace_cell_transfer._get_bootstrap_cell",
+                lambda *a, **kw: fake_cell,
+            )
+            monkeypatch.setattr(
+                "nvflare.app_opt.job_launcher.workspace_cell_transfer._close_bootstrap_cell",
+                lambda: None,
+            )
+            monkeypatch.setattr(
+                "nvflare.app_opt.job_launcher.workspace_cell_transfer.ObjectDownloader",
+                lambda *args, **kwargs: fake_downloader,
+            )
+            monkeypatch.setattr(
+                "nvflare.app_opt.job_launcher.workspace_cell_transfer.add_file",
+                lambda downloader, file_name: "ref-upload",
+            )
+
+            args = SimpleNamespace(
+                workspace=ws_root,
+                job_id=JOB_ID,
+                parent_url="tcp://parent",
+                root_url="tcp://root",
+            )
+
+            with pytest.raises(RuntimeError, match="results upload failed"):
+                upload_results(args, secure_mode=False)
+
             fake_downloader.delete_transaction.assert_called_once_with()
 
     def test_upload_results_waits_for_bootstrap_ready(self, monkeypatch):
@@ -681,3 +731,29 @@ class TestWorkspaceBootstrapHelpers:
 
             assert created["path"]
             assert not os.path.exists(created["path"])
+
+    def test_upload_results_on_shutdown_propagates_publication_failure(self, monkeypatch):
+        args = SimpleNamespace(job_id=JOB_ID)
+        monkeypatch.setattr(
+            "nvflare.app_opt.job_launcher.workspace_cell_transfer.upload_results",
+            MagicMock(side_effect=RuntimeError("publication failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="publication failed"):
+            upload_results_on_shutdown(args, secure_mode=False)
+
+    def test_upload_results_on_shutdown_preserves_primary_failure(self, monkeypatch):
+        args = SimpleNamespace(job_id=JOB_ID)
+        log = MagicMock()
+        monkeypatch.setattr(
+            "nvflare.app_opt.job_launcher.workspace_cell_transfer.upload_results",
+            MagicMock(side_effect=RuntimeError("publication failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="execution failed"):
+            try:
+                raise RuntimeError("execution failed")
+            finally:
+                upload_results_on_shutdown(args, secure_mode=False, log=log)
+
+        log.error.assert_called_once()

--- a/tests/unit_test/fuel/f3/mpm_test.py
+++ b/tests/unit_test/fuel/f3/mpm_test.py
@@ -15,6 +15,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 from nvflare.apis.fl_constant import FLMetaKey
+from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.mpm import MainProcessMonitor
 
 
@@ -77,3 +78,10 @@ class TestMainProcessMonitorReturnCode:
         # any other non-int return value also stays int-parseable
         content = self._run_and_read_rc(tmp_path, lambda: "done")
         assert int(content) == 0
+
+    def test_unhandled_publication_failure_writes_nonzero_exit_code(self, tmp_path):
+        def _fail_publication():
+            raise RuntimeError("result publication failed")
+
+        content = self._run_and_read_rc(tmp_path, _fail_publication)
+        assert int(content) == ProcessExitCode.EXCEPTION


### PR DESCRIPTION
## What changed

- Make configured workspace result publication part of successful child completion.
- Preserve the existing no-op when no external workspace owner is configured.
- Apply the same shutdown publication policy to server and client child runners.
- Preserve an exception already being handled if result publication also fails, while logging publication as a secondary error.
- Treat a configured missing result workspace as a publication failure.
- Update the workspace-transfer design documentation and add focused regression coverage.

## Why

`upload_results_safely()` caught every packaging, upload, timeout, or parent-side rejection and reduced it to a warning. A child could therefore exit 0 even though the parent never received and verified the result workspace, producing a false successful outcome and inconsistent job state.

## Behavior

- Otherwise successful child + publication success: success.
- Otherwise successful child + configured publication failure: `ProcessExitCode.EXCEPTION`; the existing parent lifecycle classifies the job as an execution failure.
- Existing primary exception + publication failure: preserve the primary exception and log publication failure as secondary.
- No `NVFL_WORKSPACE_OWNER_FQCN`: unchanged no-op.

