### PR TITLE
Enable best-model selection for Swarm recipes

### DIFF
--- a/docs/programming_guide/controllers/client_controlled_workflows.rst
+++ b/docs/programming_guide/controllers/client_controlled_workflows.rst
@@ -552,14 +552,16 @@ Use ``SwarmLearningRecipe`` for a streamlined swarm learning setup:
 The named parameters are the preferred API. For less common
 ``SwarmServerConfig`` or ``SwarmClientConfig`` fields, pass
 ``server_config_overrides`` or ``client_config_overrides``. The dictionaries are
-shallow-merged last, so an overlapping dictionary value intentionally wins over
-the named parameter. ``round_timeout`` remains available as a compatibility
-shortcut for setting both acknowledgment timeouts when their explicit parameters
-are omitted. ``client_config_overrides`` cannot replace the recipe-managed
-executor, aggregator, persistor, shareable generator, or
-``min_responses_required``; use ``BaseSwarmLearningRecipe`` for custom components
-or quorum settings. Set ``min_clients`` only through the named parameter so the
-scheduler, server controller, and client aggregation quorums remain aligned.
+shallow-merged last, so an overlapping dictionary value for a non-recipe-managed
+field intentionally wins over the named parameter. ``round_timeout`` remains
+available as a compatibility shortcut for setting both acknowledgment timeouts
+when their explicit parameters are omitted. ``client_config_overrides`` cannot
+replace the recipe-managed executor, aggregator, persistor, shareable generator,
+model selector, or ``min_responses_required``. Use ``key_metric=None`` to disable
+selection; for a custom selector or other custom components, use
+``BaseSwarmLearningRecipe`` with an explicit ``SwarmClientConfig`` as shown below.
+Set ``min_clients`` only through the named parameter so the scheduler, server
+controller, and client aggregation quorums remain aligned.
 For large PyTorch models, use
 ``aggregation_format=ExchangeFormat.PYTORCH`` together with
 ``enable_tensor_disk_offload=True``. The first keeps CCWF payloads on the

