### PR TITLE
Verify task result retries after stream failure

### DIFF
--- a/tests/unit_test/private/fed/client/client_runner_test.py
+++ b/tests/unit_test/private/fed/client/client_runner_test.py
@@ -228,10 +228,21 @@ def test_try_send_result_once_sends_after_task_check(monkeypatch):
 
 def test_send_task_result_retries_after_transport_failure(monkeypatch):
     runner = _runner()
-    runner._check_task_once = MagicMock(return_value=_TASK_CHECK_RESULT_OK)
+    call_order = []
+    send_results = iter([False, True])
+
+    def check_task(*_args, **_kwargs):
+        call_order.append("check")
+        return _TASK_CHECK_RESULT_OK
+
+    def send_result(*_args, **_kwargs):
+        call_order.append("send")
+        return next(send_results)
+
+    runner._check_task_once = MagicMock(side_effect=check_task)
     # Cell._send_one_request maps a failed StreamFuture to a timeout reply,
     # which send_task_result reports as False.
-    runner.engine.send_task_result.side_effect = [False, True]
+    runner.engine.send_task_result.side_effect = send_result
     monkeypatch.setattr("nvflare.private.fed.client.client_runner.time.sleep", MagicMock())
     monkeypatch.setattr("nvflare.private.fed.client.client_runner.delete_msg_root", MagicMock())
     result = Shareable()
@@ -240,6 +251,7 @@ def test_send_task_result_retries_after_transport_failure(monkeypatch):
 
     assert runner._check_task_once.call_count == 2
     assert runner.engine.send_task_result.call_count == 2
+    assert call_order == ["check", "send", "check", "send"]
     assert all(call.args[0] is result for call in runner.engine.send_task_result.call_args_list)
     runner.log_error.assert_called_once()
 

--- a/tests/unit_test/private/fed/client/client_runner_test.py
+++ b/tests/unit_test/private/fed/client/client_runner_test.py
@@ -226,6 +226,24 @@ def test_try_send_result_once_sends_after_task_check(monkeypatch):
     assert result.get_header(ReservedHeaderKey.MSG_ROOT_ID)
 
 
+def test_send_task_result_retries_after_transport_failure(monkeypatch):
+    runner = _runner()
+    runner._check_task_once = MagicMock(return_value=_TASK_CHECK_RESULT_OK)
+    # Cell._send_one_request maps a failed StreamFuture to a timeout reply,
+    # which send_task_result reports as False.
+    runner.engine.send_task_result.side_effect = [False, True]
+    monkeypatch.setattr("nvflare.private.fed.client.client_runner.time.sleep", MagicMock())
+    monkeypatch.setattr("nvflare.private.fed.client.client_runner.delete_msg_root", MagicMock())
+    result = Shareable()
+
+    assert runner._send_task_result(result, "task-1", FLContext()) is True
+
+    assert runner._check_task_once.call_count == 2
+    assert runner.engine.send_task_result.call_count == 2
+    assert all(call.args[0] is result for call in runner.engine.send_task_result.call_args_list)
+    runner.log_error.assert_called_once()
+
+
 def test_task_check_and_control_handlers():
     runner = _runner()
     fl_ctx = FLContext()


### PR DESCRIPTION
## Summary

- add a regression test for a task-result transport failure followed by a successful retry
- verify the client rechecks the task before retrying
- verify the same result payload is retried and the initial failure is logged

## Why

This answers the retry-versus-drop question raised while investigating FLARE-3093. When a streamed task-result send is mapped to a failed return value, `ClientRunner._send_task_result()` retries the update rather than silently dropping it.

This is a focused follow-up to #5039 and does not change runtime behavior.

Jira: https://jirasw.nvidia.com/browse/FLARE-3093

## Validation

- `python -m pytest -q tests/unit_test/private/fed/client/client_runner_test.py` — 27 passed
- scoped Black, isort, flake8, and whitespace checks passed

The repository-wide style command reaches only three unrelated generated `node_modules/flatted.py` files; the other 2,611 files pass.
