### PR TITLE
Fix Lightning best-model metric reporting

### DIFF
--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -55,6 +55,17 @@ Compatibility and Migration Notes
   multi-optimizer FedAvg client reports their combined step count unless it
   supplies ``NUM_STEPS_CURRENT_ROUND`` explicitly; explicit client metadata is
   still preserved.
+- Patched PyTorch Lightning clients now transmit validation metrics captured by
+  an explicit ``trainer.validate()`` call before ``trainer.fit()``, regardless
+  of ``train_with_evaluation``. Sanity-check and in-fit validation metrics are
+  not transmitted as global-model scores. Setting
+  ``train_with_evaluation=True`` continues to require validation metrics;
+  otherwise metrics remain optional, but ``False`` no longer suppresses metrics
+  from an explicit pre-fit validation. This enables ``IntimeModelSelector`` and
+  best-global-model persistence for recipe-based Lightning jobs. Applications
+  that must keep such metrics local should omit the explicit pre-fit validation;
+  if they still require it locally, a custom task-result filter must remove
+  ``MetaKey.INITIAL_METRICS`` before the result reaches the server.
 - Recipe discovery now exposes the concrete PyTorch ``FedProxRecipe`` as
   ``fedprox-pt`` and no longer advertises the ``fedprox-tf`` manual pattern as
   a concrete recipe. TensorFlow clients can continue to combine a FedAvg

--- a/examples/hello-world/hello-lightning/job.py
+++ b/examples/hello-world/hello-lightning/job.py
@@ -71,6 +71,7 @@ def main():
             # For pre-trained weights: initial_ckpt="/server/path/to/pretrained.pt",
             train_script="client.py",
             train_args=train_args,
+            key_metric="val_acc_epoch",
         )
     elif args.algorithm == "fedprox":
         recipe = FedProxRecipe(
@@ -81,6 +82,7 @@ def main():
             train_script="client.py",
             train_args=train_args,
             fedprox_mu=args.fedprox_mu,
+            key_metric="val_acc_epoch",
         )
     else:
         recipe = ScaffoldRecipe(
@@ -90,6 +92,7 @@ def main():
             model=LitNet(),
             train_script="client.py",
             train_args=train_args,
+            key_metric="val_acc_epoch",
         )
 
     env = SimEnv(num_clients=n_clients, num_threads=n_clients)

--- a/examples/hello-world/hello-lightning/job.py
+++ b/examples/hello-world/hello-lightning/job.py
@@ -71,7 +71,6 @@ def main():
             # For pre-trained weights: initial_ckpt="/server/path/to/pretrained.pt",
             train_script="client.py",
             train_args=train_args,
-            key_metric="val_acc_epoch",
         )
     elif args.algorithm == "fedprox":
         recipe = FedProxRecipe(
@@ -82,7 +81,6 @@ def main():
             train_script="client.py",
             train_args=train_args,
             fedprox_mu=args.fedprox_mu,
-            key_metric="val_acc_epoch",
         )
     else:
         recipe = ScaffoldRecipe(
@@ -92,7 +90,6 @@ def main():
             model=LitNet(),
             train_script="client.py",
             train_args=train_args,
-            key_metric="val_acc_epoch",
         )
 
     env = SimEnv(num_clients=n_clients, num_threads=n_clients)

--- a/examples/hello-world/hello-lightning/model.py
+++ b/examples/hello-world/hello-lightning/model.py
@@ -76,7 +76,8 @@ class LitNet(LightningModule):
 
         if stage:
             self.log(f"{stage}_loss", loss)
-            self.log(f"{stage}_acc", self.valid_acc, on_step=True, on_epoch=True)
+            # Keep the federated selection metric stable and framework-neutral.
+            self.log("accuracy", self.valid_acc, on_step=False, on_epoch=True)
         return outputs
 
     def validation_step(self, batch, batch_idx):

--- a/examples/hello-world/hello-lightning/model.py
+++ b/examples/hello-world/hello-lightning/model.py
@@ -76,8 +76,11 @@ class LitNet(LightningModule):
 
         if stage:
             self.log(f"{stage}_loss", loss)