--- a/docs/programming_guide/controllers/client_controlled_workflows.rst
+++ b/docs/programming_guide/controllers/client_controlled_workflows.rst
@@ -411,11 +411,17 @@ The swarm learning workflow is implemented with :class:`nvflare.app_common.ccwf.
 
 Best Model Selection
 ====================
-Optionally, a model selection widget can be used to determine the best global model, just as in the server-controlled
-fed-average workflow (SAG). The widget listens to the BEFORE and AFTER events of ``accept`` and ``aggregate`` calls of the
+``SwarmLearningRecipe`` configures a client-side model selection widget by default. Job API configurations can add one
+explicitly, as in the server-controlled fed-average workflow (SAG). The widget listens to the BEFORE and AFTER events of
+``accept`` and ``aggregate`` calls of the
 aggregator to dynamically compute the aggregated validation metrics reported from the training clients. When a better
 metric is achieved, it fires the ``AppEventType.GLOBAL_BEST_MODEL_AVAILABLE`` event with the best metric value. If the
 persistor listens to this event, it can persist the current global model (the current best).
+
+The metric must score the received global model before local training. For example,
+a patched Lightning client calls ``trainer.validate()`` before ``trainer.fit()``,
+and a manual Client API script sends that pre-training value in ``FLModel.metrics``.
+The metric dictionary key must match the recipe's ``key_metric``.
 
 However, unlike the server-controlled SAG where the aggregation is always done on the server and hence only a single
 global model is present at any time, many clients could do aggregation during the course of swarm learning. Each aggregation
@@ -522,6 +528,8 @@ Use ``SwarmLearningRecipe`` for a streamlined swarm learning setup:
         num_rounds=10,
         train_script="train.py",
         train_args={"batch_size": 32, "epochs": 5},
+        key_metric="accuracy",
+        key_metric_mode="max",
         progress_timeout=7200,
         learn_task_timeout=None,       # No per-task time limit
         learn_task_ack_timeout=3600,   # P2P task-transfer ACK budget
@@ -566,6 +574,7 @@ For advanced customization, use ``BaseSwarmLearningRecipe`` with explicit server
 
     from nvflare.app_common.ccwf.recipes.swarm import BaseSwarmLearningRecipe
     from nvflare.app_common.ccwf.ccwf_job import SwarmServerConfig, SwarmClientConfig
+    from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 
     server_config = SwarmServerConfig(
         num_rounds=10,
@@ -578,6 +587,7 @@ For advanced customization, use ``BaseSwarmLearningRecipe`` with explicit server
         aggregator=my_aggregator,
         persistor=my_persistor,
         shareable_generator=my_generator,
+        model_selector=IntimeModelSelector(key_metric="accuracy"),
     )
 
     recipe = BaseSwarmLearningRecipe(
@@ -701,7 +711,9 @@ For users who need fine-grained control, here is the equivalent JSON configurati
         {
           "id": "model_selector",
           "path": "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector",
-          "args": {}
+          "args": {
+            "key_metric": "accuracy"
+          }
         }
       ]
     }
@@ -1090,6 +1102,8 @@ Use ``SwarmLearningRecipe`` for swarm learning with optional cross-site evaluati
         min_clients=3,
         num_rounds=3,
         train_script="train.py",
+        key_metric="accuracy",
+        key_metric_mode="max",
         do_cross_site_eval=True,
         cross_site_eval_timeout=300,
         round_timeout=3600,   # P2P model-transfer ACK budget; increase for large models (7B+)
@@ -1223,7 +1237,9 @@ Cross Site Evaluation: config_fed_client.json
         {
           "id": "model_selector",
           "path": "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector",
-          "args": {}
+          "args": {
+            "key_metric": "accuracy"
+          }
         }
       ]
     }

--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -119,4 +119,5 @@ Compatibility and Migration Notes
   and ``key_metric_mode="min"`` for lower-is-better metrics. Clients must report
   a pre-training validation metric with the configured name for selection to
   occur; jobs without that metric continue to persist the last global model but
-  do not create ``best_FL_global_model.pt``.
+  do not create ``best_FL_global_model.pt``. Set ``key_metric=None`` to opt out
+  and preserve the pre-2.9 last-model-only behavior.

--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -114,3 +114,9 @@ Compatibility and Migration Notes
   missing client. The accepted envelope may already have exposed references to
   downstream consumers and cannot be safely withdrawn. An explicit job abort
   that wins the terminal-state race remains ``ABORTED``.
+- ``SwarmLearningRecipe`` now configures client-side best-model selection by
+  default. Use ``key_metric`` to select a dictionary-valued validation metric
+  and ``key_metric_mode="min"`` for lower-is-better metrics. Clients must report
+  a pre-training validation metric with the configured name for selection to
+  occur; jobs without that metric continue to persist the last global model but
+  do not create ``best_FL_global_model.pt``.

--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -120,4 +120,11 @@ Compatibility and Migration Notes
   a pre-training validation metric with the configured name for selection to
   occur; jobs without that metric continue to persist the last global model but
   do not create ``best_FL_global_model.pt``. Set ``key_metric=None`` to opt out
-  and preserve the pre-2.9 last-model-only behavior.
+  and preserve the pre-2.9 last-model-only behavior. Selection skips round 0,
+  so a one-round job does not create a best-model checkpoint. With
+  ``key_metric_mode="min"``, Swarm best-metric logs and records expose the
+  negated comparison value (for example, a loss of 2.31 is shown as -2.31).
+  ``client_config_overrides`` can no longer replace ``model_selector``: migrate
+  the former ``{"model_selector": None}`` opt-out to ``key_metric=None``, and
+  use ``BaseSwarmLearningRecipe`` with an explicit ``SwarmClientConfig`` for a
+  custom selector.

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -1040,6 +1040,8 @@ Decentralized federated learning without a central server.
         min_clients=3,
         num_rounds=5,
         train_script="client.py",
+        key_metric="accuracy",
+        key_metric_mode="max",
         initial_ckpt="path/to/pretrained.pt",  # Optional: pre-trained weights
         progress_timeout=7200,
         learn_task_timeout=None,  # No training-task time limit
@@ -1055,6 +1057,12 @@ Decentralized federated learning without a central server.
 For ``initial_ckpt``, a relative path is bundled and distributed to every client.
 An absolute path is not distributed; it must be readable at the same path on every
 client because the Swarm model persistor runs client-side.
+
+The recipe configures client-side best-model selection by default. Training clients
+must report a pre-training validation metric matching ``key_metric``; for dictionary
+metrics, the named entry is selected. Set ``key_metric_mode="min"`` for metrics such
+as loss. The best model is distributed at workflow completion and the default
+PyTorch persistor writes ``best_FL_global_model.pt`` at each result client.
 
 .. note::
    For large models (>2 GB), tune the following parameters:

--- a/docs/user_guide/data_scientist_guide/available_recipes.rst
+++ b/docs/user_guide/data_scientist_guide/available_recipes.rst
@@ -1061,8 +1061,14 @@ client because the Swarm model persistor runs client-side.
 The recipe configures client-side best-model selection by default. Training clients
 must report a pre-training validation metric matching ``key_metric``; for dictionary
 metrics, the named entry is selected. Set ``key_metric_mode="min"`` for metrics such
-as loss. The best model is distributed at workflow completion and the default
-PyTorch persistor writes ``best_FL_global_model.pt`` at each result client.
+as loss, or set ``key_metric=None`` to disable best-model selection. In ``"min"``
+mode, Swarm logs and best-metric records expose the negated comparison value. Model
+selection starts after round 0, so a one-round job does not create a best-model
+checkpoint. The best model is distributed at successful workflow completion and the
+default PyTorch persistor writes ``best_FL_global_model.pt`` at each result client.
+Rotating aggregation clients can write interim per-client best checkpoints during
+the run; those files are authoritative only after successful completion at result
+clients.
 
 .. note::
    For large models (>2 GB), tune the following parameters:
@@ -1088,12 +1094,14 @@ PyTorch persistor writes ``best_FL_global_model.pt`` at each result client.
 
 For advanced controller settings, ``server_config_overrides`` and
 ``client_config_overrides`` are shallow-merged into ``SwarmServerConfig`` and
-``SwarmClientConfig`` after the named parameters. Overlapping dictionary values
-therefore take precedence over the documented named API. Client overrides cannot
-replace the recipe-managed executor, aggregator, persistor, shareable generator, or
-``min_responses_required``; use ``BaseSwarmLearningRecipe`` for custom components or
-quorum settings. Server overrides cannot replace ``min_clients``; set it through the
-named parameter so all scheduler and workflow quorum settings remain aligned.
+``SwarmClientConfig`` after the named parameters. Overlapping dictionary values for
+non-recipe-managed fields therefore take precedence over the documented named API.
+Client overrides cannot replace the recipe-managed executor, aggregator, persistor,
+shareable generator, model selector, or ``min_responses_required``. Use
+``key_metric=None`` to disable selection; for a custom selector or other custom
+components, use ``BaseSwarmLearningRecipe`` with an explicit ``SwarmClientConfig``.
+Server overrides cannot replace ``min_clients``; set it through the named parameter
+so all scheduler and workflow quorum settings remain aligned.
 
 
 Edge Recipes

--- a/examples/advanced/swarm_learning/swarm_pt/README.md
+++ b/examples/advanced/swarm_learning/swarm_pt/README.md
@@ -84,7 +84,7 @@ input_model = flare.receive()         # 2. Receive global LoRA adapter from the 
 apply_global_adapter(model, input_model.params)  # 3. Apply global adapter weights
 
 metrics = {}
-if round_num > 0:
+if input_model.current_round != 0:
     val_loss = evaluate_loss(model, validation_dataloader, validation_steps)
     metrics = {"val_loss": val_loss}
 adapter_diff = local_train(model, train_dataloader, local_steps)  # local fine-tuning

--- a/examples/advanced/swarm_learning/swarm_pt/README.md
+++ b/examples/advanced/swarm_learning/swarm_pt/README.md
@@ -54,6 +54,11 @@ A CUDA-capable GPU is strongly recommended. The base model is loaded in `bfloat1
 
 This example uses the [wikitext-2-raw-v1](https://huggingface.co/datasets/wikitext) dataset (Apache-2.0, no license acceptance required). The training split is partitioned into disjoint shards — one per client — to simulate real-world data silos where each participant trains only on their own local data.
 
+When `--data_dir` is supplied, the directory must contain both each site's local
+training dataset at `<data_dir>/<site>/train` and a shared validation dataset at
+`<data_dir>/validation`. Custom corpora must provide the same layout; they do not
+need to be regenerated with this example's `prepare_data.py`.
+
 ## Model
 
 [Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B) (Apache-2.0, default) or [Qwen2.5-1.5B](https://huggingface.co/Qwen/Qwen2.5-1.5B) is used as the base model, selectable via `--model_size`. LoRA adapters are attached to the query and value projection layers of every attention block:
@@ -78,27 +83,31 @@ flare.init()                          # 1. Initialize NVFlare Client API
 input_model = flare.receive()         # 2. Receive global LoRA adapter from the workflow
 apply_global_adapter(model, input_model.params)  # 3. Apply global adapter weights
 
-val_loss = evaluate_loss(model, validation_dataloader, validation_steps)
-adapter_diff = local_train(model, dataloader, steps)  # local fine-tuning
+metrics = {}
+if round_num > 0:
+    val_loss = evaluate_loss(model, validation_dataloader, validation_steps)
+    metrics = {"val_loss": val_loss}
+adapter_diff = local_train(model, train_dataloader, local_steps)  # local fine-tuning
 
 flare.send(flare.FLModel(             # 4. Send LoRA adapter diff back
     params_type=ParamsType.DIFF,
     params=adapter_diff,
-    metrics={"val_loss": val_loss},
+    metrics=metrics,
 ))
 ```
 
-Each client first evaluates the received global adapter on the validation split, then fine-tunes for a fixed number of gradient steps and returns the adapter weight **diff** (after − before). The selected Swarm aggregation client averages both the pre-training `val_loss` values and the model diffs. Because the metric describes the received global model rather than a locally updated model, it can be used safely for global best-model selection.
+Starting in round 1, each client first evaluates the received global adapter on the validation split, then fine-tunes for a fixed number of gradient steps and returns the adapter weight **diff** (after − before). Round 0 skips validation because no aggregated global adapter exists yet. The selected Swarm aggregation client averages both the pre-training `val_loss` values and the model diffs. Because the metric describes the received global model rather than a locally updated model, it can be used safely for global best-model selection.
 
 ## Peer-to-Peer Workflow
 
 This example uses [Swarm Learning](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.ccwf.html), a decentralized federated workflow where clients act as both trainers and aggregators in a peer-to-peer fashion — there is no central aggregation server. The workflow proceeds as follows:
 
 1. A designated starting client scatters the global LoRA adapter to all peers.
-2. Each client trains locally and submits its adapter diff to a designated aggregator.
-3. The aggregator accumulates diffs and produces a new global adapter.
-4. The updated adapter is scattered to the next round of trainers.
-5. This repeats for `num_rounds` rounds.
+2. Starting in round 1, each client validates the received global adapter before training.
+3. Each client trains locally and submits its adapter diff to a designated aggregator.
+4. The aggregator accumulates diffs and produces a new global adapter.
+5. The updated adapter is scattered to the next round of trainers.
+6. This repeats for `num_rounds` rounds.
 
 ## Job Recipe Code
 
@@ -144,6 +153,10 @@ recipe = SwarmLearningRecipe(
 - `InTimeAccumulateWeightedAggregator` for peer-to-peer adapter aggregation
 - `SimpleModelShareableGenerator` for model ↔ shareable conversion
 - `IntimeModelSelector` for client-side best-model selection using pre-training `val_loss`
+
+Because `key_metric_mode="min"` converts loss into a higher-is-better comparison
+value, Swarm best-metric logs and records display the negated loss. For example,
+an actual `val_loss` of 2.31 is displayed as -2.31.
 
 ## Step-by-Step Instructions
 
@@ -257,11 +270,11 @@ This writes a standard NVFlare job folder that can be submitted to a production 
 
 #### Each Round
 - **Scatter**: Starting client sends global LoRA adapter to all trainers.
-- **Validate**: Each client scores the received global adapter on the shared validation split before training.
+- **Validate**: Starting in round 1, each client scores the received global adapter on the shared validation split before training.
 - **Local training**: Each client fine-tunes for `local_steps` gradient steps on its data shard, reporting loss every 5 steps.
-- **Submit**: Each client sends its pre-training `val_loss` and LoRA adapter diff to the designated aggregator.
+- **Submit**: Each client sends its LoRA adapter diff and, starting in round 1, its pre-training `val_loss` to the designated aggregator.
 - **Aggregate**: Aggregator accumulates metrics and diffs, produces the updated global adapter, and records a new best model when `val_loss` improves.
 
 #### Completion
-- Final and best-scoring global LoRA adapters are distributed and persisted to the simulation workspace.
+- Final and best-scoring global LoRA adapters are distributed and persisted to the simulation workspace. Best-model selection starts after round 0, so at least two rounds are required to create a best-model checkpoint.
 - Results available at `<workspace>/ccwf_swarm_pt_lora/`.

--- a/examples/advanced/swarm_learning/swarm_pt/README.md
+++ b/examples/advanced/swarm_learning/swarm_pt/README.md
@@ -39,7 +39,7 @@ cd examples/advanced/swarm_learning/swarm_pt
 swarm_pt/
 |
 |-- client.py           # client LoRA fine-tuning script (runs as subprocess)
-|-- model.py            # QwenLoRAModelWrapper — LoRA-adapted model for server persistor
+|-- model.py            # QwenLoRAModelWrapper — LoRA-adapted model for client persistors
 |-- job.py              # job recipe using SwarmLearningRecipe
 |-- download_data.py    # pre-download wikitext-2 dataset and Qwen2.5 model
 |-- prepare_data.py     # split dataset among N clients
@@ -63,7 +63,7 @@ LoraConfig(r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"],
            lora_dropout=0.05, bias="none", task_type="CAUSAL_LM")
 ```
 
-The `QwenLoRAModelWrapper` in `model.py` overrides `state_dict()` / `load_state_dict()` to expose only the LoRA adapter parameters (~2 MB for 0.5B, ~4 MB for 1.5B) to the server persistor and aggregator, instead of the full base model weights (~1 GB / ~3 GB). The base model weights are loaded in `bfloat16` to halve memory usage.
+The `QwenLoRAModelWrapper` in `model.py` overrides `state_dict()` / `load_state_dict()` to expose only the LoRA adapter parameters (~2 MB for 0.5B, ~4 MB for 1.5B) to the client-side persistors and aggregators, instead of the full base model weights (~1 GB / ~3 GB). The base model weights are loaded in `bfloat16` to halve memory usage.
 
 `load_state_dict()` also detects shape mismatches between a saved checkpoint and the current model size. If you switch `--model_size` between runs without clearing the workspace, the incompatible checkpoint is silently discarded and training restarts from a fresh adapter — no manual cleanup required.
 
@@ -75,20 +75,22 @@ The `QwenLoRAModelWrapper` in `model.py` overrides `state_dict()` / `load_state_
 import nvflare.client as flare
 
 flare.init()                          # 1. Initialize NVFlare Client API
-input_model = flare.receive()         # 2. Receive global LoRA adapter from server
+input_model = flare.receive()         # 2. Receive global LoRA adapter from the workflow
 apply_global_adapter(model, input_model.params)  # 3. Apply global adapter weights
 
+val_loss = evaluate_loss(model, validation_dataloader, validation_steps)
 adapter_diff = local_train(model, dataloader, steps)  # local fine-tuning
 
 flare.send(flare.FLModel(             # 4. Send LoRA adapter diff back
     params_type=ParamsType.DIFF,
     params=adapter_diff,
+    metrics={"val_loss": val_loss},
 ))
 ```
 
-Each client fine-tunes for a fixed number of gradient steps per round, then returns the adapter weight **diff** (after − before). The server aggregates these diffs across clients using weighted averaging.
+Each client first evaluates the received global adapter on the validation split, then fine-tunes for a fixed number of gradient steps and returns the adapter weight **diff** (after − before). The selected Swarm aggregation client averages both the pre-training `val_loss` values and the model diffs. Because the metric describes the received global model rather than a locally updated model, it can be used safely for global best-model selection.
 
-## Server-Side Workflow
+## Peer-to-Peer Workflow
 
 This example uses [Swarm Learning](https://nvflare.readthedocs.io/en/main/apidocs/nvflare.app_common.ccwf.html), a decentralized federated workflow where clients act as both trainers and aggregators in a peer-to-peer fashion — there is no central aggregation server. The workflow proceeds as follows:
 
@@ -111,6 +113,8 @@ recipe = SwarmLearningRecipe(
     num_rounds=args.num_rounds,
     train_script="client.py",
     min_clients=2,
+    key_metric="val_loss",
+    key_metric_mode="min",
     launch_external_process=True,       # run client.py as a subprocess
     cuda_empty_cache=True,              # free GPU cache between rounds
     train_args={"script_args": script_args},
@@ -139,6 +143,7 @@ recipe = SwarmLearningRecipe(
 - `PTFileModelPersistor` for checkpoint management (stores only LoRA adapter weights)
 - `InTimeAccumulateWeightedAggregator` for peer-to-peer adapter aggregation
 - `SimpleModelShareableGenerator` for model ↔ shareable conversion
+- `IntimeModelSelector` for client-side best-model selection using pre-training `val_loss`
 
 ## Step-by-Step Instructions
 
@@ -237,6 +242,7 @@ This writes a standard NVFlare job folder that can be submitted to a production 
 | `--num_rounds` | 3 | Number of swarm learning rounds |
 | `--model_size` | `0.5B` | Base model size: `0.5B` or `1.5B` |
 | `--local_steps` | 10 | Gradient steps per client per round |
+| `--validation_steps` | 10 | Validation batches used to score the received global model each round |
 | `--batch_size` | 4 | Training batch size per client |
 | `--max_seq_len` | 128 | Maximum tokenized sequence length |
 | `--data_dir` | *(empty)* | Pre-split data root from `prepare_data.py`; in-memory if omitted |
@@ -251,10 +257,11 @@ This writes a standard NVFlare job folder that can be submitted to a production 
 
 #### Each Round
 - **Scatter**: Starting client sends global LoRA adapter to all trainers.
+- **Validate**: Each client scores the received global adapter on the shared validation split before training.
 - **Local training**: Each client fine-tunes for `local_steps` gradient steps on its data shard, reporting loss every 5 steps.
-- **Submit**: Each client sends its LoRA adapter diff to the designated aggregator.
-- **Aggregate**: Aggregator accumulates diffs, produces updated global adapter.
+- **Submit**: Each client sends its pre-training `val_loss` and LoRA adapter diff to the designated aggregator.
+- **Aggregate**: Aggregator accumulates metrics and diffs, produces the updated global adapter, and records a new best model when `val_loss` improves.
 
 #### Completion
-- Final global LoRA adapter persisted to the simulation workspace.
+- Final and best-scoring global LoRA adapters are distributed and persisted to the simulation workspace.
 - Results available at `<workspace>/ccwf_swarm_pt_lora/`.

--- a/examples/advanced/swarm_learning/swarm_pt/client.py
+++ b/examples/advanced/swarm_learning/swarm_pt/client.py
@@ -51,6 +51,16 @@ DEFAULT_LOCAL_STEPS = 10
 DEFAULT_VALIDATION_STEPS = 10
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
 def build_lora_model(model_path: str):
     """Load the base model and attach LoRA adapters."""
     tokenizer = AutoTokenizer.from_pretrained(model_path)
@@ -84,6 +94,7 @@ def build_dataloader(
     max_seq_len: int = MAX_SEQ_LEN,
     batch_size: int = BATCH_SIZE,
     split: str = "train",
+    max_steps: int | None = None,
 ) -> DataLoader:
     """Build a DataLoader for this site's training shard or the validation split.
 
@@ -101,8 +112,9 @@ def build_dataloader(
         dataset_path = os.path.join(data_dir, site_name, "train") if split == "train" else os.path.join(data_dir, split)
         if not os.path.isdir(dataset_path):
             raise FileNotFoundError(
-                f"Prepared {split} data not found at '{dataset_path}'. "
-                f"Run prepare_data.py --n_clients <N> --output_dir {data_dir} first."
+                f"Required {split} data not found at '{dataset_path}'. When --data_dir is set, provide each site's "
+                f"training dataset under '<data_dir>/<site>/train' and the shared validation dataset under "
+                f"'<data_dir>/validation'."
             )
         print(f"[{site_name}] Loading prepared {split} data from {dataset_path}")
         dataset = load_from_disk(dataset_path)
@@ -117,6 +129,11 @@ def build_dataloader(
                 site_idx = 0
             dataset = dataset.shard(num_shards=n_shards, index=site_idx % n_shards)
 
+    if split == "validation" and max_steps is not None:
+        if max_steps < 1:
+            raise ValueError("max_steps must be greater than 0")
+        dataset = dataset.select(range(min(len(dataset), max_steps * batch_size)))
+
     def tokenize(batch):
         enc = tokenizer(
             batch["text"],
@@ -124,12 +141,15 @@ def build_dataloader(
             max_length=max_seq_len,
             padding="max_length",
         )
-        enc["labels"] = enc["input_ids"].copy()
+        enc["labels"] = [
+            [token_id if attention else -100 for token_id, attention in zip(input_ids, attention_mask)]
+            for input_ids, attention_mask in zip(enc["input_ids"], enc["attention_mask"])
+        ]
         return enc
 
     dataset = dataset.map(tokenize, batched=True, remove_columns=["text"])
     dataset.set_format("torch")
-    return DataLoader(dataset, batch_size=batch_size, shuffle=split == "train", drop_last=True)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=split == "train", drop_last=split == "train")
 
 
 def apply_global_adapter(model, global_params: dict):
@@ -201,7 +221,7 @@ def evaluate_loss(model, dataloader: DataLoader, steps: int) -> float:
             losses.append(loss.item())
 
     if not losses:
-        raise ValueError("validation dataloader produced no complete batches")
+        raise ValueError("validation dataloader produced no batches")
     return sum(losses) / len(losses)
 
 
@@ -219,7 +239,7 @@ def main():
         "(e.g. /tmp/swarm_data). If omitted, falls back to in-memory shard.",
     )
     parser.add_argument("--local_steps", type=int, default=DEFAULT_LOCAL_STEPS)
-    parser.add_argument("--validation_steps", type=int, default=DEFAULT_VALIDATION_STEPS)
+    parser.add_argument("--validation_steps", type=positive_int, default=DEFAULT_VALIDATION_STEPS)
     parser.add_argument("--batch_size", type=int, default=BATCH_SIZE)
     parser.add_argument("--max_seq_len", type=int, default=MAX_SEQ_LEN)
     parser.add_argument(
@@ -252,6 +272,7 @@ def main():
         max_seq_len=args.max_seq_len,
         batch_size=args.batch_size,
         split="validation",
+        max_steps=args.validation_steps,
     )
 
     print(
@@ -268,8 +289,13 @@ def main():
         print(f"[{site_name}] Round {round_num}: applying global LoRA adapter")
         apply_global_adapter(model, input_model.params)
 
-        val_loss = evaluate_loss(model, validation_dataloader, args.validation_steps)
-        print(f"[{site_name}] Round {round_num}: received global adapter val_loss={val_loss:.4f}")
+        metrics = {}
+        if round_num == 0:
+            print(f"[{site_name}] Round 0: skipping validation because no aggregated global adapter exists yet")
+        else:
+            val_loss = evaluate_loss(model, validation_dataloader, args.validation_steps)
+            metrics = {"val_loss": val_loss}
+            print(f"[{site_name}] Round {round_num}: received global adapter val_loss={val_loss:.4f}")
 
         print(f"[{site_name}] Round {round_num}: local training for {args.local_steps} steps")
         diff = local_train(model, train_dataloader, args.local_steps)
@@ -278,7 +304,7 @@ def main():
             flare.FLModel(
                 params_type=ParamsType.DIFF,
                 params=diff,
-                metrics={"val_loss": val_loss},
+                metrics=metrics,
                 meta={"NUM_STEPS_CURRENT_ROUND": args.local_steps},
             )
         )

--- a/examples/advanced/swarm_learning/swarm_pt/client.py
+++ b/examples/advanced/swarm_learning/swarm_pt/client.py
@@ -280,24 +280,29 @@ def main():
         f"({len(train_dataloader)} training batches, {len(validation_dataloader)} validation batches)"
     )
 
-    round_num = 0
+    fallback_round = 0
     while flare.is_running():
         input_model = flare.receive()
         if input_model is None:
             break
 
-        print(f"[{site_name}] Round {round_num}: applying global LoRA adapter")
+        workflow_round = getattr(input_model, "current_round", None)
+        if workflow_round is None:
+            workflow_round = fallback_round
+            print(f"[{site_name}] Received model without current_round; using fallback round {workflow_round}")
+
+        print(f"[{site_name}] Round {workflow_round}: applying global LoRA adapter")
         apply_global_adapter(model, input_model.params)
 
         metrics = {}
-        if round_num == 0:
+        if workflow_round == 0:
             print(f"[{site_name}] Round 0: skipping validation because no aggregated global adapter exists yet")
         else:
             val_loss = evaluate_loss(model, validation_dataloader, args.validation_steps)
             metrics = {"val_loss": val_loss}
-            print(f"[{site_name}] Round {round_num}: received global adapter val_loss={val_loss:.4f}")
+            print(f"[{site_name}] Round {workflow_round}: received global adapter val_loss={val_loss:.4f}")
 
-        print(f"[{site_name}] Round {round_num}: local training for {args.local_steps} steps")
+        print(f"[{site_name}] Round {workflow_round}: local training for {args.local_steps} steps")
         diff = local_train(model, train_dataloader, args.local_steps)
 
         flare.send(
@@ -308,8 +313,8 @@ def main():
                 meta={"NUM_STEPS_CURRENT_ROUND": args.local_steps},
             )
         )
-        print(f"[{site_name}] Round {round_num}: submitted LoRA adapter diff")
-        round_num += 1
+        print(f"[{site_name}] Round {workflow_round}: submitted LoRA adapter diff")
+        fallback_round = workflow_round + 1
 
 
 if __name__ == "__main__":

--- a/examples/advanced/swarm_learning/swarm_pt/client.py
+++ b/examples/advanced/swarm_learning/swarm_pt/client.py
@@ -201,7 +201,7 @@ def evaluate_loss(model, dataloader: DataLoader, steps: int) -> float:
             losses.append(loss.item())
 
     if not losses:
-        raise RuntimeError("validation dataloader produced no complete batches")
+        raise ValueError("validation dataloader produced no complete batches")
     return sum(losses) / len(losses)
 
 

--- a/examples/advanced/swarm_learning/swarm_pt/client.py
+++ b/examples/advanced/swarm_learning/swarm_pt/client.py
@@ -20,7 +20,8 @@ parameters (~0.4 % of total weights) are exchanged each round, keeping
 communication cost low regardless of base-model size.
 
 Dataset heterogeneity: the training split is partitioned by site index so each
-participant trains on a disjoint shard, simulating real-world data silos.
+participant trains on a disjoint shard, simulating real-world data silos. A
+shared validation split scores each received global adapter before local training.
 """
 
 import argparse
@@ -47,6 +48,7 @@ MAX_SEQ_LEN = 128
 BATCH_SIZE = 4
 LEARNING_RATE = 3e-4
 DEFAULT_LOCAL_STEPS = 10
+DEFAULT_VALIDATION_STEPS = 10
 
 
 def build_lora_model(model_path: str):
@@ -81,34 +83,39 @@ def build_dataloader(
     n_shards: int = 4,
     max_seq_len: int = MAX_SEQ_LEN,
     batch_size: int = BATCH_SIZE,
+    split: str = "train",
 ) -> DataLoader:
-    """Build a DataLoader for this site's training shard.
+    """Build a DataLoader for this site's training shard or the validation split.
 
-    If data_dir is given, loads the pre-split Arrow dataset written by
-    prepare_data.py from {data_dir}/{site_name}/train.  Otherwise falls back
-    to an in-memory shard of the full wikitext-2 train split (useful for
-    quick runs without running prepare_data.py first).
+    If data_dir is given, loads the Arrow dataset written by prepare_data.py.
+    Otherwise falls back to the matching in-memory wikitext-2 split. Only the
+    training split is sharded; validation is shared so every site scores the
+    same received global model on the same examples.
     """
+    if split not in ("train", "validation"):
+        raise ValueError(f"split must be 'train' or 'validation', but got {split!r}")
+
     if data_dir is not None:
         from datasets import load_from_disk
 
-        shard_path = os.path.join(data_dir, site_name, "train")
-        if not os.path.isdir(shard_path):
+        dataset_path = os.path.join(data_dir, site_name, "train") if split == "train" else os.path.join(data_dir, split)
+        if not os.path.isdir(dataset_path):
             raise FileNotFoundError(
-                f"Pre-split data not found at '{shard_path}'. "
+                f"Prepared {split} data not found at '{dataset_path}'. "
                 f"Run prepare_data.py --n_clients <N> --output_dir {data_dir} first."
             )
-        print(f"[{site_name}] Loading pre-split data from {shard_path}")
-        dataset = load_from_disk(shard_path)
+        print(f"[{site_name}] Loading prepared {split} data from {dataset_path}")
+        dataset = load_from_disk(dataset_path)
     else:
-        print(f"[{site_name}] No --data_dir given; using in-memory shard of wikitext-2")
-        dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+        print(f"[{site_name}] No --data_dir given; loading in-memory wikitext-2 {split} split")
+        dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split=split)
         dataset = dataset.filter(lambda x: len(x["text"].strip()) > 0)
-        try:
-            site_idx = int(site_name.rsplit("-", 1)[-1]) - 1
-        except ValueError:
-            site_idx = 0
-        dataset = dataset.shard(num_shards=n_shards, index=site_idx % n_shards)
+        if split == "train":
+            try:
+                site_idx = int(site_name.rsplit("-", 1)[-1]) - 1
+            except ValueError:
+                site_idx = 0
+            dataset = dataset.shard(num_shards=n_shards, index=site_idx % n_shards)
 
     def tokenize(batch):
         enc = tokenizer(
@@ -122,7 +129,7 @@ def build_dataloader(
 
     dataset = dataset.map(tokenize, batched=True, remove_columns=["text"])
     dataset.set_format("torch")
-    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=split == "train", drop_last=True)
 
 
 def apply_global_adapter(model, global_params: dict):
@@ -177,6 +184,27 @@ def local_train(model, dataloader: DataLoader, steps: int) -> dict:
     return diff
 
 
+def evaluate_loss(model, dataloader: DataLoader, steps: int) -> float:
+    """Evaluate the received global adapter before local training."""
+    device = next(model.parameters()).device
+    losses = []
+    model.eval()
+    with torch.no_grad():
+        for step, batch in enumerate(dataloader):
+            if step >= steps:
+                break
+            loss = model(
+                input_ids=batch["input_ids"].to(device),
+                attention_mask=batch["attention_mask"].to(device),
+                labels=batch["labels"].to(device),
+            ).loss
+            losses.append(loss.item())
+
+    if not losses:
+        raise RuntimeError("validation dataloader produced no complete batches")
+    return sum(losses) / len(losses)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -191,6 +219,7 @@ def main():
         "(e.g. /tmp/swarm_data). If omitted, falls back to in-memory shard.",
     )
     parser.add_argument("--local_steps", type=int, default=DEFAULT_LOCAL_STEPS)
+    parser.add_argument("--validation_steps", type=int, default=DEFAULT_VALIDATION_STEPS)
     parser.add_argument("--batch_size", type=int, default=BATCH_SIZE)
     parser.add_argument("--max_seq_len", type=int, default=MAX_SEQ_LEN)
     parser.add_argument(
@@ -207,7 +236,7 @@ def main():
     print(f"[{site_name}] Loading model from '{args.model_path}'")
 
     model, tokenizer = build_lora_model(args.model_path)
-    dataloader = build_dataloader(
+    train_dataloader = build_dataloader(
         tokenizer,
         site_name,
         data_dir=args.data_dir,
@@ -215,8 +244,20 @@ def main():
         max_seq_len=args.max_seq_len,
         batch_size=args.batch_size,
     )
+    validation_dataloader = build_dataloader(
+        tokenizer,
+        site_name,
+        data_dir=args.data_dir,
+        n_shards=args.n_shards,
+        max_seq_len=args.max_seq_len,
+        batch_size=args.batch_size,
+        split="validation",
+    )
 
-    print(f"[{site_name}] Dataset ready ({len(dataloader)} batches/round)")
+    print(
+        f"[{site_name}] Datasets ready "
+        f"({len(train_dataloader)} training batches, {len(validation_dataloader)} validation batches)"
+    )
 
     round_num = 0
     while flare.is_running():
@@ -227,13 +268,17 @@ def main():
         print(f"[{site_name}] Round {round_num}: applying global LoRA adapter")
         apply_global_adapter(model, input_model.params)
 
+        val_loss = evaluate_loss(model, validation_dataloader, args.validation_steps)
+        print(f"[{site_name}] Round {round_num}: received global adapter val_loss={val_loss:.4f}")
+
         print(f"[{site_name}] Round {round_num}: local training for {args.local_steps} steps")
-        diff = local_train(model, dataloader, args.local_steps)
+        diff = local_train(model, train_dataloader, args.local_steps)
 
         flare.send(
             flare.FLModel(
                 params_type=ParamsType.DIFF,
                 params=diff,
+                metrics={"val_loss": val_loss},
                 meta={"NUM_STEPS_CURRENT_ROUND": args.local_steps},
             )
         )

--- a/examples/advanced/swarm_learning/swarm_pt/job.py
+++ b/examples/advanced/swarm_learning/swarm_pt/job.py
@@ -60,6 +60,7 @@ def define_parser():
         help="Root workspace directory for SimEnv (job results written to <workspace>/<job_name>)",
     )
     parser.add_argument("--local_steps", type=int, default=10, help="Gradient steps per client per round")
+    parser.add_argument("--validation_steps", type=int, default=10, help="Validation batches per client per round")
     parser.add_argument("--batch_size", type=int, default=4, help="Training batch size")
     parser.add_argument("--max_seq_len", type=int, default=128, help="Maximum tokenized sequence length")
     parser.add_argument(
@@ -83,7 +84,10 @@ def main():
     script_args = f"--model_path {model_path}"
     if args.data_dir:
         script_args += f" --data_dir {args.data_dir}"
-    script_args += f" --local_steps {args.local_steps} --batch_size {args.batch_size} --max_seq_len {args.max_seq_len}"
+    script_args += (
+        f" --local_steps {args.local_steps} --validation_steps {args.validation_steps}"
+        f" --batch_size {args.batch_size} --max_seq_len {args.max_seq_len}"
+    )
     script_args += f" --n_shards {args.n_clients}"
 
     recipe = SwarmLearningRecipe(
@@ -93,6 +97,8 @@ def main():
         train_script="client.py",
         train_args={"script_args": script_args},
         min_clients=args.n_clients,
+        key_metric="val_loss",
+        key_metric_mode="min",
         launch_external_process=True,
         cuda_empty_cache=True,
         # LoRA adapters are small — exchange full adapter state each round (FedAvg)

--- a/examples/advanced/swarm_learning/swarm_pt/job.py
+++ b/examples/advanced/swarm_learning/swarm_pt/job.py
@@ -42,6 +42,16 @@ MODEL_SIZES = {
 }
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
 def define_parser():
     parser = argparse.ArgumentParser(description="Swarm LoRA fine-tuning job")
     parser.add_argument("--n_clients", type=int, default=2, help="Number of clients")
@@ -60,7 +70,9 @@ def define_parser():
         help="Root workspace directory for SimEnv (job results written to <workspace>/<job_name>)",
     )
     parser.add_argument("--local_steps", type=int, default=10, help="Gradient steps per client per round")
-    parser.add_argument("--validation_steps", type=int, default=10, help="Validation batches per client per round")
+    parser.add_argument(
+        "--validation_steps", type=positive_int, default=10, help="Validation batches per client per round"
+    )
     parser.add_argument("--batch_size", type=int, default=4, help="Training batch size")
     parser.add_argument("--max_seq_len", type=int, default=128, help="Maximum tokenized sequence length")
     parser.add_argument(

--- a/examples/advanced/swarm_learning/swarm_pt/model.py
+++ b/examples/advanced/swarm_learning/swarm_pt/model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Server-side model wrapper for PTFileModelPersistor.
+"""Client-side model wrapper for the Swarm PTFileModelPersistor.
 
 Exposes only the LoRA adapter parameters through state_dict() / load_state_dict()
 so the persistor stores a compact checkpoint (~2 MB) instead of the full base

--- a/nvflare/app_common/widgets/intime_model_selector.py
+++ b/nvflare/app_common/widgets/intime_model_selector.py
@@ -163,6 +163,7 @@ class IntimeModelSelector(Widget):
                 )
                 return False
 
+        validation_metric = float(validation_metric)
         raw_validation_metric = validation_metric
         if self.negate_key_metric:
             validation_metric = -1.0 * validation_metric

--- a/nvflare/app_common/widgets/intime_model_selector.py
+++ b/nvflare/app_common/widgets/intime_model_selector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import re
 
 import numpy as np
@@ -163,7 +164,19 @@ class IntimeModelSelector(Widget):
                 )
                 return False
 
-        validation_metric = float(validation_metric)
+        try:
+            validation_metric = float(validation_metric)
+        except (TypeError, ValueError):
+            self.log_warning(
+                fl_ctx, f"validation metric {validation_metric!r} from {client_name} is not a number; skipping"
+            )
+            return False
+        if not math.isfinite(validation_metric):
+            self.log_warning(
+                fl_ctx, f"validation metric {validation_metric!r} from {client_name} is not finite; skipping"
+            )
+            return False
+
         raw_validation_metric = validation_metric
         if self.negate_key_metric:
             validation_metric = -1.0 * validation_metric

--- a/nvflare/app_opt/pt/recipes/swarm.py
+++ b/nvflare/app_opt/pt/recipes/swarm.py
@@ -37,13 +37,13 @@ from nvflare.recipe.utils import merge_config_overrides, validate_aggregator_dat
 
 _RECIPE_MANAGED_SERVER_CONFIG_KEYS = frozenset({"min_clients"})
 _RECIPE_MANAGED_CLIENT_CONFIG_KEYS = frozenset(
-    {"executor", "aggregator", "persistor", "shareable_generator", "min_responses_required"}
+    {"executor", "aggregator", "persistor", "shareable_generator", "model_selector", "min_responses_required"}
 )
 
 
 class _SwarmValidator(BaseModel):
     initial_ckpt: Optional[str] = None
-    key_metric: str = "accuracy"
+    key_metric: Optional[str] = "accuracy"
     key_metric_mode: Literal["min", "max"] = "max"
 
     @field_validator("initial_ckpt")
@@ -168,7 +168,7 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             This dictionary is stored in the job definition and must not contain secrets.
         client_config_overrides: Advanced shallow overrides for ``SwarmClientConfig``.
             Values here take precedence over named constructor parameters. Recipe-managed
-            fields (executor, aggregator, persistor, shareable generator, and
+            fields (executor, aggregator, persistor, shareable generator, model selector, and
             ``min_responses_required``) cannot be replaced through this dictionary; use
             ``BaseSwarmLearningRecipe`` for custom components or quorum settings.
             This dictionary is stored in the job definition and must not contain secrets.
@@ -181,9 +181,9 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             ``aggregation_format=ExchangeFormat.PYTORCH`` to take effect. Defaults to False.
         key_metric: Metric used to determine the best global model. If validation metrics are
             a dictionary, this selects the metric used by the client-side model selector.
-            Defaults to "accuracy".
+            Set to ``None`` to disable best-model selection. Defaults to "accuracy".
         key_metric_mode: Whether lower ("min") or higher ("max") values of ``key_metric``
-            indicate a better model. Defaults to "max".
+            indicate a better model. Ignored when ``key_metric`` is ``None``. Defaults to "max".
 
     Example:
         Using nn.Module instance:
@@ -241,7 +241,7 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
         client_config_overrides: Optional[Dict[str, Any]] = None,
         aggregation_format: ExchangeFormat = ExchangeFormat.NUMPY,
         enable_tensor_disk_offload: bool = False,
-        key_metric: str = "accuracy",
+        key_metric: Optional[str] = "accuracy",
         key_metric_mode: Literal["min", "max"] = "max",
     ):
         _SwarmValidator(
@@ -380,10 +380,6 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
                 allow_numpy_conversion=aggregation_format != ExchangeFormat.PYTORCH,
             ),
             "shareable_generator": SimpleModelShareableGenerator(),
-            "model_selector": IntimeModelSelector(
-                key_metric=key_metric,
-                negate_key_metric=key_metric_mode == "min",
-            ),
             "enable_tensor_disk_offload": enable_tensor_disk_offload,
             "memory_gc_rounds": memory_gc_rounds,
             "cuda_empty_cache": cuda_empty_cache,
@@ -395,6 +391,11 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
                 round_timeout if final_result_ack_timeout is None else final_result_ack_timeout
             ),
         }
+        if key_metric is not None:
+            client_config_args["model_selector"] = IntimeModelSelector(
+                key_metric=key_metric,
+                negate_key_metric=key_metric_mode == "min",
+            )
         if learn_task_abort_timeout is not None:
             client_config_args["learn_task_abort_timeout"] = learn_task_abort_timeout
         client_config_args = merge_config_overrides(

--- a/nvflare/app_opt/pt/recipes/swarm.py
+++ b/nvflare/app_opt/pt/recipes/swarm.py
@@ -14,7 +14,7 @@
 
 import os
 import warnings
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from pydantic import BaseModel, field_validator
 
@@ -22,6 +22,7 @@ from nvflare.apis.dxo import DataKind
 from nvflare.app_common.aggregators.intime_accumulate_model_aggregator import InTimeAccumulateWeightedAggregator
 from nvflare.app_common.ccwf.ccwf_job import CCWFJob, CrossSiteEvalConfig, SwarmClientConfig, SwarmServerConfig
 from nvflare.app_common.ccwf.comps.simple_model_shareable_generator import SimpleModelShareableGenerator
+from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.client.config import ExchangeFormat, normalize_exchange_format
 from nvflare.fuel.utils.secret_utils import (
@@ -42,6 +43,8 @@ _RECIPE_MANAGED_CLIENT_CONFIG_KEYS = frozenset(
 
 class _SwarmValidator(BaseModel):
     initial_ckpt: Optional[str] = None
+    key_metric: str = "accuracy"
+    key_metric_mode: Literal["min", "max"] = "max"
 
     @field_validator("initial_ckpt")
     @classmethod
@@ -176,6 +179,11 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             files on aggregation clients and materialize them lazily during aggregation. The
             trainer's source tensors remain in memory. This requires
             ``aggregation_format=ExchangeFormat.PYTORCH`` to take effect. Defaults to False.
+        key_metric: Metric used to determine the best global model. If validation metrics are
+            a dictionary, this selects the metric used by the client-side model selector.
+            Defaults to "accuracy".
+        key_metric_mode: Whether lower ("min") or higher ("max") values of ``key_metric``
+            indicate a better model. Defaults to "max".
 
     Example:
         Using nn.Module instance:
@@ -233,8 +241,14 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
         client_config_overrides: Optional[Dict[str, Any]] = None,
         aggregation_format: ExchangeFormat = ExchangeFormat.NUMPY,
         enable_tensor_disk_offload: bool = False,
+        key_metric: str = "accuracy",
+        key_metric_mode: Literal["min", "max"] = "max",
     ):
-        _SwarmValidator(initial_ckpt=initial_ckpt)
+        _SwarmValidator(
+            initial_ckpt=initial_ckpt,
+            key_metric=key_metric,
+            key_metric_mode=key_metric_mode,
+        )
         warn_on_potential_secrets(command, context="recipe parameter 'command'")
         aggregation_format = normalize_exchange_format(aggregation_format, "aggregation_format")
         self.aggregation_format = aggregation_format
@@ -366,6 +380,10 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
                 allow_numpy_conversion=aggregation_format != ExchangeFormat.PYTORCH,
             ),
             "shareable_generator": SimpleModelShareableGenerator(),
+            "model_selector": IntimeModelSelector(
+                key_metric=key_metric,
+                negate_key_metric=key_metric_mode == "min",
+            ),
             "enable_tensor_disk_offload": enable_tensor_disk_offload,
             "memory_gc_rounds": memory_gc_rounds,
             "cuda_empty_cache": cuda_empty_cache,

--- a/nvflare/app_opt/pt/recipes/swarm.py
+++ b/nvflare/app_opt/pt/recipes/swarm.py
@@ -53,6 +53,13 @@ class _SwarmValidator(BaseModel):
             validate_ckpt(v)
         return v
 
+    @field_validator("key_metric")
+    @classmethod
+    def validate_key_metric(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("key_metric must be a non-empty string or None")
+        return v
+
     model_config = {"arbitrary_types_allowed": True}
 
 
@@ -167,10 +174,12 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             scheduler, server-controller, and client aggregation quorums aligned.
             This dictionary is stored in the job definition and must not contain secrets.
         client_config_overrides: Advanced shallow overrides for ``SwarmClientConfig``.
-            Values here take precedence over named constructor parameters. Recipe-managed
-            fields (executor, aggregator, persistor, shareable generator, model selector, and
-            ``min_responses_required``) cannot be replaced through this dictionary; use
-            ``BaseSwarmLearningRecipe`` for custom components or quorum settings.
+            Values for non-recipe-managed fields take precedence over named constructor
+            parameters. Recipe-managed fields (executor, aggregator, persistor, shareable
+            generator, model selector, and ``min_responses_required``) cannot be replaced
+            through this dictionary. Use ``key_metric=None`` to disable model selection, or
+            ``BaseSwarmLearningRecipe`` with an explicit ``SwarmClientConfig`` for a custom
+            selector, other custom components, or quorum settings.
             This dictionary is stored in the job definition and must not contain secrets.
         aggregation_format: Parameter representation used by the CCWF controllers and aggregator.
             Use ``ExchangeFormat.PYTORCH`` to keep tensors on the streaming path. Defaults to
@@ -184,6 +193,8 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             Set to ``None`` to disable best-model selection. Defaults to "accuracy".
         key_metric_mode: Whether lower ("min") or higher ("max") values of ``key_metric``
             indicate a better model. Ignored when ``key_metric`` is ``None``. Defaults to "max".
+            In ``"min"`` mode, selector comparison values exposed through Swarm best-metric
+            logs and records are negated; for example, a loss of 2.31 is shown as -2.31.
 
     Example:
         Using nn.Module instance:
@@ -298,7 +309,8 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             fields = ", ".join(sorted(protected_overrides))
             raise ValueError(
                 f"client_config_overrides cannot override recipe-managed fields: {fields}. "
-                "Use named recipe parameters for quorum settings or BaseSwarmLearningRecipe for custom components."
+                "Use named recipe parameters (key_metric=None disables model selection) or "
+                "BaseSwarmLearningRecipe with an explicit SwarmClientConfig for custom components."
             )
 
         validate_aggregator_data_kind(

--- a/nvflare/tool/recipe/recipe_catalog.json
+++ b/nvflare/tool/recipe/recipe_catalog.json
@@ -4095,7 +4095,7 @@
           },
           {
             "name": "key_metric",
-            "type": "str",
+            "type": "Optional[str]",
             "required": false,
             "default": "accuracy",
             "kind": "positional_or_keyword"

--- a/nvflare/tool/recipe/recipe_catalog.json
+++ b/nvflare/tool/recipe/recipe_catalog.json
@@ -4092,6 +4092,20 @@
             "required": false,
             "default": false,
             "kind": "positional_or_keyword"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Literal['min', 'max']",
+            "required": false,
+            "default": "max",
+            "kind": "positional_or_keyword"
           }
         ],
         "optional_dependencies": [

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -14,6 +14,7 @@
 
 import logging
 
+import numpy as np
 import pytest
 
 from nvflare.apis.dxo import DXO, DataKind, MetaKey
@@ -171,3 +172,28 @@ class TestInTimeModelSelector:
             "best_round": 1,
             "best_metrics": {"loss": 0.2},
         }
+
+    def test_numpy_metric_is_coerced_to_float(self):
+        handler = IntimeModelSelector(key_metric="loss", negate_key_metric=True)
+        engine = MockSimpleEngine()
+        peer_ctx = FLContext()
+        dxo = DXO(
+            DataKind.WEIGHT_DIFF,
+            data=dict(),
+            meta={MetaKey.INITIAL_METRICS: {"loss": np.float32(0.2)}},
+        )
+        shareable = dxo.to_shareable()
+        shareable.add_cookie(AppConstants.CONTRIBUTION_ROUND, 1)
+        peer_ctx.set_prop(FLContextKey.SHAREABLE, shareable, private=True)
+        fl_ctx = engine.fl_ctx_mgr.new_context()
+        fl_ctx.set_prop(AppConstants.CURRENT_ROUND, 1, private=True, sticky=False)
+        fl_ctx.set_peer_context(peer_ctx)
+
+        handler.handle_event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT, fl_ctx)
+        handler.handle_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
+
+        assert isinstance(handler.val_metric, float)
+        assert handler.val_metric == pytest.approx(-0.2)
+        assert isinstance(handler.raw_val_metric, float)
+        assert handler.raw_val_metric == pytest.approx(0.2)
+        assert isinstance(fl_ctx.get_prop(AppConstants.VALIDATION_RESULT), float)

--- a/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
+++ b/tests/unit_test/app_common/widgets/in_time_model_selector_test.py
@@ -192,8 +192,42 @@ class TestInTimeModelSelector:
         handler.handle_event(AppEventType.BEFORE_CONTRIBUTION_ACCEPT, fl_ctx)
         handler.handle_event(AppEventType.BEFORE_AGGREGATION, fl_ctx)
 
-        assert isinstance(handler.val_metric, float)
+        assert type(handler.val_metric) is float
         assert handler.val_metric == pytest.approx(-0.2)
-        assert isinstance(handler.raw_val_metric, float)
+        assert type(handler.raw_val_metric) is float
         assert handler.raw_val_metric == pytest.approx(0.2)
-        assert isinstance(fl_ctx.get_prop(AppConstants.VALIDATION_RESULT), float)
+        assert type(fl_ctx.get_prop(AppConstants.VALIDATION_RESULT)) is float
+
+    @pytest.mark.parametrize("metric", ([0.5, 0.6], "N/A", None))
+    def test_non_numeric_metric_is_skipped(self, caplog, metric):
+        handler = IntimeModelSelector(key_metric="loss")
+        engine = MockSimpleEngine()
+        peer_ctx = FLContext()
+        dxo = DXO(DataKind.WEIGHT_DIFF, data=dict(), meta={MetaKey.INITIAL_METRICS: {"loss": metric}})
+        shareable = dxo.to_shareable()
+        shareable.add_cookie(AppConstants.CONTRIBUTION_ROUND, 1)
+        peer_ctx.set_prop(FLContextKey.SHAREABLE, shareable, private=True)
+        fl_ctx = engine.fl_ctx_mgr.new_context()
+        fl_ctx.set_prop(AppConstants.CURRENT_ROUND, 1, private=True, sticky=False)
+        fl_ctx.set_peer_context(peer_ctx)
+
+        assert handler._before_accept(fl_ctx) is False
+        assert handler.validation_metric_sum_of_weights == 0
+        assert "is not a number; skipping" in caplog.text
+
+    @pytest.mark.parametrize("metric", (float("nan"), float("inf"), float("-inf")))
+    def test_non_finite_metric_is_skipped(self, caplog, metric):
+        handler = IntimeModelSelector(key_metric="loss")
+        engine = MockSimpleEngine()
+        peer_ctx = FLContext()
+        dxo = DXO(DataKind.WEIGHT_DIFF, data=dict(), meta={MetaKey.INITIAL_METRICS: {"loss": metric}})
+        shareable = dxo.to_shareable()
+        shareable.add_cookie(AppConstants.CONTRIBUTION_ROUND, 1)
+        peer_ctx.set_prop(FLContextKey.SHAREABLE, shareable, private=True)
+        fl_ctx = engine.fl_ctx_mgr.new_context()
+        fl_ctx.set_prop(AppConstants.CURRENT_ROUND, 1, private=True, sticky=False)
+        fl_ctx.set_peer_context(peer_ctx)
+
+        assert handler._before_accept(fl_ctx) is False
+        assert handler.validation_metric_sum_of_weights == 0
+        assert "is not finite; skipping" in caplog.text

--- a/tests/unit_test/recipe/swarm_recipe_test.py
+++ b/tests/unit_test/recipe/swarm_recipe_test.py
@@ -146,6 +146,20 @@ class TestSwarmLearningRecipe:
                 key_metric_mode="median",
             )
 
