### PR TITLE
Enable Slurm internal CellNet mTLS

### DIFF
--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -82,6 +82,11 @@ does not need Slurm commands. The submission host that runs the generated
 all four parent commands after its service environment or
 ``parent.environment_setup`` has run.
 
+Internal TCP links use mTLS by default. Each Slurm job receives the existing
+participant startup CA, certificate, and key, while CellNet binds the
+certificate identity to the participant's logical FQCN rather than the
+allocated Slurm hostname.
+
 Build a Container Worker Image
 ==============================
 
@@ -150,6 +155,7 @@ login or service host:
      image: /lustre/images/nvflare-prod.sif
      python_path: /usr/bin/python3
      parent_host: nvflare-site1.internal
+     internal_connection_security: mtls
      sbatch_directives:
        partition: fl-gpu
        account: proj123
@@ -194,6 +200,10 @@ Important keys are:
        runtime parent host.
    * - ``internal_port``
      - Worker-to-parent port; default ``8102``.
+   * - ``internal_connection_security``
+     - Security mode for internal parent/job TCP links (SP/SJ and CP/CJ).
+       Accepts ``mtls`` or ``clear`` and defaults to ``mtls``. Use ``clear``
+       only as an explicit insecure opt-out on a trusted, isolated network.
    * - ``poll_interval``
      - Scheduler polling interval; default ``10`` seconds.
    * - ``submit_timeout``
@@ -302,7 +312,9 @@ host and all compute nodes. ``connect_generation: 1`` routes all job traffic
 through the parent, so workers need no network connectivity at all.
 ``nvflare deploy prepare`` preserves a file-based comm config as-is and does
 not apply the TCP host and port patch; ``internal_port`` and ``parent_host``
-are then not used for the worker channel.
+are then not used for the worker channel. ``internal_connection_security``
+also applies only to TCP; shared-file transport remains ``clear`` and relies
+on filesystem permissions for access control.
 
 At runtime the parent creates a listener directory under ``root_dir`` and
 passes its ``shared-file://0/...`` URL to each worker unchanged. Apptainer and Pyxis

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -367,6 +367,7 @@ minimal ``slurm.yaml`` is:
      image: /lustre/images/nvflare-prod.sif
      python_path: /usr/bin/python3
      parent_host: nvflare-site1.internal
+     internal_connection_security: mtls
 
 Prepare directly into the shared runtime workspace, then start the parent:
 
@@ -379,7 +380,13 @@ The output is the live workspace and must be visible at the same absolute path
 on the parent and compute nodes. Preparing to the same output again replaces
 the complete workspace. A client kit can optionally generate
 ``startup/parent.slurm``; prepare prints the direct ``sbatch`` command that runs
-it in an allocation. See :ref:`slurm_job_launcher` for the complete guide.
+it in an allocation. Internal TCP links use mTLS by default and preserve
+``stcp://`` while the launcher rewrites only the parent host and port. Set
+``job_launcher.internal_connection_security: clear`` only as an explicit
+insecure opt-out; it emits ``tcp://`` links without certificate authentication.
+Receiver-side CellNet authorization still applies, but it does not replace peer
+authentication. Shared-file transport is unchanged and remains clear. See
+:ref:`slurm_job_launcher` for the complete guide.
 
 **********
 Job Images
@@ -433,4 +440,4 @@ causes include:
 - ``--output`` pointing at or inside the input kit
 - a Slurm ``--output`` path that is not valid as a runtime workspace
 - a missing/non-executable Slurm parent CLI, invalid sandbox/image, or
-  unsupported Slurm ``connection_security`` or server ``parent`` configuration
+  invalid Slurm ``internal_connection_security`` or server ``parent`` configuration

