### PR TITLE
Preserve server transit across relay routes

### DIFF
--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -1114,6 +1114,22 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             if reply:
                 return reply
 
+    def _filter_outgoing_reply(self, reply: Message) -> Message:
+        channel = reply.get_header(MessageHeaderKey.CHANNEL, "")
+        topic = reply.get_header(MessageHeaderKey.TOPIC, "")
+        reply_filters = self.out_reply_filter_reg.find(channel, topic)
+        if not reply_filters:
+            return reply
+
+        self.logger.debug(f"{self.my_info.fqcn}: invoking outgoing reply filters")
+        assert isinstance(reply_filters, list)
+        for f in reply_filters:
+            assert isinstance(f, Callback)
+            filtered_reply = self._try_cb(reply, f.cb, *f.args, **f.kwargs)
+            if filtered_reply:
+                return filtered_reply
+        return reply
+
     def _try_path(self, fqcn_path: List[str]) -> Union[None, Endpoint]:
         self.logger.debug(f"{self.my_info.fqcn}: trying path {fqcn_path} ...")
         target = FQCN.join(fqcn_path)
@@ -1139,7 +1155,11 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             ep = self._try_find_ep(target_fqcn, for_msg)
             if not ep:
                 return ReturnCode.TARGET_UNREACHABLE, None
-            if ep.name != target_fqcn and self._already_visited(ep.name, for_msg):
+            if (
+                ep.name != target_fqcn
+                and self._already_visited(ep.name, for_msg)
+                and not self._is_server_transit_revisit_allowed(ep.name, for_msg)
+            ):
                 # Deterministic resolution means a revisited cell would pick the
                 # same next leg again - refuse the hop so the message fails
                 # cleanly instead of bouncing between cells that cannot reach
@@ -1167,6 +1187,41 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         # after decoding
         return any(isinstance(hop, (list, tuple)) and len(hop) > 0 and hop[0] == fqcn for hop in route)
 
+    def _is_server_transit_revisit_allowed(self, next_fqcn: str, msg: Union[None, Message]) -> bool:
+        """Allow only the intentional downstream revisits after the server boundary."""
+        if not msg or not msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False):
+            return False
+
+        if self.my_info.fqcn == FQCN.ROOT_SERVER:
+            return not self._already_visited(FQCN.ROOT_SERVER, msg)
+
+        return self.is_server_transit_return(msg) and FQCN.is_ancestor(self.my_info.fqcn, next_fqcn)
+
+    def is_server_transit_return(self, msg: Union[None, Message]) -> bool:
+        """Return whether a marked message arrived from this cell's trusted upstream after the server hop.
+
+        The route identifies the transit phase but is sender-controlled, so it is
+        insufficient on its own. The actual incoming endpoint must also be the
+        root server or the cell's configured topology parent.
+        """
+        if (
+            not msg
+            or self.my_info.is_on_server
+            or not msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False)
+            or not self._already_visited(FQCN.ROOT_SERVER, msg)
+        ):
+            return False
+
+        incoming_endpoint = msg.get_prop(MessagePropKey.ENDPOINT)
+        if not isinstance(incoming_endpoint, Endpoint):
+            return False
+
+        if incoming_endpoint.name == FQCN.ROOT_SERVER:
+            return True
+        if self.my_info.gen <= 1:
+            return False
+        return incoming_endpoint.name == FQCN.get_parent(self.my_info.fqcn)
+
     def _try_find_ep(self, target_fqcn: str, for_msg: Message) -> Union[None, Endpoint]:
         self.logger.debug(f"{self.my_info.fqcn}: finding path to {target_fqcn}")
         if target_fqcn == self.my_info.fqcn:
@@ -1181,11 +1236,18 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             for_msg
             and for_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False)
             and not self.my_info.is_on_server
+            and not self.is_server_transit_return(for_msg)
         ):
-            # Prefer the closest connected local ancestor so a client-job
-            # message follows its configured client/relay hierarchy. Some
-            # supported descendants connect directly to the server root, so do
-            # not fail merely because their FQCN parent is not connected.
+            # Prefer this cell's own server connection when available. This
+            # avoids detouring a client job through its parent and preserves
+            # delivery when the parent's uplink is unavailable.
+            if FQCN.ROOT_SERVER in self.ALL_CELLS:
+                return Endpoint(FQCN.ROOT_SERVER)
+            root_agent = self.agents.get(FQCN.ROOT_SERVER)
+            if root_agent:
+                return root_agent.endpoint
+
+            # Otherwise walk the connected local ancestors toward the server.
             ancestor_path = self.my_info.path[:-1]
             while ancestor_path:
                 ancestor_fqcn = FQCN.join(ancestor_path)
@@ -1196,11 +1258,6 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                     return agent.endpoint
                 ancestor_path = ancestor_path[:-1]
 
-            if FQCN.ROOT_SERVER in self.ALL_CELLS:
-                return Endpoint(FQCN.ROOT_SERVER)
-            root_agent = self.agents.get(FQCN.ROOT_SERVER)
-            if root_agent:
-                return root_agent.endpoint
             self.log_warning(msg=for_msg, log_text="no server-transit path through a local ancestor or server")
             return None
 
@@ -1375,6 +1432,8 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             # is this a direct path?
             ti = FqcnInfo(t)
             allow_adhoc = self.connector_manager.is_adhoc_allowed(ti, self.my_info)