-            # Keep the federated selection metric stable and framework-neutral.
-            self.log("accuracy", self.valid_acc, on_step=False, on_epoch=True)
+            if stage == "val":
+                # Match the recipes' default key_metric for federated model selection.
+                self.log("accuracy", self.valid_acc, on_step=False, on_epoch=True)
+            else:
+                self.log(f"{stage}_acc", self.valid_acc, on_step=True, on_epoch=True)
         return outputs
 
     def validation_step(self, batch, batch_idx):

--- a/examples/hello-world/hello-lightning/model.py
+++ b/examples/hello-world/hello-lightning/model.py
@@ -68,19 +68,19 @@ class LitNet(LightningModule):
         self.log("train_acc", self.train_acc, on_step=True, on_epoch=False)
         return loss
 
-    def evaluate(self, batch, stage=None):
+    def evaluate(self, batch, evaluation_mode=None):
         x, labels = batch
         outputs = self(x)
         loss = criterion(outputs, labels)
         self.valid_acc(outputs, labels)
 
-        if stage:
-            self.log(f"{stage}_loss", loss)
-            if stage == "val":
+        if evaluation_mode:
+            self.log(f"{evaluation_mode}_loss", loss)
+            if evaluation_mode == "val":
                 # Match the recipes' default key_metric for federated model selection.
                 self.log("accuracy", self.valid_acc, on_step=False, on_epoch=True)
             else:
-                self.log(f"{stage}_acc", self.valid_acc, on_step=True, on_epoch=True)
+                self.log(f"{evaluation_mode}_acc", self.valid_acc, on_step=True, on_epoch=True)
         return outputs
 
     def validation_step(self, batch, batch_idx):

--- a/nvflare/app_common/executors/client_api_executor.py
+++ b/nvflare/app_common/executors/client_api_executor.py
@@ -140,8 +140,9 @@ class ClientAPIExecutor(Executor):
                 Defaults to AppConstants.TASK_VALIDATION.
             submit_model_task_name (str): Task name treated as "submit_model" by
                 flare.is_submit_model(). Defaults to AppConstants.TASK_SUBMIT_MODEL.
-            train_with_evaluation (bool): Whether the trainer also returns evaluation metrics with
-                the trained model.
+            train_with_evaluation (bool): Whether a training result is required to include pre-training
+                evaluation metrics. When False, metrics are optional; metrics supplied by the trainer
+                or a framework integration are still returned.
             params_exchange_format (ExchangeFormat): Framework-native parameter representation
                 exposed by ``flare.receive()`` and accepted by ``flare.send()``. The declaration
                 is transported to the trainer in ``TASK_EXCHANGE``; the executor does not perform

--- a/nvflare/app_opt/lightning/api.py
+++ b/nvflare/app_opt/lightning/api.py
@@ -17,6 +17,7 @@ from typing import Dict
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import Callback
+from pytorch_lightning.trainer.states import TrainerFn
 from torch import Tensor
 
 from nvflare.app_common.abstract.fl_model import FLModel, MetaKey
@@ -233,24 +234,24 @@ class FLCallback(Callback):
                     else self._get_round_num_steps(trainer)
                 )
             model = FLModel(params=pl_module.cpu().state_dict(), meta=fl_meta)
-            if self.train_with_evaluation:
-                if self.metrics is None:
-                    raise RuntimeError(
-                        "train with evaluation missing training metrics, please remember to call validate."
-                    )
+            if self.train_with_evaluation and self.metrics is None:
+                raise RuntimeError("train with evaluation requires validation metrics; call validate before fit.")
+            if self.metrics is not None:
                 model.metrics = self.metrics
             if trainer.global_rank == 0:
                 self._send_model(model)
             self.reset_state(trainer)
 
     def on_validation_start(self, trainer, pl_module):
