### PR TITLE
Fix safe default component allow-list gaps

### DIFF
--- a/docs/user_guide/admin_guide/security/unsafe_component_detection.rst
+++ b/docs/user_guide/admin_guide/security/unsafe_component_detection.rst
@@ -75,8 +75,9 @@ When BYOC is disabled, NVFLARE runs a built-in component path authorization chec
 configuration. Sites get this protection without installing an authorizer component in ``resources.json``. The policy
 allows only class paths that match ``class_allow_list`` in the site's top-level ``resources.json`` or
 ``resources.json.default``. Standard provisioning installs a curated list of built-in components. If
-``class_allow_list`` is not configured, NVFLARE uses the curated built-in default shown below and records an audit
-event for the implicit policy decision. An explicitly configured list replaces that default.
+``class_allow_list`` is not configured, NVFLARE uses the curated built-in default defined in
+``nvflare/app_common/default_component_policy.py`` and records an audit event for the implicit policy decision. An
+explicitly configured list replaces that default.
 
 ``SimEnv`` also installs this curated list in new simulation workspaces without changing POC or production authorization.
 
@@ -116,9 +117,11 @@ checks without repeating the wildcard warning. Simulator runs use warning logs b
 
 Provisioned ``resources.json.default`` Results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When provisioning generates startup kits, the server and client ``resources.json.default`` files include the following
-top-level ``class_allow_list``. It is also the built-in fallback when the setting is omitted. Operators can replace it in
-``resources.json`` or ``resources.json.default`` to match the classes their non-BYOC jobs are allowed to load.
+When provisioning generates startup kits, the server and client ``resources.json.default`` files include a top-level
+``class_allow_list``. It is also the built-in fallback when the setting is omitted. Operators can replace it in
+``resources.json`` or ``resources.json.default`` to match the classes their non-BYOC jobs are allowed to load. The JSON
+below is an intentionally partial example of the generated configuration, not the complete default. The
+``DEFAULT_CLASS_ALLOW_LIST`` in ``nvflare/app_common/default_component_policy.py`` is the source of truth.
 
 Every class in ``DEFAULT_CLASS_ALLOW_LIST`` must remain safe to import and construct with untrusted, job-controlled
 arguments. Future additions to the default list require review under this security bar, including constructor side effects

