### PR TITLE
Fix F3 reassembly buffer sizing under load

### DIFF
--- a/dev_tools/f3/README.md
+++ b/dev_tools/f3/README.md
@@ -154,7 +154,10 @@ with all available options. Key defaults:
 | `streaming_chunk_size` | 1 MiB |
 | `streaming_window_size` | 64 MiB (64 chunks) |
 | `streaming_ack_interval` | 16 MiB |
-| `streaming_max_out_seq_chunks` | 16 |
 | `streaming_retry_max_pending_bytes` | 128 MiB |
+
+The receiver's out-of-sequence chunk limit is left unset so it is derived from
+the effective window and chunk sizes. For these benchmark defaults, the derived
+limit is 65 chunks.
 
 Byte-size fields accept integer bytes or binary suffixes (`1K`, `1M`, `1G`).

--- a/dev_tools/f3/comm_config.yml
+++ b/dev_tools/f3/comm_config.yml
@@ -18,7 +18,6 @@
 streaming_chunk_size: 1M
 streaming_window_size: 64M                 # 64 chunks
 streaming_ack_interval: 16M                # one quarter of the window
-streaming_max_out_seq_chunks: 16
 streaming_retry_max_pending_bytes: 128M
 
 # Any native F3 comm_config option can be added here. Common flat options are:

--- a/docs/user_guide/admin_guide/configurations/communication_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/communication_configuration.rst
@@ -242,7 +242,9 @@ This section describes all parameters that you can configure.
                                                                    
 The messaging parameters can be specified in <site_workspace>/local/comm_config.json file as first-level elements, or by using environment variables as described in the beginning of this document.
 
-This is an example of comm_config.json file with default values for all the parameters,
+This is an example of comm_config.json with the fixed default values. Parameters
+whose defaults are derived from other settings, such as ``streaming_max_out_seq_chunks``,
+are intentionally omitted.
 
 .. code-block:: json
 
@@ -253,7 +255,6 @@ This is an example of comm_config.json file with default values for all the para
     "streaming_chunk_size": 1048576,
     "streaming_max_blob_size": 2144337904,
     "streaming_read_timeout": 60,
-    "streaming_max_out_seq_chunks": 16,
     "streaming_window_size": 67108864,
     "streaming_ack_interval": 16777216,
     "streaming_ack_wait": 10,
@@ -345,7 +346,12 @@ streaming_max_out_seq_chunks
 
 The chunks may arrive on the receiving end out of sequence. 
 The receiver keeps out-of-sequence chunks in a reassembly buffer while waiting for the expected chunk to arrive.
-The streaming terminates with error if the number of chunks in the reassembly buffer is larger than this value. The default is 16. 
+The streaming terminates with error if the number of chunks in the reassembly buffer is larger than this value.
+
+When this parameter is unset, the limit is derived from the effective streaming window and chunk sizes, with a minimum
+fallback of 16 chunks and a peer-derived ceiling of 1024. An explicitly configured value is a hard receiver-side maximum
+and is not increased to match a sender's window. Configure it only when a fixed memory-control limit is required, and
+ensure that it can accommodate the number of chunks allowed by the streaming window.
 
 The streaming implements a sliding-window protocol for flow-control. The receiver sends ACKs after the chunks are retrieved by the reader.
 The window is all the chunks sent but not being acknowledged by the receiver. Once the window reaches a certain size, the sender pauses and waits for more ACKs.

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -45,7 +45,7 @@ MIN_OUT_SEQ_CHUNKS = 16
 # ratio would let a peer size this receiver's reassembly buffer at will. A site
 # that legitimately needs more can raise streaming_max_out_seq_chunks in its own
 # config, which is not capped.
-MAX_DERIVED_OUT_SEQ_CHUNKS = 1024
+MAX_PEER_DERIVED_OUT_SEQ_CHUNKS = 1024
 # Headerless legacy senders can use windows smaller than the new sender
 # default. Keep their receiver-side fallback at the historical 4 MiB so an
 # ACK is sent before those senders exhaust their flow-control window.
@@ -88,13 +88,13 @@ def required_out_seq_chunks(window_size: int, chunk_size: int) -> int:
     the FLARE-3093 regression, where a 64 MiB default window put far more than 16
     chunks in flight.
 
