### PR TITLE
Harden internal CellNet trust boundaries

### DIFF
--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -21,6 +21,14 @@ Compatibility and Migration Notes
   and must use the documented portable types. Custom resource managers that previously interpreted these names
   differently must migrate to the portable types or rename their custom fields. Legacy nested resource specifications
   without ``@default`` remain unchanged.
+- Internal CellNet listeners now bind to loopback for local process launches.
+  Docker, Kubernetes, and Slurm deployments use mTLS for internal parent/job
+  hops that must cross a network namespace. Non-loopback internal listeners
+  without mutual TLS are rejected. Administrative CP and server-job
+  command receivers also validate their parent route, pre-authentication server
+  replies no longer carry reusable bearer headers, and ``configure_job_log``
+  accepts only log levels or built-in log modes instead of arbitrary Python
+  ``dictConfig`` payloads.
 - F3 retains its 16 MiB streaming-window and 4 MiB ACK-interval defaults for
   compatibility and bounded per-stream memory. High-bandwidth deployments may
   opt into larger values on all endpoints; ``dev_tools/f3/comm_config.yml``

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -455,8 +455,8 @@ class SlurmJobLauncher(JobLauncherSpec):
         if not isinstance(connection_entry, (tuple, list)) or len(connection_entry) != 2:
             raise SlurmLauncherError(f"malformed {JobProcessArgs.PARENT_CONN_SEC} in JOB_PROCESS_ARGS")
         process_connection_security = _require_string(connection_entry[1], f"{JobProcessArgs.PARENT_CONN_SEC} value")
-        if process_connection_security != "clear":
-            raise SlurmLauncherError("Slurm job launch requires clear parent connection security")
+        if process_connection_security not in ("clear", "mtls"):
+            raise SlurmLauncherError("Slurm job launch requires clear or mTLS parent connection security")
         job_args = _rewrite_parent_url(
             raw_job_args,
             parent_host=self.config.parent_host,

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 import shlex
 from abc import abstractmethod
@@ -221,15 +222,21 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
         host = parsed.hostname
     except ValueError as e:
         raise SlurmLauncherError("malformed parent URL in JOB_PROCESS_ARGS") from e
-    if parsed.scheme != "tcp" or port != internal_port or not host:
+    if parsed.scheme not in ("tcp", "stcp") or port != internal_port or not host:
         raise SlurmLauncherError(
-            f"parent URL must use {SHARED_FILE_SCHEME} or tcp with configured internal_port "
+            f"parent URL must use {SHARED_FILE_SCHEME}, tcp, or stcp with configured internal_port "
             f"{internal_port}, got {raw_url!r}"
         )
     host = _resolve_parent_host(parent_host)
-    rendered_host = host if host.startswith("[") and host.endswith("]") else f"[{host}]" if ":" in host else host
-    netloc = f"{rendered_host}:{internal_port}"
-    rewritten = urlunsplit(("tcp", netloc, parsed.path, parsed.query, parsed.fragment))
+    unbracketed_host = host[1:-1] if host.startswith("[") and host.endswith("]") else host
+    try:
+        address = ipaddress.ip_address(unbracketed_host)
+    except ValueError:
+        address = None
+    if isinstance(address, ipaddress.IPv6Address) or ":" in host:
+        raise SlurmLauncherError("IPv6 parent_host is not supported by the F3 TCP transport")
+    netloc = f"{host}:{internal_port}"
+    rewritten = urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
     copied[JobProcessArgs.PARENT_URL] = (flag, rewritten)
     return copied
 
@@ -462,6 +469,14 @@ class SlurmJobLauncher(JobLauncherSpec):
             parent_host=self.config.parent_host,
             internal_port=self.config.internal_port,
         )
+        parent_scheme = urlsplit(str(job_args[JobProcessArgs.PARENT_URL][1])).scheme
+        if parent_scheme != SHARED_FILE_SCHEME:
+            expected_scheme = "stcp" if process_connection_security == "mtls" else "tcp"
+            if parent_scheme != expected_scheme:
+                raise SlurmLauncherError(
+                    f"parent URL scheme '{parent_scheme}' does not match "
+                    f"parent connection security '{process_connection_security}' (expected '{expected_scheme}')"
+                )
 
         study = job_meta.get(JobMetaKey.STUDY.value)
         if study is not None:

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -99,7 +99,7 @@ class ConnectorManager:
         # set up default drivers
         self.int_scheme = comm_configurator.get_internal_connection_scheme(_Defaults.SCHEME_FOR_INTERNAL_CONNECTIONS)
         self.int_resources = {
-            _KEY_HOST: "localhost",
+            _KEY_HOST: "127.0.0.1",
         }
         self.adhoc_allowed = comm_configurator.allow_adhoc_connections(_Defaults.ALLOW_ADHOC_CONNECTIONS)
         self.adhoc_scheme = comm_configurator.get_adhoc_connection_scheme(_Defaults.SCHEME_FOR_ADHOC_CONNECTIONS)
@@ -131,7 +131,7 @@ class ConnectorManager:
 
     def _validate_internal_listener_security(self):
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY, ConnectionSecurity.CLEAR)
-        host = self.int_resources.get(DriverParams.LISTEN_HOST, self.int_resources.get(_KEY_HOST, "localhost"))
+        host = self.int_resources.get(DriverParams.LISTEN_HOST, self.int_resources.get(_KEY_HOST, "127.0.0.1"))
         if _is_loopback_host(host):
             return
         if conn_sec == ConnectionSecurity.MTLS:

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -34,6 +34,33 @@ _KEY_HOST = "host"
 _KEY_PORTS = "ports"
 
 
+def _is_loopback_host(host) -> bool:
+    if not isinstance(host, str):
+        return False
+
+    host = host.strip()
+    if host.rstrip(".").lower() == "localhost":
+        return True
+
+    # Accept the bracketed form commonly used for IPv6 URL hosts as well as
+    # bare address literals used by listener resources.
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+
+    if address.is_loopback:
+        return True
+
+    # On older supported Python versions, IPv4-mapped IPv6 addresses do not
+    # inherit the mapped IPv4 address's is_loopback value.
+    mapped_address = getattr(address, "ipv4_mapped", None)
+    return mapped_address is not None and mapped_address.is_loopback
+
+
 class _Defaults:
 
     ALLOW_ADHOC_CONNECTIONS = False
@@ -105,13 +132,8 @@ class ConnectorManager:
     def _validate_internal_listener_security(self):
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY, ConnectionSecurity.CLEAR)
         host = self.int_resources.get(DriverParams.LISTEN_HOST, self.int_resources.get(_KEY_HOST, "localhost"))
-        if host == "localhost":
+        if _is_loopback_host(host):
             return
-        try:
-            if ipaddress.ip_address(host).is_loopback:
-                return
-        except ValueError:
-            pass
         if conn_sec == ConnectionSecurity.MTLS:
             return
         raise ConfigError(

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ipaddress
 import os
 import time
 from typing import Union
@@ -95,9 +96,28 @@ class ConnectorManager:
         if not conn_sec:
             self.int_resources[DriverParams.CONNECTION_SECURITY] = ConnectionSecurity.CLEAR
 
+        self._validate_internal_listener_security()
+
         self.logger.debug(f"internal scheme={self.int_scheme}, resources={self.int_resources}")
         self.logger.debug(f"adhoc scheme={self.adhoc_scheme}, resources={self.adhoc_resources}")
         self.comm_config = comm_config
+
+    def _validate_internal_listener_security(self):
+        conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY, ConnectionSecurity.CLEAR)
+        host = self.int_resources.get(DriverParams.LISTEN_HOST, self.int_resources.get(_KEY_HOST, "localhost"))
+        if host == "localhost":
+            return
+        try:
+            if ipaddress.ip_address(host).is_loopback:
+                return
+        except ValueError:
+            pass
+        if conn_sec == ConnectionSecurity.MTLS:
+            return
+        raise ConfigError(
+            "internal CellNet listeners outside loopback require connection_security='mtls' "
+            "to authenticate remote peers"
+        )
 
     def get_config_info(self):
         return {

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -32,6 +32,7 @@ _KEY_ADHOC = "adhoc"
 _KEY_SCHEME = "scheme"
 _KEY_HOST = "host"
 _KEY_PORTS = "ports"
+_SHARED_FILE_SCHEME = "shared-file"
 
 
 def _is_loopback_host(host) -> bool:
@@ -115,10 +116,17 @@ class ConnectorManager:
                 self.adhoc_scheme = adhoc_conf.get(_KEY_SCHEME)
                 self.adhoc_resources = adhoc_conf.get(_KEY_RESOURCES)
 
-        # default conn sec
+        # Job cells attach to this listener.  In secure mode, network transports
+        # must authenticate the attaching process even when the listener is only
+        # reachable over loopback: another local process must not be able to claim
+        # the parent cell's FQCN during the F3 handshake.
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY)
         if not conn_sec:
-            self.int_resources[DriverParams.CONNECTION_SECURITY] = ConnectionSecurity.CLEAR
+            self.int_resources[DriverParams.CONNECTION_SECURITY] = (
+                ConnectionSecurity.MTLS
+                if self.secure and self.int_scheme != _SHARED_FILE_SCHEME
+                else ConnectionSecurity.CLEAR
+            )
 
         self._validate_internal_listener_security()
 
