### PR TITLE
Fix pass-through tensor download retention

### DIFF
--- a/nvflare/fuel/f3/cellnet/cell.py
+++ b/nvflare/fuel/f3/cellnet/cell.py
@@ -255,8 +255,21 @@ class Cell(StreamCell):
         results = dict()
         future_to_target = {}
 
-        # encode the request now so each target thread won't need to do it again.
-        self._encode_message(request, abort_signal, num_receivers=len(targets), receiver_ids=targets)
+        # Encode the request now so each target thread won't need to do it again.
+        # For a direct broadcast, the routing targets are also the tensor download
+        # consumers, so the transaction can track their exact identities. With
+        # PASS_THROUGH, each target may forward the refs to another Cell (for
+        # example, an external trainer), and only the final consumer count is known.
+        # Pinning the transaction to the first-hop identities would prevent it from
+        # completing after those downstream consumers finish downloading.
+        pass_through = bool(request.get_header(MessageHeaderKey.PASS_THROUGH, False))
+        receiver_ids = None if pass_through else targets
+        self._encode_message(
+            request,
+            abort_signal,
+            num_receivers=len(targets),
+            receiver_ids=receiver_ids,
+        )
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(targets)) as executor:
             self.logger.debug(f"broadcast to {targets=}")

--- a/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/cell_progress_wait_test.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 import nvflare.fuel.f3.cellnet.cell as cell_module
 from nvflare.apis.signal import Signal
 from nvflare.fuel.f3.cellnet.cell import Cell
-from nvflare.fuel.f3.cellnet.defs import ReturnCode
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.utils.fobs import FOBSContextKey
 from nvflare.fuel.utils.fobs.decomposers.via_downloader import RESULT_UPLOAD_TX_CREATED_CB_CTX_KEY
@@ -85,6 +85,39 @@ def test_encode_message_can_stamp_receiver_ids_for_multi_receiver_download_refs(
 
     assert captured[FOBSContextKey.NUM_RECEIVERS] == 2
     assert captured[FOBSContextKey.RECEIVER_IDS] == ["receiver-a", "receiver-b"]
+
+
+def _broadcast_and_capture_encode(pass_through: bool):
+    cell = _make_cell()
+    cell._encode_message = MagicMock()
+    cell._send_one_request = MagicMock(return_value=Message(headers={}, payload=None))
+    headers = {MessageHeaderKey.PASS_THROUGH: True} if pass_through else {}
+    request = Message(headers=headers, payload=None)
+    targets = ["site-1", "site-2"]
+
+    cell._broadcast_request(
+        channel="task",
+        topic="train",
+        targets=targets,
+        request=request,
+        abort_signal=Signal(),
+    )
+
+    return cell._encode_message.call_args.kwargs
+
+
+def test_broadcast_stamps_receiver_ids_for_direct_downloads():
+    encode_args = _broadcast_and_capture_encode(pass_through=False)
+
+    assert encode_args["num_receivers"] == 2
+    assert encode_args["receiver_ids"] == ["site-1", "site-2"]
+
+
+def test_broadcast_uses_count_based_completion_for_pass_through_downloads():
+    encode_args = _broadcast_and_capture_encode(pass_through=True)
+
+    assert encode_args["num_receivers"] == 2
+    assert encode_args["receiver_ids"] is None
 
 
 def test_encode_message_applies_call_scoped_fobs_props_without_mutating_them(monkeypatch):


### PR DESCRIPTION
## Summary

- use count-based tensor-download completion for broadcasts explicitly marked `PASS_THROUGH`
- preserve receiver-identity-aware completion for direct broadcasts
- add regression coverage for both paths

Follow-up to #4965. Tracks the observed regression in FLARE-3104; the longer-term delegated logical-receiver design is tracked in FLARE-3107.

## Root cause

Broadcast encoding records the first-hop Cell targets as `receiver_ids`. For a direct broadcast, those targets are also the tensor consumers and identity-aware completion is correct.

With `PASS_THROUGH`, however, a target client-job Cell can forward the lazy tensor reference to an external trainer Cell. The trainer is allowed to download the valid reference, but the transaction records the trainer FQCN while waiting for the original client-job FQCN. Completion is therefore never reached, and the source transaction retains its model-sized `TensorDownloadable.base_obj` until timeout or run shutdown.

This change keeps `num_receivers` for pass-through broadcasts but omits first-hop `receiver_ids`, so the transaction completes after the expected number of downstream consumers download the object.

## Impact

In a fixed-aggregator Swarm workload, the stale source transactions retained roughly one 5 GiB model per aggregation round in the aggregator client-job process. The fix releases each broadcast transaction promptly and keeps post-round RSS bounded.

## Validation

Large-model qualification used four clients, external-process trainers, a fixed site-1 aggregator, PyTorch aggregation, and an exact 5 GiB synthetic model:

- unmodified offload path: cleanup `RssAnon` grew by approximately 4.943 GiB/round and reached about 190.12 GiB by round 29
- count-based pass-through fix: 6/6 rounds completed, all 7 broadcast transactions finished, zero transactions remained outstanding, and steady-round cleanup `RssAnon` stayed within a 0.84 GiB range
- patched run peak site-1 RSS: approximately 23.95 GiB

Local checks on current `main`:

- `214 passed` — Cell unit-test suite
- `61 passed` — streaming download transaction/object/starvation suites
- `1 passed, 4 deselected` — secure Swarm tensor disk-offload integration case
- `./runtest.sh -s` — passed
