### PR TITLE
Harden resource admission failure handling

### DIFF
--- a/nvflare/app_common/job_schedulers/job_scheduler.py
+++ b/nvflare/app_common/job_schedulers/job_scheduler.py
@@ -206,7 +206,7 @@ class DefaultJobScheduler(JobSchedulerSpec, FLComponent):
                     required_sites_not_enough_resource.remove(site_name)
             else:
                 if site_name in required_sites:
-                    no_resource_message += site_name + ":" + token + ";"
+                    no_resource_message += site_name + ":" + (token or "") + ";"
                 if token:
                     resource_failure_details.append(f"{site_name}: {token}")
 

--- a/nvflare/private/fed/client/scheduler_cmds.py
+++ b/nvflare/private/fed/client/scheduler_cmds.py
@@ -86,7 +86,6 @@ class CheckResourceProcessor(RequestProcessor):
             except Exception as e:
                 logger.error(f"Job {job_id}: resource check failed: {secure_format_exception(e)}")
                 token = "resource manager raised an exception; see site log"
-                result.set_return_code(ReturnCode.EXECUTION_EXCEPTION)
 
         result.set_header(ShareableHeader.IS_RESOURCE_ENOUGH, is_resource_enough)
         result.set_header(ShareableHeader.RESOURCE_RESERVE_TOKEN, token)

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -413,6 +413,11 @@ class TestDefaultJobScheduler:
                 job_manager=job_manager, job_candidates=[candidate], fl_ctx=fl_ctx
             )
         assert job is None
+        assert candidate.meta[JobMetaKey.SCHEDULE_COUNT.value] == 1
+        assert (
+            "required sites: ['site2'] don't have enough resources"
+            in candidate.meta[JobMetaKey.SCHEDULE_HISTORY.value][0]
+        )
 
     def test_not_enough_sites_has_enough_resource(self, setup_and_teardown):
         servers, scheduler, num_sites, job_manager = setup_and_teardown

--- a/tests/unit_test/private/fed/client/scheduler_cmds_test.py
+++ b/tests/unit_test/private/fed/client/scheduler_cmds_test.py
@@ -14,7 +14,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from nvflare.apis.fl_constant import ReturnCode, SystemComponents
+from nvflare.apis.fl_constant import SystemComponents
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.resource_manager_spec import ResourceManagerSpec
 from nvflare.private.admin_defs import Message
@@ -39,7 +39,6 @@ def test_check_resource_processor_keeps_resource_manager_error_local():
     ):
         reply = CheckResourceProcessor().process(request, engine)
 
-    assert reply.body.get_return_code() == ReturnCode.EXECUTION_EXCEPTION
     assert not reply.body.get_header(ShareableHeader.IS_RESOURCE_ENOUGH)
     assert (
         reply.body.get_header(ShareableHeader.RESOURCE_RESERVE_TOKEN)


### PR DESCRIPTION
## Description

- tolerate resource managers returning no reservation token for a required-site rejection
- keep the normal cancellation, scheduling-history, retry-backoff, and maximum-attempt path intact
- remove the unused return code from the resource-check response body
- strengthen the existing required-site test so it cannot pass through the scheduler's broad exception handler

## Root cause

The required-site error message concatenated the reservation token without handling `None`. A resource manager returning `(False, None)` raised `TypeError` before cancellation and scheduling bookkeeping could run. Separately, the client set a return code inside the response `Shareable`, but the server reads only the outer admin message return code and the resource token.

## Impact

Required-site resource rejection now follows the intended no-resource path even when no token is returned. Resource-manager exception details remain site-local, and the cross-site diagnostic behavior introduced in #5148 is unchanged.

## Validation

- `22 passed`: focused scheduler and client resource-check unit tests
- `./runtest.sh -s`
- `git diff --check`
