### PR TITLE
Fix stale Recipe CLI documentation commands

### DIFF
--- a/examples/tutorials/flare_api.ipynb
+++ b/examples/tutorials/flare_api.ipynb
@@ -105,7 +105,7 @@
     "import sys\n",
     "\n",
     "# Run export\n",
-    "os.system(\"cd ../hello-world/hello-numpy && python job.py --export_config\")\n",
+    "os.system(\"cd ../hello-world/hello-numpy && python job.py --export --export-dir /tmp/nvflare/jobs/job_config\")\n",
     "\n",
     "# Copy exported job to transfer directory\n",
     "transfer_dir = \"/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com/transfer/\"\n",

--- a/examples/tutorials/flare_api.ipynb
+++ b/examples/tutorials/flare_api.ipynb
@@ -105,7 +105,7 @@
     "import sys\n",
     "\n",
     "# Run export\n",
-    "os.system(\"cd ../hello-world/hello-numpy && python job.py --export --export-dir /tmp/nvflare/jobs/job_config\")\n",
+    "os.system(f\"cd ../hello-world/hello-numpy && \\\"{sys.executable}\\\" job.py --export --export-dir /tmp/nvflare/jobs/job_config\")\n",
     "\n",
     "# Copy exported job to transfer directory\n",
     "transfer_dir = \"/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com/transfer/\"\n",

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/LLM_SFT.ipynb
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.2_llm_sft/LLM_SFT.ipynb
@@ -172,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft --train_mode SFT "
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft --train_mode SFT "
    ]
   },
   {

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/LLM_PEFT.ipynb
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.3_llm_peft/LLM_PEFT.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! python job.py --client_ids dolly oasst1 --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/all_fl_peft --job_dir /tmp/nvflare/workspace/jobs/llm_fl_peft --train_mode PEFT --threads 2 "
+    "! python job.py --client_ids dolly oasst1 --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/all_fl_peft --train_mode PEFT --threads 2 "
    ]
   },
   {

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/LLM_quantization.ipynb
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-8_federated_LLM_training/08.4_llm_quantization/LLM_quantization.ipynb
@@ -49,10 +49,10 @@
    },
    "outputs": [],
    "source": [
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_16 --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft_16 --train_mode SFT --quantize_mode float16\n",
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_8 --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft_8 --train_mode SFT --quantize_mode blockwise8\n",
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_fp4 --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft_fp4 --train_mode SFT --quantize_mode float4\n",
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_nf4 --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft_nf4 --train_mode SFT --quantize_mode normfloat4"
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_16 --train_mode SFT --quantize_mode float16\n",
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_8 --train_mode SFT --quantize_mode blockwise8\n",
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_fp4 --train_mode SFT --quantize_mode float4\n",
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_nf4 --train_mode SFT --quantize_mode normfloat4"
    ]
   },
   {
@@ -83,8 +83,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_tensor --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft_tensor --train_mode SFT  --message_mode tensor\n",
-    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_tensor_fp4 --job_dir /tmp/nvflare/workspace/jobs/llm_hf_sft_tensor_fp4 --train_mode SFT  --message_mode tensor --quantize_mode float4"
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_tensor --train_mode SFT  --message_mode tensor\n",
+    "! python job.py --client_ids dolly --data_path /tmp/nvflare/dataset/llm/ --workspace_dir /tmp/nvflare/workspace/llm/dolly_fl_sft_tensor_fp4 --train_mode SFT  --message_mode tensor --quantize_mode float4"
    ]
   },
   {

--- a/research/fedobd/README.md
+++ b/research/fedobd/README.md
@@ -42,7 +42,7 @@ python ./utils/preprocess_dolly.py --training_file dataset/databricks-dolly-15k/
 python ./utils/preprocess_alpaca.py --training_file dataset/alpaca/data/train-00000-of-00001-a09b74b3ef9c3b56.parquet --output_dir dataset/alpaca
 python ./utils/preprocess_oasst1.py --training_file dataset/oasst1/data/train-00000-of-00001-b42a775f407cee45.parquet --validation_file dataset/oasst1/data/validation-00000-of-00001-134b8fd0c89408b6.parquet --output_dir dataset/oasst1
 
-python3 job.py --client_ids dolly --data_path ${PWD}/dataset --workspace_dir ${PWD}/workspace/hf_sft_adaquant --job_dir ${PWD}/workspace/jobs/hf_sft_adaquant --train_mode SFT --quantize_mode adaquant
+python3 job.py --client_ids dolly --data_path ${PWD}/dataset --workspace_dir ${PWD}/workspace/hf_sft_adaquant --train_mode SFT --quantize_mode adaquant
 ```
 
 ## Citation


### PR DESCRIPTION
## What changed

- Update the FLARE API tutorial notebook to export hello-numpy through the system-level `--export --export-dir` Recipe interface.
- Remove the obsolete `--job_dir` argument from the FedOBD LLM training command.

## Why

PR #5048 migrated Recipe examples away from per-example export flags, but these two callers live outside the migrated example directories and retained removed arguments.

The notebook command now exports to `/tmp/nvflare/jobs/job_config`, preserving the following cell path at `/tmp/nvflare/jobs/job_config/hello-numpy`. The FedOBD command only runs training, so it does not need an export directory.

## Validation

- Reproduced both removed-argument parser failures on current main.
- Corrected hello-numpy export command completed successfully and produced the expected named job folder.
- Corrected llm_hf command arguments were accepted by its parser.
- Notebook JSON validation passed.
- Recipe export migration regression tests passed: 2 tests.
- `./runtest.sh -s` passed.