### PR TITLE
Preserve reportable Slurm worker exit codes

### DIFF
--- a/nvflare/app_opt/job_launcher/slurm/manager.py
+++ b/nvflare/app_opt/job_launcher/slurm/manager.py
@@ -54,7 +54,7 @@ from nvflare.app_opt.job_launcher.slurm.config import (
     resolve_slurm_parent_executables,
 )
 from nvflare.app_opt.job_launcher.slurm.scheduler_client import _command_diagnostic, _SlurmCliAdapter
-from nvflare.fuel.common.exit_codes import ProcessExitCode
+from nvflare.fuel.common.exit_codes import PROCESS_EXIT_REASON, ProcessExitCode
 
 _HEALTHY_MISSES = 5
 _ACCOUNTING_RETRY_INTERVAL = 6.0
@@ -336,6 +336,8 @@ class SlurmJobManager:
             return JobReturnCode.ABORTED
         if record.state == "CANCELLED":
             return ProcessExitCode.INFRASTRUCTURE_ERROR
+        if record.exit_status in PROCESS_EXIT_REASON:
+            return record.exit_status
         if record.exit_status or record.exit_signal:
             return JobReturnCode.EXECUTION_ERROR
         return JobReturnCode.SUCCESS if record.state == "COMPLETED" else JobReturnCode.EXECUTION_ERROR

--- a/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
@@ -663,7 +663,7 @@ def test_requeued_job_is_refused_by_batch_guard(tmp_path):
     assert "SLURM_RESTART_COUNT" in adapter.submitted_batch
     assert handle.poll() == JobReturnCode.UNKNOWN
     assert not any(call[0] == "cancel" for call in adapter.calls)
-    assert handle.poll() == JobReturnCode.EXECUTION_ERROR
+    assert handle.poll() == ProcessExitCode.EXCEPTION
 
 
 def test_framework_termination_path_handles_job_without_slurm_system_end_sweep(tmp_path):


### PR DESCRIPTION
## Summary

- preserve NVFlare-defined process exit codes reported by Slurm accounting
- keep unknown nonzero exits mapped to generic `EXECUTION_ERROR`
- update the existing requeue-guard regression expectation

## Root cause

Slurm accounting retained worker exit codes such as `ProcessExitCode.EXCEPTION` (101), but `SlurmJobManager._result_for` flattened every application nonzero exit to `JobReturnCode.EXECUTION_ERROR` (1). The client parent intentionally does not report generic code 1, so a reportable worker failure could be lost before reaching the server.

## Scope

This is intentionally narrow. It only preserves exit codes already defined in `PROCESS_EXIT_REASON` (101-104). It does not change generic exit 1 handling, client/server reporting policy, diagnostics, or server-side liveness behavior.


