### PR TITLE
Align Network Attach profile with internal mTLS defaults

### DIFF
--- a/docs/design/client_api_attach_mode.md
+++ b/docs/design/client_api_attach_mode.md
@@ -183,8 +183,8 @@ Typed Attach profiles have `schema_version=1`, `execution_mode="attach"`, an
   "execution_mode": "attach",
   "attach_id": "numpy_trainer",
   "site_name": "site-1",
-  "connect_url": "tcp://site-1.example.com:8004",
-  "connection_security": "clear",
+  "connect_url": "stcp://site-1.example.com:8004",
+  "connection_security": "mtls",
   "secure_mode": true,
   "ca_cert": "/absolute/path/to/site/startup/rootCA.pem",
   "job_wait_timeout": null
@@ -205,10 +205,13 @@ differ from defaults:
 }
 ```
 
-`connection_security` must match the CP listener. Bare server-auth-only TLS is
-not supported. A secure transport requires `secure_mode=true`; a clear CP
-transport may still use `secure_mode=true`, which is the normal secure-job
-configuration.
+`connection_security` must match the CP listener. Prepared Docker, Kubernetes,
+and Slurm parents use `stcp` with mTLS by default. Bare server-auth-only TLS is
+not supported. A secure transport requires `secure_mode=true`. To opt out on a
+trusted, isolated network, set `parent.internal_connection_security: clear` for
+Docker/Kubernetes or `job_launcher.internal_connection_security: clear` for
+Slurm, then use `tcp` with `connection_security="clear"`; that clear transport
+may still use `secure_mode=true` for end-to-end Cell message protection.
 
 ### Shared-file profile
 

--- a/docs/programming_guide/execution_api_type/client_api_attach.rst
+++ b/docs/programming_guide/execution_api_type/client_api_attach.rst
@@ -237,8 +237,8 @@ the profile must match that listener.
      "execution_mode": "attach",
      "attach_id": "trainer_a",
      "site_name": "site-1",
-     "connect_url": "tcp://site-1.example.com:8004",
-     "connection_security": "clear",
+     "connect_url": "stcp://site-1.example.com:8004",
+     "connection_security": "mtls",
      "secure_mode": true,
      "ca_cert": "/absolute/path/to/site/startup/rootCA.pem",
      "job_wait_timeout": null
@@ -249,6 +249,12 @@ identity lets it start before the job and discover the dynamic CJ through
 authenticated ``SESSION_OPEN``. For a relayed site, include ``cp_fqcn``; include
 ``auth_identity`` when the provisioned certificate CN differs from
 ``site_name``. An optional ``cj_fqcn`` can pin the profile to one job.
+
+Prepared Docker, Kubernetes, and Slurm parents use ``stcp`` with mTLS by
+default. To opt out on a trusted, isolated network, set
+``parent.internal_connection_security: clear`` for Docker/Kubernetes or
+``job_launcher.internal_connection_security: clear`` for Slurm, then use
+``tcp`` with ``connection_security="clear"``.
 
 See the :github_nvflare_link:`Client API Attach example <examples/advanced/client-api-attach>`
 for complete shared-file, CP-routed network, and local POC instructions.

--- a/docs/user_guide/admin_guide/configurations/communication_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/communication_configuration.rst
@@ -292,8 +292,8 @@ certificate/key for Cell authentication and end-to-end message protection.
     "execution_mode": "attach",
     "attach_id": "trainer_a",
     "site_name": "site-1",
-    "connect_url": "tcp://site-1.example.com:8004",
-    "connection_security": "clear",
+    "connect_url": "stcp://site-1.example.com:8004",
+    "connection_security": "mtls",
     "secure_mode": true,
     "ca_cert": "/absolute/path/to/site/startup/rootCA.pem",
     "job_wait_timeout": null
@@ -304,6 +304,12 @@ certificate/key for Cell authentication and end-to-end message protection.
 trainer identity can start before the job and bind the dynamic CJ through
 authenticated ``SESSION_OPEN``; the trainer never receives the site's server
 bearer token.
+
+Prepared Docker, Kubernetes, and Slurm parents use ``stcp`` with mTLS by
+default. To opt out on a trusted, isolated network, set
+``parent.internal_connection_security: clear`` for Docker/Kubernetes or
+``job_launcher.internal_connection_security: clear`` for Slurm, then use
+``tcp`` with ``connection_security="clear"``.
 
 See :ref:`client_api_attach` for job and trainer configuration.
 

--- a/examples/advanced/client-api-attach/README.md
+++ b/examples/advanced/client-api-attach/README.md
@@ -38,18 +38,22 @@ Start from `attach_profile_network.json`:
   "execution_mode": "attach",
   "attach_id": "numpy_trainer",
   "site_name": "site-1",
-  "connect_url": "tcp://site-1.example.com:8004",
-  "connection_security": "clear",
+  "connect_url": "stcp://site-1.example.com:8004",
+  "connection_security": "mtls",
   "secure_mode": true,
   "ca_cert": "/absolute/path/to/site/startup/rootCA.pem",
   "job_wait_timeout": null
 }
 ```
 
-`connect_url` must be the provisioned CP internal listener, not a CJ URL. Keep
-`client.crt` and `client.key` beside `rootCA.pem`. `secure_mode=true` uses those
-site credentials for Cell authentication and end-to-end payload encryption even
-when the CP transport itself is `connection_security="clear"`.
+`connect_url` must be the provisioned CP internal listener, not a CJ URL. Prepared
+Docker, Kubernetes, and Slurm parents use `stcp` with mTLS by default. Keep
+`client.crt` and `client.key` beside `rootCA.pem`; they provide transport and Cell
+authentication, while `secure_mode=true` provides end-to-end payload encryption.
+To opt out on a trusted, isolated network, set
+`parent.internal_connection_security: clear` for Docker/Kubernetes or
+`job_launcher.internal_connection_security: clear` for Slurm, then use `tcp`
+with `connection_security="clear"`.
 
 The trainer identity is stable:
 

