### PR TITLE
Raise default streaming blob size to 4 GiB

### DIFF
--- a/nvflare/fuel/f3/comm_config.py
+++ b/nvflare/fuel/f3/comm_config.py
@@ -19,6 +19,7 @@ _comm_config_files = ["comm_config.json", "comm_config.json.default"]
 
 
 DEFAULT_MAX_MSG_SIZE = MAX_PAYLOAD_SIZE
+DEFAULT_STREAMING_MAX_BLOB_SIZE = 4 * 1024 * 1024 * 1024
 
 
 class VarName:
@@ -112,7 +113,9 @@ class CommConfigurator:
         return ConfigService.get_int_var(VarName.STREAMING_CHUNK_SIZE, self.config, default=default)
 
     def get_streaming_max_blob_size(self):
-        return ConfigService.get_int_var(VarName.STREAMING_MAX_BLOB_SIZE, self.config, default=DEFAULT_MAX_MSG_SIZE)
+        return ConfigService.get_int_var(
+            VarName.STREAMING_MAX_BLOB_SIZE, self.config, default=DEFAULT_STREAMING_MAX_BLOB_SIZE
+        )
 
     def get_streaming_ack_wait(self, default):
         return ConfigService.get_int_var(VarName.STREAMING_ACK_WAIT, self.config, default=default)

--- a/tests/unit_test/fuel/f3/comm_config_test.py
+++ b/tests/unit_test/fuel/f3/comm_config_test.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nvflare.fuel.f3.comm_config import CommConfigurator
+from nvflare.fuel.utils.config_service import ConfigService
+
+
+@pytest.fixture
+def configurator(monkeypatch):
+    ConfigService.reset()
+    CommConfigurator.reset()
+    monkeypatch.delenv("NVFLARE_STREAMING_MAX_BLOB_SIZE", raising=False)
+    monkeypatch.setattr(ConfigService, "load_configuration", lambda file_basename: None)
+    yield CommConfigurator()
+    ConfigService.reset()
+    CommConfigurator.reset()
+
+
+def test_streaming_max_blob_size_defaults_to_four_gib(configurator):
+    assert configurator.get_streaming_max_blob_size() == 4 * 1024 * 1024 * 1024


### PR DESCRIPTION
## What changed

- Raise the default `streaming_max_blob_size` from the F3 message payload limit (2,144,337,904 bytes) to 4 GiB (4,294,967,296 bytes).
- Keep `streaming_max_blob_size` and `NVFLARE_STREAMING_MAX_BLOB_SIZE` overrides unchanged.
- Add one focused regression test for the new default.

## Why

A Qwen2.5-72B BF16 tensor was observed with a declared streamed size of 2,491,416,937 bytes. The receiver rejected it under the old default even though streaming transports the blob incrementally; a 3 GiB override allowed the transfer to proceed.

The streaming blob ceiling is independent of F3 message framing, so retaining the message payload limit as its default unnecessarily blocks large streamed tensors. A 4 GiB default covers the observed 72B tensor while preserving a finite receiver safety boundary.

## User impact

The observed 72B tensor now fits without additional configuration. This change does not reserve 4 GiB for small models, change frame/chunk/window sizes, or silently remove the runtime receive limit. Objects above 4 GiB still require an explicit override or future tensor-layout/chunking work.

## Validation

- `python -m pytest -q tests/unit_test/fuel/f3/comm_config_test.py tests/unit_test/fuel/f3/streaming/blob_streamer_test.py` — 21 passed
- `./runtest.sh -s` — passed (Black, isort, flake8, and agent-skill lint)

End-to-end 72B or multinode training was not run locally; this removes the observed default-limit blocker only.

Jira: [FLARE-3076](https://jirasw.nvidia.com/browse/FLARE-3076)
