### PR TITLE
Restore Docker DinD compatibility

### DIFF
--- a/docs/design/docker_job_launcher_design.md
+++ b/docs/design/docker_job_launcher_design.md
@@ -175,8 +175,8 @@ docker run ... -e NVFL_DOCKER_WORKSPACE="$HOST_WORKSPACE" ...
 SP/CP container (site admin grants via start_docker.sh)
   ├── /var/run/docker.sock mounted            ← can create job containers
   ├── --user $(id -u):$(id -g)               ← runs as calling user (workspace files not root-owned)
-  ├── --group-add <docker-socket-gid>         ← grants access when the socket is locally visible
-  ├── --group-add 0 when needed               ← handles locally visible sockets that appear root-owned
+  ├── --group-add <docker-socket-gid>         ← grants access using the local stat or daemon-host probe
+  ├── --group-add 0 when needed               ← handles sockets that appear root-owned
   ├── workspace bind mount at /var/tmp/nvflare/workspace
   ├── nvflare-network                         ← intra-site: SP↔SJ / CP↔CJ (PARENT_URL, Docker DNS)
   └── host network (-p fed_learn_port)        ← cross-site: CP→SP over HTTPS, same as process mode
@@ -424,13 +424,13 @@ On the server machine:
 cd workspace/server/startup
 nohup ./start_docker.sh > server.log 2>&1 &
 # → creates nvflare-network if it doesn't exist
-# → docker run --name server \
+# → docker [--host unix://$DOCKER_SOCK] run --name server \
 #              --user "$(id -u):$(id -g)" \
 #              --group-add 0 (on macOS or when the socket GID is 0) \
 #              --group-add <docker-socket-gid> (if non-zero) \
 #              --network nvflare-network \
 #              -v $HOST_WORKSPACE:/var/tmp/nvflare/workspace \
-#              -v $DOCKER_SOCK:/var/run/docker.sock \
+#              --mount type=bind,src=$DOCKER_SOCK,dst=/var/run/docker.sock \
 #              -e NVFL_DOCKER_WORKSPACE=$HOST_WORKSPACE \
 #              -p 8002:8002 \
 #              --rm nvflare-site:latest \
@@ -455,10 +455,22 @@ different Docker socket explicitly:
 NVFL_DOCKER_SOCK=/path/to/docker.sock ./start_docker.sh
 ```
 
-The Docker CLI uses the caller's existing `DOCKER_HOST` or Docker context. `NVFL_DOCKER_SOCK` selects the bind-mount
-source path on the daemon host; it does not select the Docker CLI endpoint. When that socket is locally visible, the
-script validates it and adds the supplementary groups needed by the non-root parent. With a remote daemon such as a
-DinD sidecar, the path is evaluated on the daemon host and cannot be validated or inspected by the CLI container.
+For a local Unix endpoint, the script pins all outer Docker CLI commands to the selected socket. This ensures the
+parent, its network, and the job containers all use the same daemon when `NVFL_DOCKER_SOCK` overrides the default.
+
+For a remote endpoint such as a DinD sidecar, the Docker CLI continues to use the caller's `DOCKER_HOST` or Docker
+context, while `NVFL_DOCKER_SOCK` is interpreted as a bind-mount source path on the daemon host. The script starts a
+short-lived container from the configured parent image to verify that the mounted path is a socket and discover its
+numeric GID. The parent receives that GID through `--group-add`, so its non-root process can access the socket.
+
+An administrator can bypass the remote probe by supplying a verified numeric GID explicitly:
+
+```bash
+NVFL_DOCKER_SOCK=/var/run/docker.sock NVFL_DOCKER_SOCK_GID=999 ./start_docker.sh
+```
+
+This override trusts the administrator's daemon-host path and GID. The socket uses Docker's `--mount` syntax so a
+missing bind source is rejected instead of being silently created as a directory.
 
 ### Step 4 — Configure site data (optional)
 

--- a/docs/design/docker_job_launcher_design.md
+++ b/docs/design/docker_job_launcher_design.md
@@ -175,8 +175,8 @@ docker run ... -e NVFL_DOCKER_WORKSPACE="$HOST_WORKSPACE" ...
 SP/CP container (site admin grants via start_docker.sh)
   ├── /var/run/docker.sock mounted            ← can create job containers
   ├── --user $(id -u):$(id -g)               ← runs as calling user (workspace files not root-owned)
-  ├── --group-add <docker-socket-gid>         ← grants socket access on standard Linux engines
-  ├── --group-add 0 when needed               ← grants access when the mounted socket appears root-owned
+  ├── --group-add <docker-socket-gid>         ← grants access when the socket is locally visible
+  ├── --group-add 0 when needed               ← handles locally visible sockets that appear root-owned
   ├── workspace bind mount at /var/tmp/nvflare/workspace
   ├── nvflare-network                         ← intra-site: SP↔SJ / CP↔CJ (PARENT_URL, Docker DNS)
   └── host network (-p fed_learn_port)        ← cross-site: CP→SP over HTTPS, same as process mode
@@ -424,7 +424,7 @@ On the server machine:
 cd workspace/server/startup
 nohup ./start_docker.sh > server.log 2>&1 &
 # → creates nvflare-network if it doesn't exist
-# → docker --host "unix://$DOCKER_SOCK" run --name server \
+# → docker run --name server \
 #              --user "$(id -u):$(id -g)" \
 #              --group-add 0 (on macOS or when the socket GID is 0) \
 #              --group-add <docker-socket-gid> (if non-zero) \
@@ -455,8 +455,10 @@ different Docker socket explicitly:
 NVFL_DOCKER_SOCK=/path/to/docker.sock ./start_docker.sh
 ```
 