-        # receive the global model and update the local model with global model
-        # the 1st time validate() or train() is called.
-        # expect user will validate the global model first (i.e. validate()), once that's done.
-        # the metrics will be set.
-        # The subsequent validate() calls will not trigger the receive update model.
-        # Hence the validate() will be validating the local model.
-        if pl_module and self.metrics is None and not self._training_round_started:
+        # Only an explicit validation before fit evaluates the received global model for model selection.
+        # Lightning keeps trainer.state.fn at FITTING for both fit sanity checks and in-fit validation,
+        # so neither is eligible to become INITIAL_METRICS on the server.
+        if (
+            pl_module
+            and self.metrics is None
+            and not self._training_round_started
+            and trainer.state.fn == TrainerFn.VALIDATING
+        ):
             input_model = self._receive_and_update_model(trainer, pl_module)
             if input_model and self._is_training:
                 self._pending_train_model = input_model
@@ -269,7 +270,12 @@ class FLCallback(Callback):
         return completed_steps
 
     def on_validation_end(self, trainer, pl_module):
-        if pl_module and self.metrics is None:
+        if (
+            pl_module
+            and self.metrics is None
+            and not self._training_round_started
+            and trainer.state.fn == TrainerFn.VALIDATING
+        ):
             self.metrics = _extract_metrics(trainer.callback_metrics)
             if self._is_evaluation:
                 if trainer.global_rank == 0:

--- a/tests/unit_test/app_opt/lightning/api_test.py
+++ b/tests/unit_test/app_opt/lightning/api_test.py
@@ -22,6 +22,7 @@ import pytorch_lightning as pl
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from pytorch_lightning.trainer.states import TrainerFn
 from torch.utils.data import DataLoader, TensorDataset
 
 from nvflare.app_common.abstract.fl_model import FLModel, MetaKey
