### PR TITLE
Enable Docker internal CellNet mTLS

### DIFF
--- a/docs/user_guide/admin_guide/deployment/containerized_deployment.rst
+++ b/docs/user_guide/admin_guide/deployment/containerized_deployment.rst
@@ -94,6 +94,7 @@ Create a Docker runtime config for ``nvflare deploy prepare``:
   parent:
     docker_image: nvflare-site:latest
     network: nvflare-network
+    internal_connection_security: mtls
 
   job_launcher:
     default_python_path: /usr/local/bin/python
@@ -129,6 +130,12 @@ Start prepared parent processes with:
 Run the same command from each prepared client kit. The generated script creates
 the configured Docker network if needed and mounts the prepared kit into the
 parent container.
+
+Parent/job TCP links (SP/SJ and CP/CJ) use mTLS by default. The parent listener
+remains reachable on the Docker network so job containers can connect, while
+both peers authenticate with the provisioned participant credentials. Set
+``parent.internal_connection_security: clear`` only as an explicit insecure
+opt-out on a trusted, isolated Docker network.
 
 Jobs submitted to Docker-mode sites must specify their job image in
 ``launcher_spec``:

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -73,6 +73,7 @@ Example ``docker.yaml``:
    parent:
      docker_image: registry.example.com/nvflare-site:2.8
      network: nvflare-network
+     internal_connection_security: mtls
 
    job_launcher:
      default_python_path: /usr/local/bin/python
@@ -93,6 +94,11 @@ Top-level keys:
 - ``docker_image``: required parent image used by ``startup/start_docker.sh``.
 - ``network``: Docker network for parent and job containers. Defaults to
   ``nvflare-network``.
+- ``internal_connection_security``: security mode for internal parent/job TCP
+  links (SP/SJ and CP/CJ). Accepts ``mtls`` or ``clear`` and defaults to
+  ``mtls``. Use ``clear`` only as an explicit insecure opt-out because it
+  removes certificate authentication while the parent port remains reachable
+  from containers attached to the Docker network.
 
 ``job_launcher`` keys:
 
@@ -121,6 +127,10 @@ The command writes:
 - patched ``local/resources.json.default`` with ``DockerJobLauncher``
 - patched ``local/comm_config.json``
 - ``local/study_runtime.yaml`` template when missing (skipped for legacy kits that already have ``study_data.yaml``)
+
+The Docker launcher preserves ``stcp://`` while replacing the parent hostname
+with its Docker DNS name. It rejects URL and connection-security mismatches
+instead of silently downgrading an mTLS parent connection to clear TCP.
 
 **********
 K8s Config

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -18,7 +18,7 @@ import re
 import threading
 import time
 from abc import abstractmethod
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 try:
     import docker.errors
@@ -31,7 +31,7 @@ except ImportError:
 
 from nvflare.apis.app_validation import AppValidationKey
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_constant import FLContextKey, JobConstants, WorkspaceConstants
+from nvflare.apis.fl_constant import ConnectionSecurity, FLContextKey, JobConstants, WorkspaceConstants
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
 from nvflare.apis.job_launcher_spec import JobHandleSpec, JobLauncherSpec, JobProcessArgs, JobReturnCode, add_launcher