+            if req.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False):
+                allow_adhoc = False
             if allow_adhoc and t != ep.name:
                 # Not a direct path since the destination and the next leg are not the same
                 if not ti.is_on_server and (self.my_info.is_on_server or self.my_info.fqcn > t):
@@ -1709,7 +1768,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         if err:
             return err
         reply.set_header(MessageHeaderKey.TO_CELL, ep.name)
-        return self._send_to_endpoint(ep, reply)
+        return self._send_reply(reply, ep)
 
     def _try_cb(self, message, cb, *args, **kwargs):
         try:
@@ -2070,7 +2129,9 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
         # handle ad-hoc
         my_conn_url = None
-        if msg_type in [MessageType.REQ, MessageType.REPLY]:
+        if msg_type in [MessageType.REQ, MessageType.REPLY] and not message.get_header(
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False
+        ):
             from_cell = message.get_header(MessageHeaderKey.FROM_CELL)
             oi = FqcnInfo(origin)
             if from_cell != origin and not same_family(oi, self.my_info):
@@ -2143,17 +2204,6 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             if my_conn_url:
                 reply.set_header(MessageHeaderKey.CONN_URL, my_conn_url)
 
-            # invoke outgoing reply filters
-            reply_filters = self.out_reply_filter_reg.find(channel, topic)
-            if reply_filters:
-                self.logger.debug(f"{self.my_info.fqcn}: invoking outgoing reply filters")
-                assert isinstance(reply_filters, list)
-                for f in reply_filters:
-                    assert isinstance(f, Callback)
-                    r = self._try_cb(reply, f.cb, *f.args, **f.kwargs)
-                    if r:
-                        reply = r
-                        break
             self._send_reply(reply, endpoint)
             if should_close_connection and connection:
                 connection.close()
@@ -2161,13 +2211,17 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             # the message is either a reply or a return for a previous request: handle replies
             self._process_reply(origin, message, msg_type)
 
-    def _send_reply(self, reply: Message, endpoint: Endpoint):
+    def _send_reply(self, reply: Message, endpoint: Endpoint) -> str:
+        reply = self._filter_outgoing_reply(reply)
         if reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False):
             destination = reply.get_header(MessageHeaderKey.DESTINATION)
             err, transit_ep = self._find_endpoint(destination, reply)
             if not transit_ep:
                 self.log_error(f"cannot send server-transit reply to '{destination}': {err}", reply)
-                return
+                self.received_msg_counter_pool.increment(
+                    category=self._stats_category(reply), counter_name=ReturnCode.COMM_ERROR
+                )
+                return ReturnCode.COMM_ERROR
             endpoint = transit_ep
             reply.add_headers({MessageHeaderKey.FROM_CELL: self.my_info.fqcn, MessageHeaderKey.TO_CELL: endpoint.name})
         self.logger.debug(f"{self.my_info.fqcn}: sending reply back to {endpoint.name}")
@@ -2182,6 +2236,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             )
             rc = reply.get_header(MessageHeaderKey.RETURN_CODE)
             self.received_msg_counter_pool.increment(category=self._stats_category(reply), counter_name=rc)
+        return err
 
     def _check_bulk(self):
         while not self.asked_to_stop:

--- a/nvflare/fuel/sec/authn.py
+++ b/nvflare/fuel/sec/authn.py
@@ -48,6 +48,8 @@ def _is_client_family_member(fqcn: str, family_fqcn: Optional[str]) -> bool:
 def is_cross_client_family(origin: str, destination: str, client_name: Optional[str] = None) -> bool:
     if not origin or not destination:
         return False
+    if origin == destination:
+        return False
     origin_info = FqcnInfo(origin)
     destination_info = FqcnInfo(destination)
     if origin_info.is_on_server or destination_info.is_on_server:
@@ -57,22 +59,10 @@ def is_cross_client_family(origin: str, destination: str, client_name: Optional[
     if family_fqcn:
         return not _is_client_family_member(destination, family_fqcn)
 
-    # Preserve routing for callers whose authentication identity cannot be
-    # mapped to an FQCN segment (for example custom identity mappings).
-    return origin_info.root != destination_info.root
-
-
-def _is_cross_site_reply_via_local_parent(origin: str, destination: str, to_cell: str, client_name: str) -> bool:
-    """Return whether a peer reply first travels upward through its local client family.
-
-    A job cell can connect directly to the server or connect to its client parent first
-    (for example through the shared-file internal driver). In the latter topology,
-    ``TO_CELL`` is a local ancestor even though the reply must subsequently cross the
-    server trust boundary to reach a different client family.
-    """
-    if not origin or not destination or not to_cell:
-        return False
-    return is_cross_client_family(origin, destination, client_name) and FQCN.is_ancestor(to_cell, origin)
+    # An authentication identity that cannot be mapped to the origin's FQCN
+    # cannot prove that a non-server destination belongs to the same client.
+    # Fail closed and require the server trust boundary.
+    return True
 
 
 def add_authentication_headers(msg: Message, client_name: str, auth_token, token_signature, ssid=None):
@@ -108,16 +98,15 @@ def add_server_path_reply_authentication_headers(
     origin = msg.get_header(MessageHeaderKey.ORIGIN)
     destination = msg.get_header(MessageHeaderKey.DESTINATION)
     to_cell = msg.get_header(MessageHeaderKey.TO_CELL)
-    # Auth headers are for the server trust boundary, not for peer clients. A peer
-    # reply may reach that boundary directly or first travel through its local client
-    # parent. The server validates and strips these headers before forwarding to the
-    # peer. Server-owned job/transfer cells also keep auth on replies from or to server
-    # paths.
+    # Auth headers are for the server trust boundary, not for peer clients. All
+    # cross-client replies must be marked even when a cached direct peer endpoint
+    # supplied the initial return path. The transport reroutes the marked reply to
+    # the server, which validates and strips these headers before forwarding it.
     if (
         _is_server_fqcn(origin)
         or _is_server_fqcn(destination)
         or _is_server_fqcn(to_cell)
-        or _is_cross_site_reply_via_local_parent(origin, destination, to_cell, client_name)
+        or is_cross_client_family(origin, destination, client_name)
     ):
         add_authentication_headers(msg, client_name, auth_token, token_signature, ssid)
 

--- a/nvflare/private/fed/app/relay/relay.py
+++ b/nvflare/private/fed/app/relay/relay.py
@@ -222,6 +222,7 @@ def main(args):
             token_verifier=token_verifier,
             logger=logger,
             local_cell_fqcn=my_fqcn,
+            core_cell=cell.core_cell,
         )
 
     logger.info(f"Successfully authenticated to {server_identity}: {ssid=}")
@@ -233,15 +234,21 @@ def main(args):
     logger.info(f"Relay {my_fqcn} stopped.")
 
 
-def _validate_auth_headers(message: CellMessage, token_verifier: TokenVerifier, logger, local_cell_fqcn=None):
+def _validate_auth_headers(
+    message: CellMessage, token_verifier: TokenVerifier, logger, local_cell_fqcn=None, core_cell=None
+):
     """Validate auth headers from messages that go through the relay.
     Args:
         message: the message to validate
         token_verifier: verifier for the token and signature
         logger: logger
         local_cell_fqcn: FQCN of this relay's cell, used to scope the cellnet bye auth bypass
+        core_cell: relay CoreCell used to verify a post-server message's actual upstream endpoint
     Returns:
     """
+    if core_cell and core_cell.is_server_transit_return(message):
+        logger.debug("accepting sanitized server-transit message from configured upstream parent")
+        return None
     return validate_auth_headers(message, token_verifier, logger, local_cell_fqcn=local_cell_fqcn)
 
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -53,7 +53,7 @@ from nvflare.fuel.f3.cellnet.identity import ADMIN_LISTENER_KEY
 from nvflare.fuel.f3.cellnet.net_agent import NetAgent
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
-from nvflare.fuel.sec.authn import add_authentication_headers, is_cross_client_family
+from nvflare.fuel.sec.authn import add_authentication_headers
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.private.defs import (
@@ -422,18 +422,14 @@ class FederatedServer(BaseServer):
         )
         self.logger.debug(f"added auth headers:  {origin=} {dest=} {channel=} {topic=}")
 
-    def _strip_peer_transit_auth_headers(self, message: Message):
-        origin = message.get_header(MessageHeaderKey.ORIGIN)
-        destination = message.get_header(MessageHeaderKey.DESTINATION)
-        if not origin or not destination:
-            return
-        client_name = message.get_header(CellMessageHeaderKeys.CLIENT_NAME)
-        if not is_cross_client_family(origin, destination, client_name):
+    def _strip_peer_transit_headers(self, message: Message):
+        if not message.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, False):
             return
 
         # Cross-client requests and replies authenticate at the server boundary,
-        # but a peer client must never receive another client's bearer material.
-        # This runs after successful server validation and before forwarding.
+        # but a peer client must never receive another client's bearer material
+        # or an invitation to create a direct ad-hoc connector. Keep the transit
+        # marker so downstream routing knows that the server boundary was crossed.
         for key in [
             CellMessageHeaderKeys.CLIENT_NAME,
             CellMessageHeaderKeys.TOKEN,
@@ -441,7 +437,7 @@ class FederatedServer(BaseServer):
             CellMessageHeaderKeys.SSID,
         ]:
             message.remove_header(key)
-        message.remove_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED)
+        message.remove_header(MessageHeaderKey.CONN_URL)
 
     def _validate_auth_headers(self, message: Message):
         """Validate auth headers from messages that go through the server.
@@ -451,6 +447,7 @@ class FederatedServer(BaseServer):
         """
         id_asserter = self._get_id_asserter()
         if not id_asserter:
+            self._strip_peer_transit_headers(message)
             return None
 
         token_verifier = TokenVerifier(id_asserter.cert)
@@ -463,7 +460,7 @@ class FederatedServer(BaseServer):
             local_cell_fqcn=self.cell.get_fqcn() if getattr(self, "cell", None) else None,
         )
         if not reply:
-            self._strip_peer_transit_auth_headers(message)
+            self._strip_peer_transit_headers(message)
         return reply
 
     def _resolve_client_fqcn_for_auth(self, client_name: str, token: str):
@@ -1144,8 +1141,8 @@ class FederatedServer(BaseServer):
         self.engine.initialize_comm(self.cell)
         self._register_cellnet_cbs()
 
+        core_cell = self.cell.core_cell
         if secure_train:
-            core_cell = self.cell.core_cell
             core_cell.add_incoming_filter(
                 channel="*",
                 topic="*",
@@ -1154,6 +1151,8 @@ class FederatedServer(BaseServer):
 
             core_cell.add_outgoing_reply_filter(channel="*", topic="*", cb=self._add_auth_headers)
             core_cell.add_outgoing_request_filter(channel="*", topic="*", cb=self._add_auth_headers)
+        else:
+            core_cell.add_incoming_filter(channel="*", topic="*", cb=self._strip_peer_transit_headers)
 
     def stop_training(self):
         self.status = ServerStatus.STOPPED

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_routing_test.py
@@ -17,7 +17,7 @@
 import logging
 
 from nvflare.fuel.f3.cellnet.core_cell import CoreCell
-from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessagePropKey, ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FqcnInfo
 from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message
@@ -82,6 +82,16 @@ def test_server_transit_required_job_cell_uses_local_parent():
     assert endpoint.name == "site-1"
 
 
+def test_server_transit_required_job_cell_prefers_own_server_connection():
+    cell = _routing_cell("site-1.job-1", ["site-1", "server", "site-2.job-2"])
+    message = Message(headers={MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True})
+
+    endpoint = cell._try_find_ep("site-2.job-2", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "server"
+
+
 def test_server_transit_required_job_cell_falls_back_to_server_root():
     cell = _routing_cell("site-1.job-1", ["server", "site-2.job-2"])
     message = Message(headers={MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True})
@@ -92,11 +102,128 @@ def test_server_transit_required_job_cell_falls_back_to_server_root():
     assert endpoint.name == "server"
 
 
+def test_server_transit_return_routes_down_from_configured_upstream():
+    cell = _routing_cell("relay-1", ["server", "relay-1.site-2"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("site-1", 0.0), ("server", 1.0)],
+        }
+    )
+    message.set_prop(MessagePropKey.ENDPOINT, Endpoint("server"))
+
+    endpoint = cell._try_find_ep("relay-1.site-2", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "relay-1.site-2"
+
+
+def test_server_transit_return_routes_down_from_direct_server_connection():
+    cell = _routing_cell("site-2.job", ["site-2", "server", "site-2.job.worker"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("site-1", 0.0), ("server", 1.0)],
+        }
+    )
+    message.set_prop(MessagePropKey.ENDPOINT, Endpoint("server"))
+
+    endpoint = cell._try_find_ep("site-2.job.worker", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "site-2.job.worker"
+
+
+def test_forged_server_route_from_child_still_routes_upstream():
+    cell = _routing_cell("relay-1", ["server", "relay-1.site-1", "relay-1.site-2"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("server", 0.0)],
+        }
+    )
+    message.set_prop(MessagePropKey.ENDPOINT, Endpoint("relay-1.site-1"))
+
+    endpoint = cell._try_find_ep("relay-1.site-2", message)
+
+    assert endpoint is not None
+    assert endpoint.name == "server"
+
+
 def test_find_endpoint_refuses_next_leg_already_on_route():
     cell = _routing_cell("server", ["site-1"])
     message = Message(headers={MessageHeaderKey.ROUTE: [("site-1", 0.0)]})
 
     rc, endpoint = cell._find_endpoint("site-1.job-dead", message)
+
+    assert endpoint is None
+    assert rc == ReturnCode.TARGET_UNREACHABLE
+
+
+def test_server_transit_can_return_through_visited_shared_relay_once():
+    cell = _routing_cell("server", ["relay-1"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("relay-1.site-1", 0.0), ("relay-1", 1.0)],
+        }
+    )
+
+    rc, endpoint = cell._find_endpoint("relay-1.site-2", message)
+
+    assert rc == ""
+    assert endpoint is not None
+    assert endpoint.name == "relay-1"
+
+
+def test_post_server_shared_relay_can_revisit_downstream_relay():
+    cell = _routing_cell("relay-1", ["server", "relay-1.relay-2"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [
+                ("relay-1.relay-2.site-1", 0.0),
+                ("relay-1.relay-2", 1.0),
+                ("relay-1", 2.0),
+                ("server", 3.0),
+            ],
+        }
+    )
+    message.set_prop(MessagePropKey.ENDPOINT, Endpoint("server"))
+
+    rc, endpoint = cell._find_endpoint("relay-1.relay-2.site-2", message)
+
+    assert rc == ""
+    assert endpoint is not None
+    assert endpoint.name == "relay-1.relay-2"
+
+
+def test_post_server_relay_cannot_revisit_upstream_server():
+    cell = _routing_cell("relay-1", ["server"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("relay-1.site-1", 0.0), ("relay-1", 1.0), ("server", 2.0)],
+        }
+    )
+    message.set_prop(MessagePropKey.ENDPOINT, Endpoint("server"))
+
+    rc, endpoint = cell._find_endpoint("relay-2.site-2", message)
+
+    assert endpoint is None
+    assert rc == ReturnCode.TARGET_UNREACHABLE
+
+
+def test_server_transit_cannot_cross_server_boundary_twice():
+    cell = _routing_cell("server", ["relay-1"])
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("relay-1", 0.0), ("server", 1.0)],
+        }
+    )
+
+    rc, endpoint = cell._find_endpoint("relay-1.site-2", message)
 
     assert endpoint is None
     assert rc == ReturnCode.TARGET_UNREACHABLE

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_test.py
@@ -29,6 +29,7 @@ from nvflare.fuel.f3.cellnet.core_cell import (
 )
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FqcnInfo
+from nvflare.fuel.f3.cellnet.registry import Registry
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.endpoint import Endpoint
 from nvflare.fuel.f3.message import Message