@@ -208,7 +209,11 @@ def test_validation_end_sends_only_from_runtime_global_rank_zero(runtime_rank, e
     callback._is_evaluation = True
     callback._send_model = MagicMock()
     callback.reset_state = MagicMock()
-    trainer = SimpleNamespace(global_rank=runtime_rank, callback_metrics={"val_loss": torch.tensor(0.5)})
+    trainer = SimpleNamespace(
+        global_rank=runtime_rank,
+        callback_metrics={"val_loss": torch.tensor(0.5)},
+        state=SimpleNamespace(fn=TrainerFn.VALIDATING),
+    )
 
     callback.on_validation_end(trainer, SimpleNet())
 
@@ -1151,6 +1156,42 @@ def test_train_end_delivers_initial_metrics_when_train_with_evaluation_is_disabl
     assert server_model.metrics == metrics
 
 
+@pytest.mark.parametrize("train_with_evaluation", [False, True])
+def test_train_end_sends_captured_metrics_regardless_of_train_with_evaluation(train_with_evaluation):
+    callback = _make_callback()
+    callback.train_with_evaluation = train_with_evaluation
+    callback._is_training = True
+    callback._receive_and_update_model = MagicMock(return_value=FLModel())
+    callback._send_model = MagicMock()
+    callback.reset_state = MagicMock()
+    callback._round_start_global_step = 0
+    trainer = SimpleNamespace(
+        global_rank=0,
+        global_step=3,
+        callback_metrics={"accuracy": torch.tensor(0.75)},
+        state=SimpleNamespace(fn=TrainerFn.VALIDATING),
+    )
+
+    callback.on_validation_start(trainer, SimpleNet())
+    callback.on_validation_end(trainer, SimpleNet())
+    callback.on_train_end(trainer, SimpleNet())
+
+    outgoing_model = callback._send_model.call_args.args[0]
+    assert outgoing_model.metrics == {"accuracy": 0.75}
+    server_model = FLModelUtils.from_shareable(FLModelUtils.to_shareable(outgoing_model))
+    assert server_model.metrics == {"accuracy": 0.75}
+
+
+def test_train_end_requires_captured_metrics_when_train_with_evaluation_is_enabled():
+    callback = _make_callback()
+    callback.train_with_evaluation = True
+    callback._is_training = True
+    callback._round_start_global_step = 0
+
+    with pytest.raises(RuntimeError, match="train with evaluation requires validation metrics"):
+        callback.on_train_end(SimpleNamespace(global_rank=0, global_step=3), SimpleNet())
+
+
 def test_train_end_rejects_user_metadata_that_conflicts_with_automatic_algorithm_metadata():
     callback = _make_callback()
     callback._is_training = True
@@ -1189,7 +1230,7 @@ def test_validation_before_fit_reuses_pending_training_model():
     callback._algorithm_handler_manager.start_round = MagicMock()
     callback._is_training = True
     module = SimpleNet()
-    trainer = SimpleNamespace(global_step=0)
+    trainer = SimpleNamespace(global_step=0, state=SimpleNamespace(fn=TrainerFn.VALIDATING))
 
     callback.on_validation_start(trainer, module)
     callback._algorithm_handler_manager.start_round.assert_not_called()
@@ -1214,7 +1255,7 @@ def test_validation_before_fit_reapplies_pending_model_to_a_different_module():
     callback._is_training = True
     validation_module = SimpleNet()
     training_module = SimpleNet()
-    trainer = SimpleNamespace(global_step=0)
+    trainer = SimpleNamespace(global_step=0, state=SimpleNamespace(fn=TrainerFn.VALIDATING))
 
     callback.on_validation_start(trainer, validation_module)
     callback.on_train_start(trainer, training_module)
@@ -1233,7 +1274,7 @@ def test_validation_before_fit_reapplies_pending_model_to_same_module_after_muta
     input_model = FLModel(params=global_params)
     callback._receive_and_update_model = MagicMock(return_value=input_model)
     callback._is_training = True
-    trainer = SimpleNamespace(global_step=0)
+    trainer = SimpleNamespace(global_step=0, state=SimpleNamespace(fn=TrainerFn.VALIDATING))
 
     callback.on_validation_start(trainer, module)
     with torch.no_grad():
@@ -1245,17 +1286,35 @@ def test_validation_before_fit_reapplies_pending_model_to_same_module_after_muta
         assert torch.equal(value, global_params[key])
 
 
-def test_mid_fit_validation_collects_metrics_without_receiving_or_reloading_model():
+def test_mid_fit_validation_does_not_collect_global_model_metrics_or_reload_model():
     callback = _make_callback()
     callback._training_round_started = True
     callback._receive_and_update_model = MagicMock()
-    trainer = SimpleNamespace(callback_metrics={"val_loss": torch.tensor(0.5)})
+    trainer = SimpleNamespace(
+        callback_metrics={"val_loss": torch.tensor(0.5)}, state=SimpleNamespace(fn=TrainerFn.FITTING)
+    )
 
     callback.on_validation_start(trainer, SimpleNet())
     callback.on_validation_end(trainer, SimpleNet())
 
     callback._receive_and_update_model.assert_not_called()
-    assert callback.metrics == {"val_loss": 0.5}
+    assert callback.metrics is None
+
+
+def test_sanity_validation_does_not_collect_global_model_metrics_or_receive_model():
+    callback = _make_callback()
+    callback._receive_and_update_model = MagicMock()
+    trainer = SimpleNamespace(
+        sanity_checking=True,
+        callback_metrics={"val_loss": torch.tensor(0.5)},
+        state=SimpleNamespace(fn=TrainerFn.FITTING),
+    )
+
+    callback.on_validation_start(trainer, SimpleNet())
+    callback.on_validation_end(trainer, SimpleNet())
+
+    callback._receive_and_update_model.assert_not_called()
+    assert callback.metrics is None
 
 
 def test_real_lightning_fit_with_fedprox_and_gradient_accumulation():
@@ -1374,6 +1433,7 @@ def test_real_lightning_train_with_evaluation_reuses_scaffold_model_and_returns_
             enable_model_summary=False,
             num_sanity_val_steps=1,
         )
+        trainer.validate(module, dataloaders=loader)
         trainer.fit(module, train_dataloaders=loader, val_dataloaders=loader)
 
     output_model = send.call_args.args[0]
