### PR TITLE
Handle FedCE client participation edge cases

### DIFF
--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -196,6 +196,11 @@ FedCE
 contribution from gradient-direction novelty and a client-computed leave-one-out (minus-model) score,
 then uses those estimates as aggregation weights.
 
+FedCE requires at least two clients and assumes full participation in every round. Configure
+``min_clients`` to include all participating clients whenever possible. If the client set changes,
+NVFlare logs a warning, initializes unseen clients with a uniform prior, and carries the most recent
+contribution weights of absent clients forward.
+
 .. code-block:: python
 
     from nvflare.app_opt.pt.recipes import FedCERecipe

--- a/nvflare/app_opt/pt/fedce.py
+++ b/nvflare/app_opt/pt/fedce.py
@@ -39,9 +39,13 @@ class PTFedCEHelper:
     """Client-side utilities for the FedCE-specific training contract."""
 
     @staticmethod
-    def get_contribution_weight(global_model: FLModel, client_name: str, default: float = 0.0) -> float:
+    def get_contribution_weight(global_model: FLModel, client_name: str, default: Optional[float] = None) -> float:
         weights = (global_model.meta or {}).get(FedCEConstants.CONTRIBUTION_WEIGHTS, {})
-        return float(weights.get(client_name, default))
+        if client_name in weights:
+            return float(weights[client_name])
+        if default is not None:
+            return float(default)
+        return 1.0 / len(weights) if weights else 0.0
 
     @staticmethod
     def make_minus_model(global_model, previous_local_state: Dict, contribution_weight: float):
@@ -102,6 +106,10 @@ class FedCEModelAggregator(ModelAggregator):
     shapes. Contribution scores are computed from the configured trainable
     parameter subset, while the resulting contribution weights are applied to
     every returned parameter, including non-trainable buffers.
+
+    FedCE assumes full client participation. If the participating client set
+    changes, the aggregator logs a warning, uses a uniform prior for new
+    clients, and carries forward the last weights of absent clients.
     """
 
     MODES = ("plus", "times")
@@ -159,6 +167,13 @@ class FedCEModelAggregator(ModelAggregator):
             raise ValueError("FedCE cannot aggregate an empty result set")
 
         clients = sorted(self._results)
+        known_clients = set(self._contribution_weights)
+        if known_clients and set(clients) != known_clients:
+            self.warning(
+                "FedCE detected partial participation or a changing client set. "
+                f"Current clients: {clients}; clients with prior contribution weights: {sorted(known_clients)}. "
+                "Using a uniform prior for new clients and carrying forward weights for absent clients."
+            )
         param_names = self._get_cosine_param_names(clients)
         prior_weights = self._get_prior_weights(clients)
         consensus = self._weighted_vector(clients, prior_weights, param_names)
@@ -187,7 +202,7 @@ class FedCEModelAggregator(ModelAggregator):
         else:
             combined = [cosine * minus for cosine, minus in zip(cosine_weights, minus_weights)]
         normalized = _normalize(combined, self.epsilon)
-        self._contribution_weights = dict(zip(clients, normalized))
+        self._contribution_weights.update(zip(clients, normalized))
 
         params_helper = WeightedAggregationHelper()
         metrics_helper = WeightedAggregationHelper()
@@ -259,7 +274,8 @@ class FedCEModelAggregator(ModelAggregator):
         return sorted(common)
 
     def _get_prior_weights(self, clients: List[str]) -> Dict[str, float]:
-        values = [self._contribution_weights.get(client, 1.0) for client in clients]
+        uniform_weight = 1.0 / len(clients)
+        values = [self._contribution_weights.get(client, uniform_weight) for client in clients]
         return dict(zip(clients, _normalize(values, self.epsilon)))
 
     def _weighted_vector(self, clients: List[str], weights: Dict[str, float], param_names: List[str]):

--- a/nvflare/app_opt/pt/fedce.py
+++ b/nvflare/app_opt/pt/fedce.py
@@ -35,6 +35,10 @@ class FedCEConstants:
     CONTRIBUTION_WEIGHTS = "fedce_coef"
 
 
+def _get_unseen_client_weight(weights: Dict[str, float]) -> float:
+    return 1.0 / (len(weights) + 1) if weights else 0.0
+
+
 class PTFedCEHelper:
     """Client-side utilities for the FedCE-specific training contract."""
 
@@ -45,7 +49,7 @@ class PTFedCEHelper:
             return float(weights[client_name])
         if default is not None:
             return float(default)
-        return 1.0 / len(weights) if weights else 0.0
+        return _get_unseen_client_weight(weights)
 
     @staticmethod
     def make_minus_model(global_model, previous_local_state: Dict, contribution_weight: float):
@@ -274,9 +278,15 @@ class FedCEModelAggregator(ModelAggregator):
         return sorted(common)
 
     def _get_prior_weights(self, clients: List[str]) -> Dict[str, float]:
-        uniform_weight = 1.0 / len(clients)
-        values = [self._contribution_weights.get(client, uniform_weight) for client in clients]
-        return dict(zip(clients, _normalize(values, self.epsilon)))
+        if not self._contribution_weights:
+            uniform_weight = 1.0 / len(clients)
+            return dict.fromkeys(clients, uniform_weight)
+
+        # Keep the server prior identical to the coefficient an unseen client
+        # used for its minus model. Normalization is unnecessary because these
+        # weights are used only to derive cosine directions.
+        unseen_client_weight = _get_unseen_client_weight(self._contribution_weights)
+        return {client: self._contribution_weights.get(client, unseen_client_weight) for client in clients}
 
     def _weighted_vector(self, clients: List[str], weights: Dict[str, float], param_names: List[str]):
         result = None

--- a/nvflare/app_opt/pt/recipes/fedce.py
+++ b/nvflare/app_opt/pt/recipes/fedce.py
@@ -32,6 +32,9 @@ class FedCERecipe(FedAvgRecipe):
 
     This recipe intentionally requires PyTorch exchange format and DIFF transfer.
     It is a dedicated algorithm rather than a passive FedAvg option.
+    FedCE requires at least two clients and assumes that the same clients
+    participate in every round. If participation changes, the aggregator logs
+    a warning and carries prior contribution weights forward.
     """
 
     def __init__(
@@ -61,6 +64,10 @@ class FedCERecipe(FedAvgRecipe):
         client_memory_gc_rounds: int = 0,
         cuda_empty_cache: bool = False,
     ):
