### PR TITLE
Fix Recipe API usage in secure XGBoost examples

### DIFF
--- a/examples/advanced/xgboost/fedxgb_secure/README.md
+++ b/examples/advanced/xgboost/fedxgb_secure/README.md
@@ -229,7 +229,10 @@ recipe = XGBVerticalRecipe(
 set_per_site_config(recipe, per_site_config)
 
 # Run simulation with the clients configured on the recipe
-env = SimEnv(clients=recipe.configured_sites())
+env = SimEnv(
+    clients=recipe.configured_sites(),
+    workspace_root="/tmp/nvflare/workspace/fedxgb_secure/train_fl/works",
+)
 recipe.execute(env)
 ```
 
@@ -282,8 +285,11 @@ recipe = XGBHorizontalRecipe(
 set_per_site_config(recipe, per_site_config)
 
 # Export job (simulator run requires additional context setup for secure horizontal)
-env = SimEnv(clients=recipe.configured_sites())
-recipe.export("/tmp/nvflare/workspace/jobs/horizontal_secure", env=env)
+env = SimEnv(
+    clients=recipe.configured_sites(),
+    workspace_root="/tmp/nvflare/workspace/fedxgb_secure/train_fl/works",
+)
+recipe.export("/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs", env=env)
 ```
 
 #### Secure Horizontal Training - Additional Setup Required

--- a/examples/advanced/xgboost/fedxgb_secure/README.md
+++ b/examples/advanced/xgboost/fedxgb_secure/README.md
@@ -230,8 +230,7 @@ set_per_site_config(recipe, per_site_config)
 
 # Run simulation with the clients configured on the recipe
 env = SimEnv(clients=recipe.configured_sites())
-run = recipe.execute(env)
-run.simulator_run("/tmp/nvflare/workspace/works/vertical_secure")
+recipe.execute(env)
 ```
 
 #### Horizontal Federated Learning
@@ -284,8 +283,7 @@ set_per_site_config(recipe, per_site_config)
 
 # Export job (simulator run requires additional context setup for secure horizontal)
 env = SimEnv(clients=recipe.configured_sites())
-run = recipe.execute(env)
-run.export_job("/tmp/nvflare/workspace/jobs/horizontal_secure")
+recipe.export("/tmp/nvflare/workspace/jobs/horizontal_secure", env=env)
 ```
 
 #### Secure Horizontal Training - Additional Setup Required

--- a/examples/advanced/xgboost/fedxgb_secure/job.py
+++ b/examples/advanced/xgboost/fedxgb_secure/job.py
@@ -100,10 +100,9 @@ def main():
     )
     set_per_site_config(recipe, per_site_config)
 
-    # Export and run
+    # Export the job and run it when no additional setup is required
     env = SimEnv(clients=recipe.configured_sites())
-    run = recipe.execute(env)
-    run.export_job(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs/{job_name}")
+    recipe.export(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs/{job_name}", env=env)
 
     # Note: Secure horizontal training requires special tenseal context setup
     if args.secure:
@@ -114,7 +113,7 @@ def main():
         print("Please see README for next steps.")
         print("=" * 80 + "\n")
     else:
-        run.simulator_run(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/works/{job_name}")
+        recipe.execute(env)
         print("\n" + "=" * 80)
         print("Training Complete!")
         print("=" * 80 + "\n")

--- a/examples/advanced/xgboost/fedxgb_secure/job.py
+++ b/examples/advanced/xgboost/fedxgb_secure/job.py
@@ -101,8 +101,11 @@ def main():
     set_per_site_config(recipe, per_site_config)
 
     # Export the job and run it when no additional setup is required
-    env = SimEnv(clients=recipe.configured_sites())
-    recipe.export(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs/{job_name}", env=env)
+    env = SimEnv(
+        clients=recipe.configured_sites(),
+        workspace_root="/tmp/nvflare/workspace/fedxgb_secure/train_fl/works",
+    )
+    recipe.export("/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs", env=env)
 
     # Note: Secure horizontal training requires special tenseal context setup
     if args.secure:

--- a/examples/advanced/xgboost/fedxgb_secure/job_vertical.py
+++ b/examples/advanced/xgboost/fedxgb_secure/job_vertical.py
@@ -114,8 +114,11 @@ def main():
     set_per_site_config(recipe, per_site_config)
 
     # Export and run
-    env = SimEnv(clients=recipe.configured_sites())
-    recipe.export(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs/{job_name}", env=env)
+    env = SimEnv(
+        clients=recipe.configured_sites(),
+        workspace_root="/tmp/nvflare/workspace/fedxgb_secure/train_fl/works",
+    )
+    recipe.export("/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs", env=env)
     recipe.execute(env)
 
     print("\n" + "=" * 80)

--- a/examples/advanced/xgboost/fedxgb_secure/job_vertical.py
+++ b/examples/advanced/xgboost/fedxgb_secure/job_vertical.py
@@ -115,9 +115,8 @@ def main():
 
     # Export and run
     env = SimEnv(clients=recipe.configured_sites())
-    run = recipe.execute(env)
-    run.export_job(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs/{job_name}")
-    run.simulator_run(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/works/{job_name}")
+    recipe.export(f"/tmp/nvflare/workspace/fedxgb_secure/train_fl/jobs/{job_name}", env=env)
+    recipe.execute(env)
 
     print("\n" + "=" * 80)
     print("Training Complete!")


### PR DESCRIPTION
## What changed

- Export the horizontal and vertical secure XGBoost recipes with `recipe.export(..., env=env)`.
- Execute runnable simulations once with `recipe.execute(env)` instead of calling legacy `FedJob` methods on the returned `Run`.
- Keep secure horizontal as an export-only path because it requires the documented TenSEAL provisioning step.
- Update the README snippets to use the Recipe API.

## Root cause

The FedJob-to-Recipe migration retained calls to `export_job()` and `simulator_run()` after assigning the result of `recipe.execute(env)` to `run`. That result is `nvflare.recipe.run.Run`, which exposes job status and result operations but not FedJob construction or simulator methods. Since `recipe.execute(env)` already runs the simulation, the legacy `simulator_run()` calls were also redundant.

This became visible while verifying #4980: after the explicit-client topology blocker was fixed, training completed and the example failed on the next line with:

```text
AttributeError: 'Run' object has no attribute 'export_job'
```

## Validation

Runtime validation used Python 3.12 and the exact XGBoost 2.2.0 development wheel pinned by `examples/advanced/xgboost/requirements.txt`, with generated two-site CSV data:

- Unchanged `python job.py --site_num 2 --round_num 1`: reproduced the post-training `Run.export_job` `AttributeError`.
- Fixed `python job.py --site_num 2 --round_num 1`: one round completed, printed `Training Complete!`, and exported the horizontal job.
- Fixed `python job.py --secure --site_num 2 --round_num 1`: exported the secure horizontal job and exited without starting simulation.
- Fixed `python job_vertical.py --site_num 2 --round_num 1`: one vertical round completed, printed `Training Complete!`, and exported the vertical job.
- `pytest tests/unit_test/app_opt/xgboost/xgboost_recipe_test.py -q`: 6 passed.
- `pytest tests/unit_test/recipe/spec_test.py -q -k 'not TestRecipeTensorStreaming'`: 57 passed, 8 deselected because PyTorch was not installed in the XGBoost-specific environment.
- `./runtest.sh -s`: passed Black, isort, flake8, and agent-skill lint.
