### PR TITLE
Correct documented F3 streaming defaults

### DIFF
--- a/docs/user_guide/admin_guide/configurations/communication_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/communication_configuration.rst
@@ -331,6 +331,7 @@ are intentionally omitted.
     "streaming_window_size": 67108864,
     "streaming_ack_interval": 16777216,
     "streaming_ack_wait": 300,
+    "streaming_ack_progress_timeout": 60.0,
     "streaming_reliable": false,
     "streaming_retry_wait": 5.0,
     "streaming_retry_timeout": 60.0,
@@ -452,10 +453,20 @@ with an older sender that does not include these headers, the receiver uses its 
 streaming_ack_wait
 ------------------
 
-The number of seconds that the sender waits for the next ACK.
+The maximum number of seconds that the sender may remain blocked by its flow-control window.
 The default value is 300 seconds.
 
-This timeout is used to detect dead receivers. On a very slow network, this value may need to be increased.
+This limit applies to one blocked-window wait and does not reset merely because a partial ACK advances within that window.
+The sender also enforces ``streaming_ack_progress_timeout``, so a stalled stream stops when either timeout expires.
+
+streaming_ack_progress_timeout
+------------------------------
+
+The sender records the time of the most recent ACK progress. While blocked by its flow-control window, it stops the stream
+if no ACK progress has occurred for this number of seconds. The default value is 60.0 seconds. An increase in the
+acknowledged byte offset, or the acknowledged sequence number for reliable streaming, counts as progress and resets the
+timestamp. With the defaults, a stalled stream normally stops after 60 seconds without ACK progress, before the
+300-second ``streaming_ack_wait`` expires.
 
 streaming_reliable
 ------------------

--- a/docs/user_guide/admin_guide/configurations/communication_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/communication_configuration.rst
@@ -62,7 +62,7 @@ The following is an example of the comm_config.json:
     "allow_adhoc_conns": false,
     "backbone_conn_gen": 2,
     "max_message_size": 2000000000,
-    "streaming_max_blob_size": 2144337904,
+    "streaming_max_blob_size": 4294967296,
     "internal": {
       "scheme": "tcp",
       "resources": {
@@ -326,11 +326,11 @@ are intentionally omitted.
     "heartbeat_interval": 60,
     "tcp_no_delay": true,
     "streaming_chunk_size": 1048576,
-    "streaming_max_blob_size": 2144337904,
-    "streaming_read_timeout": 60,
+    "streaming_max_blob_size": 4294967296,
+    "streaming_read_timeout": 300,
     "streaming_window_size": 67108864,
     "streaming_ack_interval": 16777216,
-    "streaming_ack_wait": 10,
+    "streaming_ack_wait": 300,
     "streaming_reliable": false,
     "streaming_retry_wait": 5.0,
     "streaming_retry_timeout": 60.0,
@@ -401,7 +401,7 @@ The chunk size in bytes. The default value is 1M. When deciding chunk size the f
 streaming_max_blob_size
 -----------------------
 
-The maximum total size in bytes of a received blob stream. The default value is 2144337904 (about 2 GB).
+The maximum total size in bytes of a received blob stream. The default value is 4294967296 (4 GiB).
 This limit is enforced before pre-allocating a declared-size blob and while buffering a blob whose size is not declared up front.
 
 This parameter is separate from ``max_message_size``. ``max_message_size`` limits each individual frame, while
@@ -410,7 +410,7 @@ This parameter is separate from ``max_message_size``. ``max_message_size`` limit
 streaming_read_timeout
 ----------------------
 
-The receiver of streaming times out after this value while waiting for the next chunk. The unit is seconds and the default is 60. 
+The receiver of streaming times out after this value while waiting for the next chunk. The unit is seconds and the default is 300.
 
 This timeout is used to detect dead senders. On a very slow network or extremely busy host, this value may need to be increased.
 
@@ -453,7 +453,7 @@ streaming_ack_wait
 ------------------
 
 The number of seconds that the sender waits for the next ACK.
-The default value is 10 seconds. 
+The default value is 300 seconds.
 
 This timeout is used to detect dead receivers. On a very slow network, this value may need to be increased.
 


### PR DESCRIPTION
Correct documented F3 streaming defaults.

### Description

Align the communication guide with the effective runtime defaults: a 4 GiB maximum streamed blob size and 300-second read and ACK timeouts.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
