### PR TITLE
Fix Agent Inspector denied job authority routing

### DIFF
--- a/nvflare/tool/agent/inspection/existing_job.py
+++ b/nvflare/tool/agent/inspection/existing_job.py
@@ -68,7 +68,13 @@ def _directory_source_state(scan: SourceScan, ownership: dict, graph: LocalImpor
             return "credible"
         if len(roots) > 1 or len(authoritative) > 1:
             return "possible"
-        return "credible" if authoritative else "none"
+        if authoritative:
+            return "credible"
+        # Independent non-secondary jobs are real evidence but cannot override the selected owner.
+        # Secondary fixtures remain ignored so they do not suppress an active conversion target.
+        has_active_candidate = any(not is_secondary(candidate) for candidate in candidates)
+        secondary_only_owner = bool(owner_files) and all(is_secondary(path) for path in owner_files)
+        return "possible" if has_active_candidate or secondary_only_owner else "none"
 
     roots = {candidate for candidate in candidates if _is_root(candidate) and not is_secondary(candidate)}
     if len(roots) == 1:
@@ -92,7 +98,9 @@ def _directory_source_state(scan: SourceScan, ownership: dict, graph: LocalImpor
         return "credible" if len(next(iter(independent.values()))) == 1 else "possible"
     if len(independent) > 1:
         return "possible"
-    return "possible" if active else "none"
+    # Candidates exist, but no active owner or launcher can distinguish a secondary-only project
+    # from a fixture. Preserve that uncertainty instead of reporting that no job evidence exists.
+    return "possible"
 
 
 def _exported_marker_state(scan: SourceScan) -> str:

--- a/tests/unit_test/tool/agent/agent_inspector_test.py
+++ b/tests/unit_test/tool/agent/agent_inspector_test.py
@@ -657,6 +657,59 @@ def test_pr4955_unique_contained_job_is_authoritative(tmp_path):
     assert inspect_source(tmp_path)["routing"]["reason"] == "existing_job"
 
 
+def test_pr4955_nested_converted_job_keeps_authority_beside_model_only_root(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "import torch\ndef train():\n    return torch.nn.Linear(1, 1)\n",
+            "jobs/fedavg/job.py": "from nvflare.app_common.workflows.fedavg import FedAvg\n"
+            "from nvflare.job_config.api import FedJob\n"
+            "job = FedJob()\ncontroller = FedAvg()\njob.export()\n",
+        },
+    )
+
+    assert inspect_source(tmp_path)["routing"] == {"recommended_skill": None, "reason": "existing_job"}
+
+
+def test_independent_nested_job_beside_active_owner_fails_closed(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from torch.optim import SGD\noptimizer = SGD(params)\noptimizer.step()\n",
+            "jobs/fedavg/job.py": "from nvflare.job_config.api import FedJob\njob = FedJob()\n",
+        },
+    )
+
+    assert inspect_source(tmp_path)["routing"] == {
+        "recommended_skill": "nvflare-orient",
+        "reason": "possible_existing_job",
+    }
+
+
+@pytest.mark.parametrize(
+    "model_source",
+    [
+        "import torch\nclass Net(torch.nn.Module):\n    pass\n",
+        "from torch.optim import SGD\nclass Net:\n    pass\noptimizer = SGD(params)\noptimizer.step()\n",
+    ],
+)
+def test_only_project_under_secondary_tree_fails_closed(tmp_path, model_source):
+    write_project(
+        tmp_path,
+        {
+            "tests/integration/model.py": model_source,
+            "tests/integration/job.py": "from model import Net\n"
+            "from nvflare.job_config.api import FedJob\n"
+            "job = FedJob()\nnet = Net()\n",
+        },
+    )
+
+    assert inspect_source(tmp_path)["routing"] == {
+        "recommended_skill": "nvflare-orient",
+        "reason": "possible_existing_job",
+    }
+
+
 def test_pr4955_multiple_independent_jobs_fail_closed(tmp_path):
     write_project(
         tmp_path,


### PR DESCRIPTION
### Description

Fix Agent Inspector existing-job routing when source-job evidence is present but cannot establish unique project authority.

- Preserve an authoritative nested generated job beside model-only root source.
- Route an independent non-secondary nested job beside an active training owner to `nvflare-orient` instead of recommending another conversion.
- Route a project that exists entirely under a secondary-tree name to `nvflare-orient` instead of treating its job evidence as absent.
- Keep historical secondary fixtures from suppressing a real root conversion target, preserving the PR #4955 regression boundary.

The change is limited to the final existing-job authority fallback. It does not restore directory-global evidence scoring or broaden static framework detection.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.

### Validation

- `python -m pytest -q tests/unit_test/tool/agent`: 287 passed, 1 skipped
- `./runtest.sh -s`: passed
- `./runtest.sh -l`: passed
- `git diff --check`: passed
