### PR TITLE
Refactor external task-delivery liveness into explicit phases

### DIFF
--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -27,6 +27,7 @@ import subprocess
 import threading
 import time
 import uuid
+from enum import Enum
 from typing import Any, Optional, Sequence, Tuple, Union
 
 from nvflare.apis.fl_constant import FLContextKey, FLMetaKey, ReturnCode
@@ -77,6 +78,14 @@ _TRAINER_LEAF_PREFIX = "client_api_trainer"
 
 class _LaunchAborted(Exception):
     """The task's abort_signal triggered while waiting for a per-task trainer launch."""
+
+
+class _TaskDeliveryPhase(Enum):
+    """Derived TASK_READY phases; TRANSFER_COMPLETE uses normal heartbeat liveness."""
+
+    INLINE_WAIT = "inline_wait"
+    TRANSFERRING = "transferring"
+    TRANSFER_COMPLETE = "transfer_complete"
 
 
 # Conditions that can interrupt TASK_READY delivery.
@@ -846,8 +855,16 @@ class ExternalProcessBackend(CellBackendBase):
         def _on_transaction_created(transaction):
             transfer_waiters.append(DownloadService.get_transfer_waiter(transaction.tx_id))
 
-        def _has_live_task_download():
-            return any(not waiter.done() for waiter in tuple(transfer_waiters))
+        def _delivery_phase():
+            waiters = tuple(transfer_waiters)
+            if not waiters:
+                return _TaskDeliveryPhase.INLINE_WAIT
+            if any(not waiter.done() for waiter in waiters):
+                return _TaskDeliveryPhase.TRANSFERRING
+            return _TaskDeliveryPhase.TRANSFER_COMPLETE
+
+        def _is_transferring():
+            return _delivery_phase() is _TaskDeliveryPhase.TRANSFERRING
 
         def _cancel_cause():
             if abort_signal.triggered or (self._context.launch_once and self._abort):
@@ -856,8 +873,7 @@ class ExternalProcessBackend(CellBackendBase):
                 return _SEND_CLOSED, None
             if not self._process_group_alive(trainer):
                 return _SEND_PROCESS_DEAD, None
-            # Transfer progress supersedes heartbeat expiry while materialization is active.
-            if not _has_live_task_download():
+            if not _is_transferring():
                 liveness_error = self._trainer_liveness_error(trainer)
                 if liveness_error:
                     return _SEND_SESSION_DEAD, liveness_error
@@ -872,7 +888,7 @@ class ExternalProcessBackend(CellBackendBase):
                 request=new_cell_message({}, task_message),
                 timeout=timeout,
                 abort_signal=cancel,
