### PR TITLE
Route cross-client authentication through server

### DIFF
--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -1174,6 +1174,23 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
         target_info = FqcnInfo(target_fqcn)
 
+        # Authenticated messages between different client families must cross
+        # the server trust boundary. Do not let a direct or ad-hoc peer route
+        # bypass server validation merely because that endpoint is cached.
+        if (
+            for_msg
+            and for_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False)
+            and not self.my_info.is_on_server
+        ):
+            next_fqcn = FQCN.ROOT_SERVER if self.my_info.is_root else FQCN.get_parent(self.my_info.fqcn)
+            if next_fqcn in self.ALL_CELLS:
+                return Endpoint(next_fqcn)
+            agent = self.agents.get(next_fqcn)
+            if agent:
+                return agent.endpoint
+            self.log_warning(msg=for_msg, log_text=f"no server-transit path through {next_fqcn}")
+            return None
+
         # is there a direct path to the target?
         if target_fqcn in self.ALL_CELLS:
             return Endpoint(target_fqcn)
@@ -1356,6 +1373,17 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                 if send_errs.get(t):
                     # process next target
                     continue
+
+            # The authentication filter can require server transit after the
+            # preliminary endpoint lookup above. Resolve again with the fully
+            # populated request so a cached/ad-hoc peer endpoint is not used.
+            if req.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False):
+                err, ep = self._find_endpoint(t, req)
+                if not ep:
+                    self.log_error(f"cannot send server-transit message to '{t}': {err}", req)
+                    send_errs[t] = err
+                    continue
+                req.set_header(MessageHeaderKey.TO_CELL, ep.name)
 
             # is this a direct path?
             ti = FqcnInfo(t)
@@ -2147,6 +2175,14 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             self._process_reply(origin, message, msg_type)
 
     def _send_reply(self, reply: Message, endpoint: Endpoint):
+        if reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False):
+            destination = reply.get_header(MessageHeaderKey.DESTINATION)
+            err, transit_ep = self._find_endpoint(destination, reply)
+            if not transit_ep:
+                self.log_error(f"cannot send server-transit reply to '{destination}': {err}", reply)
+                return
+            endpoint = transit_ep
+            reply.add_headers({MessageHeaderKey.FROM_CELL: self.my_info.fqcn, MessageHeaderKey.TO_CELL: endpoint.name})
         self.logger.debug(f"{self.my_info.fqcn}: sending reply back to {endpoint.name}")
         self.logger.debug(f"Reply message: {reply.headers}")
         err = self._send_to_endpoint(endpoint, reply)

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -1182,13 +1182,26 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             and for_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False)
             and not self.my_info.is_on_server
         ):
-            next_fqcn = FQCN.ROOT_SERVER if self.my_info.is_root else FQCN.get_parent(self.my_info.fqcn)
-            if next_fqcn in self.ALL_CELLS:
-                return Endpoint(next_fqcn)
-            agent = self.agents.get(next_fqcn)
-            if agent:
-                return agent.endpoint
-            self.log_warning(msg=for_msg, log_text=f"no server-transit path through {next_fqcn}")
+            # Prefer the closest connected local ancestor so a client-job
+            # message follows its configured client/relay hierarchy. Some
+            # supported descendants connect directly to the server root, so do
+            # not fail merely because their FQCN parent is not connected.
+            ancestor_path = self.my_info.path[:-1]
+            while ancestor_path:
+                ancestor_fqcn = FQCN.join(ancestor_path)
+                if ancestor_fqcn in self.ALL_CELLS:
+                    return Endpoint(ancestor_fqcn)
+                agent = self.agents.get(ancestor_fqcn)
+                if agent:
+                    return agent.endpoint
+                ancestor_path = ancestor_path[:-1]
+
+            if FQCN.ROOT_SERVER in self.ALL_CELLS:
+                return Endpoint(FQCN.ROOT_SERVER)
+            root_agent = self.agents.get(FQCN.ROOT_SERVER)
+            if root_agent:
+                return root_agent.endpoint
+            self.log_warning(msg=for_msg, log_text="no server-transit path through a local ancestor or server")
             return None
 
         # is there a direct path to the target?

--- a/nvflare/fuel/f3/cellnet/defs.py
+++ b/nvflare/fuel/f3/cellnet/defs.py
@@ -45,6 +45,9 @@ class MessageHeaderKey:
     CLEAR_PAYLOAD_LEN = CELLNET_PREFIX + "clear_payload_len"
     ENCRYPTED = CELLNET_PREFIX + "encrypted"
     OPTIONAL = CELLNET_PREFIX + "optional"
