### PR TITLE
Support bounded training factories in agent inspection

### DIFF
--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/evals.json
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/evals.json
@@ -562,6 +562,86 @@
       }
     },
     {
+      "id": "huggingface-factory-train-only",
+      "prompt": "Convert this train-only Hugging Face Trainer factory into a two-site NVFLARE FedAvg job without inventing evaluation.",
+      "expected_output": "The factory is a clear Hugging Face owner and converts through the patched Trainer path while preserving its train-only lifecycle and disabling unrequested model selection.",
+      "files": [
+        "files/factory-train-only/train.py",
+        "files/factory-train-only/model.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect source first, confirms clear Hugging Face Trainer ownership, and selects nvflare-convert-huggingface.",
+        "The conversion preserves train-only execution, uses flare.patch(trainer), and does not invent evaluation metrics.",
+        "The generated job disables unrequested model selection with an empty key_metric."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-huggingface",
+        "mandatory_behavior": [
+          {"id": "factory-train-only-preserved", "description": "converts the clear Trainer factory without adding evaluation or active model selection"}
+        ]
+      }
+    },
+    {
+      "id": "huggingface-factory-evaluated-callback-metrics",
+      "prompt": "Convert this evaluated Hugging Face Trainer factory to NVFLARE while preserving its callback and accuracy metric.",
+      "expected_output": "The factory routes clearly to the Hugging Face converter, which preserves callback and compute_metrics wiring and evaluates the received model before training.",
+      "files": [
+        "files/factory-evaluated/train.py",
+        "files/factory-evaluated/model.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect source first, confirms clear Hugging Face Trainer ownership, and selects nvflare-convert-huggingface.",
+        "The generated client preserves LifecycleAuditCallback and compute_metrics and calls evaluate before train.",
+        "The recipe selects the actual Trainer accuracy metric key rather than inventing metric semantics."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-huggingface",
+        "mandatory_behavior": [
+          {"id": "factory-evaluation-contract", "description": "preserves callback, accuracy, and global-model evaluation before local training"}
+        ]
+      }
+    },
+    {
+      "id": "huggingface-factory-peft-sft-local-return",
+      "prompt": "Convert this PEFT SFTTrainer factory to NVFLARE and exchange LoRA adapters only.",
+      "expected_output": "The local-variable-return factory is a clear Hugging Face owner and converts with the patched SFTTrainer while preserving LoRA configuration and adapter-only exchange.",
+      "files": [
+        "files/factory-peft-sft/train.py",
+        "files/factory-peft-sft/model.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect source first, confirms clear SFTTrainer ownership, and selects nvflare-convert-huggingface.",
+        "The conversion preserves the local-variable factory return, PEFT validation, AdapterAuditCallback, and LoRA configuration.",
+        "The server and clients exchange adapter-only state with matching PEFT keys."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-huggingface",
+        "mandatory_behavior": [
+          {"id": "factory-peft-adapter-exchange", "description": "preserves the SFTTrainer factory and validates adapter-only state exchange"}
+        ]
+      }
+    },
+    {
+      "id": "huggingface-factory-distributed-direct-return",
+      "prompt": "Convert this distributed Hugging Face Trainer factory to NVFLARE while preserving its WORLD_SIZE and LOCAL_RANK behavior.",
+      "expected_output": "The direct-return factory routes clearly to the Hugging Face converter, which preserves distributed Trainer arguments without conflating local rank with NVFLARE rank.",
+      "files": [
+        "files/factory-distributed/train.py",
+        "files/factory-distributed/model.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect source first, confirms clear Hugging Face Trainer ownership, and selects nvflare-convert-huggingface.",
+        "The conversion preserves WORLD_SIZE, LOCAL_RANK, and conditional DDP configuration through the patched Trainer path.",
+        "The generated client does not use LOCAL_RANK as global rank or invent a distributed launcher."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-huggingface",
+        "mandatory_behavior": [
+          {"id": "factory-distributed-semantics", "description": "preserves source-backed distributed Trainer semantics and rank boundaries"}
+        ]
+      }
+    },
+    {
       "id": "huggingface-negative-manual-pytorch",
       "prompt": "Convert this AutoModel-based manual torch optimizer and backward loop to an NVFLARE job. It does not use transformers.Trainer.",
       "expected_output": "The Hugging Face conversion skill is not selected; the request routes to nvflare-convert-pytorch because a manual PyTorch loop owns training.",

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-distributed/model.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-distributed/model.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers import AutoModelForSequenceClassification
+
+MODEL_NAME = "distilbert/distilbert-base-uncased"
+
+
+def create_model():
+    return AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-distributed/train.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-distributed/train.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from datasets import Dataset
+from model import create_model
+from transformers import Trainer, TrainingArguments
+
+
+def build_trainer(world_size, local_rank):
+    train_data = Dataset.from_dict({"input_ids": [[1, 2], [3, 4]], "labels": [0, 1]})
+    args = TrainingArguments(output_dir="outputs", max_steps=2, local_rank=local_rank, report_to=[])
+    if world_size > 1:
+        args.ddp_find_unused_parameters = False
+    return Trainer(model=create_model(), args=args, train_dataset=train_data)
+
+
+world_size = int(os.environ.get("WORLD_SIZE", "1"))
+local_rank = int(os.environ.get("LOCAL_RANK", "-1"))
+trainer = build_trainer(world_size, local_rank)
+trainer.train()

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-evaluated/model.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-evaluated/model.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers import AutoModelForSequenceClassification
+
+MODEL_NAME = "distilbert/distilbert-base-uncased"
+
+
+def create_model():
+    return AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-evaluated/train.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-evaluated/train.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from datasets import Dataset
+from model import create_model
+from transformers import Trainer, TrainerCallback, TrainingArguments
+
+
+class LifecycleAuditCallback(TrainerCallback):
+    def on_train_begin(self, args, state, control, **kwargs):
+        print("training started")
+
+
+def compute_metrics(eval_pred):
+    logits, labels = eval_pred
+    predictions = np.argmax(logits, axis=-1)
+    return {"accuracy": float((predictions == labels).mean())}
+
+
+def build_trainer():
+    train_data = Dataset.from_dict({"input_ids": [[1, 2], [3, 4]], "labels": [0, 1]})
+    eval_data = Dataset.from_dict({"input_ids": [[5, 6], [7, 8]], "labels": [0, 1]})
+    args = TrainingArguments(output_dir="outputs", max_steps=2, report_to=[])
+    return Trainer(
+        model=create_model(),
+        args=args,
+        train_dataset=train_data,
+        eval_dataset=eval_data,
+        compute_metrics=compute_metrics,
+        callbacks=[LifecycleAuditCallback()],
+    )
+
+
+trainer = build_trainer()
+trainer.evaluate()
+trainer.train()

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-peft-sft/model.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-peft-sft/model.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from peft import LoraConfig, TaskType
+from transformers import AutoModelForCausalLM
+
+MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+def create_model_and_peft_config():
+    model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+    config = LoraConfig(r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"], task_type=TaskType.CAUSAL_LM)
+    return model, config

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-peft-sft/train.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-peft-sft/train.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datasets import Dataset
+from model import create_model_and_peft_config
+from peft import PeftModel
+from transformers import TrainerCallback
+from trl import SFTConfig, SFTTrainer
+
+
+class AdapterAuditCallback(TrainerCallback):
+    pass
+
+
+def build_trainer():
+    model, peft_config = create_model_and_peft_config()
+    train_data = Dataset.from_dict({"text": ["first example", "second example"]})
+    args = SFTConfig(output_dir="outputs", max_steps=2, report_to=[])
+    trainer = SFTTrainer(model=model, args=args, train_dataset=train_data, peft_config=peft_config)
+    if not isinstance(trainer.model, PeftModel):
+        raise RuntimeError("expected PEFT model")
+    trainer.add_callback(AdapterAuditCallback())
+    return trainer
+
+
+trainer = build_trainer()
+trainer.train()

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-train-only/model.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-train-only/model.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers import AutoModelForSequenceClassification
+
+MODEL_NAME = "distilbert/distilbert-base-uncased"
+
+
+def create_model():
+    return AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)

--- a/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-train-only/train.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-huggingface/files/factory-train-only/train.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datasets import Dataset
+from model import create_model
+from transformers import Trainer, TrainingArguments
+
+
+def build_trainer():
+    train_data = Dataset.from_dict({"input_ids": [[1, 2], [3, 4]], "labels": [0, 1]})
+    args = TrainingArguments(output_dir="outputs", max_steps=2, report_to=[])
+    return Trainer(model=create_model(), args=args, train_dataset=train_data)
+
+
+trainer = build_trainer()
+trainer.train()

--- a/dev_tools/agent/skill_evals/nvflare-convert-lightning/evals.json
+++ b/dev_tools/agent/skill_evals/nvflare-convert-lightning/evals.json
@@ -657,6 +657,27 @@
       }
     },
     {
+      "id": "lightning-factory-owner-routing",
+      "prompt": "Convert this Lightning Trainer factory into a two-site NVFLARE FedAvg job.",
+      "expected_output": "Inspection resolves the same-module factory to a clear Lightning owner and the Lightning conversion preserves the patched Trainer fit lifecycle.",
+      "files": [
+        "files/factory-lightning/train.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect source first, confirms clear Lightning ownership, and selects nvflare-convert-lightning.",
+        "The conversion preserves the Trainer factory, LightningModule, and DataLoader behavior through flare.patch(trainer)."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-lightning",
+        "mandatory_behavior": [
+          {
+            "id": "factory-lightning-owner",
+            "description": "routes a recognized Trainer factory to Lightning conversion and preserves the patched fit lifecycle"
+          }
+        ]
+      }
+    },
+    {
       "id": "lightning-negative-plain-pytorch",
       "prompt": "Convert my plain PyTorch nn.Module and manual training loop to an NVFLARE job. There is no Lightning here.",
       "expected_output": "The Lightning conversion skill should not be the lead; route to nvflare-convert-pytorch for plain PyTorch manual loops.",

--- a/dev_tools/agent/skill_evals/nvflare-convert-lightning/files/factory-lightning/train.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-lightning/files/factory-lightning/train.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import lightning as L
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class Classifier(L.LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(2, 2)
+
+    def training_step(self, batch, batch_idx):
+        features, labels = batch
+        return torch.nn.functional.cross_entropy(self.layer(features), labels)
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=0.1)
+
+
+def build_trainer():
+    trainer = L.Trainer(max_epochs=1, logger=False, enable_checkpointing=False)
+    return trainer
+
+
+dataset = TensorDataset(torch.randn(8, 2), torch.randint(0, 2, (8,)))
+trainer = build_trainer()
+trainer.fit(Classifier(), DataLoader(dataset, batch_size=4))

--- a/dev_tools/agent/skill_evals/nvflare-convert-pytorch/evals.json
+++ b/dev_tools/agent/skill_evals/nvflare-convert-pytorch/evals.json
@@ -783,6 +783,27 @@
       }
     },
     {
+      "id": "pytorch-optimizer-factory-owner-routing",
+      "prompt": "Convert this manual PyTorch loop with an optimizer factory into a two-site NVFLARE FedAvg job.",
+      "expected_output": "Inspection resolves the same-module optimizer factory and optimizer.step lifecycle to a clear PyTorch owner, then the PyTorch conversion preserves the manual loop.",
+      "files": [
+        "files/factory-optimizer/train.py"
+      ],
+      "assertions": [
+        "The agent runs nvflare agent inspect source first, confirms clear PyTorch ownership, and selects nvflare-convert-pytorch.",
+        "The conversion preserves the optimizer factory, backward call, optimizer step, and manual training-loop semantics."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-pytorch",
+        "mandatory_behavior": [
+          {
+            "id": "factory-pytorch-optimizer-owner",
+            "description": "routes a recognized optimizer factory to PyTorch conversion and preserves the manual step lifecycle"
+          }
+        ]
+      }
+    },
+    {
       "id": "pytorch-negative-lightning",
       "prompt": "Convert my PyTorch Lightning Trainer and LightningModule to an NVFLARE workflow.",
       "expected_output": "The PyTorch conversion skill should not be the lead; route to the Lightning conversion skill when available.",

--- a/dev_tools/agent/skill_evals/nvflare-convert-pytorch/files/factory-optimizer/train.py
+++ b/dev_tools/agent/skill_evals/nvflare-convert-pytorch/files/factory-optimizer/train.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def build_optimizer(parameters):
+    return torch.optim.SGD(parameters, lr=0.1)
+
+
+model = torch.nn.Linear(2, 2)
+features = torch.randn(8, 2)
+labels = torch.randint(0, 2, (8,))
+optimizer = build_optimizer(model.parameters())
+
+for _ in range(2):
+    optimizer.zero_grad()
+    loss = torch.nn.functional.cross_entropy(model(features), labels)
+    loss.backward()
+    optimizer.step()

--- a/dev_tools/agent/skill_evals/nvflare-orient/evals.json
+++ b/dev_tools/agent/skill_evals/nvflare-orient/evals.json
@@ -126,11 +126,11 @@
     },
     {
       "id": "orient-huggingface-owner-handoff",
-      "prompt": "Inspection found Hugging Face Trainer configuration, but the Trainer is built through a factory and the train() owner is unresolved. What should I do next?",
-      "expected_output": "The orientation skill asks for the training entrypoint or Trainer construction that owns train(), then routes confirmed Hugging Face Trainer ownership to nvflare-convert-huggingface.",
+      "prompt": "Inspection found Hugging Face Trainer configuration, but build_trainer(flag) conditionally returns either Trainer(...) or a non-Trainer object, so the train() owner is unresolved. What should I do next?",
+      "expected_output": "The orientation skill asks which conditional branch and training entrypoint owns train(), then routes only confirmed Hugging Face Trainer ownership to nvflare-convert-huggingface.",
       "files": [],
       "assertions": [
-        "The orientation step asks the user to identify the training entrypoint or owning Trainer construction.",
+        "The orientation step asks the user to identify the active conditional branch and owning Trainer construction.",
         "Confirmed Hugging Face Trainer ownership routes to nvflare-convert-huggingface.",
         "The orientation step remains read-only and does not route the unresolved request to nvflare-convert-pytorch."
       ],

--- a/nvflare/tool/agent/inspection/source.py
+++ b/nvflare/tool/agent/inspection/source.py
@@ -40,6 +40,13 @@ CLASS_BODY_COMPOUND_NODES = (ast.If, ast.While, ast.For, ast.AsyncFor, ast.With,
 EXCLUDED_EXPRESSION_SCOPES = (ast.Lambda, ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
 
 
+@dataclass(frozen=True)
+class _RecognizedReceiver:
+    framework: str
+    kind: str
+    dependencies: tuple[Dependency, ...]
+
+
 @dataclass
 class Bindings:
     path: str = "."
@@ -47,6 +54,7 @@ class Bindings:
     findings: list[dict] = field(default_factory=list)
     symbols: dict[str, str] = field(default_factory=dict)
     subclasses: dict[str, str] = field(default_factory=dict)
+    factories: dict[str, _RecognizedReceiver] = field(default_factory=dict)
     instances: dict[str, str] = field(default_factory=dict)
     optimizers: set[str] = field(default_factory=set)
     scalers: set[str] = field(default_factory=set)
@@ -67,6 +75,7 @@ class Bindings:
             findings=self.findings,
             symbols=dict(self.symbols),
             subclasses=dict(self.subclasses),
+            factories=dict(self.factories),
             client_names_seen=dict(self.client_names_seen),
             uncertain_client_names=set(self.uncertain_client_names),
             inherited_names=set(self.symbols) | set(self.subclasses),
@@ -93,6 +102,7 @@ class Bindings:
             findings=self.findings,
             symbols=dict(self.symbols),
             subclasses=dict(self.subclasses),
+            factories=dict(self.factories),
             instances=dict(self.instances),
             optimizers=set(self.optimizers),
             scalers=set(self.scalers),
@@ -112,6 +122,7 @@ class Bindings:
             self.outer_symbol_kills.add(name)
         self.symbols.pop(name, None)
         self.subclasses.pop(name, None)
+        self.factories.pop(name, None)
         self.instances.pop(name, None)
         self.optimizers.discard(name)
         self.scalers.discard(name)
@@ -231,6 +242,10 @@ def _analyze_body(
             )
             if statement.decorator_list or child_yield:
                 _move_owners_to_unresolved(facts, owner_start)
+            elif function_depth == 0 and isinstance(statement, ast.FunctionDef):
+                factory = _factory_result(statement, child)
+                if factory:
+                    bindings.factories[statement.name] = factory
         elif isinstance(statement, (ast.Global, ast.Nonlocal)):
             bindings.outer_names.update(statement.names)
         elif isinstance(statement, ast.ClassDef):
@@ -537,34 +552,32 @@ def _record_assignment(
     names = set().union(*(_target_names(target) for target in targets)) if targets else set()
     simple_name = targets[0].id if len(targets) == 1 and isinstance(targets[0], ast.Name) else None
     _record_secret_assignment(node, names, bindings)
-    canonical = (
-        _resolve_expr(value.func, bindings, allow_outer=bool(names & bindings.outer_names))
-        if isinstance(value, ast.Call)
-        else None
-    )
-    dependencies = _inherited_dependencies(value.func, bindings) if isinstance(value, ast.Call) else ()
+    receiver = None
+    factory = None
+    if isinstance(value, ast.Call):
+        receiver = _classify_constructor(
+            value.func,
+            bindings,
+            allow_outer=bool(names & bindings.outer_names),
+        )
+        factory_name = value.func.id if isinstance(value.func, ast.Name) else None
+        factory = bindings.factories.get(factory_name or "")
+        if factory and factory_name:
+            receiver = _RecognizedReceiver(
+                framework=factory.framework,
+                kind=factory.kind,
+                dependencies=tuple(sorted({*factory.dependencies, (factory_name, ())})),
+            )
     contains_yield = _record_expression_calls(value, bindings, facts, bound_names) if value is not None else False
     _invalidate(bindings, names, remember_framework=False)
     bound_names.update(names)
-    if not isinstance(value, ast.Call) or simple_name is None:
+    if simple_name is None or receiver is None:
         return contains_yield
-    framework = bindings.subclasses.get(canonical or "") or _trainer_framework(canonical)
-    optimizer = _is_optimizer(canonical)
-    scaler = _is_scaler(canonical)
     if simple_name in bindings.outer_names:
-        candidate = framework or ("pytorch" if optimizer or scaler else None)
-        if candidate:
-            facts.unresolved.append((candidate, node.lineno, dependencies))
+        if factory is None:
+            facts.unresolved.append((receiver.framework, node.lineno, receiver.dependencies))
         return contains_yield
-    if framework:
-        bindings.instances[simple_name] = framework
-        bindings.dependencies[simple_name] = dependencies
-    elif optimizer:
-        bindings.optimizers.add(simple_name)
-        bindings.dependencies[simple_name] = dependencies
-    elif scaler:
-        bindings.scalers.add(simple_name)
-        bindings.dependencies[simple_name] = dependencies
+    _bind_receiver(simple_name, receiver, bindings)
     return contains_yield
 
 
@@ -635,7 +648,9 @@ def _invalidate(bindings: Bindings, names: set[str], *, remember_framework: bool
     for name in names:
         if remember_framework:
             canonical = bindings.symbols.get(name)
+            factory = bindings.factories.get(name)
             framework = bindings.instances.get(name) or bindings.subclasses.get(name)
+            framework = framework or (factory.framework if factory else None)
             framework = framework or _trainer_framework(canonical) or _framework_family(canonical)
             if (
                 name in bindings.optimizers
@@ -780,6 +795,7 @@ def _merge_framework_context(target: Bindings, source: Bindings) -> None:
     frameworks.update(filter(None, (_trainer_framework(value) for value in source.symbols.values())))
     frameworks.update(filter(None, (_framework_family(value) for value in source.symbols.values())))
     frameworks.update(source.subclasses.values())
+    frameworks.update(factory.framework for factory in source.factories.values())
     frameworks.update(source.instances.values())
     if source.optimizers or source.scalers:
         frameworks.add("pytorch")
@@ -846,6 +862,90 @@ def _record_parameter_bindings(arguments: ast.arguments, bindings: Bindings) -> 
             bindings.optimizers.add(parameter.arg)
 
 
+def _factory_result(function: ast.FunctionDef, bindings: Bindings) -> _RecognizedReceiver | None:
+    if not function.body or not isinstance(function.body[-1], ast.Return):
+        return None
+    returns = _scope_returns(function.body)
+    if len(returns) != 1 or returns[0] is not function.body[-1]:
+        return None
+    value = returns[0].value
+    receiver = None
+    if isinstance(value, ast.Call):
+        receiver = _classify_constructor(value.func, bindings)
+    elif isinstance(value, ast.Name):
+        receiver = _classify_bound_receiver(value.id, bindings)
+    chained_factory = receiver and any(
+        not suffix and name in bindings.factories for name, suffix in receiver.dependencies
+    )
+    if (
+        receiver
+        and not chained_factory
+        and all(
+            _dependency_framework(name, suffix, bindings) == receiver.framework
+            for name, suffix in receiver.dependencies
+        )
+    ):
+        return receiver
+    return None
+
+
+def _classify_constructor(
+    constructor: ast.AST, bindings: Bindings, *, allow_outer: bool = False
+) -> _RecognizedReceiver | None:
+    canonical = _resolve_expr(constructor, bindings, allow_outer=allow_outer)
+    framework = bindings.subclasses.get(canonical or "") or _trainer_framework(canonical)
+    kind = "trainer"
+    if _is_optimizer(canonical):
+        framework, kind = "pytorch", "optimizer"
+    elif _is_scaler(canonical):
+        framework, kind = "pytorch", "scaler"
+    if not framework:
+        return None
+    return _RecognizedReceiver(
+        framework=framework,
+        kind=kind,
+        dependencies=_inherited_dependencies(constructor, bindings),
+    )
+
+
+def _classify_bound_receiver(name: str, bindings: Bindings) -> _RecognizedReceiver | None:
+    framework = bindings.instances.get(name)
+    kind = "trainer"
+    if name in bindings.optimizers:
+        framework, kind = "pytorch", "optimizer"
+    elif name in bindings.scalers:
+        framework, kind = "pytorch", "scaler"
+    if not framework:
+        return None
+    return _RecognizedReceiver(
+        framework=framework,
+        kind=kind,
+        dependencies=bindings.dependencies.get(name, ()),
+    )
+
+
+def _bind_receiver(name: str, receiver: _RecognizedReceiver, bindings: Bindings) -> None:
+    if receiver.kind == "trainer":
+        bindings.instances[name] = receiver.framework
+    elif receiver.kind == "optimizer":
+        bindings.optimizers.add(name)
+    else:
+        bindings.scalers.add(name)
+    bindings.dependencies[name] = receiver.dependencies
+
+
+def _scope_returns(body: list[ast.stmt]) -> list[ast.Return]:
+    returns: list[ast.Return] = []
+    pending: list[ast.AST] = list(reversed(body))
+    while pending:
+        node = pending.pop()
+        if isinstance(node, ast.Return):
+            returns.append(node)
+        elif not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            pending.extend(reversed(list(ast.iter_child_nodes(node))))
+    return returns
+
+
 def _inherited_dependencies(node: ast.AST, bindings: Bindings) -> tuple[Dependency, ...]:
     root = _root_name(node)
     suffix = _attribute_suffix(node)
@@ -854,7 +954,7 @@ def _inherited_dependencies(node: ast.AST, bindings: Bindings) -> tuple[Dependen
 
 
 def _shadowed_names(parent: Bindings, child: Bindings, bound_names: set[str]) -> set[str]:
-    inherited = set(parent.symbols) | set(parent.subclasses)
+    inherited = set(parent.symbols) | set(parent.subclasses) | set(parent.factories)
     return (bound_names - child.outer_names) & inherited
 
 
@@ -898,6 +998,8 @@ def _constructor_framework(node: ast.AST, bindings: Bindings) -> str | None:
 
 
 def _dependency_framework(name: str, suffix: tuple[str, ...], bindings: Bindings) -> str | None:
+    if not suffix and name in bindings.factories:
+        return bindings.factories[name].framework
     if not suffix and name in bindings.subclasses:
         return bindings.subclasses[name]
     canonical = bindings.symbols.get(name)

--- a/tests/unit_test/tool/agent/agent_inspector_test.py
+++ b/tests/unit_test/tool/agent/agent_inspector_test.py
@@ -725,14 +725,8 @@ def test_pr4955_multiple_independent_jobs_fail_closed(tmp_path):
     }
 
 
-@pytest.mark.parametrize(
-    "source",
-    [
-        "from transformers import Trainer\ndef make():\n    return Trainer()\nt = make()\nt.train()\n",
-        "from transformers import Trainer\nt = Trainer()\ndef run():\n    t.train()\n",
-    ],
-)
-def test_factory_and_cross_scope_owner_attempts_are_unresolved(tmp_path, source):
+def test_cross_scope_owner_attempt_is_unresolved(tmp_path):
+    source = "from transformers import Trainer\nt = Trainer()\ndef run():\n    t.train()\n"
     write_project(tmp_path, {"train.py": source})
 
     result = inspect_source(tmp_path)
@@ -740,6 +734,448 @@ def test_factory_and_cross_scope_owner_attempts_are_unresolved(tmp_path, source)
     assert result["ownership"]["state"] == "unresolved"
     assert result["ownership"]["reason"] == "unsupported_indirection"
     assert result["routing"]["recommended_skill"] == "nvflare-orient"
+
+
+def test_single_top_level_hf_factory_routes_to_converter(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer, TrainerCallback, TrainingArguments\n"
+            "class LifecycleAuditCallback(TrainerCallback):\n"
+            "    def on_train_begin(self, args, state, control, **kwargs):\n"
+            "        self.record('train_begin')\n"
+            "def build_trainer(*, output_dir, max_steps) -> Trainer:\n"
+            "    args = TrainingArguments(output_dir=output_dir, max_steps=max_steps)\n"
+            "    return Trainer(model=model, args=args, train_dataset=dataset, "
+            "callbacks=[LifecycleAuditCallback()])\n"
+            "def main():\n"
+            "    trainer = build_trainer(output_dir='out', max_steps=2)\n"
+            "    evaluation = trainer.evaluate()\n"
+            "    result = trainer.train()\n"
+            "main()\n"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "clear"
+    assert result["ownership"]["framework"] == "huggingface"
+    assert result["routing"] == {"recommended_skill": "nvflare-convert-huggingface", "reason": "clear_owner"}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from peft import PeftModel\n"
+        "from trl import SFTTrainer\n"
+        "def make():\n"
+        "    trainer = SFTTrainer()\n"
+        "    if not isinstance(trainer.model, PeftModel):\n"
+        "        raise RuntimeError('expected PeftModel')\n"
+        "    trainer.add_callback(callback)\n"
+        "    return trainer\n"
+        "trainer = make()\ntrainer.train()\n",
+        "from transformers import Trainer\n"
+        "def make(world_size):\n"
+        "    if world_size > 1:\n"
+        "        setattr(arguments, 'device', device)\n"
+        "    return Trainer()\n"
+        "trainer = make()\ntrainer.train()\n",
+    ],
+)
+def test_supported_hf_factory_return_forms(tmp_path, source):
+    write_project(tmp_path, {"train.py": source})
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["framework"] == "huggingface"
+    assert result["routing"]["recommended_skill"] == "nvflare-convert-huggingface"
+
+
+@pytest.mark.parametrize(
+    ("source", "framework", "skill"),
+    [
+        (
+            "import lightning as L\n"
+            "def build_trainer():\n"
+            "    trainer = L.Trainer()\n"
+            "    return trainer\n"
+            "trainer = build_trainer()\ntrainer.fit(model)\n",
+            "lightning",
+            "nvflare-convert-lightning",
+        ),
+        (
+            "import torch\n"
+            "def build_optimizer(params):\n"
+            "    return torch.optim.AdamW(params)\n"
+            "optimizer = build_optimizer(params)\noptimizer.step()\n",
+            "pytorch",
+            "nvflare-convert-pytorch",
+        ),
+        (
+            "from torch.amp import GradScaler\n"
+            "from torch.optim import SGD\n"
+            "def build_scaler():\n"
+            "    scaler = GradScaler()\n"
+            "    return scaler\n"
+            "optimizer = SGD(params)\n"
+            "scaler = build_scaler()\nscaler.step(optimizer)\n",
+            "pytorch",
+            "nvflare-convert-pytorch",
+        ),
+        (
+            "import transformers as hf\n"
+            "def build_trainer():\n"
+            "    return hf.Trainer()\n"
+            "trainer = build_trainer()\ntrainer.train()\n",
+            "huggingface",
+            "nvflare-convert-huggingface",
+        ),
+        (
+            "from transformers import Trainer as HFTrainer\n"
+            "def build_trainer():\n"
+            "    return HFTrainer()\n"
+            "trainer = build_trainer()\ntrainer.train()\n",
+            "huggingface",
+            "nvflare-convert-huggingface",
+        ),
+        (
+            "import trl as trl_api\n"
+            "def build_trainer():\n"
+            "    return trl_api.SFTTrainer()\n"
+            "trainer = build_trainer()\ntrainer.train()\n",
+            "huggingface",
+            "nvflare-convert-huggingface",
+        ),
+        (
+            "from lightning.pytorch import Trainer as PLTrainer\n"
+            "def build_trainer():\n"
+            "    return PLTrainer()\n"
+            "trainer = build_trainer()\ntrainer.fit(model)\n",
+            "lightning",
+            "nvflare-convert-lightning",
+        ),
+        (
+            "import pytorch_lightning as pl\n"
+            "def build_trainer():\n"
+            "    return pl.Trainer()\n"
+            "trainer = build_trainer()\ntrainer.fit(model)\n",
+            "lightning",
+            "nvflare-convert-lightning",
+        ),
+        (
+            "from torch import optim as opt\n"
+            "def build_optimizer(params):\n"
+            "    return opt.AdamW(params)\n"
+            "optimizer = build_optimizer(params)\noptimizer.step()\n",
+            "pytorch",
+            "nvflare-convert-pytorch",
+        ),
+        (
+            "from torch.optim import SGD as Optimizer\n"
+            "def build_optimizer(params):\n"
+            "    return Optimizer(params)\n"
+            "optimizer = build_optimizer(params)\noptimizer.step()\n",
+            "pytorch",
+            "nvflare-convert-pytorch",
+        ),
+    ],
+)
+def test_single_top_level_factory_preserves_framework_routing(tmp_path, source, framework, skill):
+    write_project(tmp_path, {"train.py": source})
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "clear"
+    assert result["ownership"]["framework"] == framework
+    assert result["routing"] == {"recommended_skill": skill, "reason": "clear_owner"}
+
+
+@pytest.mark.parametrize(
+    ("direct_source", "factory_source", "framework", "skill"),
+    [
+        (
+            "from transformers import Trainer\ntrainer = Trainer()\ntrainer.train()\n",
+            "from transformers import Trainer\n"
+            "def make():\n    return Trainer()\n"
+            "trainer = make()\ntrainer.train()\n",
+            "huggingface",
+            "nvflare-convert-huggingface",
+        ),
+        (
+            "import lightning as L\ntrainer = L.Trainer()\ntrainer.fit(model)\n",
+            "import lightning as L\n" "def make():\n    return L.Trainer()\n" "trainer = make()\ntrainer.fit(model)\n",
+            "lightning",
+            "nvflare-convert-lightning",
+        ),
+        (
+            "from torch.optim import Adam\noptimizer = Adam(params)\noptimizer.step()\n",
+            "from torch.optim import Adam\n"
+            "def make(params):\n    return Adam(params)\n"
+            "optimizer = make(params)\noptimizer.step()\n",
+            "pytorch",
+            "nvflare-convert-pytorch",
+        ),
+    ],
+)
+def test_factory_and_direct_constructor_have_same_route(tmp_path, direct_source, factory_source, framework, skill):
+    direct = tmp_path / "direct"
+    factory = tmp_path / "factory"
+    write_project(direct, {"train.py": direct_source})
+    write_project(factory, {"train.py": factory_source})
+
+    direct_result = inspect_source(direct)
+    factory_result = inspect_source(factory)
+
+    expected = {"recommended_skill": skill, "reason": "clear_owner"}
+    assert direct_result["ownership"]["framework"] == factory_result["ownership"]["framework"] == framework
+    assert direct_result["routing"] == factory_result["routing"] == expected
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from transformers import Trainer\n" "def make():\n    return Trainer()\n" "trainer = make()\n",
+        "from transformers import Trainer\n"
+        "import lightning as L\n"
+        "from torch.optim import SGD\n"
+        "def make_hf():\n    return Trainer()\n"
+        "def make_lightning():\n    return L.Trainer()\n"
+        "def make_optimizer():\n    return SGD(params)\n",
+    ],
+)
+def test_recognized_factories_without_lifecycle_do_not_route(tmp_path, source):
+    write_project(tmp_path, {"train.py": source})
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "none"
+    assert result["routing"] == {"recommended_skill": None, "reason": "no_route"}
+
+
+def test_cross_scope_factory_assignment_without_lifecycle_does_not_route(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer\n"
+            "def make():\n    return Trainer()\n"
+            "def setup():\n    global trainer\n    trainer = make()\n"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "none"
+    assert result["routing"] == {"recommended_skill": None, "reason": "no_route"}
+
+
+@pytest.mark.parametrize(
+    "lifecycle_and_rebind",
+    [
+        "make = replacement\ntrainer.train()\n",
+        "trainer.train()\nmake = replacement\n",
+    ],
+)
+def test_factory_symbol_rebind_invalidates_dependent_lifecycle(tmp_path, lifecycle_and_rebind):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer\n"
+            "def make():\n    return Trainer()\n"
+            "trainer = make()\n"
+            f"{lifecycle_and_rebind}"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "none"
+    assert result["routing"] == {"recommended_skill": None, "reason": "no_route"}
+
+
+def test_factory_constructor_rebound_after_definition_invalidates_owner(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer\n"
+            "def make():\n    return Trainer()\n"
+            "Trainer = replacement\n"
+            "trainer = make()\ntrainer.train()\n"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "none"
+    assert result["routing"] == {"recommended_skill": None, "reason": "no_route"}
+
+
+@pytest.mark.parametrize(
+    ("lifecycle_and_rebind", "state", "skill"),
+    [
+        ("trainer = replacement\ntrainer.train()\n", "unresolved", "nvflare-orient"),
+        ("trainer.train()\ntrainer = replacement\n", "clear", "nvflare-convert-huggingface"),
+    ],
+)
+def test_factory_receiver_rebind_respects_lifecycle_order(tmp_path, lifecycle_and_rebind, state, skill):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer\n"
+            "def make():\n    return Trainer()\n"
+            "trainer = make()\n"
+            f"{lifecycle_and_rebind}"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == state
+    assert result["routing"]["recommended_skill"] == skill
+
+
+@pytest.mark.parametrize(
+    ("files", "expected_state"),
+    [
+        (
+            {
+                "factory.py": "from transformers import Trainer\ndef make():\n    return Trainer()\n",
+                "train.py": "from factory import make\ntrainer = make()\ntrainer.train()\n",
+            },
+            "none",
+        ),
+        (
+            {
+                "train.py": "from transformers import Trainer\n"
+                "def main():\n"
+                "    def make():\n        return Trainer()\n"
+                "    trainer = make()\n"
+                "    trainer.train()\n"
+            },
+            "unresolved",
+        ),
+        (
+            {
+                "train.py": "from transformers import Trainer\n"
+                "def make():\n    return Trainer()\n"
+                "builder = make\ntrainer = builder()\ntrainer.train()\n"
+            },
+            "unresolved",
+        ),
+        (
+            {
+                "train.py": "from transformers import Trainer\n"
+                "def make():\n    return Trainer()\n"
+                "trainer = make()\nother = trainer\nother.train()\n"
+            },
+            "unresolved",
+        ),
+    ],
+)
+def test_factory_support_stays_top_level_same_file_without_value_aliasing(tmp_path, files, expected_state):
+    write_project(tmp_path, files)
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == expected_state
+    assert result["routing"]["recommended_skill"] != "nvflare-convert-huggingface"
+
+
+@pytest.mark.parametrize(
+    ("factory_body", "state", "skill"),
+    [
+        (
+            "    kwargs = {}\n"
+            "    if with_callback:\n        kwargs['callbacks'] = [callback]\n"
+            "    return Trainer(**kwargs)\n",
+            "clear",
+            "nvflare-convert-huggingface",
+        ),
+        (
+            "    if use_first:\n        return Trainer()\n" "    return Trainer()\n",
+            "unresolved",
+            "nvflare-orient",
+        ),
+    ],
+)
+def test_factory_conditional_setup_but_not_conditional_return_is_supported(tmp_path, factory_body, state, skill):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer\n"
+            "def make(with_callback=False, use_first=False):\n"
+            f"{factory_body}"
+            "trainer = make()\ntrainer.train()\n"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == state
+    assert result["routing"]["recommended_skill"] == skill
+
+
+def test_conflicting_resolved_factory_receivers_route_to_orient(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer as HFTrainer\n"
+            "from lightning.pytorch import Trainer as PLTrainer\n"
+            "def make_hf():\n    return HFTrainer()\n"
+            "def make_lightning():\n    return PLTrainer()\n"
+            "hf_trainer = make_hf()\n"
+            "lightning_trainer = make_lightning()\n"
+            "hf_trainer.train()\n"
+            "lightning_trainer.fit(model)\n"
+        },
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "conflicting"
+    assert result["ownership"]["candidate_frameworks"] == ["huggingface", "lightning"]
+    assert result["routing"] == {"recommended_skill": "nvflare-orient", "reason": "conflicting_owner"}
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        "@decorate\ndef make():\n    return Trainer()\n",
+        "def make(flag):\n    if flag:\n        return Trainer()\n    return object()\n",
+        "def inner():\n    return Trainer()\ndef make():\n    return inner()\n",
+        "def inner():\n    return Trainer()\n" "def make(flag):\n    trainer = inner()\n    return trainer\n",
+        "def make(flag):\n    trainer = Trainer()\n    Trainer = replacement\n    return trainer\n",
+        "import transformers as hf\n"
+        "def make(flag):\n    trainer = hf.Trainer()\n    hf = replacement\n    return trainer\n",
+    ],
+)
+def test_ambiguous_hf_factories_remain_unresolved(tmp_path, factory):
+    write_project(
+        tmp_path,
+        {"train.py": f"from transformers import Trainer\n{factory}trainer = make(flag)\ntrainer.train()\n"},
+    )
+
+    result = inspect_source(tmp_path)
+
+    assert result["ownership"]["state"] == "unresolved"
+    assert result["ownership"]["reason"] == "unsupported_indirection"
+    assert result["routing"]["recommended_skill"] == "nvflare-orient"
+
+
+def test_function_local_factory_shadowing_does_not_route_to_converter(tmp_path):
+    write_project(
+        tmp_path,
+        {
+            "train.py": "from transformers import Trainer\n"
+            "def make():\n    return Trainer()\n"
+            "def main():\n"
+            "    trainer = make()\n"
+            "    def make():\n        return object()\n"
+            "    trainer.train()\n"
+        },
+    )
+
+    assert inspect_source(tmp_path)["routing"]["recommended_skill"] != "nvflare-convert-huggingface"
 
 
 def test_incomplete_scan_fails_closed_before_converter(tmp_path):


### PR DESCRIPTION
## Summary

- Recognize bounded same-module factories that return a known training lifecycle receiver.
- Keep existing lifecycle calls as the sole ownership authority and fail closed for ambiguous forms.
- Add inspector and cross-framework delivery-eval coverage, including the four reported Hugging Face factory projects.

## Behavior

The inspector now supports one top-level, undecorated synchronous factory with one unconditional terminal return. The return may be a recognized constructor or an unchanged local receiver.

The implementation is framework-neutral for existing receiver types:

- Hugging Face `Trainer` and TRL `SFTTrainer`
- Lightning `Trainer`
- Supported PyTorch optimizers and `GradScaler`

Unsupported forms continue routing conservatively: cross-file, nested, decorated, async, generator, chained, conditional/multiple-return, value-alias, receiver-alias, tuple, attribute, and container propagation.

No public schema, routing policy, or skill instruction files changed. The runtime inspector change is net +102 LOC.

## Delivery coverage

- Hugging Face train-only Trainer factory
- Hugging Face evaluated Trainer factory with callback and accuracy metric
- Hugging Face PEFT SFTTrainer factory returning a configured local receiver
- Hugging Face distributed Trainer factory with conditional setup
- Lightning Trainer factory routed through the patched `fit` lifecycle
- PyTorch optimizer factory routed through the manual `step` lifecycle
- Updated the Orient factory case to use a genuinely unresolved conditional return

## Validation

- `./runtest.sh -s`
- `python -m pytest -q tests/unit_test/tool/agent` — 324 passed, 1 skipped
- `python -m pytest -q tests/unit_test/tool/agent_skill_checks` — 197 passed, 46 skipped
- All four Hugging Face fixtures route to `nvflare-convert-huggingface`
- The Lightning fixture routes to `nvflare-convert-lightning`
- The optimizer factory fixture routes to `nvflare-convert-pytorch`
- Compilation, JSON validation, skill lint, and `git diff --check` passed