@@ -128,6 +136,10 @@ class ConnectorManager:
 
     def _validate_internal_listener_security(self):
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY, ConnectionSecurity.CLEAR)
+        if self.int_scheme == _SHARED_FILE_SCHEME:
+            return
+        if self.secure and conn_sec != ConnectionSecurity.MTLS:
+            raise ConfigError("secure-mode internal CellNet listeners require connection_security='mtls'")
         host = self.int_resources.get(DriverParams.LISTEN_HOST, self.int_resources.get(_KEY_HOST, "127.0.0.1"))
         if _is_loopback_host(host):
             return

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -52,13 +52,10 @@ def _is_loopback_host(host) -> bool:
     except ValueError:
         return False
 
-    if address.is_loopback:
-        return True
-
-    # On older supported Python versions, IPv4-mapped IPv6 addresses do not
-    # inherit the mapped IPv4 address's is_loopback value.
-    mapped_address = getattr(address, "ipv4_mapped", None)
-    return mapped_address is not None and mapped_address.is_loopback
+    # Literal IPv6 listener hosts are not supported by all F3 TCP drivers yet.
+    # Do not classify them as safe loopback addresses: rendering an unbracketed
+    # IPv6 URL can otherwise degrade into a wildcard IPv4 bind.
+    return isinstance(address, ipaddress.IPv4Address) and address.is_loopback
 
 
 class _Defaults:

--- a/nvflare/fuel/f3/drivers/driver_params.py
+++ b/nvflare/fuel/f3/drivers/driver_params.py
@@ -21,6 +21,7 @@ class DriverParams(str, Enum):
     URL = "url"
     SCHEME = "scheme"
     HOST = "host"
+    LISTEN_HOST = "listen_host"
     PORT = "port"
     PATH = "path"
     PARAMS = "params"

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -282,14 +282,14 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
 
     host = resources.get("host") if resources else None
     if not host:
-        host = "localhost"
+        host = "127.0.0.1"
 
     port = get_open_tcp_port(resources)
     if not port:
         raise CommError(CommError.BAD_CONFIG, "Can't find an open port in the specified range")
 
     # Internal listeners default to the requested connect host. This keeps the
-    # default "localhost" transport local to the host instead of silently
+    # default loopback transport local to the host instead of silently
     # widening it to every interface. Distributed launchers must explicitly
     # request a wildcard listener and protect it with mTLS.
     listen_host = resources.get(DriverParams.LISTEN_HOST.value, host) if resources else host

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -288,8 +288,12 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     if not port:
         raise CommError(CommError.BAD_CONFIG, "Can't find an open port in the specified range")
 
-    # Always listen on all interfaces
-    listening_url = f"{scheme}://0:{port}"
+    # Internal listeners default to the requested connect host. This keeps the
+    # default "localhost" transport local to the host instead of silently
+    # widening it to every interface. Distributed launchers must explicitly
+    # request a wildcard listener and protect it with mTLS.
+    listen_host = resources.get(DriverParams.LISTEN_HOST.value, host) if resources else host
+    listening_url = f"{scheme}://{listen_host}:{port}"
     connect_url = f"{scheme}://{host}:{port}"
 
     return connect_url, listening_url
@@ -339,6 +343,9 @@ def enhance_credential_info(params: dict):
         server_cert_path = os.path.join(cred_folder, SSL_SERVER_CERT)
         if os.path.exists(server_cert_path):
             params[DriverParams.SERVER_CERT.value] = server_cert_path
+        elif client_cert_path:
+            # Internal CellNet peers can act as both connector and listener.
+            params[DriverParams.SERVER_CERT.value] = client_cert_path
 
     server_key_path = params.get(DriverParams.SERVER_KEY.value)
     if not server_key_path:
@@ -346,6 +353,13 @@ def enhance_credential_info(params: dict):
         server_key_path = os.path.join(cred_folder, SSL_SERVER_PRIVATE_KEY)
         if os.path.exists(server_key_path):
             params[DriverParams.SERVER_KEY.value] = server_key_path
+        elif client_key_path:
+            params[DriverParams.SERVER_KEY.value] = client_key_path
+
+    if not client_cert_path and server_cert_path:
+        params[DriverParams.CLIENT_CERT.value] = server_cert_path
+    if not client_key_path and server_key_path:
+        params[DriverParams.CLIENT_KEY.value] = server_key_path
 
     custom_ca_cert_path = params.get(DriverParams.CUSTOM_CA_CERT.value)
     if not custom_ca_cert_path:

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ipaddress
 import logging
 import os
 import random
@@ -284,6 +285,16 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     if not host:
         host = "127.0.0.1"
 
+    listen_host = resources.get(DriverParams.LISTEN_HOST.value, host) if resources else host
+    for value in (host, listen_host):
+        address = value[1:-1] if value.startswith("[") and value.endswith("]") else value
+        try:
+            is_ipv6 = isinstance(ipaddress.ip_address(address), ipaddress.IPv6Address)
+        except ValueError:
+            is_ipv6 = False
+        if is_ipv6:
+            raise CommError(CommError.BAD_CONFIG, "literal IPv6 hosts are not supported by F3 TCP listeners")
+
     port = get_open_tcp_port(resources)
     if not port:
         raise CommError(CommError.BAD_CONFIG, "Can't find an open port in the specified range")
@@ -292,7 +303,6 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     # default loopback transport local to the host instead of silently
     # widening it to every interface. Distributed launchers must explicitly
     # request a wildcard listener and protect it with mTLS.
-    listen_host = resources.get(DriverParams.LISTEN_HOST.value, host) if resources else host
     listening_url = f"{scheme}://{listen_host}:{port}"
     connect_url = f"{scheme}://{host}:{port}"
 

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -326,39 +326,43 @@ def enhance_credential_info(params: dict):
     client_cert_path = params.get(DriverParams.CLIENT_CERT.value)
     if not client_cert_path:
         # see whether the client cert file exists
-        client_cert_path = os.path.join(cred_folder, SSL_CLIENT_CERT)
-        if os.path.exists(client_cert_path):
-            params[DriverParams.CLIENT_CERT.value] = client_cert_path
+        candidate = os.path.join(cred_folder, SSL_CLIENT_CERT)
+        if os.path.exists(candidate):
+            client_cert_path = candidate
+            params[DriverParams.CLIENT_CERT.value] = candidate
 
     client_key_path = params.get(DriverParams.CLIENT_KEY.value)
     if not client_key_path:
         # see whether the client key file exists
-        client_key_path = os.path.join(cred_folder, SSL_CLIENT_PRIVATE_KEY)
-        if os.path.exists(client_key_path):
-            params[DriverParams.CLIENT_KEY.value] = client_key_path
+        candidate = os.path.join(cred_folder, SSL_CLIENT_PRIVATE_KEY)
+        if os.path.exists(candidate):
+            client_key_path = candidate
+            params[DriverParams.CLIENT_KEY.value] = candidate
 
     server_cert_path = params.get(DriverParams.SERVER_CERT.value)
     if not server_cert_path:
         # see whether the server cert file exists
-        server_cert_path = os.path.join(cred_folder, SSL_SERVER_CERT)
-        if os.path.exists(server_cert_path):
-            params[DriverParams.SERVER_CERT.value] = server_cert_path
-        elif client_cert_path:
-            # Internal CellNet peers can act as both connector and listener.
-            params[DriverParams.SERVER_CERT.value] = client_cert_path
+        candidate = os.path.join(cred_folder, SSL_SERVER_CERT)
+        if os.path.exists(candidate):
+            server_cert_path = candidate
+            params[DriverParams.SERVER_CERT.value] = candidate
 
     server_key_path = params.get(DriverParams.SERVER_KEY.value)
     if not server_key_path:
         # see whether the server key file exists
-        server_key_path = os.path.join(cred_folder, SSL_SERVER_PRIVATE_KEY)
-        if os.path.exists(server_key_path):
-            params[DriverParams.SERVER_KEY.value] = server_key_path
-        elif client_key_path:
-            params[DriverParams.SERVER_KEY.value] = client_key_path
+        candidate = os.path.join(cred_folder, SSL_SERVER_PRIVATE_KEY)
+        if os.path.exists(candidate):
+            server_key_path = candidate
+            params[DriverParams.SERVER_KEY.value] = candidate
 
-    if not client_cert_path and server_cert_path:
+    # Internal CellNet peers act as both connector and listener. Participant
+    # certificates are issued for both TLS purposes, so a complete role pair
+    # can safely fill the other role. Never combine halves of different pairs.
+    if not server_cert_path and not server_key_path and client_cert_path and client_key_path:
+        params[DriverParams.SERVER_CERT.value] = client_cert_path
+        params[DriverParams.SERVER_KEY.value] = client_key_path
+    elif not client_cert_path and not client_key_path and server_cert_path and server_key_path:
         params[DriverParams.CLIENT_CERT.value] = server_cert_path
-    if not client_key_path and server_key_path:
         params[DriverParams.CLIENT_KEY.value] = server_key_path
 
     custom_ca_cert_path = params.get(DriverParams.CUSTOM_CA_CERT.value)

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -192,6 +192,17 @@ def parse_url(url: str) -> dict:
 
     params = {DriverParams.URL.value: url}
     parsed_url = urlparse(url)
+    try:
+        host = parsed_url.hostname
+    except ValueError as e:
+        raise CommError(CommError.BAD_CONFIG, f"malformed network URL: {url!r}") from e
+    if host:
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            address = None
+        if isinstance(address, ipaddress.IPv6Address):
+            raise CommError(CommError.BAD_CONFIG, "literal IPv6 hosts are not supported by F3 network transports")
     params[DriverParams.SCHEME.value] = parsed_url.scheme
     parts = parsed_url.netloc.split(":")
     if len(parts) >= 1:
