### PR TITLE
Strengthen conversion skills for FedAvg and data locality

### DIFF
--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -93,9 +93,11 @@ user's purpose is to understand data distribution; handle conversion later as a 
    packaged project-local modules in the same writable source directory. Never
    use `..` in `train_script`, `add_server_file()`, or `add_client_file()`; use
    an existing resolved absolute path when co-location is impossible. Keep the
-   server and Trainer model factory and exchange keyspace identical, with
-   explicit model config rather than a live model. Apply only options confirmed
-   by the construction reference. Preserve the job asset's recipe-before-parser
+   server and Trainer model factory and exchange keyspace identical. Follow the
+   shared "Recipe Model Config" policy; a direct instance must not use
+   `from_pretrained()`, downloads, or checkpoint loading during job
+   construction. Apply only options confirmed by the construction reference.
+   Preserve the job asset's recipe-before-parser
    ordering, `ArgumentParser(allow_abbrev=False)`, and strict `parse_args()`; do
    not use `parse_known_args()`.
 7. Only after generated files exist, load

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -91,9 +91,10 @@ distribution; handle conversion later as a separate request.
    alone does not prove delivery. Ask or fail closed when validation semantics
    are missing. Partition site data per the "Site Data Partitioning" rule in
    `../nvflare-shared/references/conversion-common.md`.
-7. Add or update `job.py` with explicit model config
-   `{"class_path": ..., "args": ...}` (never a live `LightningModule`),
-   requested `aggregator=` wiring, and the metric, tensor-transport, server
+7. Add or update `job.py` under the shared "Recipe Model Config" policy. A
+   direct instance, when allowed by that policy, must be the complete
+   `LightningModule`, not its inner network. Add the requested `aggregator=`
+   wiring and the metric, tensor-transport, server
    offload, and execution settings derived from the shared PyTorch-family
    construction profile.
 8. Validate in a ladder per `../nvflare-shared/references/validation-evidence.md`:
@@ -126,9 +127,10 @@ distribution; handle conversion later as a separate request.
 - Must audit model constructor arguments before writing `job.py` by reading the
   `LightningModule.__init__` signature and the selected recipe's `model`
   parameter from `nvflare recipe show <recipe-name> --format json`, not by
-  reading NVFLARE library source. Emit explicit recipe model config with
-  `class_path` and `args` only when the values are statically clear from literal
-  source, configuration, or supplied metadata; otherwise ask one semantic
+  reading NVFLARE library source. The shared "Recipe Model Config" policy
+  governs whether to emit `class_path`/`args` config or a direct
+  `LightningModule`; required values must be statically clear from literal
+  source, configuration, or supplied metadata. Otherwise ask one semantic
   question when an answer channel exists or fail closed on that missing value.
 - Must use the PyTorch recipe family; must not invent a Lightning-only recipe.
 - Must apply

--- a/skills/nvflare-convert-lightning/references/lightning-conversion.md
+++ b/skills/nvflare-convert-lightning/references/lightning-conversion.md
@@ -200,16 +200,15 @@ remain shared only when that matches the source's validation/test semantics.
 
 Follow the shared model-config and construction-consistency rule in
 `../../nvflare-shared/references/conversion-workflow.md` ("Recipe Model Config"):
-same class and constructor args on server and client, explicit
-`{"class_path": ..., "args": ...}` config (no live instance), and
-derive-or-ask/fail-closed for required values.
+same class and constructor args on server and client, an allowed recipe model
+form, and derive-or-ask/fail-closed for required values.
 
 Lightning-specific delta: the exchanged unit is the whole `LightningModule`
 managed by the patched trainer, so construct the identical `LightningModule` on
-the server (via the recipe `model` config) and on the client in `client.py`, not
-just the inner `torch.nn.Module`. Express shared arguments as a `model_args`
-dict in the recipe model config (prefer `class_path`; `path` is the normalized
-job-config key).
+the server and on the client in `client.py`, not just the inner
+`torch.nn.Module`. For explicit config, express shared arguments as a
+`model_args` dict (prefer `class_path`; `path` is the normalized job-config
+key).
 
 ## Source Layout
 

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -81,7 +81,7 @@ distribution; handle conversion later as a separate request.
    evaluation code into the packaged evaluation template; if evaluation is
    required but missing, ask or fail closed. Partition site data per the "Site
    Data Partitioning" rule in `../nvflare-shared/references/conversion-common.md`.
