### PR TITLE
Correct runtime and CLI documentation inconsistencies

### DIFF
--- a/docs/flare_system_architecture.rst
+++ b/docs/flare_system_architecture.rst
@@ -114,8 +114,11 @@ Communication Mechanisms
   
 **Client API Backends**: ``ClientAPIExecutor`` selects the communication and
 lifecycle backend for ``in_process``, ``external_process``, or ``attach`` mode.
-Network Attach reuses the site's Client Parent listener; protected shared-file
-Attach uses a dedicated Client Job-owned listener.
+For network Attach, the external trainer connects to the site's existing Client
+Parent endpoint, which routes the Attach session to the per-job Client Job.
+Only protected shared-file Attach creates a separate listener: a job-specific
+FileDriver listener owned by the Client Job and secured by filesystem
+permissions.
 
 Deployment Modes
 ################

--- a/docs/flare_system_architecture.rst
+++ b/docs/flare_system_architecture.rst
@@ -114,7 +114,8 @@ Communication Mechanisms
   
 **Client API Backends**: ``ClientAPIExecutor`` selects the communication and
 lifecycle backend for ``in_process``, ``external_process``, or ``attach`` mode.
-Attach uses a dedicated CJ-owned listener rather than the CP-to-CJ connection.
+Network Attach reuses the site's Client Parent listener; protected shared-file
+Attach uses a dedicated Client Job-owned listener.
 
 Deployment Modes
 ################

--- a/docs/programming_guide/controllers/client_controlled_workflows.rst
+++ b/docs/programming_guide/controllers/client_controlled_workflows.rst
@@ -923,7 +923,7 @@ Server-Side Parameters
 
 **CrossSiteEvalServerController (if enabled):**
 
-- ``eval_task_timeout``: Timeout for evaluation tasks. **Default: 300 (CONFIG_TASK_TIMEOUT)**. **Suggested: 1200** for large models.
+- ``eval_task_timeout``: Timeout for evaluation tasks. **Default: 30**. **Suggested: 1200** for large models.
 
 Optional NVFlare Global Config
 ------------------------------

--- a/docs/programming_guide/fed_job_api.rst
+++ b/docs/programming_guide/fed_job_api.rst
@@ -190,7 +190,7 @@ ScriptRunner args:
 * ``script_args``: arguments appended to the end of script.
 * ``launch_external_process``: selects the ClientAPIExecutor backend: default in-process
   (``False``) or external-process (``True``).
-* ``command``: in the ex-process mode, command is prepended to the script (defaults to "python3").
+* ``command``: in external-process mode, command is prepended to the script (defaults to "python3 -u").
 * ``framework``: determines what :class:`FrameworkType<nvflare.job_config.script_runner.FrameworkType>` to use for the script.
 
 

--- a/docs/user_guide/admin_guide/security/identity_security.rst
+++ b/docs/user_guide/admin_guide/security/identity_security.rst
@@ -34,7 +34,16 @@ The security of the system comes from the PKI credentials in the Startup Kits. A
  
 .. note::
 
-    The provisioning tool tries to use the strongest cryptography suites possible when generating the PKI credentials. All of the certificates are compliant with the X.509 standard. All private keys are generated with a size of 2048-bits. The backend is openssl 1.1.1f, released on March 31, 2020, with no known CVE.  All certificates expire within 360 days.
+    The provisioning tools generate X.509 certificates with 2048-bit RSA
+    private keys. Certificate lifetime depends on the provisioning workflow
+    and configuration. Centralized ``nvflare provision`` defaults newly
+    created root and participant certificates to 360 days; participant
+    certificates may be shortened to the root CA's expiry, and
+    ``root_valid_days`` can change a new root's validity. Distributed
+    ``nvflare cert init`` defaults the root CA to 3650 days, while
+    ``nvflare cert approve`` defaults participant certificates to 1095 days.
+    The cryptographic backend is supplied by the installed ``cryptography``
+    runtime and is not fixed to one OpenSSL release.
  
 .. note::
 

--- a/docs/user_guide/admin_guide/security/identity_security.rst
+++ b/docs/user_guide/admin_guide/security/identity_security.rst
@@ -37,11 +37,14 @@ The security of the system comes from the PKI credentials in the Startup Kits. A
     The provisioning tools generate X.509 certificates with 2048-bit RSA
     private keys. Certificate lifetime depends on the provisioning workflow
     and configuration. Centralized ``nvflare provision`` defaults newly
-    created root and participant certificates to 360 days; participant
-    certificates may be shortened to the root CA's expiry, and
+    created root and participant certificates to 360 days, and
     ``root_valid_days`` can change a new root's validity. Distributed
     ``nvflare cert init`` defaults the root CA to 3650 days, while
     ``nvflare cert approve`` defaults participant certificates to 1095 days.
