### PR TITLE
Fix Docker example IPC configuration

### DIFF
--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -131,8 +131,10 @@ Available jobs:
   Every site configured with a Docker job launcher needs either a site-specific `docker`
   entry or a `launcher_spec.default.docker` entry that supplies the job image.
 - Site-level Docker defaults (e.g. `shm_size`, `ipc_mode`) can be set via
-  `default_job_container_kwargs` in `resources.json` — job-level
-  `launcher_spec[site][docker]` takes precedence on conflict.
+  `job_launcher.default_job_container_kwargs` in `docker.yaml`; `nvflare deploy prepare`
+  writes them to `resources.json`. This example configures `ipc_mode: host` there because
+  host-isolation options are site-owned and cannot be supplied by job metadata. Job-level
+  `launcher_spec[site][docker]` takes precedence for supported options.
 - Some multi-GPU Docker environments may need `NCCL_P2P_DISABLE=1` to avoid NCCL hangs.
   Set this site-wide with `default_job_env` in `resources.json`, for example:
   ```json

--- a/examples/docker/docker.yaml
+++ b/examples/docker/docker.yaml
@@ -4,3 +4,5 @@ parent:
   network: nvflare-network
 job_launcher:
   default_python_path: /usr/local/bin/python
+  default_job_container_kwargs:
+    ipc_mode: host

--- a/examples/docker/jobs/hello-pt-docker/meta.json
+++ b/examples/docker/jobs/hello-pt-docker/meta.json
@@ -11,15 +11,13 @@
         "site-1": {
             "docker": {
                 "image": "nvflare-job:latest",
-                "shm_size": "8g",
-                "ipc_mode": "host"
+                "shm_size": "8g"
             }
         },
         "site-2": {
             "docker": {
                 "image": "nvflare-job:latest",
-                "shm_size": "8g",
-                "ipc_mode": "host"
+                "shm_size": "8g"
             }
         }
     },

--- a/examples/docker/jobs/pt-ddp-docker/meta.json
+++ b/examples/docker/jobs/pt-ddp-docker/meta.json
@@ -13,15 +13,13 @@
         "site-1": {
             "docker": {
                 "image": "nvflare-job:latest",
-                "shm_size": "8g",
-                "ipc_mode": "host"
+                "shm_size": "8g"
             }
         },
         "site-2": {
             "docker": {
                 "image": "nvflare-job:latest",
-                "shm_size": "8g",
-                "ipc_mode": "host"
+                "shm_size": "8g"
             }
         }
     },


### PR DESCRIPTION
## What changed

- Move `ipc_mode: host` from job-controlled `launcher_spec` metadata to site-owned `job_launcher.default_job_container_kwargs` in `docker.yaml`.
- Update the Docker example documentation to explain where host-isolation options belong.

## Why

The hardened Docker launcher allowlist rejects isolation-sensitive options supplied by job metadata. The PyTorch Docker example jobs still set `ipc_mode`, causing submission to fail with `JOB_INVALID`.

## Impact

The Docker example jobs satisfy the job metadata allowlist while retaining host IPC as a site-controlled deployment setting.

## Validation

- Validated all three Docker job metadata files against the Docker launcher allowlist and verified `docker.yaml` supplies site-owned `ipc_mode: host`.
- `./runtest.sh -s --skip-install examples/docker`
- `git diff --check`