-    The result is capped at MAX_DERIVED_OUT_SEQ_CHUNKS because window_size and
+    The result is capped at MAX_PEER_DERIVED_OUT_SEQ_CHUNKS because window_size and
     chunk_size may be adopted from peer-supplied headers.
     """
     if chunk_size <= 0:
         return MIN_OUT_SEQ_CHUNKS
     window_chunks = (window_size + chunk_size - 1) // chunk_size
-    return max(MIN_OUT_SEQ_CHUNKS, min(window_chunks + 1, MAX_DERIVED_OUT_SEQ_CHUNKS))
+    return max(MIN_OUT_SEQ_CHUNKS, min(window_chunks + 1, MAX_PEER_DERIVED_OUT_SEQ_CHUNKS))
 
 
 class RxTask:
@@ -319,11 +319,11 @@ class RxTask:
         )
         if self.chunk_size > 0:
             window_chunks = (self.window_size + self.chunk_size - 1) // self.chunk_size
-            if window_chunks + 1 > MAX_DERIVED_OUT_SEQ_CHUNKS:
+            if window_chunks + 1 > MAX_PEER_DERIVED_OUT_SEQ_CHUNKS:
                 log.warning(
                     f"{self} streaming_window_size {self.window_size} from {self.origin} needs "
                     f"{window_chunks + 1} out-of-sequence chunks, above the "
-                    f"{MAX_DERIVED_OUT_SEQ_CHUNKS} cap; raise streaming_max_out_seq_chunks on this "
+                    f"{MAX_PEER_DERIVED_OUT_SEQ_CHUNKS} cap; raise streaming_max_out_seq_chunks on this "
                     f"site if this peer's window is legitimate"
                 )
         required_max_out_seq = required_out_seq_chunks(self.window_size, self.chunk_size)

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -41,6 +41,12 @@ from nvflare.fuel.f3.streaming.stream_utils import ONE_MB, stream_stats_category
 log = logging.getLogger(__name__)
 
 MAX_OUT_SEQ_CHUNKS = 16
+# Upper bound on the out-of-sequence tolerance derived from a peer's
+# WINDOW_SIZE/CHUNK_SIZE headers. Those headers are hints, and an unbounded
+# ratio would let a peer size this receiver's reassembly buffer at will. A site
+# that legitimately needs more can raise streaming_max_out_seq_chunks in its own
+# config, which is not capped.
+MAX_DERIVED_OUT_SEQ_CHUNKS = 1024
 # Headerless legacy senders can use windows smaller than the new sender
 # default. Keep their receiver-side fallback at the historical 4 MiB so an
 # ACK is sent before those senders exhaust their flow-control window.
@@ -69,10 +75,30 @@ def _abbrev(value, limit: int = 64) -> str:
 
 
 def required_out_seq_chunks(window_size: int, chunk_size: int) -> int:
-    """Return the number of chunks that can be in flight for a stream window."""
+    """Return the out-of-sequence tolerance needed for a sender's flow-control window.
+
+    Inbound frames are dispatched to a thread pool (ConnManager.process_frame), so
+    chunks that arrive in order can still be *processed* out of order, with a depth
+    that grows under scheduling jitter. The depth is bounded by how many chunks the
+    sender may have unacked, which is what its flow-control window governs:
+    TxTask.send_loop blocks while ``window >= window_size`` and every non-final chunk
+    is exactly chunk_size bytes, so at most ``window_size // chunk_size`` normal chunks
+    are unacked at a time. Tolerating fewer than that aborts healthy streams under load
+    -- the FLARE-3093 regression, where a 64 MiB default window put 64 chunks in flight
+    against a fixed tolerance of 16.
+
+    The extra chunk covers the final frame, which TxTask sends from its EOS branch
+    before applying the normal flow-control check. It also supports senders predating
+    the current ``>=`` check: they blocked only while ``window > window_size`` and
+    could therefore send one additional full chunk. Both cases matter during a
+    rolling upgrade.
+
+    The result is capped at MAX_DERIVED_OUT_SEQ_CHUNKS because window_size and
+    chunk_size may be adopted from peer-supplied headers.
+    """
     if chunk_size <= 0:
         return MAX_OUT_SEQ_CHUNKS
-    return max(MAX_OUT_SEQ_CHUNKS, window_size // chunk_size + 1)
+    return max(MAX_OUT_SEQ_CHUNKS, min(window_size // chunk_size + 1, MAX_DERIVED_OUT_SEQ_CHUNKS))
 
 
 class RxTask:
@@ -99,6 +125,7 @@ class RxTask:
         # Out-of-sequence chunks to be assembled
         self.out_seq_chunks: Dict[int, Tuple[bool, BytesAlike]] = {}
         self.stream_future = None
+        self.sender_flow_control_received = False
         self.next_seq = 0
         self.offset = 0
         self.received_offset = 0
@@ -216,6 +243,11 @@ class RxTask:
                 else:
                     self._handle_new_stream(message)
                     new_stream = True
+            elif not self.stream_future and not self.sender_flow_control_received:
+                # Sequence 0 can be delayed by ConnManager's frame-processing pool.
+                # New senders repeat these headers so the reassembly limit can be
+                # raised before admitting later chunks.
+                self._update_sender_flow_control(message)
 
             if not duplicate_start:
                 should_stop, ack_to_send, stop_error = self._handle_incoming_data(seq, message)
@@ -235,29 +267,8 @@ class RxTask:
         self.topic = message.get_header(StreamHeaderKey.TOPIC)
         self.headers = message.headers
         self.size = message.get_header(StreamHeaderKey.SIZE, 0)
-        self.chunk_size = self._get_sender_parameter(
-            message, StreamHeaderKey.CHUNK_SIZE, "streaming_chunk_size", self.chunk_size
-        )
-        self.window_size = self._get_sender_parameter(
-            message, StreamHeaderKey.WINDOW_SIZE, "streaming_window_size", self.window_size
-        )
-        self.ack_interval = self._get_sender_parameter(
-            message, StreamHeaderKey.ACK_INTERVAL, "streaming_ack_interval", self.ack_interval
-        )
-        self.retry_max_pending_bytes = self._get_sender_parameter(
-            message,
-            StreamHeaderKey.RETRY_MAX_PENDING_BYTES,
-            "streaming_retry_max_pending_bytes",
-            self.retry_max_pending_bytes,
-            allow_non_positive=True,
-        )
-        self.max_out_seq = max(self.max_out_seq, required_out_seq_chunks(self.window_size, self.chunk_size))
-        if self.ack_interval > self.window_size:
-            log.warning(
-                f"{self} streaming_ack_interval {self.ack_interval} from {self.origin} exceeds "
-                f"streaming_window_size {self.window_size}; using {self.window_size}"
-            )
-            self.ack_interval = self.window_size
+        self._update_sender_flow_control(message)
+
         retry_timeout = message.get_header(StreamHeaderKey.RETRY_TIMEOUT, None)
         retry_wait = message.get_header(StreamHeaderKey.RETRY_WAIT, None)
         if retry_timeout is not None and retry_wait is not None:
@@ -292,6 +303,46 @@ class RxTask:
 
         self.stream_future = StreamFuture(self.sid, self.headers)
         self.stream_future.set_size(self.size)
+
+    def _update_sender_flow_control(self, message: Message):
+        has_flow_control_headers = all(
+            message.get_header(key, None) is not None
+            for key in (
+                StreamHeaderKey.CHUNK_SIZE,
+                StreamHeaderKey.WINDOW_SIZE,
+            )
+        )
+        self.chunk_size = self._get_sender_parameter(
+            message, StreamHeaderKey.CHUNK_SIZE, "streaming_chunk_size", self.chunk_size
+        )
+        self.window_size = self._get_sender_parameter(
+            message, StreamHeaderKey.WINDOW_SIZE, "streaming_window_size", self.window_size
+        )
+        self.ack_interval = self._get_sender_parameter(
+            message, StreamHeaderKey.ACK_INTERVAL, "streaming_ack_interval", self.ack_interval
+        )
+        self.retry_max_pending_bytes = self._get_sender_parameter(
+            message,
+            StreamHeaderKey.RETRY_MAX_PENDING_BYTES,
+            "streaming_retry_max_pending_bytes",
+            self.retry_max_pending_bytes,
+            allow_non_positive=True,
+        )
+        if self.chunk_size > 0 and self.window_size // self.chunk_size > MAX_DERIVED_OUT_SEQ_CHUNKS:
+            log.warning(
+                f"{self} streaming_window_size {self.window_size} from {self.origin} needs "
+                f"{self.window_size // self.chunk_size} out-of-sequence chunks, above the "
+                f"{MAX_DERIVED_OUT_SEQ_CHUNKS} cap; raise streaming_max_out_seq_chunks on this "
+                f"site if this peer's window is legitimate"
+            )
+        self.max_out_seq = max(self.max_out_seq, required_out_seq_chunks(self.window_size, self.chunk_size))
+        if self.ack_interval > self.window_size:
+            log.warning(
+                f"{self} streaming_ack_interval {self.ack_interval} from {self.origin} exceeds "
+                f"streaming_window_size {self.window_size}; using {self.window_size}"
+            )
+            self.ack_interval = self.window_size
+        self.sender_flow_control_received = has_flow_control_headers
 
     def _get_sender_parameter(
         self,

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -82,10 +82,10 @@ def required_out_seq_chunks(window_size: int, chunk_size: int) -> int:
     that grows under scheduling jitter. The depth is bounded by how many chunks the
     sender may have unacked, which is what its flow-control window governs:
     TxTask.send_loop blocks while ``window >= window_size`` and every non-final chunk
-    is exactly chunk_size bytes, so at most ``window_size // chunk_size`` normal chunks
-    are unacked at a time. Tolerating fewer than that aborts healthy streams under load
-    -- the FLARE-3093 regression, where a 64 MiB default window put 64 chunks in flight
-    against a fixed tolerance of 16.
+    is exactly chunk_size bytes, so at most ``ceil(window_size / chunk_size)`` normal
+    chunks are unacked at a time. Tolerating fewer than that aborts healthy streams
+    under load -- the FLARE-3093 regression, where a 64 MiB default window put 64
+    chunks in flight against a fixed tolerance of 16.
 
     The extra chunk covers the final frame, which TxTask sends from its EOS branch
     before applying the normal flow-control check. It also supports senders predating
@@ -98,7 +98,8 @@ def required_out_seq_chunks(window_size: int, chunk_size: int) -> int:
     """
     if chunk_size <= 0:
         return MAX_OUT_SEQ_CHUNKS