--- a/nvflare/app_opt/job_launcher/slurm/launcher.py
+++ b/nvflare/app_opt/job_launcher/slurm/launcher.py
@@ -221,15 +221,15 @@ def _rewrite_parent_url(job_args: dict, parent_host: Optional[str], internal_por
         host = parsed.hostname
     except ValueError as e:
         raise SlurmLauncherError("malformed parent URL in JOB_PROCESS_ARGS") from e
-    if parsed.scheme != "tcp" or port != internal_port or not host:
+    if parsed.scheme not in ("tcp", "stcp") or port != internal_port or not host:
         raise SlurmLauncherError(
-            f"parent URL must use {SHARED_FILE_SCHEME} or tcp with configured internal_port "
+            f"parent URL must use {SHARED_FILE_SCHEME}, tcp, or stcp with configured internal_port "
             f"{internal_port}, got {raw_url!r}"
         )
     host = _resolve_parent_host(parent_host)
     rendered_host = host if host.startswith("[") and host.endswith("]") else f"[{host}]" if ":" in host else host
     netloc = f"{rendered_host}:{internal_port}"
-    rewritten = urlunsplit(("tcp", netloc, parsed.path, parsed.query, parsed.fragment))
+    rewritten = urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
     copied[JobProcessArgs.PARENT_URL] = (flag, rewritten)
     return copied
 
@@ -455,13 +455,16 @@ class SlurmJobLauncher(JobLauncherSpec):
         if not isinstance(connection_entry, (tuple, list)) or len(connection_entry) != 2:
             raise SlurmLauncherError(f"malformed {JobProcessArgs.PARENT_CONN_SEC} in JOB_PROCESS_ARGS")
         process_connection_security = _require_string(connection_entry[1], f"{JobProcessArgs.PARENT_CONN_SEC} value")
-        if process_connection_security != "clear":
-            raise SlurmLauncherError("Slurm job launch requires clear parent connection security")
+        if process_connection_security not in ("clear", "mtls"):
+            raise SlurmLauncherError("Slurm job launch requires clear or mTLS parent connection security")
         job_args = _rewrite_parent_url(
             raw_job_args,
             parent_host=self.config.parent_host,
             internal_port=self.config.internal_port,
         )
+        parent_scheme = urlsplit(str(job_args[JobProcessArgs.PARENT_URL][1])).scheme
+        if (parent_scheme == "stcp") != (process_connection_security == "mtls"):
+            raise SlurmLauncherError("parent URL scheme does not match parent connection security")
 
         study = job_meta.get(JobMetaKey.STUDY.value)
         if study is not None:

--- a/nvflare/tool/deploy/slurm_deploy.py
+++ b/nvflare/tool/deploy/slurm_deploy.py
@@ -21,6 +21,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from nvflare.apis.fl_constant import ConnectionSecurity
 from nvflare.app_opt.job_launcher.slurm.config import (
     SlurmLauncherError,
     normalize_slurm_directives,
@@ -60,6 +61,7 @@ def prepare(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) -> di
     _validate_role_config(config, kit_info.role)
     workspace_path = _workspace_path(final_output)
     job_launcher = config["job_launcher"]
+    connection_security = job_launcher.get("internal_connection_security", ConnectionSecurity.MTLS)
 
     launcher_path = SLURM_SERVER_LAUNCHER if kit_info.role == ROLE_SERVER else SLURM_CLIENT_LAUNCHER
     launcher_args = _normalize_job_launcher(job_launcher)
@@ -69,7 +71,7 @@ def prepare(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) -> di
         launcher_args.pop("multi_node_port_range", None)
     launcher_args["workspace_path"] = workspace_path
     _patch_resources(kit_info.kit_dir, "slurm_launcher", launcher_path, launcher_args)
-    _patch_comm_config(kit_info.kit_dir, port=launcher_args["internal_port"])
+    _patch_comm_config(kit_info.kit_dir, launcher_args["internal_port"], connection_security)
     _ensure_study_runtime_template(kit_info.kit_dir)
     if kit_info.role == ROLE_SERVER:
         _relocate_server_storage_to_workspace(kit_info.kit_dir, workspace_path)
@@ -133,6 +135,7 @@ def validate_config(config: dict[str, Any]) -> None:
             "sandbox",
             "image",
             "internal_port",
+            "internal_connection_security",
             "sbatch_directives",
             "setup",
             "python_path",
@@ -148,6 +151,14 @@ def validate_config(config: dict[str, Any]) -> None:
         },
         "job_launcher",
     )