+    @pytest.mark.parametrize("key_metric", ("", "   "))
+    def test_rejects_empty_key_metric(self, mock_file_system, simple_pt_model, key_metric):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        with pytest.raises(ValueError, match="key_metric must be a non-empty string or None"):
+            SwarmLearningRecipe(
+                name="test_swarm_empty_metric",
+                model=simple_pt_model,
+                num_rounds=5,
+                train_script="train.py",
+                min_clients=2,
+                key_metric=key_metric,
+            )
+
     def test_key_metric_none_disables_client_side_best_model_selection(self, mock_file_system, simple_pt_model):
         from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
 
@@ -160,6 +174,32 @@ class TestSwarmLearningRecipe:
 
         client_components = recipe._job._deploy_map[ALL_SITES].app_config.components
         assert "model_selector" not in client_components
+
+    def test_base_recipe_accepts_custom_model_selector(self, mock_file_system, simple_pt_model):
+        from nvflare.app_common.aggregators.intime_accumulate_model_aggregator import InTimeAccumulateWeightedAggregator
+        from nvflare.app_common.ccwf.ccwf_job import SwarmClientConfig, SwarmServerConfig
+        from nvflare.app_common.ccwf.comps.simple_model_shareable_generator import SimpleModelShareableGenerator
+        from nvflare.app_opt.pt.recipes.swarm import BaseSwarmLearningRecipe
+        from nvflare.job_config.script_runner import ScriptRunner
+
+        selector = IntimeModelSelector(key_metric="custom_score")
+        client_config = SwarmClientConfig(
+            executor=ScriptRunner(script="train.py"),
+            aggregator=InTimeAccumulateWeightedAggregator(),
+            persistor=PTFileModelPersistor(model=simple_pt_model),
+            shareable_generator=SimpleModelShareableGenerator(),
+            model_selector=selector,
+            min_responses_required=2,
+        )
+        recipe = BaseSwarmLearningRecipe(
+            name="test_custom_swarm_selector",
+            server_config=SwarmServerConfig(num_rounds=5, min_clients=2),
+            client_config=client_config,
+            min_clients=2,
+        )
+
+        client_components = recipe._job._deploy_map[ALL_SITES].app_config.components
+        assert client_components["model_selector"] is selector
 
     def test_weight_diff_with_default_transfer_is_valid(self, mock_file_system, simple_pt_model):
         from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe

--- a/tests/unit_test/recipe/swarm_recipe_test.py
+++ b/tests/unit_test/recipe/swarm_recipe_test.py
@@ -21,6 +21,9 @@ import pytest
 
 from nvflare.apis.dxo import DataKind
 from nvflare.apis.job_def import ALL_SITES, SERVER_SITE_NAME
+from nvflare.app_common.app_constant import DefaultCheckpointFileName
+from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
+from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.client.config import ExchangeFormat
 from nvflare.fuel.utils.secret_utils import PotentialSecretWarning
 
@@ -91,6 +94,57 @@ class TestSwarmLearningRecipe:
         )
 
         assert recipe._job is not None
+
+    @pytest.mark.parametrize(
+        "key_metric,key_metric_mode,negate_key_metric",
+        [
+            ("accuracy", "max", False),
+            ("val_loss", "min", True),
+        ],
+    )
+    def test_configures_client_side_best_model_selection(
+        self,
+        mock_file_system,
+        simple_pt_model,
+        key_metric,
+        key_metric_mode,
+        negate_key_metric,
+    ):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        recipe = SwarmLearningRecipe(
+            name="test_swarm_model_selection",
+            model=simple_pt_model,
+            num_rounds=5,
+            train_script="train.py",
+            min_clients=2,
+            key_metric=key_metric,
+            key_metric_mode=key_metric_mode,
+        )
+
+        client_components = recipe._job._deploy_map[ALL_SITES].app_config.components
+        selector = client_components["model_selector"]
+        persistor = client_components["persistor"]
+
+        assert isinstance(selector, IntimeModelSelector)
+        assert selector.key_metric == key_metric
+        assert selector.negate_key_metric is negate_key_metric
+        assert isinstance(persistor, PTFileModelPersistor)
+        assert persistor.best_global_model_file_name == DefaultCheckpointFileName.BEST_GLOBAL_MODEL
+        assert "model_selector" not in recipe._job._deploy_map[SERVER_SITE_NAME].app_config.components
+
+    def test_rejects_invalid_key_metric_mode(self, mock_file_system, simple_pt_model):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        with pytest.raises(ValueError, match="key_metric_mode"):
+            SwarmLearningRecipe(
+                name="test_swarm_invalid_metric_mode",
+                model=simple_pt_model,
+                num_rounds=5,
+                train_script="train.py",
+                min_clients=2,
+                key_metric_mode="median",
+            )
 
     def test_weight_diff_with_default_transfer_is_valid(self, mock_file_system, simple_pt_model):
         from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