-The script pins its Docker CLI operations to the selected Unix socket so the parent and job containers use the same
-local daemon, regardless of the active Docker context.
+The Docker CLI uses the caller's existing `DOCKER_HOST` or Docker context. `NVFL_DOCKER_SOCK` selects the bind-mount
+source path on the daemon host; it does not select the Docker CLI endpoint. When that socket is locally visible, the
+script validates it and adds the supplementary groups needed by the non-root parent. With a remote daemon such as a
+DinD sidecar, the path is evaluated on the daemon host and cannot be validated or inspected by the CLI container.
 
 ### Step 4 — Configure site data (optional)
 

--- a/nvflare/tool/deploy/templates/docker/start_docker.sh
+++ b/nvflare/tool/deploy/templates/docker/start_docker.sh
@@ -5,6 +5,27 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 HOST_WORKSPACE="$(cd "$DIR/.." && pwd)"
 DOCKER_IMAGE=${NVFL_P_IMAGE:-@@NVFLARE_DOCKER_IMAGE@@}
 DOCKER_SOCK="${NVFL_DOCKER_SOCK:-/var/run/docker.sock}"
+DOCKER_ENDPOINT="${DOCKER_HOST:-}"
+
+if [ -z "$DOCKER_ENDPOINT" ]; then
+    DOCKER_CONTEXT=$(docker context show 2>/dev/null || echo "")
+    if [ -n "$DOCKER_CONTEXT" ]; then
+        DOCKER_ENDPOINT=$(
+            docker context inspect "$DOCKER_CONTEXT" --format '{{.Endpoints.docker.Host}}' 2>/dev/null || echo ""
+        )
+    fi
+fi
+
+if [ -z "${NVFL_DOCKER_SOCK:-}" ]; then
+    case "$DOCKER_ENDPOINT" in
+        unix://*)
+            ENDPOINT_DOCKER_SOCK=${DOCKER_ENDPOINT#unix://}
+            if [ -S "$ENDPOINT_DOCKER_SOCK" ]; then
+                DOCKER_SOCK="$ENDPOINT_DOCKER_SOCK"
+            fi
+            ;;
+    esac
+fi
 
 if [ -z "${NVFL_DOCKER_SOCK:-}" ] && [ -L "$DOCKER_SOCK" ]; then
     RESOLVED_DOCKER_SOCK=$(readlink "$DOCKER_SOCK")
@@ -26,15 +47,23 @@ if [ -z "${NVFL_DOCKER_SOCK:-}" ] && [ -L "$DOCKER_SOCK" ]; then
     fi
 fi
 
-if [ ! -S "$DOCKER_SOCK" ]; then
-    echo "ERROR: Docker socket not found or not a socket: $DOCKER_SOCK"
-    echo "Set NVFL_DOCKER_SOCK=/path/to/docker.sock to override the Docker socket path."
-    exit 1
+DOCKER_SOCK_IS_LOCAL=false
+if [ -S "$DOCKER_SOCK" ]; then
+    DOCKER_SOCK_IS_LOCAL=true
+else
+    case "$DOCKER_ENDPOINT" in
+        unix://*)
+            echo "ERROR: Docker socket not found or not a socket: $DOCKER_SOCK"
+            echo "Set NVFL_DOCKER_SOCK=/path/to/docker.sock to override the Docker socket path."
+            exit 1
+            ;;
+        *)
+            echo "Docker socket is not visible locally; using daemon-host path: $DOCKER_SOCK"
+            ;;
+    esac
 fi
 
