### PR TITLE
Fix portable resource spec regressions

### DIFF
--- a/nvflare/app_common/resource_managers/gpu_resource_manager.py
+++ b/nvflare/app_common/resource_managers/gpu_resource_manager.py
@@ -159,6 +159,8 @@ class GPUResourceManager(AutoCleanResourceManager):
         is_resource_enough = False
         num_gpu = resource_requirement[self.num_gpu_key]
         gpu_mem = resource_requirement.get(self.gpu_mem_key, 0)
+        if num_gpu == 0:
+            return True
 
         satisfied = 0
         for k in self.resources:
@@ -180,6 +182,9 @@ class GPUResourceManager(AutoCleanResourceManager):
         reserved_resources = {}
         num_gpu = resource_requirement[self.num_gpu_key]
         gpu_mem = resource_requirement.get(self.gpu_mem_key, 0)
+        if num_gpu == 0:
+            return reserved_resources
+
         reserved = 0
         for k in self.resources:
             r: GPUResource = self.resources[k]

--- a/nvflare/utils/job_launcher_utils.py
+++ b/nvflare/utils/job_launcher_utils.py
@@ -250,10 +250,13 @@ def get_resource_manager_spec(job_meta: dict, site_name: str) -> dict:
         return get_site_launcher_spec(site_spec, "process")
     resolved = resolve_site_resource_spec(job_meta, site_name)
     result = {key: value for key, value in resolved.items() if key not in ("num_of_cpus", "memory")}
-    if result.get("num_of_gpus") == 0:
+    if (
+        result.get("num_of_gpus") == 0
+        and set(result).issubset({"num_of_gpus", "mem_per_gpu_in_GiB"})
+        and result.get("mem_per_gpu_in_GiB", 0) == 0
+    ):
         result.pop("num_of_gpus")
-        if result.get("mem_per_gpu_in_GiB") == 0:
-            result.pop("mem_per_gpu_in_GiB")
+        result.pop("mem_per_gpu_in_GiB", None)
     return result
 
 
@@ -289,7 +292,7 @@ def portable_memory_to_bytes(memory: str) -> int:
 def _validate_legacy_nested_gpu_consistency(job_meta: dict, site_name: str, resource_spec: dict) -> None:
     """Keep legacy process GPU admission consistent with the effective launcher request."""
     site_spec = resource_spec.get(site_name) or {}
-    if PORTABLE_RESOURCE_DEFAULT_KEY in resource_spec or not any(key in site_spec for key in _LAUNCHER_MODE_KEYS):
+    if not any(key in site_spec for key in _LAUNCHER_MODE_KEYS):
         return
 
     process_spec = get_site_launcher_spec(site_spec, "process")
@@ -332,11 +335,16 @@ def validate_portable_resource_conflicts(job_meta: dict) -> None:
     site_names = (set(resource_spec) - {PORTABLE_RESOURCE_DEFAULT_KEY}) | (set(launcher_spec) - {"default"})
     for site_name in site_names:
         _validate_legacy_nested_gpu_consistency(job_meta, site_name, resource_spec)
+        site_spec = resource_spec.get(site_name) or {}
+        process_spec = get_site_launcher_spec(site_spec, "process")
+        has_legacy_process_gpu = any(key in site_spec for key in _LAUNCHER_MODE_KEYS) and "num_of_gpus" in process_spec
         portable = get_portable_resource_spec(job_meta, site_name)
         for mode, portable_to_native in _PORTABLE_NATIVE_RESOURCE_KEYS.items():
             native = get_job_launcher_spec(job_meta, site_name, mode)
             for portable_key, native_keys in portable_to_native.items():
                 conflicts = sorted(native_keys & set(native)) if portable_key in portable else []