@@ -519,6 +573,33 @@ class TestSwarmLearningRecipeTensorDiskOffload:
 
 class TestSwarmLearningRecipeExport:
     """Export behavior tests for SwarmLearningRecipe."""
+
+    def test_export_includes_client_side_best_model_selector(self, tmp_path):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        train_script = tmp_path / "train.py"
+        train_script.write_text("print('train')\n")
+        recipe = SwarmLearningRecipe(
+            name="swarm_best_model",
+            model={"class_path": "torch.nn.Linear", "args": {"in_features": 2, "out_features": 2}},
+            num_rounds=2,
+            train_script=str(train_script),
+            min_clients=2,
+            key_metric="val_loss",
+            key_metric_mode="min",
+        )
+
+        export_dir = tmp_path / "job"
+        recipe.export(str(export_dir))
+
+        client_config_path = export_dir / "swarm_best_model" / "app" / "config" / "config_fed_client.json"
+        with open(client_config_path, "r") as f:
+            client_config = json.load(f)
+        selector = next(component for component in client_config["components"] if component["id"] == "model_selector")
+
+        assert selector["path"].endswith(".IntimeModelSelector")
+        assert selector["args"]["key_metric"] == "val_loss"
+        assert selector["args"]["negate_key_metric"] is True
 
     def test_export_nested_relative_ckpt_uses_configured_basename(self, tmp_path, monkeypatch):
         """A nested relative checkpoint is flattened into each client app."""