@@ -1416,7 +1476,7 @@ def test_real_lightning_fedavg_reports_per_round_steps_across_two_fits():
     assert [call.args[0].meta[MetaKey.NUM_STEPS_CURRENT_ROUND] for call in send.call_args_list] == [4, 4]
 
 
-def test_real_lightning_fit_only_reuses_one_received_model_per_round_with_mid_fit_validation():
+def test_real_lightning_fit_only_ignores_sanity_and_mid_fit_validation_metrics():
     module = TinyLightningNet()
     global_params = {key: torch.zeros_like(value) for key, value in module.state_dict().items()}
     input_models = [
@@ -1447,13 +1507,14 @@ def test_real_lightning_fit_only_reuses_one_received_model_per_round_with_mid_fi
             enable_checkpointing=False,
             enable_progress_bar=False,
             enable_model_summary=False,
-            num_sanity_val_steps=0,
+            num_sanity_val_steps=1,
         )
         trainer.fit(module, train_dataloaders=loader, val_dataloaders=loader)
         trainer.fit(module, train_dataloaders=loader, val_dataloaders=loader)
 
     assert receive.call_count == 2
     assert send.call_count == 2
+    assert [call.args[0].metrics for call in send.call_args_list] == [None, None]
     second_output = send.call_args_list[1].args[0]
     assert any(not torch.equal(second_output.params[key], global_params[key]) for key in global_params)
     assert set(second_output.meta[AlgorithmConstants.SCAFFOLD_CTRL_DIFF]) == set(dict(module.named_parameters()))

