### PR TITLE
Bind localhost TCP listeners to loopback

### DIFF
--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -292,7 +292,7 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
 
     listening_host = resources.get(DriverParams.LISTEN_HOST.value) if resources else None
     if not listening_host:
-        listening_host = "0"
+        listening_host = "127.0.0.1" if host.rstrip(".").lower() == "localhost" else "0"
 
     port = get_open_tcp_port(resources)
     if not port:

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ipaddress
 import logging
 import os
 import random
@@ -292,7 +293,15 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
 
     listening_host = resources.get(DriverParams.LISTEN_HOST.value) if resources else None
     if not listening_host:
-        listening_host = "127.0.0.1" if host.rstrip(".").lower() == "localhost" else "0"
+        if host.rstrip(".").lower() == "localhost":
+            listening_host = "127.0.0.1"
+        else:
+            try:
+                address = ipaddress.ip_address(host)
+            except ValueError:
+                address = None
+            # F3 URL parsing and the TCP driver do not yet support IPv6 end to end.
+            listening_host = host if isinstance(address, ipaddress.IPv4Address) and address.is_loopback else "0"
 
     port = get_open_tcp_port(resources)
     if not port:

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -78,10 +78,19 @@ class TestNetUtils:
             "tcp://127.0.0.1:1234",
         )
 
+    @pytest.mark.parametrize("host", ["127.0.0.1", "127.42.0.9"])
     @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
-    def test_tcp_listener_default_remains_wildcard(self, _):
-        assert get_tcp_urls("tcp", {DriverParams.HOST.value: "server.example"}) == (
-            "tcp://server.example:1234",
+    def test_tcp_listener_defaults_ipv4_loopback_literal_to_itself(self, _, host):
+        assert get_tcp_urls("tcp", {DriverParams.HOST.value: host}) == (
+            f"tcp://{host}:1234",
+            f"tcp://{host}:1234",
+        )
+
+    @pytest.mark.parametrize("host", ["server.example", "::1"])
+    @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
+    def test_tcp_listener_default_remains_wildcard(self, _, host):
+        assert get_tcp_urls("tcp", {DriverParams.HOST.value: host}) == (
+            f"tcp://{host}:1234",
             "tcp://0:1234",
         )
 

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -68,6 +68,16 @@ class TestNetUtils:
 
         assert get_tcp_urls("tcp", resources) == ("tcp://127.0.0.1:1234", "tcp://127.0.0.1:1234")
 
+    @pytest.mark.parametrize("host", [None, "localhost", "LOCALHOST."])
+    @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
+    def test_tcp_listener_defaults_localhost_to_ipv4_loopback(self, _, host):
+        resources = {} if host is None else {DriverParams.HOST.value: host}
+
+        assert get_tcp_urls("tcp", resources) == (
+            f"tcp://{host or 'localhost'}:1234",
+            "tcp://127.0.0.1:1234",
+        )
+
     @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
     def test_tcp_listener_default_remains_wildcard(self, _):
         assert get_tcp_urls("tcp", {DriverParams.HOST.value: "server.example"}) == (


### PR DESCRIPTION
## Summary

- bind TCP listeners to explicit IPv4 loopback when the advertised host defaults to or is configured as `localhost`
- preserve explicit `listen_host` values
- preserve the wildcard listener fallback for non-local advertised hosts

## Root cause

`get_tcp_urls()` advertised `localhost` to local child cells but independently defaulted the listening URL to `0`, which bound the socket on all interfaces. As a result, generic process-mode parent listeners could expose a clear internal CellNet port beyond loopback even though children were instructed to connect locally.

## Impact

Default local process listeners now bind to `127.0.0.1`. Kubernetes, Slurm, Docker, and other non-local configurations retain their existing explicit or wildcard bind behavior.

## Validation

- `python -m pytest -q tests/unit_test/fuel/f3/drivers/net_utils_test.py tests/unit_test/fuel/f3/cellnet/core_cell_test.py tests/unit_test/private/fed/server/fed_server_test.py tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py` — 76 passed
- `./runtest.sh -s --skip-install`
- `git diff --check`