--- a/docs/user_guide/admin_guide/security/unsafe_component_detection.rst
+++ b/docs/user_guide/admin_guide/security/unsafe_component_detection.rst
@@ -130,15 +130,19 @@ and any argument values that could trigger file, process, network, deserializati
         "format_version": 2,
         "class_list_enforcement_mode": "enforce",
         "class_allow_list": [
+            "nvflare.app_common.aggregators.collect_and_assemble_aggregator.CollectAndAssembleAggregator",
             "nvflare.app_common.aggregators.collect_and_assemble_model_aggregator.CollectAndAssembleModelAggregator",
             "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
+            "nvflare.app_common.ccwf.client_controller_executor.ClientControllerExecutor",
             "nvflare.app_common.ccwf.comps.simple_model_shareable_generator.SimpleModelShareableGenerator",
             "nvflare.app_common.ccwf.cse_client_ctl.CrossSiteEvalClientController",
             "nvflare.app_common.ccwf.cse_server_ctl.CrossSiteEvalServerController",
             "nvflare.app_common.ccwf.cyclic_client_ctl.CyclicClientController",
             "nvflare.app_common.ccwf.cyclic_server_ctl.CyclicServerController",
+            "nvflare.app_common.ccwf.server_ctl.ServerSideController",
             "nvflare.app_common.ccwf.swarm_client_ctl.SwarmClientController",
             "nvflare.app_common.ccwf.swarm_server_ctl.SwarmServerController",
+            "nvflare.app_common.executors.model_learner_executor.ModelLearnerExecutor",
             "nvflare.app_common.executors.statistics.statistics_executor.StatisticsExecutor",
             "nvflare.app_common.filters.statistics_privacy_filter.StatisticsPrivacyFilter",
             "nvflare.app_common.logging.job_log_receiver.JobLogReceiver",
@@ -154,6 +158,7 @@ and any argument values that could trigger file, process, network, deserializati
             "nvflare.app_common.statistics.json_stats_file_persistor.JsonStatsFileWriter",
             "nvflare.app_common.statistics.min_count_cleanser.MinCountCleanser",
             "nvflare.app_common.statistics.min_max_cleanser.AddNoiseToMinMax",
+            "nvflare.app_common.utils.json_utils.ObjectEncoder",
             "nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent",
             "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector",
             "nvflare.app_common.widgets.metrics_artifact_writer.MetricsArtifactWriter",
@@ -173,6 +178,7 @@ and any argument values that could trigger file, process, network, deserializati
             "nvflare.app_opt.he.model_shareable_generator.HEModelShareableGenerator",
             "nvflare.app_opt.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
             "nvflare.app_opt.pt.fedopt.PTFedOptModelShareableGenerator",
+            "nvflare.app_opt.pt.fedopt_ctl.FedOpt",
             "nvflare.app_opt.pt.file_model_locator.PTFileModelLocator",
             "nvflare.app_opt.pt.recipes.fedeval.EvalController",
             "nvflare.app_opt.sklearn.kmeans_assembler.KMeansAssembler",
@@ -201,6 +207,11 @@ not match any entry in ``class_allow_list``. The same rule applies to ``"class_p
 The provisioned list intentionally excludes framework optimizer, scheduler, and model classes. If a job configures those
 classes, each site must add the reviewed class paths or package prefixes to
 ``class_allow_list`` before running the job with BYOC disabled.
+
+The default also excludes components that can execute job-controlled code or deserialize executable model formats,
+including ``ClientAPIExecutor``, ``PTFileModelPersistor``, ``TFModelPersistor``, and
+``JoblibModelParamPersistor``. Templates that invoke training code from ``custom/`` are BYOC jobs once that required code
+is added. Do not allow-list these components merely to submit an incomplete template without its required custom code.
 
 This is an allow-list baseline. It is not a replacement for secure job review, least-privilege runtime environments, container or
 process sandboxing, and other controls appropriate to your deployment.

--- a/nvflare/app_common/default_component_policy.py
+++ b/nvflare/app_common/default_component_policy.py
@@ -20,6 +20,7 @@ also uses it as the built-in default when a site does not configure
 """
 
 DEFAULT_CLASS_ALLOW_LIST = (
+    "nvflare.app_common.aggregators.collect_and_assemble_aggregator.CollectAndAssembleAggregator",
     "nvflare.app_common.aggregators.collect_and_assemble_model_aggregator.CollectAndAssembleModelAggregator",
     "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
     "nvflare.app_common.ccwf.CrossSiteEvalClientController",
@@ -28,6 +29,7 @@ DEFAULT_CLASS_ALLOW_LIST = (
     "nvflare.app_common.ccwf.CyclicServerController",
     "nvflare.app_common.ccwf.SwarmClientController",
     "nvflare.app_common.ccwf.SwarmServerController",
+    "nvflare.app_common.ccwf.client_controller_executor.ClientControllerExecutor",
     "nvflare.app_common.ccwf.comps.cwe_result_printer.CWEResultPrinter",
     "nvflare.app_common.ccwf.comps.np_file_model_persistor.NPFileModelPersistor",
     "nvflare.app_common.ccwf.comps.np_trainer.NPTrainer",
@@ -37,8 +39,10 @@ DEFAULT_CLASS_ALLOW_LIST = (
     "nvflare.app_common.ccwf.cse_server_ctl.CrossSiteEvalServerController",
     "nvflare.app_common.ccwf.cyclic_client_ctl.CyclicClientController",
     "nvflare.app_common.ccwf.cyclic_server_ctl.CyclicServerController",
+    "nvflare.app_common.ccwf.server_ctl.ServerSideController",
     "nvflare.app_common.ccwf.swarm_client_ctl.SwarmClientController",
     "nvflare.app_common.ccwf.swarm_server_ctl.SwarmServerController",
+    "nvflare.app_common.executors.model_learner_executor.ModelLearnerExecutor",
     "nvflare.app_common.executors.statistics.statistics_executor.StatisticsExecutor",
     "nvflare.app_common.filters.exclude_vars.ExcludeVars",
     "nvflare.app_common.filters.percentile_privacy.PercentilePrivacy",
@@ -59,6 +63,7 @@ DEFAULT_CLASS_ALLOW_LIST = (
     "nvflare.app_common.statistics.json_stats_file_persistor.JsonStatsFileWriter",
     "nvflare.app_common.statistics.min_count_cleanser.MinCountCleanser",
     "nvflare.app_common.statistics.min_max_cleanser.AddNoiseToMinMax",
+    "nvflare.app_common.utils.json_utils.ObjectEncoder",
     "nvflare.app_common.widgets.convert_to_fed_event.ConvertToFedEvent",
     "nvflare.app_common.widgets.event_recorder.ClientEventRecorder",
     "nvflare.app_common.widgets.event_recorder.ServerEventRecorder",
@@ -82,6 +87,7 @@ DEFAULT_CLASS_ALLOW_LIST = (
     "nvflare.app_opt.he.model_shareable_generator.HEModelShareableGenerator",
     "nvflare.app_opt.psi.dh_psi.dh_psi_task_handler.DhPSITaskHandler",
     "nvflare.app_opt.pt.fedopt.PTFedOptModelShareableGenerator",
+    "nvflare.app_opt.pt.fedopt_ctl.FedOpt",
     "nvflare.app_opt.pt.file_model_locator.PTFileModelLocator",
     "nvflare.app_opt.pt.recipes.fedeval.EvalController",
     "nvflare.app_opt.sklearn.kmeans_assembler.KMeansAssembler",

--- a/tests/unit_test/app_common/widgets/component_path_authorizer_test.py
+++ b/tests/unit_test/app_common/widgets/component_path_authorizer_test.py
@@ -224,6 +224,24 @@ def test_default_allow_list_allows_metrics_artifact_writer():
     authorizer.handle_event(EventType.BEFORE_BUILD_COMPONENT, fl_ctx)
 
 
+@pytest.mark.parametrize(
+    "component_path",
+    [
+        "nvflare.app_common.aggregators.collect_and_assemble_aggregator.CollectAndAssembleAggregator",
+        "nvflare.app_common.ccwf.client_controller_executor.ClientControllerExecutor",
+        "nvflare.app_common.ccwf.server_ctl.ServerSideController",
+        "nvflare.app_common.executors.model_learner_executor.ModelLearnerExecutor",
+        "nvflare.app_common.utils.json_utils.ObjectEncoder",
+        "nvflare.app_opt.pt.fedopt_ctl.FedOpt",
+    ],
+)
+def test_default_allow_list_allows_components_used_by_shipped_job_templates(component_path):
+    authorizer = ComponentPathAuthorizer()
+    fl_ctx = _make_fl_ctx({"path": component_path, "args": {}}, job_meta={AppValidationKey.BYOC: False})
+
+    authorizer.handle_event(EventType.BEFORE_BUILD_COMPONENT, fl_ctx)
+
+
 def test_implicit_default_allow_list_is_audited_and_warned_once_per_job(monkeypatch, caplog):
     audit = MagicMock(return_value="event-id")
     monkeypatch.setattr(AuditService, "add_event", audit)

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -381,11 +381,16 @@ class TestStaticFileBuilder:
         template = _load_master_template()
 
         forbidden_paths = [
+            # ClientAPIExecutor launches a job-controlled command or imports and runs a
+            # job-controlled Python script.
+            "nvflare.app_common.executors.client_api_executor.ClientAPIExecutor",
             # tf.keras.models.load_model executes code embedded in .keras/.h5/SavedModel files
             # (Lambda layers / custom objects); there is no safe-load flag.
             "nvflare.app_opt.tf.model_persistor.TFModelPersistor",
             # torch.load is pickle-based and runs arbitrary code when load_weights_only=False.
             "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor",
+            # joblib.load uses pickle and can execute code from a job-controlled model file.
+            "nvflare.app_opt.sklearn.joblib_model_param_persistor.JoblibModelParamPersistor",
             # ConfigParser importlib-imports a class path read from a config file (plus
             # sys.path.append) -> arbitrary code import.
             "nvflare.edge.simulation.config.ConfigParser",


### PR DESCRIPTION
## What changed

- Add six safe NVFlare components used by shipped job templates to the curated default class allow-list.
- Add regression coverage that exercises those component paths explicitly with `byoc=false`.
- Extend the existing code-execution-sink guard to cover `ClientAPIExecutor` and `JoblibModelParamPersistor` alongside the PyTorch and TensorFlow persistors.
- Document why templates that execute code from `custom/` are BYOC and why executable/deserializing components remain excluded from the default policy.

## Why

The curated default policy had drifted from safe built-in components referenced by NVFlare job templates, causing otherwise-authorized non-BYOC component builds to fail.

The broader reported set also included components that launch job-controlled commands or deserialize executable model formats. Adding those paths to the site-wide default would weaken the non-BYOC security boundary. A bare `sag_pt` export is incomplete: its configuration requires `custom/cifar10.py` and `net.Net`; after that required code is supplied, the job is correctly classified as BYOC.

## Impact

Non-BYOC jobs can use the six safe shipped components without site-specific allow-list changes. Components that execute custom code or load executable serialization formats continue to require BYOC or an explicit operator-reviewed site policy.

## Validation

- `.venv/bin/python -m pytest -q tests/unit_test/app_common/widgets/component_path_authorizer_test.py tests/unit_test/lighter/static_file_builder_test.py tests/unit_test/recipe/sim_env_test.py` (`110 passed`)
- `./runtest.sh -s`
- `git diff --check upstream/main...HEAD`
