### PR TITLE
Keep resource manager exceptions site-local

### DIFF
--- a/nvflare/private/fed/client/scheduler_cmds.py
+++ b/nvflare/private/fed/client/scheduler_cmds.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 from typing import List
 
 from nvflare.apis.event_type import EventType
@@ -25,6 +26,8 @@ from nvflare.private.fed.client.admin import RequestProcessor
 from nvflare.private.fed.client.client_engine_internal_spec import ClientEngineInternalSpec
 from nvflare.private.scheduler_constants import ShareableHeader
 from nvflare.security.logging import secure_format_exception
+
+logger = logging.getLogger(__name__)
 
 
 def _get_resource_manager(engine: ClientEngineInternalSpec):
@@ -81,9 +84,8 @@ class CheckResourceProcessor(RequestProcessor):
                         resource_requirement=resource_spec, fl_ctx=fl_ctx
                     )
             except Exception as e:
-                reason = f"resource check failed: {secure_format_exception(e)}"
-                engine.logger.error(f"Job {job_id}: {reason}")
-                token = reason
+                logger.error(f"Job {job_id}: resource check failed: {secure_format_exception(e)}")
+                token = "resource manager raised an exception; see site log"
                 result.set_return_code(ReturnCode.EXECUTION_EXCEPTION)
 
         result.set_header(ShareableHeader.IS_RESOURCE_ENOUGH, is_resource_enough)

--- a/tests/unit_test/private/fed/client/scheduler_cmds_test.py
+++ b/tests/unit_test/private/fed/client/scheduler_cmds_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from nvflare.apis.fl_constant import ReturnCode, SystemComponents
 from nvflare.apis.fl_context import FLContext
@@ -24,22 +24,26 @@ from nvflare.private.fed.client.scheduler_cmds import CheckResourceProcessor
 from nvflare.private.scheduler_constants import ShareableHeader
 
 
-def test_check_resource_processor_returns_resource_manager_error():
+def test_check_resource_processor_keeps_resource_manager_error_local():
     resource_manager = MagicMock(spec=ResourceManagerSpec)
     resource_manager.check_resources.side_effect = ValueError("resource_requirement is missing num_gpu_key num_of_gpus")
     engine = MagicMock(spec=ClientEngineInternalSpec)
     engine.get_component.return_value = resource_manager
     engine.new_context.return_value.__enter__.return_value = FLContext()
-    engine.logger = MagicMock()
-
     request = Message(topic=TrainingTopic.CHECK_RESOURCE, body={"license": 2})
     request.set_header(RequestHeader.JOB_ID, "job-1")
 
-    reply = CheckResourceProcessor().process(request, engine)
+    with (
+        patch("nvflare.private.fed.client.scheduler_cmds.logger") as logger,
+        patch("nvflare.private.fed.client.scheduler_cmds.secure_format_exception", return_value="sensitive detail"),
+    ):
+        reply = CheckResourceProcessor().process(request, engine)
 
-    reason = "resource check failed: ValueError: resource_requirement is missing num_gpu_key num_of_gpus"
     assert reply.body.get_return_code() == ReturnCode.EXECUTION_EXCEPTION
     assert not reply.body.get_header(ShareableHeader.IS_RESOURCE_ENOUGH)
-    assert reply.body.get_header(ShareableHeader.RESOURCE_RESERVE_TOKEN) == reason
+    assert (
+        reply.body.get_header(ShareableHeader.RESOURCE_RESERVE_TOKEN)
+        == "resource manager raised an exception; see site log"
+    )
     engine.get_component.assert_called_once_with(SystemComponents.RESOURCE_MANAGER)
-    engine.logger.error.assert_called_once_with(f"Job job-1: {reason}")
+    logger.error.assert_called_once_with("Job job-1: resource check failed: sensitive detail")


### PR DESCRIPTION
## Description

Follow-up to #5143.

The resource-check exception path returned `secure_format_exception(e)` to the server. Unless secure logging was enabled at the client, that included `str(e)`, allowing site-local exception details to enter scheduling history and job metadata.

This change keeps the formatted exception in the site-local log and returns the fixed, bounded diagnostic `resource manager raised an exception; see site log` across the site boundary. It also uses a module logger instead of relying on an undeclared `engine.logger` attribute.

Resource admission and scheduling behavior are otherwise unchanged.

## Validation

- 22 focused scheduler and resource-check tests passed
- `./runtest.sh -s` passed
- `git diff --check` passed
