### PR TITLE
Fix external_process listener with fixed listening_host

### DIFF
--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -29,7 +29,7 @@ import time
 import uuid
 from typing import Any, Optional, Sequence, Tuple, Union
 
-from nvflare.apis.fl_constant import FLContextKey, FLMetaKey, ReturnCode, ServerCommandNames
+from nvflare.apis.fl_constant import ConnectionSecurity, FLContextKey, FLMetaKey, ReturnCode, ServerCommandNames
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import UnsafeJobError
 from nvflare.apis.shareable import Shareable, make_reply
@@ -52,6 +52,7 @@ from nvflare.fuel.f3.cellnet.defs import ReturnCode as CellReturnCode
 from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.utils import make_reply as make_cell_reply
 from nvflare.fuel.f3.cellnet.utils import new_cell_message
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.f3.streaming.download_service import DownloadService
 from nvflare.fuel.f3.streaming.transfer_progress import DEFAULT_STREAMING_IDLE_TIMEOUT
 from nvflare.fuel.utils.fobs import FOBSContextKey
@@ -190,7 +191,13 @@ class ExternalProcessBackend(CellBackendBase):
             self._app_dir = workspace.get_app_dir(self._job_id)
             self._custom_dir = workspace.get_app_custom_dir(self._job_id)
 
-            cell.make_internal_listener()
+            cell.make_internal_listener(
+                scheme="tcp",
+                resources={
+                    DriverParams.HOST.value: "localhost",
+                    DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
+                },
+            )
             connect_url = cell.get_internal_listener_url()
             if not connect_url:
                 raise RuntimeError("CJ cell has no internal listener url for the trainer to connect to")

--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -20,6 +20,7 @@ Client Job (CJ) Cell. Task and result Shareables use Cell/F3 directly, including
 ``nvflare/client/cell/api.py``.
 """
 
+import ipaddress
 import os
 import secrets
 import signal
@@ -53,6 +54,7 @@ from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.utils import make_reply as make_cell_reply
 from nvflare.fuel.f3.cellnet.utils import new_cell_message
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
+from nvflare.fuel.f3.drivers.net_utils import parse_url
 from nvflare.fuel.f3.streaming.download_service import DownloadService
 from nvflare.fuel.f3.streaming.transfer_progress import DEFAULT_STREAMING_IDLE_TIMEOUT
 from nvflare.fuel.utils.fobs import FOBSContextKey
@@ -124,8 +126,8 @@ class _TrainerSession(CellSession):
     def __init__(self, token: str, trainer_fqcn: str):
         super().__init__(trainer_fqcn)
         self.token = token
-        # latched when the HELLO of THIS launch's own process is rejected, so the launch
-        # wait fails fast instead of waiting out launch_timeout
+        # Latched when a token-authenticated HELLO is rejected so the launch wait fails
+        # fast instead of waiting out launch_timeout.
         self.reject_reason: Optional[str] = None
         self.bootstrap_path: Optional[str] = None
         self.process: Optional[subprocess.Popen] = None
@@ -195,13 +197,33 @@ class ExternalProcessBackend(CellBackendBase):
                 scheme="tcp",
                 resources={
                     DriverParams.HOST.value: "localhost",
-                    DriverParams.LISTEN_HOST.value: "localhost",
+                    DriverParams.LISTEN_HOST.value: "127.0.0.1",
                     DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
                 },
             )
             connect_url = cell.get_internal_listener_url()
             if not connect_url:
                 raise RuntimeError("CJ cell has no internal listener url for the trainer to connect to")
+            listener_params = cell.get_internal_listener_params() or {}
+            connect_scheme = parse_url(connect_url).get(DriverParams.SCHEME.value)
+            listener_scheme = listener_params.get(DriverParams.SCHEME.value)
+            bind_host = listener_params.get(DriverParams.HOST.value)
+            connection_security = listener_params.get(DriverParams.CONNECTION_SECURITY.value)
+            try:
+                loopback_bound = ipaddress.ip_address(bind_host).is_loopback
+            except (TypeError, ValueError):
+                loopback_bound = False
+            if (
+                connect_scheme != "tcp"
+                or listener_scheme != "tcp"
+                or connection_security != ConnectionSecurity.CLEAR
+                or not loopback_bound
+            ):
+                raise RuntimeError(
+                    "external_process trainer requires a clear TCP listener bound to loopback, but the CJ internal "
+                    f"listener is incompatible: connect_scheme={connect_scheme!r}, listener_scheme={listener_scheme!r}, "
+                    f"bind_host={bind_host!r}, connection_security={connection_security!r}"
+                )
             self._connect_url = connect_url
 
             cell.register_request_cb(channel=CHANNEL, topic=Topic.HELLO, cb=self._handle_hello)
@@ -981,7 +1003,8 @@ class ExternalProcessBackend(CellBackendBase):
             or not trainer.token
             or not secrets.compare_digest(proof.encode("utf-8"), trainer.token.encode("utf-8"))
         ):
-            return self._hello_reject(trainer, origin, "launch token mismatch", latch=True)
+            # Clear loopback transport cannot prove that an invalid-token sender is the launched trainer.
+            return self._hello_reject(trainer, origin, "launch token mismatch", latch=False)
 
         if payload.get(MsgKey.PROTOCOL_VERSION) != PROTOCOL_VERSION:
             return self._hello_reject(

--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -195,6 +195,7 @@ class ExternalProcessBackend(CellBackendBase):
                 scheme="tcp",
                 resources={
                     DriverParams.HOST.value: "localhost",
+                    DriverParams.LISTEN_HOST.value: "localhost",
                     DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
                 },
             )

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -172,7 +172,15 @@ class ConnectorManager:
         return conn_config
 
     def _get_connector(
-        self, url: str, active: bool, internal: bool, adhoc: bool, secure: bool, conn_resources=None
+        self,
+        url: str,
+        active: bool,
+        internal: bool,
+        adhoc: bool,
+        secure: bool,
+        conn_resources=None,
+        listener_scheme=None,
+        listener_resources=None,
     ) -> Union[None, ConnectorData]:
         if active and not url:
             raise RuntimeError("url is required by not provided for active connector!")
@@ -189,8 +197,8 @@ class ConnectorManager:
                 ssl_required = secure
             else:
                 # internal
-                scheme = self.int_scheme
-                resources = self.int_resources
+                scheme = listener_scheme or self.int_scheme
+                resources = self.int_resources if listener_resources is None else listener_resources
         else:
             # ad-hoc - must be external
             if internal:
@@ -254,11 +262,19 @@ class ConnectorManager:
         """
         return self._get_connector(url=url, active=True, internal=False, adhoc=adhoc, secure=self.secure)
 