-DOCKER_HOST_URI="unix://$DOCKER_SOCK"
-
-if ! docker --host "$DOCKER_HOST_URI" info > /dev/null 2>&1; then
+if ! docker info > /dev/null 2>&1; then
     echo "ERROR: cannot connect to Docker daemon. Make sure your user has permission to run docker."
     echo "  Option 1 (docker group): sudo usermod -aG docker \$USER  then log out and back in."
     echo "  Option 2 (rootless Docker): https://docs.docker.com/engine/security/rootless/"
@@ -45,24 +74,26 @@ echo "Starting NVFlare @@NVFLARE_ROLE_LABEL@@ @@NVFLARE_SITE_NAME@@ with image $
 echo "Host workspace: $HOST_WORKSPACE"
 
 NETWORK_NAME=@@NVFLARE_NETWORK_NAME@@
-if ! docker --host "$DOCKER_HOST_URI" network ls --filter name="$NETWORK_NAME" --format "{{.Name}}" | grep -wq "$NETWORK_NAME"; then
-    docker --host "$DOCKER_HOST_URI" network create "$NETWORK_NAME"
+if ! docker network ls --filter name="$NETWORK_NAME" --format "{{.Name}}" | grep -wq "$NETWORK_NAME"; then
+    docker network create "$NETWORK_NAME"
     echo "Created Docker network: $NETWORK_NAME"
 fi
 
 rm -f "$HOST_WORKSPACE/daemon_pid.fl"
 
-SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK" 2>/dev/null || stat -f '%g' "$DOCKER_SOCK" 2>/dev/null || echo "")
-HOST_OS=$(uname -s)
 GROUP_ADD_ARGS=()
-if [ "$HOST_OS" = "Darwin" ] || [ "$SOCK_GID" = "0" ]; then
-    GROUP_ADD_ARGS+=(--group-add 0)
-fi
-if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
-    GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")
+if [ "$DOCKER_SOCK_IS_LOCAL" = "true" ]; then
+    SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK" 2>/dev/null || stat -f '%g' "$DOCKER_SOCK" 2>/dev/null || echo "")
+    HOST_OS=$(uname -s)
+    if [ "$HOST_OS" = "Darwin" ] || [ "$SOCK_GID" = "0" ]; then
+        GROUP_ADD_ARGS+=(--group-add 0)
+    fi
+    if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
+        GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")
+    fi
 fi
 
-docker --host "$DOCKER_HOST_URI" run --name @@NVFLARE_CONTAINER_NAME@@ \
+docker run --name @@NVFLARE_CONTAINER_NAME@@ \
     --user "$(id -u):$(id -g)" \
     "${GROUP_ADD_ARGS[@]}" \
     --network "$NETWORK_NAME" \

--- a/nvflare/tool/deploy/templates/docker/start_docker.sh
+++ b/nvflare/tool/deploy/templates/docker/start_docker.sh
@@ -16,13 +16,18 @@ if [ -z "$DOCKER_ENDPOINT" ]; then
     fi
 fi
 