@@ -212,6 +213,79 @@ def test_internal_listener_host_overrides_default_resources():
 
     assert manager.int_resources[DriverParams.HOST.value] == "127.0.0.1"
     assert manager.int_resources[DriverParams.LISTEN_HOST.value] == "127.0.0.1"
+
+
+def test_public_send_reply_applies_filters_before_server_transit_routing():
+    cell = _cell("site-2.job")
+    cell.out_reply_filter_reg = Registry()
+    cell.received_msg_counter_pool = MagicMock()
+    cell._stats_category = MagicMock(return_value="reply:test")
+    cell._send_to_endpoint = MagicMock(return_value="")
+    cell._find_endpoint = MagicMock(
+        side_effect=[
+            ("", Endpoint("site-1.job")),
+            ("", Endpoint("server")),
+        ]
+    )
+
+    def require_server_transit(message):
+        message.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
+
+    cell.add_outgoing_reply_filter("*", "*", require_server_transit)
+
+    rc = cell.send_reply(Message(), "site-1.job", ["req-1"])
+
+    assert rc == ""
+    assert cell._find_endpoint.call_count == 2
+    assert cell._send_to_endpoint.call_args.args[0].name == "server"
+
+
+def test_send_reply_reports_comm_error_when_server_transit_path_is_unreachable():
+    cell = _cell("site-2.job")
+    cell.out_reply_filter_reg = Registry()
+    cell.received_msg_counter_pool = MagicMock()
+    cell._find_endpoint = MagicMock(return_value=(ReturnCode.TARGET_UNREACHABLE, None))
+    cell._send_to_endpoint = MagicMock()
+    reply = Message(
+        headers={
+            MessageHeaderKey.DESTINATION: "site-1.job",
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+        }
+    )
+
+    rc = cell._send_reply(reply, Endpoint("site-1.job"))
+
+    assert rc == ReturnCode.COMM_ERROR
+    cell._send_to_endpoint.assert_not_called()
+
+
+def test_server_transit_request_does_not_advertise_ad_hoc_connector():
+    cell = _cell("site-1")
+    cell.out_req_filter_reg = Registry()
+    cell.sent_msg_counter_pool = MagicMock()
+    cell.connector_manager = MagicMock()
+    cell.connector_manager.is_adhoc_allowed.return_value = True
+    cell._create_external_listener = MagicMock()
+    cell._send_to_endpoint = MagicMock(return_value="")
+    cell._find_endpoint = MagicMock(
+        side_effect=[
+            ("", Endpoint("site-2")),
+            ("", Endpoint("server")),
+        ]
+    )
+
+    def require_server_transit(message):
+        message.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
+
+    cell.add_outgoing_request_filter("*", "*", require_server_transit)
+    target_message = TargetMessage("site-2", "peer", "ping", Message(payload="hello"))
+
+    result = cell._send_target_messages({"site-2": target_message})
+
+    assert result == {"site-2": ""}
+    cell._create_external_listener.assert_not_called()
+    sent_message = cell._send_to_endpoint.call_args.args[1]
+    assert sent_message.get_header(MessageHeaderKey.CONN_URL) is None
 
 
 def test_encrypt_and_decrypt_secure_payload():