+        if not isinstance(min_clients, int):
+            raise TypeError(f"min_clients must be int, got {type(min_clients).__name__}")
+        if min_clients < 2:
+            raise ValueError(f"FedCERecipe requires min_clients >= 2, got {min_clients}")
         if server_expected_format != ExchangeFormat.PYTORCH:
             raise ValueError("FedCERecipe requires server_expected_format=ExchangeFormat.PYTORCH")
 

--- a/tests/unit_test/app_opt/pt/fedce_test.py
+++ b/tests/unit_test/app_opt/pt/fedce_test.py
@@ -85,7 +85,10 @@ def test_fedce_carries_weights_across_partial_participation(caplog):
     aggregator.accept_model(_result("site-2", [1.0, 1.0], 0.5, round_number=1))
     aggregator.accept_model(_result("site-3", [0.0, 1.0], 0.5, round_number=1))
 
-    assert aggregator._get_prior_weights(["site-2", "site-3"]) == {"site-2": 0.5, "site-3": 0.5}
+    prior_weights = aggregator._get_prior_weights(["site-2", "site-3"])
+    dispatched = FLModel(meta={FedCEConstants.CONTRIBUTION_WEIGHTS: first_weights})
+    assert prior_weights == {"site-2": pytest.approx(1.0 / 3.0), "site-3": pytest.approx(0.5)}
+    assert PTFedCEHelper.get_contribution_weight(dispatched, "site-2") == pytest.approx(prior_weights["site-2"])
     with caplog.at_level("WARNING"):
         second = aggregator.aggregate_model()
 
@@ -95,6 +98,9 @@ def test_fedce_carries_weights_across_partial_participation(caplog):
     assert second_weights["site-1"] == pytest.approx(first_weights["site-1"])
     assert second_weights["site-2"] + second_weights["site-3"] == pytest.approx(1.0)
     assert PTFedCEHelper.get_contribution_weight(second, "site-1") == pytest.approx(first_weights["site-1"])
+
+    next_prior_weights = aggregator._get_prior_weights(["site-3", "site-4"])
+    assert PTFedCEHelper.get_contribution_weight(second, "site-4") == pytest.approx(next_prior_weights["site-4"])
 
 
 def test_fedce_requires_minus_model_score():
@@ -144,7 +150,7 @@ def test_fedce_helper_reads_weight_and_handles_non_trainable_buffers():
 
     global_model = FLModel(meta={FedCEConstants.CONTRIBUTION_WEIGHTS: {"site-1": 0.4, "site-3": 0.6}})
     assert PTFedCEHelper.get_contribution_weight(global_model, "site-1") == pytest.approx(0.4)
-    assert PTFedCEHelper.get_contribution_weight(global_model, "site-2") == pytest.approx(0.5)
+    assert PTFedCEHelper.get_contribution_weight(global_model, "site-2") == pytest.approx(1.0 / 3.0)
     assert PTFedCEHelper.get_contribution_weight(global_model, "site-2", default=0.2) == pytest.approx(0.2)
     assert PTFedCEHelper.get_contribution_weight(FLModel(meta={}), "site-1") == pytest.approx(0.0)
 

--- a/tests/unit_test/app_opt/pt/fedce_test.py
+++ b/tests/unit_test/app_opt/pt/fedce_test.py
@@ -75,6 +75,28 @@ def test_fedce_recovers_prior_weights_from_dispatched_model_metadata():
     assert aggregator._get_prior_weights(["site-1", "site-2"]) == prior_weights
 
 