@@ -268,6 +279,18 @@ def short_url(params: dict) -> str:
     return encode_url(subset)
 
 
+def _normalize_ipv4_loopback(host: str) -> str:
+    if host.rstrip(".").lower() == "localhost":
+        return "127.0.0.1"
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return host
+    if isinstance(address, ipaddress.IPv4Address) and address.is_loopback:
+        return "127.0.0.1"
+    return host
+
+
 def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     """Generate URL pairs for connecting and listening for TCP-based protocols
 
@@ -285,7 +308,15 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     if not host:
         host = "127.0.0.1"
 
-    listen_host = resources.get(DriverParams.LISTEN_HOST.value, host) if resources else host
+    host = _normalize_ipv4_loopback(host)
+    if host == "127.0.0.1":
+        # A loopback connect address is a same-host transport.  Never widen its
+        # listener to a wildcard address, even if a stale deployment override
+        # still supplies listen_host=0.0.0.0.
+        listen_host = host
+    else:
+        listen_host = resources.get(DriverParams.LISTEN_HOST.value, host) if resources else host
+        listen_host = _normalize_ipv4_loopback(listen_host)
     for value in (host, listen_host):
         address = value[1:-1] if value.startswith("[") and value.endswith("]") else value
         try:

--- a/nvflare/fuel/utils/log_utils.py
+++ b/nvflare/fuel/utils/log_utils.py
@@ -422,6 +422,26 @@ def dynamic_log_config(config: Union[dict, str], dir_path: str, reload_path: str
         )
 
 
+def _validate_remote_log_config(config, command_name: str) -> str:
+    """Validate a remotely supplied log control value."""
+    error = f"{command_name} only supports log levels and built-in log modes"
+    if not isinstance(config, str):
+        raise ValueError(error)
+
+    config = config.strip()
+    if not config:
+        raise ValueError(error)
+
+    if config == LogMode.RELOAD or config in logmode_config_dict:
+        return config
+
+    level = int(config) if config.isdigit() else getattr(logging, config.upper(), None)
+    if level is None or not (0 <= level <= 50):
+        raise ValueError(error)
+
+    return config
+
+
 def validate_site_log_config(config) -> str:
     """Validate site-wide log configuration input.
 
