### PR TITLE
Warn that recipe export arguments are reserved

### DIFF
--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -73,6 +73,10 @@ All concrete recipes support the common execution surface:
 
       python job.py --export --export-dir /tmp/nvflare/job
 
+   Recipe scripts reserve ``--export`` and ``--export-dir``. NVFlare consumes
+   these arguments during module import, before the script's argument parser
+   runs. Use different option names for script-specific behavior.
+
 ``recipe.run(env, server_exec_params=None, client_exec_params=None)``
    Submit directly through the environment and return a ``Run`` handle. Most
    user examples should use ``execute`` so export flags continue to work.

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -75,7 +75,8 @@ All concrete recipes support the common execution surface:
 
    Recipe scripts reserve ``--export`` and ``--export-dir``. NVFlare consumes
    these arguments during module import, before the script's argument parser
-   runs. Use different option names for script-specific behavior.
+   runs, and emits a warning identifying them as system-level arguments. Use
+   different option names for script-specific behavior.
 
 ``recipe.run(env, server_exec_params=None, client_exec_params=None)``
    Submit directly through the environment and return a ``Run`` handle. Most

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Union
@@ -47,6 +48,7 @@ def _consume_recipe_args() -> tuple:
     argv = sys.argv[1:]
     export = False
     export_dir = DEFAULT_EXPORT_DIR
+    export_dir_seen = False
     remaining = []
     i = 0
     while i < len(argv):
@@ -64,13 +66,24 @@ def _consume_recipe_args() -> tuple:
                 _CONSUMED = True
                 return False, DEFAULT_EXPORT_DIR
             export_dir = argv[i + 1]
+            export_dir_seen = True
             i += 2
         elif argv[i].startswith("--export-dir="):
             export_dir = argv[i].split("=", 1)[1]
+            export_dir_seen = True
             i += 1
         else:
             remaining.append(argv[i])
             i += 1
