### PR TITLE
Document Podman support for OpenShift image builds

### DIFF
--- a/examples/devops/openshift/README.md
+++ b/examples/devops/openshift/README.md
@@ -74,6 +74,8 @@ export CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
 "$CONTAINER_TOOL" push "$WORKLOAD_IMAGE"
 ```
 
+After the images are pushed, keep `PARENT_IMAGE` and `WORKLOAD_IMAGE` in the same shell and map them to the variables consumed by `k8s_e2e.sh`:
+
 ```bash
 export IMAGE="$PARENT_IMAGE"
 export JOB_IMAGE="$WORKLOAD_IMAGE"

--- a/examples/devops/openshift/README.md
+++ b/examples/devops/openshift/README.md
@@ -61,11 +61,22 @@ PULL_SECRET_FILE="$HOME/Downloads/pull-secret.txt" \
 bash examples/devops/openshift/scripts/start_openshift_cluster.sh
 ```
 
-Run scripts from the repository root. Build the maintained images from `docker/Dockerfile.parent` and `docker/Dockerfile.job`, push them to a registry the cluster can pull from, then set `IMAGE` to the parent image and `JOB_IMAGE` to the workload image. `ADMIN_IMAGE` defaults to `IMAGE`, so the parent image can also be used for the temporary admin pod. The parent image needs NVFlare with the `K8S` extra/Kubernetes Python client. A custom `COPY_IMAGE` needs `sh`, `sleep`, and `tar`; `JOB_IMAGE` only needs `tar` when the job workload itself needs it.
+Run scripts from the repository root. Build the maintained images from `docker/Dockerfile.parent` and `docker/Dockerfile.job`, push them to a registry the cluster can pull from, then set `IMAGE` to the parent image and `JOB_IMAGE` to the workload image. Podman is supported for these build and push steps and is typically available by default on RHEL OpenShift hosts; Docker can be used instead by setting `CONTAINER_TOOL=docker`, and some RHEL installations provide `docker` as a Podman alias. A Docker daemon is not required. `ADMIN_IMAGE` defaults to `IMAGE`, so the parent image can also be used for the temporary admin pod. The parent image needs NVFlare with the `K8S` extra/Kubernetes Python client. A custom `COPY_IMAGE` needs `sh`, `sleep`, and `tar`; `JOB_IMAGE` only needs `tar` when the job workload itself needs it.
 
 ```bash
-export IMAGE=registry.example.com/nvflare-parent:dev
-export JOB_IMAGE=registry.example.com/nvflare-job:dev
+export PARENT_IMAGE=registry.example.com/nvflare-parent:dev
+export WORKLOAD_IMAGE=registry.example.com/nvflare-job:dev
+export CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
+
+"$CONTAINER_TOOL" build -t "$PARENT_IMAGE" -f docker/Dockerfile.parent .
+"$CONTAINER_TOOL" build -t "$WORKLOAD_IMAGE" -f docker/Dockerfile.job .
+"$CONTAINER_TOOL" push "$PARENT_IMAGE"
+"$CONTAINER_TOOL" push "$WORKLOAD_IMAGE"
+```
+
+```bash
+export IMAGE="$PARENT_IMAGE"
+export JOB_IMAGE="$WORKLOAD_IMAGE"
 export NAMESPACE=nvflare-e2e
 
 bash examples/devops/openshift/scripts/k8s_e2e.sh

--- a/examples/devops/openshift/index.md
+++ b/examples/devops/openshift/index.md
@@ -185,17 +185,20 @@ Common variables for `start_openshift_cluster.sh`:
 
 ## Build an OpenShift-Compatible Image
 
-The maintained NVFlare Dockerfiles are in the repository `docker/` directory. Use the parent image for long-running server/client parent pods and the temporary admin pod. Use a job image for the submitted `hello-numpy` job pods:
+The maintained NVFlare Dockerfiles are in the repository `docker/` directory and can be built with Podman or Docker. Podman is typically available by default on RHEL OpenShift hosts and does not require a Docker daemon. The commands below use Podman; set `CONTAINER_TOOL=docker` to use Docker instead. On systems where `docker` is an alias for Podman, either command name works.
+
+Use the parent image for long-running server/client parent pods and the temporary admin pod. Use a job image for the submitted `hello-numpy` job pods:
 
 ``` bash
 export PARENT_IMAGE=registry.example.com/nvflare-parent:dev
 export WORKLOAD_IMAGE=registry.example.com/nvflare-job:dev
+export CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
 
-docker build -t "$PARENT_IMAGE" -f docker/Dockerfile.parent .
-docker build -t "$WORKLOAD_IMAGE" -f docker/Dockerfile.job .
+"$CONTAINER_TOOL" build -t "$PARENT_IMAGE" -f docker/Dockerfile.parent .
+"$CONTAINER_TOOL" build -t "$WORKLOAD_IMAGE" -f docker/Dockerfile.job .
 
-docker push "$PARENT_IMAGE"
-docker push "$WORKLOAD_IMAGE"
+"$CONTAINER_TOOL" push "$PARENT_IMAGE"
+"$CONTAINER_TOOL" push "$WORKLOAD_IMAGE"
 ```
 
 Set the OpenShift workflow image variables from those pushed images:


### PR DESCRIPTION
## Summary

- document Podman as a supported container tool for building and pushing the OpenShift parent and workload images
- default the examples to Podman while allowing Docker through `CONTAINER_TOOL=docker`
- clarify that RHEL installations may provide `docker` as a Podman alias and that a Docker daemon is not required
- add complete build and push commands to the OpenShift helper README

## Validation

- `git diff --check`
- `./runtest.sh -s`
- balanced Markdown code-fence check using `./.venv/bin/python`

The parent and job Dockerfiles were reported as successfully built with Podman 5.8.2 on RHEL 9.8, and both images were successfully pushed to the OpenShift internal registry.
