### PR TITLE
Bound non-aggregator Swarm client job RSS

### DIFF
--- a/nvflare/app_common/ccwf/client_ctl.py
+++ b/nvflare/app_common/ccwf/client_ctl.py
@@ -477,10 +477,22 @@ class ClientSideController(Executor, TaskController):
                         # expected to raise and is not a job failure.
                         self.update_status(action="do_learn_task", error=ReturnCode.EXECUTION_EXCEPTION)
                 finally:
-                    # force garbage collection
-                    gc.collect()
-                self.learn_task = None
+                    # Drop all references to the finished task before reclaiming
+                    # memory: `t` and self.learn_task would otherwise pin the
+                    # (possibly multi-GB) task payload until the next task arrives.
+                    self.learn_task = None
+                    t = None
+                    self._cleanup_learn_task_memory()
             time.sleep(self.learn_task_check_interval)
+
+    def _cleanup_learn_task_memory(self):
+        """Reclaim memory after a learn task finishes.
+
+        The base behavior is Python-level garbage collection only. Subclasses
+        may override with allocator-aware cleanup that also returns freed
+        native heap pages to the OS.
+        """
+        gc.collect()
 
     def update_status(self, last_round=None, action=None, error=None, all_done=False):
         with self.status_lock:

--- a/nvflare/app_common/ccwf/swarm_client_ctl.py
+++ b/nvflare/app_common/ccwf/swarm_client_ctl.py
@@ -338,10 +338,10 @@ class SwarmClientController(ClientSideController):
                 Since submission req is a tiny message, this timeout value should be small.
             request_to_submit_result_interval: interval between requests to submit result.
             max_concurrent_submissions: max number of concurrent submissions allowed on the aggregation client.
-            memory_gc_rounds: run allocator-aware memory cleanup (gc.collect() + malloc_trim) every
-                N FL rounds — after each completed learn task on every client, and additionally after
-                each aggregation on the aggregation client. Defaults to 1 (every round). Set to 0 to
-                disable (a plain gc.collect() still runs after each learn task).
+            memory_gc_rounds: run allocator-aware memory cleanup (gc.collect() + malloc_trim) after every
+                N completed learn tasks in each client job, and independently after every N aggregations
+                in the aggregation client job. Defaults to 1. Set to 0 to disable allocator-aware cleanup.
+                A plain gc.collect() still runs after every learn task regardless of this value.
             cuda_empty_cache: also call torch.cuda.empty_cache() during memory cleanup.
                 In swarm learning the aggregator runs on the same client as the trainer, so GPU
                 memory may be relevant. Defaults to False.
@@ -716,11 +716,12 @@ class SwarmClientController(ClientSideController):
                 self.log_info(fl_ctx, f"Swarm aggregator memory cleanup at round {self._aggr_round_count}")
 
     def _cleanup_learn_task_memory(self):
-        """Allocator-aware cleanup after each learn task, gated by memory_gc_rounds.
+        """Run allocator-aware cleanup on the configured learn-task cadence.
 
         A non-aggregation client never runs _end_gather(), so this is the only
         point where its client job returns the freed learn-task payload from