+                if portable_key == "num_of_gpus" and conflicts == ["num_of_gpus"] and has_legacy_process_gpu:
+                    continue
                 if conflicts:
                     raise ValueError(
                         f"portable resource '{portable_key}' conflicts with launcher_spec {mode} field(s) "

--- a/nvflare/utils/job_launcher_utils.py
+++ b/nvflare/utils/job_launcher_utils.py
@@ -247,14 +247,11 @@ def get_resource_manager_spec(job_meta: dict, site_name: str) -> dict:
     resource_spec = job_meta.get(JobMetaKey.RESOURCE_SPEC.value, {}) or {}
     site_spec = resource_spec.get(site_name) or {}
     if PORTABLE_RESOURCE_DEFAULT_KEY not in resource_spec and any(key in site_spec for key in _LAUNCHER_MODE_KEYS):
-        return get_site_launcher_spec(site_spec, "process")
-    resolved = resolve_site_resource_spec(job_meta, site_name)
-    result = {key: value for key, value in resolved.items() if key not in ("num_of_cpus", "memory")}
-    if (
-        result.get("num_of_gpus") == 0
-        and set(result).issubset({"num_of_gpus", "mem_per_gpu_in_GiB"})
-        and result.get("mem_per_gpu_in_GiB", 0) == 0
-    ):
+        result = dict(get_site_launcher_spec(site_spec, "process"))
+    else:
+        resolved = resolve_site_resource_spec(job_meta, site_name)
+        result = {key: value for key, value in resolved.items() if key not in ("num_of_cpus", "memory")}
+    if result.get("num_of_gpus") == 0:
         result.pop("num_of_gpus")
         result.pop("mem_per_gpu_in_GiB", None)
     return result

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -473,7 +473,7 @@ class TestDefaultJobScheduler:
         assert dispatch_info["site1"].resource_requirements == {}
         assert dispatch_info["site2"].resource_requirements == {}
 
-    def test_legacy_zero_gpu_pair_bypasses_gpu_resource_manager(self):
+    def test_zero_gpu_with_gpu_memory_bypasses_gpu_resource_manager(self):
         sites = [
             Site(
                 name="site1",
@@ -483,7 +483,7 @@ class TestDefaultJobScheduler:
         ]
         candidate = create_job(
             job_id="cpu-only",
-            resource_spec={"site1": {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 0}},
+            resource_spec={"site1": {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8}},
             deploy_map={"app": [ALL_SITES]},
             min_sites=1,
         )

--- a/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
+++ b/tests/unit_test/app_common/resource_managers/gpu_resource_manager_test.py
@@ -194,6 +194,22 @@ class TestGPUResourceManager:
         if expected_check_result:
             assert expected_reserved_resources == gpu_resource_manager.reserved_resources[token][0]
 
+    @pytest.mark.parametrize("managed_gpus", [0, 2])
+    def test_zero_gpu_requirement_reserves_nothing(self, managed_gpus):
+        engine = MockEngine()
+        gpu_resource_manager = GPUResourceManager(num_of_gpus=managed_gpus, mem_per_gpu_in_GiB=16, ignore_host=True)
+        resource_requirement = _gen_requirement(0, 8)
+
+        with engine.new_context() as fl_ctx:
+            check_result, token = gpu_resource_manager.check_resources(resource_requirement, fl_ctx)
+
+        assert check_result
+        assert gpu_resource_manager.reserved_resources[token][0] == {}
+        assert all(resource.memory == 16 for resource in gpu_resource_manager.resources.values())
+        with engine.new_context() as fl_ctx:
+            assert gpu_resource_manager.allocate_resources(resource_requirement, token, fl_ctx) == {}
+        assert all(resource.memory == 16 for resource in gpu_resource_manager.resources.values())
+
     @pytest.mark.parametrize("gpus, gpu_mem, resource_requirement, expected_reserved_resources", TEST_CASES)
     def test_cancel_resource(
         self, mock_get_host_gpu_ids, gpus, gpu_mem, resource_requirement, expected_reserved_resources

--- a/tests/unit_test/utils/job_launcher_utils_test.py
+++ b/tests/unit_test/utils/job_launcher_utils_test.py
@@ -23,6 +23,7 @@ from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_launcher_spec import JobProcessArgs, JobProcessEnv
 from nvflare.app_common.resource_managers.gpu_resource_manager import GPUResourceManager
+from nvflare.app_common.resource_managers.list_resource_manager import ListResourceManager
 from nvflare.utils.job_launcher_utils import (
     _validate_launcher_spec,
     generate_client_command,
@@ -195,19 +196,38 @@ class TestPortableResourceSpec:
             }
         }
 
-        assert get_resource_manager_spec(meta, "site-1") == {
-            "num_of_gpus": 0,
-            "mem_per_gpu_in_GiB": 0,
-            "license": 2,
-        }
-
-    def test_resource_manager_accepts_zero_gpu_with_nonzero_gpu_memory(self):
-        meta = {"resource_spec": {"site-1": {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8}}}
         resource_spec = get_resource_manager_spec(meta, "site-1")
-        resource_manager = GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16, ignore_host=True)
+        resource_manager = ListResourceManager(resources={"license": ["a", "b"]})
 
-        assert resource_spec == {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8}
-        assert resource_manager.check_resources(resource_spec, FLContext())[0]
+        assert resource_spec == {"license": 2}
+        enough, token = resource_manager.check_resources(resource_spec, FLContext())
+        assert enough
+        assert resource_manager.reserved_resources[token][0] == {"license": ["a", "b"]}
+        allocated = resource_manager.allocate_resources(resource_spec, token, FLContext())
+        assert allocated == {"license": ["a", "b"]}
+        resource_manager.free_resources(allocated, token, FLContext())
+        assert set(resource_manager.resources["license"]) == {"a", "b"}
+
+    @pytest.mark.parametrize(
+        "site_spec",
+        [
+            {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8},
+            {"process": {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8}, "docker": {"image": "x"}},
+        ],
+    )
+    def test_resource_manager_ignores_zero_gpu_with_nonzero_gpu_memory(self, site_spec):
+        meta = {"resource_spec": {"site-1": site_spec}}
+        original = deepcopy(meta)
+        resource_spec = get_resource_manager_spec(meta, "site-1")
+        resource_manager = GPUResourceManager(num_of_gpus=2, mem_per_gpu_in_GiB=16, ignore_host=True)
+
+        assert resource_spec == {}
+        enough, token = resource_manager.check_resources(resource_spec, FLContext())
+        assert enough
+        assert resource_manager.reserved_resources[token][0] == {}
+        assert all(resource.memory == 16 for resource in resource_manager.resources.values())
+        assert resource_manager.allocate_resources(resource_spec, token, FLContext()) == {}
+        assert meta == original
 
     def test_legacy_nested_spec_is_not_reinterpreted_without_default(self):
         meta = {"resource_spec": {"site-1": {"process": {"num_of_cpus": 4}, "docker": {"image": "x"}}}}

--- a/tests/unit_test/utils/job_launcher_utils_test.py
+++ b/tests/unit_test/utils/job_launcher_utils_test.py
@@ -22,6 +22,7 @@ import pytest
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_launcher_spec import JobProcessArgs, JobProcessEnv
+from nvflare.app_common.resource_managers.gpu_resource_manager import GPUResourceManager
 from nvflare.utils.job_launcher_utils import (
     _validate_launcher_spec,
     generate_client_command,
@@ -194,7 +195,19 @@ class TestPortableResourceSpec:
             }
         }
 