@@ -83,6 +83,52 @@ _RESERVED_WORKSPACE_CHILD_NAMES = {
 # Site-level defaults and study docker_kwargs additionally reserve "image": jobs select
 # their image through docker_spec["image"], so it must not trip the job-spec warning.
 _RESERVED_DEFAULT_KWARGS = RESERVED_DOCKER_KWARGS
+
+
+def _rewrite_parent_url(job_args: dict, site_name: str) -> tuple[dict, str | None]:
+    """Rewrite a parent URL to Docker DNS while preserving its transport security."""
+    entry = job_args.get(JobProcessArgs.PARENT_URL)
+    if not entry:
+        return job_args, None
+    if not isinstance(entry, (tuple, list)) or len(entry) != 2:
+        raise ValueError(f"malformed {JobProcessArgs.PARENT_URL} in JOB_PROCESS_ARGS")
+
+    connection_entry = job_args.get(JobProcessArgs.PARENT_CONN_SEC, (None, ConnectionSecurity.CLEAR))
+    if not isinstance(connection_entry, (tuple, list)) or len(connection_entry) != 2:
+        raise ValueError(f"malformed {JobProcessArgs.PARENT_CONN_SEC} in JOB_PROCESS_ARGS")
+    connection_security = connection_entry[1]
+    if connection_security not in (ConnectionSecurity.CLEAR, ConnectionSecurity.MTLS):
+        raise ValueError("Docker job launch requires clear or mTLS parent connection security")
+
+    flag, original_url = entry
+    try:
+        parsed = urlsplit(str(original_url))
+    except ValueError as e:
+        raise ValueError(f"invalid parent URL {original_url!r}") from e
+
+    if parsed.scheme == SHARED_FILE_SCHEME:
+        if connection_security != ConnectionSecurity.CLEAR:
+            raise ValueError("shared-file parent URL scheme does not match parent connection security")
+        try:
+            file_parent_dir = parse_file_url(str(original_url))
+        except CommError as e:
+            raise ValueError(f"invalid shared-file parent URL {original_url!r}: {e}") from e
+        return dict(job_args), file_parent_dir
+
+    try:
+        port = parsed.port
+        host = parsed.hostname
+    except ValueError as e:
+        raise ValueError(f"invalid parent URL {original_url!r}") from e
+    if parsed.scheme not in ("tcp", "stcp") or not host or not port:
+        raise ValueError(f"parent URL must use {SHARED_FILE_SCHEME}, tcp, or stcp with a host and port")
+    if (parsed.scheme == "stcp") != (connection_security == ConnectionSecurity.MTLS):
+        raise ValueError("parent URL scheme does not match parent connection security")
+
+    parent_url = urlunsplit((parsed.scheme, f"{site_name}:{port}", parsed.path, parsed.query, parsed.fragment))
+    copied = dict(job_args)
+    copied[JobProcessArgs.PARENT_URL] = (flag, parent_url)
+    return copied, None
 
 
 def _sanitize_container_name(name: str) -> str:
@@ -555,25 +601,9 @@ class DockerJobLauncher(JobLauncherSpec):
         # Derive parent_url at runtime: site name (= container name on Docker DNS) + port
         # from the original PARENT_URL in job_args. This avoids baking parent_url into
         # resources.json at provision time.
-        file_parent_dir = None
-        if JobProcessArgs.PARENT_URL in job_args:
-            flag, original_url = job_args[JobProcessArgs.PARENT_URL]
-            if urlsplit(str(original_url)).scheme == SHARED_FILE_SCHEME:
-                # Shared-file transport URLs are location-independent; pass through unchanged and
-                # bind-mount the listener directory at the same path inside the container
-                try:
-                    file_parent_dir = parse_file_url(str(original_url))
-                except CommError as e:
-                    raise ValueError(f"invalid shared-file parent URL {original_url!r}: {e}")
-                if file_parent_dir.startswith(self.WORKSPACE_MOUNT):
-                    raise ValueError(
-                        f"shared-file parent directory {file_parent_dir} overlaps the container workspace mount"
-                    )
-            else:
-                port = original_url.rsplit(":", 1)[-1]
-                parent_url = f"tcp://{site_name}:{port}"
-                job_args = dict(job_args)
-                job_args[JobProcessArgs.PARENT_URL] = (flag, parent_url)
+        job_args, file_parent_dir = _rewrite_parent_url(job_args, site_name)
+        if file_parent_dir and file_parent_dir.startswith(self.WORKSPACE_MOUNT):
+            raise ValueError(f"shared-file parent directory {file_parent_dir} overlaps the container workspace mount")
 
         module_args = self.get_module_args(job_args)
         module_args_list = []

--- a/nvflare/tool/deploy/docker_deploy.py
+++ b/nvflare/tool/deploy/docker_deploy.py
@@ -22,6 +22,7 @@ import stat
 from pathlib import Path
 from typing import Any
 
+from nvflare.apis.fl_constant import ConnectionSecurity
 from nvflare.app_opt.job_launcher.study_runtime import RESERVED_DOCKER_KWARGS
 from nvflare.fuel.f3.drivers.file_driver import SCHEME as SHARED_FILE_SCHEME
 from nvflare.tool.deploy.deploy_common import (
@@ -60,13 +61,20 @@ def validate_config(config: dict[str, Any]) -> None:
     _validate_allowed_keys(config, {"runtime", "parent", "job_launcher"}, "docker config")
     parent = _mapping(config.get("parent"), "parent")
     job_launcher = _mapping(config.get("job_launcher", {}), "job_launcher")
-    _validate_allowed_keys(parent, {"docker_image", "network"}, "parent")
+    _validate_allowed_keys(parent, {"docker_image", "network", "internal_connection_security"}, "parent")
     _validate_allowed_keys(
         job_launcher,
         {"default_python_path", "default_job_env", "default_job_container_kwargs"},
         "job_launcher",
     )
     _required_str(parent, "docker_image", "parent")
+    connection_security = parent.get("internal_connection_security", ConnectionSecurity.MTLS)
+    if connection_security not in (ConnectionSecurity.CLEAR, ConnectionSecurity.MTLS):
+        _fail(
+            "INVALID_CONFIG",
+            "parent.internal_connection_security must be 'clear' or 'mtls'.",
+            "Set parent.internal_connection_security to 'clear' or 'mtls'.",
+        )
     if "network" in parent:
         _required_str(parent, "network", "parent")
     _optional_str(job_launcher, "default_python_path", "job_launcher")
@@ -88,6 +96,7 @@ def prepare(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) -> di
     job_launcher = config.get("job_launcher") or {}
     docker_image = parent["docker_image"]
     network = parent.get("network", "nvflare-network")
+    connection_security = parent.get("internal_connection_security", ConnectionSecurity.MTLS)
 
     launcher_path = DOCKER_SERVER_LAUNCHER if kit_info.role == ROLE_SERVER else DOCKER_CLIENT_LAUNCHER
     launcher_args = {
@@ -99,7 +108,7 @@ def prepare(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) -> di
     _patch_resources(kit_info.kit_dir, "docker_launcher", launcher_path, launcher_args)
     if kit_info.role == ROLE_SERVER:
         _relocate_server_storage_to_workspace(kit_info.kit_dir, WORKSPACE_MOUNT_PATH)
-    _patch_comm_config_for_docker(kit_info.kit_dir)
+    _patch_comm_config_for_docker(kit_info.kit_dir, connection_security)
     _ensure_study_runtime_template(kit_info.kit_dir)
     _remove_start_scripts(kit_info.kit_dir, keep={DOCKER_START_SH})
     start_script = _write_docker_start_script(kit_info, docker_image=docker_image, network=network)
@@ -116,7 +125,7 @@ def prepare(kit_info: KitInfo, final_output: Path, config: dict[str, Any]) -> di
     }
 
 
-def _patch_comm_config_for_docker(kit_dir: Path) -> None:
+def _patch_comm_config_for_docker(kit_dir: Path, connection_security: str = ConnectionSecurity.MTLS) -> None:
     comm_config_path = kit_dir / "local" / COMM_CONFIG_JSON
     comm_config = _load_or_default_comm_config(comm_config_path)
     internal = comm_config.setdefault("internal", {})
@@ -129,7 +138,7 @@ def _patch_comm_config_for_docker(kit_dir: Path) -> None:
     internal["scheme"] = "tcp"
     resources = _internal_resources(comm_config)
     resources["host"] = "0.0.0.0"
-    resources.setdefault("connection_security", "clear")
+    resources["connection_security"] = connection_security
     _write_json(comm_config_path, comm_config)
 
 

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -505,7 +505,8 @@ class TestDockerJobLauncherInit:
 def _make_fl_ctx(
     job_id="job-1",
     exe_module="nvflare.private.fed.app.client.worker_process",
-    parent_url="localhost:8002",
+    parent_url="tcp://localhost:8002",
+    parent_conn_sec=None,
     identity_name="site-1",
     workspace_path="/ws",
     set_list=None,
@@ -521,6 +522,8 @@ def _make_fl_ctx(
         JobProcessArgs.WORKSPACE: ("-w", workspace_path),
         JobProcessArgs.STARTUP_DIR: ("-s", workspace_path + "/startup"),
     }
+    if parent_conn_sec is not None:
+        job_args[JobProcessArgs.PARENT_CONN_SEC] = ("--parent_conn_sec", parent_conn_sec)
     fl_ctx.get_prop.side_effect = lambda key, *a, **kw: {
         FLContextKey.JOB_PROCESS_ARGS: job_args,
         FLContextKey.WORKSPACE_OBJECT: None,
@@ -623,6 +626,40 @@ class TestDockerJobLauncherLaunchJob:
         # Must replace localhost with container name (site name)
         assert "localhost" not in command_str
         assert "tcp://site-1:8004" in command_str
+
+    def test_launch_preserves_secure_parent_url(self):
+        launcher = _make_launcher()
+        dc = launcher._docker_client
+        container = MagicMock()
+        container.id = "abc123"
+        dc.containers.run.return_value = container
+
+        fl_ctx, _ = _make_fl_ctx(
+            identity_name="site-1",
+            parent_url="stcp://localhost:8004/path?option=value",
+            parent_conn_sec="mtls",
+        )
+        launcher.launch_job(_make_job_meta(), fl_ctx)
+
+        command = dc.containers.run.call_args.kwargs["command"]
+        assert "stcp://site-1:8004/path?option=value" in command
+        assert command[command.index("--parent_conn_sec") + 1] == "mtls"
+
+    @pytest.mark.parametrize(
+        ("parent_url", "parent_conn_sec", "message"),
+        [
+            ("stcp://localhost:8004", "clear", "does not match"),
+            ("tcp://localhost:8004", "mtls", "does not match"),
+            ("tcp://localhost:8004", "tls", "requires clear or mTLS"),
+            ("http://localhost:8004", "clear", "must use shared-file, tcp, or stcp"),
+        ],
+    )
+    def test_launch_rejects_invalid_parent_security(self, parent_url, parent_conn_sec, message):
+        launcher = _make_launcher()
+        fl_ctx, _ = _make_fl_ctx(parent_url=parent_url, parent_conn_sec=parent_conn_sec)
+
+        with pytest.raises(ValueError, match=message):
+            launcher.launch_job(_make_job_meta(), fl_ctx)
 
     def test_launch_raises_on_missing_job_id(self):
         launcher = _make_launcher()

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -319,6 +319,7 @@ def test_prepare_docker_client_copies_and_patches_runtime_files(tmp_path, capsys
 
     comm_config = json.loads((output / "local" / "comm_config.json").read_text())
     assert comm_config["internal"]["resources"]["host"] == "0.0.0.0"
+    assert comm_config["internal"]["resources"]["connection_security"] == "mtls"
     study_runtime_path = output / "local" / "study_runtime.yaml"
     study_runtime_text = study_runtime_path.read_text()
     assert "@@NVFLARE_" not in study_runtime_text
@@ -859,8 +860,51 @@ def test_prepare_docker_creates_comm_config_when_missing(tmp_path, capsys):
     assert comm_config["internal"]["scheme"] == "tcp"
     assert comm_config["internal"]["resources"] == {
         "host": "0.0.0.0",
-        "connection_security": "clear",
+        "connection_security": "mtls",
     }
+
+
+def test_prepare_docker_accepts_clear_internal_connection_security(tmp_path, capsys):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+
+    _run_prepare(
+        kit,
+        output,
+        {
+            "runtime": "docker",
+            "parent": {
+                "docker_image": "repo/nvflare:dev",
+                "internal_connection_security": "clear",
+            },
+        },
+    )
+    capsys.readouterr()
+
+    comm_config = json.loads((output / "local" / "comm_config.json").read_text())
+    assert comm_config["internal"]["resources"]["connection_security"] == "clear"
+
+
+@pytest.mark.parametrize("connection_security", ["tls", "MTLS", "", None, 7, True])
+def test_prepare_docker_rejects_invalid_internal_connection_security(tmp_path, capsys, connection_security):
+    kit = _make_client_kit(tmp_path)
+    output = tmp_path / "site-1-docker"
+
+    with pytest.raises(SystemExit):
+        _run_prepare(
+            kit,
+            output,
+            {
+                "runtime": "docker",
+                "parent": {
+                    "docker_image": "repo/nvflare:dev",
+                    "internal_connection_security": connection_security,
+                },
+            },
+        )
+
+    assert "parent.internal_connection_security" in capsys.readouterr().err
+    assert not output.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- enable mTLS by default for Docker SP/SJ and CP/CJ internal TCP links, with `parent.internal_connection_security: clear` as an explicit opt-out
- preserve `stcp://` when rewriting the parent hostname to the Docker DNS name
- reject malformed parent URLs, unsupported security modes, and URL/security mismatches that could downgrade a secure parent connection
- document the Docker internal transport security mode

## Root cause

Docker deployment preparation forced the internal parent listener to clear transport, and `DockerJobLauncher` unconditionally rewrote every TCP parent URL to `tcp://`. That prevented Docker job containers from using the participant certificate reuse supported by CellNet and could silently discard an `stcp://` parent scheme.

## Impact

Parent listeners remain reachable on the Docker network so separately networked job containers can connect, but both endpoints authenticate with the provisioned participant credentials by default. Existing deployments that require clear transport can explicitly set `parent.internal_connection_security: clear`.

## Validation

- `python -m pytest -q tests/unit_test/app_opt/job_launcher/docker_launcher_test.py tests/unit_test/tool/deploy/deploy_commands_test.py -k docker` — 157 passed, 98 deselected
- `./runtest.sh -s --skip-install`
- `git diff --check`