### PR TITLE
Add bare-metal Confidential Containers deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,13 @@
 !.git/shallow
 !job_templates/
 !job_templates/**
+!examples/
+examples/*
+!examples/hello-world/
+examples/hello-world/*
+!examples/hello-world/hello-numpy/
+examples/hello-world/hello-numpy/*
+!examples/hello-world/hello-numpy/client.py
 !nvflare/
 !nvflare/**
 !pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ eggs/
 .eggs/
 lib/
 lib64/
+# The bare-metal CoCo example intentionally ships shell helpers in lib/.
+!examples/devops/CoCo/lib/
+!examples/devops/CoCo/lib/*.sh
 parts/
 sdist/
 var/

--- a/docker/Dockerfile.coco
+++ b/docker/Dockerfile.coco
@@ -1,0 +1,126 @@
+# NVFlare parent runtime for CoCo server/client processes. This purpose-built
+# image includes CPU/GPU attestation clients but intentionally excludes the
+# Kubernetes Python extra because this deployment uses ProcessJobLauncher.
+ARG PYTHON_BUILD_BASE=python:3.12.12-slim-trixie@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+ARG PYTHON_RUNTIME_BASE=nvcr.io/nvidia/distroless/python:3.12-v4.0.7@sha256:9e7012ce1816b720123ae11fc0edd005ff1373c9eb562ded2b3e9da869ed7bc9
+ARG PYTHON_MINOR=3.12
+ARG SNPGUEST_VERSION=0.10.0
+ARG SNPGUEST_SHA256=70e700465e3523e67dd5104583dc36cd11eef630c6f04c5b9ccafd6ba2e76ca0
+ARG TRUSTAUTHORITY_CLI_VERSION=v1.10.1
+ARG TRUSTAUTHORITY_CLI_SHA256=d3875adbee96268471c82dd54f012b726fa8d6eefdd8f3243c0e7650fb55ff4e
+ARG NVAT_VERSION=1.2.2
+ARG NVAT_REPO_SHA256=31b0a1646f2bbc08ee599d10dbae106124ef2903f39e37095b96493913b37657
+ARG NVAT_REPO_URL=https://developer.download.nvidia.com/compute/nvat/1.2.2/local_installers/nvat-local-repo-ubuntu2404-1-2-local_1.0-1_amd64.deb
+ARG NVAT_BUILD_BASE=ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
+ARG TENSORBOARD_VERSION=2.20.0
+
+FROM ${NVAT_BUILD_BASE} AS nvat-builder
+
+ARG NVAT_VERSION
+ARG NVAT_REPO_SHA256
+ARG NVAT_REPO_URL
+
+# Resolve NVAT against its supported Ubuntu release and relocate the complete
+# non-glibc dependency closure. Private RPATHs keep these libraries isolated
+# from the Python process in the final distroless image.
+# The glibc exclusion set below is validated only for the pinned NVAT 1.2.2
+# dependency graph. Re-audit lddtree output before changing NVAT_VERSION.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg patchelf pax-utils \
+    && curl -L --fail --silent --show-error "${NVAT_REPO_URL}" -o /tmp/nvat-repo.deb \
+    && echo "${NVAT_REPO_SHA256}  /tmp/nvat-repo.deb" | sha256sum -c - \
+    && dpkg -i /tmp/nvat-repo.deb \
+    && cp /var/nvat-local-repo-*/nvat-local-*-keyring.gpg /usr/share/keyrings/ \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nvattest \
+    && mkdir -p /opt/nvat/bin /opt/nvat/lib \
+    && install -m 0755 /usr/bin/nvattest /opt/nvat/bin/nvattest \
+    && lddtree -l /usr/bin/nvattest | while read -r library; do \
+         name="$(basename "$library")"; \
+         case "$name" in \
+           nvattest|ld-linux-x86-64.so.2|libc.so.6|libdl.so.2|libgcc_s.so.1|libm.so.6|libpthread.so.0|librt.so.1|libstdc++.so.6) continue ;; \
+         esac; \
+         cp -L "$library" "/opt/nvat/lib/$name"; \
+       done \
+    && patchelf --set-rpath '$ORIGIN/../lib' /opt/nvat/bin/nvattest \
+    && find /opt/nvat/lib -type f -exec patchelf --set-rpath '$ORIGIN' {} \; \
+    && /opt/nvat/bin/nvattest version \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM ${PYTHON_BUILD_BASE} AS builder
+
+ARG PYTHON_MINOR
+ARG SNPGUEST_VERSION
+ARG SNPGUEST_SHA256
+ARG TRUSTAUTHORITY_CLI_VERSION
+ARG TRUSTAUTHORITY_CLI_SHA256
+ARG TENSORBOARD_VERSION
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates curl git tar zip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/NVFlare
+COPY . .
+
+# Install base NVFlare plus the standard hello-numpy job's TensorBoard
+# receiver. In particular, do not install the K8S extra or the kubernetes
+# Python package: jobs stay in these parent containers and are launched with
+# ProcessJobLauncher.
+RUN mkdir -p /opt/attestation/bin \
+    && NVFL_RELEASE=1 python -m pip install --prefix=/opt/nvflare . "tensorboard==${TENSORBOARD_VERSION}" \
+    && PYTHONPATH="/opt/nvflare/lib/python${PYTHON_MINOR}/site-packages" python -m pip check \
+    && PYTHONPATH="/opt/nvflare/lib/python${PYTHON_MINOR}/site-packages" \
+        python -c "import importlib.util, tensorboard; assert tensorboard.__version__ == '${TENSORBOARD_VERSION}'; assert importlib.util.find_spec('kubernetes') is None" \
+    && mkdir -p "/usr/local/lib/python${PYTHON_MINOR}/site-packages" \
+    && printf "/opt/nvflare/lib/python%s/site-packages\n" "${PYTHON_MINOR}" \
+        > "/usr/local/lib/python${PYTHON_MINOR}/site-packages/nvflare-prefix.pth"
+
+RUN curl -L --fail --silent --show-error \
+      "https://github.com/virtee/snpguest/releases/download/v${SNPGUEST_VERSION}/snpguest" \
+      -o /tmp/snpguest \
+    && echo "${SNPGUEST_SHA256}  /tmp/snpguest" | sha256sum -c - \
+    && install -D -m 0755 /tmp/snpguest /opt/attestation/bin/snpguest \
+    && curl -L --fail --silent --show-error \
+      "https://github.com/intel/trustauthority-client-for-go/releases/download/${TRUSTAUTHORITY_CLI_VERSION}/trustauthority-cli-${TRUSTAUTHORITY_CLI_VERSION}.tar.gz" \
+      -o /tmp/trustauthority-cli.tar \
+    && echo "${TRUSTAUTHORITY_CLI_SHA256}  /tmp/trustauthority-cli.tar" | sha256sum -c - \
+    && mkdir -p /tmp/trustauthority-cli \
+    && tar -xf /tmp/trustauthority-cli.tar -C /tmp/trustauthority-cli \
+    && install -m 0755 /tmp/trustauthority-cli/trustauthority-cli /opt/attestation/bin/trustauthority-cli \
+    && /opt/attestation/bin/snpguest --version \
+    && /opt/attestation/bin/trustauthority-cli version
+
+FROM ${PYTHON_RUNTIME_BASE}
+
+ARG PYTHON_MINOR
+
+ENV PATH=/opt/attestation/bin:/opt/nvflare/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY --from=builder /opt/nvflare /opt/nvflare
+# CoCo rejects submitted BYOC. Keep the standard validation trainer inside the
+# signed parent image so Stage 60 submits configuration only.
+COPY --from=builder /opt/NVFlare/examples/hello-world/hello-numpy/client.py /opt/nvflare/examples/hello-numpy/client.py
+COPY --from=builder /opt/attestation /opt/attestation
+COPY --from=nvat-builder /opt/nvat/bin /opt/attestation/bin
+COPY --from=nvat-builder /opt/nvat/lib /opt/attestation/lib
+COPY --from=builder /usr/local/lib/python${PYTHON_MINOR}/site-packages/nvflare-prefix.pth /usr/local/lib/python${PYTHON_MINOR}/site-packages/nvflare-prefix.pth
+COPY --from=builder /usr/bin/zip /usr/bin/zip
+
+RUN ["python", "-c", "import importlib.util, nvflare; assert importlib.util.find_spec('kubernetes') is None"]
+RUN ["python", "-c", "import ast; ast.parse(open('/opt/nvflare/examples/hello-numpy/client.py', encoding='utf-8').read())"]
+RUN ["/opt/attestation/bin/nvattest", "version"]
+RUN ["/usr/bin/zip", "--version"]
+
+CMD ["python"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,16 +82,45 @@ code, or framework packages. If you need to change packages constrained by the
 NGC PyTorch image, review the base image release notes first; recent PyTorch
 containers include `/etc/pip/constraint.txt` to protect the tested package set.
 
+## Confidential Containers Parent Image
+
+`Dockerfile.coco` is the purpose-built parent image for the workflow under
+`examples/devops/CoCo`. It installs the pinned SNP, TDX, and NVIDIA NVAT
+attestation clients needed by the NVFlare confidential-computing authorizers.
+It installs base NVFlare and pinned TensorBoard 2.20.0 for the workflow's
+standard `hello-numpy` check, without the `K8S` extra, and asserts at build time
+that the Kubernetes Python package is absent. That workflow uses
+`ProcessJobLauncher`, so job processes execute inside the existing
+confidential VM.
+
+Build it from the repository root with the pinned build arguments documented
+in `examples/devops/CoCo/config.env.example`, or run the workflow's Stage 40:
+
+```bash
+cd examples/devops/CoCo
+./40-nvflare-build-sign-images.sh
+```
+
+The stage builds distinct server and client image digests from the same
+Dockerfile, checks their attestation tools and TensorBoard dependency, signs
+them, and publishes the verification policy. After Stage 50 deploys the
+parents, Stage 60 submits `hello-numpy` and requires successful completion. Do
+not add Kubernetes packages to `Dockerfile.coco`; Kubernetes remains a
+host/cluster administration dependency.
+
 ## Choosing an Image
 
-- Use `Dockerfile.parent` for parent server/client processes.
+- Use `Dockerfile.parent` for non-CoCo parent server/client processes.
 - Use `Dockerfile.parent` for the dashboard runtime; tag the same build as a
   dashboard image if you want a dashboard-specific image name.
+- Use `Dockerfile.coco` for the CoCo server/client parent processes deployed by
+  `examples/devops/CoCo`.
 - Use `Dockerfile.job` for submitted job containers.
 - Do not rely on a shell being available in the parent image; it is absent by
   design.
-- Add user workload dependencies to the job image, not the parent image, unless
-  the parent process itself needs them.
+- Add user workload dependencies to the job image when using a container job
+  launcher. A `ProcessJobLauncher` deployment such as the CoCo workflow must
+  instead include every submitted job's dependency in its signed parent image.
 
 ## References
 

--- a/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
+++ b/docs/user_guide/confidential_computing/on_premises/cc_deployment_guide.rst
@@ -674,17 +674,21 @@ Notes on using NVIDIA GPU CC
         path: nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer
         token_expiration: 100 # seconds, needs to be less than check_frequency
 
-2. The NVFlare `GPUAuthorizer` uses NVIDIA's `nv_attestation_sdk`.
-   When building the NVFlare app docker image, make sure to include it in the requirements, for example:
+2. The NVFlare ``GPUAuthorizer`` uses NVIDIA's native NVAT ``nvattest`` CLI.
+   Install a pinned NVAT release and its runtime libraries in the NVFlare app image, then configure the executable path:
 
-.. code-block:: bash
+.. code-block:: yaml
 
-    torch
-    torchvision
-    tensorboard
-    tensorflow
-    safetensors
-    nv_attestation_sdk
+    args:
+      nvat_command: /opt/attestation/bin/nvattest
+      verifier: remote
+      nras_url: https://nras.attestation.nvidia.com
+
+   A custom ``policy_file`` must contain an NVAT Rego policy defining
+   ``nv_match``; the retired Python SDK's JSON policy format is not accepted.
+   For authenticated remote NRAS, pass the ``service_key`` argument or provide
+   it through the official ``NV_ATTESTATION_SERVICE_KEY`` environment variable.
+   Keep that credential outside the image and startup kit.
 
 3. To get GPU working in CVM, you need to ensure:
        - No GPU driver installed on host, otherwise the passthrough will fail.

--- a/examples/advanced/cc_provision/README.md
+++ b/examples/advanced/cc_provision/README.md
@@ -139,17 +139,21 @@ cc_issuers:
     token_expiration: 100 # seconds, needs to be less than check_frequency
 ```
 
-3. The NVFlare `GPUAuthorizer` uses NVIDIA's `nv_attestation_sdk`.
-   When building the NVFlare app docker image, make sure to include it in the requirements, for example:
+3. The NVFlare `GPUAuthorizer` uses NVIDIA's native NVAT `nvattest` CLI.
+   Install a pinned NVAT release and its runtime libraries in the NVFlare app image, then configure the executable path:
 
+```yaml
+args:
+  nvat_command: /opt/attestation/bin/nvattest
+  verifier: remote
+  nras_url: https://nras.attestation.nvidia.com
 ```
-torch
-torchvision
-tensorboard
-tensorflow
-safetensors
-nv_attestation_sdk
-```
+
+Custom `policy_file` values must contain an NVAT Rego policy defining
+`nv_match`; the retired Python SDK's JSON policy format is not accepted.
+For authenticated remote NRAS, pass the `service_key` argument or provide it
+through the official `NV_ATTESTATION_SERVICE_KEY` environment variable. Keep
+that credential outside the image and startup kit.
 
 4. To get GPU working in CVM, you need to ensure:
        - No GPU driver installed on host, otherwise the passthrough will fail.

--- a/examples/devops/CoCo/.gitignore
+++ b/examples/devops/CoCo/.gitignore
@@ -1,0 +1,2 @@
+config.env
+state/

--- a/examples/devops/CoCo/00-verify-host.sh
+++ b/examples/devops/CoCo/00-verify-host.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+
+failures=0
+warnings=0
+pass() { printf 'PASS  %s\n' "$*"; }
+warn() { printf 'WARN  %s\n' "$*"; warnings=$((warnings+1)); }
+fail() { printf 'FAIL  %s\n' "$*"; failures=$((failures+1)); }
+has() { command -v "$1" >/dev/null 2>&1; }
+
+echo "CoCo ${TEE_NAME} + NVIDIA GPU host prerequisite report"
+echo "Node address: $NODE_IP"
+echo "Selected runtime: $RUNTIME_CLASS"
+
+root_write_probe="$(as_root mktemp -p /etc .bare-metal-coco-write-check.XXXXXX 2>/dev/null || true)"
+if [[ -n "$root_write_probe" ]]; then
+  as_root rm -f -- "$root_write_probe"
+  pass "Root filesystem accepts writes"
+else
+  fail "Root filesystem is not writable; repair the filesystem/device before installation"
+fi
+
+if has findmnt && has lsblk; then
+  root_source="$(findmnt -n -o SOURCE / 2>/dev/null || true)"
+  root_kname="$(lsblk -n -o KNAME "$root_source" 2>/dev/null | tail -n 1 || true)"
+  ext4_errors_file="/sys/fs/ext4/${root_kname}/errors_count"
+  if [[ -r "$ext4_errors_file" ]]; then
+    ext4_errors="$(<"$ext4_errors_file")"
+    if [[ "$ext4_errors" =~ ^[0-9]+$ ]] && ((ext4_errors > 0)); then
+      fail "Root ext4 filesystem reports ${ext4_errors} error(s); inspect storage and run an offline fsck"
+    else
+      pass "Root ext4 filesystem reports no errors"
+    fi
+  fi
+fi
+
+[[ "$(uname -m)" == x86_64 ]] && pass "x86_64 architecture" || fail "x86_64 is required"
+if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  [[ "${ID:-}" == ubuntu ]] && pass "Ubuntu ${VERSION_ID:-unknown}" || warn "Scripts target Ubuntu; found ${PRETTY_NAME:-unknown}"
+else
+  fail "Cannot identify operating system"
+fi
+
+case "$TEE_PLATFORM" in
+  snp)
+    grep -q AuthenticAMD /proc/cpuinfo && pass "AMD processor" || fail "AMD processor not detected"
+    grep -qw sev_snp /proc/cpuinfo &&
+      pass "SEV-SNP CPU flag" ||
+      fail "SEV-SNP flag missing; enable SVM/SEV/SNP in BIOS and use a supported CPU/kernel"
+    [[ -e /sys/module/kvm_amd/parameters/sev ]] &&
+      grep -qiE '^(1|Y)$' /sys/module/kvm_amd/parameters/sev &&
+      pass "kvm_amd SEV enabled" ||
+      fail "kvm_amd SEV is not enabled"
+    [[ -e /dev/sev ]] && pass "/dev/sev present" || fail "/dev/sev missing"
+    ;;
+  tdx)
+    grep -q GenuineIntel /proc/cpuinfo && pass "Intel processor" || fail "Intel processor not detected"
+    grep -qw tdx_host_platform /proc/cpuinfo &&
+      pass "TDX host-platform CPU flag" ||
+      fail "tdx_host_platform flag missing; enable TME/TME-MT/TDX in firmware and use a supported kernel"
+    [[ -e /sys/module/kvm_intel/parameters/tdx ]] &&
+      grep -qiE '^(1|Y)$' /sys/module/kvm_intel/parameters/tdx &&
+      pass "kvm_intel TDX enabled" ||
+      fail "kvm_intel TDX is not enabled"
+    # Some supported kernels do not retain or emit Canonical's optional
+    # "virt/tdx: module initialized" log line. The exported KVM parameter
+    # above is the stable capability interface; do not gate on dmesg wording.
+    [[ -e /dev/kvm ]] && pass "/dev/kvm present" || fail "/dev/kvm missing"
+    ;;
+esac
+[[ -d /sys/kernel/iommu_groups ]] && [[ -n "$(find /sys/kernel/iommu_groups -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]] \
+  && pass "IOMMU groups populated" || fail "IOMMU groups absent; enable the platform IOMMU in firmware/kernel"
+
+if has lspci && lspci -Dnn -d 10de: | grep -qE 'VGA compatible controller|3D controller'; then
+  gpu_line="$(lspci -Dnn -d 10de: | grep -m1 -E 'VGA compatible controller|3D controller')"
+  pass "NVIDIA PCI device: $gpu_line"
+  if [[ "$gpu_line" =~ GH100|H100|H200|B200|GB200|Blackwell ]]; then
+    pass "GPU family advertises confidential-computing support"
+  else
+    warn "GPU is not recognized as H100/H200/B200/GB200; confirm confidential-computing support"
+  fi
+  gpu_bdf="${gpu_line%% *}"
+  driver_link="/sys/bus/pci/devices/0000:${gpu_bdf#0000:}/driver"
+  driver=""
+  [[ ! -L "$driver_link" ]] ||
+    driver="$(basename "$(readlink -f "$driver_link")")"
+  case "$driver" in
+    vfio-pci) pass "GPU is already bound to vfio-pci (binding is validated after GPU Operator installation)" ;;
+    "") pass "GPU is currently unbound; this is valid before GPU Operator installation" ;;
+    nvidia|nouveau) fail "GPU is bound to conflicting host driver $driver; remove it before installation" ;;
+    *) warn "GPU is bound to $driver; stage 20 will require GPU Operator VFIO Manager to replace it with vfio-pci" ;;
+  esac
+  iommu_group="$(readlink -f "/sys/bus/pci/devices/$gpu_bdf/iommu_group" 2>/dev/null || true)"
+  if [[ -n "$iommu_group" ]]; then
+    group_members="$(find "$iommu_group/devices" -mindepth 1 -maxdepth 1 -type l 2>/dev/null | wc -l)"
+    ((group_members == 1)) && pass "GPU has an isolated IOMMU group" || warn "GPU IOMMU group has $group_members functions; confirm all can be assigned together"
+  else
+    fail "GPU has no IOMMU group"
+  fi
+else
+  fail "NVIDIA GPU not detected"
+fi
+
+if lsmod | awk '$1 ~ /^(nvidia(_|$)|nouveau$)/{found=1} END{exit !found}'; then
+  fail "A host NVIDIA/nouveau kernel module is loaded; GPU passthrough requires VFIO instead"
+else
+  pass "No host NVIDIA or nouveau kernel module loaded"
+fi
+if has dpkg-query && dpkg-query -W -f='${db:Status-Abbrev} ${binary:Package}\n' 'nvidia-driver-*' 2>/dev/null | grep -q '^.i '; then
+  fail "Host NVIDIA driver packages are installed; remove them before GPU passthrough"
+else
+  pass "No host NVIDIA driver package installed"
+fi
+
+if find /sys/kernel/iommu_groups -type l 2>/dev/null | grep -q .; then pass "PCI devices assigned to IOMMU groups"; fi
+grep -qw swap /proc/swaps 2>/dev/null && warn "Swap is enabled; Kubernetes installer will disable it" || pass "Swap disabled"
+mem_gib=$(( $(awk '/MemTotal/{print $2}' /proc/meminfo) / 1024 / 1024 ))
+((mem_gib >= 64)) && pass "Memory: ${mem_gib} GiB" || warn "Only ${mem_gib} GiB RAM; 64 GiB or more is recommended"
+disk_gib="$(df -Pk "$SUITE_DIR" | awk 'NR==2{print int($4/1024/1024)}')"
+((disk_gib >= 50)) && pass "Free disk: ${disk_gib} GiB" || warn "Only ${disk_gib} GiB free; at least 50 GiB is recommended"
+
+endpoints=(
+  https://registry.k8s.io/v2/ \
+  https://pkgs.k8s.io/ \
+  https://github.com/ \
+  https://raw.githubusercontent.com/ \
+  https://ghcr.io/v2/ \
+  https://helm.ngc.nvidia.com/ \
+  https://nvcr.io/v2/ \
+  https://quay.io/v2/ \
+  https://registry-1.docker.io/v2/ \
+  https://developer.download.nvidia.com/
+)
+if [[ "$TEE_PLATFORM" == snp ]]; then
+  endpoints+=(https://kdsintf.amd.com/)
+else
+  endpoints+=(
+    https://api.trustedservices.intel.com/
+    https://ppa.launchpadcontent.net/
+    https://keyserver.ubuntu.com/
+  )
+fi
+for endpoint in "${endpoints[@]}"; do
+  if curl -L -I --connect-timeout 8 --max-time 15 --silent "$endpoint" >/dev/null; then pass "Reachable: $endpoint"; else fail "Cannot reach: $endpoint"; fi
+done
+
+echo
+echo "Summary: $failures failure(s), $warnings warning(s)"
+((failures == 0)) || exit 1

--- a/examples/devops/CoCo/10-install-kubernetes.sh
+++ b/examples/devops/CoCo/10-install-kubernetes.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+download_dir="$STATE_DIR/downloads"
+prepare_download_dir
+
+if [[ "$ALLOW_PACKAGE_DOWNGRADES" != 1 ]]; then
+  for package in kubelet kubeadm kubectl; do
+    installed_version="$(dpkg-query -W -f='${Version}' "$package" 2>/dev/null || true)"
+    if [[ -n "$installed_version" ]] &&
+      dpkg --compare-versions "$installed_version" gt "$KUBERNETES_VERSION"; then
+      die "$package $installed_version is newer than pinned $KUBERNETES_VERSION; set ALLOW_PACKAGE_DOWNGRADES=1 only after approving the downgrade"
+    fi
+  done
+fi
+
+log "Installing host packages and Kubernetes prerequisites"
+as_root apt-get update
+host_packages=(ca-certificates curl gpg jq openssl gcc make git python3-venv skopeo pciutils uidmap xxd)
+if [[ "$TEE_PLATFORM" == tdx ]] && ! command -v go >/dev/null 2>&1; then
+  host_packages+=(golang-go)
+fi
+[[ -x /usr/bin/runc ]] || host_packages+=(runc)
+as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y "${host_packages[@]}"
+[[ -x /usr/bin/runc ]] || die "A trusted runc binary is required at /usr/bin/runc"
+printf 'overlay\nbr_netfilter\n' | as_root tee /etc/modules-load.d/k8s.conf >/dev/null
+as_root modprobe overlay
+as_root modprobe br_netfilter
+printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\nnet.ipv4.ip_forward = 1\n' | as_root tee /etc/sysctl.d/99-kubernetes-cri.conf >/dev/null
+as_root sysctl --system >/dev/null
+as_root swapoff -a
+as_root sed -ri '/^[^#].+[[:space:]]swap[[:space:]]/s/^/# disabled-by-bare-metal-coco: /' /etc/fstab
+
+if ! command -v containerd >/dev/null || [[ "$(containerd --version 2>/dev/null)" != *"v${CONTAINERD_VERSION}"* ]]; then
+  log "Installing containerd ${CONTAINERD_VERSION}"
+  archive="$download_dir/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz"
+  ensure_download_verified "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz" "$CONTAINERD_SHA256" "$archive"
+  as_root tar -C /usr/local -xzf "$archive"
+fi
+
+log "Installing CNI plugins ${CNI_PLUGINS_VERSION}"
+cni_name="cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz"
+cni_archive="$download_dir/$cni_name"
+ensure_download "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/$cni_name" "$cni_archive"
+ensure_download "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/$cni_name.sha256" "$cni_archive.sha256"
+if ! (cd "$download_dir" && sha256sum -c "$(basename "$cni_archive.sha256")"); then
+  if [[ "$IGNORE_CHECKSUM_MISMATCH" == 1 ]]; then
+    echo "WARNING: ignoring CNI plugin checksum mismatch for $cni_archive" >&2
+  else
+    rm -f "$cni_archive" "$cni_archive.sha256"
+    ensure_download "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/$cni_name" "$cni_archive"
+    ensure_download "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/$cni_name.sha256" "$cni_archive.sha256"
+    (cd "$download_dir" && sha256sum -c "$(basename "$cni_archive.sha256")")
+  fi
+fi
+as_root install -d -m 0755 /opt/cni/bin
+as_root tar -C /opt/cni/bin -xzf "$cni_archive"
+
+as_root install -d -m 0755 /etc/containerd /etc/containerd/conf.d
+as_root tee /etc/containerd/config.toml >/dev/null <<'EOF'
+version = 3
+root = '/var/lib/containerd'
+state = '/run/containerd'
+imports = ['/etc/containerd/conf.d/*.toml', '/opt/kata/containerd/config.d/*.toml']
+[grpc]
+  address = '/run/containerd/containerd.sock'
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    snapshotter = 'overlayfs'
+    [plugins.'io.containerd.cri.v1.images'.registry]
+      config_path = '/etc/containerd/certs.d'
+    [plugins.'io.containerd.cri.v1.images'.pinned_images]
+      sandbox = 'registry.k8s.io/pause:3.10.1'
+  [plugins.'io.containerd.cri.v1.runtime']
+    enable_cdi = true
+    cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']
+    [plugins.'io.containerd.cri.v1.runtime'.containerd]
+      default_runtime_name = 'runc'
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+        runtime_type = 'io.containerd.runc.v2'
+        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+          BinaryName = '/usr/bin/runc'
+          SystemdCgroup = true
+    [plugins.'io.containerd.cri.v1.runtime'.cni]
+      bin_dirs = ['/opt/cni/bin']
+      conf_dir = '/etc/cni/net.d'
+      max_conf_num = 1
+EOF
+as_root tee /etc/systemd/system/containerd.service >/dev/null <<'EOF'
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+[Install]
+WantedBy=multi-user.target
+EOF
+as_root systemctl daemon-reload
+as_root systemctl enable containerd
+# Apply the generated configuration on both first install and idempotent reruns.
+as_root systemctl restart containerd
+as_root systemctl is-active --quiet containerd ||
+  die "containerd did not start with the generated configuration"
+
+log "Installing Kubernetes ${KUBERNETES_VERSION}"
+as_root install -d -m 0755 /etc/apt/keyrings
+ensure_download "https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MINOR}/deb/Release.key" "$download_dir/kubernetes-${KUBERNETES_MINOR}-Release.key"
+gpg --dearmor <"$download_dir/kubernetes-${KUBERNETES_MINOR}-Release.key" >"$tmp_dir/kubernetes.gpg"
+as_root install -m 0644 "$tmp_dir/kubernetes.gpg" /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MINOR}/deb/ /" | as_root tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+as_root apt-get update
+kubernetes_apt_options=(-y)
+[[ "$ALLOW_PACKAGE_DOWNGRADES" != 1 ]] ||
+  kubernetes_apt_options+=(--allow-downgrades --allow-change-held-packages)
+as_root env DEBIAN_FRONTEND=noninteractive apt-get install "${kubernetes_apt_options[@]}" \
+  "kubelet=${KUBERNETES_VERSION}" "kubeadm=${KUBERNETES_VERSION}" "kubectl=${KUBERNETES_VERSION}"
+as_root apt-mark hold kubelet kubeadm kubectl
+# An existing package may not re-enable its unit. Ensure the cluster remains
+# available after the next host reboot.
+as_root systemctl enable kubelet
+if [[ ! -x /usr/local/bin/helm ]] || [[ "$(/usr/local/bin/helm version --short 2>/dev/null)" != *"v${HELM_VERSION}"* ]]; then
+  log "Installing Helm ${HELM_VERSION}"
+  helm_archive="$download_dir/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+  ensure_download_verified "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" "$HELM_SHA256" "$helm_archive"
+  tar -C "$tmp_dir" -xzf "$helm_archive"
+  as_root install -m 0755 "$tmp_dir/linux-amd64/helm" /usr/local/bin/helm
+fi
+
+if [[ ! -s "$KUBECONFIG_PATH" ]]; then
+  log "Initializing the single-node Kubernetes control plane"
+  kubeadm_config="$tmp_dir/kubeadm.yaml"
+  sed -e "s|@@NODE_IP@@|$NODE_IP|g" -e "s|@@K8S_SEMVER@@|$KUBERNETES_SEMVER|g" -e "s|@@POD_CIDR@@|$POD_CIDR|g" -e "s|@@SERVICE_CIDR@@|$SERVICE_CIDR|g" -e "s|@@CLUSTER_DNS@@|$CLUSTER_DNS|g" "$SCRIPT_DIR/templates/kubeadm.yaml.in" >"$kubeadm_config"
+  as_root kubeadm init --config "$kubeadm_config"
+else
+  log "Existing cluster found at $KUBECONFIG_PATH; kubeadm init skipped"
+fi
+
+log "Installing Calico ${CALICO_VERSION} and enabling single-node scheduling"
+calico="$download_dir/calico-${CALICO_VERSION}.yaml"
+ensure_download_verified \
+  "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml" \
+  "$CALICO_SHA256" "$calico"
+kctl apply -f "$calico"
+kctl taint nodes --all node-role.kubernetes.io/control-plane- >/dev/null 2>&1 || true
+kctl wait --for=condition=Ready nodes --all --timeout=15m
+
+login_user="${SUDO_USER:-${USER:-root}}"
+if [[ "$login_user" != root ]]; then
+  login_home="$(getent passwd "$login_user" | cut -d: -f6)"
+  as_root install -d -o "$login_user" -g "$login_user" -m 0700 "$login_home/.kube"
+  as_root install -o "$login_user" -g "$login_user" -m 0600 "$KUBECONFIG_PATH" "$login_home/.kube/config"
+fi
+log "Kubernetes is ready"

--- a/examples/devops/CoCo/20-install-coco-gpu.sh
+++ b/examples/devops/CoCo/20-install-coco-gpu.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+need kubectl
+need helm
+need containerd
+need ctr
+need lspci
+
+kctl get nodes >/dev/null
+node_name="$(kctl get nodes -o jsonpath='{.items[0].metadata.name}')"
+[[ -n "$node_name" ]] || die "No Kubernetes node found"
+
+install_tdx_quote_service() {
+  local suite base key_url key_fingerprint tmp_dir observed_fingerprint
+  local pccs_config pcs_key configured_key pcs_client
+  [[ "$TEE_PLATFORM" == tdx ]] || return 0
+
+  pccs_config="/opt/intel/sgx-dcap-pccs/config/default.json"
+  configured_key=""
+  if as_root test -s "$pccs_config"; then
+    configured_key="$(as_root jq -r '.ApiKey // ""' "$pccs_config")"
+  fi
+  pcs_key="${INTEL_PCS_API_KEY:-}"
+  if [[ -n "${INTEL_PCS_API_KEY_FILE:-}" ]]; then
+    [[ -z "$pcs_key" ]] ||
+      die "Set only one of INTEL_PCS_API_KEY or INTEL_PCS_API_KEY_FILE"
+    [[ -r "$INTEL_PCS_API_KEY_FILE" ]] ||
+      die "Intel PCS API-key file is not readable: $INTEL_PCS_API_KEY_FILE"
+    IFS= read -r pcs_key <"$INTEL_PCS_API_KEY_FILE" || true
+  fi
+  [[ -n "$pcs_key" ]] || pcs_key="$configured_key"
+  if [[ -n "$pcs_key" && ! "$pcs_key" =~ ^[[:alnum:]]{32}$ ]]; then
+    die "Intel PCS subscription key must be empty or exactly 32 alphanumeric characters"
+  fi
+
+  if ! systemctl is-active --quiet qgsd 2>/dev/null; then
+    # Canonical's TDX project installs these DCAP/QGS packages from its release
+    # PPA. Keep the suite override explicit because mixing an older PPA suite
+    # onto a newer Ubuntu host is a compatibility decision, not a safe default.
+    # shellcheck disable=SC1091
+    source /etc/os-release
+    suite="${TDX_ATTESTATION_PPA_SUITE:-${VERSION_CODENAME:-}}"
+    [[ -n "$suite" ]] || die "Could not determine the Ubuntu suite for the TDX attestation PPA"
+    base="https://ppa.launchpadcontent.net/kobuk-team/tdx-attestation-release/ubuntu"
+    if ! curl -L --fail --silent --show-error --head "$base/dists/$suite/Release" >/dev/null; then
+      die "Canonical's TDX attestation PPA has no '$suite' suite; set TDX_ATTESTATION_PPA_SUITE only after approving a compatible published suite"
+    fi
+
+    log "Installing Intel TDX QGS/DCAP packages from Canonical's ${suite} release PPA"
+    tmp_dir="$(mktemp -d)"
+    key_fingerprint="0C0E6AF955CE463C03FC51574D098D70AFBE5E1F"
+    key_url="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${key_fingerprint}"
+    curl -L --fail --silent --show-error "$key_url" -o "$tmp_dir/ppa.asc"
+    observed_fingerprint="$(
+      gpg --show-keys --with-colons "$tmp_dir/ppa.asc" |
+        awk -F: '$1 == "fpr" {print $10; exit}'
+    )"
+    [[ "$observed_fingerprint" == "$key_fingerprint" ]] ||
+      die "Unexpected Canonical TDX PPA signing-key fingerprint: $observed_fingerprint"
+    gpg --dearmor <"$tmp_dir/ppa.asc" >"$tmp_dir/ppa.gpg"
+    as_root install -m 0644 "$tmp_dir/ppa.gpg" /etc/apt/keyrings/canonical-tdx-attestation.gpg
+    printf 'deb [signed-by=/etc/apt/keyrings/canonical-tdx-attestation.gpg] %s %s main\n' \
+      "$base" "$suite" |
+      as_root tee /etc/apt/sources.list.d/canonical-tdx-attestation.list >/dev/null
+    as_root apt-get update
+    as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades \
+      sgx-dcap-pccs tdx-qgs libsgx-dcap-default-qpl \
+      sgx-ra-service sgx-pck-id-retrieval-tool
+    rm -rf "$tmp_dir"
+  else
+    log "Intel TDX Quote Generation Service is already installed"
+  fi
+
+  pccs_config="/opt/intel/sgx-dcap-pccs/config/default.json"
+  as_root test -s "$pccs_config" ||
+    die "PCCS configuration is missing after installing the TDX attestation packages"
+
+  if [[ -n "$pcs_key" && "$configured_key" != "$pcs_key" ]]; then
+    log "Installing the Intel PCS subscription key into the root-owned PCCS configuration"
+    tmp_dir="$(mktemp -d)"
+    chmod 0700 "$tmp_dir"
+    printf '%s' "$pcs_key" >"$tmp_dir/pcs-api-key"
+    chmod 0600 "$tmp_dir/pcs-api-key"
+    as_root cat "$pccs_config" >"$tmp_dir/pccs.json"
+    jq --rawfile api_key "$tmp_dir/pcs-api-key" \
+      '.ApiKey = ($api_key | rtrimstr("\n"))' \
+      "$tmp_dir/pccs.json" >"$tmp_dir/pccs-updated.json"
+    # PCCS runs as the unprivileged pccs user and must be able to read this
+    # file. Keep the subscription key root-owned and expose it only to the
+    # service account through its private group.
+    as_root install -o root -g pccs -m 0640 "$tmp_dir/pccs-updated.json" "$pccs_config"
+    rm -rf "$tmp_dir"
+  fi
+
+  if [[ -z "$pcs_key" ]]; then
+    # Canonical PCCS 1.21 constructs an empty Ocp-Apim-Subscription-Key
+    # header even though Intel's production PCS accepts an omitted header.
+    # Apply a guarded compatibility edit at the common request boundary.
+    pcs_client="/opt/intel/sgx-dcap-pccs/pcs_client/pcs_client.js"
+    as_root test -s "$pcs_client" ||
+      die "PCCS client source is missing: $pcs_client"
+    if ! as_root grep -Fq 'bare-metal-coco: omit an empty Intel PCS subscription header' "$pcs_client"; then
+      log "Patching PCCS to omit its empty Intel PCS subscription header"
+      tmp_dir="$(mktemp -d)"
+      chmod 0700 "$tmp_dir"
+      as_root cat "$pcs_client" >"$tmp_dir/pcs_client.js"
+      awk '
+        { print }
+        $0 == "async function do_request(url, options) {" {
+          print "  // bare-metal-coco: omit an empty Intel PCS subscription header"
+          print "  if (!Config.get('\''ApiKey'\'') && options.headers) {"
+          print "    delete options.headers['\''Ocp-Apim-Subscription-Key'\''];"
+          print "  }"
+          inserted++
+        }
+        END { if (inserted != 1) exit 42 }
+      ' "$tmp_dir/pcs_client.js" >"$tmp_dir/pcs_client-updated.js" ||
+        die "Installed PCCS client does not contain the expected request-function anchor"
+      node --check "$tmp_dir/pcs_client-updated.js" >/dev/null ||
+        die "Refusing a keyless PCCS compatibility edit that does not pass node --check"
+      as_root install -o root -g root -m 0644 "$tmp_dir/pcs_client-updated.js" "$pcs_client"
+      rm -rf "$tmp_dir"
+    fi
+  fi
+
+  as_root runuser -u pccs -- test -r "$pccs_config" ||
+    die "PCCS configuration is not readable by the pccs service account"
+  as_root systemctl enable --now pccs qgsd
+  as_root systemctl restart pccs qgsd
+  pccs_endpoint_ready() {
+    systemctl is-active --quiet pccs &&
+      curl --insecure --silent --show-error --max-time 2 \
+        --output /dev/null https://127.0.0.1:8081/
+  }
+  wait_for "Intel PCCS HTTPS endpoint" 60 pccs_endpoint_ready
+  as_root systemctl is-active --quiet qgsd ||
+    die "Intel TDX Quote Generation Service failed to start"
+  if [[ -n "$pcs_key" ]]; then
+    log "Intel PCCS and QGS are active with a configured PCS subscription key"
+  else
+    log "Intel PCCS and QGS are active in production-PCS keyless mode"
+  fi
+}
+
+install_tdx_quote_service
+
+log "Labelling $node_name for ${TEE_NAME} and NVIDIA VM passthrough"
+kctl label node "$node_name" "${TEE_NODE_LABEL_KEY}=true" --overwrite
+kctl label node "$node_name" nvidia.com/gpu.workload.config=vm-passthrough --overwrite
+
+log "Installing Kata Containers ${KATA_VERSION}"
+helmctl upgrade --install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
+  --namespace kata-system --create-namespace --version "$KATA_VERSION" \
+  --set nfd.enabled=false --wait --timeout 15m
+
+log "Waiting for Kata host installation and containerd runtime fragment"
+kata_host_files_ready() {
+  as_root test -x /opt/kata/bin/containerd-shim-kata-v2 &&
+    as_root test -s /opt/kata/containerd/config.d/kata-deploy.toml &&
+    as_root grep -Fq "runtimes.${RUNTIME_CLASS}]" /opt/kata/containerd/config.d/kata-deploy.toml
+}
+wait_for "Kata host files for ${RUNTIME_CLASS}" 900 kata_host_files_ready
+
+# Older executions of stage 10 did not predeclare the Kata import. kata-deploy
+# normally adds it, but repair the suite-owned base configuration if it did not.
+if ! as_root grep -Fq "/opt/kata/containerd/config.d/" /etc/containerd/config.toml; then
+  log "Adding the Kata runtime fragment import to containerd"
+  as_root sed -i \
+    "s|^imports = \\['/etc/containerd/conf.d/\\*.toml'\\]$|imports = ['/etc/containerd/conf.d/*.toml', '/opt/kata/containerd/config.d/*.toml']|" \
+    /etc/containerd/config.toml
+fi
+as_root grep -Fq "/opt/kata/containerd/config.d/" /etc/containerd/config.toml ||
+  die "Could not add the Kata import to /etc/containerd/config.toml"
+
+log "Restarting containerd with the Kata runtime configuration"
+as_root systemctl restart containerd
+as_root systemctl is-active --quiet containerd ||
+  die "containerd did not restart successfully with the Kata configuration"
+# Kubernetes 1.34 can cache the CRI runtime's cgroup-driver response. After the
+# Kata fragment changes and restarts containerd, restart kubelet so new pod
+# sandboxes use the effective systemd-cgroup runtime configuration.
+as_root systemctl restart kubelet
+kubernetes_api_ready() {
+  kctl get --raw=/readyz >/dev/null 2>&1
+}
+wait_for "Kubernetes API after runtime restart" 180 kubernetes_api_ready
+
+containerd_runtime_ready() {
+  as_root containerd config dump |
+    awk -v needle="runtimes.${RUNTIME_CLASS}]" 'index($0, needle) {found=1} END {exit !found}'
+}
+wait_for "effective containerd runtime ${RUNTIME_CLASS}" 300 containerd_runtime_ready
+
+nydus_plugin_ready() {
+  as_root ctr plugins ls |
+    awk '$1 == "io.containerd.snapshotter.v1" && $2 == "nydus-for-kata-tee" && $4 == "ok" {found=1} END {exit !found}'
+}
+wait_for "nydus-for-kata-tee containerd snapshotter" 300 nydus_plugin_ready
+
+runtime_config="$(
+  as_root awk -F' = ' -v runtime="$RUNTIME_CLASS" '
+    $0 ~ "runtimes\\." runtime "\\.options\\]" {in_runtime=1; next}
+    in_runtime && /^\[/ {exit}
+    in_runtime && $1 == "ConfigPath" {
+      gsub(/"/, "", $2)
+      print $2
+      exit
+    }
+  ' /opt/kata/containerd/config.d/kata-deploy.toml
+)"
+[[ -n "$runtime_config" ]] ||
+  die "Could not resolve the Kata configuration for ${RUNTIME_CLASS}"
+as_root grep -Eq '^emptydir_mode = "block-encrypted"$' "$runtime_config" ||
+  die "${RUNTIME_CLASS} does not enable released CoCo block-encrypted emptyDir volumes"
+log "Released CoCo LUKS2/dm-crypt emptyDir support is enabled"
+
+log "Installing NVIDIA GPU Operator ${GPU_OPERATOR_VERSION} for Kata passthrough"
+helmctl repo add nvidia https://helm.ngc.nvidia.com/nvidia --force-update
+helmctl repo update nvidia
+helmctl upgrade --install gpu-operator nvidia/gpu-operator \
+  --namespace gpu-operator --create-namespace --version "$GPU_OPERATOR_VERSION" \
+  --set sandboxWorkloads.enabled=true \
+  --set sandboxWorkloads.mode=kata \
+  --set sandboxWorkloads.defaultWorkload=container \
+  --set nfd.enabled=true \
+  --set nfd.nodefeaturerules=true \
+  --set ccManager.enabled=true \
+  --set ccManager.defaultMode=on \
+  --set vfioManager.enabled=true \
+  --set kataSandboxDevicePlugin.enabled=true \
+  --set kataManager.enabled=false \
+  --wait --timeout 25m
+
+log "Waiting for CoCo GPU readiness"
+kctl wait --for=condition=Ready nodes "$node_name" --timeout=10m
+runtime_ready() { kctl get runtimeclass "$RUNTIME_CLASS" >/dev/null 2>&1; }
+cc_ready() { [[ "$(kctl get node "$node_name" -o jsonpath='{.metadata.labels.nvidia\.com/cc\.ready\.state}' 2>/dev/null)" == true ]]; }
+gpu_allocatable() {
+  local escaped_resource value
+  escaped_resource="${GPU_RESOURCE//./\\.}"
+  value="$(kctl get node "$node_name" -o "jsonpath={.status.allocatable.${escaped_resource}}" 2>/dev/null || true)"
+  [[ "${value:-0}" != 0 ]]
+}
+wait_for "RuntimeClass ${RUNTIME_CLASS}" 900 runtime_ready
+wait_for "NVIDIA confidential-computing readiness label" 1800 cc_ready
+wait_for "$GPU_RESOURCE allocatable resource" 1800 gpu_allocatable
+
+mapfile -t gpu_bdfs < <(lspci -Dnd 10de: | awk '$2 ~ /^03(00|02):$/{print $1}')
+((${#gpu_bdfs[@]} > 0)) || die "No NVIDIA VGA/3D GPU PCI device was detected"
+for gpu_bdf in "${gpu_bdfs[@]}"; do
+  gpu_driver="$(basename "$(readlink -f "/sys/bus/pci/devices/$gpu_bdf/driver" 2>/dev/null)" 2>/dev/null || true)"
+  [[ "$gpu_driver" == vfio-pci ]] || die "GPU $gpu_bdf is bound to '${gpu_driver:-no driver}', not vfio-pci, after GPU Operator deployment"
+  log "Post-install validation: GPU $gpu_bdf is bound to vfio-pci"
+done
+log "Kata CoCo runtime and GPU passthrough are ready"

--- a/examples/devops/CoCo/30-deploy-security-services.sh
+++ b/examples/devops/CoCo/30-deploy-security-services.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+need kubectl
+need openssl
+need jq
+
+[[ "$REGISTRY_IMAGE" =~ @sha256:[0-9a-f]{64}$ ]] ||
+  die "REGISTRY_IMAGE must be pinned by sha256 digest"
+[[ "$TRUSTEE_IMAGE" =~ @sha256:[0-9a-f]{64}$ ]] ||
+  die "TRUSTEE_IMAGE must be pinned by sha256 digest"
+ip -4 -o addr show | awk '{print $4}' | cut -d/ -f1 | grep -Fxq "$REGISTRY_BIND_ADDRESS" ||
+  die "REGISTRY_BIND_ADDRESS is not assigned to this host: $REGISTRY_BIND_ADDRESS"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+download_dir="$STATE_DIR/downloads"
+prepare_download_dir
+security_dir="$STATE_DIR/security"
+tls_dir="$STATE_DIR/registry-tls"
+mkdir -p "$security_dir" "$tls_dir"
+chmod 0700 "$security_dir" "$tls_dir"
+
+if ! command -v cosign >/dev/null || [[ "$(cosign version 2>/dev/null)" != *"${COSIGN_VERSION#v}"* ]]; then
+  log "Installing Cosign ${COSIGN_VERSION}"
+  cosign_download="$download_dir/cosign-${COSIGN_VERSION}-linux-amd64"
+  ensure_download_verified "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" "$COSIGN_SHA256" "$cosign_download"
+  as_root install -m 0755 "$cosign_download" /usr/local/bin/cosign
+fi
+
+if [[ "${ROTATE_SECURITY_MATERIAL}" == 1 ]]; then
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  for item in "$security_dir/cosign.key" "$security_dir/cosign.pub" "$tls_dir/ca.key" "$tls_dir/ca.crt" "$tls_dir/ca.srl" "$tls_dir/server.key" "$tls_dir/server.crt"; do
+    [[ ! -e "$item" ]] || mv "$item" "$item.$stamp.bak"
+  done
+fi
+
+if [[ ! -s "$security_dir/cosign.key" || ! -s "$security_dir/cosign.pub" ]]; then
+  log "Generating the image-signing key pair"
+  COSIGN_PASSWORD="${COSIGN_PASSWORD:-}" cosign generate-key-pair --output-key-prefix "$security_dir/cosign"
+fi
+chmod 0600 "$security_dir/cosign.key"
+chmod 0644 "$security_dir/cosign.pub"
+
+public_key_digest_from_cert() {
+  openssl x509 -in "$1" -pubkey -noout 2>/dev/null |
+    openssl pkey -pubin -outform DER 2>/dev/null |
+    sha256sum | awk '{print $1}'
+}
+
+public_key_digest_from_key() {
+  openssl pkey -in "$1" -pubout -outform DER 2>/dev/null |
+    sha256sum | awk '{print $1}'
+}
+
+certificate_key_match() {
+  [[ -s "$1" && -s "$2" ]] || return 1
+  [[ "$(public_key_digest_from_cert "$1")" == "$(public_key_digest_from_key "$2")" ]]
+}
+
+backup_tls_file() {
+  local item=$1 stamp=$2
+  [[ ! -e "$item" ]] || mv "$item" "$item.replaced-$stamp"
+}
+
+tls_repair_stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+ca_needs_generation=0
+if [[ ! -s "$tls_dir/ca.crt" || ! -s "$tls_dir/ca.key" ]]; then
+  ca_needs_generation=1
+elif ! openssl x509 -in "$tls_dir/ca.crt" -noout -checkend 86400 >/dev/null 2>&1; then
+  ca_needs_generation=1
+elif ! certificate_key_match "$tls_dir/ca.crt" "$tls_dir/ca.key"; then
+  ca_needs_generation=1
+fi
+
+if ((ca_needs_generation == 1)); then
+  log "Generating a private registry CA"
+  for item in "$tls_dir/ca.key" "$tls_dir/ca.crt" "$tls_dir/ca.srl" "$tls_dir/server.key" "$tls_dir/server.crt"; do
+    backup_tls_file "$item" "$tls_repair_stamp"
+  done
+  openssl genrsa -out "$tls_dir/ca.key" 4096
+  openssl req -x509 -new -sha256 -days 3650 -key "$tls_dir/ca.key" \
+    -subj "/CN=CoCo Local Registry CA" -out "$tls_dir/ca.crt"
+fi
+
+registry_tls_name="${REGISTRY_HOST%:*}"
+if [[ "$registry_tls_name" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+  registry_san="IP:${registry_tls_name}"
+  registry_check=(-checkip "$registry_tls_name")
+else
+  registry_san="DNS:${registry_tls_name}"
+  registry_check=(-checkhost "$registry_tls_name")
+fi
+
+server_needs_generation=0
+if [[ ! -s "$tls_dir/server.crt" || ! -s "$tls_dir/server.key" ]]; then
+  server_needs_generation=1
+elif ! openssl x509 -in "$tls_dir/server.crt" -noout -checkend 86400 >/dev/null 2>&1; then
+  server_needs_generation=1
+elif ! certificate_key_match "$tls_dir/server.crt" "$tls_dir/server.key"; then
+  server_needs_generation=1
+elif ! openssl verify -CAfile "$tls_dir/ca.crt" "$tls_dir/server.crt" >/dev/null 2>&1; then
+  server_needs_generation=1
+elif ! openssl x509 -in "$tls_dir/server.crt" -noout "${registry_check[@]}" >/dev/null 2>&1; then
+  server_needs_generation=1
+fi
+
+if ((server_needs_generation == 1)); then
+  log "Issuing a registry server certificate for ${registry_san}"
+  backup_tls_file "$tls_dir/server.key" "$tls_repair_stamp"
+  backup_tls_file "$tls_dir/server.crt" "$tls_repair_stamp"
+  openssl genrsa -out "$tls_dir/server.key" 3072
+  openssl req -new -key "$tls_dir/server.key" -subj "/CN=$registry_tls_name" -out "$tmp_dir/server.csr"
+  printf 'subjectAltName=%s\nextendedKeyUsage=serverAuth\n' "$registry_san" >"$tmp_dir/server.ext"
+  openssl x509 -req -sha256 -days 825 -in "$tmp_dir/server.csr" \
+    -CA "$tls_dir/ca.crt" -CAkey "$tls_dir/ca.key" \
+    -CAserial "$tls_dir/ca.srl" -CAcreateserial \
+    -extfile "$tmp_dir/server.ext" -out "$tls_dir/server.crt"
+fi
+
+certificate_key_match "$tls_dir/server.crt" "$tls_dir/server.key" ||
+  die "Registry server certificate and private key do not match"
+openssl verify -CAfile "$tls_dir/ca.crt" "$tls_dir/server.crt" >/dev/null ||
+  die "Registry server certificate is not signed by the configured CA"
+openssl x509 -in "$tls_dir/server.crt" -noout "${registry_check[@]}" >/dev/null ||
+  die "Registry certificate SAN does not match $registry_tls_name"
+chmod 0600 "$tls_dir/ca.key" "$tls_dir/server.key"
+chmod 0644 "$tls_dir/ca.crt" "$tls_dir/server.crt"
+
+log "Deploying the TLS registry"
+kctl create namespace "$REGISTRY_NAMESPACE" --dry-run=client -o yaml | kctl apply -f -
+kctl -n "$REGISTRY_NAMESPACE" create secret tls coco-registry-tls \
+  --cert="$tls_dir/server.crt" --key="$tls_dir/server.key" --dry-run=client -o yaml | kctl apply -f -
+registry_manifest="$tmp_dir/registry.yaml"
+sed -e "s|@@NAMESPACE@@|$REGISTRY_NAMESPACE|g" \
+  -e "s|@@PORT@@|$REGISTRY_PORT|g" \
+  -e "s|@@HOST_IP@@|$REGISTRY_BIND_ADDRESS|g" \
+  -e "s|@@REGISTRY_IMAGE@@|$REGISTRY_IMAGE|g" \
+  -e "s|@@DATA_DIR@@|$REGISTRY_DATA_DIR|g" \
+  "$SCRIPT_DIR/templates/registry.yaml.in" >"$registry_manifest"
+kctl apply -f "$registry_manifest"
+kctl -n "$REGISTRY_NAMESPACE" rollout restart deployment/coco-registry
+kctl -n "$REGISTRY_NAMESPACE" rollout status deployment/coco-registry --timeout=10m
+
+log "Trusting the private registry from containerd"
+as_root install -d -m 0755 "/etc/containerd/certs.d/$REGISTRY_HOST"
+as_root install -m 0644 "$tls_dir/ca.crt" "/etc/containerd/certs.d/$REGISTRY_HOST/ca.crt"
+printf 'server = "https://%s"\n\n[host."https://%s"]\n  capabilities = ["pull", "resolve", "push"]\n  ca = "/etc/containerd/certs.d/%s/ca.crt"\n' \
+  "$REGISTRY_HOST" "$REGISTRY_HOST" "$REGISTRY_HOST" | as_root tee "/etc/containerd/certs.d/$REGISTRY_HOST/hosts.toml" >/dev/null
+as_root systemctl restart containerd
+
+log "Deploying Trustee KBS and its image-verification resources"
+policy="$(jq -cn --arg repo "$TARGET_REPOSITORY" --arg key "$(<"$security_dir/cosign.pub")" '{default:[{type:"reject"}],transports:{docker:{($repo):[{type:"sigstoreSigned",keyData:$key,signedIdentity:{type:"matchRepository"}}]}}}')"
+kctl create namespace "$SECURITY_NAMESPACE" --dry-run=client -o yaml | kctl apply -f -
+kctl -n "$SECURITY_NAMESPACE" create secret generic coco-image-verification-resources \
+  --from-literal=security-policy="$policy" \
+  --from-file=cosign-public-key="$security_dir/cosign.pub" \
+  --from-file=registry-ca="$tls_dir/ca.crt" \
+  --dry-run=client -o yaml | kctl apply -f -
+trustee_manifest="$tmp_dir/trustee.yaml"
+sed -e "s|@@NAMESPACE@@|$SECURITY_NAMESPACE|g" \
+  -e "s|@@SERVICE@@|$KBS_SERVICE|g" \
+  -e "s|@@TRUSTEE_IMAGE@@|$TRUSTEE_IMAGE|g" \
+  "$SCRIPT_DIR/templates/trustee-kbs.yaml.in" >"$trustee_manifest"
+kctl apply -f "$trustee_manifest"
+kctl -n "$SECURITY_NAMESPACE" rollout restart "deployment/$KBS_SERVICE"
+kctl -n "$SECURITY_NAMESPACE" rollout status "deployment/$KBS_SERVICE" --timeout=10m
+
+log "Staging NVFlare hardware-attestation service configuration"
+if [[ "$TEE_PLATFORM" == tdx && -n "$NVFLARE_TDX_ATTESTATION_CONFIG_FILE" ]]; then
+  [[ -r "$NVFLARE_TDX_ATTESTATION_CONFIG_FILE" ]] ||
+    die "Cannot read NVFLARE_TDX_ATTESTATION_CONFIG_FILE: $NVFLARE_TDX_ATTESTATION_CONFIG_FILE"
+  jq -e '
+    type == "object" and
+    (.trustauthority_url | type == "string" and length > 0) and
+    (.trustauthority_api_url | type == "string" and test("^https://")) and
+    (.trustauthority_api_key | type == "string" and length > 0)
+  ' "$NVFLARE_TDX_ATTESTATION_CONFIG_FILE" >/dev/null ||
+    die "TDX config.json must contain trustauthority_url, an HTTPS trustauthority_api_url, and trustauthority_api_key"
+  ensure_coco_managed_namespace "$NVFLARE_NAMESPACE"
+  kctl -n "$NVFLARE_NAMESPACE" create secret generic nvflare-tdx-attestation \
+    --from-file="config.json=$NVFLARE_TDX_ATTESTATION_CONFIG_FILE" \
+    --dry-run=client -o yaml | kctl apply -f -
+elif [[ "$TEE_PLATFORM" == tdx ]]; then
+  log "No TDX Trust Authority config staged; the generic workflow is unaffected, but NVFlare Stage 50 will fail closed until Stage 30 is rerun with NVFLARE_TDX_ATTESTATION_CONFIG_FILE"
+fi
+
+if [[ -n "$NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE" ]]; then
+  [[ -r "$NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE" ]] ||
+    die "Cannot read NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE: $NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE"
+  gpu_service_key="$(<"$NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE")"
+  [[ -n "$gpu_service_key" && "$gpu_service_key" != *$'\n'* && ${#gpu_service_key} -le 4096 ]] ||
+    die "The NVIDIA attestation service-key file must contain one non-empty line of at most 4096 characters"
+  install -m 0600 /dev/null "$tmp_dir/nvidia-attestation-service-key"
+  printf '%s' "$gpu_service_key" >"$tmp_dir/nvidia-attestation-service-key"
+  ensure_coco_managed_namespace "$NVFLARE_NAMESPACE"
+  kctl -n "$NVFLARE_NAMESPACE" create secret generic nvflare-gpu-attestation \
+    --from-file="service-key=$tmp_dir/nvidia-attestation-service-key" \
+    --dry-run=client -o yaml | kctl apply -f -
+else
+  log "No NVIDIA service-key file configured; local NVAT verification needs none, while authenticated remote NRAS verification requires one"
+fi
+
+curl --fail --silent --show-error --cacert "$tls_dir/ca.crt" "https://${REGISTRY_HOST}/v2/" >/dev/null
+log "Registry and Trustee KBS are ready"
+echo "Signing key: $security_dir/cosign.key"
+echo "Registry CA: $tls_dir/ca.crt"

--- a/examples/devops/CoCo/40-nvflare-build-sign-images.sh
+++ b/examples/devops/CoCo/40-nvflare-build-sign-images.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+need jq
+need skopeo
+need openssl
+need kubectl
+
+server_dockerfile="$REPO_ROOT/docker/Dockerfile.coco"
+client_dockerfile="$REPO_ROOT/docker/Dockerfile.coco"
+[[ -s "$server_dockerfile" ]] || die "NVFlare server Dockerfile is missing: $server_dockerfile"
+[[ -s "$client_dockerfile" ]] || die "NVFlare client Dockerfile is missing: $client_dockerfile"
+
+for value_name in NVFLARE_SERVER_IMAGE_NAME NVFLARE_CLIENT_IMAGE_NAME; do
+  value="${!value_name:-}"
+  [[ "$value" =~ ^[a-z0-9]+([._/-][a-z0-9]+)*$ ]] ||
+    die "$value_name must be a lowercase OCI repository path"
+done
+for value_name in NVFLARE_SERVER_IMAGE_TAG NVFLARE_CLIENT_IMAGE_TAG; do
+  value="${!value_name:-}"
+  [[ "$value" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] ||
+    die "$value_name is not a valid OCI tag"
+done
+for value_name in SNPGUEST_SHA256 TRUSTAUTHORITY_CLI_SHA256 NVAT_REPO_SHA256; do
+  [[ "${!value_name:-}" =~ ^[0-9a-f]{64}$ ]] || die "$value_name must be a lowercase SHA-256 digest"
+done
+[[ "$SNPGUEST_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "SNPGUEST_VERSION must use numeric X.Y.Z form"
+[[ "$TRUSTAUTHORITY_CLI_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "TRUSTAUTHORITY_CLI_VERSION must use vX.Y.Z form"
+[[ "$NVAT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "NVAT_VERSION must use numeric X.Y.Z form"
+[[ "$TENSORBOARD_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "TENSORBOARD_VERSION must use numeric X.Y.Z form"
+[[ "$NVAT_REPO_URL" == https://developer.download.nvidia.com/compute/nvat/${NVAT_VERSION}/local_installers/nvat-local-repo-ubuntu2404-*.deb ]] ||
+  die "NVAT_REPO_URL must be the pinned NVIDIA NVAT repository package for NVAT_VERSION"
+for value_name in NVFLARE_COCO_PYTHON_BUILD_BASE NVFLARE_COCO_PYTHON_RUNTIME_BASE NVAT_BUILD_BASE; do
+  [[ "${!value_name:-}" =~ ^[^[:space:]]+@sha256:[0-9a-f]{64}$ ]] ||
+    die "$value_name must be an immutable digest-pinned image"
+done
+[[ "$NVFLARE_COCO_PYTHON_MINOR" =~ ^[0-9]+\.[0-9]+$ ]] ||
+  die "NVFLARE_COCO_PYTHON_MINOR must use numeric X.Y form"
+
+# Stage 30 is an explicit prerequisite. Do not hide infrastructure deployment
+# inside this image-build stage: operators must run the numbered stages in
+# order and can inspect the registry, signing material, and Trustee separately.
+[[ -r "$STATE_DIR/security/cosign.key" && -r "$STATE_DIR/security/cosign.pub" ]] ||
+  die "Run 30-deploy-security-services.sh first: Cosign signing material is missing"
+[[ -r "$STATE_DIR/registry-tls/ca.crt" ]] ||
+  die "Run 30-deploy-security-services.sh first: registry CA is missing"
+kctl -n "$REGISTRY_NAMESPACE" get deployment coco-registry >/dev/null 2>&1 ||
+  die "Run 30-deploy-security-services.sh first: registry deployment is missing"
+kctl -n "$SECURITY_NAMESPACE" get deployment "$KBS_SERVICE" >/dev/null 2>&1 ||
+  die "Run 30-deploy-security-services.sh first: Trustee KBS deployment is missing"
+
+if ! command -v podman >/dev/null 2>&1; then
+  log "Installing Podman for daemonless NVFlare image builds"
+  as_root apt-get update
+  as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y podman
+fi
+need podman
+need cosign
+
+security_dir="$STATE_DIR/security"
+tls_dir="$STATE_DIR/registry-tls"
+cert_dir="$STATE_DIR/nvflare-build-certs"
+podman_root="$STATE_DIR/podman-storage"
+podman_runroot="$STATE_DIR/podman-runroot"
+mkdir -p "$cert_dir"
+as_root install -d -m 0755 "$podman_root" "$podman_runroot"
+install -m 0644 "$tls_dir/ca.crt" "$cert_dir/ca.crt"
+[[ -r "$security_dir/cosign.key" ]] || die "Cosign private key is missing after security-service deployment"
+
+server_repository="${REGISTRY_HOST}/${NVFLARE_SERVER_IMAGE_NAME}"
+client_repository="${REGISTRY_HOST}/${NVFLARE_CLIENT_IMAGE_NAME}"
+[[ "$server_repository" != "$client_repository" ]] ||
+  die "Server and client image repositories must be different"
+server_tagged="${server_repository}:${NVFLARE_SERVER_IMAGE_TAG}"
+client_tagged="${client_repository}:${NVFLARE_CLIENT_IMAGE_TAG}"
+
+source_revision="unknown"
+if command -v git >/dev/null 2>&1 && git -C "$REPO_ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
+  source_revision="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+fi
+
+build_and_push() {
+  local role=$1 dockerfile=$2 destination=$3 local_image
+  local_image="localhost/nvflare-coco-${role}:${destination##*:}"
+  log "Building the NVFlare ${role} image from $dockerfile"
+  # Use the host's already-qualified egress path. Rootful Podman's private
+  # build network cannot reach package mirrors on some TDX host firewalls.
+  as_root podman --root "$podman_root" --runroot "$podman_runroot" build \
+    --network=host --pull=always \
+    --build-arg "PYTHON_BUILD_BASE=$NVFLARE_COCO_PYTHON_BUILD_BASE" \
+    --build-arg "PYTHON_RUNTIME_BASE=$NVFLARE_COCO_PYTHON_RUNTIME_BASE" \
+    --build-arg "PYTHON_MINOR=$NVFLARE_COCO_PYTHON_MINOR" \
+    --build-arg "SNPGUEST_VERSION=$SNPGUEST_VERSION" \
+    --build-arg "SNPGUEST_SHA256=$SNPGUEST_SHA256" \
+    --build-arg "TRUSTAUTHORITY_CLI_VERSION=$TRUSTAUTHORITY_CLI_VERSION" \
+    --build-arg "TRUSTAUTHORITY_CLI_SHA256=$TRUSTAUTHORITY_CLI_SHA256" \
+    --build-arg "NVAT_VERSION=$NVAT_VERSION" \
+    --build-arg "NVAT_REPO_SHA256=$NVAT_REPO_SHA256" \
+    --build-arg "NVAT_REPO_URL=$NVAT_REPO_URL" \
+    --build-arg "NVAT_BUILD_BASE=$NVAT_BUILD_BASE" \
+    --build-arg "TENSORBOARD_VERSION=$TENSORBOARD_VERSION" \
+    --label "org.opencontainers.image.source=NVFlare" \
+    --label "org.opencontainers.image.revision=${source_revision}" \
+    --label "org.opencontainers.image.role=${role}" \
+    --file "$dockerfile" --tag "$local_image" "$REPO_ROOT"
+
+  log "Checking attestation and hello-numpy dependencies in the ${role} runtime image"
+  as_root podman --root "$podman_root" --runroot "$podman_runroot" run --rm \
+    --entrypoint /opt/attestation/bin/snpguest "$local_image" --version 2>&1 |
+    grep -F "snpguest $SNPGUEST_VERSION" >/dev/null ||
+    die "The ${role} image does not contain snpguest $SNPGUEST_VERSION"
+  as_root podman --root "$podman_root" --runroot "$podman_runroot" run --rm \
+    --entrypoint /opt/attestation/bin/trustauthority-cli "$local_image" version 2>&1 |
+    grep -F "Version: $TRUSTAUTHORITY_CLI_VERSION" >/dev/null ||
+    die "The ${role} image does not contain Intel Trust Authority CLI $TRUSTAUTHORITY_CLI_VERSION"
+  as_root podman --root "$podman_root" --runroot "$podman_runroot" run --rm \
+    --entrypoint /opt/attestation/bin/nvattest "$local_image" version 2>&1 |
+    grep -F "nvattest $NVAT_VERSION" >/dev/null ||
+    die "The ${role} image does not contain NVIDIA NVAT $NVAT_VERSION"
+  as_root podman --root "$podman_root" --runroot "$podman_runroot" run --rm \
+    --entrypoint python "$local_image" -c \
+    "import importlib.util, os, tensorboard; from nvflare.app_opt.confidential_computing.coco_hello_numpy_executor import CoCoHelloNumpyExecutor; from nvflare.app_opt.confidential_computing.snp_authorizer import SNPAuthorizer; from nvflare.app_opt.confidential_computing.tdx_authorizer import TDXAuthorizer; from nvflare.app_opt.confidential_computing.gpu_authorizer import GPUAuthorizer; assert tensorboard.__version__ == '$TENSORBOARD_VERSION'; assert importlib.util.find_spec('kubernetes') is None; assert os.path.isfile(CoCoHelloNumpyExecutor.TRAINER_PATH)"
+  log "Pushing $destination to the private TLS registry"
+  as_root podman --root "$podman_root" --runroot "$podman_runroot" push \
+    --cert-dir "$cert_dir" --tls-verify=true "$local_image" "docker://$destination"
+}
+
+build_and_push server "$server_dockerfile" "$server_tagged"
+build_and_push client "$client_dockerfile" "$client_tagged"
+
+sign_and_verify() {
+  local role=$1 tagged=$2 repository=$3 digest signed_ref stderr_file
+  digest="$(skopeo inspect --retry-times 5 --cert-dir "$cert_dir" "docker://$tagged" | jq -er .Digest)"
+  [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die "Registry returned an invalid digest for $tagged"
+  signed_ref="${repository}@${digest}"
+  log "Signing the ${role} image digest $signed_ref"
+  if [[ "$COSIGN_TLOG_MODE" == rekor ]]; then
+    COSIGN_PASSWORD="${COSIGN_PASSWORD:-}" cosign sign --yes --tlog-upload=true \
+      --allow-insecure-registry --key "$security_dir/cosign.key" "$signed_ref"
+  else
+    COSIGN_PASSWORD="${COSIGN_PASSWORD:-}" cosign sign --yes --tlog-upload=false \
+      --allow-insecure-registry --key "$security_dir/cosign.key" "$signed_ref"
+  fi
+
+  stderr_file="$STATE_DIR/.nvflare-${role}-cosign-stderr.$$"
+  if [[ "$COSIGN_TLOG_MODE" == rekor ]]; then
+    if ! cosign verify --allow-insecure-registry \
+      --key "$security_dir/cosign.pub" "$signed_ref" \
+      >"$STATE_DIR/nvflare-${role}-cosign-verification.json" 2>"$stderr_file"; then
+      cat "$stderr_file" >&2
+      rm -f "$stderr_file"
+      die "Cosign/Rekor verification failed for the NVFlare ${role} image"
+    fi
+  else
+    if ! cosign verify --allow-insecure-registry --insecure-ignore-tlog \
+      --key "$security_dir/cosign.pub" "$signed_ref" \
+      >"$STATE_DIR/nvflare-${role}-cosign-verification.json" 2>"$stderr_file"; then
+      cat "$stderr_file" >&2
+      rm -f "$stderr_file"
+      die "Cosign verification failed for the NVFlare ${role} image"
+    fi
+    sed '/^WARNING: Skipping tlog verification is an insecure practice/d' "$stderr_file" >&2
+  fi
+  rm -f "$stderr_file"
+  SIGNED_REF="$signed_ref"
+}
+
+sign_and_verify server "$server_tagged" "$server_repository"
+server_image="$SIGNED_REF"
+sign_and_verify client "$client_tagged" "$client_repository"
+client_image="$SIGNED_REF"
+
+policy_file="$STATE_DIR/nvflare-image-security-policy.json"
+jq -cn \
+  --arg server "$server_repository" \
+  --arg client "$client_repository" \
+  --arg key "$(<"$security_dir/cosign.pub")" \
+  '{default:[{type:"reject"}],transports:{docker:{
+    ($server):[{type:"sigstoreSigned",keyData:$key,signedIdentity:{type:"matchRepository"}}],
+    ($client):[{type:"sigstoreSigned",keyData:$key,signedIdentity:{type:"matchRepository"}}]
+  }}}' >"$policy_file"
+
+# Keep Trustee's public verification resources aligned with the measured
+# init-data policy used by the NVFlare deployments.
+kctl -n "$SECURITY_NAMESPACE" create secret generic coco-image-verification-resources \
+  --from-file=security-policy="$policy_file" \
+  --from-file=cosign-public-key="$security_dir/cosign.pub" \
+  --from-file=registry-ca="$tls_dir/ca.crt" \
+  --dry-run=client -o yaml | kctl apply -f -
+kctl -n "$SECURITY_NAMESPACE" rollout restart "deployment/$KBS_SERVICE"
+kctl -n "$SECURITY_NAMESPACE" rollout status "deployment/$KBS_SERVICE" --timeout=10m
+
+state_tmp="$STATE_DIR/.nvflare-images.env.$$"
+{
+  printf 'NVFLARE_SERVER_IMAGE=%q\n' "$server_image"
+  printf 'NVFLARE_CLIENT_IMAGE=%q\n' "$client_image"
+  printf 'NVFLARE_SERVER_REPOSITORY=%q\n' "$server_repository"
+  printf 'NVFLARE_CLIENT_REPOSITORY=%q\n' "$client_repository"
+  printf 'NVFLARE_SOURCE_REVISION=%q\n' "$source_revision"
+  printf 'NVFLARE_IMAGE_PYTHON_BUILD_BASE=%q\n' "$NVFLARE_COCO_PYTHON_BUILD_BASE"
+  printf 'NVFLARE_IMAGE_PYTHON_RUNTIME_BASE=%q\n' "$NVFLARE_COCO_PYTHON_RUNTIME_BASE"
+  printf 'NVFLARE_IMAGE_PYTHON_MINOR=%q\n' "$NVFLARE_COCO_PYTHON_MINOR"
+  printf 'NVFLARE_IMAGE_NVAT_BUILD_BASE=%q\n' "$NVAT_BUILD_BASE"
+  printf 'NVFLARE_SNPGUEST_VERSION=%q\n' "$SNPGUEST_VERSION"
+  printf 'NVFLARE_TRUSTAUTHORITY_CLI_VERSION=%q\n' "$TRUSTAUTHORITY_CLI_VERSION"
+  printf 'NVFLARE_NVAT_VERSION=%q\n' "$NVAT_VERSION"
+  printf 'NVFLARE_TENSORBOARD_VERSION=%q\n' "$TENSORBOARD_VERSION"
+  printf 'COSIGN_TLOG_MODE=%q\n' "$COSIGN_TLOG_MODE"
+  printf 'SIGNED_AT=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$state_tmp"
+mv "$state_tmp" "$STATE_DIR/nvflare-images.env"
+
+cat >"$STATE_DIR/nvflare-image-signing-report.txt" <<EOF
+NVFLARE COCO IMAGE BUILD AND SIGNING REPORT
+===========================================
+Source checkout: $REPO_ROOT
+Source revision: $source_revision
+Server Dockerfile: docker/Dockerfile.coco
+Server image: $server_image
+Client Dockerfile: docker/Dockerfile.coco (client role)
+Client image: $client_image
+CoCo Python builder: $NVFLARE_COCO_PYTHON_BUILD_BASE
+CoCo Python runtime: $NVFLARE_COCO_PYTHON_RUNTIME_BASE
+NVAT dependency builder: $NVAT_BUILD_BASE
+SNP guest tool: snpguest $SNPGUEST_VERSION (runtime check PASS)
+TDX tool: Intel Trust Authority CLI $TRUSTAUTHORITY_CLI_VERSION (runtime check PASS)
+GPU tool: NVIDIA NVAT $NVAT_VERSION (runtime CLI check PASS)
+hello-numpy signed trainer: /opt/nvflare/examples/hello-numpy/client.py (runtime file check PASS)
+hello-numpy tracking dependency: TensorBoard $TENSORBOARD_VERSION (runtime import PASS)
+Kubernetes Python package: ABSENT (ProcessJobLauncher workflow)
+Signature policy: $policy_file
+Transparency-log mode: $COSIGN_TLOG_MODE
+Server Cosign verification: PASS
+Client Cosign verification: PASS
+EOF
+
+log "Signed NVFlare images are ready"
+echo "Server: $server_image"
+echo "Client: $client_image"

--- a/examples/devops/CoCo/40-sign-image.sh
+++ b/examples/devops/CoCo/40-sign-image.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+need skopeo
+need cosign
+need jq
+
+source_image="${1:-$SOURCE_IMAGE}"
+target_tag="${2:-signed}"
+target_image="${TARGET_REPOSITORY}:${target_tag}"
+security_dir="$STATE_DIR/security"
+tls_dir="$STATE_DIR/registry-tls"
+cert_dir="$STATE_DIR/containers-certs.d/$REGISTRY_HOST"
+mkdir -p "$cert_dir"
+[[ -r "$security_dir/cosign.key" ]] || die "Run 30-deploy-security-services.sh first"
+[[ -r "$tls_dir/ca.crt" ]] || die "Registry CA is missing; run stage 30"
+install -m 0644 "$tls_dir/ca.crt" "$cert_dir/ca.crt"
+
+log "Copying $source_image to $target_image"
+skopeo copy --retry-times 5 --dest-cert-dir "$cert_dir" \
+  "docker://$source_image" "docker://$target_image"
+digest="$(skopeo inspect --retry-times 5 --cert-dir "$cert_dir" "docker://$target_image" | jq -er .Digest)"
+signed_image="${TARGET_REPOSITORY}@${digest}"
+
+log "Signing the digest-pinned image"
+if [[ "$COSIGN_TLOG_MODE" == rekor ]]; then
+  COSIGN_PASSWORD="${COSIGN_PASSWORD:-}" cosign sign --yes --tlog-upload=true \
+    --allow-insecure-registry --key "$security_dir/cosign.key" "$signed_image"
+else
+  COSIGN_PASSWORD="${COSIGN_PASSWORD:-}" cosign sign --yes --tlog-upload=false \
+    --allow-insecure-registry --key "$security_dir/cosign.key" "$signed_image"
+fi
+
+log "Verifying the signature before producing deployment state"
+cosign_stderr="$STATE_DIR/.cosign-verify-stderr.$$"
+if [[ "$COSIGN_TLOG_MODE" == rekor ]]; then
+  if ! cosign verify --allow-insecure-registry \
+    --key "$security_dir/cosign.pub" "$signed_image" \
+    >"$STATE_DIR/cosign-verification.json" 2>"$cosign_stderr"; then
+    cat "$cosign_stderr" >&2
+    rm -f "$cosign_stderr"
+    die "Cosign signature or Rekor transparency-log verification failed"
+  fi
+else
+  echo "NOTICE: COSIGN_TLOG_MODE=disabled; verifying the private-key signature without public transparency-log inclusion."
+  if ! cosign verify --allow-insecure-registry --insecure-ignore-tlog \
+    --key "$security_dir/cosign.pub" "$signed_image" \
+    >"$STATE_DIR/cosign-verification.json" 2>"$cosign_stderr"; then
+    cat "$cosign_stderr" >&2
+    rm -f "$cosign_stderr"
+    die "Cosign private-key signature verification failed"
+  fi
+  sed '/^WARNING: Skipping tlog verification is an insecure practice/d' "$cosign_stderr" >&2
+fi
+rm -f "$cosign_stderr"
+
+{
+  printf 'SIGNED_IMAGE=%q\n' "$signed_image"
+  printf 'POLICY_REPOSITORY=%q\n' "$TARGET_REPOSITORY"
+  printf 'REGISTRY_HOST=%q\n' "$REGISTRY_HOST"
+  printf 'SOURCE_IMAGE=%q\n' "$source_image"
+  printf 'COSIGN_TLOG_MODE=%q\n' "$COSIGN_TLOG_MODE"
+  printf 'SIGNED_AT=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$STATE_DIR/signed-image.env"
+
+cat >"$STATE_DIR/image-signing-report.txt" <<EOF
+CONTAINER IMAGE SIGNING REPORT
+==============================
+Source image: $source_image
+Local tagged image: $target_image
+Signed digest reference: $signed_image
+Signing key: $security_dir/cosign.key
+Verification key: $security_dir/cosign.pub
+Transparency-log mode: $COSIGN_TLOG_MODE
+Cosign verification: PASS
+EOF
+log "Signed image ready: $signed_image"

--- a/examples/devops/CoCo/50-launch-and-attest.sh
+++ b/examples/devops/CoCo/50-launch-and-attest.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+prepare_download_dir
+
+signed_env="$STATE_DIR/signed-image.env"
+[[ -r "$signed_env" ]] || die "Run 40-sign-image.sh first: $signed_env is missing"
+# shellcheck disable=SC1090
+source "$signed_env"
+case "${COSIGN_TLOG_MODE:-disabled}" in
+  disabled|rekor) ;;
+  *) die "Signed-image state contains an invalid COSIGN_TLOG_MODE" ;;
+esac
+case "$TEE_PLATFORM" in
+  snp)
+    EXPECTED_SNP_LAUNCH_MEASUREMENT="${EXPECTED_SNP_LAUNCH_MEASUREMENT,,}"
+    [[ "$EXPECTED_SNP_LAUNCH_MEASUREMENT" =~ ^[0-9a-f]{96}$ ]] ||
+      die "EXPECTED_SNP_LAUNCH_MEASUREMENT must be the approved 48-byte SNP launch measurement (96 lowercase hex characters)"
+    ;;
+  tdx)
+    for reference_name in EXPECTED_TDX_MRTD EXPECTED_TDX_RTMR0 EXPECTED_TDX_RTMR1 EXPECTED_TDX_RTMR2 EXPECTED_TDX_RTMR3; do
+      printf -v "$reference_name" '%s' "${!reference_name,,}"
+      [[ "${!reference_name}" =~ ^[0-9a-f]{96}$ ]] ||
+        die "$reference_name must be an independently approved 48-byte TDX reference value (96 lowercase hex characters)"
+    done
+    ;;
+esac
+CONFIDENTIAL_VOLUME_SIZE="${CONFIDENTIAL_VOLUME_SIZE:-8Gi}"
+[[ "$CONFIDENTIAL_VOLUME_SIZE" =~ ^[1-9][0-9]*(Ki|Mi|Gi|Ti)$ ]] ||
+  die "CONFIDENTIAL_VOLUME_SIZE must be a positive binary Kubernetes quantity such as 8Gi"
+
+report_dir="${1:-$STATE_DIR/attestation-reports-$(date -u +%Y%m%dT%H%M%SZ)}"
+driver="$SCRIPT_DIR/lib/deploy-coco-attest.sh"
+[[ -x "$driver" ]] || die "Attestation driver is missing or not executable: $driver"
+
+if ! as_root containerd config dump |
+  awk -v needle="runtimes.${RUNTIME_CLASS}]" 'index($0, needle) {found=1} END {exit !found}'; then
+  die "containerd has no runtime handler for ${RUNTIME_CLASS}; rerun 20-install-coco-gpu.sh"
+fi
+if ! as_root ctr plugins ls |
+  awk '$1 == "io.containerd.snapshotter.v1" && $2 == "nydus-for-kata-tee" && $4 == "ok" {found=1} END {exit !found}'; then
+  die "containerd snapshotter nydus-for-kata-tee is not ready; rerun 20-install-coco-gpu.sh"
+fi
+
+log "Launching a signed-image CoCo pod and collecting CPU/GPU evidence"
+driver_args=(--kubeconfig "$KUBECONFIG_PATH" --output-dir "$report_dir")
+[[ "$KEEP_ATTESTATION_POD" == 1 ]] || driver_args+=(--cleanup)
+as_root env \
+  KUBECONFIG="$KUBECONFIG_PATH" \
+  TEE_PLATFORM="$TEE_PLATFORM" \
+  POD_IMAGE="$SIGNED_IMAGE" \
+  POLICY_REPOSITORY="$POLICY_REPOSITORY" \
+  REGISTRY_HOST="$REGISTRY_HOST" \
+  COSIGN_PUBLIC_KEY="$STATE_DIR/security/cosign.pub" \
+  REGISTRY_CA_CERT="$STATE_DIR/registry-tls/ca.crt" \
+  RUNTIME_CLASS="$RUNTIME_CLASS" \
+  GPU_RESOURCE="$GPU_RESOURCE" \
+  GPU_COUNT="$GPU_COUNT" \
+  POD_MEMORY="$POD_MEMORY" \
+  CONFIDENTIAL_VOLUME_SIZE="$CONFIDENTIAL_VOLUME_SIZE" \
+  AMD_KDS_PRODUCT="$AMD_KDS_PRODUCT" \
+  EXPECTED_SNP_LAUNCH_MEASUREMENT="$EXPECTED_SNP_LAUNCH_MEASUREMENT" \
+  EXPECTED_TDX_MRTD="${EXPECTED_TDX_MRTD:-}" \
+  EXPECTED_TDX_RTMR0="${EXPECTED_TDX_RTMR0:-}" \
+  EXPECTED_TDX_RTMR1="${EXPECTED_TDX_RTMR1:-}" \
+  EXPECTED_TDX_RTMR2="${EXPECTED_TDX_RTMR2:-}" \
+  EXPECTED_TDX_RTMR3="${EXPECTED_TDX_RTMR3:-}" \
+  KBS_NAMESPACE="$SECURITY_NAMESPACE" \
+  KBS_SERVICE="$KBS_SERVICE" \
+  ARTIFACT_CACHE_DIR="$STATE_DIR/downloads" \
+  IGNORE_CHECKSUM_MISMATCH="$IGNORE_CHECKSUM_MISMATCH" \
+  COSIGN_TLOG_MODE="${COSIGN_TLOG_MODE:-disabled}" \
+  "$driver" "${driver_args[@]}"
+
+as_root chown -R "$(id -u):$(id -g)" "$report_dir"
+ln -sfn "$report_dir" "$STATE_DIR/latest-attestation-reports"
+log "Human-readable reports are in $report_dir"
+sed -n '/Overall CPU attestation result:/p' "$report_dir/cpu-attestation-report.txt"
+sed -n '/Overall GPU attestation result:/p' "$report_dir/gpu-attestation-report.txt"
+sed -n '/Overall confidential storage result:/p' "$report_dir/storage-verification-report.txt"

--- a/examples/devops/CoCo/50-nvflare-deploy.sh
+++ b/examples/devops/CoCo/50-nvflare-deploy.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+need kubectl
+need jq
+need gzip
+need base64
+need sha256sum
+need cosign
+
+work_dir="$STATE_DIR/nvflare-deployment"
+current_deployment="$work_dir/current.env"
+mkdir -p "$work_dir"
+# Any Stage-50 attempt invalidates the old active pointer before preflight.
+# It is recreated only after the new deployment passes every check.
+rm -f "$current_deployment"
+
+images_env="$STATE_DIR/nvflare-images.env"
+policy_file="$STATE_DIR/nvflare-image-security-policy.json"
+[[ -r "$images_env" ]] || die "Run 40-nvflare-build-sign-images.sh first: $images_env is missing"
+[[ -r "$policy_file" ]] || die "NVFlare image policy is missing: $policy_file"
+# shellcheck disable=SC1090
+source "$images_env"
+
+for value_name in NVFLARE_SERVER_IMAGE NVFLARE_CLIENT_IMAGE; do
+  [[ "${!value_name:-}" =~ ^[^[:space:]]+@sha256:[0-9a-f]{64}$ ]] ||
+    die "$value_name must be a digest-pinned image"
+done
+[[ "${NVFLARE_SNPGUEST_VERSION:-}" == "$SNPGUEST_VERSION" ]] ||
+  die "Signed images do not record snpguest $SNPGUEST_VERSION; rerun 40-nvflare-build-sign-images.sh"
+[[ "${NVFLARE_TRUSTAUTHORITY_CLI_VERSION:-}" == "$TRUSTAUTHORITY_CLI_VERSION" ]] ||
+  die "Signed images do not record Trust Authority CLI $TRUSTAUTHORITY_CLI_VERSION; rerun Stage 40"
+[[ "${NVFLARE_NVAT_VERSION:-}" == "$NVAT_VERSION" ]] ||
+  die "Signed images do not record NVIDIA NVAT $NVAT_VERSION; rerun Stage 40"
+[[ "${NVFLARE_TENSORBOARD_VERSION:-}" == "$TENSORBOARD_VERSION" ]] ||
+  die "Signed images do not record TensorBoard $TENSORBOARD_VERSION; rerun Stage 40"
+[[ "${NVFLARE_IMAGE_PYTHON_BUILD_BASE:-}" == "$NVFLARE_COCO_PYTHON_BUILD_BASE" &&
+  "${NVFLARE_IMAGE_PYTHON_RUNTIME_BASE:-}" == "$NVFLARE_COCO_PYTHON_RUNTIME_BASE" &&
+  "${NVFLARE_IMAGE_PYTHON_MINOR:-}" == "$NVFLARE_COCO_PYTHON_MINOR" &&
+  "${NVFLARE_IMAGE_NVAT_BUILD_BASE:-}" == "$NVAT_BUILD_BASE" ]] ||
+  die "Signed images do not match the configured CoCo Python/NVAT base images; rerun Stage 40"
+for value_name in NVFLARE_NAMESPACE NVFLARE_SERVER_NAME NVFLARE_CLIENT_NAME; do
+  value="${!value_name:-}"
+  [[ "$value" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ && ${#value} -le 63 ]] ||
+    die "$value_name must be a lowercase RFC 1123 name"
+done
+[[ "${NVFLARE_ADMIN_NAME:-}" =~ ^[A-Za-z0-9@_.-]+$ ]] ||
+  die "NVFLARE_ADMIN_NAME contains unsupported characters"
+[[ "${NVFLARE_PROJECT_NAME:-}" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+  die "NVFLARE_PROJECT_NAME contains unsupported characters"
+[[ "${NVFLARE_ORG:-}" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+  die "NVFLARE_ORG contains unsupported characters"
+[[ "${NVFLARE_CLIENT_GPU_COUNT:-}" =~ ^[1-9][0-9]*$ ]] ||
+  die "NVFLARE_CLIENT_GPU_COUNT must be a positive integer"
+[[ "${NVFLARE_FS_GROUP:-}" =~ ^[1-9][0-9]*$ && "$NVFLARE_FS_GROUP" -le 2147483647 ]] ||
+  die "NVFLARE_FS_GROUP must be a positive 32-bit integer"
+for value_name in NVFLARE_SERVER_RUNTIME_CLASS NVFLARE_CLIENT_RUNTIME_CLASS; do
+  value="${!value_name:-}"
+  [[ "$value" =~ ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$ && ${#value} -le 253 ]] ||
+    die "$value_name must be a lowercase DNS subdomain"
+  kctl get runtimeclass "$value" >/dev/null 2>&1 ||
+    die "$value_name does not exist in the cluster: $value"
+done
+[[ "${GPU_RESOURCE:-}" =~ ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?/[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$ ]] ||
+  die "GPU_RESOURCE must be a Kubernetes extended-resource name"
+for value_name in NVFLARE_SERVER_MEMORY NVFLARE_CLIENT_MEMORY NVFLARE_WORKSPACE_SIZE; do
+  [[ "${!value_name:-}" =~ ^[1-9][0-9]*(Ki|Mi|Gi|Ti)$ ]] ||
+    die "$value_name must be a positive binary Kubernetes quantity"
+done
+[[ "${AMD_KDS_PRODUCT:-}" =~ ^[A-Za-z0-9_-]+$ ]] || die "AMD_KDS_PRODUCT contains unsupported characters"
+ensure_coco_managed_namespace "$NVFLARE_NAMESPACE"
+
+case "$TEE_PLATFORM" in
+  snp)
+    cpu_attestation_device="sev-guest"
+    cpu_mechanism="amd_sev_snp"
+    cpu_authorizer_id="snp_authorizer"
+    cpu_authorizer_path="nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer"
+    ;;
+  tdx)
+    cpu_attestation_device="tdx_guest"
+    cpu_mechanism="intel_tdx"
+    cpu_authorizer_id="tdx_authorizer"
+    cpu_authorizer_path="nvflare.app_opt.confidential_computing.tdx_authorizer.TDXAuthorizer"
+    kctl -n "$NVFLARE_NAMESPACE" get secret nvflare-tdx-attestation \
+      -o jsonpath='{.data.config\.json}' | grep -q . ||
+      die "TDX attestation Secret is missing; rerun 30-deploy-security-services.sh with NVFLARE_TDX_ATTESTATION_CONFIG_FILE"
+    ;;
+  *) die "Unsupported TEE_PLATFORM: $TEE_PLATFORM" ;;
+esac
+
+security_dir="$STATE_DIR/security"
+tls_dir="$STATE_DIR/registry-tls"
+[[ -r "$security_dir/cosign.pub" ]] || die "Cosign public key is missing"
+[[ -r "$tls_dir/ca.crt" ]] || die "Registry CA is missing"
+
+verify_signed_image() {
+  local role=$1 image=$2 stderr_file
+  stderr_file="$STATE_DIR/.nvflare-deploy-${role}-cosign-stderr.$$"
+  if [[ "${COSIGN_TLOG_MODE:-disabled}" == rekor ]]; then
+    if ! cosign verify --allow-insecure-registry --key "$security_dir/cosign.pub" \
+      "$image" >/dev/null 2>"$stderr_file"; then
+      cat "$stderr_file" >&2
+      rm -f "$stderr_file"
+      die "Cosign/Rekor verification failed for $role image $image"
+    fi
+  else
+    if ! cosign verify --allow-insecure-registry --insecure-ignore-tlog \
+      --key "$security_dir/cosign.pub" "$image" >/dev/null 2>"$stderr_file"; then
+      cat "$stderr_file" >&2
+      rm -f "$stderr_file"
+      die "Cosign verification failed for $role image $image"
+    fi
+    sed '/^WARNING: Skipping tlog verification is an insecure practice/d' "$stderr_file" >&2
+  fi
+  rm -f "$stderr_file"
+}
+
+log "Re-verifying both digest-pinned NVFlare image signatures"
+verify_signed_image server "$NVFLARE_SERVER_IMAGE"
+verify_signed_image client "$NVFLARE_CLIENT_IMAGE"
+
+jq -e --arg server "$NVFLARE_SERVER_REPOSITORY" --arg client "$NVFLARE_CLIENT_REPOSITORY" \
+  --arg key "$(<"$security_dir/cosign.pub")" '
+  . as $policy |
+  ($policy.default == [{type:"reject"}]) and
+  all([$server, $client][];
+    . as $repository |
+    ($policy.transports.docker[$repository][0].type == "sigstoreSigned") and
+    ($policy.transports.docker[$repository][0].keyData == $key) and
+    ($policy.transports.docker[$repository][0].signedIdentity.type == "matchRepository"))
+' "$policy_file" >/dev/null || die "NVFlare image policy is not deny-by-default for both repositories"
+
+nvflare_cli="${NVFLARE_CLI:-}"
+if [[ -z "$nvflare_cli" ]] && command -v nvflare >/dev/null 2>&1; then
+  nvflare_cli="$(command -v nvflare)"
+fi
+if [[ -z "$nvflare_cli" && -x "$REPO_ROOT/.venv/bin/nvflare" ]]; then
+  nvflare_cli="$REPO_ROOT/.venv/bin/nvflare"
+fi
+[[ -x "$nvflare_cli" ]] ||
+  die "NVFlare CLI not found; install this checkout in a virtual environment or set NVFLARE_CLI"
+
+project_file="$work_dir/project.yml"
+manifest="$work_dir/nvflare-coco.yaml"
+initdata_file="$work_dir/initdata.toml"
+server_cc_config="$work_dir/cc-server.yml"
+client_cc_config="$work_dir/cc-client.yml"
+
+write_cc_config() {
+  local role=$1 destination=$2
+  cat >"$destination" <<EOF
+compute_env: onprem_cvm
+cc_cpu_mechanism: $cpu_mechanism
+role: $role
+cc_issuers:
+  - id: $cpu_authorizer_id
+    path: $cpu_authorizer_path
+    token_expiration: 100
+    args:
+EOF
+  if [[ "$TEE_PLATFORM" == snp ]]; then
+    cat >>"$destination" <<EOF
+      snpguest_binary: /opt/attestation/bin/snpguest
+      amd_certs_dir: /var/tmp/nvflare/workspace/attestation/snp-certs
+      cpu_model: ${AMD_KDS_PRODUCT,,}
+EOF
+  else
+    cat >>"$destination" <<EOF
+      tdx_cli_command: /opt/attestation/bin/trustauthority-cli
+      config_dir: /etc/nvflare/tdx-attestation
+      use_sudo: false
+EOF
+  fi
+  if [[ "$role" == client ]]; then
+    cat >>"$destination" <<EOF
+  - id: gpu_authorizer
+    path: nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer
+    token_expiration: 100
+    args:
+      nvat_command: /opt/attestation/bin/nvattest
+      verifier: $NVFLARE_GPU_VERIFIER
+EOF
+    if [[ "$NVFLARE_GPU_VERIFIER" == remote ]]; then
+      printf '      nras_url: %s\n' "$NVFLARE_GPU_NRAS_URL" >>"$destination"
+    fi
+  fi
+  cat >>"$destination" <<'EOF'
+cc_attestation:
+  check_frequency: 120
+  # NVAT permits a 180-second subprocess timeout. Keep the peer request
+  # deadline above it so a slow appraisal cannot trigger federation shutdown.
+  get_token_request_timeout: 200
+class_allow_list:
+  - nvflare.app_opt.confidential_computing.cc_manager.CCManager
+  - nvflare.app_opt.confidential_computing.coco_hello_numpy_executor.CoCoHelloNumpyExecutor
+  - nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer
+  - nvflare.app_opt.confidential_computing.tdx_authorizer.TDXAuthorizer
+  - nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer
+EOF
+}
+
+write_cc_config server "$server_cc_config"
+write_cc_config client "$client_cc_config"
+# NVFlare increments prod_00 to prod_01, prod_02, ... when a workspace already
+# exists.  Provision into a fresh directory so prod_00 always belongs to this
+# run and an interrupted rerun cannot deploy stale participant credentials.
+workspace_dir="$(mktemp -d "$work_dir/workspace.XXXXXX")"
+
+sed \
+  -e "s|@@PROJECT_NAME@@|$NVFLARE_PROJECT_NAME|g" \
+  -e "s|@@SERVER_NAME@@|$NVFLARE_SERVER_NAME|g" \
+  -e "s|@@CLIENT_NAME@@|$NVFLARE_CLIENT_NAME|g" \
+  -e "s|@@ADMIN_NAME@@|$NVFLARE_ADMIN_NAME|g" \
+  -e "s|@@ORG@@|$NVFLARE_ORG|g" \
+  -e "s|@@NAMESPACE@@|$NVFLARE_NAMESPACE|g" \
+  -e "s|@@CLIENT_GPU_COUNT@@|$NVFLARE_CLIENT_GPU_COUNT|g" \
+  -e "s|@@SERVER_CC_CONFIG@@|$server_cc_config|g" \
+  -e "s|@@CLIENT_CC_CONFIG@@|$client_cc_config|g" \
+  "$SCRIPT_DIR/templates/nvflare-project.yml.in" >"$project_file"
+
+log "Provisioning NVFlare identities with CPU and client-GPU hardware authorizers"
+provision_log="$work_dir/provision.log"
+if ! "$nvflare_cli" provision -p "$project_file" -w "$workspace_dir" --force 2>&1 | tee "$provision_log"; then
+  die "NVFlare provisioning failed; see $provision_log"
+fi
+if grep -Fq "CC is not enabled for" "$provision_log"; then
+  die "CCBuilder rejected a participant configuration; see $provision_log"
+fi
+prod_dir="$workspace_dir/$NVFLARE_PROJECT_NAME/prod_00"
+server_kit="$prod_dir/$NVFLARE_SERVER_NAME"
+client_kit="$prod_dir/$NVFLARE_CLIENT_NAME"
+admin_kit="$prod_dir/$NVFLARE_ADMIN_NAME"
+for kit in "$server_kit" "$client_kit" "$admin_kit"; do
+  [[ -d "$kit/startup" ]] || die "Provisioned startup kit is missing: $kit/startup"
+done
+[[ -d "$server_kit/local" ]] || die "Provisioned server local configuration is missing"
+[[ -d "$client_kit/local" ]] || die "Provisioned client local configuration is missing"
+
+for kit in "$server_kit" "$client_kit"; do
+  for resource in cc_manager__p_resources.json "${cpu_authorizer_id}__p_resources.json" gpu_authorizer__p_resources.json; do
+    [[ -s "$kit/local/$resource" ]] ||
+      die "CCBuilder did not generate $resource for ${kit##*/}"
+  done
+done
+jq -e --arg issuer "$cpu_authorizer_id" '
+  .components[0].path == "nvflare.app_opt.confidential_computing.cc_manager.CCManager" and
+  .components[0].args.get_token_request_timeout == 200 and
+  (.components[0].args.cc_issuers_conf | map(.issuer_id) | index($issuer) != null) and
+  (.components[0].args.cc_verifier_ids | index($issuer) != null) and
+  (.components[0].args.cc_verifier_ids | index("gpu_authorizer") != null)
+' "$server_kit/local/cc_manager__p_resources.json" >/dev/null ||
+  die "Server CCManager is not configured for CPU issuance and CPU/GPU verification"
+jq -e --arg issuer "$cpu_authorizer_id" '
+  .components[0].path == "nvflare.app_opt.confidential_computing.cc_manager.CCManager" and
+  .components[0].args.get_token_request_timeout == 200 and
+  (.components[0].args.cc_issuers_conf | length == 2) and
+  (.components[0].args.cc_issuers_conf | map(.issuer_id) | index($issuer) != null) and
+  (.components[0].args.cc_issuers_conf | map(.issuer_id) | index("gpu_authorizer") != null) and
+  (.components[0].args.cc_verifier_ids | index($issuer) != null) and
+  (.components[0].args.cc_verifier_ids | index("gpu_authorizer") != null)
+' "$client_kit/local/cc_manager__p_resources.json" >/dev/null ||
+  die "Client CCManager is not configured for CPU/GPU issuance and verification"
+for kit in "$server_kit" "$client_kit"; do
+  jq -e --arg verifier "$NVFLARE_GPU_VERIFIER" '
+    .components[0].path == "nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer" and
+    .components[0].args.verifier == $verifier
+  ' "$kit/local/gpu_authorizer__p_resources.json" >/dev/null ||
+    die "GPUAuthorizer for ${kit##*/} does not use verifier mode $NVFLARE_GPU_VERIFIER"
+done
+
+# The stock provisioned server uses /tmp for job and snapshot storage. Keep
+# those files on the released CoCo block-encrypted emptyDir instead.
+server_resources="$server_kit/local/resources.json.default"
+[[ -r "$server_resources" ]] || die "Provisioned server resources are missing: $server_resources"
+server_resources_tmp="${server_resources}.tmp.$$"
+jq --arg workspace "/var/tmp/nvflare/workspace" '
+  (.snapshot_persistor.args.storage.args.root_dir) = ($workspace + "/snapshot-storage") |
+  (.components[] | select(.id == "job_manager") | .args.uri_root) = ($workspace + "/jobs-storage")
+' "$server_resources" >"$server_resources_tmp"
+mv "$server_resources_tmp" "$server_resources"
+jq -e '
+  .snapshot_persistor.args.storage.args.root_dir == "/var/tmp/nvflare/workspace/snapshot-storage" and
+  any(.components[]; .id == "job_manager" and .args.uri_root == "/var/tmp/nvflare/workspace/jobs-storage")
+' "$server_resources" >/dev/null || die "Could not relocate NVFlare server storage to the encrypted workspace"
+
+image_policy="$(<"$policy_file")"
+registry_ca="$(<"$tls_dir/ca.crt")"
+cat >"$initdata_file" <<EOF
+version = "0.1.0"
+algorithm = "sha256"
+
+[data]
+"cdh.toml" = '''
+[kbc]
+name = "offline_fs_kbc"
+url = ""
+
+[image]
+image_security_policy = '${image_policy}'
+extra_root_certificates = ["""${registry_ca}"""]
+
+[image.registry_config]
+unqualified-search-registries = ["docker.io"]
+
+[[image.registry_config.registry]]
+location = "${REGISTRY_HOST}"
+insecure = false
+'''
+
+"policy.rego" = '''
+package agent_policy
+default AddARPNeighborsRequest := true
+default AddSwapRequest := true
+default CloseStdinRequest := true
+default CopyFileRequest := true
+default CreateContainerRequest := true
+default CreateSandboxRequest := true
+default DestroySandboxRequest := true
+default ExecProcessRequest := true
+default GetMetricsRequest := true
+default GetOOMEventRequest := true
+default GuestDetailsRequest := true
+default ListInterfacesRequest := true
+default ListRoutesRequest := true
+default MemHotplugByProbeRequest := true
+default OnlineCPUMemRequest := true
+default PauseContainerRequest := true
+default PullImageRequest := true
+default ReadStreamRequest := true
+default RemoveContainerRequest := true
+default RemoveStaleVirtiofsShareMountsRequest := true
+default ReseedRandomDevRequest := true
+default ResumeContainerRequest := true
+default SetGuestDateTimeRequest := true
+default SetPolicyRequest := false
+default SignalProcessRequest := true
+default StartContainerRequest := true
+default StartTracingRequest := true
+default StatsContainerRequest := true
+default StopTracingRequest := true
+default TtyWinResizeRequest := true
+default UpdateContainerRequest := true
+default UpdateEphemeralMountsRequest := true
+default UpdateInterfaceRequest := true
+default UpdateRoutesRequest := true
+default WaitProcessRequest := true
+default WriteStreamRequest := true
+'''
+EOF
+
+init_data="$(gzip -c "$initdata_file" | base64 -w 0)"
+initdata_sha256="$(sha256sum "$initdata_file" | awk '{print $1}')"
+
+log "Staging provisioned startup kits as Kubernetes Secrets and local configuration as ConfigMaps"
+log "Allowing privileged Kata workloads in the dedicated NVFlare namespace"
+kctl label namespace "$NVFLARE_NAMESPACE" \
+  pod-security.kubernetes.io/enforce=privileged --overwrite
+for participant in "$NVFLARE_SERVER_NAME" "$NVFLARE_CLIENT_NAME"; do
+  if [[ "$participant" == "$NVFLARE_SERVER_NAME" ]]; then
+    kit="$server_kit"
+  else
+    kit="$client_kit"
+  fi
+  kctl -n "$NVFLARE_NAMESPACE" create secret generic "${participant}-startup" \
+    --from-file="$kit/startup" --dry-run=client -o yaml | kctl apply -f -
+  kctl -n "$NVFLARE_NAMESPACE" create configmap "${participant}-local" \
+    --from-file="$kit/local" --dry-run=client -o yaml | kctl apply -f -
+done
+
+sed \
+  -e "s|@@NAMESPACE@@|$NVFLARE_NAMESPACE|g" \
+  -e "s|@@SERVER_NAME@@|$NVFLARE_SERVER_NAME|g" \
+  -e "s|@@CLIENT_NAME@@|$NVFLARE_CLIENT_NAME|g" \
+  -e "s|@@ORG@@|$NVFLARE_ORG|g" \
+  -e "s|@@SERVER_RUNTIME_CLASS@@|$NVFLARE_SERVER_RUNTIME_CLASS|g" \
+  -e "s|@@CLIENT_RUNTIME_CLASS@@|$NVFLARE_CLIENT_RUNTIME_CLASS|g" \
+  -e "s|@@SERVER_IMAGE@@|$NVFLARE_SERVER_IMAGE|g" \
+  -e "s|@@CLIENT_IMAGE@@|$NVFLARE_CLIENT_IMAGE|g" \
+  -e "s|@@SERVER_MEMORY@@|$NVFLARE_SERVER_MEMORY|g" \
+  -e "s|@@CLIENT_MEMORY@@|$NVFLARE_CLIENT_MEMORY|g" \
+  -e "s|@@GPU_RESOURCE@@|$GPU_RESOURCE|g" \
+  -e "s|@@CLIENT_GPU_COUNT@@|$NVFLARE_CLIENT_GPU_COUNT|g" \
+  -e "s|@@WORKSPACE_SIZE@@|$NVFLARE_WORKSPACE_SIZE|g" \
+  -e "s|@@FS_GROUP@@|$NVFLARE_FS_GROUP|g" \
+  -e "s|@@CPU_ATTESTATION_DEVICE@@|$cpu_attestation_device|g" \
+  -e "s|@@INIT_DATA@@|$init_data|g" \
+  "$SCRIPT_DIR/templates/nvflare-coco.yaml.in" >"$manifest"
+if grep -Eq '@@[A-Z0-9_]+@@' "$manifest"; then
+  die "Unresolved placeholder remains in $manifest"
+fi
+
+log "Deploying a CPU-only NVFlare server and GPU NVFlare client as Kata confidential VMs"
+kctl apply -f "$manifest"
+kctl -n "$NVFLARE_NAMESPACE" rollout restart "deployment/$NVFLARE_SERVER_NAME" "deployment/$NVFLARE_CLIENT_NAME"
+kctl -n "$NVFLARE_NAMESPACE" rollout status "deployment/$NVFLARE_SERVER_NAME" --timeout=20m
+kctl -n "$NVFLARE_NAMESPACE" rollout status "deployment/$NVFLARE_CLIENT_NAME" --timeout=20m
+
+verify_deployment() {
+  local participant=$1 expected_image=$2 expected_runtime=$3
+  local pod runtime annotation pod_image image_id expected_digest privileged
+  pod="$(kctl -n "$NVFLARE_NAMESPACE" get pod -l "app=$participant" \
+    -o jsonpath='{.items[0].metadata.name}')"
+  [[ -n "$pod" ]] || die "No pod found for $participant"
+  kctl -n "$NVFLARE_NAMESPACE" wait --for=condition=Ready "pod/$pod" --timeout=20m
+  runtime="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$pod" -o jsonpath='{.spec.runtimeClassName}')"
+  [[ "$runtime" == "$expected_runtime" ]] ||
+    die "$participant used $runtime instead of $expected_runtime"
+  annotation="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$pod" \
+    -o 'jsonpath={.metadata.annotations.io\.katacontainers\.config\.hypervisor\.cc_init_data}')"
+  [[ "$annotation" == "$init_data" ]] || die "$participant measured init-data annotation changed"
+  pod_image="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$pod" -o jsonpath='{.spec.containers[0].image}')"
+  [[ "$pod_image" == "$expected_image" ]] || die "$participant pod image is not the signed digest"
+  image_id="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$pod" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+  expected_digest="${expected_image##*@}"
+  [[ "$image_id" == *"$expected_digest" ]] ||
+    die "$participant runtime image ID does not match the signed digest: $image_id"
+  # This is a Pod-spec pre-flight check, not proof of the runtime's effective
+  # security context. Opening the guest TEE device below is authoritative.
+  privileged="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$pod" -o jsonpath='{.spec.containers[0].securityContext.privileged}')"
+  [[ "$privileged" == true ]] ||
+    die "$participant is not privileged inside its Kata VM and cannot access the guest TEE interface"
+  kctl -n "$NVFLARE_NAMESPACE" exec "$pod" -- python -c '
+import os, stat, subprocess, sys
+import tensorboard
+
+name, snp_version, tdx_version, nvat_version, tensorboard_version = sys.argv[1:]
+path = f"/dev/{name}"
+info = os.stat(path)
+assert stat.S_ISCHR(info.st_mode), f"not a character device: {path}"
+fd = os.open(path, os.O_RDWR | os.O_CLOEXEC)
+os.close(fd)
+assert snp_version in subprocess.check_output(["/opt/attestation/bin/snpguest", "--version"], text=True)
+assert tdx_version in subprocess.check_output(["/opt/attestation/bin/trustauthority-cli", "version"], text=True)
+nvat = subprocess.check_output(
+    ["/opt/attestation/bin/nvattest", "version"], stderr=subprocess.STDOUT, text=True
+)
+assert f"nvattest {nvat_version}" in nvat
+assert tensorboard.__version__ == tensorboard_version
+' "$cpu_attestation_device" "$SNPGUEST_VERSION" "$TRUSTAUTHORITY_CLI_VERSION" "$NVAT_VERSION" \
+    "$TENSORBOARD_VERSION" ||
+    die "$participant failed its in-guest TEE-device or attestation-tool checks"
+  VERIFIED_POD="$pod"
+  VERIFIED_IMAGE_ID="$image_id"
+}
+
+verify_deployment "$NVFLARE_SERVER_NAME" "$NVFLARE_SERVER_IMAGE" "$NVFLARE_SERVER_RUNTIME_CLASS"
+server_pod="$VERIFIED_POD"
+server_image_id="$VERIFIED_IMAGE_ID"
+verify_deployment "$NVFLARE_CLIENT_NAME" "$NVFLARE_CLIENT_IMAGE" "$NVFLARE_CLIENT_RUNTIME_CLASS"
+client_pod="$VERIFIED_POD"
+client_image_id="$VERIFIED_IMAGE_ID"
+
+server_gpu_request="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$server_pod" -o json |
+  jq -r --arg resource "$GPU_RESOURCE" '.spec.containers[0].resources.requests[$resource] // "0"')"
+server_gpu_limit="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$server_pod" -o json |
+  jq -r --arg resource "$GPU_RESOURCE" '.spec.containers[0].resources.limits[$resource] // "0"')"
+client_gpu_request="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$client_pod" -o json |
+  jq -r --arg resource "$GPU_RESOURCE" '.spec.containers[0].resources.requests[$resource] // "0"')"
+client_gpu_limit="$(kctl -n "$NVFLARE_NAMESPACE" get pod "$client_pod" -o json |
+  jq -r --arg resource "$GPU_RESOURCE" '.spec.containers[0].resources.limits[$resource] // "0"')"
+[[ "$server_gpu_request" == 0 ]] ||
+  die "NVFlare server unexpectedly requests $server_gpu_request $GPU_RESOURCE"
+[[ "$server_gpu_limit" == 0 ]] ||
+  die "NVFlare server unexpectedly limits $server_gpu_limit $GPU_RESOURCE"
+[[ "$client_gpu_request" == "$NVFLARE_CLIENT_GPU_COUNT" ]] ||
+  die "NVFlare client requests $client_gpu_request $GPU_RESOURCE instead of $NVFLARE_CLIENT_GPU_COUNT"
+[[ "$client_gpu_limit" == "$NVFLARE_CLIENT_GPU_COUNT" ]] ||
+  die "NVFlare client limit is $client_gpu_limit $GPU_RESOURCE instead of $NVFLARE_CLIENT_GPU_COUNT"
+
+cc_peer_validation_passed() {
+  local pod=$1
+  # "Validated CC info for" is logged by CCManager in
+  # nvflare/app_opt/confidential_computing/cc_manager.py. If that string changes,
+  # update this check and retest Stage 50.
+  kctl -n "$NVFLARE_NAMESPACE" logs "$pod" 2>/dev/null | grep -Fq "Validated CC info for"
+}
+log "Waiting for the NVFlare CPU/GPU authorization handshake"
+wait_for "server validation of the client's CPU/GPU evidence" 600 cc_peer_validation_passed "$server_pod"
+wait_for "client validation of the server's CPU token" 600 cc_peer_validation_passed "$client_pod"
+
+report="$STATE_DIR/nvflare-deployment-integrity-report.txt"
+cat >"$report" <<EOF
+NVFLARE ON COCO DEPLOYMENT AND IMAGE-INTEGRITY REPORT
+====================================================
+Namespace: $NVFLARE_NAMESPACE
+Server pod: $server_pod
+Server runtime class: $NVFLARE_SERVER_RUNTIME_CLASS
+Server GPU request: none
+Server signed image: $NVFLARE_SERVER_IMAGE
+Server runtime image ID: $server_image_id
+Client pod: $client_pod
+Client runtime class: $NVFLARE_CLIENT_RUNTIME_CLASS
+Client GPU request: $NVFLARE_CLIENT_GPU_COUNT $GPU_RESOURCE
+Client signed image: $NVFLARE_CLIENT_IMAGE
+Client runtime image ID: $client_image_id
+Image policy: $policy_file
+Image policy default: reject
+Measured init-data SHA-256: $initdata_sha256
+Host Cosign verification: PASS
+Digest-pinned pod specifications: PASS
+Measured init-data annotation match: PASS
+Kata RuntimeClass matches: PASS
+Exclusive client GPU assignment: PASS
+Guest image-rs enforcement: PASS (both signed-image pods reached Ready)
+SNP tool in both signed images: snpguest $SNPGUEST_VERSION (PASS)
+TDX tool in both signed images: Trust Authority CLI $TRUSTAUTHORITY_CLI_VERSION (PASS)
+GPU verifier in both signed images: NVIDIA NVAT $NVAT_VERSION (PASS)
+GPU verification mode: $NVFLARE_GPU_VERIFIER (PASS)
+hello-numpy tracking dependency in both signed images: TensorBoard $TENSORBOARD_VERSION (PASS)
+Guest CPU device: /dev/$cpu_attestation_device (character-device open PASS)
+NVFlare CCBuilder resources: CPU issuer plus CPU/GPU peer verifiers (PASS)
+Kata-VM-only privilege for guest attestation device: PASS
+NVFlare peer hardware-authorization handshake: PASS
+Server/client deployment health: PASS
+
+VM launch-reference appraisal: NOT PERFORMED BY THIS STAGE
+Use remote attestation with independently trusted SNP/TDX reference values and
+verify that HOST_DATA/MRCONFIGID binds this init-data hash before releasing
+production credentials or data.
+EOF
+
+current_deployment_tmp="$work_dir/.current.env.$$"
+install -m 0600 /dev/null "$current_deployment_tmp"
+{
+  printf 'DEPLOYED_NVFLARE_NAMESPACE=%q\n' "$NVFLARE_NAMESPACE"
+  printf 'DEPLOYED_NVFLARE_SERVER_NAME=%q\n' "$NVFLARE_SERVER_NAME"
+  printf 'DEPLOYED_NVFLARE_CLIENT_NAME=%q\n' "$NVFLARE_CLIENT_NAME"
+  printf 'DEPLOYED_NVFLARE_ADMIN_STARTUP_KIT=%q\n' "$admin_kit/startup"
+  printf 'DEPLOYED_NVFLARE_SERVER_IMAGE=%q\n' "$NVFLARE_SERVER_IMAGE"
+  printf 'DEPLOYED_NVFLARE_CLIENT_IMAGE=%q\n' "$NVFLARE_CLIENT_IMAGE"
+  printf 'DEPLOYED_AT=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$current_deployment_tmp"
+mv "$current_deployment_tmp" "$current_deployment"
+
+log "NVFlare server and client are running in CoCo"
+echo "Namespace: $NVFLARE_NAMESPACE"
+echo "Server service: $NVFLARE_SERVER_NAME:8002"
+echo "Server runtime: $NVFLARE_SERVER_RUNTIME_CLASS (no GPU)"
+echo "Client: $NVFLARE_CLIENT_NAME"
+echo "Client runtime: $NVFLARE_CLIENT_RUNTIME_CLASS ($NVFLARE_CLIENT_GPU_COUNT $GPU_RESOURCE)"
+echo "Administrator startup kit: $admin_kit/startup"
+echo "Active deployment state: $current_deployment"
+echo "Integrity report: $report"

--- a/examples/devops/CoCo/60-nvflare-submit-hello-numpy.sh
+++ b/examples/devops/CoCo/60-nvflare-submit-hello-numpy.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  cat <<'EOF'
+Export, submit, and verify the standard NVFlare hello-numpy job against the
+CoCo server/client deployment created by 50-nvflare-deploy.sh.
+
+Usage:
+  ./60-nvflare-submit-hello-numpy.sh
+
+Run 40-nvflare-build-sign-images.sh and 50-nvflare-deploy.sh first. Stage 60
+uses a loopback-only host tunnel to the server administration endpoint, waits
+for FINISHED:COMPLETED, and prints bounded server/client job logs.
+EOF
+}
+
+if [[ "${1:-}" == -h || "${1:-}" == --help ]]; then
+  usage
+  exit 0
+fi
+[[ $# -eq 0 ]] || {
+  usage >&2
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_config
+require_root_or_sudo
+need kubectl
+need jq
+need stat
+
+NVFLARE_ADMIN_LOCAL_PORT="${NVFLARE_ADMIN_LOCAL_PORT:-18003}"
+NVFLARE_CLI_CONNECT_TIMEOUT="${NVFLARE_CLI_CONNECT_TIMEOUT:-30}"
+NVFLARE_JOB_WAIT_TIMEOUT="${NVFLARE_JOB_WAIT_TIMEOUT:-900}"
+NVFLARE_JOB_WAIT_INTERVAL="${NVFLARE_JOB_WAIT_INTERVAL:-2}"
+for value_name in NVFLARE_ADMIN_LOCAL_PORT NVFLARE_CLI_CONNECT_TIMEOUT NVFLARE_JOB_WAIT_TIMEOUT \
+  NVFLARE_JOB_WAIT_INTERVAL; do
+  [[ "${!value_name:-}" =~ ^[1-9][0-9]*$ ]] || die "$value_name must be a positive integer"
+done
+((NVFLARE_ADMIN_LOCAL_PORT >= 1024 && NVFLARE_ADMIN_LOCAL_PORT <= 65535)) ||
+  die "NVFLARE_ADMIN_LOCAL_PORT must be between 1024 and 65535"
+
+nvflare_cli="${NVFLARE_CLI:-}"
+if [[ -z "$nvflare_cli" ]] && command -v nvflare >/dev/null 2>&1; then
+  nvflare_cli="$(command -v nvflare)"
+fi
+if [[ -z "$nvflare_cli" && -x "$REPO_ROOT/.venv/bin/nvflare" ]]; then
+  nvflare_cli="$REPO_ROOT/.venv/bin/nvflare"
+fi
+[[ -x "$nvflare_cli" ]] ||
+  die "NVFlare CLI not found; install this checkout in a virtual environment or set NVFLARE_CLI"
+
+nvflare_python="${NVFLARE_PYTHON:-}"
+if [[ -z "$nvflare_python" && -x "$(dirname "$nvflare_cli")/python" ]]; then
+  nvflare_python="$(dirname "$nvflare_cli")/python"
+fi
+if [[ -z "$nvflare_python" ]] && command -v python3 >/dev/null 2>&1; then
+  nvflare_python="$(command -v python3)"
+fi
+[[ -x "$nvflare_python" ]] || die "NVFlare Python interpreter not found; set NVFLARE_PYTHON"
+"$nvflare_python" -c \
+  "import numpy, nvflare, tensorboard; assert tensorboard.__version__ == '$TENSORBOARD_VERSION'" ||
+  die "NVFLARE_PYTHON must contain NVFlare, NumPy, and TensorBoard $TENSORBOARD_VERSION"
+
+deployment_state="$STATE_DIR/nvflare-deployment/current.env"
+[[ -r "$deployment_state" ]] ||
+  die "Run 50-nvflare-deploy.sh first: active deployment state is missing at $deployment_state"
+[[ "$(stat -c '%a' "$deployment_state")" == 600 ]] ||
+  die "Active deployment state must have mode 0600: $deployment_state"
+# This file is written by Stage 50 with shell-escaped values and mode 0600.
+# shellcheck disable=SC1090
+source "$deployment_state"
+[[ "${DEPLOYED_NVFLARE_NAMESPACE:-}" == "$NVFLARE_NAMESPACE" ]] ||
+  die "Stage-50 state namespace does not match NVFLARE_NAMESPACE; rerun Stage 50"
+[[ "${DEPLOYED_NVFLARE_SERVER_NAME:-}" == "$NVFLARE_SERVER_NAME" ]] ||
+  die "Stage-50 state server does not match NVFLARE_SERVER_NAME; rerun Stage 50"
+[[ "${DEPLOYED_NVFLARE_CLIENT_NAME:-}" == "$NVFLARE_CLIENT_NAME" ]] ||
+  die "Stage-50 state client does not match NVFLARE_CLIENT_NAME; rerun Stage 50"
+admin_startup_kit="${DEPLOYED_NVFLARE_ADMIN_STARTUP_KIT:-}"
+[[ -n "$admin_startup_kit" && -r "$admin_startup_kit/fed_admin.json" ]] ||
+  die "The active administrator startup kit is missing; rerun Stage 50"
+
+kctl -n "$NVFLARE_NAMESPACE" rollout status "deployment/$NVFLARE_SERVER_NAME" --timeout=2m
+kctl -n "$NVFLARE_NAMESPACE" rollout status "deployment/$NVFLARE_CLIENT_NAME" --timeout=2m
+server_image="$(kctl -n "$NVFLARE_NAMESPACE" get deployment "$NVFLARE_SERVER_NAME" \
+  -o jsonpath='{.spec.template.spec.containers[0].image}')"
+client_image="$(kctl -n "$NVFLARE_NAMESPACE" get deployment "$NVFLARE_CLIENT_NAME" \
+  -o jsonpath='{.spec.template.spec.containers[0].image}')"
+[[ "$server_image" == "${DEPLOYED_NVFLARE_SERVER_IMAGE:-}" ]] ||
+  die "Running server image differs from the successful Stage-50 deployment; rerun Stage 50"
+[[ "$client_image" == "${DEPLOYED_NVFLARE_CLIENT_IMAGE:-}" ]] ||
+  die "Running client image differs from the successful Stage-50 deployment; rerun Stage 50"
+
+hello_numpy_dir="$REPO_ROOT/examples/hello-world/hello-numpy"
+[[ -r "$hello_numpy_dir/client.py" ]] || die "hello-numpy example is missing: $hello_numpy_dir"
+runs_dir="$STATE_DIR/nvflare-job-runs"
+mkdir -p "$runs_dir"
+run_dir="$(mktemp -d "$runs_dir/$(date -u +%Y%m%dT%H%M%SZ).XXXXXX")"
+job_parent="$run_dir/job-config"
+mkdir -p "$job_parent"
+
+log "Exporting the standard one-client, three-round hello-numpy recipe"
+(
+  cd "$hello_numpy_dir"
+  "$nvflare_python" - "$job_parent" <<'PY'
+import sys
+
+from nvflare.app_common.np.recipes.fedavg import NumpyFedAvgRecipe
+from nvflare.client.config import TransferType
+from nvflare.recipe import add_experiment_tracking
+
+export_dir = sys.argv[1]
+recipe = NumpyFedAvgRecipe(
+    name="hello-numpy",
+    min_clients=1,
+    num_rounds=3,
+    model=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+    train_script="client.py",
+    train_args="--update_type full",
+    launch_external_process=False,
+    params_transfer_type=TransferType.FULL,
+)
+add_experiment_tracking(recipe, tracking_type="tensorboard")
+recipe.export(export_dir)
+PY
+)
+job_dir="$job_parent/hello-numpy"
+[[ -s "$job_dir/meta.json" ]] || die "hello-numpy export did not create $job_dir/meta.json"
+[[ -s "$job_dir/app/config/config_fed_server.json" ]] ||
+  die "hello-numpy export did not create the server job configuration"
+client_config="$job_dir/app/config/config_fed_client.json"
+[[ -s "$client_config" && -f "$job_dir/app/custom/client.py" ]] ||
+  die "hello-numpy export did not create the expected client job definition"
+fixed_executor=nvflare.app_opt.confidential_computing.coco_hello_numpy_executor.CoCoHelloNumpyExecutor
+client_config_tmp="$client_config.$$"
+jq --arg executor "$fixed_executor" '
+  if ([.executors[] | select(.executor.args.task_script_path? == "client.py")] | length) != 1 then
+    error("unexpected hello-numpy executor configuration")
+  else
+    (.executors[] | select(.executor.args.task_script_path? == "client.py") |
+      .executor) = {"path": $executor, "args": {}}
+  end
+' "$client_config" >"$client_config_tmp" ||
+  die "Could not bind hello-numpy to the trainer in the signed parent image"
+mv "$client_config_tmp" "$client_config"
+rm -f -- "$job_dir/app/custom/client.py"
+rmdir "$job_dir/app/custom" ||
+  die "Refusing to submit hello-numpy because custom/BYOC content remains"
+
+admin_tmp="$(mktemp -d)"
+admin_tunnel_pid=""
+cleanup() {
+  if [[ -n "$admin_tunnel_pid" ]]; then
+    kill "$admin_tunnel_pid" 2>/dev/null || true
+    wait "$admin_tunnel_pid" 2>/dev/null || true
+  fi
+  if [[ -n "${admin_tmp:-}" && -d "$admin_tmp" ]]; then
+    rm -rf -- "$admin_tmp"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+admin_source_dir="$(dirname "$admin_startup_kit")"
+[[ -d "$admin_source_dir/local" ]] ||
+  die "The administrator participant kit is missing its local directory: $admin_source_dir/local"
+cp -a "$admin_source_dir/." "$admin_tmp/"
+# The CLI accepts either the participant directory or its startup child, then
+# normalizes it to a workspace containing both startup/ and local/.
+admin_kit="$admin_tmp"
+admin_config="$admin_kit/startup/fed_admin.json"
+server_identity="$(jq -er '.admin.server_identity | strings | select(length > 0)' "$admin_config")"
+[[ "$server_identity" == "$NVFLARE_SERVER_NAME" ]] ||
+  die "Administrator kit server identity is $server_identity instead of $NVFLARE_SERVER_NAME"
+admin_config_tmp="$admin_tmp/.fed_admin.json.$$"
+jq --arg host 127.0.0.1 --argjson port "$NVFLARE_ADMIN_LOCAL_PORT" \
+  '.admin.host = $host | .admin.port = $port' "$admin_config" >"$admin_config_tmp"
+mv "$admin_config_tmp" "$admin_config"
+
+server_pod_ip="$(kctl -n "$NVFLARE_NAMESPACE" get pod -l "app=$NVFLARE_SERVER_NAME" \
+  -o jsonpath='{.items[0].status.podIP}')"
+[[ "$server_pod_ip" =~ ^[0-9a-fA-F:.]+$ ]] ||
+  die "Could not resolve the NVFlare server Pod IP"
+admin_tunnel_log="$run_dir/admin-tunnel.log"
+log "Opening a loopback-only administration tunnel on port $NVFLARE_ADMIN_LOCAL_PORT"
+# kubectl port-forward dials localhost in the host-side Pod network namespace.
+# For a Kata Pod the server listener is inside the VM instead, so proxy from
+# host loopback to the routable Pod IP without exposing another host endpoint.
+"$nvflare_python" - "$NVFLARE_ADMIN_LOCAL_PORT" "$server_pod_ip" \
+  >"$admin_tunnel_log" 2>&1 <<'PY' &
+import socket
+import socketserver
+import sys
+import threading
+
+listen_port = int(sys.argv[1])
+target = (sys.argv[2], 8003)
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        with socket.create_connection(target, timeout=10) as upstream:
+            def relay(source, destination):
+                try:
+                    while data := source.recv(65536):
+                        destination.sendall(data)
+                finally:
+                    try:
+                        destination.shutdown(socket.SHUT_WR)
+                    except OSError:
+                        pass
+
+            outgoing = threading.Thread(target=relay, args=(self.request, upstream), daemon=True)
+            outgoing.start()
+            relay(upstream, self.request)
+            outgoing.join(timeout=1)
+
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+with Server(("127.0.0.1", listen_port), Handler) as server:
+    print(f"Forwarding 127.0.0.1:{listen_port} to {target[0]}:{target[1]}", flush=True)
+    server.serve_forever()
+PY
+admin_tunnel_pid=$!
+
+admin_tunnel_ready() {
+  kill -0 "$admin_tunnel_pid" 2>/dev/null || return 1
+  "$nvflare_python" - "$NVFLARE_ADMIN_LOCAL_PORT" 2>/dev/null <<'PY'
+import socket
+import sys
+
+with socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=1):
+    pass
+PY
+}
+admin_tunnel_deadline=$((SECONDS + 30))
+until admin_tunnel_ready; do
+  if ((SECONDS >= admin_tunnel_deadline)) || ! kill -0 "$admin_tunnel_pid" 2>/dev/null; then
+    sed -n '1,120p' "$admin_tunnel_log" >&2
+    die "Could not establish the NVFlare administration tunnel"
+  fi
+  sleep 1
+done
+if ! kill -0 "$admin_tunnel_pid" 2>/dev/null; then
+  sed -n '1,120p' "$admin_tunnel_log" >&2
+  die "NVFlare administration tunnel exited unexpectedly"
+fi
+
+log "Submitting hello-numpy through the mTLS administrator startup kit"
+submit_stderr="$run_dir/submit.stderr"
+submit_rc=0
+submit_json="$("$nvflare_cli" --format json --connect-timeout "$NVFLARE_CLI_CONNECT_TIMEOUT" \
+  job submit -j "$job_dir" --startup-kit "$admin_kit" 2> >(tee "$submit_stderr" >&2))" || submit_rc=$?
+printf '%s\n' "$submit_json" >"$run_dir/submit.json"
+((submit_rc == 0)) || die "hello-numpy submission failed; see $run_dir/submit.json and $submit_stderr"
+job_id="$(jq -er 'select(.status == "ok") | .data.job_id | strings | select(length > 0)' \
+  <<<"$submit_json")" || die "NVFlare submission did not return a job ID"
+echo "Submitted job ID: $job_id"
+
+log "Waiting for hello-numpy to finish"
+wait_stderr="$run_dir/wait.stderr"
+wait_rc=0
+wait_json="$("$nvflare_cli" --format json --connect-timeout "$NVFLARE_CLI_CONNECT_TIMEOUT" \
+  job wait "$job_id" --startup-kit "$admin_kit" --timeout "$NVFLARE_JOB_WAIT_TIMEOUT" \
+  --interval "$NVFLARE_JOB_WAIT_INTERVAL" 2> >(tee "$wait_stderr" >&2))" || wait_rc=$?
+printf '%s\n' "$wait_json" >"$run_dir/wait.json"
+if jq -e . >/dev/null 2>&1 <<<"$wait_json"; then
+  jq . <<<"$wait_json"
+else
+  printf '%s\n' "$wait_json"
+fi
+
+log "Showing the final bounded server/client job logs"
+if ! "$nvflare_cli" --connect-timeout "$NVFLARE_CLI_CONNECT_TIMEOUT" job logs "$job_id" \
+  --sites all --tail 120 --startup-kit "$admin_kit" \
+  2> >(tee "$run_dir/job-logs.stderr" >&2) | tee "$run_dir/job-logs.txt"; then
+  echo "WARNING: completed-job log retrieval failed; inspect the Kubernetes participant logs" >&2
+fi
+
+((wait_rc == 0)) || die "hello-numpy did not complete successfully; see $run_dir"
+job_status="$(jq -er 'select(.status == "ok") | .data.status | strings' <<<"$wait_json")" ||
+  die "NVFlare wait did not return a successful terminal status"
+[[ "$job_status" == FINISHED:COMPLETED* ]] ||
+  die "hello-numpy ended with unexpected status $job_status"
+
+report="$run_dir/report.txt"
+cat >"$report" <<EOF
+NVFLARE COCO HELLO-NUMPY JOB REPORT
+==================================
+Job ID: $job_id
+Job: hello-numpy
+Participants: $NVFLARE_SERVER_NAME, $NVFLARE_CLIENT_NAME
+Launcher: ProcessJobLauncher (inside the existing Kata confidential VMs)
+Server image: $server_image
+Client image: $client_image
+Status: $job_status
+Submission: PASS
+Terminal completion without NVFlare execution error: PASS
+EOF
+latest_run="$STATE_DIR/latest-nvflare-job-run"
+[[ ! -e "$latest_run" || -L "$latest_run" ]] ||
+  die "Refusing to replace non-symlink path: $latest_run"
+ln -sfn "$run_dir" "$latest_run"
+
+log "hello-numpy finished without error"
+echo "Job ID: $job_id"
+echo "Status: $job_status"
+echo "Report: $report"
+echo "Run artifacts: $run_dir"

--- a/examples/devops/CoCo/CHECKSUMS.md
+++ b/examples/devops/CoCo/CHECKSUMS.md
@@ -1,0 +1,21 @@
+# Download checksum audit
+
+Audited against fresh downloads and registry manifests on 2026-08-07.
+
+| Component | Exact validated object | SHA-256 | Checksum source |
+|---|---|---|---|
+| containerd 2.2.2 | `containerd-2.2.2-linux-amd64.tar.gz` | `2c08c99cbde73b3388c6d5da68e0bcaebc70c9174f2b14d785695e4401b3ede0` | [containerd release `.sha256sum`](https://github.com/containerd/containerd/releases/download/v2.2.2/containerd-2.2.2-linux-amd64.tar.gz.sha256sum) |
+| Helm 3.21.3 | `helm-v3.21.3-linux-amd64.tar.gz` | `15e041a93a590dce8100f39385cd98c84a765c9e36aeeb9e2dc6ff9e4769e2e0` | [Helm `.sha256sum`](https://get.helm.sh/helm-v3.21.3-linux-amd64.tar.gz.sha256sum) |
+| Cosign 2.6.2 | `cosign-linux-amd64` executable | `d437b8f0d30f5dec169337607fcfa0238de1348503e175f1bb5b94330b1ee409` | [Cosign release checksum list](https://github.com/sigstore/cosign/releases/download/v2.6.2/cosign_checksums.txt) |
+| CNI plugins 1.8.0 | `cni-plugins-linux-amd64-v1.8.0.tgz` | `ab3bda535f9d90766cccc90d3dddb5482003dd744d7f22bcf98186bf8eea8be6` | [CNI release `.sha256`](https://github.com/containernetworking/plugins/releases/download/v1.8.0/cni-plugins-linux-amd64-v1.8.0.tgz.sha256), downloaded by stage 10 |
+| Calico 3.32.1 | [`manifests/calico.yaml`](https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml) | `a1df919d9721cf667accdc3e72848911b0cb25cfab7d2478ad0c996302c95744` | Pinned from the exact upstream manifest; stage 10 verifies it before cluster-admin apply |
+| NVIDIA NVAT 1.2.2 | [`nvat-local-repo-ubuntu2404-1-2-local_1.0-1_amd64.deb`](https://developer.download.nvidia.com/compute/nvat/1.2.2/local_installers/nvat-local-repo-ubuntu2404-1-2-local_1.0-1_amd64.deb), the `NVAT_REPO_URL` artifact | `31b0a1646f2bbc08ee599d10dbae106124ef2903f39e37095b96493913b37657` | Pinned known-good hash confirmed against a fresh NVIDIA HTTPS download |
+| google/go-tdx-guest | GitHub source archive at commit `d0438ad179370160a3b98d9703b1559dcd1ed5ee` | `5c0a76ad4cc9f780d1dc55cf6f6bd7bccf25d3c8f7b74b05cc478b9001f7b51b` | Pinned known-good hash confirmed against a fresh GitHub archive download; stage 50 builds the quote collector and verifier from this exact source |
+| snpguest 0.10.0 | `snpguest` x86-64 release executable | `70e700465e3523e67dd5104583dc36cd11eef630c6f04c5b9ccafd6ba2e76ca0` | Pinned against the [virtee/snpguest v0.10.0 release](https://github.com/virtee/snpguest/releases/download/v0.10.0/snpguest); Stage 40 verifies it in the NVFlare image build |
+| Intel Trust Authority CLI 1.10.1 | `trustauthority-cli-v1.10.1.tar.gz` release archive (POSIX tar despite the suffix) | `d3875adbee96268471c82dd54f012b726fa8d6eefdd8f3243c0e7650fb55ff4e` | Pinned against the [Intel v1.10.1 release](https://github.com/intel/trustauthority-client-for-go/releases/download/v1.10.1/trustauthority-cli-v1.10.1.tar.gz); Stage 40 uses `tar -xf` and checks the runtime version |
+| Distribution Registry 2.8.3 image | `docker.io/library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373` | OCI manifest digest | Resolved from Docker Hub; stage 30 rejects tag-only `REGISTRY_IMAGE` values |
+| Trustee KBS staged image | `ghcr.io/confidential-containers/staged-images/kbs@sha256:c128232d271c3bc6cdfbd57b1e585b4aaa0c8de6dd987dbf2731786f60405e25` | OCI manifest digest | Resolved from GHCR for the previously validated staged-image commit; stage 30 rejects tag-only `TRUSTEE_IMAGE` values |
+
+The containerd and Helm values validate compressed release archives. They are intentionally different from the hashes of `/usr/local/bin/containerd` and `/usr/local/bin/helm` after extraction.
+
+Kubernetes Debian packages are authenticated by APT repository metadata and its installed signing key rather than the download-cache helper. OCI images above use immutable registry manifest digests. Other version-pinned Helm/OCI artifacts are verified by their registry transport and manifests.

--- a/examples/devops/CoCo/NVFlare_on_CoCo.md
+++ b/examples/devops/CoCo/NVFlare_on_CoCo.md
@@ -1,0 +1,963 @@
+# NVFlare stages 40 through 60 for Confidential Containers
+
+This guide is for host IT administrators and Kubernetes cluster administrators
+who have completed shared stages 00 through 30 in `USER_GUIDE.md` and want to
+run one NVFlare server and one GPU-enabled NVFlare client in that AMD SEV-SNP
+or Intel TDX cluster. It covers only the alternative NVFlare workload stages:
+
+- `40-nvflare-build-sign-images.sh` builds NVFlare into separate server and
+  client images, pushes them to the suite's private registry, signs their
+  immutable digests, and installs a deny-by-default verification policy.
+- `50-nvflare-deploy.sh` provisions the NVFlare identities and deploys the
+  server and client as digest-pinned Kata Confidential Container Pods.
+- `60-nvflare-submit-hello-numpy.sh` submits the standard one-client
+  `hello-numpy` job and requires it to finish without an NVFlare execution
+  error.
+
+From the Stage-30 fork point, run these exact filenames in order:
+
+```bash
+./40-nvflare-build-sign-images.sh
+./50-nvflare-deploy.sh
+./60-nvflare-submit-hello-numpy.sh
+```
+
+Run those exact filenames in order. The NVFlare stages 40 through 60 replace the
+generic `40-sign-image.sh` and `50-launch-and-attest.sh` workload stages; do not
+run both variants or use a `*-*.sh` glob. The original `run-all.sh` continues
+to run only the generic attestation sample.
+
+## Security model and deployment layout
+
+The server and client are long-running NVFlare parent processes. Each parent
+runs in its own Kata confidential VM:
+
+```text
+Kubernetes node (SNP or TDX)
+  |
+  +-- nvflare-server Deployment
+  |     runtimeClass: kata-qemu-{snp,tdx}
+  |     no GPU request or limit
+  |     /dev/{sev-guest,tdx_guest} created inside the Kata VM
+  |     CPU evidence issuer; CPU/GPU peer-token verifiers
+  |     signed server image at an immutable sha256 digest
+  |     provisioned server startup kit
+  |
+  +-- site-1 Deployment
+        runtimeClass: kata-qemu-nvidia-gpu-{snp,tdx}
+        /dev/{sev-guest,tdx_guest} created inside the Kata VM
+        signed client-parent image at an immutable sha256 digest
+        one passthrough nvidia.com/pgpu device
+        CPU and GPU evidence issuers; CPU/GPU peer-token verifiers
+        provisioned client startup kit
+```
+
+The server is a CPU-only confidential VM. It uses the platform's non-GPU CoCo
+RuntimeClass and its Pod specification contains no extended GPU resource. The
+client uses the GPU-enabled CoCo RuntimeClass and is the only Pod that requests
+`nvidia.com/pgpu`. Consequently, on a one-GPU bare-metal host, the sole GPU is
+assigned exclusively to the client. The server and client can run
+simultaneously because the server does not reserve or attach that device.
+
+The generated NVFlare configuration uses the process job launcher. Server and
+client job processes therefore run inside their existing confidential VM and
+inside the already verified parent image. This is deliberate. A conventional
+NVFlare Kubernetes job launcher creates new job Pods dynamically; those Pods
+would also need the Kata RuntimeClass, measured init-data, digest pinning, and
+the image-signature policy. Do not switch this example to the Kubernetes job
+launcher until those controls are added to every generated job Pod.
+
+The two parent images have different purposes:
+
+| Image | Dockerfile | Contents and intended use |
+|---|---|---|
+| Server | `docker/Dockerfile.coco` | NVIDIA Distroless Python runtime with NVFlare, NumPy, the standard `hello-numpy` trainer and TensorBoard receiver, `snpguest`, Intel Trust Authority CLI, and the native NVAT `nvattest` CLI. It deliberately excludes the Kubernetes Python package and has no shell or package manager. |
+| Client | `docker/Dockerfile.coco` with a client-role OCI label | The same signed `hello-numpy` trainer, NumPy/TensorBoard, and pinned attestation tool set in a separate repository and at a separately signed digest. It deliberately excludes the Kubernetes Python package. The Pod requests the passthrough GPU, but this parent image intentionally omits the large CUDA/PyTorch training stack. |
+
+Both images are built from the enclosing NVFlare checkout. `COPY . .` places
+the build context in the builder, and each Dockerfile installs that source with
+pip. The image therefore contains the NVFlare code from the checkout being
+built; it does not depend on a separately published NVFlare wheel.
+
+## Starting point and prerequisites
+
+First follow `USER_GUIDE.md` through the successful completion of
+`30-deploy-security-services.sh`. This guide begins at the choice immediately
+after that stage; it does not repeat host preparation, Kubernetes installation,
+CoCo/GPU installation, or security-service deployment.
+
+Before Stage 40, confirm that the shared workflow reported `Registry and Trustee
+KBS are ready`. Its completed state must include the platform-specific Kata
+RuntimeClasses, `nvidia.com/pgpu` capacity, VFIO-bound GPU, released
+`block-encrypted` confidential-`emptyDir` support, registry and Trustee
+Deployments, registry CA, and Cosign key pair. See `USER_GUIDE.md` if any shared
+prerequisite is absent.
+
+The shared registry is digest-pinned and binds its host port only to
+`REGISTRY_BIND_ADDRESS` (normally `NODE_IP`), but this demo registry has no
+client authentication and permits push/delete. Firewall it to trusted
+administrators. Runtime pulls remain protected by immutable digests, Cosign,
+and the measured deny-by-default image policy.
+
+Stages 30 and 50 treat `NVFLARE_NAMESPACE` as a dedicated security boundary.
+When first needed, they create it with
+`nvflare.nvidia.com/coco-managed=true`. If the namespace already exists without
+that label, they fail before writing hardware-authorizer or participant
+credentials and before changing Pod Security Admission. Never add the ownership
+label to a shared namespace. For a dedicated namespace created by an older
+version of this workflow, inspect its workloads, RBAC, Secrets, and ConfigMaps
+before explicitly labeling it for migration.
+
+Both participant containers use `privileged: true` inside their isolated Kata
+VM so they can materialize `/dev/sev-guest` or `/dev/tdx_guest` from guest
+sysfs. Restricted or baseline Pod Security Admission would reject them. After
+the ownership check, Stage 50 performs the equivalent of the following before
+applying the Deployments:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  label namespace "$NVFLARE_NAMESPACE" \
+  pod-security.kubernetes.io/enforce=privileged --overwrite
+```
+
+Restrict who can create or modify Pods and who can read Secrets in this
+namespace. The admission label permits privileged admission for every workload
+there; Kata isolation is established separately by each Pod's RuntimeClass.
+
+On TDX, Stage 30 also requires an Intel Trust Authority `config.json` through
+`NVFLARE_TDX_ATTESTATION_CONFIG_FILE`. It must be a JSON object containing a
+nonempty `trustauthority_url`, an HTTPS `trustauthority_api_url`, and a nonempty
+`trustauthority_api_key`. That key is distinct from an Intel PCS subscription
+key. If Stage 30 was run before setting this file, set it and rerun Stage 30;
+the script validates it without printing its contents and creates
+`nvflare-tdx-attestation` in the NVFlare namespace.
+
+Stage 50 defaults to self-contained local NVAT verification through
+`NVFLARE_GPU_VERIFIER=local`; that mode does not use a service key. To select
+remote NRAS verification, set `NVFLARE_GPU_VERIFIER=remote` and, when required,
+set
+`NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE` to a root-readable, one-line service
+key file before Stage 30. Stage 30 stores it in `nvflare-gpu-attestation`, and
+the Pod template exposes it to NVAT under its official
+`NV_ATTESTATION_SERVICE_KEY` environment variable. `NVFLARE_GPU_NRAS_URL`
+selects the HTTPS remote service. When constructing `GPUAuthorizer`
+directly, a non-`None` `service_key` argument takes precedence; the environment
+variable is consulted only when that argument is `None`.
+
+The deployment stage needs the `nvflare` provisioning CLI on the host. Create a
+virtual environment from the same checkout used as the image build context:
+
+```bash
+cd ../../..
+python3 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -e '.[K8S]' tensorboard
+cd examples/devops/CoCo
+```
+
+This repository's `main` branch is development for the next NVFlare release.
+Use the checkout installation above when that version is not yet published on
+PyPI. `50-nvflare-deploy.sh` and `60-nvflare-submit-hello-numpy.sh` discover
+`nvflare` on `PATH`, then `NVFlare/.venv/bin/nvflare`; `NVFLARE_CLI` can select
+another executable. Stage 60 uses the interpreter beside that CLI, then
+`python3`; set `NVFLARE_PYTHON` when neither is the intended environment.
+
+The image build needs outbound access to the base-image registries and Python
+package sources. The script installs Podman if it is absent. Docker is not
+required. Registry, signing, and Kubernetes commands require passwordless
+non-interactive `sudo` when the scripts are not run as root.
+
+## Configure the NVFlare deployment
+
+Review these values in `config.env`:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NVFLARE_NAMESPACE` | `nvflare-coco` | Dedicated Kubernetes namespace for the server and client. Stages 30/50 create it with `nvflare.nvidia.com/coco-managed=true` and refuse an existing namespace without that ownership label. |
+| `NVFLARE_PROJECT_NAME` | `nvflare_coco` | NVFlare provisioned project name. |
+| `NVFLARE_SERVER_NAME` | `nvflare-server` | NVFlare server identity, Service, and Deployment name. |
+| `NVFLARE_CLIENT_NAME` | `site-1` | NVFlare client identity and Deployment name. |
+| `NVFLARE_ADMIN_NAME` | `admin@nvidia.com` | Provisioned project-administrator identity. |
+| `NVFLARE_ORG` | `nvidia` | Organization recorded in all three identities. |
+| `NVFLARE_SERVER_IMAGE_NAME` | `coco/nvflare-server` | Server repository below the private registry. |
+| `NVFLARE_CLIENT_IMAGE_NAME` | `coco/nvflare-client` | Client repository below the private registry. |
+| `NVFLARE_SERVER_IMAGE_TAG` | `dev` | Mutable server distribution tag; deployment does not use it after digest resolution. |
+| `NVFLARE_CLIENT_IMAGE_TAG` | `dev` | Mutable client distribution tag; deployment does not use it after digest resolution. |
+| `NVFLARE_SERVER_MEMORY` | `8Gi` | Server Pod memory request and limit. |
+| `NVFLARE_CLIENT_MEMORY` | `32Gi` | Client Pod memory request and limit. |
+| `NVFLARE_SERVER_RUNTIME_CLASS` | `auto` | Selects `kata-qemu-snp` or `kata-qemu-tdx`, the CPU-only confidential runtime used by the server. |
+| `NVFLARE_CLIENT_RUNTIME_CLASS` | `auto` | Selects `kata-qemu-nvidia-gpu-snp` or `kata-qemu-nvidia-gpu-tdx`, the GPU-enabled confidential runtime used by the client. |
+| `NVFLARE_CLIENT_GPU_COUNT` | `1` | Number of passthrough GPU resources requested and limited by the client only. |
+| `NVFLARE_WORKSPACE_SIZE` | `16Gi` | Ephemeral encrypted workspace limit for each participant. |
+| `NVFLARE_FS_GROUP` | `65532` | Pod `fsGroup` applied to each writable encrypted workspace. The NVFlare process starts as root only inside its isolated Kata VM because the CPU evidence clients require guest-device/configfs access. |
+| `NVFLARE_CLI` | empty | Optional absolute path to the host provisioning CLI. |
+| `NVFLARE_PYTHON` | empty | Optional Python interpreter used to export `hello-numpy`; it must contain NVFlare, NumPy, and the configured TensorBoard version. |
+| `NVFLARE_ADMIN_LOCAL_PORT` | `18003` | Loopback port used by Stage 60's temporary host-to-Kata administration tunnel to server port 8003. |
+| `NVFLARE_CLI_CONNECT_TIMEOUT` | `30` | Seconds allowed for each Stage-60 administrator CLI connection. |
+| `NVFLARE_JOB_WAIT_TIMEOUT` | `900` | Maximum seconds Stage 60 waits for the job to reach a terminal state. |
+| `NVFLARE_JOB_WAIT_INTERVAL` | `2` | Seconds between Stage-60 job-status polls. |
+| `TENSORBOARD_VERSION` | `2.20.0` | TensorBoard version installed and runtime-checked in both signed parent images for the standard `hello-numpy` receiver. |
+| `NVFLARE_COCO_PYTHON_BUILD_BASE` / `NVFLARE_COCO_PYTHON_RUNTIME_BASE` | digest-pinned Python 3.12 images | ABI-matched builder and NVIDIA Distroless runtime used only by Stage 40. This is the validated image combination; NVAT itself is a native CLI and has no Python ABI dependency. |
+| `NVFLARE_COCO_PYTHON_MINOR` | `3.12` | Python ABI directory used when copying the built NVFlare installation into the runtime image; it must match both base images. |
+| `SNPGUEST_VERSION` | `0.10.0` | Pinned `snpguest` release installed in both images. |
+| `TRUSTAUTHORITY_CLI_VERSION` | `v1.10.1` | Pinned Intel Trust Authority CLI installed in both images. |
+| `NVAT_VERSION` | `1.2.2` | Pinned NVIDIA NVAT CLI and native library installed in both images. |
+| `NVAT_BUILD_BASE` | digest-pinned Ubuntu 24.04 image | Resolves NVAT's supported native dependency closure; Stage 40 relocates it with private RPATHs into the final distroless image. |
+| `AMD_KDS_PRODUCT` | `Genoa` | AMD product generation passed to `snpguest certificates`; set it to the generation used by the SNP host. |
+| `NVFLARE_TDX_ATTESTATION_CONFIG_FILE` | empty | Required on TDX before Stage 30; path to a secret Trust Authority `config.json`. |
+| `NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE` | empty | Optional one-line NVIDIA attestation service key file staged by Stage 30 and injected as a Secret-backed environment variable. |
+| `NVFLARE_GPU_VERIFIER` | `local` | NVAT verifier mode used by both participants. Set `remote` only with approved NRAS access. |
+| `NVFLARE_GPU_NRAS_URL` | `https://nras.attestation.nvidia.com` | HTTPS endpoint used only when `NVFLARE_GPU_VERIFIER=remote`. |
+
+The server and client names must be lowercase Kubernetes RFC 1123 names. The
+server and client image repositories must be different. `GPU_RESOURCE` remains
+the common suite setting and normally has the value `nvidia.com/pgpu`.
+The direct-download URLs and SHA-256 pins remain in `config.env`; their audited
+defaults and exact artifact meanings are recorded in `CHECKSUMS.md`. Treat a
+change to any of those values as a supply-chain review, not routine deployment
+configuration.
+
+Leave both RuntimeClass settings at `auto` unless the cluster administrator has
+reviewed an equivalent custom Kata installation. `RUNTIME_CLASS` remains the
+GPU RuntimeClass used by the generic stage-50 attestation sample and is also the
+default source for `NVFLARE_CLIENT_RUNTIME_CLASS`; it is not used by the NVFlare
+server. Stage 50 fails before provisioning if either selected RuntimeClass is
+absent. It also verifies after deployment that the server has no GPU request
+and that both the client's GPU request and limit equal
+`NVFLARE_CLIENT_GPU_COUNT`.
+
+`REGISTRY_HOST` is derived from `NODE_IP` and `REGISTRY_PORT` and must match the
+registry certificate and services created by the completed shared workflow. If
+that address must change, return to `USER_GUIDE.md` before running Stage 40.
+
+## Stage 40: build, push, sign, and authorize the images
+
+Run the NVFlare image stage after stage 30 succeeds:
+
+```bash
+./40-nvflare-build-sign-images.sh
+```
+
+The script fails if the stage-30 signing material, registry deployment, or KBS
+deployment is absent. It then performs the following operations:
+
+1. Builds `docker/Dockerfile.coco` as both compact parent-process images,
+   with pinned `snpguest`, Intel Trust Authority CLI, and
+   NVIDIA NVAT installation. The direct artifacts are SHA-256 checked,
+   and Stage 40 starts each completed runtime image to check both CLI versions,
+   the NVAT CLI, all three NVFlare authorizer imports, and the absence of the
+   Kubernetes Python package before applying
+   distinct server/client OCI role labels and pushing the images to separate
+   repositories. The NGC job image is intentionally not used as the long-running
+   client root filesystem: its expanded size can exceed confidential-guest image
+   storage. The script uses rootful Podman storage
+   below `state/`, not the Docker daemon or a global Podman image store. The
+   build uses the host network because some TDX host firewall configurations
+   do not provide package-repository egress to Podman's private build network.
+2. Pushes both tagged images to the TLS registry and validates the registry
+   with `state/registry-tls/ca.crt`.
+3. Reads each digest back from the registry with Skopeo. From this point on,
+   the authoritative references have the form
+   `REGISTRY/repository@sha256:...`; tags are not trusted deployment inputs.
+4. Signs each immutable digest with `state/security/cosign.key` and immediately
+   verifies it with `state/security/cosign.pub`.
+5. Writes a policy whose default action is `reject` and whose only allowed
+   repositories require a `sigstoreSigned` signature from that public key.
+6. Updates Trustee's public verification-resource Secret with that policy, the
+   public key, and the private registry CA.
+
+The key outputs are:
+
+| File | Purpose |
+|---|---|
+| `state/nvflare-images.env` | Exact digest references consumed by stage 50. |
+| `state/nvflare-image-security-policy.json` | Deny-by-default guest image policy for the two NVFlare repositories. |
+| `state/nvflare-server-cosign-verification.json` | Host-side server signature-verification result. |
+| `state/nvflare-client-cosign-verification.json` | Host-side client signature-verification result. |
+| `state/nvflare-image-signing-report.txt` | Source revision, Dockerfiles, signed references, and overall result. |
+
+For each recorded digest, the script's signing operation is equivalent to:
+
+```bash
+COSIGN_PASSWORD="${COSIGN_PASSWORD:-}" cosign sign --yes \
+  --tlog-upload=false --allow-insecure-registry \
+  --key state/security/cosign.key \
+  'REGISTRY/repository@sha256:APPROVED_DIGEST'
+```
+
+The actual reference is resolved from the registry and is never constructed
+from a tag alone. Rekor mode changes `--tlog-upload` to `true`. Let the script
+perform this operation so the signed references, policy, verification results,
+and deployment input stay synchronized.
+
+Inspect the result without printing the private key:
+
+```bash
+sed -n '1,120p' state/nvflare-image-signing-report.txt
+. state/nvflare-images.env
+cosign verify --allow-insecure-registry --insecure-ignore-tlog \
+  --key state/security/cosign.pub "$NVFLARE_SERVER_IMAGE"
+cosign verify --allow-insecure-registry --insecure-ignore-tlog \
+  --key state/security/cosign.pub "$NVFLARE_CLIENT_IMAGE"
+jq . state/nvflare-image-security-policy.json
+```
+
+Those verification commands match the default
+`COSIGN_TLOG_MODE=disabled`. In that mode the cryptographic signature is
+verified, but no public transparency-log inclusion is claimed. Set
+`COSIGN_TLOG_MODE=rekor` before stage 40 to upload and require public Rekor
+evidence; this requires network access and publishes signature metadata.
+
+Treat `state/security/cosign.key` as a secret. Never commit it, place it in an
+image, or copy it into the workload namespace. A production deployment should
+use a protected KMS/HSM or an approved keyless identity and an auditable key
+rotation process.
+
+### Source and base-image provenance
+
+The Cosign signature protects the exact bytes represented by the final registry
+digest. It does not prove that the source checkout was reviewed, that the build
+host was trustworthy, or that a mutable base-image tag had a particular value.
+`Dockerfile.coco` pins its bases by digest. If you separately build
+`Dockerfile.job` for GPU training, its NGC PyTorch base currently uses a mutable
+tag. For a production build:
+
+- build from a reviewed, clean commit and record that commit independently;
+- pin every base image by digest;
+- build in a controlled CI builder;
+- produce and retain an SBOM and signed provenance attestation; and
+- promote only an independently approved final digest.
+
+Re-signing an image authorizes it under the configured repository policy. Limit
+access to the signing key accordingly.
+
+### Include NVFlare authorizer dependencies in the signed images
+
+If the deployment enables the authorizers under
+`nvflare/app_opt/confidential_computing`, every Python module, executable,
+configuration file, trust root, and native library used by the selected
+authorizers must be present in the image that runs them. Installing a tool on
+the bare-metal host does not make it available inside a Kata confidential VM.
+Do not download these dependencies after launch: add pinned, reviewed artifacts
+at build time, validate them in the Dockerfile, and let Stage 40 sign the
+resulting immutable digest.
+
+The authorizer-specific requirements visible in the current NVFlare source are:
+
+| Authorizer | Content required in the image | Runtime requirements outside the image |
+|---|---|---|
+| `SNPAuthorizer` (`snp_authorizer.py`) | Pinned `snpguest` at `/opt/attestation/bin/snpguest`; Stage 50 puts its certificate cache under the encrypted workspace and selects `AMD_KDS_PRODUCT`. | `/dev/sev-guest` created from the guest's own sysfs device identity and egress to AMD KDS. |
+| `TDXAuthorizer` (`tdx_authorizer.py`) | Pinned Intel Trust Authority CLI at `/opt/attestation/bin/trustauthority-cli`, its runtime libraries/trust roots, and a read-only secret `config.json`. | `/dev/tdx_guest`, configfs TSM, QGS, and egress to the configured Intel Trust Authority endpoints. |
+| `GPUAuthorizer` (`gpu_authorizer.py`) | Pinned native NVAT `nvattest` CLI at `/opt/attestation/bin/nvattest`, `libnvat`, its runtime libraries, CA certificates, and the default Rego relying-party policy embedded in the authorizer. | A GPU assigned to the issuing VM and the required guest GPU device/driver interfaces. This workflow defaults to NVAT local verification; remote mode uses NVIDIA NRAS and verifier egress. For authenticated NRAS, inject the key as `NV_ATTESTATION_SERVICE_KEY` from a Kubernetes Secret or pass the `service_key` constructor argument. A non-`None` constructor argument takes precedence over the environment. Never bake the key into the image or startup kit. A CPU-only peer verifies the client's transported evidence from a temporary file and does not need a GPU. |
+
+Both role images contain the verifier dependencies because every participant
+must verify its peers. Only evidence issuance follows the hardware assignment:
+
+| Image | AMD SEV-SNP host | Intel TDX host | GPU authorizer |
+|---|---|---|---|
+| Server | Issues SNP evidence on an SNP host and verifies peer SNP evidence. | Issues TDX evidence on a TDX host and verifies peer TDX evidence. | Contains NVAT and verifies client GPU evidence, but does not issue GPU evidence and receives no GPU. |
+| Client | Issues and verifies SNP evidence on an SNP host. | Issues and verifies TDX evidence on a TDX host. | Issues and verifies nonce-bound GPU evidence; it is the only Pod receiving a GPU. |
+
+Stage 40 uses `docker/Dockerfile.coco` for both builds. The supplied Dockerfile
+always installs the attestation tools, base NVFlare, and TensorBoard without
+the `K8S` extra, and verifies that the Kubernetes Python package is absent. Stage 40
+validates the pinned downloads and performs runtime checks
+equivalent to:
+
+```bash
+python -c 'from nvflare.app_opt.confidential_computing.snp_authorizer import SNPAuthorizer'
+python -c 'from nvflare.app_opt.confidential_computing.tdx_authorizer import TDXAuthorizer'
+python -c 'from nvflare.app_opt.confidential_computing.gpu_authorizer import GPUAuthorizer'
+python -c 'import numpy, tensorboard; assert tensorboard.__version__ == "2.20.0"'
+python -c 'import importlib.util; assert importlib.util.find_spec("kubernetes") is None'
+/opt/attestation/bin/snpguest --version
+/opt/attestation/bin/trustauthority-cli version
+/opt/attestation/bin/nvattest version
+```
+
+These checks run for both images. They do not replace the Stage-50 in-guest
+device check and NVFlare peer authorization handshake.
+
+`TDXAuthorizer` invokes the pinned Trust Authority CLI directly, captures
+output without shared files, checks its exit status, requires
+exactly one compact JWT in stdout, bounds token size, and enforces a command
+timeout. It retains SHA-256 fingerprints of successfully verified JWTs and
+rejects replay. The class's default `use_sudo=None` chooses non-interactive
+sudo only for a non-root host process when sudo is available; Stage 50 sets
+`use_sudo: false` because the container starts as root inside the isolated Kata
+VM and contains no sudo. The default token command omits a TEE selector because
+the pinned v1.10.1 CLI selects TDX in that case, preserving compatibility with
+older CLIs that do not recognize `--tdx`. `token_options` permits reviewed,
+version-specific token flags without parsing informational output as a token.
+Hardware testing also found a narrow clock-boundary condition: Intel Trust
+Authority can issue a token whose `nbf` (not-before) time is about one second
+ahead of an otherwise NTP-synchronized TDX guest. Immediate CLI verification
+then reports `token is not valid yet`. `TDXAuthorizer` handles only that exact
+diagnostic from either stdout or stderr with a bounded five-attempt window,
+waiting two seconds between attempts. It does not retry
+signature, collateral, configuration, timeout, or other verification failures,
+and it never writes verifier stderr (which can contain the bearer token) to the
+NVFlare log. A not-before failure after that eight-second window remains
+fail-closed and should be
+investigated as a host, guest, or service clock-synchronization problem.
+
+`GPUAuthorizer` uses NVIDIA's supported native NVAT client and has no
+`nv_attestation_sdk` dependency. The issuer runs `nvattest collect-evidence`
+with a fresh 32-byte nonce and transports the resulting JSON evidence. The peer
+runs `nvattest attest` against that file, requires successful NVAT appraisal and
+the configured Rego policy, checks the verified claims nonce, and only then
+updates its replay cache. NVAT 1.2.2 specifies a distinct failure when
+`nv_match` is false; for the built-in policy the authorizer additionally checks
+every secure-boot, debug, signature, certificate/OCSP, RIM, and mismatch claim
+itself. Thus a zero CLI/result code with weak claims still fails closed. NVAT
+failures, timeouts, malformed evidence, policy mismatches, nonce mismatches,
+and replays all fail closed.
+
+GPU generation and verification are not serialized: every invocation uses
+isolated temporary files, while the replay cache is internally synchronized.
+Stage 50 provisions `get_token_request_timeout: 200`, above NVAT's 180-second
+command limit, so the CC peer request does not expire first and shut down the
+federation during a slow appraisal.
+
+`SNPAuthorizer` retries only report generation and AMD CA/VCEK network fetches.
+Local `snpguest verify attestation` runs once; deterministic signature failure
+does not enter the exponential network retry loop.
+
+If overriding `policy_file`, supply an NVAT Rego policy that defines the
+boolean rule `nv_match`. The JSON policy format accepted by the retired Python
+SDK is not compatible with NVAT and is rejected during authorizer
+initialization. The legacy `verifier_url` constructor argument remains an alias
+for `nras_url` to ease configuration migration.
+
+Dependencies alone do not activate authorization. Stage 50 now generates a
+platform-specific CPU authorizer configuration for both participants, adds the
+GPU issuer only to the client, and provisions both through `CCBuilder`. It
+fails if `CCBuilder` rejects a configuration or omits any expected manager or
+authorizer resource.
+
+### Generate authorizer-configured startup kits with `CCBuilder`
+
+NVFlare can add confidential-computing authorization configuration to startup
+kits during `nvflare provision`. The
+[Azure confidential-VM deployment guide](https://nvflare.readthedocs.io/en/main/user_guide/confidential_computing/azure/azure_confidential_virtual_machine_deployment.html#azure-confidential-virtual-machine-deployment-guide)
+demonstrates the provisioning pattern: assign a `cc_config` YAML file to every
+confidential participant and place
+`nvflare.lighter.cc_provision.impl.cc.CCBuilder` after `StaticFileBuilder` and
+before `SignatureBuilder`.
+
+The supplied `templates/nvflare-project.yml.in` uses this pattern:
+
+```yaml
+participants:
+  - name: nvflare-server
+    type: server
+    org: nvidia
+    fed_learn_port: 8002
+    admin_port: 8003
+    cc_config: "@@SERVER_CC_CONFIG@@"
+  - name: site-1
+    type: client
+    org: nvidia
+    cc_config: "@@CLIENT_CC_CONFIG@@"
+
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      config_folder: config
+      scheme: grpc
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.cc_provision.impl.cc.CCBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder
+```
+
+The paths must be readable by the host-side `nvflare provision` process used in
+Stage 50. Use a separate configuration for each participant. Select one CPU
+issuer matching the host platform:
+
+```yaml
+# AMD SEV-SNP participant
+compute_env: onprem_cvm
+cc_cpu_mechanism: amd_sev_snp
+role: server  # use client in cc_site-1.yml
+cc_issuers:
+  - id: snp_authorizer
+    path: nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer
+    token_expiration: 100
+    args:
+      snpguest_binary: /opt/attestation/bin/snpguest
+      amd_certs_dir: /var/tmp/nvflare/workspace/attestation/snp-certs
+      cpu_model: genoa  # use the generation that matches the deployed AMD host
+cc_attestation:
+  check_frequency: 120
+```
+
+```yaml
+# Intel TDX participant
+compute_env: onprem_cvm
+cc_cpu_mechanism: intel_tdx
+role: server  # use client in cc_site-1.yml
+cc_issuers:
+  - id: tdx_authorizer
+    path: nvflare.app_opt.confidential_computing.tdx_authorizer.TDXAuthorizer
+    token_expiration: 100
+    args:
+      tdx_cli_command: /opt/attestation/bin/trustauthority-cli
+      config_dir: /etc/nvflare/tdx-attestation
+      use_sudo: false
+cc_attestation:
+  check_frequency: 120
+```
+
+The TDX `config_dir` receives the reviewed `config.json` read-only from the
+`nvflare-tdx-attestation` Secret created by Stage 30. The authorizer does not
+write token, verification, or error files there.
+
+For the GPU client, add the GPU mechanism and append a second issuer alongside
+the selected CPU issuer. This complete SNP-plus-GPU client fragment illustrates
+the required single `cc_issuers` list:
+
+```yaml
+compute_env: onprem_cvm
+cc_cpu_mechanism: amd_sev_snp
+cc_gpu_mechanism: nvidia_cc
+role: client
+cc_issuers:
+  - id: snp_authorizer
+    path: nvflare.app_opt.confidential_computing.snp_authorizer.SNPAuthorizer
+    token_expiration: 100
+    args:
+      snpguest_binary: /opt/attestation/bin/snpguest
+      amd_certs_dir: /var/tmp/nvflare/workspace/attestation/snp-certs
+      cpu_model: genoa  # use the generation that matches the deployed AMD host
+  - id: gpu_authorizer
+    path: nvflare.app_opt.confidential_computing.gpu_authorizer.GPUAuthorizer
+    token_expiration: 100
+    args:
+      nvat_command: /opt/attestation/bin/nvattest
+      verifier: local
+cc_attestation:
+  check_frequency: 120
+```
+
+For a TDX-plus-GPU client, replace the SNP mechanism and issuer in that fragment
+with the complete TDX mechanism and issuer shown above; retain the GPU issuer in
+the same list. Do not declare a second `cc_issuers` key, because YAML would
+replace the first list.
+
+Do not configure `GPUAuthorizer` as an issuer for the CPU-only server. It is
+still installed there as a verifier so the server can validate the client's GPU
+token. `CCBuilder` adds `CCManager` and authorizer resources to the startup
+kits; Stage 40 supplies their binaries and Python packages. Quotes are generated
+at runtime, not at provision time.
+
+Treat provisioning diagnostics as a security gate. `CCBuilder.initialize()`
+reports a bad or missing `cc_config` as `CC is not enabled for ...`; Stage 50
+rejects that diagnostic and requires the expected `cc_manager__p_resources.json`
+and authorizer resource files before creating Kubernetes objects.
+
+After changing any authorizer dependency or Dockerfile input, rerun Stage 40 so
+both new image digests are signed and authorized, then rerun Stage 50.
+
+## Stage 50: provision and deploy the participants
+
+Run the NVFlare deployment stage:
+
+```bash
+./50-nvflare-deploy.sh
+```
+
+The script first re-verifies both signatures and checks that both references are
+immutable digests. It then:
+
+1. Generates SNP-or-TDX participant `cc_config` files, renders
+   `templates/nvflare-project.yml.in`, and runs `nvflare provision`.
+   `CCBuilder` adds the CPU issuer to both participants, the GPU issuer to the
+   client, and CPU/GPU peer verifiers to both startup kits. Stage 50 rejects
+   provisioning diagnostics or missing component resources.
+2. Requires a suite-owned dedicated namespace before storing each server/client
+   `startup/` directory in a Kubernetes Secret and each `local/` directory in a
+   ConfigMap. The administrator kit remains only under suite state and is not
+   copied to the cluster.
+   Server job and snapshot storage is relocated from its provisioned `/tmp`
+   default to the encrypted participant workspace.
+3. Constructs CoCo init-data containing the deny-by-default image policy,
+   Cosign public key, private registry CA, and guest-agent policy. The compressed
+   init-data is placed in the Kata `cc_init_data` Pod annotation, so the TEE
+   launch measurement binds these verification inputs. The demo agent policy
+   denies `SetPolicyRequest`, preventing runtime replacement of the measured
+   policy. It deliberately permits copy, exec, and stream requests because
+   Stage 50 uses `kubectl exec` for in-guest device/tool checks. Consequently,
+   this demo does not isolate the workload from a Kubernetes host administrator;
+   production deployments should remove agent operations they do not require.
+4. Creates the dedicated namespace with
+   `nvflare.nvidia.com/coco-managed=true` if absent, refuses an existing
+   namespace without that ownership marker, labels the owned namespace
+   `pod-security.kubernetes.io/enforce=privileged`, and renders
+   `templates/nvflare-coco.yaml.in` with the exact signed digests, the
+   platform-specific non-GPU Kata RuntimeClass for the server, and the
+   GPU-enabled Kata RuntimeClass for the client. Only the client manifest
+   contains the `nvidia.com/pgpu` request and limit. Each container is
+   privileged only inside its Kata VM, creates `/dev/sev-guest` or
+   `/dev/tdx_guest` from guest sysfs before starting NVFlare, and mounts TDX
+   configuration read-only when applicable.
+5. Creates the server Service and server/client Deployments, waits for both Pods
+   to be Ready, and checks each expected runtime class, the exclusive client GPU
+   assignment, init-data annotation, Pod image references, and runtime-reported
+   image IDs, opens the guest CPU device, checks the three in-image tool
+   versions, and waits for each peer to log a successful NVFlare CC validation.
+   Stage 40 checked all three authorizer imports; starting the configured
+   participants also exercises the selected authorizers. The report treats
+   successful container creation under the selected CoCo runtimes as indirect
+   evidence that guest image-rs accepted both images; it does not run a
+   separate unsigned-image rejection test.
+6. After every preceding check passes, atomically records the exact active
+   namespace, participant names, signed image digests, and administrator startup
+   kit path in `state/nvflare-deployment/current.env`. Stage 50 removes an older
+   pointer before reprovisioning, so a failed rerun cannot direct Stage 60 to a
+   stale kit.
+
+The server Service is cluster-internal and exposes:
+
+| Port | Purpose |
+|---|---|
+| `8002` | NVFlare federation traffic from clients. |
+| `8003` | NVFlare administration traffic. |
+| `8102` | NVFlare parent/child process communication. |
+
+Check the deployed objects and integrity report:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  -n nvflare-coco get service,deployments,pods -o wide
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  -n nvflare-coco get pods \
+  -o custom-columns=NAME:.metadata.name,RUNTIME:.spec.runtimeClassName,IMAGE:.spec.containers[0].image,IMAGE_ID:.status.containerStatuses[0].imageID
+sed -n '1,160p' state/nvflare-deployment-integrity-report.txt
+```
+
+To inspect the GPU allocation directly, the server value must be `none` and the
+client value must be `1` with the defaults:
+
+```bash
+for app in nvflare-server site-1; do
+  sudo kubectl --kubeconfig /etc/kubernetes/admin.conf -n nvflare-coco \
+    get pod -l "app=$app" -o json |
+    jq -r --arg app "$app" --arg gpu nvidia.com/pgpu \
+      '[$app, (.items[0].spec.runtimeClassName),
+       (.items[0].spec.containers[0].resources.requests[$gpu] // "none")] | @tsv'
+done
+```
+
+Participant logs are available through Kubernetes:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  -n nvflare-coco logs deployment/nvflare-server
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  -n nvflare-coco logs deployment/site-1
+```
+
+The administrator startup kit is reported at the end of stage 50 under a fresh,
+randomized provisioning workspace, for example:
+
+```text
+state/nvflare-deployment/workspace.A1b2C3/nvflare_coco/prod_00/admin@nvidia.com/startup
+```
+
+Keep it private. The generated server certificate contains the in-cluster
+server names. If an administrator connects from outside the cluster, use an
+approved network path to the ClusterIP Service or another tunnel to port 8003,
+and preserve the provisioned server hostname for TLS verification. Standard
+`kubectl port-forward` cannot reach a listener inside the Kata VM on every CRI
+implementation; Stage 60 therefore uses a loopback-only host proxy to the
+routable server Pod IP. Do not expose
+the administration port publicly without authentication, authorization, and
+network policy controls appropriate to the deployment.
+
+This reference workflow uses ordinary Kubernetes Secrets for participant
+startup kits, the TDX service configuration, and an optional NVIDIA service
+key. A Kubernetes or etcd administrator can retrieve those values;
+Confidential Containers cannot make an already host-visible Secret
+confidential retroactively. For a production threat model that excludes the
+host or cluster administrator, keep participant keys and service credentials
+outside Kubernetes and release them from Trustee or another key broker only
+after successful remote attestation. Mount the released material directly
+inside the guest and remove the ordinary Secrets from the manifest.
+
+## Stage 60: submit and verify hello-numpy
+
+After Stage 50 succeeds, run:
+
+```bash
+./60-nvflare-submit-hello-numpy.sh
+```
+
+Stage 60 is an end-to-end functional check of the already attested NVFlare
+parents. It does not create another Kubernetes workload or assign another GPU.
+The script performs these operations:
+
+1. Loads `state/nvflare-deployment/current.env`, requires it to match the
+   configured namespace and participant names, waits for both Deployments to be
+   available, and confirms their live image references still equal the exact
+   Stage-50 signed digests. A missing state file means Stage 50 did not complete.
+2. Uses the repository's `NumpyFedAvgRecipe` and
+   `examples/hello-world/hello-numpy/client.py` to export the standard
+   one-client, three-round job with full NumPy parameter transfer and
+   TensorBoard experiment tracking. One client is intentional because this
+   deployment has exactly one `site-1` participant. Because CCManager rejects
+   BYOC, Stage 60 removes the exported custom copy and changes the client
+   configuration to the narrowly scoped `CoCoHelloNumpyExecutor`. That executor
+   accepts no job-controlled entry point or arguments and always runs the
+   identical trainer baked into the signed parent image at
+   `/opt/nvflare/examples/hello-numpy/client.py`. Stage 50 allow-lists that exact
+   class, while the generic `ClientAPIExecutor` remains blocked. Stage 60
+   refuses to submit if any custom directory remains. The export is retained
+   below the run directory for inspection.
+3. Copies the active administrator startup kit into a mode-0700 temporary
+   directory. Only that temporary copy changes: its connection host and port
+   are set to `127.0.0.1:$NVFLARE_ADMIN_LOCAL_PORT`. The provisioned
+   `server_identity` remains `nvflare-server`, so mTLS still authenticates the
+   expected server certificate rather than weakening hostname identity checks.
+   Stage 50 includes `127.0.0.1` as an IP subject-alternative name in that
+   server certificate specifically for this local tunnel; hostname verification
+   remains enabled.
+4. Resolves the running server Pod IP and starts a small Python TCP proxy bound
+   only to host loopback, forwarding the local port to the server's
+   cluster-internal administration port 8003. This is used instead of
+   `kubectl port-forward`, whose host-network-namespace loopback does not reach
+   the listener inside a Kata VM with every CRI implementation. The private
+   administrator kit is never placed in a Kubernetes Secret or admin Pod. The
+   tunnel and temporary kit are removed by the exit trap on success, failure,
+   or interruption.
+5. Runs `nvflare --format json job submit`, extracts the returned job ID, then
+   runs `nvflare --format json job wait` with the configured timeout and poll
+   interval. NVFlare returns a nonzero exit for failed, aborted, abandoned,
+   timed-out, or execution-exception terminal states. Stage 60 additionally
+   requires the returned status to start with `FINISHED:COMPLETED`.
+6. Prints up to the last 120 server/client job-log lines and writes a PASS report.
+   Log retrieval is diagnostic and can be unavailable when client log streaming
+   is disabled; the authenticated `job wait` terminal status is the authoritative
+   completion check.
+
+Successful output ends with text equivalent to:
+
+```text
+hello-numpy finished without error
+Job ID: <server-assigned-id>
+Status: FINISHED:COMPLETED
+Report: .../report.txt
+Run artifacts: ...
+```
+
+Each invocation creates
+`state/nvflare-job-runs/<UTC-timestamp>.<random-suffix>/` containing the exported job,
+submission JSON, wait JSON, bounded job logs, CLI diagnostics, tunnel log,
+and `report.txt`. `state/latest-nvflare-job-run` points to the latest successful
+run. These files do not contain the copied administrator private key; that copy
+exists only in the temporary directory removed at exit. Treat all suite state
+as administrator-controlled data nonetheless.
+
+Stage 60 uses `ProcessJobLauncher`: the server and client child processes run
+inside the existing digest-pinned Kata VMs and inherit the signed parent
+images' Python environment. Consequently, Stage 40 must be rerun after adding
+or changing a job dependency. The supplied `Dockerfile.coco` includes NumPy
+through base NVFlare, the `hello-numpy` trainer as integrity-protected image
+content, and TensorBoard because the standard recipe enables that receiver. It
+still excludes the Kubernetes Python package. A submitted custom trainer would
+be BYOC and is intentionally rejected when confidential-computing validation is
+enabled. The dedicated `CoCoHelloNumpyExecutor` has a fixed constructor so its
+allow-list entry cannot be repurposed to execute another path from job config.
+
+## How container-image integrity is enforced
+
+The complete container-image path is:
+
+```text
+reviewed NVFlare source
+  -> OCI build
+  -> registry sha256 digest
+  -> Cosign signature over that digest
+  -> deny-by-default measured guest policy
+  -> digest-pinned Kubernetes Pod
+  -> the selected CoCo runtime invokes image-rs before container creation
+  -> readiness, runtime image ID, and Pod controls checked by stage 50
+```
+
+The mutable tags are used only to push and locate a newly built object. Stage 50
+reads the recorded `@sha256:` references, and the default CoCo runtimes pass the
+measured image policy to guest image-rs. Stage 50 verifies the signatures on the
+host and confirms that both containers become Ready with matching runtime image
+IDs. Readiness is indirect enforcement evidence, not an independent negative
+test proving that an unsigned image is rejected. Because the policy, public key,
+and registry CA are in init-data, modifying those inputs changes SNP `HOST_DATA`
+or TDX `MRCONFIGID`.
+
+The CPU-only server VM and GPU-enabled client VM do not have interchangeable VM
+launch reference values: their Kata guest images and launch configurations can
+differ. A production verifier must maintain and appraise the approved reference
+set for each selected RuntimeClass, in addition to checking the shared measured
+init-data binding.
+
+Container signing alone is not complete VM-image verification. The verifier
+that releases production credentials or data must also appraise the signed TEE
+report or quote and compare the VM launch measurements with independently
+trusted references:
+
+- SNP: verify the VCEK chain, report signature, debug policy, fresh
+  `REPORT_DATA`, the full launch `MEASUREMENT`, and the init-data binding in
+  `HOST_DATA`. A signed SNP ID block can enforce an approved launch identity.
+- TDX: verify Intel PCS collateral and quote signature, debug state, fresh
+  `REPORTDATA`, MRTD and all relevant RTMR values, and the init-data binding in
+  `MRCONFIGID`.
+
+For complete VM-image verification, the launch measurement must be compared
+against a trusted reference—typically through Trustee/RVPS policy—or enforced
+with a signed SNP ID block. CoCo's
+[reference-value architecture](https://confidentialcontainers.org/docs/attestation/reference-values/)
+is specifically designed for that comparison.
+
+`50-nvflare-deploy.sh` now requires the NVFlare peers to generate and
+cryptographically verify their hardware tokens before it reports success. That
+peer handshake does not independently compare the Kata VM launch measurement
+and init-data binding against an operator-approved reference set. The report
+keeps that distinction explicit. Before releasing production data or
+credentials, use Trustee/RVPS or another verifier outside the workload host's
+failure domain with approved SNP/TDX references and this deployment's expected
+init-data hash.
+
+## Workspace encryption and persistence
+
+Both Deployments mount an `emptyDir` at `/var/tmp/nvflare/workspace` and a
+256 MiB `emptyDir` at `/applog`, which is required by the provisioned NVFlare
+file-logging configuration. Stage 20
+requires Kata's released `block-encrypted` mode for the GPU RuntimeClass used by
+the client. The pinned chart's default non-GPU SNP and TDX RuntimeClasses use the
+same mode for the server, but stage 50 checks only that the selected server
+RuntimeClass exists. Verify `emptydir_mode = "block-encrypted"` independently
+before using a custom server RuntimeClass. In that mode Kata creates a
+host-backed sparse block device and applies LUKS2/dm-crypt plus dm-integrity with
+an ephemeral key inside the confidential guest. The startup Secret and local
+ConfigMap are nested read-only mounts under that workspace.
+
+This protects transient workspace blocks from direct host inspection and
+detects block modification. It is not persistent storage: deleting the Pod
+deletes the backing file and loses its ephemeral key. It also does not prevent
+whole-volume rollback. Production persistent datasets need a separately
+designed encrypted-volume and key-release policy bound to successful remote
+attestation.
+
+## Submit other jobs safely
+
+The deployed parent processes use NVFlare's process launcher. A submitted job's
+Python code and dependencies must therefore be compatible with the signed
+parent image in which that participant runs:
+
+- server-side job code runs in the minimal server image;
+- the deployed client parent has NVFlare but not CUDA/PyTorch training
+  dependencies; and
+- packages installed after measurement or downloaded without independent
+  verification weaken the image-based software identity.
+
+For an in-process GPU training demonstration, derive a compact client-parent
+Dockerfile with only the required CUDA/Python libraries, keep its expanded size
+within the confidential guest's image-pull capacity, then rerun NVFlare stages
+40 and 50. For production, prefer a separately digest-pinned and signed job
+image under a launcher that injects all CoCo controls listed below. Avoid `pip
+install` from the network inside a running participant. The signature policy
+verifies container images, not arbitrary job archives or datasets; retain
+NVFlare's job-signature and authorization controls and govern who may submit
+jobs.
+
+If separate per-job Kubernetes Pods are required, extend the NVFlare Kubernetes
+launcher or an admission controller so every job Pod receives all of the
+following before enabling it:
+
+- the SNP/TDX GPU Kata RuntimeClass;
+- the measured `cc_init_data` annotation;
+- a digest-pinned, signed job image allowed by the measured policy;
+- the intended passthrough GPU resource and resource limits; and
+- remote-attestation-gated data and credential release.
+
+## Update or rotate the deployment
+
+After changing NVFlare code, dependencies, or a Dockerfile, rebuild and deploy:
+
+```bash
+./40-nvflare-build-sign-images.sh
+./50-nvflare-deploy.sh
+./60-nvflare-submit-hello-numpy.sh
+```
+
+Stage 40 records new digests. Stage 50 reprovisions the identities, updates the
+Secrets and ConfigMaps, applies those digests, restarts both Deployments, and
+waits for their health checks. Stage 60 verifies that the rebuilt parents can
+run the standard functional job.
+
+Security-material rotation belongs to the shared workflow in `USER_GUIDE.md`.
+After that procedure completes, rerun NVFlare Stages 40 and 50 so the images
+and participants use the new public key and registry CA. Previously signed
+images cease to be authorized unless the policy explicitly retains the old
+public key.
+
+## Troubleshooting
+
+### Build cannot pull a base image
+
+Confirm DNS, proxy, and firewall access from the host to Docker Hub, NGC, and
+the Python package sources used by the Dockerfiles. Podman storage for this
+workflow is below `state/podman-storage`; it is safe to discard only when no
+build from this suite is in progress.
+
+### Registry TLS or push fails
+
+Confirm `NODE_IP` and inspect the certificate SAN:
+
+```bash
+openssl x509 -in state/registry-tls/registry.crt -noout -issuer -subject -ext subjectAltName
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  -n coco-system get pods,service
+```
+
+If `NODE_IP` or the registry certificate must change, return to the shared
+security-service procedure in `USER_GUIDE.md`. After it succeeds, rerun
+NVFlare Stages 40 and 50 to publish and deploy references using the corrected
+registry address.
+
+### Deployment reports an unsigned image
+
+Do not change the manifest to use a tag. Rerun stage 40, inspect both
+Cosign verification JSON files, and verify that
+`state/nvflare-image-security-policy.json` contains both repository keys. Then
+rerun stage 50.
+
+### Client remains Pending
+
+Check the GPU resource and VFIO state:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get node \
+  -o custom-columns=NAME:.metadata.name,PGPU:.status.allocatable.nvidia\.com/pgpu
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+  -n nvflare-coco describe pod -l app=site-1
+lspci -Dnnk -d 10de:
+```
+
+Only one passthrough-GPU Pod can consume a single `nvidia.com/pgpu` device at a
+time. The NVFlare server is not a GPU consumer. Delete or stop the generic
+stage-50 validation Pod if it was deliberately kept with
+`KEEP_ATTESTATION_POD=1`, because it otherwise competes with the NVFlare client
+for the sole device.
+
+### Parent starts but jobs fail
+
+Inspect participant logs and the provisioned `local/resources.json`. Confirm
+that it contains the process launcher and that all job imports exist in the
+corresponding signed parent image. For Stage 60, inspect
+`state/latest-nvflare-job-run/wait.json`, `job-logs.txt`, and the participant
+logs. Confirm the host export environment and both signed images contain
+TensorBoard. Rebuild instead of installing dependencies interactively in the
+running VM.
+
+For shared-stage administration, recovery guidance, and the generic attestation
+workflow, return to `USER_GUIDE.md`.

--- a/examples/devops/CoCo/README.md
+++ b/examples/devops/CoCo/README.md
@@ -1,0 +1,137 @@
+# Bare-metal CoCo deployment and attestation
+
+This directory is a restartable, staged path from a fresh Ubuntu AMD SEV-SNP or Intel TDX host with a supported NVIDIA confidential-computing GPU to verified CPU, GPU, signed-image, and encrypted-storage reports from a Confidential Container. `TEE_PLATFORM=auto` selects the matching Kata runtime and host checks.
+
+The pinned defaults reproduce the installation validated on this machine: Kubernetes 1.34.9, containerd 2.2.2, Calico 3.32.1, Kata Containers 3.29.0, NVIDIA GPU Operator 26.3.1, Cosign 2.6.2, Trustee KBS, and NVIDIA NVAT 1.2.2.
+
+Documentation:
+
+- [`SUMMARY.md`](SUMMARY.md) is the short trial procedure.
+- [`USER_GUIDE.md`](USER_GUIDE.md) is the detailed host and Kubernetes administrator guide.
+- [`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md) covers the alternative NVFlare Stage 40/50 path that builds, signs, verifies, and deploys a server and GPU client as confidential VMs after shared Stage 30.
+
+## Before running
+
+Firmware must already have the IOMMU and either AMD SVM/SEV/SEV-SNP or Intel TDX enabled. The NVIDIA GPU must support confidential computing and must not be used by a host NVIDIA driver. These are firmware/hardware conditions the scripts can diagnose but cannot safely change.
+
+Use a dedicated or disposable single-node host. The Kubernetes stage disables swap, installs packages and binaries, writes systemd/containerd/sysctl configuration, and initializes a cluster. Restoring a trusted baseline requires reimaging the host or a separately reviewed administrator-run recovery procedure.
+
+Copy the example configuration and review it:
+
+```bash
+cd examples/devops/CoCo
+cp config.env.example config.env
+editor config.env
+```
+
+An empty `NODE_IP` is derived from the default IPv4 route. The registry certificate is issued to that IP, so set it explicitly when the selected address is not stable. Keep the whole directory on local storage: generated keys, certificates, signed-image state, and reports are placed under `state/`.
+
+Intel TDX additionally uses local PCCS/QGS to obtain the platform PCK certificate and generate a TD Quote. Intel's production PCS accepts a request with the subscription header omitted; stage 20 applies a guarded compatibility fix for PCCS 1.21, which otherwise sends an empty header that PCS rejects. If the selected PCS environment requires a key, put the 32-character key in a root-readable file and set `INTEL_PCS_API_KEY_FILE`, or supply `INTEL_PCS_API_KEY` only in the stage-20 environment. Never commit the key. Canonical currently publishes its TDX attestation packages only for selected Ubuntu suites; `TDX_ATTESTATION_PPA_SUITE` is an explicit compatibility override, not an automatic cross-release fallback.
+
+The scripts do not require any pre-existing file under `/tmp`. Host scratch directories are created with `mktemp` for the duration of one stage. Versioned external artifacts are downloaded atomically into `state/downloads/`, reused only when present, and checksum-verified where the publisher provides a pinned checksum. A missing or invalid cached artifact is downloaded again. Files used under `/tmp` inside the CoCo guest are explicitly uploaded or generated and checked before use.
+
+The exact downloaded objects, audited hashes, and publisher checksum sources are listed in [`CHECKSUMS.md`](CHECKSUMS.md). Archive checksums must not be replaced with hashes of binaries extracted from those archives.
+
+Checksum mismatches stop the workflow by default. For exceptional recovery, set `IGNORE_CHECKSUM_MISMATCH=1` in `config.env` or for one invocation, for example `IGNORE_CHECKSUM_MISMATCH=1 ./10-install-kubernetes.sh`. The script prints a warning for every ignored artifact. This disables an important supply-chain integrity check and should not be used for routine installation.
+
+`COSIGN_TLOG_MODE=disabled` is the default for the local private-registry workflow. It verifies the image against the configured Cosign public key but does not claim public transparency or auditability; stages 40 and 50 print an explicit notice. Set `COSIGN_TLOG_MODE=rekor` before running stage 40 to upload the signature to the public Rekor transparency log and require tlog verification in stage 50. Rekor mode requires Sigstore network access and publicly discloses signature metadata for the image reference/digest.
+
+## One-command path
+
+```bash
+./run-all.sh
+```
+
+The scripts request sudo when a host or cluster-admin change is required. They stop at the first failed prerequisite or deployment check. If a reboot is required to finish GPU confidential-computing mode changes, reboot and rerun `20-install-coco-gpu.sh`, then resume the later stages.
+
+## Individual stages
+
+1. `./00-verify-host.sh` detects SNP or TDX and checks the matching CPU/KVM capability, root-filesystem writeability and ext4 error state, IOMMU groups, absence of conflicting host NVIDIA/nouveau drivers, memory, disk, swap, OS, and required network endpoints. An unbound GPU is valid at this stage. A `FAIL` blocks the workflow; a `WARN` is advisory.
+2. `./10-install-kubernetes.sh` installs the host tools, containerd, CNI plugins, Kubernetes, Helm, and Calico; initializes a single-node kubeadm cluster only when one is absent.
+3. `./20-install-coco-gpu.sh` installs Kata from its official OCI chart and GPU Operator with Kata sandbox, CC Manager, VFIO Manager, and passthrough device plugin enabled. On TDX it also installs and validates PCCS/QGS, supports production-PCS keyless mode, and validates any supplied PCS key. It waits for the Kata host files, makes the Kata fragment part of containerd's effective configuration, restarts containerd, and verifies the platform-specific `kata-qemu-nvidia-gpu-{snp,tdx}` handler, `nydus-for-kata-tee` plugin, and released `block-encrypted` confidential-emptyDir mode before continuing. It then waits for the RuntimeClass, CC-ready node label, and `nvidia.com/pgpu` capacity, and requires every detected NVIDIA VGA/3D GPU to be bound to `vfio-pci`.
+4. `./30-deploy-security-services.sh` creates a private CA, TLS registry, Cosign key pair, deny-by-default image policy, and a Trustee KBS deployment containing verification resources. It also stages optional NVFlare TDX/GPU authorizer credentials; the NVFlare path on TDX requires its Trust Authority configuration here.
+5. `./40-sign-image.sh` copies the configured CUDA image into the local registry, signs its immutable digest, verifies it, and writes `state/signed-image.env`.
+6. `./50-launch-and-attest.sh` launches the digest-pinned image under the selected SNP/GPU or TDX/GPU Kata RuntimeClass. The guest image pull is accepted only by its measured, deny-by-default Cosign policy. The Pod receives a released CoCo confidential `emptyDir`; Kata creates a host-backed sparse device and applies LUKS2/dm-crypt plus dm-integrity with an ephemeral key generated inside the guest. Stage 50 verifies the mapper, performs a read/write probe, and then collects and verifies SNP or TDX CPU evidence plus NVIDIA GPU evidence. A successful validation pod is deleted so the passthrough GPU is available to reruns; set `KEEP_ATTESTATION_POD=1` only for manual guest inspection.
+
+## Alternate NVFlare workload path
+
+To run an NVFlare server and GPU client instead of the generic stage-40/50
+sample, run these exact filenames in order:
+
+```bash
+./00-verify-host.sh
+./10-install-kubernetes.sh
+./20-install-coco-gpu.sh
+./30-deploy-security-services.sh
+./40-nvflare-build-sign-images.sh
+./50-nvflare-deploy.sh
+./60-nvflare-submit-hello-numpy.sh
+```
+
+Stage 30 explicitly deploys the registry, signing material, and Trustee. Stage
+40 builds NVFlare plus pinned SNP, TDX, and GPU attestation dependencies into
+distinctly labeled server/client parent images, checks them, pushes them, signs
+their immutable digests, and installs a deny-by-default policy. Stage 50 uses
+`CCBuilder`, exposes the guest-local CPU attestation interface inside each Kata
+VM, and deploys a CPU-evidence server plus CPU/GPU-evidence client. Only the
+client requests the passthrough GPU; both verify peer CPU/GPU evidence. Stages
+30 and 50 refuse to adopt an existing NVFlare namespace without the suite
+ownership label before writing credentials or enabling privileged Pod
+admission. TDX users
+must stage an Intel Trust Authority config through Stage 30 as described in
+[`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md). That guide contains the complete trust model,
+configuration, administrator workflow, and limitations. Stage 60 submits the
+standard one-client `hello-numpy` job through an mTLS administrator tunnel and
+requires `FINISHED:COMPLETED`. `run-all.sh` does not run this alternate path. Do
+not run both stage-40/50 variants or use a shell glob to select the NVFlare
+sequence.
+
+To sign a different image or tag without editing the configuration:
+
+```bash
+./40-sign-image.sh docker.io/library/ubuntu:24.04 my-signed-tag
+```
+
+The signing key is `state/security/cosign.key`; its public verification key is `state/security/cosign.pub`. Set `COSIGN_PASSWORD` in the environment if the key was generated with a password. Never copy, print, or commit the private key.
+
+## Reports and pass criteria
+
+The latest result is linked at `state/latest-attestation-reports`. Important files are:
+
+- `cpu-attestation-report.txt`: decoded platform claims and verification results. SNP includes nonce, `HOST_DATA`, AMD VCEK chain, and ECDSA P-384/SHA-384 results; TDX includes nonce, MRCONFIGID, MRTD/RTMR appraisal, debug state, quote signature, Intel PCS collateral, TCB status, and CRLs.
+- `cpu-attestation-report.bin`: the raw 1,184-byte SNP report or raw Intel TD Quote.
+- `gpu-attestation-report.txt`: human-readable NVAT result, nonce match, certificate/OCSP, report signature, RIM, secure-boot, debug, and measurement checks.
+- `gpu-attestation-evidence.json` and `gpu-attestation-result.json`: raw GPU evidence and verified claims.
+- `image-verification-report.txt`: the signed-image policy and measured-init-data binding result.
+- `storage-verification-report.txt`: the released CoCo confidential-emptyDir mapper, LUKS2/dm-crypt, dm-integrity, capacity, and read/write verification result.
+- `SHA256SUMS`: hashes of all material report artifacts.
+
+Success requires the CPU, GPU, image, and confidential-storage reports to say `PASS`. The CPU challenge is generated fresh for every run and must match SNP `REPORT_DATA` or TDX `REPORTDATA`. The SHA-256 of the init-data containing the image policy, Cosign public key, and private registry CA must exactly match SNP `HOST_DATA` or the first 32 bytes of TDX `MRCONFIGID`.
+
+Stage 50 also requires `EXPECTED_SNP_LAUNCH_MEASUREMENT` to contain an approved 48-byte SNP launch measurement. It verifies the AMD VCEK chain and report signature before comparing the signed `MEASUREMENT` claim with that reference, and fails closed on a mismatch. The pinned example value is the measurement validated for this suite's Kata 3.29.0 `kata-qemu-nvidia-gpu-snp` VM build. Re-establish it from an independently trusted build or release manifest whenever the Kata guest kernel, firmware, rootfs image, dm-verity parameters, hypervisor, or launch configuration changes; never learn or accept a replacement value from the untrusted live host during the same attestation run. A trusted automation system can override the file value with the `EXPECTED_SNP_LAUNCH_MEASUREMENT` environment variable.
+
+On TDX, stage 50 verifies the TD Quote and Intel collateral with a checksum-pinned `google/go-tdx-guest` verifier. It fails closed until `EXPECTED_TDX_MRTD` and all four `EXPECTED_TDX_RTMR*` values are supplied from an independently trusted build manifest or appraisal policy. It also rejects debug-enabled TDs and verifies `MRCONFIGID` against measured init-data. A value merely observed on the same live host is useful for diagnostics, not a trusted reference.
+
+For complete VM-image verification, the launch measurement must be compared against a trusted reference—typically through Trustee/RVPS policy—or enforced with a signed SNP ID block. CoCo's [reference-value architecture](https://confidentialcontainers.org/docs/attestation/reference-values/) is specifically designed for that comparison. This reference deployment performs direct SNP `MEASUREMENT` or TDX MRTD/RTMR comparison in its local verifier; protect the configured references and move appraisal outside the workload host's failure domain for a production threat model.
+
+The confidential volume is ephemeral scratch storage, not an encrypted persistent volume. Its key and detached LUKS2 header exist only in TEE-protected guest memory, and Kubernetes removes its sparse backing file with the Pod. LUKS2 integrity detects individual-block modification but does not prevent a malicious host from replaying an older whole-volume state. The current Kata implementation sizes the logical sparse device from the host filesystem rather than `emptyDir.sizeLimit`; kubelet enforces the requested limit based on physically allocated blocks, so `CONFIDENTIAL_VOLUME_SIZE` must leave enough room for ext4 and integrity metadata. See the [Confidential EmptyDir documentation](https://confidentialcontainers.org/docs/features/protected-storage/confidential-emptydir/).
+
+## Trust and production notes
+
+This is a reproducible bare-metal/reference deployment, not a production PKI design. The local registry uses a private CA, binds only to `REGISTRY_BIND_ADDRESS`/`NODE_IP`, but intentionally has no client authentication and permits push/delete. Restrict its port to trusted administrators with host/network firewall policy. Confidential pulls still fail closed on digest and Cosign policy. Cosign uses key-pair signing; public transparency is optional through `COSIGN_TLOG_MODE=rekor` and disabled by default for the private-registry topology. Trustee KBS is exposed as in-cluster HTTP with an insecure token key, matching the current local validation topology. In production, put the registry and KBS behind authenticated TLS, use a protected signing key (KMS/HSM or keyless identity), enable an appropriate transparency/audit mechanism, define restrictive attestation/resource policies, persist and back up KBS state, and operate trust services outside the workload host's failure domain.
+
+Trustee is the project and KBS is its key-broker service; they are not two separate servers in this deployment. The sample puts the public policy/key/registry CA directly in TEE-measured init-data so signature enforcement is available during the earliest image pull. The same resources are also provisioned into Trustee KBS for later secret/resource retrieval workflows.
+
+## Reruns
+
+Stages use `apply` or `helm upgrade --install` and can be rerun. Existing kubeadm state is never reset. Keys and certificates are reused. To rotate them intentionally, set `ROTATE_SECURITY_MATERIAL=1`, run stage 30, then re-sign the image and rerun attestation; backups receive a UTC timestamp. After rotation, return the value to `0`.
+
+Stage 30 validates the registry certificate on every run: expiry, certificate/private-key match, CA signature, and an IP or DNS SAN matching `REGISTRY_HOST`. If only the server certificate is stale—for example, after moving the suite to a host with a different `NODE_IP`—it preserves the existing CA and Cosign key and automatically issues a new leaf certificate. Replaced leaf files receive a UTC timestamp. The registry deployment is restarted after its TLS Secret is applied so the running process serves the current certificate.
+
+## Upstream references
+
+- NVIDIA Confidential Containers deployment guide: <https://docs.nvidia.com/datacenter/cloud-native/confidential-containers/1.0.0/confidential-containers-deploy.html>
+- Kubernetes kubeadm/package installation: <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/>
+- Confidential Containers signed images: <https://confidentialcontainers.org/docs/features/signed-images/>
+- Confidential Containers confidential emptyDir: <https://confidentialcontainers.org/docs/features/protected-storage/confidential-emptydir/>
+- Trustee deployment: <https://confidentialcontainers.org/blog/2026/02/11/deploy-trustee-in-kubernetes/>

--- a/examples/devops/CoCo/SUMMARY.md
+++ b/examples/devops/CoCo/SUMMARY.md
@@ -1,0 +1,242 @@
+# Bare-metal CoCo scripts: quick trial summary
+
+This is the short path for trying the scripts on a dedicated Ubuntu bare-metal
+host with AMD SEV-SNP or Intel TDX and a supported NVIDIA confidential-computing
+GPU. For exact host changes, security assumptions, and troubleshooting, read
+[`USER_GUIDE.md`](USER_GUIDE.md).
+
+To deploy an NVFlare server and client after preparing the CoCo cluster, use
+the alternate Stage 40/50 procedure in [`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md).
+
+## Before you start
+
+These scripts install and configure containerd, Kubernetes, Calico, Kata,
+NVIDIA GPU Operator, a private registry, and Trustee. They disable swap, change
+host networking/sysctls, bind the GPU to `vfio-pci`, and create signing keys.
+Use a dedicated or disposable host and an account with passwordless `sudo`.
+
+Firmware must already enable:
+
+- AMD SVM/SEV/SNP and IOMMU, or Intel TME/TME-MT/TDX and IOMMU.
+- NVIDIA GPU confidential-computing support.
+
+The host must not have an active NVIDIA or Nouveau driver owning the GPU.
+
+## Configure
+
+From the directory containing the scripts:
+
+```bash
+cp config.env.example config.env
+chmod 0600 config.env
+editor config.env
+```
+
+Check these values first:
+
+- `NODE_IP`: leave empty only if the default-route address is stable.
+- `TEE_PLATFORM=auto`: normally detects SNP or TDX.
+- `SOURCE_IMAGE`: image to copy and sign.
+- `COSIGN_TLOG_MODE`: `disabled` for the private lab flow or `rekor` for public
+  transparency-log upload and verification.
+- `EXPECTED_SNP_LAUNCH_MEASUREMENT`: independently approved SNP measurement.
+- `EXPECTED_TDX_MRTD` and `EXPECTED_TDX_RTMR0` through `RTMR3`: independently
+  approved TDX references; stage 50 refuses empty values.
+- `TDX_ATTESTATION_PPA_SUITE`: set only when an explicitly approved compatible
+  PPA suite is required.
+- `INTEL_PCS_API_KEY_FILE`: usually empty for production-PCS keyless mode. If a
+  key is required, point to a root-readable file and never commit it.
+
+Never “approve” a VM measurement merely by copying a value observed from the
+same host during the run.
+
+## Run one stage at a time
+
+### `00-verify-host.sh`
+
+```bash
+./00-verify-host.sh
+```
+
+Checks the OS, root filesystem, SNP/TDX capability, KVM, IOMMU, GPU model and
+driver ownership, swap, RAM, disk, and required network endpoints. Continue
+only when the summary reports zero failures. An unbound GPU is normal here.
+
+### `10-install-kubernetes.sh`
+
+```bash
+./10-install-kubernetes.sh
+```
+
+Installs pinned containerd, CNI plugins, Kubernetes, Helm, and Calico. It
+creates a single-node kubeadm cluster, disables swap, uses systemd cgroups,
+pins containerd to `/usr/bin/runc`, and makes the control-plane node schedulable.
+
+Expected final line:
+
+```text
+Kubernetes is ready
+```
+
+### `20-install-coco-gpu.sh`
+
+```bash
+./20-install-coco-gpu.sh
+```
+
+Installs Kata, the Nydus proxy snapshotter, encrypted confidential-`emptyDir`
+support, and NVIDIA GPU Operator in Kata passthrough mode. It waits for the
+RuntimeClass, CC-ready label, virtual GPU resource, and `vfio-pci` binding.
+
+On TDX it also installs and validates PCCS/QGS and Intel PCS access. Reboot and
+rerun this stage if GPU CC Manager says a reboot is required.
+
+Expected final line:
+
+```text
+Kata CoCo runtime and GPU passthrough are ready
+```
+
+### `30-deploy-security-services.sh`
+
+```bash
+./30-deploy-security-services.sh
+```
+
+Creates the Cosign key pair and private registry CA, deploys a TLS registry and
+Trustee KBS, installs the registry CA for containerd, and creates a
+deny-by-default image-signature policy. It also stages optional NVFlare
+hardware-authorizer credentials. For the NVFlare path on TDX, set
+`NVFLARE_TDX_ATTESTATION_CONFIG_FILE` to an Intel Trust Authority `config.json`
+before this stage; a PCS subscription key is not a substitute. Optionally set
+Stage 50 defaults to local NVAT verification. Set `NVFLARE_GPU_VERIFIER=remote`
+and `NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE` when using authenticated NRAS.
+
+The infrastructure images are digest-pinned. The unauthenticated registry
+binds only to `REGISTRY_BIND_ADDRESS` (normally `NODE_IP`) but permits
+push/delete, so firewall port 5000 to trusted administrators.
+
+Back up `state/security/cosign.key` securely. Do not commit or print it.
+
+Expected final line:
+
+```text
+Registry and Trustee KBS are ready
+```
+
+### `40-sign-image.sh`
+
+```bash
+./40-sign-image.sh
+```
+
+Copies the configured source image into the local registry, resolves its
+immutable digest, signs that digest, verifies the signature, and writes
+`state/signed-image.env`.
+
+To choose another image and target tag:
+
+```bash
+./40-sign-image.sh docker.io/library/ubuntu:24.04 test-signed
+```
+
+### `50-launch-and-attest.sh`
+
+```bash
+./50-launch-and-attest.sh
+```
+
+Launches a Kata confidential VM with the signed image and one passthrough GPU.
+It verifies:
+
+- the measured, deny-by-default Cosign image policy;
+- the SNP report and AMD VCEK chain, or TDX quote and Intel PCS collateral;
+- approved VM launch measurements and a fresh challenge;
+- NVIDIA GPU nonce, certificate, OCSP, RIM, secure-boot, debug, signature, and
+  measurement claims; and
+- an ephemeral LUKS2/dm-crypt plus dm-integrity confidential `emptyDir` using a
+  write/read probe.
+
+The volume is encrypted scratch space, not persistent storage. A successful pod
+is deleted by default so the GPU is available for another run. A failed pod is
+left in place for diagnostics.
+
+Reports are linked from:
+
+```text
+state/latest-attestation-reports
+```
+
+Check them with:
+
+```bash
+cd state/latest-attestation-reports
+sha256sum -c SHA256SUMS
+grep -H 'Overall .* result: PASS' *-report.txt
+```
+
+## Run everything
+
+After reviewing the configuration and understanding the changes:
+
+```bash
+./run-all.sh
+```
+
+This runs the generic stages 00 through 50 and stops at the first error.
+
+## Try an NVFlare server and client instead
+
+Install this checkout for the host-side provisioning CLI, then run these exact
+NVFlare workflow filenames in order:
+
+```bash
+cd ../../..
+python3 -m venv .venv
+.venv/bin/python -m pip install -e '.[K8S]' tensorboard
+cd examples/devops/CoCo
+./00-verify-host.sh
+./10-install-kubernetes.sh
+./20-install-coco-gpu.sh
+./30-deploy-security-services.sh
+./40-nvflare-build-sign-images.sh
+./50-nvflare-deploy.sh
+./60-nvflare-submit-hello-numpy.sh
+```
+
+This builds separately labeled server/client parent images containing pinned
+SNP, TDX, and NVIDIA GPU attestation dependencies, signs and verifies their
+immutable digests, provisions `CCBuilder` hardware authorizers, and exposes the
+guest-local CPU attestation device inside both Kata VMs. The server issues CPU
+evidence; the sole GPU client issues CPU/GPU evidence; both verify peer tokens.
+Stages 30 and 50 require a dedicated NVFlare namespace carrying the suite's
+ownership label; they refuse to write credentials or enable privileged Pod
+admission in an existing unlabeled namespace.
+On TDX, configure the Intel Trust Authority file described in the full guide
+before Stage 30. Only the client requests `nvidia.com/pgpu`.
+Inspect
+`state/nvflare-image-signing-report.txt` and
+`state/nvflare-deployment-integrity-report.txt`, then require Stage 60 to report
+`FINISHED:COMPLETED` for the one-client `hello-numpy` job. The complete
+image-integrity, remote-attestation, encrypted-workspace, and job-submission
+requirements are in
+[`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md).
+The generic `40-sign-image.sh`, `50-launch-and-attest.sh`, and `run-all.sh` are
+not part of this NVFlare sequence. Do not select scripts with a wildcard.
+
+## Script map
+
+| Script | Short description |
+|---|---|
+| `run-all.sh` | Runs stages 00 through 50 in order. |
+| `00-verify-host.sh` | Validates host, TEE, GPU, storage, and network prerequisites. |
+| `10-install-kubernetes.sh` | Installs containerd, Kubernetes, Calico, CNI, and Helm. |
+| `20-install-coco-gpu.sh` | Installs TDX quote services when needed, Kata/Nydus, GPU Operator, VFIO, and encrypted-emptyDir support. |
+| `30-deploy-security-services.sh` | Creates signing/TLS material, deploys the registry and Trustee KBS, and stages optional NVFlare TDX/GPU authorizer credentials. |
+| `40-nvflare-build-sign-images.sh` | Alternate stage 40: builds NVFlare server/client images with pinned SNP/TDX/GPU attestation tools, runs in-image checks, pushes, digest-pins, signs, verifies, and authorizes both repositories. Requires the explicit shared stage 30 first. |
+| `40-sign-image.sh` | Copies, digest-pins, signs, verifies, and records the workload image. |
+| `50-nvflare-deploy.sh` | Alternate stage 50: provisions CPU/GPU authorizers, exposes `/dev/sev-guest` or `/dev/tdx_guest` inside the Kata VMs, deploys the digest-pinned server/client, and requires the peer hardware-authorization handshake. |
+| `60-nvflare-submit-hello-numpy.sh` | Alternate stage 60: exports and submits one-client `hello-numpy`, waits for `FINISHED:COMPLETED`, and prints bounded job logs. |
+| `50-launch-and-attest.sh` | Launches the CoCo VM and verifies CPU, GPU, image, and encrypted storage. |
+| `lib/common.sh` | Shared configuration, download, checksum, sudo, kubectl, and Helm helpers. |
+| `lib/deploy-coco-attest.sh` | Internal stage-50 pod deployment, evidence collection, and verification driver. |

--- a/examples/devops/CoCo/USER_GUIDE.md
+++ b/examples/devops/CoCo/USER_GUIDE.md
@@ -1,0 +1,814 @@
+# Bare-metal Confidential Containers administrator guide
+
+## 1. Purpose and scope
+
+This guide documents the staged `examples/devops/CoCo` scripts that build a
+single-node Kubernetes cluster on an Ubuntu bare-metal server, install Kata
+Confidential Containers with NVIDIA GPU passthrough, deploy local image trust
+services, sign a workload image, and validate CPU, GPU, image, and encrypted
+scratch-volume evidence from inside a confidential VM.
+
+The supported confidential-computing paths are:
+
+- AMD SEV-SNP with `kata-qemu-nvidia-gpu-snp`.
+- Intel TDX with `kata-qemu-nvidia-gpu-tdx` and local PCCS/QGS services.
+
+The scripts are a reproducible reference and validation environment. They are
+not a production PKI, multi-node Kubernetes installer, or general-purpose
+cluster lifecycle manager. Use a dedicated host. A production deployment must
+move trust services and reference-value policy outside the workload host's
+failure domain and apply the organization's controls for TLS, identity,
+secrets, audit, backup, and change management.
+
+Commands in this guide assume the working directory is the directory containing
+`00-verify-host.sh`, `config.env.example`, `lib/`, and `templates/`.
+
+This guide reaches a choice after shared Stage 30. Administrators can continue
+here with the generic signed-workload attestation path, or switch to the
+separate [`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md) guide for the alternative
+NVFlare Stage 40/50 path.
+
+## 2. Administrative ownership
+
+The workflow crosses the host and Kubernetes administrative boundaries.
+
+| Role | Responsibilities |
+|---|---|
+| Host IT administrator | Firmware configuration, Ubuntu lifecycle, IOMMU and KVM/TEE availability, storage health, network egress, package installation, systemd, kernel modules, swap, PCI/VFIO ownership, PCCS/QGS on TDX, reboot and recovery. |
+| Kubernetes cluster administrator | kubeadm configuration, node readiness, CNI, RuntimeClass, Helm releases, node labels, GPU Operator, namespaces, Secrets, registry and Trustee deployments, workload policy, pod scheduling, and recovery review. |
+| Security/attestation owner | Cosign key custody, registry CA, Intel PCS credentials if used, approved SNP/TDX reference values, Rekor policy, Trustee/RVPS policy, evidence retention, and acceptance criteria. |
+
+One operator may hold all three roles in a lab. In a controlled environment,
+separate them and require review of `config.env`, reference values, generated
+keys, and host changes.
+
+## 3. What the workflow builds
+
+The normal control flow is:
+
+```text
+host preflight
+    -> containerd + kubeadm + Calico
+    -> Kata + Nydus + GPU Operator + VFIO
+    -> private TLS registry + Cosign key + Trustee KBS
+    -> copy and sign an immutable image digest
+    -> launch a Kata confidential VM
+         -> enforce measured image policy
+         -> create encrypted confidential emptyDir
+         -> collect and verify CPU evidence
+         -> collect and verify NVIDIA GPU evidence
+    -> write reports and delete the successful test pod
+```
+
+Pinned defaults are defined in `config.env.example`. At the time this suite was
+validated, they included Kubernetes 1.34.9, containerd 2.2.2, Calico 3.32.1,
+Kata Containers 3.29.0, NVIDIA GPU Operator 26.3.1, Cosign 2.6.2, NVIDIA NVAT
+1.2.2, and a pinned Trustee KBS image.
+
+Important host-side endpoints and paths are:
+
+| Item | Default |
+|---|---|
+| Kubernetes API | `${NODE_IP}:6443` |
+| Private registry | `${NODE_IP}:5000`, implemented as a pod `hostPort` |
+| Trustee KBS | ClusterIP port 8080; lab configuration uses HTTP |
+| Intel PCCS | Local HTTPS endpoint `127.0.0.1:8081` |
+| Kubernetes admin configuration | `/etc/kubernetes/admin.conf` |
+| Registry data | `/var/lib/coco-registry` |
+| Suite-generated state | `state/` below the script directory |
+| containerd binary | `/usr/local/bin/containerd` |
+| containerd configuration | `/etc/containerd/config.toml` |
+| Kata installation | `/opt/kata` |
+
+## 4. Host prerequisites and change window
+
+Before running any installation stage, confirm the following outside the
+scripts:
+
+1. The host is x86-64 Ubuntu and has a writable, healthy root filesystem.
+2. Firmware enables the platform TEE:
+   - AMD: SVM, SEV, SEV-ES/SEV-SNP, and the IOMMU.
+   - Intel: TME, TME-MT, TDX, and VT-d/IOMMU.
+3. The kernel exposes the matching KVM capability and `/dev/sev` or `/dev/kvm`.
+4. At least one supported NVIDIA confidential-computing GPU is present. The
+   host NVIDIA or Nouveau driver must not own it.
+5. The GPU and any functions that must be assigned with it are in suitable
+   IOMMU groups.
+6. The host has at least 64 GiB RAM and 50 GiB free disk as a practical minimum.
+7. Required HTTPS egress is permitted to Kubernetes, GitHub, GHCR, NVIDIA NGC,
+   NVCR, Quay, Docker Hub, Sigstore when Rekor is enabled, AMD KDS for SNP, and
+   Intel/Launchpad/keyserver endpoints for TDX.
+8. The selected `NODE_IP` is stable and reachable from the host and Kata guest.
+   It becomes the Kubernetes advertise address and a registry certificate SAN.
+9. The operator is root or has passwordless, non-interactive `sudo`. Stages
+   fail rather than pause for a sudo password.
+Plan for a reboot or power cycle if the NVIDIA CC mode transition requires it.
+Do not run this workflow on a host whose existing Kubernetes, containerd, CNI,
+Kata, VFIO, or registry state must be preserved without first reviewing every
+path modified by stages 10 through 50.
+
+## 5. Configuration and precedence
+
+Create the working configuration before the first run:
+
+```bash
+cp config.env.example config.env
+chmod 0600 config.env
+editor config.env
+```
+
+If `config.env` does not exist, `load_config` creates it automatically from the
+example. Explicit review is preferable. Use `COCO_CONFIG=/absolute/path/file`
+to select a different configuration file. `COCO_STATE_DIR` relocates generated
+state for installation stages.
+
+The common loader preserves environment overrides for `NODE_IP`, platform and
+runtime selection, checksum/downgrade/tlog controls, attestation references,
+Intel PCS key inputs, confidential-volume size, and pod retention. Other values
+should be changed in `config.env` or through the documented positional arguments
+to stage 40.
+
+### 5.1 Platform and network settings
+
+| Variable | Meaning and operational impact |
+|---|---|
+| `TEE_PLATFORM` | `auto`, `snp`, or `tdx`. `auto` checks CPU vendor and the `sev_snp` or `tdx_host_platform` CPU flag. Do not force a platform that the host does not provide. |
+| `RUNTIME_CLASS` | `auto` selects the platform-specific NVIDIA Kata RuntimeClass. Override only for a reviewed Kata deployment. |
+| `NODE_IP` | Kubernetes advertise address and default registry address. Empty means derive the source address for the default IPv4 route, then fall back to the first `hostname -I` address. |
+| `POD_CIDR`, `SERVICE_CIDR`, `CLUSTER_DNS` | kubeadm and Calico network ranges. Check them against site routing, VPN, and management networks. |
+| `KUBECONFIG_PATH` | Administrative kubeconfig used by all cluster operations. Presence of a nonempty file makes stage 10 skip `kubeadm init`. |
+
+### 5.2 Version and supply-chain settings
+
+`KUBERNETES_*`, `CONTAINERD_VERSION`, `CNI_PLUGINS_VERSION`, `HELM_VERSION`,
+`CALICO_VERSION`, `KATA_VERSION`, `GPU_OPERATOR_VERSION`, `COSIGN_VERSION`,
+`REGISTRY_IMAGE`, and `TRUSTEE_IMAGE` pin the deployed components. Stage 10
+checks `CALICO_SHA256` before applying the cluster-admin manifest. Stage 30
+requires immutable SHA-256 image references. The values are documented in
+`CHECKSUMS.md`.
+
+The three Kubernetes values serve different consumers:
+
+- `KUBERNETES_MINOR` selects the Kubernetes APT repository, for example
+  `v1.34`.
+- `KUBERNETES_VERSION` is the exact Debian package version for kubelet,
+  kubeadm, and kubectl, for example `1.34.9-1.1`.
+- `KUBERNETES_SEMVER` is the upstream semantic version written into the kubeadm
+  configuration, for example `v1.34.9`.
+
+`CONTAINERD_SHA256`, `HELM_SHA256`, and `COSIGN_SHA256` authenticate the exact
+download objects named in their comments. Do not substitute the hash of an
+extracted executable for the hash of a compressed release archive.
+
+`IGNORE_CHECKSUM_MISMATCH=1` permits a known checksum mismatch and is an unsafe
+recovery control. It weakens supply-chain verification and must not be a normal
+installation setting. `ALLOW_PACKAGE_DOWNGRADES=1` allows the pinned Kubernetes
+packages to replace newer installed versions. Review the downgrade before using
+it.
+
+### 5.3 Registry, signing, and workload settings
+
+| Variable | Meaning |
+|---|---|
+| `REGISTRY_PORT`, `REGISTRY_BIND_ADDRESS`, `REGISTRY_NAMESPACE`, `REGISTRY_DATA_DIR` | Host port, one specific host IPv4 address (defaults to `NODE_IP`), namespace, and host-backed data directory for the private TLS registry. |
+| `REGISTRY_IMAGE`, `TRUSTEE_IMAGE` | Immutable digest-pinned infrastructure images; tag-only overrides are rejected. |
+| `SECURITY_NAMESPACE`, `KBS_SERVICE` | Namespace and Service/Deployment name for Trustee KBS. |
+| `SOURCE_IMAGE` | Image copied into the local registry by stage 40. |
+| `TARGET_IMAGE_NAME` | Repository path below `${REGISTRY_HOST}`. |
+| `COSIGN_TLOG_MODE` | `disabled` verifies only the configured public key; `rekor` uploads and requires public transparency-log evidence. Rekor reveals signature metadata and requires Sigstore connectivity. |
+| `ROTATE_SECURITY_MATERIAL` | `1` backs up and replaces the Cosign pair and registry CA/certificates during stage 30. Return it to `0` after intentional rotation. |
+| `GPU_RESOURCE`, `GPU_COUNT`, `POD_MEMORY` | Resource request used by the attestation pod. The default GPU resource is `nvidia.com/pgpu`. |
+| `CONFIDENTIAL_VOLUME_SIZE` | Positive binary Kubernetes quantity for the encrypted confidential `emptyDir`. Allow headroom for ext4 and integrity metadata. |
+| `KEEP_ATTESTATION_POD` | `0` deletes a successful validation pod; `1` leaves it running for inspection and keeps its passthrough GPU allocated. |
+
+### 5.4 CPU attestation reference values
+
+`EXPECTED_SNP_LAUNCH_MEASUREMENT` must be 96 lowercase hexadecimal characters
+representing the approved 48-byte SNP launch measurement.
+`AMD_KDS_PRODUCT` selects the AMD Key Distribution Service product path used to
+retrieve the matching VCEK and certificate chain; the default is `Genoa` and
+must match the processor generation represented by the report.
+
+TDX requires all five 48-byte references:
+
+- `EXPECTED_TDX_MRTD`
+- `EXPECTED_TDX_RTMR0`
+- `EXPECTED_TDX_RTMR1`
+- `EXPECTED_TDX_RTMR2`
+- `EXPECTED_TDX_RTMR3`
+
+Obtain these values from an independently trusted build manifest, release
+process, or Trustee/RVPS appraisal policy. A measurement observed from the same
+untrusted host during the current run is diagnostic information, not an
+approved reference.
+
+Complete VM-image verification requires comparing the launch measurements with
+trusted references, normally through Trustee/RVPS policy, or enforcing an SNP
+launch with a signed ID block. The local verifier in this suite performs direct
+comparison with protected configuration values; production policy should live
+outside the workload host's failure domain.
+
+### 5.5 Intel TDX quote-service settings
+
+`TDX_ATTESTATION_PPA_SUITE` chooses the Canonical TDX attestation PPA suite.
+Empty means the host codename. An older-suite override is an explicit
+compatibility decision and should be tested as part of OS qualification.
+
+Intel production PCS can operate without a subscription key in the validated
+topology. If the PCS environment requires a key, prefer
+`INTEL_PCS_API_KEY_FILE` pointing to a root-readable file containing one
+32-character alphanumeric key. `INTEL_PCS_API_KEY` is accepted as a one-run
+environment value. Set only one. Never commit the key, include it in an image,
+or print it in logs.
+
+## 6. Recommended execution procedure
+
+Run the stages individually during initial qualification so that change records
+and failure boundaries are clear:
+
+```bash
+./00-verify-host.sh
+./10-install-kubernetes.sh
+./20-install-coco-gpu.sh
+./30-deploy-security-services.sh
+```
+
+At this point choose one Stage 40/50 direction. For the generic attestation
+validation described by this guide, continue with:
+
+```bash
+./40-sign-image.sh
+./50-launch-and-attest.sh
+```
+
+For an NVFlare server and GPU client, use
+[`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md) instead. Do not run both Stage 40/50
+variants or select them with a wildcard.
+
+After the host has been qualified and the configuration placed under change
+control, `./run-all.sh` runs stages 00 through 50 in that order. All scripts use
+`set -Eeuo pipefail` and stop on the first unhandled error.
+
+## 7. Script reference
+
+### 7.1 `run-all.sh`
+
+This is the sequential orchestrator. It resolves its own directory, prints a
+banner for each stage, and invokes stages 00, 10, 20, 30, 40, and 50. It does
+not run the alternative NVFlare Stage 40/50/60 path.
+
+There is no rollback transaction. If a stage fails, correct the cause and rerun
+that stage, then continue. Earlier stages are designed to be mostly restartable,
+but they still rewrite suite-owned configuration and may restart services.
+
+Success is the message `End-to-end CoCo deployment and attestation completed`
+and a path to `state/latest-attestation-reports`.
+
+### 7.2 `00-verify-host.sh`
+
+Purpose: perform a mostly read-only host readiness assessment before package,
+cluster, or GPU changes.
+
+Detailed behavior:
+
+1. Loads configuration, detects SNP or TDX, derives `NODE_IP`, and selects the
+   platform RuntimeClass.
+2. Creates and deletes a temporary file under `/etc` through `sudo` to prove the
+   root filesystem accepts writes.
+3. If root is ext4 and the kernel exports `errors_count`, fails when recorded
+   filesystem errors are nonzero.
+4. Checks x86-64 and reports the Ubuntu version.
+5. For SNP, checks AMD vendor, `sev_snp`, KVM AMD SEV enablement, and `/dev/sev`.
+6. For TDX, checks Intel vendor, `tdx_host_platform`, KVM Intel TDX enablement,
+   and `/dev/kvm`.
+7. Requires populated IOMMU groups.
+8. Finds the first NVIDIA VGA/3D controller, recognizes H100/H200 and selected
+   Blackwell families, checks driver ownership and IOMMU isolation, and rejects
+   loaded host NVIDIA/Nouveau modules or installed `nvidia-driver-*` packages.
+9. Reports swap, memory, free disk, and all required network endpoints.
+
+An unbound GPU is valid before stage 20. A GPU already bound to `vfio-pci` is
+also valid. `FAIL` increments the failure count and makes the script exit
+nonzero; `WARN` is advisory. The expected gate is:
+
+```text
+Summary: 0 failure(s), 0 warning(s)
+```
+
+The script may create `config.env` and `state/` through the shared loader and
+performs the transient `/etc` write probe; it does not install software.
+
+### 7.3 `10-install-kubernetes.sh`
+
+Purpose: establish the single-node Kubernetes and container-runtime baseline.
+
+Host and package actions:
+
+1. Rejects an implicit downgrade when installed kubelet, kubeadm, or kubectl is
+   newer than the pinned version.
+2. Installs administrative dependencies. TDX also installs Go when absent;
+   native `/usr/bin/runc` is installed when absent.
+3. Loads `overlay` and `br_netfilter`, writes `/etc/modules-load.d/k8s.conf`,
+   writes Kubernetes forwarding/bridge sysctls, disables swap, and comments
+   active swap entries in `/etc/fstab` with a suite marker.
+4. Downloads the pinned containerd release archive into `state/downloads`,
+   verifies its SHA-256, and extracts it below `/usr/local`.
+5. Downloads CNI plugins and their publisher checksum, verifies them, and
+   extracts them into `/opt/cni/bin`.
+
+containerd configuration:
+
+- Writes version-3 configuration to `/etc/containerd/config.toml`.
+- Uses `/var/lib/containerd` and `/run/containerd`.
+- Imports suite fragments from `/etc/containerd/conf.d/*.toml` and Kata
+  fragments from `/opt/kata/containerd/config.d/*.toml`.
+- Enables CDI and configures the registry-certificate directory.
+- Configures systemd cgroups and explicitly pins the OCI runtime to the trusted
+  `/usr/bin/runc`, avoiding an unmanaged binary earlier in `PATH`.
+- Installs `/etc/systemd/system/containerd.service` with
+  `/usr/local/bin/containerd`, enables it, restarts it, and requires it active.
+
+Kubernetes actions:
+
+1. Installs the Kubernetes APT key and repository.
+2. Installs exact kubelet, kubeadm, and kubectl versions, holds them, and
+   explicitly enables kubelet so the cluster survives reboot.
+3. Downloads and checksum-verifies Helm into `/usr/local/bin/helm`.
+4. If `KUBECONFIG_PATH` is missing or empty, renders `templates/kubeadm.yaml.in`
+   and runs `kubeadm init`. The template uses systemd cgroups, the selected node
+   address and CIDRs, a 20-minute runtime request timeout, and the
+   `KubeletPodResourcesGet` and `RuntimeClassInImageCriApi` feature gates.
+5. Downloads and applies the pinned Calico manifest, removes the control-plane
+   scheduling taint for the single node, and waits for Ready.
+6. Copies the admin kubeconfig to the invoking non-root user's `~/.kube/config`.
+On rerun, containerd configuration is rewritten and containerd is restarted.
+An existing nonempty kubeconfig suppresses `kubeadm init`; it is therefore the
+operator's responsibility to ensure that file describes the intended cluster.
+The success marker is `Kubernetes is ready`.
+
+### 7.4 `20-install-coco-gpu.sh`
+
+Purpose: add platform attestation support, Kata/Nydus, NVIDIA GPU Operator, and
+the platform-specific confidential GPU RuntimeClass.
+
+The script requires a working Kubernetes API, Helm, containerd/ctr, and PCI
+inventory. It selects the first Kubernetes node and applies the platform TEE
+label plus `nvidia.com/gpu.workload.config=vm-passthrough`.
+
+#### Intel TDX PCCS/QGS path
+
+On TDX only, the script:
+
+1. Resolves the host or explicitly configured PPA suite and verifies that the
+   PPA publishes it.
+2. Downloads the Canonical PPA signing key and requires fingerprint
+   `0C0E6AF955CE463C03FC51574D098D70AFBE5E1F` before installing it.
+3. Installs PCCS, QGS, DCAP QPL, RA service, and PCK-ID tools.
+4. Validates the optional PCS key. A configured key is installed as
+   `root:pccs` mode `0640` and is checked for readability by the `pccs` account.
+5. In keyless mode, applies a guarded PCCS 1.21 JavaScript compatibility change
+   that removes an empty subscription header. The edit requires an exact source
+   anchor and must pass `node --check`.
+6. Enables and restarts `pccs` and `qgsd`, waits for PCCS HTTPS on loopback, and
+   requires QGS active.
+
+#### Kata, Nydus, and encrypted storage capability
+
+The script installs the pinned Kata OCI Helm chart, then waits for the Kata shim
+and the platform runtime fragment on the host. It repairs the suite-owned
+containerd import if an older stage-10 run omitted it, restarts containerd, and
+restarts kubelet to clear Kubernetes 1.34's cached CRI cgroup-driver response.
+It then requires:
+
+- the platform RuntimeClass in the effective containerd configuration;
+- the `nydus-for-kata-tee` snapshotter plugin in `ok` state; and
+- `emptydir_mode = "block-encrypted"` in the resolved Kata runtime
+  configuration.
+
+That setting enables the released confidential `emptyDir` implementation used
+in stage 50. It does not create a persistent encrypted volume.
+
+#### NVIDIA GPU Operator path
+
+The GPU Operator Helm release enables sandbox workloads in Kata mode, Node
+Feature Discovery, CC Manager with default mode `on`, VFIO Manager, and the Kata
+sandbox device plugin. Kata Manager is disabled because the upstream Kata chart
+already installed Kata.
+
+The script waits up to 30 minutes for the CC-ready node label and allocatable
+`nvidia.com/pgpu` resource. It enumerates every NVIDIA VGA/3D PCI device and
+fails unless every one is bound to `vfio-pci`.
+
+Some GPU CC-mode changes require a reboot. If the operator reports that state,
+reboot, rerun stage 20, and wait for `Kata CoCo runtime and GPU passthrough are
+ready` before proceeding.
+
+### 7.5 `30-deploy-security-services.sh`
+
+Purpose: establish the local registry, signing material, image-verification
+policy, and Trustee resource service used by the validation workflow.
+
+Cosign and key handling:
+
+- Installs the pinned Cosign binary after SHA-256 verification.
+- Stores sensitive material under `state/security` and `state/registry-tls`,
+  both mode `0700`.
+- Generates `cosign.key` mode `0600` and `cosign.pub` mode `0644` when absent.
+- Uses `COSIGN_PASSWORD` if a password-protected signing key is desired.
+- With `ROTATE_SECURITY_MATERIAL=1`, moves existing keys and certificates to
+  UTC-stamped backups before generating replacements.
+
+Registry PKI behavior:
+
+- Creates a 4096-bit RSA private CA valid for 3650 days when the CA is missing,
+  expiring, mismatched, or invalid.
+- Issues a 3072-bit RSA leaf certificate valid for 825 days with an IP or DNS
+  SAN matching `REGISTRY_HOST`.
+- On rerun, verifies expiry, key match, CA signature, and SAN. A bad leaf is
+  replaced without rotating a healthy CA; replaced files are timestamped.
+
+Kubernetes and host behavior:
+
+1. Creates the registry namespace and TLS Secret.
+2. Renders `templates/registry.yaml.in`. The digest-pinned registry uses a
+   hostPath data directory, binds `hostPort` only on
+   `REGISTRY_BIND_ADDRESS`, and uses a Recreate strategy. It deliberately has
+   no client authentication and permits push/delete; restrict that address and
+   port to trusted administrators with host/network firewall policy.
+3. Installs the registry CA and `hosts.toml` below
+   `/etc/containerd/certs.d/${REGISTRY_HOST}` and restarts containerd.
+4. Builds a containers/image policy whose default action is reject and whose
+   only allow rule is `sigstoreSigned` for `TARGET_REPOSITORY` with repository
+   identity matching.
+5. Stores the policy, Cosign public key, and registry CA in a Kubernetes Secret.
+6. Deploys digest-pinned Trustee KBS with built-in attestation/RVPS support and
+   read-only verification resources. The resource policy is mounted directly
+   from its ConfigMap; no mutable-tag init image can rewrite KBS state.
+7. Optionally stages NVFlare hardware-authorizer credentials in
+   `NVFLARE_NAMESPACE`. Before writing either credential Secret, it creates the
+   dedicated namespace with `nvflare.nvidia.com/coco-managed=true` or requires
+   that exact label on an existing namespace. It refuses to adopt an unlabeled,
+   potentially shared namespace. On TDX,
+   `NVFLARE_TDX_ATTESTATION_CONFIG_FILE` must name a readable JSON object with
+   nonempty `trustauthority_url`, HTTPS `trustauthority_api_url`, and nonempty
+   `trustauthority_api_key` fields; the script creates the
+   `nvflare-tdx-attestation` Secret without printing the file. An optional
+   `NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE` must contain one nonempty line of
+   at most 4096 characters and becomes the `nvflare-gpu-attestation` Secret.
+
+The TDX Trust Authority attestation API key above is not an Intel PCS
+subscription key. If the TDX configuration is omitted, this generic workflow
+remains usable, but the alternative NVFlare Stage 50 fails closed. Rerun Stage
+30 after setting the file to stage the Secret. NVFlare Stage 50 defaults to
+local NVAT verification and needs no NVIDIA service key. Remote NRAS mode is an
+explicit opt-in and may require the staged NVIDIA service key.
+
+The sample KBS uses HTTP, an insecure token key, ephemeral `emptyDir` state,
+and a deny-all admin interface. This is suitable only for the local validation
+topology. Stage 50 embeds the public policy, public key, and registry CA directly
+in measured init-data for early guest image-pull enforcement; the KBS endpoint
+is available for later resource workflows but is not required for that public
+material.
+
+The success marker is `Registry and Trustee KBS are ready`.
+
+#### Choose the Stage 40/50 direction
+
+Stop after this success marker and choose one of these mutually exclusive
+continuations:
+
+1. **Generic attestation validation:** continue in this document with
+   `40-sign-image.sh` and `50-launch-and-attest.sh`. This path signs one
+   configured workload image, launches a GPU-enabled confidential VM, and
+   produces CPU, GPU, image-integrity, and encrypted-storage attestation
+   reports.
+2. **NVFlare deployment:** switch to
+   [`NVFlare_on_CoCo.md`](NVFlare_on_CoCo.md). That guide builds and signs
+   separate NVFlare server and client images, then deploys a CPU-only server
+   and a one-GPU client as confidential VMs. It assumes shared stages 00–30 are
+   already complete and covers only its alternative Stages 40 through 60,
+   including an end-to-end `hello-numpy` job check.
+   Stages 30 and 50 create the dedicated `NVFLARE_NAMESPACE` with
+   `nvflare.nvidia.com/coco-managed=true` and refuse an existing namespace that
+   lacks that ownership label. This fail-closed check occurs before credential
+   Secrets are written or Pod Security Admission is changed. Never add the
+   ownership label to a shared namespace. Stage 50 then labels the owned
+   namespace with
+   `pod-security.kubernetes.io/enforce=privileged` before deployment because
+   both Kata Pods require `privileged: true` to create the guest-local TEE
+   device. Restrict Pod-creation RBAC in that namespace; the admission label
+   applies to every Pod there, not only to Kata-isolated workloads.
+
+   Stage 50 runs the following operation automatically (with the configured
+   kubeconfig and namespace):
+
+   ```bash
+   kubectl label namespace "$NVFLARE_NAMESPACE" \
+     pod-security.kubernetes.io/enforce=privileged --overwrite
+   ```
+
+Do not run both continuations or use a wildcard such as `40-*.sh` or
+`50-*.sh`; the scripts at each number are alternative workload paths.
+
+### 7.6 `40-sign-image.sh`
+
+Purpose: copy a source image into the local TLS registry, sign its immutable
+digest, verify the signature, and publish state for stage 50.
+
+Invocation forms are:
+
+```bash
+./40-sign-image.sh
+./40-sign-image.sh SOURCE_IMAGE TARGET_TAG
+```
+
+The default source is `SOURCE_IMAGE` and the default target tag is `signed`.
+The script:
+
+1. Requires the stage-30 Cosign private key and registry CA.
+2. Copies the CA to a containers-certs directory used by Skopeo.
+3. Uses Skopeo to copy the image to `${TARGET_REPOSITORY}:${TARGET_TAG}`.
+4. Resolves the registry digest and signs `${TARGET_REPOSITORY}@sha256:...`, not
+   the mutable tag.
+5. Uploads and verifies Rekor evidence when `COSIGN_TLOG_MODE=rekor`; otherwise
+   signs without tlog upload and verifies with the configured public key while
+   printing an explicit transparency notice.
+6. Writes `state/cosign-verification.json`,
+   `state/image-signing-report.txt`, and shell-quoted
+   `state/signed-image.env` for stage 50.
+
+Rerunning with the same tag can replace the tag target and add another
+signature, but stage 50 consumes the last verified digest saved in
+`signed-image.env`. Protect `cosign.key`; do not print, commit, or embed it in a
+container image. The success marker begins `Signed image ready:`.
+
+### 7.7 `50-launch-and-attest.sh`
+
+Purpose: launch the signed workload in the selected Kata confidential VM and
+produce fail-closed CPU, GPU, image, and encrypted-storage verification reports.
+
+Before launching, the wrapper requires:
+
+- `state/signed-image.env` from stage 40;
+- correctly formatted platform reference values;
+- a valid confidential-volume size;
+- the platform RuntimeClass in effective containerd configuration; and
+- the Nydus proxy snapshotter in `ok` state.
+
+The optional first argument is the report directory. Otherwise a UTC-stamped
+directory is created below `state/`. The wrapper passes configuration to
+`lib/deploy-coco-attest.sh`, restores report ownership to the invoking user, and
+updates `state/latest-attestation-reports`.
+
+#### Internal pod and image-policy flow
+
+The driver first verifies the digest-pinned image from the host. It creates
+`initdata.toml` containing:
+
+- an offline filesystem KBC configuration;
+- the deny-by-default `sigstoreSigned` image policy and Cosign public key;
+- the private registry CA and registry configuration; and
+- a Kata agent policy allowing the operations required by this validation pod.
+
+The measured demo agent policy permits host-admin copy, exec, and stream access
+because the validation scripts use `kubectl exec` and read command output. It
+denies `SetPolicyRequest`, so the host cannot replace that measured policy at
+runtime. This is an operational demo boundary, not workload isolation from a
+cluster administrator; production policy should remove exec/copy/stream rules
+that the workload does not need.
+
+The file is gzip/base64 encoded in the
+`io.katacontainers.config.hypervisor.cc_init_data` annotation. Its uncompressed
+SHA-256 is later compared with SNP `HOST_DATA` or the first 32 bytes of TDX
+`MRCONFIGID`. The pod uses the selected RuntimeClass, requests the configured
+GPU and memory, and is privileged inside its isolated Kata VM so it can use the
+guest attestation interfaces. Privilege inside the VM is not equivalent to a
+host-privileged runc container.
+
+The pod reaches Ready only after guest `image-rs` accepts the signed image under
+the measured deny-by-default policy.
+
+#### Confidential scratch-volume verification
+
+The pod receives a confidential `emptyDir`. Kata creates a host-backed sparse
+device; inside the guest it generates an ephemeral key and applies LUKS2,
+dm-crypt, dm-integrity, and ext4. The driver requires:
+
+- a writable ext4 mount backed by `/dev/mapper/*`;
+- a `CRYPT-LUKS2-*` device-mapper UUID;
+- an underlying `INTEGRITY-*` mapping; and
+- a successful random write, sync, and readback probe.
+
+This volume is ephemeral and is removed with the pod. It is not an encrypted
+persistent volume. Its key and detached header remain in TEE-protected guest
+memory. dm-integrity detects block modification but does not prevent replay of
+an older complete volume state.
+
+#### AMD SEV-SNP CPU verification
+
+The driver compiles a small collector on the host and copies it into the guest.
+It requests the fixed 1,184-byte SNP report with a fresh 64-byte challenge. On
+the host it:
+
+1. checks `REPORT_DATA` against the challenge;
+2. checks `HOST_DATA` against measured init-data SHA-256;
+3. parses the signed launch measurement and TCB/chip values;
+4. retrieves the matching AMD VCEK and certificate chain from AMD KDS;
+5. verifies the VCEK chain and ECDSA P-384/SHA-384 report signature; and
+6. compares the signed launch measurement with
+   `EXPECTED_SNP_LAUNCH_MEASUREMENT`.
+
+An authentic signature without a matching approved measurement fails.
+
+#### Intel TDX CPU verification
+
+The driver checksum-verifies source for a pinned `google/go-tdx-guest` commit,
+builds its collector and verifier, and copies only the collector into the
+guest. It obtains a fresh TD Quote through configfs/TSM and QGS, then runs the
+host verifier with Intel collateral and CRL checking enabled. It requires:
+
+1. quote signature and embedded certificate-chain verification;
+2. acceptable Intel PCS collateral and TCB status;
+3. the fresh 64-byte challenge in `REPORTDATA`;
+4. measured init-data SHA-256 plus zero padding in `MRCONFIGID`;
+5. exact MRTD and RTMR0-3 reference matches; and
+6. the TD debug attribute disabled.
+
+The raw parser supports TDX quote versions 4 and 5 and independently extracts
+the claims used in the human-readable report.
+
+#### NVIDIA GPU verification
+
+The driver checksum-verifies the pinned NVIDIA NVAT repository package, copies
+it into the guest, installs `nvattest`, and generates a fresh 32-byte GPU nonce.
+It collects evidence and performs local NVAT appraisal. A pass requires, among
+other claims:
+
+- result code zero and message `Ok`;
+- nonce match;
+- successful measurement appraisal;
+- secure boot enabled and debug disabled;
+- report signature verified;
+- valid attestation certificate and good OCSP status;
+- driver and VBIOS RIM signature/version matches; and
+- no mismatched measurement records.
+
+#### Reports, cleanup, and failure behavior
+
+The driver writes CPU, GPU, image, and storage reports plus raw evidence and a
+`SHA256SUMS` manifest. With the default `KEEP_ATTESTATION_POD=0`, the wrapper
+requests `--cleanup`, but the trap deletes the pod only after all verification
+has succeeded. A failed pod is intentionally left for `kubectl describe`, logs,
+and guest inspection. Delete it manually after collecting diagnostics so the
+passthrough GPU can be allocated again.
+
+Success requires all human-readable reports to contain an overall `PASS`.
+
+### 7.8 `lib/deploy-coco-attest.sh`
+
+This is the implementation driver used by stage 50. Cluster administrators may
+invoke it directly for a different namespace, pod name, output directory, or
+kubeconfig:
+
+```bash
+lib/deploy-coco-attest.sh \
+  --namespace default \
+  --pod-name coco-attestation-manual \
+  --output-dir ./manual-reports \
+  --kubeconfig /etc/kubernetes/admin.conf \
+  --cleanup
+```
+
+Direct invocation requires all environment inputs that stage 50 normally
+provides: digest-pinned image, policy repository, registry host and CA, Cosign
+public key, RuntimeClass, platform, approved measurement references, resources,
+and artifact cache. Prefer the wrapper unless debugging or integrating with an
+external automation system.
+
+### 7.9 `lib/common.sh`
+
+This shared library is sourced by stages 00 through 50. It:
+
+- resolves suite, configuration, and state paths;
+- detects SNP versus TDX and selects labels/RuntimeClass;
+- validates boolean and enum controls;
+- derives node, registry, and repository addresses;
+- implements root, kubectl, and Helm wrappers;
+- downloads artifacts atomically through process-specific `.partial` files;
+- verifies pinned SHA-256 values and rejects mismatches by default; and
+- supplies bounded polling and passwordless-sudo checks.
+
+It is not intended as a standalone command.
+
+## 8. Generated state and evidence
+
+Treat `state/` as sensitive administrative state:
+
+| Path | Contents |
+|---|---|
+| `state/downloads/` | Persistent artifact cache and pinned TDX verifier source. |
+| `state/security/cosign.key` | Image-signing private key; mode `0600`. |
+| `state/security/cosign.pub` | Public verification key. |
+| `state/registry-tls/` | Private CA and registry leaf key/certificate. |
+| `state/signed-image.env` | Last verified immutable workload image reference. |
+| `state/cosign-verification.json` | Host-side Cosign verification output. |
+| `state/latest-attestation-reports` | Symlink to the latest report directory. |
+
+The report directory includes:
+
+- `cpu-attestation-report.bin` and `.txt`;
+- `gpu-attestation-evidence.json`;
+- `gpu-attestation-result.json`;
+- `gpu-attestation-report.txt`;
+- `gpu-confidential-compute-status.txt`;
+- `image-verification-report.txt`;
+- `storage-verification-report.txt`;
+- `initdata.toml` and the applied pod manifest; and
+- `SHA256SUMS` covering the material verification reports.
+
+The checksums detect later report-file changes; they do not timestamp or
+externally notarize evidence. Copy required reports to controlled storage and
+apply the site's retention and signing policy.
+
+## 9. Operational verification commands
+
+After stage 10:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o wide
+systemctl is-enabled containerd kubelet
+systemctl is-active containerd kubelet
+sudo containerd config dump | sed -n '/runtimes.runc.options/,/^[[:space:]]*\[/p'
+```
+
+After stage 20:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get runtimeclass
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get node -o json
+sudo ctr plugins ls | grep nydus-for-kata-tee
+lspci -Dnnk -d 10de:
+```
+
+On TDX:
+
+```bash
+systemctl is-active pccs qgsd
+curl --insecure --fail https://127.0.0.1:8081/ >/dev/null
+```
+
+After stages 30 and 40:
+
+```bash
+sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get deployments -A
+curl --fail --cacert state/registry-tls/ca.crt "https://${NODE_IP}:5000/v2/"
+sed -n '1,120p' state/image-signing-report.txt
+```
+
+After stage 50:
+
+```bash
+cd state/latest-attestation-reports
+sha256sum -c SHA256SUMS
+grep -H 'Overall .* result: PASS' *-report.txt
+```
+
+## 10. Failure handling and reruns
+
+- Preflight failure: correct firmware, kernel, storage, driver, IOMMU, DNS,
+  proxy, or firewall state before installation.
+- Kubernetes failure: inspect `systemctl status containerd kubelet`, their
+  journals, `kubeadm` output, CNI state, and CIDR conflicts. Rerun stage 10 after
+  correction; it does not reset an existing cluster.
+- Kata/GPU failure: inspect Helm releases and pods in `kata-system` and
+  `gpu-operator`, node labels/capacity, containerd's effective config, Nydus
+  plugin state, and PCI driver ownership. Reboot if CC Manager requests it,
+  then rerun stage 20.
+- Registry/Trustee failure: validate the configured node address, registry SAN,
+  host port availability, registry hostPath permissions, Kubernetes Secrets,
+  and deployment logs. Rerun stage 30; healthy keys and CA are reused.
+- Signing failure: validate registry TLS, source registry access, key password,
+  image reference, and Rekor connectivity/policy. Rerun stage 40.
+- Attestation failure: keep the failed pod, inspect `kubectl describe`, validate
+  QGS/PCCS or AMD KDS access, check the approved references, and review raw
+  reports. Never solve a reference mismatch by copying the observed value into
+  trusted configuration without an independent approval process.
+
+The workflow has no rollback transaction. Use a separately reviewed recovery
+procedure, or reimage the dedicated host when an exact trusted baseline is
+required.
+
+## 11. Production hardening gaps
+
+Before adapting the example for production, at minimum address:
+
+- external, authenticated TLS for Trustee KBS and the registry;
+- protected Cosign identity or KMS/HSM-backed signing;
+- formal transparency and audit policy;
+- external Trustee/RVPS reference values and restrictive appraisal policy;
+- persistent, backed-up KBS state and controlled secret release;
+- least-privilege Kubernetes RBAC and namespace/network policies;
+- image and chart mirroring with organization-controlled provenance;
+- patch and upgrade ownership for all pinned components;
+- evidence export, timestamping, retention, and incident response; and
+- a validated host reimage/recovery procedure.

--- a/examples/devops/CoCo/config.env.example
+++ b/examples/devops/CoCo/config.env.example
@@ -1,0 +1,175 @@
+# Copy to config.env and edit only values that differ on the target host.
+# Versions below reproduce installations on AMD SEV-SNP and Intel TDX hosts
+# with NVIDIA confidential-computing GPUs.
+
+KUBERNETES_MINOR=v1.34
+KUBERNETES_VERSION=1.34.9-1.1
+KUBERNETES_SEMVER=v1.34.9
+CONTAINERD_VERSION=2.2.2
+# SHA-256 of containerd-2.2.2-linux-amd64.tar.gz (not the extracted binary).
+CONTAINERD_SHA256=2c08c99cbde73b3388c6d5da68e0bcaebc70c9174f2b14d785695e4401b3ede0
+CNI_PLUGINS_VERSION=v1.8.0
+HELM_VERSION=v3.21.3
+# SHA-256 of helm-v3.21.3-linux-amd64.tar.gz (not linux-amd64/helm).
+HELM_SHA256=15e041a93a590dce8100f39385cd98c84a765c9e36aeeb9e2dc6ff9e4769e2e0
+CALICO_VERSION=v3.32.1
+# SHA-256 of the exact upstream calico.yaml for CALICO_VERSION.
+CALICO_SHA256=a1df919d9721cf667accdc3e72848911b0cb25cfab7d2478ad0c996302c95744
+KATA_VERSION=3.29.0
+GPU_OPERATOR_VERSION=v26.3.1
+COSIGN_VERSION=v2.6.2
+# SHA-256 of the downloaded cosign-linux-amd64 binary.
+COSIGN_SHA256=d437b8f0d30f5dec169337607fcfa0238de1348503e175f1bb5b94330b1ee409
+# disabled: private/offline key verification; rekor: require public tlog upload/verification.
+COSIGN_TLOG_MODE=disabled
+TRUSTEE_IMAGE=ghcr.io/confidential-containers/staged-images/kbs@sha256:c128232d271c3bc6cdfbd57b1e585b4aaa0c8de6dd987dbf2731786f60405e25
+
+# Empty NODE_IP means: derive the IPv4 address used by the default route.
+NODE_IP=
+POD_CIDR=192.168.0.0/16
+SERVICE_CIDR=10.96.0.0/12
+CLUSTER_DNS=10.96.0.10
+KUBECONFIG_PATH=/etc/kubernetes/admin.conf
+
+REGISTRY_PORT=5000
+# Empty binds hostPort only to NODE_IP. The registry intentionally has no
+# client authentication; firewall NODE_IP:REGISTRY_PORT to trusted admins.
+REGISTRY_BIND_ADDRESS=
+REGISTRY_IMAGE=docker.io/library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+REGISTRY_NAMESPACE=coco-system
+REGISTRY_DATA_DIR=/var/lib/coco-registry
+SECURITY_NAMESPACE=coco-tenant
+KBS_SERVICE=trustee-kbs
+
+SOURCE_IMAGE=nvcr.io/nvidia/cuda:12.9.1-base-ubuntu24.04
+TARGET_IMAGE_NAME=coco/cuda-attest
+# auto selects AMD SEV-SNP or Intel TDX from host CPU/KVM capabilities.
+TEE_PLATFORM=auto
+RUNTIME_CLASS=auto
+GPU_RESOURCE=nvidia.com/pgpu
+GPU_COUNT=1
+POD_MEMORY=16Gi
+# Released CoCo confidential emptyDir. Kata creates a sparse host backing file,
+# then generates an ephemeral key and applies LUKS2/dm-crypt plus dm-integrity
+# inside the confidential guest. Use enough headroom for metadata.
+CONFIDENTIAL_VOLUME_SIZE=8Gi
+# Successful stage-50 validation pods are deleted so a rerun can acquire the
+# passthrough GPU. Set to 1 only when keeping the guest for manual inspection.
+KEEP_ATTESTATION_POD=0
+
+# Alternate NVFlare server/client workflow. Run 30-deploy-security-services.sh
+# explicitly first. Stage 40-nvflare-build-sign-images.sh builds these images
+# from the enclosing NVFlare source checkout. Stage 50-nvflare-deploy.sh
+# provisions and deploys one server and one client as digest-pinned CoCo pods;
+# Stage 60 submits and verifies the one-client hello-numpy job.
+# NVFLARE_NAMESPACE must be dedicated to this workflow. Stages 30 and 50
+# refuse an existing namespace unless it has the suite ownership label.
+NVFLARE_NAMESPACE=nvflare-coco
+NVFLARE_PROJECT_NAME=nvflare_coco
+NVFLARE_SERVER_NAME=nvflare-server
+NVFLARE_CLIENT_NAME=site-1
+NVFLARE_ADMIN_NAME=admin@nvidia.com
+NVFLARE_ORG=nvidia
+NVFLARE_SERVER_IMAGE_NAME=coco/nvflare-server
+NVFLARE_CLIENT_IMAGE_NAME=coco/nvflare-client
+NVFLARE_SERVER_IMAGE_TAG=dev
+NVFLARE_CLIENT_IMAGE_TAG=dev
+NVFLARE_SERVER_MEMORY=8Gi
+NVFLARE_CLIENT_MEMORY=32Gi
+# auto selects kata-qemu-snp or kata-qemu-tdx for the CPU-only server.
+NVFLARE_SERVER_RUNTIME_CLASS=auto
+# auto selects the platform's kata-qemu-nvidia-gpu-* runtime for the client.
+NVFLARE_CLIENT_RUNTIME_CLASS=auto
+# Only the client receives this many passthrough GPUs. The server manifest has
+# no GPU request or limit, so a one-GPU host assigns its sole GPU to the client.
+NVFLARE_CLIENT_GPU_COUNT=1
+NVFLARE_WORKSPACE_SIZE=16Gi
+# Supplemental group applied to the encrypted workspace volumes so non-root
+# runtime users can write participant state.
+NVFLARE_FS_GROUP=65532
+# Empty means discover nvflare on PATH, then <repo>/.venv/bin/nvflare.
+NVFLARE_CLI=
+# Empty means use the Python interpreter beside NVFLARE_CLI, then python3.
+NVFLARE_PYTHON=
+# Stage-60 administrator tunnel and job-wait controls.
+NVFLARE_ADMIN_LOCAL_PORT=18003
+NVFLARE_CLI_CONNECT_TIMEOUT=30
+NVFLARE_JOB_WAIT_TIMEOUT=900
+NVFLARE_JOB_WAIT_INTERVAL=2
+# Pinned tracking receiver required by the standard hello-numpy smoke test.
+TENSORBOARD_VERSION=2.20.0
+
+# Pinned in-image hardware-attestation dependencies. Stage 40 validates each
+# direct artifact digest, builds both role images with all three verifier
+# families, and refuses to sign an image whose runtime checks fail.
+# Python 3.12 remains pinned for this validated CoCo image combination. GPU
+# authorization uses the native NVAT CLI and has no Python-SDK ABI dependency.
+NVFLARE_COCO_PYTHON_BUILD_BASE=python:3.12.12-slim-trixie@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+NVFLARE_COCO_PYTHON_RUNTIME_BASE=nvcr.io/nvidia/distroless/python:3.12-v4.0.7@sha256:9e7012ce1816b720123ae11fc0edd005ff1373c9eb562ded2b3e9da869ed7bc9
+NVFLARE_COCO_PYTHON_MINOR=3.12
+SNPGUEST_VERSION=0.10.0
+SNPGUEST_SHA256=70e700465e3523e67dd5104583dc36cd11eef630c6f04c5b9ccafd6ba2e76ca0
+TRUSTAUTHORITY_CLI_VERSION=v1.10.1
+TRUSTAUTHORITY_CLI_SHA256=d3875adbee96268471c82dd54f012b726fa8d6eefdd8f3243c0e7650fb55ff4e
+NVAT_VERSION=1.2.2
+NVAT_REPO_SHA256=31b0a1646f2bbc08ee599d10dbae106124ef2903f39e37095b96493913b37657
+NVAT_REPO_URL=https://developer.download.nvidia.com/compute/nvat/1.2.2/local_installers/nvat-local-repo-ubuntu2404-1-2-local_1.0-1_amd64.deb
+NVAT_BUILD_BASE=ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
+
+# Intel Trust Authority configuration used by TDXAuthorizer. On a TDX host,
+# point this at a reviewed config.json containing nonempty trustauthority_url,
+# HTTPS trustauthority_api_url, and nonempty trustauthority_api_key fields.
+# This is not an Intel PCS subscription key. Stage 30 copies it into a
+# Kubernetes Secret; never commit the source file.
+NVFLARE_TDX_ATTESTATION_CONFIG_FILE=
+
+# Optional NVIDIA attestation service key, stored as a single line in a
+# root-readable file. Stage 30 creates a Kubernetes Secret and Stage 50 injects
+# it into both participants because both appraise GPU evidence. Never put the key
+# directly in this configuration.
+NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE=
+# Local NVAT verification is self-contained and is the default for this
+# bare-metal workflow. Remote NRAS verification requires an approved service
+# credential in the file above in environments where NRAS rejects keyless use.
+NVFLARE_GPU_VERIFIER=local
+NVFLARE_GPU_NRAS_URL=https://nras.attestation.nvidia.com
+
+# SNP verification.
+AMD_KDS_PRODUCT=Genoa
+# Approved SHA-384 SNP launch measurement for the pinned Kata 3.29.0
+# kata-qemu-nvidia-gpu-snp guest. Re-establish this value out of band whenever
+# the guest kernel, firmware, rootfs image, dm-verity parameters, or VM launch
+# configuration changes. Stage 50 fails closed if the signed report differs.
+EXPECTED_SNP_LAUNCH_MEASUREMENT=c85a7b17331325d34dca0afb55991e44d8e0da92ede91c5ff761d862f29f037966bad1a6cfce58be18c0e96c5e86afd0
+
+# TDX verification. These must come from an independently trusted Kata build
+# manifest or Trustee/RVPS policy. Stage 50 refuses to attest a TDX guest while
+# any reference is empty; never learn and approve them from that same live host.
+EXPECTED_TDX_MRTD=
+EXPECTED_TDX_RTMR0=
+EXPECTED_TDX_RTMR1=
+EXPECTED_TDX_RTMR2=
+EXPECTED_TDX_RTMR3=
+
+# Canonical currently publishes tdx-qgs only for selected Ubuntu suites. Empty
+# means use the host suite. An explicit older suite is an operator-approved
+# compatibility override and must be tested carefully (for example, plucky on
+# an early Ubuntu 26.04 TDX host while native packages remain unavailable).
+TDX_ATTESTATION_PPA_SUITE=
+
+# Intel's production PCS accepts keyless PCK-certificate retrieval. Leave this
+# empty for that mode. If your PCS environment requires a subscription key,
+# prefer a root-readable file containing only the 32-character key.
+# INTEL_PCS_API_KEY may instead be supplied as a one-run environment variable;
+# do not commit the key to this configuration.
+INTEL_PCS_API_KEY_FILE=
+
+# Set to 1 only when intentionally rotating keys/certificates.
+ROTATE_SECURITY_MATERIAL=0
+
+# Fail before changing packages if a pinned Kubernetes version would downgrade
+# an existing installation. Set to 1 only after explicitly approving it.
+ALLOW_PACKAGE_DOWNGRADES=0
+
+# Unsafe recovery option. Keep 0 unless a known publisher checksum is stale.
+IGNORE_CHECKSUM_MISMATCH=0

--- a/examples/devops/CoCo/lib/common.sh
+++ b/examples/devops/CoCo/lib/common.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_FILE="${COCO_CONFIG:-${SUITE_DIR}/config.env}"
+STATE_DIR="${COCO_STATE_DIR:-${SUITE_DIR}/state}"
+readonly COCO_MANAGED_NAMESPACE_LABEL="nvflare.nvidia.com/coco-managed"
+
+detect_tee_platform() {
+  if grep -q AuthenticAMD /proc/cpuinfo 2>/dev/null &&
+    grep -qw sev_snp /proc/cpuinfo 2>/dev/null; then
+    printf 'snp\n'
+  elif grep -q GenuineIntel /proc/cpuinfo 2>/dev/null &&
+    grep -qw tdx_host_platform /proc/cpuinfo 2>/dev/null; then
+    printf 'tdx\n'
+  else
+    printf 'unknown\n'
+  fi
+}
+
+load_config() {
+  local node_ip_override="${NODE_IP:-}"
+  local checksum_override="${IGNORE_CHECKSUM_MISMATCH:-}"
+  local downgrade_override="${ALLOW_PACKAGE_DOWNGRADES:-}"
+  local tlog_mode_override="${COSIGN_TLOG_MODE:-}"
+  local tee_platform_override="${TEE_PLATFORM:-}"
+  local runtime_class_override="${RUNTIME_CLASS:-}"
+  local nvflare_server_runtime_class_override="${NVFLARE_SERVER_RUNTIME_CLASS:-}"
+  local nvflare_client_runtime_class_override="${NVFLARE_CLIENT_RUNTIME_CLASS:-}"
+  local snp_measurement_override="${EXPECTED_SNP_LAUNCH_MEASUREMENT:-}"
+  local tdx_mrtd_override="${EXPECTED_TDX_MRTD:-}"
+  local tdx_rtmr0_override="${EXPECTED_TDX_RTMR0:-}"
+  local tdx_rtmr1_override="${EXPECTED_TDX_RTMR1:-}"
+  local tdx_rtmr2_override="${EXPECTED_TDX_RTMR2:-}"
+  local tdx_rtmr3_override="${EXPECTED_TDX_RTMR3:-}"
+  local intel_pcs_api_key_override="${INTEL_PCS_API_KEY:-}"
+  local intel_pcs_api_key_file_override="${INTEL_PCS_API_KEY_FILE:-}"
+  local confidential_volume_size_override="${CONFIDENTIAL_VOLUME_SIZE:-}"
+  local keep_attestation_pod_override="${KEEP_ATTESTATION_POD:-}"
+  local nvflare_tdx_config_override="${NVFLARE_TDX_ATTESTATION_CONFIG_FILE:-}"
+  local nvflare_gpu_key_file_override="${NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE:-}"
+  local nvflare_gpu_verifier_override="${NVFLARE_GPU_VERIFIER:-}"
+  local nvflare_gpu_nras_url_override="${NVFLARE_GPU_NRAS_URL:-}"
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    cp "${SUITE_DIR}/config.env.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE from the example configuration." >&2
+  fi
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+  [[ -z "$node_ip_override" ]] || NODE_IP="$node_ip_override"
+  [[ -z "$checksum_override" ]] || IGNORE_CHECKSUM_MISMATCH="$checksum_override"
+  [[ -z "$downgrade_override" ]] || ALLOW_PACKAGE_DOWNGRADES="$downgrade_override"
+  [[ -z "$tlog_mode_override" ]] || COSIGN_TLOG_MODE="$tlog_mode_override"
+  [[ -z "$tee_platform_override" ]] || TEE_PLATFORM="$tee_platform_override"
+  [[ -z "$runtime_class_override" ]] || RUNTIME_CLASS="$runtime_class_override"
+  [[ -z "$nvflare_server_runtime_class_override" ]] ||
+    NVFLARE_SERVER_RUNTIME_CLASS="$nvflare_server_runtime_class_override"
+  [[ -z "$nvflare_client_runtime_class_override" ]] ||
+    NVFLARE_CLIENT_RUNTIME_CLASS="$nvflare_client_runtime_class_override"
+  [[ -z "$snp_measurement_override" ]] ||
+    EXPECTED_SNP_LAUNCH_MEASUREMENT="$snp_measurement_override"
+  [[ -z "$tdx_mrtd_override" ]] || EXPECTED_TDX_MRTD="$tdx_mrtd_override"
+  [[ -z "$tdx_rtmr0_override" ]] || EXPECTED_TDX_RTMR0="$tdx_rtmr0_override"
+  [[ -z "$tdx_rtmr1_override" ]] || EXPECTED_TDX_RTMR1="$tdx_rtmr1_override"
+  [[ -z "$tdx_rtmr2_override" ]] || EXPECTED_TDX_RTMR2="$tdx_rtmr2_override"
+  [[ -z "$tdx_rtmr3_override" ]] || EXPECTED_TDX_RTMR3="$tdx_rtmr3_override"
+  [[ -z "$intel_pcs_api_key_override" ]] || INTEL_PCS_API_KEY="$intel_pcs_api_key_override"
+  [[ -z "$intel_pcs_api_key_file_override" ]] ||
+    INTEL_PCS_API_KEY_FILE="$intel_pcs_api_key_file_override"
+  [[ -z "$confidential_volume_size_override" ]] ||
+    CONFIDENTIAL_VOLUME_SIZE="$confidential_volume_size_override"
+  [[ -z "$keep_attestation_pod_override" ]] ||
+    KEEP_ATTESTATION_POD="$keep_attestation_pod_override"
+  [[ -z "$nvflare_tdx_config_override" ]] ||
+    NVFLARE_TDX_ATTESTATION_CONFIG_FILE="$nvflare_tdx_config_override"
+  [[ -z "$nvflare_gpu_key_file_override" ]] ||
+    NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE="$nvflare_gpu_key_file_override"
+  [[ -z "$nvflare_gpu_verifier_override" ]] || NVFLARE_GPU_VERIFIER="$nvflare_gpu_verifier_override"
+  [[ -z "$nvflare_gpu_nras_url_override" ]] || NVFLARE_GPU_NRAS_URL="$nvflare_gpu_nras_url_override"
+  TEE_PLATFORM="${TEE_PLATFORM:-auto}"
+  if [[ "$TEE_PLATFORM" == auto ]]; then
+    TEE_PLATFORM="$(detect_tee_platform)"
+  fi
+  case "$TEE_PLATFORM" in
+    snp)
+      TEE_NAME="AMD SEV-SNP"
+      TEE_NODE_LABEL_KEY="amd.feature.node.kubernetes.io/snp"
+      platform_runtime_class="kata-qemu-nvidia-gpu-snp"
+      platform_nvflare_server_runtime_class="kata-qemu-snp"
+      ;;
+    tdx)
+      TEE_NAME="Intel TDX"
+      TEE_NODE_LABEL_KEY="intel.feature.node.kubernetes.io/tdx"
+      platform_runtime_class="kata-qemu-nvidia-gpu-tdx"
+      platform_nvflare_server_runtime_class="kata-qemu-tdx"
+      ;;
+    *)
+      die "Could not detect AMD SEV-SNP or Intel TDX; set TEE_PLATFORM=snp or tdx only on a matching host"
+      ;;
+  esac
+  RUNTIME_CLASS="${RUNTIME_CLASS:-auto}"
+  [[ "$RUNTIME_CLASS" != auto ]] || RUNTIME_CLASS="$platform_runtime_class"
+  NVFLARE_SERVER_RUNTIME_CLASS="${NVFLARE_SERVER_RUNTIME_CLASS:-auto}"
+  [[ "$NVFLARE_SERVER_RUNTIME_CLASS" != auto ]] ||
+    NVFLARE_SERVER_RUNTIME_CLASS="$platform_nvflare_server_runtime_class"
+  NVFLARE_CLIENT_RUNTIME_CLASS="${NVFLARE_CLIENT_RUNTIME_CLASS:-auto}"
+  [[ "$NVFLARE_CLIENT_RUNTIME_CLASS" != auto ]] ||
+    NVFLARE_CLIENT_RUNTIME_CLASS="$RUNTIME_CLASS"
+  IGNORE_CHECKSUM_MISMATCH="${IGNORE_CHECKSUM_MISMATCH:-0}"
+  case "$IGNORE_CHECKSUM_MISMATCH" in
+    0|1) ;;
+    *) die "IGNORE_CHECKSUM_MISMATCH must be 0 or 1" ;;
+  esac
+  ALLOW_PACKAGE_DOWNGRADES="${ALLOW_PACKAGE_DOWNGRADES:-0}"
+  case "$ALLOW_PACKAGE_DOWNGRADES" in
+    0|1) ;;
+    *) die "ALLOW_PACKAGE_DOWNGRADES must be 0 or 1" ;;
+  esac
+  COSIGN_TLOG_MODE="${COSIGN_TLOG_MODE:-disabled}"
+  case "$COSIGN_TLOG_MODE" in
+    disabled|rekor) ;;
+    *) die "COSIGN_TLOG_MODE must be 'disabled' or 'rekor'" ;;
+  esac
+  KEEP_ATTESTATION_POD="${KEEP_ATTESTATION_POD:-0}"
+  case "$KEEP_ATTESTATION_POD" in
+    0|1) ;;
+    *) die "KEEP_ATTESTATION_POD must be 0 or 1" ;;
+  esac
+  CALICO_SHA256="${CALICO_SHA256:-a1df919d9721cf667accdc3e72848911b0cb25cfab7d2478ad0c996302c95744}"
+  REGISTRY_IMAGE="${REGISTRY_IMAGE:-docker.io/library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373}"
+  TRUSTEE_IMAGE="${TRUSTEE_IMAGE:-ghcr.io/confidential-containers/staged-images/kbs@sha256:c128232d271c3bc6cdfbd57b1e585b4aaa0c8de6dd987dbf2731786f60405e25}"
+  SNPGUEST_VERSION="${SNPGUEST_VERSION:-0.10.0}"
+  NVFLARE_COCO_PYTHON_BUILD_BASE="${NVFLARE_COCO_PYTHON_BUILD_BASE:-python:3.12.12-slim-trixie@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c}"
+  NVFLARE_COCO_PYTHON_RUNTIME_BASE="${NVFLARE_COCO_PYTHON_RUNTIME_BASE:-nvcr.io/nvidia/distroless/python:3.12-v4.0.7@sha256:9e7012ce1816b720123ae11fc0edd005ff1373c9eb562ded2b3e9da869ed7bc9}"
+  NVFLARE_COCO_PYTHON_MINOR="${NVFLARE_COCO_PYTHON_MINOR:-3.12}"
+  SNPGUEST_SHA256="${SNPGUEST_SHA256:-70e700465e3523e67dd5104583dc36cd11eef630c6f04c5b9ccafd6ba2e76ca0}"
+  TRUSTAUTHORITY_CLI_VERSION="${TRUSTAUTHORITY_CLI_VERSION:-v1.10.1}"
+  TRUSTAUTHORITY_CLI_SHA256="${TRUSTAUTHORITY_CLI_SHA256:-d3875adbee96268471c82dd54f012b726fa8d6eefdd8f3243c0e7650fb55ff4e}"
+  NVAT_VERSION="${NVAT_VERSION:-1.2.2}"
+  TENSORBOARD_VERSION="${TENSORBOARD_VERSION:-2.20.0}"
+  NVAT_REPO_SHA256="${NVAT_REPO_SHA256:-31b0a1646f2bbc08ee599d10dbae106124ef2903f39e37095b96493913b37657}"
+  NVAT_REPO_URL="${NVAT_REPO_URL:-https://developer.download.nvidia.com/compute/nvat/1.2.2/local_installers/nvat-local-repo-ubuntu2404-1-2-local_1.0-1_amd64.deb}"
+  NVAT_BUILD_BASE="${NVAT_BUILD_BASE:-ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea}"
+  NVFLARE_TDX_ATTESTATION_CONFIG_FILE="${NVFLARE_TDX_ATTESTATION_CONFIG_FILE:-}"
+  NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE="${NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE:-}"
+  NVFLARE_GPU_VERIFIER="${NVFLARE_GPU_VERIFIER:-local}"
+  case "$NVFLARE_GPU_VERIFIER" in
+    local|remote) ;;
+    *) die "NVFLARE_GPU_VERIFIER must be 'local' or 'remote'" ;;
+  esac
+  NVFLARE_GPU_NRAS_URL="${NVFLARE_GPU_NRAS_URL:-https://nras.attestation.nvidia.com}"
+  if [[ "$NVFLARE_GPU_VERIFIER" == remote && ! "$NVFLARE_GPU_NRAS_URL" =~ ^https:// ]]; then
+    die "NVFLARE_GPU_NRAS_URL must be HTTPS for remote GPU verification"
+  fi
+  if [[ -z "${NODE_IP:-}" ]]; then
+    NODE_IP="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src"){print $(i+1); exit}}' || true)"
+  fi
+  if [[ -z "$NODE_IP" ]]; then
+    NODE_IP="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+  fi
+  [[ -n "$NODE_IP" ]] || die "Could not derive NODE_IP; set it in $CONFIG_FILE"
+  REGISTRY_BIND_ADDRESS="${REGISTRY_BIND_ADDRESS:-$NODE_IP}"
+  REGISTRY_HOST="${REGISTRY_HOST:-${NODE_IP}:${REGISTRY_PORT}}"
+  TARGET_REPOSITORY="${REGISTRY_HOST}/${TARGET_IMAGE_NAME}"
+  export NODE_IP REGISTRY_HOST TARGET_REPOSITORY IGNORE_CHECKSUM_MISMATCH ALLOW_PACKAGE_DOWNGRADES COSIGN_TLOG_MODE
+  export TEE_PLATFORM TEE_NAME TEE_NODE_LABEL_KEY RUNTIME_CLASS
+  export NVFLARE_SERVER_RUNTIME_CLASS NVFLARE_CLIENT_RUNTIME_CLASS
+  export EXPECTED_SNP_LAUNCH_MEASUREMENT EXPECTED_TDX_MRTD
+  export EXPECTED_TDX_RTMR0 EXPECTED_TDX_RTMR1 EXPECTED_TDX_RTMR2 EXPECTED_TDX_RTMR3
+  export INTEL_PCS_API_KEY INTEL_PCS_API_KEY_FILE
+  export CONFIDENTIAL_VOLUME_SIZE KEEP_ATTESTATION_POD
+  export CALICO_SHA256 REGISTRY_IMAGE TRUSTEE_IMAGE REGISTRY_BIND_ADDRESS
+  export SNPGUEST_VERSION SNPGUEST_SHA256 TRUSTAUTHORITY_CLI_VERSION TRUSTAUTHORITY_CLI_SHA256
+  export NVFLARE_COCO_PYTHON_BUILD_BASE NVFLARE_COCO_PYTHON_RUNTIME_BASE NVFLARE_COCO_PYTHON_MINOR
+  export NVAT_VERSION NVAT_REPO_SHA256 NVAT_REPO_URL NVAT_BUILD_BASE
+  export TENSORBOARD_VERSION
+  export NVFLARE_TDX_ATTESTATION_CONFIG_FILE NVFLARE_GPU_ATTESTATION_SERVICE_KEY_FILE
+  export NVFLARE_GPU_VERIFIER NVFLARE_GPU_NRAS_URL
+  mkdir -p "$STATE_DIR"
+}
+
+log() { printf '\n[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"; }
+as_root() { if ((EUID == 0)); then "$@"; else sudo "$@"; fi; }
+
+prepare_download_dir() {
+  local owner_uid owner_gid
+  owner_uid="${SUDO_UID:-$(id -u)}"
+  owner_gid="${SUDO_GID:-$(id -g)}"
+  as_root install -d -m 0775 "$STATE_DIR/downloads"
+  as_root chown "$owner_uid:$owner_gid" "$STATE_DIR/downloads"
+}
+
+kctl() {
+  if ((EUID == 0)); then kubectl --kubeconfig "$KUBECONFIG_PATH" "$@"
+  elif [[ -r "$KUBECONFIG_PATH" ]]; then kubectl --kubeconfig "$KUBECONFIG_PATH" "$@"
+  else sudo kubectl --kubeconfig "$KUBECONFIG_PATH" "$@"
+  fi
+}
+
+ensure_coco_managed_namespace() {
+  local namespace=$1 managed
+  [[ "$namespace" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ && ${#namespace} -le 63 ]] ||
+    die "Namespace must be a lowercase RFC 1123 name: $namespace"
+
+  if kctl get namespace "$namespace" >/dev/null 2>&1; then
+    managed="$(
+      kctl get namespace "$namespace" \
+        -o 'jsonpath={.metadata.labels.nvflare\.nvidia\.com/coco-managed}'
+    )"
+    [[ "$managed" == true ]] ||
+      die "Namespace $namespace already exists without $COCO_MANAGED_NAMESPACE_LABEL=true; refusing to adopt a potentially shared namespace"
+    return
+  fi
+
+  log "Creating suite-owned namespace $namespace"
+  kctl create -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $namespace
+  labels:
+    $COCO_MANAGED_NAMESPACE_LABEL: "true"
+EOF
+}
+
+helmctl() {
+  if ((EUID == 0)); then helm --kubeconfig "$KUBECONFIG_PATH" "$@"
+  elif [[ -r "$KUBECONFIG_PATH" ]]; then helm --kubeconfig "$KUBECONFIG_PATH" "$@"
+  else sudo helm --kubeconfig "$KUBECONFIG_PATH" "$@"
+  fi
+}
+
+# Populate a persistent cache atomically. A missing/empty artifact is downloaded;
+# a verified artifact is also redownloaded whenever its checksum is wrong.
+ensure_download() {
+  local url=$1 out=$2 partial
+  [[ -s "$out" ]] && return 0
+  mkdir -p "$(dirname "$out")"
+  partial="${out}.partial.$$"
+  if ! curl -L --fail --silent --show-error "$url" -o "$partial"; then
+    rm -f "$partial"
+    return 1
+  fi
+  mv "$partial" "$out"
+}
+
+ensure_download_verified() {
+  local url=$1 sha=$2 out=$3 partial
+  if [[ -s "$out" ]]; then
+    if echo "$sha  $out" | sha256sum --check --status; then
+      return 0
+    fi
+    if [[ "${IGNORE_CHECKSUM_MISMATCH:-0}" == 1 ]]; then
+      echo "WARNING: ignoring checksum mismatch for cached artifact $out (expected SHA-256: $sha)" >&2
+      return 0
+    fi
+  fi
+  mkdir -p "$(dirname "$out")"
+  partial="${out}.partial.$$"
+  if ! curl -L --fail --silent --show-error "$url" -o "$partial"; then
+    rm -f "$partial"
+    return 1
+  fi
+  if ! echo "$sha  $partial" | sha256sum -c -; then
+    if [[ "${IGNORE_CHECKSUM_MISMATCH:-0}" == 1 ]]; then
+      echo "WARNING: ignoring checksum mismatch for downloaded artifact $url (expected SHA-256: $sha)" >&2
+      mv "$partial" "$out"
+      return 0
+    fi
+    rm -f "$partial"
+    return 1
+  fi
+  mv "$partial" "$out"
+}
+
+wait_for() {
+  local description=$1 timeout=$2; shift 2
+  local deadline=$((SECONDS + timeout))
+  until "$@"; do
+    ((SECONDS < deadline)) || die "Timed out waiting for $description"
+    sleep 10
+  done
+}
+
+require_root_or_sudo() {
+  if ((EUID != 0)); then
+    need sudo
+    sudo -n true ||
+      die "Passwordless non-interactive sudo is required; run as root or configure NOPASSWD for this workflow"
+  fi
+}

--- a/examples/devops/CoCo/lib/deploy-coco-attest.sh
+++ b/examples/devops/CoCo/lib/deploy-coco-attest.sh
@@ -1,0 +1,861 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Deploy one NVIDIA GPU into an AMD SEV-SNP or Intel TDX Kata CoCo pod,
+# collect fresh CPU/GPU attestation evidence, verify it, and save reports.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE="${NAMESPACE:-default}"
+POD_NAME="coco-attestation-$(date -u +%Y%m%d%H%M%S | tr '[:upper:]' '[:lower:]')"
+OUTPUT_DIR="${PWD}/coco-attestation-reports-$(date -u +%Y%m%dT%H%M%SZ)"
+KUBECONFIG_PATH="${KUBECONFIG:-}"
+CLEANUP_POD=0
+RUNTIME_CLASS="${RUNTIME_CLASS:-kata-qemu-nvidia-gpu-snp}"
+TEE_PLATFORM="${TEE_PLATFORM:-snp}"
+POD_IMAGE="${POD_IMAGE:-}"
+POLICY_REPOSITORY="${POLICY_REPOSITORY:-${POD_IMAGE%@*}}"
+REGISTRY_HOST="${REGISTRY_HOST:-${POLICY_REPOSITORY%%/*}}"
+GPU_RESOURCE="${GPU_RESOURCE:-nvidia.com/pgpu}"
+GPU_COUNT="${GPU_COUNT:-1}"
+POD_MEMORY="${POD_MEMORY:-16Gi}"
+CONFIDENTIAL_VOLUME_SIZE="${CONFIDENTIAL_VOLUME_SIZE:-8Gi}"
+CONFIDENTIAL_VOLUME_MOUNT="/confidential-data"
+AMD_KDS_PRODUCT="${AMD_KDS_PRODUCT:-Genoa}"
+EXPECTED_SNP_LAUNCH_MEASUREMENT="${EXPECTED_SNP_LAUNCH_MEASUREMENT:-}"
+EXPECTED_TDX_MRTD="${EXPECTED_TDX_MRTD:-}"
+EXPECTED_TDX_RTMR0="${EXPECTED_TDX_RTMR0:-}"
+EXPECTED_TDX_RTMR1="${EXPECTED_TDX_RTMR1:-}"
+EXPECTED_TDX_RTMR2="${EXPECTED_TDX_RTMR2:-}"
+EXPECTED_TDX_RTMR3="${EXPECTED_TDX_RTMR3:-}"
+KBS_NAMESPACE="${KBS_NAMESPACE:-coco-tenant}"
+KBS_SERVICE="${KBS_SERVICE:-trustee-kbs}"
+IMAGE_POLICY_SOURCE="measured init-data"
+COSIGN_PUBLIC_KEY="${COSIGN_PUBLIC_KEY:-}"
+REGISTRY_CA_CERT="${REGISTRY_CA_CERT:-}"
+ARTIFACT_CACHE_DIR="${ARTIFACT_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME:-/var/tmp}/.cache}/bare-metal-coco}"
+IGNORE_CHECKSUM_MISMATCH="${IGNORE_CHECKSUM_MISMATCH:-0}"
+COSIGN_TLOG_MODE="${COSIGN_TLOG_MODE:-disabled}"
+
+NVAT_VERSION="1.2.2"
+NVAT_DEB="nvat-local-repo-ubuntu2404-1-2-local_1.0-1_amd64.deb"
+NVAT_URL="https://developer.download.nvidia.com/compute/nvat/1.2.2/local_installers/${NVAT_DEB}"
+# SHA-256 of the downloaded NVIDIA .deb package.
+NVAT_SHA256="31b0a1646f2bbc08ee599d10dbae106124ef2903f39e37095b96493913b37657"
+GO_TDX_GUEST_COMMIT="d0438ad179370160a3b98d9703b1559dcd1ed5ee"
+GO_TDX_GUEST_SHA256="5c0a76ad4cc9f780d1dc55cf6f6bd7bccf25d3c8f7b74b05cc478b9001f7b51b"
+
+usage() {
+  cat <<'USAGE'
+Usage: deploy-coco-attest.sh [options]
+
+Options:
+  --namespace NAME       Kubernetes namespace (default: default)
+  --pod-name NAME        Pod name (default: timestamped unique name)
+  --output-dir DIR       Report directory (default: timestamped directory)
+  --kubeconfig FILE      Kubeconfig file (default: $KUBECONFIG/current context)
+  --cleanup              Delete the pod after successful attestation
+  -h, --help             Show this help
+
+Environment overrides:
+  TEE_PLATFORM           snp or tdx
+  AMD_KDS_PRODUCT        AMD KDS product name (default: Genoa)
+  EXPECTED_SNP_LAUNCH_MEASUREMENT
+                         Approved SNP launch measurement (96 hex characters)
+  EXPECTED_TDX_MRTD      Approved TDX MRTD (96 hex characters)
+  EXPECTED_TDX_RTMR0..3  Approved TDX RTMR values (96 hex each)
+  POD_IMAGE              Digest-pinned signed image
+  POLICY_REPOSITORY      Repository authorized by the image policy
+  REGISTRY_HOST          Registry host:port visible to the guest
+  COSIGN_PUBLIC_KEY      Cosign public-key PEM
+  REGISTRY_CA_CERT       Private registry CA PEM
+  RUNTIME_CLASS          CoCo RuntimeClass
+  GPU_RESOURCE           Extended GPU resource (default: nvidia.com/pgpu)
+  GPU_COUNT              GPUs assigned to the pod (default: 1)
+  POD_MEMORY             Pod memory limit (default: 16Gi)
+  CONFIDENTIAL_VOLUME_SIZE
+                         Encrypted emptyDir size limit (default: 8Gi)
+
+The pod is privileged only inside its isolated Kata VM so it can access the
+guest-local attestation interface. It receives one nvidia.com/pgpu device.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --pod-name) POD_NAME="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --kubeconfig) KUBECONFIG_PATH="$2"; shift 2 ;;
+    --cleanup) CLEANUP_POD=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ "$POD_IMAGE" == *@sha256:* ]] || { echo "POD_IMAGE must be a digest-pinned signed image" >&2; exit 1; }
+[[ -n "$POLICY_REPOSITORY" ]] || { echo "POLICY_REPOSITORY is required" >&2; exit 1; }
+[[ -n "$REGISTRY_HOST" ]] || { echo "REGISTRY_HOST is required" >&2; exit 1; }
+case "$TEE_PLATFORM" in
+  snp)
+    TEE_DISPLAY_NAME="AMD SEV-SNP"
+    EXPECTED_SNP_LAUNCH_MEASUREMENT="${EXPECTED_SNP_LAUNCH_MEASUREMENT,,}"
+    [[ "$EXPECTED_SNP_LAUNCH_MEASUREMENT" =~ ^[0-9a-f]{96}$ ]] || {
+      echo "EXPECTED_SNP_LAUNCH_MEASUREMENT must be the approved 48-byte SNP launch measurement (96 hex characters)" >&2
+      exit 1
+    }
+    ;;
+  tdx)
+    TEE_DISPLAY_NAME="Intel TDX"
+    for reference_name in EXPECTED_TDX_MRTD EXPECTED_TDX_RTMR0 EXPECTED_TDX_RTMR1 EXPECTED_TDX_RTMR2 EXPECTED_TDX_RTMR3; do
+      printf -v "$reference_name" '%s' "${!reference_name,,}"
+      [[ "${!reference_name}" =~ ^[0-9a-f]{96}$ ]] || {
+        echo "$reference_name must be an approved 48-byte TDX reference value (96 hex characters)" >&2
+        exit 1
+      }
+    done
+    ;;
+  *)
+    echo "TEE_PLATFORM must be snp or tdx" >&2
+    exit 1
+    ;;
+esac
+[[ "$CONFIDENTIAL_VOLUME_SIZE" =~ ^[1-9][0-9]*(Ki|Mi|Gi|Ti)$ ]] || {
+  echo "CONFIDENTIAL_VOLUME_SIZE must be a positive binary Kubernetes quantity such as 8Gi" >&2
+  exit 1
+}
+
+for tool in kubectl curl openssl gcc jq xxd awk sed sha256sum mktemp gzip base64 cosign; do
+  command -v "$tool" >/dev/null || { echo "Missing required command: $tool" >&2; exit 1; }
+done
+if [[ "$TEE_PLATFORM" == tdx ]]; then
+  command -v go >/dev/null || { echo "Missing required command for TDX verification: go" >&2; exit 1; }
+fi
+
+K=(kubectl)
+if [[ -n "$KUBECONFIG_PATH" ]]; then
+  K+=(--kubeconfig "$KUBECONFIG_PATH")
+fi
+
+TMP_DIR="$(mktemp -d)"
+SUCCESS=0
+on_exit() {
+  status=$?
+  if ((status != 0)); then
+    echo "Attestation failed. Pod diagnostics:" >&2
+    "${K[@]}" describe pod -n "$NAMESPACE" "$POD_NAME" >&2 2>/dev/null || true
+  fi
+  if ((CLEANUP_POD == 1 && SUCCESS == 1)); then
+    "${K[@]}" delete pod -n "$NAMESPACE" "$POD_NAME" --wait=true >/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap on_exit EXIT
+
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$ARTIFACT_CACHE_DIR"
+case "$IGNORE_CHECKSUM_MISMATCH" in
+  0|1) ;;
+  *) echo "IGNORE_CHECKSUM_MISMATCH must be 0 or 1" >&2; exit 1 ;;
+esac
+case "$COSIGN_TLOG_MODE" in
+  disabled|rekor) ;;
+  *) echo "COSIGN_TLOG_MODE must be 'disabled' or 'rekor'" >&2; exit 1 ;;
+esac
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+MANIFEST="$OUTPUT_DIR/coco-attestation-pod.yaml"
+
+[[ -r "$COSIGN_PUBLIC_KEY" ]] || { echo "Missing Cosign public key: $COSIGN_PUBLIC_KEY" >&2; exit 1; }
+[[ -r "$REGISTRY_CA_CERT" ]] || { echo "Missing registry CA certificate: $REGISTRY_CA_CERT" >&2; exit 1; }
+COSIGN_PUBLIC_KEY_DATA="$(<"$COSIGN_PUBLIC_KEY")"
+REGISTRY_CA_CERT_DATA="$(<"$REGISTRY_CA_CERT")"
+IMAGE_SECURITY_POLICY="$(jq -cn \
+  --arg repository "$POLICY_REPOSITORY" \
+  --arg key "$COSIGN_PUBLIC_KEY_DATA" \
+  '{default:[{type:"reject"}],transports:{docker:{($repository):[{type:"sigstoreSigned",keyData:$key,signedIdentity:{type:"matchRepository"}}]}}}')"
+echo "Verifying the pinned CUDA image signature from the host ..."
+if [[ "$COSIGN_TLOG_MODE" == rekor ]]; then
+  if ! cosign verify --allow-insecure-registry \
+    --key "$COSIGN_PUBLIC_KEY" "$POD_IMAGE" \
+    >/dev/null 2>"$TMP_DIR/cosign-stderr"; then
+    cat "$TMP_DIR/cosign-stderr" >&2
+    exit 1
+  fi
+else
+  echo "NOTICE: COSIGN_TLOG_MODE=disabled; verifying the private-key signature without public transparency-log inclusion."
+  if ! cosign verify --allow-insecure-registry --insecure-ignore-tlog \
+    --key "$COSIGN_PUBLIC_KEY" "$POD_IMAGE" \
+    >/dev/null 2>"$TMP_DIR/cosign-stderr"; then
+    cat "$TMP_DIR/cosign-stderr" >&2
+    exit 1
+  fi
+  sed '/^WARNING: Skipping tlog verification is an insecure practice/d' "$TMP_DIR/cosign-stderr" >&2
+fi
+
+KBS_IP="$("${K[@]}" get service -n "$KBS_NAMESPACE" "$KBS_SERVICE" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+if [[ -n "$KBS_IP" && "$KBS_IP" != "None" ]]; then
+  KBS_ADDRESS="http://${KBS_IP}:8080"
+else
+  KBS_ADDRESS="not required for public policy/key delivered in measured init-data"
+fi
+
+cat >"$OUTPUT_DIR/initdata.toml" <<EOF
+version = "0.1.0"
+algorithm = "sha256"
+
+[data]
+"cdh.toml" = '''
+[kbc]
+name = "offline_fs_kbc"
+url = ""
+
+[image]
+image_security_policy = '${IMAGE_SECURITY_POLICY}'
+extra_root_certificates = ["""${REGISTRY_CA_CERT_DATA}"""]
+
+[image.registry_config]
+unqualified-search-registries = ["docker.io"]
+
+[[image.registry_config.registry]]
+location = "${REGISTRY_HOST}"
+insecure = false
+'''
+
+"policy.rego" = '''
+package agent_policy
+default AddARPNeighborsRequest := true
+default AddSwapRequest := true
+default CloseStdinRequest := true
+default CopyFileRequest := true
+default CreateContainerRequest := true
+default CreateSandboxRequest := true
+default DestroySandboxRequest := true
+default ExecProcessRequest := true
+default GetMetricsRequest := true
+default GetOOMEventRequest := true
+default GuestDetailsRequest := true
+default ListInterfacesRequest := true
+default ListRoutesRequest := true
+default MemHotplugByProbeRequest := true
+default OnlineCPUMemRequest := true
+default PauseContainerRequest := true
+default PullImageRequest := true
+default ReadStreamRequest := true
+default RemoveContainerRequest := true
+default RemoveStaleVirtiofsShareMountsRequest := true
+default ReseedRandomDevRequest := true
+default ResumeContainerRequest := true
+default SetGuestDateTimeRequest := true
+default SetPolicyRequest := false
+default SignalProcessRequest := true
+default StartContainerRequest := true
+default StartTracingRequest := true
+default StatsContainerRequest := true
+default StopTracingRequest := true
+default TtyWinResizeRequest := true
+default UpdateContainerRequest := true
+default UpdateEphemeralMountsRequest := true
+default UpdateInterfaceRequest := true
+default UpdateRoutesRequest := true
+default WaitProcessRequest := true
+default WriteStreamRequest := true
+'''
+EOF
+INIT_DATA="$(gzip -c "$OUTPUT_DIR/initdata.toml" | base64 -w 0)"
+INITDATA_SHA256="$(sha256sum "$OUTPUT_DIR/initdata.toml" | awk '{print $1}')"
+
+"${K[@]}" get runtimeclass "$RUNTIME_CLASS" >/dev/null
+"${K[@]}" get namespace "$NAMESPACE" >/dev/null
+
+cat >"$MANIFEST" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME}
+  namespace: ${NAMESPACE}
+  annotations:
+    io.katacontainers.config.hypervisor.cc_init_data: "${INIT_DATA}"
+  labels:
+    app: coco-attestation-sample
+spec:
+  runtimeClassName: ${RUNTIME_CLASS}
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
+  containers:
+    - name: attestation-client
+      image: ${POD_IMAGE}
+      command: ["/bin/bash", "-lc", "trap : TERM INT; sleep infinity & wait"]
+      securityContext:
+        privileged: true
+        runAsUser: 0
+      volumeMounts:
+        - name: confidential-scratch
+          mountPath: ${CONFIDENTIAL_VOLUME_MOUNT}
+      resources:
+        limits:
+          ${GPU_RESOURCE}: "${GPU_COUNT}"
+          memory: ${POD_MEMORY}
+  volumes:
+    - name: confidential-scratch
+      emptyDir:
+        sizeLimit: ${CONFIDENTIAL_VOLUME_SIZE}
+EOF
+
+cat >"$TMP_DIR/snp_report_collect.c" <<'EOF_C'
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <linux/sev-guest.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#define REPORT_OFFSET 32
+#define REPORT_SIZE 1184
+static uint32_t le32(const uint8_t *p){return (uint32_t)p[0]|((uint32_t)p[1]<<8)|((uint32_t)p[2]<<16)|((uint32_t)p[3]<<24);}
+static uint64_t le64(const uint8_t *p){return (uint64_t)le32(p)|((uint64_t)le32(p+4)<<32);}
+static void hex(const uint8_t *p,size_t n){for(size_t i=0;i<n;i++)printf("%02x",p[i]);}
+static int hv(char c){if(c>='0'&&c<='9')return c-'0';if(c>='a'&&c<='f')return c-'a'+10;if(c>='A'&&c<='F')return c-'A'+10;return -1;}
+static int parse64(const char*s,uint8_t out[64]){if(strlen(s)!=128)return-1;for(size_t i=0;i<64;i++){int h=hv(s[i*2]),l=hv(s[i*2+1]);if(h<0||l<0)return-1;out[i]=(h<<4)|l;}return 0;}
+static void tcb(const char*n,uint64_t v){printf("%s: boot_loader=%u tee=%u snp=%u microcode=%u (raw=0x%016"PRIx64")\n",n,(unsigned)(v&255),(unsigned)((v>>8)&255),(unsigned)((v>>48)&255),(unsigned)((v>>56)&255),v);}
+int main(int ac,char**av){
+ if(ac!=4){fprintf(stderr,"usage: %s DEVICE NONCE_HEX RAW_REPORT\n",av[0]);return 2;}
+ struct snp_report_req q={0};struct snp_report_resp s={0};
+ struct snp_guest_request_ioctl io={.msg_version=1,.req_data=(uint64_t)(uintptr_t)&q,.resp_data=(uint64_t)(uintptr_t)&s};
+ if(parse64(av[2],q.user_data)){fprintf(stderr,"nonce must be 128 hex characters\n");return 2;}q.vmpl=0;
+ int fd=open(av[1],O_RDWR|O_CLOEXEC);if(fd<0){perror("open sev-guest");return 1;}
+ if(ioctl(fd,SNP_GET_REPORT,&io)<0){fprintf(stderr,"SNP_GET_REPORT: %s fw=%u vmm=%u\n",strerror(errno),io.fw_error,io.vmm_error);return 1;}close(fd);
+ uint32_t st=le32(s.data),sz=le32(s.data+4);if(st||sz<REPORT_SIZE){fprintf(stderr,"bad response status=%u size=%u\n",st,sz);return 1;}
+ const uint8_t*r=s.data+REPORT_OFFSET;FILE*f=fopen(av[3],"wb");if(!f||fwrite(r,1,REPORT_SIZE,f)!=REPORT_SIZE||fclose(f)){perror("write report");return 1;}
+ uint64_t p=le64(r+8),pi=le64(r+64);
+ puts("AMD SEV-SNP ATTESTATION REPORT\n================================");
+ printf("Report version: %u\nGuest SVN: %u\nGuest policy: 0x%016"PRIx64"\n",le32(r),le32(r+4),p);
+ printf("  ABI: %u.%u\n  SMT allowed: %s\n  Migration agent allowed: %s\n  Debug allowed: %s\n  Single-socket required: %s\n",(unsigned)((p>>8)&255),(unsigned)(p&255),(p&(1ULL<<16))?"yes":"no",(p&(1ULL<<18))?"yes":"no",(p&(1ULL<<19))?"yes":"no",(p&(1ULL<<20))?"yes":"no");
+ printf("Family ID: ");hex(r+16,16);printf("\nImage ID: ");hex(r+32,16);
+ printf("\nVMPL: %u\nSignature algorithm: %u (%s)\n",le32(r+48),le32(r+52),le32(r+52)==1?"ECDSA P-384 with SHA-384":"unknown");
+ tcb("Current TCB",le64(r+56));printf("Platform info: 0x%016"PRIx64"\n",pi);
+ printf("  SMT enabled: %s\n  TSME enabled: %s\n  ECC memory enabled: %s\nAuthor key enabled: %s\n",pi&1?"yes":"no",pi&2?"yes":"no",pi&4?"yes":"no",le32(r+72)?"yes":"no");
+ printf("Report data / nonce: ");hex(r+80,64);printf("\nLaunch measurement: ");hex(r+144,48);
+ printf("\nHost data: ");hex(r+192,32);printf("\nID key digest: ");hex(r+224,48);
+ printf("\nAuthor key digest: ");hex(r+272,48);printf("\nReport ID: ");hex(r+320,32);
+ printf("\nMigration-agent report ID: ");hex(r+352,32);printf("\n");tcb("Reported TCB",le64(r+384));
+ printf("Chip ID: ");hex(r+416,64);printf("\n");tcb("Committed TCB",le64(r+480));
+ printf("Current firmware: API %u.%u build %u\nCommitted firmware: API %u.%u build %u\n",r[490],r[489],r[488],r[494],r[493],r[492]);
+ tcb("Launch TCB",le64(r+496));printf("Raw signed report: cpu-attestation-report.bin (%u bytes)\n",REPORT_SIZE);return 0;
+}
+EOF_C
+
+echo "Deploying $NAMESPACE/$POD_NAME with runtime $RUNTIME_CLASS ..."
+"${K[@]}" apply -f "$MANIFEST"
+"${K[@]}" wait -n "$NAMESPACE" --for=condition=Ready "pod/$POD_NAME" --timeout=20m
+
+kexec(){ "${K[@]}" exec -n "$NAMESPACE" "$POD_NAME" -- "$@"; }
+kcp_to(){ "${K[@]}" cp "$1" "$NAMESPACE/$POD_NAME:$2"; }
+kcp_from(){ "${K[@]}" cp "$NAMESPACE/$POD_NAME:$1" "$2"; }
+GUEST_TMP="/tmp/coco-attestation-${POD_NAME}"
+kexec mkdir -p "$GUEST_TMP"
+
+echo "Verifying the released CoCo LUKS2/dm-crypt emptyDir volume ..."
+STORAGE_MOUNT_LINE="$(
+  kexec findmnt -n -o SOURCE,FSTYPE,OPTIONS --target "$CONFIDENTIAL_VOLUME_MOUNT"
+)"
+read -r STORAGE_SOURCE STORAGE_FSTYPE STORAGE_OPTIONS <<<"$STORAGE_MOUNT_LINE"
+[[ "$STORAGE_SOURCE" == /dev/mapper/* ]] || {
+  echo "Confidential emptyDir is not mounted from a device-mapper path: $STORAGE_SOURCE" >&2
+  exit 1
+}
+[[ "$STORAGE_FSTYPE" == ext4 ]] || {
+  echo "Confidential emptyDir has unexpected filesystem type: $STORAGE_FSTYPE" >&2
+  exit 1
+}
+[[ ",$STORAGE_OPTIONS," == *,rw,* ]] || {
+  echo "Confidential emptyDir is not writable: $STORAGE_OPTIONS" >&2
+  exit 1
+}
+STORAGE_MAPPER_NAME="${STORAGE_SOURCE##*/}"
+STORAGE_DM_NAME="$(
+  kexec bash -lc '
+    for path in /sys/block/dm-*/dm/name; do
+      test -r "$path" || continue
+      if test "$(cat "$path")" = "$1"; then
+        basename "$(dirname "$(dirname "$path")")"
+        exit 0
+      fi
+    done
+    exit 1
+  ' _ "$STORAGE_MAPPER_NAME"
+)"
+STORAGE_DM_DEVICE="/dev/$STORAGE_DM_NAME"
+[[ "$STORAGE_DM_NAME" =~ ^dm-[0-9]+$ ]] || {
+  echo "Confidential emptyDir mapper did not resolve through guest sysfs: $STORAGE_SOURCE" >&2
+  exit 1
+}
+STORAGE_DM_UUID="$(kexec cat "/sys/block/$STORAGE_DM_NAME/dm/uuid")"
+[[ "$STORAGE_DM_UUID" == CRYPT-LUKS2-* ]] || {
+  echo "Confidential emptyDir is not a LUKS2/dm-crypt mapping: $STORAGE_DM_UUID" >&2
+  exit 1
+}
+STORAGE_DM_UUIDS="$(
+  kexec bash -lc 'for path in /sys/block/dm-*/dm/uuid; do test -r "$path" || continue; printf "%s: " "${path#/sys/block/}"; cat "$path"; done'
+)"
+grep -q 'CRYPT-LUKS2-' <<<"$STORAGE_DM_UUIDS" || {
+  echo "No LUKS2/dm-crypt mapping was found in the guest device-mapper inventory." >&2
+  exit 1
+}
+grep -q 'INTEGRITY-' <<<"$STORAGE_DM_UUIDS" || {
+  echo "No dm-integrity mapping was found beneath the confidential volume." >&2
+  exit 1
+}
+STORAGE_CHALLENGE="$(openssl rand -hex 32)"
+kexec bash -lc "umask 077; printf '%s\n' '$STORAGE_CHALLENGE' > '$CONFIDENTIAL_VOLUME_MOUNT/encryption-probe'; sync; test \"\$(cat '$CONFIDENTIAL_VOLUME_MOUNT/encryption-probe')\" = '$STORAGE_CHALLENGE'"
+STORAGE_CAPACITY="$(kexec df -hP "$CONFIDENTIAL_VOLUME_MOUNT" | tail -n 1)"
+cat >"$OUTPUT_DIR/storage-verification-report.txt" <<EOF
+COCO CONFIDENTIAL EMPTYDIR VERIFICATION
+=======================================
+Result: PASS
+Pod: ${NAMESPACE}/${POD_NAME}
+Runtime class: ${RUNTIME_CLASS}
+Configured emptyDir mode: block-encrypted
+Volume type: released CoCo confidential emptyDir
+Mount point: ${CONFIDENTIAL_VOLUME_MOUNT}
+Requested Kubernetes sizeLimit: ${CONFIDENTIAL_VOLUME_SIZE}
+Mounted source: ${STORAGE_SOURCE}
+Filesystem: ${STORAGE_FSTYPE}
+Mount options: ${STORAGE_OPTIONS}
+Device-mapper node: ${STORAGE_DM_DEVICE}
+LUKS mapper UUID: ${STORAGE_DM_UUID}
+
+Device-mapper inventory:
+${STORAGE_DM_UUIDS}
+
+Capacity:
+${STORAGE_CAPACITY}
+
+Encryption: LUKS2 / dm-crypt
+Integrity: dm-integrity
+Key origin: random ephemeral key generated inside the confidential guest
+LUKS2 header location: ${TEE_DISPLAY_NAME}-protected guest memory
+Persistence: ephemeral; removed with the Pod
+Replay protection: not provided
+Read/write probe: VERIFIED OK
+Overall confidential storage result: PASS
+EOF
+
+if [[ "$TEE_PLATFORM" == snp ]]; then
+  echo "Compiling and injecting the AMD SNP report collector ..."
+  gcc -O2 -Wall -Wextra "$TMP_DIR/snp_report_collect.c" -o "$TMP_DIR/snp_report_collect"
+  kcp_to "$TMP_DIR/snp_report_collect" "$GUEST_TMP/snp_report_collect"
+  kexec test -s "$GUEST_TMP/snp_report_collect"
+  kexec chmod 0755 "$GUEST_TMP/snp_report_collect"
+
+  SEV_DEV="$(kexec cat /sys/class/misc/sev-guest/dev)"
+  SEV_MAJOR="${SEV_DEV%%:*}"
+  SEV_MINOR="${SEV_DEV##*:}"
+  kexec bash -lc "test -e /dev/sev-guest || mknod -m 600 /dev/sev-guest c '$SEV_MAJOR' '$SEV_MINOR'"
+
+  CPU_NONCE="$(openssl rand -hex 64)"
+  echo "Collecting AMD SEV-SNP report ..."
+  kexec bash -lc "'$GUEST_TMP/snp_report_collect' /dev/sev-guest '$CPU_NONCE' '$GUEST_TMP/cpu-attestation-report.bin' > '$GUEST_TMP/cpu-attestation-report.txt'"
+  kexec test -s "$GUEST_TMP/cpu-attestation-report.bin"
+  kexec test -s "$GUEST_TMP/cpu-attestation-report.txt"
+  kcp_from "$GUEST_TMP/cpu-attestation-report.bin" "$OUTPUT_DIR/cpu-attestation-report.bin"
+  kcp_from "$GUEST_TMP/cpu-attestation-report.txt" "$OUTPUT_DIR/cpu-attestation-report.txt"
+  grep -q "^Report data / nonce: ${CPU_NONCE}$" "$OUTPUT_DIR/cpu-attestation-report.txt"
+  grep -q "^Host data: ${INITDATA_SHA256}$" "$OUTPUT_DIR/cpu-attestation-report.txt"
+  OBSERVED_SNP_LAUNCH_MEASUREMENT="$(
+    sed -n 's/^Launch measurement: //p' "$OUTPUT_DIR/cpu-attestation-report.txt"
+  )"
+  [[ "$OBSERVED_SNP_LAUNCH_MEASUREMENT" =~ ^[0-9a-f]{96}$ ]] || {
+    echo "SNP report did not contain a valid 48-byte launch measurement" >&2
+    exit 1
+  }
+
+  CHIP_ID="$(sed -n 's/^Chip ID: //p' "$OUTPUT_DIR/cpu-attestation-report.txt")"
+  TCB_LINE="$(sed -n 's/^Reported TCB: //p' "$OUTPUT_DIR/cpu-attestation-report.txt")"
+  BL_SPL="$(sed -n 's/.*boot_loader=\([0-9]*\).*/\1/p' <<<"$TCB_LINE")"
+  TEE_SPL="$(sed -n 's/.*tee=\([0-9]*\).*/\1/p' <<<"$TCB_LINE")"
+  SNP_SPL="$(sed -n 's/.*snp=\([0-9]*\).*/\1/p' <<<"$TCB_LINE")"
+  UCODE_SPL="$(sed -n 's/.*microcode=\([0-9]*\).*/\1/p' <<<"$TCB_LINE")"
+
+  echo "Fetching the matching AMD ${AMD_KDS_PRODUCT} VCEK and certificate chain ..."
+  curl -L --fail --silent --show-error \
+    "https://kdsintf.amd.com/vcek/v1/${AMD_KDS_PRODUCT}/${CHIP_ID}?blSPL=${BL_SPL}&teeSPL=${TEE_SPL}&snpSPL=${SNP_SPL}&ucodeSPL=${UCODE_SPL}" \
+    -o "$TMP_DIR/vcek.der"
+  curl -L --fail --silent --show-error \
+    "https://kdsintf.amd.com/vcek/v1/${AMD_KDS_PRODUCT}/cert_chain" \
+    -o "$TMP_DIR/cert-chain.pem"
+
+  R_HEX="$(xxd -p -c 48 -s 672 -l 48 "$OUTPUT_DIR/cpu-attestation-report.bin" | awk '{for(i=length($0)-1;i>=1;i-=2)printf substr($0,i,2)}')"
+  S_HEX="$(xxd -p -c 48 -s 744 -l 48 "$OUTPUT_DIR/cpu-attestation-report.bin" | awk '{for(i=length($0)-1;i>=1;i-=2)printf substr($0,i,2)}')"
+  cat >"$TMP_DIR/signature.asn1" <<EOF
+asn1=SEQUENCE:signature
+[signature]
+r=INTEGER:0x${R_HEX}
+s=INTEGER:0x${S_HEX}
+EOF
+  openssl asn1parse -genconf "$TMP_DIR/signature.asn1" -out "$TMP_DIR/signature.der" -noout
+  head -c 672 "$OUTPUT_DIR/cpu-attestation-report.bin" >"$TMP_DIR/signed-data.bin"
+  openssl x509 -inform DER -in "$TMP_DIR/vcek.der" -out "$TMP_DIR/vcek.pem"
+  openssl x509 -in "$TMP_DIR/vcek.pem" -pubkey -noout >"$TMP_DIR/vcek-public-key.pem"
+  VCEK_CHAIN_RESULT="$(openssl verify -CAfile "$TMP_DIR/cert-chain.pem" "$TMP_DIR/vcek.pem")"
+  CPU_SIG_RESULT="$(openssl dgst -sha384 -verify "$TMP_DIR/vcek-public-key.pem" -signature "$TMP_DIR/signature.der" "$TMP_DIR/signed-data.bin")"
+  [[ "$VCEK_CHAIN_RESULT" == *": OK" ]]
+  [[ "$CPU_SIG_RESULT" == "Verified OK" ]]
+  # An authentic report is not sufficient by itself: its launch measurement
+  # must also identify an approved VM build.
+  if [[ "$OBSERVED_SNP_LAUNCH_MEASUREMENT" != "$EXPECTED_SNP_LAUNCH_MEASUREMENT" ]]; then
+    echo "SNP launch measurement does not match the approved reference" >&2
+    echo "Expected: $EXPECTED_SNP_LAUNCH_MEASUREMENT" >&2
+    echo "Observed: $OBSERVED_SNP_LAUNCH_MEASUREMENT" >&2
+    exit 1
+  fi
+  VCEK_SUBJECT="$(openssl x509 -in "$TMP_DIR/vcek.pem" -noout -subject | sed 's/^subject=//')"
+  VCEK_ISSUER="$(openssl x509 -in "$TMP_DIR/vcek.pem" -noout -issuer | sed 's/^issuer=//')"
+  VCEK_DATES="$(openssl x509 -in "$TMP_DIR/vcek.pem" -noout -dates | tr '\n' ' ')"
+  SIGNED_SHA384="$(openssl dgst -sha384 "$TMP_DIR/signed-data.bin" | sed 's/^.*= //')"
+  CPU_RAW_SHA256="$(sha256sum "$OUTPUT_DIR/cpu-attestation-report.bin" | awk '{print $1}')"
+  cat >>"$OUTPUT_DIR/cpu-attestation-report.txt" <<EOF
+
+CRYPTOGRAPHIC VERIFICATION
+==========================
+Nonce freshness: MATCHES generated 64-byte challenge
+Expected SNP launch measurement: ${EXPECTED_SNP_LAUNCH_MEASUREMENT}
+Observed SNP launch measurement: ${OBSERVED_SNP_LAUNCH_MEASUREMENT}
+SNP launch measurement reference: VERIFIED OK
+Measured init-data SHA-256: ${INITDATA_SHA256}
+SNP HOST_DATA binding: VERIFIED OK
+VCEK subject: ${VCEK_SUBJECT}
+VCEK issuer: ${VCEK_ISSUER}
+VCEK validity: ${VCEK_DATES}
+AMD VCEK certificate chain: VERIFIED OK
+Report signature (ECDSA P-384 / SHA-384): VERIFIED OK
+Signed data SHA-384: ${SIGNED_SHA384}
+Raw report SHA-256: ${CPU_RAW_SHA256}
+Overall CPU attestation result: PASS
+EOF
+else
+  echo "Building the pinned Intel TDX quote collector and verifier ..."
+  TDX_ARCHIVE="$ARTIFACT_CACHE_DIR/go-tdx-guest-${GO_TDX_GUEST_COMMIT}.tar.gz"
+  TDX_DOWNLOAD=0
+  if [[ ! -s "$TDX_ARCHIVE" ]]; then
+    TDX_DOWNLOAD=1
+  elif ! echo "${GO_TDX_GUEST_SHA256}  $TDX_ARCHIVE" | sha256sum --check --status; then
+    if [[ "$IGNORE_CHECKSUM_MISMATCH" == 1 ]]; then
+      echo "WARNING: ignoring checksum mismatch for cached TDX verifier source $TDX_ARCHIVE" >&2
+    else
+      TDX_DOWNLOAD=1
+    fi
+  fi
+  if ((TDX_DOWNLOAD == 1)); then
+    TDX_PARTIAL="${TDX_ARCHIVE}.partial.$$"
+    curl -L --fail --silent --show-error \
+      "https://github.com/google/go-tdx-guest/archive/${GO_TDX_GUEST_COMMIT}.tar.gz" \
+      -o "$TDX_PARTIAL"
+    if ! echo "${GO_TDX_GUEST_SHA256}  $TDX_PARTIAL" | sha256sum -c -; then
+      if [[ "$IGNORE_CHECKSUM_MISMATCH" != 1 ]]; then
+        rm -f "$TDX_PARTIAL"
+        exit 1
+      fi
+      echo "WARNING: ignoring checksum mismatch for downloaded TDX verifier source" >&2
+    fi
+    mv "$TDX_PARTIAL" "$TDX_ARCHIVE"
+  fi
+  tar -C "$TMP_DIR" -xzf "$TDX_ARCHIVE"
+  TDX_SOURCE_DIR="$TMP_DIR/go-tdx-guest-${GO_TDX_GUEST_COMMIT}"
+  (
+    cd "$TDX_SOURCE_DIR"
+    CGO_ENABLED=0 go build -trimpath -o "$TMP_DIR/tdx-attest" ./tools/attest
+    CGO_ENABLED=0 go build -trimpath -o "$TMP_DIR/tdx-check" ./tools/check
+  )
+  kcp_to "$TMP_DIR/tdx-attest" "$GUEST_TMP/tdx-attest"
+  kexec chmod 0755 "$GUEST_TMP/tdx-attest"
+  if ! kexec mountpoint -q /sys/kernel/config >/dev/null 2>&1; then
+    kexec mount -t configfs configfs /sys/kernel/config
+  fi
+  kexec test -r /sys/kernel/config/tsm/report
+
+  CPU_NONCE="$(openssl rand -hex 64)"
+  echo "Collecting a fresh Intel TDX quote ..."
+  kexec "$GUEST_TMP/tdx-attest" \
+    -in "$CPU_NONCE" -inform hex -outform bin \
+    -out "$GUEST_TMP/cpu-attestation-report.bin"
+  if ! kexec test -s "$GUEST_TMP/cpu-attestation-report.bin"; then
+    echo "Intel QGS returned an empty quote; verify PCCS has a valid Intel PCS subscription key and platform PCK collateral" >&2
+    exit 1
+  fi
+  kcp_from "$GUEST_TMP/cpu-attestation-report.bin" "$OUTPUT_DIR/cpu-attestation-report.bin"
+
+  MRCONFIG_EXPECTED="${INITDATA_SHA256}00000000000000000000000000000000"
+  RTMR_REFERENCES="${EXPECTED_TDX_RTMR0},${EXPECTED_TDX_RTMR1},${EXPECTED_TDX_RTMR2},${EXPECTED_TDX_RTMR3}"
+  echo "Verifying TDX quote signature, Intel collateral, freshness, and reference values ..."
+  TDX_CHECK_RESULT="$(
+    "$TMP_DIR/tdx-check" \
+      -in "$OUTPUT_DIR/cpu-attestation-report.bin" -inform bin \
+      -get_collateral=true -check_crl=true \
+      -mr_td "$EXPECTED_TDX_MRTD" \
+      -mr_config_id "$MRCONFIG_EXPECTED" \
+      -rtmrs "$RTMR_REFERENCES" \
+      -report_data "$CPU_NONCE"
+  )"
+  # With set -e, the assignment above fails immediately when the verifier
+  # returns a nonzero verification, network, or policy exit code. Do not infer
+  # success from its human-readable message, whose capitalization can change.
+
+  quote_hex() {
+    xxd -p -c 256 -s "$1" -l "$2" "$OUTPUT_DIR/cpu-attestation-report.bin" |
+      tr -d '\n'
+  }
+  QUOTE_VERSION_HEX="$(quote_hex 0 2)"
+  case "$QUOTE_VERSION_HEX" in
+    0400) QUOTE_BODY_SHIFT=0 ;;
+    # Quote v5 inserts a 2-byte body type and 4-byte body-size field between
+    # the common 48-byte header and the otherwise shared TDX 1.0 body.
+    0500) QUOTE_BODY_SHIFT=6 ;;
+    *)
+      echo "Unsupported Intel TD Quote version bytes: $QUOTE_VERSION_HEX" >&2
+      exit 1
+      ;;
+  esac
+  OBSERVED_TDX_MRTD="$(quote_hex $((184 + QUOTE_BODY_SHIFT)) 48)"
+  OBSERVED_TDX_MRCONFIGID="$(quote_hex $((232 + QUOTE_BODY_SHIFT)) 48)"
+  OBSERVED_TDX_RTMR0="$(quote_hex $((376 + QUOTE_BODY_SHIFT)) 48)"
+  OBSERVED_TDX_RTMR1="$(quote_hex $((424 + QUOTE_BODY_SHIFT)) 48)"
+  OBSERVED_TDX_RTMR2="$(quote_hex $((472 + QUOTE_BODY_SHIFT)) 48)"
+  OBSERVED_TDX_RTMR3="$(quote_hex $((520 + QUOTE_BODY_SHIFT)) 48)"
+  OBSERVED_TDX_REPORTDATA="$(quote_hex $((568 + QUOTE_BODY_SHIFT)) 64)"
+  TDX_ATTRIBUTES="$(quote_hex $((168 + QUOTE_BODY_SHIFT)) 8)"
+  (( (16#${TDX_ATTRIBUTES:0:2} & 1) == 0 )) || {
+    echo "TDX quote reports a debug-enabled Trust Domain" >&2
+    exit 1
+  }
+  [[ "$OBSERVED_TDX_MRTD" == "$EXPECTED_TDX_MRTD" ]]
+  [[ "$OBSERVED_TDX_MRCONFIGID" == "$MRCONFIG_EXPECTED" ]]
+  [[ "$OBSERVED_TDX_RTMR0" == "$EXPECTED_TDX_RTMR0" ]]
+  [[ "$OBSERVED_TDX_RTMR1" == "$EXPECTED_TDX_RTMR1" ]]
+  [[ "$OBSERVED_TDX_RTMR2" == "$EXPECTED_TDX_RTMR2" ]]
+  [[ "$OBSERVED_TDX_RTMR3" == "$EXPECTED_TDX_RTMR3" ]]
+  [[ "$OBSERVED_TDX_REPORTDATA" == "$CPU_NONCE" ]]
+  CPU_RAW_SHA256="$(sha256sum "$OUTPUT_DIR/cpu-attestation-report.bin" | awk '{print $1}')"
+  cat >"$OUTPUT_DIR/cpu-attestation-report.txt" <<EOF
+INTEL TDX ATTESTATION REPORT
+============================
+Pod: ${NAMESPACE}/${POD_NAME}
+Runtime class: ${RUNTIME_CLASS}
+Quote version (little-endian): ${QUOTE_VERSION_HEX}
+TD attributes: ${TDX_ATTRIBUTES}
+Debug enabled: no
+MRTD: ${OBSERVED_TDX_MRTD}
+MRCONFIGID: ${OBSERVED_TDX_MRCONFIGID}
+RTMR0: ${OBSERVED_TDX_RTMR0}
+RTMR1: ${OBSERVED_TDX_RTMR1}
+RTMR2: ${OBSERVED_TDX_RTMR2}
+RTMR3: ${OBSERVED_TDX_RTMR3}
+Report data / nonce: ${OBSERVED_TDX_REPORTDATA}
+
+CRYPTOGRAPHIC AND REFERENCE VERIFICATION
+========================================
+Nonce freshness: MATCHES generated 64-byte challenge
+Measured init-data SHA-256: ${INITDATA_SHA256}
+TDX MRCONFIGID binding: VERIFIED OK
+TDX MRTD reference: VERIFIED OK
+TDX RTMR0 reference: VERIFIED OK
+TDX RTMR1 reference: VERIFIED OK
+TDX RTMR2 reference: VERIFIED OK
+TDX RTMR3 reference: VERIFIED OK
+TDX debug attribute: DISABLED
+Quote signature and embedded certificate chain: VERIFIED OK
+Intel PCS collateral, TCB status, and CRLs: VERIFIED OK
+Verifier: google/go-tdx-guest ${GO_TDX_GUEST_COMMIT}
+Verifier output: ${TDX_CHECK_RESULT}
+Raw quote SHA-256: ${CPU_RAW_SHA256}
+Overall CPU attestation result: PASS
+EOF
+fi
+
+echo "Downloading and verifying NVIDIA NVAT ${NVAT_VERSION} ..."
+NVAT_PATH="$ARTIFACT_CACHE_DIR/$NVAT_DEB"
+NVAT_DOWNLOAD=0
+if [[ ! -s "$NVAT_PATH" ]]; then
+  NVAT_DOWNLOAD=1
+elif ! echo "${NVAT_SHA256}  $NVAT_PATH" | sha256sum --check --status; then
+  if [[ "$IGNORE_CHECKSUM_MISMATCH" == 1 ]]; then
+    echo "WARNING: ignoring checksum mismatch for cached NVAT package $NVAT_PATH" >&2
+  else
+    NVAT_DOWNLOAD=1
+  fi
+fi
+if ((NVAT_DOWNLOAD == 1)); then
+  NVAT_PARTIAL="${NVAT_PATH}.partial.$$"
+  if ! curl -L --fail --silent --show-error "$NVAT_URL" -o "$NVAT_PARTIAL"; then
+    rm -f "$NVAT_PARTIAL"
+    exit 1
+  fi
+  if ! echo "${NVAT_SHA256}  $NVAT_PARTIAL" | sha256sum -c -; then
+    if [[ "$IGNORE_CHECKSUM_MISMATCH" == 1 ]]; then
+      echo "WARNING: ignoring checksum mismatch for downloaded NVAT package $NVAT_URL" >&2
+    else
+      rm -f "$NVAT_PARTIAL"
+      exit 1
+    fi
+  fi
+  mv "$NVAT_PARTIAL" "$NVAT_PATH"
+fi
+kcp_to "$NVAT_PATH" "$GUEST_TMP/nvat-local-repo.deb"
+kexec test -s "$GUEST_TMP/nvat-local-repo.deb"
+kexec bash -lc "dpkg -i '$GUEST_TMP/nvat-local-repo.deb' >/dev/null; keyring=\$(find /var/nvat-local-repo-* -maxdepth 1 -name '*-keyring.gpg' -print -quit); test -s \"\$keyring\"; cp \"\$keyring\" /usr/share/keyrings/; apt-get update >/dev/null; DEBIAN_FRONTEND=noninteractive apt-get install -y nvattest >/dev/null"
+
+GPU_NONCE="$(openssl rand -hex 32)"
+echo "Collecting and locally verifying NVIDIA GPU evidence ..."
+kexec bash -lc "nvattest --format json --log-level warn collect-evidence --device gpu --nonce '$GPU_NONCE' > '$GUEST_TMP/gpu-attestation-evidence.json'"
+kexec bash -lc "nvattest --format json --log-level warn attest --device gpu --verifier local --nonce '$GPU_NONCE' > '$GUEST_TMP/gpu-attestation-result.json'"
+kexec test -s "$GUEST_TMP/gpu-attestation-evidence.json"
+kexec test -s "$GUEST_TMP/gpu-attestation-result.json"
+kcp_from "$GUEST_TMP/gpu-attestation-evidence.json" "$OUTPUT_DIR/gpu-attestation-evidence.json"
+kcp_from "$GUEST_TMP/gpu-attestation-result.json" "$OUTPUT_DIR/gpu-attestation-result.json"
+kexec nvidia-smi conf-compute -q >"$OUTPUT_DIR/gpu-confidential-compute-status.txt"
+GPU_IDENTITY="$(kexec nvidia-smi --query-gpu=uuid,name,driver_version,vbios_version --format=csv,noheader)"
+
+jq -e --arg nonce "$GPU_NONCE" '
+  .result_code == 0 and .result_message == "Ok" and
+  .claims[0].eat_nonce == $nonce and
+  .claims[0].measres == "success" and
+  .claims[0].secboot == true and
+  .claims[0].dbgstat == "disabled" and
+  .claims[0]."x-nvidia-gpu-attestation-report-nonce-match" == true and
+  .claims[0]."x-nvidia-gpu-attestation-report-signature-verified" == true and
+  .claims[0]."x-nvidia-gpu-attestation-report-cert-chain"."x-nvidia-cert-status" == "valid" and
+  .claims[0]."x-nvidia-gpu-attestation-report-cert-chain"."x-nvidia-cert-ocsp-status" == "good" and
+  .claims[0]."x-nvidia-gpu-driver-rim-signature-verified" == true and
+  .claims[0]."x-nvidia-gpu-driver-rim-version-match" == true and
+  .claims[0]."x-nvidia-gpu-vbios-rim-signature-verified" == true and
+  .claims[0]."x-nvidia-gpu-vbios-rim-version-match" == true and
+  .claims[0]."x-nvidia-mismatch-measurement-records" == null
+' "$OUTPUT_DIR/gpu-attestation-result.json" >/dev/null
+
+GPU_EVIDENCE_SHA256="$(sha256sum "$OUTPUT_DIR/gpu-attestation-evidence.json" | awk '{print $1}')"
+GPU_RESULT_SHA256="$(sha256sum "$OUTPUT_DIR/gpu-attestation-result.json" | awk '{print $1}')"
+COLLECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+{
+  cat <<EOF
+NVIDIA GPU ATTESTATION REPORT
+=============================
+Collected at: ${COLLECTED_AT}
+Collector/verifier: NVIDIA NVAT ${NVAT_VERSION}, local verifier
+Pod: ${NAMESPACE}/${POD_NAME}
+Runtime class: ${RUNTIME_CLASS}
+GPU identity: ${GPU_IDENTITY}
+
+EOF
+  jq -r --arg nonce "$GPU_NONCE" '
+    .claims[0] as $c |
+    $c."x-nvidia-gpu-driver-version" as $driver_version |
+    $c."x-nvidia-gpu-vbios-version" as $vbios_version |
+    $c."x-nvidia-gpu-attestation-report-nonce-match" as $nonce_match |
+    $c."x-nvidia-gpu-attestation-report-parsed" as $report_parsed |
+    $c."x-nvidia-gpu-attestation-report-signature-verified" as $report_signature |
+    $c."x-nvidia-gpu-attestation-report-cert-chain" as $cert_chain |
+    $cert_chain."x-nvidia-cert-status" as $cert_status |
+    $cert_chain."x-nvidia-cert-ocsp-status" as $ocsp_status |
+    $c."x-nvidia-gpu-attestation-report-cert-chain-fwid-match" as $fwid_match |
+    $c."x-nvidia-gpu-arch-check" as $arch_check |
+    $c."x-nvidia-gpu-driver-rim-signature-verified" as $driver_rim_signature |
+    $c."x-nvidia-gpu-driver-rim-version-match" as $driver_rim_version |
+    $c."x-nvidia-gpu-vbios-rim-signature-verified" as $vbios_rim_signature |
+    $c."x-nvidia-gpu-vbios-rim-version-match" as $vbios_rim_version |
+    $c."x-nvidia-mismatch-measurement-records" as $mismatches |
+    "Hardware model claim: \($c.hwmodel)\n" +
+    "Driver version: \($driver_version)\n" +
+    "VBIOS version: \($vbios_version)\n" +
+    "Secure boot claim: \($c.secboot)\n" +
+    "Debug state claim: \($c.dbgstat)\n\n" +
+    "FRESHNESS\n---------\n" +
+    "Challenge nonce: \($nonce)\n" +
+    "Evidence nonce match: \($nonce_match)\n\n" +
+    "CRYPTOGRAPHIC AND MEASUREMENT VERIFICATION\n------------------------------------------\n" +
+    "Attestation report parsed: \($report_parsed)\n" +
+    "Attestation report signature verified: \($report_signature)\n" +
+    "Attestation certificate status / OCSP: \($cert_status) / \($ocsp_status)\n" +
+    "Firmware identity matched certificate: \($fwid_match)\n" +
+    "GPU architecture check: \($arch_check)\n" +
+    "Measurement appraisal: \($c.measres)\n" +
+    "Driver RIM signature/version verified: \($driver_rim_signature) / \($driver_rim_version)\n" +
+    "VBIOS RIM signature/version verified: \($vbios_rim_signature) / \($vbios_rim_version)\n" +
+    "Mismatched measurement records: \($mismatches)\n\n" +
+    "NVAT result: \(.result_code) / \(.result_message)\n" +
+    "Overall GPU attestation result: PASS\n"
+  ' "$OUTPUT_DIR/gpu-attestation-result.json"
+  cat <<EOF
+
+EVIDENCE ARTIFACTS
+------------------
+Raw signed evidence: gpu-attestation-evidence.json
+Verified claims and detached EAT: gpu-attestation-result.json
+Raw evidence SHA-256: ${GPU_EVIDENCE_SHA256}
+Verified result SHA-256: ${GPU_RESULT_SHA256}
+EOF
+} >"$OUTPUT_DIR/gpu-attestation-report.txt"
+
+if [[ "$TEE_PLATFORM" == snp ]]; then
+  IMAGE_TEE_BINDING="SNP HOST_DATA binding: VERIFIED OK
+SNP launch measurement reference: VERIFIED OK"
+  IMAGE_ENFORCEMENT_POINT="image-rs inside the Kata SEV-SNP guest"
+  IMAGE_READY_EXPLANATION="from SNP-bound init-data"
+else
+  IMAGE_TEE_BINDING="TDX MRCONFIGID binding: VERIFIED OK
+TDX MRTD and RTMR references: VERIFIED OK"
+  IMAGE_ENFORCEMENT_POINT="image-rs inside the Kata TDX guest"
+  IMAGE_READY_EXPLANATION="from TDX MRCONFIGID-bound init-data"
+fi
+cat >"$OUTPUT_DIR/image-verification-report.txt" <<EOF
+CONTAINER IMAGE SIGNATURE VERIFICATION
+======================================
+Result: PASS
+Image: ${POD_IMAGE}
+Policy source: ${IMAGE_POLICY_SOURCE}
+Policy default: reject
+Signature rule: sigstoreSigned
+Public key: embedded as keyData in measured init-data
+Registry configuration: embedded in measured init-data
+Registry transport: HTTPS with an embedded private root CA
+Measured init-data SHA-256: ${INITDATA_SHA256}
+${IMAGE_TEE_BINDING}
+Available Trustee endpoint: ${KBS_ADDRESS}
+Transparency-log mode: ${COSIGN_TLOG_MODE}
+Enforcement point: ${IMAGE_ENFORCEMENT_POINT}
+
+The pod reached Ready only after image-rs loaded the deny-by-default policy
+${IMAGE_READY_EXPLANATION} and verified the image's Cosign signature.
+EOF
+
+(
+  cd "$OUTPUT_DIR"
+  sha256sum \
+    cpu-attestation-report.txt \
+    cpu-attestation-report.bin \
+    gpu-attestation-report.txt \
+    gpu-attestation-evidence.json \
+    gpu-attestation-result.json \
+    image-verification-report.txt \
+    storage-verification-report.txt \
+    >SHA256SUMS
+)
+
+SUCCESS=1
+echo
+echo "CPU attestation: PASS"
+echo "GPU attestation: PASS"
+echo "Confidential storage: PASS"
+echo "Reports saved in: $OUTPUT_DIR"
+echo "Human-readable reports:"
+echo "  $OUTPUT_DIR/cpu-attestation-report.txt"
+echo "  $OUTPUT_DIR/gpu-attestation-report.txt"
+echo "  $OUTPUT_DIR/image-verification-report.txt"
+echo "  $OUTPUT_DIR/storage-verification-report.txt"
+echo "Pod: $NAMESPACE/$POD_NAME ($([[ $CLEANUP_POD == 1 ]] && echo deleted || echo left running))"

--- a/examples/devops/CoCo/run-all.sh
+++ b/examples/devops/CoCo/run-all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+stages=(
+  00-verify-host.sh
+  10-install-kubernetes.sh
+  20-install-coco-gpu.sh
+  30-deploy-security-services.sh
+  40-sign-image.sh
+  50-launch-and-attest.sh
+)
+
+for stage in "${stages[@]}"; do
+  printf '\n========== %s ==========\n' "$stage"
+  "$SCRIPT_DIR/$stage"
+done
+
+echo
+echo "End-to-end CoCo deployment and attestation completed."
+echo "Reports: $SCRIPT_DIR/state/latest-attestation-reports"

--- a/examples/devops/CoCo/templates/kubeadm.yaml.in
+++ b/examples/devops/CoCo/templates/kubeadm.yaml.in
@@ -1,0 +1,31 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: @@NODE_IP@@
+  bindPort: 6443
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  kubeletExtraArgs:
+    - name: node-ip
+      value: @@NODE_IP@@
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: @@K8S_SEMVER@@
+controlPlaneEndpoint: @@NODE_IP@@:6443
+networking:
+  dnsDomain: cluster.local
+  podSubnet: @@POD_CIDR@@
+  serviceSubnet: @@SERVICE_CIDR@@
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+clusterDNS:
+  - @@CLUSTER_DNS@@
+clusterDomain: cluster.local
+featureGates:
+  KubeletPodResourcesGet: true
+  RuntimeClassInImageCriApi: true
+resolvConf: /run/systemd/resolve/resolv.conf
+runtimeRequestTimeout: 20m

--- a/examples/devops/CoCo/templates/nvflare-coco.yaml.in
+++ b/examples/devops/CoCo/templates/nvflare-coco.yaml.in
@@ -1,0 +1,189 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: @@SERVER_NAME@@
+  namespace: @@NAMESPACE@@
+spec:
+  selector:
+    app: @@SERVER_NAME@@
+  ports:
+    - {name: fed, port: 8002, targetPort: fed}
+    - {name: admin, port: 8003, targetPort: admin}
+    - {name: parent, port: 8102, targetPort: parent}
+---
+# kind: List keeps both Deployments in one YAML document so the
+# &coco-init-args anchor can be shared. kubectl apply processes all items.
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: @@SERVER_NAME@@
+      namespace: @@NAMESPACE@@
+    spec:
+      replicas: 1
+      strategy: {type: Recreate}
+      selector:
+        matchLabels: {app: @@SERVER_NAME@@}
+      template:
+        metadata:
+          labels: {app: @@SERVER_NAME@@}
+          annotations:
+            io.katacontainers.config.hypervisor.cc_init_data: "@@INIT_DATA@@"
+        spec:
+          runtimeClassName: @@SERVER_RUNTIME_CLASS@@
+          securityContext:
+            fsGroup: @@FS_GROUP@@
+            fsGroupChangePolicy: OnRootMismatch
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          containers:
+            - name: server
+              image: @@SERVER_IMAGE@@
+              imagePullPolicy: IfNotPresent
+              # Privilege is confined to this participant's isolated Kata VM. It is
+              # required to materialize the guest-local TEE character device; no
+              # hostPath device is passed through from the bare-metal host.
+              securityContext:
+                privileged: true
+                runAsUser: 0
+                runAsGroup: 0
+              command: ["python"]
+              args:
+                - -c
+                - &coco-init-args |
+                  import ctypes, errno, os, stat, sys
+                  name = "@@CPU_ATTESTATION_DEVICE@@"
+                  sysfs = f"/sys/class/misc/{name}/dev"
+                  if not os.path.isfile(sysfs):
+                      raise SystemExit(f"missing guest attestation interface: {sysfs}")
+                  if name == "tdx_guest" and not os.path.isdir("/sys/kernel/config/tsm/report"):
+                      os.makedirs("/sys/kernel/config", exist_ok=True)
+                      libc = ctypes.CDLL(None, use_errno=True)
+                      if libc.mount(b"configfs", b"/sys/kernel/config", b"configfs", 0, None) != 0:
+                          error = ctypes.get_errno()
+                          if error != errno.EBUSY:
+                              raise OSError(error, os.strerror(error), "/sys/kernel/config")
+                  with open(sysfs, encoding="ascii") as sysfs_stream:
+                      major, minor = map(int, sysfs_stream.read().split(":"))
+                  path = f"/dev/{name}"
+                  if not os.path.exists(path):
+                      os.mknod(path, stat.S_IFCHR | 0o600, os.makedev(major, minor))
+                  info = os.stat(path)
+                  if not stat.S_ISCHR(info.st_mode) or os.major(info.st_rdev) != major or os.minor(info.st_rdev) != minor:
+                      raise SystemExit(f"incorrect guest attestation device: {path}")
+                  os.execv(sys.executable, [sys.executable, *sys.argv[1:]])
+                - -u
+                - -m
+                - nvflare.private.fed.app.server.server_train
+                - -m
+                - /var/tmp/nvflare/workspace
+                - -s
+                - fed_server.json
+                - --set
+                - secure_train=true
+                - config_folder=config
+                - org=@@ORG@@
+              ports:
+                - {name: fed, containerPort: 8002}
+                - {name: admin, containerPort: 8003}
+                - {name: parent, containerPort: 8102}
+              resources:
+                requests: {memory: "@@SERVER_MEMORY@@"}
+                limits: {memory: "@@SERVER_MEMORY@@"}
+              volumeMounts:
+                - {name: app-log, mountPath: /applog}
+                - {name: workspace, mountPath: /var/tmp/nvflare/workspace}
+                - {name: startup, mountPath: /var/tmp/nvflare/workspace/startup, readOnly: true}
+                - {name: local, mountPath: /var/tmp/nvflare/workspace/local, readOnly: true}
+                - {name: tdx-attestation, mountPath: /etc/nvflare/tdx-attestation, readOnly: true}
+              env:
+                - name: NV_ATTESTATION_SERVICE_KEY
+                  valueFrom:
+                    secretKeyRef: {name: nvflare-gpu-attestation, key: service-key, optional: true}
+          volumes:
+            - name: app-log
+              emptyDir: {sizeLimit: 256Mi}
+            - name: workspace
+              emptyDir: {sizeLimit: "@@WORKSPACE_SIZE@@"}
+            - name: startup
+              secret: {secretName: @@SERVER_NAME@@-startup}
+            - name: local
+              configMap: {name: @@SERVER_NAME@@-local}
+            - name: tdx-attestation
+              secret: {secretName: nvflare-tdx-attestation, optional: true}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: @@CLIENT_NAME@@
+      namespace: @@NAMESPACE@@
+    spec:
+      replicas: 1
+      strategy: {type: Recreate}
+      selector:
+        matchLabels: {app: @@CLIENT_NAME@@}
+      template:
+        metadata:
+          labels: {app: @@CLIENT_NAME@@}
+          annotations:
+            io.katacontainers.config.hypervisor.cc_init_data: "@@INIT_DATA@@"
+        spec:
+          runtimeClassName: @@CLIENT_RUNTIME_CLASS@@
+          securityContext:
+            fsGroup: @@FS_GROUP@@
+            fsGroupChangePolicy: OnRootMismatch
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          containers:
+            - name: client
+              image: @@CLIENT_IMAGE@@
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                privileged: true
+                runAsUser: 0
+                runAsGroup: 0
+              command: ["python"]
+              args:
+                - -c
+                - *coco-init-args
+                - -u
+                - -m
+                - nvflare.private.fed.app.client.client_train
+                - -m
+                - /var/tmp/nvflare/workspace
+                - -s
+                - fed_client.json
+                - --set
+                - uid=@@CLIENT_NAME@@
+                - secure_train=true
+                - config_folder=config
+                - org=@@ORG@@
+              resources:
+                requests:
+                  memory: "@@CLIENT_MEMORY@@"
+                  @@GPU_RESOURCE@@: "@@CLIENT_GPU_COUNT@@"
+                limits:
+                  memory: "@@CLIENT_MEMORY@@"
+                  @@GPU_RESOURCE@@: "@@CLIENT_GPU_COUNT@@"
+              volumeMounts:
+                - {name: app-log, mountPath: /applog}
+                - {name: workspace, mountPath: /var/tmp/nvflare/workspace}
+                - {name: startup, mountPath: /var/tmp/nvflare/workspace/startup, readOnly: true}
+                - {name: local, mountPath: /var/tmp/nvflare/workspace/local, readOnly: true}
+                - {name: tdx-attestation, mountPath: /etc/nvflare/tdx-attestation, readOnly: true}
+              env:
+                - name: NV_ATTESTATION_SERVICE_KEY
+                  valueFrom:
+                    secretKeyRef: {name: nvflare-gpu-attestation, key: service-key, optional: true}
+          volumes:
+            - name: app-log
+              emptyDir: {sizeLimit: 256Mi}
+            - name: workspace
+              emptyDir: {sizeLimit: "@@WORKSPACE_SIZE@@"}
+            - name: startup
+              secret: {secretName: @@CLIENT_NAME@@-startup}
+            - name: local
+              configMap: {name: @@CLIENT_NAME@@-local}
+            - name: tdx-attestation
+              secret: {secretName: nvflare-tdx-attestation, optional: true}

--- a/examples/devops/CoCo/templates/nvflare-project.yml.in
+++ b/examples/devops/CoCo/templates/nvflare-project.yml.in
@@ -1,0 +1,45 @@
+api_version: 3
+name: @@PROJECT_NAME@@
+description: NVFlare server and client in Kata Confidential Containers
+
+participants:
+  - name: @@SERVER_NAME@@
+    type: server
+    org: @@ORG@@
+    default_host: "@@SERVER_NAME@@"
+    host_names:
+      - "@@SERVER_NAME@@"
+      - "@@SERVER_NAME@@.@@NAMESPACE@@"
+      - "@@SERVER_NAME@@.@@NAMESPACE@@.svc"
+      - "@@SERVER_NAME@@.@@NAMESPACE@@.svc.cluster.local"
+      # Stage 60 terminates no TLS: it tunnels host loopback to this server.
+      # The IP SAN lets gRPC verify that loopback endpoint without disabling
+      # certificate hostname verification or changing server_identity.
+      - "127.0.0.1"
+    fed_learn_port: 8002
+    admin_port: 8003
+    cc_config: "@@SERVER_CC_CONFIG@@"
+  - name: @@CLIENT_NAME@@
+    type: client
+    org: @@ORG@@
+    capacity:
+      num_of_gpus: @@CLIENT_GPU_COUNT@@
+      mem_per_gpu_in_GiB: 0
+    cc_config: "@@CLIENT_CC_CONFIG@@"
+  - name: @@ADMIN_NAME@@
+    type: admin
+    org: @@ORG@@
+    role: project_admin
+
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+    args:
+      template_file:
+        - master_template.yml
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      config_folder: config
+      scheme: grpc
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.cc_provision.impl.cc.CCBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder

--- a/examples/devops/CoCo/templates/registry.yaml.in
+++ b/examples/devops/CoCo/templates/registry.yaml.in
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coco-registry
+  namespace: @@NAMESPACE@@
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app: coco-registry}
+  template:
+    metadata:
+      labels: {app: coco-registry}
+    spec:
+      containers:
+        - name: registry
+          image: @@REGISTRY_IMAGE@@
+          env:
+            - {name: REGISTRY_STORAGE_DELETE_ENABLED, value: "true"}
+            - {name: REGISTRY_HTTP_TLS_CERTIFICATE, value: /run/registry-tls/tls.crt}
+            - {name: REGISTRY_HTTP_TLS_KEY, value: /run/registry-tls/tls.key}
+          ports:
+            - {name: registry, containerPort: 5000, hostPort: @@PORT@@, hostIP: @@HOST_IP@@}
+          readinessProbe:
+            httpGet: {scheme: HTTPS, path: /v2/, port: registry}
+          volumeMounts:
+            - {name: registry-data, mountPath: /var/lib/registry}
+            - {name: registry-tls, mountPath: /run/registry-tls, readOnly: true}
+      volumes:
+        - name: registry-data
+          hostPath: {path: @@DATA_DIR@@, type: DirectoryOrCreate}
+        - name: registry-tls
+          secret: {secretName: coco-registry-tls}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coco-registry
+  namespace: @@NAMESPACE@@
+spec:
+  selector: {app: coco-registry}
+  ports:
+    - {name: registry, port: 5000, targetPort: registry}

--- a/examples/devops/CoCo/templates/trustee-kbs.yaml.in
+++ b/examples/devops/CoCo/templates/trustee-kbs.yaml.in
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kbs-config
+  namespace: @@NAMESPACE@@
+data:
+  kbs-config.toml: |
+    [http_server]
+    sockets = ["0.0.0.0:8080"]
+    insecure_http = true
+    [attestation_token]
+    insecure_key = true
+    [attestation_service]
+    type = "coco_as_builtin"
+    [attestation_service.attestation_token_broker]
+    duration_min = 5
+    [attestation_service.rvps_config]
+    type = "BuiltIn"
+    [admin]
+    type = "DenyAll"
+    insecure_api = false
+    [[plugins]]
+    name = "resource"
+    type = "kvstorage"
+    [storage_backend]
+    storage_type = "LocalFs"
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/kbs"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kbs-resource-policy
+  namespace: @@NAMESPACE@@
+data:
+  policy.rego: |
+    package policy
+    default allow = false
+    allow if {
+      data.plugin == "resource"
+      not input["submods"]["cpu0"]["ear.veraison.annotated-evidence"]["sample"]
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: @@SERVICE@@
+  namespace: @@NAMESPACE@@
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: @@SERVICE@@}
+  template:
+    metadata:
+      labels: {app: @@SERVICE@@}
+    spec:
+      containers:
+        - name: kbs
+          image: @@TRUSTEE_IMAGE@@
+          command: ["/usr/local/bin/kbs", "--config-file", "/etc/kbs/kbs-config.toml"]
+          ports:
+            - {name: http, containerPort: 8080}
+          readinessProbe:
+            tcpSocket: {port: http}
+            initialDelaySeconds: 5
+          volumeMounts:
+            - {name: kbs-config, mountPath: /etc/kbs}
+            - {name: kbs-state, mountPath: /opt/confidential-containers/kbs}
+            - {name: resource-policy, mountPath: /opt/confidential-containers/kbs/policy.rego, subPath: policy.rego, readOnly: true}
+            - {name: verification-resources, mountPath: /opt/confidential-containers/kbs/repository, readOnly: true}
+      volumes:
+        - name: kbs-config
+          configMap: {name: kbs-config}
+        - name: resource-policy
+          configMap: {name: kbs-resource-policy}
+        - name: kbs-state
+          emptyDir: {}
+        - name: verification-resources
+          secret:
+            secretName: coco-image-verification-resources
+            items:
+              - {key: security-policy, path: default/security-policy/coco}
+              - {key: cosign-public-key, path: default/cosign-public-key/coco}
+              - {key: registry-ca, path: default/registry-ca/coco}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: @@SERVICE@@
+  namespace: @@NAMESPACE@@
+spec:
+  selector: {app: @@SERVICE@@}
+  ports:
+    - {name: http, port: 8080, targetPort: http}

--- a/examples/devops/README.md
+++ b/examples/devops/README.md
@@ -25,6 +25,9 @@ classes, and participants for the clusters you want to test.
 
 - `multicloud/` - YAML-driven NVFlare deployment, status, dashboard, and image
   build/push helpers.
+- `CoCo/` - staged bare-metal AMD SEV-SNP or Intel TDX Confidential Containers
+  deployment, signed-image enforcement, encrypted scratch storage, NVIDIA GPU
+  passthrough, and attestation validation.
 - `openshift/` - OpenShift-specific deployment guide and helper scripts using
   the Kubernetes runtime support.
 - `gcp/gke/`, `aws/eks/`, `azure/aks/` - cloud cluster setup scripts and notes.

--- a/nvflare/app_opt/confidential_computing/coco_hello_numpy_executor.py
+++ b/nvflare/app_opt/confidential_computing/coco_hello_numpy_executor.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixed executor for the signed CoCo hello-numpy validation trainer."""
+
+from nvflare.app_common.executors.client_api_executor import ClientAPIExecutor, ExecutionMode
+from nvflare.client.config import ExchangeFormat, TransferType
+
+
+class CoCoHelloNumpyExecutor(ClientAPIExecutor):
+    """Run only the hello-numpy trainer baked into the signed CoCo image.
+
+    The constructor intentionally accepts no job-controlled entry point or
+    arguments. This makes the exact class safe to add to a participant's CoCo
+    component allow-list without allowing a submitted configuration to select
+    another executable path.
+    """
+
+    TRAINER_PATH = "/opt/nvflare/examples/hello-numpy/client.py"
+
+    def __init__(self):
+        super().__init__(
+            execution_mode=ExecutionMode.IN_PROCESS,
+            task_script_path=self.TRAINER_PATH,
+            task_script_args="--update_type full",
+            params_exchange_format=ExchangeFormat.NUMPY,
+            server_expected_format=ExchangeFormat.NUMPY,
+            params_transfer_type=TransferType.FULL,
+        )

--- a/nvflare/app_opt/confidential_computing/gpu_authorizer.py
+++ b/nvflare/app_opt/confidential_computing/gpu_authorizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,122 +12,280 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import json
 import logging
-import uuid
+import os
+import re
+import secrets
+import subprocess
+import tempfile
 
-import jwt
-from nv_attestation_sdk import attestation
-
-from nvflare.app_opt.confidential_computing.cc_authorizer import CCAuthorizer
+from nvflare.app_opt.confidential_computing.cc_authorizer import CCAuthorizer, CCTokenGenerateError
 
 from .utils import NonceHistory
 
 GPU_NAMESPACE = "x-nv-gpu"
-default_policy = """{
-  "version":"4.0",
-  "authorization-rules":{
-    "type": "JWT",
-    "overall-claims": {
-      "x-nvidia-overall-att-result": true,
-      "x-nvidia-ver": "3.0"
-    },
-    "detached-claims":{
-      "measres": "success",
-      "x-nvidia-gpu-arch-check": true,
-      "x-nvidia-gpu-attestation-report-parsed": true,
-      "x-nvidia-gpu-attestation-report-nonce-match": true,
-      "x-nvidia-gpu-attestation-report-signature-verified": true,
-      "x-nvidia-gpu-attestation-report-cert-chain":
-      {
-        "x-nvidia-cert-status": "valid",
-        "x-nvidia-cert-ocsp-status": "good"
-      },
-      "x-nvidia-gpu-attestation-report-cert-chain-fwid-match": true,
-      "x-nvidia-gpu-driver-rim-fetched": true,
-      "x-nvidia-gpu-driver-rim-schema-validated": true,
-      "x-nvidia-gpu-driver-rim-signature-verified": true,
-      "x-nvidia-gpu-driver-rim-version-match": true,
-      "x-nvidia-gpu-driver-rim-cert-chain":
-      {
-        "x-nvidia-cert-status": "valid",
-        "x-nvidia-cert-ocsp-status": "good"
-      },
-      "x-nvidia-gpu-driver-rim-measurements-available": true,
-      "x-nvidia-gpu-vbios-rim-fetched": true,
-      "x-nvidia-gpu-vbios-rim-schema-validated": true,
-      "x-nvidia-gpu-vbios-rim-signature-verified": true,
-      "x-nvidia-gpu-vbios-rim-version-match": true,
-      "x-nvidia-gpu-vbios-rim-cert-chain":
-      {
-        "x-nvidia-cert-status": "valid",
-        "x-nvidia-cert-ocsp-status": "good"
-      },
-      "x-nvidia-gpu-vbios-rim-measurements-available": true,
-      "x-nvidia-gpu-vbios-index-no-conflict": true
-    }
+NVAT_SERVICE_KEY_ENV = "NV_ATTESTATION_SERVICE_KEY"
+LEGACY_SERVICE_KEY_ENV = "NVIDIA_ATTESTATION_SERVICE_KEY"
+DEFAULT_NRAS_URL = "https://nras.attestation.nvidia.com"
+
+# NVAT applies this Rego policy to cryptographically verified claims. Keep the
+# checks explicit so a successful CLI exit alone is never the authorization
+# decision.
+default_policy = """package policy
+import future.keywords.every
+
+default nv_match = false
+
+nv_match {
+  count(input) > 0
+  every result in input {
+    result["x-nvidia-device-type"] == "gpu"
+    result["measres"] == "success"
+    result["secboot"] == true
+    result["dbgstat"] == "disabled"
+    result["x-nvidia-gpu-arch-check"] == true
+    result["x-nvidia-gpu-attestation-report-parsed"] == true
+    result["x-nvidia-gpu-attestation-report-nonce-match"] == true
+    result["x-nvidia-gpu-attestation-report-signature-verified"] == true
+    result["x-nvidia-gpu-attestation-report-cert-chain"]["x-nvidia-cert-status"] == "valid"
+    result["x-nvidia-gpu-attestation-report-cert-chain"]["x-nvidia-cert-ocsp-status"] == "good"
+    result["x-nvidia-gpu-attestation-report-cert-chain-fwid-match"] == true
+    result["x-nvidia-gpu-driver-rim-signature-verified"] == true
+    result["x-nvidia-gpu-driver-rim-version-match"] == true
+    result["x-nvidia-gpu-vbios-rim-signature-verified"] == true
+    result["x-nvidia-gpu-vbios-rim-version-match"] == true
+    result["x-nvidia-mismatch-measurement-records"] == null
   }
 }
 """
 
 
+def _default_policy_claim_matches(claim: dict) -> bool:
+    """Evaluate the built-in Rego policy's security predicates independently."""
+    certificate_chain = claim.get("x-nvidia-gpu-attestation-report-cert-chain")
+    return (
+        claim.get("x-nvidia-device-type") == "gpu"
+        and claim.get("measres") == "success"
+        and claim.get("secboot") is True
+        and claim.get("dbgstat") == "disabled"
+        and claim.get("x-nvidia-gpu-arch-check") is True
+        and claim.get("x-nvidia-gpu-attestation-report-parsed") is True
+        and claim.get("x-nvidia-gpu-attestation-report-nonce-match") is True
+        and claim.get("x-nvidia-gpu-attestation-report-signature-verified") is True
+        and isinstance(certificate_chain, dict)
+        and certificate_chain.get("x-nvidia-cert-status") == "valid"
+        and certificate_chain.get("x-nvidia-cert-ocsp-status") == "good"
+        and claim.get("x-nvidia-gpu-attestation-report-cert-chain-fwid-match") is True
+        and claim.get("x-nvidia-gpu-driver-rim-signature-verified") is True
+        and claim.get("x-nvidia-gpu-driver-rim-version-match") is True
+        and claim.get("x-nvidia-gpu-vbios-rim-signature-verified") is True
+        and claim.get("x-nvidia-gpu-vbios-rim-version-match") is True
+        and "x-nvidia-mismatch-measurement-records" in claim
+        and claim["x-nvidia-mismatch-measurement-records"] is None
+    )
+
+
+def _parse_evidence_document(token: str, max_token_size: int) -> tuple[dict, str]:
+    if not isinstance(token, str) or not token or len(token.encode("utf-8")) > max_token_size:
+        raise ValueError("GPU evidence token is empty or exceeds the configured size limit")
+    try:
+        document = json.loads(token)
+    except json.JSONDecodeError as e:
+        raise ValueError("GPU evidence token is not valid JSON") from e
+    if not isinstance(document, dict) or document.get("result_code") != 0:
+        raise ValueError("GPU evidence collection did not report success")
+    evidences = document.get("evidences")
+    if not isinstance(evidences, list) or not evidences:
+        raise ValueError("GPU evidence token contains no device evidence")
+
+    nonce = None
+    for evidence in evidences:
+        if not isinstance(evidence, dict):
+            raise ValueError("GPU evidence token contains an invalid evidence entry")
+        evidence_nonce = evidence.get("nonce")
+        if not isinstance(evidence_nonce, str) or not re.fullmatch(r"[0-9A-Fa-f]{64}", evidence_nonce):
+            raise ValueError("GPU evidence token contains an invalid nonce")
+        normalized_nonce = evidence_nonce.lower()
+        if nonce is None:
+            nonce = normalized_nonce
+        elif nonce != normalized_nonce:
+            raise ValueError("GPU evidence token contains inconsistent nonces")
+    return document, nonce
+
+
 class GPUAuthorizer(CCAuthorizer):
+    """Generate and verify NVIDIA GPU evidence with the NVAT ``nvattest`` CLI."""
+
     def __init__(
-        self, verifier_url="https://nras.attestation.nvidia.com/v4/attest/gpu", policy_file=None, max_nonce_history=1000
+        self,
+        verifier_url=None,
+        policy_file=None,
+        max_nonce_history=1000,
+        *,
+        nvat_command="/opt/attestation/bin/nvattest",
+        verifier="remote",
+        nras_url=DEFAULT_NRAS_URL,
+        service_key=None,
+        cmd_timeout=180,
+        max_token_size=16 * 1024 * 1024,
     ):
+        """Initialize the NVAT-backed GPU authorizer.
+
+        ``verifier_url`` is retained as a compatibility alias for deployments
+        that configured the retired Python SDK authorizer.
+
+        The ``policy_file`` marker checks below are only a lightweight
+        configuration pre-check. NVAT remains authoritative: it compiles and
+        evaluates the Rego policy during attestation, so a malformed policy or
+        one that merely mentions ``nv_match`` in a comment fails closed then.
+        """
+        super().__init__()
+        if not isinstance(nvat_command, str) or not nvat_command.strip():
+            raise ValueError("nvat_command must be a non-empty string")
+        if verifier not in ("local", "remote"):
+            raise ValueError("verifier must be 'local' or 'remote'")
+        if cmd_timeout <= 0:
+            raise ValueError("cmd_timeout must be positive")
+        if max_token_size <= 0:
+            raise ValueError("max_token_size must be positive")
+
+        if verifier_url:
+            nras_url = verifier_url.removesuffix("/v4/attest/gpu")
+        if verifier == "remote" and (not isinstance(nras_url, str) or not nras_url.startswith("https://")):
+            raise ValueError("nras_url must be an HTTPS URL for remote verification")
+
+        self.logger = logging.getLogger(self.__class__.__name__)
         self._can_generate = True
-        self.client = attestation.Attestation()
-        self.client.set_name("nvflare_node")
         self.my_nonce_history = NonceHistory(max_nonce_history)
         self.seen_nonce_history = NonceHistory(max_nonce_history)
-        self.client.set_claims_version("3.0")
+        self.nvat_command = nvat_command
+        self.verifier = verifier
+        self.nras_url = nras_url.rstrip("/")
+        self.cmd_timeout = cmd_timeout
+        self.max_token_size = max_token_size
 
         if policy_file is None:
-            self.remote_att_result_policy = default_policy
+            self.relying_party_policy = default_policy
+            self._uses_default_policy = True
         else:
-            self.remote_att_result_policy = open(policy_file).read()
-        self.client.add_verifier(attestation.Devices.GPU, attestation.Environment.REMOTE, verifier_url, "")
-        self.logger = logging.getLogger(self.__class__.__name__)
+            with open(policy_file, encoding="utf-8") as policy_stream:
+                self.relying_party_policy = policy_stream.read()
+            if not self.relying_party_policy.strip():
+                raise ValueError("NVAT relying-party policy must not be empty")
+            if "package " not in self.relying_party_policy or "nv_match" not in self.relying_party_policy:
+                raise ValueError("NVAT relying-party policy must be Rego defining nv_match")
+            self._uses_default_policy = False
 
-    def generate(self):
+        if service_key is None:
+            service_key = os.environ.get(NVAT_SERVICE_KEY_ENV) or os.environ.get(LEGACY_SERVICE_KEY_ENV)
+        self.service_key = service_key
+
+    def _run(self, arguments: list[str], action: str) -> subprocess.CompletedProcess:
+        environment = os.environ.copy()
+        if self.service_key:
+            environment[NVAT_SERVICE_KEY_ENV] = self.service_key
         try:
-            nonce = uuid.uuid4().hex + uuid.uuid1().hex
-            self.client.set_nonce(nonce)
+            return subprocess.run(
+                [self.nvat_command, "--format", "json", "--log-level", "warn", *arguments],
+                capture_output=True,
+                text=True,
+                timeout=self.cmd_timeout,
+                start_new_session=True,
+                env=environment,
+            )
+        except FileNotFoundError as e:
+            raise RuntimeError(f"NVAT executable not found: {self.nvat_command}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"NVAT {action} timed out after {self.cmd_timeout} seconds") from e
+        except OSError as e:
+            raise RuntimeError(f"NVAT {action} could not start: {e}") from e
+
+    @staticmethod
+    def _successful_result(result: subprocess.CompletedProcess, action: str) -> dict:
+        if result.returncode != 0:
+            raise RuntimeError(f"NVAT {action} failed with exit status {result.returncode}")
+        try:
+            document = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"NVAT {action} returned invalid JSON") from e
+        if not isinstance(document, dict) or document.get("result_code") != 0:
+            raise RuntimeError(f"NVAT {action} did not report success")
+        return document
+
+    def generate(self) -> str:
+        nonce = secrets.token_hex(32)
+        try:
+            result = self._run(
+                ["collect-evidence", "--device", "gpu", "--nonce", nonce],
+                "GPU evidence collection",
+            )
+            document = self._successful_result(result, "GPU evidence collection")
+            token = json.dumps(document, separators=(",", ":"), sort_keys=True)
+            _, evidence_nonce = _parse_evidence_document(token, self.max_token_size)
+            if evidence_nonce != nonce:
+                raise RuntimeError("NVAT GPU evidence nonce does not match the generated challenge")
             self.my_nonce_history.add(nonce)
-            evidence_list = self.client.get_evidence()
-            self.client.attest(evidence_list)
-            token = self.client.get_token()
-        except BaseException:
-            self.can_generate = False
-            token = "[[],{}]"
-        return token
+            self._can_generate = True
+            return token
+        except (RuntimeError, ValueError) as e:
+            self._can_generate = False
+            raise CCTokenGenerateError(f"Failed to generate NVAT GPU evidence: {e}") from e
 
-    def verify(self, eat_token):
+    def verify(self, token: str) -> bool:
         try:
-            jwt_token = json.loads(eat_token)[1]
-            remote_gpu_claims = jwt_token.get("REMOTE_GPU_CLAIMS")
-            if (
-                isinstance(remote_gpu_claims, list)
-                and len(remote_gpu_claims) > 0
-                and isinstance(remote_gpu_claims[0], list)
-                and len(remote_gpu_claims[0]) > 1
-            ):
-                claims = jwt.decode(remote_gpu_claims[0][1], options={"verify_signature": False})
-            else:
-                self.logger.info("Invalid structure for REMOTE_GPU_CLAIMS")
-                return False
-            # With claims, we will retrieve the nonce
-            nonce = claims.get("eat_nonce")
-            if not self.seen_nonce_history.add(nonce):
-                return False
-            self.client.set_nonce(nonce)
-            self.client.set_token(name="nvflare_node", eat_token=eat_token)
-            result = self.client.validate_token(self.remote_att_result_policy)
-        except BaseException as e:
-            self.logger.info(f"Token verification failed {e=}")
-            result = False
-        return result
+            document, nonce = _parse_evidence_document(token, self.max_token_size)
+            with tempfile.TemporaryDirectory(prefix="nvflare-nvat-verify-") as work_dir:
+                evidence_path = os.path.join(work_dir, "gpu-evidence.json")
+                policy_path = os.path.join(work_dir, "relying-party-policy.rego")
+                with open(evidence_path, "w", encoding="utf-8") as evidence_stream:
+                    # NVAT collect-evidence returns a result wrapper, while the
+                    # 1.2.2 JSON file evidence-source API consumes the evidence
+                    # array itself.
+                    json.dump(document["evidences"], evidence_stream, separators=(",", ":"), sort_keys=True)
+                with open(policy_path, "w", encoding="utf-8") as policy_stream:
+                    policy_stream.write(self.relying_party_policy)
+
+                command = [
+                    "attest",
+                    "--device",
+                    "gpu",
+                    "--verifier",
+                    self.verifier,
+                    "--nonce",
+                    nonce,
+                    "--gpu-evidence-source",
+                    "file",
+                    "--gpu-evidence-file",
+                    evidence_path,
+                    "--relying-party-policy",
+                    policy_path,
+                ]
+                if self.verifier == "remote":
+                    command.extend(["--nras-url", self.nras_url])
+                result = self._run(command, "GPU evidence verification")
+                verified = self._successful_result(result, "GPU evidence verification")
+                claims = verified.get("claims")
+                if not isinstance(claims, list) or not claims:
+                    raise RuntimeError("NVAT verification returned no GPU claims")
+                if any(
+                    not isinstance(claim, dict) or str(claim.get("eat_nonce", "")).lower() != nonce for claim in claims
+                ):
+                    raise RuntimeError("NVAT verified claims do not match the evidence nonce")
+                # NVAT 1.2.2 documents that nv_match=false returns
+                # NVAT_RP_POLICY_MISMATCH. Re-evaluate every predicate in the
+                # built-in policy as defense in depth, so authorization never
+                # depends only on the CLI exit/result-code contract.
+                # https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/1.2.2/sdk-cli/command-reference.html
+                if self._uses_default_policy and not all(_default_policy_claim_matches(claim) for claim in claims):
+                    raise RuntimeError("NVAT verified claims do not satisfy the built-in relying-party policy")
+                if not self.seen_nonce_history.add(nonce):
+                    self.logger.warning("Rejected replayed NVAT GPU evidence")
+                    return False
+            return True
+        except (OSError, RuntimeError, ValueError) as e:
+            self.logger.warning("NVAT GPU evidence verification failed: %s", e)
+            return False
 
     def get_namespace(self) -> str:
         return GPU_NAMESPACE

--- a/nvflare/app_opt/confidential_computing/snp_authorizer.py
+++ b/nvflare/app_opt/confidential_computing/snp_authorizer.py
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 import base64
+import binascii
 import logging
 import os
 import re
 import secrets
 import shutil
 import subprocess
+import tempfile
 import time
-import uuid
+from contextlib import contextmanager
 
-from filelock import FileLock
-
-from nvflare.app_opt.confidential_computing.cc_authorizer import CCAuthorizer
+from nvflare.app_opt.confidential_computing.cc_authorizer import CCAuthorizer, CCTokenGenerateError
 
 from .utils import NonceHistory
 
@@ -36,27 +36,30 @@ AMD_ARK = "ark.pem"
 AMD_ASK = "ask.pem"
 AMD_VCEK = "vcek.pem"
 
+# These fields are stable parts of the AMD SEV-SNP attestation report ABI.  Reading
+# them directly avoids depending on the human-readable output of a particular
+# snpguest release.
+REPORT_DATA_OFFSET = 80
+REPORT_DATA_SIZE = 64
+REPORTED_TCB_OFFSET = 384
+REPORTED_TCB_SIZE = 8
+CHIP_ID_OFFSET = 416
+CHIP_ID_SIZE = 64
+MIN_REPORT_SIZE = CHIP_ID_OFFSET + CHIP_ID_SIZE
+
 
 def parse_chip_id(report_text: str) -> str:
-    # Find the block starting with "Chip ID:" followed by multiple lines of hex bytes
+    """Parse a chip ID from legacy ``snpguest display report`` output."""
     match = re.search(
-        r"Chip ID:\s*((?:[0-9A-Fa-f]{2}\s+){15}[0-9A-Fa-f]{2}(?:\s*\n\s*(?:[0-9A-Fa-f]{2}\s+){15}[0-9A-Fa-f]{2})*)",
+        r"Chip ID:\s*((?:[0-9A-Fa-f]{2}\s+){15}[0-9A-Fa-f]{2}" r"(?:\s*\n\s*(?:[0-9A-Fa-f]{2}\s+){15}[0-9A-Fa-f]{2})*)",
         report_text,
         re.MULTILINE,
     )
-    if not match:
-        return ""
-
-    # Extract all hex bytes and remove spaces/newlines
-    hex_block = match.group(1)
-    # Remove all whitespace characters and convert to lowercase
-    chip_id = "".join(hex_block.split()).lower()
-
-    return chip_id
+    return "" if not match else "".join(match.group(1).split()).lower()
 
 
 def parse_reported_tcb(report_text: str) -> dict:
-    # Match the entire Reported TCB block after the line "Reported TCB:"
+    """Parse reported TCB fields from legacy ``snpguest`` text output."""
     match = re.search(
         r"Reported TCB:\s*"
         r"TCB Version:\s*"
@@ -68,13 +71,9 @@ def parse_reported_tcb(report_text: str) -> dict:
         report_text,
         re.MULTILINE,
     )
-
     if not match:
         return {}
-
-    # Parse FMC which can be 'None' or something else
     microcode, snp, tee, boot_loader, fmc = match.groups()
-
     return {
         "Microcode": int(microcode),
         "SNP": int(snp),
@@ -84,8 +83,38 @@ def parse_reported_tcb(report_text: str) -> dict:
     }
 
 
+def _read_report_field(report: bytes, offset: int, size: int, field_name: str) -> bytes:
+    if len(report) < offset + size:
+        raise ValueError(f"SNP report is too short to contain {field_name}")
+    return report[offset : offset + size]
+
+
+@contextmanager
+def _file_lock(path: str, timeout: float):
+    """Take an inter-process lock without adding a runtime Python dependency."""
+    import fcntl  # SNP attestation is Linux-only; keep the import local for portability.
+
+    lock_file = open(path, "a+")
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f"Timed out waiting for lock: {path}")
+                time.sleep(0.1)
+        yield
+    finally:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_file.close()
+
+
 class SNPAuthorizer(CCAuthorizer):
-    """AMD SEV-SNP Authorizer"""
+    """Generate and verify AMD SEV-SNP attestation reports with ``snpguest``."""
 
     def __init__(
         self,
@@ -96,164 +125,176 @@ class SNPAuthorizer(CCAuthorizer):
         max_retries=5,
         retry_interval=10,
         cmd_timeout=60,
+        lock_timeout=60,
     ):
-        """
-        Initialize the SNPAuthorizer instance.
+        """Initialize the SNP authorizer.
 
-        Args:
-            max_nonce_history (int, optional): Maximum number of nonces to keep in history for replay protection.
-                Defaults to 1000.
-            amd_certs_dir (str, optional): Directory path where AMD certificates are stored.
-                Defaults to "/opt/certs".
-            snpguest_binary (str, optional): Path to the `snpguest` binary used for generating and verifying reports.
-                Defaults to "/host/bin/snpguest".
-            cpu_model (str, optional): CPU model identifier used when fetching certificates.
-                Defaults to "milan".
-            max_retries (int): Max number of retries on transient failures.
-            retry_interval (int): Wait time (seconds) between retries.
-            cmd_timeout (int): SNPGuest command timeout.
+        ``amd_certs_dir`` is a persistent cache for AMD ARK/ASK and per-chip
+        VCEK certificates. Request and report files are created in isolated
+        temporary directories and removed after each operation.
         """
         super().__init__()
+        if max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
+        if cmd_timeout <= 0 or lock_timeout <= 0:
+            raise ValueError("cmd_timeout and lock_timeout must be positive")
+
         self.logger = logging.getLogger(self.__class__.__name__)
         self.my_nonce_history = NonceHistory(max_nonce_history)
         self.seen_nonce_history = NonceHistory(max_nonce_history)
-        self.amd_certs_dir = amd_certs_dir
+        self.amd_certs_dir = os.path.abspath(amd_certs_dir)
         self.snpguest_binary = snpguest_binary
         self.cpu_model = cpu_model
         self.max_retries = max_retries
         self.retry_interval = retry_interval
         self.cmd_timeout = cmd_timeout
+        self.lock_timeout = lock_timeout
 
     def _run_with_retry(self, cmd: list[str], action_name: str) -> subprocess.CompletedProcess:
+        last_error = "unknown error"
         for attempt in range(1, self.max_retries + 1):
-            self.logger.info(f"[{action_name}] Attempt {attempt}/{self.max_retries}: running {cmd}")
+            self.logger.info("[%s] Attempt %d/%d", action_name, attempt, self.max_retries)
             try:
-                result = subprocess.run(cmd, capture_output=True, timeout=self.cmd_timeout)
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.cmd_timeout)
+            except FileNotFoundError as e:
+                raise RuntimeError(f"[{action_name}] executable not found: {cmd[0]}") from e
+            except subprocess.TimeoutExpired:
+                last_error = f"command timed out after {self.cmd_timeout} seconds"
+                self.logger.warning("[%s] %s", action_name, last_error)
+            except OSError as e:
+                last_error = str(e)
+                self.logger.warning("[%s] command failed to start: %s", action_name, e)
+            else:
                 if result.returncode == 0:
                     return result
-                else:
-                    self.logger.warning(
-                        f"[{action_name}] Failed with return code {result.returncode}. "
-                        f"stderr: {result.stderr.decode().strip()}"
-                    )
-            except subprocess.TimeoutExpired:
-                self.logger.warning(f"[{action_name}] Command timed out.")
+                last_error = result.stderr.strip() or f"exit status {result.returncode}"
+                self.logger.warning("[%s] Failed: %s", action_name, last_error)
 
             if attempt < self.max_retries:
-                time.sleep(min(self.retry_interval * 2 ** (attempt - 1), 60))  # Exponential backoff
-        raise RuntimeError(f"[{action_name}] Failed after {self.max_retries} attempts.")
+                time.sleep(min(self.retry_interval * 2 ** (attempt - 1), 60))
+        raise RuntimeError(f"[{action_name}] failed after {self.max_retries} attempts: {last_error}")
 
-    def generate(self):
-        nonce = bytearray(secrets.token_bytes(64))
-        with open(REQUEST_PATH, "wb") as request_file:
-            request_file.write(nonce)
-
-        cmd = [self.snpguest_binary, "report", REPORT_PATH, REQUEST_PATH]
-        self._run_with_retry(cmd, "generate_report")
-
-        with open(REPORT_PATH, "rb") as report_file:
-            token = base64.b64encode(report_file.read())
-
-        self.my_nonce_history.add(nonce)
-        return token
-
-    def verify(self, token):
-        tmp_bin_file = uuid.uuid4().hex
+    def _run_once(self, cmd: list[str], action_name: str) -> subprocess.CompletedProcess:
+        """Run a deterministic local operation exactly once."""
         try:
-            self._ensure_amd_ca_certs()
-            report_bin = base64.b64decode(token)
-            with open(tmp_bin_file, "wb") as report_file:
-                report_file.write(report_bin)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.cmd_timeout)
+        except FileNotFoundError as e:
+            raise RuntimeError(f"[{action_name}] executable not found: {cmd[0]}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"[{action_name}] command timed out after {self.cmd_timeout} seconds") from e
+        except OSError as e:
+            raise RuntimeError(f"[{action_name}] command failed to start: {e}") from e
+        if result.returncode != 0:
+            detail = result.stderr.strip() or f"exit status {result.returncode}"
+            raise RuntimeError(f"[{action_name}] failed: {detail}")
+        return result
 
-            vcek_cache_key = self._parse_report(tmp_bin_file)
-            self._ensure_amd_vcek(vcek_cache_key, tmp_bin_file)
+    def generate(self) -> str:
+        nonce = secrets.token_bytes(REPORT_DATA_SIZE)
+        try:
+            with tempfile.TemporaryDirectory(prefix="nvflare-snp-generate-") as work_dir:
+                request_path = os.path.join(work_dir, "request.bin")
+                report_path = os.path.join(work_dir, "report.bin")
+                with open(request_path, "wb") as request_file:
+                    request_file.write(nonce)
 
-            # Verify attestation
-            cmd = [self.snpguest_binary, "verify", "attestation", self.amd_certs_dir, tmp_bin_file]
-            result = self._run_with_retry(cmd, "verify_attestation")
+                self._run_with_retry([self.snpguest_binary, "report", report_path, request_path], "generate_report")
+                with open(report_path, "rb") as report_file:
+                    report = report_file.read()
+                if len(report) < MIN_REPORT_SIZE:
+                    raise RuntimeError("snpguest generated an incomplete SNP report")
+        except (OSError, RuntimeError) as e:
+            raise CCTokenGenerateError(f"Failed to generate an SNP attestation report: {e}") from e
 
-            if result.returncode == 0:
-                self.logger.info("Attestation passed")
-                if self._check_nonce(tmp_bin_file):
-                    self.logger.info("Check nonce passed")
-                    return True
-                else:
-                    self.logger.info("Check nonce failed")
-                    return False
-            else:
-                self.logger.warning("Attestation verification failed.")
+        self.my_nonce_history.add(nonce.hex())
+        return base64.b64encode(report).decode("ascii")
+
+    def verify(self, token: str) -> bool:
+        try:
+            if not isinstance(token, (str, bytes)) or not token:
+                return False
+            report = base64.b64decode(token, validate=True)
+            if len(report) < MIN_REPORT_SIZE:
                 return False
 
-        except Exception as e:
-            self.logger.error(f"Token verification failed: {e}")
+            os.makedirs(self.amd_certs_dir, mode=0o700, exist_ok=True)
+            self._ensure_amd_ca_certs()
+            with tempfile.TemporaryDirectory(prefix="nvflare-snp-verify-") as work_dir:
+                report_path = os.path.join(work_dir, "report.bin")
+                with open(report_path, "wb") as report_file:
+                    report_file.write(report)
+
+                vcek_cache_key = self._parse_report(report_path)
+                vcek_path = self._ensure_amd_vcek(vcek_cache_key, report_path)
+                for filename in (AMD_ARK, AMD_ASK):
+                    shutil.copy2(os.path.join(self.amd_certs_dir, filename), os.path.join(work_dir, filename))
+                shutil.copy2(vcek_path, os.path.join(work_dir, AMD_VCEK))
+
+                # Signature verification is local and deterministic. Retrying a
+                # bad report only amplifies an attacker's resource consumption;
+                # bounded retries are reserved for the AMD certificate fetches.
+                self._run_once(
+                    [self.snpguest_binary, "verify", "attestation", work_dir, report_path],
+                    "verify_attestation",
+                )
+
+            report_data = _read_report_field(report, REPORT_DATA_OFFSET, REPORT_DATA_SIZE, "report data")
+            if not any(report_data):
+                self.logger.warning("Rejected an SNP attestation report without a freshness nonce")
+                return False
+            nonce = report_data.hex()
+            if not self.seen_nonce_history.add(nonce):
+                self.logger.warning("Rejected a replayed SNP attestation report")
+                return False
+            self.logger.info("SNP attestation and nonce checks passed")
+            return True
+        except (binascii.Error, OSError, RuntimeError, TimeoutError, ValueError) as e:
+            self.logger.warning("SNP token verification failed: %s", e)
             return False
-        finally:
-            if os.path.exists(tmp_bin_file):
-                os.remove(tmp_bin_file)
 
-    def _ensure_amd_ca_certs(self):
-        """Ensures AMD CA certs are inside the amd_certs_dir."""
-        ask_path = os.path.join(self.amd_certs_dir, AMD_ASK)
-        ark_path = os.path.join(self.amd_certs_dir, AMD_ARK)
-        if not (os.path.exists(ark_path) and os.path.exists(ask_path)):
-            self.logger.info("AMD CA certs not found. Fetching...")
-            cmd = [self.snpguest_binary, "fetch", "ca", "pem", self.amd_certs_dir, self.cpu_model]
-            self._run_with_retry(cmd, "fetch_ca_certs")
-        else:
-            self.logger.info("AMD CA certs already exist.")
+    def _ensure_amd_ca_certs(self) -> None:
+        """Fetch the AMD CA certificates once, with cross-process serialization."""
+        os.makedirs(self.amd_certs_dir, mode=0o700, exist_ok=True)
+        lock_path = os.path.join(self.amd_certs_dir, ".ca.lock")
+        with _file_lock(lock_path, self.lock_timeout):
+            ask_path = os.path.join(self.amd_certs_dir, AMD_ASK)
+            ark_path = os.path.join(self.amd_certs_dir, AMD_ARK)
+            if os.path.isfile(ark_path) and os.path.isfile(ask_path):
+                return
+            self._run_with_retry(
+                [self.snpguest_binary, "fetch", "ca", "pem", self.amd_certs_dir, self.cpu_model],
+                "fetch_ca_certs",
+            )
+            if not (os.path.isfile(ark_path) and os.path.isfile(ask_path)):
+                raise RuntimeError("snpguest did not create the expected AMD ARK and ASK certificates")
 
-    def _ensure_amd_vcek(self, vcek_cache_key, report_bin_file, timeout=60):
-        """Ensures AMD VCEK is inside the amd_certs_dir."""
-        cache_path = os.path.join(self.amd_certs_dir, vcek_cache_key)
-        vcek_file = os.path.join(self.amd_certs_dir, AMD_VCEK)
-        lock_file = cache_path + ".lock"
-        with FileLock(lock_file, timeout=timeout):
-            if not os.path.exists(cache_path):
-                self.logger.info("AMD VCEK not cached. Fetching and caching...")
-                cmd = [self.snpguest_binary, "fetch", "vcek", "pem", self.amd_certs_dir, report_bin_file]
-                self._run_with_retry(cmd, "fetch_vcek")
-                if not os.path.exists(vcek_file):
-                    raise RuntimeError(f"VCEK file not generated at expected path: {vcek_file}")
-                # Rename vcek.pem to the cache file name
-                shutil.move(vcek_file, cache_path)
-            else:
-                self.logger.info("Using cached AMD VCEK")
-        shutil.copy(cache_path, vcek_file)
+    def _ensure_amd_vcek(self, vcek_cache_key: str, report_bin_file: str) -> str:
+        """Return a cached VCEK, fetching it safely when it is not present."""
+        cache_path = os.path.join(self.amd_certs_dir, f"vcek-{vcek_cache_key}.pem")
+        lock_path = os.path.join(self.amd_certs_dir, ".vcek.lock")
+        with _file_lock(lock_path, self.lock_timeout):
+            if not os.path.isfile(cache_path):
+                with tempfile.TemporaryDirectory(prefix="nvflare-snp-vcek-") as cert_dir:
+                    self._run_with_retry(
+                        [self.snpguest_binary, "fetch", "vcek", "pem", cert_dir, report_bin_file],
+                        "fetch_vcek",
+                    )
+                    fetched_vcek = os.path.join(cert_dir, AMD_VCEK)
+                    if not os.path.isfile(fetched_vcek):
+                        raise RuntimeError("snpguest did not create the expected VCEK certificate")
+                    temporary_cache = f"{cache_path}.{os.getpid()}.tmp"
+                    shutil.copy2(fetched_vcek, temporary_cache)
+                    os.replace(temporary_cache, cache_path)
+        return cache_path
 
-    def _parse_report(self, report_bin_file):
-        """Parses the Reported TCB and Chip ID info.
-
-        This method is used to generate a unique id to cache VCEK.
-        Because AMD KDS has rate limitation, we should avoid keep polling.
-        """
-        cmd = [self.snpguest_binary, "display", "report", report_bin_file]
-        cp = subprocess.run(cmd, capture_output=True)
-        if cp.returncode != 0:
-            self.logger.error("Can't display SNP report")
-            raise RuntimeError("Can't display SNP report")
-        output_string = cp.stdout
-        report_text = output_string.decode("utf-8")
-        chip_id = parse_chip_id(report_text)
-        reported_tcb = parse_reported_tcb(report_text)
-        if not reported_tcb:
-            raise RuntimeError("Failed to parse Reported TCB from report")
-        cache_key = f"{chip_id}-{reported_tcb['Microcode']}-{reported_tcb['SNP']}-{reported_tcb['TEE']}-{reported_tcb['Boot Loader']}"
-        return cache_key
-
-    def _check_nonce(self, report_bin_file):
-        """Parses nonce from the Report Data section and checks if it is fresh."""
-        cmd = [self.snpguest_binary, "display", "report", report_bin_file]
-        cp = subprocess.run(cmd, capture_output=True)
-        if cp.returncode != 0:
-            return False
-        output_string = cp.stdout
-        lines = output_string.decode("utf-8").split("\n")
-        report_data_string = ""
-        for i in range(len(lines)):
-            if lines[i] == "Report Data:":
-                report_data_string = " ".join(lines[i + 1 : i + 6]).replace(" ", "")
-                break
-        return self.seen_nonce_history.add(report_data_string)
+    @staticmethod
+    def _parse_report(report_bin_file: str) -> str:
+        """Build a bounded VCEK cache key from the report's chip ID and reported TCB."""
+        with open(report_bin_file, "rb") as report_file:
+            report = report_file.read()
+        chip_id = _read_report_field(report, CHIP_ID_OFFSET, CHIP_ID_SIZE, "chip ID")
+        reported_tcb = _read_report_field(report, REPORTED_TCB_OFFSET, REPORTED_TCB_SIZE, "reported TCB")
+        return f"{chip_id.hex()}-{reported_tcb.hex()}"
 
     def get_namespace(self) -> str:
         return SNP_NAMESPACE

--- a/nvflare/app_opt/confidential_computing/tdx_authorizer.py
+++ b/nvflare/app_opt/confidential_computing/tdx_authorizer.py
@@ -12,76 +12,174 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+import logging
 import os
+import re
+import shutil
 import subprocess
+import time
 
-from nvflare.app_opt.confidential_computing.cc_authorizer import CCAuthorizer
+from nvflare.app_opt.confidential_computing.cc_authorizer import CCAuthorizer, CCTokenGenerateError
+
+from .utils import NonceHistory
 
 TDX_NAMESPACE = "x-tdx"
 TDX_CLI_CONFIG = "config.json"
+TOKEN_NOT_VALID_YET = "token is not valid yet"
+NOT_BEFORE_RETRY_INTERVAL = 2.0
+NOT_BEFORE_VERIFY_ATTEMPTS = 5
+MAX_TOKEN_SIZE = 256 * 1024
+JWT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$")
+
+# Retained for source compatibility. The implementation no longer writes
+# shared result files, which made concurrent calls race with each other.
 TOKEN_FILE = "token.txt"
 VERIFY_FILE = "verify.txt"
 ERROR_FILE = "error.txt"
 
 
 class TDXAuthorizer(CCAuthorizer):
-    """Intel TDX Authorizer"""
+    """Generate and verify Intel TDX tokens with an operator-supplied CLI."""
 
-    def __init__(self, tdx_cli_command: str, config_dir: str) -> None:
-        """Initialize the TDXAuthorizer
+    def __init__(
+        self,
+        tdx_cli_command: str,
+        config_dir: str,
+        cmd_timeout: float = 60,
+        use_sudo: bool | None = None,
+        max_nonce_history: int = 1000,
+        max_token_size: int = MAX_TOKEN_SIZE,
+        token_options: list[str] | tuple[str, ...] | None = None,
+    ) -> None:
+        """Initialize the TDX authorizer.
 
         Args:
-            tdx_cli_command (str): The command to run the TDX CLI
-            config_dir (str): The directory to store the TDX CLI configuration and token
+            tdx_cli_command: Path to the TDX attestation CLI executable.
+            config_dir: Directory containing the CLI's ``config.json``.
+            cmd_timeout: Maximum seconds allowed for each CLI invocation.
+            use_sudo: Prefix the CLI with non-interactive ``sudo``. ``None``
+                selects sudo for a non-root process when it is available, while
+                root and minimal containers invoke the CLI directly.
+            max_nonce_history: Number of successfully verified token
+                fingerprints retained for replay rejection.
+            max_token_size: Maximum accepted serialized JWT size in bytes.
+            token_options: Options passed after ``token``. By default no TEE
+                selector is supplied: the pinned Intel CLI selects TDX when no
+                selector is present, and this remains compatible with older
+                CLIs. Use this hook only for version-specific reviewed flags.
         """
         super().__init__()
-        self.tdx_cli_command = tdx_cli_command
-        self.config_dir = config_dir
+        if not isinstance(tdx_cli_command, str) or not tdx_cli_command.strip():
+            raise ValueError("tdx_cli_command must be a non-empty string")
+        if cmd_timeout <= 0:
+            raise ValueError("cmd_timeout must be positive")
+        if max_token_size <= 0:
+            raise ValueError("max_token_size must be positive")
+        if use_sudo is not None and not isinstance(use_sudo, bool):
+            raise ValueError("use_sudo must be true, false, or None")
+        if token_options is None:
+            token_options = ()
+        if not isinstance(token_options, (list, tuple)) or any(
+            not isinstance(option, str) or not option for option in token_options
+        ):
+            raise ValueError("token_options must contain only non-empty strings")
 
+        self.tdx_cli_command = tdx_cli_command
+        self.config_dir = os.path.abspath(config_dir)
         self.config_file = os.path.join(self.config_dir, TDX_CLI_CONFIG)
+        self.cmd_timeout = cmd_timeout
+        self.use_sudo = os.geteuid() != 0 and shutil.which("sudo") is not None if use_sudo is None else use_sudo
+        self.max_token_size = max_token_size
+        self.token_options = tuple(token_options)
+        self.seen_token_history = NonceHistory(max_nonce_history)
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def _command(self, *arguments: str) -> list[str]:
+        command = [self.tdx_cli_command, *arguments]
+        return ["sudo", "-n", *command] if self.use_sudo else command
+
+    def _extract_token(self, output: str) -> str:
+        candidates = [line.strip() for line in output.splitlines() if JWT_PATTERN.fullmatch(line.strip())]
+        if len(candidates) != 1:
+            raise RuntimeError("TDX CLI output did not contain exactly one compact JWT")
+        token = candidates[0]
+        if len(token.encode("utf-8")) > self.max_token_size:
+            raise RuntimeError("TDX CLI returned a token exceeding the configured size limit")
+        return token
+
+    def _run(self, command: list[str], action: str) -> subprocess.CompletedProcess:
+        if not os.path.isfile(self.config_file):
+            raise RuntimeError(f"TDX CLI configuration does not exist: {self.config_file}")
+        try:
+            return subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.cmd_timeout,
+                start_new_session=True,
+            )
+        except FileNotFoundError as e:
+            raise RuntimeError(f"TDX CLI executable not found: {command[0]}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"TDX {action} timed out after {self.cmd_timeout} seconds") from e
+        except OSError as e:
+            raise RuntimeError(f"TDX {action} could not start: {e}") from e
 
     def generate(self) -> str:
-        token_file = os.path.join(self.config_dir, TOKEN_FILE)
-        out = open(token_file, "w")
-        error_file = os.path.join(self.config_dir, ERROR_FILE)
-        err_out = open(error_file, "w")
-
-        command = ["sudo", self.tdx_cli_command, "-c", self.config_file, "token", "--no-eventlog"]
-        subprocess.run(command, preexec_fn=os.setsid, stdout=out, stderr=err_out)
-
-        if not os.path.exists(error_file) or not os.path.exists(token_file):
-            return ""
-
         try:
-            with open(error_file, "r") as e_f:
-                if "Error:" in e_f.read():
-                    return ""
-                else:
-                    with open(token_file, "r") as t_f:
-                        token = t_f.readline()
-                    return token
-        except:
-            return ""
+            result = self._run(
+                self._command("-c", self.config_file, "token", *self.token_options),
+                "token generation",
+            )
+            if result.returncode != 0:
+                detail = result.stderr.strip() or f"exit status {result.returncode}"
+                raise RuntimeError(detail)
+            return self._extract_token(result.stdout)
+        except RuntimeError as e:
+            raise CCTokenGenerateError(f"Failed to generate a TDX token: {e}") from e
 
     def verify(self, token: str) -> bool:
-        out = open(os.path.join(self.config_dir, VERIFY_FILE), "w")
-        error_file = os.path.join(self.config_dir, ERROR_FILE)
-        err_out = open(error_file, "w")
-
-        command = [self.tdx_cli_command, "verify", "--config", self.config_file, "--token", token]
-        subprocess.run(command, preexec_fn=os.setsid, stdout=out, stderr=err_out)
-
-        if not os.path.exists(error_file):
+        if (
+            not isinstance(token, str)
+            or not JWT_PATTERN.fullmatch(token.strip())
+            or len(token.strip().encode("utf-8")) > self.max_token_size
+        ):
             return False
+        token = token.strip()
+        command = self._command("verify", "--config", self.config_file, "--token", token)
+        for attempt in range(NOT_BEFORE_VERIFY_ATTEMPTS):
+            try:
+                result = self._run(command, "token verification")
+            except RuntimeError as e:
+                self.logger.warning("TDX token verification failed: %s", e)
+                return False
 
-        try:
-            with open(error_file, "r") as f:
-                if "Error:" in f.read():
+            if result.returncode == 0:
+                token_fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()
+                if not self.seen_token_history.add(token_fingerprint):
+                    self.logger.warning("Rejected a replayed TDX attestation token")
                     return False
-        except:
-            return False
+                return True
 
-        return True
+            # Intel Trust Authority can issue a token whose not-before claim is
+            # just ahead of the verifier clock. Retry only this known transient
+            # result within a bounded window; every other verification failure
+            # remains fail-closed.
+            diagnostics = f"{result.stdout}\n{result.stderr}".lower()
+            if attempt + 1 < NOT_BEFORE_VERIFY_ATTEMPTS and TOKEN_NOT_VALID_YET in diagnostics:
+                self.logger.info(
+                    "TDX token is not valid yet; retrying verification in %.1f seconds",
+                    NOT_BEFORE_RETRY_INTERVAL,
+                )
+                time.sleep(NOT_BEFORE_RETRY_INTERVAL)
+                continue
+
+            # A verifier can echo its token in diagnostics. Do not copy stderr
+            # into NVFlare logs, where an attestation bearer token could leak.
+            self.logger.warning("TDX token verification failed with exit status %d", result.returncode)
+            return False
+        return False
 
     def get_namespace(self) -> str:
         return TDX_NAMESPACE

--- a/nvflare/app_opt/confidential_computing/utils.py
+++ b/nvflare/app_opt/confidential_computing/utils.py
@@ -13,15 +13,22 @@
 # limitations under the License.
 
 from collections import deque
+from threading import Lock
 
 
 class NonceHistory:
-
     def __init__(self, size=100):
-        self.history = deque(maxlen=2 * size)
+        if not isinstance(size, int) or size <= 0:
+            raise ValueError("nonce history size must be a positive integer")
+        self.history = deque(maxlen=size)
+        self._lock = Lock()
 
     def add(self, nonce):
-        if nonce in self.history:
+        """Add a non-empty nonce, returning ``False`` for invalid or replayed values."""
+        if nonce is None or nonce == "" or nonce == b"":
             return False
-        self.history.append(nonce)
-        return True
+        with self._lock:
+            if nonce in self.history:
+                return False
+            self.history.append(nonce)
+            return True

--- a/nvflare/lighter/cc_provision/cc_constants.py
+++ b/nvflare/lighter/cc_provision/cc_constants.py
@@ -47,6 +47,8 @@ class CCManagerArgs:
     CC_VERIFIER_IDS = "cc_verifier_ids"
     VERIFY_FREQUENCY = "verify_frequency"
     CC_ENABLED_SITES = "cc_enabled_sites"
+    GET_SITE_REQUEST_TIMEOUT = "get_site_request_timeout"
+    GET_TOKEN_REQUEST_TIMEOUT = "get_token_request_timeout"
 
 
 class CCIssuerConfig:

--- a/nvflare/lighter/cc_provision/impl/cc.py
+++ b/nvflare/lighter/cc_provision/impl/cc.py
@@ -148,11 +148,14 @@ class CCBuilder(Builder):
 
         all_cc_authorizers = ctx.get(CC_AUTHORIZERS_KEY, [])
         cc_verifier_ids = set([])
+        attestation_config = cc_config.get(CCConfigKey.CC_ATTESTATION_CONFIG)
+        if attestation_config:
+            cc_mgr_args[CCManagerArgs.VERIFY_FREQUENCY] = attestation_config.get("check_frequency", 600)
+            if "get_site_request_timeout" in attestation_config:
+                cc_mgr_args[CCManagerArgs.GET_SITE_REQUEST_TIMEOUT] = attestation_config["get_site_request_timeout"]
+            if "get_token_request_timeout" in attestation_config:
+                cc_mgr_args[CCManagerArgs.GET_TOKEN_REQUEST_TIMEOUT] = attestation_config["get_token_request_timeout"]
         for authorizer in all_cc_authorizers:
-            attestation_config = cc_config.get(CCConfigKey.CC_ATTESTATION_CONFIG)
-            if attestation_config:
-                cc_mgr_args[CCManagerArgs.VERIFY_FREQUENCY] = attestation_config.get("check_frequency", 600)
-
             cc_verifier_ids.add(authorizer.get(CCIssuerConfig.ID))
 
         # TODO our fl_ctx.get_identity_name always return "server"

--- a/tests/unit_test/app_opt/confidential_computing/__init__.py
+++ b/tests/unit_test/app_opt/confidential_computing/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_test/app_opt/confidential_computing/coco_hello_numpy_executor_test.py
+++ b/tests/unit_test/app_opt/confidential_computing/coco_hello_numpy_executor_test.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvflare.app_opt.confidential_computing.coco_hello_numpy_executor import CoCoHelloNumpyExecutor
+
+
+def test_coco_hello_numpy_executor_has_fixed_signed_entry_point():
+    executor = CoCoHelloNumpyExecutor()
+
+    assert executor._task_script_path == CoCoHelloNumpyExecutor.TRAINER_PATH
+    assert executor._task_script_args == "--update_type full"
+    assert executor._execution_mode == "in_process"

--- a/tests/unit_test/app_opt/confidential_computing/gpu_authorizer_test.py
+++ b/tests/unit_test/app_opt/confidential_computing/gpu_authorizer_test.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import subprocess
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from nvflare.app_opt.confidential_computing.cc_authorizer import CCTokenGenerateError
+from nvflare.app_opt.confidential_computing.gpu_authorizer import GPUAuthorizer
+
+
+def _evidence(nonce="a" * 64):
+    return {
+        "evidences": [{"arch": "HOPPER", "nonce": nonce, "evidence": "signed", "certificate": "chain"}],
+        "result_code": 0,
+        "result_message": "Ok",
+    }
+
+
+def _verification(nonce="a" * 64):
+    return {
+        "claims": [
+            {
+                "eat_nonce": nonce,
+                "x-nvidia-device-type": "gpu",
+                "measres": "success",
+                "secboot": True,
+                "dbgstat": "disabled",
+                "x-nvidia-gpu-arch-check": True,
+                "x-nvidia-gpu-attestation-report-parsed": True,
+                "x-nvidia-gpu-attestation-report-nonce-match": True,
+                "x-nvidia-gpu-attestation-report-signature-verified": True,
+                "x-nvidia-gpu-attestation-report-cert-chain": {
+                    "x-nvidia-cert-status": "valid",
+                    "x-nvidia-cert-ocsp-status": "good",
+                },
+                "x-nvidia-gpu-attestation-report-cert-chain-fwid-match": True,
+                "x-nvidia-gpu-driver-rim-signature-verified": True,
+                "x-nvidia-gpu-driver-rim-version-match": True,
+                "x-nvidia-gpu-vbios-rim-signature-verified": True,
+                "x-nvidia-gpu-vbios-rim-version-match": True,
+                "x-nvidia-mismatch-measurement-records": None,
+            }
+        ],
+        "result_code": 0,
+        "result_message": "Ok",
+    }
+
+
+class FakeRunner:
+    def __init__(self):
+        self.calls = []
+        self.verify_evidence = None
+        self.collect_result = subprocess.CompletedProcess([], 0, json.dumps(_evidence()))
+        self.verify_result = subprocess.CompletedProcess([], 0, json.dumps(_verification()))
+
+    def __call__(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        if "collect-evidence" in command:
+            nonce = command[command.index("--nonce") + 1]
+            result = json.loads(self.collect_result.stdout)
+            if self.collect_result.returncode == 0 and result.get("evidences"):
+                for evidence in result["evidences"]:
+                    evidence["nonce"] = nonce
+            return subprocess.CompletedProcess(command, self.collect_result.returncode, json.dumps(result))
+        evidence_path = command[command.index("--gpu-evidence-file") + 1]
+        with open(evidence_path, encoding="utf-8") as evidence_stream:
+            self.verify_evidence = json.load(evidence_stream)
+        return self.verify_result
+
+
+def test_generate_collects_nonce_bound_nvat_evidence(monkeypatch):
+    runner = FakeRunner()
+    monkeypatch.setattr("subprocess.run", runner)
+    monkeypatch.setenv("NV_ATTESTATION_SERVICE_KEY", "test-service-key")
+    authorizer = GPUAuthorizer(nvat_command="nvattest")
+
+    token = json.loads(authorizer.generate())
+
+    assert token["result_code"] == 0
+    assert len(token["evidences"][0]["nonce"]) == 64
+    command, kwargs = runner.calls[0]
+    assert command[:6] == ["nvattest", "--format", "json", "--log-level", "warn", "collect-evidence"]
+    assert kwargs["env"]["NV_ATTESTATION_SERVICE_KEY"] == "test-service-key"
+    assert "test-service-key" not in command
+    assert authorizer._can_generate is True
+
+
+def test_explicit_service_key_precedes_environment(monkeypatch):
+    runner = FakeRunner()
+    monkeypatch.setattr("subprocess.run", runner)
+    monkeypatch.setenv("NV_ATTESTATION_SERVICE_KEY", "environment-key")
+    authorizer = GPUAuthorizer(nvat_command="nvattest", service_key="constructor-key")
+
+    authorizer.generate()
+
+    _, kwargs = runner.calls[0]
+    assert kwargs["env"]["NV_ATTESTATION_SERVICE_KEY"] == "constructor-key"
+
+
+def test_generate_fails_closed_on_nvat_error(monkeypatch):
+    runner = FakeRunner()
+    runner.collect_result = subprocess.CompletedProcess([], 7, "{}")
+    monkeypatch.setattr("subprocess.run", runner)
+    authorizer = GPUAuthorizer(nvat_command="nvattest")
+
+    with pytest.raises(CCTokenGenerateError, match="exit status 7"):
+        authorizer.generate()
+    assert authorizer._can_generate is False
+
+
+def test_verify_appraises_file_evidence_before_recording_nonce(monkeypatch):
+    runner = FakeRunner()
+    monkeypatch.setattr("subprocess.run", runner)
+    authorizer = GPUAuthorizer(nvat_command="nvattest")
+    token = json.dumps(_evidence())
+
+    assert authorizer.verify(token) is True
+    assert authorizer.verify(token) is False
+
+    command, _ = runner.calls[0]
+    assert "attest" in command
+    assert command[command.index("--gpu-evidence-source") + 1] == "file"
+    assert command[command.index("--verifier") + 1] == "remote"
+    assert command[command.index("--nras-url") + 1] == "https://nras.attestation.nvidia.com"
+    assert "--relying-party-policy" in command
+    assert runner.verify_evidence == _evidence()["evidences"]
+
+
+def test_concurrent_verify_calls_are_parallel_and_replay_safe(monkeypatch):
+    class TrackingRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self.active = 0
+            self.max_active = 0
+            self.guard = threading.Lock()
+
+        def __call__(self, command, **kwargs):
+            with self.guard:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+            try:
+                time.sleep(0.02)
+                return super().__call__(command, **kwargs)
+            finally:
+                with self.guard:
+                    self.active -= 1
+
+    runner = TrackingRunner()
+    monkeypatch.setattr("subprocess.run", runner)
+    authorizer = GPUAuthorizer(nvat_command="nvattest")
+    token = json.dumps(_evidence())
+    start = threading.Barrier(2)
+
+    def verify():
+        start.wait()
+        return authorizer.verify(token)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = [executor.submit(verify), executor.submit(verify)]
+        results = [result.result() for result in results]
+
+    assert sorted(results) == [False, True]
+    assert runner.max_active == 2
+
+
+def test_verify_rejects_failed_or_nonce_mismatched_appraisal(monkeypatch):
+    runner = FakeRunner()
+    monkeypatch.setattr("subprocess.run", runner)
+    authorizer = GPUAuthorizer(nvat_command="nvattest")
+    token = json.dumps(_evidence())
+
+    runner.verify_result = subprocess.CompletedProcess([], 4, "{}")
+    assert authorizer.verify(token) is False
+
+    runner.verify_result = subprocess.CompletedProcess([], 0, json.dumps(_verification("b" * 64)))
+    assert authorizer.verify(token) is False
+
+    weak_policy_result = _verification()
+    weak_policy_result["claims"][0]["secboot"] = False
+    runner.verify_result = subprocess.CompletedProcess([], 0, json.dumps(weak_policy_result))
+    assert authorizer.verify(token) is False
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        "not-json",
+        "{}",
+        json.dumps({"result_code": 1, "evidences": []}),
+        json.dumps({"result_code": 0, "evidences": []}),
+        json.dumps({"result_code": 0, "evidences": [{"nonce": "short"}]}),
+        json.dumps(
+            {
+                "result_code": 0,
+                "evidences": [{"nonce": "a" * 64}, {"nonce": "b" * 64}],
+            }
+        ),
+    ],
+)
+def test_verify_rejects_malformed_evidence_without_running_nvat(token, monkeypatch):
+    runner = FakeRunner()
+    monkeypatch.setattr("subprocess.run", runner)
+    authorizer = GPUAuthorizer(nvat_command="nvattest")
+
+    assert authorizer.verify(token) is False
+    assert runner.calls == []
+
+
+def test_constructor_validates_configuration(tmp_path):
+    empty_policy = tmp_path / "empty.rego"
+    empty_policy.write_text("")
+    legacy_policy = tmp_path / "legacy.json"
+    legacy_policy.write_text('{"version":"4.0"}')
+
+    with pytest.raises(ValueError, match="verifier"):
+        GPUAuthorizer(verifier="unsupported")
+    with pytest.raises(ValueError, match="HTTPS"):
+        GPUAuthorizer(nras_url="http://verifier.example")
+    with pytest.raises(ValueError, match="must not be empty"):
+        GPUAuthorizer(policy_file=str(empty_policy))
+    with pytest.raises(ValueError, match="must be Rego"):
+        GPUAuthorizer(policy_file=str(legacy_policy))
+
+
+def test_legacy_verifier_url_is_normalized():
+    authorizer = GPUAuthorizer("https://nras.attestation.nvidia.com/v4/attest/gpu")
+
+    assert authorizer.nras_url == "https://nras.attestation.nvidia.com"

--- a/tests/unit_test/app_opt/confidential_computing/snp_authorizer_test.py
+++ b/tests/unit_test/app_opt/confidential_computing/snp_authorizer_test.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import os
+import subprocess
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nvflare.app_opt.confidential_computing.cc_authorizer import CCTokenGenerateError
+from nvflare.app_opt.confidential_computing.snp_authorizer import (
+    CHIP_ID_OFFSET,
+    CHIP_ID_SIZE,
+    MIN_REPORT_SIZE,
+    REPORT_DATA_OFFSET,
+    REPORT_DATA_SIZE,
+    REPORTED_TCB_OFFSET,
+    REPORTED_TCB_SIZE,
+    SNPAuthorizer,
+)
+
+
+def _report(nonce=b"n" * REPORT_DATA_SIZE):
+    report = bytearray(MIN_REPORT_SIZE)
+    report[REPORT_DATA_OFFSET : REPORT_DATA_OFFSET + REPORT_DATA_SIZE] = nonce
+    report[REPORTED_TCB_OFFSET : REPORTED_TCB_OFFSET + REPORTED_TCB_SIZE] = b"t" * REPORTED_TCB_SIZE
+    report[CHIP_ID_OFFSET : CHIP_ID_OFFSET + CHIP_ID_SIZE] = b"c" * CHIP_ID_SIZE
+    return bytes(report)
+
+
+def test_generate_uses_private_temporary_files_and_returns_text(tmp_path):
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0)
+
+    def run(cmd, _action):
+        assert cmd[:2] == ["snpguest", "report"]
+        with open(cmd[3], "rb") as request_stream:
+            nonce = request_stream.read()
+        assert len(nonce) == REPORT_DATA_SIZE
+        with open(cmd[2], "wb") as report_stream:
+            report_stream.write(_report(nonce))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    authorizer._run_with_retry = run
+    authorizer._run_once = run
+    token = authorizer.generate()
+
+    assert isinstance(token, str)
+    assert base64.b64decode(token)[REPORT_DATA_OFFSET : REPORT_DATA_OFFSET + REPORT_DATA_SIZE]
+    assert not os.path.exists("request.bin")
+    assert not os.path.exists("report.bin")
+
+
+def test_generate_raises_cc_error_when_snpguest_fails(tmp_path):
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0)
+    authorizer._run_with_retry = Mock(side_effect=RuntimeError("device unavailable"))
+
+    with pytest.raises(CCTokenGenerateError, match="device unavailable"):
+        authorizer.generate()
+
+
+def test_verify_checks_signature_then_rejects_replay(tmp_path):
+    (tmp_path / "ark.pem").write_text("ark")
+    (tmp_path / "ask.pem").write_text("ask")
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0)
+    report = _report()
+    expected_cache_key = f"{'63' * CHIP_ID_SIZE}-{'74' * REPORTED_TCB_SIZE}"
+    (tmp_path / f"vcek-{expected_cache_key}.pem").write_text("vcek")
+    calls = []
+
+    def run(cmd, action):
+        calls.append((cmd, action))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    authorizer._run_with_retry = run
+    authorizer._run_once = run
+    token = base64.b64encode(report).decode("ascii")
+
+    assert authorizer.verify(token) is True
+    assert authorizer.verify(token) is False
+    verify_calls = [cmd for cmd, action in calls if action == "verify_attestation"]
+    assert len(verify_calls) == 2
+    assert verify_calls[0][0:3] == ["snpguest", "verify", "attestation"]
+    assert os.path.dirname(verify_calls[0][4]) == verify_calls[0][3]
+
+
+def test_verify_rejects_signed_report_without_nonce(tmp_path):
+    (tmp_path / "ark.pem").write_text("ark")
+    (tmp_path / "ask.pem").write_text("ask")
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0)
+    report = _report(b"\0" * REPORT_DATA_SIZE)
+    cache_key = f"{'63' * CHIP_ID_SIZE}-{'74' * REPORTED_TCB_SIZE}"
+    (tmp_path / f"vcek-{cache_key}.pem").write_text("vcek")
+    authorizer._run_with_retry = Mock(return_value=subprocess.CompletedProcess([], 0, "", ""))
+    authorizer._run_once = Mock(return_value=subprocess.CompletedProcess([], 0, "", ""))
+
+    assert authorizer.verify(base64.b64encode(report).decode("ascii")) is False
+
+
+def test_verify_fetches_and_reuses_certificate_cache(tmp_path):
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0)
+    actions = []
+
+    def run(cmd, action):
+        actions.append(action)
+        if action == "fetch_ca_certs":
+            (tmp_path / "ark.pem").write_text("ark")
+            (tmp_path / "ask.pem").write_text("ask")
+        elif action == "fetch_vcek":
+            with open(os.path.join(cmd[4], "vcek.pem"), "w") as vcek_stream:
+                vcek_stream.write("vcek")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    authorizer._run_with_retry = run
+    authorizer._run_once = run
+    first = base64.b64encode(_report(b"1" * REPORT_DATA_SIZE)).decode("ascii")
+    second = base64.b64encode(_report(b"2" * REPORT_DATA_SIZE)).decode("ascii")
+
+    assert authorizer.verify(first) is True
+    assert authorizer.verify(second) is True
+    assert actions.count("fetch_ca_certs") == 1
+    assert actions.count("fetch_vcek") == 1
+    assert actions.count("verify_attestation") == 2
+
+
+def test_ca_certificate_fetch_is_serialized_across_concurrent_authorizers(tmp_path):
+    authorizers = [
+        SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0),
+        SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0),
+    ]
+    state_lock = threading.Lock()
+    start = threading.Barrier(2)
+    fetch_count = 0
+    active = 0
+    max_active = 0
+
+    def run(cmd, action):
+        nonlocal active, fetch_count, max_active
+        assert action == "fetch_ca_certs"
+        with state_lock:
+            fetch_count += 1
+            active += 1
+            max_active = max(max_active, active)
+        try:
+            time.sleep(0.05)
+            (tmp_path / "ark.pem").write_text("ark")
+            (tmp_path / "ask.pem").write_text("ask")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        finally:
+            with state_lock:
+                active -= 1
+
+    for authorizer in authorizers:
+        authorizer._run_with_retry = run
+
+    def ensure(authorizer):
+        start.wait()
+        authorizer._ensure_amd_ca_certs()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = [executor.submit(ensure, authorizer) for authorizer in authorizers]
+        for result in results:
+            result.result()
+
+    assert fetch_count == 1
+    assert max_active == 1
+
+
+@pytest.mark.parametrize("token", ["", "not-base64!", base64.b64encode(b"short").decode("ascii"), None])
+def test_verify_rejects_malformed_reports_without_running_commands(tmp_path, token):
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=1, retry_interval=0)
+    authorizer._run_with_retry = Mock()
+    authorizer._run_once = Mock()
+
+    assert authorizer.verify(token) is False
+    authorizer._run_with_retry.assert_not_called()
+    authorizer._run_once.assert_not_called()
+
+
+def test_verify_does_not_retry_deterministic_signature_failure(tmp_path):
+    (tmp_path / "ark.pem").write_text("ark")
+    (tmp_path / "ask.pem").write_text("ask")
+    cache_key = f"{'63' * CHIP_ID_SIZE}-{'74' * REPORTED_TCB_SIZE}"
+    (tmp_path / f"vcek-{cache_key}.pem").write_text("vcek")
+    authorizer = SNPAuthorizer(amd_certs_dir=str(tmp_path), max_retries=5, retry_interval=10)
+
+    with (
+        patch(
+            "subprocess.run",
+            return_value=subprocess.CompletedProcess([], 2, "", "signature verification failed"),
+        ) as run,
+        patch("nvflare.app_opt.confidential_computing.snp_authorizer.time.sleep") as sleep,
+    ):
+        assert authorizer.verify(base64.b64encode(_report()).decode("ascii")) is False
+
+    run.assert_called_once()
+    sleep.assert_not_called()

--- a/tests/unit_test/app_opt/confidential_computing/tdx_authorizer_test.py
+++ b/tests/unit_test/app_opt/confidential_computing/tdx_authorizer_test.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import textwrap
+from unittest.mock import patch
+
+import pytest
+
+from nvflare.app_opt.confidential_computing.cc_authorizer import CCTokenGenerateError
+from nvflare.app_opt.confidential_computing.tdx_authorizer import TDXAuthorizer
+
+TOKEN = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJ0cnVzdGF1dGhvcml0eSJ9.c2lnbmF0dXJl"
+OTHER_TOKEN = "eyJhbGciOiJFUzM4NCJ9.eyJqdGkiOiJhbm90aGVyIn0.c2lnbmF0dXJl"
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    (tmp_path / "config.json").write_text("{}")
+    return tmp_path
+
+
+def test_generate_runs_unprivileged_and_returns_cli_output(config_dir):
+    authorizer = TDXAuthorizer("/opt/tdx/bin/cli", str(config_dir), use_sudo=False)
+    completed = subprocess.CompletedProcess([], 0, f"{TOKEN}\n", "")
+    with patch("subprocess.run", return_value=completed) as run:
+        assert authorizer.generate() == TOKEN
+
+    command = run.call_args.args[0]
+    assert command == [
+        "/opt/tdx/bin/cli",
+        "-c",
+        str(config_dir / "config.json"),
+        "token",
+    ]
+    assert run.call_args.kwargs["timeout"] == 60
+    assert run.call_args.kwargs["start_new_session"] is True
+
+
+def test_generate_can_explicitly_use_sudo(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=True)
+    completed = subprocess.CompletedProcess([], 0, TOKEN, "")
+    with patch("subprocess.run", return_value=completed) as run:
+        authorizer.generate()
+    assert run.call_args.args[0][:3] == ["sudo", "-n", "tdx-cli"]
+
+
+def test_generate_auto_selects_noninteractive_sudo_for_non_root_host(config_dir):
+    with patch("os.geteuid", return_value=1000), patch("shutil.which", return_value="/usr/bin/sudo"):
+        authorizer = TDXAuthorizer("tdx-cli", str(config_dir))
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0, TOKEN, "")) as run:
+        authorizer.generate()
+    assert run.call_args.args[0][:3] == ["sudo", "-n", "tdx-cli"]
+
+
+def test_generate_supports_reviewed_version_specific_token_options(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False, token_options=("--no-eventlog",))
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0, TOKEN, "")) as run:
+        assert authorizer.generate() == TOKEN
+    assert run.call_args.args[0][-2:] == ["token", "--no-eventlog"]
+
+
+def test_generate_extracts_one_jwt_without_accepting_other_stdout(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    completed = subprocess.CompletedProcess([], 0, f"informational line\n{TOKEN}\n", "")
+    with patch("subprocess.run", return_value=completed):
+        assert authorizer.generate() == TOKEN
+
+
+def test_generate_rejects_ambiguous_stdout(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    completed = subprocess.CompletedProcess([], 0, f"{TOKEN}\n{OTHER_TOKEN}\n", "")
+    with patch("subprocess.run", return_value=completed), pytest.raises(CCTokenGenerateError, match="exactly one"):
+        authorizer.generate()
+
+
+@pytest.mark.parametrize(
+    "completed",
+    [
+        subprocess.CompletedProcess([], 1, "", "verification service unavailable"),
+        subprocess.CompletedProcess([], 0, "", ""),
+    ],
+)
+def test_generate_fails_closed(config_dir, completed):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    with patch("subprocess.run", return_value=completed), pytest.raises(CCTokenGenerateError):
+        authorizer.generate()
+
+
+def test_verify_uses_exit_status(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0, "verified", "")) as run:
+        assert authorizer.verify(TOKEN) is True
+    assert run.call_args.args[0] == [
+        "tdx-cli",
+        "verify",
+        "--config",
+        str(config_dir / "config.json"),
+        "--token",
+        TOKEN,
+    ]
+
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 2, "", "invalid token")):
+        assert authorizer.verify(OTHER_TOKEN) is False
+
+
+def test_verify_rejects_replayed_valid_token(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    verified = subprocess.CompletedProcess([], 0, "verified", "")
+    with patch("subprocess.run", return_value=verified) as run:
+        assert authorizer.verify(TOKEN) is True
+        assert authorizer.verify(TOKEN) is False
+    assert run.call_count == 2
+
+
+def test_verify_retries_when_token_is_not_valid_yet(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    not_yet = subprocess.CompletedProcess([], 1, "", "token has invalid claims: token is not valid yet")
+    verified = subprocess.CompletedProcess([], 0, "verified", "")
+
+    with (
+        patch("subprocess.run", side_effect=[not_yet, verified]) as run,
+        patch("nvflare.app_opt.confidential_computing.tdx_authorizer.time.sleep") as sleep,
+    ):
+        assert authorizer.verify(TOKEN) is True
+
+    assert run.call_count == 2
+    sleep.assert_called_once_with(2.0)
+
+
+def test_verify_exhausts_bounded_not_before_retry_window(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    not_yet = subprocess.CompletedProcess([], 1, "token has invalid claims: token is not valid yet", "")
+
+    with (
+        patch("subprocess.run", return_value=not_yet) as run,
+        patch("nvflare.app_opt.confidential_computing.tdx_authorizer.time.sleep") as sleep,
+    ):
+        assert authorizer.verify(TOKEN) is False
+
+    assert run.call_count == 5
+    assert sleep.call_count == 4
+
+
+def test_verify_does_not_retry_other_failures(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    invalid = subprocess.CompletedProcess([], 1, "", "signature verification failed")
+
+    with (
+        patch("subprocess.run", return_value=invalid) as run,
+        patch("nvflare.app_opt.confidential_computing.tdx_authorizer.time.sleep") as sleep,
+    ):
+        assert authorizer.verify(TOKEN) is False
+
+    run.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_verify_rejects_empty_token_without_starting_cli(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), use_sudo=False)
+    with patch("subprocess.run") as run:
+        assert authorizer.verify("") is False
+    run.assert_not_called()
+
+
+def test_timeout_fails_closed_for_generation_and_verification(config_dir):
+    authorizer = TDXAuthorizer("tdx-cli", str(config_dir), cmd_timeout=0.01, use_sudo=False)
+    timeout = subprocess.TimeoutExpired(["tdx-cli"], 0.01)
+
+    with patch("subprocess.run", side_effect=timeout), pytest.raises(CCTokenGenerateError, match="timed out"):
+        authorizer.generate()
+
+    with patch("subprocess.run", side_effect=timeout):
+        assert authorizer.verify(TOKEN) is False
+
+
+def test_generate_and_verify_with_real_subprocess_contract(config_dir, tmp_path):
+    cli = tmp_path / "tdx-cli"
+    cli.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import sys
+
+            if "token" in sys.argv:
+                print("eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJ0cnVzdGF1dGhvcml0eSJ9.c2lnbmF0dXJl")
+                raise SystemExit(0)
+            if "verify" in sys.argv and sys.argv[-1] == "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJ0cnVzdGF1dGhvcml0eSJ9.c2lnbmF0dXJl":
+                raise SystemExit(0)
+            print("invalid token", file=sys.stderr)
+            raise SystemExit(2)
+            """
+        )
+    )
+    cli.chmod(0o755)
+    authorizer = TDXAuthorizer(str(cli), str(config_dir), use_sudo=False)
+
+    token = authorizer.generate()
+
+    assert token == TOKEN
+    assert authorizer.verify(token) is True
+    assert authorizer.verify(OTHER_TOKEN) is False

--- a/tests/unit_test/app_opt/confidential_computing/utils_test.py
+++ b/tests/unit_test/app_opt/confidential_computing/utils_test.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nvflare.app_opt.confidential_computing.utils import NonceHistory
+
+
+def test_nonce_history_rejects_invalid_and_replayed_values():
+    history = NonceHistory(2)
+
+    assert history.add(None) is False
+    assert history.add("") is False
+    assert history.add("nonce-1") is True
+    assert history.add("nonce-1") is False
+
+
+def test_nonce_history_evicts_oldest_value_at_configured_size():
+    history = NonceHistory(2)
+
+    assert history.add("nonce-1") is True
+    assert history.add("nonce-2") is True
+    assert history.add("nonce-3") is True
+    assert history.add("nonce-1") is True
+
+
+@pytest.mark.parametrize("size", [0, -1, 1.5, None])
+def test_nonce_history_requires_positive_integer_size(size):
+    with pytest.raises(ValueError):
+        NonceHistory(size)

--- a/tests/unit_test/examples/devops/coco_namespace_test.py
+++ b/tests/unit_test/examples/devops/coco_namespace_test.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+COCO_DIR = REPO_ROOT / "examples" / "devops" / "CoCo"
+COMMON_SCRIPT = COCO_DIR / "lib" / "common.sh"
+
+
+def _run_common(script: str, **environment: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.update(environment)
+    env["COMMON_SCRIPT"] = str(COMMON_SCRIPT)
+    return subprocess.run(
+        ["bash", "-c", 'source "$COMMON_SCRIPT"\n' + script],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=5,
+    )
+
+
+def test_managed_namespace_accepts_existing_owned_namespace():
+    result = _run_common(
+        """
+kctl() {
+  if [[ "$*" == *jsonpath* ]]; then
+    printf '%s' "$FAKE_LABEL"
+  else
+    return 0
+  fi
+}
+ensure_coco_managed_namespace nvflare-coco
+""",
+        FAKE_LABEL="true",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_managed_namespace_rejects_existing_unowned_namespace():
+    result = _run_common(
+        """
+kctl() {
+  if [[ "$*" == *jsonpath* ]]; then
+    printf '%s' "$FAKE_LABEL"
+  else
+    return 0
+  fi
+}
+ensure_coco_managed_namespace shared-namespace
+""",
+        FAKE_LABEL="",
+    )
+
+    assert result.returncode != 0
+    assert "refusing to adopt a potentially shared namespace" in result.stderr
+
+
+def test_managed_namespace_creates_new_namespace_with_ownership_label():
+    result = _run_common(
+        """
+kctl() {
+  if [[ "$1" == get ]]; then
+    return 1
+  fi
+  if [[ "$1" == create ]]; then
+    cat
+    return 0
+  fi
+  return 2
+}
+ensure_coco_managed_namespace nvflare-coco
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "name: nvflare-coco" in result.stdout
+    assert 'nvflare.nvidia.com/coco-managed: "true"' in result.stdout
+
+
+def test_credential_and_deployment_stages_use_namespace_ownership_guard():
+    stage_30 = (COCO_DIR / "30-deploy-security-services.sh").read_text()
+    stage_50 = (COCO_DIR / "50-nvflare-deploy.sh").read_text()
+
+    assert 'ensure_coco_managed_namespace "$NVFLARE_NAMESPACE"' in stage_30
+    assert 'ensure_coco_managed_namespace "$NVFLARE_NAMESPACE"' in stage_50
+    assert 'create namespace "$NVFLARE_NAMESPACE"' not in stage_30
+    assert 'create namespace "$NVFLARE_NAMESPACE"' not in stage_50

--- a/tests/unit_test/lighter/cc_provision/impl/test_cc.py
+++ b/tests/unit_test/lighter/cc_provision/impl/test_cc.py
@@ -17,7 +17,7 @@ import os
 
 import pytest
 
-from nvflare.lighter.cc_provision.cc_constants import CCConfigKey, CCConfigValue
+from nvflare.lighter.cc_provision.cc_constants import CC_AUTHORIZERS_KEY, CCConfigKey, CCConfigValue
 from nvflare.lighter.cc_provision.impl.cc import CCBuilder
 from nvflare.lighter.constants import PropKey, ProvFileName
 from nvflare.lighter.ctx import ProvisionContext
@@ -114,3 +114,35 @@ def test_cc_builder_rejects_invalid_class_allow_list(tmp_path):
 
     with pytest.raises(ValueError, match=CCConfigKey.CLASS_ALLOW_LIST):
         builder.build(project, ctx)
+
+
+def test_cc_builder_provisions_manager_request_timeouts(tmp_path):
+    project = _project_with_server(
+        {
+            PropKey.CC_ENABLED: True,
+            PropKey.CC_CONFIG_DICT: {
+                CCConfigKey.COMPUTE_ENV: CCConfigValue.MOCK,
+                CCConfigKey.CC_ATTESTATION_CONFIG: {
+                    "check_frequency": 120,
+                    "get_site_request_timeout": 30,
+                    "get_token_request_timeout": 200,
+                },
+            },
+            PropKey.CC_ISSUERS: [],
+        }
+    )
+    ctx = ProvisionContext(str(tmp_path), project)
+    ctx[CC_AUTHORIZERS_KEY] = []
+    server = project.get_server()
+    os.makedirs(ctx.get_local_dir(server), exist_ok=True)
+    builder = CCBuilder()
+    builder._cc_enabled_sites = [server]
+
+    builder._build_cc_manager_component(server, ctx)
+
+    resources_file = os.path.join(ctx.get_local_dir(server), "cc_manager__p_resources.json")
+    with open(resources_file) as resources_stream:
+        manager = json.load(resources_stream)["components"][0]
+    assert manager["args"]["verify_frequency"] == 120
+    assert manager["args"]["get_site_request_timeout"] == 30
+    assert manager["args"]["get_token_request_timeout"] == 200


### PR DESCRIPTION
## Summary

This PR adds a staged bare-metal Confidential Containers (CoCo) reference workflow for both AMD SEV-SNP and Intel TDX hosts with NVIDIA confidential-computing GPUs. It covers host validation, Kubernetes/Kata installation, GPU confidential-computing setup, security services, signed-image launch and attestation, NVFlare deployment, end-to-end job validation, and administrator documentation.

## Workflow

The new `examples/devops/CoCo` workflow is intentionally split into auditable stages:

1. `00-verify-host.sh` validates SNP or TDX host capabilities, IOMMU/GPU prerequisites, storage, networking, and configured credentials.
2. `10-install-kubernetes.sh` installs pinned Kubernetes, containerd, CNI, Helm, and a SHA-256-verified Calico manifest.
3. `20-install-coco-gpu.sh` installs Kata Confidential Containers and configures the NVIDIA GPU Operator/CC Manager for passthrough.
4. `30-deploy-security-services.sh` creates the Cosign and registry PKI material and deploys a digest-pinned private registry and Trustee KBS resources.
5. After stage 30, users choose one of two paths:
   - generic CoCo validation: `40-sign-image.sh` then `50-launch-and-attest.sh`;
   - NVFlare validation: `40-nvflare-build-sign-images.sh`, `50-nvflare-deploy.sh`, then `60-nvflare-submit-hello-numpy.sh`.

The scripts auto-detect SNP versus TDX and use the same workflow on both platforms. Configuration, checksum inventory, Kubernetes templates, a concise quick-start, and detailed host/cluster administrator guides are included.

## NVFlare on CoCo

- Adds `docker/Dockerfile.coco` without modifying `Dockerfile.parent` or installing Kubernetes packages in the image.
- Builds and signs separate NVFlare server and client images containing the SNP, TDX, and NVIDIA NVAT authorizer dependencies.
- Deploys one CPU-only NVFlare server and one GPU-assigned client in Kata confidential VMs.
- Uses `ProcessJobLauncher` for this release.
- Provisions the NVFlare CCManager with CPU/GPU issuers and verifiers, exposes the required guest attestation devices, and sets the peer token timeout above NVAT's command timeout.
- Adds a fixed, signed hello-numpy executor and stage 60 submission script that waits for the job to reach `FINISHED:COMPLETED`.

## Attestation and supply-chain hardening

- SNP authorization uses fresh report data, verifies AMD collateral/signatures, rejects replay, and does not retry deterministic local signature failures.
- TDX authorization uses Intel Trust Authority CLI tokens, strict compact-JWT extraction and size bounds, bounded clock-skew retry, configurable legacy CLI flags/sudo behavior, and replay rejection.
- GPU authorization uses NVAT `nvattest`, fresh nonces, replay rejection, parallel-safe verification, and explicit validation of every built-in secure-boot/debug/certificate/RIM policy claim in addition to NVAT's policy result.
- Signed workload images are resolved to immutable registry digests and verified with Cosign.
- Kata init-data measures the image policy, Cosign public key, registry CA, and guest-agent policy. `SetPolicyRequest` is denied so the measured policy cannot be replaced at runtime.
- Calico, registry, Trustee, NVAT, snpguest, Trust Authority CLI, and other downloaded/runtime artifacts are checksum- or digest-pinned.
- Complete VM-image trust still requires comparing the launch measurement with an approved reference value, for example through Trustee/RVPS policy, or enforcing a signed SNP ID block; the guides call out that boundary.

## Explicit demo boundaries

This is a reproducible bare-metal reference workflow, not a production trust-service topology:

- The measured Kata agent policy permits copy, exec, and stream operations because the validation scripts use `kubectl exec`; it does not isolate workloads from a Kubernetes host administrator.
- The private registry binds to one configured host IP, but intentionally has no client authentication and permits push/delete. The guides require restricting the port to trusted administrators.
- The sample Trustee KBS uses the local in-cluster topology. Production deployments should use authenticated TLS, protected signing keys, restrictive attestation/resource policies, and trust services outside the workload host failure domain.
- The workflow has no uninstall or rollback script. Use a dedicated host and follow a separately reviewed recovery or reimage procedure.

## Documentation

- `USER_GUIDE.md`: detailed host IT/Kubernetes administrator guide.
- `NVFlare_on_CoCo.md`: detailed stages 40-60 NVFlare deployment and attestation guide.
- `SUMMARY.md`: concise try-it workflow.
- `README.md` and `CHECKSUMS.md`: entry point, trust boundaries, workflow configuration, and pinned artifact inventory.

## Validation

Hardware validation:

- Stages 00-60 completed on an AMD SEV-SNP bare-metal host.
- The identical scripts completed on an Intel TDX bare-metal host.
- Both deployments ran the signed NVFlare server/client topology and reported the hello-numpy job as `FINISHED:COMPLETED`.

Automated validation:

- `.venv/bin/python -m pytest -q tests/unit_test/app_opt/confidential_computing tests/unit_test/lighter/cc_provision/impl/test_cc.py` — **66 passed**
- `./runtest.sh -s` — **passed** (Black, isort, flake8, and agent-skill lint)
- `./runtest.sh -l` — **passed**
- `bash -n` for all touched workflow scripts — **passed**
- Rendered registry and Trustee manifests parsed successfully
- `git diff --check` — **passed**