-        assert get_resource_manager_spec(meta, "site-1") == {"license": 2}
+        assert get_resource_manager_spec(meta, "site-1") == {
+            "num_of_gpus": 0,
+            "mem_per_gpu_in_GiB": 0,
+            "license": 2,
+        }
+
+    def test_resource_manager_accepts_zero_gpu_with_nonzero_gpu_memory(self):
+        meta = {"resource_spec": {"site-1": {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8}}}
+        resource_spec = get_resource_manager_spec(meta, "site-1")
+        resource_manager = GPUResourceManager(num_of_gpus=1, mem_per_gpu_in_GiB=16, ignore_host=True)
+
+        assert resource_spec == {"num_of_gpus": 0, "mem_per_gpu_in_GiB": 8}
+        assert resource_manager.check_resources(resource_spec, FLContext())[0]
 
     def test_legacy_nested_spec_is_not_reinterpreted_without_default(self):
         meta = {"resource_spec": {"site-1": {"process": {"num_of_cpus": 4}, "docker": {"image": "x"}}}}
@@ -277,13 +290,15 @@ class TestPortableResourceSpec:
             ("slurm", {"nodes": 2, "gpus_per_node": 4}),
         ],
     )
-    def test_rejects_legacy_nested_gpu_count_mismatch(self, mode, launcher_spec):
+    @pytest.mark.parametrize("default_spec", [{}, {"@default": {"num_of_cpus": 4}}])
+    def test_rejects_legacy_nested_gpu_count_mismatch(self, mode, launcher_spec, default_spec):
         meta = {
             "resource_spec": {
+                **default_spec,
                 "site-1": {
                     "process": {"num_of_gpus": 1},
                     mode: launcher_spec,
-                }
+                },
             }
         }
 
@@ -298,13 +313,15 @@ class TestPortableResourceSpec:
             ("slurm", {"nodes": 2, "gpus_per_node": 1}),
         ],
     )
-    def test_allows_matching_legacy_nested_gpu_count(self, mode, launcher_spec):
+    @pytest.mark.parametrize("default_spec", [{}, {"@default": {"num_of_cpus": 4}}])
+    def test_allows_matching_legacy_nested_gpu_count(self, mode, launcher_spec, default_spec):
         meta = {
             "resource_spec": {
+                **default_spec,
                 "site-1": {
                     "process": {"num_of_gpus": 2},
                     mode: launcher_spec,
-                }
+                },
             }
         }
 


### PR DESCRIPTION
## What this PR does

- Keeps `num_of_gpus: 0` in non-empty resource-manager requests so zero-GPU jobs with GPU-memory or custom sibling fields remain structurally valid.
- Continues collapsing an otherwise empty zero-GPU/zero-memory request to `{}`.
- Runs legacy nested GPU consistency validation even when `resource_spec` contains `@default`.
- Accepts matching legacy process and launcher GPU counts while continuing to reject genuine mismatches.

## Root cause

Zero GPU counts were removed unconditionally, which could leave a non-empty `GPUResourceManager` request without its required GPU-count key. Separately, the presence of `@default` disabled legacy GPU consistency validation while the generic portable/native conflict check still treated matching legacy declarations as conflicting.

## Validation

- 664 affected scheduler, validator, resource-manager, and Docker/Kubernetes/Slurm launcher tests passed.
- `./runtest.sh -s` passed.
- `git diff --check` passed.

Fixes #5132