-                progress_wait_cb=_has_live_task_download,
+                progress_wait_cb=_is_transferring,
                 receiver_ids=(trainer.trainer_fqcn,),
                 fobs_ctx_props={
                     FOBSContextKey.STREAM_PROGRESS_CB: lambda **_kwargs: None,

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -1157,6 +1157,8 @@ class TestHeartbeatAndOperationalLiveness:
                 tx_created = env.cell.sent_kwargs[-1]["fobs_ctx_props"][ebp.RESULT_UPLOAD_TX_CREATED_CB_CTX_KEY]
                 tx_created(SimpleNamespace(tx_id="task-payload-tx"))
                 time.sleep(0.1)  # longer than the heartbeat timeout
+                cancel = env.cell.sent_kwargs[-1]["abort_signal"]
+                assert not cancel.triggered
                 transfer_settled.set()
                 payload = request.payload
                 env.cell.deliver(
@@ -1176,6 +1178,43 @@ class TestHeartbeatAndOperationalLiveness:
             )
             result = backend.execute("train", Shareable(), fl_ctx, Signal())
             assert result.get_return_code() == ReturnCode.OK
+            get_transfer_waiter.assert_called_once_with("task-payload-tx")
+        finally:
+            backend.finalize(FLContext())
+
+    def test_completed_task_payload_transaction_resumes_heartbeat_expiry(self, env, monkeypatch):
+        transfer_settled = threading.Event()
+        waiter = SimpleNamespace(transaction_id="task-payload-tx", done=lambda: transfer_settled.is_set())
+        get_transfer_waiter = MagicMock(return_value=waiter)
+        monkeypatch.setattr(ebp.DownloadService, "get_transfer_waiter", get_transfer_waiter)
+        backend, fl_ctx = _initialized_backend(
+            env,
+            heartbeat_interval=0.02,
+            heartbeat_timeout=0.05,
+            task_wait_timeout=None,
+            result_wait_timeout=None,
+        )
+        try:
+
+            def completed_transfer_pending_reply(topic, target, request):
+                assert topic == Topic.TASK_READY
+                tx_created = env.cell.sent_kwargs[-1]["fobs_ctx_props"][ebp.RESULT_UPLOAD_TX_CREATED_CB_CTX_KEY]
+                tx_created(SimpleNamespace(tx_id="task-payload-tx"))
+                transfer_settled.set()
+                cancel = env.cell.sent_kwargs[-1]["abort_signal"]
+                while not cancel.triggered:
+                    time.sleep(0.005)
+                return _task_accepted_reply()
+
+            env.cell.on_request = completed_transfer_pending_reply
+            start = time.monotonic()
+            result = backend.execute("train", Shareable(), fl_ctx, Signal())
+            elapsed = time.monotonic() - start
+
+            assert result.get_return_code() == ReturnCode.EXECUTION_EXCEPTION
+            assert elapsed < 0.5
+            assert "heartbeat timed out" in backend._abort_reason
+            assert "TASK_READY was pending" in backend._abort_reason
             get_transfer_waiter.assert_called_once_with("task-payload-tx")
         finally:
             backend.finalize(FLContext())


### PR DESCRIPTION
## Summary

- introduce a private, derived TASK_READY delivery phase with `INLINE_WAIT`, `TRANSFERRING`, and `TRANSFER_COMPLETE`
- use that same derived phase for the existing Cell progress callback and trainer-heartbeat gate
- add characterization coverage for the post-transfer heartbeat boundary

This is a zero-functional-change characterization and refactor. Phase is derived from the existing transfer waiter facts, so there is no mutable state that can drift.

The current policy is intentionally unchanged: only `TRANSFERRING` defers heartbeat expiry. `INLINE_WAIT` and `TRANSFER_COMPLETE` both use existing heartbeat liveness, so heartbeat checking resumes immediately when every transfer waiter is done.

The FLARE-3077 functional behavior is deferred to follow-up PR #5018 after this refactor lands.

## Validation

- `.venv/bin/python -m pytest -q tests/unit_test/app_common/executors/external_process_backend_test.py::TestHeartbeatAndOperationalLiveness::test_live_task_payload_transaction_suppresses_heartbeat_expiry tests/unit_test/app_common/executors/external_process_backend_test.py::TestHeartbeatAndOperationalLiveness::test_completed_task_payload_transaction_resumes_heartbeat_expiry tests/unit_test/app_common/executors/external_process_backend_test.py::TestHeartbeatAndOperationalLiveness::test_inline_task_ready_pending_is_bounded_by_heartbeat tests/unit_test/app_common/executors/external_process_backend_test.py::TestExecute::test_task_ready_send_does_not_hang_past_abort tests/unit_test/app_common/executors/external_process_backend_test.py::TestExecute::test_task_ready_send_detects_process_death` — 5 passed
- `.venv/bin/python -m pytest -q tests/unit_test/app_common/executors/external_process_backend_test.py` — 103 passed
- `.venv/bin/python -m pytest -q tests/unit_test/app_common/executors/client_api_executor_test.py` — 114 passed
- `./runtest.sh -s` — passed Black, isort, flake8 (0 findings), and agent-skill lint
- `git diff --check` — passed