-6. Add or update `job.py` with explicit model config (never a live model),
+6. Add or update `job.py` under the shared "Recipe Model Config" policy,
    requested `aggregator=` wiring, and the metric, tensor-transport, server
    offload, and execution settings derived from the shared PyTorch-family
    construction profile.
@@ -102,10 +102,11 @@ distribution; handle conversion later as a separate request.
 - Must audit model constructor arguments before writing `job.py` by reading the
   model module's `__init__` and the selected recipe's `model` parameter from
   `nvflare recipe show <recipe-name> --format json`, not by reading NVFLARE
-  library source. Emit explicit recipe model config with `class_path` and
-  `args` only when the values are statically clear from literal source,
-  configuration, or supplied metadata; otherwise ask one semantic question when
-  an answer channel exists or fail closed on that missing value.
+  library source. The shared "Recipe Model Config" policy governs whether to
+  emit `class_path`/`args` config or a direct `torch.nn.Module`; required
+  values must be statically clear from literal source, configuration, or
+  supplied metadata. Otherwise ask one semantic question when an answer channel
+  exists or fail closed on that missing value.
 - Must follow `../nvflare-shared/references/pytorch-model-exchange.md` and
   `references/pytorch-client-api-conversion.md` for the canonical plain-PyTorch
   payload and round-loop pattern.

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -76,7 +76,8 @@ distribution; handle conversion later as a separate request.
 5. Convert training and evaluation as a pair using
    `references/pytorch-client-api-conversion.md`: initialize FLARE, receive an
    `FLModel`, load `params`, evaluate the received global model, train, and
-   send an `FLModel` with updated `params` and `metrics`. Adapt the user's
+   send an `FLModel` with updated `params`, `metrics`, and the actual completed
+   local optimizer-step count in `NUM_STEPS_CURRENT_ROUND`. Adapt the user's
    evaluation code into the packaged evaluation template; if evaluation is
    required but missing, ask or fail closed. Partition site data per the "Site
    Data Partitioning" rule in `../nvflare-shared/references/conversion-common.md`.
@@ -117,6 +118,10 @@ distribution; handle conversion later as a separate request.
 - Must convert source evaluation alongside training and return metrics through
   `FLModel.metrics`; must not synthesize metric semantics without source
   evidence.
+- Must count completed local optimizer steps in each generated training round
+  and send that positive value as `MetaKey.NUM_STEPS_CURRENT_ROUND`. This is the
+  FedAvg aggregation weight; do not omit it, reuse a cumulative count, or
+  invent a value when the source loop cannot establish it.
 - Must load checkpoints with `torch.load(..., weights_only=True)`; a
   checkpoint that needs full unpickling is ask/fail, per
   `references/pytorch-client-api-conversion.md`.

--- a/skills/nvflare-convert-pytorch/assets/client_with_eval.py
+++ b/skills/nvflare-convert-pytorch/assets/client_with_eval.py
@@ -15,9 +15,12 @@ initializes FLARE, then builds model and training state once before FLARE
 rounds; each round only loads received weights into that persistent state.
 """
 
+import math
+
 import torch
 
 import nvflare.client as flare
+from nvflare.app_common.abstract.fl_model import MetaKey
 
 
 def evaluate(model, val_loader, device="cpu"):
@@ -48,6 +51,19 @@ def evaluate(model, val_loader, device="cpu"):
     return correct / total
 
 
+def _validate_round_num_steps(value):
+    """Return a valid positive FedAvg weight from completed local optimizer steps."""
+    if isinstance(value, bool):
+        raise RuntimeError("train_one_round() must return a positive number of completed optimizer steps")
+    try:
+        num_steps = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise RuntimeError("train_one_round() must return a positive number of completed optimizer steps") from exc
+    if not math.isfinite(num_steps) or num_steps <= 0:
+        raise RuntimeError("train_one_round() must return a positive number of completed optimizer steps")
+    return num_steps
+
+
 def main(model_factory, train_setup_factory, train_one_round, val_loader, device="cpu", metric_name="accuracy"):
     """Client API round loop with global-model evaluation before local training.
 
