### PR TITLE
Fail fast when streamed blobs exceed size limit

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -185,7 +185,13 @@ class Adapter:
         self.logger.debug(f"sending: {stream_req_id=}: {response.headers=}, target={origin}")
         try:
             reply_future = self.cell.send_blob(
-                CellChannel.RETURN_ONLY, f"{channel}:{topic}", origin, response, secure, optional
+                CellChannel.RETURN_ONLY,
+                f"{channel}:{topic}",
+                origin,
+                response,
+                secure,
+                optional,
+                reliable=True,
             )
         except BlobSizeError as ex:
             if _is_server_job_cell(self.my_info):

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -28,7 +28,7 @@ from nvflare.fuel.f3.cellnet.utils import decode_payload, encode_payload, make_r
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.stream_cell import StreamCell
 from nvflare.fuel.f3.streaming.stream_const import StreamHeaderKey
-from nvflare.fuel.f3.streaming.stream_types import StreamFuture
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, StreamFuture
 from nvflare.fuel.utils.fobs import FOBSContextKey
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.fuel.utils.waiter_utils import WaiterRC, conditional_wait
@@ -167,9 +167,18 @@ class Adapter:
 
         encode_payload(response, StreamHeaderKey.PAYLOAD_ENCODING, fobs_ctx=self.cell.get_fobs_context())
         self.logger.debug(f"sending: {stream_req_id=}: {response.headers=}, target={origin}")
-        reply_future = self.cell.send_blob(
-            CellChannel.RETURN_ONLY, f"{channel}:{topic}", origin, response, secure, optional
-        )
+        try:
+            reply_future = self.cell.send_blob(
+                CellChannel.RETURN_ONLY, f"{channel}:{topic}", origin, response, secure, optional
+            )
+        except BlobSizeError as ex:
+            if _is_server_job_cell(self.my_info):
+                self.logger.critical(
+                    f"streamed response from server job cell {self.my_info.fqcn} is too large; "
+                    f"exiting job process to fail the job: {secure_format_exception(ex)}"
+                )
+                os._exit(1)
+            raise
         self.logger.debug(f"Done sending: {stream_req_id=}: {reply_future=}")
 
 

--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -146,6 +146,22 @@ class Adapter:
             response = make_reply(ReturnCode.PROCESS_EXCEPTION)
         self._send_response(response, *reply_args)
 
+    def _handle_reply_stream_done(self, reply_future):
+        error = reply_future.exception()
+        if not error:
+            return
+
+        if isinstance(error, BlobSizeError) and _is_server_job_cell(self.my_info):
+            self.logger.critical(
+                f"streamed response from server job cell {self.my_info.fqcn} was rejected as too large; "
+                f"exiting job process to fail the job: {secure_format_exception(error)}"
+            )
+            os._exit(1)
+
+        self.logger.error(
+            f"streamed response from {self.my_info.fqcn} failed asynchronously: {secure_format_exception(error)}"
+        )
+
     def _send_response(self, response, stream_req_id, req_id, channel, topic, origin, secure, optional):
         self.logger.debug(f"response available: {stream_req_id=}: on {channel=}, {topic=}")
         if not stream_req_id:
@@ -179,6 +195,7 @@ class Adapter:
                 )
                 os._exit(1)
             raise
+        reply_future.add_done_callback(self._handle_reply_stream_done, reply_future)
         self.logger.debug(f"Done sending: {stream_req_id=}: {reply_future=}")
 
 

--- a/nvflare/fuel/f3/cellnet/registry.py
+++ b/nvflare/fuel/f3/cellnet/registry.py
@@ -15,10 +15,11 @@ from typing import Any
 
 
 class Callback:
-    def __init__(self, cb, args, kwargs):
+    def __init__(self, cb, args, kwargs, preflight_cb=None):
         self.cb = cb
         self.args = args
         self.kwargs = kwargs
+        self.preflight_cb = preflight_cb
 
 
 class Registry:

--- a/nvflare/fuel/f3/streaming/blob_streamer.py
+++ b/nvflare/fuel/f3/streaming/blob_streamer.py
@@ -110,6 +110,12 @@ class BlobHandler:
         self.chunk_size = config.get_streaming_chunk_size(STREAM_CHUNK_SIZE)
         self.max_blob_size = config.get_streaming_max_blob_size()
 
+    def validate_size(self, headers: dict) -> Optional[BlobSizeError]:
+        size = (headers or {}).get(StreamHeaderKey.SIZE, 0)
+        if self.max_blob_size > 0 and isinstance(size, int) and size > self.max_blob_size:
+            return _make_blob_size_error(size, self.max_blob_size)
+        return None
+
     @staticmethod
     def _fail(stream: Stream, future: StreamFuture, error: StreamError):
         if hasattr(stream, "task"):