--- a/tests/unit_test/recipe/swarm_recipe_test.py
+++ b/tests/unit_test/recipe/swarm_recipe_test.py
@@ -146,6 +146,21 @@ class TestSwarmLearningRecipe:
                 key_metric_mode="median",
             )
 
+    def test_key_metric_none_disables_client_side_best_model_selection(self, mock_file_system, simple_pt_model):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        recipe = SwarmLearningRecipe(
+            name="test_swarm_without_model_selection",
+            model=simple_pt_model,
+            num_rounds=5,
+            train_script="train.py",
+            min_clients=2,
+            key_metric=None,
+        )
+
+        client_components = recipe._job._deploy_map[ALL_SITES].app_config.components
+        assert "model_selector" not in client_components
+
     def test_weight_diff_with_default_transfer_is_valid(self, mock_file_system, simple_pt_model):
         from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
 
@@ -403,6 +418,8 @@ class TestSwarmLearningRecipeControllerConfig:
             SwarmLearningRecipe(**defaults, client_config_overrides={"executor": object()})
         with pytest.raises(ValueError, match="cannot override recipe-managed fields: min_responses_required"):
             SwarmLearningRecipe(**defaults, client_config_overrides={"min_responses_required": 5})
+        with pytest.raises(ValueError, match="cannot override recipe-managed fields: model_selector"):
+            SwarmLearningRecipe(**defaults, client_config_overrides={"model_selector": None})
         with pytest.raises(TypeError, match="server_config_overrides must be a dict"):
             SwarmLearningRecipe(**defaults, server_config_overrides=[])
         with pytest.raises(TypeError, match="server_config_overrides keys must be strings"):
