### PR TITLE
Clarify Hugging Face evaluation metric requirement

### DIFF
--- a/docs/design/hf_trainer_client_api.md
+++ b/docs/design/hf_trainer_client_api.md
@@ -236,8 +236,8 @@ for plain training; the full contract is:
 - train task, `train_with_evaluation=False`: `trainer.train()` alone is enough.
 - train task, `train_with_evaluation=True`: the user must call
   `trainer.evaluate()` before `trainer.train()` — otherwise `on_train_end` fails
-  with the same actionable error as Lightning ("missing training metrics, please
-  remember to call evaluate").
+  with an actionable error ("train with evaluation requires evaluation metrics;
+  call evaluate before train").
 - `evaluate` task: the loop must call `trainer.evaluate()`; a loop that only
   calls `train()` hits the fail-fast pending-task error (see Failure semantics).
 
@@ -450,11 +450,11 @@ per-round-bump fallback.
    on the wrapped/DDP model or on the trainer itself are not consulted (PEFT/DDP
    wrapping makes "on the model" ambiguous unless pinned).
 5. Metrics: only what the **wrapped pre-train `evaluate()`** captured this round
-   (e.g. `eval_loss` of the global model) rides on the outgoing `FLModel` when
-   `train_with_evaluation` is configured — same contract and same "call evaluate()
-   or fail with an actionable error" rule as Lightning. Mid-training evaluations
-   triggered by `eval_strategy` never populate `FLModel.metrics` (see the
-   `on_evaluate` hook rule).
+   (e.g. `eval_loss` of the global model) rides on the outgoing `FLModel`.
+   `train_with_evaluation=True` makes these metrics required; when it is `False`,
+   captured metrics remain optional and are still returned. Mid-training
+   evaluations triggered by `eval_strategy` never populate `FLModel.metrics`
+   (see the `on_evaluate` hook rule).
 
 ## Task Types and Task Dispatch
 

--- a/nvflare/app_opt/hf/api.py
+++ b/nvflare/app_opt/hf/api.py
@@ -788,7 +788,7 @@ class _HFTaskState:
         if self.task_kind != TASK_TRAIN or not self.pending:
             return
         if self.train_with_evaluation and self.pre_train_metrics is None:
-            raise RuntimeError("train with evaluation missing training metrics, please remember to call evaluate.")
+            raise RuntimeError("train with evaluation requires evaluation metrics; call evaluate before train.")
 
         end_global_step = int(getattr(hf_train_state, "global_step", 0) or 0)
         end_tokens = _optional_int(getattr(hf_train_state, "num_input_tokens_seen", None))

--- a/tests/unit_test/app_opt/hf/task_dispatch_contract_test.py
+++ b/tests/unit_test/app_opt/hf/task_dispatch_contract_test.py
@@ -271,7 +271,9 @@ def test_train_with_evaluation_fails_fast_when_pre_train_evaluate_was_not_called
 
     hf_api.patch(trainer, restore_state=False, local_steps=1)
 
-    with pytest.raises(RuntimeError, match="missing.*metrics|remember to call evaluate"):
+    with pytest.raises(
+        RuntimeError, match="train with evaluation requires evaluation metrics; call evaluate before train"
+    ):
         trainer.train()
 
 


### PR DESCRIPTION
## Summary
- replace the misleading Hugging Face "missing training metrics" error with an explicit pre-train evaluation instruction
- tighten the regression test to require the actionable diagnostic
- document that train_with_evaluation makes captured metrics required rather than controlling whether they are returned

This is an independent, behavior-preserving follow-up identified during the review of #5145.

## Validation
- python3 -m pytest tests/unit_test/app_opt/hf/task_dispatch_contract_test.py -q (46 passed)
- ./runtest.sh -s
- git diff --check