### PR TITLE
Align remote job log configuration controls

### DIFF
--- a/nvflare/fuel/flare_api/api_spec.py
+++ b/nvflare/fuel/flare_api/api_spec.py
@@ -336,7 +336,7 @@ class SessionSpec(ABC):
 
         Args:
             job_id: ID of the running job
-            config: log level, log mode, file path, or dictConfig payload
+            config: log level or built-in log mode
             target: ``all``, ``server``, or a client site name
 
         Returns: None

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -1484,7 +1484,7 @@ class Session(SessionSpec):
 
         Args:
             job_id (str): ID of the job (must be RUNNING)
-            config: str (level or LogMode), dict (dictConfig), or file path
+            config: str log level or built-in LogMode
             target (str): "all", "server", or a client site name. Any value
                 other than "all" or "server" is sent through the client-targeted
                 admin command path.

--- a/nvflare/private/fed/client/admin_commands.py
+++ b/nvflare/private/fed/client/admin_commands.py
@@ -17,7 +17,7 @@
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.fuel.utils.log_utils import dynamic_log_config
+from nvflare.fuel.utils.log_utils import dynamic_log_config, validate_site_log_config
 from nvflare.private.fed.client.client_status import get_status_message
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import InfoCollector
@@ -272,8 +272,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_site_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -29,7 +29,7 @@ from nvflare.apis.fl_constant import (
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
-from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger
+from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger, validate_site_log_config
 from nvflare.private.defs import SpecialTaskName, TaskConstant
 from nvflare.security.logging import secure_format_exception, secure_format_traceback
 from nvflare.widgets.widget import WidgetID
@@ -453,8 +453,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_site_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/tests/unit_test/private/fed/configure_job_log_security_test.py
+++ b/tests/unit_test/private/fed/configure_job_log_security_test.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nvflare.fuel.utils.log_utils import LogMode
+from nvflare.private.fed.client.admin_commands import ConfigureJobLogCommand as ClientConfigureJobLogCommand
+from nvflare.private.fed.server.server_commands import ConfigureJobLogCommand as ServerConfigureJobLogCommand
+
+COMMANDS = [
+    (ServerConfigureJobLogCommand, "nvflare.private.fed.server.server_commands.dynamic_log_config"),
+    (ClientConfigureJobLogCommand, "nvflare.private.fed.client.admin_commands.dynamic_log_config"),
+]
+
+
+def _log_command_context(tmp_path):
+    workspace = MagicMock()
+    workspace.get_run_dir.return_value = str(tmp_path / "run")
+    workspace.get_log_config_file_path.return_value = str(tmp_path / "log_config.json")
+    engine = MagicMock()
+    engine.get_workspace.return_value = workspace
+    fl_ctx = MagicMock()
+    fl_ctx.get_engine.return_value = engine
+    fl_ctx.get_job_id.return_value = "job-1"
+    return fl_ctx
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+@pytest.mark.parametrize("config", ["DEBUG", "20", LogMode.MSG_ONLY, LogMode.RELOAD])
+def test_remote_job_log_accepts_safe_controls(tmp_path, command_class, dynamic_path, config):
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(config, _log_command_context(tmp_path))
+
+    assert error is None
+    dynamic.assert_called_once_with(
+        config=config,
+        dir_path=str(tmp_path / "run"),
+        reload_path=str(tmp_path / "log_config.json"),
+    )
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+def test_remote_job_log_rejects_inline_json(tmp_path, command_class, dynamic_path):
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process('{"version": 1}', _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+def test_remote_job_log_rejects_existing_file_path(tmp_path, command_class, dynamic_path):
+    config_path = tmp_path / "attacker-log-config.json"
+    config_path.write_text('{"version": 1}', encoding="utf-8")
+
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(str(config_path), _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()
+
+
+@pytest.mark.parametrize("command_class", [ServerConfigureJobLogCommand, ClientConfigureJobLogCommand])
+def test_remote_job_log_rejects_dict_config_factory_before_execution(tmp_path, command_class):
+    factory_calls = []
+
+    def harmless_factory():
+        factory_calls.append(True)
+        return logging.NullHandler()
+
+    config = {
+        "version": 1,
+        "handlers": {"factory": {"()": harmless_factory}},
+        "root": {"level": "INFO", "handlers": ["factory"]},
+    }
+
+    error = command_class().process(config, _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    assert factory_calls == []


### PR DESCRIPTION
## Summary

- Reuse existing site log validation for remote job-log updates.
- Apply the same controls to server and client job processes.
- Align the API documentation with supported inputs and add regression coverage.

## Validation

- 21 focused logging and command-routing tests
- `./runtest.sh -s`
- `git diff --check`