--- a/tests/unit_test/fuel/f3/cellnet/server_transit_e2e_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/server_transit_e2e_test.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing
+import time
+import traceback
+
+import pytest
+
+from nvflare.fuel.f3.cellnet.core_cell import CoreCell
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, ReturnCode
+from nvflare.fuel.f3.message import Message
+from nvflare.fuel.utils.network_utils import get_open_ports
+
+_CHANNEL = "server_transit_test"
+_TOPIC = "ping"
+_CONNECT_TIMEOUT = 10.0
+
+
+def _mark_server_transit(message):
+    message.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
+
+
+def _wait_for_connection(cell, peer_fqcn):
+    deadline = time.time() + _CONNECT_TIMEOUT
+    while time.time() < deadline:
+        if cell.is_cell_connected(peer_fqcn):
+            return
+        time.sleep(0.05)
+    raise RuntimeError(f"{cell.get_fqcn()} did not connect to {peer_fqcn}")
+
+
+def _run_server(root_url, status_queue, stop_event):
+    cell = None
+    try:
+        cell = CoreCell("server", root_url, secure=False, credentials={})
+        cell.start()
+        status_queue.put({"ready": True})
+        stop_event.wait(30)
+    except Exception:
+        status_queue.put({"error": traceback.format_exc()})
+        raise
+    finally:
+        if cell:
+            cell.stop()
+
+
+def _run_relay(root_url, status_queue, stop_event):
+    cell = None
+    try:
+        cell = CoreCell("relay-1", root_url, secure=False, credentials={}, create_internal_listener=True)
+        cell.start()
+        _wait_for_connection(cell, "server")
+        status_queue.put({"parent_url": cell.get_internal_listener_url()})
+        stop_event.wait(30)
+    except Exception:
+        status_queue.put({"error": traceback.format_exc()})
+        raise
+    finally:
+        if cell:
+            cell.stop()
+
+
+def _run_destination(parent_url, status_queue, stop_event):
+    cell = None
+    try:
+        cell = CoreCell("relay-1.site-b", None, secure=False, credentials={}, parent_url=parent_url)
+        cell.add_outgoing_reply_filter("*", "*", _mark_server_transit)
+
+        def reply_with_route(request):
+            route = request.get_header(MessageHeaderKey.ROUTE, [])
+            return Message(
+                payload={
+                    "marker": request.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED),
+                    "route": [hop[0] for hop in route],
+                }
+            )
+
+        cell.register_request_cb(_CHANNEL, _TOPIC, reply_with_route)
+        cell.start()
+        _wait_for_connection(cell, "relay-1")
+        status_queue.put({"ready": True})
+        stop_event.wait(30)
+    except Exception:
+        status_queue.put({"error": traceback.format_exc()})
+        raise
+    finally:
+        if cell:
+            cell.stop()
+
+
+def _run_origin(parent_url, result_queue):
+    cell = None
+    try:
+        cell = CoreCell("relay-1.site-a", None, secure=False, credentials={}, parent_url=parent_url)
+        cell.add_outgoing_request_filter("*", "*", _mark_server_transit)
+        cell.start()
+        _wait_for_connection(cell, "relay-1")
+        reply = cell.send_request(
+            _CHANNEL,
+            _TOPIC,
+            "relay-1.site-b",
+            Message(payload="hello"),
+            timeout=10.0,
+        )
+        route = reply.get_header(MessageHeaderKey.ROUTE, [])
+        result_queue.put(
+            {
+                "return_code": reply.get_header(MessageHeaderKey.RETURN_CODE),
+                "payload": reply.payload,
+                "reply_marker": reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED),
+                "reply_route": [hop[0] for hop in route],
+            }
+        )
+    except Exception:
+        result_queue.put({"error": traceback.format_exc()})
+        raise
+    finally:
+        if cell:
+            cell.stop()
+
+
+def _queue_result(queue):
+    result = queue.get(timeout=30)
+    assert "error" not in result, result.get("error")
+    return result
+
+
+@pytest.mark.timeout(90)
+def test_non_secure_cross_site_request_and_reply_cross_server_under_shared_relay():
+    context = multiprocessing.get_context("spawn")
+    root_url = f"tcp://localhost:{get_open_ports(1)[0]}"
+    server_status = context.Queue()
+    relay_status = context.Queue()
+    destination_status = context.Queue()
+    result_queue = context.Queue()
+    server_stop = context.Event()
+    relay_stop = context.Event()
+    destination_stop = context.Event()
+
+    server = context.Process(target=_run_server, args=(root_url, server_status, server_stop))
+    relay = context.Process(target=_run_relay, args=(root_url, relay_status, relay_stop))
+    destination = None
+    origin = None
+    started_processes = []
+    try:
+        server.start()
+        started_processes.append(server)
+        _queue_result(server_status)
+        relay.start()
+        started_processes.append(relay)
+        parent_url = _queue_result(relay_status)["parent_url"]
+
+        destination = context.Process(
+            target=_run_destination,
+            args=(parent_url, destination_status, destination_stop),
+        )
+        destination.start()
+        started_processes.append(destination)
+        _queue_result(destination_status)
+
+        origin = context.Process(target=_run_origin, args=(parent_url, result_queue))
+        origin.start()
+        started_processes.append(origin)
+        result = _queue_result(result_queue)
+        origin.join(timeout=15)
+
+        assert result["return_code"] == ReturnCode.OK
+        assert result["payload"]["marker"] is True
+        assert result["payload"]["route"].count("relay-1") == 2
+        assert "server" in result["payload"]["route"]
+        assert result["reply_marker"] is True
+        assert result["reply_route"].count("relay-1") == 2
+        assert "server" in result["reply_route"]
+    finally:
+        destination_stop.set()
+        relay_stop.set()
+        server_stop.set()
+        for process in reversed(started_processes):
+            process.join(timeout=10)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+    assert all(process.exitcode == 0 for process in started_processes)

--- a/tests/unit_test/fuel/sec/authn_test.py
+++ b/tests/unit_test/fuel/sec/authn_test.py
@@ -110,7 +110,7 @@ def test_auth_filter_does_not_add_client_credentials_to_peer_replies():
     victim_name = _unique_fqcn("victim")
     victim = _make_running_cell(victim_name)
     peer = _make_running_cell(f"{victim_name}.peer")
-    set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
+    set_add_auth_headers_filters(victim, victim_name, "tok-victim", "sig-victim", "ssid-victim")
 
     victim.core_cell.register_request_cb("probe", "ping", lambda _request: Message(payload="pong"))
 
@@ -149,11 +149,11 @@ def test_cross_client_auth_forces_server_transit_and_strips_credentials_from_pee
     assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
     assert reply.payload == {
         "auth": {key: None for key in AUTH_HEADERS},
-        "transit_required": None,
+        "transit_required": True,
         "from_cell": "server",
     }
     assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}
-    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
 
 
 def test_cross_client_auth_under_same_relay_transits_server_and_strips_credentials(monkeypatch):
@@ -193,11 +193,11 @@ def test_cross_client_auth_under_same_relay_transits_server_and_strips_credentia
     assert reply.get_header(MessageHeaderKey.RETURN_CODE) == ReturnCode.OK
     assert reply.payload == {
         "auth": {key: None for key in AUTH_HEADERS},
-        "transit_required": None,
+        "transit_required": True,
         "from_cell": "server",
     }
     assert _auth_header_values(reply) == {key: None for key in AUTH_HEADERS}
