### PR TITLE
Fix TASK_READY heartbeat expiry during materialization

### DIFF
--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -854,15 +854,13 @@ class ExternalProcessBackend(CellBackendBase):
                     self._current_task = None
 
     def _send_task_ready(self, trainer: _TrainerSession, task_message: dict, abort_signal: Signal) -> Tuple[str, Any]:
-        """Send TASK_READY with native cancellation for abort and liveness failures."""
-        timeout = self._context.task_wait_timeout
+        """Send TASK_READY until reply, cancelling on abort, closure, process death, or deadline."""
+        max_timeout = self._context.task_wait_timeout
         transfer_waiters = []
+        started = time.monotonic()
 
         def _on_transaction_created(transaction):
             transfer_waiters.append(DownloadService.get_transfer_waiter(transaction.tx_id))
-
-        def _has_live_task_download():
-            return any(not waiter.done() for waiter in tuple(transfer_waiters))
 
         def _cancel_cause():
             if abort_signal.triggered or (self._context.launch_once and self._abort):
@@ -871,11 +869,8 @@ class ExternalProcessBackend(CellBackendBase):
                 return _SEND_CLOSED, None
             if not self._process_group_alive(trainer):
                 return _SEND_PROCESS_DEAD, None
-            # Transfer progress supersedes heartbeat expiry while materialization is active.
-            if not _has_live_task_download():
-                liveness_error = self._trainer_liveness_error(trainer)
-                if liveness_error:
-                    return _SEND_SESSION_DEAD, liveness_error
+            if max_timeout is not None and time.monotonic() - started >= max_timeout:
+                return _SEND_SESSION_DEAD, f"TASK_READY timed out after {max_timeout}s"
             return None
 
         cancel = _TaskReadyCancelSignal(_cancel_cause)
@@ -885,9 +880,8 @@ class ExternalProcessBackend(CellBackendBase):
                 topic=Topic.TASK_READY,
                 target=trainer.trainer_fqcn,
                 request=new_cell_message({}, task_message),
-                timeout=timeout,
+                timeout=None,
                 abort_signal=cancel,