--- a/tests/unit_test/app_opt/lightning/api_test.py
+++ b/tests/unit_test/app_opt/lightning/api_test.py
@@ -64,8 +64,16 @@ class TinyLightningNet(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         inputs, labels = batch
-        loss = F.cross_entropy(self.fc(inputs), labels)
+        logits = self.fc(inputs)
+        loss = F.cross_entropy(logits, labels)
         self.log("val_loss", loss, on_epoch=True, batch_size=inputs.shape[0])
+        self.log(
+            "accuracy",
+            (logits.argmax(dim=1) == labels).float().mean(),
+            on_step=False,
+            on_epoch=True,
+            batch_size=inputs.shape[0],
+        )
         return loss
 
     def configure_optimizers(self):
@@ -1439,6 +1447,7 @@ def test_real_lightning_train_with_evaluation_reuses_scaffold_model_and_returns_
     output_model = send.call_args.args[0]
     assert receive.call_count == 1
     assert output_model.metrics["val_loss"] >= 0.0
+    assert 0.0 <= output_model.metrics["accuracy"] <= 1.0
     assert AlgorithmConstants.SCAFFOLD_CTRL_DIFF in output_model.meta
     assert callback._pending_train_model is None
 

--- a/tests/unit_test/examples/hello_lightning_model_test.py
+++ b/tests/unit_test/examples/hello_lightning_model_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pl = pytest.importorskip("pytorch_lightning")
+torch = pytest.importorskip("torch")
+pytest.importorskip("torchmetrics")
+DataLoader = torch.utils.data.DataLoader
+TensorDataset = torch.utils.data.TensorDataset
+
+
+def _load_model_module():
+    repo_root = Path(__file__).parents[3]
+    module_path = repo_root / "examples" / "hello-world" / "hello-lightning" / "model.py"
+    spec = importlib.util.spec_from_file_location("hello_lightning_model", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validation_uses_recipe_metric_without_renaming_test_metric():
+    module = _load_model_module()
+    model = module.LitNet()
+    loader = DataLoader(
+        TensorDataset(torch.randn(4, 3, 32, 32), torch.tensor([0, 1, 2, 3])),
+        batch_size=2,
+    )
+    trainer = pl.Trainer(
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+
+    validation_metrics = trainer.validate(model, dataloaders=loader, verbose=False)[0]
+    test_metrics = trainer.test(model, dataloaders=loader, verbose=False)[0]
+
+    assert "accuracy" in validation_metrics
+    assert "test_acc_epoch" in test_metrics
+    assert "accuracy" not in test_metrics

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -829,7 +829,7 @@ def test_import_selects_hello_lightning_algorithm_mode(algorithm, expected_recip
     assert config["import"]["support"]["status"] == "supported"
     assert config["job"]["recipe"] == expected_recipe
     assert config["job"]["train_script"] == "client.py"
-    assert config["objective"] == _objective("val_acc_epoch", source="literal")
+    assert config["objective"] == _objective("accuracy", source="default")
 
 
 def test_import_selects_hello_numpy_cross_val_training_mode():

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -813,7 +813,7 @@ def test_import_classifies_hello_world_release_gate_examples(example, expected_s
 
 @pytest.mark.parametrize(
     ("algorithm", "expected_recipe"),
-    [("fedprox", "FedProxRecipe"), ("scaffold", "ScaffoldRecipe")],
+    [("fedavg", "FedAvgRecipe"), ("fedprox", "FedProxRecipe"), ("scaffold", "ScaffoldRecipe")],
 )
 def test_import_selects_hello_lightning_algorithm_mode(algorithm, expected_recipe):
     repo_root = Path(__file__).parents[3]
@@ -822,7 +822,6 @@ def test_import_selects_hello_lightning_algorithm_mode(algorithm, expected_recip
     config = import_job_to_autofl_config(
         str(example_root / "job.py"),
         workspace_root=str(example_root),
-        metric="accuracy",
         max_candidates=12,
         job_args=["--algorithm", algorithm],
     )
@@ -830,6 +829,7 @@ def test_import_selects_hello_lightning_algorithm_mode(algorithm, expected_recip
     assert config["import"]["support"]["status"] == "supported"
     assert config["job"]["recipe"] == expected_recipe
     assert config["job"]["train_script"] == "client.py"
+    assert config["objective"] == _objective("val_acc_epoch", source="literal")
 
 
 def test_import_selects_hello_numpy_cross_val_training_mode():


### PR DESCRIPTION
## Summary

- Forward metrics captured by an explicit PyTorch Lightning `trainer.validate()` call before `trainer.fit()`, even when `train_with_evaluation=False`.
- Keep `train_with_evaluation=True` as a requirement that pre-training validation metrics exist; when it is `False`, metrics are optional rather than suppressed.
- Exclude Lightning sanity-check and in-fit validation metrics from global-model selection.
- Keep the hello-lightning example's federated metric contract framework-neutral by reporting epoch-level validation accuracy as `accuracy`, matching the recipe default.
- Add regression coverage and document the corrected behavior in the 2.9 release notes.

## Behavior

| Client workflow | Training result |
| --- | --- |
| Explicit `validate()` before `fit()`, flag `False` | Captured metrics are returned |
| Explicit `validate()` before `fit()`, flag `True` | Captured metrics are returned |
| `fit()` without explicit pre-fit validation, flag `False` | Metrics may be absent |
| `fit()` without explicit pre-fit validation, flag `True` | Fails because required metrics are missing |
| Lightning sanity or mid-fit validation | Never treated as the received global model's score |

## Implementation

- `FLCallback` accepts validation metrics for model selection only while Lightning is in the standalone `TrainerFn.VALIDATING` state and before the training round starts. During sanity checks and in-fit validation, Lightning remains in `TrainerFn.FITTING`, so those results are ignored.
- `on_train_end()` now attaches captured metrics whenever they exist. The `train_with_evaluation` flag only determines whether their absence is an error.
- Metric names are not implicitly remapped by NVFlare. Applications may use custom metric names, but their recipe `key_metric` must match. The hello-lightning example emits the semantic key `accuracy` directly.

This allows `IntimeModelSelector` to receive the intended pre-training global-model score and persist the best global model without confusing it with local-model validation performed during training.

## Validation

- `python3 -m pytest tests/unit_test/tool/autofl_skill_job_importer_test.py -q` (46 passed)
- `./runtest.sh -s --skip-install`
- `git diff --check`
- PR CI triggered with `/build`
