### PR TITLE
Bound permanent workspace archival retries

### DIFF
--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -17,7 +17,6 @@ import shutil
 import threading
 import time
 from dataclasses import dataclass
-from time import monotonic
 from typing import Dict, List, Tuple
 
 from nvflare.apis.client import Client
@@ -49,7 +48,7 @@ from nvflare.private.fed.utils.app_deployer import AppDeployer
 from nvflare.private.fed.utils.fed_utils import extract_participants, require_signed_jobs, set_message_security_data
 from nvflare.security.logging import secure_format_exception
 
-WORKSPACE_SAVE_RETRY_GRACE_TIME = 60.0
+WORKSPACE_SAVE_RETRY_GRACE_TIME = 60
 
 
 @dataclass
@@ -429,7 +428,7 @@ class JobRunner(FLComponent):
                                 try:
                                     self._save_workspace(completion_ctx)
                                 except Exception as e:
-                                    now = monotonic()
+                                    now = time.monotonic()
                                     if finished_state.workspace_save_started_at is None:
                                         finished_state.workspace_save_started_at = now
                                     if now - finished_state.workspace_save_started_at < WORKSPACE_SAVE_RETRY_GRACE_TIME:
@@ -445,8 +444,7 @@ class JobRunner(FLComponent):
                                         f"{WORKSPACE_SAVE_RETRY_GRACE_TIME} seconds; publishing terminal status without "
                                         f"archived artifacts: {secure_format_exception(e)}",
                                     )
-                                with self.lock:
-                                    finished_state.workspace_archival_complete = True
+                                finished_state.workspace_archival_complete = True
                             try:
                                 job_manager.set_status(job.job_id, status, completion_ctx)
                             except Exception as e:
@@ -545,11 +543,6 @@ class JobRunner(FLComponent):
                 shutil.rmtree(d)
             except FileNotFoundError:
                 self.log_warning(fl_ctx, f"Workspace archive source disappeared before cleanup for job {job_id}: {d}")
-            except OSError as e:
-                self.log_warning(
-                    fl_ctx,
-                    f"Failed to clean archived workspace source for job {job_id} ({d}): {secure_format_exception(e)}",
-                )
 
     def run(self, fl_ctx: FLContext):
         """Starts job runner."""

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -17,6 +17,7 @@ import shutil
 import threading
 import time
 from dataclasses import dataclass
+from time import monotonic
 from typing import Dict, List, Tuple
 
 from nvflare.apis.client import Client
@@ -48,11 +49,14 @@ from nvflare.private.fed.utils.app_deployer import AppDeployer
 from nvflare.private.fed.utils.fed_utils import extract_participants, require_signed_jobs, set_message_security_data
 from nvflare.security.logging import secure_format_exception
 
+WORKSPACE_SAVE_RETRY_GRACE_TIME = 60.0
+
 
 @dataclass
 class _FinishedJobState:
     status: RunStatus
-    workspace_saved: bool = False
+    workspace_archival_complete: bool = False
+    workspace_save_started_at: float | None = None
 
 
 def _send_to_clients(admin_server, client_sites: List[str], engine, message, timeout=None, optional=False):
@@ -421,17 +425,28 @@ class JobRunner(FLComponent):
                                 self._finished_job_states[job.job_id] = finished_state
                             status = finished_state.status
                             # Publish terminal status only after artifacts are ready for download.
-                            if not finished_state.workspace_saved:
+                            if not finished_state.workspace_archival_complete:
                                 try:
                                     self._save_workspace(completion_ctx)
-                                    with self.lock:
-                                        finished_state.workspace_saved = True
                                 except Exception as e:
-                                    self.log_exception(
+                                    now = monotonic()
+                                    if finished_state.workspace_save_started_at is None:
+                                        finished_state.workspace_save_started_at = now
+                                    if now - finished_state.workspace_save_started_at < WORKSPACE_SAVE_RETRY_GRACE_TIME:
+                                        self.log_exception(
+                                            completion_ctx,
+                                            f"Failed to save workspace for finished job ({job.job_id}): "
+                                            f"{secure_format_exception(e)}",
+                                        )
+                                        continue
+                                    self.log_error(
                                         completion_ctx,
-                                        f"Failed to save workspace for finished job ({job.job_id}): {secure_format_exception(e)}",
+                                        f"Workspace archival for finished job ({job.job_id}) kept failing for "
+                                        f"{WORKSPACE_SAVE_RETRY_GRACE_TIME} seconds; publishing terminal status without "
+                                        f"archived artifacts: {secure_format_exception(e)}",
                                     )
-                                    continue
+                                with self.lock:
+                                    finished_state.workspace_archival_complete = True
                             try:
                                 job_manager.set_status(job.job_id, status, completion_ctx)
                             except Exception as e:
@@ -502,26 +517,39 @@ class JobRunner(FLComponent):
         run_dir = workspace.get_run_dir(job_id)
         engine = fl_ctx.get_engine()
         job_manager = engine.get_component(SystemComponents.JOB_MANAGER)
-        ws_dirs = [run_dir]
-
         result_root = workspace.get_result_root(job_id)
-        if result_root not in ws_dirs:
-            ws_dirs.append(result_root)
-
         log_root = workspace.get_log_root(job_id)
-        if log_root not in ws_dirs:
-            ws_dirs.append(log_root)
-
         audit_root = workspace.get_audit_root(job_id)
-        if audit_root not in ws_dirs:
-            ws_dirs.append(audit_root)
+
+        ws_dirs = []
+        seen_paths = set()
+        for path in (run_dir, result_root, log_root, audit_root):
+            if path in seen_paths:
+                continue
+            seen_paths.add(path)
+            if not os.path.isdir(path):
+                self.log_warning(fl_ctx, f"Skipping unavailable workspace archive source for job {job_id}: {path}")
+                continue
+            ws_dirs.append(path)
+
+        if not ws_dirs:
+            self.log_warning(fl_ctx, f"No workspace archive sources are available for finished job {job_id}")
+            return
 
         location = job_manager.save_workspace(job_id, ws_dirs, fl_ctx)
         self.log_debug(fl_ctx, f"Workspace {ws_dirs} saved to {location}")
 
-        # remove all ws dirs
+        # Only remove sources after the complete set has been archived successfully.
         for d in ws_dirs:
-            shutil.rmtree(d)
+            try:
+                shutil.rmtree(d)
+            except FileNotFoundError:
+                self.log_warning(fl_ctx, f"Workspace archive source disappeared before cleanup for job {job_id}: {d}")
+            except OSError as e:
+                self.log_warning(
+                    fl_ctx,
+                    f"Failed to clean archived workspace source for job {job_id} ({d}): {secure_format_exception(e)}",
+                )
 
     def run(self, fl_ctx: FLContext):
         """Starts job runner."""

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -64,6 +64,28 @@ def _make_runner_inputs(num_clients=1):
     return runner, fl_ctx, engine, job, client_sites
 
 
+def _make_workspace_save_inputs(run_dir, result_root, log_root, audit_root):
+    runner = JobRunner(workspace_root="/tmp")
+    runner.log_debug = MagicMock()
+    runner.log_warning = MagicMock()
+
+    workspace = MagicMock()
+    workspace.get_run_dir.return_value = run_dir
+    workspace.get_result_root.return_value = result_root
+    workspace.get_log_root.return_value = log_root
+    workspace.get_audit_root.return_value = audit_root
+
+    job_manager = MagicMock()
+    engine = MagicMock()
+    engine.get_component.return_value = job_manager
+
+    fl_ctx = MagicMock()
+    fl_ctx.get_prop.return_value = "job-1"
+    fl_ctx.get_workspace.return_value = workspace
+    fl_ctx.get_engine.return_value = engine
+    return runner, fl_ctx, job_manager
+
+
 # ---------------------------------------------------------------------------
 # strict flag wiring
 # ---------------------------------------------------------------------------
@@ -233,6 +255,57 @@ def test_start_run_sets_job_clients_meta_before_start_client_job(mock_get_bool, 
     runner._start_run(job_id=job.job_id, job=job, client_sites=client_sites, fl_ctx=fl_ctx)
 
     assert seen_job_clients_meta["value"] == [{"name": "site-1"}, {"name": "site-2"}]
+
+
+def test_save_workspace_skips_duplicate_missing_sources(tmp_path):
+    missing = str(tmp_path / "missing")
+    runner, fl_ctx, job_manager = _make_workspace_save_inputs(missing, missing, missing, missing)
+
+    runner._save_workspace(fl_ctx)
+
+    job_manager.save_workspace.assert_not_called()
+    assert runner.log_warning.call_args_list == [
+        call(fl_ctx, f"Skipping unavailable workspace archive source for job job-1: {missing}"),
+        call(fl_ctx, "No workspace archive sources are available for finished job job-1"),
+    ]
+
+
+def test_save_workspace_archives_only_existing_deduplicated_sources(tmp_path):
+    run_dir = tmp_path / "run"
+    result_root = tmp_path / "result"
+    missing = str(tmp_path / "missing")
+    run_dir.mkdir()
+    result_root.mkdir()
+    runner, fl_ctx, job_manager = _make_workspace_save_inputs(str(run_dir), str(run_dir), str(result_root), missing)
+    job_manager.save_workspace.return_value = "/store/job-1/workspace"
+
+    runner._save_workspace(fl_ctx)
+
+    job_manager.save_workspace.assert_called_once_with("job-1", [str(run_dir), str(result_root)], fl_ctx)
+    runner.log_warning.assert_called_once_with(
+        fl_ctx, f"Skipping unavailable workspace archive source for job job-1: {missing}"
+    )
+    assert not run_dir.exists()
+    assert not result_root.exists()
+
+
+def test_save_workspace_tolerates_source_disappearing_during_cleanup(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    runner, fl_ctx, job_manager = _make_workspace_save_inputs(*([str(run_dir)] * 4))
+
+    def _archive_then_remove_source(*_args):
+        run_dir.rmdir()
+        return "/store/job-1/workspace"
+
+    job_manager.save_workspace.side_effect = _archive_then_remove_source
+
+    runner._save_workspace(fl_ctx)
+
+    job_manager.save_workspace.assert_called_once_with("job-1", [str(run_dir)], fl_ctx)
+    runner.log_warning.assert_called_once_with(
+        fl_ctx, f"Workspace archive source disappeared before cleanup for job job-1: {run_dir}"
+    )
 
 
 def test_job_complete_process_saves_workspace_before_publishing_aborted_status():
@@ -676,6 +749,62 @@ def test_job_complete_process_retries_save_without_recomputing_finished_status()
         call(EventType.JOB_ABORTED, second_ctx),
         call(EventType.JOB_COMPLETED, second_ctx),
     ]
+    engine.remove_exception_process.assert_called_once_with("job-1")
+    assert "job-1" not in runner.running_jobs
+    assert "job-1" not in runner._finished_job_states
+
+
+@patch("nvflare.private.fed.server.job_runner.monotonic", side_effect=[0.0, 60.0])
+def test_job_complete_process_publishes_terminal_status_after_workspace_save_grace_time(_mock_monotonic):
+    runner = JobRunner(workspace_root="/tmp")
+    runner.fire_event = MagicMock()
+    runner.log_debug = MagicMock()
+    runner.log_error = MagicMock()
+    runner.log_exception = MagicMock()
+    runner.log_info = MagicMock()
+    runner.abort_client_run = MagicMock()
+    runner._save_workspace = MagicMock(side_effect=RuntimeError("storage unavailable"))
+    runner.ask_to_stop = False
+
+    engine = MagicMock()
+    engine.run_processes = {}
+    engine.client_manager.clients = {}
+    engine.exception_run_processes = {
+        "job-1": {
+            RunProcessKey.PARTICIPANTS: {},
+            RunProcessKey.PROCESS_RETURN_CODE: ProcessExitCode.EXCEPTION,
+        }
+    }
+
+    job_manager = MagicMock()
+    engine.get_component.return_value = job_manager
+
+    first_ctx = MagicMock()
+    second_ctx = MagicMock()
+    engine.new_context.side_effect = [nullcontext(first_ctx), nullcontext(second_ctx)]
+
+    job = MagicMock()
+    job.job_id = "job-1"
+    job.run_aborted = False
+    runner.running_jobs = {"job-1": job}
+
+    sleep_count = 0
+
+    def _stop_after_second_pass(_):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count == 2:
+            runner.ask_to_stop = True
+
+    with _patch_job_runner_sleep(_stop_after_second_pass):
+        runner._job_complete_process(engine)
+
+    assert runner._save_workspace.call_args_list == [call(first_ctx), call(second_ctx)]
+    runner.abort_client_run.assert_called_once_with("job-1", [], first_ctx)
+    runner.log_exception.assert_called_once()
+    runner.log_error.assert_called_once()
+    job_manager.set_status.assert_called_once_with("job-1", RunStatus.FINISHED_EXECUTION_EXCEPTION, second_ctx)
+    runner.fire_event.assert_called_once_with(EventType.JOB_COMPLETED, second_ctx)
     engine.remove_exception_process.assert_called_once_with("job-1")
     assert "job-1" not in runner.running_jobs
     assert "job-1" not in runner._finished_job_states

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -35,7 +35,10 @@ def _patch_job_runner_sleep(side_effect):
     calling ``time.sleep`` would run the side effect and trip the loop's stop
     condition early (FLARE-3034).
     """
-    return patch("nvflare.private.fed.server.job_runner.time", **{"sleep.side_effect": side_effect})
+    return patch(
+        "nvflare.private.fed.server.job_runner.time",
+        **{"sleep.side_effect": side_effect, "monotonic.return_value": 0.0},
+    )
 
 
 def _make_runner_inputs(num_clients=1):
@@ -306,6 +309,18 @@ def test_save_workspace_tolerates_source_disappearing_during_cleanup(tmp_path):
     runner.log_warning.assert_called_once_with(
         fl_ctx, f"Workspace archive source disappeared before cleanup for job job-1: {run_dir}"
     )
+
+
+def test_save_workspace_propagates_cleanup_errors_for_retry(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    runner, fl_ctx, job_manager = _make_workspace_save_inputs(*([str(run_dir)] * 4))
+
+    with patch("nvflare.private.fed.server.job_runner.shutil.rmtree", side_effect=PermissionError("denied")):
+        with pytest.raises(PermissionError, match="denied"):
+            runner._save_workspace(fl_ctx)
+
+    job_manager.save_workspace.assert_called_once_with("job-1", [str(run_dir)], fl_ctx)
 
 
 def test_job_complete_process_saves_workspace_before_publishing_aborted_status():
@@ -754,8 +769,7 @@ def test_job_complete_process_retries_save_without_recomputing_finished_status()
     assert "job-1" not in runner._finished_job_states
 
 
-@patch("nvflare.private.fed.server.job_runner.monotonic", side_effect=[0.0, 60.0])
-def test_job_complete_process_publishes_terminal_status_after_workspace_save_grace_time(_mock_monotonic):
+def test_job_complete_process_publishes_terminal_status_after_workspace_save_grace_time():
     runner = JobRunner(workspace_root="/tmp")
     runner.fire_event = MagicMock()
     runner.log_debug = MagicMock()
@@ -796,7 +810,10 @@ def test_job_complete_process_publishes_terminal_status_after_workspace_save_gra
         if sleep_count == 2:
             runner.ask_to_stop = True
 
-    with _patch_job_runner_sleep(_stop_after_second_pass):
+    with patch(
+        "nvflare.private.fed.server.job_runner.time",
+        **{"sleep.side_effect": _stop_after_second_pass, "monotonic.side_effect": [0.0, 60.0]},
+    ):
         runner._job_complete_process(engine)
 
     assert runner._save_workspace.call_args_list == [call(first_ctx), call(second_ctx)]


### PR DESCRIPTION
## Summary

- skip missing and duplicate workspace archive roots while preserving any remaining artifacts
- clean only sources from a successful archive operation and tolerate cleanup races
- keep retrying transient archive failures, but publish the computed terminal status after a 60-second grace period when archival keeps failing
- keep status-publication retries independent from workspace archival

## Root cause

`JobRunner._job_complete_process` retried every workspace-save exception forever before publishing terminal status. A permanently missing run directory reached `FilesystemStorage._write_multi`, failed once per second, and skipped both `job_manager.set_status(...)` and removal from `running_jobs`.

## Tracking

- [FLARE-3106](https://jirasw.nvidia.com/browse/FLARE-3106)
- Related: [FLARE-3094](https://jirasw.nvidia.com/browse/FLARE-3094)

FLARE-3094's remaining client-side result-loss false-success race is explicitly out of scope and is not changed by this PR.

## Validation

- `.venv/bin/python -m pytest tests/unit_test/private/fed/server/job_runner_test.py -q` — 37 passed
- `.venv/bin/python -m pytest tests/unit_test/apis/impl/job_def_manager_test.py tests/unit_test/app_common/storages/storage_test.py -q` — 36 passed
- `.venv/bin/python -m pytest tests/unit_test/private/fed/server/job_cmds_test.py tests/unit_test/private/fed/server/k8s_pending_timeout_status_test.py -q` — 98 passed
- `.venv/bin/python -m pytest tests/unit_test/private/fed/server/job_runner_test.py tests/unit_test/fuel/f3/mpm_test.py tests/unit_test/app_opt/job_launcher/k8s_launcher_test.py -q` — 292 passed
- `.venv/bin/python -m pytest tests/unit_test/private/fed/server -q` — 408 passed
- `PATH="$PWD/.venv/bin:$PATH" VIRTUAL_ENV="$PWD/.venv" UV_CACHE_DIR=/private/tmp/uv-cache ./runtest.sh -s` — passed

The subprocess QA case in dl/DLQASH/dlfw/nvflare MR !194 was not available in this workspace and was not rerun. This PR therefore has unit/style evidence but no fresh live subprocess E2E run.