### PR TITLE
Report FLContext property conflict call sites

### DIFF
--- a/nvflare/apis/fl_context.py
+++ b/nvflare/apis/fl_context.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import copy
 import threading
+import traceback
 from typing import Any
 
 from nvflare.fuel.utils.log_utils import get_obj_logger
@@ -78,6 +79,15 @@ class FLContext:
         self.props = {}
         self.logger = get_obj_logger(self)
 
+    def _warn_prop_attribute_change(self, key: str, existing_mask: int, new_mask: int):
+        call_site = traceback.extract_stack(limit=3)[0]
+        self.logger.warning(
+            f"property '{key}' already exists with attributes "
+            f"{to_string(existing_mask)}, cannot change to {to_string(new_mask)}; "
+            f"called from {call_site.filename}:{call_site.lineno}",
+            stacklevel=3,
+        )
+
     def get_prop_keys(self) -> list[str]:
         return list(self.props.keys())
 
@@ -142,10 +152,7 @@ class FLContext:
             if key in self.props:
                 existing_mask = self.props[key][M]
                 if mask != existing_mask:
-                    self.logger.warning(
-                        f"property '{key}' already exists with attributes "
-                        f"{to_string(existing_mask)}, cannot change to {to_string(mask)}"
-                    )
+                    self._warn_prop_attribute_change(key, existing_mask, mask)
                     return False
 
             # if the prop is sticky, also check with ctx manager to make sure it is consistent with existing mask
@@ -156,10 +163,7 @@ class FLContext:
                     assert isinstance(ctx_manager, FLContextManager)
                     exists, _, existing_mask = ctx_manager.check_sticker(key)
                     if exists and mask != existing_mask:
-                        self.logger.warning(
-                            f"property '{key}' already exists with attributes "
-                            f"{to_string(existing_mask)}, cannot change to {to_string(mask)}"
-                        )
+                        self._warn_prop_attribute_change(key, existing_mask, mask)
                         return False
                     ctx_manager.update_sticker(key, value, mask)
 

--- a/tests/unit_test/apis/fl_context_test.py
+++ b/tests/unit_test/apis/fl_context_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
 from nvflare.apis.fl_context import FLContext, FLContextManager
 
 
@@ -66,6 +68,32 @@ class TestFLContext:
         assert fl_ctx.set_prop("y", 20, private=False)
         assert fl_ctx.get_prop("y") == 20
         assert not fl_ctx.set_prop("y", 4, private=True)
+
+    def test_local_attribute_conflict_warning_reports_call_site(self, caplog):
+        fl_ctx = FLContext()
+        fl_ctx.set_prop("x", 1, private=True, sticky=True)
+
+        call_line = inspect.currentframe().f_lineno + 1
+        assert not fl_ctx.set_prop("x", 2, private=True, sticky=False)
+
+        warning = caplog.records[-1]
+        assert warning.pathname == __file__
+        assert warning.lineno == call_line
+        assert warning.message.endswith(f"called from {__file__}:{call_line}")
+
+    def test_sticky_attribute_conflict_warning_reports_call_site(self, caplog):
+        mgr = FLContextManager()
+        ctx1 = mgr.new_context()
+        ctx2 = mgr.new_context()
+        ctx1.set_prop("x", 1, private=True, sticky=True)
+
+        call_line = inspect.currentframe().f_lineno + 1
+        assert not ctx2.set_prop("x", 2, private=False, sticky=True)
+
+        warning = caplog.records[-1]
+        assert warning.pathname == __file__
+        assert warning.lineno == call_line
+        assert warning.message.endswith(f"called from {__file__}:{call_line}")
 
     def test_remove_prop(self):
         fl_ctx = FLContext()


### PR DESCRIPTION
## What changed

- Include the direct `FLContext.set_prop()` caller's file and line number in property-attribute conflict warnings.
- Set the warning record's source metadata to the same caller.
- Cover conflicts found locally and through `FLContextManager` with regression tests.

## Why

When a caller tries to change a property's private or sticky attributes, `set_prop()` rejects the update but the warning previously pointed only to `FLContext`. NVFlare's default log format does not render `LogRecord.pathname` or `LogRecord.lineno`, so users could not identify the offending call site.

The warning now reports only `filename:line`, avoiding a noisy full stack trace or source-code text while making the rejected call actionable.

## Impact

Property update behavior is unchanged: conflicting attribute changes still return `False`. Only the diagnostic warning and its log-record source metadata change.

## Validation

- `python -m pytest tests/unit_test/apis/fl_context_test.py -v` (8 passed)
- `./runtest.sh -s --skip-install` (Black, isort, Flake8, and agent-skill lint passed)