@@ -297,4 +303,11 @@ class BlobStreamer:
 
     def register_blob_callback(self, channel, topic, blob_cb: Callable, *args, **kwargs):
         handler = BlobHandler(blob_cb)
-        self.byte_receiver.register_callback(channel, topic, handler.handle_blob_cb, *args, **kwargs)
+        self.byte_receiver.register_callback(
+            channel,
+            topic,
+            handler.handle_blob_cb,
+            *args,
+            preflight_cb=handler.validate_size,
+            **kwargs,
+        )

--- a/nvflare/fuel/f3/streaming/blob_streamer.py
+++ b/nvflare/fuel/f3/streaming/blob_streamer.py
@@ -22,12 +22,20 @@ from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.streaming.byte_receiver import ByteReceiver
 from nvflare.fuel.f3.streaming.byte_streamer import STREAM_CHUNK_SIZE, STREAM_TYPE_BLOB, ByteStreamer
 from nvflare.fuel.f3.streaming.stream_const import EOS, StreamHeaderKey
-from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError, StreamFuture
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, Stream, StreamError, StreamFuture
 from nvflare.fuel.f3.streaming.stream_utils import FastBuffer, callback_thread_pool, stream_thread_pool, wrap_view
 from nvflare.fuel.utils.buffer_list import BufferList, ConsumableBufferList
 from nvflare.security.logging import secure_format_traceback
 
 log = logging.getLogger(__name__)
+
+
+def _make_blob_size_error(size: int, limit: int) -> BlobSizeError:
+    return BlobSizeError(
+        f"Blob size {size} exceeds configured limit {limit} (streaming_max_blob_size). "
+        "Increase NVFLARE_STREAMING_MAX_BLOB_SIZE (or streaming_max_blob_size), "
+        "shard the object, or use the object downloader."
+    )
 
 
 class BlobStream(Stream):
@@ -80,7 +88,7 @@ class BlobTask:
             raise StreamError(f"Declared blob size cannot be negative: {self.size}")
 
         if self.max_size > 0 and self.size > self.max_size:
-            raise StreamError(f"Declared blob size {self.size} exceeds configured limit {self.max_size}")
+            raise _make_blob_size_error(self.size, self.max_size)
 
         self.pre_allocated = self.size > 0 and not self.preserve_chunks
 
@@ -246,6 +254,7 @@ class BlobStreamer:
     def __init__(self, byte_streamer: ByteStreamer, byte_receiver: ByteReceiver):
         self.byte_streamer = byte_streamer
         self.byte_receiver = byte_receiver