+    In both workflows, a participant certificate cannot outlive its signing
+    root CA. If the root has less validity remaining than the requested
+    participant lifetime, the participant certificate is shortened to expire
+    with the root.
     The cryptographic backend is supplied by the installed ``cryptography``
     runtime and is not fixed to one OpenSSL release.
  

--- a/docs/user_guide/nvflare_cli/recipe_command.rst
+++ b/docs/user_guide/nvflare_cli/recipe_command.rst
@@ -98,6 +98,9 @@ Algorithm values:
    * - ``fedavg_logistic_regression``
      - ``numpy``
      - ``nvflare recipe list --filter algorithm=fedavg_logistic_regression``
+   * - ``fedce``
+     - ``pytorch``
+     - ``nvflare recipe list --filter algorithm=fedce``
    * - ``fedeval``
      - ``pytorch``
      - ``nvflare recipe list --filter algorithm=fedeval``
@@ -144,6 +147,9 @@ Aggregation values:
    * - ``cluster_centers``
      - ``sklearn``
      - ``nvflare recipe list --filter framework=sklearn --filter aggregation=cluster_centers``
+   * - ``contribution_weighted_average``
+     - ``pytorch``
+     - ``nvflare recipe list --filter framework=pytorch --filter aggregation=contribution_weighted_average``
    * - ``server_optimizer``
      - ``pytorch``, ``tensorflow``
      - ``nvflare recipe list --filter aggregation=server_optimizer``

--- a/examples/tutorials/flare_api.ipynb
+++ b/examples/tutorials/flare_api.ipynb
@@ -105,7 +105,7 @@
     "import sys\n",
     "\n",
     "# Run export\n",
-    "os.system(\"cd ../hello-world/hello-numpy && python job.py --export_config\")\n",
+    "os.system(\"cd ../hello-world/hello-numpy && python job.py --export --export-dir /tmp/nvflare/jobs/job_config\")\n",
     "\n",
     "# Copy exported job to transfer directory\n",
     "transfer_dir = \"/tmp/nvflare/poc/example_project/prod_00/admin@nvidia.com/transfer/\"\n",

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.2_client_api_in_depth/client_api_in_depth.ipynb
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.2_client_api_in_depth/client_api_in_depth.ipynb
@@ -174,7 +174,7 @@
     "\n",
     "### Attach Client API\n",
     "\n",
-    "Use `ClientAPIExecutor(execution_mode=\"attach\")` only when another system starts and owns the trainer. Network Attach reuses the site's existing Client Parent (CP) listener; protected shared-file Attach uses a Client Job-owned listener. See the [Client API Attach guide](https://nvflare.readthedocs.io/en/main/programming_guide/execution_api_type/client_api_attach.html).\n",
+    "Use `ClientAPIExecutor(execution_mode=\"attach\")` only when another system starts and owns the trainer. For network Attach, the external trainer connects to the site's existing Client Parent (CP) endpoint, which routes the Attach session to the per-job Client Job (CJ). Only protected shared-file Attach creates a separate listener: a job-specific FileDriver listener owned by the CJ and secured by filesystem permissions. See the [Client API Attach guide](https://nvflare.readthedocs.io/en/main/programming_guide/execution_api_type/client_api_attach.html).\n",
     "\n",
     "\n",
     "## Client API Examples\n",

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.2_client_api_in_depth/client_api_in_depth.ipynb
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-2_develop_federated_learning_applications/02.2_client_api_in_depth/client_api_in_depth.ipynb
@@ -174,7 +174,7 @@
     "\n",
     "### Attach Client API\n",
     "\n",
-    "Use `ClientAPIExecutor(execution_mode=\"attach\")` only when another system starts and owns the trainer. The trainer initiates the connection to a dedicated listener owned by the Client Job. See the [Client API Attach guide](https://nvflare.readthedocs.io/en/main/programming_guide/execution_api_type/client_api_attach.html).\n",
+    "Use `ClientAPIExecutor(execution_mode=\"attach\")` only when another system starts and owns the trainer. Network Attach reuses the site's existing Client Parent (CP) listener; protected shared-file Attach uses a Client Job-owned listener. See the [Client API Attach guide](https://nvflare.readthedocs.io/en/main/programming_guide/execution_api_type/client_api_attach.html).\n",
     "\n",
     "\n",
     "## Client API Examples\n",


### PR DESCRIPTION
Aligns user-facing documentation with current NVFlare behavior.

### Description

This PR aligns user-facing documentation with current NVFlare behavior. It clarifies Client API Attach routing, corrects the cross-site evaluation timeout and ScriptRunner defaults, documents actual certificate-validity defaults, adds missing FedCE Recipe filters, and replaces the removed Recipe export option with the supported CLI flags.

There are no runtime code changes.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