-    def get_internal_listener(self) -> Union[None, ConnectorData]:
+    def get_internal_listener(self, scheme=None, resources=None) -> Union[None, ConnectorData]:
         """
         Try to get an internal listener.
         """
-        return self._get_connector(url="", active=False, internal=True, adhoc=False, secure=False)
+        return self._get_connector(
+            url="",
+            active=False,
+            internal=True,
+            adhoc=False,
+            secure=False,
+            listener_scheme=scheme,
+            listener_resources=resources,
+        )
 
     def get_internal_connector(self, url: str, conn_resources=None) -> Union[None, ConnectorData]:
         """

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -748,14 +748,18 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                 self.logger.debug(f"{self.my_info.fqcn}: removing agent {a}")
                 self.agents.pop(a, None)
 
-    def make_internal_listener(self):
+    def make_internal_listener(self, scheme=None, resources=None):
         """
         Create the internal listener for child cells of this cell to connect to.
+
+        Args:
+            scheme: optional transport scheme for this listener
+            resources: optional resources for this listener
 
         Returns:
 
         """
-        self._create_internal_listener()
+        self._create_internal_listener(scheme, resources)
 
     def get_internal_listener_url(self) -> Union[None, str]:
         """Get the cell's internal listener url.
@@ -800,10 +804,10 @@ class CoreCell(MessageReceiver, EndpointMonitor):
                 self.logger.info(f"{self.my_info.fqcn}: cannot create adhoc connector to {url} on {to_cell}")
             return connector
 
-    def _create_internal_listener(self):
+    def _create_internal_listener(self, scheme=None, resources=None):
         # internal listener is always backbone
         if not self.int_listener:
-            self.int_listener = self.connector_manager.get_internal_listener()
+            self.int_listener = self.connector_manager.get_internal_listener(scheme, resources)
             if self.int_listener:
                 self.logger.info(
                     f"{self.my_info.fqcn}: created backbone internal listener "

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -121,6 +121,11 @@ class FakeCell:
         self.decode_pass_through_channels = set()
         self.decode_pass_through_topics = set()
         self.listener_url = "tcp://127.0.0.1:56789"
+        self.listener_params = {
+            DriverParams.SCHEME.value: "tcp",
+            DriverParams.HOST.value: "127.0.0.1",
+            DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
+        }
         self.configured_listener_url = None
         self.listener_args = None
         self.internal_listener_made = False
@@ -146,9 +151,17 @@ class FakeCell:
             self.listener_url = self.configured_listener_url
         elif scheme == "tcp" and resources:
             self.listener_url = "tcp://localhost:56789"
+            self.listener_params = {
+                DriverParams.SCHEME.value: "tcp",
+                DriverParams.HOST.value: resources[DriverParams.LISTEN_HOST.value],
+                DriverParams.CONNECTION_SECURITY.value: resources[DriverParams.CONNECTION_SECURITY.value],
+            }
 
     def get_internal_listener_url(self):
         return self.listener_url
+
+    def get_internal_listener_params(self):
+        return self.listener_params
 
     def register_request_cb(self, channel, topic, cb):
         assert channel == CHANNEL
@@ -479,7 +492,7 @@ class TestInitializeAndFinalize:
                 "tcp",
                 {
                     DriverParams.HOST.value: "localhost",
-                    DriverParams.LISTEN_HOST.value: "localhost",
+                    DriverParams.LISTEN_HOST.value: "127.0.0.1",
                     DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
                 },
             )
@@ -501,6 +514,24 @@ class TestInitializeAndFinalize:
 
         assert env.cell.parent_url == fixed_parent_url
         assert env.cell.parent_resources == original_parent_resources
+
+    def test_initialize_rejects_preexisting_mtls_listener_before_launch(self, env):
+        env.cell.listener_url = "stcp://localhost:8102"
+        env.cell.listener_params = {
+            DriverParams.SCHEME.value: "stcp",
+            DriverParams.HOST.value: "127.0.0.1",
+            DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.MTLS,
+        }
+        # CoreCell retains an internal listener that another component created first.
+        env.cell.make_internal_listener = MagicMock()
+        backend = ExternalProcessBackend()
+        fl_ctx = _make_fl_ctx(_make_engine(env.cell), env.app_dir)
+
+        with pytest.raises(RuntimeError, match="listener_scheme='stcp'.*connection_security='mtls'"):
+            backend.initialize(_make_context(), fl_ctx)
+
+        env.cell.make_internal_listener.assert_called_once()
+        assert not env.harness.processes
 
     def test_initialize_unwinds_when_hello_never_arrives(self, env):
         env.harness.auto_hello = False
@@ -530,17 +561,42 @@ class TestInitializeAndFinalize:
             backend.initialize(_make_context(launch_timeout=30.0), fl_ctx)
         assert time.monotonic() - start < 5.0
 
-    def test_initialize_fails_fast_when_hello_is_rejected(self, env):
+    def test_invalid_token_hello_does_not_reject_legitimate_trainer(self, env):
         def bad_token(payload):
             payload[MsgKey.PROOF] = "wrong-token"
 
         env.harness.hello_mutator = bad_token
-        backend = ExternalProcessBackend()
-        fl_ctx = _make_fl_ctx(_make_engine(env.cell), env.app_dir)
+        original_popen = env.harness.popen
+        legitimate_replies = []
 
-        with pytest.raises(RuntimeError, match="rejected.*launch token mismatch"):
-            backend.initialize(_make_context(launch_timeout=30.0), fl_ctx)
-        assert env.harness.processes[0].returncode is not None
+        def popen_with_attacker_hello(args, **kwargs):
+            process = original_popen(args, **kwargs)
+            config = env.harness.bootstrap_configs[-1]
+            legitimate_replies.append(
+                env.cell.deliver(
+                    Topic.HELLO,
+                    config[BootstrapKey.TRAINER_FQCN],
+                    {
+                        MsgKey.TRAINER_FQCN: config[BootstrapKey.TRAINER_FQCN],
+                        MsgKey.PROOF: config[BootstrapKey.LAUNCH_TOKEN],
+                        MsgKey.PROTOCOL_VERSION: PROTOCOL_VERSION,
+                        MsgKey.JOB_ID: "job-1",
+                        MsgKey.SITE_NAME: "site-1",
+                        MsgKey.RANK: 0,
+                    },
+                )
+            )
+            return process
+
+        env.harness.popen = popen_with_attacker_hello
+        backend, _ = _initialized_backend(env)
+        try:
+            assert env.harness.hello_replies[0].payload[MsgKey.REPLY_TOPIC] == Topic.HELLO_REJECTED
+            assert legitimate_replies[0].payload[MsgKey.REPLY_TOPIC] == Topic.HELLO_ACCEPTED
+            assert backend._active_launch.ready.is_set()
+            assert backend._active_launch.reject_reason is None
+        finally:
+            backend.finalize(FLContext())
 
     def test_finalize_idempotent_and_stops_process_tree(self, env):
         backend, _ = _initialized_backend(env)

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -479,6 +479,7 @@ class TestInitializeAndFinalize:
                 "tcp",
                 {
                     DriverParams.HOST.value: "localhost",
+                    DriverParams.LISTEN_HOST.value: "localhost",
                     DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
                 },
             )

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -25,8 +25,15 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 from nvflare.apis.analytix import AnalyticsDataType
-from nvflare.apis.dxo import DXO, DataKind
-from nvflare.apis.fl_constant import FLContextKey, FLMetaKey, ReservedKey, ReturnCode, ServerCommandNames
+from nvflare.apis.dxo import DXO, DataKind, from_shareable
+from nvflare.apis.fl_constant import (
+    ConnectionSecurity,
+    FLContextKey,
+    FLMetaKey,
+    ReservedKey,
+    ReturnCode,
+    ServerCommandNames,
+)
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import UnsafeJobError
 from nvflare.apis.shareable import Shareable
