### PR TITLE
[Auto-FL] Harden candidate accounting

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -170,9 +170,9 @@ If the user provides an `N`-candidate budget, pass it only through `--max-candid
 (keep/discard/crash) after baseline. Every candidate training, parameter update, or metric-based screen/rank must use
 the runner and counts, even when called a smoke, dry, replica, screen, or sweep. Only non-training parse, import,
 compile, schema, and interface checks are free; baseline and runner-classified infrastructure retries do not count.
-After a real crash, change the source or run arguments; repeat the identical execution only after specific user
-approval with `--confirm-user-approved-crash-repeat`. Increase a finite cap or make it uncapped only after user
-approval with `--confirm-user-approved-cap-change`. State reports the cap, remaining attempts, baseline, improvement,
+Every real crash and identical replay counts as a separate candidate attempt; prefer changing source or run arguments
+unless the replay is intentional. Increase a finite cap or make it uncapped only after user approval with
+`--confirm-user-approved-cap-change`. State reports the cap, remaining attempts, baseline, improvement,
 abandoned candidates, and accounting instruction; approved cap changes stay in campaign metadata.
 
 Treat plateau as a decision checkpoint, not an automatic stop: summarize it in the running report, refresh

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -166,14 +166,14 @@ whether to continue; continue unless the user explicitly interrupts or the code-
 not invent a replacement campaign or new objective after a recoverable failure; keep the campaign identity and
 artifacts coherent unless the human explicitly requests a new campaign.
 
-If the user provides an `N`-candidate budget, pass it only through the runner's explicit `--max-candidates` argument;
-the cap counts comparable evaluated candidate attempts (keep/discard/crash) after and excluding the baseline. Never
-infer a cap from an inherited environment variable. Do not count import, validation, smoke runs, plotting, reporting,
-baseline, or infrastructure-only retries; count a real candidate crash after execution starts. Runner state must
-report `candidate_cap_source=explicit` or `uncapped`, plus `remaining_candidates`, `baseline_status`,
-`baseline_score`, `improvement`, and `abandoned_candidates`; cap changes append to `cap_changes` in campaign metadata.
-A persisted cap change refreshes `campaign_state.json` before action gating, so raising `--max-candidates` reopens a
-cap-exhausted campaign.
+If the user provides an `N`-candidate budget, pass it only through `--max-candidates`; it counts evaluated candidates
+(keep/discard/crash) after baseline. Every candidate training, parameter update, or metric-based screen/rank must use
+the runner and counts, even when called a smoke, dry, replica, screen, or sweep. Only non-training parse, import,
+compile, schema, and interface checks are free; baseline and runner-classified infrastructure retries do not count.
+After a real crash, change the source or run arguments; repeat the identical execution only after specific user
+approval with `--confirm-user-approved-crash-repeat`. Increase a finite cap or make it uncapped only after user
+approval with `--confirm-user-approved-cap-change`. State reports the cap, remaining attempts, baseline, improvement,
+abandoned candidates, and accounting instruction; approved cap changes stay in campaign metadata.
 
 Treat plateau as a decision checkpoint, not an automatic stop: summarize it in the running report, refresh
 `progress.png`, run the runner's `status` action to refresh `.nvflare/autofl/campaign_state.json`, choose the returned

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -118,10 +118,9 @@ FedAvg/FedAvgM/FedAdam/FedOpt/SCAFFOLD choices.
 - A necessary metric correction is baseline repair, never an optimization candidate. Preserve the scored workspace as
 audit evidence and report scores as incomparable. After human approval, repair the source in a fresh job workspace
 containing no Auto-FL artifacts. Never run `initialize` in the scored workspace; it resumes old evidence.
-- If the environment provides `PYTHON`, `VIRTUAL_ENV`, or a venv on `PATH`,
-treat that prepared runtime as authoritative: verify it, then use it for import, validation, execution, metric
-extraction, plotting, and reporting. Do not search for alternate interpreters or install dependencies unless the user
-explicitly asks you to prepare the environment.
+- If the environment provides `PYTHON`, `VIRTUAL_ENV`, or a venv on `PATH`, treat that prepared runtime as authoritative:
+verify it, then use it for import, validation, execution, metric extraction, plotting, and reporting. Do not search for
+alternate interpreters or install dependencies unless the user explicitly asks you to prepare the environment.
 - Treat generated `autofl.yaml`, task-local `mutation_schema.yaml`, and
 existing NVFLARE job/runtime configuration as authoritative; the default simulation flow needs no prose profiles,
 branch setup, or harness initialization before invoking the runner.
@@ -166,14 +165,15 @@ whether to continue; continue unless the user explicitly interrupts or the code-
 not invent a replacement campaign or new objective after a recoverable failure; keep the campaign identity and
 artifacts coherent unless the human explicitly requests a new campaign.
 
-If the user provides an `N`-candidate budget, pass it only through `--max-candidates`; it counts evaluated candidates
-(keep/discard/crash) after baseline. Every candidate training, parameter update, or metric-based screen/rank must use
-the runner and counts, even when called a smoke, dry, replica, screen, or sweep. Only non-training parse, import,
-compile, schema, and interface checks are free; baseline and runner-classified infrastructure retries do not count.
-Every real crash and identical replay counts as a separate candidate attempt; prefer changing source or run arguments
-unless the replay is intentional. Increase a finite cap or make it uncapped only after user approval with
-`--confirm-user-approved-cap-change`. State reports the cap, remaining attempts, baseline, improvement,
-abandoned candidates, and accounting instruction; approved cap changes stay in campaign metadata.
+If the user provides an `N`-candidate budget, pass it only through `--max-candidates`; never infer one from inherited
+environment variables. It counts keep/discard/crash after baseline. Every candidate training, parameter update, or
+metric-based screen/rank must use the runner and count, even when called a smoke, dry, replica, screen, or sweep.
+Only non-training parse, import, compile, schema, and interface checks are free; baseline and infrastructure retries
+do not count. Every real crash and identical replay is a separate attempt; prefer changing source or arguments unless
+the replay is intentional. Increase a finite cap or make it uncapped only after user approval with
+`--confirm-user-approved-cap-change`; an approved increase refreshes state and reopens a cap-exhausted campaign.
+State reports the cap, remaining attempts, baseline, improvement, abandoned candidates, and accounting instruction;
+approved cap changes stay in campaign metadata.
 
 Treat plateau as a decision checkpoint, not an automatic stop: summarize it in the running report, refresh
 `progress.png`, run the runner's `status` action to refresh `.nvflare/autofl/campaign_state.json`, choose the returned

--- a/skills/nvflare-autofl/evals/evals.json
+++ b/skills/nvflare-autofl/evals/evals.json
@@ -96,6 +96,7 @@
       "assertions": [
         "The selected skill is nvflare-autofl even though the prompt never mentions Auto-FL, campaigns, or candidates.",
         "The agent runs all optimization through run_job_campaign.py rather than optimizing the project directly.",
+        "The agent treats candidate training and metric-based screening as counted attempts even if described as smoke, dry, replica, screen, or sweep runs.",
         "The agent limits the campaign to two evaluated candidates beyond the baseline, matching the requested number of approaches.",
         "The agent keeps the data and evaluation setup unchanged while exploring candidates.",
         "The agent reports the evaluated candidates and the best reproducible result when the campaign finishes."
@@ -116,6 +117,10 @@
             "description": "performs every optimization step through run_job_campaign.py"
           },
           {
+            "id": "training-equivalent-accounting",
+            "description": "counts every candidate training, parameter update, and metric-based screening or ranking execution regardless of its label"
+          },
+          {
             "id": "candidate-cap-respected",
             "description": "initializes the campaign with --max-candidates 2 and stops when the candidate cap is exhausted"
           }
@@ -124,6 +129,10 @@
           {
             "id": "no-direct-project-optimization",
             "description": "does not optimize or edit the user's project outside a prepared candidate"
+          },
+          {
+            "id": "no-off-runner-screening",
+            "description": "does not run smoke, dry, replica, sweep, screening, or manual candidate training outside the campaign runner"
           },
           {
             "id": "no-data-or-evaluation-changes",

--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -24,7 +24,9 @@ between invocations appends `{changed_at, old, new, source, user_approved}` to
 `cap_changes` in `.nvflare/autofl/campaign.json` so budget changes stay
 auditable. Increasing a finite cap or making it uncapped requires specific user
 approval plus `--confirm-user-approved-cap-change`; initial caps and reductions
-do not. External
+do not. Retry of the same already-applied approved cap command is idempotent.
+Never infer an initial cap from inherited environment variables. An approved
+increase refreshes campaign state and reopens a cap-exhausted campaign. External
 judges should treat `cap_changes` as evidence for runner-mediated cap changes
 only: `campaign.json` carries no integrity hash, so direct metadata edits are
 not detectable.

--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -33,10 +33,10 @@ Every candidate training, parameter update, or metric-based screening or
 ranking execution must use the campaign runner and counts toward the cap,
 regardless of whether it is called a smoke test, dry run, replica, screen, or
 sweep. Only static parse, import, compile, schema, and interface validation is
-free. After a real crash, change the candidate source or run arguments; repeat
-the identical execution only after the user specifically approves that replay
-and pass `--confirm-user-approved-crash-repeat` so the approval is recorded in
-the candidate manifest.
+free. Every real crash and identical replay is a separate counted candidate
+attempt. Prefer changing candidate source or run arguments after a crash unless
+an identical replay is intentional; the manifest records matching crash
+provenance for auditability.
 
 Only one lifecycle action may own a job workspace at a time. A concurrent
 command exits with code 2 and an in-use message; wait for the active action to

--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -20,11 +20,23 @@ exists, `baseline_score` and `improvement` (best minus baseline; campaigns
 always maximize the metric, so positive always means better) report
 baseline-versus-best progress, and `abandoned_candidates` counts abandoned candidate manifests,
 which never count as candidate attempts. Changing the effective candidate cap
-between invocations appends `{changed_at, old, new, source}` to `cap_changes`
-in `.nvflare/autofl/campaign.json` so budget changes stay auditable. External
+between invocations appends `{changed_at, old, new, source, user_approved}` to
+`cap_changes` in `.nvflare/autofl/campaign.json` so budget changes stay
+auditable. Increasing a finite cap or making it uncapped requires specific user
+approval plus `--confirm-user-approved-cap-change`; initial caps and reductions
+do not. External
 judges should treat `cap_changes` as evidence for runner-mediated cap changes
 only: `campaign.json` carries no integrity hash, so direct metadata edits are
 not detectable.
+
+Every candidate training, parameter update, or metric-based screening or
+ranking execution must use the campaign runner and counts toward the cap,
+regardless of whether it is called a smoke test, dry run, replica, screen, or
+sweep. Only static parse, import, compile, schema, and interface validation is
+free. After a real crash, change the candidate source or run arguments; repeat
+the identical execution only after the user specifically approves that replay
+and pass `--confirm-user-approved-crash-repeat` so the approval is recorded in
+the candidate manifest.
 
 Only one lifecycle action may own a job workspace at a time. A concurrent
 command exits with code 2 and an in-use message; wait for the active action to

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -111,8 +111,7 @@ INFRASTRUCTURE_RETRY = "infrastructure_retry"
 SIMULATION_APPROVAL_ACTION = "await_simulation_runner_approval"
 ACCOUNTING_INSTRUCTION = (
     "Run every candidate training, parameter update, or metric-based screening through this runner. "
-    "Real candidate crashes count; repeating an identical crash or expanding the candidate cap requires explicit "
-    "user approval."
+    "Real candidate crashes and crash replays count; expanding the candidate cap requires explicit user approval."
 )
 SIMULATOR_STALL_EXIT_CODE = 125
 SIMULATOR_STALL_PATTERNS = (
@@ -364,11 +363,6 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--failure-reason", default="", help="external execution failure")
     parser.add_argument("--baseline", action="store_true", help="record an externally executed baseline")
     parser.add_argument("--literature", action="store_true", help="record a literature-review checkpoint")
-    parser.add_argument(
-        "--confirm-user-approved-crash-repeat",
-        action="store_true",
-        help="confirm that the user explicitly approved repeating this exact candidate after its prior crash",
-    )
     parser.add_argument(
         "--confirm-user-approved-cap-change",
         action="store_true",
@@ -3680,18 +3674,6 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
     patch_sha256 = sha256_bytes(patch.encode("utf-8"))
     execution_fingerprint = candidate_execution_fingerprint(manifest, patch_sha256)
     prior_crash = matching_crashed_candidate(workspace, execution_fingerprint, manifest_path)
-    if prior_crash and not args.confirm_user_approved_crash_repeat:
-        prior_path, prior_manifest = prior_crash
-        raise ValueError(
-            f"candidate execution fingerprint {execution_fingerprint} already crashed as "
-            f"{prior_manifest.get('candidate_id')!r} ({prior_path}); change the candidate or obtain explicit user "
-            "approval and retry with --confirm-user-approved-crash-repeat"
-        )
-    if args.confirm_user_approved_crash_repeat and not prior_crash:
-        raise ValueError(
-            "--confirm-user-approved-crash-repeat is only valid when this exact execution fingerprint previously "
-            "crashed"
-        )
     manifest.update(
         {
             "updated_at": utc_now(),
@@ -3704,8 +3686,8 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
     )
     if prior_crash:
         prior_path, prior_manifest = prior_crash
-        manifest["crash_repeat_approval"] = {
-            "confirmed_at": utc_now(),
+        manifest["crash_replay"] = {
+            "detected_at": utc_now(),
             "execution_fingerprint": execution_fingerprint,
             "prior_candidate": prior_manifest.get("candidate_id"),
             "prior_manifest": str(prior_path.resolve()),
@@ -4103,8 +4085,6 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--exploration-batch-size must be non-negative")
     if args.family_repeat_limit < 0:
         raise ValueError("--family-repeat-limit must be non-negative")
-    if args.confirm_user_approved_crash_repeat and args.action != "evaluate":
-        raise ValueError("--confirm-user-approved-crash-repeat is only valid for evaluate")
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -109,6 +109,11 @@ RESERVED_CANDIDATE_PATH_PARTS = {
 
 INFRASTRUCTURE_RETRY = "infrastructure_retry"
 SIMULATION_APPROVAL_ACTION = "await_simulation_runner_approval"
+ACCOUNTING_INSTRUCTION = (
+    "Run every candidate training, parameter update, or metric-based screening through this runner. "
+    "Real candidate crashes count; repeating an identical crash or expanding the candidate cap requires explicit "
+    "user approval."
+)
 SIMULATOR_STALL_EXIT_CODE = 125
 SIMULATOR_STALL_PATTERNS = (
     "Failed to create connection to the child process in SimulatorClientRunner",
@@ -359,6 +364,16 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--failure-reason", default="", help="external execution failure")
     parser.add_argument("--baseline", action="store_true", help="record an externally executed baseline")
     parser.add_argument("--literature", action="store_true", help="record a literature-review checkpoint")
+    parser.add_argument(
+        "--confirm-user-approved-crash-repeat",
+        action="store_true",
+        help="confirm that the user explicitly approved repeating this exact candidate after its prior crash",
+    )
+    parser.add_argument(
+        "--confirm-user-approved-cap-change",
+        action="store_true",
+        help="confirm that the user explicitly approved increasing the candidate cap or making it uncapped",
+    )
     parser.add_argument("--limit", type=int, default=10, help="maximum fallback suggestions")
     args = parser.parse_args(argv)
     tokens = list(argv) if argv is not None else sys.argv[1:]
@@ -2636,6 +2651,7 @@ def write_state(
     )
     # Abandoned manifests are workspace-derived; the ledger-only guard cannot count them.
     state["abandoned_candidates"] = abandoned_candidate_count
+    state["accounting_instruction"] = ACCOUNTING_INSTRUCTION
     if records and records[-1].status == INFRASTRUCTURE_RETRY:
         attempts = len(
             [
@@ -2893,6 +2909,10 @@ def campaign_settings(args: argparse.Namespace) -> Dict[str, Any]:
     return {name: getattr(args, name) for name in CAMPAIGN_SETTING_NAMES}
 
 
+def cap_change_requires_approval(previous: Optional[int], requested: Optional[int]) -> bool:
+    return previous is not None and (requested is None or requested > previous)
+
+
 def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]) -> bool:
     """Restore persisted settings onto args; persist explicit mutable changes.
 
@@ -2922,6 +2942,7 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
         )
     explicit = getattr(args, "_explicit_settings", set())
     changed = False
+    cap_approval_used = False
     for name in CAMPAIGN_SETTING_NAMES:
         if name not in settings:
             continue
@@ -2930,13 +2951,27 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
             if name in MUTABLE_CAMPAIGN_SETTING_NAMES:
                 if settings.get(name) != requested:
                     if name == "max_candidates":
+                        previous = settings.get(name)
+                        approval_required = cap_change_requires_approval(previous, requested)
+                        if approval_required and not args.confirm_user_approved_cap_change:
+                            raise ValueError(
+                                "increasing the candidate cap or making a finite campaign uncapped requires "
+                                "explicit user approval and --confirm-user-approved-cap-change"
+                            )
+                        if args.confirm_user_approved_cap_change and not approval_required:
+                            raise ValueError(
+                                "--confirm-user-approved-cap-change is only valid for a candidate-cap increase "
+                                "or a finite-to-uncapped change"
+                            )
+                        cap_approval_used = approval_required
                         # Audit trail: mid-campaign budget changes must stay detectable by external judges.
                         metadata.setdefault("cap_changes", []).append(
                             {
                                 "changed_at": utc_now(),
-                                "old": settings.get(name),
+                                "old": previous,
                                 "new": requested,
                                 "source": "uncapped" if requested is None else "explicit",
+                                "user_approved": approval_required,
                             }
                         )
                     settings[name] = requested
@@ -2948,6 +2983,11 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
                     f"configured={settings[name]!r}, requested={requested!r}"
                 )
         setattr(args, name, settings[name])
+    if args.confirm_user_approved_cap_change and not cap_approval_used:
+        raise ValueError(
+            "--confirm-user-approved-cap-change requires an explicit candidate-cap increase or finite-to-uncapped "
+            "change"
+        )
     if changed:
         metadata["updated_at"] = utc_now()
         workspace_value = metadata.get("workspace_root")
@@ -3195,6 +3235,9 @@ def initialize_campaign(args: argparse.Namespace, job: Path) -> int:
             return 0 if baseline.score is not None else 1
         print_campaign_result(paths, records, read_json(paths["state"]), initialized=False)
         return 0
+
+    if args.confirm_user_approved_cap_change:
+        raise ValueError("--confirm-user-approved-cap-change is not valid for an initial campaign cap")
 
     paths = campaign_paths(args, job)
     paths["output_root"].mkdir(parents=True, exist_ok=True)
@@ -3444,6 +3487,40 @@ def validate_candidate_for_evaluation(
     return manifest, config, best_source, best_files, changed, created, patch
 
 
+def candidate_execution_fingerprint(manifest: Dict[str, Any], patch_sha256: str) -> str:
+    run_args = manifest.get("run_args")
+    if not isinstance(run_args, list) or not all(isinstance(item, str) for item in run_args):
+        raise ValueError("candidate manifest run_args must be a list of strings")
+    fields = {
+        "base_source_sha256": str(manifest.get("base_source_sha256") or ""),
+        "fixed_budget_sha256": str(manifest.get("fixed_budget_sha256") or ""),
+        "patch_sha256": patch_sha256,
+        "run_args": run_args,
+    }
+    if not all(fields[name] for name in ("base_source_sha256", "fixed_budget_sha256", "patch_sha256")):
+        raise ValueError("candidate manifest is missing execution fingerprint provenance")
+    return sha256_json(fields)
+
+
+def matching_crashed_candidate(
+    workspace: Path, fingerprint: str, current_manifest_path: Path
+) -> Optional[Tuple[Path, Dict[str, Any]]]:
+    root = workspace / CANDIDATE_ROOT
+    if not root.exists():
+        return None
+    for path in sorted(root.glob("*/candidate_manifest.json")):
+        if path.resolve() == current_manifest_path.resolve():
+            continue
+        manifest = read_json(path)
+        validate_candidate_manifest_identity(path, manifest)
+        if manifest.get("status") != "crash":
+            continue
+        patch_sha256 = str(manifest.get("patch_sha256") or "")
+        if patch_sha256 and candidate_execution_fingerprint(manifest, patch_sha256) == fingerprint:
+            return path, manifest
+    return None
+
+
 def update_config_for_kept_sources(config: Dict[str, Any], created: Sequence[str]) -> None:
     if not created:
         return
@@ -3600,15 +3677,39 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
     managed_paths = [path.relative_to(workspace).as_posix() for path in managed_versions]
     patch_path = manifest_path.parent / "candidate.patch"
     atomic_write_text(patch_path, patch)
+    patch_sha256 = sha256_bytes(patch.encode("utf-8"))
+    execution_fingerprint = candidate_execution_fingerprint(manifest, patch_sha256)
+    prior_crash = matching_crashed_candidate(workspace, execution_fingerprint, manifest_path)
+    if prior_crash and not args.confirm_user_approved_crash_repeat:
+        prior_path, prior_manifest = prior_crash
+        raise ValueError(
+            f"candidate execution fingerprint {execution_fingerprint} already crashed as "
+            f"{prior_manifest.get('candidate_id')!r} ({prior_path}); change the candidate or obtain explicit user "
+            "approval and retry with --confirm-user-approved-crash-repeat"
+        )
+    if args.confirm_user_approved_crash_repeat and not prior_crash:
+        raise ValueError(
+            "--confirm-user-approved-crash-repeat is only valid when this exact execution fingerprint previously "
+            "crashed"
+        )
     manifest.update(
         {
             "updated_at": utc_now(),
             "changed_files": changed,
             "created_files": created,
-            "patch_sha256": sha256_bytes(patch.encode("utf-8")),
+            "patch_sha256": patch_sha256,
             "candidate_source_sha256": source_hash(file_map(manifest_path.parent / "source")),
+            "execution_fingerprint": execution_fingerprint,
         }
     )
+    if prior_crash:
+        prior_path, prior_manifest = prior_crash
+        manifest["crash_repeat_approval"] = {
+            "confirmed_at": utc_now(),
+            "execution_fingerprint": execution_fingerprint,
+            "prior_candidate": prior_manifest.get("candidate_id"),
+            "prior_manifest": str(prior_path.resolve()),
+        }
     write_json(manifest_path, manifest)
     schema = load_mutation_schema(workspace)
     timeout, no_progress_timeout = campaign_timeout(args, schema)
@@ -4002,6 +4103,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--exploration-batch-size must be non-negative")
     if args.family_repeat_limit < 0:
         raise ValueError("--family-repeat-limit must be non-negative")
+    if args.confirm_user_approved_crash_repeat and args.action != "evaluate":
+        raise ValueError("--confirm-user-approved-crash-repeat is only valid for evaluate")
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -269,7 +269,7 @@ def env_float(name: str, default: float) -> float:
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     guard = load_campaign_guard()
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     parser.add_argument(
         "action",
         choices=["initialize", "prepare", "evaluate", "abandon", "suggest", "record", "status"],
@@ -2936,7 +2936,7 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
         )
     explicit = getattr(args, "_explicit_settings", set())
     changed = False
-    cap_approval_used = False
+    cap_confirmation_valid = False
     for name in CAMPAIGN_SETTING_NAMES:
         if name not in settings:
             continue
@@ -2957,7 +2957,7 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
                                 "--confirm-user-approved-cap-change is only valid for a candidate-cap increase "
                                 "or a finite-to-uncapped change"
                             )
-                        cap_approval_used = approval_required
+                        cap_confirmation_valid = approval_required
                         # Audit trail: mid-campaign budget changes must stay detectable by external judges.
                         metadata.setdefault("cap_changes", []).append(
                             {
@@ -2970,6 +2970,9 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
                         )
                     settings[name] = requested
                     changed = True
+                elif name == "max_candidates" and args.confirm_user_approved_cap_change:
+                    # Retrying an already-applied approved command is an idempotent success.
+                    cap_confirmation_valid = True
                 continue
             if requested != settings[name]:
                 raise ValueError(
@@ -2977,7 +2980,7 @@ def restore_campaign_settings(args: argparse.Namespace, metadata: Dict[str, Any]
                     f"configured={settings[name]!r}, requested={requested!r}"
                 )
         setattr(args, name, settings[name])
-    if args.confirm_user_approved_cap_change and not cap_approval_used:
+    if args.confirm_user_approved_cap_change and not cap_confirmation_valid:
         raise ValueError(
             "--confirm-user-approved-cap-change requires an explicit candidate-cap increase or finite-to-uncapped "
             "change"
@@ -3505,14 +3508,29 @@ def matching_crashed_candidate(
     for path in sorted(root.glob("*/candidate_manifest.json")):
         if path.resolve() == current_manifest_path.resolve():
             continue
-        manifest = read_json(path)
-        validate_candidate_manifest_identity(path, manifest)
-        if manifest.get("status") != "crash":
-            continue
-        patch_sha256 = str(manifest.get("patch_sha256") or "")
-        if patch_sha256 and candidate_execution_fingerprint(manifest, patch_sha256) == fingerprint:
-            return path, manifest
+        try:
+            manifest = read_json(path)
+            validate_candidate_manifest_identity(path, manifest)
+            if manifest.get("status") != "crash":
+                continue
+            patch_sha256 = str(manifest.get("patch_sha256") or "")
+            if patch_sha256 and candidate_execution_fingerprint(manifest, patch_sha256) == fingerprint:
+                return path, manifest
+        except (OSError, ValueError) as error:
+            print(f"Warning: ignoring invalid sibling candidate manifest {path}: {error}", file=sys.stderr)
     return None
+
+
+def crash_replay_provenance(workspace: Path, fingerprint: str, current_manifest_path: Path) -> Optional[Dict[str, Any]]:
+    prior_crash = matching_crashed_candidate(workspace, fingerprint, current_manifest_path)
+    if prior_crash is None:
+        return None
+    prior_path, prior_manifest = prior_crash
+    return {
+        "execution_fingerprint": fingerprint,
+        "prior_candidate": prior_manifest.get("candidate_id"),
+        "prior_manifest": str(prior_path.resolve()),
+    }
 
 
 def update_config_for_kept_sources(config: Dict[str, Any], created: Sequence[str]) -> None:
@@ -3552,6 +3570,7 @@ def finalize_candidate_result(
     created: List[str],
     patch: str,
     record: RunRecord,
+    crash_replay: Optional[Dict[str, Any]],
 ) -> Tuple[List[RunRecord], Dict[str, Any]]:
     rollback_files: Dict[Path, Optional[bytes]] = {}
     staged_snapshot = None
@@ -3624,6 +3643,13 @@ def finalize_candidate_result(
                 },
             }
         )
+        manifest.pop("crash_replay", None)
+        if crash_replay:
+            manifest["crash_replay"] = {
+                **crash_replay,
+                "recorded_at": utc_now(),
+                "outcome_status": record.status,
+            }
         write_json(manifest_path, manifest)
         write_json(campaign_metadata_path(job.parent), metadata)
         records.append(record)
@@ -3673,7 +3699,8 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
     atomic_write_text(patch_path, patch)
     patch_sha256 = sha256_bytes(patch.encode("utf-8"))
     execution_fingerprint = candidate_execution_fingerprint(manifest, patch_sha256)
-    prior_crash = matching_crashed_candidate(workspace, execution_fingerprint, manifest_path)
+    crash_replay = crash_replay_provenance(workspace, execution_fingerprint, manifest_path)
+    manifest.pop("crash_replay", None)
     manifest.update(
         {
             "updated_at": utc_now(),
@@ -3684,14 +3711,6 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
             "execution_fingerprint": execution_fingerprint,
         }
     )
-    if prior_crash:
-        prior_path, prior_manifest = prior_crash
-        manifest["crash_replay"] = {
-            "detected_at": utc_now(),
-            "execution_fingerprint": execution_fingerprint,
-            "prior_candidate": prior_manifest.get("candidate_id"),
-            "prior_manifest": str(prior_path.resolve()),
-        }
     write_json(manifest_path, manifest)
     schema = load_mutation_schema(workspace)
     timeout, no_progress_timeout = campaign_timeout(args, schema)
@@ -3825,6 +3844,7 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
         created,
         patch,
         run_record,
+        crash_replay,
     )
     print_campaign_result(paths, records, state, candidate_manifest=str(manifest_path.resolve()))
     return 0
@@ -4041,6 +4061,10 @@ def record_external_result(args: argparse.Namespace, job: Path) -> int:
         metric_source=evidence.source if evidence else "",
         metric_artifact=evidence.artifact if evidence else "",
     )
+    execution_fingerprint = str(manifest.get("execution_fingerprint") or "")
+    crash_replay = (
+        crash_replay_provenance(workspace, execution_fingerprint, manifest_path) if execution_fingerprint else None
+    )
     records, state = finalize_candidate_result(
         args,
         job,
@@ -4055,6 +4079,7 @@ def record_external_result(args: argparse.Namespace, job: Path) -> int:
         created,
         patch,
         record,
+        crash_replay,
     )
     updated_manifest = read_json(manifest_path)
     updated_manifest.setdefault("artifacts", {})["job_id"] = args.job_id

--- a/tests/unit_test/tool/agent_skill_checks/autofl_trigger_evals_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/autofl_trigger_evals_test.py
@@ -64,12 +64,23 @@ def test_autofl_natural_phrasing_eval_keeps_runner_and_cap_contract():
 
     assert "natural-phrasing-trigger" in mandatory_ids
     assert "campaign-runner-only" in mandatory_ids
+    assert "training-equivalent-accounting" in mandatory_ids
     assert "candidate-cap-respected" in mandatory_ids
     assert "no-direct-project-optimization" in prohibited_ids
+    assert "no-off-runner-screening" in prohibited_ids
 
     # Trigger evals ship no fixtures, so the eval text must not describe file editing.
     assert case["files"] == []
     assert not _eval_mentions_file_editing(case)
+
+
+def test_autofl_skill_defines_training_equivalent_accounting():
+    skill_text = AUTOFL_EVALS_PATH.parent.parent.joinpath("SKILL.md").read_text(encoding="utf-8")
+
+    assert "Every candidate training, parameter update, or metric-based screen/rank must use" in skill_text
+    assert "Only non-training parse, import," in skill_text
+    assert "--confirm-user-approved-crash-repeat" in skill_text
+    assert "--confirm-user-approved-cap-change" in skill_text
 
 
 def test_autofl_evals_keep_explicit_positive_and_negative_coverage():

--- a/tests/unit_test/tool/agent_skill_checks/autofl_trigger_evals_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/autofl_trigger_evals_test.py
@@ -79,7 +79,8 @@ def test_autofl_skill_defines_training_equivalent_accounting():
 
     assert "Every candidate training, parameter update, or metric-based screen/rank must use" in skill_text
     assert "Only non-training parse, import," in skill_text
-    assert "--confirm-user-approved-crash-repeat" in skill_text
+    assert "Every real crash and identical replay counts as a separate candidate attempt" in skill_text
+    assert "--confirm-user-approved-crash-repeat" not in skill_text
     assert "--confirm-user-approved-cap-change" in skill_text
 
 

--- a/tests/unit_test/tool/agent_skill_checks/autofl_trigger_evals_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/autofl_trigger_evals_test.py
@@ -76,10 +76,13 @@ def test_autofl_natural_phrasing_eval_keeps_runner_and_cap_contract():
 
 def test_autofl_skill_defines_training_equivalent_accounting():
     skill_text = AUTOFL_EVALS_PATH.parent.parent.joinpath("SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(skill_text.split())
 
-    assert "Every candidate training, parameter update, or metric-based screen/rank must use" in skill_text
-    assert "Only non-training parse, import," in skill_text
-    assert "Every real crash and identical replay counts as a separate candidate attempt" in skill_text
+    assert "Every candidate training, parameter update, or metric-based screen/rank must use" in normalized
+    assert "Only non-training parse, import," in normalized
+    assert "Every real crash and identical replay is a separate attempt" in normalized
+    assert "never infer one from inherited" in normalized
+    assert "reopens a cap-exhausted campaign" in normalized
     assert "--confirm-user-approved-crash-repeat" not in skill_text
     assert "--confirm-user-approved-cap-change" in skill_text
 

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -1969,6 +1969,118 @@ def test_baseline_crash_is_not_counted_as_candidate_attempt():
     )
 
 
+def test_candidate_execution_fingerprint_uses_existing_comparison_provenance():
+    runner = _load_runner()
+    manifest = {
+        "base_source_sha256": "a" * 64,
+        "fixed_budget_sha256": "b" * 64,
+        "run_args": ["--lr", "0.1"],
+    }
+    fingerprint = runner.candidate_execution_fingerprint(manifest, "c" * 64)
+
+    assert runner.candidate_execution_fingerprint(deepcopy(manifest), "c" * 64) == fingerprint
+    for field, value in (
+        ("base_source_sha256", "d" * 64),
+        ("fixed_budget_sha256", "e" * 64),
+        ("run_args", ["--lr", "0.2"]),
+    ):
+        changed = deepcopy(manifest)
+        changed[field] = value
+        assert runner.candidate_execution_fingerprint(changed, "c" * 64) != fingerprint
+    assert runner.candidate_execution_fingerprint(manifest, "f" * 64) != fingerprint
+
+
+def test_identical_crashed_candidate_requires_specific_user_approval(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
+    calls = []
+
+    def crash_run(run_def, **kwargs):
+        calls.append(run_def.name)
+        return runner.RunRecord(
+            "crash", run_def.name, None, 1.0, "none", run_def.description, "python job.py", "/tmp/crash"
+        )
+
+    monkeypatch.setattr(runner, "run_job", crash_run)
+    for candidate in ("first_crash", "same_after_crash"):
+        assert runner.main(["prepare", str(job), "--name", candidate, "--hypothesis", "same candidate"]) == 0
+        source = tmp_path / ".nvflare" / "autofl" / "candidates" / candidate / "source" / "client.py"
+        source.write_text("ALGORITHM = 'crashing_candidate'\n", encoding="utf-8")
+        if candidate == "first_crash":
+            assert runner.main(["evaluate", str(job)]) == 0
+
+    second_manifest_path = tmp_path / ".nvflare/autofl/candidates/same_after_crash/candidate_manifest.json"
+    assert runner.main(["evaluate", str(job), "--manifest", str(second_manifest_path)]) == 2
+    assert "already crashed" in capsys.readouterr().err
+    assert calls == ["first_crash"]
+    assert json.loads(second_manifest_path.read_text(encoding="utf-8"))["status"] == "prepared"
+
+    assert (
+        runner.main(
+            [
+                "evaluate",
+                str(job),
+                "--manifest",
+                str(second_manifest_path),
+                "--confirm-user-approved-crash-repeat",
+            ]
+        )
+        == 0
+    )
+    first_manifest = json.loads(
+        tmp_path.joinpath(".nvflare/autofl/candidates/first_crash/candidate_manifest.json").read_text(encoding="utf-8")
+    )
+    second_manifest = json.loads(second_manifest_path.read_text(encoding="utf-8"))
+    approval = second_manifest["crash_repeat_approval"]
+    assert second_manifest["execution_fingerprint"] == first_manifest["execution_fingerprint"]
+    assert approval["execution_fingerprint"] == first_manifest["execution_fingerprint"]
+    assert approval["prior_candidate"] == "first_crash"
+    assert approval["confirmed_at"]
+    assert calls == ["first_crash", "same_after_crash"]
+    records = runner.load_results(tmp_path / "results.tsv")
+    assert runner.candidate_attempts(records) == 2
+    state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
+    assert state["accounting_instruction"] == runner.ACCOUNTING_INSTRUCTION
+
+
+def test_changed_candidate_after_crash_does_not_require_approval(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
+
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            "crash", run_def.name, None, 1.0, "none", run_def.description, "python job.py", "/tmp/crash"
+        ),
+    )
+    assert runner.main(["prepare", str(job), "--name", "crash", "--hypothesis", "first candidate"]) == 0
+    tmp_path.joinpath(".nvflare/autofl/candidates/crash/source/client.py").write_text(
+        "ALGORITHM = 'first'\n", encoding="utf-8"
+    )
+    assert runner.main(["evaluate", str(job)]) == 0
+
+    assert runner.main(["prepare", str(job), "--name", "changed", "--hypothesis", "changed candidate"]) == 0
+    tmp_path.joinpath(".nvflare/autofl/candidates/changed/source/client.py").write_text(
+        "ALGORITHM = 'second'\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            "candidate", run_def.name, 0.9, 1.0, "none", run_def.description, "python job.py", "/tmp/success"
+        ),
+    )
+
+    assert runner.main(["evaluate", str(job)]) == 0
+    assert (
+        json.loads(
+            tmp_path.joinpath(".nvflare/autofl/candidates/changed/candidate_manifest.json").read_text(encoding="utf-8")
+        )["status"]
+        == "keep"
+    )
+
+
 def test_code_candidate_keeps_improvement_and_restores_discard_without_git(tmp_path, monkeypatch):
     runner = _load_runner()
     job, client, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
@@ -2811,7 +2923,7 @@ def test_explicit_mutable_campaign_settings_persist_and_uncapped_removes_cap(tmp
     assert metadata["settings"]["max_candidates"] == 7
     assert metadata["settings"]["timeout"] == 123
 
-    assert runner.main(["status", str(job), "--uncapped"]) == 0
+    assert runner.main(["status", str(job), "--uncapped", "--confirm-user-approved-cap-change"]) == 0
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     assert metadata["settings"]["max_candidates"] is None
 
@@ -2826,14 +2938,72 @@ def test_effective_cap_changes_append_audit_records_to_campaign_metadata(tmp_pat
 
     assert runner.main(["status", str(job), "--max-candidates", "7"]) == 0
     assert runner.main(["status", str(job), "--max-candidates", "7"]) == 0
-    assert runner.main(["status", str(job), "--uncapped"]) == 0
+    assert runner.main(["status", str(job), "--uncapped", "--confirm-user-approved-cap-change"]) == 0
 
     cap_changes = json.loads(metadata_path.read_text(encoding="utf-8"))["cap_changes"]
-    assert [(entry["old"], entry["new"], entry["source"]) for entry in cap_changes] == [
-        (None, 7, "explicit"),
-        (7, None, "uncapped"),
+    assert [(entry["old"], entry["new"], entry["source"], entry["user_approved"]) for entry in cap_changes] == [
+        (None, 7, "explicit", False),
+        (7, None, "uncapped", True),
     ]
     assert all(entry["changed_at"] for entry in cap_changes)
+
+
+def test_cap_expansion_requires_specific_user_approval_and_is_write_free_when_rejected(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+    metadata_path = tmp_path / ".nvflare/autofl/campaign.json"
+
+    assert runner.main(["status", str(job), "--max-candidates", "2"]) == 0
+    before = metadata_path.read_bytes()
+
+    assert runner.main(["status", str(job), "--max-candidates", "3"]) == 2
+    assert "requires explicit user approval" in capsys.readouterr().err
+    assert metadata_path.read_bytes() == before
+
+    assert runner.main(["status", str(job), "--uncapped"]) == 2
+    assert "requires explicit user approval" in capsys.readouterr().err
+    assert metadata_path.read_bytes() == before
+
+    assert (
+        runner.main(
+            [
+                "status",
+                str(job),
+                "--max-candidates",
+                "3",
+                "--confirm-user-approved-cap-change",
+            ]
+        )
+        == 0
+    )
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["settings"]["max_candidates"] == 3
+    assert [(entry["old"], entry["new"], entry["user_approved"]) for entry in metadata["cap_changes"]] == [
+        (None, 2, False),
+        (2, 3, True),
+    ]
+
+
+def test_cap_confirmation_is_rejected_when_no_expansion_requires_it(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch)
+
+    assert runner.main(["status", str(job), "--max-candidates", "3"]) == 0
+    assert (
+        runner.main(
+            [
+                "status",
+                str(job),
+                "--max-candidates",
+                "2",
+                "--confirm-user-approved-cap-change",
+            ]
+        )
+        == 2
+    )
+    assert "only valid for a candidate-cap increase" in capsys.readouterr().err
+    metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
+    assert metadata["settings"]["max_candidates"] == 3
 
 
 def test_raising_cap_reopens_exhausted_campaign_with_consistent_state(tmp_path, monkeypatch):
@@ -2853,7 +3023,17 @@ def test_raising_cap_reopens_exhausted_campaign_with_consistent_state(tmp_path, 
 
     assert (
         runner.main(
-            ["prepare", str(job), "--name", "reopened", "--hypothesis", "resume search", "--max-candidates", "2"]
+            [
+                "prepare",
+                str(job),
+                "--name",
+                "reopened",
+                "--hypothesis",
+                "resume search",
+                "--max-candidates",
+                "2",
+                "--confirm-user-approved-cap-change",
+            ]
         )
         == 0
     )

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -1990,19 +1990,22 @@ def test_candidate_execution_fingerprint_uses_existing_comparison_provenance():
     assert runner.candidate_execution_fingerprint(manifest, "f" * 64) != fingerprint
 
 
-def test_identical_crashed_candidate_replay_is_counted_without_approval(tmp_path, monkeypatch):
+def test_identical_crashed_candidate_replay_is_counted_and_records_outcome(tmp_path, monkeypatch):
     runner = _load_runner()
     job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
     assert runner.main(["status", str(job), "--max-candidates", "2"]) == 0
     calls = []
 
-    def crash_run(run_def, **kwargs):
+    outcomes = iter([("crash", None), ("candidate", 0.9)])
+
+    def replay_run(run_def, **kwargs):
         calls.append(run_def.name)
+        status, score = next(outcomes)
         return runner.RunRecord(
-            "crash", run_def.name, None, 1.0, "none", run_def.description, "python job.py", "/tmp/crash"
+            status, run_def.name, score, 1.0, "none", run_def.description, "python job.py", "/tmp/run"
         )
 
-    monkeypatch.setattr(runner, "run_job", crash_run)
+    monkeypatch.setattr(runner, "run_job", replay_run)
     for candidate in ("first_crash", "same_after_crash"):
         assert runner.main(["prepare", str(job), "--name", candidate, "--hypothesis", "same candidate"]) == 0
         source = tmp_path / ".nvflare" / "autofl" / "candidates" / candidate / "source" / "client.py"
@@ -2017,10 +2020,12 @@ def test_identical_crashed_candidate_replay_is_counted_without_approval(tmp_path
     )
     second_manifest = json.loads(second_manifest_path.read_text(encoding="utf-8"))
     replay = second_manifest["crash_replay"]
+    assert second_manifest["status"] == "keep"
     assert second_manifest["execution_fingerprint"] == first_manifest["execution_fingerprint"]
     assert replay["execution_fingerprint"] == first_manifest["execution_fingerprint"]
     assert replay["prior_candidate"] == "first_crash"
-    assert replay["detected_at"]
+    assert replay["outcome_status"] == "keep"
+    assert replay["recorded_at"]
     assert "crash_repeat_approval" not in second_manifest
     assert calls == ["first_crash", "same_after_crash"]
     records = runner.load_results(tmp_path / "results.tsv")
@@ -2031,6 +2036,100 @@ def test_identical_crashed_candidate_replay_is_counted_without_approval(tmp_path
     assert state["remaining_candidates"] == 0
     assert state["final_response_allowed"] is True
     assert state["reason"] == "candidate_cap_exhausted"
+
+
+def test_crash_replay_provenance_is_not_stamped_for_infrastructure_retry_or_changed_rerun(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
+    assert runner.main(["status", str(job), "--max-candidates", "2"]) == 0
+
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            "crash", run_def.name, None, 1.0, "none", run_def.description, "python job.py", "/tmp/crash"
+        ),
+    )
+    assert runner.main(["prepare", str(job), "--name", "first_crash", "--hypothesis", "same candidate"]) == 0
+    tmp_path.joinpath(".nvflare/autofl/candidates/first_crash/source/client.py").write_text(
+        "ALGORITHM = 'crashing_candidate'\n", encoding="utf-8"
+    )
+    assert runner.main(["evaluate", str(job)]) == 0
+
+    assert runner.main(["prepare", str(job), "--name", "retry", "--hypothesis", "same candidate"]) == 0
+    retry_manifest = tmp_path / ".nvflare/autofl/candidates/retry/candidate_manifest.json"
+    retry_source = retry_manifest.parent / "source/client.py"
+    retry_source.write_text("ALGORITHM = 'crashing_candidate'\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            runner.INFRASTRUCTURE_RETRY,
+            run_def.name,
+            None,
+            1.0,
+            "none",
+            run_def.description,
+            "python job.py",
+            "/tmp/infrastructure",
+            failure_reason="socket unavailable",
+        ),
+    )
+    assert runner.main(["evaluate", str(job), "--manifest", str(retry_manifest)]) == 75
+    manifest = json.loads(retry_manifest.read_text(encoding="utf-8"))
+    assert manifest["status"] == "prepared"
+    assert "crash_replay" not in manifest
+
+    retry_source.write_text("ALGORITHM = 'fixed_candidate'\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            "candidate", run_def.name, 0.9, 1.0, "none", run_def.description, "python job.py", "/tmp/success"
+        ),
+    )
+    assert runner.main(["evaluate", str(job), "--manifest", str(retry_manifest)]) == 0
+    manifest = json.loads(retry_manifest.read_text(encoding="utf-8"))
+    assert manifest["status"] == "keep"
+    assert "crash_replay" not in manifest
+    assert runner.candidate_attempts(runner.load_results(tmp_path / "results.tsv")) == 2
+
+
+def test_invalid_crashed_sibling_does_not_block_candidate_evaluation(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
+    assert runner.main(["prepare", str(job), "--name", "valid", "--hypothesis", "valid candidate"]) == 0
+    valid_manifest = tmp_path / ".nvflare/autofl/candidates/valid/candidate_manifest.json"
+    valid_manifest.parent.joinpath("source/client.py").write_text("ALGORITHM = 'valid'\n", encoding="utf-8")
+
+    broken_manifest = tmp_path / ".nvflare/autofl/candidates/broken_crash/candidate_manifest.json"
+    broken_manifest.parent.mkdir(parents=True)
+    broken_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": runner.CANDIDATE_MANIFEST_SCHEMA_VERSION,
+                "candidate_id": "broken_crash",
+                "workspace_root": str(tmp_path),
+                "status": "crash",
+                "patch_sha256": "a" * 64,
+                "run_args": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            "candidate", run_def.name, 0.9, 1.0, "none", run_def.description, "python job.py", "/tmp/success"
+        ),
+    )
+
+    assert runner.main(["evaluate", str(job), "--manifest", str(valid_manifest)]) == 0
+    warning = capsys.readouterr().err
+    assert "ignoring invalid sibling candidate manifest" in warning
+    assert str(broken_manifest) in warning
+    assert json.loads(valid_manifest.read_text(encoding="utf-8"))["status"] == "keep"
 
 
 def test_changed_candidate_after_crash_is_allowed(tmp_path, monkeypatch):
@@ -2929,6 +3028,9 @@ def test_effective_cap_changes_append_audit_records_to_campaign_metadata(tmp_pat
     assert runner.main(["status", str(job), "--max-candidates", "7"]) == 0
     assert runner.main(["status", str(job), "--max-candidates", "7"]) == 0
     assert runner.main(["status", str(job), "--uncapped", "--confirm-user-approved-cap-change"]) == 0
+    after_approval = metadata_path.read_bytes()
+    assert runner.main(["status", str(job), "--uncapped", "--confirm-user-approved-cap-change"]) == 0
+    assert metadata_path.read_bytes() == after_approval
 
     cap_changes = json.loads(metadata_path.read_text(encoding="utf-8"))["cap_changes"]
     assert [(entry["old"], entry["new"], entry["source"], entry["user_approved"]) for entry in cap_changes] == [
@@ -2972,6 +3074,30 @@ def test_cap_expansion_requires_specific_user_approval_and_is_write_free_when_re
         (None, 2, False),
         (2, 3, True),
     ]
+    after_approval = metadata_path.read_bytes()
+    assert (
+        runner.main(
+            [
+                "status",
+                str(job),
+                "--max-candidates",
+                "3",
+                "--confirm-user-approved-cap-change",
+            ]
+        )
+        == 0
+    )
+    assert metadata_path.read_bytes() == after_approval
+
+
+def test_runner_rejects_abbreviated_lifecycle_options(capsys):
+    runner = _load_runner()
+
+    with pytest.raises(SystemExit) as error:
+        runner.parse_args(["status", "job.py", "--max-cand", "5"])
+
+    assert error.value.code == 2
+    assert "unrecognized arguments: --max-cand 5" in capsys.readouterr().err
 
 
 def test_cap_confirmation_is_rejected_when_no_expansion_requires_it(tmp_path, monkeypatch, capsys):

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -1990,9 +1990,10 @@ def test_candidate_execution_fingerprint_uses_existing_comparison_provenance():
     assert runner.candidate_execution_fingerprint(manifest, "f" * 64) != fingerprint
 
 
-def test_identical_crashed_candidate_requires_specific_user_approval(tmp_path, monkeypatch, capsys):
+def test_identical_crashed_candidate_replay_is_counted_without_approval(tmp_path, monkeypatch):
     runner = _load_runner()
     job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
+    assert runner.main(["status", str(job), "--max-candidates", "2"]) == 0
     calls = []
 
     def crash_run(run_def, **kwargs):
@@ -2010,40 +2011,29 @@ def test_identical_crashed_candidate_requires_specific_user_approval(tmp_path, m
             assert runner.main(["evaluate", str(job)]) == 0
 
     second_manifest_path = tmp_path / ".nvflare/autofl/candidates/same_after_crash/candidate_manifest.json"
-    assert runner.main(["evaluate", str(job), "--manifest", str(second_manifest_path)]) == 2
-    assert "already crashed" in capsys.readouterr().err
-    assert calls == ["first_crash"]
-    assert json.loads(second_manifest_path.read_text(encoding="utf-8"))["status"] == "prepared"
-
-    assert (
-        runner.main(
-            [
-                "evaluate",
-                str(job),
-                "--manifest",
-                str(second_manifest_path),
-                "--confirm-user-approved-crash-repeat",
-            ]
-        )
-        == 0
-    )
+    assert runner.main(["evaluate", str(job), "--manifest", str(second_manifest_path)]) == 0
     first_manifest = json.loads(
         tmp_path.joinpath(".nvflare/autofl/candidates/first_crash/candidate_manifest.json").read_text(encoding="utf-8")
     )
     second_manifest = json.loads(second_manifest_path.read_text(encoding="utf-8"))
-    approval = second_manifest["crash_repeat_approval"]
+    replay = second_manifest["crash_replay"]
     assert second_manifest["execution_fingerprint"] == first_manifest["execution_fingerprint"]
-    assert approval["execution_fingerprint"] == first_manifest["execution_fingerprint"]
-    assert approval["prior_candidate"] == "first_crash"
-    assert approval["confirmed_at"]
+    assert replay["execution_fingerprint"] == first_manifest["execution_fingerprint"]
+    assert replay["prior_candidate"] == "first_crash"
+    assert replay["detected_at"]
+    assert "crash_repeat_approval" not in second_manifest
     assert calls == ["first_crash", "same_after_crash"]
     records = runner.load_results(tmp_path / "results.tsv")
     assert runner.candidate_attempts(records) == 2
     state = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign_state.json").read_text(encoding="utf-8"))
     assert state["accounting_instruction"] == runner.ACCOUNTING_INSTRUCTION
+    assert state["candidate_cap"] == 2
+    assert state["remaining_candidates"] == 0
+    assert state["final_response_allowed"] is True
+    assert state["reason"] == "candidate_cap_exhausted"
 
 
-def test_changed_candidate_after_crash_does_not_require_approval(tmp_path, monkeypatch):
+def test_changed_candidate_after_crash_is_allowed(tmp_path, monkeypatch):
     runner = _load_runner()
     job, _, _ = _initialize_fake_campaign(runner, tmp_path, monkeypatch, baseline_score=0.8)
 


### PR DESCRIPTION
## Summary

- define candidate training, parameter updates, and metric-based screening as runner-mediated counted work
- expose a concise accounting instruction in campaign state after every lifecycle action
- fingerprint candidate executions from retained source, fixed budget, patch, and ordered run arguments
- allow identical crashed candidates to run again while counting every replay as another candidate attempt and recording matching-crash provenance
- require explicit user confirmation before increasing a finite candidate cap or changing it to uncapped

## Motivation

QA found that agents could treat training-equivalent smoke or screening runs as free work, repeat a crashed candidate without consuming the intended budget, or expand a campaign cap without a clear user decision. This change tightens the skill contract and adds narrow runner checks using the existing ledger, manifests, campaign state, and cap-change audit trail.

An identical crash replay remains valid because a failure may be transient, but the replay is never free: it produces another ledger result and consumes another candidate slot. A modified patch, run argument set, retained base, or fixed budget naturally receives a different execution fingerprint.

This is cooperative agent-workflow enforcement, not an OS execution boundary. Arbitrary processes can still run training outside the runner; an execution broker or sandbox policy is intentionally out of scope.

## Review hardening

- make approved cap-change retries idempotent and keep their audit trail unchanged
- reject abbreviated lifecycle flags so approval checks cannot be bypassed by argparse prefix matching
- record crash-replay provenance only after a counted result is finalized, including its actual outcome
- ignore and name invalid sibling crash evidence during replay lookup without weakening authoritative campaign validation
- document that inherited environment variables never define a cap and that an approved increase reopens an exhausted campaign

## Validation

- Auto-FL runner tests: `163 passed, 2 skipped` with one PyTorch-dependent synthetic CLI fixture excluded in the lightweight validation environment
- framework-independent skill checks: `127 passed, 36 skipped`
- focused review regressions: `8 passed`
- repository style gate: Black, isort, and flake8 passed
- `git diff --check`

Fresh-agent Codex and Claude scenarios remain the final QA confirmation.