@@ -600,6 +617,29 @@ class TestSwarmLearningRecipeExport:
         assert selector["path"].endswith(".IntimeModelSelector")
         assert selector["args"]["key_metric"] == "val_loss"
         assert selector["args"]["negate_key_metric"] is True
+
+    def test_export_omits_client_side_best_model_selector_when_disabled(self, tmp_path):
+        from nvflare.app_opt.pt.recipes.swarm import SwarmLearningRecipe
+
+        train_script = tmp_path / "train.py"
+        train_script.write_text("print('train')\n")
+        recipe = SwarmLearningRecipe(
+            name="swarm_without_best_model",
+            model={"class_path": "torch.nn.Linear", "args": {"in_features": 2, "out_features": 2}},
+            num_rounds=2,
+            train_script=str(train_script),
+            min_clients=2,
+            key_metric=None,
+        )
+
+        export_dir = tmp_path / "job"
+        recipe.export(str(export_dir))
+
+        client_config_path = export_dir / "swarm_without_best_model" / "app" / "config" / "config_fed_client.json"
+        with open(client_config_path, "r") as f:
+            client_config = json.load(f)
+
+        assert all(component["id"] != "model_selector" for component in client_config["components"])
 
     def test_export_nested_relative_ckpt_uses_configured_basename(self, tmp_path, monkeypatch):
         """A nested relative checkpoint is flattened into each client app."""