+
+    connection_security = job_launcher.get("internal_connection_security", ConnectionSecurity.MTLS)
+    if connection_security not in (ConnectionSecurity.CLEAR, ConnectionSecurity.MTLS):
+        _fail(
+            "INVALID_CONFIG",
+            "job_launcher.internal_connection_security must be 'clear' or 'mtls'.",
+            "Set job_launcher.internal_connection_security to 'clear' or 'mtls'.",
+        )
 
     _normalize_job_launcher(job_launcher)
 
@@ -196,7 +207,7 @@ def _normalize_job_launcher(job_launcher: dict[str, Any]) -> dict:
         _fail("INVALID_CONFIG", str(ex), "Fix slurm config.job_launcher.")
 
 
-def _patch_comm_config(kit_dir: Path, port: int) -> None:
+def _patch_comm_config(kit_dir: Path, port: int, connection_security: str = ConnectionSecurity.MTLS) -> None:
     comm_config_path = kit_dir / "local" / COMM_CONFIG_JSON
     comm_config = _load_or_default_comm_config(comm_config_path)
     internal = comm_config.setdefault("internal", {})
@@ -212,7 +223,7 @@ def _patch_comm_config(kit_dir: Path, port: int) -> None:
         {
             "host": "0.0.0.0",
             "port": port,
-            "connection_security": "clear",
+            "connection_security": connection_security,
         }
     )
     _write_json(comm_config_path, comm_config)

--- a/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py
@@ -184,6 +184,14 @@ def test_parent_url_rewrite_is_shallow_and_preserves_other_entries():
     assert args[JobProcessArgs.PARENT_URL][1] == "tcp://old:8102"
 
 
+def test_secure_parent_url_rewrite_preserves_stcp_scheme():
+    args = {JobProcessArgs.PARENT_URL: ("-p", "stcp://old:8102/path?option=value")}
+
+    rewritten = _rewrite_parent_url(args, "new-host", 8102)
+
+    assert rewritten[JobProcessArgs.PARENT_URL][1] == "stcp://new-host:8102/path?option=value"
+
+
 def test_parent_url_rewrite_formats_ipv6_host():
     args = {JobProcessArgs.PARENT_URL: ("-p", "tcp://[2001:db8::1]:8102")}
 
@@ -207,7 +215,7 @@ def test_shared_file_parent_url_is_preserved_without_parent_host():
     [
         (None, "missing or malformed"),
         (("-p", "tcp://old:not-a-port"), "malformed parent URL"),
-        (("-p", "http://old:8102"), "must use shared-file or tcp"),
+        (("-p", "http://old:8102"), "must use shared-file, tcp, or stcp"),
         (("-p", "tcp://old:9000"), "configured internal_port"),
         (("-p", "shared-file://host/not-placeholder"), "malformed shared-file"),
         (("-p", "shared-file://0"), "malformed shared-file"),
@@ -571,13 +579,37 @@ def test_launch_plan_rejects_different_context_workspace(tmp_path):
         launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, _fl_ctx(context_workspace))
 
 
