### PR TITLE
Remove brittle Slurm version gate

### DIFF
--- a/docs/design/slurm_job_launcher_design.md
+++ b/docs/design/slurm_job_launcher_design.md
@@ -54,8 +54,8 @@ parents run on a service or login host with a stable public endpoint.
 The prepare host does not resolve scheduler commands. It preserves optional configured absolute paths in the workspace,
 and generated parent-submission guidance uses `sbatch` from the submission host's `PATH`. After the parent reaches
 its actual runtime host and trusted environment setup has run, bootstrap resolves `sbatch`, `squeue`, `sacct`, and
-`scancel`, verifies Slurm 23.02 or later, and freezes canonical paths in memory for that parent process. A restart
-therefore follows changes to a cluster-managed stable symlink without requiring a new prepare.
+`scancel` and freezes canonical paths in memory for that parent process. A restart therefore follows changes to a
+cluster-managed stable symlink without requiring a new prepare.
 
 Operators use a separate output for each NVFlare site or federation and run one parent per workspace. Preparing
 again with the same output replaces the complete workspace, including runtime data. Stop the parent and preserve
@@ -290,7 +290,7 @@ scheduler to start the ranks themselves.
 
 ## Required environment
 
-The runtime parent requires Slurm 23.02 or later because the launcher uses `sbatch --export=NIL`. Parent bootstrap
+The runtime parent requires Slurm 23.02.3 or later because the launcher uses `sbatch --export=NIL`. Parent bootstrap
 requires working `sbatch`, `squeue`, `sacct`, and `scancel` commands and working `slurmdbd` accounting. Default
 `AccountingStoreFlags` is sufficient. It targets a single, non-federated cluster, and site plugins must preserve
 local submission routing. Apptainer or Pyxis/Enroot must be installed on eligible nodes when selected; Pyxis and

--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -39,10 +39,10 @@ Prerequisites
 
 Before starting a parent, verify:
 
-- Slurm 23.02 or later provides working ``sbatch``, ``squeue``, ``sacct``, and
+- Slurm 23.02.3 or later provides working ``sbatch``, ``squeue``, ``sacct``, and
   ``scancel`` commands on the runtime parent host. Parent bootstrap resolves
-  these commands and verifies the version; 23.02 is the minimum because the
-  launcher uses ``sbatch --export=NIL``. Production sites should run a Slurm
+  these commands; 23.02.3 is the minimum because the launcher uses
+  ``sbatch --export=NIL``. Production sites should run a Slurm
   release that is still supported by SchedMD.
 - ``slurmdbd`` accounting is enabled and ``sacct`` responds. The default
   ``AccountingStoreFlags`` is sufficient.

--- a/nvflare/app_opt/job_launcher/slurm/manager.py
+++ b/nvflare/app_opt/job_launcher/slurm/manager.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-import re
 import shutil
 import stat
 import threading
@@ -58,8 +57,6 @@ from nvflare.fuel.common.exit_codes import PROCESS_EXIT_REASON, ProcessExitCode
 
 _HEALTHY_MISSES = 5
 _ACCOUNTING_RETRY_INTERVAL = 6.0
-_MIN_SLURM_VERSION = (23, 2)
-_SLURM_VERSION_RE = re.compile(r"^slurm\s+(\d+)\.(\d+)", re.IGNORECASE)
 _JOB_NAME_SITE_LENGTH = 32
 
 
@@ -166,22 +163,11 @@ class SlurmJobManager:
                 except SlurmLauncherError as e:
                     raise UnsafeComponentError(str(e)) from e
                 adapter = _SlurmCliAdapter(executables, os.getuid(), self.logger)
-                self._require_slurm_version(adapter)
                 self.config = replace(self.config, executables=executables)
                 self.adapter = adapter
             self._require_accounting()
             self.jobs_dir = jobs_dir
             self._initialized = True
-
-    def _require_slurm_version(self, adapter=None) -> None:
-        message = "Slurm 23.02 or later is required"
-        result = (adapter or self.adapter).version_probe(timeout=2.0)
-        match = _SLURM_VERSION_RE.match(result.stdout.strip()) if result.available else None
-        if match and tuple(map(int, match.groups())) >= _MIN_SLURM_VERSION:
-            return
-        detail = _command_diagnostic(result) if not result.available else f"unexpected version output={result.stdout!r}"
-        self.logger.error("%s: %s", message, detail)
-        raise UnsafeComponentError(message)
 
     def _require_accounting(self) -> None:
         message = "Slurm accounting (slurmdbd) is required"

--- a/nvflare/app_opt/job_launcher/slurm/scheduler_client.py
+++ b/nvflare/app_opt/job_launcher/slurm/scheduler_client.py
@@ -154,9 +154,6 @@ class _SlurmCliAdapter:
             timeout,
         )
 
