### PR TITLE
Clarify train_with_evaluation example comments

### DIFF
--- a/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow-client/client.py
+++ b/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow-client/client.py
@@ -104,8 +104,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (6) performing train task on received model

--- a/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow-client/client.py
+++ b/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow-client/client.py
@@ -102,13 +102,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (6) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow/client.py
+++ b/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow/client.py
@@ -104,8 +104,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (6) performing train task on received model

--- a/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow/client.py
+++ b/examples/advanced/experiment-tracking/mlflow/hello-pt-mlflow/client.py
@@ -102,13 +102,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (6) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/advanced/experiment-tracking/tensorboard/client.py
+++ b/examples/advanced/experiment-tracking/tensorboard/client.py
@@ -100,13 +100,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/advanced/experiment-tracking/tensorboard/client.py
+++ b/examples/advanced/experiment-tracking/tensorboard/client.py
@@ -102,8 +102,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/advanced/experiment-tracking/wandb/client.py
+++ b/examples/advanced/experiment-tracking/wandb/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/advanced/experiment-tracking/wandb/client.py
+++ b/examples/advanced/experiment-tracking/wandb/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.2_convert_deep_learning_to_federated_learning/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.2_convert_deep_learning_to_federated_learning/code/src/client.py
@@ -99,8 +99,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.2_convert_deep_learning_to_federated_learning/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.2_convert_deep_learning_to_federated_learning/code/src/client.py
@@ -97,13 +97,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.3_server_side_customization/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.3_server_side_customization/code/src/client.py
@@ -99,8 +99,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.3_server_side_customization/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.3_server_side_customization/code/src/client.py
@@ -97,13 +97,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.4_client_side_customization/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.4_client_side_customization/code/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.4_client_side_customization/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.4_client_side_customization/code/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.1_experiment_tracking_with_tensorboard/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.1_experiment_tracking_with_tensorboard/code/src/client.py
@@ -100,13 +100,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.1_experiment_tracking_with_tensorboard/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.1_experiment_tracking_with_tensorboard/code/src/client.py
@@ -102,8 +102,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client.py
@@ -100,13 +100,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client.py
@@ -102,8 +102,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client_mlflow.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client_mlflow.py
@@ -100,13 +100,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client_mlflow.py
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.5_experiment_tracking/01.5.2_experiment_tracking_with_mlflow/code/src/client_mlflow.py
@@ -102,8 +102,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.2_deployment_simulation/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.2_deployment_simulation/code/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.2_deployment_simulation/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.2_deployment_simulation/code/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-1/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-1/code/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-1/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-1/code/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-2/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-2/code/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-2/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-2_federated_learning_system/chapter-3_federated_computing_platform/03.4_system_monitoring/jobs/setup-2/code/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train.py
@@ -97,8 +97,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train.py
@@ -95,13 +95,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train_with_mlflow.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train_with_mlflow.py
@@ -99,8 +99,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train_with_mlflow.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-5_Privacy_In_Federated_Learning/05.3_homomorphic_encryption/code/fl/train_with_mlflow.py
@@ -97,13 +97,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.2_site_security_privacy_policy/code/federated-policies/jobs/src/client.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.2_site_security_privacy_policy/code/federated-policies/jobs/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.2_site_security_privacy_policy/code/federated-policies/jobs/src/client.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.2_site_security_privacy_policy/code/federated-policies/jobs/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_auth_system_integration/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_auth_system_integration/code/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_auth_system_integration/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_auth_system_integration/code/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_job_level_authorization/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_job_level_authorization/code/src/client.py
@@ -100,8 +100,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_job_level_authorization/code/src/client.py
+++ b/examples/tutorials/self-paced-training/part-3_security_and_privacy/chapter-6_Security_in_federated_compute_system/06.3_customized_site_security/custom_client_side_job_level_authorization/code/src/client.py
@@ -98,13 +98,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-7_algorithms_and_workflows/07.2_algorithms/train.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-7_algorithms_and_workflows/07.2_algorithms/train.py
@@ -97,8 +97,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-7_algorithms_and_workflows/07.2_algorithms/train.py
+++ b/examples/tutorials/self-paced-training/part-4_advanced_federated_learning/chapter-7_algorithms_and_workflows/07.2_algorithms/train.py
@@ -95,13 +95,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/tests/integration_test/data/jobs/hello-pt-cse/app/custom/train.py
+++ b/tests/integration_test/data/jobs/hello-pt-cse/app/custom/train.py
@@ -99,13 +99,12 @@ def main():
 
         model_path = os.path.join(MODEL_SAVE_PATH_ROOT, client_id, "cifar_net.pth")
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")

--- a/tests/integration_test/data/jobs/hello-pt-cse/app/custom/train.py
+++ b/tests/integration_test/data/jobs/hello-pt-cse/app/custom/train.py
@@ -101,8 +101,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/tests/integration_test/data/jobs/swarm_cse_pt/app/custom/train.py
+++ b/tests/integration_test/data/jobs/swarm_cse_pt/app/custom/train.py
@@ -97,8 +97,9 @@ def main():
 
         # Handle each Client API task according to its type:
         # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
-        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
-        #   makes evaluation metrics required; it does not enable their transmission.
+        #   model plus any supplied evaluation metrics. When "train_with_evaluation" is True, framework integrations
+        #   such as Lightning and Hugging Face require evaluation metrics; the raw Client API does not enforce them.
+        #   The flag does not control whether supplied metrics are transmitted.
         # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
         # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model

--- a/tests/integration_test/data/jobs/swarm_cse_pt/app/custom/train.py
+++ b/tests/integration_test/data/jobs/swarm_cse_pt/app/custom/train.py
@@ -95,13 +95,12 @@ def main():
         input_model = flare.receive()
         client_id = flare.get_site_name()
 
-        # Based on different "task" we will do different things
-        # for "train" task (flare.is_train()) we use the received model to do training and/or evaluation
-        # and send back updated model and/or evaluation metrics, if the "train_with_evaluation" is specified as True
-        # in the config_fed_client we will need to do evaluation and include the evaluation metrics
-        # for "evaluate" task (flare.is_evaluate()) we use the received model to do evaluation
-        # and send back the evaluation metrics
-        # for "submit_model" task (flare.is_submit_model()) we just need to send back the local model
+        # Handle each Client API task according to its type:
+        # - "train" (flare.is_train()): train and optionally evaluate the received model, then send the updated
+        #   model plus any supplied evaluation metrics. Setting "train_with_evaluation" to True in config_fed_client
+        #   makes evaluation metrics required; it does not enable their transmission.
+        # - "evaluate" (flare.is_evaluate()): evaluate the received model and return the metrics.
+        # - "submit_model" (flare.is_submit_model()): return the requested local model.
         # (5) performing train task on received model
         if flare.is_train():
             print(f"({client_id}) current_round={input_model.current_round}, total_rounds={input_model.total_rounds}")


### PR DESCRIPTION
## Summary
- update the duplicated Client API task comments in 19 examples/tutorials and 2 integration fixtures
- clarify that supplied evaluation metrics are transmitted regardless of train_with_evaluation
- clarify that train_with_evaluation=True makes evaluation metrics required rather than enabling transmission

This is a comments-only follow-up to #5145. It intentionally excludes the Hugging Face diagnostic wording and SimpleIntimeModelSelector behavior.

## Validation
- ./runtest.sh -s
- git diff --check
- verified all 21 stale comment blocks were replaced