@@ -51,6 +58,7 @@ from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as CellReturnCode
 from nvflare.fuel.f3.cellnet.utils import make_reply as make_cell_reply
 from nvflare.fuel.f3.cellnet.utils import new_cell_message
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
 from nvflare.fuel.utils.fobs.decomposers.via_downloader import LazyDownloadRef
 
 CJ_FQCN = "site-1.job-1"
@@ -113,6 +121,8 @@ class FakeCell:
         self.decode_pass_through_channels = set()
         self.decode_pass_through_topics = set()
         self.listener_url = "tcp://127.0.0.1:56789"
+        self.configured_listener_url = None
+        self.listener_args = None
         self.internal_listener_made = False
         self.cbs = {}
         self.sent = []  # (topic, target, payload, timeout)
@@ -129,8 +139,13 @@ class FakeCell:
     def is_cell_connected(self, target_fqcn):
         return target_fqcn not in self.disconnected
 
-    def make_internal_listener(self):
+    def make_internal_listener(self, scheme=None, resources=None):
         self.internal_listener_made = True
+        self.listener_args = (scheme, resources)
+        if self.configured_listener_url and scheme is None and resources is None:
+            self.listener_url = self.configured_listener_url
+        elif scheme == "tcp" and resources:
+            self.listener_url = "tcp://localhost:56789"
 
     def get_internal_listener_url(self):
         return self.listener_url
@@ -441,6 +456,50 @@ class TestInitializeAndFinalize:
             assert exchange[ConfigKey.SUBMIT_MODEL_TASK_NAME] == "my_submit"
         finally:
             backend.finalize(FLContext())
+
+    @pytest.mark.parametrize(
+        "parent_scheme,parent_security",
+        [
+            ("tcp", ConnectionSecurity.CLEAR),
+            ("stcp", ConnectionSecurity.MTLS),
+        ],
+    )
+    def test_trainer_listener_is_independent_from_fixed_parent_listener(self, env, parent_scheme, parent_security):
+        fixed_parent_url = f"{parent_scheme}://localhost:8102"
+        env.cell.parent_url = fixed_parent_url
+        env.cell.parent_resources = {DriverParams.CONNECTION_SECURITY.value: parent_security}
+        env.cell.configured_listener_url = fixed_parent_url
+        original_parent_resources = dict(env.cell.parent_resources)
+
+        backend, fl_ctx = _initialized_backend(env)
+        try:
+            trainer = backend._active_launch
+            assert trainer is not None and trainer.ready.is_set() and trainer.session_id
+            assert env.cell.listener_args == (
+                "tcp",
+                {
+                    DriverParams.HOST.value: "localhost",
+                    DriverParams.CONNECTION_SECURITY.value: ConnectionSecurity.CLEAR,
+                },
+            )
+            assert env.cell.listener_url == "tcp://localhost:56789"
+            assert env.cell.listener_url != fixed_parent_url
+
+            bootstrap_path = env.harness.processes[0].kwargs["env"][BOOTSTRAP_FILE_ENV_VAR]
+            bootstrap = read_bootstrap_config(bootstrap_path)
+            assert bootstrap[BootstrapKey.CONNECT_URL] == env.cell.listener_url
+            for field in ("connection_security", "ca_cert", "client_cert", "client_key"):
+                assert field not in bootstrap
+
+            seen = _install_auto_result(env)
+            result = backend.execute("train", _result_shareable(), fl_ctx, Signal())
+            assert from_shareable(result).data == {"w": [1.0]}
+            assert seen.task_payloads
+        finally:
+            backend.finalize(FLContext())
+
+        assert env.cell.parent_url == fixed_parent_url
+        assert env.cell.parent_resources == original_parent_resources
 
     def test_initialize_unwinds_when_hello_never_arrives(self, env):
         env.harness.auto_hello = False