-    def version_probe(self, timeout: float) -> CommandResult:
-        return self._run([self.executables["sbatch"], "--version"], timeout)
-
     def _warn_stray_row(self, job_name: str, job_id: str) -> None:
         now = self._monotonic()
         with self._warning_lock:

--- a/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
@@ -68,7 +68,6 @@ class Adapter:
         self.live = _query(LookupStatus.NOT_FOUND)
         self.accounting_id = _query(LookupStatus.NOT_FOUND)
         self.cancel_result = _query(LookupStatus.FOUND)
-        self.version_result = _command(stdout="slurm 23.02.0\n")
         self.probes = [_command(stdout="")]
         self.calls = []
 
@@ -100,10 +99,6 @@ class Adapter:
     def accounting_probe(self, timeout):
         self.calls.append(("probe", timeout))
         return self._take(self.probes)
-
-    def version_probe(self, timeout):
-        self.calls.append(("version", timeout))
-        return self.version_result
 
 
 def _record(job_id="42", state="RUNNING", **kwargs):
@@ -193,7 +188,6 @@ def _runtime_config(workspace, executables):
 
 def _bootstrap_adapter(monkeypatch):
     adapter = MagicMock()
-    adapter.version_probe.return_value = _command(stdout="slurm 23.02.5\n")
     adapter.accounting_probe.return_value = _command(stdout="")
     factory = MagicMock(return_value=adapter)
     monkeypatch.setattr(manager_module, "_SlurmCliAdapter", factory)
@@ -786,20 +780,3 @@ def test_accounting_probe_is_required_and_briefly_retried(tmp_path, monkeypatch,
     else:
         with pytest.raises(UnsafeComponentError, match="slurmdbd"):
             manager._require_accounting()
-
-
-@pytest.mark.parametrize("version", ["slurm 23.02.0\n", "slurm 26.05.1\n"])
-def test_supported_slurm_version_passes_bootstrap_check(tmp_path, version):
-    adapter = Adapter()
-    adapter.version_result = _command(stdout=version)
-
-    _manager(tmp_path, adapter)._require_slurm_version()
-
-
-@pytest.mark.parametrize("result", [_command(stdout="slurm 22.05.9\n"), _command(stdout="unexpected\n"), _command(1)])
-def test_unsupported_or_unreadable_slurm_version_fails_bootstrap(tmp_path, result):
-    adapter = Adapter()
-    adapter.version_result = result
-
-    with pytest.raises(UnsafeComponentError, match="23.02 or later"):
-        _manager(tmp_path, adapter)._require_slurm_version()

--- a/tests/unit_test/app_opt/job_launcher/slurm_scheduler_client_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_scheduler_client_test.py
@@ -257,14 +257,6 @@ def test_accounting_probe_is_trivial():
     ]
 
 
-def test_version_probe_uses_runtime_resolved_sbatch():
-    runner = Runner(_result("slurm 23.02.5\n"))
-    adapter = _adapter(runner)
-
-    assert adapter.version_probe(1).available
-    assert runner.calls[0][0] == ["/usr/bin/sbatch", "--version"]
-
-
 def test_subprocess_runner_clamps_timeout_and_uses_scrubbed_environment(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

- remove the Slurm bootstrap version-string parser and `sbatch --version` probe
- retain runtime executable resolution and the direct `slurmdbd` accounting check
- document Slurm 23.02.3 as the minimum version because it introduced `sbatch --export=NIL`

## Root cause

The bootstrap gate assumed that version output starts with `slurm `, so Debian and Ubuntu builds reporting `slurm-wlm 23.11.4` were rejected before their version was compared. The major/minor-only check was also not a reliable capability test: it accepted Slurm 23.02.0 through 23.02.2 even though `--export=NIL` was added in 23.02.3.

The launcher already uses `--export=NIL` on every submission and reports the real `sbatch` diagnostic if submission fails. Removing the brittle proxy allows vendor-packaged or backported Slurm builds to run while keeping the supported minimum explicit for operators.

## Validation

- `pytest -q tests/unit_test/app_opt/job_launcher/slurm_batch_test.py tests/unit_test/app_opt/job_launcher/slurm_config_test.py tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py tests/unit_test/app_opt/job_launcher/slurm_manager_test.py tests/unit_test/app_opt/job_launcher/slurm_scheduler_client_test.py tests/unit_test/tool/deploy/slurm_deploy_test.py` — 210 passed
- `./runtest.sh -s` — passed
- `git diff --check upstream/main...HEAD` — passed

Live Slurm cluster validation was not run; the change removes a preflight parser and leaves submission and accounting behavior unchanged.

Jira: https://jirasw.nvidia.com/browse/FLARE-3105