+    # Authenticated traffic between different client families must cross the
+    # server trust boundary even when an ad-hoc peer connection is available.
+    SERVER_TRANSIT_REQUIRED = CELLNET_PREFIX + "server_transit_required"
     MSG_ROOT_ID = CELLNET_PREFIX + "msg_root_id"
     MSG_ROOT_TTL = CELLNET_PREFIX + "msg_root_ttl"
     # When True on an incoming cell message, Adapter.call() builds a per-call

--- a/nvflare/fuel/sec/authn.py
+++ b/nvflare/fuel/sec/authn.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from nvflare.apis.fl_constant import CellMessageAuthHeaderKey
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
@@ -23,7 +25,44 @@ def _is_server_fqcn(fqcn: str) -> bool:
     return bool(fqcn) and FqcnInfo(fqcn).is_on_server
 
 
-def _is_cross_site_reply_via_local_parent(origin: str, destination: str, to_cell: str) -> bool:
+def _get_client_family_fqcn(origin: str, client_name: Optional[str]) -> Optional[str]:
+    if not origin or not client_name:
+        return None
+    origin_path = FQCN.split(origin)
+    try:
+        client_index = origin_path.index(client_name)
+    except ValueError:
+        return None
+    else:
+        return FQCN.join(origin_path[: client_index + 1])
+
+
+def _is_client_family_member(fqcn: str, family_fqcn: Optional[str]) -> bool:
+    if not fqcn:
+        return False
+    if family_fqcn and (fqcn == family_fqcn or FQCN.is_ancestor(family_fqcn, fqcn)):
+        return True
+    return False
+
+
+def is_cross_client_family(origin: str, destination: str, client_name: Optional[str] = None) -> bool:
+    if not origin or not destination:
+        return False
+    origin_info = FqcnInfo(origin)
+    destination_info = FqcnInfo(destination)
+    if origin_info.is_on_server or destination_info.is_on_server:
+        return False
+
+    family_fqcn = _get_client_family_fqcn(origin, client_name)
+    if family_fqcn:
+        return not _is_client_family_member(destination, family_fqcn)
+
+    # Preserve routing for callers whose authentication identity cannot be
+    # mapped to an FQCN segment (for example custom identity mappings).
+    return origin_info.root != destination_info.root
+
+
+def _is_cross_site_reply_via_local_parent(origin: str, destination: str, to_cell: str, client_name: str) -> bool:
     """Return whether a peer reply first travels upward through its local client family.
 
     A job cell can connect directly to the server or connect to its client parent first
@@ -33,24 +72,7 @@ def _is_cross_site_reply_via_local_parent(origin: str, destination: str, to_cell
     """
     if not origin or not destination or not to_cell:
         return False
-    origin_info = FqcnInfo(origin)
-    destination_info = FqcnInfo(destination)
-    return (
-        not origin_info.is_on_server
-        and not destination_info.is_on_server
-        and origin_info.root != destination_info.root
-        and FQCN.is_ancestor(to_cell, origin)
-    )
-
-
-def _is_cross_client_family(origin: str, destination: str) -> bool:
-    if not origin or not destination:
-        return False
-    origin_info = FqcnInfo(origin)
-    destination_info = FqcnInfo(destination)
-    return (
-        not origin_info.is_on_server and not destination_info.is_on_server and origin_info.root != destination_info.root
-    )
+    return is_cross_client_family(origin, destination, client_name) and FQCN.is_ancestor(to_cell, origin)
 
 
 def add_authentication_headers(msg: Message, client_name: str, auth_token, token_signature, ssid=None):
