### PR TITLE
[FLARE-3030] Address secret-redaction follow-up

### DIFF
--- a/nvflare/tool/cli_output.py
+++ b/nvflare/tool/cli_output.py
@@ -71,7 +71,10 @@ _SENSITIVE_KEY_NAMES = {
     "secret_key",
     "session_token",
 }
-_SENSITIVE_TEXT_VALUE_PATTERN = r'"(?:\\.|[^"\\])*(?:"|$)|' r"'(?:\\.|[^'\\])*(?:'|$)|" r"[^\s,;]+"
+_QUOTED_TEXT_VALUE_PATTERN = (
+    r'"(?:\\[^\r\n]|[^"\\\r\n])*(?:"|(?=[\r\n]|\Z))|' r"'(?:\\[^\r\n]|[^'\\\r\n])*(?:'|(?=[\r\n]|\Z))"
+)
+_SENSITIVE_TEXT_VALUE_PATTERN = rf"{_QUOTED_TEXT_VALUE_PATTERN}|[^\s,;]+"
 _SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
     r"(?i)\b(?P<prefix>(?:"
     r"password|passwd|passphrase|credential|credentials|"
@@ -88,10 +91,10 @@ _SENSITIVE_CLI_OPTION_PATTERN = re.compile(
     r")(?:\s+|=))"
     rf"(?P<value>{_SENSITIVE_TEXT_VALUE_PATTERN})"
 )
-_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(authorization[\"']?\s*:\s*[\"']?bearer\s+)([A-Za-z0-9._~+/=-]+)")
+_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(authorization[\"']?\s*[:=]\s*[\"']?bearer\s+)([A-Za-z0-9._~+/=-]+)")
 _AUTH_VALUE_PATTERN = re.compile(
     r"(?i)(?P<prefix>\bauthorization[\"']?\s*[:=](?!\s*[\"']?bearer\s+)\s*)"
-    r"(?P<value>\"(?:\\.|[^\"\\])*(?:\"|$)|'(?:\\.|[^'\\])*(?:'|$)|[^\r\n]+)"
+    rf"(?P<value>{_QUOTED_TEXT_VALUE_PATTERN}|[^\r\n]+)"
 )
 _PEM_PRIVATE_KEY_PATTERN = re.compile(
     r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",

--- a/tests/unit_test/tool/cli_output_test.py
+++ b/tests/unit_test/tool/cli_output_test.py
@@ -603,10 +603,15 @@ class TestSensitiveOutputRedaction:
             ("--client-secret='alpha beta gamma' --verbose", "--client-secret='<redacted>' --verbose"),
             ("Authorization: 'alpha beta gamma'", "Authorization: '<redacted>'"),
             ("Authorization: Basic dXNlcjpwYXNz", "Authorization: <redacted>"),
+            ('Authorization = "Bearer sample-token-123"', 'Authorization = "Bearer <redacted>"'),
+            ("Authorization = 'Bearer sample-token-123'", "Authorization = 'Bearer <redacted>'"),
+            ('Authorization="Bearer sample-token-123"', 'Authorization="Bearer <redacted>"'),
+            ("Authorization=Bearer sample-token-123", "Authorization=Bearer <redacted>"),
             (
                 '{"Authorization": "Bearer sk-live-abc123"}',
                 '{"Authorization": "Bearer <redacted>"}',
             ),
+            ('password="sample secret fragment\nsafe diagnostic', 'password="<redacted>\nsafe diagnostic'),
         ],
     )
     def test_redacts_sensitive_text_values(self, text, expected):

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -1287,6 +1287,19 @@ def test_stage_k8_rejects_invalid_stage_argument_values(tmp_path, capsys, monkey
     assert calls == []
 
 
+def test_stage_k8_redacts_authorization_in_missing_kit_error(tmp_path, capsys):
+    token = "sample-token-123"
+    missing_kit = tmp_path / f'Authorization = "Bearer {token}"'
+
+    with pytest.raises(SystemExit):
+        stage_k8_deployment(_stage_k8_args(missing_kit, namespace="nvflare"))
+
+    err = capsys.readouterr().err
+    assert "INVALID_KIT" in err
+    assert 'Authorization = "Bearer <redacted>"' in err
+    assert token not in err
+
+
 def test_stage_k8_rejects_symlinked_stage_folder(tmp_path, capsys, monkeypatch):
     kit = _make_client_kit(tmp_path)
     output = tmp_path / "site-1-k8s"


### PR DESCRIPTION
## What changed

- Redact Bearer credentials when Authorization uses "=" as the separator, including quoted and whitespace variants.
- Keep malformed quoted sensitive values bounded to their current line so later diagnostics remain visible.
- Add focused redaction coverage for all reported Authorization-equals-Bearer forms.
- Add a Kubernetes deploy-stage regression that drives redaction through the missing-kit CLI error path.

## Why

The original FLARE-3030 fix covered colon-separated Authorization headers but left equals-separated Bearer values unchanged. Its quoted-value grammar could also consume subsequent lines after an unterminated quote.

The unquoted Authorization behavior remains intentionally line-bounded: the complete remainder of an Authorization header is credential material, so preserving later whitespace-separated fragments would risk disclosing secrets.

## Impact

CLI error output no longer exposes equals-separated Bearer credentials. Malformed quoted values remain conservatively redacted without removing unrelated diagnostics on later lines.

## Validation

- 173 tests passed across tests/unit_test/tool/cli_output_test.py and tests/unit_test/tool/deploy/deploy_commands_test.py
- ./runtest.sh -s passed
- git diff --check passed