-def test_non_clear_internal_connection_is_rejected(tmp_path):
+@pytest.mark.parametrize("launcher_class", [ClientSlurmJobLauncher, ServerSlurmJobLauncher])
+def test_launch_plan_preserves_mtls_parent_args(tmp_path, launcher_class):
+    workspace = _workspace(tmp_path)
+    launcher = _launcher(tmp_path, workspace, launcher_class=launcher_class)
+    context = _fl_ctx(workspace)
+    job_args = context.get_prop(FLContextKey.JOB_PROCESS_ARGS)
+    job_args[JobProcessArgs.PARENT_URL] = ("-p", "stcp://old-host:8102")
+    job_args[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", "mtls")
+
+    plan = launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, context)
+
+    assert plan.module_args[plan.module_args.index("-p") + 1] == "stcp://compute.example:8102"
+    assert plan.module_args[plan.module_args.index("--parent_conn_sec") + 1] == "mtls"
+
+
+@pytest.mark.parametrize(
+    ("parent_url", "connection_security", "message"),
+    [
+        ("stcp://old-host:8102", "clear", "does not match"),
+        ("tcp://old-host:8102", "tls", "requires clear or mTLS"),
+    ],
+)
+def test_launch_plan_rejects_invalid_parent_security(tmp_path, parent_url, connection_security, message):
     workspace = _workspace(tmp_path)
     launcher = _launcher(tmp_path, workspace)
     context = _fl_ctx(workspace)