-    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
 
 
 def test_client_job_reply_routed_via_local_parents_authenticates_at_server(monkeypatch):
@@ -240,6 +240,7 @@ def test_client_job_reply_routed_via_local_parents_authenticates_at_server(monke
 def test_server_auth_filter_strips_validated_client_reply_transit_auth(monkeypatch):
     auth_filter = _make_server_auth_filter(monkeypatch)
     reply_msg = _make_routed_message("site-a", MessageType.REPLY, origin="site-b", with_auth=True)
+    reply_msg.set_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED, True)
 
     assert auth_filter(reply_msg) is None
     assert _auth_header_values(reply_msg) == {
@@ -257,7 +258,7 @@ def test_server_auth_filter_strips_validated_client_request_transit_auth(monkeyp
 
     assert auth_filter(request_msg) is None
     assert _auth_header_values(request_msg) == {key: None for key in AUTH_HEADERS}
-    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
+    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
 
 
 def test_server_auth_filter_strips_transit_auth_between_sites_under_same_relay(monkeypatch):
@@ -282,7 +283,22 @@ def test_server_auth_filter_strips_transit_auth_between_sites_under_same_relay(m
 
     assert auth_filter(request_msg) is None
     assert _auth_header_values(request_msg) == {key: None for key in AUTH_HEADERS}
-    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is None
+    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
+
+
+def test_server_auth_filter_strips_ad_hoc_url_but_keeps_transit_marker(monkeypatch):
+    auth_filter = _make_server_auth_filter(monkeypatch)
+    request_msg = _make_routed_message("site-b", MessageType.REQ, with_auth=True)
+    request_msg.add_headers(
+        {
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.CONN_URL: "tcp://site-a:9000",
+        }
+    )
+
+    assert auth_filter(request_msg) is None
+    assert request_msg.get_header(MessageHeaderKey.CONN_URL) is None
+    assert request_msg.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
 
 
 def test_server_auth_filter_rejects_untracked_unauthenticated_client_reply_transit(monkeypatch):
@@ -326,13 +342,13 @@ def test_auth_filter_keeps_auth_on_outgoing_requests():
     victim_name = _unique_fqcn("victim")
     victim = _make_running_cell(victim_name)
     peer = _make_running_cell(f"{victim_name}.peer")
-    set_add_auth_headers_filters(victim, "victim", "tok-victim", "sig-victim", "ssid-victim")
+    set_add_auth_headers_filters(victim, victim_name, "tok-victim", "sig-victim", "ssid-victim")
     peer.core_cell.register_request_cb("probe", "echo", lambda request: Message(payload=_auth_header_values(request)))
 
     reply = victim.send_request("probe", "echo", peer.get_fqcn(), Message(payload="hello"), timeout=1.0)
 
     assert reply.payload == {
-        CellMessageAuthHeaderKey.CLIENT_NAME: "victim",
+        CellMessageAuthHeaderKey.CLIENT_NAME: victim_name,
         CellMessageAuthHeaderKey.TOKEN: "tok-victim",
         CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-victim",
         CellMessageAuthHeaderKey.SSID: "ssid-victim",
@@ -400,6 +416,32 @@ def test_auth_filter_keeps_cross_site_reply_auth_when_routed_via_local_parent():
         CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-a",
         CellMessageAuthHeaderKey.SSID: "ssid-a",
     }
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
+
+
+def test_auth_filter_marks_cross_site_reply_from_direct_peer_path():
+    origin = "site-a.job-1"
+    victim = _make_running_cell(origin)
+    set_add_auth_headers_filters(victim, "site-a", "tok-a", "sig-a", "ssid-a")
+    reply = Message(
+        headers={
+            MessageHeaderKey.MSG_TYPE: MessageType.REPLY,
+            MessageHeaderKey.ORIGIN: origin,
+            MessageHeaderKey.DESTINATION: "site-b.job-1",
+            MessageHeaderKey.TO_CELL: "site-b.job-1",
+        }
+    )
+
+    for callback in victim.core_cell.out_reply_filter_reg.find("peer", "reply"):
+        callback.cb(reply, *callback.args, **callback.kwargs)
+
+    assert _auth_header_values(reply) == {
+        CellMessageAuthHeaderKey.CLIENT_NAME: "site-a",
+        CellMessageAuthHeaderKey.TOKEN: "tok-a",
+        CellMessageAuthHeaderKey.TOKEN_SIGNATURE: "sig-a",
+        CellMessageAuthHeaderKey.SSID: "ssid-a",
+    }
+    assert reply.get_header(MessageHeaderKey.SERVER_TRANSIT_REQUIRED) is True
 
 
 def test_auth_filter_keeps_cross_site_reply_auth_under_same_relay():
@@ -452,6 +494,9 @@ def test_auth_filter_does_not_add_auth_to_same_site_reply_via_parent():
     [
         ("relay-1.site-a.job-1", "relay-1.site-b.job-2", "site-a", True),
         ("relay-1.site-a.job-1", "relay-1.site-a.job-2", "site-a", False),
+        ("relay-1.site-a.job-1", "relay-1.site-b.job-2", "custom-site-cn", True),
+        ("relay-1.site-a.job-1", "relay-1.site-a.job-2", "custom-site-cn", True),
+        ("relay-1.site-a.job-1", "relay-1.site-a.job-1", "custom-site-cn", False),
     ],
 )
 def test_cross_client_family_uses_authenticated_site_identity(origin, destination, client_name, expected):

--- a/tests/unit_test/private/fed/app/relay/relay_test.py
+++ b/tests/unit_test/private/fed/app/relay/relay_test.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nvflare.fuel.f3.cellnet.core_cell import CoreCell
+from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey, MessagePropKey
+from nvflare.fuel.f3.cellnet.fqcn import FqcnInfo
+from nvflare.fuel.f3.endpoint import Endpoint
+from nvflare.fuel.f3.message import Message
+from nvflare.private.fed.app.relay.relay import _validate_auth_headers
+
+
+def _relay_core_cell(fqcn="relay-1"):
+    core_cell = CoreCell.__new__(CoreCell)
+    core_cell.my_info = FqcnInfo(fqcn)
+    return core_cell
+
+
+def _server_transit_message(incoming_endpoint):
+    message = Message(
+        headers={
+            MessageHeaderKey.SERVER_TRANSIT_REQUIRED: True,
+            MessageHeaderKey.ROUTE: [("site-1", 0.0), ("server", 1.0)],
+        }
+    )
+    message.set_prop(MessagePropKey.ENDPOINT, Endpoint(incoming_endpoint))
+    return message
+
+
+@pytest.mark.parametrize(("relay_fqcn", "upstream_fqcn"), [("relay-1", "server"), ("relay-1.relay-2", "relay-1")])
+def test_relay_accepts_sanitized_server_transit_from_configured_upstream(relay_fqcn, upstream_fqcn):
+    core_cell = _relay_core_cell(relay_fqcn)
+    message = _server_transit_message(upstream_fqcn)
+
+    with patch("nvflare.private.fed.app.relay.relay.validate_auth_headers") as validate:
+        result = _validate_auth_headers(
+            message,
+            token_verifier=MagicMock(),
+            logger=MagicMock(),
+            local_cell_fqcn=relay_fqcn,
+            core_cell=core_cell,
+        )
+
+    assert result is None
+    validate.assert_not_called()
+
+
+def test_relay_does_not_trust_forged_server_route_from_child():
+    core_cell = _relay_core_cell()
+    message = _server_transit_message("relay-1.site-1")
+    expected = Message(payload="rejected")
+
+    with patch("nvflare.private.fed.app.relay.relay.validate_auth_headers", return_value=expected) as validate:
+        result = _validate_auth_headers(
+            message,
+            token_verifier=MagicMock(),
+            logger=MagicMock(),
+            local_cell_fqcn="relay-1",
+            core_cell=core_cell,
+        )
+
+    assert result is expected
+    validate.assert_called_once()

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -95,6 +95,26 @@ class TestFederatedServer:
 
         assert server._resolve_client_fqcn_for_auth("site-a", "token-a") == MISSING_CLIENT_FQCN
 
+    def test_non_secure_server_registers_transit_header_sanitizer(self):
+        server = object.__new__(FederatedServer)
+        server.lock = MagicMock()
+        server.cell = MagicMock()
+        server.engine = MagicMock()
+        server._register_cellnet_cbs = MagicMock()
+
+        with patch("nvflare.private.fed.server.fed_server.BaseServer.deploy"):
+            server.deploy(
+                args=MagicMock(),
+                grpc_args={"service": {"target": "localhost:8002"}},
+                secure_train=False,
+            )
+
+        server.cell.core_cell.add_incoming_filter.assert_called_once_with(
+            channel="*",
+            topic="*",
+            cb=server._strip_peer_transit_headers,
+        )
+
     def test_create_job_cell_allows_missing_server_config_for_non_secure_cell(self):
         server = object.__new__(FederatedServer)
         server.engine = MagicMock()


### PR DESCRIPTION
## What changed

- Keep `SERVER_TRANSIT_REQUIRED` for the full route and use the route only to determine whether traffic is on the pre-server or post-server leg.
- Permit safe post-server traversal back through shared and nested relays while retaining loop protection for upstream bounces.
- Let relays accept post-server traffic only from their configured upstream endpoint.
- Strip client bearer headers and `CONN_URL` at the server boundary in both secure and non-secure modes, and suppress ad-hoc connector negotiation for forced-transit traffic.
- Route public and delayed replies through outgoing auth filters, prefer a direct server connection before a parent detour, and return `COMM_ERROR` when reply transit resolution fails.
- Add focused routing/auth tests plus a process-isolated shared-relay request/reply test.

## Why

This is a follow-up to #5096. The original bearer-leak fix forced cross-site traffic through the server, but enforcement was split across security filtering, transport routing, and server header stripping. In distributed relay topologies that could make the return path revisit a relay already present in `ROUTE`, causing `TARGET_UNREACHABLE`; non-secure traffic could retain the marker and bounce; and destination-side relays could reject post-server traffic after the server removed bearer credentials.

The invariant here is that the transit marker describes the entire delivery contract. Topology determines whether a message has crossed the server boundary, while authorization remains tied to the actual incoming endpoint.

## Impact

Cross-site requests and replies continue to pass through the server without exposing client bearer credentials or direct-listener connection URLs to peer sites. Shared-relay, nested-relay, and non-secure deployments retain a deliverable post-server route.

## Validation

- 99 focused CellNet/auth/server/relay tests
- 244 broader CellNet and security tests
- process-isolated shared-relay request/reply test
- `./runtest.sh -s`
