### PR TITLE
Allow Kubernetes launchers to read pod events

### DIFF
--- a/nvflare/tool/deploy/templates/helm/client/role.yaml
+++ b/nvflare/tool/deploy/templates/helm/client/role.yaml
@@ -10,6 +10,9 @@ rules:
   resources: ["pods"]
   verbs: ["create", "delete", "get", "list", "watch"]
 - apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "update", "patch", "delete"]
 ---

--- a/nvflare/tool/deploy/templates/helm/server/role.yaml
+++ b/nvflare/tool/deploy/templates/helm/server/role.yaml
@@ -10,6 +10,9 @@ rules:
   resources: ["pods"]
   verbs: ["create", "delete", "get", "list", "watch"]
 - apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "update", "patch", "delete"]
 ---

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -654,6 +654,31 @@ def test_prepare_k8s_server_exposes_admin_port_only_when_distinct(tmp_path, caps
     assert ".Values.adminPort" in tcp_services
 
 
+@pytest.mark.parametrize(
+    "make_kit",
+    [
+        _make_server_kit,
+        _make_client_kit,
+    ],
+)
+def test_prepare_k8s_parent_role_allows_reading_events(tmp_path, capsys, make_kit):
+    kit = make_kit(tmp_path)
+    output = tmp_path / "parent-k8s"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "k8s",
+            "parent": {"docker_image": "repo/nvflare:dev"},
+        },
+    )
+    capsys.readouterr()
+
+    role = (output / "helm_chart" / "templates" / "role.yaml").read_text()
+    assert '- apiGroups: [""]\n  resources: ["events"]\n  verbs: ["get", "list", "watch"]' in role
+
+
 def test_prepare_k8s_server_uses_configured_service_name(tmp_path, capsys):
     kit = _make_server_kit(tmp_path, fed_learn_port=8002, admin_port=8003)
     output = tmp_path / "server-k8s"


### PR DESCRIPTION
## Summary

- grant generated server and client parent Roles read access to Kubernetes Events
- keep Events permissions in a separate read-only RBAC rule
- verify `nvflare deploy prepare` emits the Events rule for both parent types

## Testing

- `./.venv/bin/python -m pytest -q tests/unit_test/tool/deploy/deploy_commands_test.py -k 'k8s or k8'` (81 passed)
- `umask 022 && ./.venv/bin/python -m pytest -q tests/unit_test/tool/deploy/deploy_commands_test.py` (111 passed)
- `./runtest.sh -s`
- `git diff --check`