-                progress_wait_cb=_has_live_task_download,
                 receiver_ids=(trainer.trainer_fqcn,),
                 fobs_ctx_props={
                     FOBSContextKey.STREAM_PROGRESS_CB: lambda **_kwargs: None,
@@ -910,6 +904,8 @@ class ExternalProcessBackend(CellBackendBase):
         if cause is not None:
             self._delete_task_transfers(transfer_waiters)
             return cause
+        if reply is not None and reply.get_header(MessageHeaderKey.RETURN_CODE) == CellReturnCode.OK:
+            trainer.touch_peer_activity()
         if self._check_task_accepted(reply) is not None:
             # A rejected task has no future consumer for its payload. Receiver
             # confirmation is asynchronous, so retire the source deterministically.

--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -897,7 +897,7 @@ class ExternalProcessBackend(CellBackendBase):
                 return cause
             raise
 
-        cause = cancel.value
+        cause = cancel.value if cancel.triggered else None
         if cancel.error is not None:
             self._delete_task_transfers(transfer_waiters)
             raise cancel.error

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -1151,10 +1151,9 @@ class TestHeartbeatAndOperationalLiveness:
         finally:
             backend.finalize(FLContext())
 
-    def test_live_task_payload_transaction_suppresses_heartbeat_expiry(self, env, monkeypatch):
+    def test_completed_task_payload_transaction_does_not_restore_heartbeat_expiry(self, env, monkeypatch):
         monkeypatch.setattr(ebp, "_RESULT_POLL_INTERVAL", 0.01)
-        transfer_settled = threading.Event()
-        waiter = SimpleNamespace(transaction_id="task-payload-tx", done=lambda: transfer_settled.is_set())
+        waiter = SimpleNamespace(transaction_id="task-payload-tx", done=lambda: True)
         get_transfer_waiter = MagicMock(return_value=waiter)
         monkeypatch.setattr(ebp.DownloadService, "get_transfer_waiter", get_transfer_waiter)
         backend, fl_ctx = _initialized_backend(
@@ -1170,17 +1169,14 @@ class TestHeartbeatAndOperationalLiveness:
                 tx_created = env.cell.sent_kwargs[-1]["fobs_ctx_props"][ebp.RESULT_UPLOAD_TX_CREATED_CB_CTX_KEY]
                 tx_created(SimpleNamespace(tx_id="task-payload-tx"))
                 time.sleep(0.1)  # longer than the heartbeat timeout
-                transfer_settled.set()
+                assert not env.cell.sent_kwargs[-1]["abort_signal"].triggered
                 payload = request.payload
-                env.cell.deliver(
-                    Topic.RESULT_READY,
-                    target,
-                    {
-                        MsgKey.SESSION_ID: payload[MsgKey.SESSION_ID],
-                        MsgKey.TASK_ID: payload[MsgKey.TASK_ID],
-                        MsgKey.RESULT: _result_shareable(),
-                    },
-                )
+                result_payload = {
+                    MsgKey.SESSION_ID: payload[MsgKey.SESSION_ID],
+                    MsgKey.TASK_ID: payload[MsgKey.TASK_ID],
+                    MsgKey.RESULT: _result_shareable(),
+                }
+                threading.Timer(0.02, env.cell.deliver, args=(Topic.RESULT_READY, target, result_payload)).start()
                 return _task_accepted_reply()
 
             env.cell.on_request = slow_materialization
@@ -1193,13 +1189,13 @@ class TestHeartbeatAndOperationalLiveness:
         finally:
             backend.finalize(FLContext())
 
-    def test_inline_task_ready_pending_is_bounded_by_heartbeat(self, env, monkeypatch):
+    def test_inline_task_ready_pending_is_bounded_by_task_wait_timeout(self, env, monkeypatch):
         monkeypatch.setattr(ebp, "_RESULT_POLL_INTERVAL", 0.01)
         backend, fl_ctx = _initialized_backend(
             env,
             heartbeat_interval=0.02,
             heartbeat_timeout=0.05,
-            task_wait_timeout=None,
+            task_wait_timeout=0.1,
             result_wait_timeout=None,
         )
         try:
@@ -1218,7 +1214,7 @@ class TestHeartbeatAndOperationalLiveness:
 
             assert result.get_return_code() == ReturnCode.EXECUTION_EXCEPTION
             assert elapsed < 0.5
-            assert "heartbeat timed out" in backend._abort_reason
+            assert "TASK_READY timed out after 0.1s" in backend._abort_reason
             assert "TASK_READY was pending" in backend._abort_reason
         finally:
             backend.finalize(FLContext())
@@ -1410,12 +1406,12 @@ class TestExecute:
 
         assert _is_stream_channel(CHANNEL) is True
 
-    def test_configured_task_wait_timeout_passes_through(self, env):
+    def test_task_wait_timeout_is_not_a_cell_idle_timeout(self, env):
         backend, fl_ctx = _initialized_backend(env, task_wait_timeout=7.5)
         try:
             _install_auto_result(env)
             assert backend.execute("train", Shareable(), fl_ctx, Signal()).get_return_code() == ReturnCode.OK
-            assert env.cell.sent[0][3] == 7.5
+            assert env.cell.sent[0][3] is None
         finally:
             backend.finalize(FLContext())
 

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -1189,7 +1189,7 @@ class TestHeartbeatAndOperationalLiveness:
         finally:
             backend.finalize(FLContext())
 
-    def test_inline_task_ready_pending_is_bounded_by_task_wait_timeout(self, env, monkeypatch):
+    def test_task_ready_late_reply_is_rejected_by_task_wait_timeout(self, env, monkeypatch):
         monkeypatch.setattr(ebp, "_RESULT_POLL_INTERVAL", 0.01)
         backend, fl_ctx = _initialized_backend(
             env,
@@ -1200,14 +1200,12 @@ class TestHeartbeatAndOperationalLiveness:
         )
         try:
 
-            def wedged_inline_request(topic, target, request):
+            def delayed_inline_reply(topic, target, request):
                 assert topic == Topic.TASK_READY
-                cancel = env.cell.sent_kwargs[-1]["abort_signal"]
-                while not cancel.triggered:
-                    time.sleep(0.005)
+                time.sleep(0.15)
                 return _task_accepted_reply()
 
-            env.cell.on_request = wedged_inline_request
+            env.cell.on_request = delayed_inline_reply
             start = time.monotonic()
             result = backend.execute("train", Shareable(), fl_ctx, Signal())
             elapsed = time.monotonic() - start


### PR DESCRIPTION
## Problem

During external-process task ingestion, `TASK_READY` does not return until the trainer has downloaded, decoded, materialized, and queued the task. The previous code ignored heartbeat expiry only while a download transfer waiter was active. Once the raw download completed, long model materialization could exceed `heartbeat_timeout` and make the controller falsely declare a healthy trainer dead.

## Fix

Treat the entire pending `TASK_READY` exchange as the liveness boundary:

- do not apply heartbeat expiry between sending `TASK_READY` and receiving the trainer reply
- continue to terminate immediately on user abort, backend close, or trainer process death
- enforce `task_wait_timeout`, when configured, as an absolute wall-clock deadline
- refresh peer activity when the trainer successfully replies, so result waiting starts with a fresh lease
- retain transfer waiters only for existing transaction cleanup

This deliberately adds no progress protocol, materialization state machine, converter callbacks, or phase-specific timeout handling.

## Accepted tradeoff

A live but wedged trainer is no longer detected by heartbeat while `TASK_READY` is pending. A finite `task_wait_timeout` bounds that case; `task_wait_timeout=None` is intentionally unbounded. The timeout reports a single `TASK_READY timed out` error rather than a materialization-phase stall diagnosis.

## Validation

- `.venv/bin/python -m pytest tests/unit_test/app_common/executors/external_process_backend_test.py -q` — 104 passed
- `./runtest.sh -s` — passed (black, isort, flake8, agent-skill-lint)
- `git diff --check` — passed

The regression uses an already-completed transfer waiter, waits longer than `heartbeat_timeout`, returns `TASK_ACCEPTED`, and delivers the result afterward.