### PR DESCRIPTION
## Summary

- configure a client-side `IntimeModelSelector` by default in `SwarmLearningRecipe`
- expose `key_metric` and `key_metric_mode` while preserving positional compatibility
- support higher-is-better and lower-is-better metrics without introducing a new selector or service
- update the canonical Swarm LoRA example to evaluate the received global adapter before local training and report `val_loss`
- align recipe, Job API/JSON, CSE, user-guide, release-note, and example documentation with the client-side Swarm topology and metric-timing contract

## Behavior

When clients report the configured pre-training metric, Swarm tracks the best global model across aggregation clients, distributes it at workflow completion, and persists `best_FL_global_model.pt` through the existing client-side PyTorch persistor. If the metric is absent, the workflow continues to persist the last global model and does not create a best-model checkpoint.

This uses the existing full `IntimeModelSelector`, including dictionary-metric selection and `min`/`max` handling; it does not depend on changes to `SimpleIntimeModelSelector`.

## Validation

- `python3 -m pytest tests/unit_test/recipe/swarm_recipe_test.py tests/unit_test/recipe/component_config_verification_test.py tests/unit_test/examples/recipe_export_arguments_test.py -q` (47 passed, 5 skipped)
- full recipe unit suite (532 passed, 22 skipped)
- Python syntax compilation for the updated Swarm example
- `./runtest.sh -s`
- pre-push agent-skill lint (0 findings)
- `git diff --check`

The full HTML documentation build entered Sphinx but did not complete locally because unrelated API autodoc imports stalled. The changed RST, Markdown, recipe snippets, exported JSON expectations, and example behavior were audited together for consistency.