+def test_fedce_carries_weights_across_partial_participation(caplog):
+    aggregator = FedCEModelAggregator()
+    aggregator.accept_model(_result("site-1", [1.0, 0.0], 0.5))
+    aggregator.accept_model(_result("site-3", [0.0, 1.0], 0.5))
+    first_weights = aggregator.aggregate_model().meta[FedCEConstants.CONTRIBUTION_WEIGHTS]
+
+    aggregator.reset_stats()
+    aggregator.accept_model(_result("site-2", [1.0, 1.0], 0.5, round_number=1))
+    aggregator.accept_model(_result("site-3", [0.0, 1.0], 0.5, round_number=1))
+
+    assert aggregator._get_prior_weights(["site-2", "site-3"]) == {"site-2": 0.5, "site-3": 0.5}
+    with caplog.at_level("WARNING"):
+        second = aggregator.aggregate_model()
+
+    second_weights = second.meta[FedCEConstants.CONTRIBUTION_WEIGHTS]
+    assert "partial participation" in caplog.text
+    assert set(second_weights) == {"site-1", "site-2", "site-3"}
+    assert second_weights["site-1"] == pytest.approx(first_weights["site-1"])
+    assert second_weights["site-2"] + second_weights["site-3"] == pytest.approx(1.0)
+    assert PTFedCEHelper.get_contribution_weight(second, "site-1") == pytest.approx(first_weights["site-1"])
+
+
 def test_fedce_requires_minus_model_score():
     aggregator = FedCEModelAggregator()
     result = FLModel(
@@ -120,9 +142,11 @@ def test_fedce_helper_reads_weight_and_handles_non_trainable_buffers():
             self.register_buffer("counter", torch.tensor([3], dtype=torch.int64))
             self.register_buffer("untouched", torch.tensor([4], dtype=torch.int64))
 
-    global_model = FLModel(meta={FedCEConstants.CONTRIBUTION_WEIGHTS: {"site-1": 0.4}})
+    global_model = FLModel(meta={FedCEConstants.CONTRIBUTION_WEIGHTS: {"site-1": 0.4, "site-3": 0.6}})
     assert PTFedCEHelper.get_contribution_weight(global_model, "site-1") == pytest.approx(0.4)
+    assert PTFedCEHelper.get_contribution_weight(global_model, "site-2") == pytest.approx(0.5)
     assert PTFedCEHelper.get_contribution_weight(global_model, "site-2", default=0.2) == pytest.approx(0.2)
+    assert PTFedCEHelper.get_contribution_weight(FLModel(meta={}), "site-1") == pytest.approx(0.0)
 
     model = BufferedModel()
     minus_model = PTFedCEHelper.make_minus_model(

--- a/tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py
@@ -32,6 +32,12 @@ def test_fedce_recipe_uses_fedavg_with_contribution_aggregator():
     assert recipe.server_expected_format == ExchangeFormat.PYTORCH
 
 
+@pytest.mark.parametrize("min_clients", [0, 1])
+def test_fedce_recipe_requires_at_least_two_clients(min_clients):
+    with pytest.raises(ValueError, match="requires min_clients >= 2"):
+        FedCERecipe(model=nn.Linear(2, 1), min_clients=min_clients, train_script=__file__)
+
+
 def test_fedce_recipe_rejects_non_pytorch_exchange():
     with pytest.raises(ValueError, match="requires server_expected_format"):
         FedCERecipe(

--- a/tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py
+++ b/tests/unit_test/app_opt/pt/recipes/fedce_recipe_test.py
@@ -38,6 +38,11 @@ def test_fedce_recipe_requires_at_least_two_clients(min_clients):
         FedCERecipe(model=nn.Linear(2, 1), min_clients=min_clients, train_script=__file__)
 
 
+def test_fedce_recipe_requires_integer_min_clients():
+    with pytest.raises(TypeError, match="min_clients must be int"):
+        FedCERecipe(model=nn.Linear(2, 1), min_clients=2.0, train_script=__file__)
+
+
 def test_fedce_recipe_rejects_non_pytorch_exchange():
     with pytest.raises(ValueError, match="requires server_expected_format"):
         FedCERecipe(


### PR DESCRIPTION
## What changed

- Reject FedCE recipes configured with fewer than two clients before a run starts.
- Use a uniform prior when a participating client has no prior contribution weight.
- Carry contribution weights for absent clients across rounds and warn when the client set changes.
- Document the full-participation assumption and add regression coverage for both edge cases.

## Why

FedCE requires at least two clients for its leave-one-out calculation and assumes full participation. Those constraints were implicit when the implementation was promoted into the recipe API in #4922.

With a single client, the contribution weight becomes 1.0 and the next round fails while constructing the minus model. With partial participation, a returning client previously received a 0.0 client-side fallback while the server used an incompatible 1.0 prior, silently corrupting the contribution estimate.

This change keeps full participation as the recommended configuration while making changing client sets explicit and deterministic.

## Validation

- Reproduced the pristine single-client recipe accepting min_clients=1; it now raises at construction.
- Reproduced rotating two-of-three participation; the aggregator now warns, assigns a uniform prior to the new client, and retains the absent client weight.
- 34 focused FedCE unit tests passed.
- 5 related FedCE research and recipe CLI tests passed.
- ./runtest.sh -s passed.