### PR TITLE
Require explicit NVSkills CI requests

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -3,14 +3,11 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
-      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||


### PR DESCRIPTION
## Summary
- remove the automatic `pull_request` trigger from the NVSkills CI request workflow
- preserve `/nvskills-ci` as the explicit pull-request command that dispatches NVSkills CI
- retain the signature-bot push path used after an explicitly requested validation run

## Validation
- parsed `.github/workflows/request-nvskills-ci.yml` and verified that it has no `pull_request` trigger or unconditional PR job condition
- verified the `/nvskills-ci` issue-comment condition remains present