-    context.get_prop(FLContextKey.JOB_PROCESS_ARGS)[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", "tls")
+    job_args = context.get_prop(FLContextKey.JOB_PROCESS_ARGS)
+    job_args[JobProcessArgs.PARENT_URL] = ("-p", parent_url)
+    job_args[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", connection_security)
 
-    with pytest.raises(SlurmLauncherError, match="requires clear"):
+    with pytest.raises(SlurmLauncherError, match=message):
         launcher._build_launch_plan({JobConstants.JOB_ID: "job-1"}, context)
 
 

--- a/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_manager_test.py
@@ -353,6 +353,7 @@ def test_pyxis_node_group_writes_node_script_and_mounts_job_artifacts(tmp_path):
     assert "python3 -m trainer" in node_script.read_text(encoding="utf-8")
     batch = Path(handle.job_dir, "batch.sh").read_text(encoding="utf-8")
     assert f"{handle.job_dir}:{handle.job_dir}:ro" in batch
+    assert f"{tmp_path / 'startup'}:{tmp_path / 'startup'}:ro" in batch
 
 
 def test_submission_uses_site_timeout(tmp_path):
@@ -562,7 +563,7 @@ def test_terminal_cleanup_restores_access_to_pyxis_mount_directories(tmp_path):
     assert not os.path.exists(handle.job_dir)
 
 
-def test_apptainer_resolver_mount_uses_compute_node_path(tmp_path, monkeypatch):
+def test_apptainer_startup_and_resolver_mounts_use_compute_node_paths(tmp_path, monkeypatch):
     parent_target = "/run/parent-specific/resolv.conf"
     realpath = os.path.realpath
 
@@ -575,6 +576,7 @@ def test_apptainer_resolver_mount_uses_compute_node_path(tmp_path, monkeypatch):
 
     manager.launch(_plan(tmp_path, sandbox="apptainer", image="/image.sif"))
 
+    assert f"{tmp_path / 'startup'}:{tmp_path / 'startup'}:ro" in adapter.submitted_batch
     assert f"{CONTAINER_RESOLV_CONF}:{CONTAINER_RESOLV_CONF}:ro" in adapter.submitted_batch
     assert parent_target not in adapter.submitted_batch
 

--- a/tests/unit_test/tool/deploy/slurm_deploy_test.py
+++ b/tests/unit_test/tool/deploy/slurm_deploy_test.py
@@ -177,8 +177,10 @@ def test_prepare_slurm_generates_runtime_artifacts(tmp_path, capsys):
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["internal"] == {
         "scheme": "tcp",
-        "resources": {"host": "0.0.0.0", "port": 9210, "connection_security": "clear"},
+        "resources": {"host": "0.0.0.0", "port": 9210, "connection_security": "mtls"},
     }
+    for name in ("client.crt", "client.key", "rootCA.pem"):
+        assert (output / "startup" / name).is_file()
     assert (output / "startup" / "sub_start.sh").exists()
     start_script = output / "startup" / "start_slurm.sh"
     start_text = start_script.read_text()
@@ -269,14 +271,27 @@ def test_prepare_slurm_start_script_uses_output_as_workspace(tmp_path, capsys):
     assert marker.read_text(encoding="utf-8") == f"{output}|{output}|--once"
 
 
-def test_prepare_slurm_rejects_configurable_connection_security(tmp_path, capsys):
+def test_prepare_slurm_accepts_clear_internal_connection_security(tmp_path, capsys):
     kit = _make_client_kit(tmp_path)
-    config = _slurm_config(tmp_path, connection_security="clear")
+    output = tmp_path / "site-1-slurm"
+
+    _run_prepare(kit, output, _slurm_config(tmp_path, internal_connection_security="clear"))
+    capsys.readouterr()
+
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    assert comm_config["internal"]["resources"]["connection_security"] == "clear"
+
+
+@pytest.mark.parametrize("connection_security", ["tls", "MTLS", "", None, 7, True])
+def test_prepare_slurm_rejects_invalid_internal_connection_security(tmp_path, capsys, connection_security):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-slurm"
 
     with pytest.raises(SystemExit):
-        _run_prepare(kit, tmp_path / "site-1-slurm", config)
+        _run_prepare(kit, output, _slurm_config(tmp_path, internal_connection_security=connection_security))
 
-    assert "Unknown keys" in capsys.readouterr().err
+    assert "job_launcher.internal_connection_security" in capsys.readouterr().err
+    assert not output.exists()
 
 
 def test_prepare_slurm_client_parent_scripts_use_validated_values(tmp_path, capsys):
@@ -389,6 +404,8 @@ def test_prepare_slurm_server_relocates_storage_and_rejects_parent(tmp_path, cap
     assert _component(resources, "slurm_launcher")["path"].endswith("ServerSlurmJobLauncher")
     assert resources["snapshot_persistor"]["args"]["storage"]["args"]["root_dir"] == (f"{output}/snapshot-storage")
     assert _component(resources, "job_manager")["args"]["uri_root"] == f"{output}/jobs-storage"
+    for name in ("server.crt", "server.key", "rootCA.pem"):
+        assert (output / "startup" / name).is_file()
 
     config["parent"] = {}
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary

- enable mTLS by default for Slurm SP/SJ and CP/CJ internal TCP links, with `job_launcher.internal_connection_security: clear` as an explicit opt-out
- preserve `stcp://` when rewriting only the parent host and port, and reject URL/security mismatches that could downgrade a secure parent connection
- use the existing participant startup credentials across bare Slurm, Apptainer, and Pyxis without introducing per-job certificates
- document the security mode while preserving shared-file transport and receiver-side CellNet authorization behavior

## Why

Slurm deployment preparation previously forced the internal worker channel to clear transport, and the launcher rejected mTLS parent arguments and rewrote only `tcp://` URLs. That prevented Slurm job processes from using the participant certificate reuse now available in CellNet.

This change aligns Slurm with the Kubernetes internal transport behavior while keeping certificate identity bound to the logical NVFlare participant rather than an allocated Slurm hostname.

## Validation

- 422 focused Slurm deploy, launcher, manager, TLS, certificate, and job-process credential tests passed
- 44 CellNet identity-binding, receiver authorization, server-command, and admin tests passed
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" ./runtest.sh -s --skip-install`
- `git diff --check`

Before the final sync with `main`, a CPU Slurm development cluster completed one-round SP/SJ and CP/CJ jobs through bare Slurm, Apptainer, and Pyxis. Generated commands retained `stcp://` and `--parent_conn_sec mtls`, container paths mounted the startup credentials read-only, and probes without a client certificate were rejected. The final main sync supplied the narrower shared TLS-role credential fallback; the post-sync test results above cover the resulting branch.

Production-scale, GPU, and site-policy validation remain outside this test. Shared-file transport was not rerun live because this change intentionally leaves it clear and unchanged.