-        the allocator to the OS.
+        the allocator to the OS. Between cadence points, and when allocator-aware
+        cleanup is disabled, the base hook still runs gc.collect().
         """
         if self.memory_gc_rounds > 0:
             self._learn_task_count += 1

--- a/nvflare/app_common/ccwf/swarm_client_ctl.py
+++ b/nvflare/app_common/ccwf/swarm_client_ctl.py
@@ -338,10 +338,11 @@ class SwarmClientController(ClientSideController):
                 Since submission req is a tiny message, this timeout value should be small.
             request_to_submit_result_interval: interval between requests to submit result.
             max_concurrent_submissions: max number of concurrent submissions allowed on the aggregation client.
-            memory_gc_rounds: run gc.collect() + malloc_trim on the aggregator every N FL rounds.
-                Defaults to 1 (every round) to match legacy behavior where gc.collect() was called
-                unconditionally after each trainer submission. Set to 0 to disable.
-            cuda_empty_cache: also call torch.cuda.empty_cache() during aggregator-side cleanup.
+            memory_gc_rounds: run allocator-aware memory cleanup (gc.collect() + malloc_trim) every
+                N FL rounds — after each completed learn task on every client, and additionally after
+                each aggregation on the aggregation client. Defaults to 1 (every round). Set to 0 to
+                disable (a plain gc.collect() still runs after each learn task).
+            cuda_empty_cache: also call torch.cuda.empty_cache() during memory cleanup.
                 In swarm learning the aggregator runs on the same client as the trainer, so GPU
                 memory may be relevant. Defaults to False.
             enable_tensor_disk_offload: download incoming streamed PyTorch tensors to temporary disk files
@@ -413,6 +414,7 @@ class SwarmClientController(ClientSideController):
         self.memory_gc_rounds = memory_gc_rounds
         self.cuda_empty_cache = cuda_empty_cache
         self._aggr_round_count = 0
+        self._learn_task_count = 0
 
     def process_config(self, fl_ctx: FLContext):
         all_clients = self.get_config_prop(Constant.CLIENTS)
@@ -627,11 +629,12 @@ class SwarmClientController(ClientSideController):
                 fl_ctx,
                 f"broadcasting learn task of round {for_round} to {remote_targets}; aggregation happens on {aggr}",
             )
-            if getattr(self, "enable_tensor_disk_offload", False):
-                # Keep the client job as a forwarding hop. The external trainer
-                # downloads tensors from the originating source instead of
-                # receiving process-local disk refs from the client job.
-                task_data.set_header(ReservedHeaderKey.PASS_THROUGH, True)
+            # Keep the receiving client job a forwarding hop: decode the
+            # streamed tensors into lazy refs so only their terminal consumer
+            # (external trainer, in-process learner, or aggregation controller)
+            # materializes them. Whether that consumer materializes to memory
+            # or to disk is controlled separately by enable_tensor_disk_offload.
+            task_data.set_header(ReservedHeaderKey.PASS_THROUGH, True)
             if not self.send_learn_task(targets=remote_targets, request=task_data, fl_ctx=fl_ctx):
                 return False
 
@@ -711,6 +714,23 @@ class SwarmClientController(ClientSideController):
 
                 cleanup_memory(cuda_empty_cache=self.cuda_empty_cache)
                 self.log_info(fl_ctx, f"Swarm aggregator memory cleanup at round {self._aggr_round_count}")
+
+    def _cleanup_learn_task_memory(self):
+        """Allocator-aware cleanup after each learn task, gated by memory_gc_rounds.
+
+        A non-aggregation client never runs _end_gather(), so this is the only
+        point where its client job returns the freed learn-task payload from
+        the allocator to the OS.
+        """
+        if self.memory_gc_rounds > 0:
+            self._learn_task_count += 1
+            if self._learn_task_count % self.memory_gc_rounds == 0:
+                from nvflare.fuel.utils.memory_utils import cleanup_memory
+
+                cleanup_memory(cuda_empty_cache=self.cuda_empty_cache)
+                self.logger.info(f"Swarm client job memory cleanup after learn task {self._learn_task_count}")
+                return
+        super()._cleanup_learn_task_memory()
 
     def _ask_to_share_best_result(self, client: str, metric, fl_ctx: FLContext):
         # other client has best model - ask it to distribute its result
@@ -956,10 +976,10 @@ class SwarmClientController(ClientSideController):
             current_round = request.get_header(AppConstants.CURRENT_ROUND)
             self.log_info(fl_ctx, f"got training result from {client_name} for round {current_round}")
 
-            # With disk offload enabled, the sending Swarm controller stamps
-            # PASS_THROUGH so this aggregation controller—not the Cell receive
-            # callback—is the terminal consumer. The local self-submit path also
-            # enters here after resolving explicitly.
+            # The sending Swarm controller stamps PASS_THROUGH so this
+            # aggregation controller—not the Cell receive callback—is the
+            # terminal consumer. The local self-submit path also enters here
+            # after resolving explicitly.
             if self._has_lazy_refs(request):
                 request = self._resolve_lazy_refs(request, fl_ctx)
             # PASS_THROUGH is a transport instruction for this one hop, not
@@ -1168,11 +1188,11 @@ class SwarmClientController(ClientSideController):
             else:
                 self.log_info(fl_ctx, f"sending training result to aggregation client {aggr}")
 
-                if getattr(self, "enable_tensor_disk_offload", False):
-                    # The aggregation client is the terminal consumer. Preserve
-                    # tensor transport refs through AUX decoding so its
-                    # controller can resolve them with its own offload root.
-                    result.set_header(ReservedHeaderKey.PASS_THROUGH, True)
+                # The aggregation client is the terminal consumer. Preserve
+                # tensor transport refs through AUX decoding so its controller
+                # resolves them with its own offload setting instead of the
+                # Cell receive callback materializing them.
+                result.set_header(ReservedHeaderKey.PASS_THROUGH, True)
 
                 task = Task(
                     name=self.report_learn_result_task_name,

--- a/nvflare/app_opt/pt/recipes/swarm.py
+++ b/nvflare/app_opt/pt/recipes/swarm.py
@@ -122,9 +122,10 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             Defaults to False (in-process execution).
         command: Shell command used to launch the script when launch_external_process=True.
             Defaults to "python3 -u".
-        memory_gc_rounds: Run gc.collect() + malloc_trim every N FL rounds on both the trainer
-            and aggregator roles. Defaults to 1 (every round) to match legacy behavior where
-            gc.collect() was called unconditionally after each trainer submission. Set to 0 to disable.
+        memory_gc_rounds: Run gc.collect() + malloc_trim every N FL rounds in the trainer
+            process and in every client job (after each learn task, and additionally after
+            each aggregation on the aggregation client). Defaults to 1 (every round).
+            Set to 0 to disable.
         cuda_empty_cache: Call torch.cuda.empty_cache() during cleanup. Defaults to False.
         expected_data_kind: The data kind the aggregator expects from clients. Defaults to
             DataKind.WEIGHTS for full-weight FedAvg. Clients returning differences must label

--- a/nvflare/app_opt/pt/recipes/swarm.py
+++ b/nvflare/app_opt/pt/recipes/swarm.py
@@ -122,10 +122,11 @@ class SwarmLearningRecipe(BaseSwarmLearningRecipe):
             Defaults to False (in-process execution).
         command: Shell command used to launch the script when launch_external_process=True.
             Defaults to "python3 -u".
-        memory_gc_rounds: Run gc.collect() + malloc_trim every N FL rounds in the trainer
-            process and in every client job (after each learn task, and additionally after
-            each aggregation on the aggregation client). Defaults to 1 (every round).
-            Set to 0 to disable.
+        memory_gc_rounds: Run allocator-aware cleanup (gc.collect() + malloc_trim) on three
+            independent cadences: every N training rounds in the trainer, every N completed
+            learn tasks in each client job, and every N aggregations in the aggregation client
+            job. Defaults to 1. Set to 0 to disable allocator-aware cleanup. A plain gc.collect()
+            still runs after every client-job learn task regardless of this value.
         cuda_empty_cache: Call torch.cuda.empty_cache() during cleanup. Defaults to False.
         expected_data_kind: The data kind the aggregator expects from clients. Defaults to
             DataKind.WEIGHTS for full-weight FedAvg. Clients returning differences must label

--- a/tests/unit_test/app_common/ccwf/client_ctl_test.py
+++ b/tests/unit_test/app_common/ccwf/client_ctl_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import threading
+import weakref
 from unittest.mock import MagicMock
 
 from nvflare.apis.event_type import EventType
@@ -149,6 +151,38 @@ def test_about_to_end_run_preserves_completed_workflow():
 
     ctl._abort_current_task.assert_not_called()
     ctl.finalize.assert_not_called()
+
+
+class _SucceedingClientSideController(_FailingClientSideController):
+    def __init__(self):
+        super().__init__()
+        self.task_alive_at_cleanup = None
+        self.task_ref = None
+
+    def do_learn_task(self, name: str, data: Shareable, fl_ctx: FLContext, abort_signal: Signal):
+        self.asked_to_stop = True
+
+    def _cleanup_learn_task_memory(self):
+        # By cleanup time the finished task must already be unreferenced by
+        # the learn loop (both self.learn_task and its loop-local alias), so
+        # the collection below can actually free a multi-GB payload.
+        gc.collect()
+        self.task_alive_at_cleanup = self.task_ref() is not None
+        super()._cleanup_learn_task_memory()
+
+
+def test_do_learn_drops_task_refs_before_memory_cleanup():
+    ctl = _SucceedingClientSideController()
+    ctl.logger = MagicMock()
+    task = _LearnTask("train", Shareable(), FLContext())
+    ctl.task_ref = weakref.ref(task)
+    ctl.learn_task = task
+    del task
+
+    ctl._do_learn()
+
+    assert ctl.learn_task is None
+    assert ctl.task_alive_at_cleanup is False
 
 
 def test_no_report_after_workflow_done():

--- a/tests/unit_test/app_common/ccwf/test_swarm_forward_memory_path.py
+++ b/tests/unit_test/app_common/ccwf/test_swarm_forward_memory_path.py
@@ -316,18 +316,21 @@ class TestScatterLazyRefHandling(unittest.TestCase):
 
         self.assertEqual(resolve_calls, [])
 
-    def test_offload_marks_only_remote_learn_task_for_pass_through(self):
-        ctl = self._make_real_scatter_ctl(me="site-1", trainers=["site-1", "site-2"])
-        ctl.enable_tensor_disk_offload = True
-        fl_ctx = MagicMock()
+    def test_remote_learn_task_is_marked_pass_through_regardless_of_offload(self):
+        """PASS_THROUGH is a forwarding-hop decision, decoupled from disk offload."""
+        for offload in (False, True):
+            with self.subTest(enable_tensor_disk_offload=offload):
+                ctl = self._make_real_scatter_ctl(me="site-1", trainers=["site-1", "site-2"])
+                ctl.enable_tensor_disk_offload = offload
+                fl_ctx = MagicMock()
 
-        task_data = _make_shareable_with_real_arrays()
-        ctl._scatter(task_data, for_round=0, fl_ctx=fl_ctx)
+                task_data = _make_shareable_with_real_arrays()
+                ctl._scatter(task_data, for_round=0, fl_ctx=fl_ctx)
 
-        remote_data = ctl.send_learn_task.call_args.kwargs["request"]
-        local_data = ctl.set_learn_task.call_args.kwargs["task_data"]
-        self.assertTrue(remote_data.get_header(ReservedHeaderKey.PASS_THROUGH))
-        self.assertIsNone(local_data.get_header(ReservedHeaderKey.PASS_THROUGH))
+                remote_data = ctl.send_learn_task.call_args.kwargs["request"]
+                local_data = ctl.set_learn_task.call_args.kwargs["task_data"]
+                self.assertTrue(remote_data.get_header(ReservedHeaderKey.PASS_THROUGH))
+                self.assertIsNone(local_data.get_header(ReservedHeaderKey.PASS_THROUGH))
 
 
 if __name__ == "__main__":

--- a/tests/unit_test/app_common/ccwf/test_swarm_memory_gc.py
+++ b/tests/unit_test/app_common/ccwf/test_swarm_memory_gc.py
@@ -173,3 +173,63 @@ class TestSwarmAggregatorGCLogging:
 
         all_msgs = " ".join(str(c) for c in ctrl.log_info.call_args_list)
         assert "1" in all_msgs, "GC log message must include the round count (1 after first GC call)"
+
+
+def _make_learn_cleanup_controller(memory_gc_rounds=1, cuda_empty_cache=False):
+    """Minimal controller for exercising _cleanup_learn_task_memory."""
+    ctrl = SwarmClientController.__new__(SwarmClientController)
+    ctrl.memory_gc_rounds = memory_gc_rounds
+    ctrl.cuda_empty_cache = cuda_empty_cache
+    ctrl._learn_task_count = 0
+    ctrl.logger = Mock()
+    return ctrl
+
+
+class TestSwarmLearnTaskMemoryCleanup:
+    """Every client — aggregator or not — must run allocator-aware cleanup
+    after each learn task, gated by memory_gc_rounds. A non-aggregation client
+    job never runs _end_gather(), so this hook is its only trim point."""
+
+    def test_cleanup_fires_after_every_task_when_rounds_one(self):
+        ctrl = _make_learn_cleanup_controller(memory_gc_rounds=1)
+
+        with patch("nvflare.fuel.utils.memory_utils.cleanup_memory") as mock_cleanup:
+            for _ in range(3):
+                ctrl._cleanup_learn_task_memory()
+            assert mock_cleanup.call_count == 3
+
+    def test_cleanup_respects_cadence(self):
+        ctrl = _make_learn_cleanup_controller(memory_gc_rounds=2)
+
+        with patch("nvflare.fuel.utils.memory_utils.cleanup_memory") as mock_cleanup:
+            for _ in range(4):
+                ctrl._cleanup_learn_task_memory()
+            # tasks 2 and 4 fire; tasks 1 and 3 do not
+            assert mock_cleanup.call_count == 2
+
+    def test_cleanup_disabled_falls_back_to_gc_collect(self):
+        ctrl = _make_learn_cleanup_controller(memory_gc_rounds=0)
+
+        with (
+            patch("nvflare.fuel.utils.memory_utils.cleanup_memory") as mock_cleanup,
+            patch("nvflare.app_common.ccwf.client_ctl.gc.collect") as mock_collect,
+        ):
+            ctrl._cleanup_learn_task_memory()
+            mock_cleanup.assert_not_called()
+            mock_collect.assert_called_once()
+
+    def test_cuda_flag_is_forwarded(self):
+        ctrl = _make_learn_cleanup_controller(memory_gc_rounds=1, cuda_empty_cache=True)
+
+        with patch("nvflare.fuel.utils.memory_utils.cleanup_memory") as mock_cleanup:
+            ctrl._cleanup_learn_task_memory()
+            mock_cleanup.assert_called_once_with(cuda_empty_cache=True)
+
+    def test_cleanup_logs_when_it_fires(self):
+        ctrl = _make_learn_cleanup_controller(memory_gc_rounds=1)
+
+        with patch("nvflare.fuel.utils.memory_utils.cleanup_memory"):
+            ctrl._cleanup_learn_task_memory()
+
+        msgs = " ".join(str(c) for c in ctrl.logger.info.call_args_list)
+        assert "cleanup" in msgs.lower()


### PR DESCRIPTION
### Description

Long-running Swarm jobs with large models show multi-GiB RSS growth in non-aggregator client jobs (managed external-process mode, tensor disk offload OFF). Diagnostics show the memory is already free inside glibc but never returned to the OS — a single `malloc_trim(0)` in a grown non-aggregator CJ immediately reclaimed 4.7 GiB. Two gaps cause this: allocator-aware cleanup ran only on the aggregation path (`_end_gather()`), and the learn-task path ran a bare `gc.collect()` while the finished task was still referenced by the learn loop, so it could not free the payload at all.

Two changes:

1. **Decouple learn-task PASS_THROUGH from tensor disk offload.** The Swarm controller now always requests pass-through decoding for cross-site learn tasks and remote result submissions, so an intermediate client job keeps streamed tensors lazy and only the terminal consumer (external trainer, in-process learner, or aggregation controller) materializes them. `enable_tensor_disk_offload` now controls only whether that consumer materializes to disk instead of memory. All receive paths already branch on the payload containing lazy refs (`_prepare_learn_task_data()`, `_process_learn_result()`, the `_end_gather()` guard), and pass-through decoding only affects downloader-mediated datums, so inline/numpy payloads are unaffected. With this change, a non-aggregator CJ in the reported scenario never materializes the model at all.

2. **Run allocator-aware cleanup after every learn task.** `_do_learn()` now drops the finished task's references before reclaiming memory (previously `gc.collect()` ran while `t`/`self.learn_task` still pinned the payload) and calls a new `_cleanup_learn_task_memory()` hook. `SwarmClientController` overrides it with `cleanup_memory()` gated by the existing `memory_gc_rounds`, giving every client job the same `malloc_trim` treatment the aggregator already had. This covers the consumers that still materialize in the CJ (in-process, attach, legacy executors, aggregator).

Notes for reviewers:

- Offload-OFF external-process trainers now download cross-site tensors directly from the originating source (the same transit routing the offload-ON path already exercises since #5044/#5119) instead of receiving CJ-relayed bytes.
- Until #5136 (client-filter materialization) merges, CJ task filters observe `LazyDownloadRef` under pass-through. This was already the case for all offload-ON configs and now also applies to offload-OFF external-process configs; #5136 resolves both.

Verified locally: `tests/unit_test/app_common/ccwf` (145), `app_common/executors` + `fuel/utils/fobs` (422), `recipe/swarm_recipe_test.py` + `fuel/utils/memory_utils_test.py` (43), `app_opt/pt` (152), and the transport-level pass-through suites (140) — all green; black/isort/flake8 clean on touched files.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [x] In-line docstrings updated.
- [ ] Documentation updated.
