### PR TITLE
[2.8] Fix obsolete POC setup command in tutorial

### DIFF
--- a/examples/tutorials/setup_poc.ipynb
+++ b/examples/tutorials/setup_poc.ipynb
@@ -422,25 +422,9 @@
    "source": [
     "## Prepare job example directories\n",
     "\n",
-    "By default, the `nvflare poc prepare` command will setup a symbolic link to the NVFlare/examples directory, assuming that you have used `git clone` to download  NVFlare from github and have defined the NVFLARE_HOME env. variable.\n",
-    "    \n",
-    "Rather than setting the NVFLARE_HOME env. variables, instead link to your desired jobs with the following command to setup to the job directory:\n",
-    "    \n",
-    "```\n",
-    "nvflare poc prepare-jobs-dir -j [JOBS_DIR]\n",
-    "```\n",
+    "When `NVFLARE_HOME` points to a cloned NVFlare repository, `nvflare poc prepare` automatically links `$NVFLARE_HOME/examples` to the project admin's transfer directory. No separate command is needed.\n",
     "\n",
-    "For example we can set the jobs directory to NVFlare/examples: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41053a0c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! nvflare poc prepare-jobs-dir -j .."
+    "For jobs stored elsewhere, copy them into the project admin's transfer directory before submitting them."
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Backport PR #5009 to the 2.8 branch.
- Replace the obsolete POC setup notebook command with the supported command.
- Preserve the original authored commit from Shawn Xie.

## Validation

- Notebook JSON validation passed.
- git diff --check passed.
- ./runtest.sh -s passed.