--- a/examples/advanced/client-api-attach/README.md
+++ b/examples/advanced/client-api-attach/README.md
@@ -167,6 +167,9 @@ python trainer.py --config attach_profile_shared_file.json
 For network Attach, replace the placeholders in
 `attach_profile_network.json` with the CP route and trainer credential paths,
 then run the same command with that profile.
+For this local process-mode POC, use the CP's advertised `tcp://` URL and set
+`connection_security` to `"clear"`. Keep `secure_mode` enabled so the
+provisioned credentials continue to authenticate and protect Cell messages.
 
 Successful output ends with `Status: FINISHED:COMPLETED`. For this three-round
 example, the final model is:

--- a/examples/advanced/client-api-attach/attach_profile_network.json
+++ b/examples/advanced/client-api-attach/attach_profile_network.json
@@ -3,8 +3,8 @@
   "execution_mode": "attach",
   "attach_id": "numpy_trainer",
   "site_name": "site-1",
-  "connect_url": "tcp://site-1.example.com:8004",
-  "connection_security": "clear",
+  "connect_url": "stcp://site-1.example.com:8004",
+  "connection_security": "mtls",
   "secure_mode": true,
   "ca_cert": "/absolute/path/to/site/startup/rootCA.pem",
   "job_wait_timeout": null

--- a/tests/integration_test/fast/client_api_attach_e2e_test.py
+++ b/tests/integration_test/fast/client_api_attach_e2e_test.py
@@ -425,7 +425,8 @@ def test_external_trainer_attaches_and_completes_numpy_task(tmp_path, monkeypatc
 
 
 @pytest.mark.timeout(60)
-def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeypatch):
+@pytest.mark.parametrize("parent_connection_security", ["clear", "mtls"])
+def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeypatch, parent_connection_security):
     flare_decomposers.register()
     common_decomposers.register()
     suffix = uuid.uuid4().hex[:8]
@@ -461,7 +462,7 @@ def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeyp
                 "scheme": "tcp",
                 "resources": {
                     "host": "127.0.0.1",
-                    DriverParams.CONNECTION_SECURITY.value: "clear",
+                    DriverParams.CONNECTION_SECURITY.value: parent_connection_security,
                 },
             }
         },
@@ -482,12 +483,15 @@ def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeyp
             site_name,
             server_url,
             secure=False,
-            credentials={},
+            credentials=site_credentials if parent_connection_security == "mtls" else {},
             create_internal_listener=True,
+            auth_identity_map={site_name: site_name} if parent_connection_security == "mtls" else None,
         )
         site.start()
         cells.append(site)
         site_listener = _wait_for_listener(site)
+        expected_scheme = "stcp" if parent_connection_security == "mtls" else "tcp"
+        assert site_listener.startswith(f"{expected_scheme}://")
         site.register_request_cb(
             channel="secure_attach_e2e",
             topic="result",
@@ -500,7 +504,7 @@ def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeyp
             secure=True,
             credentials=site_credentials,
             parent_url=site_listener,
-            parent_resources={DriverParams.CONNECTION_SECURITY.value: "clear"},
+            parent_resources={DriverParams.CONNECTION_SECURITY.value: parent_connection_security},
             create_internal_listener=False,
             auth_identity_map={site_name: site_name},
         )
@@ -535,8 +539,8 @@ def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeyp
 
             return _record
 
-        # Record at the clear CP hop, after the sender encrypted the stream and
-        # before CP forwards it, so both directions prove wire protection.
+        # Record at the CP hop, after the sender encrypted the stream and before
+        # CP forwards it, so both directions prove end-to-end protection.
         site.core_cell.add_incoming_filter(
             channel=STREAM_CHANNEL,
             topic=STREAM_DATA_TOPIC,
@@ -552,7 +556,7 @@ def test_secure_network_attach_uses_site_cell_identity_over_cp(tmp_path, monkeyp
                     "attach_id": attach_id,
                     "site_name": site_name,
                     "connect_url": site_listener,
-                    "connection_security": "clear",
+                    "connection_security": parent_connection_security,
                     "secure_mode": True,
                     "ca_cert": site_credentials[DriverParams.CA_CERT.value],
                     "job_wait_timeout": 20.0,


### PR DESCRIPTION
## Summary

- align the shipped Network Attach profile with the default internal mTLS listener used by prepared Docker, Kubernetes, and Slurm runtimes
- document the existing clear-transport opt-outs and their matching `tcp`/`clear` trainer profile
- extend the existing real-Cell test to cover both matching clear and mTLS configurations

## Root cause

Prepared runtime parents now use `stcp` with mTLS by default, while the shipped Network Attach profile still selected `tcp` with clear transport. Network Attach already supports the matching mTLS path with the provisioned credentials located beside `ca_cert`, so no runtime protocol change is needed.

## Impact

The normal example now works with prepared-runtime defaults. Deployments that intentionally use clear transport can continue to set `parent.internal_connection_security: clear` for Docker/Kubernetes or `job_launcher.internal_connection_security: clear` for Slurm and keep a matching `tcp`/`clear` trainer profile.

## Validation

- `python -m pytest -q tests/integration_test/fast/client_api_attach_e2e_test.py::test_secure_network_attach_uses_site_cell_identity_over_cp` — 2 passed
- `./runtest.sh -s --skip-install`
- `git diff --check`

The focused real-Cell test uses locally generated credentials; no live Docker, Kubernetes, or Slurm deployment was mutated.