--- a/tests/unit_test/fuel/f3/cellnet/core_cell_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/core_cell_test.py
@@ -200,6 +200,24 @@ def test_listener_accessors_and_callbacks():
             setter(None)
 
 
+def test_make_internal_listener_forwards_listener_override():
+    cell = _cell("site-1.job-1")
+    cell.int_listener = None
+    cell.connector_manager = MagicMock()
+    cell.connector_manager.get_internal_listener.return_value = SimpleNamespace(
+        get_connection_url=lambda: "tcp://localhost:49152"
+    )
+    resources = {
+        DriverParams.HOST.value: "localhost",
+        DriverParams.CONNECTION_SECURITY.value: "clear",
+    }
+
+    cell.make_internal_listener("tcp", resources)
+
+    cell.connector_manager.get_internal_listener.assert_called_once_with("tcp", resources)
+    assert cell.get_internal_listener_url() == "tcp://localhost:49152"
+
+
 def test_internal_listener_host_overrides_default_resources():
     comm_configurator = MagicMock()
     comm_configurator.get_config.return_value = None
@@ -213,6 +231,41 @@ def test_internal_listener_host_overrides_default_resources():
 
     assert manager.int_resources[DriverParams.HOST.value] == "127.0.0.1"
     assert manager.int_resources[DriverParams.LISTEN_HOST.value] == "127.0.0.1"
+
+
+def test_internal_listener_override_does_not_mutate_configured_resources():
+    configured_resources = {
+        DriverParams.HOST.value: "localhost",
+        DriverParams.LISTEN_HOST.value: "localhost",
+        DriverParams.PORTS.value: "8102-8102",
+        DriverParams.CONNECTION_SECURITY.value: "mtls",
+    }
+    comm_configurator = MagicMock()
+    comm_configurator.get_internal_connection_scheme.return_value = "stcp"
+    comm_configurator.get_config.return_value = {
+        "internal": {
+            "scheme": "stcp",
+            "resources": configured_resources,
+        }
+    }
+    communicator = MagicMock()
+    communicator.start_listener.return_value = ("handle", "tcp://localhost:49152", {})
+    manager = ConnectorManager(
+        communicator=communicator,
+        secure=True,
+        comm_configurator=comm_configurator,
+    )
+    listener_resources = {
+        DriverParams.HOST.value: "localhost",
+        DriverParams.CONNECTION_SECURITY.value: "clear",
+    }
+
+    listener = manager.get_internal_listener("tcp", listener_resources)
+
+    assert listener.get_connection_url() == "tcp://localhost:49152"
+    communicator.start_listener.assert_called_once_with("tcp", {"secure": False, **listener_resources})
+    assert manager.int_scheme == "stcp"
+    assert manager.int_resources == configured_resources
 
 
 def test_public_send_reply_applies_filters_before_server_transit_routing():


### PR DESCRIPTION
Fixes #5164.

### Description

In same-host process mode, a generated `comm_config.json` with a fixed internal listener is loaded by both the client parent process and the child job process. The child correctly uses the launcher-provided parent URL to connect upward, but `ExternalProcessBackend` later requested another internal listener for its trainer. That request reused the parent listener's fixed resources and attempted to bind the already-owned port.

This change lets a caller provide listener-specific scheme and resources without mutating the shared communication configuration. `ExternalProcessBackend` uses that focused seam to create an independent clear TCP listener on localhost with an ephemeral port for the external trainer.

The parent URL and connection security remain unchanged, and the trainer bootstrap continues to contain only its independent connection URL without inheriting parent TLS credentials.

### Validation

- Focused external-process and CellNet unit/regression suites: 137 passed.
- Broader relevant executor and CellNet unit suites: 506 passed.
- Existing no-communication-config external-process end-to-end test: passed.
- `./runtest.sh -s`: passed.
- Manual Linux process-mode regression:
  - fixed clear parent listener: completed;
  - fixed mTLS parent listener: completed;
  - standard no-`comm_config.json` control: completed.
- Each manual case established the trainer session, completed a real task with a non-empty accepted result, and shut down cleanly.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