+        self.max_blob_size = CommConfigurator().get_streaming_max_blob_size()
 
     def send(
         self,
@@ -264,6 +273,8 @@ class BlobStreamer:
             raise StreamError(f"BLOB is invalid type: {type(message.payload)}")
 
         blob_stream = BlobStream(message.payload, message.headers)
+        if self.max_blob_size > 0 and blob_stream.get_size() > self.max_blob_size:
+            raise _make_blob_size_error(blob_stream.get_size(), self.max_blob_size)
         return self.byte_streamer.send(
             channel,
             topic,

--- a/nvflare/fuel/f3/streaming/blob_streamer.py
+++ b/nvflare/fuel/f3/streaming/blob_streamer.py
@@ -117,6 +117,17 @@ class BlobHandler:
         else:
             future.set_exception(error)
 
+    def _fail_and_notify(
+        self,
+        stream: Stream,
+        future: StreamFuture,
+        error: StreamError,
+        args: tuple,
+        kwargs: dict,
+    ):
+        self._fail(stream, future, error)
+        callback_thread_pool.submit(self._run_blob_cb, future, stream, args, kwargs)
+
     def _store_chunk(self, blob_task: BlobTask, buf: BytesAlike, buf_size: int, thread_id: int) -> bool:
         length = len(buf)
         if blob_task.pre_allocated:
@@ -175,12 +186,12 @@ class BlobHandler:
             else:
                 blob_task = BlobTask(future, stream, self.max_blob_size)
         except StreamError as ex:
-            self._fail(stream, future, ex)
+            self._fail_and_notify(stream, future, ex, args, kwargs)
             return 0
         except MemoryError as ex:
             error = StreamError(f"Unable to allocate buffer for declared blob size {stream.get_size()}")
             error.__cause__ = ex
-            self._fail(stream, future, error)
+            self._fail_and_notify(stream, future, error, args, kwargs)
             return 0
 
         stream_thread_pool.submit(self._read_stream, blob_task)
@@ -254,7 +265,6 @@ class BlobStreamer:
     def __init__(self, byte_streamer: ByteStreamer, byte_receiver: ByteReceiver):
         self.byte_streamer = byte_streamer
         self.byte_receiver = byte_receiver
-        self.max_blob_size = CommConfigurator().get_streaming_max_blob_size()
 
     def send(
         self,
@@ -273,8 +283,6 @@ class BlobStreamer:
             raise StreamError(f"BLOB is invalid type: {type(message.payload)}")
 
         blob_stream = BlobStream(message.payload, message.headers)
-        if self.max_blob_size > 0 and blob_stream.get_size() > self.max_blob_size:
-            raise _make_blob_size_error(blob_stream.get_size(), self.max_blob_size)
         return self.byte_streamer.send(
             channel,
             topic,

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -136,6 +136,7 @@ class RxTask:
         self.failed = False
         self.error = None
         self.error_msg = None
+        self.error_type = None
         self.error_notified = False  # protected by ack_lock, like the ack state
         self.stop_lock = threading.RLock()
         self.cleanup_timer = None
@@ -214,7 +215,7 @@ class RxTask:
             completed = self.completed
         if failed:
             if self.reliable and error_msg:
-                self._send_error(error_msg)
+                self._send_error(error_msg, self.error_type)
             return False
 
         if completed:
@@ -452,6 +453,7 @@ class RxTask:
             # expects error/error_msg to be populated once failed is observed
             self.error = error
             self.error_msg = str(error)
+            self.error_type = type(error).__name__
             self.failed = True
             if self.reliable:
                 schedule_remove = True
@@ -476,14 +478,14 @@ class RxTask:
             self.waiter.set()
 
         if notify:
-            self._send_error(str(error))
+            self._send_error(str(error), type(error).__name__)
 
         if schedule_remove:
             self._schedule_remove_task()
         elif remove_now:
             self._remove_task()
 
-    def _send_error(self, error_msg: str):
+    def _send_error(self, error_msg: str, error_type: str = None):
         # Only a re-notification of an error that was already delivered is optional: the
         # first error notification is required, and a failed first attempt keeps retries
         # at ERROR (mirrors _send_ack). A retained failed task re-notifies on every
@@ -494,13 +496,14 @@ class RxTask:
         log_func = log.debug if already_notified else log.error
         message = Message()
 
-        message.add_headers(
-            {
-                StreamHeaderKey.STREAM_ID: self.sid,
-                StreamHeaderKey.DATA_TYPE: StreamDataType.ERROR,
-                StreamHeaderKey.ERROR_MSG: error_msg,
-            }
-        )
+        headers = {
+            StreamHeaderKey.STREAM_ID: self.sid,
+            StreamHeaderKey.DATA_TYPE: StreamDataType.ERROR,
+            StreamHeaderKey.ERROR_MSG: error_msg,
+        }
+        if error_type:
+            headers[StreamHeaderKey.ERROR_TYPE] = error_type
+        message.add_headers(headers)
         try:
             errors = self.cell.fire_and_forget(
                 STREAM_CHANNEL, STREAM_ACK_TOPIC, self.origin, message, optional=already_notified

--- a/nvflare/fuel/f3/streaming/byte_receiver.py
+++ b/nvflare/fuel/f3/streaming/byte_receiver.py
@@ -138,6 +138,7 @@ class RxTask:
         self.error_msg = None
         self.error_type = None
         self.error_notified = False  # protected by ack_lock, like the ack state
+        self.preflight_done = False
         self.stop_lock = threading.RLock()
         self.cleanup_timer = None
 
@@ -206,7 +207,7 @@ class RxTask:
 
             count += 1
 
-    def process_chunk(self, message: Message) -> bool:
+    def process_chunk(self, message: Message, preflight_cb: Optional[Callable] = None) -> bool:
         """Returns True if a new stream is created"""
 
         with self.stop_lock:
@@ -231,7 +232,26 @@ class RxTask:
         duplicate_start = False
         with self.lock:
             seq = message.get_header(StreamHeaderKey.SEQUENCE)
-            if seq == 0:
+            if preflight_cb and not self.preflight_done:
+                try:
+                    rejection = preflight_cb(message.headers)
+                except Exception as ex:
+                    log.error(f"{self} stream preflight callback failed: {_abbrev(ex)}")
+                    rejection = StreamError("stream rejected by receiver preflight")
+                self.preflight_done = True
+                if rejection is not None:
+                    if not isinstance(rejection, StreamError):
+                        rejection = StreamError(str(rejection))
+                    stop_error = rejection
+
+                    # A rejected stream still exposes a terminal receive future
+                    # for diagnostics, even when sequence 0 is delayed.
+                    if not self.stream_future:
+                        self._handle_new_stream(message)
+
+            if stop_error:
+                pass
+            elif seq == 0:
                 if self.stream_future:
                     log.warning(f"{self} Received duplicate chunk 0, ignored")
                     if self.reliable:
@@ -246,7 +266,7 @@ class RxTask:
                 # raised before admitting later chunks.
                 self._update_sender_flow_control(message)
 
-            if not duplicate_start:
+            if not duplicate_start and not stop_error:
                 should_stop, ack_to_send, stop_error = self._handle_incoming_data(seq, message)
 
         if ack_to_send:
@@ -257,7 +277,7 @@ class RxTask:
         elif should_stop:
             self.stop()
 
-        return new_stream
+        return new_stream and not stop_error
 
     def _handle_new_stream(self, message: Message):
         self.channel = message.get_header(StreamHeaderKey.CHANNEL)
@@ -698,11 +718,21 @@ class ByteReceiver:
         self.cell.register_request_cb(channel=STREAM_CHANNEL, topic=STREAM_DATA_TOPIC, cb=self._data_handler)
         self.registry = Registry()
 
-    def register_callback(self, channel: str, topic: str, stream_cb: Callable, *args, **kwargs):
+    def register_callback(
+        self,
+        channel: str,
+        topic: str,
+        stream_cb: Callable,
+        *args,
+        preflight_cb: Optional[Callable] = None,
+        **kwargs,
+    ):
         if not callable(stream_cb):
             raise StreamError(f"specified stream_cb {type(stream_cb)} is not callable")
+        if preflight_cb is not None and not callable(preflight_cb):
+            raise StreamError(f"specified preflight_cb {type(preflight_cb)} is not callable")
 
-        self.registry.set(channel, topic, Callback(stream_cb, args, kwargs))
+        self.registry.set(channel, topic, Callback(stream_cb, args, kwargs, preflight_cb=preflight_cb))
 
     def _data_handler(self, message: Message):
 
@@ -710,10 +740,13 @@ class ByteReceiver:
         if not task:
             return
 
-        new_stream = task.process_chunk(message)
+        callback = self.registry.find(
+            message.get_header(StreamHeaderKey.CHANNEL),
+            message.get_header(StreamHeaderKey.TOPIC),
+        )
+        new_stream = task.process_chunk(message, preflight_cb=callback.preflight_cb if callback else None)
         if new_stream:
             # Invoke callback
-            callback = self.registry.find(task.channel, task.topic)
             if not callback:
                 task.stop(StreamError(f"{task} No callback is registered for {task.channel}/{task.topic}"))
                 return

--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -34,7 +34,7 @@ from nvflare.fuel.f3.streaming.stream_const import (
     StreamDataType,
     StreamHeaderKey,
 )
-from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError, StreamFuture, StreamTaskSpec
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, Stream, StreamError, StreamFuture, StreamTaskSpec
 from nvflare.fuel.f3.streaming.stream_utils import (
     ONE_MB,
     CheckedExecutor,
@@ -517,7 +517,9 @@ class TxTask(StreamTaskSpec):
         error = message.get_header(StreamHeaderKey.ERROR_MSG, None)
 
         if error:
-            self.stop(StreamError(f"{self} Received error from {origin}: {error}"), notify=False)
+            error_type = message.get_header(StreamHeaderKey.ERROR_TYPE)
+            error_class = BlobSizeError if error_type == BlobSizeError.__name__ else StreamError
+            self.stop(error_class(f"{self} Received error from {origin}: {error}"), notify=False)
             return
 
         if self.reliable and ack_seq is None:

--- a/nvflare/fuel/f3/streaming/stream_const.py
+++ b/nvflare/fuel/f3/streaming/stream_const.py
@@ -52,6 +52,7 @@ class StreamHeaderKey:
     SEQUENCE = STREAM_PREFIX + "sq"
     OFFSET = STREAM_PREFIX + "os"
     ERROR_MSG = STREAM_PREFIX + "em"
+    ERROR_TYPE = STREAM_PREFIX + "et"
     CHANNEL = STREAM_PREFIX + "ch"
     FILE_NAME = STREAM_PREFIX + "fn"
     TOPIC = STREAM_PREFIX + "tp"

--- a/nvflare/fuel/f3/streaming/stream_types.py
+++ b/nvflare/fuel/f3/streaming/stream_types.py
@@ -27,6 +27,12 @@ class StreamError(Exception):
     pass
 
 
+class BlobSizeError(StreamError):
+    """A blob cannot be streamed because its declared size exceeds the configured limit."""
+
+    pass
+
+
 class StreamCancelled(StreamError):
     """Streaming is cancelled by sender"""
 

--- a/tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from nvflare.fuel.f3.cellnet import cell as cell_module
 from nvflare.fuel.f3.cellnet.cell import Adapter
+from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey
+from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.streaming.blob_streamer import BlobStream, BlobStreamer
+from nvflare.fuel.f3.streaming.byte_receiver import ByteReceiver, RxTask
+from nvflare.fuel.f3.streaming.byte_streamer import TxTask
+from nvflare.fuel.f3.streaming.stream_const import StreamDataType, StreamHeaderKey
 from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, StreamError, StreamFuture
 
 
@@ -85,3 +92,89 @@ def test_async_stream_error_does_not_exit_non_server_job(monkeypatch):
     reply_future.set_exception(StreamError("receiver stopped stream"))
 
     assert exit_calls == []
+
+
+def test_single_frame_receiver_rejection_fails_server_reply_and_receiver_future(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_blob_size", lambda self: 4)
+    monkeypatch.setattr(cell_module, "encode_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cell_module.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+
+    sender_cell = MagicMock()
+    tx_task = TxTask(
+        cell=sender_cell,
+        chunk_size=8,
+        channel=CellChannel.RETURN_ONLY,
+        topic="channel:topic",
+        target="client",
+        headers={},
+        stream=BlobStream(b"abcde", {}),
+        reliable=True,
+        secure=False,
+        optional=False,
+    )
+    send_kwargs = {}
+
+    def send_blob(*args, **kwargs):
+        send_kwargs.update(kwargs)
+        return tx_task.stream_future
+
+    adapter_cell = SimpleNamespace(send_blob=send_blob, get_fobs_context=lambda: {})
+    adapter = Adapter(None, SimpleNamespace(fqcn="server.job-id"), adapter_cell)
+    adapter._send_response(
+        Message(payload=b"abcde"), "stream-id", "request-id", "channel", "topic", "client", False, False
+    )
+    assert send_kwargs["reliable"] is True
+
+    receiver_cell = MagicMock()
+    receiver_cell.my_info.fqcn = "client"
+    error_messages = []
+
+    def return_error(_channel, _topic, _target, message, **_kwargs):
+        error_messages.append(message)
+        message.set_header(MessageHeaderKey.ORIGIN, "client")
+        tx_task.handle_ack(message)
+        return {}
+
+    receiver_cell.fire_and_forget.side_effect = return_error
+    byte_receiver = ByteReceiver(receiver_cell)
+    BlobStreamer(SimpleNamespace(), byte_receiver).register_blob_callback(
+        CellChannel.RETURN_ONLY,
+        "channel:topic",
+        lambda _future: pytest.fail("oversized blob callback must not run"),
+    )
+    incoming = Message(
+        {
+            MessageHeaderKey.ORIGIN: "server.job-id",
+            StreamHeaderKey.STREAM_ID: tx_task.sid,
+            StreamHeaderKey.CHANNEL: CellChannel.RETURN_ONLY,
+            StreamHeaderKey.TOPIC: "channel:topic",
+            StreamHeaderKey.SIZE: 5,
+            StreamHeaderKey.SEQUENCE: 0,
+            StreamHeaderKey.OFFSET: 0,
+            StreamHeaderKey.DATA_TYPE: StreamDataType.FINAL,
+            StreamHeaderKey.RELIABLE: True,
+            StreamHeaderKey.CHUNK_SIZE: 8,
+            StreamHeaderKey.WINDOW_SIZE: 8,
+        },
+        b"abcde",
+    )
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            byte_receiver._data_handler(incoming)
+
+        assert exc_info.value.code == 1
+        with RxTask.map_lock:
+            rx_task = RxTask.rx_task_map[("server.job-id", tx_task.sid)]
+        receiver_error = rx_task.stream_future.exception(timeout=0.1)
+        assert isinstance(receiver_error, BlobSizeError)
+        assert rx_task.failed is True
+        assert rx_task.completed is False
+        assert len(error_messages) == 1
+        assert error_messages[0].get_header(StreamHeaderKey.ERROR_TYPE) == BlobSizeError.__name__
+        assert isinstance(tx_task.stream_future.exception(timeout=0.1), BlobSizeError)
+    finally:
+        with RxTask.map_lock:
+            rx_task = RxTask.rx_task_map.pop(("server.job-id", tx_task.sid), None)
+        if rx_task and rx_task.cleanup_timer:
+            rx_task.cleanup_timer.cancel()

--- a/tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py
@@ -19,7 +19,7 @@ import pytest
 from nvflare.fuel.f3.cellnet import cell as cell_module
 from nvflare.fuel.f3.cellnet.cell import Adapter
 from nvflare.fuel.f3.message import Message
-from nvflare.fuel.f3.streaming.stream_types import BlobSizeError
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, StreamError, StreamFuture
 
 
 def _oversized_response_cell():
@@ -27,6 +27,10 @@ def _oversized_response_cell():
         raise BlobSizeError("Blob size 5 exceeds configured limit 4 (streaming_max_blob_size)")
 
     return SimpleNamespace(send_blob=send_blob, get_fobs_context=lambda: {})
+
+
+def _async_response_cell(reply_future):
+    return SimpleNamespace(send_blob=lambda *args, **kwargs: reply_future, get_fobs_context=lambda: {})
 
 
 def test_oversized_server_job_response_exits_job_process(monkeypatch):
@@ -50,3 +54,34 @@ def test_oversized_non_server_job_response_propagates_error(monkeypatch):
         adapter._send_response(
             Message(payload=b"payload"), "stream-id", "request-id", "channel", "topic", "peer", False, False
         )
+
+
+def test_asymmetric_receiver_limit_exits_server_job_after_async_rejection(monkeypatch):
+    reply_future = StreamFuture(stream_id=1)
+    adapter = Adapter(None, SimpleNamespace(fqcn="server.job-id"), _async_response_cell(reply_future))
+    monkeypatch.setattr(cell_module, "encode_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cell_module.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+
+    adapter._send_response(
+        Message(payload=b"payload"), "stream-id", "request-id", "channel", "topic", "client", False, False
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        reply_future.set_exception(BlobSizeError("receiver limit 4 is smaller than response size 5"))
+
+    assert exc_info.value.code == 1
+
+
+def test_async_stream_error_does_not_exit_non_server_job(monkeypatch):
+    reply_future = StreamFuture(stream_id=2)
+    adapter = Adapter(None, SimpleNamespace(fqcn="site-1.job-id"), _async_response_cell(reply_future))
+    monkeypatch.setattr(cell_module, "encode_payload", lambda *args, **kwargs: None)
+    exit_calls = []
+    monkeypatch.setattr(cell_module.os, "_exit", exit_calls.append)
+
+    adapter._send_response(
+        Message(payload=b"payload"), "stream-id", "request-id", "channel", "topic", "peer", False, False
+    )
+    reply_future.set_exception(StreamError("receiver stopped stream"))
+
+    assert exit_calls == []

--- a/tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nvflare.fuel.f3.cellnet import cell as cell_module
+from nvflare.fuel.f3.cellnet.cell import Adapter
+from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError
+
+
+def _oversized_response_cell():
+    def send_blob(*args, **kwargs):
+        raise BlobSizeError("Blob size 5 exceeds configured limit 4 (streaming_max_blob_size)")
+
+    return SimpleNamespace(send_blob=send_blob, get_fobs_context=lambda: {})
+
+
+def test_oversized_server_job_response_exits_job_process(monkeypatch):
+    adapter = Adapter(None, SimpleNamespace(fqcn="server.job-id"), _oversized_response_cell())
+    monkeypatch.setattr(cell_module, "encode_payload", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cell_module.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as exc_info:
+        adapter._send_response(
+            Message(payload=b"payload"), "stream-id", "request-id", "channel", "topic", "client", False, False
+        )
+
+    assert exc_info.value.code == 1
+
+
+def test_oversized_non_server_job_response_propagates_error(monkeypatch):
+    adapter = Adapter(None, SimpleNamespace(fqcn="site-1.job-id"), _oversized_response_cell())
+    monkeypatch.setattr(cell_module, "encode_payload", lambda *args, **kwargs: None)
+
+    with pytest.raises(BlobSizeError, match=r"limit 4 \(streaming_max_blob_size\)"):
+        adapter._send_response(
+            Message(payload=b"payload"), "stream-id", "request-id", "channel", "topic", "peer", False, False
+        )

--- a/tests/unit_test/fuel/f3/streaming/blob_streamer_test.py
+++ b/tests/unit_test/fuel/f3/streaming/blob_streamer_test.py
@@ -170,18 +170,17 @@ def test_blob_handler_uses_dedicated_streaming_blob_limit(monkeypatch):
     assert handler.max_blob_size == 8
 
 
-def test_blob_streamer_rejects_oversized_blob_before_sending(monkeypatch):
+def test_blob_streamer_does_not_apply_receiver_limit_on_sender(monkeypatch):
     monkeypatch.setattr(CommConfigurator, "get_streaming_max_blob_size", lambda self: 4)
-    byte_streamer = SimpleNamespace(send=lambda *args, **kwargs: pytest.fail("oversized blob was sent"))
+    expected_future = StreamFuture(stream_id=18)
+    sent = []
+    byte_streamer = SimpleNamespace(send=lambda *args, **kwargs: sent.append((args, kwargs)) or expected_future)
     streamer = BlobStreamer(byte_streamer, SimpleNamespace())
 
-    with pytest.raises(BlobSizeError) as exc_info:
-        streamer.send("channel", "topic", "target", Message(payload=b"abcde"), False, False)
+    future = streamer.send("channel", "topic", "target", Message(payload=b"abcde"), False, False)
 
-    error = str(exc_info.value)
-    assert "limit 4 (streaming_max_blob_size)" in error
-    assert "NVFLARE_STREAMING_MAX_BLOB_SIZE" in error
-    assert "shard the object" in error
+    assert future is expected_future
+    assert len(sent) == 1
 
 
 def test_blob_streamer_allows_blob_at_exact_limit(monkeypatch):
@@ -196,8 +195,12 @@ def test_blob_streamer_allows_blob_at_exact_limit(monkeypatch):
 
 
 def test_handle_blob_cb_stops_task_on_declared_size_above_limit(monkeypatch):
+    import nvflare.fuel.f3.streaming.blob_streamer as blob_streamer_module
+
     monkeypatch.setattr(CommConfigurator, "get_streaming_max_blob_size", lambda self: 4)
-    handler = BlobHandler(lambda future: None)
+    monkeypatch.setattr(blob_streamer_module.callback_thread_pool, "submit", lambda fn, *args: fn(*args))
+    callback_errors = []
+    handler = BlobHandler(lambda callback_future: callback_errors.append(callback_future.exception(timeout=0.1)))
     future = StreamFuture(stream_id=7)
     stopped = {}
 
@@ -212,8 +215,10 @@ def test_handle_blob_cb_stops_task_on_declared_size_above_limit(monkeypatch):
 
     error = future.exception(timeout=0.1)
     assert isinstance(error, StreamError)
+    assert isinstance(error, BlobSizeError)
     assert "exceeds configured limit" in str(error)
     assert stopped["error"] is error
+    assert callback_errors == [error]
 
 
 def test_handle_blob_cb_stops_task_on_memory_error(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/blob_streamer_test.py
+++ b/tests/unit_test/fuel/f3/streaming/blob_streamer_test.py
@@ -18,9 +18,10 @@ import pytest
 
 from nvflare.fuel.f3.cellnet.defs import Encoding
 from nvflare.fuel.f3.comm_config import CommConfigurator
-from nvflare.fuel.f3.streaming.blob_streamer import BlobHandler, BlobTask
+from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.streaming.blob_streamer import BlobHandler, BlobStreamer, BlobTask
 from nvflare.fuel.f3.streaming.stream_const import StreamHeaderKey
-from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError, StreamFuture
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, Stream, StreamError, StreamFuture
 
 
 class _FakeStream(Stream):
@@ -167,6 +168,31 @@ def test_blob_handler_uses_dedicated_streaming_blob_limit(monkeypatch):
     handler = BlobHandler(lambda future: None)
 
     assert handler.max_blob_size == 8
+
+
+def test_blob_streamer_rejects_oversized_blob_before_sending(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_blob_size", lambda self: 4)
+    byte_streamer = SimpleNamespace(send=lambda *args, **kwargs: pytest.fail("oversized blob was sent"))
+    streamer = BlobStreamer(byte_streamer, SimpleNamespace())
+
+    with pytest.raises(BlobSizeError) as exc_info:
+        streamer.send("channel", "topic", "target", Message(payload=b"abcde"), False, False)
+
+    error = str(exc_info.value)
+    assert "limit 4 (streaming_max_blob_size)" in error
+    assert "NVFLARE_STREAMING_MAX_BLOB_SIZE" in error
+    assert "shard the object" in error
+
+
+def test_blob_streamer_allows_blob_at_exact_limit(monkeypatch):
+    monkeypatch.setattr(CommConfigurator, "get_streaming_max_blob_size", lambda self: 4)
+    expected_future = StreamFuture(stream_id=17)
+    byte_streamer = SimpleNamespace(send=lambda *args, **kwargs: expected_future)
+    streamer = BlobStreamer(byte_streamer, SimpleNamespace())
+
+    future = streamer.send("channel", "topic", "target", Message(payload=b"abcd"), False, False)
+
+    assert future is expected_future
 
 
 def test_handle_blob_cb_stops_task_on_declared_size_above_limit(monkeypatch):

--- a/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_receiver_test.py
@@ -32,7 +32,7 @@ from nvflare.fuel.f3.streaming.byte_receiver import (
 )
 from nvflare.fuel.f3.streaming.byte_streamer import TxTask
 from nvflare.fuel.f3.streaming.stream_const import STREAM_ACK_TOPIC, STREAM_CHANNEL, StreamDataType, StreamHeaderKey
-from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, Stream, StreamError
 
 MB = 1024**2
 
@@ -205,11 +205,13 @@ def test_stop_ignores_missing_stream_future():
     with RxTask.map_lock:
         RxTask.rx_task_map[(origin, sid)] = task
 
-    task.stop(StreamError("stream failed"), notify=True)
+    task.stop(BlobSizeError("stream failed"), notify=True)
 
     with RxTask.map_lock:
         assert (origin, sid) not in RxTask.rx_task_map
     assert len(fire_and_forget_calls) > 0
+    error_message = fire_and_forget_calls[0][3]
+    assert error_message.get_header(StreamHeaderKey.ERROR_TYPE) == BlobSizeError.__name__
 
 
 def test_rxstream_close_ignores_missing_stream_future():

--- a/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
@@ -24,7 +24,7 @@ from nvflare.fuel.f3.comm_config import CommConfigurator
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.streaming.byte_streamer import TxTask
 from nvflare.fuel.f3.streaming.stream_const import STREAM_CHANNEL, STREAM_DATA_TOPIC, StreamDataType, StreamHeaderKey
-from nvflare.fuel.f3.streaming.stream_types import Stream, StreamError
+from nvflare.fuel.f3.streaming.stream_types import BlobSizeError, Stream, StreamError
 
 
 class DummyStream(Stream):
@@ -103,6 +103,27 @@ class TestByteStreamerAckWatchdog:
             optional=False,
         )
         return task, cell
+
+    def test_receiver_blob_size_error_preserves_error_type(self, monkeypatch):
+        task, _ = self._make_task(
+            monkeypatch,
+            window_size=1,
+            ack_wait=0.5,
+            ack_progress_timeout=2.0,
+            ack_progress_check_interval=0.01,
+            chunks=[b"x"],
+        )
+        message = Message(
+            {
+                MessageHeaderKey.ORIGIN: "peer",
+                StreamHeaderKey.ERROR_MSG: "blob too large",
+                StreamHeaderKey.ERROR_TYPE: BlobSizeError.__name__,
+            }
+        )
+
+        task.handle_ack(message)
+
+        assert isinstance(task.stream_future.exception(timeout=0.1), BlobSizeError)
 
     def test_ack_progress_check_interval_is_clamped_to_prevent_busy_spin(self, monkeypatch):
         task, _ = self._make_task(


### PR DESCRIPTION
## What changed

- reject blobs that exceed `streaming_max_blob_size` on the sender before any frames are transmitted
- report an actionable `BlobSizeError` with configuration, sharding, and object-downloader guidance
- terminate an affected server job process when an oversized streamed response cannot be sent, allowing the job to fail instead of leaving clients polling indefinitely
- add boundary and server-job regression tests

## Root cause and impact

The existing size guard ran only on the receiver. When a single response exceeded the configured limit, the receiver stopped consuming it while the sender and surrounding job machinery did not receive a synchronous, job-level failure. The server job could therefore remain running indefinitely.

Validating the known blob size before streaming makes the error immediate and actionable, and the server-job response path now converts that fatal transport error into a job-process failure.

Jira: [FLARE-3037](https://jirasw.nvidia.com/browse/FLARE-3037)

## Validation

- `python -m pytest -q tests/unit_test/fuel/f3/streaming/blob_streamer_test.py tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py` (24 passed)
- streaming unit suite (380 passed)
- cellnet unit suite (214 passed)
- scoped Black, isort, flake8, and `git diff --check`

The repository-wide `./runtest.sh -s` reaches Black but is blocked by three unrelated generated `node_modules/.../flatted.py` files under the medical-devices example dashboard. All files changed by this PR pass the equivalent scoped checks.