+
+    if export_dir_seen and not export:
+        warnings.warn(
+            "NVFlare recipe consumed the reserved '--export-dir' argument without '--export'; "
+            "the directory will not be used. Add '--export' for recipe export or rename the script option.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     sys.argv[1:] = remaining
     _CONSUMED = True
     return export, export_dir

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -76,10 +76,15 @@ def _consume_recipe_args() -> tuple:
             remaining.append(argv[i])
             i += 1
 
-    if export_dir_seen and not export:
+    if export or export_dir_seen:
+        message = (
+            "NVFlare reserves '--export' and '--export-dir' as system-level recipe arguments and consumes them "
+            "before the script's argument parser runs. Rename any script-defined arguments that use these names."
+        )
+        if export_dir_seen and not export:
+            message += " '--export-dir' was provided without '--export', so the directory will not be used."
         warnings.warn(
-            "NVFlare recipe consumed the reserved '--export-dir' argument without '--export'; "
-            "the directory will not be used. Add '--export' for recipe export or rename the script option.",
+            message,
             UserWarning,
             stacklevel=2,
         )

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import tempfile
+import warnings
 
 import pytest
 
@@ -655,6 +656,61 @@ def test_recipe_spec_import_strips_export_dir_equals_form(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("export_dir_args", "expected_export_dir"),
+    [
+        (["--export-dir", "/tmp/user-output"], "/tmp/user-output"),
+        (["--export-dir=/tmp/user-output"], "/tmp/user-output"),
+    ],
+)
+def test_recipe_spec_import_warns_when_export_dir_is_unused(monkeypatch, export_dir_args, expected_export_dir):
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--rounds", "3", *export_dir_args])
+
+    import nvflare.recipe.spec as spec_module
+
+    with pytest.warns(UserWarning, match="reserved '--export-dir'.*without '--export'"):
+        importlib.reload(spec_module)
+
+    assert sys.argv == ["python", "job.py", "--rounds", "3"]
+    assert spec_module._peek_recipe_args() == (False, expected_export_dir)
+
+
+def test_recipe_spec_import_does_not_warn_for_export_with_export_dir(monkeypatch):
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--export-dir", "/tmp/out"])
+
+    import nvflare.recipe.spec as spec_module
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        importlib.reload(spec_module)
+
+    assert sys.argv == ["python", "job.py"]
+    assert spec_module._peek_recipe_args() == (True, "/tmp/out")
+
+
+def test_consume_recipe_args_warning_as_error_preserves_sys_argv(monkeypatch):
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["python", "job.py"])
+
+    import nvflare.recipe.spec as spec_module
+
+    importlib.reload(spec_module)
+    monkeypatch.setattr(spec_module, "_CONSUMED", False)
+    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export-dir", "/tmp/user-output", "--other"])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        with pytest.raises(UserWarning, match="reserved '--export-dir'.*without '--export'"):
+            spec_module._consume_recipe_args()
+
+    assert sys.argv == ["python", "job.py", "--export-dir", "/tmp/user-output", "--other"]
+
+
+@pytest.mark.parametrize(
     ("local_flag", "should_parse"),
     [
         ("--max_train_samples", True),
@@ -694,7 +750,9 @@ def test_consume_recipe_args_dangling_export_dir_does_not_raise(monkeypatch):
 
     import nvflare.recipe.spec as spec_module
 
-    importlib.reload(spec_module)  # malformed input must not raise on import
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        importlib.reload(spec_module)  # malformed input must not raise or warn on import
 
     # Transactional: the whole pass is abandoned -- export stays disabled and sys.argv
     # is left untouched so the caller's own parser can surface the leftover flags.

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -622,7 +622,8 @@ def test_recipe_spec_import_strips_export_flags_from_sys_argv(monkeypatch):
 
     import nvflare.recipe.spec as spec_module
 
-    importlib.reload(spec_module)
+    with pytest.warns(UserWarning, match="system-level recipe arguments"):
+        importlib.reload(spec_module)
 
     assert sys.argv == ["python", "job.py", "--other", "value"]
     assert spec_module._peek_recipe_args() == (True, "/tmp/out")
@@ -636,7 +637,8 @@ def test_recipe_spec_import_bare_export_uses_default_dir(monkeypatch):
 
     import nvflare.recipe.spec as spec_module
 
-    importlib.reload(spec_module)
+    with pytest.warns(UserWarning, match="system-level recipe arguments"):
+        importlib.reload(spec_module)
 
     assert sys.argv == ["python", "job.py", "--other"]
     assert spec_module._peek_recipe_args() == (True, spec_module.DEFAULT_EXPORT_DIR)
@@ -649,7 +651,8 @@ def test_recipe_spec_import_strips_export_dir_equals_form(monkeypatch):
 
     import nvflare.recipe.spec as spec_module
 
-    importlib.reload(spec_module)
+    with pytest.warns(UserWarning, match="system-level recipe arguments"):
+        importlib.reload(spec_module)
 
     assert sys.argv == ["python", "job.py", "--other"]
     assert spec_module._peek_recipe_args() == (True, "out")
@@ -669,29 +672,42 @@ def test_recipe_spec_import_warns_when_export_dir_is_unused(monkeypatch, export_
 
     import nvflare.recipe.spec as spec_module
 
-    with pytest.warns(UserWarning, match="reserved '--export-dir'.*without '--export'"):
+    with pytest.warns(UserWarning, match="system-level recipe arguments.*without '--export'"):
         importlib.reload(spec_module)
 
     assert sys.argv == ["python", "job.py", "--rounds", "3"]
     assert spec_module._peek_recipe_args() == (False, expected_export_dir)
 
 
-def test_recipe_spec_import_does_not_warn_for_export_with_export_dir(monkeypatch):
+def test_recipe_spec_import_warns_script_parser_about_reserved_args(monkeypatch):
     import sys
 
-    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export", "--export-dir", "/tmp/out"])
+    monkeypatch.setattr(sys, "argv", ["job.py", "--export", "--export-dir", "/tmp/out"])
 
     import nvflare.recipe.spec as spec_module
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
+    with pytest.warns(UserWarning, match="system-level recipe arguments.*Rename any script-defined arguments"):
         importlib.reload(spec_module)
 
-    assert sys.argv == ["python", "job.py"]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--export", action="store_true")
+    parser.add_argument("--export-dir")
+    args = parser.parse_args()
+
+    assert args.export is False
+    assert args.export_dir is None
+    assert sys.argv == ["job.py"]
     assert spec_module._peek_recipe_args() == (True, "/tmp/out")
 
 
-def test_consume_recipe_args_warning_as_error_preserves_sys_argv(monkeypatch):
+@pytest.mark.parametrize(
+    "recipe_args",
+    [
+        ["--export", "--export-dir", "/tmp/user-output"],
+        ["--export-dir", "/tmp/user-output"],
+    ],
+)
+def test_consume_recipe_args_warning_as_error_preserves_sys_argv(monkeypatch, recipe_args):
     import sys
 
     monkeypatch.setattr(sys, "argv", ["python", "job.py"])
@@ -700,14 +716,15 @@ def test_consume_recipe_args_warning_as_error_preserves_sys_argv(monkeypatch):
 
     importlib.reload(spec_module)
     monkeypatch.setattr(spec_module, "_CONSUMED", False)
-    monkeypatch.setattr(sys, "argv", ["python", "job.py", "--export-dir", "/tmp/user-output", "--other"])
+    original_argv = ["job.py", *recipe_args, "--other"]
+    monkeypatch.setattr(sys, "argv", original_argv.copy())
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        with pytest.raises(UserWarning, match="reserved '--export-dir'.*without '--export'"):
+        with pytest.raises(UserWarning, match="system-level recipe arguments"):
             spec_module._consume_recipe_args()
 
-    assert sys.argv == ["python", "job.py", "--export-dir", "/tmp/user-output", "--other"]
+    assert sys.argv == original_argv
 
 
 @pytest.mark.parametrize(
@@ -729,7 +746,8 @@ def test_recipe_export_flags_allow_strict_local_argument_parsing(monkeypatch, lo
 
     import nvflare.recipe.spec as spec_module
 
-    importlib.reload(spec_module)
+    with pytest.warns(UserWarning, match="system-level recipe arguments"):
+        importlib.reload(spec_module)
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--max_train_samples", type=int)
 


### PR DESCRIPTION
## Summary

- warn whenever NVFlare consumes the reserved --export or --export-dir recipe arguments
- explain that these system-level names are unavailable to the script argument parser
- retain the additional diagnostic when --export-dir is supplied without --export
- preserve transactional argument handling when warnings are promoted to errors
- document the import-time reservation in the Recipe API guide

## Behavior

NVFlare cannot distinguish a script-defined collision from its documented recipe export syntax because both use the same command line. The warning is therefore emitted for every consumed recipe export argument, including valid NVFlare exports.

## Tests

- python -m pytest tests/unit_test/recipe/spec_test.py -q (70 passed)
- python -m pytest tests/unit_test/recipe -q (525 passed, 22 skipped)
- ./runtest.sh -s
- ./runtest.sh -l