### PR TITLE
Reject unsafe FedJob names

### DIFF
--- a/nvflare/fuel/utils/validation_utils.py
+++ b/nvflare/fuel/utils/validation_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ntpath
 import random
 
 SYMBOL_ALL = "@all"
@@ -88,6 +89,14 @@ def check_non_empty_str(name, value):
     v = value.strip()
     if not v:
         raise ValueError(f"{name} must not be empty")
+
+
+def check_job_name(name, value):
+    """Validate a job name that will be used as one directory component."""
+    check_non_empty_str(name, value)
+    drive, _ = ntpath.splitdrive(value)
+    if value in (".", "..") or "/" in value or "\\" in value or drive:
+        raise ValueError(f"{name} must be a single directory name without path components")
 
 
 def check_object_type(name, value, obj_type):

--- a/nvflare/job_config/api.py
+++ b/nvflare/job_config/api.py
@@ -22,7 +22,7 @@ from nvflare.apis.fl_constant import ConfigVarName
 from nvflare.apis.impl.controller import Controller
 from nvflare.apis.job_def import ALL_SITES, SERVER_SITE_NAME
 from nvflare.fuel.utils.class_utils import get_component_init_parameters
-from nvflare.fuel.utils.validation_utils import check_object_type, check_positive_int, check_str
+from nvflare.fuel.utils.validation_utils import check_job_name, check_object_type, check_positive_int
 from nvflare.job_config.fed_app_config import ClientAppConfig, FedAppConfig, ServerAppConfig
 from nvflare.job_config.fed_job_config import FedJobConfig
 
@@ -209,7 +209,7 @@ class FedJob:
                 When False (the default), the existing dead-client grace period behaviour applies.
 
         """
-        check_str("name", name)
+        check_job_name("name", name)
         check_positive_int("min_clients", min_clients)
         if mandatory_clients:
             check_object_type("mandatory_clients", mandatory_clients, list)

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -27,7 +27,7 @@ from typing import Dict, List
 from nvflare.fuel.utils.class_utils import get_component_init_parameters
 from nvflare.fuel.utils.job_secret_scanner import warn_on_potential_secrets_in_job_dir
 from nvflare.fuel.utils.log_utils import get_obj_logger
-from nvflare.fuel.utils.validation_utils import check_object_type
+from nvflare.fuel.utils.validation_utils import check_job_name, check_object_type
 from nvflare.job_config.base_app_config import BaseAppConfig
 from nvflare.job_config.fed_app_config import FedAppConfig
 from nvflare.private.fed.app.fl_conf import FL_PACKAGES
@@ -148,6 +148,9 @@ class FedJobConfig:
         Returns:
 
         """
+        # Revalidate at the filesystem boundary in case this low-level object was
+        # constructed directly or job_name was changed after construction.
+        check_job_name("job_name", self.job_name)
         job_dir = os.path.join(job_root, self.job_name)
         if os.path.exists(job_dir):
             if self._is_valid_job_folder(job_dir) or self._is_partial_export_folder(job_dir):

--- a/tests/unit_test/fuel/utils/validation_utils_test.py
+++ b/tests/unit_test/fuel/utils/validation_utils_test.py
@@ -16,6 +16,7 @@ import pytest
 
 from nvflare.fuel.utils.validation_utils import (
     DefaultValuePolicy,
+    check_job_name,
     check_non_empty_str,
     check_number_range,
     check_positive_int,
@@ -141,6 +142,22 @@ class TestValidationUtils:
     def test_check_non_empty_str_error(self, name, num):
         with pytest.raises(Exception):
             check_non_empty_str(name, num)
+
+    @pytest.mark.parametrize("value", ["job", "job-name_1", "job name", "job.name"])
+    def test_check_job_name(self, value):
+        check_job_name("name", value)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", " ", ".", "..", "../job", "nested/job", r"nested\job", "/tmp/job", r"C:\job", "C:job"],
+    )
+    def test_check_job_name_error(self, value):
+        with pytest.raises(ValueError):
+            check_job_name("name", value)
+
+    def test_check_job_name_type_error(self):
+        with pytest.raises(TypeError):
+            check_job_name("name", None)
 
     @pytest.mark.parametrize(
         "var_name, candidate, base, default_policy, allow_none, output",

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -21,6 +21,22 @@ from nvflare.job_config.fed_job_config import FedJobConfig
 
 
 class TestFedJobConfig:
+    @pytest.mark.parametrize("job_name", ["", ".", "..", "../job", "nested/job", r"nested\job", "/tmp/job"])
+    def test_generate_job_config_rejects_path_bearing_job_name(self, tmp_path, job_name):
+        # A meta.json makes the export root look like a replaceable job folder.
+        # Before validation, an empty or "." job name caused rmtree(tmp_path).
+        meta_file = tmp_path / "meta.json"
+        meta_file.write_text("{}", encoding="utf-8")
+        marker = tmp_path / "notes.txt"
+        marker.write_text("keep me", encoding="utf-8")
+        job_config = FedJobConfig(job_name=job_name, min_clients=1)
+
+        with pytest.raises(ValueError):
+            job_config.generate_job_config(tmp_path)
+
+        assert marker.read_text(encoding="utf-8") == "keep me"
+        assert meta_file.exists()
+
     def test_locate_imports(self):
         job_config = FedJobConfig(job_name="job_name", min_clients=1)
         cwd = os.path.dirname(__file__)

--- a/tests/unit_test/job_config/fed_job_test.py
+++ b/tests/unit_test/job_config/fed_job_test.py
@@ -36,6 +36,14 @@ def _create_model_learner():
 
 
 class TestFedJob:
+    @pytest.mark.parametrize(
+        "name",
+        ["", " ", ".", "..", "../job", "nested/job", r"nested\job", "/tmp/job", r"C:\job", "C:job"],
+    )
+    def test_rejects_invalid_job_name(self, name):
+        with pytest.raises(ValueError):
+            FedJob(name=name)
+
     def test_validate_targets(self):
         job = FedJob()
         controller = FedAvg()


### PR DESCRIPTION
## Summary

- validate job names at the shared `FedJob` entry point so every recipe rejects empty and path-bearing names
- reject POSIX and Windows separators, traversal components, absolute paths, and drive-qualified paths
- revalidate inside `FedJobConfig.generate_job_config()` so direct or mutated low-level configurations cannot collapse onto the caller's export directory
- add regression coverage proving existing user files are preserved even when the export root contains `meta.json` and would otherwise look safe to delete

## Root cause

`FedJob` previously performed only a type check on `name`. `FedJobConfig.generate_job_config()` then passed the value directly to `os.path.join(job_root, job_name)`. An empty or `.` name resolved to `job_root` itself, while traversal and absolute names escaped it. If the resolved directory contained `meta.json`, export treated it as a replaceable job folder and silently removed it with `shutil.rmtree(..., ignore_errors=True)`.

Validating at `FedJob` covers direct users and all recipe families through their shared construction path. Revalidation at the filesystem boundary provides defense in depth.

NVBug: [6567126](https://nvbugspro.nvidia.com/bug/6567126)

## Validation

- `171 passed`: validation utilities, `FedJob`, `FedJobConfig`, and Collab recipe tests
- destructive export-root regression: `7 passed`
- representative `NumpyFedAvgRecipe` construction rejects empty, traversal, absolute, and Windows path-bearing names
- Black, isort, flake8, and agent-skill lint passed on all changed files
- broader `tests/unit_test/job_config` run: `132 passed`, with 3 unrelated ScriptRunner failures because PyTorch is not installed in the focused test environment