@@ -74,7 +96,9 @@ def add_authentication_headers(msg: Message, client_name: str, auth_token, token
 
     msg.set_header(CellMessageAuthHeaderKey.TOKEN, auth_token if auth_token else "NA")
     msg.set_header(CellMessageAuthHeaderKey.TOKEN_SIGNATURE, token_signature if token_signature else "NA")
-    if _is_cross_client_family(msg.get_header(MessageHeaderKey.ORIGIN), msg.get_header(MessageHeaderKey.DESTINATION)):
+    if is_cross_client_family(
+        msg.get_header(MessageHeaderKey.ORIGIN), msg.get_header(MessageHeaderKey.DESTINATION), client_name
+    ):
         msg.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
 
 
@@ -93,7 +117,7 @@ def add_server_path_reply_authentication_headers(
         _is_server_fqcn(origin)
         or _is_server_fqcn(destination)
         or _is_server_fqcn(to_cell)
-        or _is_cross_site_reply_via_local_parent(origin, destination, to_cell)
+        or _is_cross_site_reply_via_local_parent(origin, destination, to_cell, client_name)
     ):
         add_authentication_headers(msg, client_name, auth_token, token_signature, ssid)
 

--- a/nvflare/fuel/sec/authn.py
+++ b/nvflare/fuel/sec/authn.py
@@ -14,13 +14,43 @@
 from nvflare.apis.fl_constant import CellMessageAuthHeaderKey
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
-from nvflare.fuel.f3.cellnet.fqcn import FqcnInfo
+from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.utils.validation_utils import check_object_type, check_str
 
 
 def _is_server_fqcn(fqcn: str) -> bool:
     return bool(fqcn) and FqcnInfo(fqcn).is_on_server
+
+
+def _is_cross_site_reply_via_local_parent(origin: str, destination: str, to_cell: str) -> bool:
+    """Return whether a peer reply first travels upward through its local client family.
+
+    A job cell can connect directly to the server or connect to its client parent first
+    (for example through the shared-file internal driver). In the latter topology,
+    ``TO_CELL`` is a local ancestor even though the reply must subsequently cross the
+    server trust boundary to reach a different client family.
+    """
+    if not origin or not destination or not to_cell:
+        return False
+    origin_info = FqcnInfo(origin)
+    destination_info = FqcnInfo(destination)
+    return (
+        not origin_info.is_on_server
+        and not destination_info.is_on_server
+        and origin_info.root != destination_info.root
+        and FQCN.is_ancestor(to_cell, origin)
+    )
+
+
+def _is_cross_client_family(origin: str, destination: str) -> bool:
+    if not origin or not destination:
+        return False
+    origin_info = FqcnInfo(origin)
+    destination_info = FqcnInfo(destination)
+    return (
+        not origin_info.is_on_server and not destination_info.is_on_server and origin_info.root != destination_info.root
+    )
 
 
 def add_authentication_headers(msg: Message, client_name: str, auth_token, token_signature, ssid=None):
@@ -44,6 +74,8 @@ def add_authentication_headers(msg: Message, client_name: str, auth_token, token
 
     msg.set_header(CellMessageAuthHeaderKey.TOKEN, auth_token if auth_token else "NA")
     msg.set_header(CellMessageAuthHeaderKey.TOKEN_SIGNATURE, token_signature if token_signature else "NA")
+    if _is_cross_client_family(msg.get_header(MessageHeaderKey.ORIGIN), msg.get_header(MessageHeaderKey.DESTINATION)):
+        msg.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
 
 
 def add_server_path_reply_authentication_headers(
@@ -52,10 +84,17 @@ def add_server_path_reply_authentication_headers(
     origin = msg.get_header(MessageHeaderKey.ORIGIN)
     destination = msg.get_header(MessageHeaderKey.DESTINATION)
     to_cell = msg.get_header(MessageHeaderKey.TO_CELL)
-    # Auth headers are for the server trust boundary, not for peer clients. A peer reply routed through the server
-    # must authenticate to the server on the next hop, and the server strips these headers before forwarding to peer.
-    # Server-owned job/transfer cells also keep auth on replies from or to server paths.
-    if _is_server_fqcn(origin) or _is_server_fqcn(destination) or _is_server_fqcn(to_cell):
+    # Auth headers are for the server trust boundary, not for peer clients. A peer
+    # reply may reach that boundary directly or first travel through its local client
+    # parent. The server validates and strips these headers before forwarding to the
+    # peer. Server-owned job/transfer cells also keep auth on replies from or to server
+    # paths.
+    if (
+        _is_server_fqcn(origin)
+        or _is_server_fqcn(destination)
+        or _is_server_fqcn(to_cell)
+        or _is_cross_site_reply_via_local_parent(origin, destination, to_cell)
+    ):
         add_authentication_headers(msg, client_name, auth_token, token_signature, ssid)
 
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -46,7 +46,7 @@ from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.core_cell import Message
 from nvflare.fuel.f3.cellnet.core_cell import make_reply as make_cellnet_reply
-from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, MessageType
+from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo
 from nvflare.fuel.f3.cellnet.identity import ADMIN_LISTENER_KEY
@@ -419,16 +419,19 @@ class FederatedServer(BaseServer):
         )
         self.logger.debug(f"added auth headers:  {origin=} {dest=} {channel=} {topic=}")
 
-    def _strip_peer_transit_reply_auth_headers(self, message: Message):
-        if message.get_header(MessageHeaderKey.MSG_TYPE) != MessageType.REPLY:
-            return
-
+    def _strip_peer_transit_auth_headers(self, message: Message):
+        origin = message.get_header(MessageHeaderKey.ORIGIN)
         destination = message.get_header(MessageHeaderKey.DESTINATION)
-        if not destination or FqcnInfo(destination).is_on_server:
+        if not origin or not destination:
+            return
+        origin_info = FqcnInfo(origin)
+        destination_info = FqcnInfo(destination)
+        if origin_info.is_on_server or destination_info.is_on_server or origin_info.root == destination_info.root:
             return
 
-        # Model: peer replies authenticate to the server if the server is the next hop, but peer clients must not
-        # receive another client's bearer material. This runs after successful server validation and before forwarding.
+        # Cross-client requests and replies authenticate at the server boundary,
+        # but a peer client must never receive another client's bearer material.
+        # This runs after successful server validation and before forwarding.
         for key in [
             CellMessageHeaderKeys.CLIENT_NAME,
             CellMessageHeaderKeys.TOKEN,
@@ -436,6 +439,7 @@ class FederatedServer(BaseServer):
             CellMessageHeaderKeys.SSID,
         ]:
             message.remove_header(key)
+        message.remove_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED)
 
     def _validate_auth_headers(self, message: Message):
         """Validate auth headers from messages that go through the server.
@@ -457,7 +461,7 @@ class FederatedServer(BaseServer):
             local_cell_fqcn=self.cell.get_fqcn() if getattr(self, "cell", None) else None,
         )
         if not reply:
-            self._strip_peer_transit_reply_auth_headers(message)
+            self._strip_peer_transit_auth_headers(message)
         return reply
 
     def _resolve_client_fqcn_for_auth(self, client_name: str, token: str):

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -48,12 +48,12 @@ from nvflare.fuel.f3.cellnet.core_cell import Message
 from nvflare.fuel.f3.cellnet.core_cell import make_reply as make_cellnet_reply
 from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
-from nvflare.fuel.f3.cellnet.fqcn import FQCN, FqcnInfo
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.identity import ADMIN_LISTENER_KEY
 from nvflare.fuel.f3.cellnet.net_agent import NetAgent
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
-from nvflare.fuel.sec.authn import add_authentication_headers
+from nvflare.fuel.sec.authn import add_authentication_headers, is_cross_client_family
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.private.defs import (
@@ -424,9 +424,8 @@ class FederatedServer(BaseServer):
         destination = message.get_header(MessageHeaderKey.DESTINATION)
         if not origin or not destination:
             return
-        origin_info = FqcnInfo(origin)
-        destination_info = FqcnInfo(destination)
-        if origin_info.is_on_server or destination_info.is_on_server or origin_info.root == destination_info.root:
+        client_name = message.get_header(CellMessageHeaderKeys.CLIENT_NAME)
+        if not is_cross_client_family(origin, destination, client_name):
             return
 
         # Cross-client requests and replies authenticate at the server boundary,

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
@@ -207,6 +207,16 @@ def test_server_transit_required_job_cell_uses_local_parent():
     assert endpoint.name == "site-1"
 
 
+def test_server_transit_required_job_cell_falls_back_to_server_root():
+    cell = _routing_cell("site-1.job-1", ["server", "site-2.job-2"])
+    message = Message(headers={MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True})
+
+    endpoint = cell._try_find_ep("site-2.job-2", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "server"
+
+
 def test_pipe_cell_with_no_connection_is_unreachable():
     cell = _routing_cell("site-1.cellpipe~plain~job-123~active", [])
 

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
@@ -187,6 +187,26 @@ def test_same_family_routing_still_prefers_fqcn_parent():
     assert ep.name == "site-1"
 
 
+def test_server_transit_required_bypasses_direct_cross_site_endpoint():
+    cell = _routing_cell("site-1", ["server", "site-2"])
+    message = Message(headers={MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True})
+
+    endpoint = cell._try_find_ep("site-2", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "server"
+
+
+def test_server_transit_required_job_cell_uses_local_parent():
+    cell = _routing_cell("site-1.job-1", ["site-1", "site-2.job-2"])
+    message = Message(headers={MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True})
+
+    endpoint = cell._try_find_ep("site-2.job-2", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "site-1"
+
+
 def test_pipe_cell_with_no_connection_is_unreachable():
     cell = _routing_cell("site-1.cellpipe~plain~job-123~active", [])
 

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
@@ -30,6 +30,7 @@ class _FakeAgent:
 
 def _routing_cell(fqcn, connected):
     cell = CoreCell.__new__(CoreCell)
+    cell.ALL_CELLS = {}
     cell.my_info = FqcnInfo(fqcn)
     cell.logger = logging.getLogger(__name__)
     cell.agents = {f: _FakeAgent(f) for f in connected}

--- a/tests/unit_test/fuel/sec/authn_test.py
+++ b/tests/unit_test/fuel/sec/authn_test.py
@@ -25,7 +25,7 @@ from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessageType, ReturnCo
 from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.stats_pool import StatsPoolManager
-from nvflare.fuel.sec.authn import set_add_auth_headers_filters
+from nvflare.fuel.sec.authn import is_cross_client_family, set_add_auth_headers_filters
 from nvflare.private.fed.server.fed_server import FederatedServer
 
 AUTH_HEADERS = [
@@ -75,11 +75,11 @@ class _Cert:
         return None
 
 
-def _make_server_auth_filter(monkeypatch):
+def _make_server_auth_filter(monkeypatch, client_fqcn_resolver=None):
     server_auth = FederatedServer.__new__(FederatedServer)
     server_auth.logger = logging.getLogger(__name__)
     server_auth._get_id_asserter = lambda: SimpleNamespace(cert=_Cert())
-    server_auth._resolve_client_fqcn_for_auth = lambda client_name, _token: client_name
+    server_auth._resolve_client_fqcn_for_auth = client_fqcn_resolver or (lambda client_name, _token: client_name)
     monkeypatch.setattr("nvflare.private.fed.server.fed_server.TokenVerifier", lambda _cert: _TokenVerifier())
     return server_auth._validate_auth_headers
 
@@ -156,6 +156,50 @@ def test_cross_client_auth_forces_server_transit_and_strips_credentials_from_pee
     assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
 
 
+def test_cross_client_auth_under_same_relay_transits_server_and_strips_credentials(monkeypatch):
+    relay_name = _unique_fqcn("relay")
+    site_a_name = _unique_fqcn("site_a")
+    site_b_name = _unique_fqcn("site_b")
+    server = _make_running_cell("server")
+    _make_running_cell(relay_name)
+    _make_running_cell(f"{relay_name}.{site_a_name}")
+    _make_running_cell(f"{relay_name}.{site_b_name}")
+    site_a_job = _make_running_cell(f"{relay_name}.{site_a_name}.job")
+    site_b_job = _make_running_cell(f"{relay_name}.{site_b_name}.job")
+    server.core_cell.add_incoming_filter(
+        channel="*",
+        topic="*",
+        cb=_make_server_auth_filter(
+            monkeypatch,
+            client_fqcn_resolver=lambda client_name, _token: f"{relay_name}.{client_name}",
+        ),
+    )
+    set_add_auth_headers_filters(site_a_job, site_a_name, "tok-a", "sig-a")
+    set_add_auth_headers_filters(site_b_job, site_b_name, "tok-b", "sig-b")
+    site_b_job.core_cell.register_request_cb(
+        "peer",
+        "ping",
+        lambda request: Message(
+            payload={
+                "auth": _auth_header_values(request),
+                "transit_required": request.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED),
+                "from_cell": request.get_header(MessageHeaderKey.FROM_CELL),
+            }
+        ),
+    )
+
+    reply = site_a_job.send_request("peer", "ping", site_b_job.get_fqcn(), Message(payload="hello"), timeout=1.0)
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
+    assert reply.payload == {
+        "auth": {key: None for key in AUTH_HEADERS},
+        "transit_required": None,
+        "from_cell": "server",
+    }
+    assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
+
+
 def test_client_job_reply_routed_via_local_parents_authenticates_at_server(monkeypatch):
     site_a_name = _unique_fqcn("site_a")
     site_b_name = _unique_fqcn("site_b")
@@ -210,6 +254,31 @@ def test_server_auth_filter_strips_validated_client_request_transit_auth(monkeyp
     auth_filter = _make_server_auth_filter(monkeypatch)
     request_msg = _make_routed_message("site-b", MessageType.REQ, with_auth=True)
     request_msg.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
+
+    assert auth_filter(request_msg) is None
+    assert _auth_header_values(request_msg) == {key: None for key in AUTH_HEADERS}
+    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
+
+
+def test_server_auth_filter_strips_transit_auth_between_sites_under_same_relay(monkeypatch):
+    relay = _unique_fqcn("relay")
+    site_a = _unique_fqcn("site_a")
+    site_b = _unique_fqcn("site_b")
+    origin = f"{relay}.{site_a}.job"
+    destination = f"{relay}.{site_b}.job"
+    auth_filter = _make_server_auth_filter(
+        monkeypatch,
+        client_fqcn_resolver=lambda client_name, _token: f"{relay}.{client_name}",
+    )
+    request_msg = _make_routed_message(destination, MessageType.REQ, origin=origin)
+    request_msg.add_headers(
+        {
+            CellMessageAuthHeaderKey.CLIENT_NAME: site_a,
+            CellMessageAuthHeaderKey.TOKEN: "token-site-a",
+            CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-site-a",
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+        }
+    )
 
     assert auth_filter(request_msg) is None
     assert _auth_header_values(request_msg) == {key: None for key in AUTH_HEADERS}
@@ -333,6 +402,32 @@ def test_auth_filter_keeps_cross_site_reply_auth_when_routed_via_local_parent():
     }
 
 
+def test_auth_filter_keeps_cross_site_reply_auth_under_same_relay():
+    relay = _unique_fqcn("relay")
+    origin = f"{relay}.site-a.job"
+    victim = _make_running_cell(origin)
+    set_add_auth_headers_filters(victim, "site-a", "tok-a", "sig-a", "ssid-a")
+    reply = Message(
+        headers={
+            MessageHeaderKey.MSG_TYPE: MessageType.REPLY,
+            MessageHeaderKey.ORIGIN: origin,
+            MessageHeaderKey.DESTINATION: f"{relay}.site-b.job",
+            MessageHeaderKey.TO_CELL: f"{relay}.site-a",
+        }
+    )
+
+    for callback in victim.core_cell.out_reply_filter_reg.find("peer", "reply"):
+        callback.cb(reply, *callback.args, **callback.kwargs)
+
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "site-a",
+        CellMessageAuthHeaderKey.TOKEN: "tok-a",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-a",
+        CellMessageAuthHeaderKey.SSID: "ssid-a",
+    }
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
+
+
 def test_auth_filter_does_not_add_auth_to_same_site_reply_via_parent():
     origin = f"site-a.{_unique_fqcn('job')}"
     victim = _make_running_cell(origin)
@@ -350,3 +445,14 @@ def test_auth_filter_does_not_add_auth_to_same_site_reply_via_parent():
         callback.cb(reply, *callback.args, **callback.kwargs)
 
     assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}
+
+
+@pytest.mark.parametrize(
+    ("origin", "destination", "client_name", "expected"),
+    [
+        ("relay-1.site-a.job-1", "relay-1.site-b.job-2", "site-a", True),
+        ("relay-1.site-a.job-1", "relay-1.site-a.job-2", "site-a", False),
+    ],
+)
+def test_cross_client_family_uses_authenticated_site_identity(origin, destination, client_name, expected):
+    assert is_cross_client_family(origin, destination, client_name) is expected

--- a/tests/unit_test/fuel/sec/authn_test.py
+++ b/tests/unit_test/fuel/sec/authn_test.py
@@ -24,6 +24,7 @@ from nvflare.fuel.f3.cellnet.core_cell import CoreCell
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessageType, ReturnCode
 from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message
+from nvflare.fuel.f3.stats_pool import StatsPoolManager
 from nvflare.fuel.sec.authn import set_add_auth_headers_filters
 from nvflare.private.fed.server.fed_server import FederatedServer
 
@@ -38,12 +39,16 @@ AUTH_HEADERS = [
 @pytest.fixture(autouse=True)
 def clean_core_cells():
     original_cells = dict(CoreCell.ALL_CELLS)
+    original_pools = dict(StatsPoolManager.pools)
     CoreCell.ALL_CELLS.clear()
+    StatsPoolManager.pools.clear()
     yield
     for cell in CoreCell.ALL_CELLS.values():
         cell.running = False
     CoreCell.ALL_CELLS.clear()
     CoreCell.ALL_CELLS.update(original_cells)
+    StatsPoolManager.pools.clear()
+    StatsPoolManager.pools.update(original_pools)
 
 
 def _make_running_cell(fqcn: str):
@@ -102,8 +107,9 @@ def _make_routed_message(
 
 
 def test_auth_filter_does_not_add_client_credentials_to_peer_replies():
-    victim = _make_running_cell(_unique_fqcn("victim"))
-    peer = _make_running_cell(_unique_fqcn("peer"))
+    victim_name = _unique_fqcn("victim")
+    victim = _make_running_cell(victim_name)
+    peer = _make_running_cell(f"{victim_name}.peer")
     set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
 
     victim.core_cell.register_request_cb("probe", "ping", lambda _request: Message(payload="pong"))
@@ -119,34 +125,72 @@ def test_auth_filter_does_not_add_client_credentials_to_peer_replies():
     }
 
 
-def test_client_to_client_reply_routed_through_server_is_not_blocked_by_server_auth(monkeypatch):
-    server = _make_running_cell(f"server.{_unique_fqcn('auth_server')}")
+def test_cross_client_auth_forces_server_transit_and_strips_credentials_from_peer(monkeypatch):
+    server = _make_running_cell("server")
     site_a = _make_running_cell(_unique_fqcn("site_a"))
     site_b = _make_running_cell(_unique_fqcn("site_b"))
     server.core_cell.add_incoming_filter(channel="*", topic="*", cb=_make_server_auth_filter(monkeypatch))
     set_add_auth_headers_filters(site_a, site_a.get_fqcn(), "tok-a", "sig-a")
     set_add_auth_headers_filters(site_b, site_b.get_fqcn(), "tok-b", "sig-b")
-    site_b.core_cell.register_request_cb("peer", "ping", lambda _request: Message(payload="pong"))
+    site_b.core_cell.register_request_cb(
+        "peer",
+        "ping",
+        lambda request: Message(
+            payload={
+                "auth": _auth_header_values(request),
+                "transit_required": request.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED),
+                "from_cell": request.get_header(MessageHeaderKey.FROM_CELL),
+            }
+        ),
+    )
 
-    original_find_ep = site_a.core_cell._try_find_ep
+    reply = site_a.send_request("peer", "ping", site_b.get_fqcn(), Message(payload="hello"), timeout=1.0)
 
-    def _route_site_b_via_server(target_fqcn, for_msg):
-        if target_fqcn == site_b.get_fqcn():
-            return Endpoint(server.get_fqcn())
-        return original_find_ep(target_fqcn, for_msg)
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
+    assert reply.payload == {
+        "auth": {key: None for key in AUTH_HEADERS},
+        "transit_required": None,
+        "from_cell": "server",
+    }
+    assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
 
-    monkeypatch.setattr(site_a.core_cell, "_try_find_ep", _route_site_b_via_server)
 
-    reply = site_a.send_request("peer", "ping", site_b.get_fqcn(), Message(payload="hello"), timeout=0.2)
+def test_client_job_reply_routed_via_local_parents_authenticates_at_server(monkeypatch):
+    site_a_name = _unique_fqcn("site_a")
+    site_b_name = _unique_fqcn("site_b")
+    site_a = _make_running_cell(site_a_name)
+    site_b = _make_running_cell(site_b_name)
+    site_a_job = _make_running_cell(f"{site_a_name}.job")
+    site_b_job = _make_running_cell(f"{site_b_name}.job")
+    server = _make_running_cell("server")
+
+    server.core_cell.add_incoming_filter(channel="*", topic="*", cb=_make_server_auth_filter(monkeypatch))
+    set_add_auth_headers_filters(site_a_job, site_a_name, "tok-a", "sig-a")
+    set_add_auth_headers_filters(site_b_job, site_b_name, "tok-b", "sig-b")
+    site_b_job.core_cell.register_request_cb("peer", "ping", lambda _request: Message(payload="pong"))
+
+    routes = {
+        site_a_job: {site_b_job.get_fqcn(): site_a},
+        site_a: {site_b_job.get_fqcn(): server, site_a_job.get_fqcn(): site_a_job},
+        server: {site_b_job.get_fqcn(): site_b, site_a_job.get_fqcn(): site_a},
+        site_b: {site_b_job.get_fqcn(): site_b_job, site_a_job.get_fqcn(): server},
+        site_b_job: {site_a_job.get_fqcn(): site_b},
+    }
+    for cell, target_routes in routes.items():
+        original_find_ep = cell.core_cell._try_find_ep
+
+        def _route(target_fqcn, for_msg, *, mapping=target_routes, fallback=original_find_ep):
+            next_cell = mapping.get(target_fqcn)
+            return Endpoint(next_cell.get_fqcn()) if next_cell else fallback(target_fqcn, for_msg)
+
+        monkeypatch.setattr(cell.core_cell, "_try_find_ep", _route)
+
+    reply = site_a_job.send_request("peer", "ping", site_b_job.get_fqcn(), Message(payload="hello"), timeout=1.0)
 
     assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
     assert reply.payload == "pong"
-    assert _auth_header_values(reply) == {
-        CellMessageAuthHeaderKey.CLIENT_NAME: None,
-        CellMessageAuthHeaderKey.TOKEN: None,
-        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: None,
-        CellMessageAuthHeaderKey.SSID: None,
-    }
+    assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}
 
 
 def test_server_auth_filter_strips_validated_client_reply_transit_auth(monkeypatch):
@@ -160,6 +204,16 @@ def test_server_auth_filter_strips_validated_client_reply_transit_auth(monkeypat
         CellMessageAuthHeaderKey.TOKEN_SIGNATURE: None,
         CellMessageAuthHeaderKey.SSID: None,
     }
+
+
+def test_server_auth_filter_strips_validated_client_request_transit_auth(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+    request_msg = _make_routed_message("site-b", MessageType.REQ, with_auth=True)
+    request_msg.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
+
+    assert auth_filter(request_msg) is None
+    assert _auth_header_values(request_msg) == {key: None for key in AUTH_HEADERS}
+    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
 
 
 def test_server_auth_filter_rejects_untracked_unauthenticated_client_reply_transit(monkeypatch):
@@ -200,8 +254,9 @@ def test_server_auth_filter_still_rejects_unauthenticated_server_destination(mon
 
 
 def test_auth_filter_keeps_auth_on_outgoing_requests():
-    victim = _make_running_cell(_unique_fqcn("victim"))
-    peer = _make_running_cell(_unique_fqcn("peer"))
+    victim_name = _unique_fqcn("victim")
+    victim = _make_running_cell(victim_name)
+    peer = _make_running_cell(f"{victim_name}.peer")
     set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
     peer.core_cell.register_request_cb("probe", "echo", lambda request: Message(payload=_auth_header_values(request)))
 
@@ -252,3 +307,46 @@ def test_auth_filter_keeps_auth_on_replies_from_server_path_origin():
         CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-server",
         CellMessageAuthHeaderKey.SSID: "ssid-server",
     }
+
+
+def test_auth_filter_keeps_cross_site_reply_auth_when_routed_via_local_parent():
+    origin = f"site-a.{_unique_fqcn('job')}"
+    victim = _make_running_cell(origin)
+    set_add_auth_headers_filters(victim, "site-a", "tok-a", "sig-a", "ssid-a")
+    reply = Message(
+        headers={
+            MessageHeaderKey.MSG_TYPE: MessageType.REPLY,
+            MessageHeaderKey.ORIGIN: origin,
+            MessageHeaderKey.DESTINATION: "site-b.job-1",
+            MessageHeaderKey.TO_CELL: "site-a",
+        }
+    )
+
+    for callback in victim.core_cell.out_reply_filter_reg.find("peer", "reply"):
+        callback.cb(reply, *callback.args, **callback.kwargs)
+
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "site-a",
+        CellMessageAuthHeaderKey.TOKEN: "tok-a",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-a",
+        CellMessageAuthHeaderKey.SSID: "ssid-a",
+    }
+
+
+def test_auth_filter_does_not_add_auth_to_same_site_reply_via_parent():
+    origin = f"site-a.{_unique_fqcn('job')}"
+    victim = _make_running_cell(origin)
+    set_add_auth_headers_filters(victim, "site-a", "tok-a", "sig-a", "ssid-a")
+    reply = Message(
+        headers={
+            MessageHeaderKey.MSG_TYPE: MessageType.REPLY,
+            MessageHeaderKey.ORIGIN: origin,
+            MessageHeaderKey.DESTINATION: "site-a.job-2",
+            MessageHeaderKey.TO_CELL: "site-a",
+        }
+    )
+
+    for callback in victim.core_cell.out_reply_filter_reg.find("peer", "reply"):
+        callback.cb(reply, *callback.args, **callback.kwargs)
+
+    assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}


### PR DESCRIPTION
## Summary

- Force authenticated messages between different client families through the server trust boundary, even when a direct or ad-hoc peer endpoint is cached.
- Authenticate cross-site replies that first travel through their local client parent, including shared-file internal transport.
- Strip client bearer headers and the transit marker at the server before forwarding to the peer.
- Add routing and authentication regression coverage for both client-root and client-job paths.

## Problem

With shared-file internal transport, a client-job reply first reaches its local site parent. The reply filter previously treated that next hop as local and omitted authentication. When the reply later crossed the server boundary, the server rejected it as missing the client name. Direct peer routing could also bypass server validation when an endpoint was cached.

This caused cross-site Swarm tasks to time out even though each local trainer was healthy.

## Validation

- 82 focused F3 routing/authentication tests passed.
- Full style check passed.
- License check passed.
- The same implementation previously completed secure cross-site network and FileDriver Swarm validation on Colossus, including server validation and removal of peer bearer material.


Fixes #5098.