@@ -430,21 +450,12 @@ def validate_site_log_config(config) -> str:
     allowed on this admin command path.
     """
 
-    if not isinstance(config, str):
-        raise ValueError("configure_site_log only supports log levels and built-in log modes")
+    return _validate_remote_log_config(config, "configure_site_log")
 
-    config = config.strip()
-    if not config:
-        raise ValueError("configure_site_log only supports log levels and built-in log modes")
 
-    if config == LogMode.RELOAD or config in logmode_config_dict:
-        return config
-
-    level = int(config) if config.isdigit() else getattr(logging, config.upper(), None)
-    if level is None or not (0 <= level <= 50):
-        raise ValueError("configure_site_log only supports log levels and built-in log modes")
-
-    return config
+def validate_job_log_config(config) -> str:
+    """Validate job log input without accepting executable dictConfig data."""
+    return _validate_remote_log_config(config, "configure_job_log")
 
 
 def add_log_file_handler(log_file_name):

--- a/nvflare/private/fed/client/admin.py
+++ b/nvflare/private/fed/client/admin.py
@@ -17,7 +17,9 @@ from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import ReservedHeaderKey
 from nvflare.fuel.f3.cellnet.cell import Cell
-from nvflare.fuel.f3.cellnet.core_cell import Message as CellMessage
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessagePropKey, ReturnCode
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.hci.proto import ReplyKeyword
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.fuel.sec.audit import Auditor, AuditService
@@ -103,10 +105,37 @@ class FedAdminAgent(object):
         # *args, **kwargs
     ) -> CellMessage:
         assert isinstance(request, CellMessage), "request must be CellMessage but got {}".format(type(request))
+        origin = request.get_header(MessageHeaderKey.ORIGIN)
+        destination = request.get_header(MessageHeaderKey.DESTINATION)
+        local_fqcn = self.cell.get_fqcn()
+        peer_endpoint = request.get_prop(MessagePropKey.ENDPOINT)
+        expected_parent = FQCN.get_parent(local_fqcn) or FQCN.ROOT_SERVER
+        if (
+            origin != FQCN.ROOT_SERVER
+            or destination != local_fqcn
+            or not peer_endpoint
+            or peer_endpoint.name != expected_parent
+        ):
+            self.cell.logger.warning(
+                f"rejected administrative request from {origin} via "
+                f"{getattr(peer_endpoint, 'name', '<unknown>')} to {destination}"
+            )
+            return new_cell_message(
+                {MessageHeaderKey.RETURN_CODE: ReturnCode.UNAUTHENTICATED},
+                error_reply("unauthenticated administrative request"),
+            )
         req = request.payload
 
         assert isinstance(req, Message), "request payload must be Message but got {}".format(type(req))
         topic = req.topic
+        outer_topic = request.get_header(MessageHeaderKey.TOPIC)
+        cmd = req.get_header(RequestHeader.ADMIN_COMMAND)
+        authz_flag = req.get_header(RequestHeader.REQUIRE_AUTHZ)
+        if outer_topic != topic or not cmd or authz_flag not in ("true", "false"):
+            return new_cell_message(
+                {MessageHeaderKey.RETURN_CODE: ReturnCode.INVALID_REQUEST},
+                error_reply("invalid administrative request envelope"),
+            )
 
         # create audit record
         if self.auditor:
@@ -126,7 +155,6 @@ class FedAdminAgent(object):
                 try:
                     reply = None
 
-                    cmd = req.get_header(RequestHeader.ADMIN_COMMAND, None)
                     if cmd:
                         site_security = SiteSecurity()
                         self._set_security_data(req, fl_ctx)
@@ -136,7 +164,6 @@ class FedAdminAgent(object):
 
                     if not reply:
                         # see whether pre-authorization is needed
-                        authz_flag = req.get_header(RequestHeader.REQUIRE_AUTHZ)
                         require_authz = authz_flag == "true"
                         if require_authz:
                             # authorize this command!

--- a/nvflare/private/fed/client/admin_commands.py
+++ b/nvflare/private/fed/client/admin_commands.py
@@ -17,7 +17,7 @@
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.fuel.utils.log_utils import dynamic_log_config
+from nvflare.fuel.utils.log_utils import dynamic_log_config, validate_job_log_config
 from nvflare.private.fed.client.client_status import get_status_message
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import InfoCollector
@@ -272,8 +272,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_job_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -411,6 +411,12 @@ class FederatedServer(BaseServer):
         dest = message.get_header(MessageHeaderKey.DESTINATION)
         channel = message.get_header(MessageHeaderKey.CHANNEL)
         topic = message.get_header(MessageHeaderKey.TOPIC)
+        if channel == CellChannel.SERVER_MAIN and topic in (CellChannelTopic.Challenge, CellChannelTopic.Register):
+            # These endpoints are intentionally reachable before client
+            # authentication. Do not disclose the server's reusable bearer
+            # token and signature on their replies.
+            self.logger.debug(f"not adding auth headers to pre-authentication reply: {topic=}")
+            return
         if not self.my_own_token_signature:
             self.my_own_token_signature = self.sign_auth_token(self.my_own_auth_client_name, self.my_own_token)
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -46,7 +46,7 @@ from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.core_cell import Message
 from nvflare.fuel.f3.cellnet.core_cell import make_reply as make_cellnet_reply
-from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey
+from nvflare.fuel.f3.cellnet.defs import IdentityChallengeKey, MessageHeaderKey, MessagePropKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.identity import ADMIN_LISTENER_KEY
@@ -473,9 +473,35 @@ class FederatedServer(BaseServer):
             client_fqcn_resolver=self._resolve_client_fqcn_for_auth,
             local_cell_fqcn=self.cell.get_fqcn() if getattr(self, "cell", None) else None,
         )
+        if not reply and self._uses_server_credentials(message):
+            origin = message.get_header(MessageHeaderKey.ORIGIN)
+            endpoint = message.get_prop(MessagePropKey.ENDPOINT)
+            peer_fqcn = getattr(endpoint, "name", None)
+            if not self._is_server_origin_for_peer(origin, peer_fqcn):
+                self.logger.error(
+                    f"rejected server credentials from physical peer {peer_fqcn!r} with logical origin {origin!r}"
+                )
+                reply = make_cellnet_reply(
+                    F3ReturnCode.UNAUTHENTICATED,
+                    error="server credentials may only arrive from the server cell family",
+                )
         if not reply:
             self._strip_peer_transit_auth_headers(message)
         return reply
+
+    def _uses_server_credentials(self, message: Message) -> bool:
+        return (
+            message.get_header(CellMessageHeaderKeys.CLIENT_NAME) == self.my_own_auth_client_name
+            and message.get_header(CellMessageHeaderKeys.TOKEN) == self.my_own_token
+        )
+
+    @staticmethod
+    def _is_server_origin_for_peer(origin: str, peer_fqcn: str) -> bool:
+        if not origin or not peer_fqcn:
+            return False
+        if FQCN.get_root(origin) != FQCN.ROOT_SERVER or FQCN.get_root(peer_fqcn) != FQCN.ROOT_SERVER:
+            return False
+        return origin == peer_fqcn or origin.startswith(peer_fqcn + FQCN.SEPARATOR)
 
     def _resolve_client_fqcn_for_auth(self, client_name: str, token: str):
         client = self.client_manager.clients.get(token)

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -411,11 +411,19 @@ class FederatedServer(BaseServer):
         dest = message.get_header(MessageHeaderKey.DESTINATION)
         channel = message.get_header(MessageHeaderKey.CHANNEL)
         topic = message.get_header(MessageHeaderKey.TOPIC)
-        if channel == CellChannel.SERVER_MAIN and topic in (CellChannelTopic.Challenge, CellChannelTopic.Register):
-            # These endpoints are intentionally reachable before client
-            # authentication. Do not disclose the server's reusable bearer
-            # token and signature on their replies.
-            self.logger.debug(f"not adding auth headers to pre-authentication reply: {topic=}")
+        # Endpoints that are intentionally reachable before client authentication
+        # (see authenticator.validate_auth_headers, which exempts these same
+        # channel/topic pairs from the incoming auth check). Their replies must
+        # NOT disclose the server's reusable bearer token and signature, or an
+        # uncredentialed peer could elicit a reply, harvest the headers, and
+        # replay them to authenticate as the server. This must stay in sync with
+        # the incoming exemptions: Challenge/Register on SERVER_MAIN and the
+        # direct-neighbor CELLNET/Bye teardown ack.
+        pre_auth_reply = (
+            channel == CellChannel.SERVER_MAIN and topic in (CellChannelTopic.Challenge, CellChannelTopic.Register)
+        ) or (channel == CellChannel.CELLNET and topic == CellChannelTopic.Bye)
+        if pre_auth_reply:
+            self.logger.debug(f"not adding auth headers to pre-authentication reply: {channel=} {topic=}")
             return
         if not self.my_own_token_signature:
             self.my_own_token_signature = self.sign_auth_token(self.my_own_auth_client_name, self.my_own_token)

--- a/nvflare/private/fed/server/server_command_agent.py
+++ b/nvflare/private/fed/server/server_command_agent.py
@@ -16,7 +16,9 @@ from nvflare.apis.fl_constant import ServerCommandKey
 from nvflare.apis.shareable import ReservedHeaderKey, Shareable
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
 from nvflare.fuel.f3.cellnet.cell import Cell
-from nvflare.fuel.f3.cellnet.core_cell import MessageHeaderKey, ReturnCode, make_reply
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessagePropKey, ReturnCode
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
+from nvflare.fuel.f3.cellnet.utils import make_reply
 from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.private.defs import CellChannel, CellMessageHeaderKeys, new_cell_message
@@ -68,6 +70,21 @@ class ServerCommandAgent(object):
 
         command = ServerCommands.get_command(command_name)
         if command:
+            if command_name not in ServerCommands.client_request_commands_names:
+                origin = request.get_header(MessageHeaderKey.ORIGIN)
+                destination = request.get_header(MessageHeaderKey.DESTINATION)
+                peer_endpoint = request.get_prop(MessagePropKey.ENDPOINT)
+                if (
+                    origin != FQCN.ROOT_SERVER
+                    or destination != self.cell.get_fqcn()
+                    or not peer_endpoint
+                    or peer_endpoint.name != FQCN.ROOT_SERVER
+                ):
+                    self.logger.warning(
+                        f"rejected parent command {command_name} from {origin} via "
+                        f"{getattr(peer_endpoint, 'name', '<unknown>')} to {destination}"
+                    )
+                    return make_reply(ReturnCode.AUTHENTICATION_ERROR, "unauthenticated parent command")
             if command_name in ServerCommands.client_request_commands_names:
                 if not client:
                     return make_reply(

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -29,7 +29,7 @@ from nvflare.apis.fl_constant import (
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
-from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger
+from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger, validate_job_log_config
 from nvflare.private.defs import SpecialTaskName, TaskConstant
 from nvflare.security.logging import secure_format_exception, secure_format_traceback
 from nvflare.widgets.widget import WidgetID
@@ -453,8 +453,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_job_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/nvflare/tool/cert/cert_commands.py
+++ b/nvflare/tool/cert/cert_commands.py
@@ -1202,12 +1202,12 @@ def _build_signed_cert(
             encipher_only=False,
             decipher_only=False,
         )
+        # A participant's CellNet identity can act as both a listener and a
+        # connector on internal mTLS hops. Issue the role certificate for both
+        # TLS purposes instead of reusing a purpose-limited certificate.
         eku_oids = [
-            (
-                x509.oid.ExtendedKeyUsageOID.SERVER_AUTH
-                if cert_type == "server"
-                else x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH
-            )
+            x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+            x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
         ]
 
     # Rebuild subject from safe OIDs only; do NOT copy CSR subject verbatim.

--- a/nvflare/tool/deploy/docker_deploy.py
+++ b/nvflare/tool/deploy/docker_deploy.py
@@ -129,7 +129,8 @@ def _patch_comm_config_for_docker(kit_dir: Path) -> None:
     internal["scheme"] = "tcp"
     resources = _internal_resources(comm_config)
     resources["host"] = "0.0.0.0"
-    resources.setdefault("connection_security", "clear")
+    resources["listen_host"] = "0.0.0.0"
+    resources["connection_security"] = "mtls"
     _write_json(comm_config_path, comm_config)
 
 

--- a/nvflare/tool/deploy/k8s_deploy.py
+++ b/nvflare/tool/deploy/k8s_deploy.py
@@ -186,8 +186,9 @@ def _patch_comm_config_for_k8s(
     resources.update(
         {
             "host": _k8s_parent_service_name(role, site_name, server_service_name),
+            "listen_host": "0.0.0.0",
             "port": parent_port,
-            "connection_security": "clear",
+            "connection_security": "mtls",
         }
     )
     internal["scheme"] = "tcp"

--- a/nvflare/tool/deploy/slurm_deploy.py
+++ b/nvflare/tool/deploy/slurm_deploy.py
@@ -211,8 +211,9 @@ def _patch_comm_config(kit_dir: Path, port: int) -> None:
     resources.update(
         {
             "host": "0.0.0.0",
+            "listen_host": "0.0.0.0",
             "port": port,
-            "connection_security": "clear",
+            "connection_security": "mtls",
         }
     )
     _write_json(comm_config_path, comm_config)

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -50,13 +50,14 @@ def _workspace(tmp_path):
 
 
 def _launcher(tmp_path, workspace, sandbox="none", image=None, launcher_class=ClientSlurmJobLauncher, **kwargs):
+    parent_host = kwargs.pop("parent_host", "compute.example")
     return launcher_class(
         workspace_path=str(workspace),
         sandbox=sandbox,
         image=image,
         python_path="/usr/bin/python3",
         executables={name: "/usr/bin/true" for name in ("sbatch", "squeue", "sacct", "scancel")},
-        parent_host="compute.example",
+        parent_host=parent_host,
         **kwargs,
     )
 
@@ -184,12 +185,27 @@ def test_parent_url_rewrite_is_shallow_and_preserves_other_entries():
     assert args[JobProcessArgs.PARENT_URL][1] == "tcp://old:8102"
 
 
-def test_parent_url_rewrite_formats_ipv6_host():
+def test_parent_url_rewrite_rejects_ipv6_host_until_f3_tcp_supports_it():
     args = {JobProcessArgs.PARENT_URL: ("-p", "tcp://[2001:db8::1]:8102")}
 
-    rewritten = _rewrite_parent_url(args, "2001:db8::2", 8102)
+    with pytest.raises(SlurmLauncherError, match="IPv6 parent_host is not supported"):
+        _rewrite_parent_url(args, "2001:db8::2", 8102)
 
-    assert rewritten[JobProcessArgs.PARENT_URL][1] == "tcp://[2001:db8::2]:8102"
+
+def test_launch_plan_rejects_ipv6_parent_before_worker_connector_setup(tmp_path):
+    workspace = _workspace(tmp_path)
+    launcher = _launcher(tmp_path, workspace, parent_host="2001:db8::2")
+
+    with pytest.raises(SlurmLauncherError, match="IPv6 parent_host is not supported"):
+        launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _fl_ctx(workspace))
+
+
+def test_parent_url_rewrite_preserves_secure_tcp_scheme():
+    args = {JobProcessArgs.PARENT_URL: ("-p", "stcp://old:8102")}
+
+    rewritten = _rewrite_parent_url(args, "new-host", 8102)
+
+    assert rewritten[JobProcessArgs.PARENT_URL][1] == "stcp://new-host:8102"
 
 
 def test_shared_file_parent_url_is_preserved_without_parent_host():
@@ -207,7 +223,7 @@ def test_shared_file_parent_url_is_preserved_without_parent_host():
     [
         (None, "missing or malformed"),
         (("-p", "tcp://old:not-a-port"), "malformed parent URL"),
-        (("-p", "http://old:8102"), "must use shared-file or tcp"),
+        (("-p", "http://old:8102"), "must use shared-file, tcp, or stcp"),
         (("-p", "tcp://old:9000"), "configured internal_port"),
         (("-p", "shared-file://host/not-placeholder"), "malformed shared-file"),
         (("-p", "shared-file://0"), "malformed shared-file"),
@@ -576,11 +592,30 @@ def test_launch_plan_accepts_and_propagates_mtls_parent_connection(tmp_path):
     launcher = _launcher(tmp_path, workspace)
     context = _fl_ctx(workspace)
     context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", "mtls")
+    context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_URL] = ("-p", "stcp://old:8102")
 
     plan = launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, context)
 
     connection_security_index = plan.module_args.index("--parent_conn_sec") + 1
     assert plan.module_args[connection_security_index] == "mtls"
+    parent_url_index = plan.module_args.index("-p") + 1
+    assert plan.module_args[parent_url_index] == "stcp://compute.example:8102"
+
+
+@pytest.mark.parametrize(
+    "parent_url,connection_security",
+    [("tcp://old:8102", "mtls"), ("stcp://old:8102", "clear")],
+)
+def test_launch_plan_rejects_parent_scheme_security_mismatch(tmp_path, parent_url, connection_security):
+    workspace = _workspace(tmp_path)
+    launcher = _launcher(tmp_path, workspace)
+    context = _fl_ctx(workspace)
+    args = context.get_prop(FLContextKey.JOB_PROCESS_ARGS)
+    args[JobProcessArgs.PARENT_URL] = ("-p", parent_url)
+    args[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", connection_security)
+
+    with pytest.raises(SlurmLauncherError, match="does not match parent connection security"):
+        launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, context)
 
 
 def test_tls_internal_connection_is_rejected(tmp_path):

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -571,13 +571,25 @@ def test_launch_plan_rejects_different_context_workspace(tmp_path):
         launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _fl_ctx(context_workspace))
 
 
-def test_non_clear_internal_connection_is_rejected(tmp_path):
+def test_launch_plan_accepts_and_propagates_mtls_parent_connection(tmp_path):
+    workspace = _workspace(tmp_path)
+    launcher = _launcher(tmp_path, workspace)
+    context = _fl_ctx(workspace)
+    context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", "mtls")
+
+    plan = launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, context)
+
+    connection_security_index = plan.module_args.index("--parent_conn_sec") + 1
+    assert plan.module_args[connection_security_index] == "mtls"
+
+
+def test_tls_internal_connection_is_rejected(tmp_path):
     workspace = _workspace(tmp_path)
     launcher = _launcher(tmp_path, workspace)
     context = _fl_ctx(workspace)
     context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", "tls")
 
-    with pytest.raises(SlurmLauncherError, match="requires clear"):
+    with pytest.raises(SlurmLauncherError, match="requires clear or mTLS"):
         launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, context)
 
 

--- a/tests/unit_test/client/cell/api_test.py
+++ b/tests/unit_test/client/cell/api_test.py
@@ -618,6 +618,8 @@ class TestAttachMode:
             "ca_cert": str(ca_cert),
             "client_cert": str(client_cert),
             "client_key": str(client_key),
+            "server_cert": str(client_cert),
+            "server_key": str(client_key),
         }
         assert kwargs["parent_resources"] == {"connection_security": "mtls"}
         api.shutdown()
@@ -644,6 +646,8 @@ class TestAttachMode:
             "ca_cert": str(ca_cert),
             "client_cert": str(client_cert),
             "client_key": str(client_key),
+            "server_cert": str(client_cert),
+            "server_key": str(client_key),
         }
         assert kwargs["parent_resources"] == {"connection_security": "clear"}
         assert kwargs["auth_identity_map"] == {"site-1": "custom-site-cn"}

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
@@ -52,14 +52,9 @@ def test_default_internal_listener_uses_ipv4_loopback():
         "LOCALHOST.",
         "127.0.0.1",
         "127.255.255.254",
-        "::1",
-        "0:0:0:0:0:0:0:1",
-        "[::1]",
-        "::ffff:127.0.0.1",
-        "::ffff:7f00:1",
     ],
 )
-def test_equivalent_ipv4_and_ipv6_loopback_listeners_allow_clear_transport(listen_host):
+def test_equivalent_ipv4_loopback_listeners_allow_clear_transport(listen_host):
     manager = ConnectorManager(
         communicator=MagicMock(),
         secure=False,
@@ -73,6 +68,22 @@ def test_equivalent_ipv4_and_ipv6_loopback_listeners_allow_clear_transport(liste
     )
 
     assert manager.int_resources["listen_host"] == listen_host
+
+
+@pytest.mark.parametrize("listen_host", ["::1", "0:0:0:0:0:0:0:1", "[::1]", "::ffff:127.0.0.1"])
+def test_ipv6_loopback_listener_requires_mtls_until_tcp_drivers_support_ipv6(listen_host):
+    with pytest.raises(ConfigError, match="require connection_security='mtls'"):
+        ConnectorManager(
+            communicator=MagicMock(),
+            secure=False,
+            comm_configurator=_config(
+                {
+                    "host": listen_host,
+                    "listen_host": listen_host,
+                    "connection_security": "clear",
+                }
+            ),
+        )
 
 
 @pytest.mark.parametrize("listen_host", ["0.0.0.0", "::", "::ffff:192.0.2.1", "parent-service"])

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
@@ -16,18 +16,19 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nvflare.apis.fl_constant import ConnectionSecurity
 from nvflare.fuel.common.excepts import ConfigError
 from nvflare.fuel.f3.cellnet.connector_manager import ConnectorManager
 
 
-def _config(resources):
+def _config(resources, scheme="tcp"):
     config = MagicMock()
     config.get_backbone_connection_generation.return_value = 2
-    config.get_internal_connection_scheme.return_value = "tcp"
+    config.get_internal_connection_scheme.return_value = scheme
     config.allow_adhoc_connections.return_value = False
     config.get_adhoc_connection_scheme.return_value = "tcp"
     config.get_config.return_value = {
-        "internal": {"scheme": "tcp", "resources": resources},
+        "internal": {"scheme": scheme, "resources": resources},
     }
     return config
 
@@ -43,6 +44,41 @@ def test_default_internal_listener_uses_ipv4_loopback():
     manager = ConnectorManager(communicator=MagicMock(), secure=False, comm_configurator=config)
 
     assert manager.int_resources["host"] == "127.0.0.1"
+
+
+def test_secure_internal_network_listener_defaults_to_mtls_on_loopback():
+    config = MagicMock()
+    config.get_backbone_connection_generation.return_value = 2
+    config.get_internal_connection_scheme.return_value = "tcp"
+    config.allow_adhoc_connections.return_value = False
+    config.get_adhoc_connection_scheme.return_value = "tcp"
+    config.get_config.return_value = None
+
+    manager = ConnectorManager(communicator=MagicMock(), secure=True, comm_configurator=config)
+
+    assert manager.int_resources["connection_security"] == ConnectionSecurity.MTLS
+
+
+@pytest.mark.parametrize("connection_security", ["clear", "tls"])
+def test_secure_internal_network_listener_rejects_unauthenticated_loopback(connection_security):
+    with pytest.raises(ConfigError, match="secure-mode internal CellNet listeners require"):
+        ConnectorManager(
+            communicator=MagicMock(),
+            secure=True,
+            comm_configurator=_config(
+                {"host": "127.0.0.1", "listen_host": "127.0.0.1", "connection_security": connection_security}
+            ),
+        )
+
+
+def test_secure_shared_file_internal_listener_does_not_require_mtls():
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=True,
+        comm_configurator=_config({"root_dir": "/tmp/cellnet", "connection_security": "clear"}, scheme="shared-file"),
+    )
+
+    assert manager.int_resources["connection_security"] == ConnectionSecurity.CLEAR
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
@@ -32,8 +32,39 @@ def _config(resources):
     return config
 
 
+@pytest.mark.parametrize(
+    "listen_host",
+    [
+        "localhost",
+        "LOCALHOST.",
+        "127.0.0.1",
+        "127.255.255.254",
+        "::1",
+        "0:0:0:0:0:0:0:1",
+        "[::1]",
+        "::ffff:127.0.0.1",
+        "::ffff:7f00:1",
+    ],
+)
+def test_equivalent_ipv4_and_ipv6_loopback_listeners_allow_clear_transport(listen_host):
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=_config(
+            {
+                "host": "parent-service",
+                "listen_host": listen_host,
+                "connection_security": "clear",
+            }
+        ),
+    )
+
+    assert manager.int_resources["listen_host"] == listen_host
+
+
+@pytest.mark.parametrize("listen_host", ["0.0.0.0", "::", "::ffff:192.0.2.1", "parent-service"])
 @pytest.mark.parametrize("connection_security", ["clear", "tls"])
-def test_remote_internal_listener_requires_mtls(connection_security):
+def test_remote_internal_listener_requires_mtls(listen_host, connection_security):
     with pytest.raises(ConfigError, match="require connection_security='mtls'"):
         ConnectorManager(
             communicator=MagicMock(),
@@ -41,7 +72,7 @@ def test_remote_internal_listener_requires_mtls(connection_security):
             comm_configurator=_config(
                 {
                     "host": "parent-service",
-                    "listen_host": "0.0.0.0",
+                    "listen_host": listen_host,
                     "connection_security": connection_security,
                 }
             ),

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvflare.fuel.common.excepts import ConfigError
+from nvflare.fuel.f3.cellnet.connector_manager import ConnectorManager
+
+
+def _config(resources):
+    config = MagicMock()
+    config.get_backbone_connection_generation.return_value = 2
+    config.get_internal_connection_scheme.return_value = "tcp"
+    config.allow_adhoc_connections.return_value = False
+    config.get_adhoc_connection_scheme.return_value = "tcp"
+    config.get_config.return_value = {
+        "internal": {"scheme": "tcp", "resources": resources},
+    }
+    return config
+
+
+@pytest.mark.parametrize("connection_security", ["clear", "tls"])
+def test_remote_internal_listener_requires_mtls(connection_security):
+    with pytest.raises(ConfigError, match="require connection_security='mtls'"):
+        ConnectorManager(
+            communicator=MagicMock(),
+            secure=False,
+            comm_configurator=_config(
+                {
+                    "host": "parent-service",
+                    "listen_host": "0.0.0.0",
+                    "connection_security": connection_security,
+                }
+            ),
+        )
+
+
+def test_remote_internal_listener_is_allowed_with_mtls():
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=True,
+        comm_configurator=_config({"host": "parent-service", "listen_host": "0.0.0.0", "connection_security": "mtls"}),
+    )
+
+    assert manager.int_resources["connection_security"] == "mtls"

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_security_test.py
@@ -32,6 +32,19 @@ def _config(resources):
     return config
 
 
+def test_default_internal_listener_uses_ipv4_loopback():
+    config = MagicMock()
+    config.get_backbone_connection_generation.return_value = 2
+    config.get_internal_connection_scheme.return_value = "tcp"
+    config.allow_adhoc_connections.return_value = False
+    config.get_adhoc_connection_scheme.return_value = "tcp"
+    config.get_config.return_value = None
+
+    manager = ConnectorManager(communicator=MagicMock(), secure=False, comm_configurator=config)
+
+    assert manager.int_resources["host"] == "127.0.0.1"
+
+
 @pytest.mark.parametrize(
     "listen_host",
     [

--- a/tests/unit_test/fuel/f3/communicator_test.py
+++ b/tests/unit_test/fuel/f3/communicator_test.py
@@ -86,6 +86,13 @@ def get_comm_b(comm_state):
 
 
 class TestCommunicator:
+    @pytest.mark.parametrize("scheme", ["tcp", "stcp"])
+    def test_add_tcp_connector_rejects_ipv6_literal_before_connector_setup(self, scheme):
+        comm = Communicator(Endpoint(NODE_A))
+
+        with pytest.raises(CommError, match="literal IPv6 hosts are not supported"):
+            comm.add_connector(f"{scheme}://[2001:db8::2]:23456", Mode.ACTIVE)
+
     @pytest.mark.parametrize("host", ["::1", "0:0:0:0:0:0:0:1", "[::1]", "::ffff:127.0.0.1"])
     def test_start_listener_rejects_ipv6_literal_before_binding(self, host):
         comm = Communicator(Endpoint(NODE_A))

--- a/tests/unit_test/fuel/f3/communicator_test.py
+++ b/tests/unit_test/fuel/f3/communicator_test.py
@@ -18,6 +18,7 @@ from threading import Event
 
 import pytest
 
+from nvflare.fuel.f3.comm_error import CommError
 from nvflare.fuel.f3.communicator import Communicator
 from nvflare.fuel.f3.connection import Connection
 from nvflare.fuel.f3.drivers.connector_info import Mode
@@ -85,6 +86,13 @@ def get_comm_b(comm_state):
 
 
 class TestCommunicator:
+    @pytest.mark.parametrize("host", ["::1", "0:0:0:0:0:0:0:1", "[::1]", "::ffff:127.0.0.1"])
+    def test_start_listener_rejects_ipv6_literal_before_binding(self, host):
+        comm = Communicator(Endpoint(NODE_A))
+
+        with pytest.raises(CommError, match="literal IPv6 hosts are not supported"):
+            comm.start_listener("tcp", {"host": host, "port": 23456})
+
     @pytest.mark.parametrize(
         "scheme, port_range",
         [

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -75,6 +75,14 @@ class TestNetUtils:
         assert connect_url == "tcp://localhost:9000"
         assert listen_url == "tcp://localhost:9000"
 
+    def test_tcp_listener_defaults_to_ipv4_loopback_without_host(self, monkeypatch):
+        monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
+
+        connect_url, listen_url = get_tcp_urls("tcp", {})
+
+        assert connect_url == "tcp://127.0.0.1:9000"
+        assert listen_url == "tcp://127.0.0.1:9000"
+
     def test_tcp_listener_requires_explicit_wildcard_host(self, monkeypatch):
         monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
 

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -33,6 +33,40 @@ class TestNetUtils:
         assert params[DriverParams.SERVER_CERT.value] == str(cert)
         assert params[DriverParams.SERVER_KEY.value] == str(key)
 
+    def test_internal_mtls_reuses_server_pair_for_client_direction(self, tmp_path):
+        ca = tmp_path / "rootCA.pem"
+        cert = tmp_path / "server.crt"
+        key = tmp_path / "server.key"
+        for path in (ca, cert, key):
+            path.write_text("test")
+        params = {
+            DriverParams.CA_CERT.value: str(ca),
+            DriverParams.SERVER_CERT.value: str(cert),
+            DriverParams.SERVER_KEY.value: str(key),
+        }
+
+        enhance_credential_info(params)
+
+        assert params[DriverParams.CLIENT_CERT.value] == str(cert)
+        assert params[DriverParams.CLIENT_KEY.value] == str(key)
+
+    def test_internal_mtls_does_not_mix_incomplete_credential_pairs(self, tmp_path):
+        ca = tmp_path / "rootCA.pem"
+        client_cert = tmp_path / "client.crt"
+        server_key = tmp_path / "server.key"
+        for path in (ca, client_cert, server_key):
+            path.write_text("test")
+        params = {
+            DriverParams.CA_CERT.value: str(ca),
+            DriverParams.CLIENT_CERT.value: str(client_cert),
+            DriverParams.SERVER_KEY.value: str(server_key),
+        }
+
+        enhance_credential_info(params)
+
+        assert DriverParams.CLIENT_KEY.value not in params
+        assert DriverParams.SERVER_CERT.value not in params
+
     def test_tcp_listener_defaults_to_connect_host(self, monkeypatch):
         monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
 

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -12,10 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
-from nvflare.fuel.f3.drivers.net_utils import encode_url, parse_url
+from nvflare.fuel.f3.drivers.net_utils import encode_url, enhance_credential_info, get_tcp_urls, parse_url
 
 
 class TestNetUtils:
+    def test_internal_mtls_reuses_role_certificate_for_both_directions(self, tmp_path):
+        ca = tmp_path / "rootCA.pem"
+        cert = tmp_path / "client.crt"
+        key = tmp_path / "client.key"
+        for path in (ca, cert, key):
+            path.write_text("test")
+        params = {
+            DriverParams.CA_CERT.value: str(ca),
+            DriverParams.CLIENT_CERT.value: str(cert),
+            DriverParams.CLIENT_KEY.value: str(key),
+        }
+
+        enhance_credential_info(params)
+
+        assert params[DriverParams.SERVER_CERT.value] == str(cert)
+        assert params[DriverParams.SERVER_KEY.value] == str(key)
+
+    def test_tcp_listener_defaults_to_connect_host(self, monkeypatch):
+        monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
+
+        connect_url, listen_url = get_tcp_urls("tcp", {"host": "localhost"})
+
+        assert connect_url == "tcp://localhost:9000"
+        assert listen_url == "tcp://localhost:9000"
+
+    def test_tcp_listener_requires_explicit_wildcard_host(self, monkeypatch):
+        monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
+
+        connect_url, listen_url = get_tcp_urls(
+            "tcp", {"host": "parent-service", DriverParams.LISTEN_HOST.value: "0.0.0.0"}
+        )
+
+        assert connect_url == "tcp://parent-service:9000"
+        assert listen_url == "tcp://0.0.0.0:9000"
+
     def test_encode_url(self):
 
         params = {

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -67,13 +67,31 @@ class TestNetUtils:
         assert DriverParams.CLIENT_KEY.value not in params
         assert DriverParams.SERVER_CERT.value not in params
 
-    def test_tcp_listener_defaults_to_connect_host(self, monkeypatch):
+    def test_tcp_listener_normalizes_localhost_to_ipv4_loopback(self, monkeypatch):
         monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
 
         connect_url, listen_url = get_tcp_urls("tcp", {"host": "localhost"})
 
-        assert connect_url == "tcp://localhost:9000"
-        assert listen_url == "tcp://localhost:9000"
+        assert connect_url == "tcp://127.0.0.1:9000"
+        assert listen_url == "tcp://127.0.0.1:9000"
+
+    def test_tcp_listener_does_not_widen_loopback_host_to_wildcard(self, monkeypatch):
+        monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
+
+        connect_url, listen_url = get_tcp_urls("tcp", {"host": "LOCALHOST.", DriverParams.LISTEN_HOST.value: "0.0.0.0"})
+
+        assert connect_url == "tcp://127.0.0.1:9000"
+        assert listen_url == "tcp://127.0.0.1:9000"
+
+    def test_tcp_listener_normalizes_equivalent_ipv4_loopback_address(self, monkeypatch):
+        monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)
+
+        connect_url, listen_url = get_tcp_urls(
+            "tcp", {"host": "127.255.255.254", DriverParams.LISTEN_HOST.value: "0.0.0.0"}
+        )
+
+        assert connect_url == "tcp://127.0.0.1:9000"
+        assert listen_url == "tcp://127.0.0.1:9000"
 
     def test_tcp_listener_defaults_to_ipv4_loopback_without_host(self, monkeypatch):
         monkeypatch.setattr("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", lambda _resources: 9000)

--- a/tests/unit_test/private/fed/security_boundary_test.py
+++ b/tests/unit_test/private/fed/security_boundary_test.py
@@ -112,6 +112,53 @@ def test_challenge_reply_does_not_disclose_server_bearer_headers():
     server.sign_auth_token.assert_not_called()
 
 
+def test_cellnet_bye_reply_does_not_disclose_server_bearer_headers():
+    # CELLNET/Bye is exempt from incoming auth (a direct-neighbor teardown ack),
+    # so its reply must not leak the server's reusable bearer material either;
+    # otherwise an uncredentialed peer can elicit it and replay to authenticate
+    # as the server.
+    server = FederatedServer.__new__(FederatedServer)
+    server.logger = MagicMock()
+    server.my_own_token_signature = ""
+    server.my_own_auth_client_name = "server"
+    server.my_own_token = "secret-token"
+    server.sign_auth_token = MagicMock(return_value="secret-signature")
+    reply = CellMessage(
+        {
+            MessageHeaderKey.CHANNEL: CellChannel.CELLNET,
+            MessageHeaderKey.TOPIC: CellChannelTopic.Bye,
+        }
+    )
+
+    server._add_auth_headers(reply)
+
+    assert reply.get_header(CellMessageHeaderKeys.TOKEN) is None
+    assert reply.get_header(CellMessageHeaderKeys.TOKEN_SIGNATURE) is None
+    server.sign_auth_token.assert_not_called()
+
+
+def test_authenticated_reply_still_receives_bearer_headers():
+    # Guard against over-suppression: a normal (non-pre-auth) reply must still
+    # carry the server's auth headers.
+    server = FederatedServer.__new__(FederatedServer)
+    server.logger = MagicMock()
+    server.my_own_token_signature = "secret-signature"
+    server.my_own_auth_client_name = "server"
+    server.my_own_token = "secret-token"
+    server.sign_auth_token = MagicMock(return_value="secret-signature")
+    reply = CellMessage(
+        {
+            MessageHeaderKey.CHANNEL: CellChannel.SERVER_COMMAND,
+            MessageHeaderKey.TOPIC: "some_topic",
+        }
+    )
+
+    server._add_auth_headers(reply)
+
+    assert reply.get_header(CellMessageHeaderKeys.TOKEN) == "secret-token"
+    assert reply.get_header(CellMessageHeaderKeys.TOKEN_SIGNATURE) == "secret-signature"
+
+
 def _log_command_context():
     workspace = MagicMock()
     workspace.get_run_dir.return_value = "/tmp/run"

--- a/tests/unit_test/private/fed/security_boundary_test.py
+++ b/tests/unit_test/private/fed/security_boundary_test.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from nvflare.apis.fl_constant import AdminCommandNames
+from nvflare.fuel.f3.cellnet.defs import CellChannel, CellChannelTopic, MessageHeaderKey, MessagePropKey, ReturnCode
+from nvflare.fuel.f3.message import Message as CellMessage
+from nvflare.private.admin_defs import Message
+from nvflare.private.defs import CellMessageHeaderKeys, RequestHeader
+from nvflare.private.fed.client.admin import FedAdminAgent
+from nvflare.private.fed.client.admin_commands import ConfigureJobLogCommand as ClientConfigureJobLogCommand
+from nvflare.private.fed.server.fed_server import FederatedServer
+from nvflare.private.fed.server.server_command_agent import ServerCommandAgent
+from nvflare.private.fed.server.server_commands import ConfigureJobLogCommand as ServerConfigureJobLogCommand
+
+
+def test_cp_admin_dispatch_rejects_untrusted_origin_before_processor_runs():
+    agent = FedAdminAgent.__new__(FedAdminAgent)
+    agent.cell = MagicMock()
+    agent.cell.get_fqcn.return_value = "site-1"
+    processor = MagicMock()
+    agent.processors = {"admin-topic": processor}
+    inner = Message("admin-topic", "payload")
+    inner.set_header(RequestHeader.ADMIN_COMMAND, "admin-command")
+    inner.set_header(RequestHeader.REQUIRE_AUTHZ, "true")
+    request = CellMessage(
+        {
+            MessageHeaderKey.ORIGIN: "attacker",
+            MessageHeaderKey.DESTINATION: "site-1",
+            MessageHeaderKey.TOPIC: "admin-topic",
+        },
+        inner,
+    )
+    request.set_prop(MessagePropKey.ENDPOINT, SimpleNamespace(name="attacker"))
+
+    reply = agent._dispatch_request(request)
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+    processor.process.assert_not_called()
+
+
+def test_cp_admin_dispatch_requires_server_created_envelope():
+    agent = FedAdminAgent.__new__(FedAdminAgent)
+    agent.cell = MagicMock()
+    agent.cell.get_fqcn.return_value = "site-1"
+    agent.processors = {"admin-topic": MagicMock()}
+    request = CellMessage(
+        {
+            MessageHeaderKey.ORIGIN: "server",
+            MessageHeaderKey.DESTINATION: "site-1",
+            MessageHeaderKey.TOPIC: "admin-topic",
+        },
+        Message("admin-topic", "payload"),
+    )
+    request.set_prop(MessagePropKey.ENDPOINT, SimpleNamespace(name="server"))
+
+    reply = agent._dispatch_request(request)
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.INVALID_REQUEST
+
+
+def test_server_job_rejects_parent_command_from_untrusted_connection():
+    cell = MagicMock()
+    cell.get_fqcn.return_value = "server.job-1"
+    agent = ServerCommandAgent(MagicMock(), cell)
+    request = CellMessage(
+        {
+            MessageHeaderKey.ORIGIN: "server",
+            MessageHeaderKey.DESTINATION: "server.job-1",
+            MessageHeaderKey.TOPIC: AdminCommandNames.CONFIGURE_JOB_LOG,
+        },
+        "INFO",
+    )
+    request.set_prop(MessagePropKey.ENDPOINT, SimpleNamespace(name="attacker"))
+
+    reply = agent.execute_command(request)
+
+    assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.AUTHENTICATION_ERROR
+
+
+def test_challenge_reply_does_not_disclose_server_bearer_headers():
+    server = FederatedServer.__new__(FederatedServer)
+    server.logger = MagicMock()
+    server.my_own_token_signature = ""
+    server.my_own_auth_client_name = "server"
+    server.my_own_token = "secret-token"
+    server.sign_auth_token = MagicMock(return_value="secret-signature")
+    reply = CellMessage(
+        {
+            MessageHeaderKey.CHANNEL: CellChannel.SERVER_MAIN,
+            MessageHeaderKey.TOPIC: CellChannelTopic.Challenge,
+        }
+    )
+
+    server._add_auth_headers(reply)
+
+    assert reply.get_header(CellMessageHeaderKeys.TOKEN) is None
+    assert reply.get_header(CellMessageHeaderKeys.TOKEN_SIGNATURE) is None
+    server.sign_auth_token.assert_not_called()
+
+
+def _log_command_context():
+    workspace = MagicMock()
+    workspace.get_run_dir.return_value = "/tmp/run"
+    workspace.get_log_config_file_path.return_value = "/tmp/log.json"
+    engine = MagicMock()
+    engine.get_workspace.return_value = workspace
+    fl_ctx = MagicMock()
+    fl_ctx.get_engine.return_value = engine
+    fl_ctx.get_job_id.return_value = "job-1"
+    return fl_ctx
+
+
+def test_server_job_log_command_rejects_executable_dict_config():
+    with patch("nvflare.private.fed.server.server_commands.dynamic_log_config") as dynamic:
+        error = ServerConfigureJobLogCommand().process({"()": "os.mkdir"}, _log_command_context())
+
+    assert "configure_job_log only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()
+
+
+def test_client_job_log_command_rejects_executable_dict_config():
+    with patch("nvflare.private.fed.client.admin_commands.dynamic_log_config") as dynamic:
+        error = ClientConfigureJobLogCommand().process({"()": "os.mkdir"}, _log_command_context())
+
+    assert "configure_job_log only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()

--- a/tests/unit_test/private/fed/security_boundary_test.py
+++ b/tests/unit_test/private/fed/security_boundary_test.py
@@ -16,7 +16,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from nvflare.apis.fl_constant import AdminCommandNames
+from nvflare.apis.shareable import Shareable
 from nvflare.fuel.f3.cellnet.defs import CellChannel, CellChannelTopic, MessageHeaderKey, MessagePropKey, ReturnCode
+from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.private.admin_defs import Message
 from nvflare.private.defs import CellMessageHeaderKeys, RequestHeader
@@ -157,6 +159,49 @@ def test_authenticated_reply_still_receives_bearer_headers():
 
     assert reply.get_header(CellMessageHeaderKeys.TOKEN) == "secret-token"
     assert reply.get_header(CellMessageHeaderKeys.TOKEN_SIGNATURE) == "secret-signature"
+
+
+def test_harvested_server_bearer_cannot_reach_server_job_command_processor():
+    root = FederatedServer.__new__(FederatedServer)
+    root.logger = MagicMock()
+    root.my_own_auth_client_name = "server"
+    root.my_own_token = "secret-token"
+    root.cell = MagicMock()
+    root.cell.get_fqcn.return_value = "server"
+    root._get_id_asserter = MagicMock(return_value=MagicMock(cert=MagicMock()))
+
+    replay = CellMessage(
+        {
+            MessageHeaderKey.ORIGIN: "server",
+            MessageHeaderKey.DESTINATION: "server.job-1",
+            MessageHeaderKey.TOPIC: AdminCommandNames.ABORT,
+            CellMessageHeaderKeys.CLIENT_NAME: "server",
+            CellMessageHeaderKeys.TOKEN: "secret-token",
+            CellMessageHeaderKeys.TOKEN_SIGNATURE: "harvested-signature",
+        },
+        Shareable(),
+    )
+    replay.set_prop(MessagePropKey.ENDPOINT, Endpoint("site-1"))
+
+    command = MagicMock()
+    command.process.return_value = Shareable()
+    job_cell = MagicMock()
+    job_cell.get_fqcn.return_value = "server.job-1"
+    job_agent = ServerCommandAgent(MagicMock(), job_cell)
+
+    with (
+        patch("nvflare.private.fed.server.fed_server.validate_auth_headers", return_value=None),
+        patch("nvflare.private.fed.server.server_command_agent.ServerCommands.get_command", return_value=command),
+    ):
+        root_reply = root._validate_auth_headers(replay)
+        if root_reply is None:
+            # Model the root's forwarding hop.  This is the condition that made
+            # the vulnerable server-job check trust the replayed logical origin.
+            replay.set_prop(MessagePropKey.ENDPOINT, Endpoint("server"))
+            job_agent.execute_command(replay)
+
+    assert root_reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.UNAUTHENTICATED
+    command.process.assert_not_called()
 
 
 def _log_command_context():

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -22,8 +22,9 @@ from nvflare.apis.job_def import JobMetaKey, RunStatus
 from nvflare.apis.job_launcher_spec import JobReturnCode
 from nvflare.apis.shareable import Shareable
 from nvflare.fuel.common.exit_codes import ProcessExitCode
-from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessagePropKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
+from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.private.defs import CellChannel, CellMessageHeaderKeys, ClientRegMsgKey, JobFailureMsgKey, new_cell_message
 from nvflare.private.fed.authenticator import MISSING_CLIENT_FQCN
 from nvflare.private.fed.server.fed_server import FederatedServer
@@ -37,6 +38,54 @@ def assert_client_outcome_unresolved(job_runner):
 
 
 class TestFederatedServer:
+    @staticmethod
+    def _server_credential_message(origin, peer):
+        message = new_cell_message(
+            {
+                MessageHeaderKey.ORIGIN: origin,
+                MessageHeaderKey.DESTINATION: "server.job-1",
+                CellMessageHeaderKeys.CLIENT_NAME: "server",
+                CellMessageHeaderKeys.TOKEN: "server",
+            },
+            Shareable(),
+        )
+        message.set_prop(MessagePropKey.ENDPOINT, Endpoint(peer))
+        return message
+
+    @staticmethod
+    def _server_for_auth_validation():
+        server = object.__new__(FederatedServer)
+        server.my_own_auth_client_name = "server"
+        server.my_own_token = "server"
+        server.logger = MagicMock()
+        server.cell = MagicMock()
+        server.cell.get_fqcn.return_value = "server"
+        server._get_id_asserter = MagicMock(return_value=MagicMock(cert=MagicMock()))
+        return server
+
+    @pytest.mark.parametrize(
+        "origin,peer",
+        [("server", "site-1"), ("server.job-1", "site-1.job-1"), ("server", "server.job-1")],
+    )
+    def test_server_credentials_cannot_be_replayed_from_client_family(self, origin, peer):
+        server = self._server_for_auth_validation()
+        message = self._server_credential_message(origin, peer)
+
+        with patch("nvflare.private.fed.server.fed_server.validate_auth_headers", return_value=None):
+            reply = server._validate_auth_headers(message)
+
+        assert reply.get_header(MessageHeaderKey.RETURN_CODE) == F3ReturnCode.UNAUTHENTICATED
+
+    @pytest.mark.parametrize("origin,peer", [("server", "server"), ("server.job-1", "server.job-1")])
+    def test_server_credentials_are_accepted_from_server_family(self, origin, peer):
+        server = self._server_for_auth_validation()
+        message = self._server_credential_message(origin, peer)
+
+        with patch("nvflare.private.fed.server.fed_server.validate_auth_headers", return_value=None):
+            reply = server._validate_auth_headers(message)
+
+        assert reply is None
+
     @staticmethod
     def _create_job_cell_with_command_agent(server_state):
         server = object.__new__(FederatedServer)

--- a/tests/unit_test/tool/cert/cert_commands_test.py
+++ b/tests/unit_test/tool/cert/cert_commands_test.py
@@ -1713,21 +1713,26 @@ class TestCertSign:
         eku = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value
         assert list(eku) == [x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH]
 
-    def test_sign_server_cert_sets_server_auth_eku(self, tmp_path):
+    @pytest.mark.parametrize("cert_type", ["client", "server"])
+    def test_sign_participant_cert_sets_dual_use_eku(self, tmp_path, cert_type):
         ca_dir = _setup_ca(tmp_path)
-        csr_dir = str(tmp_path / "csr-server")
+        csr_dir = str(tmp_path / f"csr-{cert_type}")
         os.makedirs(csr_dir, exist_ok=True)
-        args = _csr_args(name="fl-server", output_dir=csr_dir, cert_type="server")
+        name = f"fl-{cert_type}"
+        args = _csr_args(name=name, output_dir=csr_dir, cert_type=cert_type)
         handle_cert_csr(args)
-        csr_path = os.path.join(csr_dir, "fl-server.csr")
+        csr_path = os.path.join(csr_dir, f"{name}.csr")
 
-        out_dir = str(tmp_path / "signed-server")
-        sign_args = _sign_args(csr_path=csr_path, ca_dir=ca_dir, output_dir=out_dir, cert_type="server")
+        out_dir = str(tmp_path / f"signed-{cert_type}")
+        sign_args = _sign_args(csr_path=csr_path, ca_dir=ca_dir, output_dir=out_dir, cert_type=cert_type)
         handle_cert_sign(sign_args)
 
-        cert = load_crt(os.path.join(out_dir, "fl-server.crt"))
+        cert = load_crt(os.path.join(out_dir, f"{name}.crt"))
         eku = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value
-        assert list(eku) == [x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]
+        assert list(eku) == [
+            x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+            x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+        ]
 
     def test_sign_uses_centralized_cert_generation_for_common_x509_content(self, tmp_path):
         from nvflare.lighter.utils import Identity

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -858,7 +858,8 @@ def test_prepare_docker_creates_comm_config_when_missing(tmp_path, capsys):
     assert comm_config["internal"]["scheme"] == "tcp"
     assert comm_config["internal"]["resources"] == {
         "host": "0.0.0.0",
-        "connection_security": "clear",
+        "listen_host": "0.0.0.0",
+        "connection_security": "mtls",
     }
 
 
@@ -989,8 +990,9 @@ def test_prepare_k8s_client_writes_chart_and_launcher_config(tmp_path, capsys):
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["internal"]["resources"] == {
         "host": "site-1",
+        "listen_host": "0.0.0.0",
         "port": 9102,
-        "connection_security": "clear",
+        "connection_security": "mtls",
     }
 
     values = yaml.safe_load((output / "helm_chart" / "values.yaml").read_text())
@@ -2002,8 +2004,9 @@ def test_prepare_k8s_creates_comm_config_when_missing(tmp_path, capsys):
     assert comm_config["internal"]["scheme"] == "tcp"
     assert comm_config["internal"]["resources"] == {
         "host": "site-1",
+        "listen_host": "0.0.0.0",
         "port": 8102,
-        "connection_security": "clear",
+        "connection_security": "mtls",
     }
 
 

--- a/tests/unit_test/tool/deploy/slurm_deploy_test.py
+++ b/tests/unit_test/tool/deploy/slurm_deploy_test.py
@@ -79,6 +79,7 @@ def test_prepare_slurm_preserves_file_transport_comm_config(tmp_path, capsys):
     assert comm_config["internal"]["scheme"] == "shared-file"
     assert resources["root_dir"] == "/lustre/proj/cellnet"
     assert resources["connection_security"] == "clear"
+    assert "listen_host" not in resources
     assert "host" not in resources and "port" not in resources
 
 
@@ -177,7 +178,12 @@ def test_prepare_slurm_generates_runtime_artifacts(tmp_path, capsys):
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["internal"] == {
         "scheme": "tcp",
-        "resources": {"host": "0.0.0.0", "port": 9210, "connection_security": "clear"},
+        "resources": {
+            "host": "0.0.0.0",
+            "listen_host": "0.0.0.0",
+            "port": 9210,
+            "connection_security": "mtls",
+        },
     }
     assert (output / "startup" / "sub_start.sh").exists()
     start_script = output / "startup" / "start_slurm.sh"


### PR DESCRIPTION
## Summary

- bind clear internal CellNet listeners to loopback and require mTLS for non-loopback Docker, Kubernetes, and Slurm internal hops
- validate privileged CP administrative and server-job parent commands against both their logical headers and authenticated physical route
- avoid adding reusable bearer credentials to Challenge, Register, and CellNet Bye pre-auth replies
- restrict `configure_job_log` to log levels and built-in modes instead of accepting arbitrary `dictConfig` objects

## Root cause

Internal TCP listeners could silently bind to all interfaces, while distributed launchers used clear transport for cross-host internal links. Privileged receivers trusted caller-selected logical headers without binding them to the physical connection. Pre-auth replies could also receive reusable server bearer headers, and `configure_job_log` accepted arbitrary logging configurations.

## Validation

- focused CellNet security regression suite: 32 passed
- broader affected unit-test suite: 944 passed
- client attach end-to-end scenarios validated; one timing-sensitive gRPC observation assertion passed on isolated rerun
- scoped Black, isort, Flake8, and `git diff --check`: passed
- repository-wide `./runtest.sh -s`: Black reached three pre-existing vendored `node_modules/flatted.py` files that would be reformatted; no files in this PR were implicated

## Tracking

- [FLARE-3123](https://jirasw.nvidia.com/browse/FLARE-3123)