+DOCKER_ENDPOINT_IS_LOCAL=false
+case "$DOCKER_ENDPOINT" in
+    ""|unix://*)
+        DOCKER_ENDPOINT_IS_LOCAL=true
+        ;;
+esac
+
 if [ -z "${NVFL_DOCKER_SOCK:-}" ]; then
     case "$DOCKER_ENDPOINT" in
         unix://*)
             ENDPOINT_DOCKER_SOCK=${DOCKER_ENDPOINT#unix://}
-            if [ -S "$ENDPOINT_DOCKER_SOCK" ]; then
-                DOCKER_SOCK="$ENDPOINT_DOCKER_SOCK"
-            fi
+            DOCKER_SOCK="$ENDPOINT_DOCKER_SOCK"
             ;;
     esac
 fi
@@ -47,23 +52,27 @@ if [ -z "${NVFL_DOCKER_SOCK:-}" ] && [ -L "$DOCKER_SOCK" ]; then
     fi
 fi
 
-DOCKER_SOCK_IS_LOCAL=false
-if [ -S "$DOCKER_SOCK" ]; then
-    DOCKER_SOCK_IS_LOCAL=true
+case "$DOCKER_SOCK" in
+    /*) ;;
+    *)
+        echo "ERROR: Docker socket path must be absolute: $DOCKER_SOCK"
+        exit 1
+        ;;
+esac
+
+DOCKER_CLI_ARGS=()
+if [ "$DOCKER_ENDPOINT_IS_LOCAL" = "true" ]; then
+    if [ ! -S "$DOCKER_SOCK" ]; then
+        echo "ERROR: Docker socket not found or not a socket: $DOCKER_SOCK"
+        echo "Set NVFL_DOCKER_SOCK=/path/to/docker.sock to override the Docker socket path."
+        exit 1
+    fi
+    DOCKER_CLI_ARGS=(--host "unix://$DOCKER_SOCK")
 else
-    case "$DOCKER_ENDPOINT" in
-        unix://*)
-            echo "ERROR: Docker socket not found or not a socket: $DOCKER_SOCK"
-            echo "Set NVFL_DOCKER_SOCK=/path/to/docker.sock to override the Docker socket path."
-            exit 1
-            ;;
-        *)
-            echo "Docker socket is not visible locally; using daemon-host path: $DOCKER_SOCK"
-            ;;
-    esac
+    echo "Using Docker socket on daemon host: $DOCKER_SOCK"
 fi
 
-if ! docker info > /dev/null 2>&1; then
+if ! docker "${DOCKER_CLI_ARGS[@]}" info > /dev/null 2>&1; then
     echo "ERROR: cannot connect to Docker daemon. Make sure your user has permission to run docker."
     echo "  Option 1 (docker group): sudo usermod -aG docker \$USER  then log out and back in."
     echo "  Option 2 (rootless Docker): https://docs.docker.com/engine/security/rootless/"
@@ -74,15 +83,16 @@ echo "Starting NVFlare @@NVFLARE_ROLE_LABEL@@ @@NVFLARE_SITE_NAME@@ with image $
 echo "Host workspace: $HOST_WORKSPACE"
 
 NETWORK_NAME=@@NVFLARE_NETWORK_NAME@@
-if ! docker network ls --filter name="$NETWORK_NAME" --format "{{.Name}}" | grep -wq "$NETWORK_NAME"; then
-    docker network create "$NETWORK_NAME"
+if ! docker "${DOCKER_CLI_ARGS[@]}" network ls --filter name="$NETWORK_NAME" --format "{{.Name}}" \
+    | grep -wq "$NETWORK_NAME"; then
+    docker "${DOCKER_CLI_ARGS[@]}" network create "$NETWORK_NAME"
     echo "Created Docker network: $NETWORK_NAME"
 fi
 
 rm -f "$HOST_WORKSPACE/daemon_pid.fl"
 
 GROUP_ADD_ARGS=()
-if [ "$DOCKER_SOCK_IS_LOCAL" = "true" ]; then
+if [ "$DOCKER_ENDPOINT_IS_LOCAL" = "true" ]; then
     SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK" 2>/dev/null || stat -f '%g' "$DOCKER_SOCK" 2>/dev/null || echo "")
     HOST_OS=$(uname -s)
     if [ "$HOST_OS" = "Darwin" ] || [ "$SOCK_GID" = "0" ]; then
@@ -91,14 +101,42 @@ if [ "$DOCKER_SOCK_IS_LOCAL" = "true" ]; then
     if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
         GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")
     fi
+else
+    if [ -n "${NVFL_DOCKER_SOCK_GID:-}" ]; then
+        case "$NVFL_DOCKER_SOCK_GID" in
+            *[!0-9]*)
+                echo "ERROR: NVFL_DOCKER_SOCK_GID must be a numeric group ID."
+                exit 1
+                ;;
+        esac
+        SOCK_GID="$NVFL_DOCKER_SOCK_GID"
+        echo "Using configured daemon-host Docker socket GID: $SOCK_GID"
+    elif ! SOCK_GID=$(
+        docker "${DOCKER_CLI_ARGS[@]}" run --rm \
+            --mount "type=bind,src=$DOCKER_SOCK,dst=/var/run/docker.sock" \
+            --entrypoint /usr/local/bin/python3 \
+            "$DOCKER_IMAGE" \
+            -c 'import os, stat, sys; s = os.stat("/var/run/docker.sock"); sys.exit("not a socket") if not stat.S_ISSOCK(s.st_mode) else print(s.st_gid)'
+    ); then
+        echo "ERROR: Docker socket could not be validated on the daemon host: $DOCKER_SOCK"
+        echo "Set NVFL_DOCKER_SOCK_GID to the verified numeric socket GID to bypass this probe."
+        exit 1
+    fi
+    case "$SOCK_GID" in
+        ""|*[!0-9]*)
+            echo "ERROR: invalid Docker socket GID reported by daemon-host probe: $SOCK_GID"
+            exit 1
+            ;;
+    esac
+    GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")
 fi
 
-docker run --name @@NVFLARE_CONTAINER_NAME@@ \
+docker "${DOCKER_CLI_ARGS[@]}" run --name @@NVFLARE_CONTAINER_NAME@@ \
     --user "$(id -u):$(id -g)" \
     "${GROUP_ADD_ARGS[@]}" \
     --network "$NETWORK_NAME" \
 @@NVFLARE_NETWORK_ALIAS@@    -v "$HOST_WORKSPACE":@@NVFLARE_WORKSPACE_MOUNT_PATH@@ \
-    -v "$DOCKER_SOCK":/var/run/docker.sock \
+    --mount "type=bind,src=$DOCKER_SOCK,dst=/var/run/docker.sock" \
     -e NVFL_DOCKER_WORKSPACE="$HOST_WORKSPACE" \
 @@NVFLARE_PUBLISH_PORTS@@    --rm "$DOCKER_IMAGE" \
     @@NVFLARE_PARENT_COMMAND@@

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -17,7 +17,9 @@ import base64
 import json
 import os
 import shutil
+import socket
 import subprocess
+import tempfile
 from datetime import datetime, timedelta
 
 import pytest
@@ -177,6 +179,30 @@ def _run_prepare(kit, output, config):
     prepare_deployment(argparse.Namespace(kit=str(kit), output=str(output), config=str(config_path)))
 
 
+def _install_fake_docker(tmp_path, monkeypatch):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$*" >> "$NVFL_TEST_DOCKER_LOG"\n'
+        'case " $* " in\n'
+        '    *" network ls "*) echo nvflare-network ;;\n'
+        "esac\n"
+        'case " $* " in\n'
+        '    *" --entrypoint /usr/local/bin/python3 "*)\n'
+        '        if [ "${NVFL_TEST_PROBE_FAIL:-}" = "1" ]; then exit 1; fi\n'
+        '        echo "${NVFL_TEST_REMOTE_SOCK_GID:-2375}"\n'
+        "        ;;\n"
+        "esac\n"
+    )
+    fake_docker.chmod(0o755)
+    monkeypatch.setenv("NVFL_TEST_DOCKER_LOG", str(docker_log))
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    return docker_log
+
+
 def _stage_k8_args(kit, **overrides):
     args = {
         "kit": str(kit),
@@ -319,20 +345,22 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
     assert 'DOCKER_SOCK="${NVFL_DOCKER_SOCK:-/var/run/docker.sock}"' in script
     assert 'DOCKER_ENDPOINT="${DOCKER_HOST:-}"' in script
     assert "docker context inspect" in script
+    assert "DOCKER_ENDPOINT_IS_LOCAL=false" in script
+    assert "DOCKER_ENDPOINT_IS_LOCAL=true" in script
     assert "ENDPOINT_DOCKER_SOCK=${DOCKER_ENDPOINT#unix://}" in script
+    assert 'DOCKER_SOCK="$ENDPOINT_DOCKER_SOCK"' in script
     assert 'if [ -z "${NVFL_DOCKER_SOCK:-}" ] && [ -L "$DOCKER_SOCK" ]; then' in script
     assert 'RESOLVED_DOCKER_SOCK=$(readlink "$DOCKER_SOCK")' in script
     assert 'if RESOLVED_DOCKER_SOCK_DIR="$(' in script
-    assert "DOCKER_SOCK_IS_LOCAL=false" in script
-    assert "DOCKER_SOCK_IS_LOCAL=true" in script
-    assert "Docker socket is not visible locally; using daemon-host path" in script
+    assert "Docker socket path must be absolute" in script
+    assert "Using Docker socket on daemon host" in script
     assert "Set NVFL_DOCKER_SOCK=/path/to/docker.sock" in script
     assert "DOCKER_HOST_URI" not in script
-    assert "docker --host" not in script
-    assert "if ! docker info" in script
-    assert "if ! docker network ls" in script
-    assert "docker network create" in script
-    assert "docker run" in script
+    assert 'DOCKER_CLI_ARGS=(--host "unix://$DOCKER_SOCK")' in script
+    assert 'if ! docker "${DOCKER_CLI_ARGS[@]}" info' in script
+    assert 'if ! docker "${DOCKER_CLI_ARGS[@]}" network ls' in script
+    assert 'docker "${DOCKER_CLI_ARGS[@]}" network create' in script
+    assert 'docker "${DOCKER_CLI_ARGS[@]}" run' in script
     assert (
         "SOCK_GID=$(stat -c '%g' \"$DOCKER_SOCK\" 2>/dev/null || "
         'stat -f \'%g\' "$DOCKER_SOCK" 2>/dev/null || echo "")'
@@ -344,7 +372,11 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
     assert "GROUP_ADD_ARGS=(--group-add 0)" not in script
     assert 'GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")' in script
     assert '"${GROUP_ADD_ARGS[@]}"' in script
-    assert '-v "$DOCKER_SOCK":/var/run/docker.sock' in script
+    assert "NVFL_DOCKER_SOCK_GID" in script
+    assert "--entrypoint /usr/local/bin/python3" in script
+    assert "stat.S_ISSOCK" in script
+    assert '--mount "type=bind,src=$DOCKER_SOCK,dst=/var/run/docker.sock"' in script
+    assert '-v "$DOCKER_SOCK":/var/run/docker.sock' not in script
     assert "-v /var/run/docker.sock:/var/run/docker.sock" not in script
 
 
@@ -361,24 +393,12 @@ def test_prepare_docker_start_script_allows_daemon_host_socket_path(tmp_path, ca
     )
     capsys.readouterr()
 
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    docker_log = tmp_path / "docker.log"
-    fake_docker = fake_bin / "docker"
-    fake_docker.write_text(
-        "#!/usr/bin/env bash\n"
-        'printf \'%s\\n\' "$*" >> "$NVFL_TEST_DOCKER_LOG"\n'
-        'if [ "$1" = "network" ] && [ "$2" = "ls" ]; then\n'
-        "    echo nvflare-network\n"
-        "fi\n"
-    )
-    fake_docker.chmod(0o755)
+    docker_log = _install_fake_docker(tmp_path, monkeypatch)
 
     daemon_socket = tmp_path / "daemon-host" / "docker.sock"
     monkeypatch.setenv("DOCKER_HOST", "tcp://dind:2375")
     monkeypatch.setenv("NVFL_DOCKER_SOCK", str(daemon_socket))
-    monkeypatch.setenv("NVFL_TEST_DOCKER_LOG", str(docker_log))
-    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("NVFL_TEST_REMOTE_SOCK_GID", "2375")
 
     result = subprocess.run(
         ["bash", str(output / "startup" / "start_docker.sh")],
@@ -388,14 +408,121 @@ def test_prepare_docker_start_script_allows_daemon_host_socket_path(tmp_path, ca
     )
 
     assert result.returncode == 0, result.stderr
-    assert "Docker socket is not visible locally; using daemon-host path" in result.stdout
+    assert "Using Docker socket on daemon host" in result.stdout
     calls = docker_log.read_text().splitlines()
     assert calls[0] == "info"
     assert calls[1].startswith("network ls")
-    run_call = next(call for call in calls if call.startswith("run "))
+    probe_call = next(call for call in calls if "--entrypoint /usr/local/bin/python3" in call)
+    assert f"--mount type=bind,src={daemon_socket},dst=/var/run/docker.sock" in probe_call
+    run_call = next(call for call in calls if call.startswith("run --name"))
     assert "--host" not in run_call
-    assert "--group-add" not in run_call
-    assert f"-v {daemon_socket}:/var/run/docker.sock" in run_call
+    assert "--group-add 2375" in run_call
+    assert f"--mount type=bind,src={daemon_socket},dst=/var/run/docker.sock" in run_call
+
+
+def test_prepare_docker_start_script_pins_local_socket_override(tmp_path, capsys, monkeypatch):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+    docker_log = _install_fake_docker(tmp_path, monkeypatch)
+
+    with tempfile.TemporaryDirectory(prefix=".nvfl-sock-", dir=os.getcwd()) as socket_dir:
+        docker_socket_path = os.path.join(socket_dir, "docker.sock")
+        with socket.socket(socket.AF_UNIX) as docker_socket:
+            docker_socket.bind(docker_socket_path)
+            monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+            monkeypatch.setenv("NVFL_DOCKER_SOCK", docker_socket_path)
+
+            result = subprocess.run(
+                ["bash", str(output / "startup" / "start_docker.sh")],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    assert result.returncode == 0, result.stderr
+    calls = docker_log.read_text().splitlines()
+    expected_prefix = f"--host unix://{docker_socket_path} "
+    assert calls
+    assert all(call.startswith(expected_prefix) for call in calls)
+    assert not any("--entrypoint /usr/local/bin/python3" in call for call in calls)
+    run_call = next(call for call in calls if " run --name" in call)
+    assert f"--mount type=bind,src={docker_socket_path},dst=/var/run/docker.sock" in run_call
+
+
+def test_prepare_docker_start_script_accepts_configured_daemon_host_socket_gid(tmp_path, capsys, monkeypatch):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+    docker_log = _install_fake_docker(tmp_path, monkeypatch)
+
+    daemon_socket = tmp_path / "daemon-host" / "docker.sock"
+    monkeypatch.setenv("DOCKER_HOST", "tcp://dind:2375")
+    monkeypatch.setenv("NVFL_DOCKER_SOCK", str(daemon_socket))
+    monkeypatch.setenv("NVFL_DOCKER_SOCK_GID", "4242")
+
+    result = subprocess.run(
+        ["bash", str(output / "startup" / "start_docker.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Using configured daemon-host Docker socket GID: 4242" in result.stdout
+    calls = docker_log.read_text().splitlines()
+    assert not any("--entrypoint /usr/local/bin/python3" in call for call in calls)
+    run_call = next(call for call in calls if call.startswith("run --name"))
+    assert "--group-add 4242" in run_call
+
+
+def test_prepare_docker_start_script_fails_when_daemon_host_socket_probe_fails(tmp_path, capsys, monkeypatch):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+    docker_log = _install_fake_docker(tmp_path, monkeypatch)
+
+    daemon_socket = tmp_path / "daemon-host" / "docker.sock"
+    monkeypatch.setenv("DOCKER_HOST", "tcp://dind:2375")
+    monkeypatch.setenv("NVFL_DOCKER_SOCK", str(daemon_socket))
+    monkeypatch.setenv("NVFL_TEST_PROBE_FAIL", "1")
+
+    result = subprocess.run(
+        ["bash", str(output / "startup" / "start_docker.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Docker socket could not be validated on the daemon host" in result.stdout
+    assert "Set NVFL_DOCKER_SOCK_GID" in result.stdout
+    calls = docker_log.read_text().splitlines()
+    assert not any(call.startswith("run --name") for call in calls)
 
 
 def test_prepare_docker_start_script_rejects_missing_local_socket(tmp_path, capsys, monkeypatch):
@@ -413,7 +540,6 @@ def test_prepare_docker_start_script_rejects_missing_local_socket(tmp_path, caps
 
     missing_socket = tmp_path / "missing" / "docker.sock"
     monkeypatch.setenv("DOCKER_HOST", f"unix://{missing_socket}")
-    monkeypatch.setenv("NVFL_DOCKER_SOCK", str(missing_socket))
 
     result = subprocess.run(
         ["bash", str(output / "startup" / "start_docker.sh")],

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -15,6 +15,7 @@
 import argparse
 import base64
 import json
+import os
 import shutil
 import subprocess
 from datetime import datetime, timedelta
@@ -316,16 +317,22 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
 
     script = (output / "startup" / "start_docker.sh").read_text()
     assert 'DOCKER_SOCK="${NVFL_DOCKER_SOCK:-/var/run/docker.sock}"' in script
+    assert 'DOCKER_ENDPOINT="${DOCKER_HOST:-}"' in script
+    assert "docker context inspect" in script
+    assert "ENDPOINT_DOCKER_SOCK=${DOCKER_ENDPOINT#unix://}" in script
     assert 'if [ -z "${NVFL_DOCKER_SOCK:-}" ] && [ -L "$DOCKER_SOCK" ]; then' in script
     assert 'RESOLVED_DOCKER_SOCK=$(readlink "$DOCKER_SOCK")' in script
     assert 'if RESOLVED_DOCKER_SOCK_DIR="$(' in script
-    assert 'if [ ! -S "$DOCKER_SOCK" ]; then' in script
+    assert "DOCKER_SOCK_IS_LOCAL=false" in script
+    assert "DOCKER_SOCK_IS_LOCAL=true" in script
+    assert "Docker socket is not visible locally; using daemon-host path" in script
     assert "Set NVFL_DOCKER_SOCK=/path/to/docker.sock" in script
-    assert 'DOCKER_HOST_URI="unix://$DOCKER_SOCK"' in script
-    assert 'docker --host "$DOCKER_HOST_URI" info' in script
-    assert 'docker --host "$DOCKER_HOST_URI" network ls' in script
-    assert 'docker --host "$DOCKER_HOST_URI" network create' in script
-    assert 'docker --host "$DOCKER_HOST_URI" run' in script
+    assert "DOCKER_HOST_URI" not in script
+    assert "docker --host" not in script
+    assert "if ! docker info" in script
+    assert "if ! docker network ls" in script
+    assert "docker network create" in script
+    assert "docker run" in script
     assert (
         "SOCK_GID=$(stat -c '%g' \"$DOCKER_SOCK\" 2>/dev/null || "
         'stat -f \'%g\' "$DOCKER_SOCK" 2>/dev/null || echo "")'
@@ -339,6 +346,84 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
     assert '"${GROUP_ADD_ARGS[@]}"' in script
     assert '-v "$DOCKER_SOCK":/var/run/docker.sock' in script
     assert "-v /var/run/docker.sock:/var/run/docker.sock" not in script
+
+
+def test_prepare_docker_start_script_allows_daemon_host_socket_path(tmp_path, capsys, monkeypatch):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$*" >> "$NVFL_TEST_DOCKER_LOG"\n'
+        'if [ "$1" = "network" ] && [ "$2" = "ls" ]; then\n'
+        "    echo nvflare-network\n"
+        "fi\n"
+    )
+    fake_docker.chmod(0o755)
+
+    daemon_socket = tmp_path / "daemon-host" / "docker.sock"
+    monkeypatch.setenv("DOCKER_HOST", "tcp://dind:2375")
+    monkeypatch.setenv("NVFL_DOCKER_SOCK", str(daemon_socket))
+    monkeypatch.setenv("NVFL_TEST_DOCKER_LOG", str(docker_log))
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+
+    result = subprocess.run(
+        ["bash", str(output / "startup" / "start_docker.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Docker socket is not visible locally; using daemon-host path" in result.stdout
+    calls = docker_log.read_text().splitlines()
+    assert calls[0] == "info"
+    assert calls[1].startswith("network ls")
+    run_call = next(call for call in calls if call.startswith("run "))
+    assert "--host" not in run_call
+    assert "--group-add" not in run_call
+    assert f"-v {daemon_socket}:/var/run/docker.sock" in run_call
+
+
+def test_prepare_docker_start_script_rejects_missing_local_socket(tmp_path, capsys, monkeypatch):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+
+    missing_socket = tmp_path / "missing" / "docker.sock"
+    monkeypatch.setenv("DOCKER_HOST", f"unix://{missing_socket}")
+    monkeypatch.setenv("NVFL_DOCKER_SOCK", str(missing_socket))
+
+    result = subprocess.run(
+        ["bash", str(output / "startup" / "start_docker.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert f"ERROR: Docker socket not found or not a socket: {missing_socket}" in result.stdout
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up to #5029.

### Description

Restore compatibility with Docker-in-Docker and other remote Docker daemon setups while retaining the local socket validation and permission handling added in #5029.

The generated `start_docker.sh` previously treated `NVFL_DOCKER_SOCK` as both the Docker CLI endpoint and the bind-mount source. That fails in the Docker E2E Jenkins pod: the CLI runs in the `gpu` container and reaches a DinD sidecar through `DOCKER_HOST`, while `/var/run/docker.sock` exists only on the daemon side.

This change:

- pins outer Docker commands to `unix://$DOCKER_SOCK` for local Unix endpoints, keeping the parent, network, and jobs on one daemon;
- retains the existing `DOCKER_HOST` or Docker context for TCP/SSH/DinD endpoints, where `NVFL_DOCKER_SOCK` is a daemon-host bind source;
- safely probes remote sockets through the configured parent image to validate the file type and discover its numeric GID;
- adds the discovered socket GID to the non-root parent container;
- supports `NVFL_DOCKER_SOCK_GID` as an explicit administrator/CI override when the remote probe must be bypassed;
- uses `--mount` so a missing daemon-host bind source is rejected rather than created as a directory;
- rejects relative, missing, and non-socket local paths; and
- documents the local-versus-remote behavior.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.

### Testing

- `python -m pytest tests/unit_test/tool/deploy/deploy_commands_test.py -v` (109 passed)
- `./runtest.sh -s`
- `bash -n nvflare/tool/deploy/templates/docker/start_docker.sh`
- `git diff --check`

The behavioral tests cover both sides of the boundary:

- local socket overrides pin every outer Docker command to the selected Unix daemon;
- TCP/DinD paths are validated on the daemon host and their GID is added to the parent;
- a verified `NVFL_DOCKER_SOCK_GID` bypasses the probe without changing the remote CLI endpoint;
- failed remote probes stop before launching the parent; and
- local Unix endpoints reject missing/non-socket paths.