@@ -55,7 +71,10 @@ def main(model_factory, train_setup_factory, train_one_round, val_loader, device
     recipe uses. ``train_setup_factory`` constructs stateful training objects
     such as the optimizer, loss, scheduler, and training data loader once for
     the persistent model, after Client API context is available.
-    ``train_one_round`` runs the source training loop using that prebuilt state.
+    ``train_one_round`` runs the source training loop using that prebuilt state
+    and returns the positive number of completed optimizer steps. This value is
+    sent as ``NUM_STEPS_CURRENT_ROUND`` so FedAvg weights each site by its
+    actual per-round training work.
     """
     # Build all persistent objects before the FLARE round loop. Each round
     # should only load received weights into this state, evaluate, train, and
@@ -76,7 +95,13 @@ def main(model_factory, train_setup_factory, train_one_round, val_loader, device
             flare.send(flare.FLModel(metrics={metric_name: global_metric}))
             continue
 
-        train_one_round(model, train_state)
+        round_num_steps = _validate_round_num_steps(train_one_round(model, train_state))
 
         params = {k: v.detach().cpu() for k, v in model.state_dict().items()}
-        flare.send(flare.FLModel(params=params, metrics={metric_name: global_metric}))
+        flare.send(
+            flare.FLModel(
+                params=params,
+                metrics={metric_name: global_metric},
+                meta={MetaKey.NUM_STEPS_CURRENT_ROUND: round_num_steps},
+            )
+        )

--- a/skills/nvflare-convert-pytorch/assets/client_with_eval.py
+++ b/skills/nvflare-convert-pytorch/assets/client_with_eval.py
@@ -59,7 +59,7 @@ def _validate_round_num_steps(value):
         num_steps = float(value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise RuntimeError("train_one_round() must return a positive number of completed optimizer steps") from exc
-    if not math.isfinite(num_steps) or num_steps <= 0:
+    if not math.isfinite(num_steps) or num_steps <= 0 or not num_steps.is_integer():
         raise RuntimeError("train_one_round() must return a positive number of completed optimizer steps")
     return num_steps
 

--- a/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
+++ b/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
@@ -88,9 +88,8 @@ For generated Pandas partition code, follow "Site Data Partitioning" in
 
 Follow the shared model-config and construction-consistency rule in
 `../../nvflare-shared/references/conversion-workflow.md` ("Recipe Model Config"):
-same class and constructor args on server and client, explicit
-`{"class_path": ..., "args": ...}` config (no live `nn.Module` instance), and
-derive-or-ask/fail-closed for required values.
+same class and constructor args on server and client, an allowed recipe model
+form, and derive-or-ask/fail-closed for required values.
 
 PyTorch-specific delta: the client loads `input_model.params` into the model
 with `load_state_dict`, so the server-initial model and the client model must

--- a/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
+++ b/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
@@ -37,6 +37,9 @@ FL-only Client API entry point, not a standalone/FL auto-detecting launcher.
 - Call `flare.receive()` to get the incoming `FLModel`.
 - Load `input_model.params` into the PyTorch model with `load_state_dict`.
 - Train or evaluate using the user's existing data loader and optimizer.
+- Count only optimizer steps completed in the current round. The generated
+  `train_one_round` helper must return this positive count; do not use an
+  estimated, cumulative, or default value.
 - Send the trained weights with the canonical plain-PyTorch payload pattern in
   `../../nvflare-shared/references/pytorch-model-exchange.md`. Do not call
   `model.cpu()`, which moves the persistent model off the training device.
@@ -129,8 +132,10 @@ The self-contained runnable template ships at
 `../assets/client_with_eval.py`; adapt it rather than duplicating its code here
 or depending on repository `examples/`. It initializes setup once, receives and
 loads the global model, evaluates that received model, handles evaluation-only
-tasks, trains, and sends the canonical model payload plus the source-backed
-metric.
+tasks, trains, and sends the canonical model payload, source-backed metric, and
+the actual completed optimizer-step count for FedAvg weighting. If the source
+loop cannot establish that count, ask in interactive mode or fail closed in
+unattended mode instead of silently using equal client weights.
 
 The round `FLModel.metrics` is this pre-training evaluation of the received
 global model, not a post-training metric — see

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -56,6 +56,19 @@ site data into the job. Report split policy, seed, site count, and shared-data
 requests. For generated Pandas partitions, load the "Site Data Partitioning"
 section of `conversion-workflow.md`.
 
+## Preprocessing Data Locality
+
+Treat every preprocessing fit or learned artifact—normalization statistics,
+imputation values, feature encoders, vocabularies/tokenizers, label mappings,
+and similar—as data-derived information. Fit it using each site's local training
+partition by default. Do not pool raw records or implicitly derive a shared
+artifact from multiple sites.
+
+A shared artifact is allowed only when it is public or pre-provided, or when the
+user explicitly authorizes the cross-site statistics workflow and its disclosure
+model. Do not silently introduce a federated-statistics, secure-aggregation, or
+other cross-site workflow as a substitute.
+
 ## Custom Aggregation
 
 Custom aggregation must use the recipe `aggregator=` hook with a

--- a/skills/nvflare-shared/references/conversion-workflow.md
+++ b/skills/nvflare-shared/references/conversion-workflow.md
@@ -304,7 +304,10 @@ the framework references show the concrete placement.
 
 ## Recipe Model Config
 
-When a recipe needs a model, generate the explicit model config form:
+When a recipe needs a model, use a model form accepted by the selected recipe.
+The two supported forms are explicit model config and a directly constructed
+model instance. Prefer explicit config when it makes a reusable or
+parameterized definition clearer:
 
 ```python
 recipe = FedAvgRecipe(
@@ -316,10 +319,16 @@ recipe = FedAvgRecipe(
 )
 ```
 
-Do not generate a live model instance (`model=Net(...)`) as the recipe input,
-and do not instantiate the model in `job.py` only to pass it to the recipe.
-Prefer the `class_path` key at recipe construction time; `path` is the
-normalized job-config key.
+```python
+recipe = FedAvgRecipe(model=MyModel(num_classes=10), ...)
+```
+
+A direct instance is allowed only when the selected recipe accepts it and its
+construction is local, deterministic, and free of material side effects. Do
+not construct it through downloads, checkpoint loading, private or
+runtime-dependent data, external services, environment lookups, or unavailable
+runtime configuration. Prefer the `class_path` key over `path` for explicit
+config; `path` is the normalized job-config key.
 
 Treat model constructor args as statically clear only when the class path is an
 importable class or direct local class definition and the constructor values
@@ -333,22 +342,21 @@ The server-side initial model and the client-side model must be constructed with
 the same class and the same constructor arguments. Derive any required
 constructor values (input dimension, vocabulary size, number of classes, hidden
 size, dropout, and similar) from the source code, dataset metadata, checkpoint
-metadata, or CLI args, and make them explicit in both the recipe model config
-and the client model-construction path. If they are not statically clear, ask in
-interactive mode or fail closed in unattended mode. Framework references state
-only their compatibility delta (PyTorch state-dict shapes, Lightning whole
+metadata, or CLI args, and use the same values in the recipe and client
+construction paths. If they are not statically clear, ask in interactive mode
+or fail closed in unattended mode. Framework references state only their
+compatibility delta (PyTorch state-dict shapes, Lightning whole
 `LightningModule`).
 Factories, lambdas, partials, dynamic `**kwargs`, environment lookups, runtime
 config files unavailable during conversion, private site-local data,
 checkpoint-inferred architecture, and side-effectful code execution are not
 statically clear: ask in interactive mode or fail closed in unattended mode.
 
-A pretrained or initial model supplied as a checkpoint path still uses the
-explicit `{"class_path": ..., "args": ...}` model config, never a live,
-weight-loaded model instance. Pass the checkpoint path to the product surface
-that consumes it (for example the recipe's initial-model or `eval_ckpt` input),
-and load its weights through safe weight-only loading where the framework
-supports it.
+A pretrained or initial model supplied as a checkpoint path must not be loaded
+into a direct model instance during job construction. Pass the checkpoint path
+to the product surface that consumes it (for example the recipe's initial-model
+or `eval_ckpt` input), and load its weights through safe weight-only loading
+where the framework supports it.
 
 ## Conversion Defaults
 

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -19,8 +19,9 @@ the FedAvg constructor shape to Cyclic, FedEval, Swarm, or another recipe.
 Every recipe construction or construction preflight must include one model
 source accepted by the selected recipe, such as `model`, `initial_ckpt`, or
 `model_persistor`, and that keyword must be exposed by its capability profile.
-For an ordinary conversion, use the explicit model `class_path` and `args`
-mapping. Never instantiate an incomplete `FedAvgRecipe` merely to inspect
+For an ordinary conversion, follow the model-form policy in
+`conversion-workflow.md` ("Recipe Model Config"). Never instantiate an
+incomplete `FedAvgRecipe` merely to inspect
 attributes or discover constructor behavior; use `recipe show` and non-raising
 module/class attribute checks for capability discovery.
 

--- a/skills/nvflare-shared/references/pytorch-model-exchange.md
+++ b/skills/nvflare-shared/references/pytorch-model-exchange.md
@@ -66,6 +66,11 @@ site. FedAvg averages embedding rows by position, so a per-site token-to-ID
 mapping built independently from local data would silently blend unrelated
 tokens even when `vocab_size` matches.
 
+That shared vocabulary/tokenizer must be public or pre-provided, or come from
+an explicitly user-authorized cross-site statistics workflow under
+`conversion-common.md` ("Preprocessing Data Locality"). Never create it by
+pooling site records implicitly.
+
 Pin only architecture or state-dict compatibility values this way. Do not treat
 training-policy values or label/data-derived loss statistics as model
 constructor values that must be globally pinned for exchange compatibility.

--- a/skills/nvflare-shared/references/pytorch-model-exchange.md
+++ b/skills/nvflare-shared/references/pytorch-model-exchange.md
@@ -16,8 +16,21 @@ client code builds the payload itself:
 ```python
 params = {k: v.detach().cpu() for k, v in model.state_dict().items()}
 assert all(isinstance(v, torch.Tensor) for v in params.values())
-flare.send(flare.FLModel(params=params, metrics=metrics, meta=meta))
+flare.send(
+    flare.FLModel(
+        params=params,
+        metrics=metrics,
+        meta={**meta, MetaKey.NUM_STEPS_CURRENT_ROUND: round_num_steps},
+    )
+)
 ```
+
+`round_num_steps` is the positive number of optimizer steps completed during
+the current round. For a manually generated plain-PyTorch client, count it in
+the source-backed training loop and never omit it: FedAvg uses
+`NUM_STEPS_CURRENT_ROUND` as its aggregation weight. The patched Lightning and
+Hugging Face integrations populate this metadata themselves; do not add a
+second manual payload there.
 
 For PyTorch Lightning and Hugging Face Trainer, the patched trainer builds and
 sends the payload, so do not write this snippet in patched client code. The

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -142,6 +142,72 @@ def test_pytorch_eval_template_initializes_flare_before_training_setup():
     assert init_line < setup_line < loop_line
 
 
+def test_pytorch_eval_template_sends_completed_round_steps_for_fedavg(monkeypatch):
+    module = _load_module(PT_TEMPLATES / "client_with_eval.py")
+    sent_models = []
+
+    class _Tensor:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+    class _Model:
+        def to(self, device):
+            return self
+
+        def load_state_dict(self, params):
+            assert params == {"weight": "global"}
+
+        def state_dict(self):
+            return {"weight": _Tensor()}
+
+    running = iter((True, False))
+    monkeypatch.setattr(module.flare, "init", lambda: None)
+    monkeypatch.setattr(module.flare, "is_running", lambda: next(running))
+    monkeypatch.setattr(module.flare, "receive", lambda: types.SimpleNamespace(params={"weight": "global"}))
+    monkeypatch.setattr(module.flare, "is_evaluate", lambda: False)
+    monkeypatch.setattr(module.flare, "send", sent_models.append)
+    monkeypatch.setattr(module, "evaluate", lambda *args, **kwargs: 0.75)
+
+    module.main(
+        model_factory=_Model,
+        train_setup_factory=lambda model, device: object(),
+        train_one_round=lambda model, train_state: 7,
+        val_loader=(),
+    )
+
+    assert len(sent_models) == 1
+    assert sent_models[0].meta[module.MetaKey.NUM_STEPS_CURRENT_ROUND] == 7
+
+
+@pytest.mark.parametrize("invalid_steps", [None, 0, -1, float("inf"), True, "not-a-number"])
+def test_pytorch_eval_template_rejects_missing_or_invalid_round_steps(monkeypatch, invalid_steps):
+    module = _load_module(PT_TEMPLATES / "client_with_eval.py")
+
+    class _Model:
+        def to(self, device):
+            return self
+
+        def load_state_dict(self, params):
+            pass
+
+    monkeypatch.setattr(module.flare, "init", lambda: None)
+    monkeypatch.setattr(module.flare, "is_running", lambda: True)
+    monkeypatch.setattr(module.flare, "receive", lambda: types.SimpleNamespace(params={}))
+    monkeypatch.setattr(module.flare, "is_evaluate", lambda: False)
+    monkeypatch.setattr(module, "evaluate", lambda *args, **kwargs: 0.75)
+
+    with pytest.raises(RuntimeError, match="completed optimizer steps"):
+        module.main(
+            model_factory=_Model,
+            train_setup_factory=lambda model, device: object(),
+            train_one_round=lambda model, train_state: invalid_steps,
+            val_loader=(),
+        )
+
+
 @pytest.mark.parametrize(
     "evaluate_before_train, expected_events",
     [

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -182,7 +182,7 @@ def test_pytorch_eval_template_sends_completed_round_steps_for_fedavg(monkeypatc
     assert sent_models[0].meta[module.MetaKey.NUM_STEPS_CURRENT_ROUND] == 7
 
 
-@pytest.mark.parametrize("invalid_steps", [None, 0, -1, float("inf"), True, "not-a-number"])
+@pytest.mark.parametrize("invalid_steps", [None, 0, -1, 1.5, float("inf"), True, "not-a-number"])
 def test_pytorch_eval_template_rejects_missing_or_invalid_round_steps(monkeypatch, invalid_steps):
     module = _load_module(PT_TEMPLATES / "client_with_eval.py")
 

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -271,6 +271,26 @@ def test_pytorch_model_exchange_owns_plain_pytorch_send_pattern():
     assert "pytorch-model-exchange.md" in client_reference_text
 
 
+def test_conversion_skills_keep_preprocessing_statistics_local_by_default():
+    repo_root = Path(__file__).resolve().parents[4]
+    common_text = repo_root.joinpath("skills/nvflare-shared/references/conversion-common.md").read_text(
+        encoding="utf-8"
+    )
+    model_exchange_text = repo_root.joinpath("skills/nvflare-shared/references/pytorch-model-exchange.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_common = " ".join(common_text.split())
+    normalized_model_exchange = " ".join(model_exchange_text.split())
+
+    assert "## Preprocessing Data Locality" in common_text
+    assert "Fit it using each site's local training partition by default" in normalized_common
+    assert "Do not pool raw records or implicitly derive a shared artifact from multiple sites" in normalized_common
+    assert "user explicitly authorizes the cross-site statistics workflow" in normalized_common
+    assert "Do not silently introduce a federated-statistics, secure-aggregation" in normalized_common
+    assert '"Preprocessing Data Locality"' in normalized_model_exchange
+    assert "Never create it by pooling site records implicitly" in normalized_model_exchange
+
+
 def test_pytorch_family_construction_policy_is_canonical_and_capability_based():
     repo_root = Path(__file__).resolve().parents[4]
     pytorch_root = repo_root / "skills" / "nvflare-convert-pytorch"


### PR DESCRIPTION
## Summary
- require converted plain-PyTorch clients to report completed local optimizer steps for correct FedAvg weighting
- reject missing, invalid, and fractional step counts instead of silently falling back to equal client weights
- allow deterministic, side-effect-free direct model instances where the selected recipe supports them
- keep preprocessing statistics and learned artifacts site-local by default; require public/pre-provided artifacts or explicit authorization for cross-site statistics
- clarify shared-vocabulary requirements and add regression coverage

## Validation
- `python -m pytest tests/unit_test/tool/agent_skill_checks -v` (205 passed, 47 skipped)
- `black --check tests/unit_test/tool/agent_skill_checks/seed_skills_test.py` passed
- diff checks and repository pre-push agent-skill lint passed
- `./runtest.sh -s` was attempted but could not install build dependencies because PyPI DNS is unavailable in this environment