-    return max(MAX_OUT_SEQ_CHUNKS, min(window_size // chunk_size + 1, MAX_DERIVED_OUT_SEQ_CHUNKS))
+    window_chunks = (window_size + chunk_size - 1) // chunk_size
+    return max(MAX_OUT_SEQ_CHUNKS, min(window_chunks + 1, MAX_DERIVED_OUT_SEQ_CHUNKS))
 
 
 class RxTask:
@@ -328,13 +329,15 @@ class RxTask:
             self.retry_max_pending_bytes,
             allow_non_positive=True,
         )
-        if self.chunk_size > 0 and self.window_size // self.chunk_size > MAX_DERIVED_OUT_SEQ_CHUNKS:
-            log.warning(
-                f"{self} streaming_window_size {self.window_size} from {self.origin} needs "
-                f"{self.window_size // self.chunk_size} out-of-sequence chunks, above the "
-                f"{MAX_DERIVED_OUT_SEQ_CHUNKS} cap; raise streaming_max_out_seq_chunks on this "
-                f"site if this peer's window is legitimate"
-            )
+        if self.chunk_size > 0:
+            window_chunks = (self.window_size + self.chunk_size - 1) // self.chunk_size
+            if window_chunks + 1 > MAX_DERIVED_OUT_SEQ_CHUNKS:
+                log.warning(
+                    f"{self} streaming_window_size {self.window_size} from {self.origin} needs "
+                    f"{window_chunks + 1} out-of-sequence chunks, above the "
+                    f"{MAX_DERIVED_OUT_SEQ_CHUNKS} cap; raise streaming_max_out_seq_chunks on this "
+                    f"site if this peer's window is legitimate"
+                )
         self.max_out_seq = max(self.max_out_seq, required_out_seq_chunks(self.window_size, self.chunk_size))
         if self.ack_interval > self.window_size:
             log.warning(

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -39,7 +39,7 @@ from nvflare.fuel.f3.streaming.stream_utils import ONE_MB, stream_stats_category
 
 log = logging.getLogger(__name__)
 
-MAX_OUT_SEQ_CHUNKS = 16
+MIN_OUT_SEQ_CHUNKS = 16
 # Upper bound on the out-of-sequence tolerance derived from a peer's
 # WINDOW_SIZE/CHUNK_SIZE headers. Those headers are hints, and an unbounded
 # ratio would let a peer size this receiver's reassembly buffer at will. A site
@@ -79,26 +79,22 @@ def required_out_seq_chunks(window_size: int, chunk_size: int) -> int:
     Inbound frames are dispatched to a thread pool (ConnManager.process_frame), so
     chunks that arrive in order can still be *processed* out of order, with a depth
     that grows under scheduling jitter. The depth is bounded by how many chunks the
-    sender may have unacked, which is what its flow-control window governs:
-    TxTask.send_loop blocks while ``window >= window_size`` and every non-final chunk
-    is exactly chunk_size bytes, so at most ``ceil(window_size / chunk_size)`` normal
-    chunks are unacked at a time. Tolerating fewer than that aborts healthy streams
-    under load -- the FLARE-3093 regression, where a 64 MiB default window put 64
-    chunks in flight against a fixed tolerance of 16.
-
-    The extra chunk covers the final frame, which TxTask sends from its EOS branch
-    before applying the normal flow-control check. It also supports senders predating
-    the current ``>=`` check: they blocked only while ``window > window_size`` and
-    could therefore send one additional full chunk. Both cases matter during a
-    rolling upgrade.
+    sender may have unacked, which is what its flow-control window governs.
+    TxTask coalesces short reads so every non-final frame is chunk_size bytes and
+    pauses while ``window > window_size``. The EOS path may add one final frame,
+    while the missing expected frame is never stored in out_seq_chunks. Therefore
+    ``ceil(window_size / chunk_size) + 1`` slots cover both divisible and
+    non-divisible windows. Tolerating fewer aborts healthy streams under load --
+    the FLARE-3093 regression, where a 64 MiB default window put far more than 16
+    chunks in flight.
 
     The result is capped at MAX_DERIVED_OUT_SEQ_CHUNKS because window_size and
     chunk_size may be adopted from peer-supplied headers.
     """
     if chunk_size <= 0:
-        return MAX_OUT_SEQ_CHUNKS
+        return MIN_OUT_SEQ_CHUNKS
     window_chunks = (window_size + chunk_size - 1) // chunk_size
-    return max(MAX_OUT_SEQ_CHUNKS, min(window_chunks + 1, MAX_DERIVED_OUT_SEQ_CHUNKS))
+    return max(MIN_OUT_SEQ_CHUNKS, min(window_chunks + 1, MAX_DERIVED_OUT_SEQ_CHUNKS))
 
 
 class RxTask:
@@ -150,7 +146,9 @@ class RxTask:
         self.window_size = config.get_streaming_window_size(STREAM_WINDOW_SIZE)
         self.ack_interval = config.get_streaming_ack_interval(ACK_INTERVAL)
         required_max_out_seq = required_out_seq_chunks(self.window_size, self.chunk_size)
-        self.max_out_seq = config.get_streaming_max_out_seq_chunks(required_max_out_seq)
+        configured_max_out_seq = config.get_streaming_max_out_seq_chunks(None)
+        self.max_out_seq_is_configured = configured_max_out_seq is not None
+        self.max_out_seq = configured_max_out_seq if self.max_out_seq_is_configured else required_max_out_seq
         self.completed_task_ttl = config.get_streaming_retry_timeout(
             COMPLETED_TASK_TTL
         ) + config.get_streaming_retry_wait(RETRY_WAIT)
@@ -328,7 +326,15 @@ class RxTask:
                     f"{MAX_DERIVED_OUT_SEQ_CHUNKS} cap; raise streaming_max_out_seq_chunks on this "
                     f"site if this peer's window is legitimate"
                 )
-        self.max_out_seq = max(self.max_out_seq, required_out_seq_chunks(self.window_size, self.chunk_size))
+        required_max_out_seq = required_out_seq_chunks(self.window_size, self.chunk_size)
+        if self.max_out_seq_is_configured:
+            if required_max_out_seq > self.max_out_seq:
+                log.warning(
+                    f"{self} sender flow-control window needs {required_max_out_seq} out-of-sequence chunks, "
+                    f"above configured streaming_max_out_seq_chunks {self.max_out_seq}; stream may fail under load"
+                )
+        else:
+            self.max_out_seq = max(self.max_out_seq, required_max_out_seq)
         if self.ack_interval > self.window_size:
             log.warning(
                 f"{self} streaming_ack_interval {self.ack_interval} from {self.origin} exceeds "

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -68,6 +68,13 @@ def _abbrev(value, limit: int = 64) -> str:
     return text
 
 
+def required_out_seq_chunks(window_size: int, chunk_size: int) -> int:
+    """Return the number of chunks that can be in flight for a stream window."""
+    if chunk_size <= 0:
+        return MAX_OUT_SEQ_CHUNKS
+    return max(MAX_OUT_SEQ_CHUNKS, window_size // chunk_size + 1)
+
+
 class RxTask:
     """Receiving task for ByteStream"""
 
@@ -117,7 +124,8 @@ class RxTask:
         self.ack_interval = config.get_streaming_ack_interval(ACK_INTERVAL)
         retry_max_pending_default = max(STREAM_RETRY_MAX_PENDING_BYTES, 2 * self.window_size)
         self.retry_max_pending_bytes = config.get_streaming_retry_max_pending_bytes(retry_max_pending_default)
-        self.max_out_seq = config.get_streaming_max_out_seq_chunks(MAX_OUT_SEQ_CHUNKS)
+        required_max_out_seq = required_out_seq_chunks(self.window_size, self.chunk_size)
+        self.max_out_seq = config.get_streaming_max_out_seq_chunks(required_max_out_seq)
         self.completed_task_ttl = config.get_streaming_retry_timeout(
             COMPLETED_TASK_TTL
         ) + config.get_streaming_retry_wait(RETRY_WAIT)
@@ -243,6 +251,7 @@ class RxTask:
             self.retry_max_pending_bytes,
             allow_non_positive=True,
         )
+        self.max_out_seq = max(self.max_out_seq, required_out_seq_chunks(self.window_size, self.chunk_size))
         if self.ack_interval > self.window_size:
             log.warning(
                 f"{self} streaming_ack_interval {self.ack_interval} from {self.origin} exceeds "

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -30,7 +30,6 @@ from nvflare.fuel.f3.streaming.stream_const import (
     STREAM_CHANNEL,
     STREAM_CHUNK_SIZE,
     STREAM_DATA_TOPIC,
-    STREAM_RETRY_MAX_PENDING_BYTES,
     STREAM_WINDOW_SIZE,
     StreamDataType,
     StreamHeaderKey,
@@ -150,8 +149,6 @@ class RxTask:
         self.chunk_size = config.get_streaming_chunk_size(STREAM_CHUNK_SIZE)
         self.window_size = config.get_streaming_window_size(STREAM_WINDOW_SIZE)
         self.ack_interval = config.get_streaming_ack_interval(ACK_INTERVAL)
-        retry_max_pending_default = max(STREAM_RETRY_MAX_PENDING_BYTES, 2 * self.window_size)
-        self.retry_max_pending_bytes = config.get_streaming_retry_max_pending_bytes(retry_max_pending_default)
         required_max_out_seq = required_out_seq_chunks(self.window_size, self.chunk_size)
         self.max_out_seq = config.get_streaming_max_out_seq_chunks(required_max_out_seq)
         self.completed_task_ttl = config.get_streaming_retry_timeout(
@@ -321,13 +318,6 @@ class RxTask:
         )
         self.ack_interval = self._get_sender_parameter(
             message, StreamHeaderKey.ACK_INTERVAL, "streaming_ack_interval", self.ack_interval
-        )
-        self.retry_max_pending_bytes = self._get_sender_parameter(
-            message,
-            StreamHeaderKey.RETRY_MAX_PENDING_BYTES,
-            "streaming_retry_max_pending_bytes",
-            self.retry_max_pending_bytes,
-            allow_non_positive=True,
         )
         if self.chunk_size > 0:
             window_chunks = (self.window_size + self.chunk_size - 1) // self.chunk_size

--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -285,12 +285,16 @@ class TxTask(StreamTaskSpec):
 
             # Flow control
             window = self.offset - self.offset_ack
-            # It may take several ACKs to clear up the window
-            while window > self.window_size:
-                log.debug(f"{self} window size {window} exceeds limit: {self.window_size}")
+            # It may take several ACKs to clear up the window.
+            # The comparison is >=, not >, so a normal data chunk does not add
+            # another full chunk once the window reaches its limit. The EOS path
+            # above can still send one final frame; RxTask includes that slot when
+            # sizing its reassembly buffer.
+            while window >= self.window_size:
+                log.debug(f"{self} window size {window} reached limit: {self.window_size}")
                 wait_start = time.monotonic()
 
-                while window > self.window_size:
+                while window >= self.window_size:
                     if self.stopped:
                         return
 
@@ -355,16 +359,15 @@ class TxTask(StreamTaskSpec):
             StreamHeaderKey.OFFSET: self.offset,
             StreamHeaderKey.RELIABLE: self.reliable,
             StreamHeaderKey.OPTIONAL: self.optional,
+            # Repeat the buffer-sizing parameters because ConnManager may process a
+            # later frame before sequence 0. Older receivers ignore these headers
+            # after the first frame, so this is wire-compatible.
+            StreamHeaderKey.CHUNK_SIZE: self.chunk_size,
+            StreamHeaderKey.WINDOW_SIZE: self.window_size,
         }
         if self.seq == 0:
-            stream_headers.update(
-                {
-                    StreamHeaderKey.CHUNK_SIZE: self.chunk_size,
-                    StreamHeaderKey.WINDOW_SIZE: self.window_size,
-                    StreamHeaderKey.ACK_INTERVAL: self.ack_interval,
-                    StreamHeaderKey.RETRY_MAX_PENDING_BYTES: self.retry_max_pending_bytes,
-                }
-            )
+            stream_headers[StreamHeaderKey.ACK_INTERVAL] = self.ack_interval
+            stream_headers[StreamHeaderKey.RETRY_MAX_PENDING_BYTES] = self.retry_max_pending_bytes
             if self.reliable:
                 stream_headers[StreamHeaderKey.RETRY_WAIT] = self.retry_wait
                 stream_headers[StreamHeaderKey.RETRY_TIMEOUT] = self.retry_timeout

--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -275,7 +275,11 @@ class TxTask(StreamTaskSpec):
         """Read/send loop to transmit the whole stream with flow control"""
 
         while not self.stopped:
-            buf = self.stream.read(self.chunk_size)
+            if self.buffer_size == self.chunk_size:
+                read_size = self.chunk_size
+            else:
+                read_size = self.chunk_size - self.buffer_size
+            buf = self.stream.read(read_size)
             if not buf:
                 # End of Stream
                 if not self.send_pending_buffer(final=True):
@@ -286,15 +290,14 @@ class TxTask(StreamTaskSpec):
             # Flow control
             window = self.offset - self.offset_ack
             # It may take several ACKs to clear up the window.
-            # The comparison is >=, not >, so a normal data chunk does not add
-            # another full chunk once the window reaches its limit. The EOS path
-            # above can still send one final frame; RxTask includes that slot when
-            # sizing its reassembly buffer.
-            while window >= self.window_size:
-                log.debug(f"{self} window size {window} reached limit: {self.window_size}")
+            # Keep the historical strict comparison: a zero window provides
+            # stop-and-wait behavior by allowing the first frame to be sent.
+            # RxTask includes the possible boundary frame in its buffer sizing.
+            while window > self.window_size:
+                log.debug(f"{self} window size {window} exceeds limit: {self.window_size}")
                 wait_start = time.monotonic()
 
-                while window >= self.window_size:
+                while window > self.window_size:
                     if self.stopped:
                         return
 
@@ -314,12 +317,13 @@ class TxTask(StreamTaskSpec):
                     window = self.offset - self.offset_ack
 
             size = len(buf)
-            if size > self.chunk_size:
-                raise StreamError(f"{self} Stream returns invalid size: {size}")
+            if size > read_size:
+                raise StreamError(f"{self} Stream returns invalid size: {size} (requested {read_size})")
 
-            # Don't push out chunk when it's equal, wait till next round to detect EOS
-            # For example, if the stream size is chunk size (1M), this avoids sending two chunks.
-            if size + self.buffer_size > self.chunk_size:
+            # A full pending buffer is sent only after a non-empty lookahead read.
+            # This avoids an empty final frame when the stream size is an exact
+            # multiple of chunk_size while ensuring all non-final frames are full.
+            if self.buffer_size == self.chunk_size:
                 if not self.send_pending_buffer():
                     return
 

--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -367,7 +367,6 @@ class TxTask(StreamTaskSpec):
         }
         if self.seq == 0:
             stream_headers[StreamHeaderKey.ACK_INTERVAL] = self.ack_interval
-            stream_headers[StreamHeaderKey.RETRY_MAX_PENDING_BYTES] = self.retry_max_pending_bytes
             if self.reliable:
                 stream_headers[StreamHeaderKey.RETRY_WAIT] = self.retry_wait
                 stream_headers[StreamHeaderKey.RETRY_TIMEOUT] = self.retry_timeout

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -22,7 +22,13 @@ import pytest
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.message import Message
-from nvflare.fuel.f3.streaming.byte_receiver import MAX_COMPLETED_TASK_TTL, RxStream, RxTask
+from nvflare.fuel.f3.streaming.byte_receiver import (
+    MAX_COMPLETED_TASK_TTL,
+    MAX_OUT_SEQ_CHUNKS,
+    RxStream,
+    RxTask,
+    required_out_seq_chunks,
+)
 from nvflare.fuel.f3.streaming.byte_streamer import TxTask
 from nvflare.fuel.f3.streaming.stream_const import STREAM_ACK_TOPIC, STREAM_CHANNEL, StreamDataType, StreamHeaderKey
 from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError
@@ -223,6 +229,42 @@ def test_find_or_create_task_records_reliable_header():
     assert task.reliable is True
 
 
+@pytest.mark.parametrize(
+    "window_size, chunk_size, expected",
+    [
+        (64 * MB, MB, 65),
+        (128 * MB, 2 * MB, 65),
+        (8 * MB, MB, MAX_OUT_SEQ_CHUNKS),
+        (64 * MB, 0, MAX_OUT_SEQ_CHUNKS),
+    ],
+)
+def test_required_out_seq_chunks(window_size, chunk_size, expected):
+    assert required_out_seq_chunks(window_size, chunk_size) == expected
+
+
+def test_rx_task_default_out_seq_limit_covers_stream_window(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_chunk_size", lambda self, default: MB)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_window_size", lambda self, default: 64 * MB)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_out_seq_chunks", lambda self, default: default)
+
+    task = RxTask(sid=531, origin="site-1", cell=SimpleNamespace())
+
+    assert task.max_out_seq == 65
+
+    for seq in range(1, task.max_out_seq + 1):
+        message = _make_chunk("site-1", task.sid, seq, StreamDataType.CHUNK)
+        should_stop, _, error = task._handle_incoming_data(seq, message)
+        assert should_stop is False
+        assert error is None
+
+    assert len(task.out_seq_chunks) == 65
+
+    first_message = _make_chunk("site-1", task.sid, 0, StreamDataType.CHUNK)
+    _, _, error = task._handle_incoming_data(0, first_message)
+    assert error is None
+    assert task.out_seq_chunks == {}
+
+
 def test_new_stream_uses_sender_streaming_parameters():
     cell = SimpleNamespace()
     sender_parameters = {
@@ -246,6 +288,28 @@ def test_new_stream_uses_sender_streaming_parameters():
     assert task.window_size == sender_parameters[StreamHeaderKey.WINDOW_SIZE]
     assert task.ack_interval == sender_parameters[StreamHeaderKey.ACK_INTERVAL]
     assert task.retry_max_pending_bytes == sender_parameters[StreamHeaderKey.RETRY_MAX_PENDING_BYTES]
+    assert task.max_out_seq == 65
+
+
+@pytest.mark.parametrize("configured_max, expected", [(MAX_OUT_SEQ_CHUNKS, 129), (256, 256)])
+def test_new_stream_raises_out_seq_limit_for_sender_window(monkeypatch, configured_max, expected):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_out_seq_chunks", lambda self, default: configured_max)
+    sender_parameters = {
+        StreamHeaderKey.CHUNK_SIZE: MB,
+        StreamHeaderKey.WINDOW_SIZE: 128 * MB,
+    }
+    message = _make_chunk(
+        "site-1",
+        sid=534,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        streaming_parameters=sender_parameters,
+    )
+
+    task = RxTask.find_or_create_task(message, SimpleNamespace())
+    assert task.process_chunk(message) is True
+
+    assert task.max_out_seq == expected
 
 
 def test_new_stream_without_sender_parameters_uses_local_configuration(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -24,6 +24,7 @@ from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.streaming.byte_receiver import (
     MAX_COMPLETED_TASK_TTL,
+    MAX_DERIVED_OUT_SEQ_CHUNKS,
     MAX_OUT_SEQ_CHUNKS,
     RxStream,
     RxTask,
@@ -232,10 +233,13 @@ def test_find_or_create_task_records_reliable_header():
 @pytest.mark.parametrize(
     "window_size, chunk_size, expected",
     [
+        # window // chunk, plus one slot for a final frame or pre-">=" sender
         (64 * MB, MB, 65),
         (128 * MB, 2 * MB, 65),
         (8 * MB, MB, MAX_OUT_SEQ_CHUNKS),
         (64 * MB, 0, MAX_OUT_SEQ_CHUNKS),
+        # a peer-supplied window/chunk ratio cannot size the buffer without limit
+        (8192 * MB, MB, MAX_DERIVED_OUT_SEQ_CHUNKS),
     ],
 )
 def test_required_out_seq_chunks(window_size, chunk_size, expected):
@@ -265,6 +269,25 @@ def test_rx_task_default_out_seq_limit_covers_stream_window(monkeypatch):
     assert task.out_seq_chunks == {}
 
 
+def test_rx_task_still_rejects_reordering_beyond_the_limit(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_chunk_size", lambda self, default: MB)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_window_size", lambda self, default: 64 * MB)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_out_seq_chunks", lambda self, default: default)
+
+    task = RxTask(sid=533, origin="site-1", cell=SimpleNamespace())
+
+    for seq in range(1, task.max_out_seq + 1):
+        message = _make_chunk("site-1", task.sid, seq, StreamDataType.CHUNK)
+        _, _, error = task._handle_incoming_data(seq, message)
+        assert error is None
+
+    # one chunk past what the sender's window can put in flight
+    over_limit = _make_chunk("site-1", task.sid, task.max_out_seq + 1, StreamDataType.CHUNK)
+    _, _, error = task._handle_incoming_data(task.max_out_seq + 1, over_limit)
+    assert isinstance(error, StreamError)
+    assert "Too many out-of-sequence chunks" in str(error)
+
+
 def test_new_stream_uses_sender_streaming_parameters():
     cell = SimpleNamespace()
     sender_parameters = {
@@ -288,6 +311,7 @@ def test_new_stream_uses_sender_streaming_parameters():
     assert task.window_size == sender_parameters[StreamHeaderKey.WINDOW_SIZE]
     assert task.ack_interval == sender_parameters[StreamHeaderKey.ACK_INTERVAL]
     assert task.retry_max_pending_bytes == sender_parameters[StreamHeaderKey.RETRY_MAX_PENDING_BYTES]
+    # 128 MiB window / 2 MiB chunks, plus one slot of margin
     assert task.max_out_seq == 65
 
 
@@ -310,6 +334,51 @@ def test_new_stream_raises_out_seq_limit_for_sender_window(monkeypatch, configur
     assert task.process_chunk(message) is True
 
     assert task.max_out_seq == expected
+
+
+def test_later_chunks_adopt_sender_limit_before_delayed_sequence_zero(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_chunk_size", lambda self, default: MB)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_window_size", lambda self, default: 64 * MB)
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_out_seq_chunks", lambda self, default: default)
+    repeated_parameters = {
+        StreamHeaderKey.CHUNK_SIZE: MB,
+        StreamHeaderKey.WINDOW_SIZE: 128 * MB,
+    }
+    first_chunk_parameters = {
+        **repeated_parameters,
+        StreamHeaderKey.ACK_INTERVAL: 16 * MB,
+        StreamHeaderKey.RETRY_MAX_PENDING_BYTES: 256 * MB,
+    }
+    task = RxTask(sid=535, origin="site-1", cell=MagicMock(), reliable=False)
+
+    # Model ConnManager processing sequence 0 behind more frames than the
+    # receiver's local 65-chunk default can hold.
+    for seq in range(1, 67):
+        message = _make_chunk(
+            "site-1",
+            task.sid,
+            seq,
+            StreamDataType.CHUNK,
+            reliable=False,
+            streaming_parameters=repeated_parameters,
+        )
+        assert task.process_chunk(message) is False
+
+    assert task.max_out_seq == 129
+    assert task.failed is False
+    assert len(task.out_seq_chunks) == 66
+
+    first_message = _make_chunk(
+        "site-1",
+        task.sid,
+        0,
+        StreamDataType.CHUNK,
+        reliable=False,
+        streaming_parameters=first_chunk_parameters,
+    )
+    assert task.process_chunk(first_message) is True
+    assert task.failed is False
+    assert task.out_seq_chunks == {}
 
 
 def test_new_stream_without_sender_parameters_uses_local_configuration(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -25,7 +25,7 @@ from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.streaming.byte_receiver import (
     MAX_COMPLETED_TASK_TTL,
     MAX_DERIVED_OUT_SEQ_CHUNKS,
-    MAX_OUT_SEQ_CHUNKS,
+    MIN_OUT_SEQ_CHUNKS,
     RxStream,
     RxTask,
     required_out_seq_chunks,
@@ -238,8 +238,8 @@ def test_find_or_create_task_records_reliable_header():
         (128 * MB, 2 * MB, 65),
         # non-multiple windows require ceiling division before the final-frame slot
         (65 * MB, 2 * MB, 34),
-        (8 * MB, MB, MAX_OUT_SEQ_CHUNKS),
-        (64 * MB, 0, MAX_OUT_SEQ_CHUNKS),
+        (8 * MB, MB, MIN_OUT_SEQ_CHUNKS),
+        (64 * MB, 0, MIN_OUT_SEQ_CHUNKS),
         # a peer-supplied window/chunk ratio cannot size the buffer without limit
         (8192 * MB, MB, MAX_DERIVED_OUT_SEQ_CHUNKS),
     ],
@@ -315,9 +315,16 @@ def test_new_stream_uses_sender_streaming_parameters():
     assert task.max_out_seq == 65
 
 
-@pytest.mark.parametrize("configured_max, expected", [(MAX_OUT_SEQ_CHUNKS, 129), (256, 256)])
-def test_new_stream_raises_out_seq_limit_for_sender_window(monkeypatch, configured_max, expected):
-    monkeypatch.setattr(CommConfigurator, "get_streaming_max_out_seq_chunks", lambda self, default: configured_max)
+@pytest.mark.parametrize(
+    "configured_max, expected, warns",
+    [(None, 129, False), (MIN_OUT_SEQ_CHUNKS, 16, True), (256, 256, False)],
+)
+def test_new_stream_applies_sender_window_or_explicit_limit(monkeypatch, caplog, configured_max, expected, warns):
+    monkeypatch.setattr(
+        CommConfigurator,
+        "get_streaming_max_out_seq_chunks",
+        lambda self, default: default if configured_max is None else configured_max,
+    )
     sender_parameters = {
         StreamHeaderKey.CHUNK_SIZE: MB,
         StreamHeaderKey.WINDOW_SIZE: 128 * MB,
@@ -330,10 +337,34 @@ def test_new_stream_raises_out_seq_limit_for_sender_window(monkeypatch, configur
         streaming_parameters=sender_parameters,
     )
 
-    task = RxTask.find_or_create_task(message, SimpleNamespace())
-    assert task.process_chunk(message) is True
+    with caplog.at_level(logging.WARNING):
+        task = RxTask.find_or_create_task(message, SimpleNamespace())
+        assert task.process_chunk(message) is True
 
     assert task.max_out_seq == expected
+    warning = "above configured streaming_max_out_seq_chunks"
+    assert (warning in caplog.text) is warns
+
+
+def test_new_stream_warns_when_sender_window_exceeds_derived_limit(caplog):
+    sender_parameters = {
+        StreamHeaderKey.CHUNK_SIZE: MB,
+        StreamHeaderKey.WINDOW_SIZE: 8192 * MB,
+    }
+    message = _make_chunk(
+        "site-1",
+        sid=536,
+        seq=0,
+        data_type=StreamDataType.CHUNK,
+        streaming_parameters=sender_parameters,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        task = RxTask.find_or_create_task(message, SimpleNamespace())
+        assert task.process_chunk(message) is True
+
+    assert task.max_out_seq == MAX_DERIVED_OUT_SEQ_CHUNKS
+    assert "above the 1024 cap" in caplog.text
 
 
 def test_later_chunks_adopt_sender_limit_before_delayed_sequence_zero(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -296,7 +296,6 @@ def test_new_stream_uses_sender_streaming_parameters():
         StreamHeaderKey.CHUNK_SIZE: 2 * 1024**2,
         StreamHeaderKey.WINDOW_SIZE: 128 * 1024**2,
         StreamHeaderKey.ACK_INTERVAL: 32 * 1024**2,
-        StreamHeaderKey.RETRY_MAX_PENDING_BYTES: 256 * 1024**2,
     }
     message = _make_chunk(
         "site-1",
@@ -312,7 +311,6 @@ def test_new_stream_uses_sender_streaming_parameters():
     assert task.chunk_size == sender_parameters[StreamHeaderKey.CHUNK_SIZE]
     assert task.window_size == sender_parameters[StreamHeaderKey.WINDOW_SIZE]
     assert task.ack_interval == sender_parameters[StreamHeaderKey.ACK_INTERVAL]
-    assert task.retry_max_pending_bytes == sender_parameters[StreamHeaderKey.RETRY_MAX_PENDING_BYTES]
     # 128 MiB window / 2 MiB chunks, plus one slot of margin
     assert task.max_out_seq == 65
 
@@ -349,7 +347,6 @@ def test_later_chunks_adopt_sender_limit_before_delayed_sequence_zero(monkeypatc
     first_chunk_parameters = {
         **repeated_parameters,
         StreamHeaderKey.ACK_INTERVAL: 16 * MB,
-        StreamHeaderKey.RETRY_MAX_PENDING_BYTES: 256 * MB,
     }
     task = RxTask(sid=535, origin="site-1", cell=MagicMock(), reliable=False)
 
@@ -387,7 +384,6 @@ def test_new_stream_without_sender_parameters_uses_local_configuration(monkeypat
     monkeypatch.setattr(CommConfigurator, "get_streaming_chunk_size", lambda self, default: 2)
     monkeypatch.setattr(CommConfigurator, "get_streaming_window_size", lambda self, default: 8)
     monkeypatch.setattr(CommConfigurator, "get_streaming_ack_interval", lambda self, default: 4)
-    monkeypatch.setattr(CommConfigurator, "get_streaming_retry_max_pending_bytes", lambda self, default: 16)
     cell = SimpleNamespace()
     message = _make_chunk("site-1", sid=533, seq=0, data_type=StreamDataType.CHUNK)
 
@@ -397,7 +393,6 @@ def test_new_stream_without_sender_parameters_uses_local_configuration(monkeypat
     assert task.chunk_size == 2
     assert task.window_size == 8
     assert task.ack_interval == 4
-    assert task.retry_max_pending_bytes == 16
 
 
 def test_headerless_legacy_sender_with_small_window_completes_transfer(monkeypatch):
@@ -442,7 +437,6 @@ def test_headerless_legacy_sender_with_small_window_completes_transfer(monkeypat
                 StreamHeaderKey.CHUNK_SIZE,
                 StreamHeaderKey.WINDOW_SIZE,
                 StreamHeaderKey.ACK_INTERVAL,
-                StreamHeaderKey.RETRY_MAX_PENDING_BYTES,
             ):
                 message.remove_header(key)
             message.set_header(MessageHeaderKey.ORIGIN, "legacy-sender")

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -24,7 +24,7 @@ from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.streaming.byte_receiver import (
     MAX_COMPLETED_TASK_TTL,
-    MAX_DERIVED_OUT_SEQ_CHUNKS,
+    MAX_PEER_DERIVED_OUT_SEQ_CHUNKS,
     MIN_OUT_SEQ_CHUNKS,
     RxStream,
     RxTask,
@@ -241,7 +241,7 @@ def test_find_or_create_task_records_reliable_header():
         (8 * MB, MB, MIN_OUT_SEQ_CHUNKS),
         (64 * MB, 0, MIN_OUT_SEQ_CHUNKS),
         # a peer-supplied window/chunk ratio cannot size the buffer without limit
-        (8192 * MB, MB, MAX_DERIVED_OUT_SEQ_CHUNKS),
+        (8192 * MB, MB, MAX_PEER_DERIVED_OUT_SEQ_CHUNKS),
     ],
 )
 def test_required_out_seq_chunks(window_size, chunk_size, expected):
@@ -363,7 +363,7 @@ def test_new_stream_warns_when_sender_window_exceeds_derived_limit(caplog):
         task = RxTask.find_or_create_task(message, SimpleNamespace())
         assert task.process_chunk(message) is True
 
-    assert task.max_out_seq == MAX_DERIVED_OUT_SEQ_CHUNKS
+    assert task.max_out_seq == MAX_PEER_DERIVED_OUT_SEQ_CHUNKS
     assert "above the 1024 cap" in caplog.text
 
 

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -233,9 +233,11 @@ def test_find_or_create_task_records_reliable_header():
 @pytest.mark.parametrize(
     "window_size, chunk_size, expected",
     [
-        # window // chunk, plus one slot for a final frame or pre-">=" sender
+        # ceil(window / chunk), plus one slot for a final frame or pre-">=" sender
         (64 * MB, MB, 65),
         (128 * MB, 2 * MB, 65),
+        # non-multiple windows require ceiling division before the final-frame slot
+        (65 * MB, 2 * MB, 34),
         (8 * MB, MB, MAX_OUT_SEQ_CHUNKS),
         (64 * MB, 0, MAX_OUT_SEQ_CHUNKS),
         # a peer-supplied window/chunk ratio cannot size the buffer without limit

--- a/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
@@ -56,6 +56,14 @@ class ConformingShortReadStream(Stream):
         return b"x" * result_size
 
 
+class OversizedReadStream(Stream):
+    def __init__(self):
+        super().__init__(size=0, headers={})
+
+    def read(self, size):
+        return b"x" * (size + 1)
+
+
 class TestByteStreamerAckWatchdog:
     def _make_task(
         self,
@@ -180,6 +188,21 @@ class TestByteStreamerAckWatchdog:
         assert [len(message.payload) for message in messages] == [8, 8, 8, 1]
         assert all(message.get_header(StreamHeaderKey.DATA_TYPE) == StreamDataType.CHUNK for message in messages[:-1])
         assert messages[-1].get_header(StreamHeaderKey.DATA_TYPE) == StreamDataType.FINAL
+
+    def test_stream_cannot_return_more_than_requested(self, monkeypatch):
+        task, _ = self._make_task(
+            monkeypatch,
+            window_size=1024,
+            ack_wait=0.5,
+            ack_progress_timeout=2.0,
+            ack_progress_check_interval=0.01,
+            chunks=[b""],
+            chunk_size=8,
+        )
+        task.stream = OversizedReadStream()
+
+        with pytest.raises(StreamError, match=r"invalid size: 9 \(requested 8\)"):
+            task.send_loop()
 
     def test_watchdog_stops_when_no_ack_progress(self, monkeypatch):
         task, _ = self._make_task(

--- a/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
@@ -39,6 +39,23 @@ class DummyStream(Stream):
         return self._chunks.pop(0)
 
 
+class ConformingShortReadStream(Stream):
+    def __init__(self, size, read_pattern):
+        super().__init__(size=size, headers={})
+        self.remaining = size
+        self.read_pattern = read_pattern
+        self.read_count = 0
+
+    def read(self, size):
+        if not self.remaining:
+            return b""
+        pattern_size = self.read_pattern[self.read_count % len(self.read_pattern)]
+        self.read_count += 1
+        result_size = min(size, pattern_size, self.remaining)
+        self.remaining -= result_size
+        return b"x" * result_size
+
+
 class TestByteStreamerAckWatchdog:
     def _make_task(
         self,
@@ -118,9 +135,7 @@ class TestByteStreamerAckWatchdog:
     def test_watchdog_allows_progress_and_stream_completes(self, monkeypatch):
         task, _ = self._make_task(
             monkeypatch,
-            # smallest window the ACK can actually clear: send_loop waits while
-            # window >= window_size, so a 0 window would never open again
-            window_size=1,
+            window_size=0,
             ack_wait=0.5,
             ack_progress_timeout=2.0,
             ack_progress_check_interval=0.01,
@@ -145,6 +160,26 @@ class TestByteStreamerAckWatchdog:
 
         assert task.stream_future.done()
         assert task.stream_future.exception() is None
+
+    def test_short_reads_are_coalesced_into_full_non_final_frames(self, monkeypatch):
+        task, cell = self._make_task(
+            monkeypatch,
+            window_size=1024,
+            ack_wait=0.5,
+            ack_progress_timeout=2.0,
+            ack_progress_check_interval=0.01,
+            chunks=[b""],
+            chunk_size=8,
+        )
+        task.stream = ConformingShortReadStream(size=25, read_pattern=[7, 2])
+        task.stream_future.set_size(25)
+
+        task.send_loop()
+
+        messages = [call.args[3] for call in cell.fire_and_forget.call_args_list]
+        assert [len(message.payload) for message in messages] == [8, 8, 8, 1]
+        assert all(message.get_header(StreamHeaderKey.DATA_TYPE) == StreamDataType.CHUNK for message in messages[:-1])
+        assert messages[-1].get_header(StreamHeaderKey.DATA_TYPE) == StreamDataType.FINAL
 
     def test_watchdog_stops_when_no_ack_progress(self, monkeypatch):
         task, _ = self._make_task(

--- a/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
@@ -118,7 +118,9 @@ class TestByteStreamerAckWatchdog:
     def test_watchdog_allows_progress_and_stream_completes(self, monkeypatch):
         task, _ = self._make_task(
             monkeypatch,
-            window_size=0,
+            # smallest window the ACK can actually clear: send_loop waits while
+            # window >= window_size, so a 0 window would never open again
+            window_size=1,
             ack_wait=0.5,
             ack_progress_timeout=2.0,
             ack_progress_check_interval=0.01,
@@ -432,8 +434,8 @@ class TestReliableByteStreamer:
         assert task.pending_message_bytes == 5
         assert next_message.get_header(StreamHeaderKey.RETRY_WAIT) is None
         assert next_message.get_header(StreamHeaderKey.RETRY_TIMEOUT) is None
-        assert next_message.get_header(StreamHeaderKey.CHUNK_SIZE) is None
-        assert next_message.get_header(StreamHeaderKey.WINDOW_SIZE) is None
+        assert next_message.get_header(StreamHeaderKey.CHUNK_SIZE) == task.chunk_size
+        assert next_message.get_header(StreamHeaderKey.WINDOW_SIZE) == task.window_size
         assert next_message.get_header(StreamHeaderKey.ACK_INTERVAL) is None
         assert next_message.get_header(StreamHeaderKey.RETRY_MAX_PENDING_BYTES) is None
 

--- a/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
@@ -424,7 +424,7 @@ class TestReliableByteStreamer:
         assert message.get_header(StreamHeaderKey.CHUNK_SIZE) == task.chunk_size
         assert message.get_header(StreamHeaderKey.WINDOW_SIZE) == task.window_size
         assert message.get_header(StreamHeaderKey.ACK_INTERVAL) == task.ack_interval
-        assert message.get_header(StreamHeaderKey.RETRY_MAX_PENDING_BYTES) == task.retry_max_pending_bytes
+        assert message.get_header(StreamHeaderKey.RETRY_MAX_PENDING_BYTES) is None
 
         task.buffer[0:1] = b"e"
         task.buffer_size = 1


### PR DESCRIPTION
Jira: [FLARE-3093](https://jirasw.nvidia.com/browse/FLARE-3093)

## What changed

- derive the receiver's out-of-sequence chunk allowance from the stream window and chunk size instead of using a fixed default of 16
- cap peer-derived buffer sizing while preserving larger operator-configured limits
- repeat only `CHUNK_SIZE` and `WINDOW_SIZE` on data frames so a receiver can size its buffer even when sequence 0 is delayed by frame-pool scheduling
- adopt those sender parameters before buffering pre-sequence-0 chunks
- stop normal sends when the flow-control window reaches its limit
- remove the receiver's unused retry-pending field and stop transmitting that receiver-irrelevant parameter

## Why

FLARE-3093 reports healthy F3 streams aborting under CPU load with `Too many out-of-sequence chunks: 16`. `ConnManager` processes inbound frames in a thread pool, so a sender's in-order frames can reach `RxTask` out of order. The default 64 MiB window allows substantially more than the fixed 16-chunk receiver tolerance.

Sequence 0 carries stream negotiation parameters, but it can itself be delayed behind later frames. Repeating the two parameters needed for buffer sizing lets the receiver establish the correct limit before admitting those later chunks without changing header semantics for older receivers.

## Impact

Large F3 transfers no longer fail solely because scheduling jitter reorders more than 16 chunks. Explicit sender window sizes are honored before sequence 0 is processed, and anomalous peer-derived sizing remains bounded.

## Validation

- `python -m pytest tests/unit_test/fuel/f3/streaming -q` — 374 passed
- scoped Black, isort, and flake8 checks on the four changed files
- deterministic regression coverage for 66 later chunks processed before sequence 0 with a 128 MiB sender and default 64 MiB receiver
